### PR TITLE
Fix dangling-alias batch insert silently re-creating the deleted target

### DIFF
--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -67,7 +67,7 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	knownClasses := map[string]versioned.Class{}
 	knownClassesAuthCheck := map[string]*models.Class{}
 	classGetter := func(classname, shard string) (string, *models.Class, error) {
-		resolved, _, err := namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, classname)
+		resolved, qualifiedAlias, err := namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, classname)
 		if err != nil {
 			return "", nil, err
 		}
@@ -92,6 +92,15 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 		vClass, err := h.schemaManager.GetCachedClassNoAuth(ctx, classname)
 		if err != nil {
 			return "", nil, err
+		}
+		// Reject writes through an alias whose target collection no longer
+		// exists. Without this guard, the nil *models.Class falls through to
+		// the auto-schema path in batch_add and silently re-creates the
+		// deleted collection with an empty schema. Non-alias requests for an
+		// unknown class are still allowed through so legitimate auto-schema
+		// creates continue to work.
+		if qualifiedAlias != "" && vClass[classname].Class == nil {
+			return "", nil, fmt.Errorf("alias %q points to collection %q which does not exist", namespacing.StripQualification(qualifiedAlias), namespacing.StripQualification(classname))
 		}
 		knownClasses[classname] = vClass[classname]
 		knownClassesAuthCheck[classTenantName] = vClass[classname].Class

--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -99,12 +99,6 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 		// deleted collection with an empty schema. Non-alias requests for an
 		// unknown class are still allowed through so legitimate auto-schema
 		// creates continue to work.
-		//
-		// Pass qualified names verbatim — the deferred
-		// StripErrForPrincipal at the top of BatchObjects strips the
-		// caller's own namespace prefix, leaving foreign prefixes intact
-		// for global principals (a debugging-friendly compromise that
-		// keeps namespace policy a single source of truth).
 		if qualifiedAlias != "" && vClass[classname].Class == nil {
 			return "", nil, fmt.Errorf("alias %q points to collection %q which does not exist", qualifiedAlias, classname)
 		}

--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -93,12 +93,7 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 		if err != nil {
 			return "", nil, err
 		}
-		// Reject writes through an alias whose target collection no longer
-		// exists. Without this guard, the nil *models.Class falls through to
-		// the auto-schema path in batch_add and silently re-creates the
-		// deleted collection with an empty schema. Non-alias requests for an
-		// unknown class are still allowed through so legitimate auto-schema
-		// creates continue to work.
+		// Without this guard the nil class falls into auto-schema and silently re-creates the deleted target.
 		if qualifiedAlias != "" && vClass[classname].Class == nil {
 			return "", nil, fmt.Errorf("alias %q points to collection %q which does not exist", qualifiedAlias, classname)
 		}

--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -99,8 +99,14 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 		// deleted collection with an empty schema. Non-alias requests for an
 		// unknown class are still allowed through so legitimate auto-schema
 		// creates continue to work.
+		//
+		// Pass qualified names verbatim — the deferred
+		// StripErrForPrincipal at the top of BatchObjects strips the
+		// caller's own namespace prefix, leaving foreign prefixes intact
+		// for global principals (a debugging-friendly compromise that
+		// keeps namespace policy a single source of truth).
 		if qualifiedAlias != "" && vClass[classname].Class == nil {
-			return "", nil, fmt.Errorf("alias %q points to collection %q which does not exist", namespacing.StripQualification(qualifiedAlias), namespacing.StripQualification(classname))
+			return "", nil, fmt.Errorf("alias %q points to collection %q which does not exist", qualifiedAlias, classname)
 		}
 		knownClasses[classname] = vClass[classname]
 		knownClassesAuthCheck[classTenantName] = vClass[classname].Class

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -411,4 +411,49 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 			})
 		}
 	})
+
+	// Regression: writing through an alias whose target was deleted used to
+	// hit auto-schema and silently re-create the deleted collection with an
+	// empty schema. The batch must surface a per-object error and the schema
+	// must remain unchanged.
+	t.Run("batch insert through alias with deleted target fails", func(t *testing.T) {
+		danglingClass := "GRPCBatchAliasDanglingTarget"
+		danglingAlias := "GRPCBatchAliasDangling"
+
+		helper.CreateClass(t, &models.Class{
+			Class:      danglingClass,
+			Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
+		})
+		helper.CreateAlias(t, &models.Alias{Alias: danglingAlias, Class: danglingClass})
+		defer helper.DeleteAlias(t, danglingAlias)
+
+		// Delete the target collection — alias is now dangling.
+		helper.DeleteClass(t, danglingClass)
+
+		resp, err := grpcClient.BatchObjects(ctx, &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{
+				{
+					Collection: danglingAlias,
+					Uuid:       uuid.NewString(),
+					Properties: &pb.BatchObject_Properties{
+						NonRefProperties: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"title": structpb.NewStringValue("should not be inserted"),
+							},
+						},
+					},
+				},
+			},
+		})
+		// Per-object failure surfaces as Errors entries, not a transport error.
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Len(t, resp.Errors, 1, "expected the dangling-alias insert to fail")
+		assert.Contains(t, resp.Errors[0].Error, danglingAlias)
+		assert.Contains(t, resp.Errors[0].Error, "does not exist")
+
+		// Schema must not have been silently re-created via auto-schema.
+		got, _ := helper.GetClassWithoutAssert(t, danglingClass, "")
+		require.Nil(t, got, "alias write must not auto-create the deleted collection")
+	})
 }

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -412,10 +412,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 		}
 	})
 
