### PR TITLE
test(reindex): replace time.Sleep with dynamic polling, cap poll intervals at 50ms

### DIFF
--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -372,7 +372,7 @@ func testPostRestartOrphanAuditClearsTracker(t *testing.T, ctx context.Context, 
 			filepath.Join(lsmPath, ".migrations", orphanDir),
 		})
 		return code != 0
-	}, 60*time.Second, 500*time.Millisecond,
+	}, 60*time.Second, 50*time.Millisecond,
 		"orphan tracker dir was not cleaned up by the post-bootstrap audit")
 
 	code, _, _ := container.Exec(ctx, []string{"test", "-d", filepath.Join(lsmPath, sidecarBucket)})
@@ -629,9 +629,12 @@ func testCancelClearsTrackerDirsViaOnTaskCompleted(t *testing.T, ctx context.Con
 	classPath := fmt.Sprintf("/data/%s", strings.ToLower(className))
 
 	// Poll .migrations/ until every body-related dir is gone (cleanup
-	// runs async on the scheduler tick).
-	deadline := time.Now().Add(30 * time.Second)
-	for {
+	// runs async on the scheduler tick). assert.Eventually drives the poll;
+	// on timeout we t.Fatalf with the last observed survivors so the
+	// diagnostic matches the original (the message args of require.Eventually
+	// are captured up-front, before any survivors are known).
+	var lastMatches string
+	drained := assert.Eventually(t, func() bool {
 		code, reader, execErr := container.Exec(ctx, []string{
 			"sh", "-c",
 			fmt.Sprintf(`ls -1 %s 2>/dev/null | grep -E '_%s($|_)' | head -10`, migsPath, propName),
@@ -641,16 +644,13 @@ func testCancelClearsTrackerDirsViaOnTaskCompleted(t *testing.T, ctx context.Con
 		if reader != nil {
 			_, _ = io.Copy(out, reader)
 		}
-		matches := strings.TrimSpace(out.String())
+		lastMatches = strings.TrimSpace(out.String())
 		// grep exit 1 (no match) or empty stdout means cleanup is done.
-		if code != 0 || matches == "" {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("cancel-cleanup did not remove %s/.migrations/*_%s_* within 30s; survivors:\n%s",
-				lsmPath, propName, matches)
-		}
-		time.Sleep(500 * time.Millisecond)
+		return code != 0 || lastMatches == ""
+	}, 30*time.Second, 50*time.Millisecond)
+	if !drained {
+		t.Fatalf("cancel-cleanup did not remove %s/.migrations/*_%s_* within 30s; survivors:\n%s",
+			lsmPath, propName, lastMatches)
 	}
 
 	// MutationGuard's IsActive() gate (STARTED/PREPARING/SWAPPING only)
@@ -756,12 +756,18 @@ func execInContainer(t *testing.T, ctx context.Context, c testcontainers.Contain
 // regression).
 func awaitIndexingState(t *testing.T, restURI, collection, property string) {
 	t.Helper()
+	// BEST-EFFORT: the transient "indexing" state legitimately may not be
+	// observable on a too-small fixture, so missing it must NOT fail the
+	// test (we only warn on the deadline). A ticker drives the poll at a
+	// 50ms interval; require.Eventually is deliberately NOT used here because
+	// it would turn a tolerable miss into a hard failure.
 	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	observe := func() bool {
 		resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s/indexes", restURI, collection))
 		if err != nil {
-			time.Sleep(20 * time.Millisecond)
-			continue
+			return false
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
@@ -774,20 +780,31 @@ func awaitIndexingState(t *testing.T, restURI, collection, property string) {
 				} `json:"indexes"`
 			} `json:"properties"`
 		}
-		if err := json.Unmarshal(body, &parsed); err == nil {
-			for _, p := range parsed.Properties {
-				if p.Name != property {
-					continue
-				}
-				for _, idx := range p.Indexes {
-					if idx.Status == "indexing" {
-						t.Logf("observed indexing state for %s/%s (type=%s)", collection, property, idx.Type)
-						return
-					}
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			return false
+		}
+		for _, p := range parsed.Properties {
+			if p.Name != property {
+				continue
+			}
+			for _, idx := range p.Indexes {
+				if idx.Status == "indexing" {
+					t.Logf("observed indexing state for %s/%s (type=%s)", collection, property, idx.Type)
+					return true
 				}
 			}
 		}
-		time.Sleep(20 * time.Millisecond)
+		return false
+	}
+	// Check once immediately, then on every tick until the deadline.
+	if observe() {
+		return
+	}
+	for time.Now().Before(deadline) {
+		<-ticker.C
+		if observe() {
+			return
+		}
 	}
 	t.Logf("warning: did not observe indexing state for %s/%s within deadline; migration may have completed too fast for the test fixture", collection, property)
 }

--- a/test/acceptance/reindex_concurrent/concurrent_test.go
+++ b/test/acceptance/reindex_concurrent/concurrent_test.go
@@ -157,7 +157,7 @@ func TestConcurrentReindex(t *testing.T) {
 				}
 			}
 			return true
-		}, 60*time.Second, 1*time.Second, "schema changes should propagate within 60s")
+		}, 60*time.Second, 50*time.Millisecond, "schema changes should propagate within 60s")
 	})
 
 	// 6. Verify queries still work correctly.
@@ -181,8 +181,22 @@ func TestConcurrentReindex(t *testing.T) {
 		t.Logf("submitted retokenize for text_0: %s", taskID)
 
 		// While it's running, try to submit another for the same property.
-		// This should be rejected as a conflict.
-		time.Sleep(100 * time.Millisecond) // brief delay to let it start
+		// This should be rejected as a conflict. Deterministically wait until
+		// the first task is registered and non-terminal before submitting the
+		// conflict, instead of a fixed sleep.
+		require.Eventually(t, func() bool {
+			tasks := getTasks(t, restURI)
+			for _, task := range tasks["reindex"] {
+				if task.ID == taskID {
+					// In-flight = registered but not yet terminal.
+					return task.Status != "FINISHED" &&
+						task.Status != "FAILED" &&
+						task.Status != "CANCELLED"
+				}
+			}
+			return false
+		}, 5*time.Second, 50*time.Millisecond, "first task must be in-flight before conflict")
+
 		url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, "text_0")
 		req, err := http.NewRequest(http.MethodPut, url,
 			bytes.NewReader([]byte(`{"searchable":{"tokenization":"field"}}`)))
@@ -281,37 +295,47 @@ func importData(t *testing.T, restURI, collection string) {
 
 func awaitTask(t *testing.T, restURI, taskID string, timeout time.Duration) error {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-		if err != nil {
-			time.Sleep(1 * time.Second)
-			continue
-		}
-		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-
-		var tasks models.DistributedTasks
-		if err := json.Unmarshal(body, &tasks); err != nil {
-			time.Sleep(1 * time.Second)
-			continue
-		}
+	// failErr captures a FAILED terminal state so we can fast-exit the poll
+	// and surface it to the caller as an error (preserving the original
+	// FAILED-fast-exit behavior). FINISHED satisfies the condition; any
+	// transient error (request/unmarshal) returns false and retries on the
+	// next tick.
+	var failErr error
+	require.Eventually(t, func() bool {
+		tasks := getTasks(t, restURI)
 		for _, task := range tasks["reindex"] {
 			if task.ID == taskID {
 				switch task.Status {
 				case "FINISHED":
 					t.Logf("task %s: FINISHED", taskID)
-					return nil
+					return true
 				case "FAILED":
-					return fmt.Errorf("task %s FAILED: %s", taskID, task.Error)
-				default:
-					// Still running.
+					failErr = fmt.Errorf("task %s FAILED: %s", taskID, task.Error)
+					return true
 				}
 			}
 		}
-		time.Sleep(1 * time.Second)
+		return false
+	}, timeout, 50*time.Millisecond, "task %s should finish", taskID)
+	return failErr
+}
+
+// getTasks fetches GET /v1/tasks and unmarshals it. Returns an empty map on
+// any transient request/unmarshal error so callers (poll loops) simply retry
+// on the next tick rather than failing.
+func getTasks(t *testing.T, restURI string) models.DistributedTasks {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
+	if err != nil {
+		return models.DistributedTasks{}
 	}
-	return fmt.Errorf("task %s did not finish within %v", taskID, timeout)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	var tasks models.DistributedTasks
+	if err := json.Unmarshal(body, &tasks); err != nil {
+		return models.DistributedTasks{}
+	}
+	return tasks
 }
 
 func countWithEqualFilter(t *testing.T, restURI, collection, propName string, value int) int {

--- a/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
@@ -780,17 +780,45 @@ func testParallel_EnableFilterableCancelSame(t *testing.T, restURI string) {
 	rSubmit := newPR("enable-filterable", `{"filterable":{"enabled":true}}`)
 	rCancel := newPR("cancel-filterable", `{"filterable":{"cancel":true}}`)
 
+	// submitted is closed once the submit PUT has returned, which publishes
+	// rSubmit.taskID to the cancel goroutine (channel close provides the
+	// happens-before edge, avoiding a data race on rSubmit.taskID).
+	submitted := make(chan struct{})
+
 	enterrors.GoWrapper(func() {
 		defer wg.Done()
 		executePR(restURI, class, "score", rSubmit)
+		close(submitted)
 	}, logger)
 
 	enterrors.GoWrapper(func() {
 		defer wg.Done()
-		// Brief stagger so submit has a chance to register before cancel
-		// arrives — without this, cancel arrives first and always 404s,
-		// making the scenario trivially green.
-		time.Sleep(10 * time.Millisecond)
+		// Deterministically wait until the submit's task is registered in
+		// GET /v1/tasks before issuing the cancel, so "cancel targets a live
+		// task" is no longer timing-dependent (a fixed stagger could race the
+		// cancel ahead of registration, making the scenario trivially green).
+		<-submitted
+		if rSubmit.taskID != "" {
+			require.Eventually(t, func() bool {
+				resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
+				if err != nil {
+					return false
+				}
+				body, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				var tasks models.DistributedTasks
+				if err := json.Unmarshal(body, &tasks); err != nil {
+					return false
+				}
+				for _, task := range tasks["reindex"] {
+					if task.ID == rSubmit.taskID {
+						return true
+					}
+				}
+				return false
+			}, 5*time.Second, 50*time.Millisecond,
+				"submit task %s must be registered before cancel", rSubmit.taskID)
+		}
 		executePR(restURI, class, "score", rCancel)
 	}, logger)
 
@@ -965,19 +993,16 @@ func awaitTerminalP(t *testing.T, restURI string, r *parallelResult) {
 	if !r.accepted || r.taskID == "" {
 		return
 	}
-	deadline := time.Now().Add(3 * time.Minute)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 		if err != nil {
-			time.Sleep(500 * time.Millisecond)
-			continue
+			return false
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		var tasks models.DistributedTasks
 		if err := json.Unmarshal(body, &tasks); err != nil {
-			time.Sleep(500 * time.Millisecond)
-			continue
+			return false
 		}
 		for _, task := range tasks["reindex"] {
 			if task.ID == r.taskID {
@@ -985,13 +1010,13 @@ func awaitTerminalP(t *testing.T, restURI string, r *parallelResult) {
 				case "FINISHED", "FAILED", "CANCELLED":
 					r.terminal = task.Status
 					t.Logf("task %s reached terminal=%s", r.taskID, task.Status)
-					return
+					return true
 				}
 			}
 		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	t.Logf("task %s did NOT reach terminal within 3m", r.taskID)
+		return false
+	}, 3*time.Minute, 50*time.Millisecond,
+		"task %s must reach a terminal state", r.taskID)
 }
 
 // =============================================================================
@@ -1161,7 +1186,7 @@ func eventualBothFlags(t *testing.T, class, prop string, wantFilt, wantRange boo
 			return gotFilt == wantFilt && gotRange == wantRange
 		}
 		return false
-	}, 60*time.Second, 250*time.Millisecond,
+	}, 60*time.Second, 50*time.Millisecond,
 		"flags on %s.%s must reach filt=%v range=%v", class, prop, wantFilt, wantRange)
 }
 
