### PR TITLE
Namespace: Auto-schema and reindex bug fixes

### DIFF
--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -66,36 +66,36 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	// - to pass down the stack to reuse, index by classname so it can be found easily
 	knownClasses := map[string]versioned.Class{}
 	knownClassesAuthCheck := map[string]*models.Class{}
-	classGetter := func(classname, shard string) (*models.Class, error) {
+	classGetter := func(classname, shard string) (string, *models.Class, error) {
 		resolved, _, err := namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, classname)
 		if err != nil {
-			return nil, err
+			return "", nil, err
 		}
 		classname = resolved
 		// use a letter that cannot be in class/shard name to not allow different combinations leading to the same combined name
 		classTenantName := classname + "#" + shard
 		class, ok := knownClassesAuthCheck[classTenantName]
 		if ok {
-			return class, nil
+			return resolved, class, nil
 		}
 
 		// batch is upsert
 		if err := h.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.ShardsData(classname, shard)...); err != nil {
-			return nil, err
+			return "", nil, err
 		}
 
 		if err := h.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.ShardsData(classname, shard)...); err != nil {
-			return nil, err
+			return "", nil, err
 		}
 
 		// we don't leak any info that someone who inserts data does not have anyway
 		vClass, err := h.schemaManager.GetCachedClassNoAuth(ctx, classname)
 		if err != nil {
-			return nil, err
+			return "", nil, err
 		}
 		knownClasses[classname] = vClass[classname]
 		knownClassesAuthCheck[classTenantName] = vClass[classname].Class
-		return vClass[classname].Class, nil
+		return resolved, vClass[classname].Class, nil
 	}
 	objs, objOriginalIndex, objectParsingErrors := BatchObjectsFromProto(req, classGetter, principal, h.namespacesEnabled)
 

--- a/adapters/handlers/grpc/v1/batch/parse.go
+++ b/adapters/handlers/grpc/v1/batch/parse.go
@@ -34,7 +34,7 @@ func sliceToInterface[T any](values []T) []interface{} {
 	return tmpArray
 }
 
