### PR TITLE
fix: enable ns xref filtersexp paths

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
+++ b/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
@@ -34,8 +34,9 @@ func ExtractFilters(args map[string]interface{}, rootClass string) (*filters.Loc
 		}
 
 		// GraphQL is disabled on namespace-enabled clusters, so the
-		// namespacesEnabled flag is hard-wired to false here.
-		return filterext.Parse(filter, rootClass, false)
+		// namespacesEnabled flag is hard-wired to false here and the
+		// principal isn't consulted by Parse for path qualification.
+		return filterext.Parse(filter, rootClass, false, nil)
 	}
 }
 

--- a/adapters/handlers/mcp/search/hybrid.go
+++ b/adapters/handlers/mcp/search/hybrid.go
@@ -105,7 +105,7 @@ func (s *WeaviateSearcher) Hybrid(ctx context.Context, req mcp.CallToolRequest, 
 			return nil, fmt.Errorf("failed to unmarshal filters: %w", err)
 		}
 
-		localFilter, err = filterext.Parse(&whereFilter, args.CollectionName, s.namespacesEnabled)
+		localFilter, err = filterext.Parse(&whereFilter, args.CollectionName, s.namespacesEnabled, principal)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse filters: %w", err)
 		}

--- a/adapters/handlers/mcp/search/hybrid_test.go
+++ b/adapters/handlers/mcp/search/hybrid_test.go
@@ -76,7 +76,8 @@ func bearerReq() mcp.CallToolRequest {
 //     traverser params
 //   - invalid namespace prefixes from a namespaced principal are rejected
 //   - filterext.Parse picks up the namespacesEnabled flag (reference-path
-//     filters are rejected on NS-enabled clusters, accepted otherwise)
+//     filters have their inner class qualified on NS-enabled clusters,
+//     pass-through otherwise)
 func TestHybrid_NamespaceResolution(t *testing.T) {
 	aliases := map[string]string{
 		"customer1:Films": "customer1:Movies",
@@ -137,11 +138,11 @@ func TestHybrid_NamespaceResolution(t *testing.T) {
 			wantClassName:     "Global",
 		},
 		{
-			name:              "namespacesEnabled rejects reference-path filter",
+			name:              "namespacesEnabled accepts reference-path filter (inner class qualified)",
 			principal:         &models.Principal{Namespace: "customer1"},
 			namespacesEnabled: true,
 			args:              QueryHybridArgs{CollectionName: "Movies", Query: "x", Filters: refPathFilter},
-			wantErrSubstr:     "reference-path filters",
+			wantClassName:     "customer1:Movies",
 		},
 		{
 			name:              "namespacesEnabled accepts direct-property filter",

--- a/adapters/handlers/mcp/search/hybrid_test.go
+++ b/adapters/handlers/mcp/search/hybrid_test.go
@@ -69,15 +69,10 @@ func bearerReq() mcp.CallToolRequest {
 	return mcp.CallToolRequest{Header: http.Header{"Authorization": []string{"Bearer dummy"}}}
 }
 
-// TestHybrid_NamespaceResolution covers what the MCP search handler must do
-// once namespacing is wired in:
-//
-//   - the resolved class name (qualified, alias-resolved) flows into the
-//     traverser params
-//   - invalid namespace prefixes from a namespaced principal are rejected
-//   - filterext.Parse picks up the namespacesEnabled flag (reference-path
-//     filters have their inner class qualified on NS-enabled clusters,
-//     pass-through otherwise)
+// TestHybrid_NamespaceResolution covers the MCP search handler under
+// namespacing: the resolved (qualified, alias-resolved) class flows into the
+// traverser params, invalid prefixes from a namespaced principal are rejected,
+// and filterext.Parse qualifies reference-path inner classes on NS clusters.
 func TestHybrid_NamespaceResolution(t *testing.T) {
 	aliases := map[string]string{
 		"customer1:Films": "customer1:Movies",

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -16,17 +16,19 @@ import (
 
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // Parse Filter from REST construct to entities filter.
 //
 // When namespacesEnabled is true, reference-path filters (Path with more
-// than one element) are rejected. Inner class segments in such paths are
-// taken from caller input and are not auto-qualified by the resolver, so
-// allowing them through would silently fail downstream when the schema
-// lookup misses the unqualified inner class. Direct-property filters
-// (single-element Path) are unaffected.
-func Parse(in *models.WhereFilter, rootClass string, namespacesEnabled bool) (*filters.LocalFilter, error) {
+// than one element) get their inner class segments qualified against the
+// previous level's namespace via namespacing.QualifyRefTarget. This mirrors
+// the gRPC parser's extractPathNew. Direct-property filters (single-element
+// Path) are unchanged. The principal drives QualifyRefTarget's policy:
+// namespaced callers can't type any prefix, admins must address the
+// source's namespace, foreign-NS prefixes are rejected.
+func Parse(in *models.WhereFilter, rootClass string, namespacesEnabled bool, principal *models.Principal) (*filters.LocalFilter, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -37,14 +39,14 @@ func Parse(in *models.WhereFilter, rootClass string, namespacesEnabled bool) (*f
 	}
 
 	if operator.OnValue() {
-		filter, err := parseValueFilter(in, operator, rootClass, namespacesEnabled)
+		filter, err := parseValueFilter(in, operator, rootClass, namespacesEnabled, principal)
 		if err != nil {
 			return nil, fmt.Errorf("invalid where filter: %w", err)
 		}
 		return filter, nil
 	}
 
-	filter, err := parseNestedFilter(in, operator, rootClass, namespacesEnabled)
+	filter, err := parseNestedFilter(in, operator, rootClass, namespacesEnabled, principal)
 	if err != nil {
 		return nil, fmt.Errorf("invalid where filter: %w", err)
 	}
@@ -52,14 +54,14 @@ func Parse(in *models.WhereFilter, rootClass string, namespacesEnabled bool) (*f
 }
 
 func parseValueFilter(in *models.WhereFilter,
-	operator filters.Operator, rootClass string, namespacesEnabled bool,
+	operator filters.Operator, rootClass string, namespacesEnabled bool, principal *models.Principal,
 ) (*filters.LocalFilter, error) {
 	value, err := parseValue(in)
 	if err != nil {
 		return nil, err
 	}
 
-	path, err := parsePath(in.Path, rootClass, namespacesEnabled)
+	path, err := parsePath(in.Path, rootClass, namespacesEnabled, principal)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +76,7 @@ func parseValueFilter(in *models.WhereFilter,
 }
 
 func parseNestedFilter(in *models.WhereFilter,
-	operator filters.Operator, rootClass string, namespacesEnabled bool,
+	operator filters.Operator, rootClass string, namespacesEnabled bool, principal *models.Principal,
 ) (*filters.LocalFilter, error) {
 	if in.Path != nil {
 		return nil, fmt.Errorf(
@@ -97,7 +99,7 @@ func parseNestedFilter(in *models.WhereFilter,
 			operator.Name())
 	}
 
-	operands, err := parseOperands(in.Operands, rootClass, namespacesEnabled)
+	operands, err := parseOperands(in.Operands, rootClass, namespacesEnabled, principal)
 	if err != nil {
 		return nil, err
 	}
@@ -110,10 +112,10 @@ func parseNestedFilter(in *models.WhereFilter,
 	}, nil
 }
 
-func parseOperands(ops []*models.WhereFilter, rootClass string, namespacesEnabled bool) ([]filters.Clause, error) {
+func parseOperands(ops []*models.WhereFilter, rootClass string, namespacesEnabled bool, principal *models.Principal) ([]filters.Clause, error) {
 	out := make([]filters.Clause, len(ops))
 	for i, operand := range ops {
-		res, err := Parse(operand, rootClass, namespacesEnabled)
+		res, err := Parse(operand, rootClass, namespacesEnabled, principal)
 		if err != nil {
 			return nil, fmt.Errorf("operand %d: %w", i, err)
 		}
@@ -161,13 +163,29 @@ func parseOperator(in string) (filters.Operator, error) {
 	}
 }
 
-func parsePath(in []string, rootClass string, namespacesEnabled bool) (*filters.Path, error) {
+func parsePath(in []string, rootClass string, namespacesEnabled bool, principal *models.Principal) (*filters.Path, error) {
 	if len(in) == 0 {
 		return nil, fmt.Errorf("field 'path': must have at least one element")
 	}
 
+	// On NS-enabled clusters with a reference-path filter, qualify each
+	// inner class segment relative to its parent's namespace, mirroring
+	// the gRPC parser's extractPathNew. Inner class segments live at odd
+	// indices (path[1], path[3], ...); the parent for path[1] is rootClass,
+	// for path[3] it's the already-qualified path[1], and so on.
 	if namespacesEnabled && len(in) > 1 {
-		return nil, fmt.Errorf("field 'path': reference-path filters (path with more than one element) are not supported on namespace-enabled clusters")
+		qualified := make([]string, len(in))
+		copy(qualified, in)
+		parent := rootClass
+		for i := 1; i < len(qualified); i += 2 {
+			q, _, err := namespacing.QualifyRefTarget(principal, namespacesEnabled, parent, qualified[i])
+			if err != nil {
+				return nil, fmt.Errorf("field 'path': %w", err)
+			}
+			qualified[i] = q
+			parent = q
+		}
+		in = qualified
 	}
 
 	pathElements := make([]interface{}, len(in))

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -21,13 +21,11 @@ import (
 
 // Parse Filter from REST construct to entities filter.
 //
-// When namespacesEnabled is true, reference-path filters (Path with more
-// than one element) get their inner class segments qualified against the
-// previous level's namespace via namespacing.QualifyRefTarget. This mirrors
-// the gRPC parser's extractPathNew. Direct-property filters (single-element
-// Path) are unchanged. The principal drives QualifyRefTarget's policy:
-// namespaced callers can't type any prefix, admins must address the
-// source's namespace, foreign-NS prefixes are rejected.
+// On NS clusters, reference-path inner class segments are qualified against
+// the previous level's namespace via QualifyRefTarget (same policy as the
+// rest of the NS code). Unlike gRPC's extractPathNew, which reads the linked
+// class from the schema, REST qualifies the caller-typed name as-is — a
+// wrong-but-same-NS class only fails the schema lookup downstream.
 func Parse(in *models.WhereFilter, rootClass string, namespacesEnabled bool, principal *models.Principal) (*filters.LocalFilter, error) {
 	if in == nil {
 		return nil, nil
@@ -168,11 +166,8 @@ func parsePath(in []string, rootClass string, namespacesEnabled bool, principal 
 		return nil, fmt.Errorf("field 'path': must have at least one element")
 	}
 
-	// On NS-enabled clusters with a reference-path filter, qualify each
-	// inner class segment relative to its parent's namespace, mirroring
-	// the gRPC parser's extractPathNew. Inner class segments live at odd
-	// indices (path[1], path[3], ...); the parent for path[1] is rootClass,
-	// for path[3] it's the already-qualified path[1], and so on.
+	// Qualify each inner class segment (odd indices) against its parent's
+	// namespace: rootClass for path[1], the qualified path[1] for path[3], etc.
 	if namespacesEnabled && len(in) > 1 {
 		qualified := make([]string, len(in))
 		copy(qualified, in)

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -23,8 +23,9 @@ import (
 //
 // On NS clusters, reference-path inner class segments are qualified against
 // the previous level's namespace via QualifyRefTarget (same policy as the
-// rest of the NS code). Unlike gRPC's extractPathNew, which reads the linked
-// class from the schema, REST qualifies the caller-typed name as-is — a
+// rest of the NS code). gRPC's extractPathNew does the same for multi-target
+// refs, but derives single-target linked classes from the schema. REST has no
+// schema lookup here and qualifies the caller-typed name as-is, so a
 // wrong-but-same-NS class only fails the schema lookup downstream.
 func Parse(in *models.WhereFilter, rootClass string, namespacesEnabled bool, principal *models.Principal) (*filters.LocalFilter, error) {
 	if in == nil {

--- a/adapters/handlers/rest/filterext/parse_test.go
+++ b/adapters/handlers/rest/filterext/parse_test.go
@@ -553,13 +553,11 @@ func ptFloat32(in float32) *float32 {
 	return &in
 }
 
-// Test_Parse_NamespacesEnabledQualifiesRefPath asserts the where-filter
-// reference-path qualification on namespace-enabled clusters. Inner class
-// segments are qualified via namespacing.QualifyRefTarget relative to the
-// previous level's namespace, mirroring the gRPC parser's extractPathNew.
-// QualifyRefTarget's policy (namespaced callers can't type a prefix; admins
-// may but only matching the source NS; foreign-NS rejected) is enforced
-// here too. Non-NS clusters keep the original pass-through behavior.
+// Test_Parse_NamespacesEnabledQualifiesRefPath asserts that reference-path
+// inner class segments are qualified via QualifyRefTarget against the previous
+// level's namespace, including its policy (namespaced callers can't type a
+// prefix; admins must match the source NS; foreign-NS rejected). Non-NS
+// clusters pass through unchanged.
 func Test_Parse_NamespacesEnabledQualifiesRefPath(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/handlers/rest/filterext/parse_test.go
+++ b/adapters/handlers/rest/filterext/parse_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -180,7 +181,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo", false)
+				filter, err := Parse(test.input, "Todo", false, nil)
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -286,7 +287,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo", false)
+				filter, err := Parse(test.input, "Todo", false, nil)
 				assert.ErrorAs(t, err, &test.expectedErr)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -335,7 +336,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo", false)
+				filter, err := Parse(test.input, "Todo", false, nil)
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -469,7 +470,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo", false)
+				filter, err := Parse(test.input, "Todo", false, nil)
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -552,12 +553,14 @@ func ptFloat32(in float32) *float32 {
 	return &in
 }
 
-// Test_Parse_NamespacesEnabledRejectsRefPath asserts that on namespace-enabled
-// clusters reference-path filters (path with more than one element) are
-// rejected before parsing. Direct-property filters (single-element path)
-// are unaffected, and global-cluster behavior (namespacesEnabled == false)
-// keeps accepting nested paths so existing operator workloads keep working.
-func Test_Parse_NamespacesEnabledRejectsRefPath(t *testing.T) {
+// Test_Parse_NamespacesEnabledQualifiesRefPath asserts the where-filter
+// reference-path qualification on namespace-enabled clusters. Inner class
+// segments are qualified via namespacing.QualifyRefTarget relative to the
+// previous level's namespace, mirroring the gRPC parser's extractPathNew.
+// QualifyRefTarget's policy (namespaced callers can't type a prefix; admins
+// may but only matching the source NS; foreign-NS rejected) is enforced
+// here too. Non-NS clusters keep the original pass-through behavior.
+func Test_Parse_NamespacesEnabledQualifiesRefPath(t *testing.T) {
 	t.Parallel()
 
 	value := "v"
@@ -571,30 +574,102 @@ func Test_Parse_NamespacesEnabledRejectsRefPath(t *testing.T) {
 		Path:      []string{"inCountry", "Country", "name"},
 		ValueText: &value,
 	}
+	nestedRefPath := &models.WhereFilter{
+		Operator:  models.WhereFilterOperatorEqual,
+		Path:      []string{"inCountry", "Country", "hasCapital", "City", "name"},
+		ValueText: &value,
+	}
 	nestedAndWithRefPath := &models.WhereFilter{
 		Operator: models.WhereFilterOperatorAnd,
 		Operands: []*models.WhereFilter{directProp, refPath},
 	}
 
-	t.Run("namespacesEnabled rejects ref-path", func(t *testing.T) {
-		_, err := Parse(refPath, "City", true)
-		assert.ErrorContains(t, err, "reference-path filters")
+	nsCaller := &models.Principal{Username: "u", Namespace: "customer1"}
+	admin := &models.Principal{Username: "admin"}
+
+	t.Run("namespaced caller short ref-path is qualified via parent NS", func(t *testing.T) {
+		out, err := Parse(refPath, "customer1:City", true, nsCaller)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.NotNil(t, out.Root.On)
+		require.NotNil(t, out.Root.On.Child)
+		assert.Equal(t, "customer1:City", out.Root.On.Class.String())
+		assert.Equal(t, "customer1:Country", out.Root.On.Child.Class.String(),
+			"inner class segment should inherit the source's namespace")
 	})
 
-	t.Run("namespacesEnabled rejects ref-path nested in compound operand", func(t *testing.T) {
-		_, err := Parse(nestedAndWithRefPath, "City", true)
-		assert.ErrorContains(t, err, "reference-path filters")
+	t.Run("multi-hop ref-path qualifies every level", func(t *testing.T) {
+		out, err := Parse(nestedRefPath, "customer1:City", true, nsCaller)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.NotNil(t, out.Root.On)
+		require.NotNil(t, out.Root.On.Child)
+		require.NotNil(t, out.Root.On.Child.Child)
+		assert.Equal(t, "customer1:Country", out.Root.On.Child.Class.String())
+		assert.Equal(t, "customer1:City", out.Root.On.Child.Child.Class.String(),
+			"every linked class along the chain must inherit the source's namespace")
+	})
+
+	t.Run("admin own-namespace prefix on inner class does not double-qualify", func(t *testing.T) {
+		ownNS := &models.WhereFilter{
+			Operator:  models.WhereFilterOperatorEqual,
+			Path:      []string{"inCountry", "customer1:Country", "name"},
+			ValueText: &value,
+		}
+		out, err := Parse(ownNS, "customer1:City", true, admin)
+		require.NoError(t, err)
+		require.NotNil(t, out.Root.On.Child)
+		assert.Equal(t, "customer1:Country", out.Root.On.Child.Class.String(),
+			"admin's own-NS prefix must be normalized, not stacked")
+	})
+
+	t.Run("namespaced caller cannot type any prefix on inner class", func(t *testing.T) {
+		withPrefix := &models.WhereFilter{
+			Operator:  models.WhereFilterOperatorEqual,
+			Path:      []string{"inCountry", "customer1:Country", "name"},
+			ValueText: &value,
+		}
+		_, err := Parse(withPrefix, "customer1:City", true, nsCaller)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a valid class name")
+	})
+
+	t.Run("foreign-namespace prefix on inner class is rejected", func(t *testing.T) {
+		foreign := &models.WhereFilter{
+			Operator:  models.WhereFilterOperatorEqual,
+			Path:      []string{"inCountry", "customer2:Country", "name"},
+			ValueText: &value,
+		}
+		_, err := Parse(foreign, "customer1:City", true, admin)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a valid class name")
+	})
+
+	t.Run("compound AND threads qualification into nested operands", func(t *testing.T) {
+		out, err := Parse(nestedAndWithRefPath, "customer1:City", true, nsCaller)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		// The compound has two operands: a direct-prop and a ref-path.
+		require.Len(t, out.Root.Operands, 2)
+		var refOperand *filters.Clause
+		for i := range out.Root.Operands {
+			if out.Root.Operands[i].On != nil && out.Root.Operands[i].On.Child != nil {
+				refOperand = &out.Root.Operands[i]
+			}
+		}
+		require.NotNil(t, refOperand, "expected a ref-path operand in the AND")
+		assert.Equal(t, "customer1:Country", refOperand.On.Child.Class.String())
 	})
 
 	t.Run("namespacesEnabled accepts direct property filter", func(t *testing.T) {
-		out, err := Parse(directProp, "City", true)
-		assert.NoError(t, err)
+		out, err := Parse(directProp, "customer1:City", true, nsCaller)
+		require.NoError(t, err)
 		assert.NotNil(t, out)
 	})
 
-	t.Run("namespacesEnabled=false still accepts ref-path", func(t *testing.T) {
-		out, err := Parse(refPath, "City", false)
-		assert.NoError(t, err)
+	t.Run("namespacesEnabled=false still accepts ref-path (pass-through)", func(t *testing.T) {
+		out, err := Parse(refPath, "City", false, nil)
+		require.NoError(t, err)
 		assert.NotNil(t, out)
 	})
 }

--- a/test/acceptance/namespace/mcp_test.go
+++ b/test/acceptance/namespace/mcp_test.go
@@ -234,11 +234,12 @@ func TestNamespaces_MCP(t *testing.T) {
 
 	// filterext.Parse qualifies reference-path inner class segments against
 	// the source's namespace on NS-enabled clusters (mirroring the gRPC
-	// parser). A foreign-namespace prefix on an inner class is rejected by
-	// QualifyRefTarget BEFORE the schema lookup, so the call fails with the
-	// "is not a valid class name" wording regardless of whether the source
-	// class actually has the named ref property.
-	t.Run("hybrid reference-path filter with foreign-NS inner class is rejected", func(t *testing.T) {
+	// parser). user1Key is a namespaced caller, so QualifyRefTarget rejects
+	// ANY prefix it types on an inner class (the resolver adds the prefix
+	// automatically) — here a foreign one. The rejection happens BEFORE the
+	// schema lookup, so the call fails with the "is not a valid class name"
+	// wording regardless of whether the source class has the named ref property.
+	t.Run("hybrid reference-path filter with prefixed inner class is rejected", func(t *testing.T) {
 		var hybridResp *search.QueryHybridResp
 		err := helper.CallToolOnce(t.Context(), t, mcpToolHybrid, &search.QueryHybridArgs{
 			CollectionName: short,

--- a/test/acceptance/namespace/mcp_test.go
+++ b/test/acceptance/namespace/mcp_test.go
@@ -232,22 +232,25 @@ func TestNamespaces_MCP(t *testing.T) {
 		require.NotEmpty(t, hybridResp.Results)
 	})
 
-	// filterext.Parse rejects reference-path filters (path length > 1) on
-	// namespace-enabled clusters. Confirms the hardcoded `false` removed in
-	// hybrid.go is now wired to s.namespacesEnabled.
-	t.Run("hybrid reference-path filter is rejected on namespace-enabled cluster", func(t *testing.T) {
+	// filterext.Parse qualifies reference-path inner class segments against
+	// the source's namespace on NS-enabled clusters (mirroring the gRPC
+	// parser). A foreign-namespace prefix on an inner class is rejected by
+	// QualifyRefTarget BEFORE the schema lookup, so the call fails with the
+	// "is not a valid class name" wording regardless of whether the source
+	// class actually has the named ref property.
+	t.Run("hybrid reference-path filter with foreign-NS inner class is rejected", func(t *testing.T) {
 		var hybridResp *search.QueryHybridResp
 		err := helper.CallToolOnce(t.Context(), t, mcpToolHybrid, &search.QueryHybridArgs{
 			CollectionName: short,
 			Query:          "Inception",
 			Alpha:          &alpha0,
 			Filters: map[string]any{
-				"path":      []any{"hasAuthor", "Author", "name"},
+				"path":      []any{"hasAuthor", "customer2:Author", "name"},
 				"operator":  "Equal",
 				"valueText": "Anyone",
 			},
 		}, &hybridResp, user1Key)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "reference-path filters")
+		assert.Contains(t, err.Error(), "is not a valid class name")
 	})
 }

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -515,11 +515,13 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 		assert.Equal(t, "keep", got.Properties.(map[string]any)["title"])
 	})
 
-	t.Run("batch delete by reference-path filter is rejected", func(t *testing.T) {
-		// Inner class segments in reference-path filters are caller-supplied
-		// and not auto-qualified. The REST handler rejects path-len > 1
-		// upfront on namespace-enabled clusters; this guards against silent
-		// "class not found" failures downstream.
+	t.Run("batch delete by reference-path filter is validated against the schema", func(t *testing.T) {
+		// Reference-path filters are no longer rejected upfront on NS-enabled
+		// clusters: filterext.Parse qualifies each inner class segment against
+		// the source's namespace and then the filter is validated like any
+		// other. This fixture has no "hasOther" ref property, so the request is
+		// rejected by the downstream schema lookup ("no such prop") rather than
+		// the removed path-len > 1 guard.
 		const class = "BatchDeleteRefPath"
 		setupClassInNs1(t, class, user1Key)
 

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -519,9 +519,11 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 		// Reference-path filters are no longer rejected upfront on NS-enabled
 		// clusters: filterext.Parse qualifies each inner class segment against
 		// the source's namespace and then the filter is validated like any
-		// other. This fixture has no "hasOther" ref property, so the request is
-		// rejected by the downstream schema lookup ("no such prop") rather than
-		// the removed path-len > 1 guard.
+		// other. This fixture has no "Other" class, so QualifyRefTarget turns
+		// "Other" into "customer1:Other" and the downstream schema lookup then
+		// rejects it with "could not find class ..." — proving the qualification
+		// path runs and the removed path-len > 1 upfront guard is gone (any
+		// "customer1:" in the message is stripped before reaching this caller).
 		const class = "BatchDeleteRefPath"
 		setupClassInNs1(t, class, user1Key)
 
@@ -548,8 +550,10 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 		require.True(t, errors.As(err, &unproc), "expected 422 UnprocessableEntity, got %T: %v", err, err)
 		require.NotEmpty(t, unproc.Payload.Error)
 		msg := unproc.Payload.Error[0].Message
-		assert.Contains(t, msg, "hasOther",
-			"must fail on the unknown ref property, not the removed upfront rejection")
+		assert.Contains(t, msg, "could not find class",
+			"must fail in the downstream schema lookup, not the removed upfront rejection")
+		assert.Contains(t, msg, "Other",
+			"the leaf class name (qualified to customer1:Other and stripped to Other) must appear in the message")
 		assert.NotContains(t, msg, "reference-path filters",
 			"the upfront path-len > 1 rejection no longer exists")
 	})

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -541,9 +541,16 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 			helper.CreateAuth(user1Key),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "hasOther",
+		// A malformed where filter is caller input, so the handler returns a 422
+		// (not a 500). The swagger client hides the message behind a pointer in
+		// err.Error(), so read it from the typed payload.
+		var unproc *batch.BatchObjectsDeleteUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected 422 UnprocessableEntity, got %T: %v", err, err)
+		require.NotEmpty(t, unproc.Payload.Error)
+		msg := unproc.Payload.Error[0].Message
+		assert.Contains(t, msg, "hasOther",
 			"must fail on the unknown ref property, not the removed upfront rejection")
-		assert.NotContains(t, err.Error(), "reference-path filters",
+		assert.NotContains(t, msg, "reference-path filters",
 			"the upfront path-len > 1 rejection no longer exists")
 	})
 }

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -541,5 +541,9 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 			helper.CreateAuth(user1Key),
 		)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hasOther",
+			"must fail on the unknown ref property, not the removed upfront rejection")
+		assert.NotContains(t, err.Error(), "reference-path filters",
+			"the upfront path-len > 1 rejection no longer exists")
 	})
 }

--- a/test/acceptance/namespace/references_test.go
+++ b/test/acceptance/namespace/references_test.go
@@ -569,9 +569,10 @@ func TestNamespaces_References(t *testing.T) {
 		assert.NotContains(t, matchedIDs, zooLionID, "the lion zoo must not match")
 	})
 
-	t.Run("REST ref-path where filter rejects foreign-namespace inner class", func(t *testing.T) {
-		// QualifyRefTarget runs before any schema lookup, so a foreign-NS
-		// prefix on the inner class is rejected regardless of the schema.
+	t.Run("REST ref-path where filter rejects prefixed inner class", func(t *testing.T) {
+		// user1Key is a namespaced caller, so QualifyRefTarget rejects ANY
+		// prefix it types on the inner class (here a foreign one). The check
+		// runs before any schema lookup, so it fails regardless of the schema.
 		dryRun := true
 		anyName := "x"
 		_, err := helper.Client(t).Batch.BatchObjectsDelete(

--- a/test/acceptance/namespace/references_test.go
+++ b/test/acceptance/namespace/references_test.go
@@ -590,7 +590,13 @@ func TestNamespaces_References(t *testing.T) {
 			helper.CreateAuth(user1Key),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "is not a valid class name")
+		// A bad inner class name is caller input, so the handler returns a 422
+		// (not a 500). The swagger client hides the message behind a pointer in
+		// err.Error(), so read it from the typed payload.
+		var unproc *batch.BatchObjectsDeleteUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected 422 UnprocessableEntity, got %T: %v", err, err)
+		require.NotEmpty(t, unproc.Payload.Error)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "is not a valid class name")
 	})
 
 	t.Run("create object with ref property in Properties payload (NS happy path)", func(t *testing.T) {

--- a/test/acceptance/namespace/references_test.go
+++ b/test/acceptance/namespace/references_test.go
@@ -518,6 +518,80 @@ func TestNamespaces_References(t *testing.T) {
 		assert.False(t, sawLion, "by-ref filter must not return zoos whose ref points to a different animal")
 	})
 
+	t.Run("REST ref-path where filter resolves target via source namespace", func(t *testing.T) {
+		// REST ingress (batch-delete → filterext.Parse), independent of the
+		// gRPC path above. The short inner class "Animal" must qualify to
+		// "customer1:Animal" or the ref sub-search matches nothing. dryRun
+		// keeps the shared Zoo class intact.
+		tigerID, lionID := newID(), newID()
+		zooTigerID, zooLionID := newID(), newID()
+		createIn(t, user1Key, "Animal", tigerID, map[string]any{"name": "bd-tiger"})
+		createIn(t, user1Key, "Animal", lionID, map[string]any{"name": "bd-lion"})
+		createIn(t, user1Key, "Zoo", zooTigerID, map[string]any{"name": "zoo-bd-tiger"})
+		createIn(t, user1Key, "Zoo", zooLionID, map[string]any{"name": "zoo-bd-lion"})
+		_, err := helper.AddReferenceReturn(t,
+			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/Animal/" + string(tigerID))},
+			zooTigerID, "Zoo", "hasAnimals", "", helper.CreateAuth(user1Key))
+		require.NoError(t, err)
+		_, err = helper.AddReferenceReturn(t,
+			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/Animal/" + string(lionID))},
+			zooLionID, "Zoo", "hasAnimals", "", helper.CreateAuth(user1Key))
+		require.NoError(t, err)
+
+		dryRun := true
+		verbose := "verbose"
+		wantName := "bd-tiger"
+		resp, err := helper.Client(t).Batch.BatchObjectsDelete(
+			batch.NewBatchObjectsDeleteParams().WithBody(&models.BatchDelete{
+				DryRun: &dryRun,
+				Output: &verbose,
+				Match: &models.BatchDeleteMatch{
+					Class: "Zoo",
+					Where: &models.WhereFilter{
+						Operator:  models.WhereFilterOperatorEqual,
+						Path:      []string{"hasAnimals", "Animal", "name"},
+						ValueText: &wantName,
+					},
+				},
+			}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err, "ref-path where filter must qualify the inner class and resolve on NS clusters")
+		require.NotNil(t, resp.Payload.Results)
+		assert.Equal(t, int64(1), resp.Payload.Results.Matches,
+			"only the zoo whose hasAnimals.name=='bd-tiger' should match")
+
+		var matchedIDs []strfmt.UUID
+		for _, o := range resp.Payload.Results.Objects {
+			matchedIDs = append(matchedIDs, o.ID)
+		}
+		assert.Contains(t, matchedIDs, zooTigerID, "the tiger zoo must match the ref-path filter")
+		assert.NotContains(t, matchedIDs, zooLionID, "the lion zoo must not match")
+	})
+
+	t.Run("REST ref-path where filter rejects foreign-namespace inner class", func(t *testing.T) {
+		// QualifyRefTarget runs before any schema lookup, so a foreign-NS
+		// prefix on the inner class is rejected regardless of the schema.
+		dryRun := true
+		anyName := "x"
+		_, err := helper.Client(t).Batch.BatchObjectsDelete(
+			batch.NewBatchObjectsDeleteParams().WithBody(&models.BatchDelete{
+				DryRun: &dryRun,
+				Match: &models.BatchDeleteMatch{
+					Class: "Zoo",
+					Where: &models.WhereFilter{
+						Operator:  models.WhereFilterOperatorEqual,
+						Path:      []string{"hasAnimals", "customer2:Animal", "name"},
+						ValueText: &anyName,
+					},
+				},
+			}),
+			helper.CreateAuth(user1Key),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a valid class name")
+	})
+
 	t.Run("create object with ref property in Properties payload (NS happy path)", func(t *testing.T) {
 		// Reproduction guard: object create that *embeds* the ref in the
 		// Properties payload (instead of using the dedicated /references

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -194,20 +194,20 @@ func (c *Classifier) extractFilters(ctx context.Context, principal *models.Princ
 	}
 
 	// Classification is not exercised on namespace-enabled clusters, so the
-	// nested-path guard in filterext.Parse is hard-wired off here.
+	// nested-path qualification in filterext.Parse is hard-wired off here.
 	const namespacesEnabled = false
 
-	source, err := filterext.Parse(params.Filters.SourceWhere, params.Class, namespacesEnabled)
+	source, err := filterext.Parse(params.Filters.SourceWhere, params.Class, namespacesEnabled, principal)
 	if err != nil {
 		return classificationFilters{}, fmt.Errorf("field 'sourceWhere': %w", err)
 	}
 
-	trainingSet, err := filterext.Parse(params.Filters.TrainingSetWhere, params.Class, namespacesEnabled)
+	trainingSet, err := filterext.Parse(params.Filters.TrainingSetWhere, params.Class, namespacesEnabled, principal)
 	if err != nil {
 		return classificationFilters{}, fmt.Errorf("field 'trainingSetWhere': %w", err)
 	}
 
-	target, err := filterext.Parse(params.Filters.TargetWhere, params.Class, namespacesEnabled)
+	target, err := filterext.Parse(params.Filters.TargetWhere, params.Class, namespacesEnabled, principal)
 	if err != nil {
 		return classificationFilters{}, fmt.Errorf("field 'targetWhere': %w", err)
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -145,7 +145,7 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 	}
 	class := vclasses[match.Class].Class
 
-	filter, err := filterext.Parse(match.Where, class.Class, b.config.Config.Namespaces.Enabled)
+	filter, err := filterext.Parse(match.Where, class.Class, b.config.Config.Namespaces.Enabled, principal)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to parse where filter: %w", err)
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -145,14 +145,18 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 	}
 	class := vclasses[match.Class].Class
 
+	// A malformed where filter (bad path, unknown property, foreign-namespace
+	// class name, etc.) is caller input, so classify it as ErrInvalidUserInput
+	// — otherwise the REST handler maps the parse/validation failure to a 500
+	// instead of a 422. The message wording is preserved for callers/tests.
 	filter, err := filterext.Parse(match.Where, class.Class, b.config.Config.Namespaces.Enabled, principal)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to parse where filter: %w", err)
+		return nil, 0, NewErrInvalidUserInput("failed to parse where filter: %v", err)
 	}
 
 	err = filters.ValidateFilters(b.classGetterFunc(ctx, principal), filter)
 	if err != nil {
-		return nil, 0, fmt.Errorf("invalid where filter: %w", err)
+		return nil, 0, NewErrInvalidUserInput("invalid where filter: %v", err)
 	}
 
 	dryRunParam := false

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
 
 // DeleteObjects deletes objects in batch based on the match filter
@@ -156,6 +157,12 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 
 	err = filters.ValidateFilters(b.classGetterFunc(ctx, principal), filter)
 	if err != nil {
+		// The schema lookup inside validation authorizes class reads, so a
+		// Forbidden must stay a Forbidden (→ 403); everything else is a plain
+		// validation failure and is caller input (→ 422, not 500).
+		if errors.As(err, &authzerrs.Forbidden{}) {
+			return nil, 0, fmt.Errorf("invalid where filter: %w", err)
+		}
 		return nil, 0, NewErrInvalidUserInput("invalid where filter: %v", err)
 	}
 

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -13,6 +13,7 @@ package objects
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -287,6 +288,67 @@ func Test_BatchDelete_NamespaceResolution(t *testing.T) {
 		require.NotContains(t, authorizer.Calls()[0].Resources[0], ":Foo")
 
 		vectorRepo.AssertExpectations(t)
+	})
+}
+
+// Test_BatchDelete_ValidationErrorsAreUserInput pins that a malformed where
+// filter is classified as ErrInvalidUserInput so the REST handler returns a
+// 422 — not a bare error, which the handler maps to a 500. Covers both filter
+// stages: parse (foreign-namespace inner class) and schema validation (unknown
+// property).
+func Test_BatchDelete_ValidationErrorsAreUserInput(t *testing.T) {
+	nameProp := &models.Property{
+		Name:         "name",
+		DataType:     schema.DataTypeText.PropString(),
+		Tokenization: models.PropertyTokenizationWhitespace,
+	}
+	mkClass := func(name string) *models.Class {
+		return &models.Class{
+			Class:             name,
+			Properties:        []*models.Property{nameProp},
+			VectorIndexConfig: hnsw.UserConfig{},
+			Vectorizer:        config.VectorizerModuleNone,
+		}
+	}
+	makeManager := func(t *testing.T, nsEnabled bool, classes []*models.Class) *BatchManager {
+		t.Helper()
+		sch := schema.Schema{Objects: &models.Schema{Classes: classes}}
+		cfg := &config.WeaviateConfig{Config: config.Config{
+			AutoSchema: config.AutoSchema{Enabled: runtime.NewDynamicValue(false)},
+			Namespaces: config.Namespaces{Enabled: nsEnabled},
+		}}
+		schemaManager := &fakeSchemaManager{GetSchemaResponse: sch}
+		logger, _ := test.NewNullLogger()
+		vectorRepo := &fakeVectorRepo{}
+		return NewBatchManager(vectorRepo, getFakeModulesProvider(), schemaManager, cfg, logger, mocks.NewMockAuthorizer(), nil,
+			NewAutoSchemaManager(schemaManager, vectorRepo, cfg, logger, prometheus.NewPedanticRegistry()))
+	}
+
+	t.Run("unknown property fails validation as user input", func(t *testing.T) {
+		mgr := makeManager(t, false, []*models.Class{mkClass("Foo")})
+		match := &models.BatchDeleteMatch{
+			Class: "Foo",
+			Where: &models.WhereFilter{Path: []string{"doesNotExist"}, Operator: "Equal", ValueText: ptString("v")},
+		}
+		_, err := mgr.DeleteObjects(context.Background(), &models.Principal{Username: "admin"},
+			match, nil, ptBool(true), ptString(verbosity.OutputMinimal), nil, "")
+		require.Error(t, err)
+		assert.True(t, errors.As(err, &ErrInvalidUserInput{}),
+			"unknown-property filter must be ErrInvalidUserInput, got %T: %v", err, err)
+	})
+
+	t.Run("foreign-namespace inner class in ref-path fails parse as user input", func(t *testing.T) {
+		mgr := makeManager(t, true, []*models.Class{mkClass("customer1:Foo")})
+		match := &models.BatchDeleteMatch{
+			Class: "Foo",
+			Where: &models.WhereFilter{Path: []string{"ref", "customer2:Other", "name"}, Operator: "Equal", ValueText: ptString("v")},
+		}
+		_, err := mgr.DeleteObjects(context.Background(), &models.Principal{Username: "u", Namespace: "customer1"},
+			match, nil, ptBool(true), ptString(verbosity.OutputMinimal), nil, "")
+		require.Error(t, err)
+		assert.True(t, errors.As(err, &ErrInvalidUserInput{}),
+			"foreign-NS inner class must be ErrInvalidUserInput, got %T: %v", err, err)
+		assert.Contains(t, err.Error(), "is not a valid class name")
 	})
 }
 


### PR DESCRIPTION
### What's being changed:

REST/MCP where-filters previously rejected any reference-path filter on
NS clusters because inner class segments came from caller input and
wouldn't match qualified storage. 

Mirror the gRPC parser: thread the
principal through filterext.Parse and qualify each inner class via
namespacing.QualifyRefTarget against the previous level's namespace.

Same per-segment policy as the rest of the NS code: namespaced callers
can't type a prefix, admins must match the source NS, foreign-NS
rejected. Direct-property filters and non-NS clusters unchanged.

Tests previously asserting rejection are flipped to assert qualification
end-to-end.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
