### PR TITLE
[FIX] - Recursively hash nested blobHash properties to reduce bloat

### DIFF
--- a/entities/schema/data_type_hash.go
+++ b/entities/schema/data_type_hash.go
@@ -63,75 +63,66 @@ func HashBlobHashProperties(class *models.Class, obj *models.Object) {
 	HashBlobHashPrimitiveProperties(class, props)
 }
 
-// HashBlobHashPrimitiveProperties replaces the base64 data of all BlobHash
-// properties in the given property map with their SHA-256 hashes. This
-// variant operates on a raw property map and is used by the merge/patch path
-// where properties have already been split from references.
 func HashBlobHashPrimitiveProperties(class *models.Class, props map[string]interface{}) {
 	if class == nil || props == nil {
 		return
 	}
 
 	for _, prop := range class.Properties {
-		val, exists := props[prop.Name]
-		if !exists || val == nil {
-			continue
-		}
-
-		if IsBlobHashDataType(prop.DataType) {
-			if base64Str, ok := val.(string); ok {
-				props[prop.Name] = HashBlob(base64Str)
-			}
-		} else if len(prop.DataType) == 1 {
-			dataType := prop.DataType[0]
-			if dataType == string(DataTypeObject) {
-				if objMap, ok := val.(map[string]interface{}); ok {
-					hashBlobHashNestedProperties(prop.NestedProperties, objMap)
-				}
-			} else if dataType == string(DataTypeObjectArray) {
-				if objList, ok := val.([]interface{}); ok {
-					for _, item := range objList {
-						if objMap, ok := item.(map[string]interface{}); ok {
-							hashBlobHashNestedProperties(prop.NestedProperties, objMap)
-						}
-					}
-				}
-			}
-		}
+		hashPropValue(prop.Name, prop.DataType, prop.NestedProperties, props)
 	}
 }
 
-func hashBlobHashNestedProperties(nestedProps []*models.NestedProperty, props map[string]interface{}) {
+func hashNestedProperties(nestedProps []*models.NestedProperty, props map[string]interface{}) {
 	if len(nestedProps) == 0 || props == nil {
 		return
 	}
 
 	for _, nestedProp := range nestedProps {
-		val, exists := props[nestedProp.Name]
-		if !exists || val == nil {
-			continue
-		}
+		hashPropValue(nestedProp.Name, nestedProp.DataType, nestedProp.NestedProperties, props)
+	}
+}
 
-		if IsBlobHashDataType(nestedProp.DataType) {
-			if base64Str, ok := val.(string); ok {
-				props[nestedProp.Name] = HashBlob(base64Str)
-			}
-		} else if len(nestedProp.DataType) == 1 {
-			dataType := nestedProp.DataType[0]
-			if dataType == string(DataTypeObject) {
-				if objMap, ok := val.(map[string]interface{}); ok {
-					hashBlobHashNestedProperties(nestedProp.NestedProperties, objMap)
-				}
-			} else if dataType == string(DataTypeObjectArray) {
-				if objList, ok := val.([]interface{}); ok {
-					for _, item := range objList {
-						if objMap, ok := item.(map[string]interface{}); ok {
-							hashBlobHashNestedProperties(nestedProp.NestedProperties, objMap)
-						}
-					}
-				}
-			}
+func hashPropValue(name string, dataType []string, nestedProps []*models.NestedProperty, props map[string]interface{}) {
+	if props == nil {
+		return
+	}
+	val, exists := props[name]
+	if !exists || val == nil {
+		return
+	}
+
+	if IsBlobHashDataType(dataType) {
+		if base64Str, ok := val.(string); ok {
+			props[name] = HashBlob(base64Str)
+		}
+		return
+	}
+
+	if len(dataType) == 1 {
+		hashNestedType(dataType[0], nestedProps, val)
+	}
+}
+
+func hashNestedType(dataType string, nestedProps []*models.NestedProperty, val interface{}) {
+	switch dataType {
+	case string(DataTypeObject):
+		if objMap, ok := val.(map[string]interface{}); ok {
+			hashNestedProperties(nestedProps, objMap)
+		}
+	case string(DataTypeObjectArray):
+		if objList, ok := val.([]interface{}); ok {
+			hashObjectList(nestedProps, objList)
 		}
 	}
 }
+
+func hashObjectList(nestedProps []*models.NestedProperty, objList []interface{}) {
+	for _, item := range objList {
+		if objMap, ok := item.(map[string]interface{}); ok {
+			hashNestedProperties(nestedProps, objMap)
+		}
+	}
+}
+
 

--- a/entities/schema/data_type_hash.go
+++ b/entities/schema/data_type_hash.go
@@ -124,5 +124,3 @@ func hashObjectList(nestedProps []*models.NestedProperty, objList []interface{})
 		}
 	}
 }
