### PR TITLE
test(reindex): add WithRetryOnReadOnly mitigation for legacy PQ schema-change race

### DIFF
--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strings"
 	"testing"
@@ -28,12 +29,21 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
+// Retry budget for the WithRetryOnReadOnly mitigation. See AwaitReindexFinished.
+const (
+	readOnlyRetryInterval = 50 * time.Millisecond
+	readOnlyRetryTimeout  = 2 * time.Second
+	readOnlyMaxRetries    = 3
+	readOnlyErrorMarker   = "store is read-only"
+)
+
 // Option configures optional behavior of a helper call.
 type Option func(*options)
 
 type options struct {
-	tenants []string
-	timeout time.Duration
+	tenants            []string
+	timeout            time.Duration
+	resubmitOnReadOnly func() string
 }
 
 func applyOptions(opts []Option) options {
@@ -52,6 +62,34 @@ func WithTenants(tenants []string) Option {
 // WithTimeout overrides the default 120s require.Eventually timeout.
 func WithTimeout(d time.Duration) Option {
 	return func(o *options) { o.timeout = d }
+}
+
+// WithRetryOnReadOnly enables retry-on-read-only for AwaitReindexFinished. When
+// the task transitions to FAILED with an error containing "store is read-only"
+// (the known legacy PQ-compression schema-change code path that briefly marks a
+// collection read-only on any schema change), AwaitReindexFinished polls for
+// readOnlyRetryTimeout at readOnlyRetryInterval (with jitter) and calls
+// `resubmit` to obtain a fresh taskID, retrying up to readOnlyMaxRetries times
+// before failing.
+//
+// The `resubmit` closure must reproduce the SAME schema-change body as the
+// original submit — typically:
+//
+//	submit := func() string {
+//	    return reindexhelpers.SubmitIndexUpdate(t, restURI, class, prop, body)
+//	}
+//	taskID := submit()
+//	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
+//
+// Other FAILED reasons (anything not containing the marker substring) take
+// the original fatal path.
+//
+// The 50ms/2s/3-retry budget composes with the default 120s AwaitReindexFinished
+// timeout — pass WithTimeout(...) to shrink the per-attempt budget if needed.
+//
+// This mitigation will be removed once the server-side fix lands post-v1.38.
+func WithRetryOnReadOnly(resubmit func() string) Option {
+	return func(o *options) { o.resubmitOnReadOnly = resubmit }
 }
 
 // SubmitIndexUpdate fires PUT /v1/schema/{collection}/indexes/{property}
@@ -152,35 +190,93 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 
 // AwaitReindexFinished polls /v1/tasks until the named reindex task
 // reaches FINISHED. Fails on FAILED or on timeout (default 120s).
+//
+// If WithRetryOnReadOnly is set and the task FAILS with an error containing
+// "store is read-only" (the legacy PQ-compression schema-change race), the
+// helper polls briefly for the read-only window to clear, then resubmits via
+// the supplied closure (up to readOnlyMaxRetries times) before failing.
 func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)
 
-	require.Eventually(t, func() bool {
+	deadline := time.Now().Add(o.timeout)
+	retries := 0
+
+	for time.Now().Before(deadline) {
 		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 		if err != nil {
-			return false
+			time.Sleep(1 * time.Second)
+			continue
 		}
-		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
-			return false
+			time.Sleep(1 * time.Second)
+			continue
 		}
 		var tasks models.DistributedTasks
 		if err := json.Unmarshal(body, &tasks); err != nil {
-			return false
+			time.Sleep(1 * time.Second)
+			continue
 		}
+
 		for _, task := range tasks["reindex"] {
-			if task.ID == taskID {
-				t.Logf("task %s status: %s", taskID, task.Status)
-				if task.Status == "FAILED" {
-					t.Fatalf("reindex task failed: %s", task.Error)
-				}
-				return task.Status == "FINISHED"
+			if task.ID != taskID {
+				continue
 			}
+			t.Logf("task %s status: %s", taskID, task.Status)
+			if task.Status == "FINISHED" {
+				return
+			}
+			if task.Status == "FAILED" {
+				// Retry path: legacy PQ-compression schema-change race. The
+				// collection is briefly read-only on any schema change; the
+				// reindex writer collides and surfaces this error. We poll
+				// briefly for the window to clear and resubmit.
+				if o.resubmitOnReadOnly != nil && strings.Contains(task.Error, readOnlyErrorMarker) {
+					if retries >= readOnlyMaxRetries {
+						t.Fatalf("reindex task failed with read-only error after %d retries: %s", retries, task.Error)
+					}
+					retries++
+					t.Logf("reindex task %s hit read-only race (attempt %d/%d); waiting for window to clear before resubmitting: %s",
+						taskID, retries, readOnlyMaxRetries, task.Error)
+					waitForReadOnlyWindow(readOnlyRetryTimeout, readOnlyRetryInterval)
+					newTaskID := o.resubmitOnReadOnly()
+					t.Logf("resubmitted reindex after read-only race; new task %s (was %s)", newTaskID, taskID)
+					taskID = newTaskID
+					// Extend the deadline so a late retry still has the full
+					// per-attempt budget — the contract is documented on
+					// WithRetryOnReadOnly.
+					deadline = time.Now().Add(o.timeout)
+					break
+				}
+				t.Fatalf("reindex task failed: %s", task.Error)
+			}
+			break
 		}
-		return false
-	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
+
+		time.Sleep(1 * time.Second)
+	}
+
+	t.Fatalf("reindex task %s should reach FINISHED status within %s", taskID, o.timeout)
+}
+
+// waitForReadOnlyWindow sleeps for `total` in increments of `step` with 50%-150%
+// jitter, to desynchronize concurrent retriers competing on the same window.
+func waitForReadOnlyWindow(total, step time.Duration) {
+	end := time.Now().Add(total)
+	for time.Now().Before(end) {
+		// Jitter the step between 50% and 150% of the nominal interval.
+		factor := 0.5 + rand.Float64()
+		sleep := time.Duration(float64(step) * factor)
+		if remaining := time.Until(end); sleep > remaining {
+			sleep = remaining
+		}
+		if sleep <= 0 {
+			return
+		}
+		time.Sleep(sleep)
+	}
 }
 
 // AwaitReindexViaIndexes polls GET /v1/schema/{collection}/indexes until

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -455,10 +455,13 @@ func testAlgorithmVerb(t *testing.T, restURI string) {
 	// USE_INVERTED_SEARCHABLE=false starts the class on Map (WAND); migrate
 	// it to blockmax via the algorithm verb so the refusal cases below
 	// have an already-blockmax target.
-	preTaskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, propName,
-		`{"searchable":{"algorithm":"blockmax"}}`)
+	submitPre := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, propName,
+			`{"searchable":{"algorithm":"blockmax"}}`)
+	}
+	preTaskID := submitPre()
 	reindexhelpers.AwaitReindexFinished(t, restURI, preTaskID,
-		reindexhelpers.WithTimeout(60*time.Second))
+		reindexhelpers.WithTimeout(60*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPre))
 
 	preTasksResp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 	require.NoError(t, err)
