### PR TITLE
Reject duplicate static API keys

### DIFF
--- a/usecases/auth/authentication/apikey/client.go
+++ b/usecases/auth/authentication/apikey/client.go
@@ -56,10 +56,15 @@ func (c *StaticApiKey) validateConfig() error {
 		return fmt.Errorf("need at least one valid allowed key")
 	}
 
+	seenKeys := make(map[string]struct{}, len(c.config.AllowedKeys))
 	for _, key := range c.config.AllowedKeys {
 		if len(key) == 0 {
 			return fmt.Errorf("keys cannot have length 0")
 		}
+		if _, ok := seenKeys[key]; ok {
+			return fmt.Errorf("keys must be unique")
+		}
+		seenKeys[key] = struct{}{}
 	}
 
 	if len(c.config.Users) < 1 {

--- a/usecases/auth/authentication/apikey/client_test.go
+++ b/usecases/auth/authentication/apikey/client_test.go
@@ -166,6 +166,16 @@ func Test_APIKeyClient(t *testing.T) {
 			expectConfigErr:    true,
 			expectConfigErrMsg: "length of users and keys must match, alternatively provide single user for all keys",
 		},
+		{
+			name: "duplicate keys",
+			config: config.StaticAPIKey{
+				Enabled:     true,
+				AllowedKeys: []string{"secret-key", "secret-key"},
+				Users:       []string{"jane", "jessica"},
+			},
+			expectConfigErr:    true,
+			expectConfigErrMsg: "keys must be unique",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #11392

## Summary
- Reject duplicate static API key values during config validation.
- Add regression coverage for duplicate API keys mapping to different users.

## Tests
- Dockerized `go test ./usecases/auth/authentication/apikey` passed on this checkout after the duplicate-key validation change.
- E2E startup check with duplicate static keys exits with `invalid apikey config: keys must be unique`.
- Verified the PR compare against upstream `main` contains only duplicate-key validation and regression test additions.