### PR TITLE
Namespace: Cascading cleanup fixes

### DIFF
--- a/usecases/cron/gocron.go
+++ b/usecases/cron/gocron.go
@@ -68,6 +68,8 @@ func (c *Crons) Init(clusterService *cluster.Service, ttlCoordinator *objectttl.
 	cr.Start()
 	<-c.serverShutdownCtx.Done()
 	cr.Stop()
+	// Await the namespace-cleanup registration goroutine before returning.
+	c.namespaceCleanup.wait()
 
 	return nil
 }

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	gocron "github.com/netresearch/go-cron"
@@ -32,7 +31,12 @@ const namespaceCleanupJobName = "namespace_cleanup"
 // The interval is read from runtime config and hot-reloads via
 // RuntimeConfigHook.
 type cronsNamespaceCleanup struct {
-	currentInterval atomic.Int64 // time.Duration nanoseconds
+	// mu serialises RuntimeConfigHook so the read-compare-store and the
+	// channel drain+push run as one unit. Without it, concurrent callers
+	// can interleave and leave the channel holding a different interval
+	// than currentInterval.
+	mu              sync.Mutex
+	currentInterval time.Duration // guarded by mu
 	intervalCh      chan time.Duration
 
 	// registerWG lets shutdown await Init's registration goroutine instead
@@ -53,13 +57,13 @@ func newCronsNamespaceCleanup(serverShutdownCtx context.Context,
 	intervalCh <- current
 
 	c := &cronsNamespaceCleanup{
+		currentInterval:   current,
 		intervalCh:        intervalCh,
 		logger:            logger,
 		gocronLogger:      gocronLogger,
 		configGetter:      configGetter,
 		serverShutdownCtx: serverShutdownCtx,
 	}
-	c.currentInterval.Store(int64(current))
 	return c
 }
 
@@ -155,19 +159,26 @@ func (c *cronsNamespaceCleanup) createJob(jobLogger logrus.FieldLogger,
 	}))
 }
 
-// RuntimeConfigHook re-reads the interval from config; on change, pushes
-// the new value to the registration loop.
+// RuntimeConfigHook re-reads the interval from config and, on change,
+// pushes the new value to the registration loop. The whole read-compare-
+// store-and-push runs under mu so concurrent callers can't interleave and
+// leave the channel holding a different interval than currentInterval.
 func (c *cronsNamespaceCleanup) RuntimeConfigHook() error {
-	newInterval := int64(c.configGetter().Namespaces.CleanupInterval.Get())
-	old := c.currentInterval.Load()
-	if old == newInterval || !c.currentInterval.CompareAndSwap(old, newInterval) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	newInterval := c.configGetter().Namespaces.CleanupInterval.Get()
+	if newInterval == c.currentInterval {
 		return nil
 	}
+	c.currentInterval = newInterval
 
+	// Drain the stale value (if any) before pushing. The buffer is size 1,
+	// so the send stays non-blocking while we hold the lock.
 	select {
 	case <-c.intervalCh:
 	default:
 	}
-	c.intervalCh <- time.Duration(newInterval)
+	c.intervalCh <- newInterval
 	return nil
 }

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -35,6 +35,10 @@ type cronsNamespaceCleanup struct {
 	currentInterval atomic.Int64 // time.Duration nanoseconds
 	intervalCh      chan time.Duration
 
+	// registerWG lets shutdown await Init's registration goroutine instead
+	// of returning while it still runs.
+	registerWG sync.WaitGroup
+
 	logger            logrus.FieldLogger
 	gocronLogger      gocron.Logger
 	configGetter      configGetter
@@ -72,7 +76,9 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 	if coordinator == nil {
 		return fmt.Errorf("namespace cleanup coordinator is nil")
 	}
+	c.registerWG.Add(1)
 	errors.GoWrapper(func() {
+		defer c.registerWG.Done()
 		jobLogger := c.logger.WithField("job", namespaceCleanupJobName)
 		// runMu serialises the cron callback with the re-registration
 		// loop: the callback holds it for one tick, the loop Lock/Unlocks
@@ -119,6 +125,12 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 	}, c.logger)
 
 	return nil
+}
+
+// wait blocks until Init's registration goroutine has exited. Returns at
+// once when Init never launched one (namespaces disabled, nil coordinator).
+func (c *cronsNamespaceCleanup) wait() {
+	c.registerWG.Wait()
 }
 
 // createJob returns the per-tick callback. SkipIfStillRunning prevents

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -13,6 +13,7 @@ package cron
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -214,5 +215,48 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
 	case got := <-c.intervalCh:
 		t.Fatalf("hook pushed on unchanged value: %s", got)
 	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestCronsNamespaceCleanup_RuntimeConfigHook_ConcurrentCallsConsistent is a