@@ -1187,6 +1212,6 @@ func eventualSingleFlag(t *testing.T, class, prop, flag string, want bool) {
 			}
 		}
 		return false
-	}, 60*time.Second, 250*time.Millisecond,
+	}, 60*time.Second, 50*time.Millisecond,
 		"flag %s on %s.%s must reach %v", flag, class, prop, want)
 }

--- a/test/acceptance/reindex_concurrent/parallel_same_property_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_same_property_test.go
@@ -156,7 +156,7 @@ func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 			return filtFalse && rangeFalse
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"both IndexFilterable and IndexRangeFilters must be false after DELETE")
 
 	// Step 3: fire both PUTs in parallel.
@@ -271,7 +271,7 @@ func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 				return p.IndexRangeFilters != nil && *p.IndexRangeFilters
 			}
 			return false
-		}, 60*time.Second, 250*time.Millisecond,
+		}, 60*time.Second, 50*time.Millisecond,
 			"schema flag for the accepted %s migration must flip before retrying the rejected one — "+
 				"FINISHED status alone is not sufficient", acceptedLabel)
 	}
@@ -288,7 +288,7 @@ func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 		require.Eventually(t, func() bool {
 			retryStatus, retryTaskID, retryBody = submitIndexUpdateRaw(t, restURI, collection, propName, body)
 			return retryStatus == http.StatusAccepted
-		}, 60*time.Second, 1*time.Second,
+		}, 60*time.Second, 50*time.Millisecond,
 			"retry of %s after the in-flight task finished must eventually be accepted; "+
 				"last response was status=%d body=%s", r.label, retryStatus, retryBody)
 		require.NoError(t, awaitTask(t, restURI, retryTaskID, 3*time.Minute),
@@ -310,7 +310,7 @@ func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 			return filtOn && rangeOn
 		}
 		return false
-	}, 60*time.Second, 500*time.Millisecond,
+	}, 60*time.Second, 50*time.Millisecond,
 		"both IndexFilterable and IndexRangeFilters must be true after both migrations finish")
 
 	// Step 8: queries against both buckets must return data. The filterable

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
@@ -109,18 +110,12 @@ func TestMultiNode_CancelClearsAcrossReplicas(t *testing.T) {
 
 	// Every replica on every node must drain its .migrations/*_body_*
 	// dirs within cancelTimeout.
-	deadline := time.Now().Add(cancelTimeout)
-	for {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		survivors := scanBodyMigrationsAllReplicas(ctx, t, compose, classDirLower, allShards, propName)
-		if len(survivors) == 0 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("cancel-cleanup left .migrations/*_%s_* dirs on %d replica slots after %s:\n  %s",
-				propName, len(survivors), cancelTimeout, strings.Join(survivors, "\n  "))
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+		assert.Emptyf(c, survivors,
+			"cancel-cleanup left .migrations/*_%s_* dirs on %d replica slots:\n  %s",
+			propName, len(survivors), strings.Join(survivors, "\n  "))
+	}, cancelTimeout, 50*time.Millisecond)
 
 	// Backup must succeed. canCommit refuses while any in-flight tracker
 	// is present, so a green backup here proves the inflight registration
@@ -132,18 +127,12 @@ func TestMultiNode_CancelClearsAcrossReplicas(t *testing.T) {
 	// not-in-flight) and the on-disk class dir must disappear on every node.
 	require.NoError(t, deleteClassExpectOK(t, uri, className), "DELETE class must succeed post-cancel")
 
-	deleteDeadline := time.Now().Add(cancelTimeout)
-	for {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		survivors := scanClassDirAllNodes(ctx, t, compose, classDirLower)
-		if len(survivors) == 0 {
-			break
-		}
-		if time.Now().After(deleteDeadline) {
-			t.Fatalf("DELETE class left /data/%s on %d node(s) after %s: %v",
-				classDirLower, len(survivors), cancelTimeout, survivors)
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+		assert.Emptyf(c, survivors,
+			"DELETE class left /data/%s on %d node(s): %v",
+			classDirLower, len(survivors), survivors)
+	}, cancelTimeout, 50*time.Millisecond)
 }
 
 // awaitTaskStartedFast polls /v1/tasks until the named task reaches
@@ -168,7 +157,7 @@ func awaitTaskStartedFast(t *testing.T, restURI, taskID string, timeout time.Dur
 			}
 		}
 		return false
-	}, timeout, 100*time.Millisecond, "task %s should reach STARTED", taskID)
+	}, timeout, 50*time.Millisecond, "task %s should reach STARTED", taskID)
 }
 
 // cancelReindexProperty sends {<indexType>: {cancel: true}} to
@@ -299,6 +288,8 @@ func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) e
 	}
 
 	deadline := time.Now().Add(120 * time.Second)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		r, err := http.Get(fmt.Sprintf("http://%s/v1/backups/s3/%s", restURI, backupID))
 		if err != nil {
@@ -318,9 +309,9 @@ func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) e
 			return fmt.Errorf("backup FAILED: %s", status.Error)
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("backup did not reach SUCCESS/FAILED in 60s; last status: %s", status.Status)
+			return fmt.Errorf("backup did not reach SUCCESS/FAILED in 120s; last status: %s", status.Status)
 		}
-		time.Sleep(500 * time.Millisecond)
+		<-ticker.C
 	}
 }
 

--- a/test/acceptance/reindex_multinode/concurrent_migrations_test.go
+++ b/test/acceptance/reindex_multinode/concurrent_migrations_test.go
@@ -189,39 +189,40 @@ func TestMultiNode_ConcurrentDifferentMigrations_ExactCountsPostSettle(t *testin
 	reindexhelpers.AwaitReindexFinished(t, uri1, catTaskID, reindexhelpers.WithTimeout(180*time.Second))
 	reindexhelpers.AwaitReindexFinished(t, uri1, pathTaskID, reindexhelpers.WithTimeout(180*time.Second))
 
-	// Brief settle so schema flips propagate to every node.
-	time.Sleep(3 * time.Second)
-
 	// Phase-3 equivalent: every replica, every prop, must return the
-	// baseline. A wrong count on any (node, prop) pair is the bug.
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		uri := restURIOf(compose, nodeIdx)
+	// baseline. AwaitReindexFinished only confirms node-1; poll all replicas
+	// (50ms) until each converges instead of a fixed settle. A wrong count on
+	// any (node, prop) pair that never resolves is the bug.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			uri := restURIOf(compose, nodeIdx)
 
-		gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
-		assert.NoError(t, err, "post-mig price query node %d", nodeIdx)
-		assert.Equal(t, expectedPriceCount, gotPrice,
-			"GH #212 Issue D regression: node %d post-mig price = %d, expected %d "+
-				"(after concurrent enable-rangeable + enable-filterable + "+
-				"change-tokenization, the rangeable bucket on this shard is "+
-				"missing records)",
-			nodeIdx, gotPrice, expectedPriceCount)
+			gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
+			assert.NoError(c, err, "post-mig price query node %d", nodeIdx)
+			assert.Equalf(c, expectedPriceCount, gotPrice,
+				"GH #212 Issue D regression: node %d post-mig price = %d, expected %d "+
+					"(after concurrent enable-rangeable + enable-filterable + "+
+					"change-tokenization, the rangeable bucket on this shard is "+
+					"missing records)",
+				nodeIdx, gotPrice, expectedPriceCount)
 
-		gotCat, err := equalCount(uri, className, "category", categories[0])
-		assert.NoError(t, err, "post-mig category query node %d", nodeIdx)
-		assert.Equal(t, expectedCatCount, gotCat,
-			"GH #212 Issue D regression: node %d post-mig category = %d, expected %d "+
-				"(after concurrent migrations, the newly-created filterable "+
-				"bucket on this shard is missing records)",
-			nodeIdx, gotCat, expectedCatCount)
+			gotCat, err := equalCount(uri, className, "category", categories[0])
+			assert.NoError(c, err, "post-mig category query node %d", nodeIdx)
+			assert.Equalf(c, expectedCatCount, gotCat,
+				"GH #212 Issue D regression: node %d post-mig category = %d, expected %d "+
+					"(after concurrent migrations, the newly-created filterable "+
+					"bucket on this shard is missing records)",
+				nodeIdx, gotCat, expectedCatCount)
 
-		gotPath, err := equalCount(uri, className, "path", paths[0])
-		assert.NoError(t, err, "post-mig path query node %d", nodeIdx)
-		assert.Equal(t, expectedPathCount, gotPath,
-			"GH #212 Issue D regression: node %d post-mig path = %d, expected %d "+
-				"(after concurrent migrations, the change-tokenization'd "+
-				"searchable bucket on this shard is missing records)",
-			nodeIdx, gotPath, expectedPathCount)
-	}
+			gotPath, err := equalCount(uri, className, "path", paths[0])
+			assert.NoError(c, err, "post-mig path query node %d", nodeIdx)
+			assert.Equalf(c, expectedPathCount, gotPath,
+				"GH #212 Issue D regression: node %d post-mig path = %d, expected %d "+
+					"(after concurrent migrations, the change-tokenization'd "+
+					"searchable bucket on this shard is missing records)",
+				nodeIdx, gotPath, expectedPathCount)
+		}
+	}, 30*time.Second, 50*time.Millisecond)
 
 	// LB-side spot-check: 3 sequential calls to the same node should all
 	// return baseline. Mirrors Frontend Claude's Phase-3 LB calls.

--- a/test/acceptance/reindex_multinode/cross_replica_barrier_test.go
+++ b/test/acceptance/reindex_multinode/cross_replica_barrier_test.go
@@ -208,7 +208,7 @@ func TestMultiNode_CrossReplicaPrepBarrier(t *testing.T) {
 			}
 		}
 		return true
-	}, 30*time.Second, 500*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"tokenization should change to field on all 3 nodes after barrier completion")
 
 	// Final consistency: under FIELD tokenization, "alpha" no longer
@@ -229,7 +229,7 @@ func TestMultiNode_CrossReplicaPrepBarrier(t *testing.T) {
 			}
 		}
 		return true
-	}, 30*time.Second, 500*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"post-FIELD-tokenization, 'alpha' as a partial token should match no docs "+
 			"on any node — if any node still returns hits, the per-shard bucket "+
 			"swap or the cluster-wide schema flip did not propagate")
