### PR TITLE
fix(lsmkv): make compaction abort immediately on cancel

### DIFF
--- a/adapters/repos/db/compactor/compactor.go
+++ b/adapters/repos/db/compactor/compactor.go
@@ -27,10 +27,7 @@ import (
 // behind it..
 const SegmentWriterBufferSize = 256 * 1024
 
-// AbortCheckEveryN bounds how often a compactor probes ctx.Err() inside its
-// merge loop. Sized so per-key overhead stays negligible while ensuring an
-// abort is observed within a few hundred milliseconds even on sequential-IO
-// compactions that emit millions of keys/sec.
+// AbortCheckEveryN bounds how often a compactor probes ctx.Err().
 const AbortCheckEveryN = 1024
 
 type Writer interface {

--- a/adapters/repos/db/compactor/compactor.go
+++ b/adapters/repos/db/compactor/compactor.go
@@ -27,6 +27,12 @@ import (
 // behind it..
 const SegmentWriterBufferSize = 256 * 1024
 
+// AbortCheckEveryN bounds how often a compactor probes ctx.Err() inside its
+// merge loop. Sized so per-key overhead stays negligible while ensuring an
+// abort is observed within a few hundred milliseconds even on sequential-IO
+// compactions that emit millions of keys/sec.
+const AbortCheckEveryN = 1024
+
 type Writer interface {
 	segmentindex.SegmentWriter
 	Reset(io.Writer)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2764,12 +2764,14 @@ func (i *Index) drop() error {
 
 	// Dropping the shards only unregisters the shards callbacks, but we still
 	// need to stop the cycle managers that those shards used to register with.
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	// In-flight compaction callbacks now respect ctx and bail within
+	// compactor.AbortCheckEveryN keys (a few hundred ms), so a 5s budget is
+	// plenty even on busy disks — the previous 60s was sized for callbacks
+	// that ignored cancellation. The shorter ctx keeps db.indexLock from
+	// being held on the DELETE_CLASS apply path while the cycle drains.
+	// See weaviate/0-weaviate-issues#250.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	i.logger.WithFields(logrus.Fields{
-		"action":   "drop_index",
-		"duration": 60 * time.Second,
-	}).Debug("context.WithTimeout")
 
 	if err := i.stopCycleManagers(ctx, "drop"); err != nil {
 		return err

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path"
@@ -2762,18 +2763,13 @@ func (i *Index) drop() error {
 		return err
 	}
 
-	// Dropping the shards only unregisters the shards callbacks, but we still
-	// need to stop the cycle managers that those shards used to register with.
-	// In-flight compaction callbacks now respect ctx and bail within
-	// compactor.AbortCheckEveryN keys (a few hundred ms), so a 5s budget is
-	// plenty even on busy disks — the previous 60s was sized for callbacks
-	// that ignored cancellation. The shorter ctx keeps db.indexLock from
-	// being held on the DELETE_CLASS apply path while the cycle drains.
-	// See weaviate/0-weaviate-issues#250.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// 1s target contract per weaviate/0-weaviate-issues#250; ctx errors
+	// are best-effort (flush doesn't honor ctx yet — separable follow-up).
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	if err := i.stopCycleManagers(ctx, "drop"); err != nil {
+	if err := i.stopCycleManagers(ctx, "drop"); err != nil &&
+		!stderrors.Is(err, context.Canceled) && !stderrors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 

--- a/adapters/repos/db/lsmkv/bucket_inverted_delete_test.go
+++ b/adapters/repos/db/lsmkv/bucket_inverted_delete_test.go
@@ -375,7 +375,7 @@ func runTombstoneInvertedCompactionTest(t *testing.T, size int) {
 						case <-done:
 							return nil
 						default:
-							ok, err := bucket.disk.compactOnce()
+							ok, err := bucket.disk.compactOnce(nil)
 							require.Nil(t, err)
 							if ok {
 								k++

--- a/adapters/repos/db/lsmkv/bucket_inverted_delete_test.go
+++ b/adapters/repos/db/lsmkv/bucket_inverted_delete_test.go
@@ -375,7 +375,7 @@ func runTombstoneInvertedCompactionTest(t *testing.T, size int) {
 						case <-done:
 							return nil
 						default:
-							ok, err := bucket.disk.compactOnce(nil)
+							ok, err := bucket.disk.compactOnce(context.Background())
 							require.Nil(t, err)
 							if ok {
 								k++

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -618,7 +618,7 @@ func TestBucketCompactionFileName(t *testing.T) {
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(tt.compaction), WithStrategy(StrategyReplace),
 			)
 			require.NoError(t, err)
-			compact, err := b.disk.compactOnce(nil)
+			compact, err := b.disk.compactOnce(context.Background())
 			require.NoError(t, err)
 			require.True(t, compact)
 			dbFiles, _ = countDbAndWalFiles(t, dirName)

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -618,7 +618,7 @@ func TestBucketCompactionFileName(t *testing.T) {
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(tt.compaction), WithStrategy(StrategyReplace),
 			)
 			require.NoError(t, err)
-			compact, err := b.disk.compactOnce()
+			compact, err := b.disk.compactOnce(nil)
 			require.NoError(t, err)
 			require.True(t, compact)
 			dbFiles, _ = countDbAndWalFiles(t, dirName)

--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -127,19 +127,28 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 			require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
 				"need at least two segments on disk to exercise compactOnce")
 
-			abortCtx, cancel := context.WithCancel(ctx)
-			cancel()
+			// direct path: pre-cancelled ctx into the inner compactor
+			t.Run("direct", func(t *testing.T) {
+				abortCtx, cancel := context.WithCancel(ctx)
+				cancel()
+				start := time.Now()
+				compacted, err := bucket.disk.compactOnce(abortCtx)
+				elapsed := time.Since(start)
+				require.NoError(t, err)
+				assert.False(t, compacted)
+				assert.Less(t, elapsed, 3*time.Second, "observed %s", elapsed)
+			})
 
-			start := time.Now()
-			compacted, err := bucket.disk.compactOnce(abortCtx)
-			elapsed := time.Since(start)
-
-			require.NoError(t, err)
-			assert.False(t, compacted,
-				"compactor must return compacted=false on abort (strategy=%s)", tc.strategy)
-			assert.Less(t, elapsed, 3*time.Second,
-				"abort should land within a few seconds (strategy=%s); observed %s",
-				tc.strategy, elapsed)
+			// bridge path: shouldAbort=true exercised through compactOrCleanup;
+			// the bridge inside compactOrCleanup pre-cancels the ctx so the
+			// compactor sees the abort on its first sample.
+			t.Run("bridge", func(t *testing.T) {
+				start := time.Now()
+				didWork := bucket.disk.compactOrCleanup(func() bool { return true })
+				elapsed := time.Since(start)
+				assert.False(t, didWork)
+				assert.Less(t, elapsed, 3*time.Second, "observed %s", elapsed)
+			})
 		})
 	}
 }

--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -1,0 +1,86 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestCompactor_AbortOnShouldAbort verifies the core contract introduced by
+// weaviate/0-weaviate-issues#250: a compactor in flight observes the
+// cyclemanager's shouldAbort signal within compactor.AbortCheckEveryN keys
+// and bails — returning (false, nil) so the cycle treats it as a no-op
+// iteration. No partial .tmp file is left behind.
+func TestCompactor_AbortOnShouldAbort(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace),
+	)
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+
+	// Keep the memtable threshold high so flush only happens when we
+	// explicitly call FlushAndSwitch — predictable segment count.
+	bucket.SetMemtableThreshold(1e9)
+
+	// Fill two segments so compactOnce has a real pair to merge.
+	for seg := 0; seg < 2; seg++ {
+		for i := 0; i < 5000; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+			val := []byte(fmt.Sprintf("value-%d", i))
+			require.NoError(t, bucket.Put(key, val))
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
+		"need at least two segments on disk to exercise compactOnce")
+
+	// shouldAbort=always-true; the watcher goroutine inside compactOnce
+	// cancels the inner ctx within ~50ms (its poll interval), the compactor
+	// observes it at its next AbortCheckEveryN sample.
+	shouldAbort := func() bool { return true }
+
+	start := time.Now()
+	compacted, err := bucket.disk.compactOnce(shouldAbort)
+	elapsed := time.Since(start)
+
+	// Abort path: (false, nil) — same shape the cyclemanager sees on any
+	// no-op tick. The partial output (.tmp) is cleaned up so it does not
+	// linger across cycle ticks.
+	require.NoError(t, err)
+	assert.False(t, compacted, "compactor must return compacted=false on abort")
+	assert.Less(t, elapsed, 3*time.Second,
+		"abort should land within a few seconds; observed %s", elapsed)
+
+	// Verify no .tmp file remains in the bucket dir — the aborted
+	// compactor's partial output was cleaned up by abortAndCleanup.
+	entries, err := os.ReadDir(dirName)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".db.tmp"),
+			"aborted compactor left tmp file %q", e.Name())
+	}
+}

--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -109,10 +109,13 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 			require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
 				"need at least two segments on disk to exercise compactOnce")
 
-			shouldAbort := func() bool { return true }
+			// Pre-cancel the ctx so compactOnce's first ctx.Err() sample
+			// inside the compactor returns the abort immediately.
+			abortCtx, cancel := context.WithCancel(ctx)
+			cancel()
 
 			start := time.Now()
-			compacted, err := bucket.disk.compactOnce(shouldAbort)
+			compacted, err := bucket.disk.compactOnce(abortCtx)
 			elapsed := time.Since(start)
 
 			require.NoError(t, err)