@@ -531,7 +534,10 @@ func testMutationGuardBlocksDeleteClassDuringInFlight(t *testing.T, restURI stri
 
 	importBodies(t, className, 50_000)
 
-	taskID := submitChangeTokenization(t, restURI, className, propName, "lowercase")
+	submit := func() string {
+		return submitChangeTokenization(t, restURI, className, propName, "lowercase")
+	}
+	taskID := submit()
 	t.Logf("change-tokenization task submitted for mutation-guard probe: %s", taskID)
 
 	awaitIndexingState(t, restURI, className, propName)
@@ -563,7 +569,7 @@ func testMutationGuardBlocksDeleteClassDuringInFlight(t *testing.T, restURI stri
 	require.Equal(t, http.StatusOK, resp.StatusCode,
 		"class must survive a guard-rejected DELETE; got %d on GET", resp.StatusCode)
 
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(120*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(120*time.Second), reindexhelpers.WithRetryOnReadOnly(submit))
 
 	req, err = http.NewRequest(http.MethodDelete, deleteURL, nil)
 	require.NoError(t, err)

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -136,9 +136,12 @@ func testRepairAllTenants(t *testing.T, restURI string) {
 	}
 
 	// Submit repair-searchable (no tenants param → all tenants).
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	}
+	taskID := submit()
 	t.Logf("repair all tenants task: %s", taskID)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Verify data still intact.
 	for _, tn := range tenantNames {
@@ -173,10 +176,13 @@ func testRepairSpecificTenants(t *testing.T, restURI string) {
 
 	// Repair only t1 and t2.
 	targetTenants := []string{"t1", "t2"}
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
-		`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants(targetTenants))
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
+			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants(targetTenants))
+	}
+	taskID := submit()
 	t.Logf("repair specific tenants task: %s", taskID)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// All tenants should still have data.
 	for _, tn := range tenantNames {
@@ -236,10 +242,13 @@ func testChangeTokenizationMT(t *testing.T, restURI string) {
 	}
 
 	// Change tokenization to field (must target all tenants).
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "filepath",
-		`{"searchable":{"tokenization":"field"}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "filepath",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	taskID := submit()
 	t.Logf("change tokenization MT task: %s", taskID)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Wait for schema update.
 	require.Eventually(t, func() bool {
@@ -337,10 +346,13 @@ func testEnableRangeableMT(t *testing.T, restURI string) {
 	}
 
 	// Enable rangeable.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
-		`{"rangeable":{"enabled":true}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
+			`{"rangeable":{"enabled":true}}`)
+	}
+	taskID := submit()
 	t.Logf("enable rangeable MT task: %s", taskID)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Schema should show indexRangeFilters=true.
 	require.Eventually(t, func() bool {

--- a/test/acceptance/reindex_multinode/concurrent_migrations_test.go
+++ b/test/acceptance/reindex_multinode/concurrent_migrations_test.go
@@ -158,6 +158,18 @@ func TestMultiNode_ConcurrentDifferentMigrations_ExactCountsPostSettle(t *testin
 	// Submit 3 migrations in parallel — same shape as Frontend Claude's
 	// Phase 2 of the 1M-record demo.
 	uri1 := restURIOf(compose, 1)
+	submitPrice := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "price",
+			`{"rangeable":{"enabled":true}}`)
+	}
+	submitCat := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "category",
+			`{"filterable":{"enabled":true}}`)
+	}
+	submitPath := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
 	var (
 		priceTaskID, catTaskID, pathTaskID string
 		wg                                 sync.WaitGroup
@@ -165,18 +177,15 @@ func TestMultiNode_ConcurrentDifferentMigrations_ExactCountsPostSettle(t *testin
 	wg.Add(3)
 	go func() {
 		defer wg.Done()
-		priceTaskID = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "price",
-			`{"rangeable":{"enabled":true}}`)
+		priceTaskID = submitPrice()
 	}()
 	go func() {
 		defer wg.Done()
-		catTaskID = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "category",
-			`{"filterable":{"enabled":true}}`)
+		catTaskID = submitCat()
 	}()
 	go func() {
 		defer wg.Done()
-		pathTaskID = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
-			`{"searchable":{"tokenization":"word"}}`)
+		pathTaskID = submitPath()
 	}()
 	wg.Wait()
 	t.Logf("submitted parallel migrations: price=%s category=%s path=%s",
@@ -185,9 +194,9 @@ func TestMultiNode_ConcurrentDifferentMigrations_ExactCountsPostSettle(t *testin
 	// Block until all three reach FINISHED. The default 180s budget per
 	// task is fine — on 10k records the migrations run in seconds, but
 	// they can pile up serially through the scheduler.
-	reindexhelpers.AwaitReindexFinished(t, uri1, priceTaskID, reindexhelpers.WithTimeout(180*time.Second))
-	reindexhelpers.AwaitReindexFinished(t, uri1, catTaskID, reindexhelpers.WithTimeout(180*time.Second))
-	reindexhelpers.AwaitReindexFinished(t, uri1, pathTaskID, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, uri1, priceTaskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPrice))
+	reindexhelpers.AwaitReindexFinished(t, uri1, catTaskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitCat))
+	reindexhelpers.AwaitReindexFinished(t, uri1, pathTaskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPath))
 
 	// Brief settle so schema flips propagate to every node.
 	time.Sleep(3 * time.Second)

--- a/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
@@ -61,10 +61,13 @@ func TestMultiNode_DeleteRecreateCleansReindexTasks(t *testing.T) {
 	importObjects(t, uri, className, texts)
 
 	// Run a migration → first task record under "reindex" namespace.
-	task1 := reindexhelpers.SubmitIndexUpdate(t, uri, className, "text",
-		`{"searchable":{"tokenization":"field"}}`)
+	submit1 := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, uri, className, "text",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	task1 := submit1()
 	reindexhelpers.AwaitReindexFinished(t, uri, task1,
-		reindexhelpers.WithTimeout(180*time.Second))
+		reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submit1))
 	t.Logf("first migration FINISHED: task=%s", task1)
 
 	// Spot-check pre-delete: task record is present on this node's view.
@@ -119,12 +122,15 @@ func TestMultiNode_DeleteRecreateCleansReindexTasks(t *testing.T) {
 	// ephemeral host port on every container start.
 	postRestartURI := restURIOf(compose, 1)
 	importObjects(t, postRestartURI, className, texts[:10])
-	task2 := reindexhelpers.SubmitIndexUpdate(t, postRestartURI, className, "text",
-		`{"searchable":{"tokenization":"field"}}`)
+	submit2 := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, postRestartURI, className, "text",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	task2 := submit2()
 	require.NotEqual(t, task1, task2,
 		"recreated class must produce a fresh task ID, not the old one")
 	reindexhelpers.AwaitReindexFinished(t, postRestartURI, task2,
-		reindexhelpers.WithTimeout(180*time.Second))
+		reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submit2))
 	t.Logf("post-recreate migration FINISHED: task=%s", task2)
 }
 

--- a/test/acceptance/reindex_multinode/finalizing_window_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_window_test.go
@@ -232,11 +232,14 @@ func runLiveQueryDuringChangeTokenizationCase(
 	indexUpdateJSON := buildTokenizationIndexUpdate(t, indexType, targetTok)
 
 	var taskID string
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, compose.GetWeaviateNode(1).URI(), className, "text", indexUpdateJSON)
+	}
 	samples, migrationStart := runMigrationWithProbes(t, compose, className,
 		25*time.Millisecond, 2*time.Second, probe, func() {
-			taskID = reindexhelpers.SubmitIndexUpdate(t, compose.GetWeaviateNode(1).URI(), className, "text", indexUpdateJSON)
+			taskID = submit()
 			t.Logf("submitted change-tokenization-%s task: %s", indexType, taskID)
-			reindexhelpers.AwaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID, reindexhelpers.WithTimeout(180*time.Second))
+			reindexhelpers.AwaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submit))
 			require.Eventually(t, func() bool {
 				return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
 					className, "text") == targetTok
@@ -454,12 +457,15 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 	}
 
 	var taskID string
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, compose.GetWeaviateNode(1).URI(),
+			className, "text", `{"searchable":{"tokenization":"field"}}`)
+	}
 	samples, migrationStart := runMigrationWithProbes(t, compose, className,
 		25*time.Millisecond, 2*time.Second, probe, func() {
-			taskID = reindexhelpers.SubmitIndexUpdate(t, compose.GetWeaviateNode(1).URI(),
-				className, "text", `{"searchable":{"tokenization":"field"}}`)
+			taskID = submit()
 			t.Logf("submitted change-tokenization task: %s", taskID)
-			reindexhelpers.AwaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID, reindexhelpers.WithTimeout(180*time.Second))
+			reindexhelpers.AwaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submit))
 			require.Eventually(t, func() bool {
 				return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
 					className, "text") == "field"

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -159,14 +159,17 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	}
 
 	// Submit reindex.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	}
+	taskID := submit()
 	t.Logf("submitted reindex task: %s", taskID)
 
 	// Poll until reindex is done via /indexes endpoint.
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, className, "text", "searchable", reindexhelpers.WithTimeout(180*time.Second))
 
 	// Verify task reached FINISHED state.
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Stop background queries.
 	close(stopCh)
@@ -413,10 +416,13 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 	}
 
 	// Submit reindex (repair-searchable — the most common type).
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	}
+	taskID := submit()
 	t.Logf("submitted reindex task: %s", taskID)
 
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Continue queries for several consecutive successful rounds after
 	// completion to catch post-swap transients.

--- a/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
+++ b/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
@@ -160,14 +160,17 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 
 	// Submit enable-rangeable. We do this via the same handler the demo
 	// hits, so the on-the-wire shape matches the production failure.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURIOf(compose, 1), className, "score",
-		`{"rangeable":{"enabled":true}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURIOf(compose, 1), className, "score",
+			`{"rangeable":{"enabled":true}}`)
+	}
+	taskID := submit()
 	t.Logf("submitted enable-rangeable task: %s", taskID)
 
 	// Block until the migration has fully reached FINISHED. We then keep
 	// polling for a settle window — the schema flip RAFT can land on
 	// other nodes a moment after FINISHED.
-	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Settle window: keep polling for 3 s after FINISHED. This catches
 	// the late-window race where one node's schema flip arrived but

--- a/test/acceptance/reindex_multinode/migration_journeys_test.go
+++ b/test/acceptance/reindex_multinode/migration_journeys_test.go
@@ -134,10 +134,13 @@ func TestMultiNode_BackToBackChangeTokenization_RoundTripCounts(t *testing.T) {
 
 	// === Step 4: change-tokenization to FIELD.
 	uri1 := restURIOf(compose, 1)
-	task1 := reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
-		`{"searchable":{"tokenization":"field"}}`)
+	submitField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	task1 := submitField()
 	t.Logf("change-tokenization → field: task=%s", task1)
-	reindexhelpers.AwaitReindexFinished(t, uri1, task1, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, uri1, task1, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitField))
 	time.Sleep(3 * time.Second)
 
 	// === Step 5: every replica must serve the FIELD count.
@@ -151,10 +154,13 @@ func TestMultiNode_BackToBackChangeTokenization_RoundTripCounts(t *testing.T) {
 	}
 
 	// === Step 6: change-tokenization back to WORD.
-	task2 := reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
-		`{"searchable":{"tokenization":"word"}}`)
+	submitWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
+	task2 := submitWord()
 	t.Logf("change-tokenization → word (round-trip): task=%s", task2)
-	reindexhelpers.AwaitReindexFinished(t, uri1, task2, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, uri1, task2, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitWord))
 	time.Sleep(3 * time.Second)
 
 	// === Step 7: every replica must serve the WORD baseline again.
@@ -297,6 +303,18 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 	uri := restURIOf(compose, 1)
 	t.Log("initial enable migrations (cycle 0)")
 	{
+		submitPrice := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri, className, "price",
+				`{"rangeable":{"enabled":true}}`)
+		}
+		submitCategory := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri, className, "category",
+				`{"filterable":{"enabled":true}}`)
+		}
+		submitPath := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri, className, "path",
+				`{"searchable":{"tokenization":"field"}}`)
+		}
 		var (
 			tp, tc, tk string
 			wg         sync.WaitGroup
@@ -304,23 +322,20 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		wg.Add(3)
 		go func() {
 			defer wg.Done()
-			tp = reindexhelpers.SubmitIndexUpdate(t, uri, className, "price",
-				`{"rangeable":{"enabled":true}}`)
+			tp = submitPrice()
 		}()
 		go func() {
 			defer wg.Done()
-			tc = reindexhelpers.SubmitIndexUpdate(t, uri, className, "category",
-				`{"filterable":{"enabled":true}}`)
+			tc = submitCategory()
 		}()
 		go func() {
 			defer wg.Done()
-			tk = reindexhelpers.SubmitIndexUpdate(t, uri, className, "path",
-				`{"searchable":{"tokenization":"field"}}`)
+			tk = submitPath()
 		}()
 		wg.Wait()
-		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
+		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPrice))
+		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitCategory))
+		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPath))
 	}
 	time.Sleep(2 * time.Second)
 