+// regression test for the read-compare-store-push race: concurrent hook
+// callers must not leave intervalCh holding a different interval than
+// currentInterval. Many goroutines flip the config and call the hook at
+// once; afterwards the buffered channel value must equal currentInterval.
+// Run with -race to also catch the underlying data race directly.
+func TestCronsNamespaceCleanup_RuntimeConfigHook_ConcurrentCallsConsistent(t *testing.T) {
+	dv := configRuntime.NewDynamicValue(time.Minute)
+	getter := func() config.Config {
+		return config.Config{Namespaces: config.Namespaces{Enabled: true, CleanupInterval: dv}}
+	}
+	logger, _ := test.NewNullLogger()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	<-c.intervalCh // drain the constructor's initial value
+
+	const n = 64
+	var wg sync.WaitGroup
+	for i := 1; i <= n; i++ {
+		wg.Add(1)
+		go func(d time.Duration) {
+			defer wg.Done()
+			_ = dv.SetValue(d)
+			_ = c.RuntimeConfigHook()
+		}(time.Duration(i) * time.Second)
+	}
+	wg.Wait()
+
+	// Each change path stores currentInterval and pushes the same value under
+	// mu, so once the goroutines settle the channel must agree with
+	// currentInterval — the invariant the mutex restores.
+	c.mu.Lock()
+	current := c.currentInterval
+	c.mu.Unlock()
+	select {
+	case got := <-c.intervalCh:
+		assert.Equal(t, current, got, "channel interval diverged from currentInterval")
+	case <-time.After(time.Second):
+		t.Fatal("channel empty after concurrent hooks")
 	}
 }

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -130,6 +130,60 @@ func TestCronsNamespaceCleanup_Init_SkipsForNonPositiveInterval(t *testing.T) {
 	}
 }
 