@@ -322,21 +322,36 @@ func scanForBarrierPhaseLogs(ctx context.Context, t *testing.T, compose *docker.
 // "at least one of PREPARING or SWAPPING observed".
 func collectTaskStatusTransitions(t *testing.T, restURI, taskID string, timeout time.Duration) []string {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	// Explicit sampling cadence: tick every 50ms and shut down promptly
+	// when the timeout elapses. The tick interval (not a bare sleep)
+	// makes the status-transition sampling rate visible; cadence and the
+	// "stop on FINISHED / fatal on FAILED" semantics are unchanged.
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 	var transitions []string
 	var lastSeen string
-	for time.Now().Before(deadline) {
+	for {
 		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 		if err != nil {
-			time.Sleep(50 * time.Millisecond)
-			continue
+			select {
+			case <-ctx.Done():
+				return transitions
+			case <-ticker.C:
+				continue
+			}
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		var tasks models.DistributedTasks
 		if err := json.Unmarshal(body, &tasks); err != nil {
-			time.Sleep(50 * time.Millisecond)
-			continue
+			select {
+			case <-ctx.Done():
+				return transitions
+			case <-ticker.C:
+				continue
+			}
 		}
 		for _, task := range tasks["reindex"] {
 			if task.ID != taskID {
@@ -353,7 +368,10 @@ func collectTaskStatusTransitions(t *testing.T, restURI, taskID string, timeout 
 				}
 			}
 		}
-		time.Sleep(50 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return transitions
+		case <-ticker.C:
+		}
 	}
-	return transitions
 }

--- a/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
@@ -150,7 +150,7 @@ func assertTaskGone(t *testing.T, restURI, taskID, label string) {
 	// race after a rolling restart but not behavioural divergence.
 	require.Eventuallyf(t, func() bool {
 		return !taskExists(t, restURI, taskID)
-	}, 20*time.Second, 200*time.Millisecond,
+	}, 20*time.Second, 50*time.Millisecond,
 		"%s: reindex task %s must NOT be in /v1/tasks (cascade deleted on DELETE_CLASS)",
 		label, taskID)
 }
@@ -172,7 +172,7 @@ func assertIndexesReady(t *testing.T, restURI, className, label string) {
 			}
 		}
 		return true
-	}, 30*time.Second, 500*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"%s: every index on the recreated class %s must report status=ready",
 		label, className)
 

--- a/test/acceptance/reindex_multinode/finalizing_crash_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_crash_test.go
@@ -142,16 +142,28 @@ func TestMultiNode_RollingRestartDuringFinalizing_PerReplicaConsistency(t *testi
 	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID, reindexhelpers.WithTimeout(180*time.Second))
 	t.Log("task FINISHED post-rolling-restart")
 
-	// Settle: testcontainers reallocates ports on stop+start, so
-	// re-resolve URIs on every use. A short settle pause lets shard
-	// init complete (FinalizeCompletedMigrations + bucket load) before
-	// we sample.
-	time.Sleep(3 * time.Second)
+	// Poll until every replica converges to expectedPathCount, then sample
+	// stability below. AwaitReindexFinished only confirms node-1; a
+	// just-restarted node may still be loading buckets
+	// (FinalizeCompletedMigrations). A node that never converges fails here
+	// loudly instead of being slept past. testcontainers reallocates ports
+	// on stop+start, so restURIOf re-resolves on every call.
+	require.Eventually(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", paths[0])
+			if err != nil || got != expectedPathCount {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 50*time.Millisecond,
+		"per-replica path count never converged to %d on all 3 replicas after rolling restart during FINALIZING",
+		expectedPathCount)
 
-	// Per-replica histogram: hit each replica directly 30 times for
-	// the migrated property (90 total). A pass requires every poll on
-	// every replica to return expectedPathCount; any non-zero
-	// non-expected value in the histogram is a per-replica divergence.
+	// Per-replica histogram: having converged above, hit each replica
+	// directly 30 times (90 total) to verify post-convergence stability.
+	// Every poll on every replica must return expectedPathCount; any other
+	// value is a per-replica divergence (flap after convergence).
 	const pollsPerReplica = 30
 	histogram := make(map[string]map[int]int) // nodeID -> count -> N
 	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
@@ -290,9 +302,22 @@ func TestMultiNode_UngracefulStopDuringFinalizing_PerReplicaConsistency(t *testi
 	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID, reindexhelpers.WithTimeout(180*time.Second))
 	t.Log("task FINISHED post-kill-and-restart")
 
-	// Settle for shard init + FinalizeCompletedMigrations on the
-	// restarted node.
-	time.Sleep(3 * time.Second)
+	// Poll until every replica converges to expectedPathCount, then sample
+	// stability below. AwaitReindexFinished only confirms node-1; the
+	// SIGKILL'd-and-restarted node may still be loading buckets
+	// (FinalizeCompletedMigrations). A node that never converges fails here
+	// loudly instead of being slept past.
+	require.Eventually(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", paths[0])
+			if err != nil || got != expectedPathCount {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 50*time.Millisecond,
+		"per-replica path count never converged to %d on all 3 replicas after SIGKILL during FINALIZING",
+		expectedPathCount)
 
 	const pollsPerReplica = 30
 	histogram := make(map[string]map[int]int)

--- a/test/acceptance/reindex_multinode/finalizing_window_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_window_test.go
@@ -240,7 +240,7 @@ func runLiveQueryDuringChangeTokenizationCase(
 			require.Eventually(t, func() bool {
 				return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
 					className, "text") == targetTok
-			}, 60*time.Second, 200*time.Millisecond,
+			}, 60*time.Second, 50*time.Millisecond,
 				"tokenization should change to %s after swap phase", targetTok)
 		})
 	t.Logf("migration completed in %v, collected %d probe samples",
@@ -444,7 +444,7 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 		baselineCount = mustQueryBM25Count(t,
 			compose.GetWeaviateNode(1).URI(), className, alphaQuery, queryLimit)
 		return baselineCount == objectCount
-	}, 10*time.Second, 200*time.Millisecond,
+	}, 10*time.Second, 50*time.Millisecond,
 		"baseline BM25 'alpha' under WORD tokenization should match all %d docs (last seen=%d)",
 		objectCount, baselineCount)
 	t.Logf("baseline 'alpha' result count: %d", baselineCount)
@@ -463,7 +463,7 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 			require.Eventually(t, func() bool {
 				return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
 					className, "text") == "field"
-			}, 60*time.Second, 200*time.Millisecond,
+			}, 60*time.Second, 50*time.Millisecond,
 				"tokenization should change to field after swap phase")
 		})
 	t.Logf("migration completed in %v, collected %d probe samples",

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -136,11 +136,13 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 		nodeURI := compose.GetWeaviateNode(nodeIdx + 1).URI()
 		go func(uri string, idx int) {
 			defer wg.Done()
+			ticker := time.NewTicker(50 * time.Millisecond)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-stopCh:
 					return
-				default:
+				case <-ticker.C:
 				}
 				for _, q := range testBM25Queries {
 					ids, err := runBM25QueryOnNodeWithRetry(t, uri, className, q)
@@ -153,7 +155,6 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 						t.Logf("node %d query %q mismatch", idx+1, q)
 					}
 				}
-				time.Sleep(200 * time.Millisecond)
 			}
 		}(nodeURI, nodeIdx)
 	}
@@ -325,7 +326,7 @@ func testChangeTokenization(t *testing.T, compose *docker.DockerCompose) {
 	// the task reaches FINISHED. Wait for the schema to reflect the update.
 	require.Eventually(t, func() bool {
 		return tryGetPropertyTokenization(restURI, className, "text") == "field"
-	}, 30*time.Second, 1*time.Second, "tokenization should change to field after swap phase")
+	}, 30*time.Second, 50*time.Millisecond, "tokenization should change to field after swap phase")
 
 	// Verify schema on all nodes.
 	for i := 1; i <= 3; i++ {
@@ -344,7 +345,7 @@ func testChangeTokenization(t *testing.T, compose *docker.DockerCompose) {
 		require.Eventually(t, func() bool {
 			ids, err := runBM25QueryOnNode(t, nodeURI, className, "alpha")
 			return err == nil && len(ids) == 0
-		}, 30*time.Second, 1*time.Second,
+		}, 30*time.Second, 50*time.Millisecond,
 			"node %d: 'alpha' with FIELD should match no docs", i)
 	}
 
@@ -389,11 +390,13 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 		nodeURI := compose.GetWeaviateNode(nodeIdx + 1).URI()
 		go func(uri string, idx int) {
 			defer wg.Done()
+			ticker := time.NewTicker(50 * time.Millisecond)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-stopCh:
 					return
-				default:
+				case <-ticker.C:
 				}
 				for _, q := range testBM25Queries {
 					ids, err := runBM25QueryOnNodeWithRetry(t, uri, className, q)
@@ -407,7 +410,6 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 							idx+1, q, len(baselines[q][0]), len(ids))
 					}
 				}
-				time.Sleep(100 * time.Millisecond)
 			}
 		}(nodeURI, nodeIdx)
 	}
@@ -443,7 +445,7 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 			consecutiveSuccesses = 0
 		}
 		return consecutiveSuccesses >= requiredConsecutiveSuccesses
-	}, 30*time.Second, 200*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"expected %d consecutive successful query rounds after reindex completion",
 		requiredConsecutiveSuccesses)
 

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -195,7 +195,7 @@ func awaitReindexReachedFinalizing(t *testing.T, restURI, taskID string) string 
 			}
 		}
 		return false
-	}, 240*time.Second, 200*time.Millisecond,
+	}, 240*time.Second, 50*time.Millisecond,
 		"reindex task %s should reach FINALIZING (or FINISHED) within 240s", taskID)
 	return observed
 }
@@ -236,7 +236,7 @@ func awaitReindexMidFlight(t *testing.T, restURI, taskID string, timeout time.Du
 			return false
 		}
 		return false
-	}, timeout, 200*time.Millisecond,
+	}, timeout, 50*time.Millisecond,
 		"reindex task %s should have at least one IN_PROGRESS unit within %s",
 		taskID, timeout)
 }
@@ -259,7 +259,7 @@ func raftLeaderIndex(t *testing.T, compose *docker.DockerCompose) int {
 			}
 		}
 		return false
-	}, 30*time.Second, 200*time.Millisecond, "/v1/cluster/statistics should report a leader")
+	}, 30*time.Second, 50*time.Millisecond, "/v1/cluster/statistics should report a leader")
 	for idx, name := range []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2} {
 		if name == leaderName {
 			return idx
@@ -517,7 +517,7 @@ func runBM25QueryOnNodeWithRetry(t *testing.T, restURI, className, query string)
 	ids, err := runBM25QueryOnNode(t, restURI, className, query)
 	if err != nil {
 		// Retry once after a short delay for transient errors.
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		ids, err = runBM25QueryOnNode(t, restURI, className, query)
 	}
 	return ids, err
@@ -573,7 +573,7 @@ func rollingRestartCluster(ctx context.Context, t *testing.T, compose *docker.Do
 			}
 			defer resp.Body.Close()
 			return resp.StatusCode == http.StatusOK
-		}, 60*time.Second, 500*time.Millisecond,
+		}, 60*time.Second, 50*time.Millisecond,
 			"node %d should be ready after rolling restart", i)
 	}
 }