@@ -336,6 +351,18 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 			nextTok = "field"
 		}
 		t.Logf("repeated journey cycle %d: rebuilds + tok→%s", cycle, nextTok)
+		submitPrice := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri, className, "price",
+				`{"rangeable":{"rebuild":true}}`)
+		}
+		submitCategory := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri, className, "category",
+				`{"filterable":{"rebuild":true}}`)
+		}
+		submitPath := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri, className, "path",
+				fmt.Sprintf(`{"searchable":{"tokenization":%q}}`, nextTok))
+		}
 		var (
 			tp, tc, tk string
 			wg         sync.WaitGroup
@@ -343,23 +370,20 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		wg.Add(3)
 		go func() {
 			defer wg.Done()
-			tp = reindexhelpers.SubmitIndexUpdate(t, uri, className, "price",
-				`{"rangeable":{"rebuild":true}}`)
+			tp = submitPrice()
 		}()
 		go func() {
 			defer wg.Done()
-			tc = reindexhelpers.SubmitIndexUpdate(t, uri, className, "category",
-				`{"filterable":{"rebuild":true}}`)
+			tc = submitCategory()
 		}()
 		go func() {
 			defer wg.Done()
-			tk = reindexhelpers.SubmitIndexUpdate(t, uri, className, "path",
-				fmt.Sprintf(`{"searchable":{"tokenization":%q}}`, nextTok))
+			tk = submitPath()
 		}()
 		wg.Wait()
-		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
+		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPrice))
+		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitCategory))
+		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPath))
 		time.Sleep(2 * time.Second)
 	}
 