-func BatchObjectsFromProto(req *pb.BatchObjectsRequest, authorizedGetClass func(string, string) (*models.Class, error), principal *models.Principal, namespacesEnabled bool) ([]*models.Object, map[int]int, map[int]error) {
+func BatchObjectsFromProto(req *pb.BatchObjectsRequest, authorizedGetClass func(string, string) (string, *models.Class, error), principal *models.Principal, namespacesEnabled bool) ([]*models.Object, map[int]int, map[int]error) {
 	objectsBatch := req.Objects
 	objs := make([]*models.Object, 0, len(objectsBatch))
 	objOriginalIndex := make(map[int]int)
@@ -45,15 +45,15 @@ func BatchObjectsFromProto(req *pb.BatchObjectsRequest, authorizedGetClass func(
 		var props map[string]interface{}
 
 		collection := schema.UppercaseClassName(obj.Collection)
-		class, err := authorizedGetClass(collection, obj.Tenant)
+		resolved, class, err := authorizedGetClass(collection, obj.Tenant)
 		if err != nil {
 			objectErrors[i] = err
 			continue
 		}
-		obj.Collection = collection
+		// resolved is namespace-qualified even before the class exists, so an
+		// auto-schema create and the object write agree on the qualified name.
+		obj.Collection = resolved
 		if class != nil {
-			// class is nil when we are relying on auto schema to create a collection
-			// aliases cannot be created for non-existent classes
 			obj.Collection = class.Class
 		}
 

--- a/adapters/handlers/grpc/v1/batch/parse_test.go
+++ b/adapters/handlers/grpc/v1/batch/parse_test.go
@@ -466,8 +466,8 @@ func TestGRPCBatchRequest(t *testing.T) {
 			}},
 		},
 	}
-	getClass := func(class, shard string) (*models.Class, error) {
-		return scheme.GetClass(class), nil
+	getClass := func(class, shard string) (string, *models.Class, error) {
+		return class, scheme.GetClass(class), nil
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -506,8 +506,8 @@ func TestGRPCBatchRequest_MultiTargetNamespace(t *testing.T) {
 		},
 		a: {Class: a},
 	}
-	getClass := func(class, shard string) (*models.Class, error) {
-		return classes[class], nil
+	getClass := func(class, shard string) (string, *models.Class, error) {
+		return class, classes[class], nil
 	}
 	makeReq := func(target string) *pb.BatchObjectsRequest {
 		return &pb.BatchObjectsRequest{Objects: []*pb.BatchObject{{
@@ -553,4 +553,21 @@ func TestGRPCBatchRequest_MultiTargetNamespace(t *testing.T) {
 		require.Len(t, errs, 1)
 		require.Contains(t, errs[0].Error(), "not a valid class name")
 	})
+}
+
+// TestGRPCBatchRequest_AutoSchemaQualifiesNamespace pins the auto-schema branch
+// (class not yet in schema): the parsed object must carry the resolver's
+// qualified name, not the bare request collection.
+func TestGRPCBatchRequest_AutoSchemaQualifiesNamespace(t *testing.T) {
+	getClass := func(class, shard string) (string, *models.Class, error) {
+		// resolver qualifies the short name; class is nil (auto-schema creates it).
+		return "ns1:Movies", nil, nil
+	}
+	req := []*pb.BatchObject{{Collection: "Movies", Uuid: UUID4}}
+
+	out, _, batchErrors := batch.BatchObjectsFromProto(&pb.BatchObjectsRequest{Objects: req}, getClass, nil, false)
+
+	require.Len(t, batchErrors, 0)
+	require.Len(t, out, 1)
+	require.Equal(t, "ns1:Movies", out[0].Class)
 }

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1348,7 +1348,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	db_users.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication, appState.ServerConfig.Config.Authorization, remoteDbUsers, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.NamespacesController, appState.Logger)
 	rest_namespaces.SetupHandlers(appState.ServerConfig.Config.Namespaces.Enabled, api, appState.ClusterService.Raft, appState.Authorizer, appState.Logger)
 
-	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks)
+	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks, appState.ServerConfig.Config.Namespaces.Enabled)
 	setupIndexesHandlers(api, appState)
 	setupTokenizeHandlers(api, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.Logger)
 	setupAliasesHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -68,7 +68,12 @@ func (h *indexesHandlers) submitLock(collection, propertyName string) *sync.Mute
 
 // getIndexes implements GET /v1/schema/{className}/indexes.
 func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams, principal *models.Principal) middleware.Responder {
-	collection := params.ClassName
+	// Resolve (alias-aware) before authz so authz and the lookup use the qualified name.
+	collection, _, rErr := namespacing.Resolve(principal, h.appState.SchemaManager,
+		h.appState.ServerConfig.Config.Namespaces.Enabled, params.ClassName)
+	if rErr != nil {
+		return schema.NewSchemaObjectsIndexesGetForbidden().WithPayload(errPayloadFromSingleErr(principal, rErr))
+	}
 
 	// Require READ on the collection's metadata: this endpoint exposes
 	// per-property index state, which is collection-internal information.
@@ -134,8 +139,9 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 	props := make([]*models.PropertyIndexStatus, 0, len(class.Properties))
 	for _, prop := range class.Properties {
 		pis := &models.PropertyIndexStatus{
-			Name:     prop.Name,
-			DataType: dataTypeString(prop),
+			Name: prop.Name,
+			// Reference DataTypes carry the qualified target class.
+			DataType: namespacing.StripOwnNamespace(principal, dataTypeString(prop)),
 		}
 		pis.Description = prop.Description
 
@@ -184,7 +190,7 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 	}
 
 	return schema.NewSchemaObjectsIndexesGetOK().WithPayload(&models.IndexStatusResponse{
-		Collection: collection,
+		Collection: namespacing.StripOwnNamespace(principal, collection),
 		Properties: props,
 	})
 }
@@ -197,8 +203,14 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 // repair-searchable blocks change-tokenization on any property since
 // repair-searchable touches all searchable buckets).
 func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdateParams, principal *models.Principal) middleware.Responder {
-	collection := params.ClassName
 	propertyName := params.PropertyName
+
+	// Qualify (no alias resolution, like DeleteClassPropertyIndex) before authz + lookup.
+	collection, qErr := namespacing.QualifyClass(principal,
+		h.appState.ServerConfig.Config.Namespaces.Enabled, params.ClassName)
+	if qErr != nil {
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errPayloadFromSingleErr(principal, qErr))
+	}
 
 	// Require UPDATE on the collection itself: submitting a reindex task is a
 	// privileged, cluster-wide, destructive operation (rebuilds buckets on
@@ -236,6 +248,8 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 	// rejects the DELETE deterministically. If DELETE wins instead,
 	// PUT's class read sees IndexSearchable=false and
 	// validateTokenizationChange rejects with 400.
