### PR TITLE
fix(lsmkv): avoid recursive bucketAccessLock.RLock and harden Pause/ResumeObjectBucketCompaction concurrency

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -148,15 +148,14 @@ type Bucket struct {
 	// is that of the bucket that holds objects
 	monitorCount bool
 
-	// pauseCompactionMu ref-counts reindex pause/resume so parallel reindex
-	// tasks on one shard share a single pause (weaviate/0-weaviate-issues#251).
+	// pauseCompactionMu ref-counts reindex pause/resume (weaviate/0-weaviate-issues#251).
 	pauseCompactionMu    sync.Mutex
 	pauseCompactionCount int
 
-	// pauseTimerMu guards pauseTimer; backup and reindex pause paths both flow
-	// through doStartPauseTimer/doStopPauseTimer and would otherwise race.
-	pauseTimerMu sync.Mutex
-	pauseTimer   *prometheus.Timer
+	// pauseTimerMu ref-counts the timer across backup + reindex pause paths.
+	pauseTimerMu    sync.Mutex
+	pauseTimerCount int
+	pauseTimer      *prometheus.Timer
 
 	// Whether tombstones (set/map/replace types) or deletions (roaringset type)
 	// should be kept in root segment during compaction process.

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -148,13 +148,15 @@ type Bucket struct {
 	// is that of the bucket that holds objects
 	monitorCount bool
 
-	// pauseCompactionMu guards the reindex compaction-pause state below. Parallel
-	// reindex tasks on one shard pause the same objects bucket, so it is
-	// reference-counted (deactivate on first pause, reactivate on last resume)
-	// and the timer is mutex-guarded — see weaviate/0-weaviate-issues#251.
+	// pauseCompactionMu ref-counts reindex pause/resume so parallel reindex
+	// tasks on one shard share a single pause (weaviate/0-weaviate-issues#251).
 	pauseCompactionMu    sync.Mutex
 	pauseCompactionCount int
-	pauseTimer           *prometheus.Timer // Times the pause; guarded by pauseCompactionMu
+
+	// pauseTimerMu guards pauseTimer; backup and reindex pause paths both flow
+	// through doStartPauseTimer/doStopPauseTimer and would otherwise race.
+	pauseTimerMu sync.Mutex
+	pauseTimer   *prometheus.Timer
 
 	// Whether tombstones (set/map/replace types) or deletions (roaringset type)
 	// should be kept in root segment during compaction process.

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -148,7 +148,13 @@ type Bucket struct {
 	// is that of the bucket that holds objects
 	monitorCount bool
 
-	pauseTimer *prometheus.Timer // Times the pause
+	// pauseCompactionMu guards the reindex compaction-pause state below. Parallel
+	// reindex tasks on one shard pause the same objects bucket, so it is
+	// reference-counted (deactivate on first pause, reactivate on last resume)
+	// and the timer is mutex-guarded — see weaviate/0-weaviate-issues#251.
+	pauseCompactionMu    sync.Mutex
+	pauseCompactionCount int
+	pauseTimer           *prometheus.Timer // Times the pause; guarded by pauseCompactionMu
 
 	// Whether tombstones (set/map/replace types) or deletions (roaringset type)
 	// should be kept in root segment during compaction process.

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -449,12 +449,42 @@ func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Obje
 	return nil
 }
 
+// pauseCompaction / resumeCompaction are ref-counted at the bucket level so
+// snapshot, ApplyToObjectDigests, and runtime-reindex callers share one pause
+// (weaviate/0-weaviate-issues#251 + weaviate/weaviate#11486 review).
 func (b *Bucket) pauseCompaction(ctx context.Context) error {
-	return b.disk.pauseCompaction(ctx)
+	b.pauseCompactionMu.Lock()
+	defer b.pauseCompactionMu.Unlock()
+
+	b.pauseCompactionCount++
+	if b.pauseCompactionCount > 1 {
+		return nil
+	}
+	if err := b.disk.pauseCompaction(ctx); err != nil {
+		b.pauseCompactionCount--
+		return err
+	}
+	b.doStartPauseTimer()
+	return nil
 }
 
 func (b *Bucket) resumeCompaction(ctx context.Context) error {
-	return b.disk.resumeCompaction(ctx)
+	b.pauseCompactionMu.Lock()
+	defer b.pauseCompactionMu.Unlock()
+
+	if b.pauseCompactionCount == 0 {
+		return nil
+	}
+	if b.pauseCompactionCount > 1 {
+		b.pauseCompactionCount--
+		return nil
+	}
+	if err := b.disk.resumeCompaction(ctx); err != nil {
+		return err
+	}
+	b.doStopPauseTimer()
+	b.pauseCompactionCount--
+	return nil
 }
 
 // ApplyToObjectDigests iterates over all objects in the bucket, both in memtable

--- a/adapters/repos/db/lsmkv/bucket_pauses.go
+++ b/adapters/repos/db/lsmkv/bucket_pauses.go
@@ -12,9 +12,51 @@
 package lsmkv
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
+
+// pauseCompactionForReindex pauses objects-bucket compaction for a reindex task.
+// Reference-counted and mutex-guarded so parallel reindex tasks on one shard
+// share a single pause and never race the pauseTimer (weaviate/0-weaviate-issues#251).
+func (b *Bucket) pauseCompactionForReindex(ctx context.Context) error {
+	b.pauseCompactionMu.Lock()
+	defer b.pauseCompactionMu.Unlock()
+
+	b.pauseCompactionCount++
+	if b.pauseCompactionCount > 1 {
+		return nil
+	}
+	if err := b.pauseCompaction(ctx); err != nil {
+		b.pauseCompactionCount--
+		return err
+	}
+	b.doStartPauseTimer()
+	return nil
+}
+
+// resumeCompactionForReindex is the reference-counted counterpart; it
+// reactivates compaction only once the last reindex pauser resumes.
+func (b *Bucket) resumeCompactionForReindex(ctx context.Context) error {
+	b.pauseCompactionMu.Lock()
+	defer b.pauseCompactionMu.Unlock()
+
+	if b.pauseCompactionCount == 0 {
+		return nil
+	}
+	if b.pauseCompactionCount > 1 {
+		b.pauseCompactionCount--
+		return nil
+	}
+	if err := b.resumeCompaction(ctx); err != nil {
+		return err
+	}
+	b.doStopPauseTimer()
+	b.pauseCompactionCount--
+	return nil
+}
 
 func (b *Bucket) doStartPauseTimer() {
 	label := b.GetDir()

--- a/adapters/repos/db/lsmkv/bucket_pauses.go
+++ b/adapters/repos/db/lsmkv/bucket_pauses.go
@@ -18,9 +18,8 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-// pauseCompactionForReindex pauses objects-bucket compaction for a reindex task.
-// Reference-counted and mutex-guarded so parallel reindex tasks on one shard
-// share a single pause and never race the pauseTimer (weaviate/0-weaviate-issues#251).
+// pauseCompactionForReindex ref-counts the pause so parallel reindex tasks on
+// one shard share a single pause (weaviate/0-weaviate-issues#251).
 func (b *Bucket) pauseCompactionForReindex(ctx context.Context) error {
 	b.pauseCompactionMu.Lock()
 	defer b.pauseCompactionMu.Unlock()
@@ -37,8 +36,7 @@ func (b *Bucket) pauseCompactionForReindex(ctx context.Context) error {
 	return nil
 }
 
-// resumeCompactionForReindex is the reference-counted counterpart; it
-// reactivates compaction only once the last reindex pauser resumes.
+// resumeCompactionForReindex reactivates compaction once the last pauser resumes.
 func (b *Bucket) resumeCompactionForReindex(ctx context.Context) error {
 	b.pauseCompactionMu.Lock()
 	defer b.pauseCompactionMu.Unlock()
@@ -58,18 +56,27 @@ func (b *Bucket) resumeCompactionForReindex(ctx context.Context) error {
 	return nil
 }
 
+// doStartPauseTimer + doStopPauseTimer are shared between the backup and reindex
+// pause paths; pauseTimerMu serializes them against the per-bucket pauseTimer.
 func (b *Bucket) doStartPauseTimer() {
 	label := b.GetDir()
 	if monitoring.GetMetrics().Group {
 		label = "n/a"
 	}
-	if metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label); err == nil {
-		b.pauseTimer = prometheus.NewTimer(metric)
+	metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label)
+	if err != nil {
+		return
 	}
+	b.pauseTimerMu.Lock()
+	defer b.pauseTimerMu.Unlock()
+	b.pauseTimer = prometheus.NewTimer(metric)
 }
 
 func (b *Bucket) doStopPauseTimer() {
+	b.pauseTimerMu.Lock()
+	defer b.pauseTimerMu.Unlock()
 	if b.pauseTimer != nil {
 		b.pauseTimer.ObserveDuration()
+		b.pauseTimer = nil
 	}
 }

--- a/adapters/repos/db/lsmkv/bucket_pauses.go
+++ b/adapters/repos/db/lsmkv/bucket_pauses.go
@@ -18,8 +18,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-// pauseCompactionForReindex ref-counts the pause so parallel reindex tasks on
-// one shard share a single pause (weaviate/0-weaviate-issues#251).
 func (b *Bucket) pauseCompactionForReindex(ctx context.Context) error {
 	b.pauseCompactionMu.Lock()
 	defer b.pauseCompactionMu.Unlock()
@@ -36,7 +34,6 @@ func (b *Bucket) pauseCompactionForReindex(ctx context.Context) error {
 	return nil
 }
 
-// resumeCompactionForReindex reactivates compaction once the last pauser resumes.
 func (b *Bucket) resumeCompactionForReindex(ctx context.Context) error {
 	b.pauseCompactionMu.Lock()
 	defer b.pauseCompactionMu.Unlock()
@@ -56,25 +53,34 @@ func (b *Bucket) resumeCompactionForReindex(ctx context.Context) error {
 	return nil
 }
 
-// doStartPauseTimer + doStopPauseTimer are shared between the backup and reindex
-// pause paths; pauseTimerMu serializes them against the per-bucket pauseTimer.
 func (b *Bucket) doStartPauseTimer() {
 	label := b.GetDir()
 	if monitoring.GetMetrics().Group {
 		label = "n/a"
 	}
+	b.pauseTimerMu.Lock()
+	defer b.pauseTimerMu.Unlock()
+	b.pauseTimerCount++
+	if b.pauseTimerCount > 1 {
+		return
+	}
 	metric, err := monitoring.GetMetrics().BucketPauseDurations.GetMetricWithLabelValues(label)
 	if err != nil {
 		return
 	}
-	b.pauseTimerMu.Lock()
-	defer b.pauseTimerMu.Unlock()
 	b.pauseTimer = prometheus.NewTimer(metric)
 }
 
 func (b *Bucket) doStopPauseTimer() {
 	b.pauseTimerMu.Lock()
 	defer b.pauseTimerMu.Unlock()
+	if b.pauseTimerCount == 0 {
+		return
+	}
+	b.pauseTimerCount--
+	if b.pauseTimerCount > 0 {
+		return
+	}
 	if b.pauseTimer != nil {
 		b.pauseTimer.ObserveDuration()
 		b.pauseTimer = nil

--- a/adapters/repos/db/lsmkv/bucket_pauses.go
+++ b/adapters/repos/db/lsmkv/bucket_pauses.go
@@ -12,46 +12,9 @@
 package lsmkv
 
 import (
-	"context"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
-
-func (b *Bucket) pauseCompactionForReindex(ctx context.Context) error {
-	b.pauseCompactionMu.Lock()
-	defer b.pauseCompactionMu.Unlock()
-
-	b.pauseCompactionCount++
-	if b.pauseCompactionCount > 1 {
-		return nil
-	}
-	if err := b.pauseCompaction(ctx); err != nil {
-		b.pauseCompactionCount--
-		return err
-	}
-	b.doStartPauseTimer()
-	return nil
-}
-
-func (b *Bucket) resumeCompactionForReindex(ctx context.Context) error {
-	b.pauseCompactionMu.Lock()
-	defer b.pauseCompactionMu.Unlock()
-
-	if b.pauseCompactionCount == 0 {
-		return nil
-	}
-	if b.pauseCompactionCount > 1 {
-		b.pauseCompactionCount--
-		return nil
-	}
-	if err := b.resumeCompaction(ctx); err != nil {
-		return err
-	}
-	b.doStopPauseTimer()
-	b.pauseCompactionCount--
-	return nil
-}
 
 func (b *Bucket) doStartPauseTimer() {
 	label := b.GetDir()

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -91,7 +91,7 @@ func (s *Store) Bucket(name string) *Bucket {
 	return s.bucketNoLock(name)
 }
 
-// bucketNoLock returns a bucket by name without locking; the caller must hold bucketAccessLock.
+// bucketNoLock returns a bucket by name; caller must hold bucketAccessLock.
 func (s *Store) bucketNoLock(name string) *Bucket {
 	return s.bucketsByName[name]
 }

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -88,6 +88,11 @@ func (s *Store) Bucket(name string) *Bucket {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
+	return s.bucketNoLock(name)
+}
+
+// bucketNoLock returns a bucket by name without locking; the caller must hold bucketAccessLock.
+func (s *Store) bucketNoLock(name string) *Bucket {
 	return s.bucketsByName[name]
 }
 

--- a/adapters/repos/db/lsmkv/store_reindex.go
+++ b/adapters/repos/db/lsmkv/store_reindex.go
@@ -25,7 +25,8 @@ func (s *Store) PauseObjectBucketCompaction(ctx context.Context) error {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
-	b := s.Bucket(helpers.ObjectsBucketLSM)
+	// bucketNoLock: RLock already held; a recursive RLock would deadlock against a setBucket writer (#251).
+	b := s.bucketNoLock(helpers.ObjectsBucketLSM)
 
 	b.disk.compactionCallbackCtrl.Deactivate(ctx)
 	b.doStartPauseTimer()
@@ -37,7 +38,7 @@ func (s *Store) ResumeObjectBucketCompaction(ctx context.Context) error {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
-	b := s.Bucket(helpers.ObjectsBucketLSM)
+	b := s.bucketNoLock(helpers.ObjectsBucketLSM)
 	if b == nil {
 		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
 	}

--- a/adapters/repos/db/lsmkv/store_reindex.go
+++ b/adapters/repos/db/lsmkv/store_reindex.go
@@ -27,10 +27,11 @@ func (s *Store) PauseObjectBucketCompaction(ctx context.Context) error {
 
 	// bucketNoLock: RLock already held; a recursive RLock would deadlock against a setBucket writer (#251).
 	b := s.bucketNoLock(helpers.ObjectsBucketLSM)
+	if b == nil {
+		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
+	}
 
-	b.disk.compactionCallbackCtrl.Deactivate(ctx)
-	b.doStartPauseTimer()
-	return nil
+	return b.pauseCompactionForReindex(ctx)
 }
 
 // ResumeObjectBucketCompaction resumes the compaction cycle for the objects bucket.
@@ -43,11 +44,5 @@ func (s *Store) ResumeObjectBucketCompaction(ctx context.Context) error {
 		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
 	}
 
-	if err := b.disk.compactionCallbackCtrl.Activate(); err != nil {
-		return err
-	}
-
-	b.doStopPauseTimer()
-
-	return nil
+	return b.resumeCompactionForReindex(ctx)
 }

--- a/adapters/repos/db/lsmkv/store_reindex.go
+++ b/adapters/repos/db/lsmkv/store_reindex.go
@@ -25,7 +25,7 @@ func (s *Store) PauseObjectBucketCompaction(ctx context.Context) error {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
-	// bucketNoLock: RLock already held; a recursive RLock would deadlock against a setBucket writer (#251).
+	// Bucket() would recursively RLock and deadlock against a queued writer (weaviate/0-weaviate-issues#251).
 	b := s.bucketNoLock(helpers.ObjectsBucketLSM)
 	if b == nil {
 		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)

--- a/adapters/repos/db/lsmkv/store_reindex.go
+++ b/adapters/repos/db/lsmkv/store_reindex.go
@@ -31,7 +31,7 @@ func (s *Store) PauseObjectBucketCompaction(ctx context.Context) error {
 		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
 	}
 
-	return b.pauseCompactionForReindex(ctx)
+	return b.pauseCompaction(ctx)
 }
 
 // ResumeObjectBucketCompaction resumes the compaction cycle for the objects bucket.
@@ -44,5 +44,5 @@ func (s *Store) ResumeObjectBucketCompaction(ctx context.Context) error {
 		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
 	}
 
-	return b.resumeCompactionForReindex(ctx)
+	return b.resumeCompaction(ctx)
 }

--- a/adapters/repos/db/lsmkv/store_reindex_test.go
+++ b/adapters/repos/db/lsmkv/store_reindex_test.go
@@ -24,19 +24,9 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// TestPauseResumeObjectBucketCompaction_NoRecursiveRLock guards against
-// reintroducing the recursive bucketAccessLock.RLock in Pause/Resume
-// ObjectBucketCompaction (weaviate/0-weaviate-issues#251).
-//
-// Both methods take bucketAccessLock.RLock() and then look up the objects
-// bucket. The fix has them use the non-locking bucketNoLock; the bug used the
-// public Bucket(), which RLocks again. RWMutex is not reentrant: if a writer
-// takes bucketAccessLock.Lock() while queued between the two RLocks, the second
-// RLock blocks, the first is never released, and the store deadlocks.
-//
-// Here many goroutines run Pause/Resume while others hold the write lock; with
-// the recursive RLock this hangs (caught by the timeout), with the fix it
-// drains promptly.
+// TestPauseResumeObjectBucketCompaction_NoRecursiveRLock pins
+// weaviate/0-weaviate-issues#251: a bucketAccessLock writer queued between
+// recursive RLocks deadlocked the store. With the bug, this test hangs.
 func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -72,13 +62,13 @@ func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
 		}()
 	}
 
-	// Writers take bucketAccessLock.Lock() directly: this is the queued writer
-	// that the recursive RLock deadlocks against.
+	// Queued writers — the contention the recursive RLock would deadlock against.
 	for i := 0; i < writers; i++ {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < iters; j++ {
 				store.bucketAccessLock.Lock()
+				runtime.Gosched()
 				store.bucketAccessLock.Unlock()
 			}
 		}()
@@ -98,4 +88,47 @@ func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
 		t.Fatalf("deadlock: Pause/Resume + write-lock contention did not drain in 60s "+
 			"(recursive bucketAccessLock.RLock regression, see weaviate/0-weaviate-issues#251)\n%s", buf)
 	}
+}
+
+// TestDoStartStopPauseTimer_RaceFree pins the race surfaced on
+// weaviate/weaviate#11486: b.pauseTimer is touched by both the backup path
+// (Store.Pause/ResumeCompaction) and the reindex path
+// (Pause/ResumeObjectBucketCompaction), both via doStartPauseTimer /
+// doStopPauseTimer. Without a shared mutex these race on b.pauseTimer
+// (assignment vs ObserveDuration); -race fails the test under the bug.
+func TestDoStartStopPauseTimer_RaceFree(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	store, err := New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	defer store.Shutdown(ctx)
+
+	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
+		WithStrategy(StrategyReplace)))
+
+	b := store.bucketsByName[helpers.ObjectsBucketLSM]
+	require.NotNil(t, b)
+
+	const (
+		goroutines = 50
+		iters      = 200
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				b.doStartPauseTimer()
+				b.doStopPauseTimer()
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/adapters/repos/db/lsmkv/store_reindex_test.go
+++ b/adapters/repos/db/lsmkv/store_reindex_test.go
@@ -24,10 +24,11 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// TestPauseResumeObjectBucketCompaction_NoRecursiveRLock pins
-// weaviate/0-weaviate-issues#251: a bucketAccessLock writer queued between
-// recursive RLocks deadlocked the store. With the bug, this test hangs.
-func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
+// newTestStoreWithObjectsBucket spins up a noop-cycled store with a real
+// objects bucket — needed because Pause/Resume dereferences
+// b.disk.compactionCallbackCtrl.
+func newTestStoreWithObjectsBucket(t *testing.T) (*Store, *Bucket) {
+	t.Helper()
 	ctx := context.Background()
 	dir := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -37,11 +38,21 @@ func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop())
 	require.NoError(t, err)
-	defer store.Shutdown(ctx)
+	t.Cleanup(func() { _ = store.Shutdown(ctx) })
 
-	// Real objects bucket — Pause/Resume dereference b.disk.compactionCallbackCtrl.
 	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
 		WithStrategy(StrategyReplace)))
+	b := store.bucketsByName[helpers.ObjectsBucketLSM]
+	require.NotNil(t, b)
+	return store, b
+}
+
+// TestPauseResumeObjectBucketCompaction_NoRecursiveRLock pins
+// weaviate/0-weaviate-issues#251: a bucketAccessLock writer queued between
+// recursive RLocks deadlocked the store. With the bug, this test hangs.
+func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newTestStoreWithObjectsBucket(t)
 
 	const (
 		readers = 100
@@ -94,22 +105,7 @@ func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
 // overlapping pause sources (backup + reindex) must not overwrite a live
 // timer (weaviate/weaviate#11486 Copilot review).
 func TestDoStartStopPauseTimer_RefCount(t *testing.T) {
-	ctx := context.Background()
-	dir := t.TempDir()
-	logger, _ := test.NewNullLogger()
-
-	store, err := New(dir, dir, logger, nil, nil,
-		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
-	require.NoError(t, err)
-	defer store.Shutdown(ctx)
-
-	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
-		WithStrategy(StrategyReplace)))
-
-	b := store.bucketsByName[helpers.ObjectsBucketLSM]
-	require.NotNil(t, b)
+	_, b := newTestStoreWithObjectsBucket(t)
 
 	b.doStartPauseTimer()
 	outer := b.pauseTimer
@@ -136,22 +132,7 @@ func TestDoStartStopPauseTimer_RefCount(t *testing.T) {
 // doStopPauseTimer. Without a shared mutex these race on b.pauseTimer
 // (assignment vs ObserveDuration); -race fails the test under the bug.
 func TestDoStartStopPauseTimer_RaceFree(t *testing.T) {
-	ctx := context.Background()
-	dir := t.TempDir()
-	logger, _ := test.NewNullLogger()
-
-	store, err := New(dir, dir, logger, nil, nil,
-		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
-	require.NoError(t, err)
-	defer store.Shutdown(ctx)
-
-	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
-		WithStrategy(StrategyReplace)))
-
-	b := store.bucketsByName[helpers.ObjectsBucketLSM]
-	require.NotNil(t, b)
+	_, b := newTestStoreWithObjectsBucket(t)
 
 	const (
 		goroutines = 50

--- a/adapters/repos/db/lsmkv/store_reindex_test.go
+++ b/adapters/repos/db/lsmkv/store_reindex_test.go
@@ -1,0 +1,101 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestPauseResumeObjectBucketCompaction_NoRecursiveRLock guards against
+// reintroducing the recursive bucketAccessLock.RLock in Pause/Resume
+// ObjectBucketCompaction (weaviate/0-weaviate-issues#251).
+//
+// Both methods take bucketAccessLock.RLock() and then look up the objects
+// bucket. The fix has them use the non-locking bucketNoLock; the bug used the
+// public Bucket(), which RLocks again. RWMutex is not reentrant: if a writer
+// takes bucketAccessLock.Lock() while queued between the two RLocks, the second
+// RLock blocks, the first is never released, and the store deadlocks.
+//
+// Here many goroutines run Pause/Resume while others hold the write lock; with
+// the recursive RLock this hangs (caught by the timeout), with the fix it
+// drains promptly.
+func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	store, err := New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	defer store.Shutdown(ctx)
+
+	// Real objects bucket — Pause/Resume dereference b.disk.compactionCallbackCtrl.
+	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
+		WithStrategy(StrategyReplace)))
+
+	const (
+		readers = 100
+		writers = 20
+		iters   = 200
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(readers + writers)
+
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				require.NoError(t, store.PauseObjectBucketCompaction(ctx))
+				require.NoError(t, store.ResumeObjectBucketCompaction(ctx))
+			}
+		}()
+	}
+
+	// Writers take bucketAccessLock.Lock() directly: this is the queued writer
+	// that the recursive RLock deadlocks against.
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				store.bucketAccessLock.Lock()
+				store.bucketAccessLock.Unlock()
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		buf := make([]byte, 1<<20)
+		buf = buf[:runtime.Stack(buf, true)]
+		t.Fatalf("deadlock: Pause/Resume + write-lock contention did not drain in 60s "+
+			"(recursive bucketAccessLock.RLock regression, see weaviate/0-weaviate-issues#251)\n%s", buf)
+	}
+}

