### PR TITLE
gh-11399 validate hnsw vectorIndexConfig numeric ranges

### DIFF
--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -286,17 +286,23 @@ func (u *UserConfig) validate() error {
 
 	// Numeric range validation for fields that previously silently accepted
 	// negative or otherwise-invalid values. EF is intentionally excluded as -1
-	// is the documented "let Weaviate pick" value (see DefaultEF).
-	if u.DynamicEFMin < 0 {
-		errMsgs = append(errMsgs, "dynamicEfMin must not be negative")
+	// is the documented "let Weaviate pick" value (see DefaultEF). Listed in a
+	// fixed order so error messages stay deterministic.
+	nonNegative := []struct {
+		name  string
+		value int
+	}{
+		{"dynamicEfMin", u.DynamicEFMin},
+		{"dynamicEfMax", u.DynamicEFMax},
+		{"dynamicEfFactor", u.DynamicEFFactor},
+		{"flatSearchCutoff", u.FlatSearchCutoff},
+		{"cleanupIntervalSeconds", u.CleanupIntervalSeconds},
+		{"vectorCacheMaxObjects", u.VectorCacheMaxObjects},
 	}
-
-	if u.DynamicEFMax < 0 {
-		errMsgs = append(errMsgs, "dynamicEfMax must not be negative")
-	}
-
-	if u.DynamicEFFactor < 0 {
-		errMsgs = append(errMsgs, "dynamicEfFactor must not be negative")
+	for _, f := range nonNegative {
+		if f.value < 0 {
+			errMsgs = append(errMsgs, f.name+" must not be negative")
+		}
 	}
 
 	// Cross-field invariant: efMin must not exceed efMax. Only enforced when
@@ -307,18 +313,6 @@ func (u *UserConfig) validate() error {
 			"dynamicEfMin (%d) must be less than or equal to dynamicEfMax (%d)",
 			u.DynamicEFMin, u.DynamicEFMax,
 		))
-	}
-
-	if u.FlatSearchCutoff < 0 {
-		errMsgs = append(errMsgs, "flatSearchCutoff must not be negative")
-	}
-
-	if u.CleanupIntervalSeconds < 0 {
-		errMsgs = append(errMsgs, "cleanupIntervalSeconds must not be negative")
-	}
-
-	if u.VectorCacheMaxObjects < 0 {
-		errMsgs = append(errMsgs, "vectorCacheMaxObjects must not be negative")
 	}
 
 	if len(errMsgs) > 0 {

--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -284,6 +284,43 @@ func (u *UserConfig) validate() error {
 		errMsgs = append(errMsgs, "filterStrategy must be either 'sweeping' or 'acorn'")
 	}
 
+	// Numeric range validation for fields that previously silently accepted
+	// negative or otherwise-invalid values. EF is intentionally excluded as -1
+	// is the documented "let Weaviate pick" value (see DefaultEF).
+	if u.DynamicEFMin < 0 {
+		errMsgs = append(errMsgs, "dynamicEfMin must not be negative")
+	}
+
+	if u.DynamicEFMax < 0 {
+		errMsgs = append(errMsgs, "dynamicEfMax must not be negative")
+	}
+
+	if u.DynamicEFFactor < 0 {
+		errMsgs = append(errMsgs, "dynamicEfFactor must not be negative")
+	}
+
+	// Cross-field invariant: efMin must not exceed efMax. Only enforced when
+	// both are non-negative so the per-field messages above remain the primary
+	// signal when the user supplied a clearly bogus value.
+	if u.DynamicEFMin >= 0 && u.DynamicEFMax >= 0 && u.DynamicEFMin > u.DynamicEFMax {
+		errMsgs = append(errMsgs, fmt.Sprintf(
+			"dynamicEfMin (%d) must be less than or equal to dynamicEfMax (%d)",
+			u.DynamicEFMin, u.DynamicEFMax,
+		))
+	}
+
+	if u.FlatSearchCutoff < 0 {
+		errMsgs = append(errMsgs, "flatSearchCutoff must not be negative")
+	}
+
+	if u.CleanupIntervalSeconds < 0 {
+		errMsgs = append(errMsgs, "cleanupIntervalSeconds must not be negative")
+	}
+
+	if u.VectorCacheMaxObjects < 0 {
+		errMsgs = append(errMsgs, "vectorCacheMaxObjects must not be negative")
+	}
+
 	if len(errMsgs) > 0 {
 		return fmt.Errorf("invalid hnsw config: %s",
 			strings.Join(errMsgs, ", "))

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -715,58 +715,6 @@ func Test_UserConfig(t *testing.T) {
 			expectErrMsg: "vectorCacheMaxObjects must not be negative",
 		},
 		{
-			// Boundary: efMin == efMax is allowed (<= is the rule).
-			name: "valid dynamicEf bounds (min == max)",
-			input: map[string]interface{}{
-				"dynamicEfMin": float64(100),
-				"dynamicEfMax": float64(100),
-			},
-			expected: UserConfig{
-				CleanupIntervalSeconds: DefaultCleanupIntervalSeconds,
-				MaxConnections:         DefaultMaxConnections,
-				EFConstruction:         DefaultEFConstruction,
-				VectorCacheMaxObjects:  common.DefaultVectorCacheMaxObjects,
-				EF:                     DefaultEF,
-				FlatSearchCutoff:       DefaultFlatSearchCutoff,
-				DynamicEFMin:           100,
-				DynamicEFMax:           100,
-				DynamicEFFactor:        DefaultDynamicEFFactor,
-				Distance:               common.DefaultDistanceMetric,
-				PQ: PQConfig{
-					Enabled:        DefaultPQEnabled,
-					BitCompression: DefaultPQBitCompression,
-					Segments:       DefaultPQSegments,
-					Centroids:      DefaultPQCentroids,
-					TrainingLimit:  DefaultPQTrainingLimit,
-					Encoder: PQEncoder{
-						Type:         DefaultPQEncoderType,
-						Distribution: DefaultPQEncoderDistribution,
-					},
-				},
-				SQ: SQConfig{
-					Enabled:       DefaultSQEnabled,
-					TrainingLimit: DefaultSQTrainingLimit,
-					RescoreLimit:  DefaultSQRescoreLimit,
-				},
-				RQ: RQConfig{
-					Enabled:      DefaultRQEnabled,
-					Bits:         DefaultRQBits,
-					RescoreLimit: DefaultRQRescoreLimit,
-				},
-				FilterStrategy: DefaultFilterStrategy,
-				Multivector: MultivectorConfig{
-					Enabled:     DefaultMultivectorEnabled,
-					Aggregation: DefaultMultivectorAggregation,
-					MuveraConfig: MuveraConfig{
-						Enabled:      DefaultMultivectorMuveraEnabled,
-						KSim:         DefaultMultivectorKSim,
-						DProjections: DefaultMultivectorDProjections,
-						Repetitions:  DefaultMultivectorRepetitions,
-					},
-				},
-			},
-		},
-		{
 			name: "with bq",
 			input: map[string]interface{}{
 				"cleanupIntervalSeconds": float64(11),
@@ -1309,4 +1257,18 @@ func Test_UserConfigFilterStrategy(t *testing.T) {
 		assert.Equal(t, FilterStrategySweeping, cfg.FilterStrategy)
 		assert.Nil(t, os.Unsetenv("HNSW_DEFAULT_FILTER_STRATEGY"))
 	})
+}
+
+// Test_UserConfigDynamicEFBoundary covers the dynamicEfMin <= dynamicEfMax
+// boundary directly via validate() so the table above does not need to spell
+// out a full UserConfig literal for an "expected equals defaults" case.
+func Test_UserConfigDynamicEFBoundary(t *testing.T) {
+	cfg := NewDefaultUserConfig()
+	cfg.DynamicEFMin = 100
+	cfg.DynamicEFMax = 100
+	assert.NoError(t, cfg.validate(), "min == max must be accepted")
+
+	cfg.DynamicEFMin = 99
+	cfg.DynamicEFMax = 100
+	assert.NoError(t, cfg.validate(), "min < max must be accepted")
 }

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -653,6 +653,120 @@ func Test_UserConfig(t *testing.T) {
 				"with a minimum of 4",
 		},
 		{
+			// Reproduces gh-11399: dynamicEfMin must not exceed
+			// dynamicEfMax.
+			name: "invalid dynamicEf bounds (min > max)",
+			input: map[string]interface{}{
+				"dynamicEfMin": float64(500),
+				"dynamicEfMax": float64(10),
+			},
+			expectErr: true,
+			expectErrMsg: "dynamicEfMin (500) must be less than or " +
+				"equal to dynamicEfMax (10)",
+		},
+		{
+			// Reproduces gh-11400: negative flatSearchCutoff has no
+			// meaningful interpretation.
+			name: "invalid flatSearchCutoff (negative)",
+			input: map[string]interface{}{
+				"flatSearchCutoff": float64(-100),
+			},
+			expectErr:    true,
+			expectErrMsg: "flatSearchCutoff must not be negative",
+		},
+		{
+			name: "invalid dynamicEfMin (negative)",
+			input: map[string]interface{}{
+				"dynamicEfMin": float64(-1),
+			},
+			expectErr:    true,
+			expectErrMsg: "dynamicEfMin must not be negative",
+		},
+		{
+			name: "invalid dynamicEfMax (negative)",
+			input: map[string]interface{}{
+				"dynamicEfMax": float64(-1),
+			},
+			expectErr:    true,
+			expectErrMsg: "dynamicEfMax must not be negative",
+		},
+		{
+			name: "invalid dynamicEfFactor (negative)",
+			input: map[string]interface{}{
+				"dynamicEfFactor": float64(-1),
+			},
+			expectErr:    true,
+			expectErrMsg: "dynamicEfFactor must not be negative",
+		},
+		{
+			name: "invalid cleanupIntervalSeconds (negative)",
+			input: map[string]interface{}{
+				"cleanupIntervalSeconds": float64(-1),
+			},
+			expectErr:    true,
+			expectErrMsg: "cleanupIntervalSeconds must not be negative",
+		},
+		{
+			name: "invalid vectorCacheMaxObjects (negative)",
+			input: map[string]interface{}{
+				"vectorCacheMaxObjects": float64(-1),
+			},
+			expectErr:    true,
+			expectErrMsg: "vectorCacheMaxObjects must not be negative",
+		},
+		{
+			// Boundary: efMin == efMax is allowed (<= is the rule).
+			name: "valid dynamicEf bounds (min == max)",
+			input: map[string]interface{}{
+				"dynamicEfMin": float64(100),
+				"dynamicEfMax": float64(100),
+			},
+			expected: UserConfig{
+				CleanupIntervalSeconds: DefaultCleanupIntervalSeconds,
+				MaxConnections:         DefaultMaxConnections,
+				EFConstruction:         DefaultEFConstruction,
+				VectorCacheMaxObjects:  common.DefaultVectorCacheMaxObjects,
+				EF:                     DefaultEF,
+				FlatSearchCutoff:       DefaultFlatSearchCutoff,
+				DynamicEFMin:           100,
+				DynamicEFMax:           100,
+				DynamicEFFactor:        DefaultDynamicEFFactor,
+				Distance:               common.DefaultDistanceMetric,
+				PQ: PQConfig{
+					Enabled:        DefaultPQEnabled,
+					BitCompression: DefaultPQBitCompression,
+					Segments:       DefaultPQSegments,
+					Centroids:      DefaultPQCentroids,
+					TrainingLimit:  DefaultPQTrainingLimit,
+					Encoder: PQEncoder{
+						Type:         DefaultPQEncoderType,
+						Distribution: DefaultPQEncoderDistribution,
+					},
+				},
+				SQ: SQConfig{
+					Enabled:       DefaultSQEnabled,
+					TrainingLimit: DefaultSQTrainingLimit,
+					RescoreLimit:  DefaultSQRescoreLimit,
+				},
+				RQ: RQConfig{
+					Enabled:      DefaultRQEnabled,
+					Bits:         DefaultRQBits,
+					RescoreLimit: DefaultRQRescoreLimit,
+				},
+				FilterStrategy: DefaultFilterStrategy,
+				Multivector: MultivectorConfig{
+					Enabled:     DefaultMultivectorEnabled,
+					Aggregation: DefaultMultivectorAggregation,
+					MuveraConfig: MuveraConfig{
+						Enabled:      DefaultMultivectorMuveraEnabled,
+						KSim:         DefaultMultivectorKSim,
+						DProjections: DefaultMultivectorDProjections,
+						Repetitions:  DefaultMultivectorRepetitions,
+					},
+				},
+			},
+		},
+		{
 			name: "with bq",
 			input: map[string]interface{}{
 				"cleanupIntervalSeconds": float64(11),

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -31,6 +31,17 @@ func Test_UserConfig(t *testing.T) {
 		expectErrMsg string
 	}
 
+	// negativeCase builds a "<field> must not be negative" error-shape test.
+	// Used to keep the table compact for fields that share a validation rule.
+	negativeCase := func(field string, value int) test {
+		return test{
+			name:         "invalid " + field + " (negative)",
+			input:        map[string]interface{}{field: float64(value)},
+			expectErr:    true,
+			expectErrMsg: field + " must not be negative",
+		}
+	}
+
 	tests := []test{
 		{
 			name:  "nothing specified, all defaults",
@@ -654,7 +665,7 @@ func Test_UserConfig(t *testing.T) {
 		},
 		{
 			// Reproduces gh-11399: dynamicEfMin must not exceed
-			// dynamicEfMax.
+			// dynamicEfMax (cross-field invariant).
 			name: "invalid dynamicEf bounds (min > max)",
 			input: map[string]interface{}{
 				"dynamicEfMin": float64(500),
@@ -664,56 +675,16 @@ func Test_UserConfig(t *testing.T) {
 			expectErrMsg: "dynamicEfMin (500) must be less than or " +
 				"equal to dynamicEfMax (10)",
 		},
-		{
-			// Reproduces gh-11400: negative flatSearchCutoff has no
-			// meaningful interpretation.
-			name: "invalid flatSearchCutoff (negative)",
-			input: map[string]interface{}{
-				"flatSearchCutoff": float64(-100),
-			},
-			expectErr:    true,
-			expectErrMsg: "flatSearchCutoff must not be negative",
-		},
-		{
-			name: "invalid dynamicEfMin (negative)",
-			input: map[string]interface{}{
-				"dynamicEfMin": float64(-1),
-			},
-			expectErr:    true,
-			expectErrMsg: "dynamicEfMin must not be negative",
-		},
-		{
-			name: "invalid dynamicEfMax (negative)",
-			input: map[string]interface{}{
-				"dynamicEfMax": float64(-1),
-			},
-			expectErr:    true,
-			expectErrMsg: "dynamicEfMax must not be negative",
-		},
-		{
-			name: "invalid dynamicEfFactor (negative)",
-			input: map[string]interface{}{
-				"dynamicEfFactor": float64(-1),
-			},
-			expectErr:    true,
-			expectErrMsg: "dynamicEfFactor must not be negative",
-		},
-		{
-			name: "invalid cleanupIntervalSeconds (negative)",
-			input: map[string]interface{}{
-				"cleanupIntervalSeconds": float64(-1),
-			},
-			expectErr:    true,
-			expectErrMsg: "cleanupIntervalSeconds must not be negative",
-		},
-		{
-			name: "invalid vectorCacheMaxObjects (negative)",
-			input: map[string]interface{}{
-				"vectorCacheMaxObjects": float64(-1),
-			},
-			expectErr:    true,
-			expectErrMsg: "vectorCacheMaxObjects must not be negative",
-		},
+		// Negative-value cases for the per-field range checks. The literal
+		// gh-11400 reproducer (flatSearchCutoff=-100) is included; the rest
+		// pin adjacent fields covered by the same validation pass. Generated
+		// from a single slice so future fields can be added with one line.
+		negativeCase("flatSearchCutoff", -100), // reproduces gh-11400
+		negativeCase("dynamicEfMin", -1),
+		negativeCase("dynamicEfMax", -1),
+		negativeCase("dynamicEfFactor", -1),
+		negativeCase("cleanupIntervalSeconds", -1),
+		negativeCase("vectorCacheMaxObjects", -1),
 		{
 			name: "with bq",
 			input: map[string]interface{}{


### PR DESCRIPTION
## Summary

The HNSW `vectorIndexConfig` block currently only validates `maxConnections`, `efConstruction` and `filterStrategy`. Several other numeric fields are read by `OptionalIntFromMap` and stored verbatim, so logically/semantically invalid values are silently accepted. This PR plugs that gap.

Closes #11399 — `dynamicEfMin > dynamicEfMax` accepted (cross-field invariant)
Closes #11400 — negative `flatSearchCutoff` accepted (single-field invariant)

## Adjacent failure modes pinned

Per `CLAUDE.md` ("No bug is ever out of scope"), I enumerated and fixed the directly adjacent journeys in the same change set rather than playing whack-a-mole on the two specific reproducers:

- Negative `dynamicEfMin`, `dynamicEfMax`, `dynamicEfFactor`
- Negative `cleanupIntervalSeconds`
- Negative `vectorCacheMaxObjects`

`ef` is intentionally left untouched — `-1` is the documented "let Weaviate pick" sentinel (see `DefaultEF`).

The cross-field invariant (`dynamicEfMin <= dynamicEfMax`) is only checked once both values are non-negative, so the per-field error remains the primary signal when the user supplied a clearly bogus value.

## Implementation

Single-file change in `entities/vectorindex/hnsw/config.go`, `(*UserConfig).validate()`. Each new rule appends to the existing `errMsgs` accumulator so all violations are reported together, matching the established style for `maxConnections`/`efConstruction`. No new exported symbols. No on-disk format change. No goroutines added (no `go_wrapper.go` involvement). No logging added (no `WithError`/`Errorf` style concerns).

## Tests

`entities/vectorindex/hnsw/config_test.go::Test_UserConfig` is extended with table entries:

- `dynamicEfMin=500, dynamicEfMax=10` (the literal #11399 reproducer; asserts the exact error string)
- `flatSearchCutoff=-100` (the literal #11400 reproducer)
- One per negative-only rule: `dynamicEfMin=-1`, `dynamicEfMax=-1`, `dynamicEfFactor=-1`, `cleanupIntervalSeconds=-1`, `vectorCacheMaxObjects=-1`
- Boundary: `dynamicEfMin == dynamicEfMax = 100` is accepted (`<=` is the rule)

Style follows the existing `expectErr/expectErrMsg` pattern.

## Test plan

- [x] `go test -count=1 ./entities/vectorindex/hnsw/...` — green
- [x] `go test -count=1 ./entities/vectorindex/...` — green (dynamic, flat, hfresh all import hnsw config)
- [x] `go test -count=1 ./usecases/schema/...` — green (schema parser uses `ParseAndValidateConfig`)
- [x] `go test -count=1 ./entities/schema/...` — green (configvalidation)
- [x] `go test -count=1 -run Config ./adapters/repos/db/vector/hnsw/` — green (config update path)
- [x] `go vet ./entities/vectorindex/hnsw/...` — clean
- [x] `gofumpt -l` on both files — clean

## Compatibility

`ParseAndValidateConfig` is invoked from REST/GraphQL request handlers via `schema.NewParser`. It is **not** called from store rehydration paths, so existing on-disk schemas with previously-tolerated invalid values will continue to load. The reporter discovered these gaps in v1.37.4 and notes the values are silently mangled, so we do not expect any production deployment relies on them.

## Out of scope (related sibling issues, not addressed here)

These were considered and deliberately deferred to keep the change focused:

- **#11401** — `replicationFactor=-1` silently normalized. Different code path: `entities/models/replication_config.go::Validate` (swagger-generated). I did not want to touch generated code in this PR.
- **#11402** — `bq.rescoreLimit=-1` silently discarded. Root cause is structural: HNSW `BQConfig` has no `RescoreLimit` field at all (`entities/vectorindex/hnsw/bq_config.go`), so the parser drops the key. Adding rescoring as a configurable knob in HNSW BQ is a feature decision the team should own.
- **#11335** — Aggregate hybrid multi-target. Lives in `usecases/traverser/traverser_aggregate.go`; substantially larger refactor.

Happy to follow up on any of these if maintainers point me at the desired shape.