+	// Key on the qualified class (the reindex-task key) so short- and qualified-name
+	// callers for the same collection share the DeleteClassPropertyIndex lock.
 	propLock := h.submitLock(collection, propertyName)
 	propLock.Lock()
 	defer propLock.Unlock()
@@ -627,7 +641,8 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 	}).Info("reindex provider: submitted task")
 
 	return schema.NewSchemaObjectsIndexesUpdateAccepted().WithPayload(&models.IndexUpdateResponse{
-		TaskID: taskID,
+		// The task ID embeds the qualified collection.
+		TaskID: namespacing.StripOwnNamespace(principal, taskID),
 		Status: "STARTED",
 	})
 }
@@ -831,7 +846,8 @@ func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, pro
 	}).Info("reindex provider: cancelled task")
 
 	return schema.NewSchemaObjectsIndexesUpdateAccepted().WithPayload(&models.IndexUpdateResponse{
-		TaskID: target.ID,
+		// The task ID embeds the qualified collection.
+		TaskID: namespacing.StripOwnNamespace(principal, target.ID),
 		Status: "CANCELLED",
 	})
 }

--- a/adapters/handlers/rest/handlers_indexes_namespace_test.go
+++ b/adapters/handlers/rest/handlers_indexes_namespace_test.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// TestUpdateIndex_SubmitLockKeyedOnQualifiedClass pins the PUT side of the shared
+// submit lock: a namespaced short-name caller must lock on the qualified class,
+// the key DeleteClassPropertyIndex uses. The test pre-holds that lock — a
+// correctly-keyed handler blocks; the buggy raw-keyed one takes a different lock
+// and proceeds.
+func TestUpdateIndex_SubmitLockKeyedOnQualifiedClass(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	locks := state.NewReindexSubmitLocks()
+	h := &indexesHandlers{appState: &state.State{
+		Authorizer:         &authorization.DummyAuthorizer{},
+		ReindexSubmitLocks: locks,
+		Logger:             logger,
+		ServerConfig: &config.WeaviateConfig{Config: config.Config{
+			Namespaces: config.Namespaces{Enabled: true},
+		}},
+		// SchemaManager left nil: the correctly-keyed handler blocks before the
+		// class read; the buggy path reaches it and panics, which the goroutine recovers.
+	}}
+
+	held := locks.SubmitLockFor("customer1:Movies", "title")
+	held.Lock()
+
+	params := schema.SchemaObjectsIndexesUpdateParams{
+		HTTPRequest:  httptest.NewRequest("PUT", "/", nil),
+		ClassName:    "Movies", // short name; qualifies to customer1:Movies
+		PropertyName: "title",
+	}
+	principal := &models.Principal{Username: "customer1:u1", Namespace: "customer1"}
+
+	finished := make(chan struct{})
+	// recover swallows the nil-SchemaManager panic so the test binary survives;
+	// the deferred close fires whether updateIndex returns or panics.
+	go func() {
+		defer func() {
+			_ = recover()
+			close(finished)
+		}()
+		_ = h.updateIndex(params, principal)
+	}()
+
+	select {
+	case <-finished:
+		t.Fatal("updateIndex did not block on the qualified-class lock — submit lock is keyed on the raw class name")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	held.Unlock()
+
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("updateIndex did not proceed after the qualified-class lock was released")
+	}
+}

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -214,6 +214,7 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 	// key); the manager delete call qualifies internally, so it gets the raw name.
 	qualifiedClass, qErr := namespacing.QualifyClass(principal, s.namespacesEnabled, params.ClassName)
 	if qErr != nil {
+		s.metricRequestsTotal.logError(params.ClassName, qErr)
 		return schema.NewSchemaObjectsPropertiesDeleteUnprocessableEntity().
 			WithPayload(errPayloadFromSingleErr(principal, qErr))
 	}
@@ -592,6 +593,7 @@ func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principa
 		}
 	}
 