--- a/test/acceptance/reindex_multinode/post_restart_test.go
+++ b/test/acceptance/reindex_multinode/post_restart_test.go
@@ -360,6 +360,18 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 	// rolling restart in Phase 4 has something interesting to recover.
 	uri1 := restURIOf(compose, 1)
 	{
+		submitPrice := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "price",
+				`{"rangeable":{"enabled":true}}`)
+		}
+		submitCategory := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "category",
+				`{"filterable":{"enabled":true}}`)
+		}
+		submitPath := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
+				`{"searchable":{"tokenization":"field"}}`)
+		}
 		var (
 			tp, tc, tk string
 			wg         sync.WaitGroup
@@ -367,23 +379,20 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 		wg.Add(3)
 		go func() {
 			defer wg.Done()
-			tp = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "price",
-				`{"rangeable":{"enabled":true}}`)
+			tp = submitPrice()
 		}()
 		go func() {
 			defer wg.Done()
-			tc = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "category",
-				`{"filterable":{"enabled":true}}`)
+			tc = submitCategory()
 		}()
 		go func() {
 			defer wg.Done()
-			tk = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
-				`{"searchable":{"tokenization":"field"}}`)
+			tk = submitPath()
 		}()
 		wg.Wait()
-		reindexhelpers.AwaitReindexFinished(t, uri1, tp, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri1, tc, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri1, tk, reindexhelpers.WithTimeout(180*time.Second))
+		reindexhelpers.AwaitReindexFinished(t, uri1, tp, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPrice))
+		reindexhelpers.AwaitReindexFinished(t, uri1, tc, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitCategory))
+		reindexhelpers.AwaitReindexFinished(t, uri1, tk, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPath))
 	}
 	time.Sleep(3 * time.Second)
 
@@ -438,6 +447,21 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 	t.Log("submitting post-restart re-apply migrations (3 concurrent)")
 	uri1 = restURIOf(compose, 1)
 	{
+		submitPrice := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "price",
+				`{"rangeable":{"rebuild":true}}`)
+		}
+		submitCategory := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "category",
+				`{"filterable":{"rebuild":true}}`)
+		}
+		submitPath := func() string {
+			// Flip tokenization back to word (the pre-Phase-2 value).
+			// This matches the migration shape from the original
+			// production-scale repro.
+			return reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
+				`{"searchable":{"tokenization":"word"}}`)
+		}
 		var (
 			tp, tc, tk string
 			wg         sync.WaitGroup
@@ -445,28 +469,22 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 		wg.Add(3)
 		go func() {
 			defer wg.Done()
-			tp = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "price",
-				`{"rangeable":{"rebuild":true}}`)
+			tp = submitPrice()
 		}()
 		go func() {
 			defer wg.Done()
-			tc = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "category",
-				`{"filterable":{"rebuild":true}}`)
+			tc = submitCategory()
 		}()
 		go func() {
 			defer wg.Done()
-			// Flip tokenization back to word (the pre-Phase-2 value).
-			// This matches the migration shape from the original
-			// production-scale repro.
-			tk = reindexhelpers.SubmitIndexUpdate(t, uri1, className, "path",
-				`{"searchable":{"tokenization":"word"}}`)
+			tk = submitPath()
 		}()
 		wg.Wait()
 		t.Logf("submitted post-restart re-apply migrations: price=%s category=%s path=%s",
 			tp, tc, tk)
-		reindexhelpers.AwaitReindexFinished(t, uri1, tp, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri1, tc, reindexhelpers.WithTimeout(180*time.Second))
-		reindexhelpers.AwaitReindexFinished(t, uri1, tk, reindexhelpers.WithTimeout(180*time.Second))
+		reindexhelpers.AwaitReindexFinished(t, uri1, tp, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPrice))
+		reindexhelpers.AwaitReindexFinished(t, uri1, tc, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitCategory))
+		reindexhelpers.AwaitReindexFinished(t, uri1, tk, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitPath))
 	}
 	time.Sleep(3 * time.Second)
 

--- a/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
@@ -390,42 +390,54 @@ func TestMultiNode_ChangeTokenization_ConcurrentDifferentProps(t *testing.T) {
 	baselinesBody := captureBaselineCounts(t, compose, className, "body", testBM25Queries)
 
 	// Fire two change-tok migrations in parallel.
+	submitTitleField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	submitBodyField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
 	var wg sync.WaitGroup
 	var titleTaskID, bodyTaskID string
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		titleTaskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
-			`{"searchable":{"tokenization":"field"}}`)
+		titleTaskID = submitTitleField()
 	}()
 	go func() {
 		defer wg.Done()
-		bodyTaskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
-			`{"searchable":{"tokenization":"field"}}`)
+		bodyTaskID = submitBodyField()
 	}()
 	wg.Wait()
 
-	reindexhelpers.AwaitReindexFinished(t, restURI, titleTaskID, reindexhelpers.WithTimeout(180*time.Second))
-	reindexhelpers.AwaitReindexFinished(t, restURI, bodyTaskID, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURI, titleTaskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitTitleField))
+	reindexhelpers.AwaitReindexFinished(t, restURI, bodyTaskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitBodyField))
 	awaitTokenizationOnAllNodes(t, compose, className, "title", "field")
 	awaitTokenizationOnAllNodes(t, compose, className, "body", "field")
 
 	// Now reverse, in parallel.
