### PR TITLE
Nested object filtering — Part 21: 96-bit path hash, IsNull in operator subtrees, write-path allocation cuts  

### DIFF
--- a/adapters/repos/db/inverted/nested/assign.go
+++ b/adapters/repos/db/inverted/nested/assign.go
@@ -390,9 +390,13 @@ func (w *walker) walkScalarArray(path string, dt schema.DataType,
 	return allPositions, nil
 }
 
+// joinPath concatenates prefix + separator + name without the
+// []string + strings.Join allocation that filnested.JoinPath incurs.
+// Called once per NestedProperty per object during nested write
+// analysis, so the per-call alloc adds up on heavy ingest.
 func joinPath(prefix, name string) string {
 	if prefix == "" {
 		return name
 	}
-	return filnested.JoinPath([]string{prefix, name})
+	return prefix + filnested.PathSep + name
 }

--- a/adapters/repos/db/inverted/nested/keys.go
+++ b/adapters/repos/db/inverted/nested/keys.go
@@ -68,6 +68,16 @@ func IdxKey(path string, index int) []byte {
 	return hashKey(idxKeyPrefix(path), binary.BigEndian.AppendUint16(nil, uint16(index)))
 }
 
+// IdxKeyPrefix returns the hash-only prefix used by IdxKey / IdxKeyToBuf for
+// a path (no BE16 index suffix). Consumers building Seek-then-HasPrefix
+// iterators must use this instead of PathPrefix("_idx."+path) so the
+// empty-path handling stays aligned with the producer — otherwise a
+// root-LCA iteration would compute hash("_idx.") while Seek lands on
+// hash("_idx") and the first HasPrefix check would always fail.
+func IdxKeyPrefix(path string) []byte {
+	return hashKey(idxKeyPrefix(path), nil)
+}
+
 // IdxKeyToBuf writes an _idx key into buf and returns the populated slice.
 // buf must be at least IdxKeySize bytes. Use this in loops to avoid
 // per-iteration allocation; declare a [IdxKeySize]byte on the stack and pass

--- a/adapters/repos/db/inverted/nested/keys.go
+++ b/adapters/repos/db/inverted/nested/keys.go
@@ -14,38 +14,55 @@ package nested
 import (
 	"encoding/binary"
 
-	"github.com/cespare/xxhash/v2"
+	"github.com/zeebo/xxh3"
 )
 
 const (
-	hashSize   = 8            // xxHash64 produces 8 bytes
-	IdxKeySize = hashSize + 2 // hash8 + BE16(index)
+	// hashSize is the 96-bit (12-byte) prefix derived from xxh3-128.
+	// Birthday-paradox collision probability at 10^10 distinct paths is
+	// ~10^-12 — comfortable headroom beyond any realistic schema size,
+	// at +4 bytes per LSM key over the previous 64-bit (xxh64) prefix.
+	// Backward-incompatible on-disk format change vs the 64-bit prefix;
+	// the change is safe to land while nested filtering is preview-gated
+	// (no production data exists yet).
+	hashSize   = 12
+	IdxKeySize = hashSize + 2 // hash12 + BE16(index)
 )
 
-// hashKey is the shared primitive: allocate a buffer, write
-// xxhash.Sum64String(input) as 8 big-endian bytes, then append suffix.
+// hashKey is the shared primitive: allocate a buffer, write the top
+// 96 bits of xxh3-128(input) as big-endian bytes, then append suffix.
 func hashKey(input string, suffix []byte) []byte {
 	key := make([]byte, hashSize+len(suffix))
-	binary.BigEndian.PutUint64(key, xxhash.Sum64String(input))
+	writeHashPrefix(key, input)
 	copy(key[hashSize:], suffix)
 	return key
 }
 
-// PathPrefix returns the 8-byte hash prefix for a dot-notation property path.
-// Used as keyPrefix on RowReaderRoaringSet when reading from a nested bucket.
+// writeHashPrefix writes the 12-byte (96-bit) xxh3-128 truncated prefix
+// of input into the first hashSize bytes of dst. dst must be at least
+// hashSize bytes.
+func writeHashPrefix(dst []byte, input string) {
+	sum := xxh3.HashString128(input)
+	binary.BigEndian.PutUint64(dst, sum.Hi)
+	binary.BigEndian.PutUint32(dst[8:], uint32(sum.Lo>>32))
+}
+
+// PathPrefix returns the hashSize-byte hash prefix for a dot-notation
+// property path. Used as keyPrefix on RowReaderRoaringSet when reading
+// from a nested bucket.
 func PathPrefix(path string) []byte {
 	return hashKey(path, nil)
 }
 
 // ValueKey builds the key for the nested value bucket:
-// hash8(path) + analyzedValue.
+// hash12(path) + analyzedValue.
 func ValueKey(path string, analyzedValue []byte) []byte {
 	return hashKey(path, analyzedValue)
 }
 
 // IdxKey builds the key for an _idx metadata entry:
