### PR TITLE
Nested object filtering — Part 20: preview gate, GraphQL ingress, and pre-release correctness

### DIFF
--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -76,9 +76,9 @@ func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 		if _, ok := schema.AsNested(prop.DataType); ok {
 			// Preview gate — when off we silently skip nested analysis so no
 			// entries are appended to nested filterable or meta buckets. Pairs
-			// with the bucket-creation skip in shard_init_properties_nested.go;
-			// even if one leaks past the other, the absence of buckets makes
-			// the writes inert.
+			// with the bucket-creation skip in shard_init_properties.go; even
+			// if one leaks past the other, the absence of buckets makes the
+			// writes inert.
 			if !entcfg.NestedFilteringEnabled() {
 				continue
 			}

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -73,6 +74,14 @@ func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 		}
 
 		if _, ok := schema.AsNested(prop.DataType); ok {
+			// Preview gate — when off we silently skip nested analysis so no
+			// entries are appended to nested filterable or meta buckets. Pairs
+			// with the bucket-creation skip in shard_init_properties_nested.go;
+			// even if one leaks past the other, the absence of buckets makes
+			// the writes inert.
+			if !entcfg.NestedFilteringEnabled() {
+				continue
+			}
 			// TODO aliszka:nested_filtering respect top-level indexFilterable/
 			// indexSearchable/indexRangeable settings for nested properties. Currently
 			// these are ignored — the nested write path bypasses HasAnyInvertedIndex

--- a/adapters/repos/db/inverted/objects_nested.go
+++ b/adapters/repos/db/inverted/objects_nested.go
@@ -168,13 +168,26 @@ func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedP
 		}
 	}
 
