### PR TITLE
DRAFT perf(hnsw): re-evaluate 3 optimizations now that #11385 fsync fix is in

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -463,6 +463,17 @@ func (l *hnswCommitLogger) startSwitchLogs(shouldAbort cyclemanager.ShouldAbortC
 }
 
 func (l *hnswCommitLogger) startCommitLogsMaintenance(shouldAbort cyclemanager.ShouldAbortCallback) bool {
+	// EXPERIMENT (#199 follow-up, env-gated, not for unconditional merge): if
+	// HNSW_DISABLE_COMPACTION_CYCLE=1, skip the compactor RunCycle to measure
+	// whether maintenance-cycle compaction contributes meaningfully to the
+	// residual import-time gap on slow disks. Yesterday's pre-fsync-fix
+	// measurement showed no improvement; re-checking now that the per-batch
+	// fsync (#11385) is gone. If this shows positive impact, the production
+	// shape would be backpressure-aware scheduling (skip when write rate is
+	// high), not unconditional disable.
+	if os.Getenv("HNSW_DISABLE_COMPACTION_CYCLE") == "1" {
+		return false
+	}
 	action, err := l.compactor.RunCycle(shouldAbort)
 	switch {
 	case errors.Is(err, compact.ErrCompactionAborted):

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -451,6 +451,17 @@ func (l *hnswCommitLogger) ActiveFilePath() string {
 }
 
 func (l *hnswCommitLogger) startSwitchLogs(shouldAbort cyclemanager.ShouldAbortCallback) bool {
+	// EXPERIMENT (#199 follow-up, env-gated, not for unconditional merge): if
+	// HNSW_DISABLE_SWITCH_LOGS=1, skip the periodic commit-log switch to
+	// measure whether the rotation fsync + file-open cost contributes to the
+	// residual import-time gap on slow disks. Note disabling switch_logs
+	// entirely means the active WAL file grows unbounded for the duration of
+	// the import; this is a short-window measurement, not a production setting.
+	// The per-batch fsync fix (#11385) removed the dominant Flush-path cost;
+	// this measures whether rotation-time fsync is a secondary contributor.
+	if os.Getenv("HNSW_DISABLE_SWITCH_LOGS") == "1" {
+		return false
+	}
 	executed, err := l.switchCommitLogs(false)
 	if err != nil {
 		l.logger.WithError(err).

--- a/adapters/repos/db/vector/hnsw/compact/wal_writer.go
+++ b/adapters/repos/db/vector/hnsw/compact/wal_writer.go
@@ -62,12 +62,13 @@ func (w *WALWriter) WriteSetEntryPointMaxLevel(entrypoint uint64, level uint16) 
 
 // WriteAddLinkAtLevel writes an AddLinkAtLevel commit.
 func (w *WALWriter) WriteAddLinkAtLevel(source uint64, level uint16, target uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, AddLinkAtLevel))
-	ec.Add(writeUint64(w.w, source))
-	ec.Add(writeUint16(w.w, level))
-	ec.Add(writeUint64(w.w, target))
-	return ec.ToError()
+	var toWrite [19]byte
+	toWrite[0] = byte(AddLinkAtLevel)
+	binary.LittleEndian.PutUint64(toWrite[1:9], source)
+	binary.LittleEndian.PutUint16(toWrite[9:11], level)
+	binary.LittleEndian.PutUint64(toWrite[11:19], target)
+	_, err := w.w.Write(toWrite[:])
+	return err
 }
 
 // WriteAddLinksAtLevel writes an AddLinksAtLevel commit.
@@ -88,19 +89,21 @@ func (w *WALWriter) WriteAddLinksAtLevel(source uint64, level uint16, targets []
 
 // WriteReplaceLinksAtLevel writes a ReplaceLinksAtLevel commit.
 func (w *WALWriter) WriteReplaceLinksAtLevel(source uint64, level uint16, targets []uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, ReplaceLinksAtLevel))
-	ec.Add(writeUint64(w.w, source))
-	ec.Add(writeUint16(w.w, level))
-
 	targetLength := len(targets)
 	if targetLength > math.MaxUint16 {
 		targetLength = math.MaxUint16
 	}
-	ec.Add(writeUint16(w.w, uint16(targetLength)))
-	ec.Add(writeUint64Slice(w.w, targets[:targetLength]))
-
-	return ec.ToError()
+	toWrite := make([]byte, 13+targetLength*8)
+	toWrite[0] = byte(ReplaceLinksAtLevel)
+	binary.LittleEndian.PutUint64(toWrite[1:9], source)
+	binary.LittleEndian.PutUint16(toWrite[9:11], level)
+	binary.LittleEndian.PutUint16(toWrite[11:13], uint16(targetLength))
+	for i, target := range targets[:targetLength] {
+		offsetStart := 13 + i*8
+		binary.LittleEndian.PutUint64(toWrite[offsetStart:offsetStart+8], target)
+	}
+	_, err := w.w.Write(toWrite)
+	return err
 }
 
 // WriteClearLinks writes a ClearLinks commit.


### PR DESCRIPTION
DRAFT — #199 follow-up measurement PR. Three commits to re-evaluate optimizations that yesterday's pre-fsync-fix tests ruled out, now that the dominant cost (per-batch fsync, weaviate/weaviate#11385) is removed.

## What's in this PR

| commit | optimization | activation | shippability |
|---|---|---|---|
| `3d05a51e` | Batch `WriteAddLinkAtLevel` + `WriteReplaceLinksAtLevel` into a single `bufio.Writer.Write()` (mirrors the pattern `WriteAddLinksAtLevel` already uses) | always-on, behaviour-preserving — same bytes on disk | shippable as-is if it shows positive impact |
| `fde4fc71` | Skip `compactor.RunCycle` during hnsw maintenance callback | `HNSW_DISABLE_COMPACTION_CYCLE=1` env var, default off | **diagnostic only** — production shape would be backpressure-aware scheduling |
| `aac53f81` | Skip the `switch_logs` callback's rotation | `HNSW_DISABLE_SWITCH_LOGS=1` env var, default off | **diagnostic only** — production shape would be a larger threshold or rate-limited rotation |

## Yesterday's measurements (pre-fsync-fix, hnsw-compact-v2)

- bufio buffer 4KB→32KB: already 32KB on the branch — not actually testable
- `WriteReplaceLinksAtLevel` batching: 51.6 s — within run-to-run noise of the baseline (52.1 s)
- Compactor `RunCycle` disable: 50.6 s — same
- Cyclemanager callbacks disable (both): 50.6 s load, 64 s wallclock — same

All three were dominated by the per-batch fsync at ~80 ms each (100 batches × 80 ms ≈ 8 s on slow GCP PD), so any savings from these changes were masked. With fsync now removed (post-#11385 baseline: 41.1 s on the same machine), they're worth re-checking.

## Run plan

Suggested test matrix on a stable machine (Hetzner bare metal, openai-100 / 100k vectors):

| run | env | tests |
|---|---|---|
| A | (baseline, this branch with no env vars set) | opt 1 only — does single-Write batching show as a delta vs baseline (`origin/hnsw-compact-v2` HEAD `606398ca` after fsync merge)? |
| B | `HNSW_DISABLE_COMPACTION_CYCLE=1` | does skipping the compactor's RunCycle move the needle vs A? |
| C | `HNSW_DISABLE_SWITCH_LOGS=1` | does skipping switch_logs rotation move the needle vs A? |
| D | both env vars set | combined |

5 runs each, report median + IQR. If any of B/C/D shows ≥1 s improvement that's outside A's variance, it's worth designing a production-shape variant (backpressure-aware scheduling, rate-limited rotation).

If none of them move the needle, this PR closes without merge and the residual 1-3 s gap on Mac (within main's own variance) gets accepted as cost of doing business.

## CI on this PR

Unit + acceptance should pass identically to `origin/hnsw-compact-v2` since opts 2 and 3 are env-gated off by default. Opt 1 is behaviour-preserving (same bytes on disk, same WAL replay semantics) and `go test ./adapters/repos/db/vector/hnsw/...` is green locally (32 s).

— QA Claude