-// hash8("_idx." + path) + BE16(index) for named paths,
-// or hash8("_idx") + BE16(index) for the root (path == "").
+// hash12("_idx." + path) + BE16(index) for named paths,
+// or hash12("_idx") + BE16(index) for the root (path == "").
 // Mirrors ExistsKey's empty-path handling.
 func IdxKey(path string, index int) []byte {
 	return hashKey(idxKeyPrefix(path), binary.BigEndian.AppendUint16(nil, uint16(index)))
@@ -57,7 +74,7 @@ func IdxKey(path string, index int) []byte {
 // a slice of it.
 func IdxKeyToBuf(path string, index int, buf []byte) []byte {
 	buf = buf[:IdxKeySize]
-	binary.BigEndian.PutUint64(buf, xxhash.Sum64String(idxKeyPrefix(path)))
+	writeHashPrefix(buf, idxKeyPrefix(path))
 	binary.BigEndian.PutUint16(buf[hashSize:], uint16(index))
 	return buf
 }
@@ -73,7 +90,7 @@ func idxKeyPrefix(path string) string {
 }
 
 // ExistsKey builds the key for an _exists metadata entry:
-// hash8("_exists." + path) for named paths, or hash8("_exists") for root.
+// hash12("_exists." + path) for named paths, or hash12("_exists") for root.
 func ExistsKey(path string) []byte {
 	if path == "" {
 		return hashKey("_exists", nil)

--- a/adapters/repos/db/inverted/nested/keys.go
+++ b/adapters/repos/db/inverted/nested/keys.go
@@ -44,9 +44,11 @@ func ValueKey(path string, analyzedValue []byte) []byte {
 }
 
 // IdxKey builds the key for an _idx metadata entry:
-// hash8("_idx." + path) + BE16(index).
+// hash8("_idx." + path) + BE16(index) for named paths,
+// or hash8("_idx") + BE16(index) for the root (path == "").
+// Mirrors ExistsKey's empty-path handling.
 func IdxKey(path string, index int) []byte {
-	return hashKey("_idx."+path, binary.BigEndian.AppendUint16(nil, uint16(index)))
+	return hashKey(idxKeyPrefix(path), binary.BigEndian.AppendUint16(nil, uint16(index)))
 }
 
 // IdxKeyToBuf writes an _idx key into buf and returns the populated slice.
@@ -55,9 +57,19 @@ func IdxKey(path string, index int) []byte {
 // a slice of it.
 func IdxKeyToBuf(path string, index int, buf []byte) []byte {
 	buf = buf[:IdxKeySize]
-	binary.BigEndian.PutUint64(buf, xxhash.Sum64String("_idx."+path))
+	binary.BigEndian.PutUint64(buf, xxhash.Sum64String(idxKeyPrefix(path)))
 	binary.BigEndian.PutUint16(buf[hashSize:], uint16(index))
 	return buf
+}
+
+// idxKeyPrefix returns the string that's hashed for an _idx key. For the
+// root (empty path) it's just "_idx" — matching ExistsKey's convention so
+// the prefix conventions are consistent across the two key families.
+func idxKeyPrefix(path string) string {
+	if path == "" {
+		return "_idx"
+	}
+	return "_idx." + path
 }
 
 // ExistsKey builds the key for an _exists metadata entry:

--- a/adapters/repos/db/inverted/nested/keys_test.go
+++ b/adapters/repos/db/inverted/nested/keys_test.go
@@ -133,6 +133,31 @@ func TestIdxKeyToBuf(t *testing.T) {
 	})
 }
 
+func TestIdxKeyPrefix(t *testing.T) {
+	t.Run("matches first hashSize bytes of IdxKey for named path", func(t *testing.T) {
+		path := "addresses"
+		assert.Equal(t, IdxKeyPrefix(path), IdxKey(path, 0)[:hashSize])
+		assert.Equal(t, IdxKeyPrefix(path), IdxKey(path, 42)[:hashSize])
+	})
+
+	t.Run("matches first hashSize bytes of IdxKey for root path", func(t *testing.T) {
+		assert.Equal(t, IdxKeyPrefix(""), IdxKey("", 0)[:hashSize])
+		assert.Equal(t, IdxKeyPrefix(""), IdxKey("", 7)[:hashSize])
+	})
+
+	t.Run("root path hashes _idx without dot (aligned with IdxKey)", func(t *testing.T) {
+		assert.Equal(t, wantHashPrefix("_idx"), IdxKeyPrefix(""))
+	})
+
+	t.Run("named path hashes _idx-prefixed path", func(t *testing.T) {
+		assert.Equal(t, wantHashPrefix("_idx.cars"), IdxKeyPrefix("cars"))
+	})
+
+	t.Run("root differs from named paths", func(t *testing.T) {
+		assert.NotEqual(t, IdxKeyPrefix(""), IdxKeyPrefix("cars"))
+	})
+}
+
 func TestExistsKey(t *testing.T) {
 	t.Run("named path hashes _exists prefix with path", func(t *testing.T) {
 		key := ExistsKey("owner.firstname")

--- a/adapters/repos/db/inverted/nested/keys_test.go
+++ b/adapters/repos/db/inverted/nested/keys_test.go
@@ -15,25 +15,34 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// wantHashPrefix mirrors writeHashPrefix and returns the 12-byte expected
+// hash prefix for a given string. Used in the asserts below so the layout
+// detail (xxh3-128 truncated to 96 bits) stays in one place — bumping
+// hashSize again only requires updating writeHashPrefix and this helper.
+func wantHashPrefix(s string) []byte {
+	dst := make([]byte, hashSize)
+	writeHashPrefix(dst, s)
+	return dst
+}
+
 func TestPathPrefix(t *testing.T) {
-	t.Run("returns 8-byte xxhash of path", func(t *testing.T) {
+	t.Run("returns hashSize bytes of hash of path", func(t *testing.T) {
 		prefix := PathPrefix("addresses.city")
-		require.Len(t, prefix, 8)
-		assert.Equal(t, xxhash.Sum64String("addresses.city"), binary.BigEndian.Uint64(prefix))
+		require.Len(t, prefix, hashSize)
+		assert.Equal(t, wantHashPrefix("addresses.city"), prefix)
 	})
 
 	t.Run("different paths produce different prefixes", func(t *testing.T) {
 		assert.NotEqual(t, PathPrefix("addresses.city"), PathPrefix("addresses.postcode"))
 	})
 
-	t.Run("matches first 8 bytes of ValueKey for same path", func(t *testing.T) {
+	t.Run("matches first hashSize bytes of ValueKey for same path", func(t *testing.T) {
 		path := "addresses.city"
-		assert.Equal(t, PathPrefix(path), ValueKey(path, []byte("Berlin"))[:8])
+		assert.Equal(t, PathPrefix(path), ValueKey(path, []byte("Berlin"))[:hashSize])
 	})
 }
 
@@ -42,9 +51,9 @@ func TestValueKey(t *testing.T) {
 		value := []byte("Berlin")
 		key := ValueKey("addresses.city", value)
 
-		require.Len(t, key, 8+len(value))
-		assert.Equal(t, xxhash.Sum64String("addresses.city"), binary.BigEndian.Uint64(key[:8]))
-		assert.Equal(t, value, key[8:])
+		require.Len(t, key, hashSize+len(value))
+		assert.Equal(t, wantHashPrefix("addresses.city"), key[:hashSize])
+		assert.Equal(t, value, key[hashSize:])
 	})
 
 	t.Run("different paths same value produce different keys", func(t *testing.T) {
@@ -56,7 +65,7 @@ func TestValueKey(t *testing.T) {
 	t.Run("same path different values share hash prefix", func(t *testing.T) {
 		k1 := ValueKey("addresses.city", []byte("Berlin"))
 		k2 := ValueKey("addresses.city", []byte("Hamburg"))
-		assert.Equal(t, k1[:8], k2[:8])
+		assert.Equal(t, k1[:hashSize], k2[:hashSize])
 		assert.NotEqual(t, k1, k2)
 	})
 }
@@ -65,34 +74,34 @@ func TestIdxKey(t *testing.T) {
 	t.Run("hash prefix followed by BE16 index", func(t *testing.T) {
 		key := IdxKey("addresses", 0)
 
-		require.Len(t, key, 10)
-		assert.Equal(t, xxhash.Sum64String("_idx.addresses"), binary.BigEndian.Uint64(key[:8]))
-		assert.Equal(t, uint16(0), binary.BigEndian.Uint16(key[8:]))
+		require.Len(t, key, IdxKeySize)
+		assert.Equal(t, wantHashPrefix("_idx.addresses"), key[:hashSize])
+		assert.Equal(t, uint16(0), binary.BigEndian.Uint16(key[hashSize:]))
 	})
 
 	t.Run("same path different indices share hash prefix", func(t *testing.T) {
 		k0 := IdxKey("addresses", 0)
 		k1 := IdxKey("addresses", 1)
-		assert.Equal(t, k0[:8], k1[:8])
-		assert.Equal(t, uint16(1), binary.BigEndian.Uint16(k1[8:]))
+		assert.Equal(t, k0[:hashSize], k1[:hashSize])
+		assert.Equal(t, uint16(1), binary.BigEndian.Uint16(k1[hashSize:]))
 		assert.NotEqual(t, k0, k1)
 	})
 
 	t.Run("different paths produce different hash prefixes", func(t *testing.T) {
 		k1 := IdxKey("addresses", 0)
 		k2 := IdxKey("cars", 0)
-		assert.NotEqual(t, k1[:8], k2[:8])
+		assert.NotEqual(t, k1[:hashSize], k2[:hashSize])
 	})
 
 	t.Run("root path hashes _idx without dot", func(t *testing.T) {
 		key := IdxKey("", 0)
-		require.Len(t, key, 10)
-		assert.Equal(t, xxhash.Sum64String("_idx"), binary.BigEndian.Uint64(key[:8]))
-		assert.Equal(t, uint16(0), binary.BigEndian.Uint16(key[8:]))
+		require.Len(t, key, IdxKeySize)
+		assert.Equal(t, wantHashPrefix("_idx"), key[:hashSize])
+		assert.Equal(t, uint16(0), binary.BigEndian.Uint16(key[hashSize:]))
 	})
 
 	t.Run("root differs from named paths", func(t *testing.T) {
-		assert.NotEqual(t, IdxKey("", 0)[:8], IdxKey("addresses", 0)[:8])
+		assert.NotEqual(t, IdxKey("", 0)[:hashSize], IdxKey("addresses", 0)[:hashSize])
 	})
 }
 
@@ -127,14 +136,14 @@ func TestIdxKeyToBuf(t *testing.T) {
 func TestExistsKey(t *testing.T) {
 	t.Run("named path hashes _exists prefix with path", func(t *testing.T) {
 		key := ExistsKey("owner.firstname")
-		require.Len(t, key, 8)
-		assert.Equal(t, xxhash.Sum64String("_exists.owner.firstname"), binary.BigEndian.Uint64(key))
+		require.Len(t, key, hashSize)
+		assert.Equal(t, wantHashPrefix("_exists.owner.firstname"), key)
 	})
 
 	t.Run("root path hashes _exists without dot", func(t *testing.T) {
 		key := ExistsKey("")
-		require.Len(t, key, 8)
-		assert.Equal(t, xxhash.Sum64String("_exists"), binary.BigEndian.Uint64(key))
+		require.Len(t, key, hashSize)
+		assert.Equal(t, wantHashPrefix("_exists"), key)
 	})
 
 	t.Run("different paths produce different keys", func(t *testing.T) {

--- a/adapters/repos/db/inverted/nested/keys_test.go
+++ b/adapters/repos/db/inverted/nested/keys_test.go
@@ -83,6 +83,17 @@ func TestIdxKey(t *testing.T) {
 		k2 := IdxKey("cars", 0)
 		assert.NotEqual(t, k1[:8], k2[:8])
 	})
+
+	t.Run("root path hashes _idx without dot", func(t *testing.T) {
+		key := IdxKey("", 0)
+		require.Len(t, key, 10)
+		assert.Equal(t, xxhash.Sum64String("_idx"), binary.BigEndian.Uint64(key[:8]))
+		assert.Equal(t, uint16(0), binary.BigEndian.Uint16(key[8:]))
+	})
+
+	t.Run("root differs from named paths", func(t *testing.T) {
+		assert.NotEqual(t, IdxKey("", 0)[:8], IdxKey("addresses", 0)[:8])
+	})
 }
 
 func TestIdxKeyToBuf(t *testing.T) {
@@ -104,6 +115,12 @@ func TestIdxKeyToBuf(t *testing.T) {
 	t.Run("result length is always IdxKeySize", func(t *testing.T) {
 		var buf [IdxKeySize]byte
 		assert.Len(t, IdxKeyToBuf("some.nested.path", 42, buf[:]), IdxKeySize)
+	})
+
+	t.Run("root path produces same result as IdxKey root", func(t *testing.T) {
+		var buf [IdxKeySize]byte
+		assert.Equal(t, IdxKey("", 0), IdxKeyToBuf("", 0, buf[:]))
+		assert.Equal(t, IdxKey("", 7), IdxKeyToBuf("", 7, buf[:]))
 	})
 }
 

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -387,8 +387,8 @@ func (pv *propValuePair) fetchNestedPositions(ctx context.Context, s *Searcher) 
 // IdxKey(relPath, index) from the nested metadata bucket and ANDs it into
 // the accumulator using mergeBitmapsAndOrWithDenyList, which selects the more
 // efficient accumulator (smaller for AND) and releases the discarded buffer.
-// Returns the (potentially swapped) accumulator. On error the current
-// accumulator is returned unchanged — the caller is responsible for releasing it.
+// Returns the (potentially swapped) accumulator on success. On error the
+// accumulator is released internally and nil is returned.
 // No-op when arrayIndices is empty.
 func (pv *propValuePair) restrictByNestedIdx(s *Searcher, positions *docBitmap) (*docBitmap, error) {
 	if len(pv.nested.arrayIndices) == 0 {

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
@@ -253,31 +253,8 @@ func materializeNestedContainsNone(
 // element at LCA where the operand is missing.
 func routeDirectLeaf(ctx context.Context, leaf *propValuePair, fetcher recBitmapFetcher, bitmapOps *invnested.BitmapOps, input *recGroupInput) error {
 	if leaf.operator == filters.OperatorIsNull {
-		bm, rel, err := fetcher.fetchExists(leaf)
-		if err != nil {
-			return fmt.Errorf("normalizeRecGroup: fetch exists for %q: %w", leaf.nested.relPath, err)
-		}
-		input.releases = append(input.releases, rel)
-		isAbsent := len(leaf.value) > 0 && leaf.value[0] == 0x01
-		if isAbsent {
-			lca, err := leaf.isNullOperandLCA()
-			if err != nil {
-				return fmt.Errorf("normalizeRecGroup: compute LCA for IsNull %q: %w", leaf.nested.relPath, err)
-			}
-			lcaBm, lcaRel, err := fetcher.fetchExistsAtPath(leaf, lca)
-			if err != nil {
-				return fmt.Errorf("normalizeRecGroup: fetch exists at LCA %q for IsNull on %q: %w", lca, leaf.nested.relPath, err)
-			}
-			input.releases = append(input.releases, lcaRel)
-			existential, existRel := bitmapOps.AndNot(lcaBm, bm, concurrency.SROAR_MERGE)
-			input.releases = append(input.releases, existRel)
-			input.positives = append(input.positives, leaf)
-			input.rawsByCond[leaf] = existential
-			return nil
-		}
 		input.positives = append(input.positives, leaf)
-		input.rawsByCond[leaf] = bm
-		return nil
+		return materializeNestedIsNull(leaf, fetcher, bitmapOps, input)
 	}
 
 	bm, rel, err := fetcher.fetchValue(ctx, leaf)
@@ -287,6 +264,54 @@ func routeDirectLeaf(ctx context.Context, leaf *propValuePair, fetcher recBitmap
 	input.releases = append(input.releases, rel)
 	input.positives = append(input.positives, leaf)
 	input.rawsByCond[leaf] = bm
+	return nil
+}
+
+// materializeNestedIsNull computes the IsNull leaf's strict-existential
+// bitmap (when IsNull=true) or positive existence bitmap (when IsNull=false)
+// and stores it in input.rawsByCond keyed by the leaf. Used by both
+// routeDirectLeaf (direct child of correlated AND) and
+// fetchOperatorSubtreeBitmaps (IsNull buried inside an OR/NOT/inner-AND
+// subtree). Does NOT touch input.positives — the caller decides whether the
+// leaf is itself a planner entry.
+//
+// IsNull=true is materialized as _exists.{operandLCA} AndNot _exists.{relPath}
+// — a strict-existential bitmap at the operand's natural LCA marking elements
+// that have the field absent. IsNull=false reduces to the operand's own
+// _exists.{relPath} bitmap (the field is present at those positions).
+//
+// Phase-3 inheritance makes the resulting bitmap compose correctly through
+// OR / NOT siblings at the same operand LCA: scalars within a parent element
+// share their parent's element-position encoding, so the existential bitmap
+// and value-leaf bitmaps live at the same per-element leaf positions.
+func materializeNestedIsNull(
+	leaf *propValuePair,
+	fetcher recBitmapFetcher,
+	bitmapOps *invnested.BitmapOps,
+	input *recGroupInput,
+) error {
+	bm, rel, err := fetcher.fetchExists(leaf)
+	if err != nil {
+		return fmt.Errorf("normalizeRecGroup: fetch exists for %q: %w", leaf.nested.relPath, err)
+	}
+	input.releases = append(input.releases, rel)
+	isAbsent := len(leaf.value) > 0 && leaf.value[0] == 0x01
+	if !isAbsent {
+		input.rawsByCond[leaf] = bm
+		return nil
+	}
+	lca, err := leaf.isNullOperandLCA()
+	if err != nil {
+		return fmt.Errorf("normalizeRecGroup: compute LCA for IsNull %q: %w", leaf.nested.relPath, err)
+	}
+	lcaBm, lcaRel, err := fetcher.fetchExistsAtPath(leaf, lca)
+	if err != nil {
+		return fmt.Errorf("normalizeRecGroup: fetch exists at LCA %q for IsNull on %q: %w", lca, leaf.nested.relPath, err)
+	}
+	input.releases = append(input.releases, lcaRel)
+	existential, existRel := bitmapOps.AndNot(lcaBm, bm, concurrency.SROAR_MERGE)
+	input.releases = append(input.releases, existRel)
+	input.rawsByCond[leaf] = existential
 	return nil
 }
 
@@ -303,10 +328,9 @@ func routeDirectLeaf(ctx context.Context, leaf *propValuePair, fetcher recBitmap
 // so the planner sees the same shape regardless of how deeply the wrapper is
 // nested under operator subtrees.
 //
-// IsNull leaves inside operator subtrees are not yet supported; if encountered
-// the function returns an error so callers can detect the gap rather than
-// produce silent wrong results. Mixing IsNull with same-element OR/NOT
-// semantics will be addressed alongside the IsNull validation step.
+// IsNull leaves are materialized via materializeNestedIsNull (same path
+// routeDirectLeaf uses), so the resulting bitmap composes with sibling
+// value leaves through OR / NOT via Phase-3 inheritance.
 func fetchOperatorSubtreeBitmaps(
 	ctx context.Context,
 	node *propValuePair,
@@ -317,7 +341,7 @@ func fetchOperatorSubtreeBitmaps(
 ) error {
 	if node.nested.isNested {
 		if node.operator == filters.OperatorIsNull {
-			return fmt.Errorf("normalizeRecGroup: IsNull leaf inside operator subtree not yet supported (%q)", node.nested.relPath)
+			return materializeNestedIsNull(node, fetcher, bitmapOps, input)
 		}
 		bm, rel, err := fetcher.fetchValue(ctx, node)
 		if err != nil {

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -56,7 +56,7 @@ func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 // buildNestedFilterPair encodes the filter value for the given leaf type and
 // returns the corresponding propValuePair(s).
 func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
-	arrayIndices []filnested.ArrayIndex, leaf *models.NestedProperty, class *models.Class,
+	arrayIndices arrayIndices, leaf *models.NestedProperty, class *models.Class,
 ) (*propValuePair, error) {
 	dt := schema.DataType(leaf.DataType[0])
 	switch dt {
@@ -75,7 +75,7 @@ func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, propName, fullP
 // ASCII folding, wildcard handling) was aligned with extractTokenizableProp
 // manually. Consider extracting a shared helper to avoid future divergence.
 func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
-	leaf *models.NestedProperty, arrayIndices []filnested.ArrayIndex, class *models.Class,
+	leaf *models.NestedProperty, arrayIndices arrayIndices, class *models.Class,
 ) (*propValuePair, error) {
 	valueStr, ok := filter.Value.Value.(string)
 	if !ok {
@@ -144,7 +144,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, f
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,
 // number, bool, date and their array variants).
 func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
-	dt schema.DataType, arrayIndices []filnested.ArrayIndex, class *models.Class,
+	dt schema.DataType, arrayIndices arrayIndices, class *models.Class,
 ) (*propValuePair, error) {
 	// Map array types to their scalar equivalent — each array element is stored
 	// individually in the nested bucket, so filtering works the same way.
@@ -189,7 +189,7 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, propNa
 // nested property. relPath is "" for root-level existence (e.g. "addresses IsNull")
 // or the dot-notation sub-path (e.g. "city" for "addresses.city IsNull").
 // arrayIndices carries any arr[N] constraints from the filter path.
-func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPath string, arrayIndices []filnested.ArrayIndex, class *models.Class) (*propValuePair, error) {
+func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPath string, arrayIndices arrayIndices, class *models.Class) (*propValuePair, error) {
 	value, err := s.extractBoolValue(filter.Value.Value)
 	if err != nil {
 		return nil, fmt.Errorf("nested IsNull %q: encode bool: %w", propName, err)

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -387,7 +387,7 @@ func (e *recExecutor) runIdxLoopRecursive(ctx context.Context, g *recGroupNode, 
 		return nil, nil, err
 	}
 
-	idxPrefix := invnested.PathPrefix("_idx." + g.lca)
+	idxPrefix := invnested.IdxKeyPrefix(g.lca)
 
 	capHint := 64
 	for _, leaf := range g.here {

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -8634,6 +8634,240 @@ func TestNestedFilteringMixedArrayIndexConstraints(t *testing.T) {
 	})
 }
 
+// TestNestedFilteringIsNullInOperatorSubtree covers IsNull / IsNotNull
+// leaves *buried inside an operator subtree* (OR, NOT, or inner AND)
+// under a same-root correlated-AND wrapper. The materialization path
+// (materializeNestedIsNull) is shared with the direct-child path, so
+// composition with sibling value leaves through OR / NOT relies on
+// Phase-3 inheritance: scalars within a parent element share the
+// element's leaf positions, so the IsNull existential bitmap and
+// value-leaf bitmaps live at the same per-element leaf and intersect /
+// union correctly.
+//
+// Six shapes, all evaluated against one shared fixture:
+//
+//  1. OR with IsNull sibling:
+//     AND(cars.make=honda, OR(cars.model=civic, cars.year IS NULL))
+//  2. OR with IsNotNull sibling:
+//     AND(cars.make=honda, OR(cars.model=civic, cars.year IS NOT NULL))
+//  3. NOT(IsNull):
+//     AND(cars.make=honda, NOT(cars.year IS NULL))
+//  4. Inner AND with IsNull:
+//     AND(cars.make=honda, AND(cars.model=civic, cars.year IS NULL))
+//  5. arr[N]-pinned IsNull inside OR:
+//     AND(cars[1].make=honda, OR(cars[1].model=civic, cars[1].year IS NULL))
+//  6. Scalar-array sibling with IsNull in OR:
+//     AND(cars.make=honda, OR(cars.tags=electric, cars.year IS NULL))
+//
+// Sub-test 6 exercises the wide-vs-narrow leaf encoding that earlier
+// analysis verified composes correctly under Phase-3 inheritance.
+func TestNestedFilteringIsNullInOperatorSubtree(t *testing.T) {
+	const nestedClass = "IsNullInOpSubtree"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "model", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "year", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		}},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+	car := func(props map[string]any) map[string]any { return props }
+
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	isNullFilter := func(path string, isNull bool) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andF := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+	orF := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: operands}}
+	}
+	notF := func(inner *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorNot, Operands: []filters.Clause{*inner.Root}}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	d1 := uuid(1) // single car: make+model+year+tags(electric)
+	d2 := uuid(2) // single car: make+model+year (no tags)
+	d3 := uuid(3) // single car: make+model (no year, no tags)
+	d4 := uuid(4) // single car: make+year (no model, no tags)
+	d5 := uuid(5) // single car: make only
+	d6 := uuid(6) // single car: wrong make (ford)
+	d7 := uuid(7) // 2 cars: cars[0]=honda+civic (no year); cars[1]=ford+year
+	d8 := uuid(8) // 2 cars: cars[0]={}; cars[1]=honda+model+year
+	d9 := uuid(9) // 2 cars: cars[0]=honda+model+year; cars[1]={}
+
+	docs := []docDef{
+		{id: d1, props: map[string]any{"cars": asArr(car(map[string]any{"make": "honda", "model": "civic", "year": "2020", "tags": asTextArr("electric")}))}, note: "single car: all fields incl. tags=electric"},
+		{id: d2, props: map[string]any{"cars": asArr(car(map[string]any{"make": "honda", "model": "civic", "year": "2020"}))}, note: "single car: no tags"},
+		{id: d3, props: map[string]any{"cars": asArr(car(map[string]any{"make": "honda", "model": "civic"}))}, note: "single car: no year, no tags"},
+		{id: d4, props: map[string]any{"cars": asArr(car(map[string]any{"make": "honda", "year": "2020"}))}, note: "single car: no model, no tags"},
+		{id: d5, props: map[string]any{"cars": asArr(car(map[string]any{"make": "honda"}))}, note: "single car: make only"},
+		{id: d6, props: map[string]any{"cars": asArr(car(map[string]any{"make": "ford", "model": "civic", "year": "2020"}))}, note: "single car: wrong make"},
+		{id: d7, props: map[string]any{"cars": asArr(
+			car(map[string]any{"make": "honda", "model": "civic"}),
+			car(map[string]any{"make": "ford", "year": "2020"}),
+		)}, note: "2 cars: same-element discriminator"},
+		{id: d8, props: map[string]any{"cars": asArr(
+			car(map[string]any{}),
+			car(map[string]any{"make": "honda", "model": "civic", "year": "2020"}),
+		)}, note: "2 cars: cars[0] empty, cars[1] has all"},
+		{id: d9, props: map[string]any{"cars": asArr(
+			car(map[string]any{"make": "honda", "model": "civic", "year": "2020"}),
+			car(map[string]any{}),
+		)}, note: "2 cars: cars[0] has all, cars[1] empty"},
+	}
+
+	runScenario := func(t *testing.T, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("OR_with_IsNull_sibling", func(t *testing.T) {
+		// AND(cars.make=honda, OR(cars.model=civic, cars.year IS NULL))
+		// Per-element: make=honda AND (model=civic OR year missing).
+		// d1: model=civic → match. d2: model=civic → match. d3: model=civic
+		// → match. d4: no model, year present → no. d5: no model, no year
+		// → IsNull → match. d6: wrong make → no. d7: cars[0] honda+civic →
+		// match. d8: cars[1] honda+civic → match. d9: cars[0] match.
+		runScenario(t, andF(
+			valueFilter("cars.make", "honda"),
+			orF(valueFilter("cars.model", "civic"), isNullFilter("cars.year", true)),
+		), []strfmt.UUID{d1, d2, d3, d5, d7, d8, d9})
+	})
+
+	t.Run("OR_with_IsNotNull_sibling", func(t *testing.T) {
+		// AND(cars.make=honda, OR(cars.model=civic, cars.year IS NOT NULL))
+		// Per-element: make=honda AND (model=civic OR year present).
+		// d5 drops (no model, no year). d3 stays (model=civic). Others
+		// same as test 1 except d4 now matches (year present).
+		runScenario(t, andF(
+			valueFilter("cars.make", "honda"),
+			orF(valueFilter("cars.model", "civic"), isNullFilter("cars.year", false)),
+		), []strfmt.UUID{d1, d2, d3, d4, d7, d8, d9})
+	})
+
+	t.Run("NOT_IsNull", func(t *testing.T) {
+		// AND(cars.make=honda, NOT(cars.year IS NULL))
+		// Per-element: make=honda AND year present.
+		// d1, d2, d4 match. d3, d5 drop (no year). d6 wrong make. d7 cars[0]
+		// no year, cars[1] wrong make → no match. d8 cars[1] match. d9
+		// cars[0] match.
+		runScenario(t, andF(
+			valueFilter("cars.make", "honda"),
+			notF(isNullFilter("cars.year", true)),
+		), []strfmt.UUID{d1, d2, d4, d8, d9})
+	})
+
+	t.Run("inner_AND_with_IsNull", func(t *testing.T) {
+		// AND(cars.make=honda, AND(cars.model=civic, cars.year IS NULL))
+		// All three in same element: make=honda, model=civic, year missing.
+		// d3 matches (make+model, no year). d7 cars[0] matches. Others
+		// fail at least one clause.
+		runScenario(t, andF(
+			valueFilter("cars.make", "honda"),
+			andF(valueFilter("cars.model", "civic"), isNullFilter("cars.year", true)),
+		), []strfmt.UUID{d3, d7})
+	})
+
+	t.Run("arrN_pinned_IsNull_inside_OR", func(t *testing.T) {
+		// AND(cars[1].make=honda, OR(cars[1].model=civic, cars[1].year IS NULL))
+		// Pinned to cars[1]. Single-car docs trivially fail. d7 cars[1]=ford
+		// → no match. d8 cars[1]=honda+civic+year → matches (model=civic).
+		// d9 cars[1]={} → no make → no match.
+		runScenario(t, andF(
+			valueFilter("cars[1].make", "honda"),
+			orF(valueFilter("cars[1].model", "civic"), isNullFilter("cars[1].year", true)),
+		), []strfmt.UUID{d8})
+	})
+
+	t.Run("scalar_array_sibling_with_IsNull", func(t *testing.T) {
+		// AND(cars.make=honda, OR(cars.tags=electric, cars.year IS NULL))
+		// Per-element: make=honda AND (tags contains electric OR year
+		// missing). Exercises Phase-3 inheritance: tags=electric leaf is
+		// at the narrow per-element-of-tags-array position, year-existential
+		// is at the wide cars-element position; both still compose via the
+		// shared parent-element encoding.
+		// d1: tags=[electric] → match. d2: no tags, year present → no.
+		// d3: no tags, no year → IsNull → match. d4: no tags, year present
+		// → no. d5: no tags, no year → IsNull → match. d6: wrong make.
+		// d7: cars[0] no year → IsNull → match. d8: cars[1] year=2020, no
+		// tags → no; cars[0] no make → no. d9: cars[0] year=2020, no tags
+		// → no; cars[1] no make → no.
+		runScenario(t, andF(
+			valueFilter("cars.make", "honda"),
+			orF(valueFilter("cars.tags", "electric"), isNullFilter("cars.year", true)),
+		), []strfmt.UUID{d1, d3, d5, d7})
+	})
+}
+
 // TestNestedFilteringIsNullWithArrayIndex covers IsNull / IsNotNull combined
 // with arr[N] in *standalone* form (no AND wrapper). Three shapes:
 //   - addresses[N] IsNull/IsNotNull  → existence of a Nth element in the array

--- a/adapters/repos/db/shard_write_inverted_lsm_nested.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_nested.go
@@ -128,9 +128,18 @@ func nestedFilterableEntries(np inverted.NestedProperty, docID uint64) []lsmkv.R
 
 func nestedMetaEntries(np inverted.NestedProperty, docID uint64) []lsmkv.RoaringSetBatchEntry {
 	entries := make([]lsmkv.RoaringSetBatchEntry, 0, len(np.Idx)+len(np.Exists))
-	for _, idx := range np.Idx {
+	// Single slab for all _idx keys. Each iteration writes into its own
+	// IdxKeySize-byte slice off the slab, so every entry holds a distinct
+	// backing array while the function makes one allocation for the key
+	// bytes overall (instead of three per IdxKey call).
+	var keys []byte
+	if n := len(np.Idx); n > 0 {
+		keys = make([]byte, n*nested.IdxKeySize)
+	}
+	for i, idx := range np.Idx {
+		buf := keys[i*nested.IdxKeySize : (i+1)*nested.IdxKeySize]
 		entries = append(entries, lsmkv.RoaringSetBatchEntry{
-			Key:    nested.IdxKey(idx.Path, idx.Index),
+			Key:    nested.IdxKeyToBuf(idx.Path, idx.Index, buf),
 			Values: nested.OrDocID(idx.Positions, docID),
 		})
 	}

--- a/adapters/repos/db/shard_write_inverted_lsm_nested.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_nested.go
@@ -137,9 +137,12 @@ func nestedMetaEntries(np inverted.NestedProperty, docID uint64) []lsmkv.Roaring
 		keys = make([]byte, n*nested.IdxKeySize)
 	}
 	for i, idx := range np.Idx {
-		buf := keys[i*nested.IdxKeySize : (i+1)*nested.IdxKeySize]
+		// 3-index slice caps cap at len so a downstream append on Key can't
+		// clobber the next entry's bytes in the shared slab.
+		start := i * nested.IdxKeySize
+		end := start + nested.IdxKeySize
 		entries = append(entries, lsmkv.RoaringSetBatchEntry{
-			Key:    nested.IdxKeyToBuf(idx.Path, idx.Index, buf),
+			Key:    nested.IdxKeyToBuf(idx.Path, idx.Index, keys[start:end:end]),
 			Values: nested.OrDocID(idx.Positions, docID),
 		})
 	}

--- a/entities/filters/nested/path.go
+++ b/entities/filters/nested/path.go
@@ -20,10 +20,12 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-// pathSep is the separator character for nested property paths.
+// PathSep is the separator character for nested property paths.
 // All path construction and parsing goes through SplitPath/JoinPath so
 // this is the single place to change if the separator ever changes.
-const pathSep = "."
+// Exported so hot-path callers can concatenate without paying the
+// []string + strings.Join allocation that JoinPath incurs.
+const PathSep = "."
 
 // indexOpen / indexClose delimit an arr[N] index suffix inside a path
 // segment (e.g. "cars[0]"). All bracket parsing in this package uses
@@ -38,7 +40,7 @@ const (
 //
 //	SplitPath("cars.tires.width") → ["cars", "tires", "width"]
 func SplitPath(path string) []string {
-	return strings.Split(path, pathSep)
+	return strings.Split(path, PathSep)
 }
 
 // JoinPath joins property name segments into a dot-notation nested path.
@@ -46,7 +48,7 @@ func SplitPath(path string) []string {
 //
 //	JoinPath(["cars", "tires", "width"]) → "cars.tires.width"
 func JoinPath(segs []string) string {
-	return strings.Join(segs, pathSep)
+	return strings.Join(segs, PathSep)
 }
 
 // PathSegment represents one component of a parsed nested filter path.
@@ -108,7 +110,7 @@ func ParseIndexedPath(path string) (cleanRelPath string, cleanRelSegs []string, 
 // RootPropName returns the root property name from a nested filter path,
 // stripping any [N] index. "addresses[1].city" → "addresses".
 func RootPropName(path string) string {
-	first, _, _ := strings.Cut(path, pathSep)
+	first, _, _ := strings.Cut(path, PathSep)
 	clean, _, _ := parseSegmentIndex(first)
 	return clean
 }
@@ -177,7 +179,7 @@ func FindLeaf(segments []string, props []*models.NestedProperty) (*models.Nested
 // Keeps the syntactic conventions (the separator character, the index
 // bracket character) localized in this package.
 func HasNestedSyntax(path string) bool {
-	return strings.ContainsAny(path, pathSep+indexOpen)
+	return strings.ContainsAny(path, PathSep+indexOpen)
 }
 
 // IsNestedPath reports whether path is a nested-property filter path on
@@ -191,7 +193,7 @@ func HasNestedSyntax(path string) bool {
 // "no such property" or "not a nested property" error instead of an
 // off-target "sub-property not found".
 func IsNestedPath(class *models.Class, path string) bool {
-	if !strings.Contains(path, pathSep) {
+	if !strings.Contains(path, PathSep) {
 		return false
 	}
 	if class == nil {

--- a/entities/filters/nested/path.go
+++ b/entities/filters/nested/path.go
@@ -20,11 +20,11 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-// PathSep is the separator character for nested property paths.
-// All path construction and parsing goes through SplitPath/JoinPath so
-// this is the single place to change if the separator ever changes.
-// Exported so hot-path callers can concatenate without paying the
-// []string + strings.Join allocation that JoinPath incurs.
+// PathSep is the separator character for nested property paths. It is
+// the single source of truth for the separator: SplitPath/JoinPath use it
+// internally, and hot-path callers may concatenate with it directly to
+// avoid the []string + strings.Join allocation that JoinPath incurs.
+// Changing the separator only requires updating this constant.
 const PathSep = "."
 
 // indexOpen / indexClose delimit an arr[N] index suffix inside a path

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/weaviate/s5cmd/v2 v2.0.1
 	github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0
 	github.com/weaviate/tiktoken-go v0.0.3
+	github.com/zeebo/xxh3 v1.1.0
 	go.etcd.io/bbolt v1.4.3
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -708,6 +708,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=


### PR DESCRIPTION
### Nested object filtering — Part 21                                                                                     
   
  Twenty-first PR in the series. Five commits: one on-disk format hardening, one execution-dispatch hole, two write-path allocation reductions, one review-driven cleanup.                                                                                    
   
  **96-bit path hash (`xxhash64` → `xxh3-128` truncated)**                                                                  
                                                                                                                          
  Nested filter keys use a hashed path prefix in three key families (value, `_idx`, `_exists`). The previous 64-bit prefix gave a birthday-paradox collision probability of ~3% at 10^9 distinct paths — not the level of confidence we want for a key whose collision produces *wrong query results* (two paths whose hashes collide share an LSM key and bleed values across paths). `hashSize` bumps 8 → 12 (96 bits) via `xxh3-128` truncated to its top 96 bits; collision probability at 10^10 paths drops to ~10^-12. New `writeHashPrefix` helper centralises the layout; tests use a parallel `wantHashPrefix` helper so future bumps only touch two places. Backward-incompatible on-disk format change; safe to land now because nested filtering is preview-gated (`WEAVIATE_PREVIEW_NESTED_FILTERING`, default off — landed in Part 20). Adds `github.com/zeebo/xxh3 v1.1.0`.                                                                                      
                                                                                                                            
  **IsNull leaves inside operator subtrees (OR / NOT / inner-AND)**                                                         
                                                                                                                            
  `fetchOperatorSubtreeBitmaps` was rejecting IsNull buried inside an OR/NOT/inner-AND operand of a same-root correlated AND with a runtime error. The filter shape is valid (e.g. `AND(cars.make=honda, OR(cars.model=civic, cars.year IS NULL))`) and validation accepts it; only execution failed. Phase-3 inheritance makes the IsNull existential bitmap and value-leaf bitmaps share the same per-element encoding, so OR / NOT / nested-AND compose correctly. Extracts a `materializeNestedIsNull` helper used by both `routeDirectLeaf` and `fetchOperatorSubtreeBitmaps`, mirroring the existing `materializeNestedContainsNone`. Adds `TestNestedFilteringIsNullInOperatorSubtree` (6 subtests covering OR, NOT, inner-AND, arr[N]-pinned IsNull, scalar-array sibling).                                                              
                                                                                                                            
  **Write-path allocations: `nestedMetaEntries` single-slab + `_idx` empty-path alignment**                                                                                                  
                                                                                                                            
  `nestedMetaEntries` was calling `IdxKey` once per `_idx` entry per nested-object write, each call allocating three heap slices. Each entry's key is stored on the returned batch (consumed later by `RoaringSet{Add,Remove}Batch`), so one reused buffer would alias all keys to the last write. Migrated to `IdxKeyToBuf` with a single `len(np.Idx)*IdxKeySize` slab; each iteration takes its own non-aliasing slice off the slab. 3*N heap allocs → 1. Bundled in: `IdxKey`/`IdxKeyToBuf`'s empty-path encoding now matches `ExistsKey` (empty path hashes `"_idx"`, not `"_idx."`; named paths unchanged) via a shared `idxKeyPrefix` helper.                                                                                           
                                                                                                                            
  **Write-path allocations: `joinPath` direct concat + `PathSep` export**                                                 
                                                                                                                            
  `entities/filters/nested/path.go::pathSep` is exported as `PathSep`. `adapters/repos/db/inverted/nested/assign.go::joinPath` switches from `JoinPath([]string{prefix, name})` to `prefix + PathSep + name` — called twice per `NestedProperty` per object during write analysis, so the per-call slice-header + Join output adds up on heavy ingest.                                                       
                                                                                                                            
  **Style consistency — `arrayIndices` type + `restrictByNestedIdx` doc**                                                   
                                                                                                                            
  From review of PRs #11048 (Part 9) and #11084 (Part 10). Four `buildNested*Pair` signatures now take the named `arrayIndices` type instead of the underlying slice spelling. `restrictByNestedIdx`'s doc comment is rewritten to match the actual ownership contract (defers release on any non-success exit; returns nil from every error path).                                                      
                                                                                                                            
  **Test plan**                                                                                                           
                                                                                                                            
  - [ ] `go build ./...`
  - [ ] `go test -race ./entities/filters/nested/... ./adapters/repos/db/inverted/...`                                      
  - [ ] `go test -tags integrationTest -count 1 -race -timeout 5m -run TestNestedFiltering ./adapters/repos/db/...`       
  - [ ] `go test -tags integrationTest -count 1 -race -timeout 25m ./adapters/repos/db/inverted/...`                        
  - [ ] `pytest test/acceptance_with_python/test_nested_*.py -v`