### PR TITLE
gh-11440 parse BM25 property boosts as floats

### DIFF
--- a/adapters/repos/db/bm25f_block_test.go
+++ b/adapters/repos/db/bm25f_block_test.go
@@ -188,6 +188,15 @@ func TestBM25FJourneyBlock(t *testing.T) {
 			require.Equal(t, uint64(3), res[6].DocID)
 		})
 
+		t.Run("bm25f journey fractional boost "+location, func(t *testing.T) {
+			kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title^0.5"}, Query: "journey"}
+			res, scores, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, nil, addit, nil, "", 0, props)
+
+			require.Nil(t, err)
+			require.NotEmpty(t, res)
+			require.Greater(t, scores[0], float32(0))
+		})
+
 		t.Run("Check search with two terms "+location, func(t *testing.T) {
 			kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description"}, Query: "journey somewhere"}
 			res, scores, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, nil, addit, nil, "", 0, props)

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -377,6 +377,15 @@ func TestBM25FJourney(t *testing.T) {
 		require.Equal(t, uint64(3), res[6].DocID)
 	})
 
+	t.Run("bm25f journey fractional boost", func(t *testing.T) {
+		kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title^0.5"}, Query: "journey"}
+		res, scores, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, nil, addit, nil, "", 0, props)
+
+		require.Nil(t, err)
+		require.NotEmpty(t, res)
+		require.Greater(t, scores[0], float32(0))
+	})
+
 	t.Run("Check search with two terms", func(t *testing.T) {
 		kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: []string{"title", "description"}, Query: "journey somewhere"}
 		res, _, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, nil, addit, nil, "", 0, props)

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -199,13 +199,14 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 
 	for _, propertyWithBoost := range params.Properties {
 		property := propertyWithBoost
-		propBoost := 1
+		propBoost := float32(1)
 		if strings.Contains(propertyWithBoost, "^") {
 			property = strings.Split(propertyWithBoost, "^")[0]
 			boostStr := strings.Split(propertyWithBoost, "^")[1]
-			propBoost, _ = strconv.Atoi(boostStr)
+			boost, _ := strconv.ParseFloat(boostStr, 32)
+			propBoost = float32(boost)
 		}
-		propertyBoosts[property] = float32(propBoost)
+		propertyBoosts[property] = propBoost
 
 		propMean, err := b.GetPropertyLengthTracker().PropertyMean(property)
 		if err != nil {


### PR DESCRIPTION
### What's being changed:

This fixes BM25 property boost parsing so fractional boost values such as
`title^0.5` and `title^1.5` are handled as positive fractional boosts instead
of being treated like `0`.

Previously, the boost suffix after `^` was parsed with `strconv.Atoi`. Decimal
values such as `0.5` fail integer parsing. Because the parse error was ignored,
the boost value stored in `propertyBoosts` became zero. That meant a query like
`properties: ["title^0.5"]` could erase the BM25 contribution of `title` even
though `0.5` is a positive boost.

The fix changes the parser to use `strconv.ParseFloat(..., 32)` and stores the
result as `float32`, matching the existing `propertyBoosts` map type used by the
scoring path.

Regression coverage was added for both BM25 search paths:

- `TestBM25FJourney/bm25f journey fractional boost`
- `TestBM25FJourneyBlock/bm25f journey fractional boost memory`
- `TestBM25FJourneyBlock/bm25f journey fractional boost disk`

Before this fix, the focused regression failed because `title^0.5` returned an
empty result set in the integration test path. After the fix, the same query
returns results with a positive score.

Fixes #11440.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary; bug fix to existing query behavior.
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary; this only changes boost parsing from integer to float for requested BM25 properties.

Validation run locally:

```bash
go test -tags=integrationTest ./adapters/repos/db -run 'TestBM25FJourney/bm25f_journey_fractional_boost' -count=1
go test -tags=integrationTest ./adapters/repos/db -run 'TestBM25FJourney|TestBM25FJourneyBlock' -count=1
go test ./adapters/repos/db/inverted -count=1
git diff --check
```
