### PR TITLE
Restrict user assignment permissions to roles the user has permission to

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -134,6 +134,10 @@ func (h *authZHandlers) authorizeAssignRolePermissions(ctx context.Context, prin
 	var errs error
 	for _, policies := range roles {
 		for _, policy := range policies {
+			// GetRoles returns this placeholder for permission-less roles; it grants nothing.
+			if policy.Resource == conv.InternalPlaceHolder {
+				continue
+			}
 			if err := h.authorizer.AuthorizeSilent(ctx, principal, policy.Verb, policy.Resource); err != nil {
 				errs = errors.Join(errs, err)
 			}

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -127,6 +127,24 @@ func (h *authZHandlers) authorizeRoleScopes(ctx context.Context, principal *mode
 	return fmt.Errorf("can only create roles with less or equal permissions as the current user: %w", err)
 }
 
+// authorizeAssignRolePermissions blocks privilege escalation via role
+// assignment: the caller must already hold every permission the assigned roles
+// grant, else assign_and_revoke_users alone could be used to grant admin.
+func (h *authZHandlers) authorizeAssignRolePermissions(ctx context.Context, principal *models.Principal, roles map[string][]authorization.Policy) error {
+	var errs error
+	for _, policies := range roles {
+		for _, policy := range policies {
+			if err := h.authorizer.AuthorizeSilent(ctx, principal, policy.Verb, policy.Resource); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+	if errs != nil {
+		return fmt.Errorf("can only assign roles with less or equal permissions as the current user: %w", errs)
+	}
+	return nil
+}
+
 func (h *authZHandlers) createRole(params authz.CreateRoleParams, principal *models.Principal) middleware.Responder {
 	ctx := params.HTTPRequest.Context()
 
@@ -491,6 +509,10 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("one or more of the roles requested doesn't exist")))
 	}
 
+	if err := h.authorizeAssignRolePermissions(ctx, principal, existedRoles); err != nil {
+		return authz.NewAssignRoleToUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
+	}
+
 	userTypes, err := h.getUserTypesAndValidateExistence(params.ID, authentication.AuthType(params.Body.UserType))
 	if err != nil {
 		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user exists: %w", err)))
@@ -553,6 +575,10 @@ func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, 
 
 	if len(existedRoles) != len(params.Body.Roles) && len(params.Body.Roles) > 0 {
 		return authz.NewAssignRoleToGroupNotFound()
+	}
+
+	if err := h.authorizeAssignRolePermissions(ctx, principal, existedRoles); err != nil {
+		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.controller.AddRolesForUser(conv.PrefixGroupName(params.ID), params.Body.Roles); err != nil {

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -99,6 +99,71 @@ func TestAssignRoleToGroupSuccess(t *testing.T) {
 	assert.NotNil(t, parsed)
 }
 
+// TestAssignEmptyRoleSkipsPlaceholderPolicy: empty roles surface from GetRoles
+// as a single InternalPlaceHolder policy; the assign guard must skip it or no
+// caller below root can assign an empty role.
+func TestAssignEmptyRoleSkipsPlaceholderPolicy(t *testing.T) {
+	emptyRolePolicies := map[string][]authorization.Policy{
+		"emptyRole": {{Resource: conv.InternalPlaceHolder}},
+	}
+
+	t.Run("assign to user", func(t *testing.T) {
+		authorizer := authorization.NewMockAuthorizer(t)
+		controller := NewMockControllerAndGetUsers(t)
+		logger, _ := test.NewNullLogger()
+
+		userType := models.UserTypeInputDb
+		principal := &models.Principal{Username: "user1"}
+		params := authz.AssignRoleToUserParams{
+			ID:          "user1",
+			HTTPRequest: req,
+			Body:        authz.AssignRoleToUserBody{Roles: []string{"emptyRole"}, UserType: userType},
+		}
+
+		authorizer.On("Authorize", mock.Anything, principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Users(params.ID)[0]).Return(nil)
+		controller.On("GetRoles", params.Body.Roles[0]).Return(emptyRolePolicies, nil)
+		controller.On("AddRolesForUser", conv.UserNameWithTypeFromId(params.ID, authentication.AuthType(params.Body.UserType)), params.Body.Roles).Return(nil)
+		// AuthorizeSilent intentionally unmocked: the guard must skip the placeholder.
+
+		h := &authZHandlers{
+			authorizer:     authorizer,
+			controller:     controller,
+			apiKeysConfigs: config.StaticAPIKey{Enabled: true, Users: []string{"user1"}},
+			logger:         logger,
+		}
+		res := h.assignRoleToUser(params, principal)
+		_, ok := res.(*authz.AssignRoleToUserOK)
+		assert.True(t, ok, "expected OK, got %T", res)
+	})
+
+	t.Run("assign to group", func(t *testing.T) {
+		authorizer := authorization.NewMockAuthorizer(t)
+		controller := NewMockControllerAndGetUsers(t)
+		logger, _ := test.NewNullLogger()
+
+		principal := &models.Principal{Username: "root-user"}
+		params := authz.AssignRoleToGroupParams{
+			ID:          "group1",
+			HTTPRequest: req,
+			Body:        authz.AssignRoleToGroupBody{Roles: []string{"emptyRole"}, GroupType: models.GroupTypeOidc},
+		}
+
+		authorizer.On("Authorize", mock.Anything, principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Groups(authentication.AuthType(params.Body.GroupType), params.ID)[0]).Return(nil)
+		controller.On("GetRoles", params.Body.Roles[0]).Return(emptyRolePolicies, nil)
+		controller.On("AddRolesForUser", conv.PrefixGroupName(params.ID), params.Body.Roles).Return(nil)
+
+		h := &authZHandlers{
+			authorizer: authorizer,
+			controller: controller,
+			logger:     logger,
+			rbacconfig: rbacconf.Config{RootUsers: []string{"root-user"}},
+		}
+		res := h.assignRoleToGroup(params, principal)
+		_, ok := res.(*authz.AssignRoleToGroupOK)
+		assert.True(t, ok, "expected OK, got %T", res)
+	})
+}
+
 func TestAssignRoleToUserOrUserNotFound(t *testing.T) {
 	type testCase struct {
 		name          string

--- a/test/acceptance/authz/groups_test.go
+++ b/test/acceptance/authz/groups_test.go
@@ -108,27 +108,31 @@ func TestAuthzRolesForGroups(t *testing.T) {
 		var errType *authz.AssignRoleToGroupForbidden
 		require.True(t, errors.As(err, &errType))
 
+		// The assign guard requires the caller to already hold every permission
+		// the assigned role grants, so customUser needs read_groups in addition
+		// to assign_and_revoke_groups before it can assign groupRead.
 		helper.AssignRoleToUser(t, adminKey, groupAssignName, customUser)
+		helper.AssignRoleToUser(t, adminKey, groupReadName, customUser)
+		t.Cleanup(func() {
+			helper.RevokeRoleFromUser(t, adminKey, groupAssignName, customUser)
+			helper.RevokeRoleFromUser(t, adminKey, groupReadName, customUser)
+		})
 
 		// assigning works after user has appropriate rights
 		helper.AssignRoleToGroup(t, customKey, groupReadName, group)
-		defer helper.RevokeRoleFromGroup(t, adminKey, groupReadName, group)
+		t.Cleanup(func() { helper.RevokeRoleFromGroup(t, adminKey, groupReadName, group) })
 
 		groupRoles := helper.GetRolesForGroup(t, adminKey, group, false)
 		require.Len(t, groupRoles, 1)
 		require.Equal(t, groupReadName, *groupRoles[0].Name)
-
-		helper.RevokeRoleFromUser(t, adminKey, groupReadName, customUser)
-		helper.RevokeRoleFromUser(t, adminKey, groupAssignName, customUser)
 	})
 
 	t.Run("revoke group", func(t *testing.T) {
 		group := "revoke-group"
 
 		helper.AssignRoleToGroup(t, adminKey, groupReadName, group)
-		defer helper.RevokeRoleFromGroup(t, adminKey, groupReadName, group)
+		t.Cleanup(func() { helper.RevokeRoleFromGroup(t, adminKey, groupReadName, group) })
 
-		defer helper.RevokeRoleFromGroup(t, adminKey, groupReadName, group)
 		_, err := helper.Client(t).Authz.RevokeRoleFromGroup(
 			authz.NewRevokeRoleFromGroupParams().WithID(group).WithBody(authz.RevokeRoleFromGroupBody{GroupType: models.GroupTypeOidc, Roles: []string{groupReadName}}),
 			helper.CreateAuth(customKey),
@@ -138,13 +142,89 @@ func TestAuthzRolesForGroups(t *testing.T) {
 		require.True(t, errors.As(err, &errType))
 
 		helper.AssignRoleToUser(t, adminKey, groupAssignName, customUser)
+		t.Cleanup(func() { helper.RevokeRoleFromUser(t, adminKey, groupAssignName, customUser) })
 
 		// revoking works after user has appropriate rights
 		helper.RevokeRoleFromGroup(t, customKey, groupReadName, group)
 		groupRoles := helper.GetRolesForGroup(t, adminKey, group, false)
 		require.Len(t, groupRoles, 0)
+	})
 
-		helper.RevokeRoleFromUser(t, adminKey, groupAssignName, customUser)
+	// A delegate holding only assign_and_revoke_groups must not be able to
+	// elevate a group (and through it, every group member) to a role whose
+	// permissions the delegate itself lacks.
+	t.Run("assign_and_revoke_groups alone cannot escalate privileges", func(t *testing.T) {
+		assignGroups := authorization.AssignAndRevokeGroups
+		helper.CreateRoleAndAssign(t, adminKey, customUser, "group-delegate", &models.Permission{
+			Action: &assignGroups,
+			Groups: &models.PermissionGroups{Group: &all, GroupType: models.GroupTypeOidc},
+		})
+		helper.WaitForOwnRole(t, customKey, "group-delegate")
+
+		t.Run("cannot assign built-in admin to a group", func(t *testing.T) {
+			group := "escalation-admin-group"
+			_, err := helper.Client(t).Authz.AssignRoleToGroup(
+				authz.NewAssignRoleToGroupParams().WithID(group).WithBody(
+					authz.AssignRoleToGroupBody{Roles: []string{authorization.Admin}, GroupType: models.GroupTypeOidc}),
+				helper.CreateAuth(customKey),
+			)
+			require.Error(t, err)
+			var forbidden *authz.AssignRoleToGroupForbidden
+			require.True(t, errors.As(err, &forbidden), "expected 403, got %T", err)
+			require.Contains(t, forbidden.Payload.Error[0].Message, "less or equal permissions")
+		})
+
+		t.Run("cannot assign a custom role granting permissions it lacks", func(t *testing.T) {
+			powerful := "powerful-group-role"
+			helper.DeleteRole(t, adminKey, powerful)
+			helper.CreateRole(t, adminKey, &models.Role{
+				Name: &powerful,
+				Permissions: []*models.Permission{
+					helper.NewCollectionsPermission().WithAction(authorization.DeleteCollections).WithCollection("*").Permission(),
+				},
+			})
+			defer helper.DeleteRole(t, adminKey, powerful)
+
+			group := "escalation-custom-group"
+			_, err := helper.Client(t).Authz.AssignRoleToGroup(
+				authz.NewAssignRoleToGroupParams().WithID(group).WithBody(
+					authz.AssignRoleToGroupBody{Roles: []string{powerful}, GroupType: models.GroupTypeOidc}),
+				helper.CreateAuth(customKey),
+			)
+			require.Error(t, err)
+			var forbidden *authz.AssignRoleToGroupForbidden
+			require.True(t, errors.As(err, &forbidden), "expected 403, got %T", err)
+			require.Contains(t, forbidden.Payload.Error[0].Message, "less or equal permissions")
+		})
+
+		t.Run("can assign a role whose permissions it already holds", func(t *testing.T) {
+			readCollectionA := func() *models.Permission {
+				return helper.NewDataPermission().WithAction(authorization.ReadData).WithCollection("CollectionA").Permission()
+			}
+			// Grant the delegate read_data on CollectionA so it now holds
+			// exactly what assignable-group-role grants (identical builder =>
+			// identical policy) and the guard is satisfied.
+			helper.CreateRoleAndAssign(t, adminKey, customUser, "group-data-reader", readCollectionA())
+			helper.WaitForOwnRole(t, customKey, "group-data-reader")
+
+			assignable := "assignable-group-role"
+			helper.DeleteRole(t, adminKey, assignable)
+			helper.CreateRole(t, adminKey, &models.Role{
+				Name:        &assignable,
+				Permissions: []*models.Permission{readCollectionA()},
+			})
+			defer helper.DeleteRole(t, adminKey, assignable)
+
+			group := "escalation-ok-group"
+			resp, err := helper.Client(t).Authz.AssignRoleToGroup(
+				authz.NewAssignRoleToGroupParams().WithID(group).WithBody(
+					authz.AssignRoleToGroupBody{Roles: []string{assignable}, GroupType: models.GroupTypeOidc}),
+				helper.CreateAuth(customKey),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			helper.RevokeRoleFromGroup(t, adminKey, assignable, group)
+		})
 	})
 
 	t.Run("get role for group", func(t *testing.T) {

--- a/test/acceptance/authz/users_test.go
+++ b/test/acceptance/authz/users_test.go
@@ -248,19 +248,21 @@ func TestUserPermissions(t *testing.T) {
 		require.True(t, errors.As(err, &errType))
 
 		helper.AssignRoleToUser(t, adminKey, roleNameUpdate, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, roleNameUpdate, customUser)
 		helper.AssignRoleToUser(t, adminKey, roleNameReadRoles, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, roleNameReadRoles, customUser)
+		// grant otherRoleName up front so the assign guard (caller must
+		// already hold the role's permissions) is satisfied below
+		helper.AssignRoleToUser(t, adminKey, otherRoleName, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, otherRoleName, customUser)
 
 		// assigning works after user has appropriate rights
 		helper.AssignRoleToUser(t, customKey, otherRoleName, customUser)
-
-		// clean up
-		helper.RevokeRoleFromUser(t, adminKey, roleNameUpdate, customUser)
-		helper.RevokeRoleFromUser(t, adminKey, roleNameReadRoles, customUser)
-		helper.RevokeRoleFromUser(t, adminKey, otherRoleName, customUser)
 	})
 
 	t.Run("revoke users", func(t *testing.T) {
 		helper.AssignRoleToUser(t, adminKey, otherRoleName, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, otherRoleName, customUser)
 
 		_, err := helper.Client(t).Authz.RevokeRoleFromUser(
 			authz.NewRevokeRoleFromUserParams().WithID(customUser).WithBody(authz.RevokeRoleFromUserBody{Roles: []string{otherRoleName}}),
@@ -271,7 +273,9 @@ func TestUserPermissions(t *testing.T) {
 		require.True(t, errors.As(err, &errType))
 
 		helper.AssignRoleToUser(t, adminKey, roleNameUpdate, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, roleNameUpdate, customUser)
 		helper.AssignRoleToUser(t, adminKey, roleNameReadRoles, customUser)
+		defer helper.RevokeRoleFromUser(t, adminKey, roleNameReadRoles, customUser)
 
 		// revoking works after user has appropriate rights
 		roles := helper.GetRolesForUser(t, customUser, customKey, true)
@@ -279,9 +283,6 @@ func TestUserPermissions(t *testing.T) {
 		helper.RevokeRoleFromUser(t, customKey, otherRoleName, customUser)
 		roles = helper.GetRolesForUser(t, customUser, customKey, true)
 		require.Len(t, roles, 2)
-
-		helper.RevokeRoleFromUser(t, adminKey, roleNameUpdate, customUser)
-		helper.RevokeRoleFromUser(t, adminKey, roleNameReadRoles, customUser)
 	})
 }
 

--- a/test/acceptance/authz/users_test.go
+++ b/test/acceptance/authz/users_test.go
@@ -65,6 +65,81 @@ func TestAuthzRolesForUsers(t *testing.T) {
 		require.True(t, errors.As(err, &targetErr))
 		require.Equal(t, 404, targetErr.Code())
 	})
+
+	// A delegate holding only assign_and_revoke_users must not be able to assign
+	// itself a higher-privileged role (e.g. admin). Role setup stays in this
+	// subtest so its t.Cleanup runs before the parent's container teardown.
+	t.Run("assign_and_revoke_users alone cannot escalate privileges", func(t *testing.T) {
+		all := "*"
+		assignUsers := authorization.AssignAndRevokeUsers
+		helper.CreateRoleAndAssign(t, adminKey, customUser, "delegate", &models.Permission{
+			Action: &assignUsers,
+			Users:  &models.PermissionUsers{Users: &all},
+		})
+		helper.WaitForOwnRole(t, customKey, "delegate")
+
+		t.Run("cannot assign built-in admin to itself", func(t *testing.T) {
+			_, err := helper.Client(t).Authz.AssignRoleToUser(
+				authz.NewAssignRoleToUserParams().WithID(customUser).WithBody(
+					authz.AssignRoleToUserBody{Roles: []string{authorization.Admin}, UserType: models.UserTypeInputDb}),
+				helper.CreateAuth(customKey),
+			)
+			require.Error(t, err)
+			var forbidden *authz.AssignRoleToUserForbidden
+			require.True(t, errors.As(err, &forbidden), "expected 403, got %T", err)
+			require.Contains(t, forbidden.Payload.Error[0].Message, "less or equal permissions")
+		})
+
+		t.Run("cannot assign a custom role granting permissions it lacks", func(t *testing.T) {
+			powerful := "powerful-role"
+			helper.DeleteRole(t, adminKey, powerful)
+			helper.CreateRole(t, adminKey, &models.Role{
+				Name: &powerful,
+				Permissions: []*models.Permission{
+					helper.NewCollectionsPermission().WithAction(authorization.DeleteCollections).WithCollection("*").Permission(),
+				},
+			})
+			defer helper.DeleteRole(t, adminKey, powerful)
+
+			_, err := helper.Client(t).Authz.AssignRoleToUser(
+				authz.NewAssignRoleToUserParams().WithID(customUser).WithBody(
+					authz.AssignRoleToUserBody{Roles: []string{powerful}, UserType: models.UserTypeInputDb}),
+				helper.CreateAuth(customKey),
+			)
+			require.Error(t, err)
+			var forbidden *authz.AssignRoleToUserForbidden
+			require.True(t, errors.As(err, &forbidden), "expected 403, got %T", err)
+			require.Contains(t, forbidden.Payload.Error[0].Message, "less or equal permissions")
+		})
+
+		t.Run("can assign a role whose permissions it already holds", func(t *testing.T) {
+			readCollectionA := func() *models.Permission {
+				return helper.NewDataPermission().WithAction(authorization.ReadData).WithCollection("CollectionA").Permission()
+			}
+			// Also grant the delegate read_data on CollectionA, so it now holds
+			// exactly what assignable-role grants (identical builder => identical
+			// policy) and the guard is satisfied.
+			helper.CreateRoleAndAssign(t, adminKey, customUser, "data-reader", readCollectionA())
+			helper.WaitForOwnRole(t, customKey, "data-reader")
+
+			assignable := "assignable-role"
+			helper.DeleteRole(t, adminKey, assignable)
+			helper.CreateRole(t, adminKey, &models.Role{
+				Name:        &assignable,
+				Permissions: []*models.Permission{readCollectionA()},
+			})
+			defer helper.DeleteRole(t, adminKey, assignable)
+
+			resp, err := helper.Client(t).Authz.AssignRoleToUser(
+				authz.NewAssignRoleToUserParams().WithID(customUser).WithBody(
+					authz.AssignRoleToUserBody{Roles: []string{assignable}, UserType: models.UserTypeInputDb}),
+				helper.CreateAuth(customKey),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			helper.RevokeRoleFromUser(t, adminKey, assignable, customUser)
+		})
+	})
 }
 
 func TestAuthzRolesAndUserHaveTheSameName(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

This is equivalent to the MATCH scope for role management: A user can only assign roles whose permissions are <= of the roles the user has.

Example: user has `assign_role` privileges and
- `admin` => can assign `viewer` 
- `viewer` => cannot assign `admin`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