@@ -695,6 +695,13 @@ func waitForProbeBaseline(
 ) int {
 	t.Helper()
 	deadline := time.Now().Add(perReplicaConvergenceTimeout)
+	// Sample at 50ms via an explicit ticker. The two-consecutive-stable
+	// requirement (prevAll) is a sampling property of this baseline gate,
+	// not a simple wait-for-condition, so it is preserved verbatim rather
+	// than collapsed into require.Eventually (which would return on the
+	// first satisfying read and drop the stability check).
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 	prevAll := -1
 	for time.Now().Before(deadline) {
 		var counts [3]int
@@ -720,7 +727,7 @@ func waitForProbeBaseline(
 			// count gets fully re-validated.
 			prevAll = -1
 		}
-		time.Sleep(200 * time.Millisecond)
+		<-ticker.C
 	}
 	t.Fatalf("waitForProbeBaseline: per-replica counts did not converge within %s",
 		perReplicaConvergenceTimeout)
@@ -774,16 +781,17 @@ func runMigrationWithProbes(
 		idx := nodeIdx + 1
 		go func() {
 			defer wg.Done()
+			ticker := time.NewTicker(probeInterval)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-stopCh:
 					return
-				default:
+				case <-ticker.C:
 				}
 				start := time.Now()
 				count, err := probe(nodeURI, className)
 				record(probeSample{t: start, nodeID: idx, count: count, err: err})
-				time.Sleep(probeInterval)
 			}
 		}()
 	}

--- a/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
+++ b/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
@@ -133,11 +133,13 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 		idx := nodeIdx
 		go func() {
 			defer wg.Done()
+			ticker := time.NewTicker(50 * time.Millisecond)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-stopCh:
 					return
-				default:
+				case <-ticker.C:
 				}
 				count, err := rangeCount(uri, className, "score", rangeLo, rangeHi)
 				queryRuns.Add(1)
@@ -153,7 +155,6 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 					t.Logf("ISSUE C REPRO: node %d returned partial count %d (expected %d)",
 						idx, count, expectedBaseline)
 				}
-				time.Sleep(50 * time.Millisecond)
 			}
 		}()
 	}
@@ -169,10 +170,21 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 	// other nodes a moment after FINISHED.
 	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID, reindexhelpers.WithTimeout(180*time.Second))
 
-	// Settle window: keep polling for 3 s after FINISHED. This catches
-	// the late-window race where one node's schema flip arrived but
-	// another node's swap hasn't run yet.
-	time.Sleep(3 * time.Second)
+	// Keep the in-flight probes running until every replica serves the full
+	// rangeable count, then stop. AwaitReindexFinished only confirms node-1;
+	// polling the real cross-replica condition (50ms) instead of a fixed
+	// settle means the probes sample the entire convergence window and a
+	// node that never converges fails loudly here.
+	require.Eventually(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			count, err := rangeCount(restURIOf(compose, nodeIdx), className, "score", rangeLo, rangeHi)
+			if err != nil || count != expectedBaseline {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 50*time.Millisecond,
+		"all replicas should converge to the full rangeable count %d after enable-rangeable", expectedBaseline)
 	close(stopCh)
 	wg.Wait()
 

--- a/test/acceptance/reindex_multinode/migration_journeys_test.go
+++ b/test/acceptance/reindex_multinode/migration_journeys_test.go
@@ -138,44 +138,49 @@ func TestMultiNode_BackToBackChangeTokenization_RoundTripCounts(t *testing.T) {
 		`{"searchable":{"tokenization":"field"}}`)
 	t.Logf("change-tokenization → field: task=%s", task1)
 	reindexhelpers.AwaitReindexFinished(t, uri1, task1, reindexhelpers.WithTimeout(180*time.Second))
-	time.Sleep(3 * time.Second)
 
 	// === Step 5: every replica must serve the FIELD count.
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		uri := restURIOf(compose, nodeIdx)
-		got, err := equalCount(uri, className, "path", queryToken)
-		require.NoError(t, err)
-		require.Equal(t, expectedFieldCount, got,
-			"post-FIELD-tok node %d = %d (expected %d)",
-			nodeIdx, got, expectedFieldCount)
-	}
+	// AwaitReindexFinished only confirms node-1; poll all replicas (50ms)
+	// until each converges instead of a fixed settle — a node that never
+	// converges fails here loudly.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", queryToken)
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedFieldCount, got,
+				"post-FIELD-tok node %d = %d (expected %d)",
+				nodeIdx, got, expectedFieldCount)
+		}
+	}, 30*time.Second, 50*time.Millisecond)
 
 	// === Step 6: change-tokenization back to WORD.
 	task2 := reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
 		`{"searchable":{"tokenization":"word"}}`)
 	t.Logf("change-tokenization → word (round-trip): task=%s", task2)
 	reindexhelpers.AwaitReindexFinished(t, uri1, task2, reindexhelpers.WithTimeout(180*time.Second))
-	time.Sleep(3 * time.Second)
 
 	// === Step 7: every replica must serve the WORD baseline again.
-	// The degenerate "path=1" shape from the original production
-	// reproduction (Phase 5) would surface as `got=1` here — the
-	// assertion captures it via both the exact-count check and the
-	// "must be > N/2" defense-in-depth check.
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		uri := restURIOf(compose, nodeIdx)
-		got, err := equalCount(uri, className, "path", queryToken)
-		assert.NoError(t, err)
-		assert.Equalf(t, expectedWordCount, got,
-			"GH #212 Issue F regression: round-trip WORD count on node %d = %d (expected %d) "+
-				"— back-to-back change-tokenization broke the searchable bucket",
-			nodeIdx, got, expectedWordCount)
-		assert.Greaterf(t, got, expectedWordCount/2,
-			"GH #212 Issue F degenerate-count regression: node %d returned %d (less than half of %d). "+
-				"This is the Phase-5 `path=1`-shape failure — the round-trip migration left the bucket "+
-				"with effectively no data even though the task reached FINISHED",
-			nodeIdx, got, expectedWordCount)
-	}
+	// AwaitReindexFinished only confirms node-1; poll all replicas (50ms)
+	// until convergence instead of a fixed settle. The degenerate "path=1"
+	// shape from the original production reproduction (Phase 5) would surface
+	// as `got=1` — captured via both the exact-count check and the
+	// "must be > N/2" defense-in-depth check; a round-trip that never
+	// reconverges fails the poll loudly.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", queryToken)
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedWordCount, got,
+				"GH #212 Issue F regression: round-trip WORD count on node %d = %d (expected %d) "+
+					"— back-to-back change-tokenization broke the searchable bucket",
+				nodeIdx, got, expectedWordCount)
+			assert.Greaterf(c, got, expectedWordCount/2,
+				"GH #212 Issue F degenerate-count regression: node %d returned %d (less than half of %d). "+
+					"This is the Phase-5 `path=1`-shape failure — the round-trip migration left the bucket "+
+					"with effectively no data even though the task reached FINISHED",
+				nodeIdx, got, expectedWordCount)
+		}
+	}, 30*time.Second, 50*time.Millisecond)
 
 	// LB-side 3-call stability for the round-trip state.
 	for i := 0; i < 3; i++ {
@@ -322,7 +327,6 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
 	}
-	time.Sleep(2 * time.Second)
 
 	// Repeated journey: rebuild + tokenization round-trip, N times. The
 	// path tokenization alternates field↔word; price+category use
@@ -360,7 +364,6 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
-		time.Sleep(2 * time.Second)
 	}
 
 	// After preRestartCycles cycles, the path tokenization is:
@@ -399,11 +402,32 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 	t.Log("rolling restart cluster")
 	rollingRestartCluster(ctx, t, compose)
 
-	// Settle: testcontainers reallocates ports across stop+start, so
-	// re-resolve URIs on every use below. Give shard-init time to
-	// finalize the deferred migration dirs (FinalizeCompletedMigrations
-	// + bucket loading).
-	time.Sleep(5 * time.Second)
+	// Poll until every replica converges on all three migrated props, then
+	// run the histogram below as a post-convergence stability check.
+	// rollingRestartCluster only waits for /ready; a restarted node may
+	// still be loading buckets (FinalizeCompletedMigrations). Polling the
+	// real per-replica condition (50ms) instead of a fixed settle means a
+	// node that never converges fails loudly. testcontainers reallocates
+	// ports across stop+start, so restURIOf re-resolves on every call.
+	require.Eventually(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			uri := restURIOf(compose, nodeIdx)
+			gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
+			if err != nil || gotPrice != expectedPriceCount {
+				return false
+			}
+			gotCat, err := equalCount(uri, className, "category", categories[0])
+			if err != nil || gotCat != expectedCatCount {
+				return false
+			}
+			gotPath, err := equalCount(uri, className, "path", paths[0])
+			if err != nil || gotPath != expectedPathCount {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 50*time.Millisecond,
+		"per-replica counts never converged on all 3 replicas after rolling restart")
 
 	// === Headline assertion: per-replica histogram.
 	//

--- a/test/acceptance/reindex_multinode/post_restart_test.go
+++ b/test/acceptance/reindex_multinode/post_restart_test.go
@@ -135,6 +135,8 @@ func TestMultiNode_PostRestartMigration_NoStallPlateau(t *testing.T) {
 		finalTaskStatus string
 	)
 
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 	for time.Since(startedAt) < overallBudget {
 		status, progress, ok := tryFetchTaskStatusAndProgress(restURI, taskID)
 		if ok {
@@ -165,7 +167,7 @@ func TestMultiNode_PostRestartMigration_NoStallPlateau(t *testing.T) {
 				)
 			}
 		}
-		time.Sleep(500 * time.Millisecond)
+		<-ticker.C
 	}
 
 	if !taskFinished {
@@ -385,24 +387,27 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri1, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri1, tk, reindexhelpers.WithTimeout(180*time.Second))
 	}
-	time.Sleep(3 * time.Second)
 
-	// Pre-restart sanity: every replica returns baseline.
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		uri := restURIOf(compose, nodeIdx)
-		gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
-		require.NoError(t, err)
-		require.Equal(t, expectedPriceCount, gotPrice,
-			"pre-restart node %d price = %d (expected %d)", nodeIdx, gotPrice, expectedPriceCount)
-		gotCat, err := equalCount(uri, className, "category", categories[0])
-		require.NoError(t, err)
-		require.Equal(t, expectedCatCount, gotCat,
-			"pre-restart node %d category = %d (expected %d)", nodeIdx, gotCat, expectedCatCount)
-		gotPath, err := equalCount(uri, className, "path", paths[0])
-		require.NoError(t, err)
-		require.Equal(t, expectedPathCount, gotPath,
-			"pre-restart node %d path = %d (expected %d)", nodeIdx, gotPath, expectedPathCount)
-	}
+	// Pre-restart sanity: poll every replica until each returns baseline.
+	// AwaitReindexFinished only confirms node-1; a replica's swap can lag,
+	// so poll (50ms) instead of a fixed settle.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			uri := restURIOf(compose, nodeIdx)
+			gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedPriceCount, gotPrice,
+				"pre-restart node %d price = %d (expected %d)", nodeIdx, gotPrice, expectedPriceCount)
+			gotCat, err := equalCount(uri, className, "category", categories[0])
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedCatCount, gotCat,
+				"pre-restart node %d category = %d (expected %d)", nodeIdx, gotCat, expectedCatCount)
+			gotPath, err := equalCount(uri, className, "path", paths[0])
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedPathCount, gotPath,
+				"pre-restart node %d path = %d (expected %d)", nodeIdx, gotPath, expectedPathCount)
+		}
+	}, 30*time.Second, 50*time.Millisecond)
 
 	// === Phase 7 equivalent: rolling restart.
 	t.Log("rolling restart")
@@ -468,30 +473,34 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri1, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri1, tk, reindexhelpers.WithTimeout(180*time.Second))
 	}
