### PR TITLE
fix(test): bump CancelClearsAcrossReplicas backup deadline 60s → 120s

### DIFF
--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -298,7 +298,15 @@ func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) e
 		return fmt.Errorf("backup create returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	deadline := time.Now().Add(60 * time.Second)
+	// 120s, not 60s: 5th flake-hunt on weaviate/weaviate#11451 measured
+	// end-to-end backup wall clock at ~52-64s on a 3-node testcontainer
+	// cluster (per-participant uploader.all ~50-52s + 10s coord-poll
+	// cadence + final aggregate). 60s lands inside that distribution's
+	// long tail and produced a ~0.34% flake. 120s is well clear; backup
+	// speed is not the property under test here. The ~50s per-participant
+	// floor is itself worth investigating separately for this near-empty-
+	// shard scenario.
+	deadline := time.Now().Add(120 * time.Second)
 	for {
 		r, err := http.Get(fmt.Sprintf("http://%s/v1/backups/s3/%s", restURI, backupID))
 		if err != nil {

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -275,7 +275,7 @@ func scanClassDirAllNodes(
 	return survivors
 }
 
-// createS3Backup posts to /v1/backups/s3 and waits up to 60s for a
+// createS3Backup posts to /v1/backups/s3 and waits up to 120s for a
 // SUCCESS terminal status.
 func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) error {
 	t.Helper()
@@ -298,14 +298,6 @@ func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) e
 		return fmt.Errorf("backup create returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	// 120s, not 60s: 5th flake-hunt on weaviate/weaviate#11451 measured
-	// end-to-end backup wall clock at ~52-64s on a 3-node testcontainer
-	// cluster (per-participant uploader.all ~50-52s + 10s coord-poll
-	// cadence + final aggregate). 60s lands inside that distribution's
-	// long tail and produced a ~0.34% flake. 120s is well clear; backup
-	// speed is not the property under test here. The ~50s per-participant
-	// floor is itself worth investigating separately for this near-empty-
-	// shard scenario.
 	deadline := time.Now().Add(120 * time.Second)
 	for {
 		r, err := http.Get(fmt.Sprintf("http://%s/v1/backups/s3/%s", restURI, backupID))


### PR DESCRIPTION
SuperClaude here.

## Summary

The flake on `TestMultiNode_CancelClearsAcrossReplicas` (~0.34% during the runtime-reindex × backup work) is not a deadlock and not the channel race that motivated weaviate/weaviate#11452. It's a tight test-timeout race.

## Falsification

5th flake-hunt iteration on weaviate/weaviate#11451 (commit `da21b67f5`, 289/290 PASS, 1 FAIL shard 15 iter 7) used the participant + coordinator phase-trace logging from weaviate/weaviate#11452 to capture the full timeline. Every participant on every iteration completes `uploader.all` cleanly. The three deadlock hypotheses (channel race, bucketAccessLock contention, HaltForTransfer wait) are all dead.

Failing iter timeline (excerpted from QA's dump):

| Time (Z) | Event |
| --- | --- |
| 19:36:17 | Backup POST → 200, test polls /v1/backups/s3/`<id>` |
| 19:36:17 | All 3 participants: `participant_provider_all_start` (Transferring) |
| 19:36:19 → 19:36:59 | Coord polls #1-#5: `participant_statuses={n0:TRANSFERRING, n1:TRANSFERRING, n2:TRANSFERRING}` |
| 19:37:07 | weaviate-0: `provider_all_ok duration_ms=50059` |
| 19:37:07 | weaviate-1: `provider_all_ok duration_ms=50721` |
| 19:37:09 | weaviate-2: `provider_all_ok duration_ms=52146` |
| 19:37:09 | Coord poll #6: `{n0:SUCCESS, n1:SUCCESS, n2:TRANSFERRING}` (just missed n2) |
| 19:37:17 | **Test's 60s deadline expires** |
| 19:37:19 | Coord poll #7 would have caught all 3 SUCCESS (never logged) |

End-to-end wall clock = ~52s (per-participant `uploader.all`) + 0-10s (10s `_NextRoundPeriod` poll cadence) + ~1-2s (aggregate + meta write) = **52-64s**. 60s lands in the long tail; 120s is clear.

Backup speed is not the property under test (the property is "cancel cleanup is durable across replicas"). The deadline change is appropriate. Full forensic comment: weaviate/weaviate#11451 comment 4536846857.

## Separable follow-up

The ~50-52s per-participant floor for `uploader.all` on a near-empty class (3 surviving objects after the cancelled change-tokenization) is itself suspicious. Filing as a separate diagnostic issue — could be benign (3-node testcontainer cluster on busy CI runners) or a real cancel→backup-path performance regression worth profiling. Not blocking this fix.

## Test plan

- [x] Local reproduce — `uploader.all` duration matches QA's measurement
- [x] `go build ./...`
- [ ] CI green on the targeted shard
- [ ] Optional: 30-iter flake-hunt to confirm the failure mode is gone

— SuperClaude