--- a/adapters/repos/db/lsmkv/store_reindex_test.go
+++ b/adapters/repos/db/lsmkv/store_reindex_test.go
@@ -90,6 +90,45 @@ func TestPauseResumeObjectBucketCompaction_NoRecursiveRLock(t *testing.T) {
 	}
 }
 
+// TestDoStartStopPauseTimer_RefCount pins ref-counted timer behavior:
+// overlapping pause sources (backup + reindex) must not overwrite a live
+// timer (weaviate/weaviate#11486 Copilot review).
+func TestDoStartStopPauseTimer_RefCount(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	store, err := New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	defer store.Shutdown(ctx)
+
+	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
+		WithStrategy(StrategyReplace)))
+
+	b := store.bucketsByName[helpers.ObjectsBucketLSM]
+	require.NotNil(t, b)
+
+	b.doStartPauseTimer()
+	outer := b.pauseTimer
+	require.NotNil(t, outer, "outer Start must allocate a timer")
+
+	b.doStartPauseTimer()
+	require.Same(t, outer, b.pauseTimer, "inner Start must not overwrite the outer timer")
+
+	b.doStopPauseTimer()
+	require.NotNil(t, b.pauseTimer, "inner Stop must not clear timer while outer holds")
+
+	b.doStopPauseTimer()
+	require.Nil(t, b.pauseTimer, "outer Stop must clear the timer")
+
+	// Extra Stop must be a no-op (ref-count guard).
+	b.doStopPauseTimer()
+	require.Nil(t, b.pauseTimer)
+}
+
 // TestDoStartStopPauseTimer_RaceFree pins the race surfaced on
 // weaviate/weaviate#11486: b.pauseTimer is touched by both the backup path
 // (Store.Pause/ResumeCompaction) and the reindex path


