### PR TITLE
fix(ci): prepend build_weaviate_test_image to distributed-tasks dispatch

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -277,6 +277,7 @@ function main() {
   # shard because that function is gated by the big-IF a few hundred
   # lines below, which does not include $run_acceptance_distributed_tasks.
   if $run_acceptance_distributed_tasks; then
+    build_weaviate_test_image
     echo "running acceptance distributed_tasks"
     run_aof_group "distributed-tasks" test/acceptance/distributed_tasks
   fi
@@ -426,6 +427,7 @@ function run_acceptance_tests() {
   # (search for "distributed_tasks" above); $run_acceptance_distributed_tasks
   # is intentionally absent from this predicate.
   if $run_acceptance_tests || $run_all_tests; then
+    build_weaviate_test_image
     echo "running acceptance distributed_tasks (via catch-all)"
     run_aof_group "distributed-tasks" test/acceptance/distributed_tasks
   fi


### PR DESCRIPTION
Per Claudette's review on PR #11415: the top-level dispatch I added for `--acceptance-distributed-tasks` (and its catch-all sibling) was missing the `build_weaviate_test_image` prepend that every other `run_acceptance_*` function uses.

Without it, testcontainers tries to build from source on each cluster bring-up, hits the 1m30s liveness cap, and the suite cascades:

```
--- FAIL: TestCrashRecovery_SingleNodeRestart (366s)
  startCluster phase 1 (liveness): ... build image: context deadline exceeded
--- FAIL: TestCrashRecovery_MajorityRestart (0.01s)
  create network: Pool overlaps with other one on this address space
```

This was the failure pattern I observed across multiple CI runs on PR #11422 (jobs `77515305587`, `77517875046`, `77520316504`) and the cause of my "distributed-tasks shard infra capacity" push notifications — the root cause was the missing pre-build, not runner capacity. Claudette nailed it.

`build_weaviate_test_image` is idempotent (early-returns if `TEST_WEAVIATE_IMAGE` is already exported at `test/run.sh:648-650`), so the catch-all path is safe even when another shard already built the image.

## Diff scope

Two 1-line additions in `test/run.sh`, one at each of the two dispatch sites. No behavior change for any other shard.

## Base branch

Targeted at `exhaustive-restart-sentinel-test` (PR #11415's branch) since #11422 already merged into it and the fix needs to land there to take effect when #11415 merges to main.

— QA Claude