+	submitTitleWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
+	submitBodyWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		titleTaskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
-			`{"searchable":{"tokenization":"word"}}`)
+		titleTaskID = submitTitleWord()
 	}()
 	go func() {
 		defer wg.Done()
-		bodyTaskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
-			`{"searchable":{"tokenization":"word"}}`)
+		bodyTaskID = submitBodyWord()
 	}()
 	wg.Wait()
 
-	reindexhelpers.AwaitReindexFinished(t, restURI, titleTaskID, reindexhelpers.WithTimeout(180*time.Second))
-	reindexhelpers.AwaitReindexFinished(t, restURI, bodyTaskID, reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURI, titleTaskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitTitleWord))
+	reindexhelpers.AwaitReindexFinished(t, restURI, bodyTaskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitBodyWord))
 	awaitTokenizationOnAllNodes(t, compose, className, "title", "word")
 	awaitTokenizationOnAllNodes(t, compose, className, "body", "word")
 
@@ -549,23 +561,35 @@ func testMultiPropertyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
 	baselinesBody := captureBaselineCounts(t, compose, className, "body", testBM25Queries)
 
 	// Sequential round-trip on title.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
-		`{"searchable":{"tokenization":"field"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	submitTitleField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	taskID := submitTitleField()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitTitleField))
 	awaitTokenizationOnAllNodes(t, compose, className, "title", "field")
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
-		`{"searchable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	submitTitleWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
+	taskID = submitTitleWord()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitTitleWord))
 	awaitTokenizationOnAllNodes(t, compose, className, "title", "word")
 
 	// Then on body.
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
-		`{"searchable":{"tokenization":"field"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	submitBodyField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	taskID = submitBodyField()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitBodyField))
 	awaitTokenizationOnAllNodes(t, compose, className, "body", "field")
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
-		`{"searchable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	submitBodyWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
+	taskID = submitBodyWord()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitBodyWord))
 	awaitTokenizationOnAllNodes(t, compose, className, "body", "word")
 
 	// Poll both properties' per-replica counts until they match the

--- a/test/acceptance/reindex_multinode/round_trip_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_test.go
@@ -80,15 +80,21 @@ func TestMultiNode_ChangeTokenization_RoundTrip(t *testing.T) {
 	}
 
 	// word → field.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
-		`{"searchable":{"tokenization":"field"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	submitField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	taskID := submitField()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitField))
 	awaitTokenizationOnAllNodes(t, compose, className, "text", "field")
 
 	// field → word.
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
-		`{"searchable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	submitWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
+	taskID = submitWord()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second), reindexhelpers.WithRetryOnReadOnly(submitWord))
 	awaitTokenizationOnAllNodes(t, compose, className, "text", "word")
 
 	// Per-node assertion: every replica must return the baseline count for

--- a/test/acceptance/reindex_singlenode/blockmax_test.go
+++ b/test/acceptance/reindex_singlenode/blockmax_test.go
@@ -131,7 +131,10 @@ func testBlockmaxMigration(t *testing.T, restURI string) {
 		}
 	}()
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, blockmaxClassName, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, blockmaxClassName, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	}
+	taskID := submit()
 	t.Logf("submitted reindex task: %s", taskID)
 
 	// While the rebuild is in flight, GET /indexes must surface
@@ -146,7 +149,7 @@ func testBlockmaxMigration(t *testing.T, restURI string) {
 	}
 
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, blockmaxClassName, "text", "searchable")
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Post-rebuild: GET /indexes must surface algorithm=blockmax and must
 	// no longer carry targetAlgorithm (the rebuild has completed and the

--- a/test/acceptance/reindex_singlenode/change_tok_delete_journeys_test.go
+++ b/test/acceptance/reindex_singlenode/change_tok_delete_journeys_test.go
@@ -111,9 +111,12 @@ func testChangeTokBothThenDeleteSearchableThenChangeTokFilterable(t *testing.T, 
 	// Step 1: change-tok-both from word → field via {searchable:{tokenization:field}}.
 	// This goes through ReindexTypeChangeTokenization and retokenizes BOTH
 	// buckets.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"searchable":{"tokenization":"field"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitSearchableField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"searchable":{"tokenization":"field"}}`)
+	}
+	taskID := submitSearchableField()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitSearchableField))
 	requireTokenizationEquals(t, class, "name", "field")
 
 	// Step 2: DELETE the searchable index.
@@ -123,9 +126,12 @@ func testChangeTokBothThenDeleteSearchableThenChangeTokFilterable(t *testing.T, 
 	// the searchable bucket and its migration sentinels gone (or never
 	// having existed if step 1 collapsed them properly), this should
 	// retokenize only the filterable bucket cleanly.
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitFilterableWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"filterable":{"tokenization":"word"}}`)
+	}
+	taskID = submitFilterableWord()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitFilterableWord))
 	requireTokenizationEquals(t, class, "name", "word")
 
 	hits := equalFilterHits(t, class, "name", "alpha")
@@ -168,9 +174,12 @@ func testChangeTokFilterableThenDeleteFilterable(t *testing.T, restURI string) {
 	}
 
 	// Step 1: change-tokenization-filterable from field → word.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"filterable":{"tokenization":"word"}}`)
+	}
+	taskID := submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireTokenizationEquals(t, class, "name", "word")
 
 	require.Equal(t, 1, equalFilterHits(t, class, "name", "alpha"),
@@ -237,9 +246,12 @@ func testChangeTokFilterableThenEnableSearchable(t *testing.T, restURI string) {
 	}
 
 	// Step 1: retokenize filterable from field → word.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitFilterable := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"filterable":{"tokenization":"word"}}`)
+	}
+	taskID := submitFilterable()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitFilterable))
 	requireTokenizationEquals(t, class, "name", "word")
 
 	// Step 2: enable-searchable with matching tokenization "word".
@@ -247,9 +259,12 @@ func testChangeTokFilterableThenEnableSearchable(t *testing.T, restURI string) {
 	// tokenization differs from the property's current tokenization
 	// when there is a pre-existing filterable index, so we use the
 	// same tokenization the filterable was just changed to.
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"searchable":{"enabled":true,"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitSearchable := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"searchable":{"enabled":true,"tokenization":"word"}}`)
+	}
+	taskID = submitSearchable()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitSearchable))
 	requireSearchableEnabled(t, class, "name")
 	requireTokenizationEquals(t, class, "name", "word")
 
@@ -428,17 +443,23 @@ func testChangeTokFilterableBackToBack(t *testing.T, restURI string) {
 	}))
 
 	// Step 1: field → word.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"filterable":{"tokenization":"word"}}`)