-
-

--- a/entities/schema/data_type_hash.go
+++ b/entities/schema/data_type_hash.go
@@ -73,15 +73,65 @@ func HashBlobHashPrimitiveProperties(class *models.Class, props map[string]inter
 	}
 
 	for _, prop := range class.Properties {
-		if !IsBlobHashDataType(prop.DataType) {
-			continue
-		}
 		val, exists := props[prop.Name]
-		if !exists {
+		if !exists || val == nil {
 			continue
 		}
-		if base64Str, ok := val.(string); ok {
-			props[prop.Name] = HashBlob(base64Str)
+
+		if IsBlobHashDataType(prop.DataType) {
+			if base64Str, ok := val.(string); ok {
+				props[prop.Name] = HashBlob(base64Str)
+			}
+		} else if len(prop.DataType) == 1 {
+			dataType := prop.DataType[0]
+			if dataType == string(DataTypeObject) {
+				if objMap, ok := val.(map[string]interface{}); ok {
+					hashBlobHashNestedProperties(prop.NestedProperties, objMap)
+				}
+			} else if dataType == string(DataTypeObjectArray) {
+				if objList, ok := val.([]interface{}); ok {
+					for _, item := range objList {
+						if objMap, ok := item.(map[string]interface{}); ok {
+							hashBlobHashNestedProperties(prop.NestedProperties, objMap)
+						}
+					}
+				}
+			}
 		}
 	}
 }
+
+func hashBlobHashNestedProperties(nestedProps []*models.NestedProperty, props map[string]interface{}) {
+	if len(nestedProps) == 0 || props == nil {
+		return
+	}
+
+	for _, nestedProp := range nestedProps {
+		val, exists := props[nestedProp.Name]
+		if !exists || val == nil {
+			continue
+		}
+
+		if IsBlobHashDataType(nestedProp.DataType) {
+			if base64Str, ok := val.(string); ok {
+				props[nestedProp.Name] = HashBlob(base64Str)
+			}
+		} else if len(nestedProp.DataType) == 1 {
+			dataType := nestedProp.DataType[0]
+			if dataType == string(DataTypeObject) {
+				if objMap, ok := val.(map[string]interface{}); ok {
+					hashBlobHashNestedProperties(nestedProp.NestedProperties, objMap)
+				}
+			} else if dataType == string(DataTypeObjectArray) {
+				if objList, ok := val.([]interface{}); ok {
+					for _, item := range objList {
+						if objMap, ok := item.(map[string]interface{}); ok {
+							hashBlobHashNestedProperties(nestedProp.NestedProperties, objMap)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+

--- a/entities/schema/data_type_hash_test.go
+++ b/entities/schema/data_type_hash_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/models"
 )
 
 func TestIsLikelySHA256Hash(t *testing.T) {
@@ -94,6 +95,195 @@ func TestIsLikelySHA256Hash(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := IsLikelySHA256Hash(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHashBlobHashPrimitiveProperties(t *testing.T) {
+	tests := []struct {
+		name     string
+		class    *models.Class
+		props    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "flat top-level blobHash property",
+			class: &models.Class{
+				Class: "TestClass",
+				Properties: []*models.Property{
+					{
+						Name:     "image",
+						DataType: []string{"blobHash"},
+					},
+					{
+						Name:     "text",
+						DataType: []string{"text"},
+					},
+				},
+			},
+			props: map[string]interface{}{
+				"image": "aGVsbG8=",
+				"text":  "some text",
+			},
+			expected: map[string]interface{}{
+				"image": HashBlob("aGVsbG8="),
+				"text":  "some text",
+			},
+		},
+		{
+			name: "nested object blobHash property",
+			class: &models.Class{
+				Class: "TestClass",
+				Properties: []*models.Property{
+					{
+						Name:     "meta",
+						DataType: []string{"object"},
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:     "image",
+								DataType: []string{"blobHash"},
+							},
+							{
+								Name:     "title",
+								DataType: []string{"text"},
+							},
+						},
+					},
+				},
+			},
+			props: map[string]interface{}{
+				"meta": map[string]interface{}{
+					"image": "aGVsbG8=",
+					"title": "a title",
+				},
+			},
+			expected: map[string]interface{}{
+				"meta": map[string]interface{}{
+					"image": HashBlob("aGVsbG8="),
+					"title": "a title",
+				},
+			},
+		},
+		{
+			name: "nested object[] array blobHash properties",
+			class: &models.Class{
+				Class: "TestClass",
+				Properties: []*models.Property{
+					{
+						Name:     "gallery",
+						DataType: []string{"object[]"},
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:     "image",
+								DataType: []string{"blobHash"},
+							},
+							{
+								Name:     "caption",
+								DataType: []string{"text"},
+							},
+						},
+					},
+				},
+			},
+			props: map[string]interface{}{
+				"gallery": []interface{}{
+					map[string]interface{}{
+						"image":   "aGVsbG8=",
+						"caption": "cap 1",
+					},
+					map[string]interface{}{
+						"image":   "d29ybGQ=",
+						"caption": "cap 2",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"gallery": []interface{}{
+					map[string]interface{}{
+						"image":   HashBlob("aGVsbG8="),
+						"caption": "cap 1",
+					},
+					map[string]interface{}{
+						"image":   HashBlob("d29ybGQ="),
+						"caption": "cap 2",
+					},
+				},
+			},
+		},
+		{
+			name: "deeply nested object properties",
+			class: &models.Class{
+				Class: "TestClass",
+				Properties: []*models.Property{
+					{
+						Name:     "meta",
+						DataType: []string{"object"},
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:     "submeta",
+								DataType: []string{"object"},
+								NestedProperties: []*models.NestedProperty{
+									{
+										Name:     "image",
+										DataType: []string{"blobHash"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			props: map[string]interface{}{
+				"meta": map[string]interface{}{
+					"submeta": map[string]interface{}{
+						"image": "aGVsbG8=",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"meta": map[string]interface{}{
+					"submeta": map[string]interface{}{
+						"image": HashBlob("aGVsbG8="),
+					},
+				},
+			},
+		},
+		{
+			name: "nil and missing properties",
+			class: &models.Class{
+				Class: "TestClass",
+				Properties: []*models.Property{
+					{
+						Name:     "image",
+						DataType: []string{"blobHash"},
+					},
+					{
+						Name:     "meta",
+						DataType: []string{"object"},
+						NestedProperties: []*models.NestedProperty{
+							{
+								Name:     "image",
+								DataType: []string{"blobHash"},
+							},
+						},
+					},
+				},
+			},
+			props: map[string]interface{}{
+				"image": nil,
+				"meta":  nil,
+			},
+			expected: map[string]interface{}{
+				"image": nil,
+				"meta":  nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			HashBlobHashPrimitiveProperties(tt.class, tt.props)
+			assert.Equal(t, tt.expected, tt.props)
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:

This PR fixes a bug where nested properties of type `blobHash` (e.g. fields inside `object` or `object[]` structures) were persisted as raw base64 instead of their SHA-256 hash.

Fixes #11447 
#### Summary of problem & fix:
* **Problem:** Hashing only checked top-level class properties. Nested `blobHash` properties passed base64 validation but were saved raw, causing storage bloat in the LSM store and returning unhashed base64 payloads to GraphQL/gRPC queries.
* **Fix:** Recursively traverse nested property schemas (`object` and `object[]`) to resolve and hash all nested `blobHash` properties on the object persistence path.

#### Specific Changes:
* **`entities/schema/data_type_hash.go`:**
  * Updated `HashBlobHashPrimitiveProperties` to walk property structures recursively.
  * Added `hashBlobHashNestedProperties` private helper to handle nesting recursion for `object` and `object[]` types.
* **`entities/schema/data_type_hash_test.go`:**
  * Added the `TestHashBlobHashPrimitiveProperties` unit test suite covering top-level, single-nested objects, array of objects, deeply nested recursion, nil values, and missing fields.

#### Testing:
* Run the schema package unit tests using:
  ```bash
  go test -v ./entities/schema/ -run TestHashBlobHashPrimitiveProperties
