### PR TITLE
obs(backup): Info-level phase-trace logging on coordinator

### DIFF
--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -105,20 +105,69 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 
 	b.waitingForCoordinatorToCommit.Store(true) // is set to false by wait()
 	// waits for ack from coordinator in order to processed with the backup
+	//
+	// DEADLOCK NOTE — participant-side hang candidates between this
+	// async-goroutine start and the first u.setStatus(Transferring)
+	// inside uploader.all (which is what advances the coordinator-
+	// visible Status off Started):
+	//
+	//   1. waitForCoordinator (shard.go:104) reads c.coordChan with a
+	//      timeout — if OnCommit never lands the timer fires; that's
+	//      a coordinator-side regression, not a hang here.
+	//
+	//   2. resolveBaseBackupChain (below) does backend I/O. With
+	//      baseBackupID == "" it should be a no-op, but a slow
+	//      s3/azure HEAD can block here on a real chain. The phase
+	//      log "participant_resolve_base_start"/"_ok" brackets it.
+	//
+	//   3. The big one: provider.all → sourcer.BackupDescriptors →
+	//      per-shard backupShardWithHardlinks acquires:
+	//        a) i.backupLock.Lock(name) — per-shard mutex.
+	//        b) i.shardCreateLocks.Lock(name) — contention with
+	//           class create / lazy shard init.
+	//        c) shard.HaltForTransfer → s.haltForTransferMux.Lock,
+	//           then s.store.PauseCompaction(ctx). PauseCompaction's
+	//           compactionCallbacksCtrl.Deactivate(ctx) waits for the
+	//           currently-running compaction cycle to drain, which
+	//           can be slow under cancel-cleanup that just finished
+	//           tearing sidecar buckets. PauseCompaction also
+	//           re-acquires s.bucketAccessLock.RLock — if a parallel
+	//           ShutdownBucket is mid-flight (Write-locked) it blocks.
+	//
+	//   The participant phase trace below isolates (2) vs (3). If the
+	//   stuck-state lands AT "participant_provider_all_start" without
+	//   reaching the uploader's "start uploading files" line, the hang
+	//   is inside (3) — sourcer.BackupDescriptors / HaltForTransfer.
+	phaseLog := b.logger.WithFields(logrus.Fields{
+		"action":    "backup_phase",
+		"backup_id": req.ID,
+		"node":      b.node,
+		"backup_op": string(OpCreate),
+	})
+	phaseLog.WithField("backup_phase", "participant_async_start").Info("backup-participant: async goroutine starting; waiting for OnCommit")
 	f := func() {
 		defer b.lastOp.reset()
+		waitStart := time.Now()
 		if err := b.waitForCoordinator(expiration, id); err != nil {
+			phaseLog.WithField("backup_phase", "participant_wait_coordinator_failed").
+				WithField("duration_ms", time.Since(waitStart).Milliseconds()).
+				Errorf("backup-participant: waitForCoordinator returned error: %v", err)
 			b.logger.WithField("action", "create_backup").
 				Error(err)
 			b.lastAsyncError = err
 			return
 		}
+		phaseLog.WithField("backup_phase", "participant_wait_coordinator_ok").
+			WithField("duration_ms", time.Since(waitStart).Milliseconds()).
+			Info("backup-participant: received OnCommit from coordinator")
 
 		provider := newUploader(b.cfg, b.sourcer, b.rbacSourcer, b.dynUserSourcer, store, req.ID, b.lastOp.set, b.logger).
 			withCompression(newZipConfig(req.Compression))
 
 		compressionType, err := CompressionTypeFromLevel(req.Level)
 		if err != nil {
+			phaseLog.WithField("backup_phase", "participant_compression_failed").
+				Errorf("backup-participant: CompressionTypeFromLevel failed: %v", err)
 			b.logger.WithField("action", "create_backup").Error(err)
 			b.lastAsyncError = err
 			return
@@ -131,12 +180,23 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 		logFields := logrus.Fields{"action": "create_backup", "backup_id": req.ID, "override_bucket": req.Bucket, "override_path": req.Path}
 
 		baseBackupID := req.BaseBackupID
+		phaseLog.WithField("backup_phase", "participant_resolve_base_start").
+			WithField("base_backup_id", baseBackupID).
+			Info("backup-participant: resolving base-backup chain")
+		baseResolveStart := time.Now()
 		baseDescrs, err := resolveBaseBackupChain(ctx, baseBackupID, store.bucket, store.path, compressionType, store.MetaForBackupID)
 		if err != nil {
+			phaseLog.WithField("backup_phase", "participant_resolve_base_failed").
+				WithField("duration_ms", time.Since(baseResolveStart).Milliseconds()).
+				Errorf("backup-participant: resolveBaseBackupChain failed: %v", err)
 			b.logger.WithFields(logFields).Error(err)
 			b.lastAsyncError = err
 			return
 		}
+		phaseLog.WithField("backup_phase", "participant_resolve_base_ok").
+			WithField("duration_ms", time.Since(baseResolveStart).Milliseconds()).
+			WithField("base_descriptor_count", len(baseDescrs)).
+			Info("backup-participant: base-backup chain resolved")
 
 		result := backup.BackupDescriptor{
 			StartedAt:       time.Now().UTC(),
@@ -148,10 +208,20 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 			BaseBackupID:    baseBackupID,
 		}
 
+		phaseLog.WithField("backup_phase", "participant_provider_all_start").
+			WithField("class_count", len(req.Classes)).
+			Info("backup-participant: handing off to uploader.all (will set Transferring)")
+		providerStart := time.Now()
 		if err := provider.all(ctx, req.Classes, &result, baseDescrs, req.Bucket, req.Path); err != nil {
+			phaseLog.WithField("backup_phase", "participant_provider_all_failed").
+				WithField("duration_ms", time.Since(providerStart).Milliseconds()).
+				Errorf("backup-participant: uploader.all returned error: %v", err)
 			b.logger.WithFields(logFields).Error(err)
 			b.lastAsyncError = err
 		} else {
+			phaseLog.WithField("backup_phase", "participant_provider_all_ok").
+				WithField("duration_ms", time.Since(providerStart).Milliseconds()).
+				Info("backup-participant: uploader.all complete")
 			b.logger.WithFields(logFields).Info("backup completed successfully")
 		}
 		result.CompletedAt = time.Now().UTC()

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -162,6 +162,14 @@ func (c *coordinator) Nodes(ctx context.Context, req *Request) (map[string]strin
 // Backup coordinates a distributed backup among participants
 func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Request) error {
 	req.Method = OpCreate
+	phaseLog := c.log.WithFields(logrus.Fields{
+		"action":      "backup_phase",
+		"backup_id":   req.ID,
+		"backup_op":   string(OpCreate),
+		"backup_path": req.Path,
+	})
+	phaseLog.WithField("backup_phase", "start").Info("backup: coordinator entered")
+
 	leader := c.nodeResolver.LeaderID()
 	if leader == "" {
 		return fmt.Errorf("backup Op %s: %w, try again later", req.Method, types.ErrLeaderNotFound)
@@ -170,6 +178,9 @@ func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Reques
 	if err != nil {
 		return err
 	}
+	phaseLog.WithField("backup_phase", "group_by_shard").
+		WithField("node_count", len(groups)).
+		Info("backup: shard grouping complete")
 	// make sure there is no active backup
 	if prevID := c.lastOp.renew(req.ID, cstore.HomeDir(req.Bucket, req.Path), req.Bucket, req.Path); prevID != "" {
 		return fmt.Errorf("backup %s already in progress", prevID)
@@ -195,11 +206,20 @@ func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Reques
 		delete(c.Participants, key)
 	}
 
+	phaseLog.WithField("backup_phase", "can_commit_start").Info("backup: canCommit fan-out starting")
+	canCommitStart := time.Now()
 	nodes, err := c.canCommit(ctx, req)
 	if err != nil {
+		phaseLog.WithField("backup_phase", "can_commit_failed").
+			WithField("duration_ms", time.Since(canCommitStart).Milliseconds()).
+			Warnf("backup: canCommit refused; backup will not start: %v", err)
 		c.lastOp.reset()
 		return err
 	}
+	phaseLog.WithField("backup_phase", "can_commit_ok").
+		WithField("duration_ms", time.Since(canCommitStart).Milliseconds()).
+		WithField("nodes_accepted", len(nodes)).
+		Info("backup: canCommit accepted on all nodes")
 
 	overrideBucket := req.Bucket
 	overridePath := req.Path
@@ -207,6 +227,7 @@ func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Reques
 		c.lastOp.reset()
 		return fmt.Errorf("coordinator: cannot init meta file: %w", err)
 	}
+	phaseLog.WithField("backup_phase", "meta_written").Info("backup: initial meta file written")
 
 	statusReq := StatusRequest{
 		Method:       OpCreate,
@@ -220,7 +241,13 @@ func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Reques
 	f := func() {
 		defer c.lastOp.reset()
 		ctx := context.Background()
+		commitStart := time.Now()
+		phaseLog.WithField("backup_phase", "commit_start").Info("backup: commit phase starting (async)")
 		c.commit(ctx, &statusReq, nodes, false)
+		phaseLog.WithField("backup_phase", "commit_done").
+			WithField("duration_ms", time.Since(commitStart).Milliseconds()).
+			WithField("descriptor_status", string(c.descriptor.Status)).
+			Info("backup: commit phase complete")
 		logFields := logrus.Fields{"action": OpCreate, "backup_id": req.ID}
 		if err := cstore.PutMeta(ctx, GlobalBackupFile, c.descriptor, overrideBucket, overridePath); err != nil {
 			c.log.WithFields(logFields).Errorf("coordinator: put_meta: %v", err)
@@ -588,9 +615,23 @@ func (c *coordinator) commit(ctx context.Context,
 		return
 	}
 
+	phaseLog := c.log.WithFields(logrus.Fields{
+		"action":      "backup_phase",
+		"backup_id":   req.ID,
+		"backup_op":   string(req.Method),
+		"backup_path": req.Path,
+	})
+	phaseLog.WithField("backup_phase", "commit_all_start").
+		WithField("nodes_in_flight", len(node2Host)).
+		Info("commit: firing per-node commit RPCs")
 	nFailures := c.commitAll(ctx, req, node2Host)
+	phaseLog.WithField("backup_phase", "commit_all_done").
+		WithField("nodes_still_in_flight", len(node2Host)).
+		WithField("failures_so_far", nFailures).
+		Info("commit: first round complete; entering poll loop")
 	retryAfter := c.timeoutNextRound / 5 // 2s for first time
 	canContinue := len(node2Host) > 0 && (toleratePartialFailure || nFailures == 0)
+	pollIter := 0
 	for canContinue {
 		// Check for external cancellation in polling loop
 		if c.lastOp.get().Status == backup.Cancelled {
@@ -616,9 +657,16 @@ func (c *coordinator) commit(ctx context.Context,
 			c.descriptor.Error = "restore cancelled: context cancelled"
 			return
 		}
+		pollIter++
 		retryAfter = c.timeoutNextRound
 		nFailures += c.queryAll(ctx, req, node2Host)
 		canContinue = len(node2Host) > 0 && (toleratePartialFailure || nFailures == 0)
+		phaseLog.WithField("backup_phase", "commit_poll").
+			WithField("poll_iter", pollIter).
+			WithField("nodes_still_in_flight", len(node2Host)).
+			WithField("failures_so_far", nFailures).
+			WithField("continue", canContinue).
+			Info("commit: polled in-flight nodes")
 	}
 	if !toleratePartialFailure && nFailures > 0 {
 		req := &AbortRequest{Method: req.Method, ID: req.ID, Backend: req.Backend}

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -661,11 +661,20 @@ func (c *coordinator) commit(ctx context.Context,
 		retryAfter = c.timeoutNextRound
 		nFailures += c.queryAll(ctx, req, node2Host)
 		canContinue = len(node2Host) > 0 && (toleratePartialFailure || nFailures == 0)
+		// Include per-node status strings so a future post-mortem can tell
+		// "stuck before u.setStatus(Transferring)" from "stuck after". The
+		// Participants map carries the last queryAll-observed Status for
+		// every node, so this is just a render.
+		nodeStatuses := make(map[string]string, len(c.Participants))
+		for node, p := range c.Participants {
+			nodeStatuses[node] = string(p.Status)
+		}
 		phaseLog.WithField("backup_phase", "commit_poll").
 			WithField("poll_iter", pollIter).
 			WithField("nodes_still_in_flight", len(node2Host)).
 			WithField("failures_so_far", nFailures).
 			WithField("continue", canContinue).
+			WithField("participant_statuses", nodeStatuses).
 			Info("commit: polled in-flight nodes")
 	}
 	if !toleratePartialFailure && nFailures > 0 {


### PR DESCRIPTION
SuperClaude here.

## Summary

QA Claude's [flake-hunt on `TestMultiNode_CancelClearsAcrossReplicas`](https://github.com/weaviate/weaviate/pull/11327#issuecomment-4536168991) (~0.34% baseline after the `ErrBucketNotFound` short-circuit) leaves the backup-stuck-at-STARTED 60s timeout as a blackbox. The only signal today is the test's `last status: STARTED` assertion failure. There's no breadcrumb between "backup created" and "60s elapsed".

This PR adds Info-level phase transitions on `usecases/backup/coordinator.go`:

- `Backup()` emits one structured line each at: `start`, `group_by_shard`, `can_commit_start`, `can_commit_ok|can_commit_failed` (with `duration_ms`, `nodes_accepted`), `meta_written`, `commit_start`, `commit_done`.
- `commit()` emits: `commit_all_start`, `commit_all_done`, plus one `commit_poll` per polling iteration with `poll_iter`, `nodes_still_in_flight`, `continue`.

All lines carry `action=backup_phase` + `backup_phase=<name>` so a single `action=backup_phase` filter in a log aggregator produces the per-backup trail. No behaviour change — pure observability.

Once this lands, QA can rebase weaviate/weaviate#11451 onto it for the next 300-iter flake-hunt; the failure dumps will show which phase the coordinator is hanging in.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test -race ./usecases/backup/...` — green (6.3s).
- [ ] Wait for full CI matrix.
- [ ] Verify the trace lines appear in a fresh `TestMultiNode_CancelClearsAcrossReplicas` log dump (via QA's rebase).

— SuperClaude