+	}
+	taskID := submitWord()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitWord))
 	requireTokenizationEquals(t, class, "name", "word")
 	require.Equal(t, 1, equalFilterHits(t, class, "name", "alpha"),
 		"after first retokenize (word): Equal('alpha') must hit 1")
 
 	// Step 2: word → field.
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"tokenization":"field"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"filterable":{"tokenization":"field"}}`)
+	}
+	taskID = submitField()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitField))
 	requireTokenizationEquals(t, class, "name", "field")
 
 	// With "field" the whole string is a single token. Equal('alpha
@@ -556,27 +577,36 @@ func testChangeTokFilterableEnableSearchableThenChangeTokBoth(t *testing.T, rest
 	}
 
 	// Step 1: retokenize filterable from word → field.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"tokenization":"field"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitFilterableField := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"filterable":{"tokenization":"field"}}`)
+	}
+	taskID := submitFilterableField()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitFilterableField))
 	requireTokenizationEquals(t, class, "name", "field")
 	require.Equal(t, 1, equalFilterHits(t, class, "name", "alpha beta"),
 		"after step 1 (filterable field): Equal('alpha beta') must hit 1")
 
 	// Step 2: enable-searchable with matching field tokenization (must
 	// match because validateEnableSearchableProperty rejects mismatch).
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"searchable":{"enabled":true,"tokenization":"field"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitEnableSearchable := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"searchable":{"enabled":true,"tokenization":"field"}}`)
+	}
+	taskID = submitEnableSearchable()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitEnableSearchable))
 	requireSearchableEnabled(t, class, "name")
 	requireTokenizationEquals(t, class, "name", "field")
 
 	// Step 3: change-tok-both from field → word using
 	// {searchable:{tokenization:word}}. This runs ReindexTypeChangeTokenization
 	// which retokenizes BOTH buckets.
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"searchable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submitBothWord := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"searchable":{"tokenization":"word"}}`)
+	}
+	taskID = submitBothWord()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submitBothWord))
 	requireTokenizationEquals(t, class, "name", "word")
 
 	// Step 4: assert both buckets reflect word tokenization. With

--- a/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
+++ b/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
@@ -89,9 +89,12 @@ func testFilterableTokenizationFilterableOnly(t *testing.T, restURI, dataType st
 		"pre-migration: Equal('alpha') with field tokenization must match exactly one object")
 
 	// Submit {"filterable":{"tokenization":"word"}} — the new body shape.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "name",
