### PR TITLE
no longer hardcode region in text2vec-google

### DIFF
--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -17,6 +17,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"io"
 	"net/http"
 	"time"
@@ -63,8 +64,20 @@ func buildURL(useGenerativeAI bool, apiEndpoint, projectID, modelID string) stri
 		}
 		return fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:batchEmbedContents", modelID)
 	}
-	urlTemplate := "https://%s/v1/projects/%s/locations/us-central1/publishers/google/models/%s:predict"
-	return fmt.Sprintf(urlTemplate, apiEndpoint, projectID, modelID)
+
+	// Strip scheme prefixes if accidentally included
+	apiEndpoint = strings.TrimPrefix(apiEndpoint, "https://")
+
+	// Default location to us-central1
+	location := "us-central1"
+	
+	// If apiEndpoint is explicitly set with Google's domain, extract the region prefix
+	if strings.Contains(apiEndpoint, "-aiplatform.googleapis.com") {
+		location = strings.Split(apiEndpoint, "-aiplatform.googleapis.com")[0]
+	}
+
+	urlTemplate := "https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:predict"
+	return fmt.Sprintf(urlTemplate, apiEndpoint, projectID, location, modelID)
 }
 
 type settings struct {

--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -17,9 +17,9 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/moduletools"


### PR DESCRIPTION
### What's being changed:

Currently, `us-central1` is hardcoded in `text2vec-google`. There is an [existing abandoned PR](https://github.com/weaviate/weaviate/pull/8418) which tries to solve this with API change, but this is a simple PR that extracts the location from the `apiEndpoint`.

E.g. the `apiEndpoint` might be `europe-west2-aiplatform.googleapis.com`

The function still defaults to `us-central1`.

I love Weaviate, but I'm also mainly a Java/Python dev, so apologies if there's any Go rustiness, or lack of contextual awareness. So I hope a change that doesn't touch the API is useful. 

As far as I understand it, this is the code that is touched when I'm doing something like the following - and I really need to make sure it's using the Europe region for my use case:

``` python
client.collections.create(
    "DemoCollection",
    vector_config=Configure.Vectors.text2vec_google(
        name="title_vector",
        source_properties=["title"],
        project_id="<google-cloud-project-id>",  
        model="<google-model-id>",
        api_endpoint="<google-api-endpoint>",
    ),
)
```

I appreciate your time!

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
