### PR TITLE
fix(cyclemanager): immediately cancel cycle work on collection delete

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2762,16 +2762,22 @@ func (i *Index) drop() error {
 		return err
 	}
 
-	// Dropping the shards only unregisters the shards callbacks, but we still
-	// need to stop the cycle managers that those shards used to register with.
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	i.logger.WithFields(logrus.Fields{
-		"action":   "drop_index",
-		"duration": 60 * time.Second,
-	}).Debug("context.WithTimeout")
+	// The index and its data are about to be removed — there is no reason
+	// to wait for cycle callbacks (compaction, flush, vector commit logger,
+	// etc.) to finish their current iteration. Pass an already-cancelled
+	// ctx so cycleManager.StopAndWait signals immediate abort to in-flight
+	// callbacks AND returns without blocking the caller (which on the
+	// DELETE_CLASS apply path holds db.indexLock and blocks the raft apply
+	// loop). See weaviate/0-weaviate-issues#250.
+	//
+	// stopCycleManagers returns context.Canceled by design — the cycle
+	// goroutines remain marked as stopping and exit on their own when
+	// their in-flight callback honours shouldAbort. Any error that is NOT
+	// context.Canceled is unexpected and propagated.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	if err := i.stopCycleManagers(ctx, "drop"); err != nil {
+	if err := i.stopCycleManagers(ctx, "drop"); err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
 

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -51,7 +51,12 @@ func TestStoreBackup(t *testing.T) {
 func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
-	t.Run("assert that context timeout works for long compactions", func(t *testing.T) {
+	t.Run("expired context does not block the deactivate step when no compaction is in flight", func(t *testing.T) {
+		// Mirrors the FlushMemtables case: with no compaction in flight,
+		// Deactivate applies the mutation and returns nil even on expired
+		// ctx. The previous assertion was pinning the buggy "always error
+		// on expired ctx" behaviour that weaviate/0-weaviate-issues#250
+		// fixes for the delete path.
 		for _, buckets := range [][]string{
 			{"test_bucket"},
 			{"test_bucket1", "test_bucket2"},
@@ -77,10 +82,7 @@ func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				defer cancel()
 
 				err = store.PauseCompaction(expiredCtx)
-				require.NotNil(t, err)
-				assert.Equal(t, "long-running compaction in progress:"+
-					" deactivating callback 'store/compaction-non-objects/.' of 'classCompactionNonObjects' failed:"+
-					" context deadline exceeded", err.Error())
+				require.Nil(t, err)
 
 				err = store.Shutdown(ctx)
 				require.Nil(t, err)
@@ -186,7 +188,13 @@ func resumeCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
-	t.Run("assert that context timeout works for long flushes", func(t *testing.T) {
+	t.Run("expired context does not block the deactivate step when no flush is in flight", func(t *testing.T) {
+		// Under the new cyclemanager semantics, ctx.Err() != nil no longer
+		// fails the Deactivate mutation when no callback is currently
+		// running — the mutation applies and the call returns nil. The
+		// previous assertion (always error on expired ctx, even with
+		// nothing in flight) was pinning the buggy behaviour that the
+		// delete-path fix on weaviate/0-weaviate-issues#250 removes.
 		for _, buckets := range [][]string{
 			{"test_bucket"},
 			{"test_bucket1", "test_bucket2"},
@@ -212,10 +220,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				defer cancel()
 
 				err = store.FlushMemtables(expiredCtx)
-				require.NotNil(t, err)
-				assert.Equal(t, "long-running memtable flush in progress:"+
-					" deactivating callback 'store/flush/.' of 'classFlush' failed:"+
-					" context deadline exceeded", err.Error())
+				require.Nil(t, err)
 
 				err = store.Shutdown(ctx)
 				require.Nil(t, err)

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -81,15 +81,29 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 		return err
 	}
 
-	// unregister all callbacks at once, in parallel
-	if err = cyclemanager.NewCombinedCallbackCtrl(0, s.index.logger,
+	// Unregister cycle callbacks for THIS shard with an already-cancelled
+	// ctx — the shard is being deleted, there is no reason to wait for
+	// in-flight compaction/flush callbacks on it. The mutation (marking
+	// shouldAbort=true and removing the callback from the cyclemanager's
+	// dispatch list) still applies; only the wait is skipped. See
+	// weaviate/0-weaviate-issues#250.
+	//
+	// Iterate the ctrls one by one so we can distinguish the expected
+	// context.Canceled (from the just-cancelled ctx) from real errors.
+	// NewCombinedCallbackCtrl coalesces via errorcompounder, which flattens
+	// wrapping and would defeat errors.Is.
+	cycleCancelCtx, cycleCancel := context.WithCancel(context.Background())
+	cycleCancel()
+	for _, ctrl := range []cyclemanager.CycleCallbackCtrl{
 		s.cycleCallbacks.compactionCallbacksCtrl,
 		s.cycleCallbacks.compactionAuxCallbacksCtrl,
 		s.cycleCallbacks.flushCallbacksCtrl,
 		s.cycleCallbacks.vectorCombinedCallbacksCtrl,
 		s.cycleCallbacks.geoPropsCombinedCallbacksCtrl,
-	).Unregister(ctx); err != nil {
-		return err
+	} {
+		if err := ctrl.Unregister(cycleCancelCtx); err != nil && !errors.Is(err, context.Canceled) {
+			return fmt.Errorf("unregister shard cycle callback: %w", err)
+		}
 	}
 
 	if err = s.store.Shutdown(ctx); err != nil {

--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -52,7 +52,10 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		assert.False(t, ctrl2.IsActive())
 	})
 
-	t.Run("does not unregister on expired context", func(t *testing.T) {
+	t.Run("unregisters with expired context when no callback is running", func(t *testing.T) {
+		// Expired ctx no longer blocks the mutation — it only bounds how
+		// long we wait for in-flight work. When nothing is running, the
+		// unregister applies cleanly with no wait.
 		expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
 		defer cancel()
 
@@ -75,13 +78,11 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		defer cycle.StopAndWait(ctx)
 
 		err := combinedCtrl.Unregister(expiredCtx)
-		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), "unregistering callback 'c1' of 'id' failed: context deadline exceeded")
-		assert.Contains(t, err.Error(), "unregistering callback 'c2' of 'id' failed: context deadline exceeded")
+		require.Nil(t, err)
 
-		assert.True(t, combinedCtrl.IsActive())
-		assert.True(t, ctrl1.IsActive())
-		assert.True(t, ctrl2.IsActive())
+		assert.False(t, combinedCtrl.IsActive())
+		assert.False(t, ctrl1.IsActive())
+		assert.False(t, ctrl2.IsActive())
 	})
 
 	t.Run("fails unregistering one", func(t *testing.T) {
@@ -150,7 +151,10 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		assert.False(t, ctrl2.IsActive())
 	})
 
-	t.Run("does not deactivate on expired context", func(t *testing.T) {
+	t.Run("deactivates with expired context when no callback is running", func(t *testing.T) {
+		// Expired ctx no longer blocks the mutation — it only bounds how
+		// long we wait for in-flight work. When nothing is running, the
+		// deactivate applies cleanly with no wait.
 		expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
 		defer cancel()
 
@@ -173,13 +177,11 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		defer cycle.StopAndWait(ctx)
 
 		err := combinedCtrl.Deactivate(expiredCtx)
-		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), "deactivating callback 'c1' of 'id' failed: context deadline exceeded")
-		assert.Contains(t, err.Error(), "deactivating callback 'c1' of 'id' failed: context deadline exceeded")
+		require.Nil(t, err)
 
-		assert.True(t, combinedCtrl.IsActive())
-		assert.True(t, ctrl1.IsActive())
-		assert.True(t, ctrl2.IsActive())
+		assert.False(t, combinedCtrl.IsActive())
+		assert.False(t, ctrl1.IsActive())
+		assert.False(t, ctrl2.IsActive())
 	})
 
 	t.Run("fails deactivating one, activates other again", func(t *testing.T) {

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -286,9 +286,11 @@ func (c *cycleCallbackGroup) mutateCallback(ctx context.Context, callbackId uint
 	onMetaNotFound func(callbackId uint32) error,
 	onMetaFound func(callbackId uint32, meta *cycleCallbackMeta, running bool) error,
 ) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
+	// The mutation itself (e.g. marking shouldAbort=true for unregister) is
+	// applied unconditionally — ctx only bounds how long we wait for the
+	// currently-running callback to honor that mutation. Callers passing an
+	// already-cancelled ctx (delete path) get the mark + an immediate
+	// ctx.Err() return.
 
 	for {
 		// mutate callback in collection only if not running (not yet started of finished)

--- a/entities/cyclemanager/cyclemanager.go
+++ b/entities/cyclemanager/cyclemanager.go
@@ -100,10 +100,13 @@ func (c *cycleManager) Start() {
 // Stops running instance, does not block
 // Returns channel with final stop result - true / false
 //
-// If given context is cancelled before it is handled by stop logic, instance is not stopped
-// If called multiple times, all contexts have to be cancelled to cancel stop
-// (any valid will result in stopping instance)
-// stopResult is the same (consistent) for multiple calls
+// Once Stop has been called, the cycle will stop unconditionally — the ctx
+// only bounds how aggressively in-flight cycle callbacks should abort. A
+// callback receives shouldAbort()=true once any stop ctx has expired, giving
+// the caller a way to force immediate cancellation (delete path: pass an
+// already-cancelled ctx) or a graceful drain (shutdown path: pass a ctx
+// with a generous deadline).
+// stopResult is the same (consistent) for multiple calls.
 func (c *cycleManager) Stop(ctx context.Context) (stopResult chan bool) {
 	c.Lock()
 	defer c.Unlock()
@@ -162,20 +165,28 @@ func (c *cycleManager) Running() bool {
 	return c.running
 }
 
+// shouldStop reports whether Stop has been requested at all. Once any caller
+// has called Stop, the cycle commits to stopping; this state is independent
+// of the caller's wait deadline.
 func (c *cycleManager) shouldStop() bool {
-	for _, ctx := range c.stopContexts {
-		if ctx.Err() == nil {
-			return true
-		}
-	}
-	return false
+	return len(c.stopContexts) > 0
 }
 
+// shouldAbortCycleCallback reports whether a running cycle callback should
+// abort its in-flight work. True iff at least one stop request's ctx has
+// expired — the caller has signalled "don't bother finishing, I'm done
+// waiting." This is the hook delete-path callers exercise by passing an
+// already-cancelled ctx.
 func (c *cycleManager) shouldAbortCycleCallback() bool {
 	c.RLock()
 	defer c.RUnlock()
 
-	return c.shouldStop()
+	for _, ctx := range c.stopContexts {
+		if ctx.Err() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *cycleManager) isStopRequested() bool {
@@ -219,13 +230,8 @@ func (c *cycleManagerNoop) Start() {
 }
 
 func (c *cycleManagerNoop) Stop(ctx context.Context) chan bool {
-	if !c.running {
-		return c.closedChan(true)
-	}
-	if ctx.Err() != nil {
-		return c.closedChan(false)
-	}
-
+	// Stop is unconditional; ctx state does not gate the transition (matches
+	// the real cycleManager semantics — see Stop docstring there).
 	c.running = false
 	return c.closedChan(true)
 }

--- a/entities/cyclemanager/cyclemanager_test.go
+++ b/entities/cyclemanager/cyclemanager_test.go
@@ -137,6 +137,12 @@ func TestCycleManager_beforeTimeoutWithWait(t *testing.T) {
 }
 
 func TestCycleManager_timeout(t *testing.T) {
+	// Stop with a ctx shorter than the in-flight callback duration. The ctx
+	// expiry no longer flips the "should stop" decision — Stop, once
+	// requested, commits to stopping the cycle. The ctx only governs whether
+	// the cycle callback honors an early abort. This callback (aborts=1) does
+	// not check shouldAbort, so it runs to completion; the manager then
+	// transitions to stopped.
 	cycleInterval := 5 * time.Millisecond
 	cycleDuration := 20 * time.Millisecond
 	stopTimeout := 12 * time.Millisecond
@@ -160,16 +166,10 @@ func TestCycleManager_timeout(t *testing.T) {
 			t.Fatal("stopped before timeout")
 		}
 
-		// make sure it is still running
-		assert.False(t, <-stopResult)
-		assert.True(t, cm.Running())
-		assert.Equal(t, "something wonderful...", <-p.results)
-	})
-
-	t.Run("stop", func(t *testing.T) {
-		stopResult := cm.Stop(context.Background())
+		// callback runs to completion, then handleStopRequest(true) fires.
 		assert.True(t, <-stopResult)
 		assert.False(t, cm.Running())
+		assert.Equal(t, "something wonderful...", <-p.results)
 	})
 }
 
@@ -308,102 +308,98 @@ func TestCycleManager_stopsIfNotAllContextsAreCancelled(t *testing.T) {
 	})
 }
 
-func TestCycleManager_doesNotStopIfAllContextsAreCancelled(t *testing.T) {
+func TestCycleManager_stopsEvenIfAllContextsAreCancelled(t *testing.T) {
+	// Once Stop is called, the cycle commits to stopping regardless of ctx
+	// state. Expired ctx only signals "don't wait on me," not "never mind,
+	// keep running" — that distinction is what the delete path relies on.
 	cycleInterval := 50 * time.Millisecond
 	cycleDuration := 10 * time.Millisecond
-	stopTimeout := 50 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
 	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
-	t.Run("multiple stops, few cancelled", func(t *testing.T) {
-		timeout1Ctx, cancel1 := context.WithTimeout(context.Background(), stopTimeout)
-		timeout2Ctx, cancel2 := context.WithTimeout(context.Background(), stopTimeout)
-		timeout3Ctx, cancel3 := context.WithTimeout(context.Background(), stopTimeout)
-		defer cancel1()
-		defer cancel2()
-		defer cancel3()
+	t.Run("multiple stops, all already cancelled", func(t *testing.T) {
+		expired1, cancel1 := context.WithCancel(context.Background())
+		expired2, cancel2 := context.WithCancel(context.Background())
+		expired3, cancel3 := context.WithCancel(context.Background())
+		cancel1()
+		cancel2()
+		cancel3()
 
 		cm.Start()
 		<-p.firstCycleStarted
 
-		stopResult1 := cm.Stop(timeout1Ctx)
-		stopResult2 := cm.Stop(timeout2Ctx)
-		stopResult3 := cm.Stop(timeout3Ctx)
+		stopResult1 := cm.Stop(expired1)
+		stopResult2 := cm.Stop(expired2)
+		stopResult3 := cm.Stop(expired3)
 
-		// all produce the same result: cycle was stopped
-		assert.False(t, <-stopResult1)
-		assert.False(t, <-stopResult2)
-		assert.False(t, <-stopResult3)
+		assert.True(t, <-stopResult1)
+		assert.True(t, <-stopResult2)
+		assert.True(t, <-stopResult3)
 
-		assert.True(t, cm.Running())
-		assert.Equal(t, "something wonderful...", <-p.results)
-	})
-
-	t.Run("stop", func(t *testing.T) {
-		stopResult := cm.Stop(context.Background())
-		assert.True(t, <-stopResult)
 		assert.False(t, cm.Running())
+		assert.Equal(t, "something wonderful...", <-p.results)
 	})
 }
 
-func TestCycleManager_cycleCallbackStoppedDueToFrequentStopChecks(t *testing.T) {
+func TestCycleManager_cycleCallbackAbortsImmediatelyOnPreExpiredCtx(t *testing.T) {
+	// The delete-path contract: a pre-expired ctx tells the cycle to abort
+	// in-flight work immediately. A callback that honors shouldAbort at any
+	// frequency bails on its very next check.
 	cycleInterval := 50 * time.Millisecond
 	cycleDuration := 300 * time.Millisecond
-	stopTimeout := 100 * time.Millisecond
 
-	// despite cycleDuration is 30ms, cycle callback checks every 20ms (300/15) if it needs to be stopped
+	// Callback checks shouldAbort every ~20ms (15 checks across 300ms).
 	p := newProviderAbortable(cycleDuration, 1, 15)
 	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
-	t.Run("cycle function stopped before timeout reached", func(t *testing.T) {
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
-		defer cancel()
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
 
-		cm.Start()
-		<-p.firstCycleStarted
+	cm.Start()
+	<-p.firstCycleStarted
 
-		err := cm.StopAndWait(timeoutCtx)
+	start := time.Now()
+	err := cm.StopAndWait(expired)
+	elapsed := time.Since(start)
 
-		assert.Nil(t, err)
-		assert.False(t, cm.Running())
-		assert.Equal(t, 0, len(p.results))
-	})
-
-	t.Run("stop", func(t *testing.T) {
-		stopResult := cm.Stop(context.Background())
-		assert.True(t, <-stopResult)
-		assert.False(t, cm.Running())
-	})
+	// StopAndWait returns the ctx error — caller already gave up waiting.
+	assert.ErrorIs(t, err, context.Canceled)
+	// Callback should abort within ~20ms (its check frequency); we leave
+	// generous headroom for slow CI.
+	assert.Less(t, elapsed, 100*time.Millisecond)
+	// Manager transitions to stopped after callback aborts.
+	assert.Eventually(t, func() bool { return !cm.Running() }, time.Second, 5*time.Millisecond)
+	// Callback aborted before sending its result.
+	assert.Equal(t, 0, len(p.results))
 }
 
-func TestCycleManager_cycleCallbackNotStoppedDueToRareStopChecks(t *testing.T) {
+func TestCycleManager_cycleCallbackAbortsOnExpiredCtx(t *testing.T) {
+	// With the ctx-expiry-driven abort signal, even a callback with rare
+	// shouldAbort checks aborts on its first check after ctx expiry. Compare
+	// to the legacy semantics where "rare checks + tight ctx = callback runs
+	// to completion"; the new semantics honour the caller's deadline.
 	cycleInterval := 50 * time.Millisecond
 	cycleDuration := 300 * time.Millisecond
 	stopTimeout := 100 * time.Millisecond
 
-	// despite cycleDuration is 30ms, cycle callback checks every 150ms (300/2) if it needs to be stopped
+	// Callback checks shouldAbort every 150ms during a 300ms cycle.
 	p := newProviderAbortable(cycleDuration, 1, 2)
 	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
-	t.Run("timeout reached", func(t *testing.T) {
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
-		defer cancel()
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+	defer cancel()
 
-		cm.Start()
-		<-p.firstCycleStarted
+	cm.Start()
+	<-p.firstCycleStarted
 
-		err := cm.StopAndWait(timeoutCtx)
+	err := cm.StopAndWait(timeoutCtx)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, "context deadline exceeded", err.Error())
-		assert.True(t, cm.Running())
-		assert.Equal(t, "something wonderful...", <-p.results)
-	})
-
-	t.Run("stop", func(t *testing.T) {
-		stopResult := cm.Stop(context.Background())
-		assert.True(t, <-stopResult)
-		assert.False(t, cm.Running())
-	})
+	// StopAndWait returns ctx.Err() — the caller stopped waiting.
+	assert.NotNil(t, err)
+	assert.Equal(t, "context deadline exceeded", err.Error())
+	// Callback aborted at its next abort-check (~150ms in), so it never
+	// produced a result.
+	assert.Eventually(t, func() bool { return !cm.Running() }, time.Second, 5*time.Millisecond)
+	assert.Equal(t, 0, len(p.results))
 }


### PR DESCRIPTION
SuperClaude here.

Draft against `stable/v1.35` per Etienne's direction on weaviate/0-weaviate-issues#250. Plan is to land here first, then port to `stable/v1.36`, `stable/v1.37`, and `main`.

## What changes

Once `Stop(ctx)` is requested, the cycleManager commits to stopping unconditionally. The ctx no longer flips the "should stop" decision — it drives a secondary "should abort in-flight work" signal: a cycle callback observes `shouldAbort()=true` once any stop ctx has expired.

Result:
- **Delete path** passes an already-cancelled ctx → `shouldAbort=true` immediately, `StopAndWait` returns `context.Canceled` without blocking, in-flight callbacks bail on their next shouldAbort check, the cycle loop exits at the next tick boundary.
- **Shutdown / tenant deactivation** keeps current behaviour — pass a live, generous-deadline ctx → `shouldAbort=false` during the wait → callbacks finish their work → cycle stops cleanly.

`Index.drop` (60s timeout) and `Shard.drop`'s cycle-callback `Unregister` (20s timeout) now both pass a cancelled ctx. The expected `context.Canceled` is checked explicitly via `errors.Is`; any unexpected error still propagates.

## What this does NOT yet cover

In-flight long-running operations ignore `shouldAbort` today:

- `bucket.flushAndSwitchIfThresholdsMet` — runs to completion, no `shouldAbort` check.
- `segmentGroup.compactOnce` and the underlying `compactor.do()` row-by-row merge loops — no `shouldAbort` check.

So a compaction or flush already started when the DELETE_CLASS apply arrives will still run to completion. The new semantics give us the contract — plumbing the actual abort into those inner loops is a separable follow-up. I will file it as a sub-issue once this PR lands.

The other Etienne-noted follow-up — `os.RemoveAll` not being ctx-aware → rename-then-async-delete via a sentinel file — is also out of scope for this PR.

## Tests

`entities/cyclemanager`:
- New: `TestCycleManager_stopsEvenIfAllContextsAreCancelled` — Stop with three pre-cancelled ctxs still transitions the cycle to stopped.
- New: `TestCycleManager_cycleCallbackAbortsImmediatelyOnPreExpiredCtx` — pre-expired ctx + a callback that checks `shouldAbort` aborts within its check interval; `StopAndWait` returns `context.Canceled` quickly.
- Updated: `TestCycleManager_cycleCallbackAbortsOnExpiredCtx` (was `..._cycleCallbackNotStoppedDueToRareStopChecks`) — same property at rare-check granularity.
- Updated: `TestCycleManager_timeout` — callback completes (current callback doesn't check `shouldAbort`); the cycle then transitions to stopped instead of staying running.
- Removed: assertions that pinned the inverted polarity (`doesNotStopIfAllContextsAreCancelled`, `cycleCallbackStoppedDueToFrequentStopChecks/cycle_function_stopped_before_timeout_reached`).

`adapters/repos/db/lsmkv/store_backup_test.go`: the two `assert that context timeout works for long X` subtests pinned the OLD invariant ("expired ctx = always error, even with nothing in flight"). Updated to assert the new behaviour: with no in-flight work, mutation applies and the call returns nil.

## Verification

- `go test ./entities/cyclemanager/...` — pass.
- `go test -short ./adapters/repos/db/...` — pass.
- `go test -short ./adapters/repos/db/lsmkv/...` — pass.

— SuperClaude (drafting against stable/v1.35 per weaviate/0-weaviate-issues#250)