-		`{"filterable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "name",
+			`{"filterable":{"tokenization":"word"}}`)
+	}
+	taskID := submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Schema flag: Tokenization must now be "word".
 	require.Eventually(t, func() bool {
@@ -194,9 +197,12 @@ func testFilterableTokenizationOnBothIndexes(t *testing.T, restURI string) {
 		Class: className, Properties: map[string]interface{}{"name": "gamma"},
 	}))
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "name",
-		`{"filterable":{"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "name",
+			`{"filterable":{"tokenization":"word"}}`)
+	}
+	taskID := submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	require.Eventually(t, func() bool {
 		c := helper.GetClass(t, className)

--- a/test/acceptance/reindex_singlenode/change_tokenization_test.go
+++ b/test/acceptance/reindex_singlenode/change_tokenization_test.go
@@ -123,11 +123,14 @@ func testChangeTokenization(t *testing.T, restURI string) {
 		}
 	}()
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, retokenizeClassName, "filepath", `{"searchable":{"tokenization":"field"}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, retokenizeClassName, "filepath", `{"searchable":{"tokenization":"field"}}`)
+	}
+	taskID := submit()
 	t.Logf("submitted reindex task: %s", taskID)
 
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, retokenizeClassName, "filepath", "searchable")
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	require.Eventually(t, func() bool {
 		cls := helper.GetClass(t, retokenizeClassName)

--- a/test/acceptance/reindex_singlenode/delete_reenable_indexing_bleed_test.go
+++ b/test/acceptance/reindex_singlenode/delete_reenable_indexing_bleed_test.go
@@ -154,8 +154,11 @@ func runEnableThenDeleteCycle(
 	requireEnabled func(),
 ) {
 	t.Helper()
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, propName, putBody)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, propName, putBody)
+	}
+	taskID := submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireEnabled()
 	deleteIndex(t, restURI, class, propName, deleteIndexName)
 }

--- a/test/acceptance/reindex_singlenode/delete_reenable_multicycle_test.go
+++ b/test/acceptance/reindex_singlenode/delete_reenable_multicycle_test.go
@@ -71,10 +71,13 @@ func testDeleteThenReEnableSearchableMultiCycle(t *testing.T, restURI string, cy
 		}), "object %d", i)
 	}
 
-	for cycle := 1; cycle <= cycles; cycle++ {
-		taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "body",
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "body",
 			`{"searchable":{"enabled":true,"tokenization":"word"}}`)
-		reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	}
+	for cycle := 1; cycle <= cycles; cycle++ {
+		taskID := submit()
+		reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 		requireSearchableEnabled(t, class, "body")
 		require.GreaterOrEqual(t, bm25Hits(t, class, "fox"), 3,
 			"cycle %d/%d: post-enable bm25('fox') must return all 3 docs", cycle, cycles)
@@ -107,10 +110,13 @@ func testDeleteThenReEnableFilterableMultiCycle(t *testing.T, restURI string, cy
 		}))
 	}
 
-	for cycle := 1; cycle <= cycles; cycle++ {
-		taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
 			`{"filterable":{"enabled":true}}`)
-		reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	}
+	for cycle := 1; cycle <= cycles; cycle++ {
+		taskID := submit()
+		reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 		requireFilterableEnabled(t, class, "name")
 		require.Equal(t, 1, equalFilterHits(t, class, "name", "alpha"),
 			"cycle %d/%d: post-enable Equal('alpha') must return 1", cycle, cycles)
@@ -142,10 +148,13 @@ func testDeleteThenReEnableRangeableMultiCycle(t *testing.T, restURI string, cyc
 		}))
 	}
 
-	for cycle := 1; cycle <= cycles; cycle++ {
-		taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
 			`{"rangeable":{"enabled":true}}`)
-		reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	}
+	for cycle := 1; cycle <= cycles; cycle++ {
+		taskID := submit()
+		reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 		requireRangeableEnabled(t, class, "score")
 		require.Equal(t, 2, rangeFilterHits(t, class, "score", 30),
 			"cycle %d/%d: post-enable LessThan(30) must return 2", cycle, cycles)

--- a/test/acceptance/reindex_singlenode/delete_reenable_shortcircuit_test.go
+++ b/test/acceptance/reindex_singlenode/delete_reenable_shortcircuit_test.go
@@ -81,11 +81,14 @@ func testDeleteThenReEnableShortCircuit(t *testing.T, restURI string) {
 	}
 	results := make([]cycleResult, 3)
 
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "body",
+			`{"searchable":{"enabled":true,"tokenization":"word"}}`)
+	}
 	for cycle := 0; cycle < 3; cycle++ {
 		start := time.Now()
-		taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "body",
-			`{"searchable":{"enabled":true,"tokenization":"word"}}`)
-		reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+		taskID := submit()
+		reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 		results[cycle].taskID = taskID
 		results[cycle].finishedT = time.Now()
 		results[cycle].duration = time.Since(start)

--- a/test/acceptance/reindex_singlenode/delete_then_reenable_test.go
+++ b/test/acceptance/reindex_singlenode/delete_then_reenable_test.go
@@ -75,9 +75,12 @@ func testDeleteThenReEnableSearchable(t *testing.T, restURI string) {
 
 	// Step 1: first enable via the reindex API — lays down the
 	// .migrations/enable_searchable_body/ tidied sentinel on disk.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "body",
-		`{"searchable":{"enabled":true,"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "body",
+			`{"searchable":{"enabled":true,"tokenization":"word"}}`)
+	}
+	taskID := submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireSearchableEnabled(t, class, "body")
 	require.GreaterOrEqual(t, bm25Hits(t, class, "fox"), 3,
 		"after first enable-searchable, bm25 must find all three docs")
@@ -89,9 +92,8 @@ func testDeleteThenReEnableSearchable(t *testing.T, restURI string) {
 	// sentinel from step 1 survived the DELETE, OnAfterLsmInitAsync
 	// will short-circuit on rt.IsTidied()=true and re-flip the schema
 	// flag while the freshly-removed bucket stays empty.
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "body",
-		`{"searchable":{"enabled":true,"tokenization":"word"}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	taskID = submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireSearchableEnabled(t, class, "body")
 
 	hits := bm25Hits(t, class, "fox")
@@ -117,18 +119,20 @@ func testDeleteThenReEnableFilterable(t *testing.T, restURI string) {
 		}))
 	}
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"enabled":true}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
+			`{"filterable":{"enabled":true}}`)
+	}
+	taskID := submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireFilterableEnabled(t, class, "name")
 	require.Equal(t, 1, equalFilterHits(t, class, "name", "alpha"),
 		"after first enable-filterable, Equal('alpha') must match 1 object")
 
 	deleteIndex(t, restURI, class, "name", "filterable")
 
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
-		`{"filterable":{"enabled":true}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	taskID = submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireFilterableEnabled(t, class, "name")
 
 	hits := equalFilterHits(t, class, "name", "alpha")
@@ -154,18 +158,20 @@ func testDeleteThenReEnableRangeable(t *testing.T, restURI string) {
 		}))
 	}
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
-		`{"rangeable":{"enabled":true}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
+			`{"rangeable":{"enabled":true}}`)
+	}
+	taskID := submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireRangeableEnabled(t, class, "score")
 	require.Equal(t, 2, rangeFilterHits(t, class, "score", 30),
 		"after first enable-rangeable, LessThan(30) must match 2 (10, 20)")
 
 	deleteIndex(t, restURI, class, "score", "rangeFilters")
 
-	taskID = reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
-		`{"rangeable":{"enabled":true}}`)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	taskID = submit()
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	requireRangeableEnabled(t, class, "score")
 
 	hits := rangeFilterHits(t, class, "score", 30)

--- a/test/acceptance/reindex_singlenode/enable_filterable_test.go
+++ b/test/acceptance/reindex_singlenode/enable_filterable_test.go
@@ -142,14 +142,20 @@ func testEnableFilterable(t *testing.T, restURI string) {
 	}()
 
 	// 1) Enable filterable on the int property.
-	taskID1 := reindexhelpers.SubmitIndexUpdate(t, restURI, enableFilterableClassName, "score", `{"filterable":{"enabled":true}}`)
+	submitScore := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, enableFilterableClassName, "score", `{"filterable":{"enabled":true}}`)
+	}
+	taskID1 := submitScore()
 	t.Logf("submitted enable-filterable task for score: %s", taskID1)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID1)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID1, reindexhelpers.WithRetryOnReadOnly(submitScore))
 
 	// 2) Enable filterable on the boolean property.
-	taskID2 := reindexhelpers.SubmitIndexUpdate(t, restURI, enableFilterableClassName, "available", `{"filterable":{"enabled":true}}`)
+	submitAvailable := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, enableFilterableClassName, "available", `{"filterable":{"enabled":true}}`)
+	}
+	taskID2 := submitAvailable()
 	t.Logf("submitted enable-filterable task for available: %s", taskID2)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID2)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID2, reindexhelpers.WithRetryOnReadOnly(submitAvailable))
 
 	close(stopCh)
 	wg.Wait()

--- a/test/acceptance/reindex_singlenode/enable_rangeable_test.go
+++ b/test/acceptance/reindex_singlenode/enable_rangeable_test.go
@@ -112,15 +112,21 @@ func testEnableRangeable(t *testing.T, restURI string) {
 		}
 	}()
 
-	taskID1 := reindexhelpers.SubmitIndexUpdate(t, restURI, rangeableClassName, "score", `{"rangeable":{"enabled":true}}`)
+	submitScore := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, rangeableClassName, "score", `{"rangeable":{"enabled":true}}`)
+	}
+	taskID1 := submitScore()
 	t.Logf("submitted reindex task for score: %s", taskID1)
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, rangeableClassName, "score", "rangeable")
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID1)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID1, reindexhelpers.WithRetryOnReadOnly(submitScore))
 
-	taskID2 := reindexhelpers.SubmitIndexUpdate(t, restURI, rangeableClassName, "price", `{"rangeable":{"enabled":true}}`)
+	submitPrice := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, rangeableClassName, "price", `{"rangeable":{"enabled":true}}`)
+	}
+	taskID2 := submitPrice()
 	t.Logf("submitted reindex task for price: %s", taskID2)
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, rangeableClassName, "price", "rangeable")
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID2)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID2, reindexhelpers.WithRetryOnReadOnly(submitPrice))
 
 	close(stopCh)
 	wg.Wait()

--- a/test/acceptance/reindex_singlenode/enable_searchable_test.go
+++ b/test/acceptance/reindex_singlenode/enable_searchable_test.go
@@ -136,10 +136,13 @@ func testEnableSearchable(t *testing.T, restURI string) {
 
 	// Submit enable-searchable with tokenization=word so the BM25 queries
 	// below split on whitespace.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, enableSearchableClassName, "description",
-		`{"searchable":{"enabled":true,"tokenization":"word"}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, enableSearchableClassName, "description",
+			`{"searchable":{"enabled":true,"tokenization":"word"}}`)
+	}
+	taskID := submit()
 	t.Logf("submitted enable-searchable task for description: %s", taskID)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	close(stopCh)
 	wg.Wait()