--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -24,23 +24,9 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// TestCompactor_AbortOnShouldAbort verifies the core contract introduced by
-// weaviate/0-weaviate-issues#250: a compactor in flight observes the
-// cyclemanager's shouldAbort signal within compactor.AbortCheckEveryN keys
-// and bails — returning (false, nil) so the cycle treats it as a no-op
-// iteration.
-//
-// The partial .tmp file is intentionally left behind. segment_group.init
-// removes orphan .tmp segments at the next startup, and for the
-// delete-path the parent dir is unlinked synchronously by the caller, so
-// no synchronous remove is needed here.
-//
-// All strategies that go through SegmentGroup.compactOnce share the same
-// bridge (shouldAbort → ctx + pre-cancel + watcher goroutine), so the
-// test parametrises across the strategies that use the bucket Put/SetAdd
-// /MapSet APIs to exercise each strategy's inner-loop ctx.Err() probe.
-// Roaring and Inverted strategies share the same plumbing but require
-// different setup; covered separately on a follow-up.
+// TestCompactor_AbortOnShouldAbort exercises the abort contract for every
+// strategy that SegmentGroup.compactOnce dispatches to. See
+// weaviate/0-weaviate-issues#250.
 func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -86,6 +72,39 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:     "inverted",
+			strategy: StrategyInverted,
+			seed: func(t *testing.T, bucket *Bucket, seg, n int) {
+				for i := 0; i < n; i++ {
+					key := []byte(fmt.Sprintf("seg-%d-row-%08d", seg, i))
+					pair := NewMapPairFromDocIdAndTf(uint64(seg*n+i), float32(i+1), float32(i+2), false)
+					require.NoError(t, bucket.MapSet(key, pair))
+				}
+			},
+		},
+		{
+			name:     "roaringset",
+			strategy: StrategyRoaringSet,
+			seed: func(t *testing.T, bucket *Bucket, seg, n int) {
+				for i := 0; i < n; i++ {
+					key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+					require.NoError(t, bucket.RoaringSetAddOne(key, uint64(seg*n+i)))
+				}
+			},
+		},
+		{
+			name:     "roaringsetrange",
+			strategy: StrategyRoaringSetRange,
+			seed: func(t *testing.T, bucket *Bucket, seg, n int) {
+				// roaringsetrange uses a single bitmap keyed by a value;
+				// stamping `n` distinct ids per seg keeps both segments
+				// non-empty so the merge has work to do.
+				for i := 0; i < n; i++ {
+					require.NoError(t, bucket.RoaringSetRangeAdd(uint64(seg*n+i), uint64(i)))
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -101,7 +120,6 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 			defer bucket.Shutdown(ctx)
 			bucket.SetMemtableThreshold(1e9)
 
-			// Two segments → compactOnce has a real pair to merge.
 			for seg := 0; seg < 2; seg++ {
 				tc.seed(t, bucket, seg, 5000)
 				require.NoError(t, bucket.FlushAndSwitch())
@@ -109,8 +127,6 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 			require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
 				"need at least two segments on disk to exercise compactOnce")
 
-			// Pre-cancel the ctx so compactOnce's first ctx.Err() sample
-			// inside the compactor returns the abort immediately.
 			abortCtx, cancel := context.WithCancel(ctx)
 			cancel()
 

--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -31,56 +31,100 @@ import (
 // cyclemanager's shouldAbort signal within compactor.AbortCheckEveryN keys
 // and bails — returning (false, nil) so the cycle treats it as a no-op
 // iteration. No partial .tmp file is left behind.
+//
+// All strategies that go through SegmentGroup.compactOnce share the same
+// bridge (shouldAbort → ctx + pre-cancel + watcher goroutine), so the
+// test parametrises across the strategies that use the bucket Put/SetAdd
+// /MapSet APIs to exercise each strategy's inner-loop ctx.Err() probe.
+// Roaring and Inverted strategies share the same plumbing but require
+// different setup; covered separately on a follow-up.
 func TestCompactor_AbortOnShouldAbort(t *testing.T) {
-	ctx := context.Background()
-	dirName := t.TempDir()
-
-	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace),
-	)
-	require.NoError(t, err)
-	defer bucket.Shutdown(ctx)
-
-	// Keep the memtable threshold high so flush only happens when we
-	// explicitly call FlushAndSwitch — predictable segment count.
-	bucket.SetMemtableThreshold(1e9)
-
-	// Fill two segments so compactOnce has a real pair to merge.
-	for seg := 0; seg < 2; seg++ {
-		for i := 0; i < 5000; i++ {
-			key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
-			val := []byte(fmt.Sprintf("value-%d", i))
-			require.NoError(t, bucket.Put(key, val))
-		}
-		require.NoError(t, bucket.FlushAndSwitch())
+	cases := []struct {
+		name     string
+		strategy string
+		seed     func(t *testing.T, bucket *Bucket, seg, n int)
+	}{
+		{
+			name:     "replace",
+			strategy: StrategyReplace,
+			seed: func(t *testing.T, bucket *Bucket, seg, n int) {
+				for i := 0; i < n; i++ {
+					key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+					val := []byte(fmt.Sprintf("value-%d", i))
+					require.NoError(t, bucket.Put(key, val))
+				}
+			},
+		},
+		{
+			name:     "set",
+			strategy: StrategySetCollection,
+			seed: func(t *testing.T, bucket *Bucket, seg, n int) {
+				for i := 0; i < n; i++ {
+					key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+					vals := [][]byte{
+						[]byte(fmt.Sprintf("val-a-%d", i)),
+						[]byte(fmt.Sprintf("val-b-%d", i)),
+					}
+					require.NoError(t, bucket.SetAdd(key, vals))
+				}
+			},
+		},
+		{
+			name:     "map",
+			strategy: StrategyMapCollection,
+			seed: func(t *testing.T, bucket *Bucket, seg, n int) {
+				for i := 0; i < n; i++ {
+					key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+					pair := MapPair{
+						Key:   []byte(fmt.Sprintf("mk-%d", i)),
+						Value: []byte(fmt.Sprintf("mv-%d", i)),
+					}
+					require.NoError(t, bucket.MapSet(key, pair))
+				}
+			},
+		},
 	}
-	require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
-		"need at least two segments on disk to exercise compactOnce")
 
-	// shouldAbort=always-true; the watcher goroutine inside compactOnce
-	// cancels the inner ctx within ~50ms (its poll interval), the compactor
-	// observes it at its next AbortCheckEveryN sample.
-	shouldAbort := func() bool { return true }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dirName := t.TempDir()
 
-	start := time.Now()
-	compacted, err := bucket.disk.compactOnce(shouldAbort)
-	elapsed := time.Since(start)
+			bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(tc.strategy),
+			)
+			require.NoError(t, err)
+			defer bucket.Shutdown(ctx)
+			bucket.SetMemtableThreshold(1e9)
 
-	// Abort path: (false, nil) — same shape the cyclemanager sees on any
-	// no-op tick. The partial output (.tmp) is cleaned up so it does not
-	// linger across cycle ticks.
-	require.NoError(t, err)
-	assert.False(t, compacted, "compactor must return compacted=false on abort")
-	assert.Less(t, elapsed, 3*time.Second,
-		"abort should land within a few seconds; observed %s", elapsed)
+			// Two segments → compactOnce has a real pair to merge.
+			for seg := 0; seg < 2; seg++ {
+				tc.seed(t, bucket, seg, 5000)
+				require.NoError(t, bucket.FlushAndSwitch())
+			}
+			require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
+				"need at least two segments on disk to exercise compactOnce")
 
-	// Verify no .tmp file remains in the bucket dir — the aborted
-	// compactor's partial output was cleaned up by abortAndCleanup.
-	entries, err := os.ReadDir(dirName)
-	require.NoError(t, err)
-	for _, e := range entries {
-		assert.False(t, strings.HasSuffix(e.Name(), ".db.tmp"),
-			"aborted compactor left tmp file %q", e.Name())
+			shouldAbort := func() bool { return true }
+
+			start := time.Now()
+			compacted, err := bucket.disk.compactOnce(shouldAbort)
+			elapsed := time.Since(start)
+
+			require.NoError(t, err)
+			assert.False(t, compacted,
+				"compactor must return compacted=false on abort (strategy=%s)", tc.strategy)
+			assert.Less(t, elapsed, 3*time.Second,
+				"abort should land within a few seconds (strategy=%s); observed %s",
+				tc.strategy, elapsed)
+
+			entries, err := os.ReadDir(dirName)
+			require.NoError(t, err)
+			for _, e := range entries {
+				assert.False(t, strings.HasSuffix(e.Name(), ".db.tmp"),
+					"aborted compactor left tmp file %q (strategy=%s)", e.Name(), tc.strategy)
+			}
+		})
 	}
 }

--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -16,8 +16,6 @@ package lsmkv
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,7 +28,12 @@ import (
 // weaviate/0-weaviate-issues#250: a compactor in flight observes the
 // cyclemanager's shouldAbort signal within compactor.AbortCheckEveryN keys
 // and bails — returning (false, nil) so the cycle treats it as a no-op
-// iteration. No partial .tmp file is left behind.
+// iteration.
+//
+// The partial .tmp file is intentionally left behind. segment_group.init
+// removes orphan .tmp segments at the next startup, and for the
+// delete-path the parent dir is unlinked synchronously by the caller, so
+// no synchronous remove is needed here.
 //
 // All strategies that go through SegmentGroup.compactOnce share the same
 // bridge (shouldAbort → ctx + pre-cancel + watcher goroutine), so the
@@ -118,13 +121,6 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 			assert.Less(t, elapsed, 3*time.Second,
 				"abort should land within a few seconds (strategy=%s); observed %s",
 				tc.strategy, elapsed)
-
-			entries, err := os.ReadDir(dirName)
-			require.NoError(t, err)
-			for _, e := range entries {
-				assert.False(t, strings.HasSuffix(e.Name(), ".db.tmp"),
-					"aborted compactor left tmp file %q (strategy=%s)", e.Name(), tc.strategy)
-			}
 		})
 	}
 }