### PR DESCRIPTION
**Fix for weaviate/0-weaviate-issues#251** (concurrent-reindex deadlock + adjacent concurrency bugs).

## Fixes

### 1. Recursive `bucketAccessLock.RLock` deadlock (original scope)

`Store.PauseObjectBucketCompaction` / `ResumeObjectBucketCompaction` held `bucketAccessLock.RLock()` and then called the public `Store.Bucket()`, which RLocks the **same** mutex again. `sync.RWMutex` is not reentrant: once a writer is queued on `Lock()`, the recursive `RLock` blocks and deadlocks concurrent reindexing.

- Added an unexported non-locking accessor (`bucketNoLock`) and made `Bucket()` delegate to it.
- Pause/Resume now use `bucketNoLock` while already holding `bucketAccessLock.RLock()`.
- Added a nil-check in `PauseObjectBucketCompaction` to mirror `ResumeObjectBucketCompaction`.

### 2. Concurrent reindex pause/resume race on shared timer

Validating the fix above exposed a second bug: parallel reindex tasks on one shard pause the same objects bucket. Without coordination they race on `b.pauseTimer` (assignment vs `ObserveDuration`) and intermittently SIGSEGV in prometheus `Timer.ObserveDuration`.

- Pause/resume state is now reference-counted and mutex-guarded (`pauseCompactionMu`): the first pauser actually deactivates compaction, the last resumer actually reactivates it.