--- a/test/acceptance/reindex_singlenode/repair_rangeable_test.go
+++ b/test/acceptance/reindex_singlenode/repair_rangeable_test.go
@@ -96,9 +96,12 @@ func testRepairRangeable(t *testing.T, restURI string) {
 	})
 
 	t.Run("RebuildSucceedsOnEnabledNumeric", func(t *testing.T) {
-		taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score", `{"rangeable":{"rebuild":true}}`)
+		submit := func() string {
+			return reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score", `{"rangeable":{"rebuild":true}}`)
+		}
+		taskID := submit()
 		t.Logf("submitted repair-rangeable task: %s", taskID)
 		reindexhelpers.AwaitReindexViaIndexes(t, restURI, className, "score", "rangeable")
-		reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+		reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 	})
 }

--- a/test/acceptance/reindex_singlenode/roaring_set_test.go
+++ b/test/acceptance/reindex_singlenode/roaring_set_test.go
@@ -118,11 +118,14 @@ func testRoaringSetRefresh(t *testing.T, restURI string) {
 		}
 	}()
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, roaringSetClassName, "category", `{"filterable":{"rebuild":true}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, roaringSetClassName, "category", `{"filterable":{"rebuild":true}}`)
+	}
+	taskID := submit()
 	t.Logf("submitted reindex task: %s", taskID)
 
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, roaringSetClassName, "category", "filterable")
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	close(stopCh)
 	wg.Wait()

--- a/test/acceptance/reindex_singlenode/scope_assertion_test.go
+++ b/test/acceptance/reindex_singlenode/scope_assertion_test.go
@@ -317,7 +317,10 @@ func testReindexScopeAssertion(t *testing.T, restURI string) {
 			}()
 
 			// Submit the reindex and wait for it to finish.
-			taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, tc.className, tc.target, tc.body)
+			submit := func() string {
+				return reindexhelpers.SubmitIndexUpdate(t, restURI, tc.className, tc.target, tc.body)
+			}
+			taskID := submit()
 			t.Logf("submitted reindex task: %s", taskID)
 
 			// Assertion 3: the task ID must encode the targeted property.
@@ -330,7 +333,7 @@ func testReindexScopeAssertion(t *testing.T, restURI string) {
 			// after FINISHED the task may be pruned, so capture early.
 			assertPayloadProperties(t, restURI, taskID, tc.target)
 
-			reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+			reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 			stopPoller()
 

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -142,10 +142,13 @@ func testTornResumeEnableRangeable(t *testing.T, restURI string, container testc
 	migDir := "filterable_to_rangeable_score"
 	plantTornSentinels(t, container, class, migDir, []string{"score"})
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
-		`{"rangeable":{"enabled":true}}`)
+	submit := func() string {
+		return reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
+			`{"rangeable":{"enabled":true}}`)
+	}
+	taskID := submit()
 	t.Logf("torn-resume rangeable: submitted task %s with planted torn sentinels", taskID)
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithRetryOnReadOnly(submit))
 
 	// Functional check: half the objects have score<50, half score>50.
 	expected := tornResumeObjectCount / 2


### PR DESCRIPTION
# Background

A legacy code path in PQ-compression briefly marks a collection read-only on
**any** schema change. When the reindex writer runs against a collection that
has concurrent ingest or other schema activity, it collides with that read-only
window and surfaces as:

```
adding prop '<bm25-term>': store is read-only
```

(emitted from `adapters/repos/db/inverted_reindex_strategy_blockmax.go:75`).

The fix belongs server-side and is being tracked for post-v1.38. Until then,
the reindex acceptance suite is flaky on every workflow that has concurrent
traffic, which is most of them. This PR adds a **test-side mitigation only**
so the suite stops false-flagging the race while the real fix lands.

# What this PR does

Adds a new option to the reindex helper:

```go
reindexhelpers.WithRetryOnReadOnly(resubmit func() string)
```

When the option is set and `AwaitReindexFinished` observes a task in `FAILED`
state with an error containing the marker substring `store is read-only`, the
helper:

1. Polls for the read-only window to clear (50ms interval × 2s budget, with
   50%-150% jitter so concurrent retriers desync).
2. Calls the supplied `resubmit` closure to obtain a fresh taskID and starts
   awaiting it.
3. Retries up to **3** times before failing — to bound the budget and not
   mask a genuinely persistent read-only condition.

Any other `FAILED` reason takes the original `t.Fatalf` path verbatim. When
the option is not passed, behavior is unchanged.

Constants are centralized in `helpers.go`:

```go
const (
    readOnlyRetryInterval = 50 * time.Millisecond
    readOnlyRetryTimeout  = 2 * time.Second
    readOnlyMaxRetries    = 3
    readOnlyErrorMarker   = "store is read-only"
)
```

The helper restructures `AwaitReindexFinished` from `require.Eventually` to a
manual deadline loop so the polled `taskID` can be replaced mid-await.

# Scope of test-side application

Applied to **all** singlenode and multinode tests where there is concurrent
traffic during a schema change (the HIGH-risk set), plus MEDIUM-risk tests
that do back-to-back schema changes on data-bearing collections where the
race is cheap to mitigate.

**Intentionally NOT applied to:**

- **Cancel-semantics tests** (`cancel_test.go`, `cancel_then_retry_test.go`,
  `cancel_cleanup_cluster_wide_test.go`, `change_tok_delete_journeys_test.go`
  Journey-4 + Journey-6). A retry-on-read-only would mask the cancel-then-X
  intent.
- **Crash-mid-finalize tests** (`finalizing_crash_test.go`,
  `restart_test.go`, `restart_matrix_test.go`). These deliberately race the
  task into FINALIZING and crash nodes — retry semantics get tangled with
  the crash-recovery semantics the tests are pinning.
- **Bespoke await loops** that don't go through `AwaitReindexFinished`.
  These are scope for a follow-up PR (see below).

# Follow-up scope (separate PR)

The mitigation can be propagated to these bespoke await loops, but each one
needs its own decision on retry semantics:

- `reindex_concurrent/concurrent_test.go` — `awaitTask` helper
- `reindex_concurrent/parallel_same_property_test.go` — same `awaitTask`
- `reindex_concurrent/parallel_conflict_matrix_test.go` — own polling
- `reindex_singlenode/property_state_migration_matrix_test.go` — `awaitTaskTerminal`
- `reindex_multinode/cross_replica_barrier_test.go` — `collectTaskStatusTransitions`

# Removal plan

Once the server-side fix lands post-v1.38, the option, helper, and all
call-site closures can be removed in a single revert-style PR. The grep
target is `WithRetryOnReadOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)