-	time.Sleep(3 * time.Second)
 
-	// Final per-replica counts. The path query is the headline check
-	// for Issue G (Frontend Claude saw `0 / 0 / 0` here).
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		uri := restURIOf(compose, nodeIdx)
-		gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
-		assert.NoError(t, err, "post-reapply price query node %d", nodeIdx)
-		assert.Equalf(t, expectedPriceCount, gotPrice,
-			"GH #212 Issue G regression: post-restart re-apply node %d price = %d (expected %d) — rangeable rebuild lost data after restart",
-			nodeIdx, gotPrice, expectedPriceCount)
+	// Final per-replica counts. The path query is the headline check for
+	// Issue G (Frontend Claude saw `0 / 0 / 0` here). AwaitReindexFinished
+	// only confirms node-1; poll all replicas (50ms) until convergence
+	// instead of a fixed settle — a node stuck at the 0/0/0 shape never
+	// converges and fails here loudly.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			uri := restURIOf(compose, nodeIdx)
+			gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
+			assert.NoError(c, err, "post-reapply price query node %d", nodeIdx)
+			assert.Equalf(c, expectedPriceCount, gotPrice,
+				"GH #212 Issue G regression: post-restart re-apply node %d price = %d (expected %d) — rangeable rebuild lost data after restart",
+				nodeIdx, gotPrice, expectedPriceCount)
 
-		gotCat, err := equalCount(uri, className, "category", categories[0])
-		assert.NoError(t, err, "post-reapply category query node %d", nodeIdx)
-		assert.Equalf(t, expectedCatCount, gotCat,
-			"GH #212 Issue G regression: post-restart re-apply node %d category = %d (expected %d) — filterable rebuild lost data after restart",
-			nodeIdx, gotCat, expectedCatCount)
+			gotCat, err := equalCount(uri, className, "category", categories[0])
+			assert.NoError(c, err, "post-reapply category query node %d", nodeIdx)
+			assert.Equalf(c, expectedCatCount, gotCat,
+				"GH #212 Issue G regression: post-restart re-apply node %d category = %d (expected %d) — filterable rebuild lost data after restart",
+				nodeIdx, gotCat, expectedCatCount)
 
-		gotPath, err := equalCount(uri, className, "path", paths[0])
-		assert.NoError(t, err, "post-reapply path query node %d", nodeIdx)
-		assert.Equalf(t, expectedPathCount, gotPath,
-			"GH #212 Issue G regression: post-restart re-apply node %d path = %d (expected %d) — change-tokenization lost data after restart (Phase-8-final shape)",
-			nodeIdx, gotPath, expectedPathCount)
-	}
+			gotPath, err := equalCount(uri, className, "path", paths[0])
+			assert.NoError(c, err, "post-reapply path query node %d", nodeIdx)
+			assert.Equalf(c, expectedPathCount, gotPath,
+				"GH #212 Issue G regression: post-restart re-apply node %d path = %d (expected %d) — change-tokenization lost data after restart (Phase-8-final shape)",
+				nodeIdx, gotPath, expectedPathCount)
+		}
+	}, 30*time.Second, 50*time.Millisecond)
 
 	// LB-side 3-call stability spot check.
 	for i := 0; i < 3; i++ {

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -69,7 +69,7 @@ func assertReindexCompleteAndConsistent(
 			}
 		}
 		return true
-	}, 30*time.Second, 500*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"tokenization should flip to field on every replica post-restart")
 
 	const expected = reindexRestartDataset / 5
@@ -128,7 +128,7 @@ func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
 			require.Eventually(t, func() bool {
 				_, err := equalCount(restURIOf(compose, 1), "LeaderRestartDuringReindex", "path", "alpha-path")
 				return err == nil
-			}, 60*time.Second, 1*time.Second, "cluster should be ready after leader restart")
+			}, 60*time.Second, 50*time.Millisecond, "cluster should be ready after leader restart")
 		})
 }
 
@@ -201,7 +201,7 @@ func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 		require.Eventually(t, func() bool {
 			_, err := runBM25QueryOnNode(t, restartedURI, className, "alpha")
 			return err == nil
-		}, 30*time.Second, 1*time.Second, "node %d should be ready after restart", nodeIdx+1)
+		}, 30*time.Second, 50*time.Millisecond, "node %d should be ready after restart", nodeIdx+1)
 
 		// Wait for Raft quorum to be restored before moving on. Object
 		// imports require Raft consensus, so a successful write proves the
@@ -210,7 +210,7 @@ func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 		writeURI := compose.GetWeaviateNode(((nodeIdx + 1) % 3) + 1).URI()
 		require.Eventually(t, func() bool {
 			return tryImportObject(writeURI, className, "raft-health-probe") == nil
-		}, 60*time.Second, 1*time.Second, "cluster should have Raft quorum after restarting node %d", nodeIdx+1)
+		}, 60*time.Second, 50*time.Millisecond, "cluster should have Raft quorum after restarting node %d", nodeIdx+1)
 
 		for _, q := range testBM25Queries {
 			ids, err := runBM25QueryOnNode(t, restartedURI, className, q)

--- a/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
@@ -273,13 +274,13 @@ func TestMultiNode_ChangeTokenization_RestartThenRoundTrip(t *testing.T) {
 		require.Eventually(t, func() bool {
 			_, err := runBM25QueryOnNode(t, restartedURI, className, "alpha")
 			return err == nil
-		}, 60*time.Second, 1*time.Second,
+		}, 60*time.Second, 50*time.Millisecond,
 			"node %d should be ready after restart", nodeIdx+1)
 
 		writeURI := compose.GetWeaviateNode(((nodeIdx + 1) % 3) + 1).URI()
 		require.Eventually(t, func() bool {
 			return tryImportObject(writeURI, className, "raft-probe") == nil
-		}, 90*time.Second, 1*time.Second,
+		}, 90*time.Second, 50*time.Millisecond,
 			"raft quorum should be restored after restart of node %d", nodeIdx+1)
 	}
 	// Re-fetch URI after the rolling restart.
@@ -432,47 +433,24 @@ func TestMultiNode_ChangeTokenization_ConcurrentDifferentProps(t *testing.T) {
 	// Poll until each property's per-replica counts settle to the
 	// baseline. The schema flip propagates faster than per-node
 	// OnGroupCompleted runs in some races; see perReplicaConvergenceTimeout.
-	var (
-		lastTitle, lastBody map[string][]int
-		failures            []string
-	)
-	deadline := time.Now().Add(perReplicaConvergenceTimeout)
-	for time.Now().Before(deadline) {
-		lastTitle = make(map[string][]int, len(testBM25Queries))
-		lastBody = make(map[string][]int, len(testBM25Queries))
-		failures = failures[:0]
+	// On timeout the per-(prop,query,node) assert messages reproduce the
+	// exact mismatch diagnostic the hand-rolled failures list emitted.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, q := range testBM25Queries {
 			titleActual := perNodeBM25CountsProperty(t, compose, className, "title", q)
 			bodyActual := perNodeBM25CountsProperty(t, compose, className, "body", q)
-			lastTitle[q] = titleActual
-			lastBody[q] = bodyActual
 			for i := 0; i < 3; i++ {
-				if titleActual[i] != baselinesTitle[q][i] {
-					failures = append(failures,
-						fmt.Sprintf("prop=title query=%q node%d expected=%d actual=%d",
-							q, i+1, baselinesTitle[q][i], titleActual[i]))
-				}
-				if bodyActual[i] != baselinesBody[q][i] {
-					failures = append(failures,
-						fmt.Sprintf("prop=body query=%q node%d expected=%d actual=%d",
-							q, i+1, baselinesBody[q][i], bodyActual[i]))
-				}
+				assert.Equalf(c, baselinesTitle[q][i], titleActual[i],
+					"prop=title query=%q node%d expected=%d actual=%d",
+					q, i+1, baselinesTitle[q][i], titleActual[i])
+				assert.Equalf(c, baselinesBody[q][i], bodyActual[i],
+					"prop=body query=%q node%d expected=%d actual=%d",
+					q, i+1, baselinesBody[q][i], bodyActual[i])
 			}
 		}
-		if len(failures) == 0 {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	for _, q := range testBM25Queries {
-		t.Logf("post-concurrent title %q: baseline=%v actual=%v", q, baselinesTitle[q], lastTitle[q])
-		t.Logf("post-concurrent body %q: baseline=%v actual=%v", q, baselinesBody[q], lastBody[q])
-	}
-	sort.Strings(failures)
-	t.Fatalf(
-		"per-replica inverted-bucket mismatch after concurrent two-property round-trip (after %s wait); %d mismatches:\n  %s",
-		perReplicaConvergenceTimeout, len(failures), strings.Join(failures, "\n  "))
+	}, perReplicaConvergenceTimeout, 50*time.Millisecond,
+		"per-replica inverted-bucket mismatch after concurrent two-property round-trip (after %s wait)",
+		perReplicaConvergenceTimeout)
 }
 
 // ----------------------------------------------------------------------------
@@ -570,35 +548,22 @@ func testMultiPropertyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
 
 	// Poll both properties' per-replica counts until they match the
 	// baseline. Same settle-window rationale as assertPerReplicaConsistent.
-	var failures []string
-	deadline := time.Now().Add(perReplicaConvergenceTimeout)
-	for time.Now().Before(deadline) {
-		failures = failures[:0]
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, q := range testBM25Queries {
 			titleActual := perNodeBM25CountsProperty(t, compose, className, "title", q)
 			bodyActual := perNodeBM25CountsProperty(t, compose, className, "body", q)
 			for i := 0; i < 3; i++ {
-				if titleActual[i] != baselinesTitle[q][i] {
-					failures = append(failures,
-						fmt.Sprintf("prop=title q=%q node%d expected=%d actual=%d",
-							q, i+1, baselinesTitle[q][i], titleActual[i]))
-				}
-				if bodyActual[i] != baselinesBody[q][i] {
-					failures = append(failures,
-						fmt.Sprintf("prop=body q=%q node%d expected=%d actual=%d",
-							q, i+1, baselinesBody[q][i], bodyActual[i]))
-				}
+				assert.Equalf(c, baselinesTitle[q][i], titleActual[i],
+					"prop=title q=%q node%d expected=%d actual=%d",
+					q, i+1, baselinesTitle[q][i], titleActual[i])
+				assert.Equalf(c, baselinesBody[q][i], bodyActual[i],
+					"prop=body q=%q node%d expected=%d actual=%d",
+					q, i+1, baselinesBody[q][i], bodyActual[i])
 			}
 		}
-		if len(failures) == 0 {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	sort.Strings(failures)
-	t.Fatalf(
-		"per-replica multi-property round-trip mismatch (after %s wait); %d mismatches:\n  %s",
-		perReplicaConvergenceTimeout, len(failures), strings.Join(failures, "\n  "))
+	}, perReplicaConvergenceTimeout, 50*time.Millisecond,
+		"per-replica multi-property round-trip mismatch (after %s wait)",
+		perReplicaConvergenceTimeout)
 }
 
 func testFilterableOnlyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
@@ -646,29 +611,18 @@ func testFilterableOnlyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
 	awaitTokenizationOnAllNodes(t, compose, className, "text", "word")
 
 	// Poll Equal-filter per-replica counts until they match baseline.
