### PR TITLE
Namespaces: Require RBAC to be enabled

### DIFF
--- a/docker-compose-namespaces-test.yml
+++ b/docker-compose-namespaces-test.yml
@@ -3,13 +3,16 @@
 # Mirrors the wiring produced by test/docker/compose.go for
 #   docker.New().
 #     WithApiKey().
+#     WithRBAC().
 #     WithUserApiKey("admin-user", "admin-key").
+#     WithRbacRoots("admin-user").
 #     WithDbUsers().
 #     WithNamespaces().
 #     WithWeaviateClusterWithGRPC()
 #
 # Namespaces.Enabled forces:
 #   - DISABLE_GRAPHQL=true                  (Config.Validate requirement)
+#   - RBAC enabled                          (Config.Validate requirement)
 #   - REPLICATION_MAXIMUM_FACTOR=1          (home_node pins each shard)
 #
 # Usage:
@@ -28,6 +31,8 @@ x-weaviate-env: &weaviate-env
   AUTHENTICATION_APIKEY_ALLOWED_KEYS: "admin-key"
   AUTHENTICATION_APIKEY_USERS: "admin-user"
   AUTHENTICATION_DB_USERS_ENABLED: "true"
+  AUTHORIZATION_RBAC_ENABLED: "true"
+  AUTHORIZATION_RBAC_ROOT_USERS: "admin-user"
   NAMESPACES_ENABLED: "true"
   DISABLE_GRAPHQL: "true"
   REPLICATION_MAXIMUM_FACTOR: "1"

--- a/test/acceptance/authn/dynamic_users_test.go
+++ b/test/acceptance/authn/dynamic_users_test.go
@@ -390,8 +390,10 @@ func TestCreateUser_Namespaces(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// NS clusters require RBAC; adminUser is the root that creates namespaces and
+	// namespaced DB users.
 	compose, err := docker.New().WithWeaviate().
-		WithApiKey().WithUserApiKey(adminUser, adminKey).
+		WithApiKey().WithRBAC().WithUserApiKey(adminUser, adminKey).WithRbacRoots(adminUser).
 		WithDbUsers().
 		WithNamespaces().
 		Start(ctx)

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -68,6 +68,12 @@ func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
 	// DeleteUser revokes all bindings on cleanup, so no explicit revoke is needed.
 	helper.AssignRoleToUser(t, adminKey, authorization.Admin, ns+":"+userID)
 
+	// AssignRoleToUser returns once the leader applies the binding; the follower
+	// the test client talks to may still be replicating it. Wait until the role
+	// is locally visible so the caller's next request can't race that
+	// replication and get a spurious 403.
+	helper.WaitForOwnRole(t, apikey, authorization.Admin)
+
 	return apikey
 }
 

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/client/users"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
@@ -61,14 +62,21 @@ func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
 		assert.NoError(c, err)
 	}, 10*time.Second, 50*time.Millisecond, "user %q apikey not recognized after create", userID)
 
+	// Mandatory RBAC: grant the built-in admin role so the namespaced user can
+	// reach the data/schema/tenant/alias/MCP handlers. The role's wildcard
+	// templates are specialized to the caller's namespace by the matcher.
+	// DeleteUser revokes all bindings on cleanup, so no explicit revoke is needed.
+	helper.AssignRoleToUser(t, adminKey, authorization.Admin, ns+":"+userID)
+
 	return apikey
 }
 
 // TestNamespaces_CollectionAndAliasCreate exercises the inline qualification
 // added to AddClass / AddAlias, as well as the read path with namespace resolution.
