### PR TITLE
Require OIDC subject claim for user identity

### DIFF
--- a/usecases/auth/authentication/oidc/middleware.go
+++ b/usecases/auth/authentication/oidc/middleware.go
@@ -50,6 +50,8 @@ type Client struct {
 	rbac rbacconf.Config
 }
 
+const oidcSubjectClaim = "sub"
+
 // New OIDC Client: It tries to retrieve the JWKs at startup (or fails), it
 // provides a middleware which can be used at runtime with a go-swagger style
 // API.
@@ -130,8 +132,11 @@ func (c *Client) validateConfig() error {
 		msgs = append(msgs, "missing required field 'issuer'")
 	}
 
-	if c.Config.UsernameClaim.Get() == "" {
+	usernameClaim := c.Config.UsernameClaim.Get()
+	if usernameClaim == "" {
 		msgs = append(msgs, "missing required field 'username_claim'")
+	} else if usernameClaim != oidcSubjectClaim {
+		msgs = append(msgs, "username_claim must be 'sub' to use the stable OIDC subject as the authorization identity")
 	}
 
 	if !c.Config.SkipClientIDCheck.Get() && c.Config.ClientID.Get() == "" {

--- a/usecases/auth/authentication/oidc/middleware_test.go
+++ b/usecases/auth/authentication/oidc/middleware_test.go
@@ -66,6 +66,28 @@ func Test_Middleware_IncompleteConfiguration(t *testing.T) {
 	assert.ErrorAs(t, err, &expectedErr)
 }
 
+func Test_Middleware_RejectsNonSubjectUsernameClaim(t *testing.T) {
+	server := newOIDCServer(t)
+	defer server.Close()
+
+	cfg := config.Config{
+		Authentication: config.Authentication{
+			OIDC: config.OIDC{
+				Enabled:           true,
+				Issuer:            runtime.NewDynamicValue(server.URL),
+				ClientID:          runtime.NewDynamicValue("best_client"),
+				SkipClientIDCheck: runtime.NewDynamicValue(false),
+				UsernameClaim:     runtime.NewDynamicValue("email"),
+			},
+		},
+	}
+
+	logger, _ := logrustest.NewNullLogger()
+	_, err := New(cfg, nil, false, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "username_claim must be 'sub'")
+}
+
 type claims struct {
 	jwt.StandardClaims
 	Email         string   `json:"email"`
@@ -100,7 +122,7 @@ func Test_Middleware_WithValidToken(t *testing.T) {
 		assert.Equal(t, "best-user", principal.Username)
 	})
 
-	t.Run("with a non-standard username claim", func(t *testing.T) {
+	t.Run("with same email claim but different subjects", func(t *testing.T) {
 		server := newOIDCServer(t)
 		defer server.Close()
 
@@ -111,20 +133,24 @@ func Test_Middleware_WithValidToken(t *testing.T) {
 					Issuer:            runtime.NewDynamicValue(server.URL),
 					ClientID:          runtime.NewDynamicValue("best_client"),
 					SkipClientIDCheck: runtime.NewDynamicValue(false),
-					UsernameClaim:     runtime.NewDynamicValue("email"),
+					UsernameClaim:     runtime.NewDynamicValue("sub"),
 					GroupsClaim:       runtime.NewDynamicValue("groups"),
 				},
 			},
 		}
 
-		token := tokenWithEmail(t, "best-user", server.URL, "best_client", "foo@bar.com")
+		tokenA := tokenWithEmail(t, "best-user-a", server.URL, "best_client", "foo@bar.com")
+		tokenB := tokenWithEmail(t, "best-user-b", server.URL, "best_client", "foo@bar.com")
 		logger, _ := logrustest.NewNullLogger()
 		client, err := New(cfg, nil, false, logger)
 		require.Nil(t, err)
 
-		principal, err := client.ValidateAndExtract(token, []string{})
+		principalA, err := client.ValidateAndExtract(tokenA, []string{})
 		require.Nil(t, err)
-		assert.Equal(t, "foo@bar.com", principal.Username)
+		principalB, err := client.ValidateAndExtract(tokenB, []string{})
+		require.Nil(t, err)
+		assert.Equal(t, "best-user-a", principalA.Username)
+		assert.Equal(t, "best-user-b", principalB.Username)
 	})
 
 	t.Run("with groups claim", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- require OIDC `username_claim` to be `sub` so RBAC identities use the stable OIDC subject
- reject non-subject username claims such as `email` during OIDC startup validation
- update OIDC middleware tests to cover duplicate email claims with distinct subjects

Fixes #11424

## Testing
- `docker run --rm -v /tmp/weaviate-main-api.qVcBSa:/workspace -v /tmp/weaviate-go-cache:/go/pkg/mod -v /tmp/weaviate-go-build-cache:/root/.cache/go-build -w /workspace golang:1.26-alpine go test ./usecases/auth/authentication/oidc -count=1 -v`