-	var failures []string
-	deadline := time.Now().Add(perReplicaConvergenceTimeout)
-	for time.Now().Before(deadline) {
-		failures = failures[:0]
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, p := range probes {
 			actual := perNodeEqualCounts(t, compose, className, "text", p)
 			for i := 0; i < 3; i++ {
-				if actual[i] != baselines[p][i] {
-					failures = append(failures,
-						fmt.Sprintf("filter=Equal(%q) node%d expected=%d actual=%d",
-							p, i+1, baselines[p][i], actual[i]))
-				}
+				assert.Equalf(c, baselines[p][i], actual[i],
+					"filter=Equal(%q) node%d expected=%d actual=%d",
+					p, i+1, baselines[p][i], actual[i])
 			}
 		}
-		if len(failures) == 0 {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	sort.Strings(failures)
-	t.Fatalf(
-		"filterable-only per-replica mismatch after word→field→word round-trip (after %s wait); %d mismatches:\n  %s",
-		perReplicaConvergenceTimeout, len(failures), strings.Join(failures, "\n  "))
+	}, perReplicaConvergenceTimeout, 50*time.Millisecond,
+		"filterable-only per-replica mismatch after word→field→word round-trip (after %s wait)",
+		perReplicaConvergenceTimeout)
 }
 
 func testSearchableOnlyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
@@ -738,7 +692,7 @@ func testEnableFilterableThenChangeTok(t *testing.T, compose *docker.DockerCompo
 			}
 		}
 		return false
-	}, 30*time.Second, 200*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"text.IndexFilterable should be true after enable-filterable")
 
 	// Step 2: change-tokenization word→field on the same property.
@@ -802,7 +756,7 @@ func testEnableSearchableThenChangeTok(t *testing.T, compose *docker.DockerCompo
 			}
 		}
 		return false
-	}, 30*time.Second, 200*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"text.IndexSearchable should be true after enable-searchable")
 
 	// Now BM25 is available — record those baselines for downstream
@@ -834,39 +788,26 @@ func testEnableSearchableThenChangeTok(t *testing.T, compose *docker.DockerCompo
 	// Poll until both filterable (Equal) and searchable (BM25) per-replica
 	// counts match the baseline. Same settle-window rationale as
 	// assertPerReplicaConsistent.
-	var failures []string
-	deadline := time.Now().Add(perReplicaConvergenceTimeout)
-	for time.Now().Before(deadline) {
-		failures = failures[:0]
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, p := range probes {
 			actual := perNodeEqualCounts(t, compose, className, "text", p)
 			for i := 0; i < 3; i++ {
-				if actual[i] != baselinesEqual[p][i] {
-					failures = append(failures,
-						fmt.Sprintf("Equal(%q) node%d expected=%d actual=%d",
-							p, i+1, baselinesEqual[p][i], actual[i]))
-				}
+				assert.Equalf(c, baselinesEqual[p][i], actual[i],
+					"Equal(%q) node%d expected=%d actual=%d",
+					p, i+1, baselinesEqual[p][i], actual[i])
 			}
 		}
 		for _, q := range testBM25Queries {
 			actual := perNodeBM25Counts(t, compose, className, q)
 			for i := 0; i < 3; i++ {
-				if actual[i] != baselinesBM25[q][i] {
-					failures = append(failures,
-						fmt.Sprintf("BM25(%q) node%d expected=%d actual=%d",
-							q, i+1, baselinesBM25[q][i], actual[i]))
-				}
+				assert.Equalf(c, baselinesBM25[q][i], actual[i],
+					"BM25(%q) node%d expected=%d actual=%d",
+					q, i+1, baselinesBM25[q][i], actual[i])
 			}
 		}
-		if len(failures) == 0 {
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	sort.Strings(failures)
-	t.Fatalf(
-		"enable-searchable+change-tok round-trip mismatch (after %s wait); %d mismatches:\n  %s",
-		perReplicaConvergenceTimeout, len(failures), strings.Join(failures, "\n  "))
+	}, perReplicaConvergenceTimeout, 50*time.Millisecond,
+		"enable-searchable+change-tok round-trip mismatch (after %s wait)",
+		perReplicaConvergenceTimeout)
 }
 
 // assertPerReplicaAgreement requires every replica to return the same
@@ -899,37 +840,20 @@ func assertPerReplicaAgreement(
 ) {
 	t.Helper()
 
-	var (
-		lastCounts map[string][]int
-		failures   []string
-	)
-	deadline := time.Now().Add(perReplicaConvergenceTimeout)
-	for time.Now().Before(deadline) {
-		lastCounts = make(map[string][]int, len(queries))
-		failures = failures[:0]
+	lastCounts := make(map[string][]int, len(queries))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, q := range queries {
 			counts := perNodeBM25Counts(t, compose, className, q)
 			lastCounts[q] = counts
-			if counts[0] != counts[1] || counts[0] != counts[2] {
-				failures = append(failures,
-					fmt.Sprintf("query=%q counts=%v (replicas disagree)", q, counts))
-			}
+			assert.Truef(c, counts[0] == counts[1] && counts[0] == counts[2],
+				"query=%q counts=%v (replicas disagree)", q, counts)
 		}
-		if len(failures) == 0 {
-			for _, q := range queries {
-				t.Logf("%s %q: %v", label, q, lastCounts[q])
-			}
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	}, perReplicaConvergenceTimeout, 50*time.Millisecond,
+		"%s — per-replica disagreement (after %s wait)", label, perReplicaConvergenceTimeout)
 
 	for _, q := range queries {
 		t.Logf("%s %q: %v", label, q, lastCounts[q])
 	}
-	sort.Strings(failures)
-	t.Fatalf("%s — per-replica disagreement (after %s wait); %d mismatches:\n  %s",
-		label, perReplicaConvergenceTimeout, len(failures), strings.Join(failures, "\n  "))
 }
 
 // assertPerReplicaConsistent polls per-replica counts until every
@@ -942,41 +866,24 @@ func assertPerReplicaConsistent(
 ) {
 	t.Helper()
 
-	var (
-		lastActual map[string][]int
-		failures   []string
-	)
-	deadline := time.Now().Add(perReplicaConvergenceTimeout)
-	for time.Now().Before(deadline) {
-		lastActual = make(map[string][]int, len(queries))
-		failures = failures[:0]
+	lastActual := make(map[string][]int, len(queries))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, q := range queries {
 			actual := perNodeBM25Counts(t, compose, className, q)
 			lastActual[q] = actual
 			expected := baselines[q]
 			for i := 0; i < 3; i++ {
-				if actual[i] != expected[i] {
-					failures = append(failures,
-						fmt.Sprintf("query=%q node%d expected=%d actual=%d",
-							q, i+1, expected[i], actual[i]))
-				}
+				assert.Equalf(c, expected[i], actual[i],
+					"query=%q node%d expected=%d actual=%d",
+					q, i+1, expected[i], actual[i])
 			}
 		}
-		if len(failures) == 0 {
-			for _, q := range queries {
-				t.Logf("%s %q: baseline=%v actual=%v", label, q, baselines[q], lastActual[q])
-			}
-			return
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	}, perReplicaConvergenceTimeout, 50*time.Millisecond,
+		"%s — per-replica mismatch (after %s wait)", label, perReplicaConvergenceTimeout)
 
 	for _, q := range queries {
 		t.Logf("%s %q: baseline=%v actual=%v", label, q, baselines[q], lastActual[q])
 	}
-	sort.Strings(failures)
-	t.Fatalf("%s — per-replica mismatch (after %s wait); %d mismatches:\n  %s",
-		label, perReplicaConvergenceTimeout, len(failures), strings.Join(failures, "\n  "))
 }
 
 func captureBaselineCounts(
@@ -1010,39 +917,24 @@ func waitForPerReplicaBaseline(
 ) map[string][]int {
 	t.Helper()
 
-	var (
-		lastCounts map[string][]int
-		failures   []string
-	)
-	deadline := time.Now().Add(perReplicaConvergenceTimeout)
-	for time.Now().Before(deadline) {
-		lastCounts = make(map[string][]int, len(queries))
-		failures = failures[:0]
+	lastCounts := make(map[string][]int, len(queries))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		for _, q := range queries {
 			counts := perNodeBM25Counts(t, compose, className, q)
 			lastCounts[q] = counts
+			// Preserve the original else-if branching: a query is only
+			// flagged "zero on every replica" once the replicas agree.
 			if counts[0] != counts[1] || counts[0] != counts[2] {
-				failures = append(failures,
-					fmt.Sprintf("baseline %q inconsistent: %v", q, counts))
+				c.Errorf("baseline %q inconsistent: %v", q, counts)
 			} else if counts[0] == 0 {
-				failures = append(failures,
-					fmt.Sprintf("baseline %q is zero on every replica", q))
+				c.Errorf("baseline %q is zero on every replica", q)
 			}
 		}
-		if len(failures) == 0 {
-			for _, q := range queries {
-				t.Logf("baseline %q: %v", q, lastCounts[q])
-			}
-			return lastCounts
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
+	}, perReplicaConvergenceTimeout, 50*time.Millisecond,
+		"baseline did not converge across replicas within %s", perReplicaConvergenceTimeout)
 
 	for _, q := range queries {
 		t.Logf("baseline %q: %v", q, lastCounts[q])
 	}
-	sort.Strings(failures)
-	t.Fatalf("baseline did not converge across replicas within %s; %d issues:\n  %s",
-		perReplicaConvergenceTimeout, len(failures), strings.Join(failures, "\n  "))
-	return nil
+	return lastCounts
 }

--- a/test/acceptance/reindex_multinode/round_trip_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_test.go
@@ -146,7 +146,7 @@ func awaitTokenizationOnAllNodes(
 		uri := compose.GetWeaviateNode(i + 1).URI()
 		require.Eventuallyf(t, func() bool {
 			return tryGetPropertyTokenization(uri, className, propName) == target
-		}, 30*time.Second, 200*time.Millisecond,
+		}, 30*time.Second, 50*time.Millisecond,
 			"node %d: property %q tokenization should be %q", i+1, propName, target)
 	}
 }

--- a/test/acceptance/reindex_singlenode/blockmax_test.go
+++ b/test/acceptance/reindex_singlenode/blockmax_test.go
@@ -112,11 +112,13 @@ func testBlockmaxMigration(t *testing.T, restURI string) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stopCh:
 				return
-			default:
+			case <-ticker.C:
 			}
 			for _, bl := range blockmaxBaselines {
 				ids, err := blockmaxBM25QuerySafe(t, bl.query)
@@ -127,7 +129,6 @@ func testBlockmaxMigration(t *testing.T, restURI string) {
 					queryFailures.Add(1)
 				}
 			}
-			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 
@@ -210,8 +211,14 @@ func assertSearchableAlgorithm(t *testing.T, restURI, collection, property, want
 // (small data sets) where the rebuild may complete before we can observe.
 func pollForTargetAlgorithm(t *testing.T, restURI, collection, property, want string, timeout time.Duration) bool {
 	t.Helper()
+	// Best-effort observation: a fast migration may legitimately complete
+	// before the transient targetAlgorithm signal can be sampled. This must
+	// NOT fail the test, so we drive a plain ticker + deadline loop and
+	// return whether the signal was observed (never require.Eventually).
 	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
 		resp := reindexhelpers.GetIndexes(t, restURI, collection)
 		for _, prop := range resp.Properties {
 			if prop.Name != property {
@@ -223,9 +230,15 @@ func pollForTargetAlgorithm(t *testing.T, restURI, collection, property, want st
 				}
 			}
 		}
-		time.Sleep(100 * time.Millisecond)
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		select {
+		case <-ticker.C:
+		case <-time.After(time.Until(deadline)):
+			return false
+		}
 	}
-	return false
 }
 
 func blockmaxBM25Query(t *testing.T, query string) []string {

--- a/test/acceptance/reindex_singlenode/cancel_test.go
+++ b/test/acceptance/reindex_singlenode/cancel_test.go
@@ -110,7 +110,7 @@ func testCancelReindex(t *testing.T, restURI string) {
 				}
 			}
 			return false
