### PR TITLE
gh-11401 reject negative replicationFactor in schema validation

### DIFF
--- a/usecases/replica/config.go
+++ b/usecases/replica/config.go
@@ -22,6 +22,22 @@ type nodeCounter interface {
 	NodeCount() int
 }
 
+// validateReplicationFactor rejects semantically invalid (negative) values
+// up front. Previously both ValidateConfig and ValidateConfigUpdate fell
+// through to a silent-normalize branch that coerced any Factor < 1 to
+// MinimumFactor, making misconfiguration invisible (HTTP 200 with a stored
+// value different from the requested one). See issue #11401.
+//
+// Factor == 0 is intentionally accepted here because callers downstream
+// treat it as "use the configured default" (it is the JSON zero value when
+// a client omits the field).
+func validateReplicationFactor(factor int64) error {
+	if factor < 0 {
+		return fmt.Errorf("invalid replication factor: must be >= 1, got %d", factor)
+	}
+	return nil
+}
+
 func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) error {
 	if class.ReplicationConfig == nil {
 		class.ReplicationConfig = &models.ReplicationConfig{
@@ -31,13 +47,8 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 		return nil
 	}
 
-	// A negative replication factor is semantically invalid. Previously this
-	// path silently normalized any Factor < 1 to MinimumFactor, which made
-	// misconfiguration invisible (HTTP 200 with a stored value different
-	// from the requested one). See issue #11401.
-	if class.ReplicationConfig.Factor < 0 {
-		return fmt.Errorf("invalid replication factor: must be >= 1, got %d",
-			class.ReplicationConfig.Factor)
+	if err := validateReplicationFactor(class.ReplicationConfig.Factor); err != nil {
+		return err
 	}
 
 	if class.ReplicationConfig.Factor > 0 && class.ReplicationConfig.Factor < int64(globalCfg.MinimumFactor) {
@@ -75,13 +86,8 @@ func ValidateConfigUpdate(old, updated *models.Class, nodeCounter nodeCounter) e
 		updated.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
 	}
 
-	// Reject negative replication factors explicitly. Previously this path
-	// fell through to the scale check, where a negative factor would never
-	// trigger the node-count comparison and the bad value would be stored
-	// silently. See issue #11401 (same root cause as ValidateConfig).
-	if updated.ReplicationConfig.Factor < 0 {
-		return fmt.Errorf("invalid replication factor: must be >= 1, got %d",
-			updated.ReplicationConfig.Factor)
+	if err := validateReplicationFactor(updated.ReplicationConfig.Factor); err != nil {
+		return err
 	}
 
 	if old.ReplicationConfig.Factor != updated.ReplicationConfig.Factor {

--- a/usecases/replica/config.go
+++ b/usecases/replica/config.go
@@ -31,6 +31,15 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 		return nil
 	}
 
+	// A negative replication factor is semantically invalid. Previously this
+	// path silently normalized any Factor < 1 to MinimumFactor, which made
+	// misconfiguration invisible (HTTP 200 with a stored value different
+	// from the requested one). See issue #11401.
+	if class.ReplicationConfig.Factor < 0 {
+		return fmt.Errorf("invalid replication factor: must be >= 1, got %d",
+			class.ReplicationConfig.Factor)
+	}
+
 	if class.ReplicationConfig.Factor > 0 && class.ReplicationConfig.Factor < int64(globalCfg.MinimumFactor) {
 		return fmt.Errorf("invalid replication factor: setup requires a minimum replication factor of %d: got %d",
 			globalCfg.MinimumFactor, class.ReplicationConfig.Factor)
@@ -41,6 +50,9 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 			globalCfg.MaximumFactor, class.ReplicationConfig.Factor)
 	}
 
+	// Factor == 0 means "use the configured default". This is preserved for
+	// clients that send an empty ReplicationConfig object (the JSON zero
+	// value is 0).
 	if class.ReplicationConfig.Factor < 1 {
 		class.ReplicationConfig.Factor = int64(globalCfg.MinimumFactor)
 	}
@@ -61,6 +73,15 @@ func ValidateConfigUpdate(old, updated *models.Class, nodeCounter nodeCounter) e
 
 	if updated.ReplicationConfig == nil {
 		updated.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
+	}
+
+	// Reject negative replication factors explicitly. Previously this path
+	// fell through to the scale check, where a negative factor would never
+	// trigger the node-count comparison and the bad value would be stored
+	// silently. See issue #11401 (same root cause as ValidateConfig).
+	if updated.ReplicationConfig.Factor < 0 {
+		return fmt.Errorf("invalid replication factor: must be >= 1, got %d",
+			updated.ReplicationConfig.Factor)
 	}
 
 	if old.ReplicationConfig.Factor != updated.ReplicationConfig.Factor {

--- a/usecases/replica/config_test.go
+++ b/usecases/replica/config_test.go
@@ -122,21 +122,24 @@ func Test_ValidateConfigUpdate(t *testing.T) {
 			initial: &models.ReplicationConfig{Factor: 3},
 			update:  &models.ReplicationConfig{Factor: 4},
 			expectedError: fmt.Errorf(
-				"cannot scale to 4 replicas, cluster has only 3 nodes"),
+				"cannot scale to 4 replicas, cluster has only 3 nodes",
+			),
 		},
 		{
 			name:    "updating to factor = -1 is rejected",
 			initial: &models.ReplicationConfig{Factor: 2},
 			update:  &models.ReplicationConfig{Factor: -1},
 			expectedError: fmt.Errorf(
-				"invalid replication factor: must be >= 1, got -1"),
+				"invalid replication factor: must be >= 1, got -1",
+			),
 		},
 		{
 			name:    "updating to large negative factor is rejected",
 			initial: &models.ReplicationConfig{Factor: 2},
 			update:  &models.ReplicationConfig{Factor: -100},
 			expectedError: fmt.Errorf(
-				"invalid replication factor: must be >= 1, got -100"),
+				"invalid replication factor: must be >= 1, got -100",
+			),
 		},
 	}
 
