### PR TITLE
Namespaces: Close test gaps

### DIFF
--- a/test/acceptance/namespace/crud_test.go
+++ b/test/acceptance/namespace/crud_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/client/namespaces"
+	"github.com/weaviate/weaviate/client/users"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
 )
@@ -168,6 +169,32 @@ func TestNamespaces_UpdateHomeNode(t *testing.T) {
 			}
 		})
 	})
+}
+
+// TestNamespaces_CreateUserInMissingNamespace pins that CreateUser rejects
+// with 422 when the target namespace does not exist.
+func TestNamespaces_CreateUserInMissingNamespace(t *testing.T) {
+	const ghost = "ghostns"
+
+	_, err := helper.Client(t).Namespaces.GetNamespace(
+		namespaces.NewGetNamespaceParams().WithNamespaceID(ghost),
+		helper.CreateAuth(adminKey),
+	)
+	require.Error(t, err)
+	var nf *namespaces.GetNamespaceNotFound
+	require.True(t, errors.As(err, &nf), "expected GetNamespaceNotFound for %q, got %T: %v", ghost, err, err)
+
+	_, err = helper.Client(t).Users.CreateUser(
+		users.NewCreateUserParams().WithUserID("orphan").WithBody(users.CreateUserBody{Namespace: ghost}),
+		helper.CreateAuth(adminKey),
+	)
+	require.Error(t, err)
+	var unproc *users.CreateUserUnprocessableEntity
+	require.True(t, errors.As(err, &unproc), "expected CreateUserUnprocessableEntity, got %T: %v", err, err)
+	require.NotNil(t, unproc.Payload)
+	require.NotEmpty(t, unproc.Payload.Error)
+	assert.Contains(t, unproc.Payload.Error[0].Message, "namespace",
+		"422 message must explain the namespace existence failure; got %q", unproc.Payload.Error[0].Message)
 }
 
 // TestNamespaces_UpdateHomeNode_Invalid rejects an unknown home_node with 422.

--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/client/backups"
 	"github.com/weaviate/weaviate/client/cluster"
 	"github.com/weaviate/weaviate/client/export"
+	clns "github.com/weaviate/weaviate/client/namespaces"
 	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/client/replication"
 	"github.com/weaviate/weaviate/entities/models"
@@ -126,6 +127,37 @@ func TestNamespaces_RBACSurfaces(t *testing.T) {
 			helper.CreateAuth(adminKey))
 		require.NoError(t, err)
 		helper.ExpectBackupEventuallyCreated(t, backupID, s3Backend, helper.CreateAuth(adminKey))
+	})
+
+	t.Run("create namespace: namespaced denied, root allowed", func(t *testing.T) {
+		// manage_namespaces is root-only; the narrowed admin lacks it.
+		const newNS = "ns-deny-create"
+		_, err := helper.Client(t).Namespaces.CreateNamespace(
+			clns.NewCreateNamespaceParams().WithNamespaceID(newNS),
+			helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *clns.CreateNamespaceForbidden
+		require.True(t, errors.As(err, &forbidden), "expected CreateNamespaceForbidden, got %T: %v", err, err)
+
+		helper.CreateNamespace(t, newNS, adminKey)
+		t.Cleanup(func() { helper.DeleteNamespace(t, newNS, adminKey) })
+	})
+
+	t.Run("delete namespace: namespaced denied, root allowed", func(t *testing.T) {
+		// Throwaway target so a regression letting the call through cannot
+		// remove customer1 mid-test; authz runs before existence checks.
+		const throwaway = "ns-root-delete"
+		helper.CreateNamespace(t, throwaway, adminKey)
+
+		_, err := helper.Client(t).Namespaces.DeleteNamespace(
+			clns.NewDeleteNamespaceParams().WithNamespaceID(throwaway),
+			helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var forbidden *clns.DeleteNamespaceForbidden
+		require.True(t, errors.As(err, &forbidden), "expected DeleteNamespaceForbidden, got %T: %v", err, err)
+
+		// Positive control: root completes the delete.
+		helper.DeleteNamespace(t, throwaway, adminKey)
 	})
 
 	t.Run("export: namespaced denied via empty backups filter, root passes filter", func(t *testing.T) {

--- a/test/acceptance/namespace/response_stripping_test.go
+++ b/test/acceptance/namespace/response_stripping_test.go
@@ -353,6 +353,43 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		assert.Equal(t, "customer1:"+class, helper.GetClassAuth(t, "customer1:"+class, adminKey).Class)
 		assert.Equal(t, "customer2:"+class, helper.GetClassAuth(t, "customer2:"+class, adminKey).Class)
 	})
+
+	t.Run("SchemaDump strips for namespaced caller and keeps qualified for admin", func(t *testing.T) {
+		const class = "SchemaDumpStrip"
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		dump := func(key string) []*models.Class {
+			resp, err := helper.Client(t).Schema.SchemaDump(clschema.NewSchemaDumpParams(), helper.CreateAuth(key))
+			require.NoError(t, err)
+			require.NotNil(t, resp.Payload)
+			return resp.Payload.Classes
+		}
+
+		u1Classes := dump(user1Key)
+		var u1Names []string
+		for _, c := range u1Classes {
+			u1Names = append(u1Names, c.Class)
+			assert.NotContains(t, c.Class, ":",
+				"namespaced caller must see no qualified class names; got %q", c.Class)
+		}
+		assert.Contains(t, u1Names, class)
+
+		u2Classes := dump(user2Key)
+		var u2Names []string
+		for _, c := range u2Classes {
+			u2Names = append(u2Names, c.Class)
+			assert.NotContains(t, c.Class, ":",
+				"namespaced caller must see no qualified class names; got %q", c.Class)
+		}
+		assert.Contains(t, u2Names, class)
+
+		var adminNames []string
+		for _, c := range dump(adminKey) {
+			adminNames = append(adminNames, c.Class)
+		}
+		assert.Contains(t, adminNames, "customer1:"+class)
+		assert.Contains(t, adminNames, "customer2:"+class)
+	})
 }
 
 // TestNamespaces_ResponseStripping_OwnInfoUsername pins the Username strip


### PR DESCRIPTION
### What's being changed:

This adds 3 new acceptance tests to close some test gaps:
- creating user in missing namespace
- RBAC surface tests for namespace management (== denied for normal users)
- test for list schema endpoint

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
