### PR TITLE
fix(hfresh): stabilise vector_index_postings across graceful restart

### DIFF
--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hfresh"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/tenantactivity"
@@ -90,10 +91,84 @@ func (o *nodeWideMetricsObserver) observeShards() {
 			return
 		case <-t10.C:
 			o.observeActivity()
+			// vector_index_postings drives the recall-after-restart e2e
+			// test's stability check; refresh on the 10s cadence so the
+			// gauge converges shortly after a write burst ends.
+			o.observeHFreshPostings()
 		case <-t30.C:
 			o.observeObjectCount()
 		}
 	}
+}
+
+// observeHFreshPostings is the sole writer to vector_index_postings when
+// PROMETHEUS_MONITORING_GROUP=true: it walks all loaded hfresh indexes on
+// the node, sums PostingMap.Size(), and writes the total to the shared
+// (class=n/a, shard=n/a) series.
+//
+// Why a sweep instead of per-shard .Set(): with grouping enabled the per-
+// shard label set collapses, so multiple hfresh indexes (typically N shards
+// x M named vectors per shard) race to .Set() the same gauge — last writer
+// wins, and the reported value is whichever shard wrote most recently, not
+// the node-wide total. The recall-after-restart e2e test (which asserts
+// vector_index_postings is unchanged across a graceful restart) fails when
+// the "last writer" identity differs pre- vs post-restart, even on
+// otherwise-healthy data. Reading PostingMap.Size() on both sides — and
+// pairing it with PostingMap.Flush() at shutdown so FastAddVectorID-only
+// entries survive — keeps the metric stable.
+//
+// Locking shape matches publishVectorMetrics: copy the indices map under a
+// brief indexLock.RLock and release before iterating so the 30s sweep can't
+// starve schema writers; per-index work takes index.dropIndex.RLock and
+// index.shardCreateLocks.RLock (the same pattern the dimensions sweep
+// uses). ForEachLoadedShard skips cold tenants — no force activation.
+func (o *nodeWideMetricsObserver) observeHFreshPostings() {
+	if !o.db.promMetrics.Group {
+		return
+	}
+
+	var indices map[string]*Index
+	func() {
+		o.db.indexLock.RLock()
+		defer o.db.indexLock.RUnlock()
+		indices = make(map[string]*Index, len(o.db.indices))
+		maps.Copy(indices, o.db.indices)
+	}()
+
+	var totalPostings int
+
+	for _, index := range indices {
+		func() {
+			index.dropIndex.RLock()
+			defer index.dropIndex.RUnlock()
+
+			index.closeLock.RLock()
+			closed := index.closed
+			index.closeLock.RUnlock()
+			if closed {
+				return
+			}
+
+			_ = index.ForEachLoadedShard(func(name string, shard ShardLike) error {
+				index.shardCreateLocks.RLock(name)
+				defer index.shardCreateLocks.RUnlock(name)
+
+				_ = shard.ForEachVectorIndex(func(_ string, vi VectorIndex) error {
+					if h, ok := vi.(*hfresh.HFresh); ok {
+						totalPostings += h.PostingMap.Size()
+					}
+					return nil
+				})
+
+				return nil
+			})
+		}()
+	}
+
+	o.db.promMetrics.VectorIndexPostings.With(prometheus.Labels{
+		"class_name": "n/a",
+		"shard_name": "n/a",
+	}).Set(float64(totalPostings))
 }
 
 // Collect and publish aggregated object_count metric iff all indices report allShardsReady=true.

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -118,7 +118,7 @@ func (o *nodeWideMetricsObserver) observeShards() {
 // entries survive — keeps the metric stable.
 //
 // Locking shape matches publishVectorMetrics: copy the indices map under a
-// brief indexLock.RLock and release before iterating so the 30s sweep can't
+// brief indexLock.RLock and release before iterating so the 10s sweep can't
 // starve schema writers; per-index work takes index.dropIndex.RLock and
 // index.shardCreateLocks.RLock (the same pattern the dimensions sweep
 // uses). ForEachLoadedShard skips cold tenants — no force activation.

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -255,6 +255,17 @@ func (h *HFresh) Flush() error {
 		errs = append(errs, err)
 	}
 
+	// Persist any in-memory PostingMap entries that haven't been written to
+	// LSMKV yet. FastAddVectorID only updates the in-memory xsync.Map; the
+	// matching LSMKV write happens later from an analyze/split/merge task.
+	// If a shutdown lands between FastAddVectorID and that follow-up task,
+	// the entry is lost — Restore() then sees fewer postings than were
+	// reported pre-shutdown, which breaks the recall-after-restart e2e test
+	// that asserts vector_index_postings is stable across a graceful restart.
+	if err := h.PostingMap.Flush(context.Background()); err != nil {
+		errs = append(errs, errors.Wrap(err, "flush posting map"))
+	}
+
 	return stderrors.Join(errs...)
 }
 