@@ -145,7 +148,8 @@ func Test_ValidateConfigUpdate(t *testing.T) {
 			err := replica.ValidateConfigUpdate(
 				&models.Class{ReplicationConfig: test.initial},
 				&models.Class{ReplicationConfig: test.update},
-				&fakeNodeCounter{3})
+				&fakeNodeCounter{3},
+			)
 			if test.expectedError == nil {
 				assert.Nil(t, err)
 			} else {

--- a/usecases/replica/config_test.go
+++ b/usecases/replica/config_test.go
@@ -50,10 +50,16 @@ func Test_ValidateConfig(t *testing.T) {
 			globalConfig:  replication.GlobalConfig{MinimumFactor: 1},
 		},
 		{
-			name:          "config provided, factor < 0",
+			name:          "config provided, factor = -1 is rejected",
 			initialconfig: &models.ReplicationConfig{Factor: -1},
-			resultConfig:  &models.ReplicationConfig{Factor: 1},
 			globalConfig:  replication.GlobalConfig{MinimumFactor: 1},
+			expectedErr:   fmt.Errorf("invalid replication factor: must be >= 1, got -1"),
+		},
+		{
+			name:          "config provided, large negative factor is rejected",
+			initialconfig: &models.ReplicationConfig{Factor: -100},
+			globalConfig:  replication.GlobalConfig{MinimumFactor: 1},
+			expectedErr:   fmt.Errorf("invalid replication factor: must be >= 1, got -100"),
 		},
 		{
 			name:          "config provided, valid factor",
@@ -117,6 +123,20 @@ func Test_ValidateConfigUpdate(t *testing.T) {
 			update:  &models.ReplicationConfig{Factor: 4},
 			expectedError: fmt.Errorf(
 				"cannot scale to 4 replicas, cluster has only 3 nodes"),
+		},
+		{
+			name:    "updating to factor = -1 is rejected",
+			initial: &models.ReplicationConfig{Factor: 2},
+			update:  &models.ReplicationConfig{Factor: -1},
+			expectedError: fmt.Errorf(
+				"invalid replication factor: must be >= 1, got -1"),
+		},
+		{
+			name:    "updating to large negative factor is rejected",
+			initial: &models.ReplicationConfig{Factor: 2},
+			update:  &models.ReplicationConfig{Factor: -100},
+			expectedError: fmt.Errorf(
+				"invalid replication factor: must be >= 1, got -100"),
 		},
 	}
 


### PR DESCRIPTION
## What

`replica.ValidateConfig` and `replica.ValidateConfigUpdate` now reject any explicit `replicationConfig.factor < 0` with `invalid replication factor: must be >= 1, got %d`. Previously both paths silently coerced a negative factor to `MinimumFactor`, leaving the user with HTTP 200 and a stored value that differed from the request.

Closes #11401.

## Why

The issue reports a `POST /v1/schema` with `replicationConfig.factor: -1` succeeding (HTTP 200) and silently rewriting the value to 1. The same coercion sits at the symmetric `ValidateConfigUpdate` path, so this PR fixes both — per the CLAUDE.md "no bug out of scope" rule for the obvious adjacent journey.

`Factor == 0` is intentionally preserved as a "use the configured default" sentinel (it's the JSON zero value when a client sends an empty `ReplicationConfig` object — already exercised by the existing `config provided, factor not provided` test). Only explicit negative values are rejected.

## How

`usecases/replica/config.go`:
- Added explicit `Factor < 0` checks at the top of both `ValidateConfig` and `ValidateConfigUpdate`, returning a clear error before any silent-normalization branch could run.
- Added a clarifying comment on the `Factor < 1 → MinimumFactor` line documenting that it now only catches the `Factor == 0` ("use default") case.

`usecases/replica/config_test.go`:
- The existing case `config provided, factor < 0` codified the buggy behavior (`Factor: -1 → resultConfig: Factor: 1`). Replaced it with `config provided, factor = -1 is rejected` asserting the new error, plus a `large negative factor is rejected` boundary case.
- Added the symmetric two cases to `Test_ValidateConfigUpdate`.

## Tests

Ran inside `golang:1.26` Docker (Go isn't installed locally, Pi sandbox):

```
go test -count=1 -v -run Test_ValidateConfig ./usecases/replica/
# 13 passed (10 ValidateConfig + 3 ValidateConfigUpdate)
gofmt -l usecases/replica/config.go usecases/replica/config_test.go
# clean
go vet ./usecases/replica/
# one pre-existing finding in coordinator.go:283 (see notes below)
```

Race detector (`-race`) is skipped locally because the Pi's kernel reports a 47-bit VMA range and ThreadSanitizer requires 48-bit. The validation functions are pure logic with no concurrency, so this doesn't affect coverage; CI will exercise `-race`.

## Notes for the reviewer

- **Behavior change captured by the existing test rewrite.** The pre-fix test asserted that `Factor: -1` was silently normalized to `Factor: 1`. That assertion is now replaced with an error assertion. If keeping the silent-coerce path under any flag is desired for backward compatibility, let me know and I'll gate this behind a config knob — but the issue body is unambiguous that 422 is the wanted behavior.
- **`Factor == 0` is preserved.** Clients sending `{"replicationConfig": {}}` (JSON zero value) still get the configured default. The existing `config provided, factor not provided` test asserts this and still passes unchanged.
- **Pre-existing finding flagged.** `go vet` reports `coordinator.go:283: the cancel function returned by context.WithTimeout should be called, not discarded` in the same package. I did **not** touch it (out of scope of this PR), but per CLAUDE.md's "no bug out of scope" spirit, surfacing it in case it's news.
- **CLA.** I haven't signed the Weaviate CLA yet — happy to do that when the bot prompts.
