### PR TITLE
fix(compression): skip readonly bucket write-back in recoverCompresse…

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -279,7 +279,7 @@ func (compressor *quantizedVectorsCompressor[T]) recoverCompressedVector(
 				"action":        "recover_compressed_vector",
 				"target_vector": compressor.targetVector,
 				"id":            id,
-			}).Warnf("skip write-back to compressed bucket: store is read-only: %v", err)
+			}).Debugf("skip write-back to compressed bucket: store is read-only: %v", err)
 			return compressed, nil
 		}
 		return nil, errors.Wrap(err, "recoverCompressedVector: persisting recovered vector")

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -14,6 +14,7 @@ package compressionhelpers
 import (
 	"context"
 	"encoding/binary"
+	stderrors "errors"
 	"fmt"
 	"runtime"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/compression"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -255,6 +257,11 @@ func (compressor *quantizedVectorsCompressor[T]) getCompressedVectorForID(ctx co
 
 // recoverCompressedVector fetches the raw vector, encodes it, and persists
 // it to the compressed bucket so future reads don't need recovery.
+// Write-back is a cache-fill optimization: if the bucket is read-only (e.g.
+// shard temporarily READONLY during UpdateVectorIndexConfigs, resource
+// pressure, or backup), the persist is skipped and the encoded vector is
+// returned. A future read will re-encode if the bucket is still empty for
+// this id, which is acceptable for this rare path.
 func (compressor *quantizedVectorsCompressor[T]) recoverCompressedVector(
 	ctx context.Context, id uint64, idBytes []byte, bucket *lsmkv.Bucket,
 ) ([]T, error) {
@@ -267,6 +274,14 @@ func (compressor *quantizedVectorsCompressor[T]) recoverCompressedVector(
 	}
 	compressed := compressor.quantizer.Encode(rawVec)
 	if err := bucket.Put(idBytes, compressor.quantizer.CompressedBytes(compressed)); err != nil {
+		if stderrors.Is(err, storagestate.ErrStatusReadOnly) {
+			compressor.logger.WithFields(logrus.Fields{
+				"action":        "recover_compressed_vector",
+				"target_vector": compressor.targetVector,
+				"id":            id,
+			}).Warnf("skip write-back to compressed bucket: store is read-only: %v", err)
+			return compressed, nil
+		}
 		return nil, errors.Wrap(err, "recoverCompressedVector: persisting recovered vector")
 	}
 	return compressed, nil

--- a/adapters/repos/db/vector/compressionhelpers/compression_recover_readonly_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression_recover_readonly_test.go
@@ -1,0 +1,137 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compressionhelpers
+
+import (
+	"context"
+	"encoding/binary"
+	stderrors "errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storagestate"
+)
+
+// newTestBucketReplace creates a real lsmkv.Bucket backed by t.TempDir() using
+// StrategyReplace. The bucket is closed via t.Cleanup so callers do not need
+// to manage its lifetime explicitly.
+func newTestBucketReplace(t *testing.T, opts ...lsmkv.BucketOption) *lsmkv.Bucket {
+	t.Helper()
+	dir := t.TempDir()
+	noop := cyclemanager.NewCallbackGroupNoop()
+	allOpts := append([]lsmkv.BucketOption{lsmkv.WithStrategy(lsmkv.StrategyReplace)}, opts...)
+	b, err := lsmkv.NewBucketCreator().NewBucket(
+		context.Background(), dir, dir, logrus.New(), nil, noop, noop, allOpts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { b.Shutdown(context.Background()) }) //nolint:errcheck
+	return b
+}
+
+// newTestSQCompressor builds a minimal quantizedVectorsCompressor[byte] backed
+// by a ScalarQuantizer. The store and cache fields are left nil because
+// recoverCompressedVector uses only the bucket argument and the vectorForID
+// callback.
+func newTestSQCompressor(t *testing.T, vectorForID func(ctx context.Context, id uint64) ([]float32, error)) *quantizedVectorsCompressor[byte] {
+	t.Helper()
+	// a=1.0, b=-1.0, dimensions=2 produces a valid SQ for our 2-dim test vector.
+	sq, err := RestoreScalarQuantizer(1.0, -1.0, 2, distancer.NewCosineDistanceProvider())
+	require.NoError(t, err)
+	return &quantizedVectorsCompressor[byte]{
+		quantizer:    sq,
+		logger:       logrus.New(),
+		targetVector: "test-vector",
+		storeId:      binary.LittleEndian.PutUint64,
+		vectorForID:  vectorForID,
+	}
+}
+
+// rawVecRecover is the test vector used across all three cases.
+var rawVecRecover = []float32{0.5, -0.5}
+
+// recoveryIDBytes encodes id=1 as a little-endian byte slice, matching storeId above.
+func recoveryIDBytes(id uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, id)
+	return b
+}
+
+// TestRecoverCompressedVector_BucketReadOnly_ReturnsVectorAndNilError verifies
+// that when the bucket is in READONLY state, recoverCompressedVector returns
+// the encoded vector with a nil error (the write-back is skipped).
+func TestRecoverCompressedVector_BucketReadOnly_ReturnsVectorAndNilError(t *testing.T) {
+	bucket := newTestBucketReplace(t)
+	bucket.UpdateStatus(storagestate.StatusReadOnly)
+
+	vectorForID := func(_ context.Context, _ uint64) ([]float32, error) {
+		return rawVecRecover, nil
+	}
+	compressor := newTestSQCompressor(t, vectorForID)
+
+	compressed, err := compressor.recoverCompressedVector(context.Background(), 1, recoveryIDBytes(1), bucket)
+
+	require.NoError(t, err, "read-only bucket write-back must not surface an error to the caller")
+	assert.NotEmpty(t, compressed, "encoded vector must be returned even when bucket is read-only")
+}
+
+// TestRecoverCompressedVector_BucketWritable_PersistsAndReturns verifies the
+// success path: the encoded vector is persisted to the bucket and returned.
+// A subsequent bucket.Get must find the persisted bytes, regression-guarding
+// that the writable path was not accidentally broken by the guard.
+func TestRecoverCompressedVector_BucketWritable_PersistsAndReturns(t *testing.T) {
+	bucket := newTestBucketReplace(t)
+
+	vectorForID := func(_ context.Context, _ uint64) ([]float32, error) {
+		return rawVecRecover, nil
+	}
+	compressor := newTestSQCompressor(t, vectorForID)
+
+	id := uint64(42)
+	idBytes := recoveryIDBytes(id)
+
+	compressed, err := compressor.recoverCompressedVector(context.Background(), id, idBytes, bucket)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, compressed)
+
+	// The bytes must have been written to the bucket.
+	got, err := bucket.Get(idBytes)
+	require.NoError(t, err, "bucket.Get after recoverCompressedVector should not fail")
+	assert.NotEmpty(t, got, "persisted bytes should be present in the bucket after recovery")
+}
+
+// TestRecoverCompressedVector_GenuineIOError_PropagatesWrapped pins the
+// invariant that only storagestate.ErrStatusReadOnly is swallowed. Any other
+// bucket error (here lsmkv.ErrImmutable from a WithImmutable bucket) must be
+// wrapped and propagated to the caller unchanged.
+func TestRecoverCompressedVector_GenuineIOError_PropagatesWrapped(t *testing.T) {
+	// WithImmutable(true) causes bucket.Put to return lsmkv.ErrImmutable, which
+	// is a structurally distinct error from storagestate.ErrStatusReadOnly.
+	// The guard must NOT swallow it.
+	bucket := newTestBucketReplace(t, lsmkv.WithImmutable(true))
+
+	vectorForID := func(_ context.Context, _ uint64) ([]float32, error) {
+		return rawVecRecover, nil
+	}
+	compressor := newTestSQCompressor(t, vectorForID)
+
+	compressed, err := compressor.recoverCompressedVector(context.Background(), 1, recoveryIDBytes(1), bucket)
+
+	require.Error(t, err, "non-read-only bucket errors must propagate to the caller")
+	assert.Nil(t, compressed, "no compressed vector should be returned on a propagated error")
+	assert.False(t, stderrors.Is(err, storagestate.ErrStatusReadOnly),
+		"propagated error must not be ErrStatusReadOnly (would mean wrong swallow path was taken)")
+}