-	// Regression: writing through an alias whose target was deleted used to
-	// hit auto-schema and silently re-create the deleted collection with an
-	// empty schema. The batch must surface a per-object error and the schema
-	// must remain unchanged.
+	// Regression: dangling-alias writes used to fall into auto-schema and silently re-create the deleted target.
 	t.Run("batch insert through alias with deleted target fails", func(t *testing.T) {
 		danglingClass := "GRPCBatchAliasDanglingTarget"
 		danglingAlias := "GRPCBatchAliasDangling"
@@ -426,8 +423,6 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 		})
 		helper.CreateAlias(t, &models.Alias{Alias: danglingAlias, Class: danglingClass})
 		defer helper.DeleteAlias(t, danglingAlias)
-
-		// Delete the target collection — alias is now dangling.
 		helper.DeleteClass(t, danglingClass)
 
 		resp, err := grpcClient.BatchObjects(ctx, &pb.BatchObjectsRequest{
@@ -445,17 +440,13 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 				},
 			},
 		})
-		// Per-object failure surfaces as Errors entries, not a transport error.
+		// Per-object failure: transport call succeeds, error surfaces in resp.Errors.
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Errors, 1, "expected the dangling-alias insert to fail")
 		assert.Contains(t, resp.Errors[0].Error, danglingAlias)
 		assert.Contains(t, resp.Errors[0].Error, "does not exist")
 
-		// Schema must not have been silently re-created via auto-schema.
-		// Assert on both the API error and the nil payload so a transient
-		// API failure can't mask the regression: the bug we are guarding
-		// against produces a present class, not a missing one.
 		got, getErr := helper.GetClassWithoutAssert(t, danglingClass, "")
 		require.Error(t, getErr, "deleted collection should return an error from the schema API")
 		require.Nil(t, got, "alias write must not auto-create the deleted collection")

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -453,7 +453,11 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 		assert.Contains(t, resp.Errors[0].Error, "does not exist")
 
 		// Schema must not have been silently re-created via auto-schema.
-		got, _ := helper.GetClassWithoutAssert(t, danglingClass, "")
+		// Assert on both the API error and the nil payload so a transient
+		// API failure can't mask the regression: the bug we are guarding
+		// against produces a present class, not a missing one.
+		got, getErr := helper.GetClassWithoutAssert(t, danglingClass, "")
+		require.Error(t, getErr, "deleted collection should return an error from the schema API")
 		require.Nil(t, got, "alias write must not auto-create the deleted collection")
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes a server-side bug where a gRPC `BatchObjects` insert through an alias whose target collection was deleted silently fell through to auto-schema and **re-created the deleted collection** with an empty schema (no vector config, no user-defined properties). The fetch / aggregate / delete paths correctly failed, so the data API was also inconsistent.
- Captures `qualifiedAlias` from `namespacing.Resolve` in `BatchObjects.classGetter` and returns an explicit `alias \"X\" points to collection \"Y\" which does not exist` error when the input was an alias and the underlying class is gone. Non-alias requests for unknown classes still flow into auto-schema unchanged.
- Adds a Go acceptance regression test that creates a class+alias, deletes the class, calls `BatchObjects` through the alias, and asserts both the per-object error and that the schema is **not** silently re-created.

Fixes weaviate/0-weaviate-issues#252.

## Why this matters

The reported failure is the e2e test `tests/e2e/python_e2e/core/collection_alias_test.py::test_alias_with_deleted_collection` (see CI run [26501718914](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/26501718914/job/78045374644)). Pod logs at the failure window show the original collection's shards (`CTOmqRYJI1ru`, `nLg4L65yK6Yj`, `IzDFzXj9YGGR`) being torn down, then new shards (`zuzNkDmqmpLQ`, `Gzb7StGt2mr6`, `AxSwDUH8jtE6`) appearing for the same class name with `targetVector=\"\"` — the signature of an auto-schema re-create on a write that should have failed.

The streaming batch path (`adapters/handlers/grpc/v1/batch/stream.go`) ultimately calls back into `BatchObjects` from the worker (`worker.go:139`), so this single fix covers both the regular and streaming batch flows. The pre-write `Resolve` in stream.go is only used for the vectorisation hint — actual writes are gated by the corrected handler.

## Risk / scope

- Behavior change is narrow: the *only* request that now fails was one that previously silently corrupted user state. No flag, no migration.
- Aliases are intentionally **not** cascade-deleted when their target collection is deleted — `alias.update` to repoint at a new target is a supported flow that the same e2e test exercises right after the dangling-write assertions.
- REST batch and single-object insert paths were not changed in this PR; the failing test (and the Python v4 client's `insert_many`) goes through the gRPC `BatchObjects` path. A follow-up audit of REST / single-object paths is worth doing but is out of scope here.

## Test plan

- [x] `go build ./adapters/handlers/grpc/v1/batch/...` — clean.
- [x] `go test ./adapters/handlers/grpc/v1/batch/...` — existing batch unit tests pass (156s).
- [x] `go test -c ./test/acceptance/aliases/...` — acceptance test binary compiles with the new subtest.
- [ ] CI: run `Test_AliasesAPI_gRPC` acceptance test (Docker-based) and confirm the new `batch insert through alias with deleted target fails` subtest passes.
- [ ] CI: confirm the upstream e2e regression `test_alias_with_deleted_collection` now passes against an image built from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)