-	exists := make([]NestedMeta, len(assignResult.Exists))
-	for i, entry := range assignResult.Exists {
-		exists[i] = NestedMeta{
+	// _exists entries are gated by the same per-leaf config as values:
+	// a leaf with no inverted index can't be filtered on (the validator
+	// rejects IS NULL on non-filterable leaves), so writing its _exists
+	// is pure waste. The root sentinel (Path="") and intermediate
+	// object-array paths (e.g. "cars" or "cars.tires") are not in
+	// indexConfigs and stay — they back IS NULL on the array property
+	// itself, which is a doc-level / element-level question independent
+	// of any leaf flag.
+	exists := make([]NestedMeta, 0, len(assignResult.Exists))
+	for _, entry := range assignResult.Exists {
+		if entry.Path != "" {
+			if cfg, isLeaf := indexConfigs[entry.Path]; isLeaf && !cfg.hasAny() {
+				continue
+			}
+		}
+		exists = append(exists, NestedMeta{
 			Path:      entry.Path,
 			Index:     -1,
 			Positions: entry.Positions,
-		}
+		})
 	}
 
 	return &NestedProperty{

--- a/adapters/repos/db/inverted/objects_nested_test.go
+++ b/adapters/repos/db/inverted/objects_nested_test.go
@@ -425,7 +425,7 @@ func TestAnalyzeNestedProp(t *testing.T) {
 		assert.NotEmpty(t, result.Exists)
 	})
 
-	t.Run("non-filterable paths are excluded from values", func(t *testing.T) {
+	t.Run("non-filterable paths are excluded from values and exists", func(t *testing.T) {
 		prop := &models.Property{
 			Name:     "nested",
 			DataType: schema.DataTypeObject.PropString(),
@@ -444,18 +444,22 @@ func TestAnalyzeNestedProp(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		// Only "indexed" should produce values
+		// Only "indexed" should produce values.
 		for _, v := range result.Values {
 			assert.Equal(t, "indexed", v.Path, "skipped path should not appear in values")
 		}
 
-		// But metadata still includes both (structural)
+		// _exists entries for non-indexable leaves are also skipped:
+		// the validator rejects IS NULL on such leaves, so writing
+		// _exists.{skipped} would be pure waste. Root sentinel ("")
+		// stays — used by IS NULL on the root prop itself.
 		existsPaths := map[string]bool{}
 		for _, e := range result.Exists {
 			existsPaths[e.Path] = true
 		}
-		assert.True(t, existsPaths["indexed"])
-		assert.True(t, existsPaths["skipped"])
+		assert.True(t, existsPaths[""], "root sentinel _exists is always kept")
+		assert.True(t, existsPaths["indexed"], "indexed leaf _exists kept")
+		assert.False(t, existsPaths["skipped"], "non-indexable leaf _exists dropped")
 	})
 
 	t.Run("aggregate flags reflect index types", func(t *testing.T) {
@@ -480,6 +484,92 @@ func TestAnalyzeNestedProp(t *testing.T) {
 		assert.False(t, result.HasFilterableIndex, "no filterable paths")
 		assert.True(t, result.HasSearchableIndex, "title is searchable by default")
 		assert.True(t, result.HasRangeableIndex, "price is rangeable")
+	})
+
+	t.Run("per-leaf filterable gates values and exists across mixed leaf types", func(t *testing.T) {
+		// Mixed-leaf fixture exercising every leaf kind that produces _exists
+		// entries:
+		//   - scalar leaf indexed (make) / non-indexed (color)
+		//   - scalar-array leaf indexed (tags) / non-indexed (repair_years)
+		//   - object-array intermediate (tires) — not a leaf, never gated
+		//   - leaves nested INSIDE the intermediate, indexed (tires.width)
+		//     and non-indexed (tires.brand)
+		//
+		// "Non-indexed" means all of IndexFilterable/IndexSearchable/
+		// IndexRangeFilters explicitly false. Schema accepts the prop and
+		// it ends up in the assignResult, but the analyzer must drop both
+		// values AND per-leaf _exists for it.
+		off := boolPtr(false)
+		prop := &models.Property{
+			Name:     "cars",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: "field", IndexFilterable: boolPtr(true)},
+				{Name: "color", DataType: schema.DataTypeText.PropString(), Tokenization: "field", IndexFilterable: off, IndexSearchable: off},
+				{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: "field", IndexFilterable: boolPtr(true)},
+				{Name: "repair_years", DataType: schema.DataTypeIntArray.PropString(), IndexFilterable: off, IndexRangeFilters: off},
+				{
+					Name:     "tires",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: boolPtr(true)},
+						{Name: "brand", DataType: schema.DataTypeText.PropString(), Tokenization: "field", IndexFilterable: off, IndexSearchable: off},
+					},
+				},
+			},
+		}
+		value := []any{
+			map[string]any{
+				"make":         "Toyota",
+				"color":        "red",
+				"tags":         []any{"family", "hybrid"},
+				"repair_years": []any{float64(2020), float64(2021)},
+				"tires": []any{
+					map[string]any{"width": float64(215), "brand": "Michelin"},
+				},
+			},
+		}
+
+		result, err := analyzer.analyzeNestedProp(prop, value)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// --- Values: only indexed leaves contribute -----------------
+		valuePaths := map[string]int{}
+		for _, v := range result.Values {
+			valuePaths[v.Path]++
+		}
+		assert.Equal(t, 1, valuePaths["make"], "indexed scalar leaf produces one value")
+		assert.Equal(t, 2, valuePaths["tags"], "indexed scalar-array leaf produces one value per token")
+		assert.Equal(t, 1, valuePaths["tires.width"], "indexed leaf inside object-array intermediate produces one value")
+		assert.Zero(t, valuePaths["color"], "non-indexable scalar leaf must not appear in values")
+		assert.Zero(t, valuePaths["repair_years"], "non-indexable scalar-array leaf must not appear in values")
+		assert.Zero(t, valuePaths["tires.brand"], "non-indexable leaf inside object-array intermediate must not appear in values")
+
+		// --- _exists: same gating as values plus structural sentinels --
+		existsPaths := map[string]bool{}
+		for _, e := range result.Exists {
+			existsPaths[e.Path] = true
+		}
+		assert.True(t, existsPaths[""], "root sentinel _exists always kept (IS NULL on root nested prop)")
+		assert.True(t, existsPaths["tires"], "intermediate object-array _exists always kept (IS NULL on the array prop)")
+		assert.True(t, existsPaths["make"], "indexed scalar leaf _exists kept")
+		assert.True(t, existsPaths["tags"], "indexed scalar-array leaf _exists kept")
+		assert.True(t, existsPaths["tires.width"], "indexed leaf inside intermediate _exists kept")
+		assert.False(t, existsPaths["color"], "non-indexable scalar leaf _exists dropped")
+		assert.False(t, existsPaths["repair_years"], "non-indexable scalar-array leaf _exists dropped")
+		assert.False(t, existsPaths["tires.brand"], "non-indexable leaf inside intermediate _exists dropped")
+
+		// --- _idx: per-array-path, universal (orthogonal to leaf flags) ---
+		// Root-array idx entries use Path="" (the root nested prop's own
+		// element index); deeper array intermediates use the dotted
+		// relative path.
+		idxPaths := map[string]bool{}
+		for _, i := range result.Idx {
+			idxPaths[i.Path] = true
+		}
+		assert.True(t, idxPaths[""], "root cars[] idx kept (arr[N] dispatch on cars)")
+		assert.True(t, idxPaths["tires"], "nested object-array idx kept (arr[N] dispatch on cars.tires)")
 	})
 
 	t.Run("per-value flags match path config", func(t *testing.T) {

--- a/adapters/repos/db/inverted/objects_nested_test.go
+++ b/adapters/repos/db/inverted/objects_nested_test.go
@@ -12,13 +12,19 @@
 package inverted
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var; individual tests that want the off state use t.Setenv.
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 func boolPtr(v bool) *bool { return &v }
 

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -78,7 +78,7 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		case pv.operator == filters.OperatorIsNull:
 			return pv.fetchNestedIsNull(s)
 		case pv.operator.OnValue():
-			return pv.fetchNestedDocIDs(ctx, s, limit)
+			return pv.fetchNestedDocIDs(ctx, s)
 		}
 	}
 

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -59,8 +59,15 @@ type arrayIndices []filnested.ArrayIndex
 // fetchNestedDocIDs resolves a value filter on a nested property, returning
 // docID-only results. It fetches raw positions, applies any arr[N] index
 // constraints, then strips position bits to extract plain docIDs.
-func (pv *propValuePair) fetchNestedDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	positions, err := pv.fetchNestedPositions(ctx, s, limit)
+//
+// No limit parameter: the underlying position bitmap holds (root|leaf|docID)
+// entries, so a cursor cardinality limit applied during the bucket read would
+// short-circuit on position count rather than docID count and return fewer
+// docs than the caller asked for. Limits are enforced at the docID-bitmap
+// layer by the iterator clamp (DocIDsLimited → LimitedIterator,
+// Objects → objectsByDocID).
+func (pv *propValuePair) fetchNestedDocIDs(ctx context.Context, s *Searcher) (*docBitmap, error) {
+	positions, err := pv.fetchNestedPositions(ctx, s)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +278,7 @@ func (pv *propValuePair) fetchContainsChildBitmap(ctx context.Context, s *Search
 			}
 		}()
 		for _, gc := range child.children {
-			dbm, err := gc.fetchNestedPositions(ctx, s, 0)
+			dbm, err := gc.fetchNestedPositions(ctx, s)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -292,7 +299,7 @@ func (pv *propValuePair) fetchContainsChildBitmap(ctx context.Context, s *Search
 		succeeded = true
 		return anded, cleanup, nil
 	}
-	dbm, err := child.fetchNestedPositions(ctx, s, 0)
+	dbm, err := child.fetchNestedPositions(ctx, s)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -336,6 +343,12 @@ func (pv *propValuePair) isNullOperandLCA() (string, error) {
 // to docIDs — callers that need docIDs use fetchNestedDocIDs instead; the
 // correlated resolution path (resolveNestedSubtree) uses this directly.
 //
+// No limit parameter: positions (root|leaf|docID) don't map 1:1 to docs, so a
+// cursor-level limit would short-circuit on position cardinality and produce
+// wrong results once any matching doc contributes multiple positions. The
+// bucket read is always unlimited; docID-count limits apply post-MaskRootLeaf
+// at the iterator boundary.
+//
 // NotEqual returns a denylist position bitmap from readFromBucket. We
 // materialize the positive bitmap here at the leaf's natural LCA: positions
 // where the property is indexed AND-NOT the denylist set. This yields the
@@ -344,8 +357,8 @@ func (pv *propValuePair) isNullOperandLCA() (string, error) {
 // level (existential per-element). Lazy: the universe is only loaded when
 // isDenyList is set. Rangeable indices (future) that return positive
 // bitmaps directly skip the materialization.
-func (pv *propValuePair) fetchNestedPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	raw, err := pv.readFromBucket(ctx, s, limit)
+func (pv *propValuePair) fetchNestedPositions(ctx context.Context, s *Searcher) (*docBitmap, error) {
+	raw, err := pv.readFromBucket(ctx, s, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -451,6 +464,12 @@ func (pv *propValuePair) fetchNestedExistsPositions(s *Searcher) (*sroar.Bitmap,
 // intermediate arr[N] constraints with unconstrained conditions at the same
 // level in filter validation. Until that lands, unconstrained items in that
 // shape are silently dropped during plan construction.
+//
+// No user limit reaches this path: leaf reads go through fetchNestedPositions
+// which has no limit parameter — positions don't map 1:1 to docs, so the
+// bucket cursor would short-circuit on position cardinality and produce
+// wrong results. The user limit applies post-MaskRootLeaf at the iterator
+// clamp (objectsByDocID / LimitedIterator) in the outer caller.
 func (pv *propValuePair) resolveNestedSubtree(ctx context.Context, s *Searcher) (*docBitmap, error) {
 	if pv.operator == filters.OperatorOr || pv.operator == filters.OperatorNot ||
 		pv.operator == filters.ContainsAny {
@@ -562,6 +581,12 @@ func (pv *propValuePair) resolveNestedSubtreeGroup(ctx context.Context, s *Searc
 // recursive plan + executor. Used directly by resolveMultiGroupRootDocIDAnd
 // to combine groups via CrossLeafCopresenceAll before stripping to docIDs,
 // and indirectly by resolveNestedSubtreeGroup which strips immediately.
+//
+// Invariant: callers must apply MaskRootLeaf to the returned bitmap before
+// it reaches any docID-counting code (cardinality checks, iterator clamps,
+// sort). Raw positions are (root|leaf|docID) tuples; treating their
+// cardinality as a doc count yields wrong results once a single doc
+// contributes multiple positions.
 func (pv *propValuePair) resolveGroupRaw(ctx context.Context, s *Searcher, children []*propValuePair) (*sroar.Bitmap, func(), error) {
 	plan, executor, releases, err := pv.buildRecGroupExecutor(ctx, s, children)
 	if err != nil {

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -15,6 +15,7 @@ package inverted
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
@@ -33,6 +35,10 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
 )
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var; individual tests that want the off state use t.Setenv.
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 // ---------------------------------------------------------------------------
 // Test schema and helpers

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
@@ -404,7 +404,7 @@ type searcherBitmapFetcher struct {
 }
 
 func (f *searcherBitmapFetcher) fetchValue(ctx context.Context, leaf *propValuePair) (*sroar.Bitmap, func(), error) {
-	dbm, err := leaf.fetchNestedPositions(ctx, f.s, 0)
+	dbm, err := leaf.fetchNestedPositions(ctx, f.s)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
@@ -12,13 +12,19 @@
 package inverted
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var; individual tests that want the off state use t.Setenv.
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 // nestedPvp builds a minimal nested leaf propValuePair.
 func nestedPvp(prop, relPath string) *propValuePair {

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/entities/additional"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/inverted"
@@ -509,6 +510,12 @@ func (s *Searcher) buildPropValuePair(
 	}
 
 	if _, ok := schema.AsNested(property.DataType); ok {
+		// Defensive preview gate. The validator catches this first under the
+		// normal request flow; this duplicate guards any code path that
+		// reaches the searcher without going through validation.
+		if !entcfg.NestedFilteringEnabled() {
+			return nil, entcfg.NestedFilteringDisabledError()
+		}
 		return s.extractNestedProp(filter, props[0], property, class)
 	}
 

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
@@ -15,6 +15,7 @@ package inverted
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,9 +25,14 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 )
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var; individual tests that want the off state use t.Setenv.
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 // TestRecExecutorFilterExamples mirrors the eight F-scenarios from
 // TestCorrelatedAndFilterExamplesIndexed but exercises the new recursive plan

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
@@ -14,13 +14,19 @@
 package inverted
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 )
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var; individual tests that want the off state use t.Setenv.
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 // rootNestedProps returns the NestedProperties slice for the named root
 // property in filterExamplesClass(). Used by recursive plan structural tests

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -12,6 +12,7 @@
 package inverted
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -21,11 +22,16 @@ import (
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var; individual tests that want the off state use t.Setenv.
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 // nestedSearcherClass is the test schema used across all extractNestedProp tests:
 //

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -16,6 +16,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/additional"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -35,6 +37,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var; individual tests that want the off state use t.Setenv.
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 // TestNestedFilteringViaShardWritePath exercises nested property filtering
 // end-to-end using the full production write and search pipelines:

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -22461,3 +22461,94 @@ func TestNestedFilteringIntraSubArrayOrCrossSubArrayAnd3Levels(t *testing.T) {
 		)
 	})
 }
+
+// TestNestedFilteringLimitRespectedOnRangeScan is a regression test for the
+// cursor early-exit bug on nested filter reads (Copilot review #10974).
+//
+// Before fetchNestedDocIDs / fetchNestedPositions dropped their limit
+// parameters, the bucket cursor for nested range / LIKE / Equal-via-
+// RoaringSet scans short-circuited when the raw position bitmap's
+// GetCardinality reached the user limit — but positions (root|leaf|docID)
+// don't map 1:1 to docs, so a single doc with multiple matching nested
+// elements could exhaust the position quota before later matching docs
+// were read. Result: queries like "cars.year > 2010 LIMIT 5" returned far
+// fewer than 5 docs even though many more matched.
+//
+// After the fix the nested fetch is always unlimited at the bucket-read
+// layer; the iterator clamp (objectsByDocID for Search, LimitedIterator
+// for FindUUIDs) applies the user limit at the docID layer instead.
+//
+// Fixture: 10 docs, each with 5 cars all at the same year (year unique per
+// doc, in [2011..2020]). The range scan for "cars.year > 2010" reads keys
+// in ascending order; with the bug, reading key=2011 alone produces 5
+// positions (from doc1's 5 cars), which exceeds limit=5 and stops the
+// cursor — leaving docs 2..10 unread and returning just 1 doc to the
+// caller. With the fix, all 10 keys are read, the resolver returns all
+// 10 matching docs, and the iterator clamps to exactly the requested 5.
+func TestNestedFilteringLimitRespectedOnRangeScan(t *testing.T) {
+	const nestedClass = "NestedLimitRangeRegression"
+	vTrue := true
+
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: []*models.NestedProperty{
+				{
+					Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "year", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+			}},
+		},
+	}
+
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+	ctx := context.Background()
+
+	const totalDocs = 10
+	const carsPerDoc = 5
+	matchingIDs := make(map[strfmt.UUID]bool, totalDocs)
+	for i := 1; i <= totalDocs; i++ {
+		id := uuid(i)
+		matchingIDs[id] = true
+		year := 2010 + i // 2011..2020, unique per doc
+		// All cars in the same doc share the same year so the doc contributes
+		// carsPerDoc (=5) positions to a single key, exceeding the limit on
+		// the first key the cursor reads.
+		cars := make([]any, carsPerDoc)
+		for j := range cars {
+			cars[j] = map[string]any{"year": year}
+		}
+		require.NoError(t, db.PutObject(ctx, &models.Object{
+			Class: nestedClass, ID: id,
+			Properties: map[string]any{
+				"doc": map[string]any{"cars": cars},
+			},
+		}, nil, nil, nil, nil, 0))
+	}
+
+	filter := &filters.LocalFilter{Root: &filters.Clause{
+		Operator: filters.OperatorGreaterThan,
+		Value:    &filters.Value{Type: schema.DataTypeInt, Value: 2010},
+		On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName("doc.cars.year")},
+	}}
+
+	const limit = 5
+	res, err := db.Search(ctx, dto.GetParams{
+		ClassName:  nestedClass,
+		Pagination: &filters.Pagination{Limit: limit},
+		Filters:    filter,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res, limit, "limit must be honored exactly (got %d, expected %d)", len(res), limit)
+	for _, r := range res {
+		assert.True(t, matchingIDs[r.ID], "unexpected doc id %s in result", r.ID)
+	}
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -22558,3 +22558,140 @@ func TestNestedFilteringLimitRespectedOnRangeScan(t *testing.T) {
 		assert.True(t, matchingIDs[r.ID], "unexpected doc id %s in result", r.ID)
 	}
 }
+
+// TestNestedFilteringIsNullWithNonIndexableSibling is a smoke test for the
+// per-leaf _exists gating in analyzeNestedProp. Confirms IS NULL on an
+// indexed leaf still resolves correctly end-to-end when the cars
+// sub-property has a sibling leaf with IndexFilterable explicitly off —
+// that sibling's _exists entry is dropped from the meta bucket, and the
+// validator rejects IsNull filters that target it.
+//
+// Catches regressions where dropping a sibling's _exists could
+// accidentally affect the indexed leaf's IsNull semantics. The two
+// _exists keys (_exists.cars.make / _exists.cars.color) are independent
+// in the meta bucket; dropping one must leave the other intact.
+func TestNestedFilteringIsNullWithNonIndexableSibling(t *testing.T) {
+	const nestedClass = "NestedNonIndexableSibling"
+	vTrue := true
+	vFalse := false
+	tok := models.NestedPropertyTokenizationField
+
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{
+				Name:     "cars",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "make",
+						DataType:        schema.DataTypeText.PropString(),
+						Tokenization:    tok,
+						IndexFilterable: &vTrue,
+					},
+					{
+						// Non-indexable sibling — IndexFilterable AND
+						// IndexSearchable forced off so collectNestedIndexConfig
+						// reports cfg.hasAny()=false and the new gating drops
+						// the per-leaf _exists.cars.color entry.
+						Name:            "color",
+						DataType:        schema.DataTypeText.PropString(),
+						Tokenization:    tok,
+						IndexFilterable: &vFalse,
+						IndexSearchable: &vFalse,
+					},
+				},
+			},
+		},
+	}
+
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+	ctx := context.Background()
+
+	// Two docs: one with make populated, one with make omitted. Both have
+	// the (non-indexable) color populated to confirm the writer doesn't
+	// trip on its meta entry being dropped.
+	const (
+		hasMake     = "00000000-0000-0000-0000-000000000001"
+		missingMake = "00000000-0000-0000-0000-000000000002"
+	)
+	require.NoError(t, db.PutObject(ctx, &models.Object{
+		Class: nestedClass, ID: uuid(1),
+		Properties: map[string]any{
+			"cars": []any{map[string]any{"make": "Toyota", "color": "red"}},
+		},
+	}, nil, nil, nil, nil, 0))
+	require.NoError(t, db.PutObject(ctx, &models.Object{
+		Class: nestedClass, ID: uuid(2),
+		Properties: map[string]any{
+			"cars": []any{map[string]any{"color": "blue"}},
+		},
+	}, nil, nil, nil, nil, 0))
+
+	search := func(t *testing.T, filter *filters.LocalFilter) []string {
+		t.Helper()
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		ids := make([]string, len(res))
+		for i, r := range res {
+			ids[i] = string(r.ID)
+		}
+		return ids
+	}
+
+	t.Run("equal_on_indexed_leaf_matches_populated_doc", func(t *testing.T) {
+		got := search(t, &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: "Toyota"},
+			On:       &filters.Path{Class: nestedClass, Property: "cars.make"},
+		}})
+		assert.ElementsMatch(t, []string{hasMake}, got)
+	})
+
+	t.Run("is_null_on_indexed_leaf_matches_doc_with_missing_field", func(t *testing.T) {
+		// Universe at the cars LCA still includes both docs (cars present
+		// in both); operand _exists.cars.make covers only doc 1. The
+		// AndNot yields doc 2, which lacks make. Dropping
+		// _exists.cars.color from the meta bucket must not interfere.
+		got := search(t, &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: true},
+			On:       &filters.Path{Class: nestedClass, Property: "cars.make"},
+		}})
+		assert.ElementsMatch(t, []string{missingMake}, got)
+	})
+
+	t.Run("is_null_false_on_indexed_leaf_matches_populated_doc", func(t *testing.T) {
+		got := search(t, &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: false},
+			On:       &filters.Path{Class: nestedClass, Property: "cars.make"},
+		}})
+		assert.ElementsMatch(t, []string{hasMake}, got)
+	})
+
+	t.Run("filter_on_non_indexable_sibling_is_rejected_by_validator", func(t *testing.T) {
+		// Sanity: the sibling leaf isn't filterable so the validator
+		// must reject before the searcher attempts a meta-bucket read.
+		_, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters: &filters.LocalFilter{Root: &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeText, Value: "red"},
+				On:       &filters.Path{Class: nestedClass, Property: "cars.color"},
+			}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not filterable")
+	})
+}