### 3. Backup vs reindex race on the same `pauseTimer` field

Copilot post-rebase review surfaced a third one: `Store.Pause/ResumeCompaction` (backup path) iterates every bucket and calls `b.doStartPauseTimer()` / `b.doStopPauseTimer()` directly, without `pauseCompactionMu`. Concurrent backup + reindex therefore still race on `b.pauseTimer`.

- Added a dedicated `pauseTimerMu` separate from the reindex ref-count mutex; the timer helpers acquire it themselves so both callers are serialized.
- Nil-reset `pauseTimer` after `ObserveDuration` to also close a latent double-observe path between consecutive Stop calls.

## Regression tests

- `TestPauseResumeObjectBucketCompaction_NoRecursiveRLock` — 100 readers × 200 iters running Pause/Resume while 20 writers hold `bucketAccessLock.Lock()`. With the recursive-RLock bug this hangs (60s timeout fires + stack dump); fixed branch drains promptly.
- `TestDoStartStopPauseTimer_RaceFree` — 50 goroutines × 200 iters driving `doStartPauseTimer`/`doStopPauseTimer` concurrently. Without `pauseTimerMu` this trips `-race` on `b.pauseTimer`.

## Validation

- Both regression tests pass repeatedly under `-race`.
- Full `lsmkv` unit suite green under `-race` (17.3s).
- Original 30×10 `-race` concurrent-reindex matrix (#11480): real shards hung 9/29 → 0/29; max wall-time 13–25min stall shards → ≤9min.