-// RBAC is off so namespaced DB users reach the handler unconditionally; the only
-// gating in play is the handler-level IsGlobalOperator/Namespace check plus the
-// entity-name validators.
+// The namespaced users hold the built-in admin role (granted in
+// createNamespacedUser), whose wildcard templates the matcher specializes to the
+// caller's namespace; on top of that sits the handler-level
+// IsGlobalOperator/Namespace check plus the entity-name validators.
 func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	const (
 		ns1 = "customer1"

--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -1,0 +1,161 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/backups"
+	"github.com/weaviate/weaviate/client/cluster"
+	"github.com/weaviate/weaviate/client/export"
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/replication"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// s3Backend is the backend identifier for the backup-s3 module wired in
+// setup_test.go; the same MinIO bucket also backs export.
+const s3Backend = "s3"
+
+// TestNamespaces_RBACSurfaces locks the contract that a namespaced user holding
+// the built-in admin role (granted in createNamespacedUser) is denied every
+// cluster-wide operator surface, because the narrowed admin covers only
+// collections/data/tenants/aliases/mcp. Each surface is paired with the
+// env-var root accessing it successfully, proving the denies are real auth
+// denials — narrowing, not a missing grant or a disabled endpoint.
+func TestNamespaces_RBACSurfaces(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+
+	const (
+		class     = "Surfaces"
+		qualified = "customer1:" + class
+	)
+	setupClassInNs1(t, class, user1Key)
+
+	// Positive control for the namespaced admin itself: prove the admin grant is
+	// live with real data permissions. Without this, the operator-surface 403s
+	// below could pass for the wrong reason — a user with no role would also 403
+	// everywhere. This pins those 403s to role narrowing specifically.
+	t.Run("namespaced admin retains in-namespace data access", func(t *testing.T) {
+		id := strfmt.UUID("11111111-1111-1111-1111-111111111111")
+		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			ID: id, Class: class, Properties: map[string]any{"title": "in-namespace"},
+		}, user1Key)
+		require.NoError(t, err)
+
+		got, err := helper.GetObjectAuth(t, class, id, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "in-namespace", got.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("nodes status: namespaced denied, root allowed", func(t *testing.T) {
+		_, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *nodes.NodesGetForbidden
+		require.True(t, errors.As(err, &forbidden), "expected NodesGetForbidden, got %T: %v", err, err)
+
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+		assert.NotEmpty(t, resp.Payload.Nodes)
+	})
+
+	t.Run("cluster statistics: namespaced denied, root allowed", func(t *testing.T) {
+		_, err := helper.Client(t).Cluster.ClusterGetStatistics(cluster.NewClusterGetStatisticsParams(), helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *cluster.ClusterGetStatisticsForbidden
+		require.True(t, errors.As(err, &forbidden), "expected ClusterGetStatisticsForbidden, got %T: %v", err, err)
+
+		resp, err := helper.Client(t).Cluster.ClusterGetStatistics(cluster.NewClusterGetStatisticsParams(), helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+		assert.NotEmpty(t, resp.Payload.Statistics)
+	})
+
+	t.Run("replicate: namespaced denied, root authorized", func(t *testing.T) {
+		// REPLICA_MOVEMENT_ENABLED is set so the handler reaches the authz check
+		// (it 501s before authz when movement is off). The handler validates the
+		// required body fields then authorizes, before any node/shard existence
+		// check — so this synthetic request isolates the authz decision: the
+		// narrowed admin is denied, while root passes the auth gate and only then
+		// fails downstream on the non-existent nodes (never a 403).
+		coll, shard, src, tgt := qualified, "shard-0", "node1", "node2"
+		req := &models.ReplicationReplicateReplicaRequest{
+			Collection: &coll, Shard: &shard, SourceNode: &src, TargetNode: &tgt,
+		}
+
+		_, err := helper.Client(t).Replication.Replicate(replication.NewReplicateParams().WithBody(req), helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *replication.ReplicateForbidden
+		require.True(t, errors.As(err, &forbidden), "expected ReplicateForbidden, got %T: %v", err, err)
+
+		_, err = helper.Client(t).Replication.Replicate(replication.NewReplicateParams().WithBody(req), helper.CreateAuth(adminKey))
+		require.False(t, errors.As(err, &forbidden), "root must not be forbidden on replicate; got %v", err)
+	})
+
+	t.Run("backup create: namespaced denied, root allowed", func(t *testing.T) {
+		// Qualified include name: backup selection does not namespace-resolve short
+		// names, so a short name would fail on empty selection rather than authz.
+		_, err := helper.CreateBackupWithAuthz(
+			t, helper.DefaultBackupConfig(), qualified, s3Backend, "ns-deny-backup",
+			helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *backups.BackupsCreateForbidden
+		require.True(t, errors.As(err, &forbidden), "expected BackupsCreateForbidden, got %T: %v", err, err)
+
+		// Root backs up the same namespaced class by qualified name and the backup
+		// reaches SUCCESS — a real, completed operator action.
+		const backupID = "ns-root-backup"
+		_, err = helper.CreateBackupWithAuthz(
+			t, helper.DefaultBackupConfig(), qualified, s3Backend, backupID,
+			helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		helper.ExpectBackupEventuallyCreated(t, backupID, s3Backend, helper.CreateAuth(adminKey))
+	})
+
+	t.Run("export: namespaced denied via empty backups filter, root passes filter", func(t *testing.T) {
+		// Export gates on EXPORT_ENABLED before authorize, then authorizes through a
+		// filter over the backups domain. The namespaced admin lacks backups, so the
+		// class set empties to "no exportable classes" → 422 (the deny mechanism is
+		// the empty filter, not a hard 403). Qualified include name for the same
+		// reason as backup create above.
+		nsID, fileFormat := "ns-deny-export", "parquet"
+		_, err := helper.Client(t).Export.ExportCreate(
+			export.NewExportCreateParams().WithBackend(s3Backend).WithBody(
+				&models.ExportCreateRequest{ID: &nsID, FileFormat: &fileFormat, Include: []string{qualified}}),
+			helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var unproc *export.ExportCreateUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected ExportCreateUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "no exportable classes")
+
+		// Root has the backups domain, so the filter keeps the class. It therefore
+		// never hits the "no exportable classes" path; it only fails afterwards on
+		// this RF=1 test class lacking async replication — orthogonal to auth, and
+		// proof that root passed the backups-domain gate the namespaced user did not.
+		rootID := "root-export-deny"
+		_, err = helper.Client(t).Export.ExportCreate(
+			export.NewExportCreateParams().WithBackend(s3Backend).WithBody(
+				&models.ExportCreateRequest{ID: &rootID, FileFormat: &fileFormat, Include: []string{qualified}}),
+			helper.CreateAuth(adminKey))
+		require.Error(t, err)
+		require.True(t, errors.As(err, &unproc), "expected ExportCreateUnprocessableEntity, got %T: %v", err, err)
+		assert.NotContains(t, unproc.Payload.Error[0].Message, "no exportable classes")
+		assert.Contains(t, unproc.Payload.Error[0].Message, "async replication")
+	})
+}

--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -144,18 +144,19 @@ func TestNamespaces_RBACSurfaces(t *testing.T) {
 		require.True(t, errors.As(err, &unproc), "expected ExportCreateUnprocessableEntity, got %T: %v", err, err)
 		assert.Contains(t, unproc.Payload.Error[0].Message, "no exportable classes")
 
-		// Root has the backups domain, so the filter keeps the class. It therefore
-		// never hits the "no exportable classes" path; it only fails afterwards on
-		// this RF=1 test class lacking async replication — orthogonal to auth, and
-		// proof that root passed the backups-domain gate the namespaced user did not.
-		rootID := "root-export-deny"
-		_, err = helper.Client(t).Export.ExportCreate(
+		// Root has the backups domain, so the filter keeps the qualified class
+		// instead of emptying it. The class is RF=1, which
+		// IsAsyncReplicationEnabled treats as async-not-required, so root clears
+		// every gate and the export actually starts — proof that root passed the
+		// backups-domain filter the namespaced admin did not.
+		rootID := "root-export-allowed"
+		ok, err := helper.Client(t).Export.ExportCreate(
 			export.NewExportCreateParams().WithBackend(s3Backend).WithBody(
 				&models.ExportCreateRequest{ID: &rootID, FileFormat: &fileFormat, Include: []string{qualified}}),
 			helper.CreateAuth(adminKey))
-		require.Error(t, err)
-		require.True(t, errors.As(err, &unproc), "expected ExportCreateUnprocessableEntity, got %T: %v", err, err)
-		assert.NotContains(t, unproc.Payload.Error[0].Message, "no exportable classes")
-		assert.Contains(t, unproc.Payload.Error[0].Message, "async replication")
+		require.NoError(t, err)
+		require.NotNil(t, ok.Payload)
+		assert.Contains(t, ok.Payload.Classes, qualified,
+			"root's export must retain the qualified class through the backups filter")
 	})
 }

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -12,6 +12,7 @@
 package namespace
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -608,9 +609,11 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 }
 
 // TestNamespaces_NodesGetClass exercises GET /v1/nodes/<class> on a
-// namespaced class. The cluster-API URL routes through `regxNodesClass`
-// for cross-node hops, which only accepts namespace-qualified names once
-// it is built from IndexNameRegexCore.
+// namespaced class. /nodes is an operator-only surface: under the narrowed
+// built-in admin a namespaced user is denied (403), while the env-var root
+// reaches it by qualified name. The qualified-name path also covers the
+// cluster-API URL routing through `regxNodesClass`, which only accepts
+// namespace-qualified names once it is built from IndexNameRegexCore.
 func TestNamespaces_NodesGetClass(t *testing.T) {
 	const ns1 = "customer1"
 
@@ -630,12 +633,12 @@ func TestNamespaces_NodesGetClass(t *testing.T) {
 
 	verbose := "verbose"
 
-	t.Run("namespaced user gets node status by short class name", func(t *testing.T) {
+	t.Run("namespaced user denied node status by short class name", func(t *testing.T) {
 		params := nodes.NewNodesGetClassParams().WithClassName("Movies").WithOutput(&verbose)
-		resp, err := helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(user1Key))
-		require.NoError(t, err)
-		require.NotNil(t, resp.Payload)
-		assert.NotEmpty(t, resp.Payload.Nodes)
+		_, err := helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *nodes.NodesGetClassForbidden
+		require.True(t, errors.As(err, &forbidden), "expected NodesGetClassForbidden, got %T: %v", err, err)
 	})
 
 	t.Run("global admin gets node status by qualified class name", func(t *testing.T) {
@@ -646,7 +649,7 @@ func TestNamespaces_NodesGetClass(t *testing.T) {
 		assert.NotEmpty(t, resp.Payload.Nodes)
 	})
 
-	t.Run("namespaced user gets node status via alias", func(t *testing.T) {
+	t.Run("namespaced user denied node status via alias", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{
 			Class: "Concerts",
 			Properties: []*models.Property{
@@ -657,17 +660,12 @@ func TestNamespaces_NodesGetClass(t *testing.T) {
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
 		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
 
-		// retryOnAliasLag absorbs the brief window where the alias entry has
-		// been applied on the leader but the follower has not yet replicated
-		// it, which would surface here as a 404 from local alias resolution.
-		var resp *nodes.NodesGetClassOK
-		retryOnAliasLag(t, func() error {
-			params := nodes.NewNodesGetClassParams().WithClassName("Gigs").WithOutput(&verbose)
-			var err error
-			resp, err = helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(user1Key))
-			return err
-		})
-		require.NotNil(t, resp.Payload)
-		assert.NotEmpty(t, resp.Payload.Nodes)
+		// A 403 is immediate (the authz deny precedes alias resolution), so no
+		// retryOnAliasLag wrapper is needed here.
+		params := nodes.NewNodesGetClassParams().WithClassName("Gigs").WithOutput(&verbose)
+		_, err := helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *nodes.NodesGetClassForbidden
+		require.True(t, errors.As(err, &forbidden), "expected NodesGetClassForbidden, got %T: %v", err, err)
 	})
 }

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -63,6 +63,14 @@ func TestMain(m *testing.M) {
 		WithNamespaces().
 		WithMCP().
 		WithOffloadS3("offloading", "us-west-1").
+		// backup-s3 + export share the MinIO sidecar; the "backups" bucket backs
+		// both. REPLICA_MOVEMENT_ENABLED ensures the Replicate handler reaches the
+		// auth check (it 501s before authz when movement is off), so the RBAC deny
+		// in rbac_surfaces_test.go is observable.
+		WithBackendS3("backups", "us-west-1").
+		WithWeaviateEnv("EXPORT_ENABLED", "true").
+		WithWeaviateEnv("EXPORT_DEFAULT_BUCKET", "backups").
+		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 		WithWeaviateClusterWithGRPC().
 		Start(ctx)

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -39,16 +39,9 @@ func retryOnAliasLag(t *testing.T, op func() error) {
 	}, 10*time.Second, 50*time.Millisecond, "operation kept failing while waiting for alias to be visible locally")
 }
 
-// Test personas. All API keys are statically declared at compose-up time.
-// Per-test work is limited to creating a role with the desired permissions
-// and assigning it to one of these users (reversed in t.Cleanup).
-const (
-	adminUser, adminKey               = "admin-user", "admin-key"
-	manageUser, manageKey             = "manage-user", "manage-key"
-	scopedManageUser, scopedManageKey = "scoped-manage-user", "scoped-manage-key"
-	viewerUser, viewerKey             = "viewer-user", "viewer-key"
-	noPermsUser, noPermsKey           = "no-perms-user", "no-perms-key"
-)
+// adminUser is the env-var root. Namespaced DB users are created at runtime via
+// createNamespacedUser and granted the built-in admin role by this root.
+const adminUser, adminKey = "admin-user", "admin-key"
 
 var sharedCompose *docker.DockerCompose
 
@@ -63,11 +56,9 @@ func TestMain(m *testing.M) {
 
 	compose, err := docker.New().
 		WithApiKey().
+		WithRBAC().
 		WithUserApiKey(adminUser, adminKey).
-		WithUserApiKey(manageUser, manageKey).
-		WithUserApiKey(scopedManageUser, scopedManageKey).
-		WithUserApiKey(viewerUser, viewerKey).
-		WithUserApiKey(noPermsUser, noPermsKey).
+		WithRbacRoots(adminUser).
 		WithDbUsers().
 		WithNamespaces().
 		WithMCP().

--- a/test/acceptance/namespace_limits/setup_test.go
+++ b/test/acceptance/namespace_limits/setup_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/client/users"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 const (
@@ -44,7 +45,9 @@ func TestMain(m *testing.M) {
 
 	compose, err := docker.New().
 		WithApiKey().
+		WithRBAC().
 		WithUserApiKey(adminUser, adminKey).
+		WithRbacRoots(adminUser).
 		WithDbUsers().
 		WithNamespaces().
 		WithWeaviateEnv("MAXIMUM_ALLOWED_OBJECTS_COUNT", strconv.Itoa(objectCap)).
@@ -69,8 +72,9 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// createNamespacedUser creates a namespaced DB user and waits for the
-// apikey to be recognized by the follower the test client talks to.
+// createNamespacedUser creates a namespaced DB user, waits for the apikey to be
+// recognized by the follower the test client talks to, and grants the built-in
+// admin role so the user can act within its namespace under mandatory RBAC.
 func createNamespacedUser(t *testing.T, userID, ns string) string {
 	t.Helper()
 
@@ -94,6 +98,11 @@ func createNamespacedUser(t *testing.T, userID, ns string) string {
 			users.NewGetOwnInfoParams(), helper.CreateAuth(apikey))
 		assert.NoError(c, err)
 	}, 10*time.Second, 50*time.Millisecond, "user %q apikey not recognized after create", userID)
+
+	// Mandatory RBAC: grant the built-in admin so the namespaced user can create
+	// classes and write objects. The quota chokepoint is orthogonal to RBAC and
+	// still fires. DeleteUser revokes all bindings on cleanup.
+	helper.AssignRoleToUser(t, adminKey, authorization.Admin, ns+":"+userID)
 
 	return apikey
 }

--- a/test/acceptance/namespace_limits/setup_test.go
+++ b/test/acceptance/namespace_limits/setup_test.go
@@ -104,5 +104,12 @@ func createNamespacedUser(t *testing.T, userID, ns string) string {
 	// still fires. DeleteUser revokes all bindings on cleanup.
 	helper.AssignRoleToUser(t, adminKey, authorization.Admin, ns+":"+userID)
 
+	// AssignRoleToUser returns once the leader applies the binding; the follower
+	// the test client talks to may still be replicating it. Tests that create a
+	// class immediately after this helper would otherwise race that replication
+	// and get a spurious create_collections 403, so wait until the role is
+	// locally visible before returning.
+	helper.WaitForOwnRole(t, apikey, authorization.Admin)
+
 	return apikey
 }

--- a/test/acceptance_with_python/test_namespace_refs.py
+++ b/test/acceptance_with_python/test_namespace_refs.py
@@ -165,8 +165,25 @@ def _create_namespace(http_port: int, name: str) -> None:
         r.raise_for_status()
 
 
+def _assign_admin_role(http_port: int, qualified_user: str) -> None:
+    """Grant the built-in admin role to a namespaced DB user.
+
+    RBAC is mandatory on NS clusters, so without a role the user is denied on
+    every data/schema/ref op. Mirrors helper.AssignRoleToUser in
+    createNamespacedUser (test/acceptance/namespace/collection_alias_test.go).
+    """
+    r = _http(
+        "POST",
+        f"{_rest_base(http_port)}/authz/users/{qualified_user}/assign",
+        headers=_admin_headers(),
+        json_body={"roles": ["admin"], "userType": "db"},
+    )
+    if r.status_code not in (200, 201):
+        r.raise_for_status()
+
+
 def _create_namespaced_user(http_port: int, user_id: str, namespace: str) -> str:
-    """POST /users/db/{user}. Returns the apikey to authenticate as that user.
+    """POST /users/db/{user}, then grant the admin role. Returns the apikey.
 
     Mirrors createNamespacedUser in test/acceptance/namespace/collection_alias_test.go.
     On 409 (user already exists from a prior run) we delete and recreate so
@@ -184,6 +201,7 @@ def _create_namespaced_user(http_port: int, user_id: str, namespace: str) -> str
         if r.status_code == 201:
             apikey = r.json().get("apikey")
             assert apikey, f"createUser returned no apikey: {r.text}"
+            _assign_admin_role(http_port, qualified)
             return apikey
         if r.status_code == 409:
             d = _http(

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -671,6 +671,9 @@ func (d *Compose) WithDbUsers() *Compose {
 
 // WithNamespaces enables NAMESPACES_ENABLED on the Weaviate container and
 // disables GraphQL, which Config.Validate requires whenever namespaces are on.
+// Config.Validate also requires RBAC on namespace-enabled clusters, so callers
+// that need a bootable NS cluster must pair this with WithRBAC()/WithRbacRoots().
+// This helper does not auto-enable RBAC.
 func (d *Compose) WithNamespaces() *Compose {
 	d.withWeaviateNamespaces = true
 	return d

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/client/authz"
@@ -232,6 +233,29 @@ func CreateRoleAndAssign(t *testing.T, adminKey, userName, roleName string, perm
 		RevokeRoleFromUser(t, adminKey, roleName, userName)
 		DeleteRole(t, adminKey, roleName)
 	})
+}
+
+// WaitForOwnRole polls GetOwnInfo with the caller's own apikey until roleName
+// appears in its roles. AssignRoleToUser returns once the RAFT leader applies
+// the binding, but the follower the test client talks to may still be
+// replicating it. The caller's next authorized request reads that follower's
+// local RBAC state, and GetOwnInfo reads the same state — so gating on it
+// prevents a request issued immediately after AssignRoleToUser from racing
+// replication and getting a spurious 403.
+func WaitForOwnRole(t *testing.T, apikey, roleName string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := Client(t).Users.GetOwnInfo(users.NewGetOwnInfoParams(), CreateAuth(apikey))
+		if !assert.NoError(c, err) {
+			return
+		}
+		for _, role := range resp.Payload.Roles {
+			if role != nil && role.Name != nil && *role.Name == roleName {
+				return
+			}
+		}
+		assert.Fail(c, "role not yet locally visible", "role %q not in own-info roles", roleName)
+	}, 10*time.Second, 50*time.Millisecond, "role %q binding did not become locally visible via GetOwnInfo", roleName)
 }
 
 func AssignRoleToUser(t *testing.T, key, role, user string) {

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -519,7 +519,7 @@ func roleHasResourceVerb(rows [][]string, resourceContains, verb string) bool {
 
 // TestApplyPredefinedRoles_NamespacesEnabled_AdminViewerNarrowed asserts
 // admin/viewer on NS-enabled clusters cover only collections/data/tenants/
-// aliases.
+// aliases plus MCP.
 func TestApplyPredefinedRoles_NamespacesEnabled_AdminViewerNarrowed(t *testing.T) {
 	dir := freshPolicyDir(t)
 	conf := rbacconf.Config{Enabled: true}
@@ -534,17 +534,20 @@ func TestApplyPredefinedRoles_NamespacesEnabled_AdminViewerNarrowed(t *testing.T
 	rootRows := rolePolicies(t, m, authorization.Root)
 	readOnlyRows := rolePolicies(t, m, authorization.ReadOnly)
 
-	// admin: must contain CRUD over schema/data/aliases; tenant rows
+	// admin: must contain CRUD over schema/data/aliases plus MCP; tenant rows
 	// share the schema domain. No backups/replicate/cluster/nodes/users/
-	// roles/groups/namespaces/mcp.
+	// roles/groups/namespaces.
 	assert.True(t, roleHasResourceVerb(adminRows, "schema/collections/", authorization.CREATE))
 	assert.True(t, roleHasResourceVerb(adminRows, "schema/collections/", authorization.READ))
 	assert.True(t, roleHasResourceVerb(adminRows, "schema/collections/", authorization.UPDATE))
 	assert.True(t, roleHasResourceVerb(adminRows, "schema/collections/", authorization.DELETE))
 	assert.True(t, roleHasResourceVerb(adminRows, "data/collections/", authorization.READ))
 	assert.True(t, roleHasResourceVerb(adminRows, "aliases/collections/", authorization.READ))
+	assert.True(t, roleHasResourceVerb(adminRows, conv.CasbinMcp(), authorization.CREATE))
+	assert.True(t, roleHasResourceVerb(adminRows, conv.CasbinMcp(), authorization.READ))
+	assert.True(t, roleHasResourceVerb(adminRows, conv.CasbinMcp(), authorization.UPDATE))
 	for _, prohibited := range []string{
-		"backups/", "cluster/", "nodes/", "users/", "roles/", "groups/", "namespaces/", "replicate/", "mcp",
+		"backups/", "cluster/", "nodes/", "users/", "roles/", "groups/", "namespaces/", "replicate/",
 	} {
 		for _, row := range adminRows {
 			assert.NotContains(t, row[1], prohibited, "admin (NS-enabled) must not have policy on %s domain", prohibited)
@@ -552,12 +555,13 @@ func TestApplyPredefinedRoles_NamespacesEnabled_AdminViewerNarrowed(t *testing.T
 	}
 
 	// viewer: read-only over the same domains, no other verbs, no other
-	// domains.
+	// domains. MCP is included as READ only.
 	for _, row := range viewerRows {
 		assert.Equal(t, authorization.READ, row[2], "viewer (NS-enabled) must only have READ verb")
 	}
 	assert.True(t, roleHasResourceVerb(viewerRows, "schema/collections/", authorization.READ))
 	assert.True(t, roleHasResourceVerb(viewerRows, "data/collections/", authorization.READ))
+	assert.True(t, roleHasResourceVerb(viewerRows, conv.CasbinMcp(), authorization.READ))
 
 	// root and read-only keep wildcard cluster-wide policies.
 	require.Len(t, rootRows, 1)

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -238,7 +238,7 @@ var (
 
 // BuiltInPermissionsFor returns the canonical permission shape of the four
 // built-in roles. On namespace-enabled clusters admin/viewer are narrowed
-// to collections/schema, data, multi-tenancy, and aliases; root/read-only
+// to collections/schema, data, multi-tenancy, aliases, and MCP; root/read-only
 // keep wildcard CRUD/READ across all domains.
 func BuiltInPermissionsFor(namespacesEnabled bool) map[string][]*models.Permission {
 	if !namespacesEnabled {
@@ -667,12 +667,17 @@ var tenantSafeActions = []string{
 	CreateAliases, ReadAliases, UpdateAliases, DeleteAliases,
 }
 
+// tenantSafeMcpActions are namespace-safe because the MCP tools self-scope to
+// principal.Namespace; the mcp resource carries no collection field. A future
+// non-self-scoping MCP tool would require revisiting this.
+var tenantSafeMcpActions = []string{CreateMcp, ReadMcp, UpdateMcp}
+
 // tenantSafeAdminPermissions returns the narrowed admin shape for
-// namespace-enabled clusters: CRUD over the namespace-bearing domains only.
+// namespace-enabled clusters: CRUD over the namespace-bearing domains plus MCP.
 // Cluster-only domains (backups, replicate, nodes, cluster, users, roles,
-// groups, namespaces, mcp) are excluded.
+// groups, namespaces) are excluded.
 func tenantSafeAdminPermissions() []*models.Permission {
-	perms := make([]*models.Permission, 0, len(tenantSafeActions))
+	perms := make([]*models.Permission, 0, len(tenantSafeActions)+len(tenantSafeMcpActions))
 	for _, action := range tenantSafeActions {
 		perms = append(perms, &models.Permission{
 			Action:      &action,
@@ -681,6 +686,9 @@ func tenantSafeAdminPermissions() []*models.Permission {
 			Tenants:     AllTenants,
 			Aliases:     AllAliases,
 		})
+	}
+	for _, action := range tenantSafeMcpActions {
+		perms = append(perms, &models.Permission{Action: &action})
 	}
 	return perms
 }
@@ -700,6 +708,12 @@ func tenantSafeViewerPermissions() []*models.Permission {
 			Tenants:     AllTenants,
 			Aliases:     AllAliases,
 		})
+	}
+	for _, action := range tenantSafeMcpActions {
+		if strings.ToUpper(action)[0] != READ[0] {
+			continue
+		}
+		perms = append(perms, &models.Permission{Action: &action})
 	}
 	return perms
 }

--- a/usecases/auth/authorization/types_test.go
+++ b/usecases/auth/authorization/types_test.go
@@ -298,7 +298,7 @@ func TestBuiltInPermissions_NamespaceManageOnly(t *testing.T) {
 
 // TestBuiltInPermissions_NamespacesEnabled asserts the narrowed admin/viewer
 // shape on NS-enabled clusters: CRUD/READ over collections/data/tenants/
-// aliases only, no cluster-only domains. Root/read-only keep wildcard
+// aliases plus MCP, no cluster-only domains. Root/read-only keep wildcard
 // permissions regardless of NAMESPACES_ENABLED.
 func TestBuiltInPermissions_NamespacesEnabled(t *testing.T) {
 	builtIn := BuiltInPermissionsFor(true)
@@ -312,9 +312,12 @@ func TestBuiltInPermissions_NamespacesEnabled(t *testing.T) {
 		CreateData: {}, ReadData: {}, UpdateData: {}, DeleteData: {},
 		CreateTenants: {}, ReadTenants: {}, UpdateTenants: {}, DeleteTenants: {},
 		CreateAliases: {}, ReadAliases: {}, UpdateAliases: {}, DeleteAliases: {},
+		// MCP tools self-scope to principal.Namespace, so they are namespace-safe.
+		CreateMcp: {}, ReadMcp: {}, UpdateMcp: {},
 	}
 	allowedViewerActions := map[string]struct{}{
 		ReadCollections: {}, ReadData: {}, ReadTenants: {}, ReadAliases: {},
+		ReadMcp: {},
 	}
 
 	collectActions := func(perms []*models.Permission) map[string]struct{} {
@@ -336,7 +339,8 @@ func TestBuiltInPermissions_NamespacesEnabled(t *testing.T) {
 	assert.Equal(t, allowedAdminActions, gotAdmin, "Admin (NS-enabled) must contain only CRUD over namespace-bearing domains")
 	assert.Equal(t, allowedViewerActions, gotViewer, "Viewer (NS-enabled) must contain only READ over namespace-bearing domains")
 
-	// Disallowed domains for narrowed admin/viewer
+	// Disallowed domains for narrowed admin/viewer. MCP is intentionally absent
+	// here — it is namespace-safe and covered by the allowed maps above.
 	for _, action := range []string{
 		ManageBackups, ManageNamespaces,
 		ReadNodes, ReadCluster,
@@ -344,7 +348,6 @@ func TestBuiltInPermissions_NamespacesEnabled(t *testing.T) {
 		AssignAndRevokeGroups, ReadGroups,
 		ReadRoles, CreateRoles, UpdateRoles, DeleteRoles,
 		CreateReplicate, ReadReplicate, UpdateReplicate, DeleteReplicate,
-		CreateMcp, ReadMcp, UpdateMcp,
 	} {
 		_, hasAdmin := gotAdmin[action]
 		_, hasViewer := gotViewer[action]

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -372,6 +372,13 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("NAMESPACES_ENABLED=true requires DISABLE_GRAPHQL=true: GraphQL is not supported on namespace-enabled clusters")
 	}
 
+	// Without RBAC the role narrowing that keeps namespaced principals off
+	// cluster-wide operator surfaces never runs. Also rejects AdminList-only,
+	// which sets Rbac.Enabled=false.
+	if c.Namespaces.Enabled && !c.Authorization.Rbac.Enabled {
+		return fmt.Errorf("NAMESPACES_ENABLED=true requires RBAC to be enabled")
+	}
+
 	if err := c.validateOIDCNamespaceClaims(); err != nil {
 		return configErr(err)
 	}

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -381,6 +381,8 @@ func TestConfigValidation_OIDCNamespaceClaims(t *testing.T) {
 						GlobalPrincipalClaim: runtime.NewDynamicValue(tc.globalClaim),
 					},
 				},
+				// RBAC is required whenever NS is on; enable in lockstep.
+				Authorization:  Authorization{Rbac: rbacconf.Config{Enabled: tc.namespacesEnabled}},
 				DisableGraphQL: true,
 				Namespaces:     Namespaces{Enabled: tc.namespacesEnabled},
 			}
@@ -396,60 +398,67 @@ func TestConfigValidation_OIDCNamespaceClaims(t *testing.T) {
 	}
 }
 
-// TestConfigValidation_Namespaces covers the cross-field requirement that
-// NAMESPACES_ENABLED=true mandates DISABLE_GRAPHQL=true. The check fires
-// before Persistence.Validate (which would otherwise also fail on an empty
-// DataPath), so we assert on the error message to distinguish the namespace
-// error from downstream validation noise.
+// TestConfigValidation_Namespaces covers the two cross-field requirements that
+// NAMESPACES_ENABLED=true mandates: DISABLE_GRAPHQL=true and RBAC enabled. We
+// assert on the error substring to distinguish these from downstream validation
+// noise. The graphql check runs before the RBAC check, so each row isolates a
+// single expected failure.
 func TestConfigValidation_Namespaces(t *testing.T) {
 	tests := []struct {
 		name              string
 		namespacesEnabled bool
 		disableGraphQL    bool
-		wantNamespacesErr bool
+		rbacEnabled       bool
+		// wantErrSubstr is empty when no namespace cross-field error is expected.
+		wantErrSubstr string
 	}{
 		{
-			name:              "namespaces disabled, graphql enabled — no namespace error",
-			namespacesEnabled: false,
-			disableGraphQL:    false,
-			wantNamespacesErr: false,
-		},
-		{
-			name:              "namespaces disabled, graphql disabled — no namespace error",
+			name:              "namespaces disabled — no namespace error",
 			namespacesEnabled: false,
 			disableGraphQL:    true,
-			wantNamespacesErr: false,
+			rbacEnabled:       false,
+			wantErrSubstr:     "",
 		},
 		{
-			name:              "namespaces enabled without DISABLE_GRAPHQL — error",
-			namespacesEnabled: true,
-			disableGraphQL:    false,
-			wantNamespacesErr: true,
-		},
-		{
-			name:              "namespaces enabled with DISABLE_GRAPHQL — no namespace error",
+			name:              "namespaces enabled without RBAC — requires RBAC error",
 			namespacesEnabled: true,
 			disableGraphQL:    true,
-			wantNamespacesErr: false,
+			rbacEnabled:       false,
+			wantErrSubstr:     "NAMESPACES_ENABLED=true requires RBAC to be enabled",
+		},
+		{
+			name:              "namespaces enabled without DISABLE_GRAPHQL — requires DISABLE_GRAPHQL error",
+			namespacesEnabled: true,
+			disableGraphQL:    false,
+			rbacEnabled:       true,
+			wantErrSubstr:     "NAMESPACES_ENABLED=true requires DISABLE_GRAPHQL=true",
+		},
+		{
+			name:              "namespaces enabled with DISABLE_GRAPHQL and RBAC — no namespace error",
+			namespacesEnabled: true,
+			disableGraphQL:    true,
+			rbacEnabled:       true,
+			wantErrSubstr:     "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &Config{
-				Authentication: Authentication{AnonymousAccess: AnonymousAccess{Enabled: true}},
+				Authentication: Authentication{APIKey: StaticAPIKey{Enabled: true, Users: []string{"u"}, AllowedKeys: []string{"k"}}},
+				Authorization:  Authorization{Rbac: rbacconf.Config{Enabled: tc.rbacEnabled}},
 				DisableGraphQL: tc.disableGraphQL,
 				Namespaces:     Namespaces{Enabled: tc.namespacesEnabled},
 			}
 			err := c.Validate()
-			if tc.wantNamespacesErr {
+			if tc.wantErrSubstr != "" {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "NAMESPACES_ENABLED=true requires DISABLE_GRAPHQL=true")
+				assert.Contains(t, err.Error(), tc.wantErrSubstr)
 			} else if err != nil {
-				// Validate may still fail on unrelated fields (e.g. Persistence).
-				// What matters here is that it does NOT fail on the namespaces
-				// cross-field check.
+				// Validate may still fail on unrelated fields (e.g. Persistence);
+				// only assert it does NOT fail on either namespace cross-field check.
 				assert.NotContains(t, err.Error(), "NAMESPACES_ENABLED=true requires DISABLE_GRAPHQL=true")
+				assert.NotContains(t, err.Error(), "NAMESPACES_ENABLED=true requires RBAC to be enabled")
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:

This requires RBAC to be enabled for namespaced clusters to reduce test surface.

Besides the requirement check this mostly changes tests to actually assign the `admin` role to the test user 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