--- a/adapters/repos/db/nested_filtering_preview_gate_integration_test.go
+++ b/adapters/repos/db/nested_filtering_preview_gate_integration_test.go
@@ -1,0 +1,144 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+// This file proves the load-bearing constraint of the
+// WEAVIATE_PREVIEW_NESTED_FILTERING gate: when the flag is off there are
+// no persistent data side effects (no nested filterable / meta buckets
+// created, no inverted index entries appended) and any filter request
+// surfaces an actionable user-facing error.
+//
+// The file is part of the temporary preview gate and goes away with the
+// gate at GA. See entities/config/feature_flags.go.
+
+package db
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	"github.com/weaviate/weaviate/entities/dto"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// Nested filtering is preview-gated. Enable the gate at package init via
+// the env var so all nested tests in this binary see the gate as
+// enabled. This file's own test overrides per-case via t.Setenv (which
+// auto-restores via cleanup and panics on t.Parallel()).
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
+
+// TestNestedFilteringPreviewGateOff proves the load-bearing constraint
+// of the preview gate. With the gate off:
+//
+//   - writes succeed at the doc-store level (no panic, no error)
+//   - no nested filterable value bucket or meta bucket is created in
+//     the shard store
+//   - any nested filter request returns the user-facing
+//     "preview disabled" error including the env-var name so the user
+//     knows how to opt in
+//
+// Cycle behaviour (off → on with previously-written data) is
+// intentionally out of scope here — the gate-off window leaves no
+// nested infrastructure on the shard, so a later flip-on doesn't
+// produce empty results but rather "bucket not found" until the shard
+// is recreated. Documented as accepted behaviour for the preview
+// (see entities/config/feature_flags.go and the gate memo).
+func TestNestedFilteringPreviewGateOff(t *testing.T) {
+	// The package init sets the gate-on env var for the rest of this
+	// binary; t.Setenv overrides it to off for this test only, restores
+	// on cleanup, and panics if a parallel test or a parallel ancestor
+	// tries the same — automatic isolation against future t.Parallel()
+	// in this package.
+	t.Setenv(entcfg.EnvNestedFilteringPreview, "")
+
+	const className = "NestedFilteringPreviewGateOff"
+	vTrue := true
+	class := &models.Class{
+		Class:             className,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{
+				Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "make",
+						DataType:        schema.DataTypeText.PropString(),
+						Tokenization:    models.NestedPropertyTokenizationField,
+						IndexFilterable: &vTrue,
+					},
+				},
+			},
+		},
+	}
+	db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+	ctx := context.Background()
+
+	t.Run("writes succeed without nested analysis", func(t *testing.T) {
+		// The nested analyzer skip in adapters/repos/db/inverted/objects.go
+		// does not return an error; it silently continues so the doc-store
+		// write completes normally.
+		objID := strfmt.UUID("00000000-0000-0000-0000-000000000001")
+		require.NoError(t, db.PutObject(ctx, &models.Object{
+			Class: className, ID: objID,
+			Properties: map[string]any{
+				"cars": []any{map[string]any{"make": "Toyota"}},
+			},
+		}, nil, nil, nil, nil, 0))
+	})
+
+	t.Run("no nested buckets created in shard store", func(t *testing.T) {
+		// The bucket-creation skip in shard_init_properties.go avoids the
+		// goroutine entirely; createNestedPropertyBuckets is never reached,
+		// so the buckets are not in the store.
+		idx := db.GetIndex(schema.ClassName(className))
+		require.NotNil(t, idx, "index for the test class should exist")
+		var shard ShardLike
+		require.NoError(t, idx.ForEachShard(func(_ string, s ShardLike) error {
+			shard = s
+			return nil
+		}))
+		require.NotNil(t, shard, "test database should expose at least one shard")
+		assert.Nil(t, shard.Store().Bucket(helpers.BucketNestedFromPropNameLSM("cars")),
+			"nested filterable value bucket must not exist when gate is off")
+		assert.Nil(t, shard.Store().Bucket(helpers.BucketNestedMetaFromPropNameLSM("cars")),
+			"nested meta bucket must not exist when gate is off")
+	})
+
+	t.Run("filter returns user-facing preview-disabled error", func(t *testing.T) {
+		// Validator gate at the top of filters_validator.go. The message
+		// must name the env var so users know how to opt in.
+		_, err := db.Search(ctx, dto.GetParams{
+			ClassName:  className,
+			Pagination: &filters.Pagination{Limit: 10},
+			Filters: &filters.LocalFilter{Root: &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeText, Value: "Toyota"},
+				On:       &filters.Path{Class: schema.ClassName(className), Property: "cars.make"},
+			}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), entcfg.EnvNestedFilteringPreview,
+			"error must name the env var so users can opt in")
+		assert.Contains(t, err.Error(), "preview",
+			"error must identify nested filtering as a preview feature")
+	})
+}

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -70,6 +71,13 @@ func (s *Shard) initPropertyBuckets(ctx context.Context, eg *enterrors.ErrorGrou
 		propCopy := *prop // prevent loop variable capture
 
 		if _, ok := schema.AsNested(prop.DataType); ok {
+			// Preview gate — strict skip when off (no goroutine spawned,
+			// no buckets created). Pairs with the analyzer skip in
+			// adapters/repos/db/inverted/objects.go; even if one leaks past
+			// the other, absence of buckets keeps writes inert.
+			if !entcfg.NestedFilteringEnabled() {
+				continue
+			}
 			// TODO aliszka:nested_filtering respect top-level HasAnyInvertedIndex for
 			// nested properties before creating buckets — currently bypassed because
 			// the interaction between top-level and per-nested-property index settings

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -36,6 +36,7 @@ services:
       QUERY_MAXIMUM_RESULTS: 10005
       OBJECTS_TTL_DELETE_SCHEDULE: "@every 12h"
       ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT: "true"
+      WEAVIATE_PREVIEW_NESTED_FILTERING: "true"
 
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in

--- a/entities/config/feature_flags.go
+++ b/entities/config/feature_flags.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package config
+
+// Env-driven feature flags.
+//
+// This file holds env-var-backed feature flags that don't fit the main
+// Config struct — preview / experimental gates, low-frequency operator
+// escape hatches, or any flag whose lifetime is short enough that struct
+// plumbing is more churn than value.
+//
+// Helpers read their env var on every call (no in-process cache) so
+// tests can override per-case with t.Setenv. Go's testing package
+// auto-restores via cleanup and panics if the override is attempted in
+// a parallel test or one with a parallel ancestor, giving these flags
+// automatic isolation against future t.Parallel() adoption.
+
+import (
+	"fmt"
+	"os"
+)
+
+// EnvNestedFilteringPreview is the env var that toggles the preview gate
+// for nested property indexing and filtering. Exported so callers can
+// reference it from user-facing error messages without duplicating the
+// literal string.
+const EnvNestedFilteringPreview = "WEAVIATE_PREVIEW_NESTED_FILTERING"
+
+// NestedFilteringEnabled reports whether the preview gate for nested
+// property indexing and filtering is on for this server.
+//
+// Preview feature. Off by default. Toggle via EnvNestedFilteringPreview;
+// truthy values are the ones recognised by Enabled ("on", "enabled",
+// "1", "true").
+//
+// Reads the env var on each call (no cache) so tests can override via
+// t.Setenv — Go's testing package serializes env mutations and panics
+// if a parallel test or a test with a parallel ancestor attempts the
+// override, giving us automatic isolation against future t.Parallel()
+// adoption in nested test packages. The cost is one map lookup +
+// boolean parse per call; the call sites are request-boundary
+// dispatches (validator / searcher / analyzer / bucket-creation), not
+// hot loops.
+//
+// Removed at GA — at that point the feature is unconditionally enabled
+// and call sites lose the gate. Do not depend on this function from
+// long-lived code paths.
+func NestedFilteringEnabled() bool {
+	return Enabled(os.Getenv(EnvNestedFilteringPreview))
+}
+
+// NestedFilteringDisabledError returns the standard user-facing error
+// for a nested filter request rejected because the preview gate is off.
+// Centralises the message + env-var name so callers don't drift.
+func NestedFilteringDisabledError() error {
+	return fmt.Errorf("filtering on nested properties is a preview feature, disabled by default; set %s=true to enable", EnvNestedFilteringPreview)
+}

--- a/entities/config/feature_flags.go
+++ b/entities/config/feature_flags.go
@@ -47,9 +47,12 @@ const EnvNestedFilteringPreview = "WEAVIATE_PREVIEW_NESTED_FILTERING"
 // if a parallel test or a test with a parallel ancestor attempts the
 // override, giving us automatic isolation against future t.Parallel()
 // adoption in nested test packages. The cost is one map lookup +
-// boolean parse per call; the call sites are request-boundary
-// dispatches (validator / searcher / analyzer / bucket-creation), not
-// hot loops.
+// boolean parse per call. Most call sites are request-boundary
+// dispatches (validator / searcher / bucket-creation); the analyzer
+// call site (objects.go) is on the per-object/per-property write loop
+// — the per-call env read is acceptable today, but if the cost shows
+// up in profiles, hoist the lookup to once per AnalyzeObject and pass
+// the bool down.
 //
 // Removed at GA — at that point the feature is unconditionally enabled
 // and call sites lose the gate. Do not depend on this function from

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -105,6 +106,13 @@ func validateClause(authorizedGetClass func(string) (*models.Class, error), cw *
 	}
 
 	if _, ok := schema.AsNested(prop.DataType); ok {
+		// Preview gate — fires before any other nested validation so the user
+		// sees a single actionable message instead of a downstream
+		// "sub-property not found" / contradiction error. See
+		// entities/config/feature_flags.go.
+		if !entcfg.NestedFilteringEnabled() {
+			return entcfg.NestedFilteringDisabledError()
+		}
 		return validateNestedProp(prop, propName, isPropLengthFilter, cw)
 	}
 

--- a/entities/filters/filters_validator_nested_test.go
+++ b/entities/filters/filters_validator_nested_test.go
@@ -12,13 +12,22 @@
 package filters
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
+
+// Nested filtering is preview-gated. Tests in this file exercise the
+// validator's nested branch and need the gate on. Sets the env var
+// process-wide so all tests in this binary see the gate as enabled;
+// individual tests that want the off state use t.Setenv (which
+// auto-restores and panics on t.Parallel()).
+func init() { os.Setenv(entcfg.EnvNestedFilteringPreview, "true") }
 
 // nestedClass builds the shared test class used across nested filter tests:
 //

--- a/entities/filters/nested/path.go
+++ b/entities/filters/nested/path.go
@@ -25,6 +25,14 @@ import (
 // this is the single place to change if the separator ever changes.
 const pathSep = "."
 
+// indexOpen / indexClose delimit an arr[N] index suffix inside a path
+// segment (e.g. "cars[0]"). All bracket parsing in this package uses
+// these constants so callers don't hard-code the characters.
+const (
+	indexOpen  = "["
+	indexClose = "]"
+)
+
 // SplitPath splits a dot-notation nested path into its property name segments.
 // The inverse of JoinPath.
 //
@@ -110,10 +118,10 @@ func RootPropName(path string) string {
 // "tags[2]" → ("tags", 2, true); "tags" → ("tags", 0, false).
 func parseSegmentIndex(seg string) (clean string, index int, hasIndex bool) {
 	// The closing bracket must be the very last character.
-	if len(seg) == 0 || seg[len(seg)-1] != ']' {
+	if !strings.HasSuffix(seg, indexClose) {
 		return seg, 0, false
 	}
-	start := strings.Index(seg, "[")
+	start := strings.Index(seg, indexOpen)
 	if start < 0 {
 		return seg, 0, false
 	}
@@ -157,6 +165,19 @@ func FindLeaf(segments []string, props []*models.NestedProperty) (*models.Nested
 		props = np.NestedProperties
 	}
 	return np, nil
+}
+
+// HasNestedSyntax reports whether path uses nested-property syntax — a
+// dotted name like "cars.make" or an indexed name like "cars[0]" or
+// "cars[1].tags". Purely syntactic; performs no schema lookup. Use
+// IsNestedPath for the full schema-aware check.
+//
+// Useful at ingress layers (REST/GraphQL/gRPC) that need to route a
+// path string to the nested filter pipeline before a schema is in scope.
+// Keeps the syntactic conventions (the separator character, the index
+// bracket character) localized in this package.
+func HasNestedSyntax(path string) bool {
+	return strings.ContainsAny(path, pathSep+indexOpen)
 }
 
 // IsNestedPath reports whether path is a nested-property filter path on

--- a/entities/filters/path.go
+++ b/entities/filters/path.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
@@ -75,6 +76,28 @@ func appendNestedPath(p *Path, omitClass bool) []string {
 // [0] ClassName -> The root class name we're drilling down from
 // [1] propertyName -> The property name we're interested in.
 func ParsePath(pathElements []interface{}, rootClass string) (*Path, error) {
+	// Single-element nested path: a dotted name like "cars.make" or an indexed
+	// name like "cars[1].make" is a nested-property filter target, not a
+	// reference-following path. ValidatePropertyName rejects dots and brackets
+	// (they're not valid in flat property names), but those are the standard
+	// nested filter path syntax — the gRPC ingress and the downstream
+	// validator/searcher already accept this shape. Build the Path directly;
+	// the nested filter validator performs the schema lookup downstream.
+	//
+	// Detection is delegated to nested.HasNestedSyntax so the syntactic
+	// conventions (separator, index brackets) stay localized in the nested
+	// package. Backward compatible: existing flat / reference-following
+	// queries never emit dots or brackets in their path elements, so the
+	// short-circuit only triggers for genuinely nested filter input.
+	if len(pathElements) == 1 {
+		if s, ok := pathElements[0].(string); ok && nested.HasNestedSyntax(s) {
+			return &Path{
+				Class:    schema.ClassName(rootClass),
+				Property: schema.PropertyName(s),
+			}, nil
+		}
+	}
+
 	// we need to manually insert the root class, as that is omitted from the user
 	pathElements = append([]interface{}{rootClass}, pathElements...)
 

--- a/test/acceptance_with_go_client/backup_test.go
+++ b/test/acceptance_with_go_client/backup_test.go
@@ -46,6 +46,18 @@ func TestBackupWithConcurrentDelete(t *testing.T) {
 			Properties: []*models.Property{
 				{Name: "num", DataType: schema.DataTypeText.PropString()},
 				{Name: "int", DataType: schema.DataTypeInt.PropString()},
+				{
+					Name:     "cars",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:            "make",
+							DataType:        schema.DataTypeText.PropString(),
+							Tokenization:    models.NestedPropertyTokenizationField,
+							IndexFilterable: &vTrue,
+						},
+					},
+				},
 			},
 			Vectorizer:         "none",
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
@@ -54,13 +66,27 @@ func TestBackupWithConcurrentDelete(t *testing.T) {
 		classNames[i] = className
 
 		require.NoError(t, c.Schema().TenantsCreator().WithClassName(class.Class).WithTenants(models.Tenant{Name: tenant}).Do(ctx))
-		objs := make([]*models.Object, 100+i)
+		numObjects := 100 + i
+		objs := make([]*models.Object, numObjects)
 		for j := range objs {
+			// Two cars per object: cars[0]=Toyota for even j, Honda for odd j.
+			// Used post-restore to verify both the nested filterable value bucket
+			// (cars.make = X) and the nested meta bucket / arr[N] (_idx.cars.0)
+			// survive the backup-restore cycle.
+			carToyota := "Toyota"
+			carHonda := "Honda"
+			if j%2 == 1 {
+				carToyota, carHonda = carHonda, carToyota
+			}
 			objs[j] = &models.Object{
 				Class: className,
 				Properties: map[string]interface{}{
 					"num": string(rune(j)),
 					"int": j,
+					"cars": []any{
+						map[string]any{"make": carToyota},
+						map[string]any{"make": carHonda},
+					},
 				},
 				Tenant: tenant,
 			}
@@ -128,6 +154,8 @@ func TestBackupWithConcurrentDelete(t *testing.T) {
 	}
 
 	for i, name := range classNames {
+		numObjects := 100 + i
+
 		exists, err := c.Schema().ClassExistenceChecker().WithClassName(name).Do(ctx)
 		require.NoError(t, err)
 		require.True(t, exists, "class %s should exist after restore", name)
@@ -142,8 +170,7 @@ func TestBackupWithConcurrentDelete(t *testing.T) {
 
 		classData := data.Data["Aggregate"].(map[string]interface{})[name].([]interface{})[0].(map[string]interface{})
 		count := classData["meta"].(map[string]interface{})["count"].(float64)
-		expectedCount := float64(100 + i)
-		require.Equal(t, expectedCount, count, "class %s should have %d objects after restore", name, int(expectedCount))
+		require.Equal(t, float64(numObjects), count, "class %s should have %d objects after restore", name, numObjects)
 
 		// filter work
 		filter := filters.Where()
@@ -158,6 +185,39 @@ func TestBackupWithConcurrentDelete(t *testing.T) {
 
 		objects := result.Data["Get"].(map[string]interface{})[name].([]interface{})
 		require.Len(t, objects, 5, "class %s should have 5 objects with int < 5 after restore", name)
+
+		// Nested filter post-restore — verifies that the nested filterable
+		// value bucket and the meta bucket were both included in the backup
+		// and rebuilt on restore. Every object owns a Toyota (cars[0] or
+		// cars[1]), so the existential cars.make=Toyota matches all docs.
+		// The pinned cars[0].make=Toyota narrows to the half-with-Toyota-at-
+		// position-0 subset, exercising _idx.{cars}.0 in the meta bucket.
+		nestedAnyFilter := filters.Where().
+			WithOperator(filters.Equal).
+			WithValueText("Toyota").
+			WithPath([]string{"cars.make"})
+		nestedAnyResult, err := c.GraphQL().Get().WithClassName(name).WithTenant(tenant).
+			WithWhere(nestedAnyFilter).WithLimit(numObjects).
+			WithFields(graphql.Field{Name: "num"}).Do(ctx)
+		require.NoError(t, err)
+		require.Nil(t, nestedAnyResult.Errors)
+		nestedAnyObjects := nestedAnyResult.Data["Get"].(map[string]any)[name].([]any)
+		require.Len(t, nestedAnyObjects, numObjects,
+			"class %s: cars.make=Toyota must match all %d objects after restore (nested filterable value bucket)", name, numObjects)
+
+		nestedPinnedFilter := filters.Where().
+			WithOperator(filters.Equal).
+			WithValueText("Toyota").
+			WithPath([]string{"cars[0].make"})
+		nestedPinnedResult, err := c.GraphQL().Get().WithClassName(name).WithTenant(tenant).
+			WithWhere(nestedPinnedFilter).WithLimit(numObjects).
+			WithFields(graphql.Field{Name: "num"}).Do(ctx)
+		require.NoError(t, err)
+		require.Nil(t, nestedPinnedResult.Errors)
+		nestedPinnedObjects := nestedPinnedResult.Data["Get"].(map[string]any)[name].([]any)
+		expectedPinned := (numObjects + 1) / 2 // even j → cars[0]=Toyota
+		require.Len(t, nestedPinnedObjects, expectedPinned,
+			"class %s: cars[0].make=Toyota must match %d objects after restore (nested meta bucket / _idx.{cars}.0)", name, expectedPinned)
 	}
 
 	// verify usage stats to ensure no data loss and all data is correctly restored

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -193,7 +193,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/weaviate/s5cmd/v2 v2.0.1 // indirect
-	github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c // indirect
+	github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0 // indirect
 	github.com/weaviate/tiktoken-go v0.0.3 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -533,8 +533,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c h1:g/D24on7qR0hxroUkvxtCnn9kQKl4FstM3rxlNYZ+Qg=
-github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0 h1:aQv9zppxi/PHT2StZoZBpBtZ8zQE9NnvFTuCixt2hPE=
+github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/weaviate/weaviate-go-client/v5 v5.7.3-0.20260413120914-0d665cebe735 h1:bNIIkKU7/Ex4XaOfntkKcbfxHCqdt5ShIGwFctflDy0=

--- a/test/acceptance_with_go_client/nested_filters_test.go
+++ b/test/acceptance_with_go_client/nested_filters_test.go
@@ -1,0 +1,173 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/filters"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+
+	"acceptance_tests_with_client/internal/wvhost"
+)
+
+// TestNestedFiltersViaGraphQL exercises the smallest set of nested-property
+// filters that prove GraphQL ingress accepts the dotted single-path syntax
+// (e.g. "cars.make", "cars[0].make") used by the nested filter pipeline.
+//
+// Filter-correctness corner cases (same-element AND, IsNull, NOT, every
+// scalar datatype, etc.) live in the Python e2e suites
+// (test_nested_props_*.py) which exercise the gRPC path. The three subtests
+// here are the GraphQL parity smoke tests.
+func TestNestedFiltersViaGraphQL(t *testing.T) {
+	c := client.New(client.Config{Scheme: "http", Host: wvhost.REST()})
+	ctx := context.Background()
+
+	const className = "NestedFiltersGraphQLSmoke"
+	class := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     "cars",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "make",
+						DataType:        schema.DataTypeText.PropString(),
+						Tokenization:    models.NestedPropertyTokenizationField,
+						IndexFilterable: &vTrue,
+					},
+					{
+						Name:            "color",
+						DataType:        schema.DataTypeText.PropString(),
+						Tokenization:    models.NestedPropertyTokenizationField,
+						IndexFilterable: &vTrue,
+					},
+				},
+			},
+		},
+		Vectorizer: "none",
+	}
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
+	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+	car := func(make, color string) map[string]any {
+		return map[string]any{"make": make, "color": color}
+	}
+
+	// Four docs covering the partitions needed by all three subtests.
+	docs := []struct {
+		id   string
+		cars []any
+	}{
+		{
+			id:   "00000000-0000-0000-0000-000000000001",
+			cars: []any{car("Toyota", "red"), car("Honda", "blue")},
+		},
+		{
+			id:   "00000000-0000-0000-0000-000000000002",
+			cars: []any{car("Honda", "blue"), car("Toyota", "red")},
+		},
+		{
+			id:   "00000000-0000-0000-0000-000000000003",
+			cars: []any{car("Toyota", "blue"), car("Honda", "red")},
+		},
+		{
+			id:   "00000000-0000-0000-0000-000000000004",
+			cars: []any{car("Ford", "green")},
+		},
+	}
+	objs := make([]*models.Object, len(docs))
+	for i, d := range docs {
+		objs[i] = &models.Object{
+			Class:      className,
+			ID:         strfmt.UUID(d.id),
+			Properties: map[string]any{"cars": d.cars},
+		}
+	}
+	resp, err := c.Batch().ObjectsBatcher().WithObjects(objs...).Do(ctx)
+	require.NoError(t, err)
+	for i := range resp {
+		require.Nil(t, resp[i].Result.Errors)
+	}
+
+	runQuery := func(t *testing.T, filter *filters.WhereBuilder) []string {
+		t.Helper()
+		result, err := c.GraphQL().Get().
+			WithClassName(className).
+			WithWhere(filter).
+			WithLimit(len(docs)).
+			WithFields(graphql.Field{Name: "_additional", Fields: []graphql.Field{{Name: "id"}}}).
+			Do(ctx)
+		require.NoError(t, err)
+		require.Nil(t, result.Errors, "graphql errors: %+v", result.Errors)
+		return GetIds(t, result, className)
+	}
+
+	t.Run("Equal_on_nested_leaf", func(t *testing.T) {
+		// Existential: any doc with any car owning make=Toyota matches.
+		// Exercises the dotted path "cars.make" + nested filterable value
+		// bucket.
+		ids := runQuery(t, filters.Where().
+			WithOperator(filters.Equal).
+			WithValueText("Toyota").
+			WithPath([]string{"cars.make"}))
+		require.ElementsMatch(t, []string{
+			"00000000-0000-0000-0000-000000000001",
+			"00000000-0000-0000-0000-000000000002",
+			"00000000-0000-0000-0000-000000000003",
+		}, ids)
+	})
+
+	t.Run("ArrayIndexPin", func(t *testing.T) {
+		// cars[0].make=Toyota — pins to position 0 only. Exercises the
+		// indexed path "cars[0].make" + the meta bucket entry _idx.cars.0.
+		ids := runQuery(t, filters.Where().
+			WithOperator(filters.Equal).
+			WithValueText("Toyota").
+			WithPath([]string{"cars[0].make"}))
+		require.ElementsMatch(t, []string{
+			"00000000-0000-0000-0000-000000000001",
+			"00000000-0000-0000-0000-000000000003",
+		}, ids)
+	})
+
+	t.Run("SameElementAnd", func(t *testing.T) {
+		// cars.make=Toyota AND cars.color=red — both leaves must be
+		// satisfied by the SAME car. Exercises same-element correlation
+		// dispatch through the GraphQL ingress.
+		andFilter := filters.Where().
+			WithOperator(filters.And).
+			WithOperands([]*filters.WhereBuilder{
+				filters.Where().
+					WithOperator(filters.Equal).
+					WithValueText("Toyota").
+					WithPath([]string{"cars.make"}),
+				filters.Where().
+					WithOperator(filters.Equal).
+					WithValueText("red").
+					WithPath([]string{"cars.color"}),
+			})
+		ids := runQuery(t, andFilter)
+		require.ElementsMatch(t, []string{
+			"00000000-0000-0000-0000-000000000001", // cars[0] = Toyota+red
+			"00000000-0000-0000-0000-000000000002", // cars[1] = Toyota+red
+		}, ids)
+	})
+}

--- a/test/acceptance_with_python/test_nested_filter_regressions.py
+++ b/test/acceptance_with_python/test_nested_filter_regressions.py
@@ -1,0 +1,71 @@
+"""End-to-end regression tests for nested object property filtering.
+
+This file is the home for *property-oriented* regression tests — narrow
+discriminators for bug fixes, focused on the wire path. Filter-shape
+coverage (Equal, AND, OR, IsNull, Contains, etc.) lives in
+test_nested_props_array_intermediates.py and
+test_nested_props_object_intermediates.py.
+
+Add a new test here whenever a correctness fix lands that's worth a
+wire-level lock.
+"""
+
+from __future__ import annotations
+
+from weaviate.classes.config import Configure, DataType, Property
+from weaviate.collections.classes.filters import Filter
+
+from .conftest import CollectionFactory
+
+
+def test_limit_respected_on_nested_range_scan(collection_factory: CollectionFactory) -> None:
+    """Limit must be honored on nested range scans even when each matching
+    doc contributes many positions to the underlying bitmap.
+
+    Before the fix, the bucket cursor for nested range / LIKE /
+    Equal-via-RoaringSet scans short-circuited when the raw position
+    bitmap's cardinality reached the user limit. Positions are
+    (root|leaf|docID) tuples — they don't map 1:1 to docs — so a single
+    doc with multiple matching nested elements could exhaust the position
+    quota before later matching docs were even read, and the query
+    returned far fewer docs than requested.
+
+    Fixture: 10 docs, each with 5 cars all at the same year (year unique
+    per doc, in [2011..2020]). The range scan for `cars.year > 2010`
+    reads keys in ascending order; with the bug, reading key=2011 alone
+    produces 5 positions (doc1's 5 cars), filling limit=5 and stopping
+    the cursor — leaving docs 2..10 unread.
+    """
+    collection = collection_factory(
+        properties=[
+            Property(
+                name="cars",
+                data_type=DataType.OBJECT_ARRAY,
+                nested_properties=[
+                    Property(name="year", data_type=DataType.INT),
+                ],
+            ),
+        ],
+        vector_config=Configure.Vectors.self_provided(),
+    )
+
+    total_docs = 10
+    cars_per_doc = 5
+    inserted_ids: set = set()
+    for i in range(1, total_docs + 1):
+        year = 2010 + i  # 2011..2020, unique per doc
+        cars = [{"year": year} for _ in range(cars_per_doc)]
+        doc_id = collection.data.insert({"cars": cars})
+        inserted_ids.add(doc_id)
+
+    limit = 5
+    result = collection.query.fetch_objects(
+        filters=Filter.by_property("cars.year").greater_than(2010),
+        limit=limit,
+    ).objects
+    ids = {o.uuid for o in result}
+
+    assert len(result) == limit, (
+        f"limit must be honored exactly (got {len(result)}, expected {limit})"
+    )
+    assert ids.issubset(inserted_ids), "unexpected ids in result"

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c // indirect
+	github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.mongodb.org/mongo-driver v1.17.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -280,8 +280,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c h1:g/D24on7qR0hxroUkvxtCnn9kQKl4FstM3rxlNYZ+Qg=
-github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0 h1:aQv9zppxi/PHT2StZoZBpBtZ8zQE9NnvFTuCixt2hPE=
+github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/weaviate-go-client/v5 v5.0.2 h1:aptmTJy6d4OxGHBTGnqHheJe0WDbzH2SVmQkvy7+EGY=
 github.com/weaviate/weaviate-go-client/v5 v5.0.2/go.mod h1:CwZehIL4s3VfkzTu12Wy8VAUtELRtQFUt2ZniBF/lQM=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=


### PR DESCRIPTION
### Nested object filtering — Part 20                                                                                     
                                                                                                                          
  Twentieth PR in the series. Five commits: one user-facing rollout mechanism, one ingress gap, three correctness fixes.    
   
  **Preview gate — `WEAVIATE_PREVIEW_NESTED_FILTERING`**
                                                                                                                          
  Nested filtering ships as preview, default off. Encoding/data format may still change before GA, so users who haven't opted in must not accumulate persistent nested-index data. At GA the env var is removed and the feature becomes unconditional.
                                                                                                                            
  Helper in new `entities/config/feature_flags.go` (forced there by an import cycle — `usecases/config` transitively imports `entities/filters`). Reads env on every call so tests can use `t.Setenv` for parallel-safe per-case overrides. Gates wired at four caller sites — validator dispatch, searcher dispatch, analyzer dispatch, and bucket-creation dispatch (the last before `eg.Go(...)` so no goroutine spawns when off). Per-file `init()` in 8 nested test files sets the env var process-wide; the gate-off integration test uses `t.Setenv` so Go's testing package auto-restores and panics on any future `t.Parallel()`. New `nested_filtering_preview_gate_integration_test.go` proves writes succeed silently, no buckets are created, and the validator returns the user-facing preview-disabled error.

  **GraphQL nested filter ingress**
                                                                                                                            
  GraphQL `where` filters rejected every nested property path — `ParsePath` treats path elements in pairs (ClassName + property) and `ValidatePropertyName`'s regex rejects dots/brackets. Any GraphQL-based client (including the official Go client) could not filter by any nested property. `ParsePath` now short-circuits a single dotted/indexed element and builds the same `filters.Path` shape the gRPC ingress emits; detection delegated to new `nested.HasNestedSyntax` and bracket literals factored into `indexOpen`/`indexClose` consts so the syntax stays localized in the nested package.             

  **Limit short-circuit on nested filter reads**
                                                                                                                            
  `docBitmap*`'s `GetCardinality`-based early-exit counts raw positions (`root|leaf|docID`), not docIDs. A single doc with multiple matching nested elements could exhaust the position quota on the first key read, returning far fewer docs than the `LIMIT`. Drop the `limit` parameter from `fetchNestedDocIDs`/`fetchNestedPositions` — positions don't map 1:1 to docs so a cursor-level limit is structurally wrong here. The iterator clamp (`objectsByDocID` for `Search`, `LimitedIterator` for `FindUUIDs`) applies the user limit at the docID layer post-`MaskRootLeaf`. `readFromBucket` stays flat-only-aware. Audit-confirmed `usecases/traverser` sort/cursor wiring operates on bare docIDs throughout.

  **Per-leaf `IndexFilterable` gating on nested `_exists` writes**
                                                                                                                            
  Leaf VALUES were already gated by `nestedIndexConfig.hasAny()` — non-indexable leaves contributed nothing to the value bucket. The `_exists` copy in `analyzeNestedProp` was forwarding every entry unconditionally, leaving wasted meta-bucket entries for leaves no filter can ever reach. Now gated by the same predicate. Root sentinel and intermediate object-array paths stay (used by IS NULL on the array prop). `Idx` stays universal (arr[N] dispatch is orthogonal to leaf flags).      
                                                                                                                          
  **Backup / restore preserves nested buckets**
                                                                                                                            
  Extended `TestBackupWithConcurrentDelete` to verify nested filter artifacts survive backup/restore. Added a nested `cars[]` property to the test class + two post-restore filter assertions: `cars.make = Toyota` (filterable value bucket) and `cars[0].make = Toyota` (`_idx.{cars}.0` meta bucket). The GraphQL ingress fix above is what makes this expressible from the Go client. Confirmed: filesystem backup correctly preserves both bucket families.                                
                                                                                                                          
  **Test plan**

  - [ ] `go build ./...`
  - [ ] `go test -race ./entities/config/... ./entities/filters/... ./adapters/repos/db/inverted/...`
  - [ ] `go test -tags integrationTest -timeout 5m -run TestNestedFiltering ./adapters/repos/db/`                           
  - [ ] `pytest test/acceptance_with_python/test_nested_filter_regressions.py -v`                                                                                
  - [ ] `go test -count 1 -run "TestBackupWithConcurrentDelete|TestNestedFiltersViaGraphQL" ./test/acceptance_with_go_client/...`