### PR TITLE
Namespaces: Fix stripping in batch delete

### DIFF
--- a/adapters/handlers/grpc/v1/batch_delete.go
+++ b/adapters/handlers/grpc/v1/batch_delete.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, authorizedGetClass classGetterWithAuthzFunc, namespacesEnabled bool, principal *models.Principal) (objects.BatchDeleteParams, error) {
@@ -66,7 +67,7 @@ func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, authorizedGetClass c
 	return params, nil
 }
 
-func batchDeleteReplyFromObjects(response objects.BatchDeleteResult, verbose bool) (*pb.BatchDeleteReply, error) {
+func batchDeleteReplyFromObjects(response objects.BatchDeleteResult, verbose bool, principal *models.Principal) (*pb.BatchDeleteReply, error) {
 	var successful, failed int64
 
 	var objs []*pb.BatchDeleteObject
@@ -86,7 +87,7 @@ func batchDeleteReplyFromObjects(response objects.BatchDeleteResult, verbose boo
 			}
 			errorString := ""
 			if obj.Err != nil {
-				errorString = obj.Err.Error()
+				errorString = namespacing.StripErrorMessage(principal, obj.Err.Error())
 			}
 
 			resultObj := &pb.BatchDeleteObject{

--- a/adapters/handlers/grpc/v1/batch_delete_test.go
+++ b/adapters/handlers/grpc/v1/batch_delete_test.go
@@ -221,11 +221,13 @@ var (
 )
 
 func TestBatchDeleteReply(t *testing.T) {
+	strippedErrorString := "leaked TestClass not found"
 	tests := []struct {
-		name     string
-		response objects.BatchDeleteResult
-		verbose  bool
-		out      *pb.BatchDeleteReply
+		name      string
+		response  objects.BatchDeleteResult
+		verbose   bool
+		principal *models.Principal
+		out       *pb.BatchDeleteReply
 	}{
 		{
 			name:     "single object",
@@ -251,12 +253,21 @@ func TestBatchDeleteReply(t *testing.T) {
 				{Uuid: idByte(string(UUID2)), Successful: true, Error: &noErrorString},
 			}},
 		},
+		{
+			name:      "verbose error message strips principal's namespace",
+			response:  objects.BatchDeleteResult{Matches: 1, Objects: objects.BatchSimpleObjects{{UUID: UUID1, Err: errors.New("leaked customer1:TestClass not found")}}},
+			verbose:   true,
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			out: &pb.BatchDeleteReply{Matches: 1, Successful: 0, Failed: 1, Objects: []*pb.BatchDeleteObject{
+				{Uuid: idByte(string(UUID1)), Successful: false, Error: &strippedErrorString},
+			}},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := batchDeleteReplyFromObjects(tt.response, tt.verbose)
-			require.Nil(t, err)
+			out, err := batchDeleteReplyFromObjects(tt.response, tt.verbose, tt.principal)
+			require.NoError(t, err)
 			require.Equal(t, tt.out, out)
 		})
 	}

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -204,7 +204,7 @@ func (s *Service) batchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (
 		return nil, fmt.Errorf("batch delete: %w", err)
 	}
 
-	result, err := batchDeleteReplyFromObjects(response, req.Verbose)
+	result, err := batchDeleteReplyFromObjects(response, req.Verbose, principal)
 	if err != nil {
 		return nil, fmt.Errorf("batch delete reply: %w", err)
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -136,13 +136,17 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 		return nil, 0, errors.New("empty match.where clause")
 	}
 
-	// Validate schema given in body with the weaviate schema
+	// GetCachedClass authorizes READ; preserve Forbidden (→ 403), classify
+	// other lookup failures as caller input (→ 422).
 	vclasses, err := b.schemaManager.GetCachedClass(ctx, principal, match.Class)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get class: %s: %w", match.Class, err)
+		if errors.As(err, &authzerrs.Forbidden{}) {
+			return nil, 0, fmt.Errorf("failed to get class: %s: %w", match.Class, err)
+		}
+		return nil, 0, NewErrInvalidUserInput("failed to get class: %s: %v", match.Class, err)
 	}
 	if vclasses[match.Class].Class == nil {
-		return nil, 0, fmt.Errorf("failed to get class: %s", match.Class)
+		return nil, 0, NewErrInvalidUserInput("failed to get class: %s", match.Class)
 	}
 	class := vclasses[match.Class].Class
 

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -183,6 +183,17 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			assert.Equal(t, test.expectedError, err.Error())
 		}
 	})
+
+	t.Run("class-not-found classifies as ErrInvalidUserInput", func(t *testing.T) {
+		match := &models.BatchDeleteMatch{
+			Class: "SomeMissingClass",
+			Where: &models.WhereFilter{Path: []string{"name"}, Operator: "Equal", ValueText: ptString("value")},
+		}
+		_, err := manager.DeleteObjects(ctx, nil, match, nil, nil, nil, nil, "")
+		require.Error(t, err)
+		var invalid ErrInvalidUserInput
+		require.True(t, errors.As(err, &invalid), "expected ErrInvalidUserInput, got %T: %v", err, err)
+	})
 }
 
 // Test_BatchDelete_NamespaceResolution proves DeleteObjects routes the


### PR DESCRIPTION
### What's being changed:

This adds stripping of the namespace in case of errors when doing a batch delete. The second commits fixes a related bug where we returned the wrong error code in case a class was not found (422 because its wrong user input, was 500)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