+	s.metricRequestsTotal.logOk(params.ClassName)
 	return schema.NewTenantExistsOK()
 }
 

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -71,6 +71,7 @@ type schemaHandlers struct {
 	metricRequestsTotal restApiRequestsTotal
 	reindexTaskLister   reindexInFlightChecker
 	reindexSubmitLocks  reindexSubmitLockProvider
+	namespacesEnabled   bool
 }
 
 func (s *schemaHandlers) addClass(params schema.SchemaObjectsCreateParams,
@@ -209,6 +210,14 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
 
+	// Conflict check and submit lock key on the qualified class (the reindex-task
+	// key); the manager delete call qualifies internally, so it gets the raw name.
+	qualifiedClass, qErr := namespacing.QualifyClass(principal, s.namespacesEnabled, params.ClassName)
+	if qErr != nil {
+		return schema.NewSchemaObjectsPropertiesDeleteUnprocessableEntity().
+			WithPayload(errPayloadFromSingleErr(principal, qErr))
+	}
+
 	// Serialize with the reindex-submit REST handler on the same
 	// (collection, property) tuple. Without this lock, a parallel
 	// PUT /v1/schema/{class}/indexes/{prop} (which submits a reindex
@@ -226,7 +235,7 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 	// nil-safe: reindexSubmitLocks is wired in production but may be
 	// nil in unit tests that construct schemaHandlers directly.
 	if s.reindexSubmitLocks != nil {
-		lock := s.reindexSubmitLocks.SubmitLockFor(params.ClassName, params.PropertyName)
+		lock := s.reindexSubmitLocks.SubmitLockFor(qualifiedClass, params.PropertyName)
 		lock.Lock()
 		defer lock.Unlock()
 	}
@@ -238,7 +247,7 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 	// UpdateProperty apply ([MutationGuard]) still closes the
 	// multi-node race that this per-node check cannot — they are
 	// complementary, not redundant.
-	if conflict := s.checkReindexConflictForPropertyMutation(ctx, params.ClassName, params.PropertyName); conflict != "" {
+	if conflict := s.checkReindexConflictForPropertyMutation(ctx, qualifiedClass, params.PropertyName); conflict != "" {
 		s.metricRequestsTotal.logError(params.ClassName, fmt.Errorf("reindex conflict: %s", conflict))
 		return schema.NewSchemaObjectsPropertiesDeleteUnprocessableEntity().
 			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("%s", conflict)))
@@ -586,12 +595,13 @@ func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principa
 	return schema.NewTenantExistsOK()
 }
 