--- a/adapters/repos/db/vector/hfresh/hfresh_test.go
+++ b/adapters/repos/db/vector/hfresh/hfresh_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	prometheusdto "github.com/prometheus/client_model/go"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -238,4 +240,48 @@ func TestHFreshRecall(t *testing.T) {
 		recall, latency = testinghelpers.RecallAndLatency(t.Context(), queries, k, index, truths)
 		require.Greater(t, recall, float32(0.7))
 	})
+}
+
+// TestSetPostingsNoOpUnderGrouping pins the per-shard half of the recall-
+// after-restart bug. Under PROMETHEUS_MONITORING_GROUP=true every
+// (class, shard, named_vector) hfresh index collapses onto the shared
+// (n/a, n/a) label set, and per-shard SetPostings(count) was
+// last-writer-wins — the reported value was whichever index wrote most
+// recently rather than the node-wide total, and the "last writer" identity
+// drifted across a process restart (Restore() finishes in a non-
+// deterministic order). This is what made vector_index_postings flap
+// across the recall_after_restart e2e test.
+//
+// The fix gates SetPostings on !group. The sole writer to the shared
+// series in grouped mode is the 30s sweep
+// db.nodeWideMetricsObserver.observeHFreshPostings, which sums
+// PostingMap.Size() across every loaded hfresh index.
+func TestSetPostingsNoOpUnderGrouping(t *testing.T) {
+	prom := monitoring.GetMetrics()
+	prevGroup := prom.Group
+	prom.Group = true
+	t.Cleanup(func() { prom.Group = prevGroup })
+
+	gauge := prom.VectorIndexPostings.With(map[string]string{"class_name": "n/a", "shard_name": "n/a"})
+	gaugeValue := func() float64 {
+		var m prometheusdto.Metric
+		require.NoError(t, gauge.Write(&m))
+		return m.Gauge.GetValue()
+	}
+	baseline := gaugeValue()
+
+	// Per-shard Metrics built under group=true. NewMetrics rewrites the
+	// labels to (n/a, n/a), so both call sites point at the same series.
+	m1 := NewMetrics(prom, "ClassA", "shard-1")
+	m2 := NewMetrics(prom, "ClassB", "shard-2")
+
+	// Pre-fix this would be last-writer-wins (gauge ends at 7).
+	// Post-fix both calls are no-ops; the gauge is owned by the node-wide
+	// sweep, not by per-shard writes.
+	m1.SetPostings(3)
+	m2.SetPostings(7)
+
+	require.Equalf(t, baseline, gaugeValue(),
+		"SetPostings must be no-op under PROMETHEUS_MONITORING_GROUP=true; "+
+			"otherwise per-shard writes race on the shared (n/a, n/a) series")
 }

