### PR TITLE
fix(lsmkv): avoid recursive bucketAccessLock.RLock in Pause/ResumeObjectBucketCompaction

### DIFF
--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -88,6 +88,14 @@ func (s *Store) Bucket(name string) *Bucket {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
+	return s.bucket(name)
+}
+
+// bucket returns a bucket by name without locking. The caller MUST already
+// hold bucketAccessLock (read or write). Use this from paths that already hold
+// the lock: RWMutex is not reentrant, so taking RLock recursively deadlocks if
+// a writer (e.g. setBucket) is waiting in between.
+func (s *Store) bucket(name string) *Bucket {
 	return s.bucketsByName[name]
 }
 

--- a/adapters/repos/db/lsmkv/store_reindex.go
+++ b/adapters/repos/db/lsmkv/store_reindex.go
@@ -25,7 +25,10 @@ func (s *Store) PauseObjectBucketCompaction(ctx context.Context) error {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
-	b := s.Bucket(helpers.ObjectsBucketLSM)
+	// Already holding bucketAccessLock — use the non-locking accessor. Calling
+	// the public Bucket() here would take RLock recursively and deadlock if a
+	// setBucket writer is waiting (see weaviate/0-weaviate-issues#251).
+	b := s.bucket(helpers.ObjectsBucketLSM)
 
 	b.disk.compactionCallbackCtrl.Deactivate(ctx)
 	b.doStartPauseTimer()
@@ -37,7 +40,8 @@ func (s *Store) ResumeObjectBucketCompaction(ctx context.Context) error {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()
 
-	b := s.Bucket(helpers.ObjectsBucketLSM)
+	// Non-locking accessor: we already hold bucketAccessLock (see above / #251).
+	b := s.bucket(helpers.ObjectsBucketLSM)
 	if b == nil {
 		return fmt.Errorf("no bucket named 'objects' found in store %s", s.dir)
 	}


### PR DESCRIPTION
**Fixes weaviate/0-weaviate-issues#251** — concurrent-reindex deadlock. Targeting `stable/v1.35` to merge forward (the buggy code is present on v1.35 → main).

## Problem

`Store.PauseObjectBucketCompaction` / `ResumeObjectBucketCompaction` held `bucketAccessLock.RLock()` and then called the public `Store.Bucket()`, which RLocks the **same** mutex again. `sync.RWMutex` is not reentrant: once a writer (`setBucket`, via concurrent `CreateOrLoadBucket` from parallel reindex tasks on one shard) is waiting on `Lock()`, the recursive `RLock` blocks → the first RLock is never released → writer + all subsequent readers deadlock.

These two methods are the only place the pattern occurs and are only called from the reindex/BMW path (`inverted_reindex_task_generic.go`). The pattern has been latent since the methods were added (2025-06-27, `d5faec053d`); concurrent reindex on a single shard is what triggers it, surfaced by `TestConcurrentReindex`.

## Fix

```go
func (s *Store) bucket(name string) *Bucket { return s.bucketsByName[name] } // caller holds the lock
func (s *Store) Bucket(name string) *Bucket  { s.bucketAccessLock.RLock(); defer s.bucketAccessLock.RUnlock(); return s.bucket(name) }
// store_reindex.go: b := s.bucket(helpers.ObjectsBucketLSM)
```

Removes the recursion; the outer RLock still pins the objects bucket while its compaction callback is toggled. Confined to these two methods (swept `store.go`/`store_reindex.go`).

## Validation

This is the byte-identical patch validated on `main` in weaviate/weaviate#11480 (where `TestConcurrentReindex` lives): a 30×10 `-race` matrix went from **9/29 real shards hung (pre-fix)** to **0/29 (post-fix)**, with stall-shard wall-time collapsing 13–25min → ≤9min. Supersedes the main-targeted draft weaviate/weaviate#11486.