-func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider) {
+func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider, namespacesEnabled bool) {
 	h := &schemaHandlers{
 		manager:             manager,
 		metricRequestsTotal: newSchemaRequestsTotal(metrics, logger),
 		reindexTaskLister:   reindexTaskLister,
 		reindexSubmitLocks:  reindexSubmitLocks,
+		namespacesEnabled:   namespacesEnabled,
 	}
 
 	api.SchemaSchemaObjectsCreateHandler = schema.

--- a/adapters/handlers/rest/handlers_schema_namespace_test.go
+++ b/adapters/handlers/rest/handlers_schema_namespace_test.go
@@ -1,0 +1,125 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+type fakeReindexTaskLister struct {
+	tasks map[string][]*distributedtask.Task
+}
+
+func (f fakeReindexTaskLister) ListDistributedTasks(ctx context.Context) (map[string][]*distributedtask.Task, error) {
+	return f.tasks, nil
+}
+
+// recordingLockProvider records the (collection, property) keys passed to
+// SubmitLockFor so a test can assert which class-name form the handler locks on.
+type recordingLockProvider struct {
+	mu   sync.Mutex
+	keys []string
+}
+
+func (r *recordingLockProvider) SubmitLockFor(collection, property string) *sync.Mutex {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.keys = append(r.keys, collection+"/"+property)
+	return &sync.Mutex{}
+}
+
+// TestDeleteClassPropertyIndex_NamespaceConflictPreflight: reindex tasks are keyed by
+// the qualified class, so a namespaced caller deleting by short name must still match an
+// in-flight task on customer1:Movies and get a 422 — i.e. the handler qualifies first.
+func TestDeleteClassPropertyIndex_NamespaceConflictPreflight(t *testing.T) {
+	payload, err := json.Marshal(db.ReindexTaskPayload{
+		MigrationType: db.ReindexTypeChangeTokenization,
+		Collection:    "customer1:Movies",
+		Properties:    []string{"title"},
+	})
+	require.NoError(t, err)
+
+	h := &schemaHandlers{
+		namespacesEnabled:   true,
+		metricRequestsTotal: newSchemaRequestsTotal(nil, logrus.New()),
+		reindexTaskLister: fakeReindexTaskLister{tasks: map[string][]*distributedtask.Task{
+			db.ReindexNamespace: {{
+				Namespace:      db.ReindexNamespace,
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: "t1"},
+				Status:         distributedtask.TaskStatusStarted,
+				Payload:        payload,
+			}},
+		}},
+	}
+
+	resp := h.deleteClassPropertyIndex(schema.SchemaObjectsPropertiesDeleteParams{
+		HTTPRequest:  httptest.NewRequest("DELETE", "/", nil),
+		ClassName:    "Movies", // short name; the handler qualifies to customer1:Movies
+		PropertyName: "title",
+	}, &models.Principal{Username: "customer1:u1", Namespace: "customer1"})
+
+	_, ok := resp.(*schema.SchemaObjectsPropertiesDeleteUnprocessableEntity)
+	require.True(t, ok, "expected 422 reindex-conflict — the handler must qualify the class before the conflict pre-flight")
+}
+
+// TestDeleteClassPropertyIndex_SubmitLockKeyedOnQualifiedClass: the submit lock
+// must key on the qualified class. Otherwise a namespaced caller (short "Movies")
+// and a global admin (qualified "customer1:Movies") take different locks for the
+// same collection and stop serializing, reopening the PUT-vs-DELETE torn-bucket race.
+func TestDeleteClassPropertyIndex_SubmitLockKeyedOnQualifiedClass(t *testing.T) {
+	// A matching in-flight task makes the conflict pre-flight return 422 after
+	// the lock is taken, so the handler never reaches the (nil) manager.
+	payload, err := json.Marshal(db.ReindexTaskPayload{
+		MigrationType: db.ReindexTypeChangeTokenization,
+		Collection:    "customer1:Movies",
+		Properties:    []string{"title"},
+	})
+	require.NoError(t, err)
+
+	rec := &recordingLockProvider{}
+	h := &schemaHandlers{
+		namespacesEnabled:   true,
+		metricRequestsTotal: newSchemaRequestsTotal(nil, logrus.New()),
+		reindexSubmitLocks:  rec,
+		reindexTaskLister: fakeReindexTaskLister{tasks: map[string][]*distributedtask.Task{
+			db.ReindexNamespace: {{
+				Namespace:      db.ReindexNamespace,
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: "t1"},
+				Status:         distributedtask.TaskStatusStarted,
+				Payload:        payload,
+			}},
+		}},
+	}
+
+	resp := h.deleteClassPropertyIndex(schema.SchemaObjectsPropertiesDeleteParams{
+		HTTPRequest:  httptest.NewRequest("DELETE", "/", nil),
+		ClassName:    "Movies", // short name; the handler qualifies to customer1:Movies
+		PropertyName: "title",
+	}, &models.Principal{Username: "customer1:u1", Namespace: "customer1"})
+
+	_, ok := resp.(*schema.SchemaObjectsPropertiesDeleteUnprocessableEntity)
+	require.True(t, ok)
+	require.Equal(t, []string{"customer1:Movies/title"}, rec.keys,
+		"submit lock must be keyed on the qualified class so callers using the short vs qualified name share it")
+}

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -857,3 +857,45 @@ func TestNamespaces_GRPC_RemoteShardAggregate(t *testing.T) {
 	require.NotNil(t, aggResp.GetSingleResult())
 	assert.Equal(t, int64(objCount), aggResp.GetSingleResult().GetObjectsCount())
 }
