### PR TITLE
Perf: reuse heap compaction inverted

### DIFF
--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -57,7 +57,6 @@ type compactorInverted struct {
 	tombstonesToClean *sroar.Bitmap
 
 	propertyLengthsToWrite map[uint64]uint32
-	propertyLengthsToClean map[uint64]uint32
 
 	invertedHeader *segmentindex.HeaderInverted
 
@@ -72,6 +71,11 @@ type compactorInverted struct {
 
 	segmentFile    *segmentindex.SegmentFile
 	maxNewFileSize int64
+
+	// reusable buffers to reduce allocations during compaction
+	writeBuf   [8]byte                  // reused by writeIndividualNode to avoid per-key allocation
+	arena      keyArena                 // arena allocator for key copies
+	encodeBufs compactorInvertedBuffers // reusable encode pipeline buffers
 }
 
 func newCompactorInverted(w io.WriteSeeker,
@@ -106,6 +110,7 @@ func newCompactorInverted(w io.WriteSeeker,
 		enableChecksumValidation: enableChecksumValidation,
 		maxNewFileSize:           maxNewFileSize,
 		allocChecker:             allocChecker,
+		encodeBufs:               newCompactorInvertedBuffers(),
 	}
 }
 
@@ -141,11 +146,12 @@ func (c *compactorInverted) do() error {
 		return errors.Wrap(err, "get property lengths")
 	}
 
-	c.propertyLengthsToWrite = make(map[uint64]uint32, len(propertyLengthsToWrite))
-	c.propertyLengthsToClean = make(map[uint64]uint32, len(propertyLengthsToClean))
-
+	// Merge both segments' property lengths into a single map. We copy into
+	// a new map (not the segment's cached map) to avoid data races. Entries
+	// from c2 (clean) override c1 (write) on duplicate keys.
+	c.propertyLengthsToWrite = make(map[uint64]uint32, len(propertyLengthsToWrite)+len(propertyLengthsToClean))
 	maps.Copy(c.propertyLengthsToWrite, propertyLengthsToWrite)
-	maps.Copy(c.propertyLengthsToClean, propertyLengthsToClean)
+	maps.Copy(c.propertyLengthsToWrite, propertyLengthsToClean)
 
 	tombstones := c.computeTombstonesAndPropLengths()
 
@@ -168,7 +174,7 @@ func (c *compactorInverted) do() error {
 		return errors.Wrap(err, "write property lengths")
 	}
 	treeOffset := uint64(c.offset)
-	if err := c.writeIndices(kis); err != nil {
+	if err := c.writeIndices(kis, uint64(keysOffset)); err != nil {
 		return errors.Wrap(err, "write index")
 	}
 
@@ -302,13 +308,13 @@ func (c *compactorInverted) writePropertyLengths(propLengths map[uint64]uint32) 
 	return len(encoded) + 8 + 8 + 8, nil
 }
 
-func (c *compactorInverted) writeKeys() ([]segmentindex.Key, error) {
+func (c *compactorInverted) writeKeys() ([]segmentindex.KeyRedux, error) {
 	key1, value1, _ := c.c1.first()
 	key2, value2, _ := c.c2.first()
 
 	// the (dummy) header was already written, this is our initial offset
 
-	var kis []segmentindex.Key
+	kis := make([]segmentindex.KeyRedux, 0, c.c1.segment.index.KeyCount()+c.c2.segment.index.KeyCount())
 	sim := newSortedMapMerger()
 
 	for {
@@ -378,36 +384,25 @@ func (c *compactorInverted) writeKeys() ([]segmentindex.Key, error) {
 
 func (c *compactorInverted) writeIndividualNode(offset int, key []byte,
 	values []MapPair, propertyLengths map[uint64]uint32,
-) (segmentindex.Key, error) {
-	// NOTE: There are no guarantees in the cursor logic that any memory is valid
-	// for more than a single iteration. Every time you call next() to advance
-	// the cursor, any memory might be reused.
-	//
-	// This includes the key buffer which was the cause of
-	// https://github.com/weaviate/weaviate/issues/3517
-	//
-	// A previous logic created a new assignment in each iteration, but thatwas
-	// not an explicit guarantee. A change in v1.21 (for pread/mmap) added a
-	// reusable buffer for the key which surfaced this bug.
-	keyCopy := make([]byte, len(key))
-	copy(keyCopy, key)
+) (segmentindex.KeyRedux, error) {
+	// With reusable cursors, the key buffer is shared across iterations.
+	// We must copy it before writing, as the KeyRedux stores a reference.
+	// See: https://github.com/weaviate/weaviate/issues/3517
+	keyCopy := c.arena.CopyKey(key)
 
 	return segmentInvertedNode{
 		values:      values,
 		primaryKey:  keyCopy,
 		offset:      offset,
 		propLengths: propertyLengths,
-	}.KeyIndexAndWriteTo(c.segmentFile.BodyWriter(), c.docIdEncoder, c.tfEncoder, c.k1, c.b, c.avgPropLen)
+	}.KeyIndexAndWriteToCompaction(c.segmentFile.BodyWriter(), c.writeBuf[:], &c.encodeBufs, c.docIdEncoder, c.tfEncoder, c.k1, c.b, c.avgPropLen)
 }
 
-func (c *compactorInverted) writeIndices(keys []segmentindex.Key) error {
-	indices := segmentindex.Indexes{
-		Keys:                keys,
-		SecondaryIndexCount: c.secondaryIndexCount,
-		AllocChecker:        c.allocChecker,
+func (c *compactorInverted) writeIndices(keys []segmentindex.KeyRedux, dataStartOffset uint64) error {
+	if c.secondaryIndexCount > 0 {
+		return fmt.Errorf("unsupported secondary indexes in compactorInverted")
 	}
-
-	_, err := indices.WriteTo(c.segmentFile.BodyWriter())
+	_, err := segmentindex.MarshalSortedKeys(c.segmentFile.BodyWriter(), keys, dataStartOffset)
 	return err
 }
 
@@ -434,7 +429,7 @@ func (c *compactorInverted) cleanupValues(values []MapPair) (vals []MapPair, ski
 }
 
 func (c *compactorInverted) computeTombstonesAndPropLengths() *sroar.Bitmap {
-	maps.Copy(c.propertyLengthsToWrite, c.propertyLengthsToClean)
+	// Property lengths are already merged in do() — no merge needed here.
 
 	if c.cleanupTombstones { // no tombstones to write
 		return sroar.NewBitmap()

--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -429,8 +429,6 @@ func (c *compactorInverted) cleanupValues(values []MapPair) (vals []MapPair, ski
 }
 
 func (c *compactorInverted) computeTombstonesAndPropLengths() *sroar.Bitmap {
-	// Property lengths are already merged in do() — no merge needed here.
-
 	if c.cleanupTombstones { // no tombstones to write
 		return sroar.NewBitmap()
 	}

--- a/adapters/repos/db/lsmkv/compactor_set.go
+++ b/adapters/repos/db/lsmkv/compactor_set.go
@@ -258,7 +258,7 @@ func (c *compactorSet) writeIndexes(f *segmentindex.SegmentFile,
 		return fmt.Errorf("unsupported secondary indexes in compactorSet")
 	}
 
-	_, err := segmentindex.MarshalSortedKeys(f.BodyWriter(), keys)
+	_, err := segmentindex.MarshalSortedKeys(f.BodyWriter(), keys, segmentindex.HeaderSize)
 	return err
 }
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -23,11 +23,12 @@ import (
 )
 
 type CursorMap struct {
-	innerCursors []innerCursorMap
-	state        []cursorStateMap
-	unlock       func()
-	listCfg      MapListOptionConfig
-	keyOnly      bool
+	innerCursors      []innerCursorMap
+	state             []cursorStateMap
+	unlock            func()
+	listCfg           MapListOptionConfig
+	keyOnly           bool
+	pendingAdvanceIDs []int // cursor IDs whose advance was deferred from the previous return
 }
 
 type cursorStateMap struct {
@@ -94,6 +95,7 @@ func (b *Bucket) MapCursorKeyOnly(cfgs ...MapListOption) (*CursorMap, error) {
 }
 
 func (c *CursorMap) Seek(ctx context.Context, key []byte) ([]byte, []MapPair) {
+	c.pendingAdvanceIDs = c.pendingAdvanceIDs[:0]
 	c.seekAll(key)
 	return c.serveCurrentStateAndAdvance(ctx)
 }
@@ -103,6 +105,7 @@ func (c *CursorMap) Next(ctx context.Context) ([]byte, []MapPair) {
 }
 
 func (c *CursorMap) First(ctx context.Context) ([]byte, []MapPair) {
+	c.pendingAdvanceIDs = c.pendingAdvanceIDs[:0]
 	c.firstAll()
 	return c.serveCurrentStateAndAdvance(ctx)
 }
@@ -156,6 +159,15 @@ func (c *CursorMap) firstAll() {
 }
 
 func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []MapPair) {
+	// Apply deferred cursor advances from the previous return. Inner cursors
+	// that reuse buffers (e.g. segmentCursorInvertedReusable) overwrite their
+	// Key/Value data on next(), so the advance must be deferred until the
+	// caller has consumed the previously returned data.
+	for _, id := range c.pendingAdvanceIDs {
+		c.advanceInner(id)
+	}
+	c.pendingAdvanceIDs = c.pendingAdvanceIDs[:0]
+
 	for {
 		id, err := c.cursorWithLowestKey()
 		if err != nil {
@@ -166,17 +178,19 @@ func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []
 
 		ids, _ := c.haveDuplicatesInState(id)
 
-		// take the key from any of the results, we have the guarantee that they're
-		// all the same
-		key := c.state[ids[0]].key
+		// Take the key from any of the results — they're all equal. Copy it
+		// because some inner cursors (e.g. segmentCursorInvertedReusable on the
+		// mmap path) reuse a single key buffer across iterations, so the slice
+		// would otherwise be overwritten when the caller advances the cursor.
+		src := c.state[ids[0]].key
+		key := make([]byte, len(src))
+		copy(key, src)
 
 		var perSegmentResults [][]MapPair
 
 		for _, id := range ids {
 			candidates := c.state[id].value
 			perSegmentResults = append(perSegmentResults, candidates)
-
-			c.advanceInner(id)
 		}
 
 		if c.listCfg.legacyRequireManualSorting {
@@ -192,10 +206,19 @@ func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []
 		if err != nil {
 			panic(fmt.Errorf("unexpected error decoding map values: %w", err))
 		}
+
 		if len(merged) == 0 {
-			// all values deleted, proceed
+			// All values deleted. Safe to advance now since the data is discarded.
+			for _, id := range ids {
+				c.advanceInner(id)
+			}
 			continue
 		}
+
+		// Defer cursor advancement until the next call so the caller can
+		// consume the returned Key/Value data before reusable buffers are
+		// overwritten.
+		c.pendingAdvanceIDs = append(c.pendingAdvanceIDs, ids...)
 
 		// TODO remove keyOnly option, not used anyway
 		if !c.keyOnly {

--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -128,9 +128,7 @@ func (c *CursorMap) seekAll(target []byte) {
 		}
 
 		state[i].key = key
-		if !c.keyOnly {
-			state[i].value = value
-		}
+		state[i].value = value
 	}
 
 	c.state = state
@@ -150,9 +148,7 @@ func (c *CursorMap) firstAll() {
 		}
 
 		state[i].key = key
-		if !c.keyOnly {
-			state[i].value = value
-		}
+		state[i].value = value
 	}
 
 	c.state = state
@@ -220,7 +216,6 @@ func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []
 		// overwritten.
 		c.pendingAdvanceIDs = append(c.pendingAdvanceIDs, ids...)
 
-		// TODO remove keyOnly option, not used anyway
 		if !c.keyOnly {
 			return key, merged
 		}
@@ -292,8 +287,6 @@ func (c *CursorMap) advanceInner(id int) {
 	}
 
 	c.state[id].key = k
-	if !c.keyOnly {
-		c.state[id].value = v
-	}
+	c.state[id].value = v
 	c.state[id].err = nil
 }

--- a/adapters/repos/db/lsmkv/cursor_bucket_map_inverted_reusable_integration_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map_inverted_reusable_integration_test.go
@@ -1,0 +1,289 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestCursorMap_InvertedReusable_DeferredAdvance drives a Next→consume→Next
+// loop over a multi-segment inverted bucket whose disk-resident segments use
+// the reusable cursor (segmentCursorInvertedReusable). It asserts:
+//
+//  1. Each iteration's returned key/values match the expected merge across
+//     segments — i.e. mergeMapPairs ran against unclobbered inner-cursor
+//     buffers (the deferred-advance contract added in PR #11450).
+//  2. Between consecutive Next calls — the "consume" window — the previously
+//     returned key remains bit-identical (CursorMap copies the key before
+//     return so it survives subsequent deferred advances).
+//  3. After all Next calls, the snapshots captured during the consume window
+//     still match the expected data for that iteration.
+func TestCursorMap_InvertedReusable_DeferredAdvance(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9)
+
+	// Two segments. Each row's logical value list is the union of segment1
+	// and segment2 entries for that row, so the merge path is exercised.
+	type rowSpec struct {
+		key      []byte
+		seg1Tfs  []float32 // doc IDs 0..len-1 written in segment 1
+		seg2Tfs  []float32 // doc IDs base..base+len-1 written in segment 2
+		seg2Base uint64
+	}
+	rows := []rowSpec{
+		// Small row: single value per segment -> small-value (ENCODE_AS_FULL_BYTES) path.
+		{key: []byte("aaa-small"), seg1Tfs: []float32{1}, seg2Tfs: []float32{2}, seg2Base: 1000},
+		// Mid-sized row: spans one block in each segment.
+		{key: []byte("bbb-onelock"), seg1Tfs: floatRange(50, 1), seg2Tfs: floatRange(50, 1), seg2Base: 1000},
+		// Large row: forces multi-block encoding so the reusable
+		// block-decode buffers are exercised across iterations.
+		{key: []byte("ccc-multi"), seg1Tfs: floatRange(300, 1), seg2Tfs: floatRange(200, 1), seg2Base: 10000},
+		// Row only in segment 1 (no merge for this key).
+		{key: []byte("ddd-seg1only"), seg1Tfs: floatRange(10, 1), seg2Tfs: nil, seg2Base: 0},
+		// Row only in segment 2.
+		{key: []byte("eee-seg2only"), seg1Tfs: nil, seg2Tfs: floatRange(10, 1), seg2Base: 2000},
+	}
+
+	// Build, insert, and flush segment 1.
+	for _, r := range rows {
+		for docId, tf := range r.seg1Tfs {
+			require.NoError(t, bucket.MapSet(r.key,
+				NewMapPairFromDocIdAndTf(uint64(docId), tf, tf, false)))
+		}
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// Build, insert, and flush segment 2.
+	for _, r := range rows {
+		for i, tf := range r.seg2Tfs {
+			require.NoError(t, bucket.MapSet(r.key,
+				NewMapPairFromDocIdAndTf(r.seg2Base+uint64(i), tf, tf, false)))
+		}
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// Build the expected (key -> sorted-by-docId []docId) result for the scan.
+	type expectedRow struct {
+		key    []byte
+		docIds []uint64
+	}
+	expected := make([]expectedRow, 0, len(rows))
+	for _, r := range rows {
+		if r.seg1Tfs == nil && r.seg2Tfs == nil {
+			continue
+		}
+		var docIds []uint64
+		for d := range r.seg1Tfs {
+			docIds = append(docIds, uint64(d))
+		}
+		for i := range r.seg2Tfs {
+			docIds = append(docIds, r.seg2Base+uint64(i))
+		}
+		sort.Slice(docIds, func(i, j int) bool { return docIds[i] < docIds[j] })
+		expected = append(expected, expectedRow{
+			key:    append([]byte(nil), r.key...),
+			docIds: docIds,
+		})
+	}
+	sort.Slice(expected, func(i, j int) bool {
+		return bytes.Compare(expected[i].key, expected[j].key) < 0
+	})
+
+	c, err := bucket.MapCursor()
+	require.NoError(t, err)
+	defer c.Close()
+
+	type snapshot struct {
+		returnedKey    []byte // the slice as returned by First/Next (alias check)
+		snapshotKey    []byte // a deep copy captured at consume time
+		snapshotDocIds []uint64
+	}
+	var snapshots []snapshot
+
+	var prevKeyAlias []byte // slice from the previous iteration (not a copy)
+	var prevKeySnap []byte  // deep copy snapshot from the previous iteration
+
+	idx := 0
+	for k, vs := c.First(ctx); k != nil; k, vs = c.Next(ctx) {
+		require.Lessf(t, idx, len(expected),
+			"cursor returned more rows than expected at idx=%d (key=%q)", idx, k)
+
+		exp := expected[idx]
+
+		// Assertion (1): the data returned by this call matches expectations.
+		assert.Equalf(t, exp.key, k,
+			"key mismatch at idx=%d", idx)
+		require.Equalf(t, len(exp.docIds), len(vs),
+			"value count mismatch at idx=%d (key=%q)", idx, k)
+		gotDocIds := make([]uint64, len(vs))
+		for i, mp := range vs {
+			gotDocIds[i] = binary.BigEndian.Uint64(mp.Key)
+		}
+		assert.Equalf(t, exp.docIds, gotDocIds,
+			"docId list mismatch at idx=%d (key=%q)", idx, k)
+
+		// Assertion (2): the PREVIOUS iteration's key (as a live slice
+		// alias) still equals the snapshot we took for it. The deferred
+		// advance triggered at the start of *this* Next must not have
+		// mutated the previously returned key — CursorMap copies the key
+		// before returning, so it survives.
+		if idx > 0 {
+			assert.Truef(t, bytes.Equal(prevKeyAlias, prevKeySnap),
+				"previous iteration's key was mutated by the deferred advance at idx=%d", idx)
+		}
+
+		// Capture for assertion (3) and for the next iteration's
+		// previous-key check.
+		snap := snapshot{
+			returnedKey:    k,
+			snapshotKey:    append([]byte(nil), k...),
+			snapshotDocIds: append([]uint64(nil), gotDocIds...),
+		}
+		snapshots = append(snapshots, snap)
+		prevKeyAlias = k
+		prevKeySnap = snap.snapshotKey
+
+		idx++
+	}
+	require.Equalf(t, len(expected), idx, "cursor returned fewer rows than expected")
+
+	// Assertion (3): after the full scan, every snapshot taken at
+	// consume-time must still match the expected data for that iteration.
+	// Plus, each snapshot's returnedKey alias must still equal its own
+	// snapshotKey (the key slice is independent of reusable buffers).
+	for i, snap := range snapshots {
+		assert.Equalf(t, expected[i].key, snap.snapshotKey,
+			"snapshot key at idx=%d does not match expected", i)
+		assert.Equalf(t, expected[i].docIds, snap.snapshotDocIds,
+			"snapshot docId list at idx=%d does not match expected", i)
+		assert.Truef(t, bytes.Equal(snap.returnedKey, snap.snapshotKey),
+			"the returned key slice at idx=%d was mutated post-return", i)
+	}
+}
+
+func floatRange(n int, base float32) []float32 {
+	out := make([]float32, n)
+	for i := range out {
+		out[i] = base + float32(i)
+	}
+	return out
+}
+
+// TestCursorMap_InvertedReusable_ConsumeBetweenCalls is a focused variant:
+// it captures BOTH key and value byte slices returned by Next, performs a
+// "consume" step that reads every byte, then advances the cursor and
+// re-reads the captured slices. This verifies that during the consume
+// window (between Next calls), the returned data is stable.
+//
+// The values' underlying bytes ARE expected to be invalidated by the next
+// Next call (they alias the inner cursor's reusable mapPairBuf/kvArena),
+// so we only assert stability WITHIN a consume window, not across it.
+func TestCursorMap_InvertedReusable_ConsumeBetweenCalls(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9)
+
+	rowKeys := [][]byte{
+		[]byte("row-a"),
+		[]byte("row-b"),
+		[]byte("row-c"),
+	}
+	// Each row gets enough values to land in the block-encoded path.
+	const valuesPerRow = 200
+	for rIdx, key := range rowKeys {
+		for d := 0; d < valuesPerRow; d++ {
+			docId := uint64(rIdx)*1000 + uint64(d)
+			tf := float32(d + 1)
+			require.NoError(t, bucket.MapSet(key,
+				NewMapPairFromDocIdAndTf(docId, tf, tf, false)))
+		}
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	c, err := bucket.MapCursor()
+	require.NoError(t, err)
+	defer c.Close()
+
+	k1, v1 := c.First(ctx)
+	require.NotNil(t, k1)
+	require.Len(t, v1, valuesPerRow)
+
+	// Consume step: read every byte of every returned value, capturing
+	// docIds. The slices must remain readable for the duration of the
+	// consume.
+	consumed1 := make([]uint64, len(v1))
+	for i, mp := range v1 {
+		require.Lenf(t, mp.Key, 8, "key[%d]", i)
+		require.Lenf(t, mp.Value, 8, "value[%d]", i)
+		consumed1[i] = binary.BigEndian.Uint64(mp.Key)
+	}
+	keySnapshot1 := append([]byte(nil), k1...)
+
+	// Now advance. The deferred advance from First runs at the start of
+	// Next, invalidating the inner cursor's reusable buffers (which back
+	// v1's slices). However, k1 was copied by CursorMap and must remain
+	// intact.
+	k2, v2 := c.Next(ctx)
+	require.NotNil(t, k2)
+	require.Len(t, v2, valuesPerRow)
+
+	assert.Truef(t, bytes.Equal(k1, keySnapshot1),
+		"k1 must be intact across the Next call (CursorMap copies returned keys)")
+
+	// k2 must be a fresh, independent slice — not the same backing array
+	// as k1.
+	if len(k1) > 0 && len(k2) > 0 {
+		assert.NotSamef(t, &k1[0], &k2[0],
+			"k1 and k2 must not alias the same underlying array")
+	}
+
+	// And v2 must contain the second row's docIds (i.e. the merge ran
+	// against unclobbered buffers).
+	consumed2 := make([]uint64, len(v2))
+	for i, mp := range v2 {
+		consumed2[i] = binary.BigEndian.Uint64(mp.Key)
+	}
+	require.Equal(t, valuesPerRow, len(consumed2))
+	// First docId of the second row equals 1000 (rIdx=1, d=0) by construction.
+	assert.Equal(t, uint64(1000), consumed2[0],
+		"v2 must contain the second row's docIds — wrong data here would indicate the merge saw clobbered buffers")
+
+	// And the consumed1 we captured during the consume window of First
+	// still matches the first row (rIdx=0, docIds 0..valuesPerRow-1).
+	for i, got := range consumed1 {
+		require.Equal(t, uint64(i), got, fmt.Sprintf("consumed1[%d]", i))
+	}
+}

--- a/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
@@ -177,3 +177,74 @@ func TestMapCursorConsistentView(t *testing.T) {
 	}
 	require.Equal(t, expected, actual)
 }
+
+// MapCursorKeyOnly must walk every primary key just like MapCursor — it just
+// drops the values from the returned tuple. Regression for a bug where the
+// keyOnly fast-path left state[i].value=nil, the merger saw only empty
+// per-segment results, and every key was skipped (callers like
+// filterableToSearchableMigrator.isEmptyMapBucket then mis-classified
+// non-empty buckets as empty).
+func TestMapCursorKeyOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	logger, _ := test.NewNullLogger()
+
+	diskSegments := &SegmentGroup{
+		logger: logger,
+		segments: []Segment{
+			newFakeMapSegment(map[string][]MapPair{
+				"key1": {{Key: []byte("dk1"), Value: []byte("dv1")}},
+			}),
+			newFakeMapSegment(map[string][]MapPair{
+				"key2": {{Key: []byte("dk2"), Value: []byte("dv2")}},
+			}),
+		},
+	}
+
+	active := newTestMemtableMap(map[string][]MapPair{
+		"key3": {{Key: []byte("ak1"), Value: []byte("av1")}},
+	})
+
+	b := Bucket{
+		active:   active,
+		disk:     diskSegments,
+		strategy: StrategyMapCollection,
+	}
+
+	cur, err := b.MapCursorKeyOnly()
+	require.NoError(t, err)
+	defer cur.Close()
+
+	var keys []string
+	for k, v := cur.First(ctx); k != nil; k, v = cur.Next(ctx) {
+		assert.Nil(t, v, "keyOnly cursor must not return values")
+		keys = append(keys, string(k))
+	}
+	require.Equal(t, []string{"key1", "key2", "key3"}, keys)
+}
+
+// Mirrors the filterableToSearchableMigrator.isEmptyMapBucket usage: only the
+// first key is read. If the cursor's keyOnly path is broken, this looks like
+// an empty bucket even though it has data.
+func TestMapCursorKeyOnly_FirstKeyOnNonEmptyBucket(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	logger, _ := test.NewNullLogger()
+
+	b := Bucket{
+		active: newTestMemtableMap(map[string][]MapPair{
+			"only": {{Key: []byte("sk"), Value: []byte("sv")}},
+		}),
+		disk:     &SegmentGroup{logger: logger},
+		strategy: StrategyMapCollection,
+	}
+
+	cur, err := b.MapCursorKeyOnly()
+	require.NoError(t, err)
+	defer cur.Close()
+
+	k, _ := cur.First(ctx)
+	require.Equal(t, []byte("only"), k)
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -160,6 +160,10 @@ func (s *segmentCursorInvertedReusable) decodeBlocksAndConvert(data []byte, coll
 			arenaOff += 8
 			value := s.kvArena[arenaOff : arenaOff+8]
 			copy(value, data[offset+8:offset+12])
+			// Value layout is [0:4]=TF, [4:8]=propLength. The on-disk
+			// format only carries TF; zero the PL slot so it isn't
+			// reused from a prior entry's bytes in the arena.
+			binary.LittleEndian.PutUint32(value[4:], 0)
 			arenaOff += 8
 			s.mapPairBuf = append(s.mapPairBuf, MapPair{Key: key, Value: value})
 			offset += 16
@@ -220,7 +224,11 @@ func (s *segmentCursorInvertedReusable) decodeBlocksAndConvert(data []byte, coll
 			arenaOff += 8
 
 			value := s.kvArena[arenaOff : arenaOff+8]
-			binary.LittleEndian.PutUint32(value, math.Float32bits(float32(tfs[j])))
+			// Pack TF as uint64; the high 4 bytes are zero, which is the
+			// expected propLength placeholder (set later from propLengths
+			// map). Using PutUint64 instead of PutUint32 avoids leaving
+			// stale arena bytes in value[4:8].
+			binary.LittleEndian.PutUint64(value, uint64(math.Float32bits(float32(tfs[j]))))
 			arenaOff += 8
 
 			s.mapPairBuf = append(s.mapPairBuf, MapPair{Key: key, Value: value})

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -13,8 +13,10 @@ package lsmkv
 
 import (
 	"encoding/binary"
+	"math"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
@@ -23,6 +25,18 @@ type segmentCursorInvertedReusable struct {
 	nextOffset  uint64
 	nodeBuf     binarySearchNodeMap
 	propLengths map[uint64]uint32
+
+	// reusable decode buffers to reduce allocations during compaction
+	readBuf    []byte    // reusable buffer for reading node data from disk (non-memory path)
+	mapPairBuf []MapPair // reusable slice for decoded MapPairs
+	kvArena    []byte    // contiguous arena for MapPair Key/Value (8+8 bytes each)
+	deltaEnc   varenc.VarEncEncoder[uint64]
+	tfEnc      varenc.VarEncEncoder[uint64]
+
+	// reusable buffers for block decode (memory path)
+	keyBuf        []byte             // reusable key buffer
+	blockEntryBuf []terms.BlockEntry // reusable storage for decoded block entries
+	blockDataBuf  []terms.BlockData  // reusable storage for decoded block data
 }
 
 func (s *segment) newInvertedCursorReusable() *segmentCursorInvertedReusable {
@@ -33,6 +47,8 @@ func (s *segment) newInvertedCursorReusable() *segmentCursorInvertedReusable {
 	return &segmentCursorInvertedReusable{
 		segment:     s,
 		propLengths: propLengths,
+		deltaEnc:    &varenc.VarIntDeltaEncoder{},
+		tfEnc:       &varenc.VarIntEncoder{},
 	}
 }
 
@@ -80,6 +96,140 @@ func (s *segmentCursorInvertedReusable) first() ([]byte, []MapPair, error) {
 }
 
 func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset) error {
+	// Fast path: read directly from mmap'd memory, no reader allocations
+	if s.segment.readFromMemory {
+		return s.parseInvertedNodeFromMemory(offset)
+	}
+	return s.parseInvertedNodeFromDisk(offset)
+}
+
+// parseInvertedNodeFromMemory reads node data directly from mmap'd segment
+// contents, avoiding bytes.NewReader and nodeReader allocations entirely.
+func (s *segmentCursorInvertedReusable) parseInvertedNodeFromMemory(offset nodeOffset) error {
+	contents := s.segment.contents
+
+	docCount := binary.LittleEndian.Uint64(contents[offset.start:])
+	dataEnd := offset.start + 20
+	if docCount > uint64(terms.ENCODE_AS_FULL_BYTES) {
+		dataEnd = offset.start + binary.LittleEndian.Uint64(contents[offset.start+8:]) + 16
+	}
+	dataEnd += 4 // keyLen uint32 at end
+
+	data := contents[offset.start:dataEnd]
+	s.decodeBlocksAndConvert(data, docCount)
+
+	keyLen := binary.LittleEndian.Uint32(data[len(data)-4:])
+	keyStart := dataEnd
+	keyEnd := keyStart + uint64(keyLen)
+
+	if cap(s.keyBuf) < int(keyLen) {
+		s.keyBuf = make([]byte, keyLen)
+	} else {
+		s.keyBuf = s.keyBuf[:keyLen]
+	}
+	if keyLen > 0 {
+		copy(s.keyBuf, contents[keyStart:keyEnd])
+	}
+
+	s.nodeBuf.key = s.keyBuf
+	s.nodeBuf.values = s.mapPairBuf
+	s.nextOffset = keyEnd
+
+	return nil
+}
+
+// decodeBlocksAndConvert decodes block-encoded data into s.mapPairBuf using
+// reusable buffers for block entries/data, eliminating per-block heap
+// allocations of BlockEntry and BlockData structs.
+func (s *segmentCursorInvertedReusable) decodeBlocksAndConvert(data []byte, collectionSize uint64) {
+	if collectionSize <= uint64(terms.ENCODE_AS_FULL_BYTES) {
+		neededArena := int(collectionSize) * 16
+		if cap(s.kvArena) < neededArena {
+			s.kvArena = make([]byte, neededArena)
+		}
+		if cap(s.mapPairBuf) < int(collectionSize) {
+			s.mapPairBuf = make([]MapPair, 0, collectionSize)
+		} else {
+			s.mapPairBuf = s.mapPairBuf[:0]
+		}
+		arenaOff := 0
+		offset := 8
+		for i := 0; i < int(collectionSize*16); i += 16 {
+			key := s.kvArena[arenaOff : arenaOff+8]
+			copy(key, data[offset:offset+8])
+			arenaOff += 8
+			value := s.kvArena[arenaOff : arenaOff+8]
+			copy(value, data[offset+8:offset+12])
+			arenaOff += 8
+			s.mapPairBuf = append(s.mapPairBuf, MapPair{Key: key, Value: value})
+			offset += 16
+		}
+		return
+	}
+
+	offset := 16
+	blockCount := (int(collectionSize) + terms.BLOCK_SIZE - 1) / terms.BLOCK_SIZE
+
+	if cap(s.blockEntryBuf) < blockCount {
+		s.blockEntryBuf = make([]terms.BlockEntry, blockCount)
+		s.blockDataBuf = make([]terms.BlockData, blockCount)
+	} else {
+		s.blockEntryBuf = s.blockEntryBuf[:blockCount]
+		s.blockDataBuf = s.blockDataBuf[:blockCount]
+	}
+
+	blockDataInitialOffset := offset + blockCount*20 // BlockEntry.Size() == 20
+
+	for i := 0; i < blockCount; i++ {
+		s.blockEntryBuf[i] = terms.BlockEntry{
+			MaxId:               binary.LittleEndian.Uint64(data[offset:]),
+			Offset:              binary.LittleEndian.Uint32(data[offset+8:]),
+			MaxImpactTf:         binary.LittleEndian.Uint32(data[offset+12:]),
+			MaxImpactPropLength: binary.LittleEndian.Uint32(data[offset+16:]),
+		}
+		dataOffset := int(s.blockEntryBuf[i].Offset) + blockDataInitialOffset
+		terms.DecodeBlockDataReusable(data[dataOffset:], &s.blockDataBuf[i])
+		offset += 20
+	}
+
+	objectCount := collectionSize
+	if cap(s.mapPairBuf) < int(objectCount) {
+		s.mapPairBuf = make([]MapPair, 0, objectCount)
+	} else {
+		s.mapPairBuf = s.mapPairBuf[:0]
+	}
+
+	neededArena := int(objectCount) * 16
+	if cap(s.kvArena) < neededArena {
+		s.kvArena = make([]byte, neededArena)
+	}
+	arenaOff := 0
+
+	for i := range s.blockEntryBuf {
+		blockSize := uint64(terms.BLOCK_SIZE)
+		if i == len(s.blockEntryBuf)-1 {
+			blockSize = objectCount - uint64(terms.BLOCK_SIZE)*uint64(i)
+		}
+		blockSizeInt := int(blockSize)
+
+		docIds, tfs := packedDecode(&s.blockDataBuf[i], blockSizeInt, s.deltaEnc, s.tfEnc)
+
+		for j := 0; j < blockSizeInt; j++ {
+			key := s.kvArena[arenaOff : arenaOff+8]
+			binary.BigEndian.PutUint64(key, docIds[j])
+			arenaOff += 8
+
+			value := s.kvArena[arenaOff : arenaOff+8]
+			binary.LittleEndian.PutUint32(value, math.Float32bits(float32(tfs[j])))
+			arenaOff += 8
+
+			s.mapPairBuf = append(s.mapPairBuf, MapPair{Key: key, Value: value})
+		}
+	}
+}
+
+// parseInvertedNodeFromDisk is the fallback path for non-memory-mapped segments.
+func (s *segmentCursorInvertedReusable) parseInvertedNodeFromDisk(offset nodeOffset) error {
 	buffer := make([]byte, 16)
 	r, err := s.segment.newNodeReader(offset, "segmentCursorInvertedReusable")
 	if err != nil {
@@ -104,16 +254,22 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset)
 	}
 	defer r.Release()
 
-	allBytes := make([]byte, offset.end-offset.start)
+	needed := int(offset.end - offset.start)
+	if cap(s.readBuf) < needed {
+		s.readBuf = make([]byte, needed, needed*5/4)
+	} else {
+		s.readBuf = s.readBuf[:needed]
+	}
 
-	_, err = r.Read(allBytes)
+	_, err = r.Read(s.readBuf)
 	if err != nil {
 		return err
 	}
 
-	nodes, _ := decodeAndConvertFromBlocks(allBytes)
+	s.mapPairBuf, s.kvArena, _ = decodeAndConvertFromBlocksReusable(
+		s.readBuf, s.mapPairBuf, s.kvArena, s.deltaEnc, s.tfEnc)
 
-	keyLen := binary.LittleEndian.Uint32(allBytes[len(allBytes)-4:])
+	keyLen := binary.LittleEndian.Uint32(s.readBuf[len(s.readBuf)-4:])
 
 	offset.start = offset.end
 	offset.end += uint64(keyLen)
@@ -132,7 +288,7 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset)
 		}
 	}
 	s.nodeBuf.key = key
-	s.nodeBuf.values = nodes
+	s.nodeBuf.values = s.mapPairBuf
 
 	s.nextOffset = offset.end
 

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"encoding/binary"
+	"io"
 	"math"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
@@ -245,8 +246,7 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeFromDisk(offset nodeOff
 	}
 	defer r.Release()
 
-	_, err = r.Read(buffer)
-	if err != nil {
+	if _, err := io.ReadFull(r, buffer); err != nil {
 		return err
 	}
 	docCount := binary.LittleEndian.Uint64(buffer[:8])
@@ -269,8 +269,11 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeFromDisk(offset nodeOff
 		s.readBuf = s.readBuf[:needed]
 	}
 
-	_, err = r.Read(s.readBuf)
-	if err != nil {
+	// io.ReadFull is required: s.readBuf is reused across iterations, so a
+	// short read would leave trailing bytes from a prior node in place and
+	// the block decoder / keyLen parser below would silently operate on
+	// stale data.
+	if _, err := io.ReadFull(r, s.readBuf); err != nil {
 		return err
 	}
 
@@ -290,8 +293,7 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeFromDisk(offset nodeOff
 			return err
 		}
 		defer r.Release()
-		_, err = r.Read(key)
-		if err != nil {
+		if _, err := io.ReadFull(r, key); err != nil {
 			return err
 		}
 	}

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -695,6 +695,11 @@ func createAndEncodeBlocksCompaction(nodes []MapPair, propLengths map[uint64]uin
 // KeyIndexAndWriteTo. It returns a KeyRedux (no ValueStart/SecondaryKeys),
 // reuses the supplied encode buffers, and uses an externally-provided buf
 // (must be at least 4 bytes) to avoid per-call allocations.
+//
+// NOTE: this path does not emit secondary keys. It is only safe to call when
+// the segment has SecondaryIndexCount == 0. compactorInverted.writeIndices
+// enforces this; do not wire this method into a code path with secondary
+// indexes without adding secondary-key handling here.
 func (s segmentInvertedNode) KeyIndexAndWriteToCompaction(w io.Writer, buf []byte, bufs *compactorInvertedBuffers, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) (segmentindex.KeyRedux, error) {
 	written := 0
 

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -367,7 +367,11 @@ func convertFromBlocksReusable(blockEntries []*terms.BlockEntry, encodedBlocks [
 			arenaOff += 8
 
 			value := kvArena[arenaOff : arenaOff+8]
-			binary.LittleEndian.PutUint32(value, math.Float32bits(float32(tfs[j])))
+			// Pack TF as uint64; the high 4 bytes are zero, which is the
+			// expected propLength placeholder (set later from propLengths
+			// map). Using PutUint64 instead of PutUint32 avoids leaving
+			// stale arena bytes in value[4:8].
+			binary.LittleEndian.PutUint64(value, uint64(math.Float32bits(float32(tfs[j]))))
 			arenaOff += 8
 
 			out = append(out, MapPair{
@@ -403,6 +407,10 @@ func decodeAndConvertFromBlocksReusable(data []byte, mapPairBuf []MapPair, kvAre
 			arenaOff += 8
 			value := kvArena[arenaOff : arenaOff+8]
 			copy(value, data[offset+8:offset+12])
+			// Value layout is [0:4]=TF, [4:8]=propLength. The on-disk
+			// format only carries TF; zero the PL slot so it isn't
+			// reused from a prior entry's bytes in the arena.
+			binary.LittleEndian.PutUint32(value[4:], 0)
 			arenaOff += 8
 			mapPairBuf = append(mapPairBuf, MapPair{
 				Key:   key,

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
@@ -335,6 +336,87 @@ func convertFromBlocks(blockEntries []*terms.BlockEntry, encodedBlocks []*terms.
 	return out
 }
 
+// convertFromBlocksReusable is like convertFromBlocks but reuses pre-allocated
+// buffers for the output MapPair slice and the key/value arena. This avoids
+// millions of individual make([]byte, 8) calls per compaction round.
+func convertFromBlocksReusable(blockEntries []*terms.BlockEntry, encodedBlocks []*terms.BlockData, objectCount uint64, out []MapPair, kvArena []byte, deltaEnc, tfEnc varenc.VarEncEncoder[uint64]) ([]MapPair, []byte) {
+	if cap(out) < int(objectCount) {
+		out = make([]MapPair, 0, objectCount)
+	} else {
+		out = out[:0]
+	}
+
+	neededArena := int(objectCount) * 16
+	if cap(kvArena) < neededArena {
+		kvArena = make([]byte, neededArena)
+	}
+	arenaOff := 0
+
+	for i := range blockEntries {
+		blockSize := uint64(terms.BLOCK_SIZE)
+		if i == len(blockEntries)-1 {
+			blockSize = objectCount - uint64(terms.BLOCK_SIZE)*uint64(i)
+		}
+		blockSizeInt := int(blockSize)
+
+		docIds, tfs := packedDecode(encodedBlocks[i], blockSizeInt, deltaEnc, tfEnc)
+
+		for j := 0; j < blockSizeInt; j++ {
+			key := kvArena[arenaOff : arenaOff+8]
+			binary.BigEndian.PutUint64(key, docIds[j])
+			arenaOff += 8
+
+			value := kvArena[arenaOff : arenaOff+8]
+			binary.LittleEndian.PutUint32(value, math.Float32bits(float32(tfs[j])))
+			arenaOff += 8
+
+			out = append(out, MapPair{
+				Key:   key,
+				Value: value,
+			})
+		}
+	}
+	return out, kvArena
+}
+
+// decodeAndConvertFromBlocksReusable is like decodeAndConvertFromBlocks but
+// reuses pre-allocated buffers. Returns updated mapPairBuf and kvArena for
+// the caller to store back.
+func decodeAndConvertFromBlocksReusable(data []byte, mapPairBuf []MapPair, kvArena []byte, deltaEnc, tfEnc varenc.VarEncEncoder[uint64]) ([]MapPair, []byte, int) {
+	collectionSize := binary.LittleEndian.Uint64(data)
+
+	if collectionSize <= uint64(terms.ENCODE_AS_FULL_BYTES) {
+		neededArena := int(collectionSize) * 16
+		if cap(kvArena) < neededArena {
+			kvArena = make([]byte, neededArena)
+		}
+		if cap(mapPairBuf) < int(collectionSize) {
+			mapPairBuf = make([]MapPair, 0, collectionSize)
+		} else {
+			mapPairBuf = mapPairBuf[:0]
+		}
+		arenaOff := 0
+		offset := 8
+		for i := 0; i < int(collectionSize*16); i += 16 {
+			key := kvArena[arenaOff : arenaOff+8]
+			copy(key, data[offset:offset+8])
+			arenaOff += 8
+			value := kvArena[arenaOff : arenaOff+8]
+			copy(value, data[offset+8:offset+12])
+			arenaOff += 8
+			mapPairBuf = append(mapPairBuf, MapPair{
+				Key:   key,
+				Value: value,
+			})
+			offset += 16
+		}
+		return mapPairBuf, kvArena, offset
+	}
+	blockEntries, blockDatas, offset := decodeBlocks(data)
+	mapPairBuf, kvArena = convertFromBlocksReusable(blockEntries, blockDatas, collectionSize, mapPairBuf, kvArena, deltaEnc, tfEnc)
+	return mapPairBuf, kvArena, offset
+}
+
 func convertFixedLengthFromMemory(data []byte, blockSize int) *terms.BlockDataDecoded {
 	out := &terms.BlockDataDecoded{
 		DocIds: make([]uint64, blockSize),
@@ -393,6 +475,245 @@ func (s segmentInvertedNode) KeyIndexAndWriteTo(w io.Writer, deltaEnc, tfEnc var
 	}
 
 	return out, nil
+}
+
+// compactorInvertedBuffers holds pre-allocated buffers for the encode pipeline
+// during compaction. These are stored on the compactorInverted struct and
+// passed through to avoid per-key and per-block allocations.
+type compactorInvertedBuffers struct {
+	docIdsBuf       []uint64
+	termFreqsBuf    []uint64
+	blockEntries    []*terms.BlockEntry
+	blockDatas      []*terms.BlockData
+	blockEntryStore []terms.BlockEntry
+	blockDataStore  []terms.BlockData
+	encodeOutBuf    []byte
+	encArena        []byte
+	singleValBuf    []byte
+}
+
+func newCompactorInvertedBuffers() compactorInvertedBuffers {
+	return compactorInvertedBuffers{
+		docIdsBuf:    make([]uint64, terms.BLOCK_SIZE),
+		termFreqsBuf: make([]uint64, terms.BLOCK_SIZE),
+	}
+}
+
+// filterTombstonesInPlace removes tombstoned entries in-place without creating
+// a bitmap. Used in the compaction encode path where the bitmap is not needed
+// (tombstones are tracked separately by the compactor).
+func filterTombstonesInPlace(nodes []MapPair) []MapPair {
+	writeIdx := 0
+	for readIdx := 0; readIdx < len(nodes); readIdx++ {
+		if !nodes[readIdx].Tombstone {
+			if writeIdx != readIdx {
+				nodes[writeIdx] = nodes[readIdx]
+			}
+			writeIdx++
+		}
+	}
+	return nodes[:writeIdx]
+}
+
+// packedEncodeArena encodes docIds and termFreqs, appending the encoded bytes
+// to arena. Writes the result into the provided out BlockData (avoiding heap
+// allocation). Returns the updated arena.
+func packedEncodeArena(docIds, termFreqs []uint64, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], arena []byte, out *terms.BlockData) []byte {
+	deltaEnc.Init(len(docIds))
+	out.DocIds, arena = deltaEnc.EncodeAppend(docIds, arena)
+
+	tfEnc.Init(len(termFreqs))
+	out.Tfs, arena = tfEnc.EncodeAppend(termFreqs, arena)
+
+	return arena
+}
+
+// encodeBlockParamReusable is like encodeBlockParam but writes into provided
+// docIds/termFreqs slices and appends encoded data to an arena. Writes the
+// result into the provided out BlockData. Returns the updated arena.
+func encodeBlockParamReusable(nodes []MapPair, docIds, termFreqs []uint64, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], arena []byte, out *terms.BlockData) []byte {
+	for i, n := range nodes {
+		docIds[i] = binary.BigEndian.Uint64(n.Key)
+		termFreqs[i] = uint64(math.Float32frombits(binary.LittleEndian.Uint32(n.Value[0:4])))
+	}
+	return packedEncodeArena(docIds[:len(nodes)], termFreqs[:len(nodes)], deltaEnc, tfEnc, arena, out)
+}
+
+// createBlocksCompaction is like createBlocks but uses filterTombstonesInPlace
+// (no bitmap), pre-allocated struct storage, and a shared arena for
+// varint-encoded block data.
+func createBlocksCompaction(nodes []MapPair, propLengths map[uint64]uint32, bufs *compactorInvertedBuffers, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]*terms.BlockEntry, []*terms.BlockData, map[uint64]uint32) {
+	values := filterTombstonesInPlace(nodes)
+	externalPropLengths := len(propLengths) != 0
+
+	blockCount := (len(values) + (terms.BLOCK_SIZE - 1)) / terms.BLOCK_SIZE
+
+	if cap(bufs.blockEntries) < blockCount {
+		bufs.blockEntries = make([]*terms.BlockEntry, blockCount)
+		bufs.blockEntryStore = make([]terms.BlockEntry, blockCount)
+	} else {
+		bufs.blockEntries = bufs.blockEntries[:blockCount]
+		bufs.blockEntryStore = bufs.blockEntryStore[:blockCount]
+	}
+	if cap(bufs.blockDatas) < blockCount {
+		bufs.blockDatas = make([]*terms.BlockData, blockCount)
+		bufs.blockDataStore = make([]terms.BlockData, blockCount)
+	} else {
+		bufs.blockDatas = bufs.blockDatas[:blockCount]
+		bufs.blockDataStore = bufs.blockDataStore[:blockCount]
+	}
+
+	// Reset arena for this key — all blocks' encoded data must coexist
+	// until encodeBlocksInto serializes them.
+	bufs.encArena = bufs.encArena[:0]
+
+	offset := uint32(0)
+
+	for i := 0; i < blockCount; i++ {
+		start := i * terms.BLOCK_SIZE
+		end := start + terms.BLOCK_SIZE
+		if end > len(values) {
+			end = len(values)
+		}
+		maxImpact := float64(0)
+		maxImpactTf := uint32(0)
+		maxImpactPropLength := uint32(0)
+
+		for j := start; j < end; j++ {
+			tf := float64(math.Float32frombits(binary.LittleEndian.Uint32(values[j].Value[0:4])))
+			pl := float64(math.Float32frombits(binary.LittleEndian.Uint32(values[j].Value[4:8])))
+			docId := binary.BigEndian.Uint64(values[j].Key)
+			if externalPropLengths {
+				pl = float64(propLengths[docId])
+			} else {
+				propLengths[docId] = uint32(pl)
+			}
+
+			impact := tf / (tf + k1*(1-b+b*(pl/avgPropLen)))
+
+			if impact > maxImpact {
+				maxImpact = impact
+				maxImpactTf = uint32(tf)
+				maxImpactPropLength = uint32(pl)
+			}
+		}
+
+		maxId := binary.BigEndian.Uint64(values[end-1].Key)
+
+		bufs.encArena = encodeBlockParamReusable(values[start:end], bufs.docIdsBuf, bufs.termFreqsBuf, deltaEnc, tfEnc, bufs.encArena, &bufs.blockDataStore[i])
+		bufs.blockDatas[i] = &bufs.blockDataStore[i]
+
+		bufs.blockEntryStore[i] = terms.BlockEntry{
+			MaxId:               maxId,
+			Offset:              offset,
+			MaxImpactTf:         maxImpactTf,
+			MaxImpactPropLength: maxImpactPropLength,
+		}
+		bufs.blockEntries[i] = &bufs.blockEntryStore[i]
+
+		offset += uint32(bufs.blockDatas[i].Size())
+	}
+
+	return bufs.blockEntries, bufs.blockDatas, propLengths
+}
+
+// encodeBlocksInto is like encodeBlocks but writes into a reusable buffer
+// and uses EncodeInto to avoid per-block allocations. Returns the updated
+// buffer and the number of bytes written.
+func encodeBlocksInto(blockEntries []*terms.BlockEntry, blockDatas []*terms.BlockData, docCount uint64, buf []byte) ([]byte, int) {
+	length := 0
+	for i := range blockDatas {
+		length += blockDatas[i].Size() + blockEntries[i].Size()
+	}
+	needed := length + 8 + 8
+	if cap(buf) < needed {
+		buf = make([]byte, needed)
+	} else {
+		buf = buf[:needed]
+	}
+
+	binary.LittleEndian.PutUint64(buf, docCount)
+	offset := 8
+	binary.LittleEndian.PutUint64(buf[offset:], uint64(length))
+	offset += 8
+
+	for _, blockEntry := range blockEntries {
+		blockEntry.EncodeInto(buf[offset:])
+		offset += blockEntry.Size()
+	}
+	for _, blockData := range blockDatas {
+		blockData.EncodeInto(buf[offset:])
+		offset += blockData.Size()
+	}
+
+	return buf, offset
+}
+
+// createAndEncodeSingleValueCompaction is like createAndEncodeSingleValue but
+// skips bitmap allocation (tombstones are tracked by the compactor) and reuses
+// a buffer from bufs.
+func createAndEncodeSingleValueCompaction(mapPairs []MapPair, bufs *compactorInvertedBuffers) []byte {
+	needed := 8 + 12*len(mapPairs)
+	if cap(bufs.singleValBuf) < needed {
+		bufs.singleValBuf = make([]byte, needed)
+	} else {
+		bufs.singleValBuf = bufs.singleValBuf[:needed]
+	}
+	buf := bufs.singleValBuf
+
+	binary.LittleEndian.PutUint64(buf, uint64(len(mapPairs)))
+	offset := 8
+	for i := 0; i < len(mapPairs); i++ {
+		copy(buf[offset:offset+8], mapPairs[i].Key)
+		copy(buf[offset+8:offset+12], mapPairs[i].Value)
+		offset += 12
+	}
+	return buf[:offset]
+}
+
+// createAndEncodeBlocksCompaction is the compaction-optimized version of
+// createAndEncodeBlocks. It uses in-place tombstone extraction, reusable
+// encode buffers, and inline block serialization.
+func createAndEncodeBlocksCompaction(nodes []MapPair, propLengths map[uint64]uint32, bufs *compactorInvertedBuffers, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) []byte {
+	if len(nodes) <= terms.ENCODE_AS_FULL_BYTES {
+		return createAndEncodeSingleValueCompaction(nodes, bufs)
+	}
+	blockEntries, blockDatas, _ := createBlocksCompaction(nodes, propLengths, bufs, deltaEnc, tfEnc, k1, b, avgPropLen)
+	bufs.encodeOutBuf, _ = encodeBlocksInto(blockEntries, blockDatas, uint64(len(nodes)), bufs.encodeOutBuf)
+	return bufs.encodeOutBuf
+}
+
+// KeyIndexAndWriteToCompaction is the compaction-optimized counterpart to
+// KeyIndexAndWriteTo. It returns a KeyRedux (no ValueStart/SecondaryKeys),
+// reuses the supplied encode buffers, and uses an externally-provided buf
+// (must be at least 4 bytes) to avoid per-call allocations.
+func (s segmentInvertedNode) KeyIndexAndWriteToCompaction(w io.Writer, buf []byte, bufs *compactorInvertedBuffers, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) (segmentindex.KeyRedux, error) {
+	written := 0
+
+	blocksEncoded := createAndEncodeBlocksCompaction(s.values, s.propLengths, bufs, deltaEnc, tfEnc, k1, b, avgPropLen)
+	n, err := w.Write(blocksEncoded)
+	if err != nil {
+		return segmentindex.KeyRedux{}, errors.Wrapf(err, "write values for node")
+	}
+	written += n
+
+	keyLength := uint32(len(s.primaryKey))
+	binary.LittleEndian.PutUint32(buf[0:4], keyLength)
+	if _, err := w.Write(buf[0:4]); err != nil {
+		return segmentindex.KeyRedux{}, errors.Wrapf(err, "write key length encoding for node")
+	}
+	written += 4
+
+	n, err = w.Write(s.primaryKey)
+	if err != nil {
+		return segmentindex.KeyRedux{}, errors.Wrapf(err, "write node")
+	}
+	written += n
+
+	return segmentindex.KeyRedux{
+		ValueEnd: s.offset + written,
+		Key:      s.primaryKey,
+	}, nil
 }
 
 // ParseInvertedNode reads from r and parses the Inverted values into a segmentCollectionNode

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted_test.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted_test.go
@@ -144,6 +144,68 @@ func TestDecodeAndConvertFromBlocksReusable_PreservesPLZeroInvariant(t *testing.
 	})
 }
 
+// TestDecodeAndConvertFromBlocksReusable_Roundtrip drives encode → decode
+// with reused mapPairBuf and kvArena across multiple distinct payloads,
+// and confirms that on each decode every entry's docId and TF round-trip
+// exactly and Value[4:8] is zero. The varenc TF encoder rounds floats to
+// uint64, so the test uses integer TFs to keep the round-trip exact.
+func TestDecodeAndConvertFromBlocksReusable_Roundtrip(t *testing.T) {
+	deltaEnc := &varenc.VarIntDeltaEncoder{}
+	tfEnc := &varenc.VarIntEncoder{}
+
+	makePayload := func(n int, docIdBase uint64, tfBase float32) ([]byte, []MapPair) {
+		input := make([]MapPair, n)
+		plm := make(map[uint64]uint32, n)
+		for i := 0; i < n; i++ {
+			docId := docIdBase + uint64(i)
+			tf := tfBase + float32(i)
+			input[i] = makeInvertedPair(docId, tf, float32(i+1))
+			plm[docId] = uint32(i + 1)
+		}
+		encoded, _ := createAndEncodeBlocks(input, plm, deltaEnc, tfEnc, 1.2, 0.75, 10.0)
+		return encoded, input
+	}
+
+	// Sequence of payloads with distinct sizes so the arena/mapPairBuf
+	// are sometimes reused at full size, sometimes truncated.
+	payloads := []struct {
+		n         int
+		docIdBase uint64
+		tfBase    float32
+	}{
+		{200, 1000, 10},
+		{50, 5000, 1},
+		{300, 7000, 20},
+		{1, 9000, 7},
+		{129, 11000, 3},
+	}
+
+	var mapPairBuf []MapPair
+	var arena []byte
+
+	for _, p := range payloads {
+		t.Run(fmt.Sprintf("n=%d/docIdBase=%d", p.n, p.docIdBase), func(t *testing.T) {
+			encoded, input := makePayload(p.n, p.docIdBase, p.tfBase)
+			mapPairBuf, arena, _ = decodeAndConvertFromBlocksReusable(
+				encoded, mapPairBuf, arena, deltaEnc, tfEnc)
+
+			require.Len(t, mapPairBuf, p.n)
+			for i, mp := range mapPairBuf {
+				wantDocId := binary.BigEndian.Uint64(input[i].Key)
+				gotDocId := binary.BigEndian.Uint64(mp.Key)
+				assert.Equalf(t, wantDocId, gotDocId, "docId mismatch at i=%d", i)
+
+				wantTF := math.Float32frombits(binary.LittleEndian.Uint32(input[i].Value[0:4]))
+				gotTF := math.Float32frombits(binary.LittleEndian.Uint32(mp.Value[0:4]))
+				assert.Equalf(t, wantTF, gotTF, "TF mismatch at i=%d (docId=%d)", i, gotDocId)
+
+				assert.Equalf(t, float32(0), plFromValue(mp.Value),
+					"Value[4:8] must be zero at i=%d", i)
+			}
+		})
+	}
+}
+
 // TestCreateAndEncodeBlocksCompaction_MatchesNonReusable confirms that the
 // compaction-optimised encoder produces byte-identical output to the
 // canonical encoder when both receive the same input and a fully-populated

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted_test.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted_test.go
@@ -11,49 +11,269 @@
 
 package lsmkv
 
-/*
-func Test_SerializeAndParseInvertedNode(t *testing.T) {
-	tfs := []float32{2.0, 3.0, 4.0}
-	lens := []uint32{1, 2, 3}
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"testing"
 
-	values := make([]value, len(tfs))
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
+)
 
-	for i := range tfs {
-		buf := make([]byte, invPayloadLen)
-		binary.LittleEndian.PutUint64(buf[0:8], uint64(i))
-		binary.LittleEndian.PutUint32(buf[8:12], math.Float32bits(tfs[i]))
-		binary.LittleEndian.PutUint32(buf[12:16], lens[i])
+// makeInvertedPair builds a MapPair with the 8-byte inverted Value layout:
+// Value[0:4] = TF (float32 bits), Value[4:8] = propLength (float32 bits).
+func makeInvertedPair(docId uint64, tf, pl float32) MapPair {
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, docId)
+	value := make([]byte, 8)
+	binary.LittleEndian.PutUint32(value[0:4], math.Float32bits(tf))
+	binary.LittleEndian.PutUint32(value[4:8], math.Float32bits(pl))
+	return MapPair{Key: key, Value: value}
+}
 
-		values[i] = value{value: buf}
+func plFromValue(v []byte) float32 {
+	return math.Float32frombits(binary.LittleEndian.Uint32(v[4:8]))
+}
+
+// Sizes span the three encode paths:
+//   - n=1: small (ENCODE_AS_FULL_BYTES) path
+//   - n=2..128: single block
+//   - n=129+: multi-block
+var reusableTestSizes = []int{1, 2, 100, 128, 129, 256, 300}
+
+// TestDecodeAndConvertFromBlocksReusable_MatchesNonReusable confirms that the
+// reusable decoder produces the same MapPairs (key bytes and value bytes) as
+// the canonical non-reusable decoder, across the small / single-block /
+// multi-block paths.
+func TestDecodeAndConvertFromBlocksReusable_MatchesNonReusable(t *testing.T) {
+	for _, n := range reusableTestSizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			input := make([]MapPair, n)
+			plm := make(map[uint64]uint32, n)
+			for i := 0; i < n; i++ {
+				input[i] = makeInvertedPair(uint64(i+1), float32(i+1), float32(i*2+1))
+				plm[uint64(i+1)] = uint32(i*2 + 1)
+			}
+			encoded, _ := createAndEncodeBlocks(input, plm,
+				&varenc.VarIntDeltaEncoder{}, &varenc.VarIntEncoder{},
+				1.2, 0.75, 10.0)
+
+			expected, _ := decodeAndConvertFromBlocks(encoded)
+
+			got, _, _ := decodeAndConvertFromBlocksReusable(
+				encoded, nil, nil,
+				&varenc.VarIntDeltaEncoder{}, &varenc.VarIntEncoder{})
+
+			require.Equal(t, len(expected), len(got))
+			for i := range expected {
+				assert.Equal(t, expected[i].Key, got[i].Key, "key mismatch at i=%d", i)
+				assert.Equal(t, expected[i].Value, got[i].Value, "value mismatch at i=%d", i)
+			}
+		})
+	}
+}
+
+// TestDecodeAndConvertFromBlocksReusable_PreservesPLZeroInvariant is the
+// regression test for the arena-residue bug: when the kvArena is reused
+// across decode calls (or pre-poisoned), Value[4:8] (the propLength slot)
+// must be zero for every decoded pair, matching the prior make([]byte, 8)
+// behaviour. The disk format does not carry propLengths in the value
+// payload — they live in a separate map — so the decoded slot must be
+// clean.
+func TestDecodeAndConvertFromBlocksReusable_PreservesPLZeroInvariant(t *testing.T) {
+	deltaEnc := &varenc.VarIntDeltaEncoder{}
+	tfEnc := &varenc.VarIntEncoder{}
+
+	encode := func(n int) []byte {
+		input := make([]MapPair, n)
+		plm := make(map[uint64]uint32, n)
+		for i := 0; i < n; i++ {
+			input[i] = makeInvertedPair(uint64(i+1), float32(i+1), float32(i+1))
+			plm[uint64(i+1)] = uint32(i + 1)
+		}
+		out, _ := createAndEncodeBlocks(input, plm, deltaEnc, tfEnc, 1.2, 0.75, 10.0)
+		return out
 	}
 
-	before := segmentInvertedNode{
-		primaryKey: []byte("this-is-my-primary-key"),
-		values:     values,
+	for _, n := range reusableTestSizes {
+		t.Run(fmt.Sprintf("poisoned-arena/n=%d", n), func(t *testing.T) {
+			// Pre-poison the arena with 0xFF so any unwritten byte in
+			// Value[4:8] would show up as non-zero.
+			arena := make([]byte, n*16)
+			for i := range arena {
+				arena[i] = 0xFF
+			}
+
+			got, _, _ := decodeAndConvertFromBlocksReusable(
+				encode(n), nil, arena, deltaEnc, tfEnc)
+
+			require.Len(t, got, n)
+			for i, mp := range got {
+				require.Equal(t, 8, len(mp.Value), "i=%d", i)
+				assert.Equalf(t, float32(0), plFromValue(mp.Value),
+					"Value[4:8] must be zero at i=%d (got %v)", i, plFromValue(mp.Value))
+			}
+		})
 	}
 
-	buf := &bytes.Buffer{}
-	_, err := before.KeyIndexAndWriteTo(buf)
-	require.Nil(t, err)
-	encoded := buf.Bytes()
+	t.Run("reused-buffers-across-calls", func(t *testing.T) {
+		// Two distinct payloads decoded with the same buffers. After the
+		// second call, no byte in Value[4:8] may carry over from the first.
+		data1 := encode(200)
+		data2 := encode(150)
 
-	expected := segmentCollectionNode{
-		primaryKey: []byte("this-is-my-primary-key"),
-		values:     values,
-		offset:     buf.Len(),
-	}
+		var mapPairBuf []MapPair
+		var arena []byte
 
-	t.Run("parse using the _regular_ way", func(t *testing.T) {
-		after, err := ParseInvertedNode(bytes.NewReader(encoded))
-		assert.Nil(t, err)
-		assert.Equal(t, expected, after)
-	})
+		mapPairBuf, arena, _ = decodeAndConvertFromBlocksReusable(
+			data1, mapPairBuf, arena, deltaEnc, tfEnc)
+		for i, mp := range mapPairBuf {
+			require.Equal(t, float32(0), plFromValue(mp.Value),
+				"first call: PL must be zero at i=%d", i)
+		}
 
-	t.Run("parse using the reusable way", func(t *testing.T) {
-		var node segmentCollectionNode
-		err := ParseInvertedNodeInto(bytes.NewReader(encoded), &node)
-		assert.Nil(t, err)
-		assert.Equal(t, expected, node)
+		mapPairBuf, _, _ = decodeAndConvertFromBlocksReusable(
+			data2, mapPairBuf, arena, deltaEnc, tfEnc)
+		require.Len(t, mapPairBuf, 150)
+		for i, mp := range mapPairBuf {
+			assert.Equal(t, float32(0), plFromValue(mp.Value),
+				"second call (reused arena): PL must be zero at i=%d", i)
+		}
 	})
 }
-*/
+
+// TestCreateAndEncodeBlocksCompaction_MatchesNonReusable confirms that the
+// compaction-optimised encoder produces byte-identical output to the
+// canonical encoder when both receive the same input and a fully-populated
+// propLengths map (the externalPropLengths==true path that compaction
+// always takes).
+func TestCreateAndEncodeBlocksCompaction_MatchesNonReusable(t *testing.T) {
+	for _, n := range reusableTestSizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			input := make([]MapPair, n)
+			for i := 0; i < n; i++ {
+				input[i] = makeInvertedPair(uint64(i+1), float32(i+1), float32(i*2+1))
+			}
+			plmA := make(map[uint64]uint32, n)
+			plmB := make(map[uint64]uint32, n)
+			for i := 0; i < n; i++ {
+				plmA[uint64(i+1)] = uint32(i*2 + 1)
+				plmB[uint64(i+1)] = uint32(i*2 + 1)
+			}
+
+			expected, _ := createAndEncodeBlocks(input, plmA,
+				&varenc.VarIntDeltaEncoder{}, &varenc.VarIntEncoder{},
+				1.2, 0.75, 10.0)
+
+			// createAndEncodeBlocksCompaction mutates its input slice
+			// via filterTombstonesInPlace — pass a copy.
+			inputCopy := make([]MapPair, n)
+			copy(inputCopy, input)
+			bufs := newCompactorInvertedBuffers()
+			got := createAndEncodeBlocksCompaction(inputCopy, plmB, &bufs,
+				&varenc.VarIntDeltaEncoder{}, &varenc.VarIntEncoder{},
+				1.2, 0.75, 10.0)
+
+			assert.Equal(t, expected, got)
+		})
+	}
+}
+
+// TestCreateAndEncodeBlocksCompaction_BufferReuse drives the same
+// compactor buffers through multiple keys (the actual compaction
+// workload) and checks the produced bytes are independent of buffer
+// state from prior calls.
+func TestCreateAndEncodeBlocksCompaction_BufferReuse(t *testing.T) {
+	deltaEnc := &varenc.VarIntDeltaEncoder{}
+	tfEnc := &varenc.VarIntEncoder{}
+
+	makeInput := func(n int, tfBase float32) ([]MapPair, map[uint64]uint32) {
+		input := make([]MapPair, n)
+		plm := make(map[uint64]uint32, n)
+		for i := 0; i < n; i++ {
+			input[i] = makeInvertedPair(uint64(i+1), tfBase+float32(i), float32(i+1))
+			plm[uint64(i+1)] = uint32(i + 1)
+		}
+		return input, plm
+	}
+
+	sizes := []int{200, 50, 300, 1, 129}
+
+	bufs := newCompactorInvertedBuffers()
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			input, plm := makeInput(n, 5.0)
+			expected, _ := createAndEncodeBlocks(input, plm, deltaEnc, tfEnc, 1.2, 0.75, 10.0)
+
+			inputCopy := make([]MapPair, n)
+			copy(inputCopy, input)
+			plmCopy := make(map[uint64]uint32, len(plm))
+			for k, v := range plm {
+				plmCopy[k] = v
+			}
+
+			got := createAndEncodeBlocksCompaction(inputCopy, plmCopy, &bufs,
+				deltaEnc, tfEnc, 1.2, 0.75, 10.0)
+
+			// The returned slice aliases bufs.encodeOutBuf for the
+			// multi-block path; copy before the next iteration mutates it.
+			gotCopy := append([]byte(nil), got...)
+			assert.Equal(t, expected, gotCopy)
+		})
+	}
+}
+
+func TestFilterTombstonesInPlace(t *testing.T) {
+	mk := func(id byte, tombstone bool) MapPair {
+		return MapPair{Key: []byte{id}, Tombstone: tombstone}
+	}
+
+	tests := []struct {
+		name     string
+		input    []MapPair
+		expected []MapPair
+	}{
+		{
+			name:     "empty",
+			input:    []MapPair{},
+			expected: []MapPair{},
+		},
+		{
+			name:     "none tombstoned",
+			input:    []MapPair{mk('a', false), mk('b', false)},
+			expected: []MapPair{mk('a', false), mk('b', false)},
+		},
+		{
+			name:     "all tombstoned",
+			input:    []MapPair{mk('a', true), mk('b', true), mk('c', true)},
+			expected: []MapPair{},
+		},
+		{
+			name: "interleaved",
+			input: []MapPair{
+				mk('a', false), mk('b', true), mk('c', false),
+				mk('d', true), mk('e', false),
+			},
+			expected: []MapPair{mk('a', false), mk('c', false), mk('e', false)},
+		},
+		{
+			name:     "leading tombstones",
+			input:    []MapPair{mk('a', true), mk('b', true), mk('c', false)},
+			expected: []MapPair{mk('c', false)},
+		},
+		{
+			name:     "trailing tombstones",
+			input:    []MapPair{mk('a', false), mk('b', true), mk('c', true)},
+			expected: []MapPair{mk('a', false)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterTombstonesInPlace(tc.input)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -342,8 +342,10 @@ func (t *Tree) Size() int {
 // MarshalSortedKeys serializes a balanced BST index directly from sorted
 // KeyRedux entries, without constructing intermediate Tree or Node structures.
 // Keys must be in sorted order. Each key's ValueEnd is the absolute byte
-// offset where that key's data ends in the segment file.
-func MarshalSortedKeys(w io.Writer, keys []KeyRedux) (int64, error) {
+// offset where that key's data ends in the segment file. dataStartOffset is
+// the byte position where the first key's data begins (e.g. HeaderSize for
+// most strategies, but larger for inverted segments with extended headers).
+func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (int64, error) {
 	n := len(keys)
 	if n == 0 {
 		return 0, nil
@@ -387,7 +389,7 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux) (int64, error) {
 		// Derive Start from the previous key's ValueEnd.
 		var start uint64
 		if si == 0 {
-			start = uint64(HeaderSize)
+			start = dataStartOffset
 		} else {
 			start = uint64(keys[si-1].ValueEnd)
 		}

--- a/adapters/repos/db/lsmkv/varenc/simple.go
+++ b/adapters/repos/db/lsmkv/varenc/simple.go
@@ -89,6 +89,14 @@ func (e *SimpleEncoder[T]) Encode(values []T) []byte {
 	return e.buf
 }
 
+func (e *SimpleEncoder[T]) EncodeAppend(values []T, arena []byte) ([]byte, []byte) {
+	e.EncodeReusable(values, e.buf)
+	n := 8 + len(values)*e.elementSize
+	start := len(arena)
+	arena = append(arena, e.buf[:n]...)
+	return arena[start:], arena
+}
+
 func (e *SimpleEncoder[T]) Decode(data []byte) []T {
 	e.DecodeReusable(data, e.values)
 	return e.values

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding.go
@@ -29,6 +29,11 @@ const (
 type VarEncEncoder[T any] interface {
 	Init(expectedCount int)
 	Encode(values []T) []byte
+	// EncodeAppend encodes values into the encoder's internal buffer, then
+	// appends the encoded bytes to arena. Returns the encoded sub-slice and
+	// the updated arena. This avoids per-call allocations when encoding
+	// multiple blocks whose data must coexist.
+	EncodeAppend(values []T, arena []byte) (encoded []byte, updatedArena []byte)
 	Decode(data []byte) []T
 	EncodeReusable(values []T, buf []byte)
 	DecodeReusable(data []byte, values []T)

--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -168,6 +168,13 @@ func (e *VarIntEncoder) Encode(values []uint64) []byte {
 	return output
 }
 
+func (e *VarIntEncoder) EncodeAppend(values []uint64, arena []byte) ([]byte, []byte) {
+	n := encodeReusable(values, e.buf, false)
+	start := len(arena)
+	arena = append(arena, e.buf[:n]...)
+	return arena[start:], arena
+}
+
 func (e *VarIntEncoder) Decode(data []byte) []uint64 {
 	decodeReusable(e.values, data, false)
 	return e.values
@@ -200,6 +207,13 @@ func (e *VarIntDeltaEncoder) Encode(values []uint64) []byte {
 	output := make([]byte, n)
 	copy(output, e.buf[:n])
 	return output
+}
+
+func (e *VarIntDeltaEncoder) EncodeAppend(values []uint64, arena []byte) ([]byte, []byte) {
+	n := encodeReusable(values, e.buf, true)
+	start := len(arena)
+	arena = append(arena, e.buf[:n]...)
+	return arena[start:], arena
 }
 
 func (e *VarIntDeltaEncoder) Decode(data []byte) []uint64 {


### PR DESCRIPTION
### What's being changed:

Follow up on https://github.com/weaviate/weaviate/pull/10440 for the inverted strategy
(rebase on 1.35 from https://github.com/weaviate/weaviate/pull/10505)

- Reuse buffers for reading and encoding posting lists
- Use arena to support contiguous allocations
- Don't create duplicate 
- Use direct tree serialization


Metric | Baseline (v1.33) | Current | Delta
-- | -- | -- | --
Peak TotalAlloc | 83.85 GB | 5.83 GB | -78.03 GB (-93.1%)
Peak HeapAlloc | 4.29 GB | 3.36 GB | -955.88 MB (-21.7%)
Peak HeapInuse | 4.35 GB | 3.36 GB | -1009.67 MB (-22.7%)
Peak HeapSys | 5.00 GB | 3.51 GB | -1.49 GB (-29.8%)
Compaction rounds | 6 | 6 | 0
Compaction time | 1m6.67s | 49.83s | -16.84s
Segment count | 1 | 1 | 0
Total segment size | 822.98 MB | 822.98 MB | +0 B (+0.0%)



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
