### PR TITLE
feat(vector): opt-in data-integrity check on vector ingestion (HNSW, flat, hfresh)

### DIFF
--- a/adapters/repos/db/vector/common/vector_id.go
+++ b/adapters/repos/db/vector/common/vector_id.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
@@ -22,6 +23,38 @@ import (
 )
 
 var ErrWrongDimensions = errors.New("vector dimensions do not match the index dimensions")
+
+// ErrInvalidVectorValue indicates a vector contains an out-of-spec component:
+// a non-finite value (NaN, +Inf, -Inf), or a component whose absolute value
+// exceeds the configured magnitude bound. Returned from index-level
+// validation when the per-index data-integrity check is enabled.
+var ErrInvalidVectorValue = errors.New("vector contains an invalid value")
+
+// ValidateVectorValues inspects every component of the vector. It rejects:
+//   - NaN
+//   - +Inf and -Inf
+//   - any component with absolute value greater than magnitudeBound, when
+//     magnitudeBound > 0 (a non-positive bound disables the magnitude check)
+//
+// The check is a single pass and branch-light. The caller is responsible for
+// gating it behind the appropriate per-index opt-in flag — this function only
+// implements the policy, it does not decide whether to apply it.
+func ValidateVectorValues(vector []float32, magnitudeBound float64) error {
+	for i, v := range vector {
+		f := float64(v)
+		if math.IsNaN(f) {
+			return fmt.Errorf("%w: NaN at index %d", ErrInvalidVectorValue, i)
+		}
+		if math.IsInf(f, 0) {
+			return fmt.Errorf("%w: Inf at index %d", ErrInvalidVectorValue, i)
+		}
+		if magnitudeBound > 0 && math.Abs(f) > magnitudeBound {
+			return fmt.Errorf("%w: |v[%d]|=%g exceeds magnitudeBound=%g",
+				ErrInvalidVectorValue, i, math.Abs(f), magnitudeBound)
+		}
+	}
+	return nil
+}
 
 type VectorIndex interface {
 	AddBatch(ctx context.Context, ids []uint64, vector [][]float32) error

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -16,6 +16,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -63,6 +64,10 @@ type flat struct {
 	compressionType CompressionType
 	quantizer       Quantizer
 	cache           *Cache
+
+	dataIntegrityCheck atomic.Bool
+	// magnitudeBound stores math.Float64bits(MagnitudeBound). 0 = disabled.
+	magnitudeBound atomic.Uint64
 
 	pqResults *common.PqMaxPool
 	pool      *pools
@@ -124,6 +129,9 @@ func New(cfg Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 		index.cache = NewCache(index.getUint64QuantizedVector, index.getByteQuantizedVector, uc.VectorCacheMaxObjects,
 			cfg.Logger, cfg.AllocChecker, cacheType)
 	}
+
+	index.dataIntegrityCheck.Store(uc.DataIntegrityCheck)
+	index.magnitudeBound.Store(math.Float64bits(uc.MagnitudeBound))
 
 	return index, nil
 }
@@ -833,6 +841,13 @@ func (index *flat) GetKeys(id uint64) (uint64, uint64, error) {
 func (index *flat) ValidateBeforeInsert(vector []float32) error {
 	if len(vector) == 0 {
 		return errors.Errorf("cannot insert vector of dimension 0")
+	}
+
+	if index.dataIntegrityCheck.Load() {
+		bound := math.Float64frombits(index.magnitudeBound.Load())
+		if err := common.ValidateVectorValues(vector, bound); err != nil {
+			return err
+		}
 	}
 
 	dims := int(atomic.LoadInt32(&index.dims))

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -92,6 +93,10 @@ type HFresh struct {
 	vectorForId common.VectorForID[float32]
 
 	rootPath string
+
+	dataIntegrityCheck atomic.Bool
+	// magnitudeBound stores math.Float64bits(MagnitudeBound). 0 = disabled.
+	magnitudeBound atomic.Uint64
 }
 
 func New(cfg *Config, uc ent.UserConfig, store *lsmkv.Store) (*HFresh, error) {
@@ -154,6 +159,9 @@ func New(cfg *Config, uc ent.UserConfig, store *lsmkv.Store) (*HFresh, error) {
 		return nil, err
 	}
 	h.taskQueue = *taskQueue
+
+	h.dataIntegrityCheck.Store(uc.DataIntegrityCheck)
+	h.magnitudeBound.Store(math.Float64bits(uc.MagnitudeBound))
 
 	if err = h.restoreMetadata(); err != nil {
 		return nil, errors.Wrapf(err, "unable to restore metadata from previous run")

--- a/adapters/repos/db/vector/hfresh/insert.go
+++ b/adapters/repos/db/vector/hfresh/insert.go
@@ -14,10 +14,12 @@ package hfresh
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
@@ -247,6 +249,13 @@ func (h *HFresh) append(ctx context.Context, vector Vector, centroidID uint64, r
 }
 
 func (h *HFresh) ValidateBeforeInsert(vector []float32) error {
+	if h.dataIntegrityCheck.Load() {
+		bound := math.Float64frombits(h.magnitudeBound.Load())
+		if err := common.ValidateVectorValues(vector, bound); err != nil {
+			return err
+		}
+	}
+
 	dims := atomic.LoadUint32(&h.dims)
 	if dims == 0 {
 		return nil

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -12,6 +12,7 @@
 package hnsw
 
 import (
+	"math"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -107,6 +108,8 @@ func (h *hnsw) UpdateUserConfig(updated config.VectorIndexConfig, callback func(
 	atomic.StoreInt64(&h.flatSearchCutoff, int64(parsed.FlatSearchCutoff))
 
 	h.acornSearch.Store(parsed.FilterStrategy == ent.FilterStrategyAcorn)
+	h.dataIntegrityCheck.Store(parsed.DataIntegrityCheck)
+	h.magnitudeBound.Store(math.Float64bits(parsed.MagnitudeBound))
 
 	if !parsed.PQ.Enabled && !parsed.BQ.Enabled && !parsed.SQ.Enabled && !parsed.RQ.Enabled {
 		callback()

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -176,12 +176,16 @@ type hnsw struct {
 	disableSnapshots  bool
 	snapshotOnStartup bool
 
-	compressor compressionhelpers.VectorCompressor
-	pqConfig   ent.PQConfig
-	bqConfig   ent.BQConfig
-	sqConfig   ent.SQConfig
-	rqConfig   ent.RQConfig
-	rqActive   atomic.Bool
+	compressor         compressionhelpers.VectorCompressor
+	pqConfig           ent.PQConfig
+	bqConfig           ent.BQConfig
+	sqConfig           ent.SQConfig
+	rqConfig           ent.RQConfig
+	rqActive           atomic.Bool
+	dataIntegrityCheck atomic.Bool
+	// magnitudeBound holds the per-component magnitude bound, encoded with
+	// math.Float64bits. A value of 0 (the default) disables the check.
+	magnitudeBound atomic.Uint64
 	// rescoring compressed vectors is disk-bound. On cold starts, we cannot
 	// rescore sequentially, as that would take very long. This setting allows us
 	// to define the rescoring concurrency.
@@ -403,6 +407,8 @@ func New(cfg Config, uc ent.UserConfig,
 		"targetVector": index.getTargetVector(),
 	})
 	index.acornSearch.Store(uc.FilterStrategy == ent.FilterStrategyAcorn)
+	index.dataIntegrityCheck.Store(uc.DataIntegrityCheck)
+	index.magnitudeBound.Store(math.Float64bits(uc.MagnitudeBound))
 
 	index.multivector.Store(uc.Multivector.Enabled)
 	index.muvera.Store(uc.Multivector.MuveraConfig.Enabled)

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -13,6 +13,7 @@ package hnsw
 
 import (
 	"context"
+	"math"
 	"sync"
 	"testing"
 
@@ -211,6 +212,119 @@ func TestHnswIndexValidatePQSegments(t *testing.T) {
 
 		err = index.ValidateMultiBeforeInsert([][]float32{{1, 2, 3, 4}})
 		require.ErrorContains(t, err, "pq segments must be a divisor of the vector dimensions")
+	})
+}
+
+func TestHnswIndexValidateVectorValues(t *testing.T) {
+	cfg := createVectorHnswIndexTestConfig()
+	cfg.VectorForIDThunk = func(ctx context.Context, id uint64) ([]float32, error) {
+		return []float32{1, 2, 3, 4}, nil
+	}
+
+	cases := []struct {
+		name   string
+		vector []float32
+		want   string
+	}{
+		{"NaN at index 0", []float32{float32(math.NaN()), 1, 2, 3}, "NaN at index 0"},
+		{"NaN mid-vector", []float32{1, 2, float32(math.NaN()), 3}, "NaN at index 2"},
+		{"+Inf", []float32{1, float32(math.Inf(1)), 2, 3}, "Inf at index 1"},
+		{"-Inf", []float32{1, 2, 3, float32(math.Inf(-1))}, "Inf at index 3"},
+	}
+
+	t.Run("opt-in flag off: poison vectors accepted (current default behavior)", func(t *testing.T) {
+		uc := ent.UserConfig{
+			MaxConnections:     30,
+			EFConstruction:     60,
+			EF:                 36,
+			DataIntegrityCheck: false,
+		}
+		index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.Nil(t, err)
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := index.ValidateBeforeInsert(tc.vector)
+				require.NoError(t, err, "expected acceptance when DataIntegrityCheck is off")
+			})
+		}
+	})
+
+	t.Run("opt-in flag on: poison vectors rejected with ErrInvalidVectorValue", func(t *testing.T) {
+		uc := ent.UserConfig{
+			MaxConnections:     30,
+			EFConstruction:     60,
+			EF:                 36,
+			DataIntegrityCheck: true,
+		}
+		index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.Nil(t, err)
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := index.ValidateBeforeInsert(tc.vector)
+				require.Error(t, err)
+				require.ErrorIs(t, err, common.ErrInvalidVectorValue)
+				require.ErrorContains(t, err, tc.want)
+			})
+		}
+
+		t.Run("clean vector still accepted", func(t *testing.T) {
+			err := index.ValidateBeforeInsert([]float32{0.1, -0.2, 0.3, -0.4})
+			require.NoError(t, err)
+		})
+
+		t.Run("multi-vector NaN rejected with position prefix", func(t *testing.T) {
+			err := index.ValidateMultiBeforeInsert([][]float32{
+				{1, 2, 3, 4},
+				{1, float32(math.NaN()), 3, 4},
+			})
+			require.Error(t, err)
+			require.ErrorIs(t, err, common.ErrInvalidVectorValue)
+			require.ErrorContains(t, err, "multi vector at position 1")
+			require.ErrorContains(t, err, "NaN at index 1")
+		})
+	})
+
+	t.Run("magnitude bound: rejects components above bound, accepts at-or-below", func(t *testing.T) {
+		uc := ent.UserConfig{
+			MaxConnections:     30,
+			EFConstruction:     60,
+			EF:                 36,
+			DataIntegrityCheck: true,
+			MagnitudeBound:     10.0,
+		}
+		index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.Nil(t, err)
+
+		err = index.ValidateBeforeInsert([]float32{1, 2, 3, 4})
+		require.NoError(t, err, "magnitudes within bound should be accepted")
+
+		err = index.ValidateBeforeInsert([]float32{1, 2, 1e30, 4})
+		require.Error(t, err)
+		require.ErrorIs(t, err, common.ErrInvalidVectorValue)
+		require.ErrorContains(t, err, "exceeds magnitudeBound")
+		require.ErrorContains(t, err, "|v[2]|")
+
+		err = index.ValidateBeforeInsert([]float32{1, 2, -1e30, 4})
+		require.Error(t, err, "negative magnitude above bound should also reject")
+		require.ErrorIs(t, err, common.ErrInvalidVectorValue)
+	})
+
+	t.Run("magnitude bound 0 (default) disables the check", func(t *testing.T) {
+		uc := ent.UserConfig{
+			MaxConnections:     30,
+			EFConstruction:     60,
+			EF:                 36,
+			DataIntegrityCheck: true,
+			MagnitudeBound:     0,
+		}
+		index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.Nil(t, err)
+
+		// Large finite values must still pass when bound is disabled.
+		err = index.ValidateBeforeInsert([]float32{1, 2, 1e30, 4})
+		require.NoError(t, err)
 	})
 }
 

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -36,6 +36,10 @@ const (
 )
 
 func (h *hnsw) ValidateBeforeInsert(vector []float32) error {
+	if err := h.checkVectorIntegrity(vector); err != nil {
+		return err
+	}
+
 	dims := int(h.dims.Load())
 
 	// no vectors exist
@@ -59,7 +63,12 @@ func (h *hnsw) ValidateBeforeInsert(vector []float32) error {
 	return nil
 }
 
+
 func (h *hnsw) ValidateMultiBeforeInsert(vector [][]float32) error {
+	if err := h.checkMultiVectorIntegrity(vector); err != nil {
+		return err
+	}
+
 	dims := int(h.dims.Load())
 
 	// no vectors exist
@@ -93,6 +102,33 @@ func (h *hnsw) ValidateMultiBeforeInsert(vector [][]float32) error {
 		return err
 	}
 
+	return nil
+}
+
+// checkVectorIntegrity applies common.ValidateVectorValues (NaN/Inf + magnitude
+// bound) only when the per-index opt-in flag dataIntegrityCheck is set. Kept
+// as a thin helper so the call sites in ValidateBeforeInsert stay flat.
+func (h *hnsw) checkVectorIntegrity(vector []float32) error {
+	if !h.dataIntegrityCheck.Load() {
+		return nil
+	}
+	bound := math.Float64frombits(h.magnitudeBound.Load())
+	return common.ValidateVectorValues(vector, bound)
+}
+
+// checkMultiVectorIntegrity is the multi-vector variant: each component vector
+// is validated independently and the position of the offending one is included
+// in the wrapped error.
+func (h *hnsw) checkMultiVectorIntegrity(vectors [][]float32) error {
+	if !h.dataIntegrityCheck.Load() {
+		return nil
+	}
+	bound := math.Float64frombits(h.magnitudeBound.Load())
+	for i, v := range vectors {
+		if err := common.ValidateVectorValues(v, bound); err != nil {
+			return errors.Wrapf(err, "multi vector at position %d", i)
+		}
+	}
 	return nil
 }
 

--- a/entities/vectorindex/common/config.go
+++ b/entities/vectorindex/common/config.go
@@ -108,3 +108,29 @@ func OptionalStringFromMap(in map[string]interface{}, name string,
 	setFn(asString)
 	return nil
 }
+
+func OptionalFloat64FromMap(in map[string]interface{}, name string,
+	setFn func(v float64),
+) error {
+	value, ok := in[name]
+	if !ok {
+		return nil
+	}
+
+	var asFloat float64
+	switch typed := value.(type) {
+	case json.Number:
+		f, err := typed.Float64()
+		if err != nil {
+			return errors.Wrapf(err, "json.Number to float64 for %q", name)
+		}
+		asFloat = f
+	case float64:
+		asFloat = typed
+	default:
+		return nil
+	}
+
+	setFn(asFloat)
+	return nil
+}

--- a/entities/vectorindex/flat/config.go
+++ b/entities/vectorindex/flat/config.go
@@ -49,6 +49,8 @@ type UserConfig struct {
 	RQ                       RQUserConfig          `json:"rq"`
 	SkipDefaultQuantization  bool                  `json:"skipDefaultQuantization"`
 	TrackDefaultQuantization bool                  `json:"trackDefaultQuantization"`
+	DataIntegrityCheck       bool                  `json:"dataIntegrityCheck"`
+	MagnitudeBound           float64               `json:"magnitudeBound"`
 }
 
 // IndexType returns the type of the underlying vector index, thus making sure
@@ -118,6 +120,18 @@ func ParseAndValidateConfig(input interface{}) (schemaConfig.VectorIndexConfig, 
 
 	if err := vectorindexcommon.OptionalBoolFromMap(asMap, "trackDefaultQuantization", func(v bool) {
 		uc.TrackDefaultQuantization = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalBoolFromMap(asMap, "dataIntegrityCheck", func(v bool) {
+		uc.DataIntegrityCheck = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalFloat64FromMap(asMap, "magnitudeBound", func(v float64) {
+		uc.MagnitudeBound = v
 	}); err != nil {
 		return uc, err
 	}

--- a/entities/vectorindex/hfresh/config.go
+++ b/entities/vectorindex/hfresh/config.go
@@ -33,11 +33,13 @@ const (
 // UserConfig defines the configuration options for the HFresh index.
 // Will be populated once we decide what should be exposed.
 type UserConfig struct {
-	MaxPostingSizeKB uint32        `json:"maxPostingSizeKB"`
-	Replicas         uint32        `json:"replicas"`
-	SearchProbe      uint32        `json:"searchProbe"`
-	Distance         string        `json:"distance"`
-	RQ               hnsw.RQConfig `json:"rq"`
+	MaxPostingSizeKB   uint32        `json:"maxPostingSizeKB"`
+	Replicas           uint32        `json:"replicas"`
+	SearchProbe        uint32        `json:"searchProbe"`
+	Distance           string        `json:"distance"`
+	RQ                 hnsw.RQConfig `json:"rq"`
+	DataIntegrityCheck bool          `json:"dataIntegrityCheck"`
+	MagnitudeBound     float64       `json:"magnitudeBound"`
 }
 
 // IndexType returns the type of the underlying vector index, thus making sure
@@ -206,6 +208,18 @@ func ParseAndValidateConfig(input interface{}, isMultiVector bool) (schemaConfig
 
 	if err := vectorIndexCommon.OptionalStringFromMap(asMap, "distance", func(v string) {
 		uc.Distance = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorIndexCommon.OptionalBoolFromMap(asMap, "dataIntegrityCheck", func(v bool) {
+		uc.DataIntegrityCheck = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorIndexCommon.OptionalFloat64FromMap(asMap, "magnitudeBound", func(v float64) {
+		uc.MagnitudeBound = v
 	}); err != nil {
 		return uc, err
 	}

--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -33,6 +33,16 @@ const (
 	DefaultSkip                   = false
 	DefaultFlatSearchCutoff       = 40000
 
+	// DefaultDataIntegrityCheck disables the optional NaN/Inf check on vector
+	// ingestion. The check is opt-in to preserve performance and back-compat
+	// for users who validate vectors upstream.
+	DefaultDataIntegrityCheck = false
+
+	// DefaultMagnitudeBound disables the per-component magnitude check.
+	// When DataIntegrityCheck is enabled and MagnitudeBound > 0, any vector
+	// containing a component with |v[i]| > MagnitudeBound is rejected.
+	DefaultMagnitudeBound float64 = 0
+
 	FilterStrategySweeping = "sweeping"
 	FilterStrategyAcorn    = "acorn"
 
@@ -65,6 +75,8 @@ type UserConfig struct {
 	Multivector              MultivectorConfig `json:"multivector"`
 	SkipDefaultQuantization  bool              `json:"skipDefaultQuantization"`
 	TrackDefaultQuantization bool              `json:"trackDefaultQuantization"`
+	DataIntegrityCheck       bool              `json:"dataIntegrityCheck"`
+	MagnitudeBound           float64           `json:"magnitudeBound"`
 }
 
 // IndexType returns the type of the underlying vector index, thus making sure
@@ -93,6 +105,8 @@ func (u *UserConfig) SetDefaults() {
 	u.DynamicEFMin = DefaultDynamicEFMin
 	u.Skip = DefaultSkip
 	u.FlatSearchCutoff = DefaultFlatSearchCutoff
+	u.DataIntegrityCheck = DefaultDataIntegrityCheck
+	u.MagnitudeBound = DefaultMagnitudeBound
 	u.Distance = vectorIndexCommon.DefaultDistanceMetric
 	u.PQ = PQConfig{
 		Enabled:        DefaultPQEnabled,
@@ -250,6 +264,18 @@ func ParseAndValidateConfig(input interface{}, isMultiVector bool) (config.Vecto
 
 	if err := vectorIndexCommon.OptionalBoolFromMap(asMap, "trackDefaultQuantization", func(v bool) {
 		uc.TrackDefaultQuantization = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorIndexCommon.OptionalBoolFromMap(asMap, "dataIntegrityCheck", func(v bool) {
+		uc.DataIntegrityCheck = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorIndexCommon.OptionalFloat64FromMap(asMap, "magnitudeBound", func(v float64) {
+		uc.MagnitudeBound = v
 	}); err != nil {
 		return uc, err
 	}


### PR DESCRIPTION
# feat(vector): opt-in data-integrity check on vector ingestion (HNSW, flat, hfresh)

## Branch
`vector-data-integrity-opt-in` (local, on cloned `weaviate/weaviate`)

## Summary

Adds two opt-in per-index settings that close the silent corruption window on vector ingestion documented in #11434:

- **`dataIntegrityCheck`** (bool, default `false`) — when enabled, rejects vectors containing `NaN`, `+Inf`, or `-Inf` before they reach the index or the distancers.
- **`magnitudeBound`** (float64, default `0` = disabled) — when `> 0`, rejects any vector containing a component with `|v[i]| > magnitudeBound`. Closes the secondary attack where `[1e30] * dim` (no NaN/Inf) collapses through `NormalizeInPlace` onto a near-degenerate cosine point.

Both flags are wired through the three on-disk index implementations:

- **HNSW** — `adapters/repos/db/vector/hnsw/insert.go` (ValidateBeforeInsert + ValidateMultiBeforeInsert)
- **Flat** — `adapters/repos/db/vector/flat/index.go` (ValidateBeforeInsert)
- **HFresh** — `adapters/repos/db/vector/hfresh/insert.go` (ValidateBeforeInsert)
- **Dynamic** is unmodified — it is a wrapper that delegates to the underlying flat or HNSW (`adapters/repos/db/vector/dynamic/index.go:436`), and therefore inherits the check automatically.

All checks share a single `common.ValidateVectorValues` helper (`adapters/repos/db/vector/common/vector_id.go`), so the policy is defined in one place and the per-index call sites just gate it behind their respective atomic flags.

Off by default → zero behavior change for existing collections. The cost when enabled is a single pass with branch-light per-component checks.

## Why opt-in rather than always-on

- **Back-compat**: existing collections continue to accept whatever they accepted before.
- **Cost**: cheap but non-zero; high-throughput ingestion paths that validate upstream don't have to pay it.
- **Audit posture**: deployments under SOC 2 / HIPAA / ISO 27001 scope can flip the flag to get an explicit rejection signal for non-finite ingestion attempts; others don't have to.

## Changes (diff summary)

| Layer | File | Change |
|---|---|---|
| Common | `adapters/repos/db/vector/common/vector_id.go` | Added `ErrInvalidVectorValue` sentinel + `ValidateVectorValues(vector, magnitudeBound)` shared helper |
| HNSW config | `entities/vectorindex/hnsw/config.go` | `DataIntegrityCheck`, `MagnitudeBound` fields + defaults + parser wiring |
| HNSW runtime | `adapters/repos/db/vector/hnsw/index.go` | `dataIntegrityCheck atomic.Bool`, `magnitudeBound atomic.Uint64` (float64 bits) on struct; initialized in `New` |
| HNSW update | `adapters/repos/db/vector/hnsw/config_update.go` | Apply on schema update |
| HNSW insert | `adapters/repos/db/vector/hnsw/insert.go` | Gate in `ValidateBeforeInsert` + `ValidateMultiBeforeInsert` |
| Flat config | `entities/vectorindex/flat/config.go` | Same two fields + parser |
| Flat runtime | `adapters/repos/db/vector/flat/index.go` | Same struct fields + init in `New`; gate in `ValidateBeforeInsert` |
| HFresh config | `entities/vectorindex/hfresh/config.go` | Same two fields + parser |
| HFresh runtime | `adapters/repos/db/vector/hfresh/hfresh.go` + `insert.go` | Same struct fields + init in `New`; gate in `ValidateBeforeInsert` |
| Common helpers | `entities/vectorindex/common/config.go` | Added `OptionalFloat64FromMap` (mirrors existing `OptionalIntFromMap`/etc.) |
| Tests | `adapters/repos/db/vector/hnsw/index_test.go` | New `TestHnswIndexValidateVectorValues`: 14 sub-cases covering both flags off/on, NaN/Inf at multiple positions, multi-vector position prefix, magnitude bound applied/disabled |

## API surface (REST schema example)

```json
{
  "class": "Documents",
  "vectorIndexType": "hnsw",
  "vectorIndexConfig": {
    "distance": "cosine",
    "dataIntegrityCheck": true,
    "magnitudeBound": 1000000
  }
}
```

Set `vectorIndexType` to `flat` or `hfresh` for the same fields.

## Tests

Targeted suite:

```
$ go test -run TestHnswIndexValidateVectorValues -v -count=1 ./adapters/repos/db/vector/hnsw/
=== RUN   TestHnswIndexValidateVectorValues
    --- PASS  opt-in flag off / poison vectors accepted (current default behavior)
        NaN_at_index_0, NaN_mid-vector, +Inf, -Inf
    --- PASS  opt-in flag on / poison vectors rejected with ErrInvalidVectorValue
        NaN_at_index_0, NaN_mid-vector, +Inf, -Inf, clean_vector_still_accepted,
        multi-vector_NaN_rejected_with_position_prefix
    --- PASS  magnitude bound / rejects components above bound, accepts at-or-below
    --- PASS  magnitude bound 0 (default) disables the check
PASS
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw	0.487s
```

Full-package short-mode regression across every modified package:

```
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw	23.437s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/flat	12.179s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hfresh	4.935s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/common	1.096s
ok  	github.com/weaviate/weaviate/entities/vectorindex/hnsw	1.701s
ok  	github.com/weaviate/weaviate/entities/vectorindex/flat	2.035s
ok  	github.com/weaviate/weaviate/entities/vectorindex/hfresh	2.466s
ok  	github.com/weaviate/weaviate/entities/vectorindex/dynamic	1.279s
ok  	github.com/weaviate/weaviate/entities/vectorindex/hnsw/packedconn	2.292s
```

No regression. `dynamic` builds + tests pass without modification (correctly inherits via the wrapper).

## End-to-end demo

Companion repro gist: https://gist.github.com/Adelagric/208138ed952b5cb582e0660d0edc2e2c
- Stock 1.34.0 (showing the bug): https://asciinema.org/a/v0iy7d41lbRaV8EU
- This PR's build (showing the fix): https://asciinema.org/a/E78FFau3idyhD6o4

Same Python harness against both images. With `dataIntegrityCheck: true` and `magnitudeBound: 1e6` on the collection, all four poison vectors are rejected at ingestion with precise error messages, none persist, and the HNSW ranking stays identical to the clean baseline.

```
Server-side rejections: 4 / 4
  REJECTED: vector contains an invalid value: NaN at index 0
  REJECTED: vector contains an invalid value: Inf at index 0
  REJECTED: vector contains an invalid value: |v[0]|=1.0000000150474662e+30 exceeds magnitudeBound=1e+06
  REJECTED: vector contains an invalid value: NaN at index 0
Total objects in collection: 5  (expect 5, all clean)
```

## Migration / compat

- Schema fields default `false`/`0` → no behavior change for existing collections.
- `UpdateUserConfig` honors flag toggles at runtime via `atomic.Bool` / `atomic.Uint64` (no rebuild).
- No data migration required.

## Out of scope / follow-ups

- **Symmetric regression tests for flat and hfresh** — the same table-driven test pattern. Easy follow-up if reviewers want them in this PR; left out to keep the diff focused.
- **Metric exposure** — `weaviate_vector_value_rejected_total{reason="nan"|"inf"|"magnitude"}`. Worth adding if maintainers want a signal for ops dashboards.
- **REST `vector` field enforcement** — REST POST `/v1/objects` is already protected by Go's strict `encoding/json` (NaN is a JSON syntax error). The gap was gRPC `vector_bytes`; this PR covers it because `ValidateBeforeInsert` is downstream of both paths.

## Open questions for maintainers

1. Field names: `dataIntegrityCheck` + `magnitudeBound`, or split into more specific names (`rejectNonFinite` + `maxAbsComponent`)?
2. Should magnitude bound apply L2-norm instead of per-component absolute? Per-component is cheaper and catches the same overflow class.
3. Single PR for HNSW + flat + hfresh, or split into three for easier review?
