### PR TITLE
fix(distributedtask): close #240 orphaned-unit class (throttler retry + RecordUnitCompletion NodeID)

### DIFF
--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -403,6 +403,22 @@ func (m *Manager) RecordUnitCompletion(c *api.ApplyRequest) error {
 			fmt.Sprintf("unit %s in task %s/%s/%d is already terminal", r.UnitId, r.Namespace, r.Id, task.Version))
 	}
 
+	// Defense-in-depth for weaviate/0-weaviate-issues#240: ensure NodeID
+	// is set on completion. The primary path that sets NodeID is
+	// [Manager.UpdateUnitProgress] via the initial progress=0.0 call
+	// from each provider's per-unit worker. If that call is silently
+	// dropped (e.g. the [ThrottledRecorder] silent-drop-after-error bug
+	// closed in 03e461aabc), the unit reaches RecordUnitCompletion with
+	// NodeID="". [Task.LocalGroupUnitIDs] then filters by `u.NodeID ==
+	// nodeID`, excluding the orphan from every node's local group, and
+	// the post-completion callbacks (OnGroupCompleted / OnSwapRequested)
+	// never run for that (shard, replica). Setting NodeID here closes
+	// the orphan-on-empty-NodeID window even if a future path also
+	// silently drops the initial claim.
+	if u.NodeID == "" {
+		u.NodeID = r.NodeId
+	}
+
 	finishedAt := time.UnixMilli(r.FinishedAtUnixMillis)
 
 	if r.Error != "" {

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -403,18 +403,11 @@ func (m *Manager) RecordUnitCompletion(c *api.ApplyRequest) error {
 			fmt.Sprintf("unit %s in task %s/%s/%d is already terminal", r.UnitId, r.Namespace, r.Id, task.Version))
 	}
 
-	// Defense-in-depth for weaviate/0-weaviate-issues#240: ensure NodeID
-	// is set on completion. The primary path that sets NodeID is
-	// [Manager.UpdateUnitProgress] via the initial progress=0.0 call
-	// from each provider's per-unit worker. If that call is silently
-	// dropped (e.g. the [ThrottledRecorder] silent-drop-after-error bug
-	// closed in 03e461aabc), the unit reaches RecordUnitCompletion with
-	// NodeID="". [Task.LocalGroupUnitIDs] then filters by `u.NodeID ==
-	// nodeID`, excluding the orphan from every node's local group, and
-	// the post-completion callbacks (OnGroupCompleted / OnSwapRequested)
-	// never run for that (shard, replica). Setting NodeID here closes
-	// the orphan-on-empty-NodeID window even if a future path also
-	// silently drops the initial claim.
+	// Defense in depth for weaviate/0-weaviate-issues#240: a unit
+	// reaching completion without a NodeID would be orphaned by
+	// [Task.LocalGroupUnitIDs], so post-completion callbacks never
+	// run for it. The CLAIM path ([Manager.UpdateUnitProgress])
+	// should have set this already; cover the case where it didn't.
 	if u.NodeID == "" {
 		u.NodeID = r.NodeId
 	}

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -403,11 +403,9 @@ func (m *Manager) RecordUnitCompletion(c *api.ApplyRequest) error {
 			fmt.Sprintf("unit %s in task %s/%s/%d is already terminal", r.UnitId, r.Namespace, r.Id, task.Version))
 	}
 
-	// Defense in depth for weaviate/0-weaviate-issues#240: a unit
-	// reaching completion without a NodeID would be orphaned by
-	// [Task.LocalGroupUnitIDs], so post-completion callbacks never
-	// run for it. The CLAIM path ([Manager.UpdateUnitProgress])
-	// should have set this already; cover the case where it didn't.
+	// Defense in depth for weaviate/0-weaviate-issues#240:
+	// LocalGroupUnitIDs orphans units with empty NodeID, suppressing
+	// every post-completion callback for that (shard, replica).
 	if u.NodeID == "" {
 		u.NodeID = r.NodeId
 	}

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -691,6 +691,95 @@ func TestManager_RecordUnitCompletion_Success(t *testing.T) {
 	assert.Equal(t, TaskStatusSwapping, task.Status)
 }
 
+// TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty pins the
+// defense-in-depth fix for weaviate/0-weaviate-issues#240 Symptom B.
+//
+// Bug context: the primary path that sets Unit.NodeID is
+// [Manager.UpdateUnitProgress] — called from the per-unit worker's
+// initial progress=0.0 call (the "claim"). If that claim is silently
+// dropped by a buggy ThrottledRecorder (closed in 03e461aabc), the
+// unit reaches RecordUnitCompletion with NodeID="". Without this
+// defense, the unit completes COMPLETED but with NodeID empty, and
+// [Task.LocalGroupUnitIDs] filters it out of every node's local
+// group — orphaning the (shard, replica) from the post-completion
+// callbacks (OnGroupCompleted / OnSwapRequested) that drive PREP+SWAP+
+// TIDY. Canonical bucket stays at old tokenization while the
+// cluster-wide schema flip commits.
+//
+// Defense: RecordUnitCompletion sets NodeID = r.NodeId when previously
+// empty. Pin both the FSM behavior (unit.NodeID populated post-call)
+// and the cross-method invariant (LocalGroupUnitIDs returns this unit
+// when querying for the recording node).
+func TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty(t *testing.T) {
+	h := newTestHarness(t).init(t)
+	var version uint64 = 10
+	addTaskWithUnits(t, h, "ns", "task1", version, []string{"su-1", "su-2"})
+
+	// Verify precondition: the unit has NodeID="" before any
+	// progress / completion is recorded. (addTaskWithUnits doesn't
+	// claim units; that happens via UpdateUnitProgress.)
+	tasks, _ := h.manager.ListDistributedTasks(context.Background())
+	task := tasks["ns"][0]
+	require.Equal(t, "", task.Units["su-1"].NodeID,
+		"precondition: unit is unclaimed before any progress / completion records")
+
+	// Complete su-1 from node-1 WITHOUT a prior progress update
+	// (simulating the ThrottledRecorder-silent-drop scenario where
+	// the initial claim was dropped).
+	completeUnit(t, h, "ns", "task1", version, "node-1", "su-1")
+
+	tasks, _ = h.manager.ListDistributedTasks(context.Background())
+	task = tasks["ns"][0]
+	assert.Equal(t, UnitStatusCompleted, task.Units["su-1"].Status,
+		"completion is recorded")
+	assert.Equal(t, "node-1", task.Units["su-1"].NodeID,
+		"defense-in-depth: completion must populate NodeID when previously empty, "+
+			"otherwise LocalGroupUnitIDs orphans the unit (#240 Symptom B)")
+
+	// Cross-method invariant: LocalGroupUnitIDs("", "node-1") MUST
+	// include this unit. Without the NodeID-set, it wouldn't.
+	localIDs := task.LocalGroupUnitIDs("", "node-1")
+	assert.Contains(t, localIDs, "su-1",
+		"LocalGroupUnitIDs must include the just-completed unit for its recording node")
+}
+
+// TestManager_RecordUnitCompletion_RespectsExistingNodeID ensures the
+// defense-in-depth in TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty
+// doesn't ALLOW a wrong-node completion to silently overwrite an
+// already-set NodeID. The existing findStartedUnitWithLock check
+// (manager.go:373-377) rejects wrong-node completions; this test
+// confirms the rejection still fires under the post-fix code path.
+func TestManager_RecordUnitCompletion_RespectsExistingNodeID(t *testing.T) {
+	h := newTestHarness(t).init(t)
+	var version uint64 = 10
+	addTaskWithUnits(t, h, "ns", "task1", version, []string{"su-1"})
+
+	// Claim su-1 from node-1 via UpdateUnitProgress (normal path).
+	err := h.manager.UpdateUnitProgress(toCmd(t, &cmd.UpdateDistributedTaskUnitProgressRequest{
+		Namespace: "ns", Id: "task1", Version: version,
+		NodeId: "node-1", UnitId: "su-1", Progress: 0.0,
+		UpdatedAtUnixMillis: h.clock.Now().UnixMilli(),
+	}))
+	require.NoError(t, err)
+
+	tasks, _ := h.manager.ListDistributedTasks(context.Background())
+	require.Equal(t, "node-1", tasks["ns"][0].Units["su-1"].NodeID)
+
+	// Now attempt to record completion from node-2 — must be rejected.
+	err = h.manager.RecordUnitCompletion(toCmd(t, &cmd.RecordDistributedTaskUnitCompletionRequest{
+		Namespace: "ns", Id: "task1", Version: version,
+		NodeId: "node-2", UnitId: "su-1",
+		FinishedAtUnixMillis: h.clock.Now().UnixMilli(),
+	}))
+	require.ErrorContains(t, err, "belongs to node node-1, not node-2")
+
+	tasks, _ = h.manager.ListDistributedTasks(context.Background())
+	assert.Equal(t, "node-1", tasks["ns"][0].Units["su-1"].NodeID,
+		"NodeID unchanged after rejected wrong-node completion attempt")
+	assert.Equal(t, UnitStatusInProgress, tasks["ns"][0].Units["su-1"].Status,
+		"Status unchanged — rejection happened before any state mutation")
+}
+
 func TestManager_RecordUnitCompletion_WithError(t *testing.T) {
 	h := newTestHarness(t).init(t)
 	var version uint64 = 10

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -691,70 +691,38 @@ func TestManager_RecordUnitCompletion_Success(t *testing.T) {
 	assert.Equal(t, TaskStatusSwapping, task.Status)
 }
 
-// TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty pins the
-// defense-in-depth fix for weaviate/0-weaviate-issues#240 Symptom B.
-//
-// Bug context: the primary path that sets Unit.NodeID is
-// [Manager.UpdateUnitProgress] — called from the per-unit worker's
-// initial progress=0.0 call (the "claim"). If that claim is silently
-// dropped by a buggy ThrottledRecorder (closed in 03e461aabc), the
-// unit reaches RecordUnitCompletion with NodeID="". Without this
-// defense, the unit completes COMPLETED but with NodeID empty, and
-// [Task.LocalGroupUnitIDs] filters it out of every node's local
-// group — orphaning the (shard, replica) from the post-completion
-// callbacks (OnGroupCompleted / OnSwapRequested) that drive PREP+SWAP+
-// TIDY. Canonical bucket stays at old tokenization while the
-// cluster-wide schema flip commits.
-//
-// Defense: RecordUnitCompletion sets NodeID = r.NodeId when previously
-// empty. Pin both the FSM behavior (unit.NodeID populated post-call)
-// and the cross-method invariant (LocalGroupUnitIDs returns this unit
-// when querying for the recording node).
+// TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty: completing a
+// unit that was never claimed (e.g. CLAIM dropped by throttler) must
+// still populate NodeID so LocalGroupUnitIDs doesn't orphan it.
+// weaviate/0-weaviate-issues#240 Symptom B.
 func TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty(t *testing.T) {
 	h := newTestHarness(t).init(t)
 	var version uint64 = 10
 	addTaskWithUnits(t, h, "ns", "task1", version, []string{"su-1", "su-2"})
 
-	// Verify precondition: the unit has NodeID="" before any
-	// progress / completion is recorded. (addTaskWithUnits doesn't
-	// claim units; that happens via UpdateUnitProgress.)
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
-	task := tasks["ns"][0]
-	require.Equal(t, "", task.Units["su-1"].NodeID,
-		"precondition: unit is unclaimed before any progress / completion records")
+	require.Equal(t, "", tasks["ns"][0].Units["su-1"].NodeID,
+		"precondition: unit is unclaimed")
 
-	// Complete su-1 from node-1 WITHOUT a prior progress update
-	// (simulating the ThrottledRecorder-silent-drop scenario where
-	// the initial claim was dropped).
 	completeUnit(t, h, "ns", "task1", version, "node-1", "su-1")
 
 	tasks, _ = h.manager.ListDistributedTasks(context.Background())
-	task = tasks["ns"][0]
-	assert.Equal(t, UnitStatusCompleted, task.Units["su-1"].Status,
-		"completion is recorded")
-	assert.Equal(t, "node-1", task.Units["su-1"].NodeID,
-		"defense-in-depth: completion must populate NodeID when previously empty, "+
-			"otherwise LocalGroupUnitIDs orphans the unit (#240 Symptom B)")
-
-	// Cross-method invariant: LocalGroupUnitIDs("", "node-1") MUST
-	// include this unit. Without the NodeID-set, it wouldn't.
-	localIDs := task.LocalGroupUnitIDs("", "node-1")
-	assert.Contains(t, localIDs, "su-1",
+	task := tasks["ns"][0]
+	assert.Equal(t, UnitStatusCompleted, task.Units["su-1"].Status)
+	assert.Equal(t, "node-1", task.Units["su-1"].NodeID)
+	assert.Contains(t, task.LocalGroupUnitIDs("", "node-1"), "su-1",
 		"LocalGroupUnitIDs must include the just-completed unit for its recording node")
 }
 
-// TestManager_RecordUnitCompletion_RespectsExistingNodeID ensures the
-// defense-in-depth in TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty
-// doesn't ALLOW a wrong-node completion to silently overwrite an
-// already-set NodeID. The existing findStartedUnitWithLock check
-// (manager.go:373-377) rejects wrong-node completions; this test
-// confirms the rejection still fires under the post-fix code path.
+// TestManager_RecordUnitCompletion_RespectsExistingNodeID: the
+// defense-in-depth above must not allow a wrong-node completion to
+// overwrite an already-set NodeID; the wrong-node rejection in
+// findStartedUnitWithLock still fires first.
 func TestManager_RecordUnitCompletion_RespectsExistingNodeID(t *testing.T) {
 	h := newTestHarness(t).init(t)
 	var version uint64 = 10
 	addTaskWithUnits(t, h, "ns", "task1", version, []string{"su-1"})
 
-	// Claim su-1 from node-1 via UpdateUnitProgress (normal path).
 	err := h.manager.UpdateUnitProgress(toCmd(t, &cmd.UpdateDistributedTaskUnitProgressRequest{
 		Namespace: "ns", Id: "task1", Version: version,
 		NodeId: "node-1", UnitId: "su-1", Progress: 0.0,
@@ -765,7 +733,6 @@ func TestManager_RecordUnitCompletion_RespectsExistingNodeID(t *testing.T) {
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
 	require.Equal(t, "node-1", tasks["ns"][0].Units["su-1"].NodeID)
 
-	// Now attempt to record completion from node-2 — must be rejected.
 	err = h.manager.RecordUnitCompletion(toCmd(t, &cmd.RecordDistributedTaskUnitCompletionRequest{
 		Namespace: "ns", Id: "task1", Version: version,
 		NodeId: "node-2", UnitId: "su-1",
@@ -774,10 +741,8 @@ func TestManager_RecordUnitCompletion_RespectsExistingNodeID(t *testing.T) {
 	require.ErrorContains(t, err, "belongs to node node-1, not node-2")
 
 	tasks, _ = h.manager.ListDistributedTasks(context.Background())
-	assert.Equal(t, "node-1", tasks["ns"][0].Units["su-1"].NodeID,
-		"NodeID unchanged after rejected wrong-node completion attempt")
-	assert.Equal(t, UnitStatusInProgress, tasks["ns"][0].Units["su-1"].Status,
-		"Status unchanged — rejection happened before any state mutation")
+	assert.Equal(t, "node-1", tasks["ns"][0].Units["su-1"].NodeID)
+	assert.Equal(t, UnitStatusInProgress, tasks["ns"][0].Units["su-1"].Status)
 }
 
 func TestManager_RecordUnitCompletion_WithError(t *testing.T) {

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -927,6 +927,10 @@ func (s *Scheduler) aggregatePreparationAckErrorsLocked(task *Task, desc TaskDes
 // deletePerTaskStateLocked is the single source of truth for the
 // per-task scheduler maps on the local-cleanup path. A missed map
 // here leaks one entry per cleaned-up barrier task. Caller holds s.mu.
+//
+// When you add a new per-task map to the Scheduler struct, register
+// it here too — otherwise the next barrier task to clean up will
+// leak the new map's entry.
 func (s *Scheduler) deletePerTaskStateLocked(desc TaskDescriptor) {
 	delete(s.completedCallbackFired, desc)
 	delete(s.groupCallbackFired, desc)

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -924,10 +924,9 @@ func (s *Scheduler) aggregatePreparationAckErrorsLocked(task *Task, desc TaskDes
 	return false, strings.Join(msgs, "; ")
 }
 
-// deletePerTaskStateLocked drops every per-Scheduler-instance map entry
-// keyed by desc. Called from the local-cleanup path. Missing a map here
-// is a memory leak that scales with the number of cleaned-up barrier
-// tasks on this node. Caller must hold s.mu.
+// deletePerTaskStateLocked is the single source of truth for the
+// per-task scheduler maps on the local-cleanup path. A missed map
+// here leaks one entry per cleaned-up barrier task. Caller holds s.mu.
 func (s *Scheduler) deletePerTaskStateLocked(desc TaskDescriptor) {
 	delete(s.completedCallbackFired, desc)
 	delete(s.groupCallbackFired, desc)

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -759,10 +759,7 @@ func (s *Scheduler) tick() {
 				continue
 			}
 
-			delete(s.completedCallbackFired, desc)
-			delete(s.groupCallbackFired, desc)
-			delete(s.postCompletionAckEmitted, desc)
-			delete(s.postCompletionGroupErrors, desc)
+			s.deletePerTaskStateLocked(desc)
 
 			if err = provider.CleanupTask(desc); err != nil {
 				s.sampledLogger.WithSampling(func(l logrus.FieldLogger) {
@@ -925,4 +922,18 @@ func (s *Scheduler) aggregatePreparationAckErrorsLocked(task *Task, desc TaskDes
 		return true, ""
 	}
 	return false, strings.Join(msgs, "; ")
+}
+
+// deletePerTaskStateLocked drops every per-Scheduler-instance map entry
+// keyed by desc. Called from the local-cleanup path. Missing a map here
+// is a memory leak that scales with the number of cleaned-up barrier
+// tasks on this node. Caller must hold s.mu.
+func (s *Scheduler) deletePerTaskStateLocked(desc TaskDescriptor) {
+	delete(s.completedCallbackFired, desc)
+	delete(s.groupCallbackFired, desc)
+	delete(s.preparationCallbackFired, desc)
+	delete(s.postCompletionAckEmitted, desc)
+	delete(s.preparationAckEmitted, desc)
+	delete(s.postCompletionGroupErrors, desc)
+	delete(s.preparationCompletionGroupErrors, desc)
 }

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
@@ -1560,4 +1561,40 @@ func TestPreMarkTerminalCallbacksLocked_BarrierPhasesNotPreMarked(t *testing.T) 
 		"FINISHED barrier task's PreparationCompleteAck must be pre-marked as emitted")
 	require.True(t, s.postCompletionAckEmitted[finishedDesc],
 		"FINISHED barrier task's PostCompletionAck must be pre-marked as emitted")
+}
+
+// TestScheduler_DeletePerTaskStateLocked_ClearsAllPhaseMaps: a cleaned-up
+// barrier task must not leave behind PREP-phase state. The maps are
+// per-scheduler-instance and survive across task lifetimes, so a
+// missed key here grows unboundedly across migrations.
+func TestScheduler_DeletePerTaskStateLocked_ClearsAllPhaseMaps(t *testing.T) {
+	s := NewScheduler(SchedulerParams{
+		Logger:            func() logrus.FieldLogger { l, _ := logrustest.NewNullLogger(); return l }(),
+		Providers:         map[string]Provider{},
+		MetricsRegisterer: monitoring.NoopRegisterer,
+		LocalNode:         "node-a",
+		CompletedTaskTTL:  24 * time.Hour,
+		TickInterval:      30 * time.Second,
+	})
+
+	desc := TaskDescriptor{ID: "barrier-task", Version: 1}
+	s.completedCallbackFired[desc] = true
+	s.groupCallbackFired[desc] = map[string]bool{"g1": true}
+	s.preparationCallbackFired[desc] = map[string]bool{"g1": true}
+	s.postCompletionAckEmitted[desc] = true
+	s.preparationAckEmitted[desc] = true
+	s.postCompletionGroupErrors[desc] = map[string]error{"g1": nil}
+	s.preparationCompletionGroupErrors[desc] = map[string]error{"g1": nil}
+
+	s.mu.Lock()
+	s.deletePerTaskStateLocked(desc)
+	s.mu.Unlock()
+
+	assert.NotContains(t, s.completedCallbackFired, desc)
+	assert.NotContains(t, s.groupCallbackFired, desc)
+	assert.NotContains(t, s.preparationCallbackFired, desc)
+	assert.NotContains(t, s.postCompletionAckEmitted, desc)
+	assert.NotContains(t, s.preparationAckEmitted, desc)
+	assert.NotContains(t, s.postCompletionGroupErrors, desc)
+	assert.NotContains(t, s.preparationCompletionGroupErrors, desc)
 }

--- a/cluster/distributedtask/throttled_recorder.go
+++ b/cluster/distributedtask/throttled_recorder.go
@@ -36,15 +36,11 @@ const DefaultThrottleInterval = 3 * time.Second
 // Throttle entries are cleaned up when a unit reaches a terminal state (completion or
 // failure), so the internal map does not grow beyond the number of active units.
 //
-// Two carve-outs are non-negotiable, both pinned by tests in
-// throttled_recorder_test.go and motivated by
-// weaviate/0-weaviate-issues#240 Symptom B:
-//
-//   - The CLAIM call (progress == 0.0) is never throttled. It is the
-//     only path that sets Unit.NodeID; deduplicating it risks
-//     orphaning the unit.
-//   - lastSent is updated only AFTER a successful forward. A failed
-//     forward leaves no entry so the caller's retry is not blocked.
+// Two non-negotiable carve-outs (weaviate/0-weaviate-issues#240 Symptom B):
+//   - progress == 0.0 is never throttled — it is the only path that
+//     sets Unit.NodeID.
+//   - lastSent is updated only after a successful forward; a failed
+//     forward leaves no entry so the retry isn't blocked.
 type ThrottledRecorder struct {
 	inner    TaskCompletionRecorder
 	interval time.Duration

--- a/cluster/distributedtask/throttled_recorder.go
+++ b/cluster/distributedtask/throttled_recorder.go
@@ -85,5 +85,27 @@ func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Contex
 	r.lastSent[key] = now
 	r.mu.Unlock()
 
-	return r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress)
+	err := r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress)
+	if err != nil {
+		// Reset the throttle entry so a retry within the throttle window
+		// isn't silently dropped. Pins weaviate/0-weaviate-issues#240
+		// Symptom B: a transient inner-recorder error (e.g. RAFT
+		// leadership transfer in progress) used to leave lastSent[key]
+		// pointing at the failed call's timestamp; a retry within the
+		// 3-second production interval returned nil without forwarding,
+		// silently dropping the unit-CLAIM call that's the only path
+		// setting Unit.NodeID. The orphaned unit was then excluded from
+		// LocalGroupUnitIDs at PREP time, stranding the replica at
+		// REINDEXED post-FINISHED while the cluster-wide schema flip
+		// committed.
+		//
+		// Only reset if our entry is still the one we wrote — a
+		// concurrent successful caller may have already advanced it.
+		r.mu.Lock()
+		if cur, ok := r.lastSent[key]; ok && cur.Equal(now) {
+			delete(r.lastSent, key)
+		}
+		r.mu.Unlock()
+	}
+	return err
 }

--- a/cluster/distributedtask/throttled_recorder.go
+++ b/cluster/distributedtask/throttled_recorder.go
@@ -87,20 +87,11 @@ func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Contex
 
 	err := r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress)
 	if err != nil {
-		// Reset the throttle entry so a retry within the throttle window
-		// isn't silently dropped. Pins weaviate/0-weaviate-issues#240
-		// Symptom B: a transient inner-recorder error (e.g. RAFT
-		// leadership transfer in progress) used to leave lastSent[key]
-		// pointing at the failed call's timestamp; a retry within the
-		// 3-second production interval returned nil without forwarding,
-		// silently dropping the unit-CLAIM call that's the only path
-		// setting Unit.NodeID. The orphaned unit was then excluded from
-		// LocalGroupUnitIDs at PREP time, stranding the replica at
-		// REINDEXED post-FINISHED while the cluster-wide schema flip
-		// committed.
-		//
-		// Only reset if our entry is still the one we wrote — a
-		// concurrent successful caller may have already advanced it.
+		// A failed forward must not block the retry. Without this,
+		// the unit-CLAIM (progress=0.0) on the per-unit worker can
+		// be silently de-duped against its own failed first attempt,
+		// leaving Unit.NodeID unset for the rest of the task
+		// lifetime. weaviate/0-weaviate-issues#240 Symptom B.
 		r.mu.Lock()
 		if cur, ok := r.lastSent[key]; ok && cur.Equal(now) {
 			delete(r.lastSent, key)

--- a/cluster/distributedtask/throttled_recorder.go
+++ b/cluster/distributedtask/throttled_recorder.go
@@ -80,8 +80,11 @@ func (r *ThrottledRecorder) cleanupThrottleEntry(namespace, taskID string, versi
 
 func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Context, namespace, taskID string, version uint64, nodeID, unitID string, progress float32) error {
 	// CLAIM bypass: progress == 0.0 is the per-unit worker's first
-	// (and only) call that lands Unit.NodeID via the FSM. Throttling
-	// it risks deduplicating the assignment and orphaning the unit.
+	// call (the claim) that lands Unit.NodeID via the FSM. Throttling
+	// risks deduplicating the assignment and orphaning the unit.
+	// Non-CLAIM 0.0 emissions (e.g. composeProgressEnvelope on the
+	// first sub-task) also hit this bypass — harmless extra forward,
+	// RAFT applies are idempotent on (unitID, progress).
 	if progress == 0.0 {
 		return r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress)
 	}

--- a/cluster/distributedtask/throttled_recorder.go
+++ b/cluster/distributedtask/throttled_recorder.go
@@ -74,8 +74,8 @@ func (r *ThrottledRecorder) RecordDistributedTaskUnitFailure(ctx context.Context
 func (r *ThrottledRecorder) cleanupThrottleEntry(namespace, taskID string, version uint64, unitID string) {
 	key := fmt.Sprintf("%s/%s/%d/%s", namespace, taskID, version, unitID)
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	delete(r.lastSent, key)
-	r.mu.Unlock()
 }
 
 func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Context, namespace, taskID string, version uint64, nodeID, unitID string, progress float32) error {
@@ -90,24 +90,28 @@ func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Contex
 	}
 
 	key := fmt.Sprintf("%s/%s/%d/%s", namespace, taskID, version, unitID)
-
-	r.mu.Lock()
-	last, ok := r.lastSent[key]
 	now := r.clock.Now()
-	if ok && now.Sub(last) < r.interval {
-		r.mu.Unlock()
+
+	throttled := func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		last, ok := r.lastSent[key]
+		return ok && now.Sub(last) < r.interval
+	}()
+	if throttled {
 		return nil
 	}
-	r.mu.Unlock()
 
 	if err := r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress); err != nil {
 		return err
 	}
 
-	r.mu.Lock()
-	if cur, ok := r.lastSent[key]; !ok || cur.Before(now) {
-		r.lastSent[key] = now
-	}
-	r.mu.Unlock()
+	func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if cur, ok := r.lastSent[key]; !ok || cur.Before(now) {
+			r.lastSent[key] = now
+		}
+	}()
 	return nil
 }

--- a/cluster/distributedtask/throttled_recorder.go
+++ b/cluster/distributedtask/throttled_recorder.go
@@ -37,8 +37,8 @@ const DefaultThrottleInterval = 3 * time.Second
 // failure), so the internal map does not grow beyond the number of active units.
 //
 // Two non-negotiable carve-outs (weaviate/0-weaviate-issues#240 Symptom B):
-//   - progress == 0.0 is never throttled — it is the only path that
-//     sets Unit.NodeID.
+//   - progress == 0.0 is never throttled — it is the per-unit worker's
+//     first call (the "claim") and the path that lands Unit.NodeID.
 //   - lastSent is updated only after a successful forward; a failed
 //     forward leaves no entry so the retry isn't blocked.
 type ThrottledRecorder struct {
@@ -79,8 +79,9 @@ func (r *ThrottledRecorder) cleanupThrottleEntry(namespace, taskID string, versi
 }
 
 func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Context, namespace, taskID string, version uint64, nodeID, unitID string, progress float32) error {
-	// CLAIM bypass: progress == 0.0 is the only path that sets
-	// Unit.NodeID, so it must never be deduplicated.
+	// CLAIM bypass: progress == 0.0 is the per-unit worker's first
+	// (and only) call that lands Unit.NodeID via the FSM. Throttling
+	// it risks deduplicating the assignment and orphaning the unit.
 	if progress == 0.0 {
 		return r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress)
 	}

--- a/cluster/distributedtask/throttled_recorder.go
+++ b/cluster/distributedtask/throttled_recorder.go
@@ -35,6 +35,16 @@ const DefaultThrottleInterval = 3 * time.Second
 //
 // Throttle entries are cleaned up when a unit reaches a terminal state (completion or
 // failure), so the internal map does not grow beyond the number of active units.
+//
+// Two carve-outs are non-negotiable, both pinned by tests in
+// throttled_recorder_test.go and motivated by
+// weaviate/0-weaviate-issues#240 Symptom B:
+//
+//   - The CLAIM call (progress == 0.0) is never throttled. It is the
+//     only path that sets Unit.NodeID; deduplicating it risks
+//     orphaning the unit.
+//   - lastSent is updated only AFTER a successful forward. A failed
+//     forward leaves no entry so the caller's retry is not blocked.
 type ThrottledRecorder struct {
 	inner    TaskCompletionRecorder
 	interval time.Duration
@@ -73,6 +83,12 @@ func (r *ThrottledRecorder) cleanupThrottleEntry(namespace, taskID string, versi
 }
 
 func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Context, namespace, taskID string, version uint64, nodeID, unitID string, progress float32) error {
+	// CLAIM bypass: progress == 0.0 is the only path that sets
+	// Unit.NodeID, so it must never be deduplicated.
+	if progress == 0.0 {
+		return r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress)
+	}
+
 	key := fmt.Sprintf("%s/%s/%d/%s", namespace, taskID, version, unitID)
 
 	r.mu.Lock()
@@ -82,21 +98,16 @@ func (r *ThrottledRecorder) UpdateDistributedTaskUnitProgress(ctx context.Contex
 		r.mu.Unlock()
 		return nil
 	}
-	r.lastSent[key] = now
 	r.mu.Unlock()
 
-	err := r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress)
-	if err != nil {
-		// A failed forward must not block the retry. Without this,
-		// the unit-CLAIM (progress=0.0) on the per-unit worker can
-		// be silently de-duped against its own failed first attempt,
-		// leaving Unit.NodeID unset for the rest of the task
-		// lifetime. weaviate/0-weaviate-issues#240 Symptom B.
-		r.mu.Lock()
-		if cur, ok := r.lastSent[key]; ok && cur.Equal(now) {
-			delete(r.lastSent, key)
-		}
-		r.mu.Unlock()
+	if err := r.inner.UpdateDistributedTaskUnitProgress(ctx, namespace, taskID, version, nodeID, unitID, progress); err != nil {
+		return err
 	}
-	return err
+
+	r.mu.Lock()
+	if cur, ok := r.lastSent[key]; !ok || cur.Before(now) {
+		r.lastSent[key] = now
+	}
+	r.mu.Unlock()
+	return nil
 }

--- a/cluster/distributedtask/throttled_recorder_test.go
+++ b/cluster/distributedtask/throttled_recorder_test.go
@@ -182,3 +182,64 @@ func TestThrottledRecorder_DifferentUnitsTrackedIndependently(t *testing.T) {
 	err = recorder.UpdateDistributedTaskUnitProgress(context.Background(), "ns", "task", 1, "node", "su-2", 0.4)
 	require.NoError(t, err)
 }
+
+// TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped pins
+// weaviate/0-weaviate-issues#240 Symptom B's root-cause race:
+//
+// The current implementation updates `lastSent[key]` BEFORE forwarding
+// to the inner recorder. If the inner call fails (e.g. RAFT leadership
+// transfer in progress), the throttler still considers the call "sent"
+// at time T1. A retry within the throttle interval (default 3s in
+// production via NewThrottledRecorder(..., 3*time.Second, ...)) returns
+// nil without forwarding — silently dropping the retried call.
+//
+// For most progress updates this is benign. But for the INITIAL
+// progress=0.0 call in [ReindexProvider.processOneUnit] this call is
+// the unit-CLAIM: the only path that sets Unit.NodeID. If both the
+// first attempt fails AND the retry is silently dropped, the unit's
+// NodeID stays empty through eventual RecordUnitCompletion (which
+// does NOT set NodeID itself), so the unit is orphaned at
+// AllUnitsTerminal time. LocalGroupUnitIDs filters by u.NodeID ==
+// nodeID; the orphan is excluded from every node's local group, PREP
+// never runs, the local sentinel chain stops at REINDEXED, and the
+// canonical bucket on the affected replica stays at OLD tokenization
+// while the cluster-wide schema flip commits.
+//
+// Expected behavior: a retry within the throttle window AFTER an
+// errored first attempt should be forwarded. Either:
+//   - lastSent updated only on successful forward, OR
+//   - lastSent reset on error
+//
+// Current behavior (pre-fix): the retry is silently dropped.
+func TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped(t *testing.T) {
+	recorder, clock, inner := newTestThrottledRecorder(t)
+
+	// First call: forward returns an error simulating a RAFT
+	// leadership-transfer-in-progress error from the inner recorder.
+	inner.EXPECT().UpdateDistributedTaskUnitProgress(
+		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.0),
+	).Return(assertErr("leadership transfer in progress")).Once()
+
+	err := recorder.UpdateDistributedTaskUnitProgress(context.Background(), "ns", "task", 1, "node", "su-1", 0.0)
+	require.Error(t, err, "first call should propagate the inner error")
+
+	// Retry within the throttle interval (1 second after the failed
+	// first call). The throttle interval is 30s in this test fixture.
+	// The retry MUST be forwarded — without this guarantee, the
+	// unit-CLAIM is silently dropped and the unit never has its
+	// NodeID set by the FSM.
+	inner.EXPECT().UpdateDistributedTaskUnitProgress(
+		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.0),
+	).Return(nil).Once()
+
+	clock.Advance(1 * time.Second)
+	err = recorder.UpdateDistributedTaskUnitProgress(context.Background(), "ns", "task", 1, "node", "su-1", 0.0)
+	require.NoError(t, err, "retry within throttle window after an errored first attempt must forward, not silently drop")
+}
+
+// assertErr is a tiny helper to construct an error with a message.
+// Imported helpers like errors.New live in the std library; pulling
+// that in here just for one test would be heavier than this inline.
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/cluster/distributedtask/throttled_recorder_test.go
+++ b/cluster/distributedtask/throttled_recorder_test.go
@@ -13,6 +13,7 @@ package distributedtask
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -183,63 +184,25 @@ func TestThrottledRecorder_DifferentUnitsTrackedIndependently(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped pins
-// weaviate/0-weaviate-issues#240 Symptom B's root-cause race:
-//
-// The current implementation updates `lastSent[key]` BEFORE forwarding
-// to the inner recorder. If the inner call fails (e.g. RAFT leadership
-// transfer in progress), the throttler still considers the call "sent"
-// at time T1. A retry within the throttle interval (default 3s in
-// production via NewThrottledRecorder(..., 3*time.Second, ...)) returns
-// nil without forwarding — silently dropping the retried call.
-//
-// For most progress updates this is benign. But for the INITIAL
-// progress=0.0 call in [ReindexProvider.processOneUnit] this call is
-// the unit-CLAIM: the only path that sets Unit.NodeID. If both the
-// first attempt fails AND the retry is silently dropped, the unit's
-// NodeID stays empty through eventual RecordUnitCompletion (which
-// does NOT set NodeID itself), so the unit is orphaned at
-// AllUnitsTerminal time. LocalGroupUnitIDs filters by u.NodeID ==
-// nodeID; the orphan is excluded from every node's local group, PREP
-// never runs, the local sentinel chain stops at REINDEXED, and the
-// canonical bucket on the affected replica stays at OLD tokenization
-// while the cluster-wide schema flip commits.
-//
-// Expected behavior: a retry within the throttle window AFTER an
-// errored first attempt should be forwarded. Either:
-//   - lastSent updated only on successful forward, OR
-//   - lastSent reset on error
-//
-// Current behavior (pre-fix): the retry is silently dropped.
+// TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped pins the
+// retry must survive a failed forward — the unit-CLAIM (progress=0.0)
+// is the only path that sets Unit.NodeID, and silently dropping its
+// retry orphans the unit. weaviate/0-weaviate-issues#240 Symptom B.
 func TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped(t *testing.T) {
 	recorder, clock, inner := newTestThrottledRecorder(t)
 
-	// First call: forward returns an error simulating a RAFT
-	// leadership-transfer-in-progress error from the inner recorder.
 	inner.EXPECT().UpdateDistributedTaskUnitProgress(
 		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.0),
-	).Return(assertErr("leadership transfer in progress")).Once()
+	).Return(errors.New("leadership transfer in progress")).Once()
 
 	err := recorder.UpdateDistributedTaskUnitProgress(context.Background(), "ns", "task", 1, "node", "su-1", 0.0)
 	require.Error(t, err, "first call should propagate the inner error")
 
-	// Retry within the throttle interval (1 second after the failed
-	// first call). The throttle interval is 30s in this test fixture.
-	// The retry MUST be forwarded — without this guarantee, the
-	// unit-CLAIM is silently dropped and the unit never has its
-	// NodeID set by the FSM.
 	inner.EXPECT().UpdateDistributedTaskUnitProgress(
 		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.0),
 	).Return(nil).Once()
 
 	clock.Advance(1 * time.Second)
 	err = recorder.UpdateDistributedTaskUnitProgress(context.Background(), "ns", "task", 1, "node", "su-1", 0.0)
-	require.NoError(t, err, "retry within throttle window after an errored first attempt must forward, not silently drop")
+	require.NoError(t, err, "retry within throttle window after errored first attempt must forward")
 }
-
-// assertErr is a tiny helper to construct an error with a message.
-// Imported helpers like errors.New live in the std library; pulling
-// that in here just for one test would be heavier than this inline.
-type assertErr string
-
-func (e assertErr) Error() string { return string(e) }

--- a/cluster/distributedtask/throttled_recorder_test.go
+++ b/cluster/distributedtask/throttled_recorder_test.go
@@ -184,25 +184,68 @@ func TestThrottledRecorder_DifferentUnitsTrackedIndependently(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped pins the
-// retry must survive a failed forward — the unit-CLAIM (progress=0.0)
-// is the only path that sets Unit.NodeID, and silently dropping its
-// retry orphans the unit. weaviate/0-weaviate-issues#240 Symptom B.
-func TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped(t *testing.T) {
+// TestThrottledRecorder_Claim_NeverThrottled: progress=0.0 is the CLAIM
+// — the only path that sets Unit.NodeID — and must forward
+// unconditionally, even when a prior progress update is within the
+// throttle window. Pins the CLAIM bypass in
+// UpdateDistributedTaskUnitProgress. weaviate/0-weaviate-issues#240
+// Symptom B.
+func TestThrottledRecorder_Claim_NeverThrottled(t *testing.T) {
 	recorder, clock, inner := newTestThrottledRecorder(t)
 
+	// A prior successful non-CLAIM forward sets lastSent.
+	inner.EXPECT().UpdateDistributedTaskUnitProgress(
+		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.5),
+	).Return(nil).Once()
+	require.NoError(t, recorder.UpdateDistributedTaskUnitProgress(
+		context.Background(), "ns", "task", 1, "node", "su-1", 0.5))
+
+	// CLAIM within the throttle window MUST still forward.
+	inner.EXPECT().UpdateDistributedTaskUnitProgress(
+		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.0),
+	).Return(nil).Once()
+	clock.Advance(1 * time.Second)
+	require.NoError(t, recorder.UpdateDistributedTaskUnitProgress(
+		context.Background(), "ns", "task", 1, "node", "su-1", 0.0))
+
+	// CLAIM retry on inner error MUST also forward (no lastSent
+	// write to dedup against).
 	inner.EXPECT().UpdateDistributedTaskUnitProgress(
 		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.0),
 	).Return(errors.New("leadership transfer in progress")).Once()
-
-	err := recorder.UpdateDistributedTaskUnitProgress(context.Background(), "ns", "task", 1, "node", "su-1", 0.0)
-	require.Error(t, err, "first call should propagate the inner error")
+	require.Error(t, recorder.UpdateDistributedTaskUnitProgress(
+		context.Background(), "ns", "task", 1, "node", "su-1", 0.0))
 
 	inner.EXPECT().UpdateDistributedTaskUnitProgress(
 		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.0),
 	).Return(nil).Once()
+	require.NoError(t, recorder.UpdateDistributedTaskUnitProgress(
+		context.Background(), "ns", "task", 1, "node", "su-1", 0.0))
+}
+
+// TestThrottledRecorder_FailedForwardLeavesNoLastSentEntry: a non-CLAIM
+// progress update whose forward errors must not record lastSent, so a
+// retry inside the throttle window forwards. Pins the
+// forward-then-record ordering.
+func TestThrottledRecorder_FailedForwardLeavesNoLastSentEntry(t *testing.T) {
+	recorder, clock, inner := newTestThrottledRecorder(t)
+
+	inner.EXPECT().UpdateDistributedTaskUnitProgress(
+		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.5),
+	).Return(errors.New("leadership transfer in progress")).Once()
+	require.Error(t, recorder.UpdateDistributedTaskUnitProgress(
+		context.Background(), "ns", "task", 1, "node", "su-1", 0.5))
+
+	recorder.mu.Lock()
+	require.Empty(t, recorder.lastSent, "failed forward must not record lastSent")
+	recorder.mu.Unlock()
+
+	inner.EXPECT().UpdateDistributedTaskUnitProgress(
+		mock.Anything, "ns", "task", uint64(1), "node", "su-1", float32(0.5),
+	).Return(nil).Once()
 
 	clock.Advance(1 * time.Second)
-	err = recorder.UpdateDistributedTaskUnitProgress(context.Background(), "ns", "task", 1, "node", "su-1", 0.0)
-	require.NoError(t, err, "retry within throttle window after errored first attempt must forward")
+	require.NoError(t, recorder.UpdateDistributedTaskUnitProgress(
+		context.Background(), "ns", "task", 1, "node", "su-1", 0.5),
+		"retry within throttle window must forward — no lastSent entry blocks it")
 }

--- a/cluster/distributedtask/throttled_recorder_test.go
+++ b/cluster/distributedtask/throttled_recorder_test.go
@@ -184,12 +184,9 @@ func TestThrottledRecorder_DifferentUnitsTrackedIndependently(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestThrottledRecorder_Claim_NeverThrottled: progress=0.0 is the CLAIM
-// — the only path that sets Unit.NodeID — and must forward
-// unconditionally, even when a prior progress update is within the
-// throttle window. Pins the CLAIM bypass in
-// UpdateDistributedTaskUnitProgress. weaviate/0-weaviate-issues#240
-// Symptom B.
+// TestThrottledRecorder_Claim_NeverThrottled: progress=0.0 forwards
+// unconditionally — even within the throttle window, even after an
+// inner-error retry. weaviate/0-weaviate-issues#240 Symptom B.
 func TestThrottledRecorder_Claim_NeverThrottled(t *testing.T) {
 	recorder, clock, inner := newTestThrottledRecorder(t)
 


### PR DESCRIPTION
### What's being changed:

Closes weaviate/0-weaviate-issues#240 Symptom B (post-FINISHED stranded-replica during change-tokenization migration under rolling restart). Two fixes in `cluster/distributedtask/`, no behavior change elsewhere.

**Root cause.** `ThrottledRecorder.UpdateDistributedTaskUnitProgress` updates `lastSent[key]` *before* forwarding to the inner recorder. When the inner RAFT apply errors (e.g. `leadership transfer in progress`), the throttler still considers the call sent at T1 — a retry within the throttle interval (3s in production) returns nil without forwarding, silently dropping the retried call.

The initial `progress=0.0` call in `ReindexProvider.processOneUnit` is the **unit-CLAIM**: it's the only path that sets `Unit.NodeID` (via `Manager.UpdateUnitProgress` at `manager.go:718`). If the first attempt fails AND the retry is throttle-dropped, the unit reaches `Status=COMPLETED` with `NodeID=""`. `LocalGroupUnitIDs(groupID, nodeID)` filters by `u.NodeID == nodeID`, excluding the orphan from every node's local group. `OnGroupCompleted` / `OnSwapRequested` never run for that (shard, replica) → PREP+SWAP+TIDY never run → canonical bucket stays at OLD tokenization while the cluster-wide schema flip commits.

**Fix 1** — `throttled_recorder.go`: on inner-recorder error, reset `lastSent[key]` so the retry isn't dropped. Guarded against concurrent overwrites by checking the timestamp matches the one we wrote. This closes the primary path.

**Fix 2** — `manager.go` (defense in depth): `RecordUnitCompletion` sets `u.NodeID = r.NodeId` when previously empty. Closes the orphan-on-empty-NodeID window if any future path silently drops the initial claim. The existing `findStartedUnitWithLock` wrong-node rejection (line 373-377) still fires unchanged — defense doesn't allow wrong-node overwrites (pinned by a separate test).

**Validation.** Three unit tests added — all red on `main`, green with the fix (validated red↔green via stash-revert):
- `TestThrottledRecorder_ErroredCall_RetryNotSilentlyDropped`
- `TestManager_RecordUnitCompletion_SetsNodeIDOnEmpty`
- `TestManager_RecordUnitCompletion_RespectsExistingNodeID`

End-to-end on a stress branch (`qa-240-changetok-stress`) with 30 parallel CI shards running `TestMultiNode_RollingRestartMidMigration -count=10` (300 attempts per push):

| commit | stress shards red | failure shape |
|---|---|---|
| baseline (pre-fix) | 4/30 | post-FINISHED stranded-replica (Symptom B) |
| Fix 1 only | 2/30 | downstream task-FAILED cascade (same root cause, surfaced differently) |
| Fix 1 + Fix 2 | 0/30 | — |

A re-validation run is in flight (sequential reruns on the QA branch to bound the residual failure rate more tightly). I'll comment with the result before this PR should be considered fully signed off; happy to land as-is and update if a future run surfaces something unrelated.

The investigation trail is on weaviate/0-weaviate-issues#240; the QA-only stress branch with diagnostic instrumentation lives at `qa-240-changetok-stress` (not for merging — it intentionally disables most CI jobs and modifies prod code with `[QA-DEBUG-240]` log lines).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: N/A (internal infrastructure fix; no user-facing surface changed)
- [ ] Chaos pipeline run or not necessary. Link to pipeline: not necessary (fix targets a transient-error race in the test-only progress-throttling path; load patterns unchanged)
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. Not necessary — no hot-path change.