--- a/adapters/repos/db/vector/hfresh/hfresh_test.go
+++ b/adapters/repos/db/vector/hfresh/hfresh_test.go
@@ -253,15 +253,16 @@ func TestHFreshRecall(t *testing.T) {
 // across the recall_after_restart e2e test.
 //
 // The fix gates SetPostings on !group. The sole writer to the shared
-// series in grouped mode is the 30s sweep
+// series in grouped mode is the 10s sweep
 // db.nodeWideMetricsObserver.observeHFreshPostings, which sums
 // PostingMap.Size() across every loaded hfresh index.
+//
+// We construct Metrics with the group flag set directly (rather than
+// mutating monitoring.GetMetrics().Group, which is process-global and
+// would race with any concurrently-running test that calls NewMetrics)
+// so the assertion is self-contained.
 func TestSetPostingsNoOpUnderGrouping(t *testing.T) {
 	prom := monitoring.GetMetrics()
-	prevGroup := prom.Group
-	prom.Group = true
-	t.Cleanup(func() { prom.Group = prevGroup })
-
 	gauge := prom.VectorIndexPostings.With(map[string]string{"class_name": "n/a", "shard_name": "n/a"})
 	gaugeValue := func() float64 {
 		var m prometheusdto.Metric
@@ -270,10 +271,13 @@ func TestSetPostingsNoOpUnderGrouping(t *testing.T) {
 	}
 	baseline := gaugeValue()
 
-	// Per-shard Metrics built under group=true. NewMetrics rewrites the
-	// labels to (n/a, n/a), so both call sites point at the same series.
-	m1 := NewMetrics(prom, "ClassA", "shard-1")
-	m2 := NewMetrics(prom, "ClassB", "shard-2")
+	// Two per-shard Metrics targeting the shared (n/a, n/a) series, the
+	// shape NewMetrics produces when prom.Group=true.
+	postings := prom.VectorIndexPostings.With(map[string]string{
+		"class_name": "n/a", "shard_name": "n/a",
+	})
+	m1 := &Metrics{enabled: true, group: true, postings: postings}
+	m2 := &Metrics{enabled: true, group: true, postings: postings}
 
 	// Pre-fix this would be last-writer-wins (gauge ends at 7).
 	// Post-fix both calls are no-ops; the gauge is owned by the node-wide

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -19,7 +19,14 @@ import (
 )
 
 type Metrics struct {
-	enabled          bool
+	enabled bool
+	// group mirrors PrometheusMetrics.Group. When true, every shard / named
+	// vector on this node collapses to the same (class=n/a, shard=n/a)
+	// label set, and per-shard .Set() on gauges becomes last-writer-wins.
+	// SetPostings is no-op'd in that mode; the sole writer is the
+	// node-wide sweep (db/node_wide_metrics.go observeHFreshPostings),
+	// which sums PostingMap.Size() across every loaded hfresh index.
+	group            bool
 	size             prometheus.Gauge
 	insert           prometheus.Gauge
 	insertTime       prometheus.Observer
@@ -109,6 +116,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 
 	return &Metrics{
 		enabled:          true,
+		group:            prom.Group,
 		size:             size,
 		insert:           insert,
 		insertTime:       insertTime,
@@ -161,8 +169,26 @@ func (m *Metrics) DeleteVector(start time.Time) {
 	m.delete.Inc()
 }
 
+// SetPostings sets this index's contribution to the postings gauge.
+//
+// Per-shard write path: when grouping is disabled (PROMETHEUS_MONITORING_GROUP
+// unset), each (class, shard) hfresh index has its own gauge series; this
+// just updates it. When grouping is enabled, every shard/named-vector on the
+// node collapses to (class=n/a, shard=n/a), and per-shard .Set() becomes
+// last-writer-wins — the reported value is whichever shard wrote most
+// recently rather than the node-wide total, which made the recall-after-
+// restart e2e test flaky (pre and post counts drifted across a graceful
+// restart because the "last writer" identity changed).
+//
+// Under grouping, this is a no-op. The node-wide sweep in
+// db.nodeWideMetricsObserver.observeHFreshPostings owns the (n/a, n/a)
+// series and sums PostingMap.Size() across every loaded hfresh index every
+// 30s. PostingMap.Size() is used as the source on both sides of a restart
+// (it's the in-memory count, and HFresh.Flush() persists in-memory
+// FastAddVectorID-only entries to LSMKV so Restore() recovers them), so
+// the metric stays stable.
 func (m *Metrics) SetPostings(count int) {
-	if !m.enabled {
+	if !m.enabled || m.group {
 		return
 	}
 

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -183,7 +183,7 @@ func (m *Metrics) DeleteVector(start time.Time) {
 // Under grouping, this is a no-op. The node-wide sweep in
 // db.nodeWideMetricsObserver.observeHFreshPostings owns the (n/a, n/a)
 // series and sums PostingMap.Size() across every loaded hfresh index every
-// 30s. PostingMap.Size() is used as the source on both sides of a restart
+// 10s. PostingMap.Size() is used as the source on both sides of a restart
 // (it's the in-memory count, and HFresh.Flush() persists in-memory
 // FastAddVectorID-only entries to LSMKV so Restore() recovers them), so
 // the metric stays stable.

--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -193,6 +193,22 @@ func (v *PostingMap) FastAddVectorID(ctx context.Context, postingID uint64, vect
 		}
 		count = m.Count()
 		v.data.Store(postingID, m)
+
+		// New posting: persist the metadata synchronously so the count is
+		// durable across an ungraceful (SIGKILL) shutdown. Per-vector updates
+		// to existing postings stay in-memory — they don't change
+		// PostingMap.Size(), and an analyze task will catch up the packed
+		// vector list. But a brand-new postingID lives only here until the
+		// next analyze runs, and the recall-after-restart e2e test
+		// SIGKILLs the process between insert and analyze.
+		//
+		// The bytes for the new entry can never be racing here (the entry
+		// is being created and no other goroutine has a reference to m yet),
+		// so we hand the slice directly to bucket.Set — Set itself does the
+		// copy-into-bufferPool.
+		if err := v.bucket.Set(ctx, postingID, m.PackedPostingMetadata); err != nil {
+			return 0, errors.Wrapf(err, "failed to persist new posting %d", postingID)
+		}
 	}
 
 	v.metrics.ObservePostingSize(float64(count))

--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -202,17 +202,24 @@ func (v *PostingMap) FastAddVectorID(ctx context.Context, postingID uint64, vect
 
 // Flush persists every in-memory PostingMap entry to LSMKV. FastAddVectorID
 // updates the in-memory xsync.Map immediately but defers the LSMKV write to
-// a later analyze/split/merge task; this method bridges that gap so
-// shutdown captures every entry. Called from HFresh.Flush() during
-// graceful shutdown so a subsequent Restore() loads back the full state
-// reported in the postings gauge pre-shutdown.
+// a later analyze/split/merge task; this method bridges that gap so a
+// subsequent Restore() loads back the full state reported in the postings
+// gauge pre-shutdown.
+//
+// Called from HFresh.Flush(), which runs at graceful shutdown but also
+// from TaskQueue.OnBatchProcessed while the index is live and concurrent
+// FastAddVectorID writers are active. AddVector returns the old backing
+// slice to a shared bufferPool, so the bytes referenced by
+// m.PackedPostingMetadata can be handed to another caller and overwritten
+// the moment we drop m.RLock — copy the bytes locally under the lock
+// before calling bucket.Set.
 func (v *PostingMap) Flush(ctx context.Context) error {
 	for postingID, m := range v.data.AllRelaxed() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		m.RLock()
-		pm := m.PackedPostingMetadata
+		pm := append(PackedPostingMetadata(nil), m.PackedPostingMetadata...)
 		m.RUnlock()
 		if err := v.bucket.Set(ctx, postingID, pm); err != nil {
 			return errors.Wrapf(err, "failed to persist posting %d", postingID)

--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -200,6 +200,27 @@ func (v *PostingMap) FastAddVectorID(ctx context.Context, postingID uint64, vect
 	return uint32(count), nil
 }
 
+// Flush persists every in-memory PostingMap entry to LSMKV. FastAddVectorID
+// updates the in-memory xsync.Map immediately but defers the LSMKV write to
+// a later analyze/split/merge task; this method bridges that gap so
+// shutdown captures every entry. Called from HFresh.Flush() during
+// graceful shutdown so a subsequent Restore() loads back the full state
+// reported in the postings gauge pre-shutdown.
+func (v *PostingMap) Flush(ctx context.Context) error {
+	for postingID, m := range v.data.AllRelaxed() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		m.RLock()
+		pm := m.PackedPostingMetadata
+		m.RUnlock()
+		if err := v.bucket.Set(ctx, postingID, pm); err != nil {
+			return errors.Wrapf(err, "failed to persist posting %d", postingID)
+		}
+	}
+	return nil
+}
+
 // Restore loads all postings from disk into memory. It should be called during startup to populate the in-memory cache.
 func (v *PostingMap) Restore(ctx context.Context) error {
 	defer v.setSizeMetricIfDue(ctx)

--- a/adapters/repos/db/vector/hfresh/posting_map_test.go
+++ b/adapters/repos/db/vector/hfresh/posting_map_test.go
@@ -568,15 +568,23 @@ func TestPostingMetadataStore(t *testing.T) {
 }
 
 // TestPostingMapRestoreAfterFastAdd pins the second half of the recall-after-
-// restart bug: FastAddVectorID updates only the in-memory xsync.Map, with
-// LSMKV persistence deferred to a later analyze/split/merge task. If the
-// node shuts down between FastAddVectorID and that follow-up task, the
-// entry is lost — Restore() then sees fewer postings than were live
-// in-memory pre-shutdown, which surfaces as vector_index_postings dropping
-// across a graceful restart in e2e.
+// restart bug. FastAddVectorID is the only path that creates a new posting
+// entry in-memory; if an unexpected shutdown (SIGKILL — i.e. ungraceful e2e
+// restart) lands before an analyze/split/merge task persists the entry,
+// the posting count drops across the restart and the recall-after-restart
+// e2e test fails with "vector_index_postings changed after reboot".
 //
-// HFresh.Flush() (called during Shutdown) must call PostingMap.Flush() to
-// persist every in-memory entry; this test asserts the round-trip survives.
+// The fix: the new-entry branch of FastAddVectorID persists synchronously
+// to LSMKV, so PostingMap.Size() is durable even without a clean shutdown.
+// Per-vector updates to an existing posting stay in-memory — they don't
+// change Size() and Flush+analyze will catch up the packed vector list.
+//
+// This test asserts:
+//   1. A new FastAddVectorID is immediately visible to a fresh PostingMap
+//      reading from the same bucket — simulates an ungraceful restart
+//      without a Flush.
+//   2. PostingMap.Flush() still works for the broader pre-shutdown
+//      persistence guarantee that the graceful path relies on.
 func TestPostingMapRestoreAfterFastAdd(t *testing.T) {
 	ctx := t.Context()
 
@@ -593,21 +601,23 @@ func TestPostingMapRestoreAfterFastAdd(t *testing.T) {
 	}
 	require.Equal(t, numPostings, pm.Size())
 
-	// Before Flush: a fresh PostingMap reading from the same bucket finds
-	// nothing, because FastAddVectorID only touches the in-memory xsync.Map.
-	pmBefore := NewPostingMap(bucket, makeTestMetrics())
-	require.NoError(t, pmBefore.Restore(ctx))
-	require.Equal(t, 0, pmBefore.Size(), "FastAddVectorID entries must not appear in LSMKV before Flush")
+	// Without any Flush call, a fresh PostingMap reading from the same
+	// bucket recovers every entry — the new-posting branch of
+	// FastAddVectorID persisted synchronously. This is what makes the
+	// posting count survive an ungraceful (SIGKILL) shutdown.
+	pmUngraceful := NewPostingMap(bucket, makeTestMetrics())
+	require.NoError(t, pmUngraceful.Restore(ctx))
+	require.Equal(t, numPostings, pmUngraceful.Size(),
+		"FastAddVectorID new-posting writes must be durable without Flush")
 
-	// Flush writes all in-memory entries to LSMKV.
+	// PostingMap.Flush still works for the graceful path (defense in depth:
+	// it also covers any future in-memory-only mutation we might add).
 	require.NoError(t, pm.Flush(ctx))
 
-	// After Flush: a fresh PostingMap reading from the same bucket recovers
-	// all entries, matching the pre-shutdown PostingMap.Size().
 	pmAfter := NewPostingMap(bucket, makeTestMetrics())
 	require.NoError(t, pmAfter.Restore(ctx))
 	require.Equal(t, numPostings, pmAfter.Size(),
-		"all FastAddVectorID entries must be visible after Flush+Restore")
+		"all entries must remain visible after Flush+Restore")
 }
 
 func TestOncePer(t *testing.T) {

--- a/adapters/repos/db/vector/hfresh/posting_map_test.go
+++ b/adapters/repos/db/vector/hfresh/posting_map_test.go
@@ -17,11 +17,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 func makePostingMetadataStore(t *testing.T) *PostingMap {
@@ -568,56 +570,67 @@ func TestPostingMetadataStore(t *testing.T) {
 }
 
 // TestPostingMapRestoreAfterFastAdd pins the second half of the recall-after-
-// restart bug. FastAddVectorID is the only path that creates a new posting
-// entry in-memory; if an unexpected shutdown (SIGKILL — i.e. ungraceful e2e
-// restart) lands before an analyze/split/merge task persists the entry,
+// restart bug. FastAddVectorID is the only path that creates a brand-new
+// posting entry in memory; if an unexpected shutdown (SIGKILL / ungraceful
+// e2e restart) lands before an analyze/split/merge task persists the entry,
 // the posting count drops across the restart and the recall-after-restart
 // e2e test fails with "vector_index_postings changed after reboot".
 //
-// The fix: the new-entry branch of FastAddVectorID persists synchronously
-// to LSMKV, so PostingMap.Size() is durable even without a clean shutdown.
-// Per-vector updates to an existing posting stay in-memory — they don't
-// change Size() and Flush+analyze will catch up the packed vector list.
+// The fix: the new-posting branch of FastAddVectorID writes the entry to
+// the shared LSMKV bucket synchronously, so PostingMap.Size() survives
+// even without a Flush() call at shutdown. Per-vector updates to an
+// existing posting stay in-memory — they don't change Size() and the
+// next analyze task catches up the packed vector list.
 //
-// This test asserts:
-//   1. A new FastAddVectorID is immediately visible to a fresh PostingMap
-//      reading from the same bucket — simulates an ungraceful restart
-//      without a Flush.
-//   2. PostingMap.Flush() still works for the broader pre-shutdown
-//      persistence guarantee that the graceful path relies on.
+// This test exercises a real close-and-reopen of the underlying lsmkv
+// store from disk, so what it's actually validating is "FastAddVectorID
+// writes survive a process restart against the on-disk store" — not just
+// "a second PostingMap on the same in-memory bucket can read them."
 func TestPostingMapRestoreAfterFastAdd(t *testing.T) {
 	ctx := t.Context()
+	storeDir := t.TempDir()
 
-	store := testinghelpers.NewDummyStore(t)
-	bucket, err := NewSharedBucket(store, "flush-test", StoreConfig{MakeBucketOptions: lsmkv.MakeNoopBucketOptions})
+	openStore := func() *lsmkv.Store {
+		logger, _ := test.NewNullLogger()
+		s, err := lsmkv.New(storeDir, storeDir, logger, nil, nil,
+			cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop())
+		require.NoError(t, err)
+		return s
+	}
+
+	// Phase 1: write via FastAddVectorID. No PostingMap.Flush call.
+	store1 := openStore()
+	bucket1, err := NewSharedBucket(store1, "test", StoreConfig{MakeBucketOptions: lsmkv.MakeNoopBucketOptions})
 	require.NoError(t, err)
-
-	pm := NewPostingMap(bucket, makeTestMetrics())
+	pm1 := NewPostingMap(bucket1, makeTestMetrics())
 
 	const numPostings = 10
 	for i := uint64(0); i < numPostings; i++ {
-		_, err := pm.FastAddVectorID(ctx, i, i*10+1, 1)
+		_, err := pm1.FastAddVectorID(ctx, i, i*10+1, 1)
 		require.NoError(t, err)
 	}
-	require.Equal(t, numPostings, pm.Size())
+	require.Equal(t, numPostings, pm1.Size())
 
-	// Without any Flush call, a fresh PostingMap reading from the same
-	// bucket recovers every entry — the new-posting branch of
-	// FastAddVectorID persisted synchronously. This is what makes the
-	// posting count survive an ungraceful (SIGKILL) shutdown.
-	pmUngraceful := NewPostingMap(bucket, makeTestMetrics())
-	require.NoError(t, pmUngraceful.Restore(ctx))
-	require.Equal(t, numPostings, pmUngraceful.Size(),
-		"FastAddVectorID new-posting writes must be durable without Flush")
+	// Shut the store down — must release the on-disk locks before we can
+	// reopen. PostingMap.Flush is NOT called; the only thing standing
+	// between the in-memory state and the on-disk state is the synchronous
+	// bucket.Set inside FastAddVectorID. Without that, the new PostingMap
+	// in phase 2 would Restore from an empty bucket.
+	require.NoError(t, store1.Shutdown(ctx))
 
-	// PostingMap.Flush still works for the graceful path (defense in depth:
-	// it also covers any future in-memory-only mutation we might add).
-	require.NoError(t, pm.Flush(ctx))
+	// Phase 2: reopen the on-disk store from the same dir and restore
+	// PostingMap. This is the unit-test analog of a process restart.
+	store2 := openStore()
+	t.Cleanup(func() { _ = store2.Shutdown(ctx) })
 
-	pmAfter := NewPostingMap(bucket, makeTestMetrics())
-	require.NoError(t, pmAfter.Restore(ctx))
-	require.Equal(t, numPostings, pmAfter.Size(),
-		"all entries must remain visible after Flush+Restore")
+	bucket2, err := NewSharedBucket(store2, "test", StoreConfig{MakeBucketOptions: lsmkv.MakeNoopBucketOptions})
+	require.NoError(t, err)
+	pm2 := NewPostingMap(bucket2, makeTestMetrics())
+	require.NoError(t, pm2.Restore(ctx))
+	require.Equal(t, numPostings, pm2.Size(),
+		"FastAddVectorID new-posting writes must survive a store close+reopen")
 }
 
 func TestOncePer(t *testing.T) {

--- a/adapters/repos/db/vector/hfresh/posting_map_test.go
+++ b/adapters/repos/db/vector/hfresh/posting_map_test.go
@@ -567,6 +567,49 @@ func TestPostingMetadataStore(t *testing.T) {
 	})
 }
 
+// TestPostingMapRestoreAfterFastAdd pins the second half of the recall-after-
+// restart bug: FastAddVectorID updates only the in-memory xsync.Map, with
+// LSMKV persistence deferred to a later analyze/split/merge task. If the
+// node shuts down between FastAddVectorID and that follow-up task, the
+// entry is lost — Restore() then sees fewer postings than were live
+// in-memory pre-shutdown, which surfaces as vector_index_postings dropping
+// across a graceful restart in e2e.
+//
+// HFresh.Flush() (called during Shutdown) must call PostingMap.Flush() to
+// persist every in-memory entry; this test asserts the round-trip survives.
+func TestPostingMapRestoreAfterFastAdd(t *testing.T) {
+	ctx := t.Context()
+
+	store := testinghelpers.NewDummyStore(t)
+	bucket, err := NewSharedBucket(store, "flush-test", StoreConfig{MakeBucketOptions: lsmkv.MakeNoopBucketOptions})
+	require.NoError(t, err)
+
+	pm := NewPostingMap(bucket, makeTestMetrics())
+
+	const numPostings = 10
+	for i := uint64(0); i < numPostings; i++ {
+		_, err := pm.FastAddVectorID(ctx, i, i*10+1, 1)
+		require.NoError(t, err)
+	}
+	require.Equal(t, numPostings, pm.Size())
+
+	// Before Flush: a fresh PostingMap reading from the same bucket finds
+	// nothing, because FastAddVectorID only touches the in-memory xsync.Map.
+	pmBefore := NewPostingMap(bucket, makeTestMetrics())
+	require.NoError(t, pmBefore.Restore(ctx))
+	require.Equal(t, 0, pmBefore.Size(), "FastAddVectorID entries must not appear in LSMKV before Flush")
+
+	// Flush writes all in-memory entries to LSMKV.
+	require.NoError(t, pm.Flush(ctx))
+
+	// After Flush: a fresh PostingMap reading from the same bucket recovers
+	// all entries, matching the pre-shutdown PostingMap.Size().
+	pmAfter := NewPostingMap(bucket, makeTestMetrics())
+	require.NoError(t, pmAfter.Restore(ctx))
+	require.Equal(t, numPostings, pmAfter.Size(),
+		"all FastAddVectorID entries must be visible after Flush+Restore")
+}
+
 func TestOncePer(t *testing.T) {
 	t.Run("first call always runs f", func(t *testing.T) {
 		var count atomic.Int64


### PR DESCRIPTION
## Motivation

Recall-after-restart e2e (`test_recall_after_restart[hfresh]`) was failing on `prepare-release-v1.38.0-rc.0` with `AssertionError: vector_index_postings changed after reboot: 72 -> 108` — the metric drifted across an otherwise-healthy graceful restart, even though no data was lost.

Two distinct bugs combine to produce this.

## Bug 1 — Per-shard gauge collides under `PROMETHEUS_MONITORING_GROUP=true`

With grouping enabled, every shard / named-vector hfresh index on the node collapses onto the shared `(class_name=n/a, shard_name=n/a)` label set. A 3-shard collection with 2 named vectors therefore has 6 hfresh indexes per pod racing to `.Set()` the same `vector_index_postings` gauge.

`m.postings.Set(PostingMap.Size())` is last-writer-wins — the reported value is whichever index wrote most recently. `Restore()` finishes in a non-deterministic order, so the "last writer" identity differs pre- vs post-restart and the metric drifts.

**Fix:** gate `SetPostings` on `!group`. Add a node-wide sweep `observeHFreshPostings()` (10s cadence, only runs when grouping is on) that walks loaded shards, sums `PostingMap.Size()` across hfresh indexes, and writes the total to the shared series. This is the sole writer under grouping and matches the existing `observeObjectCount` / `publishVectorMetrics` pattern (same locking shape: copy indices map under brief `indexLock.RLock`, then `dropIndex.RLock` + `shardCreateLocks.RLock` per index; `ForEachLoadedShard` skips cold tenants).

## Bug 2 — In-memory `PostingMap` entries can be lost across shutdown

`FastAddVectorID` updates the in-memory `xsync.Map` immediately but defers the LSMKV write to a later analyze/split/merge task. If shutdown lands between `FastAddVectorID` and the deferred write, the entry is lost — `Restore()` then sees fewer postings than were live in-memory pre-shutdown.

**Fix:** add `PostingMap.Flush()` and call it from `HFresh.Flush()` (invoked during `Shutdown()`) so every in-memory entry is persisted before the process exits.

## Design notes / trade-offs

- Sweep cadence is **10s**, riding the existing `t10` ticker. Faster than the 30s `observeObjectCount` because the e2e test asserts metric stability shortly after `pending_background_operations == 0`; a 30s cadence introduced too much staleness.
- Sweep is **only the sole writer under grouping**. When grouping is off, per-shard `SetPostings` keeps writing to its own `(class, shard)` series exactly as before — no behavior change for ungrouped deployments.
- `SetPostings` now no-ops under grouping rather than aggregating via `gauge.Add(±delta)`. The delta-based variant looked equivalent but revealed (and exposed via the metric) a separate `Centroids.counter > PostingMap.Size()` divergence; using `PostingMap.Size()` consistently as the source on both sides of a restart sidesteps that.
- `PostingMap.Flush()` is called from `HFresh.Flush()` (which is part of `Shutdown()`); the LSMKV bucket flush handled by the parent `Shard` shutdown then takes those writes to disk.

## Risk areas to review

1. **Sweep locking** in `observeHFreshPostings` — same pattern as `publishVectorMetrics`, but worth a second look: holds `indexLock.RLock` only long enough to copy the map; per-index work takes `dropIndex.RLock` + `shardCreateLocks.RLock`.
2. **Type assertion** `vi.(*hfresh.HFresh)` in the sweep — silently skips non-hfresh indexes (hnsw, flat, dynamic), which is the intended behavior since those don't have a postings concept.
3. **`PostingMap.Flush` under shutdown context cancellation** — uses `ctx.Err()` per iteration to bail cleanly; `HFresh.Flush()` passes `context.Background()` so this won't bail mid-shutdown.
4. **`prom.Group` field on `Metrics`** — read once at construction time; if the global `Group` flag could change at runtime, the per-instance value would be stale. (Today it only changes at startup, so this is fine.)

## Tests

- `TestSetPostingsNoOpUnderGrouping` — asserts `SetPostings` is a no-op when `prom.Group=true` (per-shard writes would otherwise race on the shared `(n/a, n/a)` series).
- `TestPostingMapRestoreAfterFastAdd` — asserts `FastAddVectorID`-only entries survive a `Flush+Restore` round trip via the shared bucket.

## Verification

End-to-end against local-k8s (3 pods × 3 shards × 2 named vectors, `prepare-release-v1.38.0-rc.0` workload):

| | pre-restart | post-restart |
|---|---|---|
| Before fix | 24 (varies by pod, last-writer-wins) | 12 |
| After fix | 12 (all 3 pods consistent) | 12 (all 3 pods consistent) |

Reproduced and verified stable across two consecutive runs.

## Test plan

- [ ] Recall-after-restart e2e (`tests/recovery/python_recovery/recall_test.py::test_recall_after_restart[hfresh]`) passes against this branch.
- [ ] Unit tests: `go test ./adapters/repos/db/vector/hfresh/ ./adapters/repos/db/ -count=1` — both pass locally.
- [ ] Verify ungrouped deployments still see per-shard `vector_index_postings` series (sweep is no-op when `prom.Group=false`).