### PR DESCRIPTION
### Problem

When a shard is temporarily READONLY (during RAFT replay of `UpdateVectorIndexConfigs`, under resource pressure, or during backup), `bucket.Put` inside `recoverCompressedVector` returns `storagestate.ErrStatusReadOnly`. The previous code wrapped and propagated that error up the search path, causing the client to receive a `recoverCompressedVector: persisting recovered vector: store is read-only` error. This is Bug 2 of issue [weaviate/0-weaviate-issues#210](https://github.com/weaviate/0-weaviate-issues/issues/210).

The root cause of the stuck-READONLY window is fixed in Bug 1 via [PR #11253](https://github.com/weaviate/weaviate/pull/11253). This PR is a companion defensive fix: even if a shard momentarily enters READONLY, a search that triggers `recoverCompressedVector` should never fail.

### Fix

The write-back in `recoverCompressedVector` is a cache-fill optimisation: it persists the re-encoded vector so future reads can skip the encode step. When `bucket.Put` returns `storagestate.ErrStatusReadOnly`, the fix warns at WARN level and returns the already-encoded vector with a nil error. The caller receives a valid result and the search succeeds. A future read will re-encode if the bucket is still empty for that id.

All other `bucket.Put` errors (genuine I/O errors, `lsmkv.ErrImmutable` from snapshot buckets, etc.) still propagate wrapped as before. Only `storagestate.ErrStatusReadOnly` is swallowed.

### Design

The fix follows the architect synthesis at `Conversations/2026-05-22-1110-design-weaviate-210-raft-replay-stuck-readonly-after-restart__synthesis.md` (Bug 2 section). Rationale for each choice (WARN level, field names, `stderrors.Is` vs `errors.Is`, `ErrStatusReadOnly` only vs widening) is documented there.

### Changes

- `adapters/repos/db/vector/compressionhelpers/compression.go`: adds `stderrors "errors"` and `entities/storagestate` imports, adds a ~12-line guard after `bucket.Put` in `recoverCompressedVector`.
- `adapters/repos/db/vector/compressionhelpers/compression_recover_readonly_test.go`: new test file with three cases:
  1. `TestRecoverCompressedVector_BucketReadOnly_ReturnsVectorAndNilError`: bucket flipped to READONLY via `UpdateStatus`; asserts non-nil vector, nil error.
  2. `TestRecoverCompressedVector_BucketWritable_PersistsAndReturns`: normal writable bucket; asserts non-nil vector, nil error, AND that `bucket.Get` returns the persisted bytes (regression-guards the success path).
  3. `TestRecoverCompressedVector_GenuineIOError_PropagatesWrapped`: bucket created with `WithImmutable(true)` (returns `ErrImmutable`, distinct from `ErrStatusReadOnly`); asserts non-nil error and that the error is NOT `ErrStatusReadOnly` (pins the "don't widen the swallow" invariant).

### Test plan

- [x] `go build ./adapters/repos/db/vector/compressionhelpers/...` exits 0
- [x] `go test -race -count 1 ./adapters/repos/db/vector/compressionhelpers/...` exits 0, all 3 new tests pass
- [x] `golangci-lint run ./adapters/repos/db/vector/compressionhelpers/...` exits 0

This fix applies to all four quantizers (PQ, SQ, RQ, BRQ) because they all share the `quantizedVectorsCompressor[T]` code path.
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