--- a/adapters/repos/db/lsmkv/compaction_bench_test.go
+++ b/adapters/repos/db/lsmkv/compaction_bench_test.go
@@ -66,7 +66,7 @@ func BenchmarkCompaction(b *testing.B) {
 					require.Equal(b, 2, fileTypes[".db"])
 					b.StartTimer()
 
-					once, err := bu.disk.compactOnce()
+					once, err := bu.disk.compactOnce(nil)
 					require.NoError(b, err)
 					require.True(b, once)
 

--- a/adapters/repos/db/lsmkv/compaction_bench_test.go
+++ b/adapters/repos/db/lsmkv/compaction_bench_test.go
@@ -66,7 +66,7 @@ func BenchmarkCompaction(b *testing.B) {
 					require.Equal(b, 2, fileTypes[".db"])
 					b.StartTimer()
 
-					once, err := bu.disk.compactOnce(nil)
+					once, err := bu.disk.compactOnce(context.Background())
 					require.NoError(b, err)
 					require.True(b, once)
 

--- a/adapters/repos/db/lsmkv/compaction_integration2_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration2_test.go
@@ -221,7 +221,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})

--- a/adapters/repos/db/lsmkv/compaction_integration2_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration2_test.go
@@ -221,7 +221,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})

--- a/adapters/repos/db/lsmkv/compaction_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_map_integration_test.go
@@ -382,7 +382,7 @@ func compactionMapStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -456,7 +456,7 @@ func compactionMapStrategy_HugeEntries(ctx context.Context, t *testing.T, opts [
 	require.NoError(t, b.FlushMemtable())
 
 	// compact and check that value is the same
-	once, err := b.disk.compactOnce()
+	once, err := b.disk.compactOnce(nil)
 	require.NoError(t, err)
 	require.True(t, once)
 
@@ -566,7 +566,7 @@ func compactionMapStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -663,7 +663,7 @@ func compactionMapStrategy_FrequentPutDeleteOperations(ctx context.Context, t *t
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/compaction_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_map_integration_test.go
@@ -382,7 +382,7 @@ func compactionMapStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -456,7 +456,7 @@ func compactionMapStrategy_HugeEntries(ctx context.Context, t *testing.T, opts [
 	require.NoError(t, b.FlushMemtable())
 
 	// compact and check that value is the same
-	once, err := b.disk.compactOnce(nil)
+	once, err := b.disk.compactOnce(context.Background())
 	require.NoError(t, err)
 	require.True(t, once)
 
@@ -566,7 +566,7 @@ func compactionMapStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -663,7 +663,7 @@ func compactionMapStrategy_FrequentPutDeleteOperations(ctx context.Context, t *t
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+				for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
@@ -199,7 +199,7 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -423,7 +423,7 @@ func compactionReplaceStrategy_WithSecondaryKeys(ctx context.Context, t *testing
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -517,7 +517,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -602,7 +602,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -672,7 +672,7 @@ func compactionReplaceStrategy_FrequentPutDeleteOperations(ctx context.Context, 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -744,7 +744,7 @@ func compactionReplaceStrategy_FrequentPutDeleteOperations_WithSecondaryKeys(ctx
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 				}
 				require.Nil(t, err)
 			})
@@ -841,7 +841,7 @@ func compactionReplaceStrategy_MismatchedSecondaryIndexCount(ctx context.Context
 
 	// --- Step 4: compact — this panicked before the fix ---
 	var compacted bool
-	for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+	for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 	}
 	require.NoError(t, err)
 
@@ -934,7 +934,7 @@ func compactionReplaceStrategy_MismatchedSecondaryIndexCount_LeftMoreThanRight(c
 
 	// --- Step 4: compact ---
 	var compacted bool
-	for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+	for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 	}
 	require.NoError(t, err)
 

--- a/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
@@ -199,7 +199,7 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -423,7 +423,7 @@ func compactionReplaceStrategy_WithSecondaryKeys(ctx context.Context, t *testing
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -517,7 +517,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -602,7 +602,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -672,7 +672,7 @@ func compactionReplaceStrategy_FrequentPutDeleteOperations(ctx context.Context, 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -744,7 +744,7 @@ func compactionReplaceStrategy_FrequentPutDeleteOperations_WithSecondaryKeys(ctx
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+				for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 				}
 				require.Nil(t, err)
 			})
@@ -841,7 +841,7 @@ func compactionReplaceStrategy_MismatchedSecondaryIndexCount(ctx context.Context
 
 	// --- Step 4: compact — this panicked before the fix ---
 	var compacted bool
-	for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+	for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 	}
 	require.NoError(t, err)
 
@@ -934,7 +934,7 @@ func compactionReplaceStrategy_MismatchedSecondaryIndexCount_LeftMoreThanRight(c
 
 	// --- Step 4: compact ---
 	var compacted bool
-	for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+	for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 	}
 	require.NoError(t, err)
 

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -63,7 +63,7 @@ func compactionRoaringSetStrategy_Random(ctx context.Context, t *testing.T, opts
 
 			var compacted bool
 			var err error
-			for compacted, err = b.disk.compactOnce(nil); err == nil && compacted; compacted, err = b.disk.compactOnce(nil) {
+			for compacted, err = b.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = b.disk.compactOnce(context.Background()) {
 				compactions++
 			}
 			require.Nil(t, err)
@@ -417,7 +417,7 @@ func compactionRoaringSetStrategy(ctx context.Context, t *testing.T, opts []Buck
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -515,7 +515,7 @@ func compactionRoaringSetStrategy_RemoveUnnecessary(ctx context.Context, t *test
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -614,7 +614,7 @@ func compactionRoaringSetStrategy_FrequentPutDeleteOperations(ctx context.Contex
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+				for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -63,7 +63,7 @@ func compactionRoaringSetStrategy_Random(ctx context.Context, t *testing.T, opts
 
 			var compacted bool
 			var err error
-			for compacted, err = b.disk.compactOnce(); err == nil && compacted; compacted, err = b.disk.compactOnce() {
+			for compacted, err = b.disk.compactOnce(nil); err == nil && compacted; compacted, err = b.disk.compactOnce(nil) {
 				compactions++
 			}
 			require.Nil(t, err)
@@ -417,7 +417,7 @@ func compactionRoaringSetStrategy(ctx context.Context, t *testing.T, opts []Buck
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -515,7 +515,7 @@ func compactionRoaringSetStrategy_RemoveUnnecessary(ctx context.Context, t *test
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -614,7 +614,7 @@ func compactionRoaringSetStrategy_FrequentPutDeleteOperations(ctx context.Contex
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_range_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_range_integration_test.go
@@ -62,7 +62,7 @@ func compactionRoaringSetRangeStrategy_Random(ctx context.Context, t *testing.T,
 	}
 
 	var compacted bool
-	for compacted, err = b.disk.compactOnce(); err == nil && compacted; compacted, err = b.disk.compactOnce() {
+	for compacted, err = b.disk.compactOnce(nil); err == nil && compacted; compacted, err = b.disk.compactOnce(nil) {
 		compactions++
 	}
 	require.Nil(t, err)
@@ -410,7 +410,7 @@ func compactionRoaringSetRangeStrategy(ctx context.Context, t *testing.T, opts [
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -498,7 +498,7 @@ func compactionRoaringSetRangeStrategy_RemoveUnnecessary(ctx context.Context, t 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -587,7 +587,7 @@ func compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations(ctx context.C
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 				}
 				require.Nil(t, err)
 			})
@@ -702,7 +702,7 @@ func compactionRoaringSetRangeStrategy_BugfixOverwrittenBuffer(ctx context.Conte
 	}
 
 	var compacted bool
-	for compacted, err = b.disk.compactOnce(); err == nil && compacted; compacted, err = b.disk.compactOnce() {
+	for compacted, err = b.disk.compactOnce(nil); err == nil && compacted; compacted, err = b.disk.compactOnce(nil) {
 	}
 	require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_range_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_range_integration_test.go
@@ -62,7 +62,7 @@ func compactionRoaringSetRangeStrategy_Random(ctx context.Context, t *testing.T,
 	}
 
 	var compacted bool
-	for compacted, err = b.disk.compactOnce(nil); err == nil && compacted; compacted, err = b.disk.compactOnce(nil) {
+	for compacted, err = b.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = b.disk.compactOnce(context.Background()) {
 		compactions++
 	}
 	require.Nil(t, err)
@@ -410,7 +410,7 @@ func compactionRoaringSetRangeStrategy(ctx context.Context, t *testing.T, opts [
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -498,7 +498,7 @@ func compactionRoaringSetRangeStrategy_RemoveUnnecessary(ctx context.Context, t 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -587,7 +587,7 @@ func compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations(ctx context.C
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+				for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 				}
 				require.Nil(t, err)
 			})
@@ -702,7 +702,7 @@ func compactionRoaringSetRangeStrategy_BugfixOverwrittenBuffer(ctx context.Conte
 	}
 
 	var compacted bool
-	for compacted, err = b.disk.compactOnce(nil); err == nil && compacted; compacted, err = b.disk.compactOnce(nil) {
+	for compacted, err = b.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = b.disk.compactOnce(context.Background()) {
 	}
 	require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/compaction_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_set_integration_test.go
@@ -309,7 +309,7 @@ func compactionSetStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -408,7 +408,7 @@ func compactionSetStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 		}
 		require.Nil(t, err)
 	})
@@ -505,7 +505,7 @@ func compactionSetStrategy_FrequentPutDeleteOperations(ctx context.Context, t *t
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+				for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/compaction_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_set_integration_test.go
@@ -309,7 +309,7 @@ func compactionSetStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 			if i == 1 {
 				// segment1 and segment2 merged
 				// none of them is root segment, so tombstones
@@ -408,7 +408,7 @@ func compactionSetStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 		}
 		require.Nil(t, err)
 	})
@@ -505,7 +505,7 @@ func compactionSetStrategy_FrequentPutDeleteOperations(ctx context.Context, t *t
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -110,8 +110,6 @@ func newCompactorInverted(w io.WriteSeeker,
 	}
 }
 
-// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
-// inside writeKeys; cancelling it returns the wrapped ctx error.
 func (c *compactorInverted) do(ctx context.Context) error {
 	var err error
 

--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -109,7 +110,9 @@ func newCompactorInverted(w io.WriteSeeker,
 	}
 }
 
-func (c *compactorInverted) do() error {
+// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
+// inside writeKeys; cancelling it returns the wrapped ctx error.
+func (c *compactorInverted) do(ctx context.Context) error {
 	var err error
 
 	if err := c.init(); err != nil {
@@ -151,7 +154,7 @@ func (c *compactorInverted) do() error {
 
 	keysOffset := segmentindex.HeaderSize + segmentindex.SegmentInvertedDefaultHeaderSize + len(c.c1.segment.invertedHeader.DataFields)
 
-	kis, err := c.writeKeys()
+	kis, err := c.writeKeys(ctx)
 	if err != nil {
 		return errors.Wrap(err, "write keys")
 	}
@@ -302,7 +305,7 @@ func (c *compactorInverted) writePropertyLengths(propLengths map[uint64]uint32) 
 	return len(encoded) + 8 + 8 + 8, nil
 }
 
-func (c *compactorInverted) writeKeys() ([]segmentindex.Key, error) {
+func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.Key, error) {
 	key1, value1, _ := c.c1.first()
 	key2, value2, _ := c.c2.first()
 
@@ -311,7 +314,13 @@ func (c *compactorInverted) writeKeys() ([]segmentindex.Key, error) {
 	var kis []segmentindex.Key
 	sim := newSortedMapMerger()
 
-	for {
+	for i := 0; ; i++ {
+		if i%compactor.AbortCheckEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("merge keys: %w", err)
+			}
+		}
+
 		if key1 == nil && key2 == nil {
 			break
 		}

--- a/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
@@ -804,7 +804,7 @@ func compactionInvertedStrategy(ctx context.Context, t *testing.T, opts []Bucket
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 			i++
 			t.Run("verify control during compaction", func(t *testing.T) {
 				var retrieved []kv
@@ -970,7 +970,7 @@ func compactionInvertedStrategy_RemoveUnnecessary(ctx context.Context, t *testin
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+		for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 			t.Run("verify control during compaction", func(t *testing.T) {
 				var retrieved []kv
 
@@ -1151,7 +1151,7 @@ func compactionInvertedStrategy_FrequentPutDeleteOperations(ctx context.Context,
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+				for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 					t.Run("check entries during compaction", func(t *testing.T) {
 						res, err := bucket.MapList(ctx, key)
 						assert.Nil(t, err)

--- a/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
@@ -804,7 +804,7 @@ func compactionInvertedStrategy(ctx context.Context, t *testing.T, opts []Bucket
 		i := 0
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 			i++
 			t.Run("verify control during compaction", func(t *testing.T) {
 				var retrieved []kv
@@ -970,7 +970,7 @@ func compactionInvertedStrategy_RemoveUnnecessary(ctx context.Context, t *testin
 	t.Run("compact until no longer eligible", func(t *testing.T) {
 		var compacted bool
 		var err error
-		for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+		for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 			t.Run("verify control during compaction", func(t *testing.T) {
 				var retrieved []kv
 
@@ -1151,7 +1151,7 @@ func compactionInvertedStrategy_FrequentPutDeleteOperations(ctx context.Context,
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 					t.Run("check entries during compaction", func(t *testing.T) {
 						res, err := bucket.MapList(ctx, key)
 						assert.Nil(t, err)

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -88,8 +88,6 @@ func newCompactorMapCollection(w io.WriteSeeker,
 	}
 }
 
-// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
-// inside writeKeys; cancelling it returns the wrapped ctx error.
 func (c *compactorMap) do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return errors.Wrap(err, "init")

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -87,7 +88,9 @@ func newCompactorMapCollection(w io.WriteSeeker,
 	}
 }
 
-func (c *compactorMap) do() error {
+// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
+// inside writeKeys; cancelling it returns the wrapped ctx error.
+func (c *compactorMap) do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return errors.Wrap(err, "init")
 	}
@@ -97,7 +100,7 @@ func (c *compactorMap) do() error {
 		segmentindex.WithChecksumsDisabled(!c.enableChecksumValidation),
 	)
 
-	kis, err := c.writeKeys(segmentFile)
+	kis, err := c.writeKeys(ctx, segmentFile)
 	if err != nil {
 		return errors.Wrap(err, "write keys")
 	}
@@ -143,7 +146,7 @@ func (c *compactorMap) init() error {
 	return nil
 }
 
-func (c *compactorMap) writeKeys(f *segmentindex.SegmentFile) ([]segmentindex.Key, error) {
+func (c *compactorMap) writeKeys(ctx context.Context, f *segmentindex.SegmentFile) ([]segmentindex.Key, error) {
 	key1, value1, _ := c.c1.first()
 	key2, value2, _ := c.c2.first()
 
@@ -155,7 +158,13 @@ func (c *compactorMap) writeKeys(f *segmentindex.SegmentFile) ([]segmentindex.Ke
 	me := newMapEncoder()
 	ssm := newSortedMapMerger()
 
-	for {
+	for i := 0; ; i++ {
+		if i%compactor.AbortCheckEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("merge keys: %w", err)
+			}
+		}
+
 		if key1 == nil && key2 == nil {
 			break
 		}

--- a/adapters/repos/db/lsmkv/compactor_proplength_test.go
+++ b/adapters/repos/db/lsmkv/compactor_proplength_test.go
@@ -109,7 +109,7 @@ func TestInvertedNaNPropLength(t *testing.T) {
 
 	ok := false
 	for !ok {
-		ok, err = bucket.disk.compactOnce(nil)
+		ok, err = bucket.disk.compactOnce(context.Background())
 		require.NoError(t, err)
 	}
 

--- a/adapters/repos/db/lsmkv/compactor_proplength_test.go
+++ b/adapters/repos/db/lsmkv/compactor_proplength_test.go
@@ -109,7 +109,7 @@ func TestInvertedNaNPropLength(t *testing.T) {
 
 	ok := false
 	for !ok {
-		ok, err = bucket.disk.compactOnce()
+		ok, err = bucket.disk.compactOnce(nil)
 		require.NoError(t, err)
 	}
 

--- a/adapters/repos/db/lsmkv/compactor_replace.go
+++ b/adapters/repos/db/lsmkv/compactor_replace.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -98,7 +99,10 @@ func newCompactorReplace(w io.WriteSeeker,
 	}
 }
 
-func (c *compactorReplace) do() error {
+// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
+// inside writeKeys; cancelling it returns the wrapped ctx error so the
+// caller (compactOnce) can clean up the partial output.
+func (c *compactorReplace) do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return fmt.Errorf("init: %w", err)
 	}
@@ -108,7 +112,7 @@ func (c *compactorReplace) do() error {
 		segmentindex.WithChecksumsDisabled(!c.enableChecksumValidation),
 	)
 
-	kis, err := c.writeKeys(segmentFile)
+	kis, err := c.writeKeys(ctx, segmentFile)
 	if err != nil {
 		return fmt.Errorf("write keys: %w", err)
 	}
@@ -154,7 +158,7 @@ func (c *compactorReplace) init() error {
 	return nil
 }
 
-func (c *compactorReplace) writeKeys(f *segmentindex.SegmentFile) ([]segmentindex.Key, error) {
+func (c *compactorReplace) writeKeys(ctx context.Context, f *segmentindex.SegmentFile) ([]segmentindex.Key, error) {
 	res1, err1 := c.c1.first()
 	res2, err2 := c.c2.first()
 
@@ -163,7 +167,13 @@ func (c *compactorReplace) writeKeys(f *segmentindex.SegmentFile) ([]segmentinde
 
 	kis := make([]segmentindex.Key, 0, c.c1.keyCount()+c.c2.keyCount())
 
-	for {
+	for i := 0; ; i++ {
+		if i%compactor.AbortCheckEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("merge keys: %w", err)
+			}
+		}
+
 		var key1, key2 []byte
 		if res1 != nil {
 			key1 = res1.primaryKey

--- a/adapters/repos/db/lsmkv/compactor_replace.go
+++ b/adapters/repos/db/lsmkv/compactor_replace.go
@@ -99,9 +99,6 @@ func newCompactorReplace(w io.WriteSeeker,
 	}
 }
 
-// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
-// inside writeKeys; cancelling it returns the wrapped ctx error so the
-// caller (compactOnce) can clean up the partial output.
 func (c *compactorReplace) do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return fmt.Errorf("init: %w", err)

--- a/adapters/repos/db/lsmkv/compactor_set.go
+++ b/adapters/repos/db/lsmkv/compactor_set.go
@@ -93,7 +93,9 @@ func newCompactorSetCollection(w io.WriteSeeker,
 	}
 }
 
-func (c *compactorSet) do() error {
+// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
+// inside writeKeys; cancelling it returns the wrapped ctx error.
+func (c *compactorSet) do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return errors.Wrap(err, "init")
 	}
@@ -103,7 +105,7 @@ func (c *compactorSet) do() error {
 		segmentindex.WithChecksumsDisabled(!c.enableChecksumValidation),
 	)
 
-	kis, err := c.writeKeys(segmentFile)
+	kis, err := c.writeKeys(ctx, segmentFile)
 	if err != nil {
 		return errors.Wrap(err, "write keys")
 	}
@@ -149,7 +151,7 @@ func (c *compactorSet) init() error {
 	return nil
 }
 
-func (c *compactorSet) writeKeys(f *segmentindex.SegmentFile) ([]segmentindex.KeyRedux, error) {
+func (c *compactorSet) writeKeys(ctx context.Context, f *segmentindex.SegmentFile) ([]segmentindex.KeyRedux, error) {
 	key1, value1, _ := c.c1.first()
 	key2, value2, _ := c.c2.first()
 
@@ -157,7 +159,13 @@ func (c *compactorSet) writeKeys(f *segmentindex.SegmentFile) ([]segmentindex.Ke
 	offset := segmentindex.HeaderSize
 	kis := make([]segmentindex.KeyRedux, 0, c.c1.cache.segment.index.KeyCount()+c.c2.cache.segment.index.KeyCount())
 
-	for {
+	for i := 0; ; i++ {
+		if i%compactor.AbortCheckEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("merge keys: %w", err)
+			}
+		}
+
 		if key1 == nil && key2 == nil {
 			break
 		}

--- a/adapters/repos/db/lsmkv/compactor_set.go
+++ b/adapters/repos/db/lsmkv/compactor_set.go
@@ -93,8 +93,6 @@ func newCompactorSetCollection(w io.WriteSeeker,
 	}
 }
 
-// do runs the merge. ctx is checked every compactor.AbortCheckEveryN keys
-// inside writeKeys; cancelling it returns the wrapped ctx error.
 func (c *compactorSet) do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return errors.Wrap(err, "init")

--- a/adapters/repos/db/lsmkv/compactor_set_skipkey_test.go
+++ b/adapters/repos/db/lsmkv/compactor_set_skipkey_test.go
@@ -108,7 +108,7 @@ func TestCompactionSetSkipKeys(t *testing.T) {
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(); err == nil && compacted; compacted, err = bucket.disk.compactOnce() {
+				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/compactor_set_skipkey_test.go
+++ b/adapters/repos/db/lsmkv/compactor_set_skipkey_test.go
@@ -108,7 +108,7 @@ func TestCompactionSetSkipKeys(t *testing.T) {
 			t.Run("compact until no longer eligible", func(t *testing.T) {
 				var compacted bool
 				var err error
-				for compacted, err = bucket.disk.compactOnce(nil); err == nil && compacted; compacted, err = bucket.disk.compactOnce(nil) {
+				for compacted, err = bucket.disk.compactOnce(context.Background()); err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
 				}
 				require.Nil(t, err)
 			})

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -505,7 +505,7 @@ func dontPrecomputeBloom(ctx context.Context, t *testing.T, opts []BucketOption)
 			WithSecondaryKey(0, []byte("bonjour2"))))
 		require.NoError(t, b.FlushMemtable())
 
-		compacted, err := b.disk.compactOnce()
+		compacted, err := b.disk.compactOnce(nil)
 		require.NoError(t, err)
 		require.True(t, compacted)
 	})

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -505,7 +505,7 @@ func dontPrecomputeBloom(ctx context.Context, t *testing.T, opts []BucketOption)
 			WithSecondaryKey(0, []byte("bonjour2"))))
 		require.NoError(t, b.FlushMemtable())
 
-		compacted, err := b.disk.compactOnce(nil)
+		compacted, err := b.disk.compactOnce(context.Background())
 		require.NoError(t, err)
 		require.True(t, compacted)
 	})

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -924,15 +924,7 @@ func segmentExistsWithID(segmentID string, files map[string]int64) (bool, string
 func (sg *SegmentGroup) compactOrCleanup(shouldAbort cyclemanager.ShouldAbortCallback) bool {
 	sg.monitorSegments()
 
-	// Bridge the cyclemanager shouldAbort callback to a ctx that
-	// compactOnce (and the per-strategy compactors below it) checks
-	// inside their inner merge loops. Two paths:
-	//   - shouldAbort=true at entry: pre-cancel so the very first
-	//     ctx.Err() check inside the compactor returns the abort.
-	//   - shouldAbort flips mid-merge: a short-lived poll goroutine
-	//     watches it and cancels the ctx; the compactor's next sample
-	//     observes it. The goroutine self-terminates on the deferred
-	//     cancel.
+	// bridge shouldAbort → ctx for the compactor inner loops
 	compactCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if shouldAbort != nil {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -925,7 +925,7 @@ func (sg *SegmentGroup) compactOrCleanup(shouldAbort cyclemanager.ShouldAbortCal
 
 	compact := func() bool {
 		sg.lastCompactionCall = time.Now()
-		compacted, err := sg.compactOnce()
+		compacted, err := sg.compactOnce(shouldAbort)
 		if err != nil {
 			sg.logger.WithField("action", "lsm_compaction").
 				WithField("path", sg.dir).

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/diskio"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -923,9 +924,43 @@ func segmentExistsWithID(segmentID string, files map[string]int64) (bool, string
 func (sg *SegmentGroup) compactOrCleanup(shouldAbort cyclemanager.ShouldAbortCallback) bool {
 	sg.monitorSegments()
 
+	// Bridge the cyclemanager shouldAbort callback to a ctx that
+	// compactOnce (and the per-strategy compactors below it) checks
+	// inside their inner merge loops. Two paths:
+	//   - shouldAbort=true at entry: pre-cancel so the very first
+	//     ctx.Err() check inside the compactor returns the abort.
+	//   - shouldAbort flips mid-merge: a short-lived poll goroutine
+	//     watches it and cancels the ctx; the compactor's next sample
+	//     observes it. The goroutine self-terminates on the deferred
+	//     cancel.
+	compactCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if shouldAbort != nil {
+		if shouldAbort() {
+			cancel()
+		} else {
+			watcher := func() {
+				t := time.NewTicker(50 * time.Millisecond)
+				defer t.Stop()
+				for {
+					select {
+					case <-compactCtx.Done():
+						return
+					case <-t.C:
+						if shouldAbort() {
+							cancel()
+							return
+						}
+					}
+				}
+			}
+			enterrors.GoWrapper(watcher, sg.logger)
+		}
+	}
+
 	compact := func() bool {
 		sg.lastCompactionCall = time.Now()
-		compacted, err := sg.compactOnce(shouldAbort)
+		compacted, err := sg.compactOnce(compactCtx)
 		if err != nil {
 			sg.logger.WithField("action", "lsm_compaction").
 				WithField("path", sg.dir).

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -407,21 +407,17 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 		return false, nil
 	}
 
-	abortAndCleanup := func() error {
-		// best-effort cleanup of the partial output. We close before
-		// removing so the file descriptor doesn't leak; the first non-nil
-		// error is surfaced and the second (if any) is dropped. Either
-		// way the caller treats the abort as a no-op iteration.
-		var firstErr error
-		if cerr := f.Close(); cerr != nil {
-			firstErr = fmt.Errorf("close aborted compactor output: %w", cerr)
+	abortAndClose := func() error {
+		// Close the .tmp fd so we don't leak the descriptor. The file
+		// itself stays on disk; segment_group.init removes any orphan
+		// .tmp segments on the next process startup (see segment_group.go
+		// around the `filepath.Ext(entry) != ".tmp"` scan). For drops
+		// the parent dir is unlinked synchronously by the caller, so the
+		// .tmp file disappears with it.
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close aborted compactor output: %w", err)
 		}
-		if rerr := os.Remove(path); rerr != nil && !os.IsNotExist(rerr) {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("remove aborted compactor output: %w", rerr)
-			}
-		}
-		return firstErr
+		return nil
 	}
 
 	switch strategy {
@@ -438,7 +434,7 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 			return false, err
 		}
 		if aborted {
-			return false, abortAndCleanup()
+			return false, abortAndClose()
 		}
 	case segmentindex.StrategySetCollection:
 		c := newCompactorSetCollection(f, left.newCollectionCursorReusable(), right.newCollectionCursorReusable(),
@@ -450,7 +446,7 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 			return false, err
 		}
 		if aborted {
-			return false, abortAndCleanup()
+			return false, abortAndClose()
 		}
 	case segmentindex.StrategyMapCollection:
 		c := newCompactorMapCollection(f, left.newCollectionCursorReusable(), right.newCollectionCursorReusable(),
@@ -462,7 +458,7 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 			return false, err
 		}
 		if aborted {
-			return false, abortAndCleanup()
+			return false, abortAndClose()
 		}
 	case segmentindex.StrategyRoaringSet:
 		c := roaringset.NewCompactor(f, left.newRoaringSetCursor(), right.newRoaringSetCursor(),
@@ -474,7 +470,7 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 			return false, err
 		}
 		if aborted {
-			return false, abortAndCleanup()
+			return false, abortAndClose()
 		}
 
 	case segmentindex.StrategyRoaringSetRange:
@@ -486,7 +482,7 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 			return false, err
 		}
 		if aborted {
-			return false, abortAndCleanup()
+			return false, abortAndClose()
 		}
 	case segmentindex.StrategyInverted:
 		avgPropLen, _ := sg.GetAveragePropertyLength()
@@ -506,7 +502,7 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 			return false, err
 		}
 		if aborted {
-			return false, abortAndCleanup()
+			return false, abortAndClose()
 		}
 	default:
 		return false, errors.Errorf("unrecognized strategy %v", strategy)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -269,13 +269,8 @@ func segmentExtraInfo(level uint16, strategy segmentindex.Strategy) string {
 	return fmt.Sprintf(".l%d.s%d", level, strategy)
 }
 
-// compactOnce performs one compaction iteration. The caller's ctx is
-// sampled inside each per-strategy compactor's inner merge loop every
-// compactor.AbortCheckEveryN keys; a cancelled ctx halts the merge,
-// causes compactOnce to close the partial .tmp file (left on disk —
-// segment_group.init removes orphan .tmp files at the next startup),
-// and returns (false, nil) — the cycle treats it the same as a no-op
-// tick. context.Background() means "never abort".
+// compactOnce performs one compaction iteration. Cancelling ctx aborts
+// the in-flight merge (sampled every compactor.AbortCheckEveryN keys).
 func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err error) {
 	// Is it safe to only occasionally lock instead of the entire duration? Yes,
 	// because other than compaction the only change to the segments array could
@@ -360,10 +355,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 	cleanupTombstones := !sg.keepTombstones && pair[0] == 0
 	maxNewFileSize := left.Size() + right.Size()
 
-	// runCompactor maps the per-strategy do/Do error into:
-	//   - (true,  nil): caller should clean up .tmp and return (false, nil)
-	//   - (false, nil): compaction completed successfully
-	//   - (false, err): real error, propagate
+	// aborted=true tells the caller to close the partial .tmp and bail
 	runCompactor := func(do func(context.Context) error) (aborted bool, err error) {
 		if err := do(ctx); err != nil {
 			if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
@@ -375,12 +367,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 	}
 
 	abortAndClose := func() error {
-		// Close the .tmp fd so we don't leak the descriptor. The file
-		// itself stays on disk; segment_group.init removes any orphan
-		// .tmp segments on the next process startup (see segment_group.go
-		// around the `filepath.Ext(entry) != ".tmp"` scan). For drops
-		// the parent dir is unlinked synchronously by the caller, so the
-		// .tmp file disappears with it.
+		// orphan .tmp is cleaned by segment_group.init on next start
 		if err := f.Close(); err != nil {
 			return fmt.Errorf("close aborted compactor output: %w", err)
 		}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -409,9 +409,9 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 
 	abortAndCleanup := func() error {
 		// best-effort cleanup of the partial output. We close before
-		// removing so the file descriptor doesn't leak; both errors are
-		// surfaced if either fails so the caller still treats the abort
-		// as a no-op iteration.
+		// removing so the file descriptor doesn't leak; the first non-nil
+		// error is surfaced and the second (if any) is dropped. Either
+		// way the caller treats the abort as a no-op iteration.
 		var firstErr error
 		if cerr := f.Close(); cerr != nil {
 			firstErr = fmt.Errorf("close aborted compactor output: %w", cerr)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -12,6 +12,8 @@
 package lsmkv
 
 import (
+	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path"
@@ -26,6 +28,8 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/usecases/config"
 )
@@ -267,7 +271,12 @@ func segmentExtraInfo(level uint16, strategy segmentindex.Strategy) string {
 	return fmt.Sprintf(".l%d.s%d", level, strategy)
 }
 
-func (sg *SegmentGroup) compactOnce() (compacted bool, err error) {
+// compactOnce performs one compaction iteration. shouldAbort is checked
+// periodically inside the per-strategy compactor's inner merge loop; an
+// observed abort cancels the merge, cleans up the partial .tmp file, and
+// returns (false, nil) — the cycle treats it the same as a no-op tick.
+// A nil shouldAbort is allowed and behaves as "never abort".
+func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback) (compacted bool, err error) {
 	// Is it safe to only occasionally lock instead of the entire duration? Yes,
 	// because other than compaction the only change to the segments array could
 	// be an append because of a new flush cycle, so we do not need to guarantee
@@ -351,6 +360,70 @@ func (sg *SegmentGroup) compactOnce() (compacted bool, err error) {
 	cleanupTombstones := !sg.keepTombstones && pair[0] == 0
 	maxNewFileSize := left.Size() + right.Size()
 
+	// Bridge the cyclemanager's shouldAbort callback to a ctx the
+	// compactors check on their per-strategy merge loops. Two paths:
+	//   - shouldAbort=true at entry: pre-cancel so the very first
+	//     ctx.Err() check inside the compactor returns the abort.
+	//   - shouldAbort flips mid-merge: a short-lived poll goroutine
+	//     watches it and cancels the ctx; the compactor's next
+	//     AbortCheckEveryN sample observes it. The goroutine
+	//     self-terminates on the deferred cancel.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if shouldAbort != nil {
+		if shouldAbort() {
+			cancel()
+		} else {
+			watcher := func() {
+				t := time.NewTicker(50 * time.Millisecond)
+				defer t.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-t.C:
+						if shouldAbort() {
+							cancel()
+							return
+						}
+					}
+				}
+			}
+			enterrors.GoWrapper(watcher, sg.logger)
+		}
+	}
+
+	// runCompactor maps the per-strategy do/Do error into:
+	//   - (true,  nil): caller should clean up .tmp and return (false, nil)
+	//   - (false, nil): compaction completed successfully
+	//   - (false, err): real error, propagate
+	runCompactor := func(do func(context.Context) error) (aborted bool, err error) {
+		if err := do(ctx); err != nil {
+			if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}
+
+	abortAndCleanup := func() error {
+		// best-effort cleanup of the partial output. We close before
+		// removing so the file descriptor doesn't leak; both errors are
+		// surfaced if either fails so the caller still treats the abort
+		// as a no-op iteration.
+		var firstErr error
+		if cerr := f.Close(); cerr != nil {
+			firstErr = fmt.Errorf("close aborted compactor output: %w", cerr)
+		}
+		if rerr := os.Remove(path); rerr != nil && !os.IsNotExist(rerr) {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("remove aborted compactor output: %w", rerr)
+			}
+		}
+		return firstErr
+	}
+
 	switch strategy {
 
 	// TODO: call metrics just once with variable strategy label
@@ -360,40 +433,60 @@ func (sg *SegmentGroup) compactOnce() (compacted bool, err error) {
 			level, secondaryIndices, cleanupTombstones,
 			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
 
-		if err := c.do(); err != nil {
+		aborted, err := runCompactor(c.do)
+		if err != nil {
 			return false, err
+		}
+		if aborted {
+			return false, abortAndCleanup()
 		}
 	case segmentindex.StrategySetCollection:
 		c := newCompactorSetCollection(f, left.newCollectionCursorReusable(), right.newCollectionCursorReusable(),
 			level, secondaryIndices, cleanupTombstones,
 			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker, sg.shouldSkipKey)
 
-		if err := c.do(); err != nil {
+		aborted, err := runCompactor(c.do)
+		if err != nil {
 			return false, err
+		}
+		if aborted {
+			return false, abortAndCleanup()
 		}
 	case segmentindex.StrategyMapCollection:
 		c := newCompactorMapCollection(f, left.newCollectionCursorReusable(), right.newCollectionCursorReusable(),
 			level, secondaryIndices, sg.mapRequiresSorting, cleanupTombstones,
 			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
 
-		if err := c.do(); err != nil {
+		aborted, err := runCompactor(c.do)
+		if err != nil {
 			return false, err
+		}
+		if aborted {
+			return false, abortAndCleanup()
 		}
 	case segmentindex.StrategyRoaringSet:
 		c := roaringset.NewCompactor(f, left.newRoaringSetCursor(), right.newRoaringSetCursor(),
 			level, cleanupTombstones,
 			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
 
-		if err := c.Do(); err != nil {
+		aborted, err := runCompactor(c.Do)
+		if err != nil {
 			return false, err
+		}
+		if aborted {
+			return false, abortAndCleanup()
 		}
 
 	case segmentindex.StrategyRoaringSetRange:
 		c := roaringsetrange.NewCompactor(f, left.newRoaringSetRangeCursor(), right.newRoaringSetRangeCursor(),
 			level, cleanupTombstones, sg.enableChecksumValidation, maxNewFileSize)
 
-		if err := c.Do(); err != nil {
+		aborted, err := runCompactor(c.Do)
+		if err != nil {
 			return false, err
+		}
+		if aborted {
+			return false, abortAndCleanup()
 		}
 	case segmentindex.StrategyInverted:
 		avgPropLen, _ := sg.GetAveragePropertyLength()
@@ -408,8 +501,12 @@ func (sg *SegmentGroup) compactOnce() (compacted bool, err error) {
 			level, secondaryIndices, cleanupTombstones,
 			k1, b, avgPropLen, maxNewFileSize, sg.allocChecker, sg.enableChecksumValidation)
 
-		if err := c.do(); err != nil {
+		aborted, err := runCompactor(c.do)
+		if err != nil {
 			return false, err
+		}
+		if aborted {
+			return false, abortAndCleanup()
 		}
 	default:
 		return false, errors.Errorf("unrecognized strategy %v", strategy)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -28,9 +28,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
-	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -271,12 +269,14 @@ func segmentExtraInfo(level uint16, strategy segmentindex.Strategy) string {
 	return fmt.Sprintf(".l%d.s%d", level, strategy)
 }
 
-// compactOnce performs one compaction iteration. shouldAbort is checked
-// periodically inside the per-strategy compactor's inner merge loop; an
-// observed abort cancels the merge, cleans up the partial .tmp file, and
-// returns (false, nil) — the cycle treats it the same as a no-op tick.
-// A nil shouldAbort is allowed and behaves as "never abort".
-func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback) (compacted bool, err error) {
+// compactOnce performs one compaction iteration. The caller's ctx is
+// sampled inside each per-strategy compactor's inner merge loop every
+// compactor.AbortCheckEveryN keys; a cancelled ctx halts the merge,
+// causes compactOnce to close the partial .tmp file (left on disk —
+// segment_group.init removes orphan .tmp files at the next startup),
+// and returns (false, nil) — the cycle treats it the same as a no-op
+// tick. context.Background() means "never abort".
+func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err error) {
 	// Is it safe to only occasionally lock instead of the entire duration? Yes,
 	// because other than compaction the only change to the segments array could
 	// be an append because of a new flush cycle, so we do not need to guarantee
@@ -359,39 +359,6 @@ func (sg *SegmentGroup) compactOnce(shouldAbort cyclemanager.ShouldAbortCallback
 	secondaryIndices := left.getSecondaryIndexCount()
 	cleanupTombstones := !sg.keepTombstones && pair[0] == 0
 	maxNewFileSize := left.Size() + right.Size()
-
-	// Bridge the cyclemanager's shouldAbort callback to a ctx the
-	// compactors check on their per-strategy merge loops. Two paths:
-	//   - shouldAbort=true at entry: pre-cancel so the very first
-	//     ctx.Err() check inside the compactor returns the abort.
-	//   - shouldAbort flips mid-merge: a short-lived poll goroutine
-	//     watches it and cancels the ctx; the compactor's next
-	//     AbortCheckEveryN sample observes it. The goroutine
-	//     self-terminates on the deferred cancel.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	if shouldAbort != nil {
-		if shouldAbort() {
-			cancel()
-		} else {
-			watcher := func() {
-				t := time.NewTicker(50 * time.Millisecond)
-				defer t.Stop()
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-t.C:
-						if shouldAbort() {
-							cancel()
-							return
-						}
-					}
-				}
-			}
-			enterrors.GoWrapper(watcher, sg.logger)
-		}
-	}
 
 	// runCompactor maps the per-strategy do/Do error into:
 	//   - (true,  nil): caller should clean up .tmp and return (false, nil)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -29,8 +29,8 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 

--- a/adapters/repos/db/lsmkv/segment_group_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction_test.go
@@ -1312,7 +1312,7 @@ func TestSegmenGroup_CompactionLargerThanMaxSize(t *testing.T) {
 		maxSegmentSize: maxSegmentSize,
 	}
 
-	ok, err := sg.compactOnce()
+	ok, err := sg.compactOnce(nil)
 	assert.False(t, ok, "segments are too large to run")
 	assert.Nil(t, err)
 }

--- a/adapters/repos/db/lsmkv/segment_group_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction_test.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -1312,7 +1313,7 @@ func TestSegmenGroup_CompactionLargerThanMaxSize(t *testing.T) {
 		maxSegmentSize: maxSegmentSize,
 	}
 
-	ok, err := sg.compactOnce(nil)
+	ok, err := sg.compactOnce(context.Background())
 	assert.False(t, ok, "segments are too large to run")
 	assert.Nil(t, err)
 }

--- a/adapters/repos/db/lsmkv/segment_group_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_integration_test.go
@@ -124,7 +124,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		})
 
 		t.Run("1st compaction", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce(nil)
+			compacted, err := bucket.disk.compactOnce(context.Background())
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -144,7 +144,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		})
 
 		t.Run("2nd compaction", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce(nil)
+			compacted, err := bucket.disk.compactOnce(context.Background())
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -173,7 +173,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		})
 
 		t.Run("3rd compaction", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce(nil)
+			compacted, err := bucket.disk.compactOnce(context.Background())
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -224,7 +224,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		t.Run("deleteme files are created after compaction", func(t *testing.T) {
 			compactions := 0
 			for {
-				compacted, err := bucket.disk.compactOnce(nil)
+				compacted, err := bucket.disk.compactOnce(context.Background())
 				require.NoError(t, err)
 
 				if !compacted {
@@ -270,7 +270,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		t.Run("compact", func(t *testing.T) {
 			compactions := 0
 			for {
-				compacted, err := bucket.disk.compactOnce(nil)
+				compacted, err := bucket.disk.compactOnce(context.Background())
 				require.NoError(t, err)
 
 				if !compacted {
@@ -317,7 +317,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		cur_1_2_3_4 := bucket.Cursor()
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce(nil)
+			compacted, err := bucket.disk.compactOnce(context.Background())
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -340,7 +340,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		cur_12_3_4 := bucket.Cursor()
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce(nil)
+			compacted, err := bucket.disk.compactOnce(context.Background())
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -365,7 +365,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		cur_1_2_3_4.Close()
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce(nil)
+			compacted, err := bucket.disk.compactOnce(context.Background())
 			require.NoError(t, err)
 			require.True(t, compacted)
 

--- a/adapters/repos/db/lsmkv/segment_group_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_integration_test.go
@@ -124,7 +124,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		})
 
 		t.Run("1st compaction", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce()
+			compacted, err := bucket.disk.compactOnce(nil)
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -144,7 +144,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		})
 
 		t.Run("2nd compaction", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce()
+			compacted, err := bucket.disk.compactOnce(nil)
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -173,7 +173,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		})
 
 		t.Run("3rd compaction", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce()
+			compacted, err := bucket.disk.compactOnce(nil)
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -224,7 +224,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		t.Run("deleteme files are created after compaction", func(t *testing.T) {
 			compactions := 0
 			for {
-				compacted, err := bucket.disk.compactOnce()
+				compacted, err := bucket.disk.compactOnce(nil)
 				require.NoError(t, err)
 
 				if !compacted {
@@ -270,7 +270,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		t.Run("compact", func(t *testing.T) {
 			compactions := 0
 			for {
-				compacted, err := bucket.disk.compactOnce()
+				compacted, err := bucket.disk.compactOnce(nil)
 				require.NoError(t, err)
 
 				if !compacted {
@@ -317,7 +317,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		cur_1_2_3_4 := bucket.Cursor()
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce()
+			compacted, err := bucket.disk.compactOnce(nil)
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -340,7 +340,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		cur_12_3_4 := bucket.Cursor()
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce()
+			compacted, err := bucket.disk.compactOnce(nil)
 			require.NoError(t, err)
 			require.True(t, compacted)
 
@@ -365,7 +365,7 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 		cur_1_2_3_4.Close()
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
-			compacted, err := bucket.disk.compactOnce()
+			compacted, err := bucket.disk.compactOnce(nil)
 			require.NoError(t, err)
 			require.True(t, compacted)
 

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -349,7 +349,7 @@ func createSegmentFiles(t *testing.T, ctx context.Context, logger logrus.FieldLo
 		}
 	}
 
-	once, err := b.disk.compactOnce(nil)
+	once, err := b.disk.compactOnce(context.Background())
 	require.NoError(t, err)
 	require.True(t, once)
 	dbFiles, walFiles = countDbAndWalFiles(t, dirName)

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -349,7 +349,7 @@ func createSegmentFiles(t *testing.T, ctx context.Context, logger logrus.FieldLo
 		}
 	}
 
-	once, err := b.disk.compactOnce()
+	once, err := b.disk.compactOnce(nil)
 	require.NoError(t, err)
 	require.True(t, once)
 	dbFiles, walFiles = countDbAndWalFiles(t, dirName)

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -278,7 +278,7 @@ func dontPrecomputeCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 		require.NoError(t, b.Put([]byte("hello2"), []byte("world2")))
 		require.NoError(t, b.FlushMemtable())
 
-		compacted, err := b.disk.compactOnce(nil)
+		compacted, err := b.disk.compactOnce(context.Background())
 		require.NoError(t, err)
 		require.True(t, compacted)
 	})

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -278,7 +278,7 @@ func dontPrecomputeCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 		require.NoError(t, b.Put([]byte("hello2"), []byte("world2")))
 		require.NoError(t, b.FlushMemtable())
 
-		compacted, err := b.disk.compactOnce()
+		compacted, err := b.disk.compactOnce(nil)
 		require.NoError(t, err)
 		require.True(t, compacted)
 	})

--- a/adapters/repos/db/roaringset/compactor.go
+++ b/adapters/repos/db/roaringset/compactor.go
@@ -147,9 +147,8 @@ func NewCompactor(w io.WriteSeeker,
 	}
 }
 
-// Do starts a compaction. See [Compactor] for an explanation of this process.
-// ctx is checked every compactor.AbortCheckEveryN keys inside the merge loop;
-// cancelling it returns the wrapped ctx error so the caller can clean up.
+// Do starts a compaction. See [Compactor]. Cancelling ctx aborts the
+// in-flight merge.
 func (c *Compactor) Do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return fmt.Errorf("init: %w", err)

--- a/adapters/repos/db/roaringset/compactor.go
+++ b/adapters/repos/db/roaringset/compactor.go
@@ -13,6 +13,7 @@ package roaringset
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 
@@ -147,7 +148,9 @@ func NewCompactor(w io.WriteSeeker,
 }
 
 // Do starts a compaction. See [Compactor] for an explanation of this process.
-func (c *Compactor) Do() error {
+// ctx is checked every compactor.AbortCheckEveryN keys inside the merge loop;
+// cancelling it returns the wrapped ctx error so the caller can clean up.
+func (c *Compactor) Do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return fmt.Errorf("init: %w", err)
 	}
@@ -157,7 +160,7 @@ func (c *Compactor) Do() error {
 		segmentindex.WithChecksumsDisabled(!c.enableChecksumValidation),
 	)
 
-	kis, err := c.writeNodes(segmentFile)
+	kis, err := c.writeNodes(ctx, segmentFile)
 	if err != nil {
 		return fmt.Errorf("write keys: %w", err)
 	}
@@ -217,7 +220,7 @@ type nodeCompactor struct {
 	emptyBitmap      *sroar.Bitmap
 }
 
-func (c *Compactor) writeNodes(f *segmentindex.SegmentFile) ([]segmentindex.Key, error) {
+func (c *Compactor) writeNodes(ctx context.Context, f *segmentindex.SegmentFile) ([]segmentindex.Key, error) {
 	nc := &nodeCompactor{
 		left:             c.left,
 		right:            c.right,
@@ -228,7 +231,7 @@ func (c *Compactor) writeNodes(f *segmentindex.SegmentFile) ([]segmentindex.Key,
 
 	nc.init()
 
-	if err := nc.loopThroughKeys(); err != nil {
+	if err := nc.loopThroughKeys(ctx); err != nil {
 		return nil, err
 	}
 
@@ -243,8 +246,13 @@ func (c *nodeCompactor) init() {
 	c.offset = segmentindex.HeaderSize
 }
 
-func (c *nodeCompactor) loopThroughKeys() error {
-	for {
+func (c *nodeCompactor) loopThroughKeys(ctx context.Context) error {
+	for i := 0; ; i++ {
+		if i%compactor.AbortCheckEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("merge keys: %w", err)
+			}
+		}
 		if c.keyLeft == nil && c.keyRight == nil {
 			return nil
 		}

--- a/adapters/repos/db/roaringset/compactor_test.go
+++ b/adapters/repos/db/roaringset/compactor_test.go
@@ -12,6 +12,7 @@
 package roaringset
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -480,7 +481,7 @@ func cursorCompactor(t *testing.T, leftCursor, rightCursor SegmentCursor, maxNew
 	require.NoError(t, err)
 
 	c := NewCompactor(f, leftCursor, rightCursor, 5, cleanup, checkSum, maxNewFileSize, nil)
-	require.NoError(t, c.Do())
+	require.NoError(t, c.Do(context.Background()))
 
 	require.NoError(t, f.Close())
 
@@ -528,7 +529,7 @@ func TestCompactor_InMemoryWritesEfficency(t *testing.T) {
 
 		c := NewCompactor(ws, leftCursor, rightCursor, 0, true, true, maxNewFileSize, nil)
 
-		err = c.Do()
+		err = c.Do(context.Background())
 		require.Nil(t, err)
 
 		b, err := ws.Bytes()

--- a/adapters/repos/db/roaringsetrange/compactor.go
+++ b/adapters/repos/db/roaringsetrange/compactor.go
@@ -203,10 +203,14 @@ func (nc *nodeCompactor) loopThroughKeys(ctx context.Context) error {
 
 	// left segment empty, take right
 	if !okLeft {
+		i := 0
 		for ; okRight; keyRight, layerRight, okRight = nc.right.Next() {
-			if err := ctx.Err(); err != nil {
-				return fmt.Errorf("merge keys: %w", err)
+			if i%compactor.AbortCheckEveryN == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("merge keys: %w", err)
+				}
 			}
+			i++
 			if err := nc.writeLayer(keyRight, layerRight); err != nil {
 				return fmt.Errorf("right segment: %w", err)
 			}
@@ -216,10 +220,14 @@ func (nc *nodeCompactor) loopThroughKeys(ctx context.Context) error {
 
 	// right segment empty, take left
 	if !okRight {
+		i := 0
 		for ; okLeft; keyLeft, layerLeft, okLeft = nc.left.Next() {
-			if err := ctx.Err(); err != nil {
-				return fmt.Errorf("merge keys: %w", err)
+			if i%compactor.AbortCheckEveryN == 0 {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("merge keys: %w", err)
+				}
 			}
+			i++
 			if err := nc.writeLayer(keyLeft, layerLeft); err != nil {
 				return fmt.Errorf("left segment: %w", err)
 			}
@@ -241,9 +249,11 @@ func (nc *nodeCompactor) loopThroughKeys(ctx context.Context) error {
 		nc.deletionsRight = layerRight.Deletions.Clone()
 	}
 
-	for okLeft || okRight {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("merge keys: %w", err)
+	for i := 0; okLeft || okRight; i++ {
+		if i%compactor.AbortCheckEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("merge keys: %w", err)
+			}
 		}
 		if okLeft && (!okRight || keyLeft < keyRight) {
 			// merge left

--- a/adapters/repos/db/roaringsetrange/compactor.go
+++ b/adapters/repos/db/roaringsetrange/compactor.go
@@ -12,6 +12,7 @@
 package roaringsetrange
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -107,7 +108,9 @@ func NewCompactor(w io.WriteSeeker, left, right SegmentCursor,
 }
 
 // Do starts a compaction. See [Compactor] for an explanation of this process.
-func (c *Compactor) Do() error {
+// ctx is checked every compactor.AbortCheckEveryN keys inside the merge loop;
+// cancelling it returns the wrapped ctx error so the caller can clean up.
+func (c *Compactor) Do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return fmt.Errorf("init: %w", err)
 	}
@@ -117,7 +120,7 @@ func (c *Compactor) Do() error {
 		segmentindex.WithChecksumsDisabled(!c.enableChecksumValidation),
 	)
 
-	written, err := c.writeNodes(segmentFile)
+	written, err := c.writeNodes(ctx, segmentFile)
 	if err != nil {
 		return fmt.Errorf("write keys: %w", err)
 	}
@@ -155,7 +158,7 @@ func (c *Compactor) init() error {
 	return nil
 }
 
-func (c *Compactor) writeNodes(f *segmentindex.SegmentFile) (int, error) {
+func (c *Compactor) writeNodes(ctx context.Context, f *segmentindex.SegmentFile) (int, error) {
 	nc := &nodeCompactor{
 		left:             c.left,
 		right:            c.right,
@@ -164,7 +167,7 @@ func (c *Compactor) writeNodes(f *segmentindex.SegmentFile) (int, error) {
 		emptyBitmap:      sroar.NewBitmap(),
 	}
 
-	if err := nc.loopThroughKeys(); err != nil {
+	if err := nc.loopThroughKeys(ctx); err != nil {
 		return 0, err
 	}
 
@@ -183,7 +186,7 @@ type nodeCompactor struct {
 	deletionsLeft, deletionsRight *sroar.Bitmap
 }
 
-func (nc *nodeCompactor) loopThroughKeys() error {
+func (nc *nodeCompactor) loopThroughKeys(ctx context.Context) error {
 	keyLeft, layerLeft, okLeft := nc.left.First()
 	keyRight, layerRight, okRight := nc.right.First()
 
@@ -202,6 +205,9 @@ func (nc *nodeCompactor) loopThroughKeys() error {
 	// left segment empty, take right
 	if !okLeft {
 		for ; okRight; keyRight, layerRight, okRight = nc.right.Next() {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("merge keys: %w", err)
+			}
 			if err := nc.writeLayer(keyRight, layerRight); err != nil {
 				return fmt.Errorf("right segment: %w", err)
 			}
@@ -212,6 +218,9 @@ func (nc *nodeCompactor) loopThroughKeys() error {
 	// right segment empty, take left
 	if !okRight {
 		for ; okLeft; keyLeft, layerLeft, okLeft = nc.left.Next() {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("merge keys: %w", err)
+			}
 			if err := nc.writeLayer(keyLeft, layerLeft); err != nil {
 				return fmt.Errorf("left segment: %w", err)
 			}
@@ -234,6 +243,9 @@ func (nc *nodeCompactor) loopThroughKeys() error {
 	}
 
 	for okLeft || okRight {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("merge keys: %w", err)
+		}
 		if okLeft && (!okRight || keyLeft < keyRight) {
 			// merge left
 			merged := nc.mergeLayers(keyLeft, layerLeft.Additions, nc.emptyBitmap)

--- a/adapters/repos/db/roaringsetrange/compactor.go
+++ b/adapters/repos/db/roaringsetrange/compactor.go
@@ -107,9 +107,8 @@ func NewCompactor(w io.WriteSeeker, left, right SegmentCursor,
 	}
 }
 
-// Do starts a compaction. See [Compactor] for an explanation of this process.
-// ctx is checked every compactor.AbortCheckEveryN keys inside the merge loop;
-// cancelling it returns the wrapped ctx error so the caller can clean up.
+// Do starts a compaction. See [Compactor]. Cancelling ctx aborts the
+// in-flight merge.
 func (c *Compactor) Do(ctx context.Context) error {
 	if err := c.init(); err != nil {
 		return fmt.Errorf("init: %w", err)

--- a/adapters/repos/db/roaringsetrange/compactor_test.go
+++ b/adapters/repos/db/roaringsetrange/compactor_test.go
@@ -12,6 +12,7 @@
 package roaringsetrange
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -527,7 +528,7 @@ func cursorCompactor(t *testing.T, leftCursor, rightCursor SegmentCursor, maxNew
 	require.NoError(t, err)
 
 	c := NewCompactor(f, leftCursor, rightCursor, 5, cleanup, checkSum, maxNewFileSize)
-	if err := c.Do(); err != nil {
+	if err := c.Do(context.Background()); err != nil {
 		require.NoError(t, f.Close())
 		return nil, err
 	}


### PR DESCRIPTION
SuperClaude here.

Ready for review. Targets `stable/v1.35` per Etienne's direction on weaviate/0-weaviate-issues#250.

## What changes

Each lsmkv compactor (`replace`, `set`, `map`, `inverted`, `roaringset`, `roaringsetrange`) now takes a `context.Context` and samples `ctx.Err()` inside its inner merge loop every `compactor.AbortCheckEveryN` keys (1024). Cancelling the ctx returns the wrapped ctx error within a few hundred ms.

`SegmentGroup.compactOnce(ctx)` is the entry point. The `cyclemanager.ShouldAbortCallback` → `context.Context` bridge lives one level up in `SegmentGroup.compactOrCleanup`: a short-lived watcher goroutine polls shouldAbort every 50ms and cancels the ctx. An entry-time check pre-cancels the "already aborted" case so the first sample fires immediately. On `context.Canceled` / `DeadlineExceeded`, `compactOnce` closes the partial `.tmp` fd (the file itself stays on disk — `segment_group.init` cleans orphan `.tmp` files on the next startup; on the drop path the parent dir is unlinked anyway) and returns `(false, nil)` — the same shape the cycle sees on any no-op tick.

`Index.drop`'s `stopCycleManagers` ctx tightened to **1s** (target contract from weaviate/0-weaviate-issues#250). `context.Canceled` / `context.DeadlineExceeded` from `stopCycleManagers` are now tolerated and don't fail the drop — flush callbacks don't honour ctx yet so the 1s budget surfaces that gap loudly without breaking the apply. Real errors still propagate.

## Out of scope (filed as follow-ups)

- `bucket.flushAndSwitchIfThresholdsMet` does not honour shouldAbort/ctx; in-flight flush still blocks `StopAndWait` past 1s. Etienne's chosen scope: separate PR (option A from the scope discussion).
- `os.RemoveAll(s.pathLSM())` is not cancellable. Addressed on the companion PR weaviate/weaviate#11462 (sync rename → `.deleteme` + async `RemoveAll`).
- Pushing the shouldAbort → ctx bridge from `compactOrCleanup` into `cyclemanager.CycleCallback` itself (15+ callbacks across HNSW, etc.) — left to a follow-up on main per Etienne's preference.

## Tests

`TestCompactor_AbortOnShouldAbort` (integration tag) — parametrized over all 6 strategies × {direct, bridge}:
- `direct`: pre-cancel a ctx, call `bucket.disk.compactOnce(ctx)` — exercises each strategy's inner-loop ctx.Err() probe.
- `bridge`: `bucket.disk.compactOrCleanup(shouldAbort=true)` — exercises the `compactOrCleanup` bridge (pre-cancel + watcher goroutine).

All 12 subtests pass within ~300ms total.

## Verification

- `go test -short ./adapters/repos/db/...` — pass.
- `go test -tags integrationTest -run TestCompactor_AbortOnShouldAbort ./adapters/repos/db/lsmkv/` — pass (12/12).
- `golangci-lint run` and `./tools/linter_go_routines.sh` — clean.

— SuperClaude (drafting against stable/v1.35 per weaviate/0-weaviate-issues#250)