+
+// TestNamespaces_GRPC_BatchAutoSchema guards the gRPC batch + auto-schema path
+// for a namespaced principal: the class does not exist yet, so the handler must
+// qualify the object's collection so the auto-created collection and the write
+// agree on the qualified name.
+func TestNamespaces_GRPC_BatchAutoSchema(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+
+	grpcClient, conn := newGrpcClient(t)
+	defer conn.Close()
+
+	const class = "GrpcAutoSchema"
+	t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+
+	id := strfmt.UUID("99999999-aaaa-bbbb-cccc-999999999999")
+	resp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
+		Objects: []*pb.BatchObject{{
+			Uuid:       id.String(),
+			Collection: class,
+			Properties: &pb.BatchObject_Properties{
+				NonRefProperties: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"title": structpb.NewStringValue("Inception"),
+					},
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Empty(t, resp.Errors)
+
+	// Read-back by short name proves the object landed under the qualified collection.
+	got, err := helper.GetObjectAuth(t, class, id, user1Key)
+	require.NoError(t, err)
+	assert.Equal(t, class, got.Class)
+	assert.Equal(t, "Inception", got.Properties.(map[string]any)["title"])
+
+	// Admin's raw view confirms auto-schema created a single-qualified class.
+	gotClass := helper.GetClassAuth(t, "customer1:"+class, adminKey)
+	assert.Equal(t, "customer1:"+class, gotClass.Class)
+}

--- a/test/acceptance/namespace/indexes_test.go
+++ b/test/acceptance/namespace/indexes_test.go
@@ -1,0 +1,177 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestNamespaces_IndexesGet: a namespaced caller hitting GET /v1/schema/{class}/indexes
+// by short name reaches the resolved collection (200, not 404); a global admin uses the
+// qualified name.
+func TestNamespaces_IndexesGet(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+	const class = "IdxStatus"
+	setupClassInNs1(t, class, user1Key)
+
+	t.Run("namespaced caller gets index status by short class name", func(t *testing.T) {
+		params := schema.NewSchemaObjectsIndexesGetParams().WithClassName(class)
+		resp, err := helper.Client(t).Schema.SchemaObjectsIndexesGet(params, helper.CreateAuth(user1Key))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+
+		assert.Equal(t, class, resp.Payload.Collection,
+			"namespaced caller must see the short collection name, not the qualified one")
+
+		var titleSeen bool
+		for _, p := range resp.Payload.Properties {
+			if p.Name == "title" {
+				titleSeen = true
+			}
+			assert.NotContains(t, p.DataType, "customer1:",
+				"property DataType must not leak the caller's namespace prefix")
+		}
+		assert.True(t, titleSeen, "expected the 'title' property in the index status")
+	})
+
+	t.Run("global admin gets index status by qualified class name", func(t *testing.T) {
+		params := schema.NewSchemaObjectsIndexesGetParams().WithClassName("customer1:" + class)
+		resp, err := helper.Client(t).Schema.SchemaObjectsIndexesGet(params, helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+		// A global admin addressed the collection by its qualified name and sees it as-is.
+		assert.Equal(t, "customer1:"+class, resp.Payload.Collection)
+	})
+
+	t.Run("cross-reference DataType is stripped for namespaced caller, qualified for admin", func(t *testing.T) {
+		const target = "IdxRefTarget"
+		const host = "IdxWithRef"
+		helper.CreateClassAuth(t, &models.Class{Class: target}, user1Key)
+		helper.CreateClassAuth(t, &models.Class{
+			Class: host,
+			Properties: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+				{Name: "directedBy", DataType: []string{target}}, // qualified to customer1:IdxRefTarget on disk
+			},
+		}, user1Key)
+		t.Cleanup(func() {
+			helper.DeleteClassAuth(t, "customer1:"+host, adminKey)
+			helper.DeleteClassAuth(t, "customer1:"+target, adminKey)
+		})
+
+		nsResp, err := helper.Client(t).Schema.SchemaObjectsIndexesGet(
+			schema.NewSchemaObjectsIndexesGetParams().WithClassName(host), helper.CreateAuth(user1Key))
+		require.NoError(t, err)
+		require.NotNil(t, nsResp.Payload)
+		assert.Equal(t, host, nsResp.Payload.Collection)
+		assert.Equal(t, target, findIndexProp(t, nsResp.Payload, "directedBy").DataType,
+			"namespaced caller must see the short cross-ref target class name")
+
+		adminResp, err := helper.Client(t).Schema.SchemaObjectsIndexesGet(
+			schema.NewSchemaObjectsIndexesGetParams().WithClassName("customer1:"+host), helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		require.NotNil(t, adminResp.Payload)
+		assert.Equal(t, "customer1:"+target, findIndexProp(t, adminResp.Payload, "directedBy").DataType,
+			"global admin must see the qualified cross-ref target class name")
+	})
+}
+
+// findIndexProp returns the per-property index status with the given name, or
+// fails the test if absent.
+func findIndexProp(t *testing.T, resp *models.IndexStatusResponse, name string) *models.PropertyIndexStatus {
+	t.Helper()
+	for _, p := range resp.Properties {
+		if p != nil && p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("property %q not found in index status response", name)
+	return nil
+}
+
+// TestNamespaces_IndexesUpdate covers PUT /v1/schema/{class}/indexes/{prop} for
+// both principals: an invalid body must resolve then fail validation (400, not
+// 404); a valid body submits a real reindex (202). Each subtest uses its own
+// class so in-flight reindexes don't conflict.
+func TestNamespaces_IndexesUpdate(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+
+	put := func(className, key string, body *models.IndexUpdateRequest) (*schema.SchemaObjectsIndexesUpdateAccepted, error) {
+		return helper.Client(t).Schema.SchemaObjectsIndexesUpdate(
+			schema.NewSchemaObjectsIndexesUpdateParams().
+				WithClassName(className).
+				WithPropertyName("title").
+				WithBody(body),
+			helper.CreateAuth(key),
+		)
+	}
+	// "title" defaults to "word"; "lowercase" is a valid different target (202).
+	// "not-a-tokenization" is rejected only after the class+property resolve (400).
+	validBody := func() *models.IndexUpdateRequest {
+		return &models.IndexUpdateRequest{Filterable: &models.IndexUpdateFilterable{Tokenization: "lowercase"}}
+	}
+	invalidBody := func() *models.IndexUpdateRequest {
+		return &models.IndexUpdateRequest{Filterable: &models.IndexUpdateFilterable{Tokenization: "not-a-tokenization"}}
+	}
+	requireResolvedNot404 := func(t *testing.T, err error) {
+		require.Error(t, err)
+		var notFound *schema.SchemaObjectsIndexesUpdateNotFound
+		require.False(t, stderrors.As(err, &notFound), "class must resolve, not 404: %v", err)
+		var badReq *schema.SchemaObjectsIndexesUpdateBadRequest
+		require.True(t, stderrors.As(err, &badReq), "expected 400 after resolution, got %T: %v", err, err)
+	}
+
+	t.Run("namespaced caller: invalid body resolves to 400, not 404", func(t *testing.T) {
+		const class = "IdxPutNsResolve"
+		setupClassInNs1(t, class, user1Key)
+		_, err := put(class, user1Key, invalidBody()) // short name
+		requireResolvedNot404(t, err)
+	})
+
+	t.Run("namespaced caller: valid reindex accepted (202)", func(t *testing.T) {
+		const class = "IdxPutNsReindex"
+		setupClassInNs1(t, class, user1Key)
+		resp, err := put(class, user1Key, validBody()) // short name
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// The task ID embeds the collection name; it must not leak the prefix.
+		require.NotEmpty(t, resp.Payload.TaskID)
+		assert.False(t, strings.HasPrefix(resp.Payload.TaskID, "customer1:"),
+			"task ID must not leak the caller's namespace prefix: %q", resp.Payload.TaskID)
+	})
+
+	t.Run("global admin: invalid body resolves to 400, not 404", func(t *testing.T) {
+		const class = "IdxPutAdminResolve"
+		setupClassInNs1(t, class, user1Key)
+		_, err := put("customer1:"+class, adminKey, invalidBody()) // qualified name
+		requireResolvedNot404(t, err)
+	})
+
+	t.Run("global admin: valid reindex accepted (202)", func(t *testing.T) {
+		const class = "IdxPutAdminReindex"
+		setupClassInNs1(t, class, user1Key)
+		resp, err := put("customer1:"+class, adminKey, validBody()) // qualified name
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// A global admin has no own namespace to strip, so the qualified task ID stands.
+		assert.True(t, strings.HasPrefix(resp.Payload.TaskID, "customer1:"),
+			"global admin should see the qualified task ID: %q", resp.Payload.TaskID)
+	})
+}

--- a/test/acceptance/namespace/response_stripping_errors_test.go
+++ b/test/acceptance/namespace/response_stripping_errors_test.go
@@ -69,6 +69,42 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 		assert.Contains(t, unproc.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", unproc.Payload.Error[0].Message)
 	})
 
+	t.Run("indexes update on missing property surfaces stripped message", func(t *testing.T) {
+		// PUT on an existing class but a non-existent property returns 404 with a
+		// message naming the qualified collection internally; the strip removes "customer1:".
+		body := &models.IndexUpdateRequest{Filterable: &models.IndexUpdateFilterable{Tokenization: "lowercase"}}
+		_, err := helper.Client(t).Schema.SchemaObjectsIndexesUpdate(
+			schema.NewSchemaObjectsIndexesUpdateParams().
+				WithClassName(class). // short name; class exists, property does not
+				WithPropertyName("ghostprop").
+				WithBody(body),
+			helper.CreateAuth(user1Key),
+		)
+		require.Error(t, err)
+		var notFound *schema.SchemaObjectsIndexesUpdateNotFound
+		require.True(t, stderrors.As(err, &notFound), "expected 404, got %T: %v", err, err)
+		require.NotEmpty(t, notFound.Payload.Error)
+		msg := notFound.Payload.Error[0].Message
+		assert.Contains(t, msg, "ghostprop", "sanity: error names the missing property: %s", msg)
+		assert.NotContains(t, msg, "customer1:", "namespaced caller must not see own-prefix in indexes error: %s", msg)
+	})
+
+	t.Run("indexes update error: global admin sees raw qualified name (control)", func(t *testing.T) {
+		body := &models.IndexUpdateRequest{Filterable: &models.IndexUpdateFilterable{Tokenization: "lowercase"}}
+		_, err := helper.Client(t).Schema.SchemaObjectsIndexesUpdate(
+			schema.NewSchemaObjectsIndexesUpdateParams().
+				WithClassName("customer1:"+class). // qualified name
+				WithPropertyName("ghostprop").
+				WithBody(body),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var notFound *schema.SchemaObjectsIndexesUpdateNotFound
+		require.True(t, stderrors.As(err, &notFound), "expected 404, got %T: %v", err, err)
+		require.NotEmpty(t, notFound.Payload.Error)
+		assert.Contains(t, notFound.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", notFound.Payload.Error[0].Message)
+	})
+
 	t.Run("batch per-item error: object with type-mismatched property is stripped", func(t *testing.T) {
 		// Number value for a text property — auto-schema can't reconcile
 		// a type conflict on an existing prop, so the validator emits a

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -564,9 +564,11 @@ func prettyPermissionsResources(principal *models.Principal, perm *models.Permis
 	if perm.Tenants != nil {
 		s := fmt.Sprintf("Domain: %s,", authorization.TenantsDomain)
 
-		if perm.Tenants.Tenant != nil && *perm.Tenants.Tenant != "" {
+		if perm.Tenants.Collection != nil && *perm.Tenants.Collection != "" {
 			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Tenants.Collection))
-			s += fmt.Sprintf(" Tenant: %s", *perm.Tenants.Tenant)
+		}
+		if perm.Tenants.Tenant != nil && *perm.Tenants.Tenant != "" {
+			s += fmt.Sprintf(" Tenant: %s,", *perm.Tenants.Tenant)
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -374,6 +374,25 @@ func TestPrettyPermissionsResources_NamespaceStripping(t *testing.T) {
 			wantNS:     "[Domain: roles, Role: admin]",
 			wantGlobal: "[Domain: roles, Role: admin]",
 		},
+		{
+			domain: "Tenants",
+			perm: &models.Permission{Tenants: &models.PermissionTenants{
+				Collection: strPtr("customer1:Movies"),
+				Tenant:     strPtr("t1"),
+			}},
+			wantNS:     "[Domain: tenants, Collection: Movies, Tenant: t1]",
+			wantGlobal: "[Domain: tenants, Collection: customer1:Movies, Tenant: t1]",
+		},
+		{
+			// Collection nil while Tenant is set must not panic: the
+			// block dereferenced *Collection while guarding only Tenant.
+			domain: "Tenants_nil_collection",
+			perm: &models.Permission{Tenants: &models.PermissionTenants{
+				Tenant: strPtr("t1"),
+			}},
+			wantNS:     "[Domain: tenants, Tenant: t1]",
+			wantGlobal: "[Domain: tenants, Tenant: t1]",
+		},
 	}
 
 	for _, r := range rows {

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -113,7 +113,7 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 				job := c.createJob(jobLogger, clusterService, coordinator, runMu)
 				entryId, err := cr.AddJob(schedule, job, gocron.WithName(namespaceCleanupJobName))
 				if err != nil {
-					jobLogger.WithError(err).Error("cron job not added")
+					jobLogger.Errorf("cron job not added: %v", err)
 					continue
 				}
 				jobLogger.WithFields(logrus.Fields{
@@ -154,7 +154,7 @@ func (c *cronsNamespaceCleanup) createJob(jobLogger logrus.FieldLogger,
 			return
 		}
 		if err := coordinator.Tick(c.serverShutdownCtx); err != nil {
-			jobLogger.WithError(err).Error("namespace cleanup tick failed")
+			jobLogger.Errorf("namespace cleanup tick failed: %v", err)
 		}
 	}))
 }


### PR DESCRIPTION
### What's being changed:

This fixes four different issues, one commit per item:
- Use `Errorf` instead of `WithError` in new log messages for better comatibility with dash0
- Fix a potential (but currently unreachable) nil-deref in permission print
- Fixes auto-schema over grpc-search
- Adds namespacing support for new reindexing-endpoints

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