-		}, 30*time.Second, 100*time.Millisecond, "task did not appear as indexing/pending before cancel")
+		}, 30*time.Second, 50*time.Millisecond, "task did not appear as indexing/pending before cancel")
 
 		// Issue the cancel.
 		url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, className, "score")
@@ -159,7 +159,7 @@ func testCancelReindex(t *testing.T, restURI string) {
 					}
 				}
 				return false
-			}, 30*time.Second, 200*time.Millisecond,
+			}, 30*time.Second, 50*time.Millisecond,
 				"task should reach CANCELLED status")
 		case "NO_OP":
 			t.Logf("cancel raced with task completion; no STARTED task to cancel (acceptable)")

--- a/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
+++ b/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
@@ -225,7 +225,7 @@ func cancelInFlightOrSkip(t *testing.T, restURI, class, prop, indexType, request
 			}
 		}
 		return false
-	}, 30*time.Second, 100*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"task did not appear as indexing/pending before cancel")
 
 	// Issue cancel.
@@ -268,7 +268,7 @@ func cancelInFlightOrSkip(t *testing.T, restURI, class, prop, indexType, request
 				}
 			}
 			return false
-		}, 60*time.Second, 250*time.Millisecond,
+		}, 60*time.Second, 50*time.Millisecond,
 			"first task did not reach a terminal state after cancel")
 		t.Logf("first task %s reached terminal state after cancel", taskID)
 		return true
@@ -294,7 +294,7 @@ func cancelInFlightOrSkip(t *testing.T, restURI, class, prop, indexType, request
 				}
 			}
 			return false
-		}, 60*time.Second, 250*time.Millisecond, "race-completed first task not terminal")
+		}, 60*time.Second, 50*time.Millisecond, "race-completed first task not terminal")
 		return false
 
 	default:

--- a/test/acceptance/reindex_singlenode/change_tok_delete_journeys_test.go
+++ b/test/acceptance/reindex_singlenode/change_tok_delete_journeys_test.go
@@ -192,7 +192,7 @@ func testChangeTokFilterableThenDeleteFilterable(t *testing.T, restURI string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"IndexFilterable on %s.name must be false after DELETE", class)
 
 	// Filter must return zero — the bucket is gone. Note: GraphQL may
@@ -607,7 +607,7 @@ func requireTokenizationEquals(t *testing.T, class, prop, expected string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"tokenization on %s.%s must be %q", class, prop, expected)
 }
 
@@ -638,7 +638,7 @@ func awaitTerminal(t *testing.T, restURI, taskID string) {
 			}
 		}
 		return false
-	}, 120*time.Second, 1*time.Second, "task %s should reach a terminal state", taskID)
+	}, 120*time.Second, 50*time.Millisecond, "task %s should reach a terminal state", taskID)
 }
 
 // bm25HitsForProp runs a bm25 query against a specific property.

--- a/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
+++ b/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
@@ -105,7 +105,7 @@ func testFilterableTokenizationFilterableOnly(t *testing.T, restURI, dataType st
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"property tokenization must flip to 'word' after change-tokenization-filterable")
 
 	// Post-migration: Equal() now uses word tokenization so an exact
@@ -209,7 +209,7 @@ func testFilterableTokenizationOnBothIndexes(t *testing.T, restURI string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"property tokenization must flip to 'word' even though both indexes exist")
 
 	require.Equal(t, 1, equalFilterHits(t, className, "name", "gamma"),

--- a/test/acceptance/reindex_singlenode/change_tokenization_test.go
+++ b/test/acceptance/reindex_singlenode/change_tokenization_test.go
@@ -94,11 +94,13 @@ func testChangeTokenization(t *testing.T, restURI string) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stopCh:
 				return
-			default:
+			case <-ticker.C:
 			}
 			for i, bl := range retokenizeBaselines {
 				bq := bm25Queries[i]
@@ -119,7 +121,6 @@ func testChangeTokenization(t *testing.T, restURI string) {
 			} else if !reindexhelpers.IdsMatchUnordered(filterEqualDescBaseline, ids) {
 				queryFailures.Add(1)
 			}
-			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 
@@ -137,7 +138,7 @@ func testChangeTokenization(t *testing.T, restURI string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 1*time.Second, "tokenization should change to field")
+	}, 30*time.Second, 50*time.Millisecond, "tokenization should change to field")
 
 	close(stopCh)
 	wg.Wait()

--- a/test/acceptance/reindex_singlenode/delete_reenable_indexing_bleed_test.go
+++ b/test/acceptance/reindex_singlenode/delete_reenable_indexing_bleed_test.go
@@ -196,7 +196,7 @@ func assertNoIndexBleedAfterDelete(
 			return true
 		}
 		return false
-	}, 12*time.Second, 250*time.Millisecond, args...)
+	}, 12*time.Second, 50*time.Millisecond, args...)
 }
 
 // TestSuppress ensures this file compiles in isolation. The actual entry

--- a/test/acceptance/reindex_singlenode/delete_then_reenable_test.go
+++ b/test/acceptance/reindex_singlenode/delete_then_reenable_test.go
@@ -206,7 +206,7 @@ func requireSearchableEnabled(t *testing.T, class, prop string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"IndexSearchable on %s.%s must be true after reindex finishes", class, prop)
 }
 
@@ -223,7 +223,7 @@ func requireFilterableEnabled(t *testing.T, class, prop string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"IndexFilterable on %s.%s must be true after reindex finishes", class, prop)
 }
 
@@ -240,7 +240,7 @@ func requireRangeableEnabled(t *testing.T, class, prop string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 250*time.Millisecond,
+	}, 30*time.Second, 50*time.Millisecond,
 		"IndexRangeFilters on %s.%s must be true after reindex finishes", class, prop)
 }
 

--- a/test/acceptance/reindex_singlenode/enable_filterable_test.go
+++ b/test/acceptance/reindex_singlenode/enable_filterable_test.go
@@ -124,11 +124,13 @@ func testEnableFilterable(t *testing.T, restURI string) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stopCh:
 				return
-			default:
+			case <-ticker.C:
 			}
 			ids, err := enableFilterableCategoryQuerySafe(t, "electronics")
 			queryRuns.Add(1)
@@ -137,7 +139,6 @@ func testEnableFilterable(t *testing.T, restURI string) {
 			} else if !reindexhelpers.IdsMatchUnordered(categoryBaseline, ids) {
 				queryFailures.Add(1)
 			}
-			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 
@@ -170,7 +171,7 @@ func testEnableFilterable(t *testing.T, restURI string) {
 			}
 		}
 		return scoreOK && availableOK
-	}, 30*time.Second, 500*time.Millisecond, "IndexFilterable must flip to true on targeted properties")
+	}, 30*time.Second, 50*time.Millisecond, "IndexFilterable must flip to true on targeted properties")
 
 	// Capture post-migration baselines so the post-restart phase can compare
 	// against the exact result set we just produced from the new index.

--- a/test/acceptance/reindex_singlenode/enable_rangeable_test.go
+++ b/test/acceptance/reindex_singlenode/enable_rangeable_test.go
@@ -93,11 +93,13 @@ func testEnableRangeable(t *testing.T, restURI string) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stopCh:
 				return
-			default:
+			case <-ticker.C:
 			}
 			for i, bl := range rangeableBaselines {
 				ids, err := rangeableQuerySafe(t, rangeableFilterQueries[i].where)
@@ -108,7 +110,6 @@ func testEnableRangeable(t *testing.T, restURI string) {
 					queryFailures.Add(1)
 				}
 			}
-			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 

--- a/test/acceptance/reindex_singlenode/enable_searchable_test.go
+++ b/test/acceptance/reindex_singlenode/enable_searchable_test.go
@@ -117,11 +117,13 @@ func testEnableSearchable(t *testing.T, restURI string) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stopCh:
 				return
-			default:
+			case <-ticker.C:
 			}
 			ids, err := enableSearchableNameQuerySafe(t, "alpha")
 			queryRuns.Add(1)
@@ -130,7 +132,6 @@ func testEnableSearchable(t *testing.T, restURI string) {
 			} else if !reindexhelpers.IdsMatchUnordered(nameBaseline, ids) {
 				queryFailures.Add(1)
 			}
-			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 
@@ -155,7 +156,7 @@ func testEnableSearchable(t *testing.T, restURI string) {
 			}
 		}
 		return false
-	}, 30*time.Second, 500*time.Millisecond, "IndexSearchable must be true and Tokenization word after migration")
+	}, 30*time.Second, 50*time.Millisecond, "IndexSearchable must be true and Tokenization word after migration")
 
 	// Functional assertion: BM25 queries against the freshly-built index
 	// must return non-empty, deterministic results.

--- a/test/acceptance/reindex_singlenode/finished_race_test.go
+++ b/test/acceptance/reindex_singlenode/finished_race_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
@@ -112,11 +113,13 @@ func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 		`{"searchable":{"tokenization":"field"}}`)
 	t.Logf("submitted reindex task: %s", taskID)
 
-	// Poll /v1/tasks every ~20ms. On the first observation of FINISHED,
-	// immediately read the schema and assert the tokenization flipped.
-	deadline := time.Now().Add(120 * time.Second)
+	// Poll /v1/tasks. On the first observation of FINISHED, immediately
+	// capture the timestamp so the convergence-lag measurement below stays
+	// accurate. Keep a tight 20ms tick — this test measures the sub-second
+	// lag between FINISHED and the schema flip, so the cadence is
+	// load-bearing.
 	var sawFinishedAt time.Time
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		status, err := fetchTaskStatus(restURI, taskID)
 		require.NoError(t, err)
 		if status == "FAILED" {
@@ -124,10 +127,10 @@ func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 		}
 		if status == "FINISHED" {
 			sawFinishedAt = time.Now()
-			break
+			return true
 		}
-		time.Sleep(20 * time.Millisecond)
-	}
+		return false
+	}, 120*time.Second, 20*time.Millisecond)
 	require.False(t, sawFinishedAt.IsZero(), "task never reached FINISHED")
 
 	// Poll the schema for up to flipWindow after FINISHED was first observed.
@@ -141,8 +144,10 @@ func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 	const flipWindow = 5 * time.Second
 	var lastObservedTokenization string
 	var sawFieldAt time.Time
