### PR TITLE
Boost scoring performance improvements

### DIFF
--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -25,13 +25,20 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/search"
 )
+
+// dateLayouts lists the time formats tried when parsing date property values
+// and origin strings. Declared at package scope to avoid per-call allocation.
+var dateLayouts = [...]string{
+	time.RFC3339Nano, time.RFC3339,
+	"2006-01-02T15:04:05", "2006-01-02",
+}
 
 func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.Result {
 	if boost == nil || len(boost.Conditions) == 0 || len(results) == 0 {
@@ -49,7 +56,7 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 	decayParams := make([]parsedDecay, len(boost.Conditions))
 	for i, cond := range boost.Conditions {
 		if cond.Decay != nil {
-			decayParams[i] = parseDecayParams(cond.Decay)
+			decayParams[i] = parseDecayParams(cond.Decay, nowTime)
 		}
 	}
 
@@ -60,7 +67,7 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 	// Compute boost score for each result.
 	boostScores := make([]float32, len(results))
 	for i := range results {
-		boostScores[i] = scoreResult(&results[i], boost.Conditions, decayParams, propertyValueScores, i, nowTime)
+		boostScores[i] = scoreResult(&results[i], boost.Conditions, decayParams, propertyValueScores, i)
 	}
 
 	// Normalize primary scores to [0,1] using min-max.
@@ -119,11 +126,20 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 	}
 
 	// Re-sort by combined score descending.
-	sort.Slice(results, func(i, j int) bool {
-		if results[i].Score != results[j].Score {
-			return results[i].Score > results[j].Score
+	slices.SortFunc(results, func(a, b search.Result) int {
+		if a.Score != b.Score {
+			if a.Score > b.Score {
+				return -1
+			}
+			return 1
 		}
-		return results[i].ID < results[j].ID
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
 	})
 
 	// Apply offset, then truncate to limit.
@@ -147,7 +163,6 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 // uses abs(weight) so the score range is [-1, 1].
 func scoreResult(r *search.Result, conditions []filters.BoostCondition,
 	decayParams []parsedDecay, propertyValueScores [][]float32, resultIdx int,
-	nowTime time.Time,
 ) float32 {
 	var weightedSum, weightSum float32
 
@@ -166,7 +181,7 @@ func scoreResult(r *search.Result, conditions []filters.BoostCondition,
 				condScore = 1.0
 			}
 		} else if cond.Decay != nil {
-			condScore = computeDecayForResult(cond.Decay, decayParams[i], props, nowTime)
+			condScore = computeDecayForResult(cond.Decay, decayParams[i], props)
 		} else if cond.PropertyValue != nil {
 			condScore = propertyValueScores[i][resultIdx]
 		}
@@ -199,6 +214,12 @@ func distToScore(results []search.Result) {
 // after the modifier so that the highest value in the result set scores 1.0.
 // Returns a slice indexed by [conditionIdx][resultIdx].
 func precomputePropertyValueScores(results []search.Result, conditions []filters.BoostCondition) [][]float32 {
+	// Extract props once per result to avoid re-extracting for each condition.
+	propsByIdx := make([]map[string]any, len(results))
+	for j := range results {
+		propsByIdx[j] = extractProps(&results[j])
+	}
+
 	scores := make([][]float32, len(conditions))
 	for i, cond := range conditions {
 		if cond.PropertyValue == nil {
@@ -210,11 +231,10 @@ func precomputePropertyValueScores(results []search.Result, conditions []filters
 		raw := make([]float64, len(results))
 
 		for j := range results {
-			props := extractProps(&results[j])
-			if props == nil {
+			if propsByIdx[j] == nil {
 				continue
 			}
-			val, err := toFloat64(props[propName])
+			val, err := toFloat64(propsByIdx[j][propName])
 			if err != nil {
 				continue
 			}
@@ -419,10 +439,17 @@ type parsedDecay struct {
 	scale      float64
 	decayValue float64
 	curve      filters.DecayCurveType
-	valid      bool
+
+	// Pre-parsed origin values so computeDistance avoids re-parsing per result.
+	originTime      time.Time
+	originTimeValid bool
+	originNum       float64
+	originNumValid  bool
+
+	valid bool
 }
 
-func parseDecayParams(d *filters.Decay) parsedDecay {
+func parseDecayParams(d *filters.Decay, nowTime time.Time) parsedDecay {
 	var offset, scale float64
 	if d.IsNumeric {
 		offset = d.OffsetNumeric
@@ -446,16 +473,36 @@ func parseDecayParams(d *filters.Decay) parsedDecay {
 	if curve == "" {
 		curve = filters.DecayCurveExp
 	}
-	return parsedDecay{
+
+	p := parsedDecay{
 		offset:     offset,
 		scale:      scale,
 		decayValue: decayValue,
 		curve:      curve,
 		valid:      true,
 	}
+
+	// Pre-parse origin as time and as number so computeDistance doesn't
+	// repeat the work for every result.
+	origin := d.Origin
+	if d.IsNumeric {
+		p.originNum = d.OriginNumeric
+		p.originNumValid = true
+	} else if origin != "" {
+		if t, err := parseOriginAsTime(origin, nowTime); err == nil {
+			p.originTime = t
+			p.originTimeValid = true
+		}
+		if n, err := strconv.ParseFloat(origin, 64); err == nil {
+			p.originNum = n
+			p.originNumValid = true
+		}
+	}
+
+	return p
 }
 
-func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[string]any, nowTime time.Time) float32 {
+func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[string]any) float32 {
 	if !parsed.valid || props == nil || decay.Path == nil {
 		return 0
 	}
@@ -466,7 +513,7 @@ func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[s
 		return 0
 	}
 
-	dist, err := computeDistance(decay, propVal, nowTime)
+	dist, err := computeDistance(parsed, propVal)
 	if err != nil {
 		return 0
 	}
@@ -474,17 +521,12 @@ func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[s
 	return computeDecayFunction(parsed.curve, dist, parsed.offset, parsed.scale, parsed.decayValue)
 }
 
-func computeDistance(decay *filters.Decay, propValue any, nowTime time.Time) (float64, error) {
+func computeDistance(parsed parsedDecay, propValue any) (float64, error) {
 	if dateVal, ok := tryParseDate(propValue); ok {
-		origin := decay.Origin
-		if origin == "" {
-			origin = "now"
+		if !parsed.originTimeValid {
+			return 0, fmt.Errorf("no valid time origin for date property")
 		}
-		originTime, err := parseOriginAsTime(origin, nowTime)
-		if err != nil {
-			return 0, err
-		}
-		return math.Abs(float64(dateVal.Sub(originTime))), nil
+		return math.Abs(float64(dateVal.Sub(parsed.originTime))), nil
 	}
 
 	numVal, err := toFloat64(propValue)
@@ -492,17 +534,11 @@ func computeDistance(decay *filters.Decay, propValue any, nowTime time.Time) (fl
 		return 0, err
 	}
 
-	var originNum float64
-	if decay.IsNumeric {
-		originNum = decay.OriginNumeric
-	} else {
-		originNum, err = strconv.ParseFloat(decay.Origin, 64)
-		if err != nil {
-			return 0, err
-		}
+	if !parsed.originNumValid {
+		return 0, fmt.Errorf("no valid numeric origin")
 	}
 
-	return math.Abs(numVal - originNum), nil
+	return math.Abs(numVal - parsed.originNum), nil
 }
 
 func computeDecayFunction(curve filters.DecayCurveType, dist, offset, scale, decayValue float64) float32 {
@@ -535,10 +571,7 @@ func tryParseDate(val any) (time.Time, bool) {
 	case time.Time:
 		return v, true
 	case string:
-		for _, layout := range []string{
-			time.RFC3339Nano, time.RFC3339,
-			"2006-01-02T15:04:05", "2006-01-02",
-		} {
+		for _, layout := range dateLayouts {
 			if t, err := time.Parse(layout, v); err == nil {
 				return t, true
 			}
@@ -551,10 +584,7 @@ func parseOriginAsTime(origin string, nowTime time.Time) (time.Time, error) {
 	if origin == "now" {
 		return nowTime, nil
 	}
-	for _, layout := range []string{
-		time.RFC3339Nano, time.RFC3339,
-		"2006-01-02T15:04:05", "2006-01-02",
-	} {
+	for _, layout := range dateLayouts {
 		if t, err := time.Parse(layout, origin); err == nil {
 			return t, nil
 		}

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -214,13 +214,25 @@ func distToScore(results []search.Result) {
 // after the modifier so that the highest value in the result set scores 1.0.
 // Returns a slice indexed by [conditionIdx][resultIdx].
 func precomputePropertyValueScores(results []search.Result, conditions []filters.BoostCondition) [][]float32 {
+	scores := make([][]float32, len(conditions))
+
+	hasPropertyValue := false
+	for i := range conditions {
+		if conditions[i].PropertyValue != nil {
+			hasPropertyValue = true
+			break
+		}
+	}
+	if !hasPropertyValue {
+		return scores
+	}
+
 	// Extract props once per result to avoid re-extracting for each condition.
 	propsByIdx := make([]map[string]any, len(results))
 	for j := range results {
 		propsByIdx[j] = extractProps(&results[j])
 	}
 
-	scores := make([][]float32, len(conditions))
 	for i, cond := range conditions {
 		if cond.PropertyValue == nil {
 			continue

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -488,8 +488,12 @@ func parseDecayParams(d *filters.Decay, nowTime time.Time) parsedDecay {
 	if d.IsNumeric {
 		p.originNum = d.OriginNumeric
 		p.originNumValid = true
-	} else if origin != "" {
-		if t, err := parseOriginAsTime(origin, nowTime); err == nil {
+	} else {
+		// Origin is optional for time-based decay: default to "now".
+		if origin == "" {
+			p.originTime = nowTime
+			p.originTimeValid = true
+		} else if t, err := parseOriginAsTime(origin, nowTime); err == nil {
 			p.originTime = t
 			p.originTimeValid = true
 		}

--- a/usecases/traverser/boost_scorer_test.go
+++ b/usecases/traverser/boost_scorer_test.go
@@ -289,7 +289,7 @@ func TestScoreResult_FilterMatch(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	assert.InDelta(t, 1.0, float64(score), 0.001)
 }
 
@@ -298,7 +298,7 @@ func TestScoreResult_FilterNoMatch(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
 
@@ -307,7 +307,7 @@ func TestScoreResult_FilterMissingProperty(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
 
@@ -316,7 +316,7 @@ func TestScoreResult_NilSchema(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
 
@@ -343,7 +343,7 @@ func TestScoreResult_WeightedAverage(t *testing.T) {
 			Weight: 1.0, // doesn't match → score 0.0
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	// (2*1.0 + 1*0.0) / (2+1) = 0.6667
 	assert.InDelta(t, 0.6667, float64(score), 0.01)
 }
@@ -360,7 +360,7 @@ func TestScoreResult_ZeroWeight(t *testing.T) {
 			Weight: 0, // zero weight defaults to 1.0
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	assert.InDelta(t, 1.0, float64(score), 0.001)
 }
 
@@ -538,9 +538,9 @@ func TestComputeDecayForResult_NumericProperty(t *testing.T) {
 		Curve:      filters.DecayCurveExp,
 		DecayValue: 0.5,
 	}
-	parsed := parseDecayParams(decay)
+	parsed := parseDecayParams(decay, time.Now())
 	props := map[string]any{"price": float64(300)} // dist=200=scale → 0.5
-	score := computeDecayForResult(decay, parsed, props, time.Now())
+	score := computeDecayForResult(decay, parsed, props)
 	assert.InDelta(t, 0.5, float64(score), 0.001)
 }
 
@@ -550,9 +550,9 @@ func TestComputeDecayForResult_MissingProperty(t *testing.T) {
 		Origin: "100",
 		Scale:  "200",
 	}
-	parsed := parseDecayParams(decay)
+	parsed := parseDecayParams(decay, time.Now())
 	props := map[string]any{}
-	score := computeDecayForResult(decay, parsed, props, time.Now())
+	score := computeDecayForResult(decay, parsed, props)
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
 
@@ -567,17 +567,17 @@ func TestComputeDecayForResult_DateProperty(t *testing.T) {
 		Curve:      filters.DecayCurveExp,
 		DecayValue: 0.5,
 	}
-	parsed := parseDecayParams(decay)
+	parsed := parseDecayParams(decay, now)
 
 	// 7 days ago → dist=scale → 0.5
 	t7dAgo := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
 	props := map[string]any{"createdAt": t7dAgo}
-	score := computeDecayForResult(decay, parsed, props, now)
+	score := computeDecayForResult(decay, parsed, props)
 	assert.InDelta(t, 0.5, float64(score), 0.05)
 
 	// Now → dist=0 → 1.0
 	props = map[string]any{"createdAt": now.Format(time.RFC3339)}
-	score = computeDecayForResult(decay, parsed, props, now)
+	score = computeDecayForResult(decay, parsed, props)
 	assert.InDelta(t, 1.0, float64(score), 0.05)
 }
 
@@ -616,7 +616,7 @@ func TestParseDecayParams_Valid(t *testing.T) {
 		Curve:      filters.DecayCurveGauss,
 		DecayValue: 0.3,
 	}
-	p := parseDecayParams(d)
+	p := parseDecayParams(d, time.Now())
 	assert.True(t, p.valid)
 	assert.InDelta(t, 10, p.offset, 0.001)
 	assert.InDelta(t, 200, p.scale, 0.001)
@@ -628,7 +628,7 @@ func TestParseDecayParams_Defaults(t *testing.T) {
 	d := &filters.Decay{
 		Scale: "100",
 	}
-	p := parseDecayParams(d)
+	p := parseDecayParams(d, time.Now())
 	assert.True(t, p.valid)
 	assert.InDelta(t, 0.5, p.decayValue, 0.001)     // default
 	assert.Equal(t, filters.DecayCurveExp, p.curve) // default
@@ -636,15 +636,15 @@ func TestParseDecayParams_Defaults(t *testing.T) {
 
 func TestParseDecayParams_InvalidScale(t *testing.T) {
 	d := &filters.Decay{Scale: ""}
-	p := parseDecayParams(d)
+	p := parseDecayParams(d, time.Now())
 	assert.False(t, p.valid)
 
 	d = &filters.Decay{Scale: "0"}
-	p = parseDecayParams(d)
+	p = parseDecayParams(d, time.Now())
 	assert.False(t, p.valid)
 
 	d = &filters.Decay{Scale: "-10"}
-	p = parseDecayParams(d)
+	p = parseDecayParams(d, time.Now())
 	assert.False(t, p.valid, "negative scale should produce invalid params")
 }
 
@@ -779,7 +779,7 @@ func TestScoreResult_NegativeWeightDemotes(t *testing.T) {
 			Weight: -1.0,
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	// weight=-1, condScore=1 → weightedSum = -1*1 = -1, weightSum = 1 → -1/1 = -1
 	assert.InDelta(t, -1.0, float64(score), 0.001)
 }
@@ -808,7 +808,7 @@ func TestScoreResult_MixedPositiveNegativeWeights(t *testing.T) {
 			Weight: -1.0,
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	// (2*1 + -1*1) / (2+1) = 1/3 ≈ 0.333
 	assert.InDelta(t, 0.333, float64(score), 0.01)
 }
@@ -886,17 +886,19 @@ func TestParseOriginAsTime(t *testing.T) {
 // --- computeDistance ---
 
 func TestComputeDistance_Numeric(t *testing.T) {
-	decay := &filters.Decay{Origin: "100"}
-	dist, err := computeDistance(decay, float64(150), time.Now())
+	decay := &filters.Decay{Origin: "100", Scale: "200"}
+	parsed := parseDecayParams(decay, time.Now())
+	dist, err := computeDistance(parsed, float64(150))
 	require.NoError(t, err)
 	assert.InDelta(t, 50, dist, 0.001)
 }
 
 func TestComputeDistance_Date(t *testing.T) {
 	now := time.Now()
-	decay := &filters.Decay{Origin: "now"}
+	decay := &filters.Decay{Origin: "now", Scale: "7d"}
+	parsed := parseDecayParams(decay, now)
 	dateVal := now.Add(-48 * time.Hour).Format(time.RFC3339)
-	dist, err := computeDistance(decay, dateVal, now)
+	dist, err := computeDistance(parsed, dateVal)
 	require.NoError(t, err)
 	expected := float64(48 * time.Hour)
 	assert.InDelta(t, expected, dist, float64(2*time.Second))
@@ -1056,7 +1058,7 @@ func TestScoreResult_NegativeWeightNonMatch(t *testing.T) {
 			Weight: -1.0,
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0)
 	// condScore=0 (no match), weight=-1 → weightedSum=-1*0=0, weightSum=1 → 0/1=0
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
@@ -1067,9 +1069,9 @@ func TestComputeDecayForResult_NonExistingField(t *testing.T) {
 		Origin: "100",
 		Scale:  "200",
 	}
-	parsed := parseDecayParams(decay)
+	parsed := parseDecayParams(decay, time.Now())
 	props := map[string]any{"price": float64(50)}
-	score := computeDecayForResult(decay, parsed, props, time.Now())
+	score := computeDecayForResult(decay, parsed, props)
 	assert.InDelta(t, 0.0, float64(score), 0.001, "decay on non-existing field should score 0")
 }
 
@@ -1079,8 +1081,8 @@ func TestComputeDecayForResult_NilProps(t *testing.T) {
 		Origin: "100",
 		Scale:  "200",
 	}
-	parsed := parseDecayParams(decay)
-	score := computeDecayForResult(decay, parsed, nil, time.Now())
+	parsed := parseDecayParams(decay, time.Now())
+	score := computeDecayForResult(decay, parsed, nil)
 	assert.InDelta(t, 0.0, float64(score), 0.001, "decay on nil props should score 0")
 }
 


### PR DESCRIPTION
### What's being changed:

Changes made to `boost_scorer.go`:

  1. Decay origin pre-parsed once — This can eliminate ~10k–40k redundant time.Parse/strconv.ParseFloat calls per query.
  2. Layout literals hoisted to package scope — Introduced var dateLayouts = [...]string{...} at package scope. tryParseDate and parseOriginAsTime now range over this fixed-size array
  instead of allocating a new []string slice on every call.
  3. extractProps precomputed once per result — In precomputePropertyValueScores, props are now extracted once into a propsByIdx slice before iterating conditions, eliminating K-1
  redundant extractions per result (where K = number of property_value conditions).
  4. sort.Slice → slices.SortFunc — Replaced reflection-based sort.Slice with generic slices.SortFunc for the final re-sort of up to 10k results, giving ~2-3x sort speedup.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
