### PR TITLE
fix: deflake TestReplicationAbort/Error and /DecodeResponse

### DIFF
--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -366,6 +366,12 @@ func TestReplicationAbort(t *testing.T) {
 	ts := fs.server(t)
 	defer ts.Close()
 	client := newReplicationClient(t, ts.Client())
+	// Abort's per-request deadline is timeoutUnit*ABORT_TIMEOUT_VALUE. With the
+	// default 20ms timeoutUnit that is only 100ms, which races a localhost
+	// round-trip and loses under parallel -race CPU load. Bump timeoutUnit so
+	// the deadline (4s) dwarfs both the round-trip and the retry budget (72ms),
+	// for every subtest below — not just ServerInternalError.
+	client.timeoutUnit = client.maxBackOff * 100
 
 	t.Run("ConnectionError", func(t *testing.T) {
 		client := newReplicationClient(t, ts.Client())
@@ -386,11 +392,7 @@ func TestReplicationAbort(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "decode response")
 	})
-	// timeoutUnit * 5 drives the per-request context deadline. Setting it to
-	// maxBackOff*100 (800ms) makes the deadline >> MaxElapsedTime (72ms), so
-	// the retry loop always exhausts retries rather than the context, even under
-	// CI scheduling pressure.
-	client.timeoutUnit = client.maxBackOff * 100
+
 	t.Run("ServerInternalError", func(t *testing.T) {
 		_, err := client.Abort(ctx, fs.host, "C1", "S1", RequestInternalError)
 		assert.NotNil(t, err)


### PR DESCRIPTION
Abort's per-request context deadline is timeoutUnit*ABORT_TIMEOUT_VALUE. ABORT_TIMEOUT_VALUE (5) is the smallest multiplier of any replication RPC, so with the test client's default 20ms timeoutUnit the deadline is only 100ms — tight enough to lose a localhost round-trip when the CPU is saturated.

The Abort subtests run in order: ConnectionError, Error, DecodeResponse, then a timeoutUnit bump, then ServerInternalError. e8b890512e ("fix flaky test timeouts") added that bump but placed it after Error and DecodeResponse, so only ServerInternalError got the larger deadline. Error and DecodeResponse stayed on 100ms.

That bump landed 89 minutes after 3621a9c3fd, which introduced TestReplicationOverwriteObjectsConcurrent — a parallel test spawning 50 goroutines doing zstd compression. Running alongside TestReplicationAbort, it starves the abort request's goroutine past 100ms, surfacing as "connect: ... context deadline exceeded". Later parallel tests (HashTreeLevel, CompareDigests, async-checkpoint) raised the baseline contention further until Error began failing too.

Move the timeoutUnit bump above all three error subtests so the deadline (4s) dwarfs both the round-trip and the retry budget (n*maxBackOff=72ms). Test-only; production uses timeoutUnit=1s.

Verified: -race -count 20 -run TestReplicationAbort passes.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