-	pollDeadline := sawFinishedAt.Add(flipWindow)
-	for time.Now().Before(pollDeadline) {
+	// Keep a tight 10ms tick so the captured sawFieldAt is as close as
+	// possible to the actual flip — the convergence-lag assertion below is
+	// sub-second. Capture the timestamp the instant the condition holds.
+	flipped := assert.Eventually(t, func() bool {
 		cls := helper.GetClass(t, className)
 		for _, prop := range cls.Properties {
 			if prop.Name == "filepath" {
@@ -151,12 +156,12 @@ func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 		}
 		if lastObservedTokenization == "field" {
 			sawFieldAt = time.Now()
-			break
+			return true
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return false
+	}, flipWindow, 10*time.Millisecond)
 
-	if sawFieldAt.IsZero() {
+	if !flipped || sawFieldAt.IsZero() {
 		t.Fatalf(
 			"schema flag never flipped to %q within %v after FINISHED was first observed; "+
 				"last observed tokenization=%q. The Journey 3 wiring "+

--- a/test/acceptance/reindex_singlenode/property_state_migration_matrix_test.go
+++ b/test/acceptance/reindex_singlenode/property_state_migration_matrix_test.go
@@ -76,6 +76,7 @@ package reindex_singlenode
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -678,18 +679,26 @@ func tryCreateClass(t *testing.T, class *models.Class) error {
 // reaches a terminal state within the timeout, returns ("TIMEOUT", "").
 func awaitTaskTerminal(t *testing.T, restURI, taskID string, timeout time.Duration) (string, string) {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "TIMEOUT", ""
+		case <-ticker.C:
+		}
 		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 		if err != nil {
-			time.Sleep(250 * time.Millisecond)
+			// transient error — retry on next tick.
 			continue
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		var tasks models.DistributedTasks
 		if err := json.Unmarshal(body, &tasks); err != nil {
-			time.Sleep(250 * time.Millisecond)
+			// transient error — retry on next tick.
 			continue
 		}
 		for _, task := range tasks["reindex"] {
@@ -705,17 +714,14 @@ func awaitTaskTerminal(t *testing.T, restURI, taskID string, timeout time.Durati
 				return "CANCELLED", task.Error
 			}
 		}
-		time.Sleep(250 * time.Millisecond)
 	}
-	return "TIMEOUT", ""
 }
 
 // verifySchemaPostMigration polls the class schema until the targeted index
 // flag is in the expected post-state.
 func verifySchemaPostMigration(t *testing.T, class, propName string, mb matrixBody) bool {
 	t.Helper()
-	deadline := time.Now().Add(20 * time.Second)
-	for time.Now().Before(deadline) {
+	return assert.Eventually(t, func() bool {
 		c := helper.GetClass(t, class)
 		if c != nil {
 			for _, p := range c.Properties {
@@ -744,9 +750,8 @@ func verifySchemaPostMigration(t *testing.T, class, propName string, mb matrixBo
 				}
 			}
 		}
-		time.Sleep(250 * time.Millisecond)
-	}
-	return false
+		return false
+	}, 20*time.Second, 50*time.Millisecond)
 }
 
 // queryIndexForBody returns which index type should be queried after a

--- a/test/acceptance/reindex_singlenode/restart_during_swap_test.go
+++ b/test/acceptance/reindex_singlenode/restart_during_swap_test.go
@@ -162,10 +162,11 @@ func TestRestartDuringSwap(t *testing.T) {
 		`{"searchable":{"tokenization":"field"}}`)
 	t.Logf("submitted reindex task: %s", taskID)
 
-	// Step 4: poll /v1/tasks every ~20ms until FINISHED.
-	deadline := time.Now().Add(120 * time.Second)
+	// Step 4: poll /v1/tasks until FINISHED. Keep a tight 20ms tick: this
+	// test SIGKILLs at the FINISHED boundary, so the poll cadence is
+	// load-bearing for hitting the swap-recovery window.
 	var sawFinishedAt time.Time
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		status, err := fetchTaskStatus(restURI, taskID)
 		require.NoError(t, err)
 		if status == "FAILED" {
@@ -173,10 +174,10 @@ func TestRestartDuringSwap(t *testing.T) {
 		}
 		if status == "FINISHED" {
 			sawFinishedAt = time.Now()
-			break
+			return true
 		}
-		time.Sleep(20 * time.Millisecond)
-	}
+		return false
+	}, 120*time.Second, 20*time.Millisecond)
 	require.False(t, sawFinishedAt.IsZero(), "task never reached FINISHED before deadline")
 	t.Logf("task observed FINISHED at %v — initiating immediate container stop", sawFinishedAt)
 
@@ -221,14 +222,9 @@ func TestRestartDuringSwap(t *testing.T) {
 
 	// Step 8: wait for the schema tokenization to flip to "field"
 	// (OnGroupCompleted has fired and the swap has completed).
-	tokenizationFlipped := false
-	for deadline := time.Now().Add(15 * time.Second); time.Now().Before(deadline); {
-		if getTokenization(t, className, "description") == "field" {
-			tokenizationFlipped = true
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
+	tokenizationFlipped := assert.Eventually(t, func() bool {
+		return getTokenization(t, className, "description") == "field"
+	}, 15*time.Second, 50*time.Millisecond)
 	if !tokenizationFlipped {
 		// Diagnostic: dump the shard's lsm + .migrations dir so we can see
 		// the on-disk state when the swap fails to fire.

--- a/test/acceptance/reindex_singlenode/roaring_set_test.go
+++ b/test/acceptance/reindex_singlenode/roaring_set_test.go
@@ -99,11 +99,13 @@ func testRoaringSetRefresh(t *testing.T, restURI string) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stopCh:
 				return
-			default:
+			case <-ticker.C:
 			}
 			for i, bl := range roaringSetBaselines {
 				ids, err := roaringSetQuerySafe(t, roaringSetFilterQueries[i].where)
@@ -114,7 +116,6 @@ func testRoaringSetRefresh(t *testing.T, restURI string) {
 					queryFailures.Add(1)
 				}
 			}
-			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 

--- a/test/acceptance/reindex_singlenode/scope_assertion_test.go
+++ b/test/acceptance/reindex_singlenode/scope_assertion_test.go
@@ -358,18 +358,15 @@ func testReindexScopeAssertion(t *testing.T, restURI string) {
 // readable, but fails if the task disappears before we can observe it.
 func assertPayloadProperties(t *testing.T, restURI, taskID, target string) {
 	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-		if err != nil {
-			time.Sleep(50 * time.Millisecond)
-			continue
+		if !assert.NoError(c, err) {
+			return
 		}
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if err != nil {
-			time.Sleep(50 * time.Millisecond)
-			continue
+		if !assert.NoError(c, err) {
+			return
 		}
 		// Use a map[string]interface{} deserialization for the task since
 		// Payload is typed as interface{} and will come back as a generic
@@ -378,27 +375,38 @@ func assertPayloadProperties(t *testing.T, restURI, taskID, target string) {
 			ID      string                 `json:"id"`
 			Payload map[string]interface{} `json:"payload"`
 		}
-		if err := json.Unmarshal(body, &envelope); err != nil {
-			time.Sleep(50 * time.Millisecond)
-			continue
+		if !assert.NoError(c, json.Unmarshal(body, &envelope)) {
+			return
 		}
+		var found bool
+		var propsList []interface{}
 		for _, task := range envelope["reindex"] {
 			if task.ID != taskID {
 				continue
 			}
+			found = true
 			rawProps, ok := task.Payload["properties"]
-			require.True(t, ok, "task %s payload has no `properties` field (payload=%+v)", taskID, task.Payload)
-			propsList, ok := rawProps.([]interface{})
-			require.True(t, ok, "task %s payload.properties is not a list: %T", taskID, rawProps)
-			require.Len(t, propsList, 1,
-				"task %s payload.properties should contain exactly one entry but has %d: %v",
-				taskID, len(propsList), propsList)
-			require.Equal(t, target, propsList[0],
-				"task %s payload.properties should be [%q] but is %v",
-				taskID, target, propsList)
+			if !assert.True(c, ok, "task %s payload has no `properties` field (payload=%+v)", taskID, task.Payload) {
+				return
+			}
+			propsList, ok = rawProps.([]interface{})
+			if !assert.True(c, ok, "task %s payload.properties is not a list: %T", taskID, rawProps) {
+				return
+			}
+			break
+		}
+		// The task must be present in /v1/tasks; if not, fail the inner
+		// assert and retry on the next tick.
+		if !assert.True(c, found, "task %s not found in /v1/tasks — could not verify payload scope", taskID) {
 			return
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatalf("task %s not found in /v1/tasks within 30s — could not verify payload scope", taskID)
+		assert.Len(c, propsList, 1,
+			"task %s payload.properties should contain exactly one entry but has %d: %v",
+			taskID, len(propsList), propsList)
+		if len(propsList) == 1 {
+			assert.Equal(c, target, propsList[0],
+				"task %s payload.properties should be [%q] but is %v",
+				taskID, target, propsList)
+		}
+	}, 30*time.Second, 50*time.Millisecond)
 }


### PR DESCRIPTION
## What

Removes every `time.Sleep` anti-pattern from the reindex acceptance suite and enforces a **≤50ms poll/tick interval everywhere** (existing `require.Eventually`/`EventuallyWithT` ticks included, not just sleeps).

Scope: **62 `time.Sleep` sites** + **~45 pre-existing `Eventually`/ticker intervals** that were >50ms, across `reindex_multinode`, `reindex_singlenode`, `reindex_concurrent`, `reindex_backup` (34 files).

## Why

A `time.Sleep` in a test is either (1) masking a window of temporarily-incorrect results, (2) an eventual-consistency wait that should be `require.Eventually`, or (3) a crude poll/pacing loop that should be a ticker/`Eventually`. None of those should be a fixed sleep. Coarse poll intervals are the same hazard in disguise: a 500ms tick in a divergence-detection test can't see a sub-500ms divergence window. Removing the sleeps also reclaims real wall-clock — the multinode restart tests alone burned ~3s of dead settle per assertion.

## Three classes of change

- **Masking settles removed** — `finalizing_crash` (×2), `in_flight_rangeable`, and the `migration_journeys` / `post_restart` post-restart per-replica histograms had a fixed settle sitting *immediately before* the correctness assertion. `AwaitReindexFinished` only confirms FINISHED on the **coordinator node**; the sleep was a guess at how long the *other* replicas needed. Replaced with `require.Eventually` convergence gates that poll every replica — a node still loading buckets gets its legitimate time, but one that **never converges fails loudly** instead of being slept past, and the histogram then runs as a post-convergence stability check.
- **Eventual-consistency waits** — fixed settle before all-replica asserts folded into `require.EventuallyWithT` polling every replica; the per-#212 diagnostic messages are preserved via `assert.*` on the `CollectT`.
- **Polling / pacing** — hand-rolled deadline loops → `Eventually`/`EventuallyWithT`; background invariant-checker goroutines → stop-aware `time.Ticker` (prompt shutdown on `close(stopCh)`, tighter in-flight sampling); all >50ms ticks lowered to 50ms.

Two sleeps remain by design: a single ≤50ms one-shot retry backoff, and a post-cutover sampling **window** (`tailDuration` — a duration to keep sampling, not a poll interval).

## Falsification (this is the experiment)

Some of these masking settles were almost certainly added to paper over real bugs that have since been fixed; the masking was never removed. Some bugs may **not** be fixed.

- **CI red under a convergence gate** → the removed sleep was masking a live (possibly since-introduced) bug; the failure log is the reproducer. We file it and fix it before merge.
- **CI green** → the sleep was dead weight from a since-fixed issue, and this removes it (and the wasted wall-clock).

Draft until CI completes so we can read that signal.

## Validation

`gofmt` clean, `go vet` clean, and all four test binaries build+link on all four packages. Full correctness validation is this PR's CI (these are docker-based e2e tests).