+func TestCronsNamespaceCleanup_Wait_AwaitsRegistrationGoroutine(t *testing.T) {
+	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
+	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+
+	// While the shutdown ctx is live the registration goroutine is parked in
+	// its select, so wait() must block.
+	done := make(chan struct{})
+	go func() {
+		c.wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("wait() returned while the registration goroutine was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Shutdown unblocks the goroutine's select; wait() must then return.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait() did not return after shutdown")
+	}
+}
+
+func TestCronsNamespaceCleanup_Wait_ReturnsWhenNoGoroutineLaunched(t *testing.T) {
+	// Namespaces disabled: Init returns without launching the goroutine, so
+	// registerWG was never incremented and wait() must not block.
+	logger, _ := test.NewNullLogger()
+	getter := func() config.Config {
+		return config.Config{Namespaces: config.Namespaces{
+			Enabled:         false,
+			CleanupInterval: configRuntime.NewDynamicValue(time.Minute),
+		}}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	cr := initGoCron(ctx, gocron.DiscardLogger)
+	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+
+	done := make(chan struct{})
+	go func() {
+		c.wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("wait() blocked even though no registration goroutine was launched")
+	}
+}
+
 func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
 	// Drive the hook directly: set up a configGetter whose returned value
 	// can change between Hook calls, and assert the new value reaches

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -110,7 +110,9 @@ func NewCoordinator(
 
 // Tick cleans up every namespace currently in the deleting state. A
 // per-namespace error is logged and the loop moves on; a not-leader
-// error stops the tick so the new leader can take over.
+// error stops the tick so the new leader can take over. A cancelled ctx
+// (server shutdown) stops the tick cleanly between namespaces and mid
+// cleanup; the next tick resumes the rest.
 //
 // Returns an error if another Tick is already running.
 func (c *Coordinator) Tick(ctx context.Context) error {
@@ -123,8 +125,11 @@ func (c *Coordinator) Tick(ctx context.Context) error {
 		return nil
 	}
 	for _, ns := range c.namespaces.ListDeleting() {
+		if ctx.Err() != nil {
+			return nil
+		}
 		if err := c.cleanupSingleNamespace(ctx, ns); err != nil {
-			if errors.Is(err, types.ErrNotLeader) {
+			if errors.Is(err, types.ErrNotLeader) || ctx.Err() != nil {
 				return nil
 			}
 			c.logger.WithField("namespace", ns).Error(err)
@@ -136,10 +141,14 @@ func (c *Coordinator) Tick(ctx context.Context) error {
 // cleanupSingleNamespace deletes the users, aliases, and classes (in this order) that
 // belong to ns, then removes the namespace entry. If the entry is not
 // empty when RemoveNamespaceEntity reaches the apply path, the error is
-// ignored and the next tick retries.
+// ignored and the next tick retries. ctx is re-checked before every RAFT
+// write so a long cleanup stops on shutdown.
 func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) error {
 	if !c.isLeader() {
 		return types.ErrNotLeader
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if err := c.raft.DeleteUsersInNamespace(ctx, ns); err != nil {
 		return err
@@ -147,6 +156,9 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 	for _, alias := range c.schema.AliasesInNamespace(ns) {
 		if !c.isLeader() {
 			return types.ErrNotLeader
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if _, err := c.raft.DeleteAlias(ctx, alias); err != nil {
 			return err
@@ -160,12 +172,18 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 		if !c.isLeader() {
 			return types.ErrNotLeader
 		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if _, err := c.raft.DeleteClass(ctx, cls); err != nil {
 			return err
 		}
 	}
 	if !c.isLeader() {
 		return types.ErrNotLeader
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if _, err := c.raft.RemoveNamespaceEntity(ctx, ns); err != nil {
 		// Apply re-checks emptiness against authoritative state; the

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -62,6 +62,16 @@ type stubRaft struct {
 	deleteClassErr   map[string]error
 	removeEntityErr  map[string]error
 	removeEntityCall map[string]int
+
+	// onCall fires at the start of every RAFT method with the op name; tests
+	// use it to cancel the tick context mid-flight.
+	onCall func(op string)
+}
+
+func (s *stubRaft) fireOnCall(op string) {
+	if s.onCall != nil {
+		s.onCall(op)
+	}
 }
 
 func newStubRaft() *stubRaft {
@@ -75,21 +85,25 @@ func newStubRaft() *stubRaft {
 }
 
 func (s *stubRaft) DeleteUsersInNamespace(_ context.Context, name string) error {
+	s.fireOnCall("users")
 	s.calls = append(s.calls, recordedCall{op: "users", arg: name, from: name})
 	return s.deleteUsersErr[name]
 }
 
 func (s *stubRaft) DeleteAlias(_ context.Context, alias string) (uint64, error) {
+	s.fireOnCall("alias")
 	s.calls = append(s.calls, recordedCall{op: "alias", arg: alias})
 	return 0, s.deleteAliasErr[alias]
 }
 
 func (s *stubRaft) DeleteClass(_ context.Context, name string) (uint64, error) {
+	s.fireOnCall("class")
 	s.calls = append(s.calls, recordedCall{op: "class", arg: name})
 	return 0, s.deleteClassErr[name]
 }
 
 func (s *stubRaft) RemoveNamespaceEntity(_ context.Context, name string) (uint64, error) {
+	s.fireOnCall("entity")
 	s.calls = append(s.calls, recordedCall{op: "entity", arg: name, from: name})
 	s.removeEntityCall[name]++
 	return 0, s.removeEntityErr[name]
@@ -364,6 +378,98 @@ func TestCoordinator_Tick_RejectsConcurrentRun(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already ongoing")
 	assert.Empty(t, raft.calls, "Tick must not enter cleanup while another run is ongoing")
+}
+
+// TestCoordinator_Tick_StopsOnContextCancellation pins that a cancelled tick
+// context halts the tick: when already cancelled, between namespaces, and
+// partway through one namespace's class deletions.
+func TestCoordinator_Tick_StopsOnContextCancellation(t *testing.T) {
+	t.Run("already-cancelled ctx does no work", func(t *testing.T) {
+		raft := newStubRaft()
+		ns := stubNamespaces{deleting: []string{"alpha", "beta"}}
+		c := newTestCoordinator(t, ns, stubSchema{}, raft, alwaysLeader)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.NoError(t, c.Tick(ctx))
+		assert.Empty(t, raft.calls, "no namespace may be touched once ctx is cancelled")
+	})
+
+	t.Run("cancellation between namespaces stops the loop", func(t *testing.T) {
+		raft := newStubRaft()
+		ns := stubNamespaces{deleting: []string{"alpha", "beta"}}
+		ctx, cancel := context.WithCancel(context.Background())
+		// Cancel on alpha's first call; the loop guard must then skip beta.
+		raft.onCall = func(string) { cancel() }
+		c := newTestCoordinator(t, ns, stubSchema{}, raft, alwaysLeader)
+		require.NoError(t, c.Tick(ctx))
+
+		require.NotEmpty(t, raft.calls)
+		for _, call := range raft.calls {
+			assert.NotEqual(t, "beta", call.arg, "beta must be untouched after cancellation")
+			assert.NotEqual(t, "beta", call.from, "beta must be untouched after cancellation")
+		}
+		assert.Equal(t, 0, raft.removeEntityCall["beta"])
+	})
+
+	t.Run("cancellation mid-namespace stops before remaining classes", func(t *testing.T) {
+		raft := newStubRaft()
+		ns := stubNamespaces{deleting: []string{"alpha"}}
+		schema := stubSchema{classes: map[string][]string{"alpha": {"alpha:Foo", "alpha:Bar", "alpha:Baz"}}}
+		ctx, cancel := context.WithCancel(context.Background())
+		var cancelled bool
+		raft.onCall = func(op string) {
+			if op == "class" && !cancelled {
+				cancelled = true
+				cancel()
+			}
+		}
+		c := newTestCoordinator(t, ns, schema, raft, alwaysLeader)
+		require.NoError(t, c.Tick(ctx))
+
+		// users + the in-flight class only; the inner guard aborts before
+		// the rest and before RemoveNamespaceEntity.
+		assert.Equal(t, []string{"users", "class"}, opsOf(raft.calls))
+		assert.Equal(t, 0, raft.removeEntityCall["alpha"],
+			"entity removal must not run when the tick was cancelled mid-cleanup")
+	})
+
+	t.Run("cancellation before the user delete issues no writes", func(t *testing.T) {
+		// Cancel on the cleanupSingleNamespace entry isLeader call (#2), just
+		// before the user delete; the pre-write guard must abort cleanly.
+		raft := newStubRaft()
+		ns := stubNamespaces{deleting: []string{"alpha"}}
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		isLeader := func() bool {
+			calls++
+			if calls == 2 {
+				cancel()
+			}
+			return true
+		}
+		c := newTestCoordinator(t, ns, stubSchema{}, raft, isLeader)
+		require.NoError(t, c.Tick(ctx))
+		assert.Empty(t, raft.calls, "no RAFT write may run once ctx is cancelled before the user delete")
+	})
+
+	t.Run("cancellation after the user delete stops before entity removal", func(t *testing.T) {
+		// No aliases or classes, so the only guard after the user delete is
+		// the one before RemoveNamespaceEntity.
+		raft := newStubRaft()
+		ns := stubNamespaces{deleting: []string{"alpha"}}
+		ctx, cancel := context.WithCancel(context.Background())
+		raft.onCall = func(op string) {
+			if op == "users" {
+				cancel()
+			}
+		}
+		c := newTestCoordinator(t, ns, stubSchema{}, raft, alwaysLeader)
+		require.NoError(t, c.Tick(ctx))
+
+		assert.Equal(t, []string{"users"}, opsOf(raft.calls))
+		assert.Equal(t, 0, raft.removeEntityCall["alpha"],
+			"entity removal must not run when ctx is cancelled before it")
+	})
 }
 
 func opsOf(calls []recordedCall) []string {


### PR DESCRIPTION
### What's being changed:

This PR fixes 3 separate bugs in 3 commits:
1. On cleanup, check teh context cancellation before each long-running command (==RAFT)
2. Await goroutine on shutdown so we dont return while the cleanup is still running
3. Make RuntimeConfigHook atomic. This should not be possible to trigger, but better be safe than sorry

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
