### PR TITLE
fix(distributedtask): RAFT snapshot restore + scheduler Close race

### DIFF
--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1261,6 +1261,7 @@ func (p *ReindexProvider) runShardSwapPhase(
 // observable query-consistency window because queries during PREP
 // still see the OLD tokenization.
 func (p *ReindexProvider) runPerUnitPhase(
+	ctx context.Context,
 	task *distributedtask.Task,
 	payload *ReindexTaskPayload,
 	localGroupUnitIDs []string,
@@ -1270,7 +1271,6 @@ func (p *ReindexProvider) runPerUnitPhase(
 	parallel bool,
 	runPhase func(unitID string, shard ShardLike, unitTasks []*ShardReindexTaskGeneric, rehydrate bool) phaseResult,
 ) error {
-	ctx := p.serverCtx
 	var agg phaseResult
 	var aggMu sync.Mutex
 
@@ -1343,7 +1343,7 @@ func (p *ReindexProvider) runPerUnitPhase(
 // Any per-node failure here flips the task to FAILED via the appropriate
 // ack, which guarantees no cluster-wide schema flip commits while buckets
 // remain un-swapped.
-func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID string, localGroupUnitIDs []string) error {
+func (p *ReindexProvider) OnGroupCompleted(ctx context.Context, task *distributedtask.Task, groupID string, localGroupUnitIDs []string) error {
 	logger := p.logger.WithField("taskID", task.ID).WithField("groupID", groupID).
 		WithField("localGroupUnitIDs", localGroupUnitIDs)
 
@@ -1415,12 +1415,12 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 	// SWAPPING. The split bounds the cross-replica stagger window at
 	// billion-scale to RAFT propagation latency rather than per-node
 	// PREP duration.
-	ctx := p.serverCtx
+	//
 	// PREP path runs heavy IO per shard (FlushAndSwitch, ShutdownBucket,
 	// PrependSegmentsFromBucket). Sequential to avoid compounding IO
 	// contention; query consistency is not at stake here because queries
 	// during PREP still see OLD tokenization.
-	return p.runPerUnitPhase(task, payload, localGroupUnitIDs, idx, logger,
+	return p.runPerUnitPhase(ctx, task, payload, localGroupUnitIDs, idx, logger,
 		"group-completion", false,
 		func(unitID string, shard ShardLike, unitTasks []*ShardReindexTaskGeneric, rehydrate bool) phaseResult {
 			return p.onGroupCompletedRunPhaseForUnit(ctx, task, payload, unitID, shard, unitTasks, rehydrate, logger)
@@ -1473,7 +1473,7 @@ func (p *ReindexProvider) onGroupCompletedRunPhaseForUnit(
 // scheduler only fires this after the cluster-wide PREPARING → SWAPPING
 // transition. Returns non-nil on any per-shard swap failure; the resulting
 // PostCompletionAck flip-to-FAILED prevents the cluster-wide schema flip.
-func (p *ReindexProvider) OnSwapRequested(task *distributedtask.Task, groupID string, localGroupUnitIDs []string) error {
+func (p *ReindexProvider) OnSwapRequested(ctx context.Context, task *distributedtask.Task, groupID string, localGroupUnitIDs []string) error {
 	logger := p.logger.WithField("taskID", task.ID).WithField("groupID", groupID).
 		WithField("localGroupUnitIDs", localGroupUnitIDs)
 
@@ -1504,7 +1504,6 @@ func (p *ReindexProvider) OnSwapRequested(task *distributedtask.Task, groupID st
 		return fmt.Errorf("collection %q not found on this node", payload.Collection)
 	}
 
-	ctx := p.serverCtx
 	// SWAP path runs the in-memory pointer flip first (the user-observable
 	// event) and then per-shard post-flip work (Shutdown drain, dir
 	// rename, sentinel writes, trim). Parallel across this node's units
@@ -1512,7 +1511,7 @@ func (p *ReindexProvider) OnSwapRequested(task *distributedtask.Task, groupID st
 	// flip on shard B — without this the per-replica cutover window
 	// grows linearly in shard count. Per-shard state is structurally
 	// disjoint (see runPerUnitPhase godoc).
-	return p.runPerUnitPhase(task, payload, localGroupUnitIDs, idx, logger,
+	return p.runPerUnitPhase(ctx, task, payload, localGroupUnitIDs, idx, logger,
 		"swap-requested", true,
 		func(unitID string, shard ShardLike, unitTasks []*ShardReindexTaskGeneric, rehydrate bool) phaseResult {
 			return p.onSwapRequestedRunPhaseForUnit(ctx, payload, unitID, shard, unitTasks, rehydrate, logger)
@@ -1565,7 +1564,7 @@ func (p *ReindexProvider) onSwapRequestedRunPhaseForUnit(
 // in [distributedtask.ErrTaskCompletionPermanent] when unrecoverable, plain
 // when transient (weaviate/0-weaviate-issues#297). Terminal-status cleanup
 // always returns nil.
-func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) error {
+func (p *ReindexProvider) OnTaskCompleted(ctx context.Context, task *distributedtask.Task) error {
 	// Clear caches up-front so a failed-task early return doesn't leak.
 	payload, payloadErr := p.loadPayload(task)
 	p.clearTaskCaches(task.TaskDescriptor)
@@ -1604,9 +1603,10 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) error {
 		return nil
 	}
 
-	// p.serverCtx outlives the per-task ctx (which is gone by the time the
-	// scheduler tick fires OnTaskCompleted).
-	ctx := p.serverCtx
+	// Use the scheduler's loop ctx (passed in) so a shutdown can cancel
+	// the schema flip mid-RAFT-apply. The flip is idempotent on retry; a
+	// post-restart tick re-fires OnTaskCompleted via [RecoveryAwareProvider]
+	// + LocalCallbacksDone.
 	if err := p.flipSemanticMigrationSchema(ctx, payload, logger); err != nil {
 		logger.Errorf("reindex provider: task-completion: schema flip failed; migration result is half-applied (bucket swapped on every node, schema still reflects pre-migration state): %v", err)
 		// Leave the overlay in place: buckets are NEW-tokenized but the

--- a/adapters/repos/db/reindex_provider_completion_classification_test.go
+++ b/adapters/repos/db/reindex_provider_completion_classification_test.go
@@ -64,7 +64,7 @@ func TestOnTaskCompletedClassification(t *testing.T) {
 			Status:         distributedtask.TaskStatusSwapping,
 			Payload:        []byte("{ this is not valid json"),
 		}
-		err := p.OnTaskCompleted(task)
+		err := p.OnTaskCompleted(context.Background(), task)
 		require.Error(t, err)
 		require.ErrorIs(t, err, distributedtask.ErrTaskCompletionPermanent)
 	})

--- a/adapters/repos/db/reindex_provider_on_group_completed_test.go
+++ b/adapters/repos/db/reindex_provider_on_group_completed_test.go
@@ -12,6 +12,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,7 @@ func TestOnGroupCompleted_TerminalStatusShortCircuit(t *testing.T) {
 			// returns a non-nil error. That's how we observe whether
 			// the short-circuit fired.
 
-			err := p.OnGroupCompleted(task, "", []string{"unit-1"})
+			err := p.OnGroupCompleted(context.Background(), task, "", []string{"unit-1"})
 
 			if tc.shortCircuit {
 				require.NoError(t, err,

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -992,6 +992,21 @@ func (m *Manager) Snapshot() ([]byte, error) {
 // Restore replaces the Manager's in-memory state from a Raft snapshot produced by
 // [Manager.Snapshot]. It is called during Raft leader election or when a follower installs
 // a snapshot from the leader.
+//
+// The hashicorp/raft FSM contract is that snapshot installation REPLACES
+// the in-memory state — not merges it. A follower that has already
+// applied N log entries before the leader sends a snapshot must look
+// identical to the leader after Restore returns. If we merged onto the
+// existing m.tasks, any task that was applied before the snapshot
+// install (and that is NOT present in the snapshot — e.g. because it
+// was cancelled and tombstone-pruned by the leader between log
+// application and snapshot install) would survive as a phantom task on
+// this follower. The next scheduler tick would observe it, fire
+// OnTaskCompleted / schema flips, and produce a state divergence the
+// SchemaMutationDetector exists specifically to prevent.
+//
+// Reset to an empty map before re-populating so the post-Restore state
+// is exactly {leader.snapshot.tasks}.
 func (m *Manager) Restore(bytes []byte) error {
 	var s snapshot
 	if err := json.Unmarshal(bytes, &s); err != nil {
@@ -1001,6 +1016,7 @@ func (m *Manager) Restore(bytes []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.tasks = make(map[string]map[string]*Task, len(s.Tasks))
 	for namespace, tasks := range s.Tasks {
 		for _, task := range tasks {
 			if _, ok := m.tasks[namespace]; !ok {

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -2006,3 +2006,54 @@ func TestManager_RecordPreparationCompleteAck_AckOrderCommutativity(t *testing.T
 		})
 	}
 }
+
+// TestManager_Restore_ReplacesExistingState pins the hashicorp/raft
+// FSM contract that snapshot installation REPLACES the in-memory
+// state. A follower that already applied log entries before the
+// leader sends a snapshot must end up identical to the leader after
+// Restore returns.
+//
+// Without this, any task that was applied locally but is NOT present
+// in the snapshot (typical: cancelled+pruned by the leader between
+// local apply and snapshot install) survives as a phantom on the
+// follower — the next scheduler tick observes it and fires
+// OnTaskCompleted / schema flips that no other node sees. Same bug
+// family the SchemaMutationDetector exists to catch.
+func TestManager_Restore_ReplacesExistingState(t *testing.T) {
+	now := time.Now().Truncate(time.Millisecond)
+
+	// Source manager: holds the snapshot that represents the leader's
+	// view at install time. Only "task1" exists here.
+	src := newTestHarness(t).init(t)
+	require.NoError(t, src.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+		Namespace:             "ns1",
+		Id:                    "task1",
+		Payload:               []byte("from-snapshot"),
+		SubmittedAtUnixMillis: now.UnixMilli(),
+		UnitIds:               []string{"su-1"},
+	}), 1))
+	snap, err := src.manager.Snapshot()
+	require.NoError(t, err)
+
+	// Destination manager: simulates a follower that already applied
+	// "phantom" before the leader sends the snapshot. The leader
+	// doesn't know about "phantom" — it must not survive Restore.
+	dst := newTestHarness(t).init(t)
+	require.NoError(t, dst.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+		Namespace:             "ns2",
+		Id:                    "phantom",
+		Payload:               []byte("must-be-erased"),
+		SubmittedAtUnixMillis: now.UnixMilli(),
+		UnitIds:               []string{"su-x"},
+	}), 99))
+
+	require.NoError(t, dst.manager.Restore(snap))
+
+	tasks, err := dst.manager.ListDistributedTasks(context.Background())
+	require.NoError(t, err)
+
+	require.Lenf(t, tasks, 1, "post-Restore namespaces must equal snapshot namespaces; phantom 'ns2' survived")
+	require.Len(t, tasks["ns1"], 1, "snapshot's ns1/task1 must be present after Restore")
+	require.Equal(t, "task1", tasks["ns1"][0].ID)
+	require.NotContains(t, tasks, "ns2", "phantom namespace must not survive Restore")
+}

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -154,6 +154,17 @@ type Scheduler struct {
 
 	stopCh chan struct{}
 
+	// loopDone is closed by the run loop just before it exits. Close()
+	// blocks on it after closing stopCh so an in-flight tick (which may
+	// be mid-RAFT-apply via provider.StartTask /
+	// MarkDistributedTaskFinalized) finishes before the caller proceeds
+	// to tear down DB / schema. Without this barrier the scheduler can
+	// race with cluster shutdown: stopCh closes → Close returns to the
+	// caller → caller starts shutting the schema manager / DB down →
+	// the previous tick's RAFT round-trip lands and operates on an
+	// already-half-torn-down node.
+	loopDone chan struct{}
+
 	// wakeCh signals the run loop to fire a scheduling cycle immediately
 	// instead of waiting for the next periodic tick. Sized 1 so concurrent
 	// callers coalesce — a pending wake-up is equivalent to any number of
@@ -223,6 +234,10 @@ func NewScheduler(params SchedulerParams) *Scheduler {
 
 		stopCh: make(chan struct{}),
 		wakeCh: make(chan struct{}, 1),
+		// loopDone is created in Start(), not here, so Close() called
+		// before Start() (or against a never-started Scheduler — a
+		// pattern the test harness relies on) does not deadlock on a
+		// channel no goroutine will ever close.
 	}
 }
 
@@ -267,6 +282,7 @@ func (s *Scheduler) Start(ctx context.Context) error {
 		s.bootstrapProviders(tasksByNamespace)
 	}
 
+	s.loopDone = make(chan struct{})
 	enterrors.GoWrapper(s.loop, s.logger)
 
 	return nil
@@ -449,6 +465,12 @@ func filterTasks(tasks map[TaskDescriptor]*Task, predicate func(task *Task) bool
 }
 
 func (s *Scheduler) loop() {
+	// close(loopDone) is the synchronisation point Close() waits on so
+	// the caller's subsequent shutdown of DB / schema does not race
+	// with an in-flight tick's RAFT round-trip. Deferred so a panic
+	// inside tick() still releases Close().
+	defer close(s.loopDone)
+
 	ticker := s.clock.NewTicker(s.tickInterval)
 	defer ticker.Stop()
 
@@ -1249,10 +1271,27 @@ func (s *Scheduler) recordRunningTaskHandleLocked(namespace string, desc TaskDes
 	s.runningTasks[namespace][desc] = handle
 }
 
-// Close stops the background tick loop and terminates all running task handles. It blocks
-// until all handles have been signalled. After Close returns, no new ticks will fire.
+// Close stops the background tick loop, waits for it to finish any
+// in-flight tick, and terminates all running task handles. After Close
+// returns, no new ticks will fire AND no previously-spawned tick is
+// still running.
+//
+// The <-loopDone barrier is load-bearing: an in-flight tick may be
+// mid-RAFT-apply (e.g. provider.StartTask, MarkDistributedTaskFinalized)
+// when stopCh closes. Without waiting on loopDone, Close would return
+// to the caller while the RAFT round-trip is still in flight; the
+// caller would then proceed to tear down DB / schema, and the late
+// apply would land on an already-half-torn-down node — racing with
+// schema mutation detectors and producing the same family of bug
+// SchemaMutationDetector was added to catch.
 func (s *Scheduler) Close() {
 	close(s.stopCh)
+	// loopDone is nil when Close runs on a never-started Scheduler
+	// (the test harness exercises this for symmetry). Only wait on it
+	// when Start actually spawned the loop.
+	if s.loopDone != nil {
+		<-s.loopDone
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -165,6 +165,15 @@ type Scheduler struct {
 	// already-half-torn-down node.
 	loopDone chan struct{}
 
+	// loopCtx is the context the tick path threads through every RAFT
+	// round-trip (currently listTasks, plus the existing
+	// TaskFinalizer / TaskCleaner / AckRecorder calls). loopCancel is
+	// invoked by Close() before <-loopDone so a tick that is stuck
+	// in a RAFT Query (leader unavailable, network partition) does
+	// not hold shutdown indefinitely.
+	loopCtx    context.Context
+	loopCancel context.CancelFunc
+
 	// wakeCh signals the run loop to fire a scheduling cycle immediately
 	// instead of waiting for the next periodic tick. Sized 1 so concurrent
 	// callers coalesce — a pending wake-up is equivalent to any number of
@@ -283,6 +292,7 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	}
 
 	s.loopDone = make(chan struct{})
+	s.loopCtx, s.loopCancel = context.WithCancel(context.Background())
 	enterrors.GoWrapper(s.loop, s.logger)
 
 	return nil
@@ -493,7 +503,7 @@ func (s *Scheduler) loop() {
 }
 
 func (s *Scheduler) tick() {
-	tasksByNamespace, err := s.listTasks(context.Background())
+	tasksByNamespace, err := s.listTasks(s.loopCtx)
 	if err != nil {
 		s.sampledLogger.WithSampling(func(l logrus.FieldLogger) {
 			l.Errorf("failed to list distributed tasks: %v", err)
@@ -1286,6 +1296,14 @@ func (s *Scheduler) recordRunningTaskHandleLocked(namespace string, desc TaskDes
 // SchemaMutationDetector was added to catch.
 func (s *Scheduler) Close() {
 	close(s.stopCh)
+	// Cancel the loop context BEFORE waiting on loopDone so a tick
+	// blocked in a RAFT round-trip (leader unavailable, network
+	// partition) unwinds quickly rather than holding shutdown
+	// indefinitely. The wait still synchronises us against the tick
+	// finishing its current step.
+	if s.loopCancel != nil {
+		s.loopCancel()
+	}
 	// loopDone is nil when Close runs on a never-started Scheduler
 	// (the test harness exercises this for symmetry). Only wait on it
 	// when Start actually spawned the loop.

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -664,7 +664,7 @@ func (s *Scheduler) tick() {
 			return s.completedTaskTTL <= s.clock.Since(task.FinishedAt)
 		})
 		for _, task := range cleanableTasks {
-			err = s.taskCleaner.CleanUpDistributedTask(context.Background(), namespace, task.ID, task.Version)
+			err = s.taskCleaner.CleanUpDistributedTask(s.loopCtx, namespace, task.ID, task.Version)
 			if err != nil {
 				s.sampledLogger.WithSampling(func(l logrus.FieldLogger) {
 					s.loggerWithTask(namespace, task.TaskDescriptor).
@@ -835,7 +835,7 @@ func (s *Scheduler) runPreparationPhase(
 	// Process without the lock. Provider does real I/O.
 	groupErrors := make([]error, len(worklist))
 	for i, w := range worklist {
-		groupErrors[i] = suProvider.OnGroupCompleted(task, w.groupID, w.localIDs)
+		groupErrors[i] = suProvider.OnGroupCompleted(s.loopCtx, task, w.groupID, w.localIDs)
 	}
 
 	// Commit group errors + ack eligibility snapshot under deferred-Unlock.
@@ -883,7 +883,7 @@ func (s *Scheduler) runPreparationPhase(
 
 	// Ack RAFT-write without the lock.
 	ackErr := s.ackRecorder.RecordDistributedTaskPreparationCompleteAck(
-		context.Background(), namespace, task.ID, task.Version,
+		s.loopCtx, namespace, task.ID, task.Version,
 		s.localNode, success, joined,
 	)
 
@@ -985,9 +985,9 @@ func (s *Scheduler) runSwapPhase(
 	groupErrors := make([]error, len(worklist))
 	for i, w := range worklist {
 		if w.isSwap {
-			groupErrors[i] = suProvider.OnSwapRequested(task, w.groupID, w.localIDs)
+			groupErrors[i] = suProvider.OnSwapRequested(s.loopCtx, task, w.groupID, w.localIDs)
 		} else {
-			groupErrors[i] = suProvider.OnGroupCompleted(task, w.groupID, w.localIDs)
+			groupErrors[i] = suProvider.OnGroupCompleted(s.loopCtx, task, w.groupID, w.localIDs)
 		}
 	}
 
@@ -1041,7 +1041,7 @@ func (s *Scheduler) runSwapPhase(
 
 	// Ack RAFT-write without the lock.
 	ackErr := s.ackRecorder.RecordDistributedTaskPostCompletionAck(
-		context.Background(), namespace, task.ID, task.Version,
+		s.loopCtx, namespace, task.ID, task.Version,
 		s.localNode, success, joined,
 	)
 
@@ -1126,7 +1126,7 @@ func (s *Scheduler) runCompletedCallbackPhase(
 
 	// Fire OnTaskCompleted without the lock. See the "Idempotency contract"
 	// note at the matching rollback site in runFinalizePhase.
-	cbErr := suProvider.OnTaskCompleted(task)
+	cbErr := suProvider.OnTaskCompleted(s.loopCtx, task)
 	if cbErr == nil {
 		return
 	}
@@ -1171,7 +1171,7 @@ func (s *Scheduler) runCompletedCallbackPhase(
 		return
 	}
 	if err := s.taskFinalizer.MarkDistributedTaskFailed(
-		context.Background(), namespace, task.ID, task.Version, failMsg,
+		s.loopCtx, namespace, task.ID, task.Version, failMsg,
 	); err != nil {
 		s.loggerWithTask(namespace, desc).
 			Warnf("failed to mark distributed task failed after OnTaskCompleted error; will retry on next tick: %v", err)
@@ -1228,7 +1228,7 @@ func (s *Scheduler) runFinalizePhase(
 	finErrors := make([]error, len(worklist))
 	for i, w := range worklist {
 		finErrors[i] = s.taskFinalizer.MarkDistributedTaskFinalized(
-			context.Background(), namespace, w.task.ID, w.task.Version,
+			s.loopCtx, namespace, w.task.ID, w.task.Version,
 		)
 	}
 

--- a/cluster/distributedtask/scheduler_flip_failure_pin_test.go
+++ b/cluster/distributedtask/scheduler_flip_failure_pin_test.go
@@ -12,6 +12,7 @@
 package distributedtask
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -41,17 +42,17 @@ func newFlipFailingProvider(t *testing.T, flipShouldFail bool) *flipFailingProvi
 	}
 }
 
-func (p *flipFailingProvider) OnGroupCompleted(_ *Task, _ string, _ []string) error {
+func (p *flipFailingProvider) OnGroupCompleted(_ context.Context, _ *Task, _ string, _ []string) error {
 	return nil
 }
 
-func (p *flipFailingProvider) OnSwapRequested(_ *Task, _ string, _ []string) error {
+func (p *flipFailingProvider) OnSwapRequested(_ context.Context, _ *Task, _ string, _ []string) error {
 	return nil
 }
 
 // OnTaskCompleted simulates the schema flip failing transiently; the
 // scheduler must withhold FINISHED and retry (weaviate/0-weaviate-issues#297).
-func (p *flipFailingProvider) OnTaskCompleted(task *Task) error {
+func (p *flipFailingProvider) OnTaskCompleted(_ context.Context, task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.completedCalls++

--- a/cluster/distributedtask/scheduler_multinode_barrier_test.go
+++ b/cluster/distributedtask/scheduler_multinode_barrier_test.go
@@ -78,7 +78,7 @@ func newBarrierRecordingProvider(t *testing.T) *barrierRecordingProvider {
 	}
 }
 
-func (p *barrierRecordingProvider) OnGroupCompleted(task *Task, _ string, _ []string) error {
+func (p *barrierRecordingProvider) OnGroupCompleted(_ context.Context, task *Task, _ string, _ []string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.groupCalls = append(p.groupCalls, task.ID)
@@ -89,7 +89,7 @@ func (p *barrierRecordingProvider) OnGroupCompleted(task *Task, _ string, _ []st
 	return nil
 }
 
-func (p *barrierRecordingProvider) OnSwapRequested(task *Task, _ string, _ []string) error {
+func (p *barrierRecordingProvider) OnSwapRequested(_ context.Context, task *Task, _ string, _ []string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.swapCalls = append(p.swapCalls, task.ID)
@@ -100,7 +100,7 @@ func (p *barrierRecordingProvider) OnSwapRequested(task *Task, _ string, _ []str
 	return nil
 }
 
-func (p *barrierRecordingProvider) OnTaskCompleted(task *Task) error {
+func (p *barrierRecordingProvider) OnTaskCompleted(_ context.Context, task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.taskCalls = append(p.taskCalls, task.ID)

--- a/cluster/distributedtask/scheduler_multinode_test.go
+++ b/cluster/distributedtask/scheduler_multinode_test.go
@@ -96,7 +96,7 @@ func newRecordingUnitAwareProvider(t *testing.T) *recordingUnitAwareProvider {
 	}
 }
 
-func (p *recordingUnitAwareProvider) OnGroupCompleted(task *Task, _ string, _ []string) error {
+func (p *recordingUnitAwareProvider) OnGroupCompleted(_ context.Context, task *Task, _ string, _ []string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.groupCalls = append(p.groupCalls, task.ID)
@@ -106,7 +106,7 @@ func (p *recordingUnitAwareProvider) OnGroupCompleted(task *Task, _ string, _ []
 	return nil
 }
 
-func (p *recordingUnitAwareProvider) OnSwapRequested(_ *Task, _ string, _ []string) error {
+func (p *recordingUnitAwareProvider) OnSwapRequested(_ context.Context, _ *Task, _ string, _ []string) error {
 	// Recording provider exercises the NeedsPreparationBarrier=false path;
 	// scheduler never fires this for these tasks. Stub for interface
 	// compliance.
@@ -122,7 +122,7 @@ func (p *recordingUnitAwareProvider) SetGroupCompletedError(err error) {
 	p.groupCompletedErr = err
 }
 
-func (p *recordingUnitAwareProvider) OnTaskCompleted(task *Task) error {
+func (p *recordingUnitAwareProvider) OnTaskCompleted(_ context.Context, task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.taskCalls = append(p.taskCalls, task.ID)

--- a/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
+++ b/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
@@ -12,6 +12,7 @@
 package distributedtask
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -43,10 +44,15 @@ func newRetryFlipProvider(t *testing.T) *retryFlipProvider {
 	}
 }
 
-func (p *retryFlipProvider) OnGroupCompleted(_ *Task, _ string, _ []string) error { return nil }
-func (p *retryFlipProvider) OnSwapRequested(_ *Task, _ string, _ []string) error  { return nil }
+func (p *retryFlipProvider) OnGroupCompleted(_ context.Context, _ *Task, _ string, _ []string) error {
+	return nil
+}
 
-func (p *retryFlipProvider) OnTaskCompleted(task *Task) error {
+func (p *retryFlipProvider) OnSwapRequested(_ context.Context, _ *Task, _ string, _ []string) error {
+	return nil
+}
+
+func (p *retryFlipProvider) OnTaskCompleted(_ context.Context, task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.callsByStatus[task.Status]++

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/backup"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -840,6 +841,119 @@ func (h *testHarness) listManagerTasks(t *testing.T) map[string][]*Task {
 	return tasks
 }
 
+// TestScheduler_Close_WaitsForLoopExit_UnitAwareCallback extends the
+// listTasks-stall coverage to the post-listTasks tick body. Six other
+// sites in tick() are uncancellable without the audit done on
+// weaviate/weaviate#11427: provider.{StartTask,GetLocalTasks,CleanupTask},
+// the three UnitAwareProvider callbacks, and the ackRecorder /
+// finalizer / cleaner RAFT writes. The Class-A swap to s.loopCtx and
+// the ctx extension on UnitAwareProvider make all of these honor
+// shutdown. This test pins the UnitAwareProvider half: stall
+// OnGroupCompleted on the loopCtx, call Close, verify both ctx
+// observation AND Close return.
+func TestScheduler_Close_WaitsForLoopExit_UnitAwareCallback(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	prov := &blockingUnitAwareProvider{
+		testTaskProvider: newTestTaskProvider(t, nil),
+		entered:          make(chan struct{}, 1),
+		release:          make(chan struct{}),
+		ctxDone:          make(chan struct{}),
+	}
+
+	h := newTestHarness(t)
+	h.registeredProviders = map[string]Provider{h.tasksNamespace: prov}
+	h.provider = prov.testTaskProvider
+	h = h.init(t)
+	h.startScheduler(t)
+
+	// Add a task whose unit-completion will trigger OnGroupCompleted on
+	// the next tick. recordingUnitAwareProvider in scheduler_multinode_test
+	// uses a similar pattern; we open-code it here so the unit-tier test
+	// stays self-contained.
+	taskID := "close-via-on-group-completed"
+	require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+		Namespace:             h.tasksNamespace,
+		Id:                    taskID,
+		SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
+		UnitIds:               []string{"u-1"},
+	}), 1))
+	// Claim the unit for this node (first progress assigns NodeID), then
+	// record terminal completion. Without the progress claim, the
+	// unit's NodeID stays empty and LocalGroupUnitIDs may not include it.
+	updateProgress(t, h, h.tasksNamespace, taskID, 1, h.localNodeID, "u-1", 0.1)
+	completeUnit(t, h, h.tasksNamespace, taskID, 1, h.localNodeID, "u-1")
+
+	// Advance the clock so the scheduler tick runs and observes the
+	// unit-terminal task, firing OnGroupCompleted on this node.
+	h.advanceClock(h.schedulerTickInterval)
+
+	select {
+	case <-prov.entered:
+	case <-time.After(5 * time.Second):
+		close(prov.release)
+		t.Fatal("OnGroupCompleted was not entered within 5s; harness drift")
+	}
+
+	closed := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		h.scheduler.Close()
+		close(closed)
+	}, h.logger)
+
+	// CANCEL: OnGroupCompleted's ctx (= s.loopCtx) must be cancelled by
+	// Close so a stuck callback unwinds.
+	select {
+	case <-prov.ctxDone:
+	case <-time.After(2 * time.Second):
+		close(prov.release)
+		t.Fatal("Scheduler.Close did not cancel OnGroupCompleted's ctx within 2s — a stuck callback would hold shutdown indefinitely")
+	}
+
+	// SYNC: Close must not return until the loop's wait barrier observes
+	// the tick exit. The provider unblocks on ctx.Done() and returns
+	// context.Canceled; scheduler's ctx.Canceled handling drops the
+	// fired-mark so this isn't permanent.
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Scheduler.Close did not return after OnGroupCompleted observed ctx cancellation — barrier deadlock")
+	}
+
+	close(prov.release) // no-op on the success path; prevents goroutine leak on failure
+}
+
+// blockingUnitAwareProvider's OnGroupCompleted blocks until either
+// `release` closes or the passed ctx is cancelled. Closes `ctxDone`
+// the moment cancellation is observed. The other callbacks are no-ops.
+type blockingUnitAwareProvider struct {
+	*testTaskProvider
+	entered chan struct{}
+	release chan struct{}
+	ctxDone chan struct{}
+	once    sync.Once
+}
+
+func (p *blockingUnitAwareProvider) OnGroupCompleted(ctx context.Context, _ *Task, _ string, _ []string) error {
+	select {
+	case p.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-p.release:
+		return nil
+	case <-ctx.Done():
+		p.once.Do(func() { close(p.ctxDone) })
+		return ctx.Err()
+	}
+}
+
+func (p *blockingUnitAwareProvider) OnSwapRequested(_ context.Context, _ *Task, _ string, _ []string) error {
+	return nil
+}
+
+func (p *blockingUnitAwareProvider) OnTaskCompleted(_ context.Context, _ *Task) error { return nil }
+
 type testTask struct {
 	*Task
 
@@ -1201,20 +1315,20 @@ func newUnitAwareTestProvider(t *testing.T) *unitAwareTestProvider {
 	}
 }
 
-func (p *unitAwareTestProvider) OnGroupCompleted(task *Task, groupID string, localGroupUnitIDs []string) error {
+func (p *unitAwareTestProvider) OnGroupCompleted(_ context.Context, task *Task, groupID string, localGroupUnitIDs []string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.onGroupCompletedCalls = append(p.onGroupCompletedCalls, task.ID)
 	return nil
 }
 
-func (p *unitAwareTestProvider) OnSwapRequested(_ *Task, _ string, _ []string) error {
+func (p *unitAwareTestProvider) OnSwapRequested(_ context.Context, _ *Task, _ string, _ []string) error {
 	// Test provider is the NeedsPreparationBarrier=false path; scheduler never
 	// fires this for these tasks. Stub for interface compliance.
 	return nil
 }
 
-func (p *unitAwareTestProvider) OnTaskCompleted(task *Task) error {
+func (p *unitAwareTestProvider) OnTaskCompleted(_ context.Context, task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.onTaskCompletedCalls = append(p.onTaskCompletedCalls, task.ID)

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -954,6 +954,419 @@ func (p *blockingUnitAwareProvider) OnSwapRequested(_ context.Context, _ *Task, 
 
 func (p *blockingUnitAwareProvider) OnTaskCompleted(_ context.Context, _ *Task) error { return nil }
 
+// TestScheduler_Close_CancelsEveryTickPathRoundTrip covers the tick-path
+// call sites that the two tests above leave open: the cleaner, the
+// finalizer, both ack round-trips, and the two remaining
+// [UnitAwareProvider] callbacks. Each row wedges exactly one of them and
+// asserts the same two things: the wedged call sees ctx cancellation, and
+// Close returns afterwards.
+//
+// Each of these was a `context.Background()` call site before the audit in
+// weaviate/weaviate#11427; a regression to that would hang shutdown
+// silently, since a hung Close only shows up as a node that never
+// finishes SIGTERM.
+func TestScheduler_Close_CancelsEveryTickPathRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		// arrange drives the FSM into the state whose tick reaches the
+		// wedged call, wires the scheduler with the wedge in place, and
+		// starts the loop.
+		arrange func(e *closeStallEnv) *stallPoint
+	}{
+		{
+			name: "taskCleaner.CleanUpDistributedTask",
+			arrange: func(e *closeStallEnv) *stallPoint {
+				stall := newStallPoint()
+				e.addTaskWithFailedUnit("ttl-cleanup")
+				e.clock.Advance(e.ttl + time.Minute)
+				e.start(tickCollaborators{cleaner: &stallingCleaner{stall: stall}})
+				return stall
+			},
+		},
+		{
+			name: "taskFinalizer.MarkDistributedTaskFinalized",
+			arrange: func(e *closeStallEnv) *stallPoint {
+				stall := newStallPoint()
+				e.addTaskWithCompletedUnit("finalize", false)
+				e.start(tickCollaborators{finalizer: &stallingFinalizer{finalized: stall}})
+				return stall
+			},
+		},
+		{
+			name: "taskFinalizer.MarkDistributedTaskFailed",
+			arrange: func(e *closeStallEnv) *stallPoint {
+				stall := newStallPoint()
+				e.addTaskWithCompletedUnit("fail-finalize", false)
+				// A permanent OnTaskCompleted error is what routes the tick
+				// into the SWAPPING → FAILED write.
+				prov := e.unitAwareProvider(stallingUnitAwareProvider{
+					taskCompletedErr: fmt.Errorf("flip is unrecoverable: %w", ErrTaskCompletionPermanent),
+				})
+				e.start(tickCollaborators{
+					provider:  prov,
+					finalizer: &stallingFinalizer{failed: stall},
+				})
+				return stall
+			},
+		},
+		{
+			name: "ackRecorder.RecordDistributedTaskPreparationCompleteAck",
+			arrange: func(e *closeStallEnv) *stallPoint {
+				stall := newStallPoint()
+				e.addTaskWithCompletedUnit("prep-ack", true)
+				e.start(tickCollaborators{
+					provider: e.unitAwareProvider(stallingUnitAwareProvider{}),
+					ack:      &stallingAckRecorder{preparation: stall},
+				})
+				return stall
+			},
+		},
+		{
+			name: "ackRecorder.RecordDistributedTaskPostCompletionAck",
+			arrange: func(e *closeStallEnv) *stallPoint {
+				stall := newStallPoint()
+				e.addTaskWithCompletedUnit("post-ack", false)
+				e.start(tickCollaborators{
+					provider: e.unitAwareProvider(stallingUnitAwareProvider{}),
+					ack:      &stallingAckRecorder{postCompletion: stall},
+				})
+				return stall
+			},
+		},
+		{
+			name: "UnitAwareProvider.OnSwapRequested",
+			arrange: func(e *closeStallEnv) *stallPoint {
+				stall := newStallPoint()
+				e.addTaskWithCompletedUnit("swap-callback", true)
+				e.liftPreparationBarrier("swap-callback")
+				e.start(tickCollaborators{
+					provider: e.unitAwareProvider(stallingUnitAwareProvider{onSwapRequested: stall}),
+					ack:      &stallingAckRecorder{},
+				})
+				return stall
+			},
+		},
+		{
+			name: "UnitAwareProvider.OnTaskCompleted",
+			arrange: func(e *closeStallEnv) *stallPoint {
+				stall := newStallPoint()
+				e.addTaskWithCompletedUnit("task-callback", false)
+				// No ack recorder: Phase 2 is not gated on a cluster-wide
+				// ack, so OnTaskCompleted fires in the same tick as PHASE B.
+				e.start(tickCollaborators{
+					provider: e.unitAwareProvider(stallingUnitAwareProvider{onTaskCompleted: stall}),
+				})
+				return stall
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer leaktest.Check(t)()
+
+			e := newCloseStallEnv(t)
+			stall := tc.arrange(e)
+
+			var closeOnce sync.Once
+			closeScheduler := func() { closeOnce.Do(e.scheduler.Close) }
+			// Deferred in this order so the release fires FIRST: a
+			// regressed call site ignores ctx, and closeScheduler would
+			// then block until the wedge is released.
+			defer closeScheduler()
+			defer close(stall.release)
+
+			e.scheduler.Wake()
+
+			select {
+			case <-stall.entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("tick never reached the wedged call; the scenario no longer drives the code path it means to cover")
+			}
+
+			closed := make(chan struct{})
+			enterrors.GoWrapper(func() {
+				closeScheduler()
+				close(closed)
+			}, e.logger)
+
+			select {
+			case <-stall.ctxDone:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Scheduler.Close did not cancel the wedged call's ctx within 2s — a stalled RAFT round-trip would hold shutdown indefinitely")
+			}
+
+			select {
+			case <-closed:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Scheduler.Close did not return after the wedged call unwound — barrier deadlock")
+			}
+		})
+	}
+}
+
+// stallPoint parks a tick inside one collaborator until its context is
+// cancelled (or the test releases it), and records both events so the
+// test can assert on them.
+type stallPoint struct {
+	entered chan struct{}
+	ctxDone chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newStallPoint() *stallPoint {
+	return &stallPoint{
+		entered: make(chan struct{}, 1),
+		ctxDone: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *stallPoint) block(ctx context.Context) error {
+	select {
+	case s.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		s.once.Do(func() { close(s.ctxDone) })
+		return ctx.Err()
+	}
+}
+
+type stallingCleaner struct{ stall *stallPoint }
+
+func (c *stallingCleaner) CleanUpDistributedTask(ctx context.Context, _, _ string, _ uint64) error {
+	return c.stall.block(ctx)
+}
+
+// stallingFinalizer wedges whichever finalize round-trip has a stall point
+// set; the other returns without touching the FSM.
+type stallingFinalizer struct {
+	finalized *stallPoint
+	failed    *stallPoint
+}
+
+func (f *stallingFinalizer) MarkDistributedTaskFinalized(ctx context.Context, _, _ string, _ uint64) error {
+	if f.finalized == nil {
+		return nil
+	}
+	return f.finalized.block(ctx)
+}
+
+func (f *stallingFinalizer) MarkDistributedTaskFailed(ctx context.Context, _, _ string, _ uint64, _ string) error {
+	if f.failed == nil {
+		return nil
+	}
+	return f.failed.block(ctx)
+}
+
+// stallingAckRecorder wedges whichever ack round-trip has a stall point
+// set; the other returns without touching the FSM.
+type stallingAckRecorder struct {
+	postCompletion *stallPoint
+	preparation    *stallPoint
+}
+
+func (r *stallingAckRecorder) RecordDistributedTaskPostCompletionAck(
+	ctx context.Context, _, _ string, _ uint64, _ string, _ bool, _ string,
+) error {
+	if r.postCompletion == nil {
+		return nil
+	}
+	return r.postCompletion.block(ctx)
+}
+
+func (r *stallingAckRecorder) RecordDistributedTaskPreparationCompleteAck(
+	ctx context.Context, _, _ string, _ uint64, _ string, _ bool, _ string,
+) error {
+	if r.preparation == nil {
+		return nil
+	}
+	return r.preparation.block(ctx)
+}
+
+// stallingUnitAwareProvider wedges whichever callback has a stall point
+// set; the others return immediately so the tick can reach the wedge.
+// OnGroupCompleted is never wedged here — TestScheduler_Close_WaitsForLoopExit_UnitAwareCallback
+// owns that site — so it returns immediately and lets the tick reach the
+// phases behind it.
+type stallingUnitAwareProvider struct {
+	*testTaskProvider
+	onSwapRequested *stallPoint
+	onTaskCompleted *stallPoint
+	// taskCompletedErr is what OnTaskCompleted returns once it is past its
+	// stall point — the SWAPPING-path error is what drives the scheduler on
+	// to MarkDistributedTaskFailed.
+	taskCompletedErr error
+}
+
+func (p *stallingUnitAwareProvider) OnGroupCompleted(_ context.Context, _ *Task, _ string, _ []string) error {
+	return nil
+}
+
+func (p *stallingUnitAwareProvider) OnSwapRequested(ctx context.Context, _ *Task, _ string, _ []string) error {
+	if p.onSwapRequested == nil {
+		return nil
+	}
+	return p.onSwapRequested.block(ctx)
+}
+
+func (p *stallingUnitAwareProvider) OnTaskCompleted(ctx context.Context, _ *Task) error {
+	if p.onTaskCompleted != nil {
+		if err := p.onTaskCompleted.block(ctx); err != nil {
+			return err
+		}
+	}
+	return p.taskCompletedErr
+}
+
+// tickCollaborators selects which of the scheduler's tick-path
+// collaborators a row overrides. Zero fields get pass-through defaults
+// that write straight to the shared Manager, except ack: a nil
+// AckRecorder is the scheduler's "no cluster-wide barrier" mode and some
+// rows want exactly that.
+type tickCollaborators struct {
+	provider  Provider
+	cleaner   TaskCleaner
+	finalizer TaskFinalizer
+	ack       PostCompletionAckRecorder
+}
+
+// closeStallEnv is a single-node scheduler over one in-memory Manager,
+// driven through the FSM by direct Manager calls so a row can reach any
+// tick phase without depending on tick ordering.
+type closeStallEnv struct {
+	t         *testing.T
+	clock     *clockwork.FakeClock
+	logger    logrus.FieldLogger
+	manager   *Manager
+	namespace string
+	node      string
+	ttl       time.Duration
+	scheduler *Scheduler
+}
+
+func newCloseStallEnv(t *testing.T) *closeStallEnv {
+	logger, _ := logrustest.NewNullLogger()
+	clock := clockwork.NewFakeClock()
+	ttl := 24 * time.Hour
+	return &closeStallEnv{
+		t:         t,
+		clock:     clock,
+		logger:    logger,
+		manager:   NewManager(ManagerParameters{Clock: clock, CompletedTaskTTL: ttl, Logger: logger}),
+		namespace: "tasks-namespace",
+		node:      "local-node",
+		ttl:       ttl,
+	}
+}
+
+func (e *closeStallEnv) unitAwareProvider(p stallingUnitAwareProvider) *stallingUnitAwareProvider {
+	p.testTaskProvider = newTestTaskProvider(e.t, nil)
+	return &p
+}
+
+func (e *closeStallEnv) start(c tickCollaborators) {
+	e.t.Helper()
+	if c.provider == nil {
+		c.provider = newTestTaskProvider(e.t, nil)
+	}
+	if c.cleaner == nil {
+		c.cleaner = &directCleaner{t: e.t, manager: e.manager}
+	}
+	if c.finalizer == nil {
+		c.finalizer = newDirectFinalizer(e.t, e.manager)
+	}
+	e.scheduler = NewScheduler(SchedulerParams{
+		CompletionRecorder: &fanoutRecorder{t: e.t, manager: e.manager},
+		TaskLister:         e.manager,
+		TaskCleaner:        c.cleaner,
+		TaskFinalizer:      c.finalizer,
+		AckRecorder:        c.ack,
+		Providers:          map[string]Provider{e.namespace: c.provider},
+		Clock:              e.clock,
+		Logger:             e.logger,
+		MetricsRegisterer:  monitoring.NoopRegisterer,
+		LocalNode:          e.node,
+		CompletedTaskTTL:   e.ttl,
+		TickInterval:       30 * time.Second,
+	})
+	require.NoError(e.t, e.scheduler.Start(context.Background()))
+}
+
+func (e *closeStallEnv) addTask(taskID string, barrier bool) {
+	e.t.Helper()
+	require.NoError(e.t, e.manager.AddTask(toCmd(e.t, &cmd.AddDistributedTaskRequest{
+		Namespace:               e.namespace,
+		Id:                      taskID,
+		SubmittedAtUnixMillis:   e.clock.Now().UnixMilli(),
+		UnitIds:                 []string{"u-1"},
+		NeedsPreparationBarrier: barrier,
+	}), 1))
+	// Progress claims the unit for this node; without it the unit's
+	// NodeID stays empty and LocalGroupUnitIDs orphans it, so no
+	// per-group callback ever fires locally.
+	require.NoError(e.t, e.manager.UpdateUnitProgress(toCmd(e.t, &cmd.UpdateDistributedTaskUnitProgressRequest{
+		Namespace:           e.namespace,
+		Id:                  taskID,
+		Version:             1,
+		NodeId:              e.node,
+		UnitId:              "u-1",
+		Progress:            0.1,
+		UpdatedAtUnixMillis: e.clock.Now().UnixMilli(),
+	})))
+}
+
+// addTaskWithCompletedUnit lands the task in PREPARING (barrier) or
+// SWAPPING (non-barrier).
+func (e *closeStallEnv) addTaskWithCompletedUnit(taskID string, barrier bool) {
+	e.t.Helper()
+	e.addTask(taskID, barrier)
+	require.NoError(e.t, e.manager.RecordUnitCompletion(toCmd(e.t, &cmd.RecordDistributedTaskUnitCompletionRequest{
+		Namespace:            e.namespace,
+		Id:                   taskID,
+		Version:              1,
+		NodeId:               e.node,
+		UnitId:               "u-1",
+		FinishedAtUnixMillis: e.clock.Now().UnixMilli(),
+	})))
+}
+
+// addTaskWithFailedUnit lands the task in FAILED with FinishedAt set, so
+// advancing the clock past the TTL makes it cleanable.
+func (e *closeStallEnv) addTaskWithFailedUnit(taskID string) {
+	e.t.Helper()
+	e.addTask(taskID, false)
+	require.NoError(e.t, e.manager.RecordUnitCompletion(toCmd(e.t, &cmd.RecordDistributedTaskUnitCompletionRequest{
+		Namespace:            e.namespace,
+		Id:                   taskID,
+		Version:              1,
+		NodeId:               e.node,
+		UnitId:               "u-1",
+		Error:                "unit failed",
+		FinishedAtUnixMillis: e.clock.Now().UnixMilli(),
+	})))
+}
+
+// liftPreparationBarrier records this node's prep ack straight on the
+// FSM, advancing a barrier task PREPARING → SWAPPING without needing a
+// tick to emit it.
+func (e *closeStallEnv) liftPreparationBarrier(taskID string) {
+	e.t.Helper()
+	require.NoError(e.t, e.manager.RecordPreparationCompleteAck(toCmd(e.t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
+		Namespace:         e.namespace,
+		Id:                taskID,
+		Version:           1,
+		NodeId:            e.node,
+		Success:           true,
+		AckedAtUnixMillis: e.clock.Now().UnixMilli(),
+	})))
+}
+
 type testTask struct {
 	*Task
 

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -713,25 +713,35 @@ func (h *testHarness) startScheduler(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-// TestScheduler_Close_WaitsForLoopExit pins the synchronisation
-// contract Close() owes its callers: when Close returns, no
-// background tick is still in flight. Without the loopDone barrier
-// an in-flight tick can land a RAFT apply (StartTask /
-// MarkDistributedTaskFinalized) AFTER the caller has started tearing
-// down DB / schema, racing with shutdown and producing the same
-// family of bug SchemaMutationDetector exists to catch.
+// TestScheduler_Close_WaitsForLoopExit pins the two-part contract
+// Close() owes its callers:
 //
-// Repro shape: tick()'s first step is listTasks(), which is called
-// BEFORE the tick acquires s.mu — so a tick stuck inside listTasks
-// does not block a concurrent Close() on s.mu. Inject a TaskLister
-// that blocks on a release channel. Without loopDone, Close()
-// returns while tick() is still inside listTasks.
+//  1. SYNC: when Close returns, the loop goroutine has exited and no
+//     tick is still in flight. Without this, a tick mid-RAFT-apply
+//     (provider.StartTask / MarkDistributedTaskFinalized /
+//     listTasks) lands AFTER the caller has started tearing down DB /
+//     schema — racing with shutdown and producing the same family of
+//     bug SchemaMutationDetector exists to catch.
+//
+//  2. CANCEL: an in-flight tick stuck in a RAFT round-trip (leader
+//     unavailable, partition) must NOT hold shutdown indefinitely.
+//     Close cancels the loop's ctx so a context-aware tick step
+//     (listTasks, finalizer, cleaner, ack recorder) unwinds promptly,
+//     then waits on loopDone for the actual exit.
+//
+// Repro shape: tick()'s first step is listTasks(), called BEFORE the
+// tick acquires s.mu, so a tick stuck inside listTasks does not block
+// a concurrent Close() on s.mu. The bug presented as Close returning
+// while listTasks was still in flight. Test verifies BOTH that the
+// lister observes ctx cancellation AND that Close does not return
+// before that observation lands.
 func TestScheduler_Close_WaitsForLoopExit(t *testing.T) {
 	defer leaktest.Check(t)()
 
 	lister := &blockingTaskLister{
 		entered: make(chan struct{}, 1),
 		release: make(chan struct{}),
+		ctxDone: make(chan struct{}),
 	}
 
 	h := newTestHarness(t).init(t)
@@ -766,35 +776,43 @@ func TestScheduler_Close_WaitsForLoopExit(t *testing.T) {
 		close(closed)
 	}()
 
-	// Bug shape: Close returns while listTasks (and therefore tick)
-	// is still in flight, because nothing waits for the loop goroutine
-	// to exit. With the loopDone barrier Close MUST block until
-	// listTasks releases and the loop's next select sees stopCh.
+	// CANCEL contract: the lister's ctx must be cancelled by Close so
+	// a stuck RAFT round-trip unwinds.
 	select {
-	case <-closed:
+	case <-lister.ctxDone:
+	case <-time.After(2 * time.Second):
 		close(lister.release)
-		t.Fatal("Scheduler.Close returned while a tick was mid-listTasks — caller would race with DB/schema teardown")
-	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Scheduler.Close did not cancel the in-flight tick's context within 2s — a stuck RAFT round-trip would hold shutdown indefinitely")
 	}
 
-	close(lister.release)
+	// SYNC contract: Close must not return BEFORE the lister observes
+	// cancellation. Without the loopDone barrier the bug shape is the
+	// inverse — Close returns immediately after close(stopCh), well
+	// before the cancel propagates anywhere.
 	select {
 	case <-closed:
 	case <-time.After(2 * time.Second):
-		t.Fatal("Scheduler.Close did not return after releasing the in-flight tick")
+		t.Fatal("Scheduler.Close did not return after the in-flight tick observed ctx cancellation — barrier deadlock")
 	}
+
+	// release is unused on the success path (ctx cancellation drove
+	// the lister out) but closing keeps a stalled lister from leaking
+	// if the test fails partway.
+	close(lister.release)
 }
 
 // blockingTaskLister is a minimal TaskLister whose
 // ListDistributedTasks returns immediately on the first call (so the
 // scheduler's Start-time bootstrap can complete) and then blocks every
-// subsequent call until `release` closes. Used by
-// TestScheduler_Close_WaitsForLoopExit to hold a tick mid-flight in
-// the pre-mu code path.
+// subsequent call until either `release` closes or its context is
+// cancelled. Closes `ctxDone` the moment cancellation is observed —
+// used by TestScheduler_Close_WaitsForLoopExit to verify the CANCEL
+// half of the Close contract.
 type blockingTaskLister struct {
 	calls   atomic.Int32
 	entered chan struct{}
 	release chan struct{}
+	ctxDone chan struct{}
 }
 
 func (l *blockingTaskLister) ListDistributedTasks(ctx context.Context) (map[string][]*Task, error) {
@@ -811,6 +829,7 @@ func (l *blockingTaskLister) ListDistributedTasks(ctx context.Context) (map[stri
 	select {
 	case <-l.release:
 	case <-ctx.Done():
+		close(l.ctxDone)
 	}
 	return map[string][]*Task{}, nil
 }

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -713,6 +713,108 @@ func (h *testHarness) startScheduler(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
+// TestScheduler_Close_WaitsForLoopExit pins the synchronisation
+// contract Close() owes its callers: when Close returns, no
+// background tick is still in flight. Without the loopDone barrier
+// an in-flight tick can land a RAFT apply (StartTask /
+// MarkDistributedTaskFinalized) AFTER the caller has started tearing
+// down DB / schema, racing with shutdown and producing the same
+// family of bug SchemaMutationDetector exists to catch.
+//
+// Repro shape: tick()'s first step is listTasks(), which is called
+// BEFORE the tick acquires s.mu — so a tick stuck inside listTasks
+// does not block a concurrent Close() on s.mu. Inject a TaskLister
+// that blocks on a release channel. Without loopDone, Close()
+// returns while tick() is still inside listTasks.
+func TestScheduler_Close_WaitsForLoopExit(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	lister := &blockingTaskLister{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+
+	h := newTestHarness(t).init(t)
+	h.scheduler = NewScheduler(SchedulerParams{
+		CompletionRecorder: h.completionRecorder,
+		TaskLister:         lister,
+		TaskCleaner:        h.cleaner,
+		TaskFinalizer:      newDirectFinalizer(t, h.manager),
+		Providers:          h.registeredProviders,
+		Clock:              h.clock,
+		Logger:             h.logger,
+		MetricsRegisterer:  monitoring.NoopRegisterer,
+		LocalNode:          h.localNodeID,
+		CompletedTaskTTL:   h.completedTaskTTL,
+		TickInterval:       h.schedulerTickInterval,
+	})
+	h.startScheduler(t)
+
+	// Wake the loop so a tick fires now and lands inside listTasks.
+	h.scheduler.Wake()
+
+	select {
+	case <-lister.entered:
+	case <-time.After(5 * time.Second):
+		close(lister.release)
+		t.Fatal("lister.ListDistributedTasks was not entered within 5s; harness drift")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		h.scheduler.Close()
+		close(closed)
+	}()
+
+	// Bug shape: Close returns while listTasks (and therefore tick)
+	// is still in flight, because nothing waits for the loop goroutine
+	// to exit. With the loopDone barrier Close MUST block until
+	// listTasks releases and the loop's next select sees stopCh.
+	select {
+	case <-closed:
+		close(lister.release)
+		t.Fatal("Scheduler.Close returned while a tick was mid-listTasks — caller would race with DB/schema teardown")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(lister.release)
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Scheduler.Close did not return after releasing the in-flight tick")
+	}
+}
+
+// blockingTaskLister is a minimal TaskLister whose
+// ListDistributedTasks returns immediately on the first call (so the
+// scheduler's Start-time bootstrap can complete) and then blocks every
+// subsequent call until `release` closes. Used by
+// TestScheduler_Close_WaitsForLoopExit to hold a tick mid-flight in
+// the pre-mu code path.
+type blockingTaskLister struct {
+	calls   atomic.Int32
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (l *blockingTaskLister) ListDistributedTasks(ctx context.Context) (map[string][]*Task, error) {
+	if l.calls.Add(1) == 1 {
+		// First call is the Start-time bootstrap. Let it through so
+		// the scheduler starts cleanly; the test arms the block on
+		// subsequent calls (the actual tick we want to hold).
+		return map[string][]*Task{}, nil
+	}
+	select {
+	case l.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-l.release:
+	case <-ctx.Done():
+	}
+	return map[string][]*Task{}, nil
+}
+
 func (h *testHarness) listManagerTasks(t *testing.T) map[string][]*Task {
 	tasks, err := h.manager.ListDistributedTasks(context.Background())
 	require.NoError(t, err)

--- a/cluster/distributedtask/shard_noop_provider.go
+++ b/cluster/distributedtask/shard_noop_provider.go
@@ -163,7 +163,7 @@ func (p *ShardNoopProvider) recordFinalizedGroup(desc TaskDescriptor, groupID st
 	)
 }
 
-func (p *ShardNoopProvider) OnGroupCompleted(task *Task, groupID string, localGroupUnitIDs []string) error {
+func (p *ShardNoopProvider) OnGroupCompleted(_ context.Context, task *Task, groupID string, localGroupUnitIDs []string) error {
 	p.recordFinalizedGroup(task.TaskDescriptor, groupID, localGroupUnitIDs)
 
 	// Write marker files for each finalized unit.
@@ -242,11 +242,11 @@ func (p *ShardNoopProvider) GetFinalizedGroups(desc TaskDescriptor) map[string][
 // provider is the canonical NeedsPreparationBarrier=false path (format-only
 // shape), so the scheduler never fires this for ShardNoopProvider
 // tasks. Implements the interface contract for build cleanliness.
-func (p *ShardNoopProvider) OnSwapRequested(_ *Task, _ string, _ []string) error {
+func (p *ShardNoopProvider) OnSwapRequested(_ context.Context, _ *Task, _ string, _ []string) error {
 	return nil
 }
 
-func (p *ShardNoopProvider) OnTaskCompleted(task *Task) error {
+func (p *ShardNoopProvider) OnTaskCompleted(_ context.Context, task *Task) error {
 	p.completedTasksMu.Lock()
 	defer p.completedTasksMu.Unlock()
 	p.completedTasks[task.TaskDescriptor] = true

--- a/cluster/distributedtask/shard_noop_provider_test.go
+++ b/cluster/distributedtask/shard_noop_provider_test.go
@@ -312,7 +312,7 @@ func TestShardNoopProvider_OnGroupCompleted(t *testing.T) {
 	f := newProviderFixture(t, "node1", nil)
 	task := f.newTask(nil)
 
-	f.provider.OnGroupCompleted(task, "", []string{"u-1", "u-2"})
+	f.provider.OnGroupCompleted(context.Background(), task, "", []string{"u-1", "u-2"})
 
 	finalized := f.provider.GetFinalizedUnits(task.TaskDescriptor)
 	assert.ElementsMatch(t, []string{"u-1", "u-2"}, finalized)
@@ -322,8 +322,8 @@ func TestShardNoopProvider_OnGroupCompleted_MultipleGroups(t *testing.T) {
 	f := newProviderFixture(t, "node1", nil)
 	task := f.newTask(nil)
 
-	f.provider.OnGroupCompleted(task, "groupA", []string{"u-1"})
-	f.provider.OnGroupCompleted(task, "groupB", []string{"u-2", "u-3"})
+	f.provider.OnGroupCompleted(context.Background(), task, "groupA", []string{"u-1"})
+	f.provider.OnGroupCompleted(context.Background(), task, "groupB", []string{"u-2", "u-3"})
 
 	groups := f.provider.GetFinalizedGroups(task.TaskDescriptor)
 	assert.ElementsMatch(t, []string{"u-1"}, groups["groupA"])
@@ -339,7 +339,7 @@ func TestShardNoopProvider_OnTaskCompleted(t *testing.T) {
 	task := f.newTask(nil)
 
 	assert.False(t, f.provider.IsTaskCompleted(task.TaskDescriptor))
-	f.provider.OnTaskCompleted(task)
+	f.provider.OnTaskCompleted(context.Background(), task)
 	assert.True(t, f.provider.IsTaskCompleted(task.TaskDescriptor))
 }
 

--- a/cluster/distributedtask/structural_invariants_test.go
+++ b/cluster/distributedtask/structural_invariants_test.go
@@ -148,13 +148,10 @@ func structuralInvariantClockHasWaiter(
 // (b) unrelated namespace, (c) intersection (correctly overwritten —
 // positive control).
 //
-// Supplementary to PR #11416's canonical fix
+// Supplementary to the canonical fix in this change
 // (`m.tasks = make(...)` before populating).
 // weaviate/0-weaviate-issues#245.
 func TestStructuralInvariant_ManagerRestore_ReplacesExistingState(t *testing.T) {
-	t.Skip("KNOWN-RED until PR #11416 lands — Manager.Restore merges instead of " +
-		"replaces. See test docstring + weaviate/0-weaviate-issues#245. Un-skip when " +
-		"#11416 merges and this branch rebases past it.")
 	now := time.Now().Truncate(time.Millisecond)
 
 	nullLogger, _ := logrustest.NewNullLogger()

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -128,18 +128,34 @@ type TaskHandle interface {
 }
 
 // Provider is an interface for the management and execution of a group of tasks denoted by a namespace.
+//
+// Bounded-by-construction contract: the three operational methods
+// ([GetLocalTasks], [CleanupTask], [StartTask]) are invoked inside the
+// scheduler tick under [Scheduler.mu] and MUST return in bounded time
+// — they have no ctx parameter precisely because the scheduler relies
+// on them to be quick. Implementations doing blocking I/O or RAFT
+// writes here will block tick progression and (transitively) shutdown
+// via [Scheduler.Close]. If a future implementation needs to do
+// long-running work, extend the interface to take ctx rather than
+// adding a hidden blocking call. The heavy lifecycle hooks live on
+// [UnitAwareProvider], which DOES take ctx (see its docstring).
 type Provider interface {
 	// SetCompletionRecorder is invoked on node startup to register TaskCompletionRecorder which
 	// should be passed to all launch tasks so they could mark their completion.
 	SetCompletionRecorder(recorder TaskCompletionRecorder)
 
 	// GetLocalTasks returns a list of tasks that provider is aware of from the local node state.
+	// Must be a fast local-state lookup; see interface-level contract above.
 	GetLocalTasks() []TaskDescriptor
 
 	// CleanupTask is a signal to clean up the task local state.
+	// Must complete in bounded time; see interface-level contract above.
 	CleanupTask(desc TaskDescriptor) error
 
 	// StartTask is a signal to start executing the task in the background.
+	// The synchronous work here is expected to be small (handle creation,
+	// goroutine spawn). The actual work runs asynchronously and is
+	// cancellable via [TaskHandle.Terminate]. See interface-level contract.
 	StartTask(task *Task) (TaskHandle, error)
 }
 
@@ -296,12 +312,20 @@ type UnitAwareProvider interface {
 	// localGroupUnitIDs contains ONLY units on this node; no-op for nodes
 	// without local units in the group. Non-nil errors feed
 	// RecordPreparationCompleteAck (barrier tasks) or RecordPostCompletionAck.
-	OnGroupCompleted(task *Task, groupID string, localGroupUnitIDs []string) error
+	//
+	// ctx is the scheduler's tick context (cancelled on Scheduler.Close).
+	// Implementations doing RAFT writes or heavy IO MUST honor it so a
+	// shutdown can't deadlock against a stuck callback. errors.Is(err,
+	// context.Canceled) is the contract for "shutdown happened mid-call";
+	// the scheduler drops the fired-mark on that and the post-restart
+	// tick re-fires the callback.
+	OnGroupCompleted(ctx context.Context, task *Task, groupID string, localGroupUnitIDs []string) error
 
 	// OnSwapRequested fires after the cluster-wide PREP barrier lifts
 	// (PREPARING → SWAPPING). Barrier tasks only. Non-nil errors feed
 	// RecordPostCompletionAck (failure → FAILED, schema flip skipped).
-	OnSwapRequested(task *Task, groupID string, localGroupUnitIDs []string) error
+	// Same ctx contract as [OnGroupCompleted].
+	OnSwapRequested(ctx context.Context, task *Task, groupID string, localGroupUnitIDs []string) error
 
 	// OnTaskCompleted is invoked by the [Scheduler] once per task that has
 	// reached a terminal status, after every local unit terminated and
@@ -324,7 +348,10 @@ type UnitAwareProvider interface {
 	// failure to fail the task immediately; a plain error is transient and
 	// retried up to a bounded count before failing. Errors on terminal-status
 	// invocations are best-effort and must not reopen the task (return nil).
-	OnTaskCompleted(task *Task) error
+	//
+	// Same ctx contract as [OnGroupCompleted]: implementations that do RAFT
+	// writes here (e.g. schema flips) MUST honor cancellation.
+	OnTaskCompleted(ctx context.Context, task *Task) error
 }
 
 type UnitStatus string


### PR DESCRIPTION
Two critical distributed-task defects flagged by human QA, plus the
shutdown-cancel audit that fell out of review. Both defects are live on
`stable/v1.38`, which is why this targets the release branch.

## 1. Manager.Restore merged instead of replaced

`cluster/distributedtask/manager.go` Restore populated `m.tasks`
without resetting first. Violates the hashicorp/raft FSM contract that
snapshot installation REPLACES state. A follower's locally-applied
task that isn't in the snapshot (e.g. cancelled+pruned on the leader
between local apply and snapshot install) survives as a phantom — the
next scheduler tick fires OnTaskCompleted / schema flips no other
node sees, the SchemaMutationDetector bug family.

Fix: `m.tasks = make(...)` before populating.

## 2. Scheduler.Close did not wait for the loop, and could not cancel it

`cluster/distributedtask/scheduler.go` Close closed stopCh and
acquired `s.mu`, but a tick mid-`listTasks` does not hold `s.mu`
(`listTasks` runs pre-mu). Close returned to the caller while a tick
was still inside `listTasks`; the caller proceeded to tear down DB /
schema; the tick's subsequent RAFT round-trips raced with shutdown.

Close now owes callers two things:

1. **SYNC**: `loopDone` is closed by the loop on exit and Close waits
   on it, so no tick is in flight when Close returns. Created in
   `Start()` so Close on a never-started Scheduler does not deadlock.
2. **CANCEL**: `loopCancel` fires before the wait barrier, so a tick
   stalled in a RAFT round-trip unwinds instead of holding shutdown.

The CANCEL half only means anything if the tick path actually threads
the cancellable context. Every RAFT round-trip reachable from `tick()`
now takes `s.loopCtx`:

| Call | Where |
| --- | --- |
| `listTasks` → `TaskLister.ListDistributedTasks` | `tick` |
| `taskCleaner.CleanUpDistributedTask` | `tick` |
| `UnitAwareProvider.OnGroupCompleted` (PREP) | `runPreparationPhase` |
| `ackRecorder.RecordDistributedTaskPreparationCompleteAck` | `runPreparationPhase` |
| `UnitAwareProvider.OnSwapRequested` | `runSwapPhase` |
| `UnitAwareProvider.OnGroupCompleted` (SWAP) | `runSwapPhase` |
| `ackRecorder.RecordDistributedTaskPostCompletionAck` | `runSwapPhase` |
| `UnitAwareProvider.OnTaskCompleted` | `runCompletedCallbackPhase` |
| `taskFinalizer.MarkDistributedTaskFailed` | `runCompletedCallbackPhase` |
| `taskFinalizer.MarkDistributedTaskFinalized` | `runFinalizePhase` |

Ten call sites over nine distinct collaborator methods —
`OnGroupCompleted` is reached from both the PREP and the SWAP phase.
The three `UnitAwareProvider` callbacks gained a `ctx` first parameter
for this; `ReindexProvider` now uses that ctx instead of its
`p.serverCtx`, and `runPerUnitPhase` takes ctx as its first parameter
so per-shard PREP/SWAP IO honors cancellation.

`Provider.GetLocalTasks` / `CleanupTask` / `StartTask` stay ctx-less
and are documented on the interface as bounded by construction, so a
future implementation that needs to block there extends the interface
rather than introducing a hidden tick-stall.

One related path is left alone deliberately:
`ReindexProvider.autoCleanupAfterTerminal` still derives from
`serverCtx`, but under explicit timeouts (10s drain, 60s cleanup). It
is bounded rather than indefinite, and cancelling it would abort
cleanup the code intends to finish.

**The cancel half is hardening, not a live hang.** There is exactly one
production `Scheduler.Close()` caller
(`adapters/handlers/rest/configure_api.go`), and it is preceded one line
above by `serverShutdownCancel`. The value is that `Close()`'s cancel
guarantee becomes intrinsic to the scheduler rather than incidental to
statement ordering elsewhere. Reorder those two statements, add a second
`Close()` caller, or call it from a restart-in-place path, and the
incidental cancellation is gone.

## Regression coverage

- `TestManager_Restore_ReplacesExistingState`: phantom must not
  survive Restore. Verified to fail without the fix.
- `TestStructuralInvariant_ManagerRestore_ReplacesExistingState`: this
  branch carried a `t.Skip` reading *"KNOWN-RED until PR #11416 lands"*.
  Landing the fix is its un-skip condition, so the skip is removed here.
  Verified green with `m.tasks = make(...)` and red without it
  (*"Manager.Restore must drop namespaces absent in the snapshot;
  keeping ns-orphan means the FSM merged instead of replaced"*).
- `TestScheduler_Close_WaitsForLoopExit`: Close must block while a
  tick is in mu-free `listTasks`. Verified to fail without the fix.
- `TestScheduler_Close_WaitsForLoopExit_UnitAwareCallback`: same
  contract for a stalled `OnGroupCompleted`.
- `TestScheduler_Close_CancelsEveryTickPathRoundTrip`: table-driven
  over the seven tick-path round-trips the two tests above leave open
  (cleaner, both finalize writes, both ack writes, `OnSwapRequested`,
  `OnTaskCompleted`). Each row wedges one collaborator on a stall that
  unblocks only on `ctx.Done()`, then asserts both that the wedged call
  observes cancellation and that `Close` returns.

Red-proof for the table is per-row, not per-set: reverting exactly one
site's `s.loopCtx` to `context.Background()` reddens exactly that row
and no other, for all seven rows. Every assertion is bounded at 2s, so
a regression is a clean failure rather than a suite timeout.

## Verification

`go build ./...`, `go vet ./...` clean on changed files,
`go test -race ./cluster/distributedtask/...` 139 pass / 0 fail / 0 skip
/ 0 races, `go test -race ./adapters/repos/db/` green,
`golangci-lint` 0 issues, `gofmt`/`gofumpt`/`goimports` clean,
`tools/linter_go_routines.sh` clean.
