### PR TITLE
fix(db): make async-delete drop idempotent for a missing source

### DIFF
--- a/adapters/repos/db/async_delete.go
+++ b/adapters/repos/db/async_delete.go
@@ -48,6 +48,13 @@ func renameForAsyncDelete(path string, logger logrus.FieldLogger) (string, error
 			asyncDeleteSuffix))
 
 	if err := os.Rename(path, target); err != nil {
+		// Source already gone: nothing to delete. The prior drop impl was
+		// os.RemoveAll, which treats a missing path as success; idempotent
+		// callers (e.g. Migrator.UpdateIndex re-running a tenant drop) rely
+		// on that. Preserve the no-op contract rather than erroring.
+		if os.IsNotExist(err) {
+			return "", nil
+		}
 		return "", fmt.Errorf("rename %q to %q: %w", path, target, err)
 	}
 

--- a/adapters/repos/db/async_delete_test.go
+++ b/adapters/repos/db/async_delete_test.go
@@ -70,6 +70,15 @@ func TestRenameForAsyncDelete_RenameInvariants(t *testing.T) {
 	require.True(t, strings.HasSuffix(deleted, asyncDeleteSuffix))
 }
 
+func TestRenameForAsyncDelete_MissingSourceIsNoOp(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	missing := filepath.Join(t.TempDir(), "never_existed")
+
+	deleted, err := renameForAsyncDelete(missing, logger)
+	require.NoError(t, err, "dropping an already-gone path must be a no-op, not an error")
+	require.Empty(t, deleted, "no target to delete when there was nothing to rename")
+}
+
 func TestSpawnAsyncDelete_BoundedConcurrency(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	root := t.TempDir()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2783,7 +2783,9 @@ func (i *Index) drop() error {
 	if err != nil {
 		return fmt.Errorf("rename index for async delete: %w", err)
 	}
-	spawnAsyncDelete(deleted, i.logger)
+	if deleted != "" {
+		spawnAsyncDelete(deleted, i.logger)
+	}
 	return nil
 }
 

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -133,7 +133,9 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 		if err != nil {
 			return fmt.Errorf("rename shard for async delete: %w", err)
 		}
-		spawnAsyncDelete(deleted, s.index.logger)
+		if deleted != "" {
+			spawnAsyncDelete(deleted, s.index.logger)
+		}
 	}
 
 	s.metrics.baseMetrics.FinishUnloadingShard()

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -408,7 +408,9 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 			if err != nil {
 				return fmt.Errorf("rename shard for async delete: %w", err)
 			}
-			spawnAsyncDelete(deleted, idx.logger)
+			if deleted != "" {
+				spawnAsyncDelete(deleted, idx.logger)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
SuperClaude here.

Follow-up to weaviate/weaviate#11462 (merged), fixing a regression that surfaced in CI right after merge.

`renameForAsyncDelete` replaced `os.RemoveAll`, which treats a missing path as success. `os.Rename` returns ENOENT instead, so an idempotent re-drop — e.g. `Migrator.UpdateIndex` re-running a tenant deletion — propagated an error where the old code was a no-op. This broke the `TestMigrator_UpdateIndex` multi-tenant "tenants to delete" integration test (and any real idempotent drop path).

**Fix:** swallow ENOENT in `renameForAsyncDelete` as a no-op (restoring the `os.RemoveAll` contract) and skip the async `RemoveAll` when there is nothing to rename. Added `TestRenameForAsyncDelete_MissingSourceIsNoOp` (unit, ms) so the regression fails fast instead of needing a ~700s integration run.

**Verified** locally on `stable/v1.35`: gofumpt + build clean, unit tests green with `-race`, and `TestMigrator_UpdateIndex` (integrationTest) passes.

— SuperClaude
