### PR TITLE
fix(reindex): promote MapToBlockmax to a semantic migration (closes weaviate/0-weaviate-issues#254 finding 3)

### DIFF
--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -125,11 +125,12 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 
 	// BM25 algorithm currently backing searchable indexes for this class.
 	// The schema-level UsingBlockMaxWAND flag flips only after every
-	// searchable bucket on every shard has been migrated to blockmax (see
-	// MapToBlockmaxStrategy.OnMigrationComplete). While a per-property
-	// repair-searchable is in flight the flag is still false; the
-	// targetAlgorithm field (set by mergeReindexStatus) carries the
-	// "incoming" signal in that case.
+	// searchable bucket on every shard has been migrated to blockmax —
+	// the cluster-wide cutover lives in
+	// [ReindexProvider.flipSemanticMigrationSchema] for
+	// ReindexTypeChangeAlgorithm. While a per-property repair-searchable
+	// is in flight the flag is still false; targetAlgorithm (set by
+	// mergeReindexStatus) carries the "incoming" signal in that case.
 	searchableAlgorithm := models.IndexStatusAlgorithmWand
 	if class.InvertedIndexConfig != nil && class.InvertedIndexConfig.UsingBlockMaxWAND {
 		searchableAlgorithm = models.IndexStatusAlgorithmBlockmax

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -123,14 +123,9 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 		finalizeWindow = finalizeWindowMax
 	}
 
-	// BM25 algorithm currently backing searchable indexes for this class.
-	// The schema-level UsingBlockMaxWAND flag flips only after every
-	// searchable bucket on every shard has been migrated to blockmax —
-	// the cluster-wide cutover lives in
-	// [ReindexProvider.flipSemanticMigrationSchema] for
-	// ReindexTypeChangeAlgorithm. While a per-property repair-searchable
-	// is in flight the flag is still false; targetAlgorithm (set by
-	// mergeReindexStatus) carries the "incoming" signal in that case.
+	// UsingBlockMaxWAND flips cluster-wide only after every searchable
+	// bucket on every shard is blockmax; mid-flight, targetAlgorithm
+	// (set by mergeReindexStatus) carries the "incoming" signal.
 	searchableAlgorithm := models.IndexStatusAlgorithmWand
 	if class.InvertedIndexConfig != nil && class.InvertedIndexConfig.UsingBlockMaxWAND {
 		searchableAlgorithm = models.IndexStatusAlgorithmBlockmax

--- a/adapters/repos/db/inverted_reindex_strategy_blockmax.go
+++ b/adapters/repos/db/inverted_reindex_strategy_blockmax.go
@@ -137,36 +137,14 @@ func (s *MapToBlockmaxStrategy) PreReindexHook(shard *Shard, props []string) {
 	shard.markSearchableBlockmaxProperties(props...)
 }
 
-// OnMigrationComplete flips the UsingBlockMaxWAND class flag, but only once
-// every searchable bucket on this shard has already been migrated to the
-// target (blockmax) strategy. When a per-property rebuild targets a subset
-// of the class's searchable properties, the remaining properties still use
-// the source (map) strategy and the class-level flag must stay off until
-// they are migrated too — otherwise BM25 queries over the still-map
-// properties would hit the wrong query path.
-//
-// The check is shard-local, which is sufficient because each shard runs its
-// own migration independently and this hook fires after that shard's swap
-// phase has finished. Once the last property on the last shard reaches this
-// hook, the class-level flag is flipped (the flag write itself is a single
-// RAFT entry guarded by an "already set" short-circuit).
-func (s *MapToBlockmaxStrategy) OnMigrationComplete(ctx context.Context, shard ShardLike) error {
-	className := shard.Index().Config.ClassName.String()
-
-	for name, bucket := range shard.Store().GetBucketsByName() {
-		_, indexType := GetPropNameAndIndexTypeFromBucketName(name)
-		if indexType != IndexTypePropSearchableValue {
-			continue
-		}
-		if bucket.Strategy() == s.SourceStrategy() {
-			// At least one searchable property on this shard still uses the
-			// pre-migration (map) strategy. Defer flipping the class flag
-			// until a subsequent per-property rebuild completes the migration.
-			return nil
-		}
-	}
-
-	return updateToBlockMaxInvertedIndexConfig(ctx, s.schemaManager, className)
+// OnMigrationComplete is a no-op: MapToBlockmax is a semantic migration, so
+// the class-level UsingBlockMaxWAND flip lives in
+// [ReindexProvider.flipSemanticMigrationSchema] after every node's swap has
+// completed. The previous shard-local flip from this hook fired the
+// `UpdateVectorIndexConfig` → `SetStatusReadonly` cascade on still-iterating
+// shards (weaviate/0-weaviate-issues#254 finding 3).
+func (s *MapToBlockmaxStrategy) OnMigrationComplete(_ context.Context, _ ShardLike) error {
+	return nil
 }
 
 // calcPropLenInverted computes property length as the sum of term frequencies.

--- a/adapters/repos/db/inverted_reindex_strategy_blockmax.go
+++ b/adapters/repos/db/inverted_reindex_strategy_blockmax.go
@@ -137,12 +137,8 @@ func (s *MapToBlockmaxStrategy) PreReindexHook(shard *Shard, props []string) {
 	shard.markSearchableBlockmaxProperties(props...)
 }
 
-// OnMigrationComplete is a no-op: MapToBlockmax is a semantic migration, so
-// the class-level UsingBlockMaxWAND flip lives in
-// [ReindexProvider.flipSemanticMigrationSchema] after every node's swap has
-// completed. The previous shard-local flip from this hook fired the
-// `UpdateVectorIndexConfig` → `SetStatusReadonly` cascade on still-iterating
-// shards (weaviate/0-weaviate-issues#254 finding 3).
+// OnMigrationComplete: no-op for a semantic migration. Class-level flip
+// happens cluster-wide in flipSemanticMigrationSchema (weaviate/0-weaviate-issues#254).
 func (s *MapToBlockmaxStrategy) OnMigrationComplete(_ context.Context, _ ShardLike) error {
 	return nil
 }

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -169,11 +169,6 @@ func migrationDirsForPropertyIndex(propName, indexType string) []string {
 			migrationDirWithProps(MigrationDirPrefixEnableSearchable, []string{propName}),
 			migrationDirWithProps(MigrationDirPrefixRebuildSearchable, []string{propName}),
 			MigrationDirPrefixSearchableRetokenize + "_" + propName,
-			// MapToBlockmax writes a class-level tracker dir (not per-property),
-			// but we include it on every searchable lookup so LocalCallbacksDone
-			// can detect interrupted blockmax swaps now that change-algorithm is
-			// a semantic migration (weaviate/0-weaviate-issues#254).
-			MigrationDirSearchableMapToBlockmax,
 		}
 	case "rangeable":
 		return []string{

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -169,6 +169,11 @@ func migrationDirsForPropertyIndex(propName, indexType string) []string {
 			migrationDirWithProps(MigrationDirPrefixEnableSearchable, []string{propName}),
 			migrationDirWithProps(MigrationDirPrefixRebuildSearchable, []string{propName}),
 			MigrationDirPrefixSearchableRetokenize + "_" + propName,
+			// MapToBlockmax writes a class-level tracker dir (not per-property),
+			// but we include it on every searchable lookup so LocalCallbacksDone
+			// can detect interrupted blockmax swaps now that change-algorithm is
+			// a semantic migration (weaviate/0-weaviate-issues#254).
+			MigrationDirSearchableMapToBlockmax,
 		}
 	case "rangeable":
 		return []string{

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names_test.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names_test.go
@@ -128,3 +128,24 @@ func TestFinalizeMigrationSuffixesUnknown(t *testing.T) {
 		t.Fatalf("migrationSuffixes(unknown) = %+v, want nil", got)
 	}
 }
+
+// TestMigrationDirsForPropertyIndex_IncludesMapToBlockmaxForSearchable pins
+// the recovery-prefix contract for ChangeAlgorithm: MapToBlockmax writes a
+// class-level tracker dir (not per-property), but LocalCallbacksDone iterates
+// per-property prefixes — so the class-level dir must be returned on every
+// searchable lookup or interrupted blockmax swaps would silently slip past
+// the post-restart recovery check (weaviate/0-weaviate-issues#254 review).
+func TestMigrationDirsForPropertyIndex_IncludesMapToBlockmaxForSearchable(t *testing.T) {
+	got := migrationDirsForPropertyIndex("text", "searchable")
+	var found bool
+	for _, p := range got {
+		if p == MigrationDirSearchableMapToBlockmax {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("migrationDirsForPropertyIndex(text, searchable) = %v, want to include %q",
+			got, MigrationDirSearchableMapToBlockmax)
+	}
+}

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names_test.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names_test.go
@@ -129,23 +129,17 @@ func TestFinalizeMigrationSuffixesUnknown(t *testing.T) {
 	}
 }
 
-// TestMigrationDirsForPropertyIndex_IncludesMapToBlockmaxForSearchable pins
-// the recovery-prefix contract for ChangeAlgorithm: MapToBlockmax writes a
-// class-level tracker dir (not per-property), but LocalCallbacksDone iterates
-// per-property prefixes — so the class-level dir must be returned on every
-// searchable lookup or interrupted blockmax swaps would silently slip past
-// the post-restart recovery check (weaviate/0-weaviate-issues#254 review).
-func TestMigrationDirsForPropertyIndex_IncludesMapToBlockmaxForSearchable(t *testing.T) {
+// TestMigrationDirsForPropertyIndex_OmitsClassLevelMapToBlockmax pins the
+// per-property contract: the class-level MapToBlockmax tracker must NOT be
+// returned here (cleanStaleMigrationDirsAt + CleanStalePartialReindexState
+// would corrupt the class-level dir on single-property cleanup). The
+// blockmax tracker is matched directly in LocalCallbacksDone instead.
+func TestMigrationDirsForPropertyIndex_OmitsClassLevelMapToBlockmax(t *testing.T) {
 	got := migrationDirsForPropertyIndex("text", "searchable")
-	var found bool
 	for _, p := range got {
 		if p == MigrationDirSearchableMapToBlockmax {
-			found = true
-			break
+			t.Fatalf("migrationDirsForPropertyIndex(text, searchable) = %v, must NOT include class-level %q",
+				got, MigrationDirSearchableMapToBlockmax)
 		}
-	}
-	if !found {
-		t.Fatalf("migrationDirsForPropertyIndex(text, searchable) = %v, want to include %q",
-			got, MigrationDirSearchableMapToBlockmax)
 	}
 }

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1568,19 +1568,9 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 			case distributedtask.TaskStatusCancelled:
 				p.autoCleanupAfterTerminal(task, payload, logger)
 			case distributedtask.TaskStatusFinished:
-				// Upgrade-compat fallback: a pre-fix MapToBlockmax task
-				// (or any semantic-migration task submitted before its
-				// type was promoted) was submitted with
-				// NeedsPreparationBarrier=false and reaches Finished via
-				// the inline non-barrier path — bypassing the
-				// flipSemanticMigrationSchema dispatch below. Fire the
-				// flip here so the cluster doesn't end up with all
-				// shards on the new format but the class flag still on
-				// the old one. The flip is idempotent at the RAFT layer
-				// (already-set short-circuit) and the per-migration-type
-				// guards inside flipSemanticMigrationSchema gate any
-				// premature cutover (e.g. the shouldDeferBlockmaxFlip
-				// shard-walk for ChangeAlgorithm).
+				// Legacy semantic task (BarrierTask=false from a pre-fix
+				// binary, in-flight at upgrade) bypasses the barrier-path
+				// flip below. Fire it explicitly.
 				if !task.NeedsPreparationBarrier && IsSemanticMigration(payload.MigrationType) {
 					ctx := p.serverCtx
 					if err := p.flipSemanticMigrationSchema(ctx, payload, logger); err != nil {
@@ -1922,6 +1912,12 @@ func (p *ReindexProvider) LocalCallbacksDone(task *distributedtask.Task, localNo
 			continue
 		}
 		lsmPath := concrete.pathLSM()
+		// ChangeAlgorithm uses a class-level tracker dir; per-property
+		// migrationDirsForPropertyIndex deliberately omits it.
+		if payload.MigrationType == ReindexTypeChangeAlgorithm &&
+			hasUntidiedTracker(lsmPath, []string{MigrationDirSearchableMapToBlockmax}) {
+			return false
+		}
 		for _, indexType := range indexTypes {
 			for _, propName := range payload.Properties {
 				prefixes := migrationDirsForPropertyIndex(propName, indexType)
@@ -2085,23 +2081,8 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 		return nil
 
 	case ReindexTypeChangeAlgorithm:
-		// Class-level flag flip — driven from here (and not from the
-		// per-shard OnMigrationComplete) so it fires only after every
-		// shard's swap is acknowledged. updateToBlockMaxInvertedIndexConfig
-		// is idempotent at the RAFT layer (already-set short-circuit), so
-		// firing it from OnTaskCompleted on multiple nodes is safe.
-		//
-		// Guard before flipping: walk loaded shards and defer if any
-		// searchable bucket is still on the source (map) strategy.
-		// payload.Properties only covers the property this task migrated;
-		// other searchable properties on the class may still be on map
-		// (per-property submit path, handlers_indexes.go). The old
-		// shard-local check in OnMigrationComplete enforced this — we
-		// restore it here so a single-property migration defers the
-		// cluster-wide flip until every searchable bucket on every shard
-		// is blockmax. Cross-node consistency holds because a ChangeAlgorithm
-		// task covers every shard for the given property, so the local
-		// blockmax/map state per property is the same on every node.
+		// Defer until every local searchable bucket is blockmax — submit is
+		// per-property, so the class may still have map buckets.
 		if defer_, err := p.shouldDeferBlockmaxFlip(ctx, payload, logger); err != nil {
 			return err
 		} else if defer_ {
@@ -2119,12 +2100,9 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 	}
 }
 
-// shouldDeferBlockmaxFlip returns true if any loaded shard on this node still
-// has a searchable bucket on the source (map) strategy. The cluster-wide
-// UsingBlockMaxWAND flip is deferred until every per-property ChangeAlgorithm
-// migration has drained — restoring the invariant the strategy file's godoc
-// states ("the class-level flag must stay off until [all properties on all
-// shards] are migrated too").
+// shouldDeferBlockmaxFlip is true while any local searchable bucket is still
+// on the source (map) strategy — defers the cluster-wide flip until every
+// per-property ChangeAlgorithm has drained (weaviate/0-weaviate-issues#254).
 func (p *ReindexProvider) shouldDeferBlockmaxFlip(
 	ctx context.Context, payload *ReindexTaskPayload, logger logrus.FieldLogger,
 ) (bool, error) {
@@ -2161,18 +2139,9 @@ func (p *ReindexProvider) shouldDeferBlockmaxFlip(
 }
 
 // IsSemanticMigration returns true for migration types that change query
-// behavior and therefore require the cross-replica swap barrier: every
-// shard must finish reindexing before any shard swaps, and the cluster-wide
-// schema flip fires only after every node has acknowledged.
-//
-// change-algorithm is semantic because the class-level UsingBlockMaxWAND
-// flag flip cascades into Shard.UpdateVectorIndexConfig → SetStatusReadonly
-// on every loaded shard; without the barrier the first-finishing shard's
-// flip would put still-iterating sidecar buckets into read-only state on
-// other shards (weaviate/0-weaviate-issues#254 finding 3).
-//
-// enable-rangeable is intentionally NOT semantic — it predates the barrier
-// family and promoting it would change existing operator behavior.
+// behavior and therefore require the cross-replica swap barrier + cluster-
+// wide schema flip after every node has acknowledged. enable-rangeable is
+// intentionally NOT semantic — predates the barrier family.
 func IsSemanticMigration(mt ReindexMigrationType) bool {
 	return mt == ReindexTypeChangeTokenization ||
 		mt == ReindexTypeChangeTokenizationFilterable ||

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1927,7 +1927,9 @@ func semanticMigrationIndexTypes(mt ReindexMigrationType) []string {
 		return []string{"searchable"}
 	case ReindexTypeEnableFilterable:
 		return []string{"filterable"}
-	case ReindexTypeChangeAlgorithm, ReindexTypeRebuildSearchable,
+	case ReindexTypeChangeAlgorithm:
+		return []string{"searchable"}
+	case ReindexTypeRebuildSearchable,
 		ReindexTypeRepairFilterable,
 		ReindexTypeEnableRangeable, ReindexTypeRepairRangeable:
 		// Format-only migrations. Returning nil short-circuits
@@ -2061,6 +2063,18 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 			Info("reindex provider: enable-searchable cutover committed")
 		return nil
 
+	case ReindexTypeChangeAlgorithm:
+		// Class-level flag flip — driven from here (and not from the
+		// per-shard OnMigrationComplete) so it fires only after every
+		// shard's swap is acknowledged. updateToBlockMaxInvertedIndexConfig
+		// is idempotent at the RAFT layer (already-set short-circuit), so
+		// firing it from OnTaskCompleted on multiple nodes is safe.
+		if err := updateToBlockMaxInvertedIndexConfig(ctx, p.schemaManager, payload.Collection); err != nil {
+			return fmt.Errorf("flip UsingBlockMaxWAND: %w", err)
+		}
+		logger.Info("reindex provider: change-algorithm cutover committed")
+		return nil
+
 	default:
 		// IsSemanticMigration above gates this; reaching here is a programming error.
 		return fmt.Errorf("unexpected semantic migration type %q in task-completion", payload.MigrationType)
@@ -2069,14 +2083,23 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 
 // IsSemanticMigration returns true for migration types that change query
 // behavior and therefore require the cross-replica swap barrier: every
-// shard must finish reindexing before any shard swaps. enable-rangeable
-// is intentionally NOT semantic — it predates the barrier family and
-// promoting it would change existing operator behavior.
+// shard must finish reindexing before any shard swaps, and the cluster-wide
+// schema flip fires only after every node has acknowledged.
+//
+// change-algorithm is semantic because the class-level UsingBlockMaxWAND
+// flag flip cascades into Shard.UpdateVectorIndexConfig → SetStatusReadonly
+// on every loaded shard; without the barrier the first-finishing shard's
+// flip would put still-iterating sidecar buckets into read-only state on
+// other shards (weaviate/0-weaviate-issues#254 finding 3).
+//
+// enable-rangeable is intentionally NOT semantic — it predates the barrier
+// family and promoting it would change existing operator behavior.
 func IsSemanticMigration(mt ReindexMigrationType) bool {
 	return mt == ReindexTypeChangeTokenization ||
 		mt == ReindexTypeChangeTokenizationFilterable ||
 		mt == ReindexTypeEnableFilterable ||
-		mt == ReindexTypeEnableSearchable
+		mt == ReindexTypeEnableSearchable ||
+		mt == ReindexTypeChangeAlgorithm
 }
 
 // IsTokenizationChangingMigration is true for migrations that flip a

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	api "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
@@ -1555,9 +1556,10 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 	logger.Info("reindex provider: task-completion")
 
 	if task.Status != distributedtask.TaskStatusSwapping {
-		// Non-SWAPPING terminal/in-flight: no cluster-wide schema flip.
-		// FAILED/CANCELLED auto-clean partial sidecar state on every node;
-		// FAILED additionally logs operator repair guidance.
+		// Non-SWAPPING terminal/in-flight: no cluster-wide schema flip via
+		// the barrier path. FAILED/CANCELLED auto-clean partial sidecar
+		// state on every node; FAILED additionally logs operator repair
+		// guidance.
 		if payloadErr == nil {
 			switch task.Status {
 			case distributedtask.TaskStatusFailed:
@@ -1565,12 +1567,31 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 				p.autoCleanupAfterTerminal(task, payload, logger)
 			case distributedtask.TaskStatusCancelled:
 				p.autoCleanupAfterTerminal(task, payload, logger)
+			case distributedtask.TaskStatusFinished:
+				// Upgrade-compat fallback: a pre-fix MapToBlockmax task
+				// (or any semantic-migration task submitted before its
+				// type was promoted) was submitted with
+				// NeedsPreparationBarrier=false and reaches Finished via
+				// the inline non-barrier path — bypassing the
+				// flipSemanticMigrationSchema dispatch below. Fire the
+				// flip here so the cluster doesn't end up with all
+				// shards on the new format but the class flag still on
+				// the old one. The flip is idempotent at the RAFT layer
+				// (already-set short-circuit) and the per-migration-type
+				// guards inside flipSemanticMigrationSchema gate any
+				// premature cutover (e.g. the shouldDeferBlockmaxFlip
+				// shard-walk for ChangeAlgorithm).
+				if !task.NeedsPreparationBarrier && IsSemanticMigration(payload.MigrationType) {
+					ctx := p.serverCtx
+					if err := p.flipSemanticMigrationSchema(ctx, payload, logger); err != nil {
+						logger.Errorf("reindex provider: task-completion (legacy non-barrier semantic): schema flip failed: %v", err)
+					}
+				}
 			case distributedtask.TaskStatusStarted,
 				distributedtask.TaskStatusPreparing,
-				distributedtask.TaskStatusSwapping,
-				distributedtask.TaskStatusFinished:
+				distributedtask.TaskStatusSwapping:
 				// SWAPPING handled below; STARTED/PREPARING never reach
-				// OnTaskCompleted; FINISHED tidies via the swap pipeline.
+				// OnTaskCompleted.
 			}
 		}
 		return
@@ -2069,6 +2090,23 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 		// shard's swap is acknowledged. updateToBlockMaxInvertedIndexConfig
 		// is idempotent at the RAFT layer (already-set short-circuit), so
 		// firing it from OnTaskCompleted on multiple nodes is safe.
+		//
+		// Guard before flipping: walk loaded shards and defer if any
+		// searchable bucket is still on the source (map) strategy.
+		// payload.Properties only covers the property this task migrated;
+		// other searchable properties on the class may still be on map
+		// (per-property submit path, handlers_indexes.go). The old
+		// shard-local check in OnMigrationComplete enforced this — we
+		// restore it here so a single-property migration defers the
+		// cluster-wide flip until every searchable bucket on every shard
+		// is blockmax. Cross-node consistency holds because a ChangeAlgorithm
+		// task covers every shard for the given property, so the local
+		// blockmax/map state per property is the same on every node.
+		if defer_, err := p.shouldDeferBlockmaxFlip(ctx, payload, logger); err != nil {
+			return err
+		} else if defer_ {
+			return nil
+		}
 		if err := updateToBlockMaxInvertedIndexConfig(ctx, p.schemaManager, payload.Collection); err != nil {
 			return fmt.Errorf("flip UsingBlockMaxWAND: %w", err)
 		}
@@ -2079,6 +2117,47 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 		// IsSemanticMigration above gates this; reaching here is a programming error.
 		return fmt.Errorf("unexpected semantic migration type %q in task-completion", payload.MigrationType)
 	}
+}
+
+// shouldDeferBlockmaxFlip returns true if any loaded shard on this node still
+// has a searchable bucket on the source (map) strategy. The cluster-wide
+// UsingBlockMaxWAND flip is deferred until every per-property ChangeAlgorithm
+// migration has drained — restoring the invariant the strategy file's godoc
+// states ("the class-level flag must stay off until [all properties on all
+// shards] are migrated too").
+func (p *ReindexProvider) shouldDeferBlockmaxFlip(
+	ctx context.Context, payload *ReindexTaskPayload, logger logrus.FieldLogger,
+) (bool, error) {
+	if p.db == nil {
+		return false, nil
+	}
+	idx := p.db.GetIndex(entschema.ClassName(payload.Collection))
+	if idx == nil {
+		return false, fmt.Errorf("collection %q not found on this node", payload.Collection)
+	}
+	var stillMap bool
+	idx.ForEachLoadedShard(func(_ string, sh ShardLike) error {
+		concrete, err := unwrapShard(ctx, sh)
+		if err != nil {
+			return nil
+		}
+		for name, bucket := range concrete.Store().GetBucketsByName() {
+			_, indexType := GetPropNameAndIndexTypeFromBucketName(name)
+			if indexType != IndexTypePropSearchableValue {
+				continue
+			}
+			if bucket.Strategy() == lsmkv.StrategyMapCollection {
+				stillMap = true
+				return nil
+			}
+		}
+		return nil
+	})
+	if stillMap {
+		logger.Info("reindex provider: change-algorithm cutover deferred — some searchable buckets still on map (subsequent per-property migration will complete the flip)")
+		return true, nil
+	}
+	return false, nil
 }
 
 // IsSemanticMigration returns true for migration types that change query

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1556,10 +1556,9 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 	logger.Info("reindex provider: task-completion")
 
 	if task.Status != distributedtask.TaskStatusSwapping {
-		// Non-SWAPPING terminal/in-flight: no cluster-wide schema flip via
-		// the barrier path. FAILED/CANCELLED auto-clean partial sidecar
-		// state on every node; FAILED additionally logs operator repair
-		// guidance.
+		// Non-SWAPPING terminal/in-flight: no cluster-wide schema flip.
+		// FAILED/CANCELLED auto-clean partial sidecar state on every node;
+		// FAILED additionally logs operator repair guidance.
 		if payloadErr == nil {
 			switch task.Status {
 			case distributedtask.TaskStatusFailed:
@@ -1567,21 +1566,12 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 				p.autoCleanupAfterTerminal(task, payload, logger)
 			case distributedtask.TaskStatusCancelled:
 				p.autoCleanupAfterTerminal(task, payload, logger)
-			case distributedtask.TaskStatusFinished:
-				// Legacy semantic task (BarrierTask=false from a pre-fix
-				// binary, in-flight at upgrade) bypasses the barrier-path
-				// flip below. Fire it explicitly.
-				if !task.NeedsPreparationBarrier && IsSemanticMigration(payload.MigrationType) {
-					ctx := p.serverCtx
-					if err := p.flipSemanticMigrationSchema(ctx, payload, logger); err != nil {
-						logger.Errorf("reindex provider: task-completion (legacy non-barrier semantic): schema flip failed: %v", err)
-					}
-				}
 			case distributedtask.TaskStatusStarted,
 				distributedtask.TaskStatusPreparing,
-				distributedtask.TaskStatusSwapping:
+				distributedtask.TaskStatusSwapping,
+				distributedtask.TaskStatusFinished:
 				// SWAPPING handled below; STARTED/PREPARING never reach
-				// OnTaskCompleted.
+				// OnTaskCompleted; FINISHED tidies via the swap pipeline.
 			}
 		}
 		return

--- a/adapters/repos/db/reindex_provider_recovery_test.go
+++ b/adapters/repos/db/reindex_provider_recovery_test.go
@@ -158,6 +158,36 @@ func TestHasUntidiedTracker(t *testing.T) {
 	}
 }
 
+// TestIsSemanticMigration pins the semantic/format-only classification.
+// change-algorithm was promoted to semantic in
+// weaviate/0-weaviate-issues#254 to close the read-only + wrong-query-path
+// races caused by the per-shard class-flag flip.
+func TestIsSemanticMigration(t *testing.T) {
+	semantic := []ReindexMigrationType{
+		ReindexTypeChangeTokenization,
+		ReindexTypeChangeTokenizationFilterable,
+		ReindexTypeEnableFilterable,
+		ReindexTypeEnableSearchable,
+		ReindexTypeChangeAlgorithm,
+	}
+	formatOnly := []ReindexMigrationType{
+		ReindexTypeRebuildSearchable,
+		ReindexTypeRepairFilterable,
+		ReindexTypeEnableRangeable,
+		ReindexTypeRepairRangeable,
+	}
+	for _, mt := range semantic {
+		t.Run(string(mt)+" → semantic", func(t *testing.T) {
+			require.True(t, IsSemanticMigration(mt))
+		})
+	}
+	for _, mt := range formatOnly {
+		t.Run(string(mt)+" → format-only", func(t *testing.T) {
+			require.False(t, IsSemanticMigration(mt))
+		})
+	}
+}
+
 // TestSemanticMigrationIndexTypes pins the migration-type → index-type
 // mapping. Format-only migrations (repair-*, enable-rangeable) MUST
 // return nil here — they don't go through the swap barrier, so

--- a/adapters/repos/db/reindex_provider_recovery_test.go
+++ b/adapters/repos/db/reindex_provider_recovery_test.go
@@ -189,9 +189,9 @@ func TestSemanticMigrationIndexTypes(t *testing.T) {
 			want: []string{"filterable"},
 		},
 		{
-			name: "repair-searchable → empty (format-only, no swap barrier)",
+			name: "change-algorithm → searchable (semantic, cluster-wide flag flip)",
 			mt:   ReindexTypeChangeAlgorithm,
-			want: nil,
+			want: []string{"searchable"},
 		},
 		{
 			name: "repair-filterable → empty (format-only)",

--- a/adapters/repos/db/reindex_provider_recovery_test.go
+++ b/adapters/repos/db/reindex_provider_recovery_test.go
@@ -158,10 +158,8 @@ func TestHasUntidiedTracker(t *testing.T) {
 	}
 }
 
-// TestIsSemanticMigration pins the semantic/format-only classification.
-// change-algorithm was promoted to semantic in
-// weaviate/0-weaviate-issues#254 to close the read-only + wrong-query-path
-// races caused by the per-shard class-flag flip.
+// TestIsSemanticMigration pins the semantic/format-only classification
+// (weaviate/0-weaviate-issues#254 promoted change-algorithm to semantic).
 func TestIsSemanticMigration(t *testing.T) {
 	semantic := []ReindexMigrationType{
 		ReindexTypeChangeTokenization,

--- a/adapters/repos/db/reindex_provider_repair_guidance_test.go
+++ b/adapters/repos/db/reindex_provider_repair_guidance_test.go
@@ -97,12 +97,13 @@ func TestLogOperatorRepairGuidanceOnFailedSemanticMigration_MultipleProperties(t
 func TestLogOperatorRepairGuidanceOnFailedSemanticMigration_FormatOnlyMigrationIsNoOp(t *testing.T) {
 	logger, hook := logrustest.NewNullLogger()
 
-	// Format-only migrations (repair-searchable, repair-filterable,
-	// repair-rangeable) don't go through the per-shard ack barrier
-	// that produces the bucket↔schema inversion family, so this
-	// helper should NOT emit operator guidance for them.
+	// Format-only migrations (repair-filterable, repair-rangeable) don't
+	// go through the per-shard ack barrier that produces the
+	// bucket↔schema inversion family, so this helper should NOT emit
+	// operator guidance for them. change-algorithm was promoted to
+	// semantic in weaviate/0-weaviate-issues#254 so it is no longer
+	// part of this exclusion set.
 	for _, mt := range []ReindexMigrationType{
-		ReindexTypeChangeAlgorithm,
 		ReindexTypeRepairFilterable,
 		ReindexTypeRepairRangeable,
 	} {

--- a/adapters/repos/db/reindex_provider_repair_guidance_test.go
+++ b/adapters/repos/db/reindex_provider_repair_guidance_test.go
@@ -97,12 +97,7 @@ func TestLogOperatorRepairGuidanceOnFailedSemanticMigration_MultipleProperties(t
 func TestLogOperatorRepairGuidanceOnFailedSemanticMigration_FormatOnlyMigrationIsNoOp(t *testing.T) {
 	logger, hook := logrustest.NewNullLogger()
 
-	// Format-only migrations (repair-filterable, repair-rangeable) don't
-	// go through the per-shard ack barrier that produces the
-	// bucket↔schema inversion family, so this helper should NOT emit
-	// operator guidance for them. change-algorithm was promoted to
-	// semantic in weaviate/0-weaviate-issues#254 so it is no longer
-	// part of this exclusion set.
+	// Format-only migrations must not emit operator guidance.
 	for _, mt := range []ReindexMigrationType{
 		ReindexTypeRepairFilterable,
 		ReindexTypeRepairRangeable,

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -152,29 +152,42 @@ func testRepairAllTenants(t *testing.T, restURI string) {
 // =============================================================================
 
 func testRepairSpecificTenants(t *testing.T, restURI string) {
+	// Format-only migration on specific tenants. The prior body
+	// `{"searchable":{"algorithm":"blockmax"}}` submitted a
+	// ChangeAlgorithm migration, which is now (post
+	// weaviate/0-weaviate-issues#254) rejected at the handler — the
+	// class-level UsingBlockMaxWAND flag cannot be flipped on a tenant
+	// subset (the un-reindexed tenants' queries would route through
+	// the wrong BM25 path post-flip). Replaced with enable-rangeable
+	// on an int property: format-only, per-tenant compatible, exercises
+	// the same tenant-filter dispatch.
 	className := "MTRepairSpecific"
 	tenantNames := []string{"t1", "t2", "t3", "t4", "t5"}
 
 	createMTClass(t, className, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
+		{Name: "score", DataType: []string{"int"}},
 	})
 	addTenants(t, className, tenantNames)
 
 	for _, tn := range tenantNames {
 		for i := 0; i < 3; i++ {
 			obj := &models.Object{
-				Class:      className,
-				Properties: map[string]interface{}{"text": fmt.Sprintf("item_%d from %s", i, tn)},
-				Tenant:     tn,
+				Class: className,
+				Properties: map[string]interface{}{
+					"text":  fmt.Sprintf("item_%d from %s", i, tn),
+					"score": float64(i + 1),
+				},
+				Tenant: tn,
 			}
 			require.NoError(t, helper.CreateObject(t, obj))
 		}
 	}
 
-	// Repair only t1 and t2.
+	// Repair only t1 and t2 via enable-rangeable on the int property.
 	targetTenants := []string{"t1", "t2"}
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
-		`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants(targetTenants))
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
+		`{"rangeable":{"enabled":true}}`, reindexhelpers.WithTenants(targetTenants))
 	t.Logf("repair specific tenants task: %s", taskID)
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
 
@@ -429,6 +442,15 @@ func testValidation(t *testing.T, restURI string) {
 			`{"searchable":{"tokenization":"field"}}`, reindexhelpers.WithTenants([]string{"active1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"MT class with tenants on change-tokenization should reject as 400: %s", got.Body)
+	})
+
+	t.Run("ChangeAlgorithm_with_tenants", func(t *testing.T) {
+		// Post weaviate/0-weaviate-issues#254, change-algorithm is
+		// semantic — same tenant-subset rejection as change-tokenization.
+		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, mtClass, "text",
+			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"active1"}))
+		require.Equal(t, http.StatusBadRequest, got.StatusCode,
+			"MT class with tenants on change-algorithm should reject as 400: %s", got.Body)
 	})
 
 	t.Run("Nonexistent_tenant", func(t *testing.T) {

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -152,15 +152,8 @@ func testRepairAllTenants(t *testing.T, restURI string) {
 // =============================================================================
 
 func testRepairSpecificTenants(t *testing.T, restURI string) {
-	// Format-only migration on specific tenants. The prior body
-	// `{"searchable":{"algorithm":"blockmax"}}` submitted a
-	// ChangeAlgorithm migration, which is now (post
-	// weaviate/0-weaviate-issues#254) rejected at the handler — the
-	// class-level UsingBlockMaxWAND flag cannot be flipped on a tenant
-	// subset (the un-reindexed tenants' queries would route through
-	// the wrong BM25 path post-flip). Replaced with enable-rangeable
-	// on an int property: format-only, per-tenant compatible, exercises
-	// the same tenant-filter dispatch.
+	// Per-tenant filter dispatch via enable-rangeable (format-only).
+	// ChangeAlgorithm + tenant subset is rejected post weaviate/0-weaviate-issues#254.
 	className := "MTRepairSpecific"
 	tenantNames := []string{"t1", "t2", "t3", "t4", "t5"}
 
@@ -445,8 +438,6 @@ func testValidation(t *testing.T, restURI string) {
 	})
 
 	t.Run("ChangeAlgorithm_with_tenants", func(t *testing.T) {
-		// Post weaviate/0-weaviate-issues#254, change-algorithm is
-		// semantic — same tenant-subset rejection as change-tokenization.
 		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, mtClass, "text",
 			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"active1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -96,12 +96,9 @@ func TestMultiNode_HappyPath(t *testing.T) {
 	})
 }
 
-// testMapToBlockmaxMultiPropertyDefersFlip pins the deferral path inside
-// flipSemanticMigrationSchema for ChangeAlgorithm: with two searchable
-// properties on the same class, the per-property reindex task for the
-// first must NOT flip UsingBlockMaxWAND while the second is still on
-// map. Single-property tests don't exercise this branch — the regression
-// QA Claude flagged on weaviate/0-weaviate-issues#254 review.
+// testMapToBlockmaxMultiPropertyDefersFlip: first property's reindex must
+// not flip UsingBlockMaxWAND while a second searchable property is still
+// on map (weaviate/0-weaviate-issues#254).
 func testMapToBlockmaxMultiPropertyDefersFlip(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeBlockmaxMultiProp"
 	restURI := compose.GetWeaviateNode(1).URI()
@@ -112,15 +109,14 @@ func testMapToBlockmaxMultiPropertyDefersFlip(t *testing.T, compose *docker.Dock
 	})
 	defer deleteCollection(t, restURI, className)
 
-	// Sanity: starting state has the class flag off.
+	// Baseline: flag off pre-migration.
 	for i := 1; i <= 3; i++ {
 		cls := getClassFromNode(t, compose.GetWeaviateNode(i).URI(), className)
 		require.False(t, cls.InvertedIndexConfig.UsingBlockMaxWAND,
 			"pre-migration: UsingBlockMaxWAND must start false on node %d", i)
 	}
 
-	// First per-property migration: "title" only. The cluster-wide flip
-	// must NOT fire because "body" is still on the map strategy.
+	// Migrate "title" only — flip must defer ("body" still on map).
 	taskID1 := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title", `{"searchable":{"algorithm":"blockmax"}}`)
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, className, "title", "searchable", reindexhelpers.WithTimeout(180*time.Second))
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID1, reindexhelpers.WithTimeout(180*time.Second))
@@ -131,9 +127,7 @@ func testMapToBlockmaxMultiPropertyDefersFlip(t *testing.T, compose *docker.Dock
 			"after single-property reindex of 'title': UsingBlockMaxWAND must still be false on node %d (body still on map)", i)
 	}
 
-	// Second per-property migration: "body". Once this lands, every
-	// searchable bucket on every shard on every node is blockmax → the
-	// deferral guard releases and the cluster-wide flip fires.
+	// Migrate "body" — last property on map → guard releases, flip fires.
 	taskID2 := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body", `{"searchable":{"algorithm":"blockmax"}}`)
 	reindexhelpers.AwaitReindexViaIndexes(t, restURI, className, "body", "searchable", reindexhelpers.WithTimeout(180*time.Second))
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID2, reindexhelpers.WithTimeout(180*time.Second))

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -82,6 +82,9 @@ func TestMultiNode_HappyPath(t *testing.T) {
 	t.Run("MapToBlockmax", func(t *testing.T) {
 		testMapToBlockmax(t, compose)
 	})
+	t.Run("MapToBlockmaxMultiPropertyDefersFlip", func(t *testing.T) {
+		testMapToBlockmaxMultiPropertyDefersFlip(t, compose)
+	})
 	t.Run("RoaringSetRefresh", func(t *testing.T) {
 		testRoaringSetRefresh(t, compose)
 	})
@@ -91,6 +94,55 @@ func TestMultiNode_HappyPath(t *testing.T) {
 	t.Run("ChangeTokenization", func(t *testing.T) {
 		testChangeTokenization(t, compose)
 	})
+}
+
+// testMapToBlockmaxMultiPropertyDefersFlip pins the deferral path inside
+// flipSemanticMigrationSchema for ChangeAlgorithm: with two searchable
+// properties on the same class, the per-property reindex task for the
+// first must NOT flip UsingBlockMaxWAND while the second is still on
+// map. Single-property tests don't exercise this branch — the regression
+// QA Claude flagged on weaviate/0-weaviate-issues#254 review.
+func testMapToBlockmaxMultiPropertyDefersFlip(t *testing.T, compose *docker.DockerCompose) {
+	className := "MultiNodeBlockmaxMultiProp"
+	restURI := compose.GetWeaviateNode(1).URI()
+
+	createCollection(t, restURI, className, 3, 3, []*models.Property{
+		{Name: "title", DataType: []string{"text"}, Tokenization: "word"},
+		{Name: "body", DataType: []string{"text"}, Tokenization: "word"},
+	})
+	defer deleteCollection(t, restURI, className)
+
+	// Sanity: starting state has the class flag off.
+	for i := 1; i <= 3; i++ {
+		cls := getClassFromNode(t, compose.GetWeaviateNode(i).URI(), className)
+		require.False(t, cls.InvertedIndexConfig.UsingBlockMaxWAND,
+			"pre-migration: UsingBlockMaxWAND must start false on node %d", i)
+	}
+
+	// First per-property migration: "title" only. The cluster-wide flip
+	// must NOT fire because "body" is still on the map strategy.
+	taskID1 := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "title", `{"searchable":{"algorithm":"blockmax"}}`)
+	reindexhelpers.AwaitReindexViaIndexes(t, restURI, className, "title", "searchable", reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID1, reindexhelpers.WithTimeout(180*time.Second))
+
+	for i := 1; i <= 3; i++ {
+		cls := getClassFromNode(t, compose.GetWeaviateNode(i).URI(), className)
+		assert.False(t, cls.InvertedIndexConfig.UsingBlockMaxWAND,
+			"after single-property reindex of 'title': UsingBlockMaxWAND must still be false on node %d (body still on map)", i)
+	}
+
+	// Second per-property migration: "body". Once this lands, every
+	// searchable bucket on every shard on every node is blockmax → the
+	// deferral guard releases and the cluster-wide flip fires.
+	taskID2 := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "body", `{"searchable":{"algorithm":"blockmax"}}`)
+	reindexhelpers.AwaitReindexViaIndexes(t, restURI, className, "body", "searchable", reindexhelpers.WithTimeout(180*time.Second))
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID2, reindexhelpers.WithTimeout(180*time.Second))
+
+	for i := 1; i <= 3; i++ {
+		cls := getClassFromNode(t, compose.GetWeaviateNode(i).URI(), className)
+		assert.True(t, cls.InvertedIndexConfig.UsingBlockMaxWAND,
+			"after last-property reindex of 'body': UsingBlockMaxWAND must now be true on node %d", i)
+	}
 }
 
 // TestMultiNode_QueryConsistencyDuringReindex pulls the query-consistency

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -157,12 +157,29 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 			wantBodyHas: "multi-tenant",
 		},
 		{
-			name:       "tenants= empty value treated as nonexistent",
+			// repair-filterable is format-only (per-tenant supported);
+			// algorithm:blockmax used to fit here but
+			// weaviate/0-weaviate-issues#254 promoted change-algorithm to
+			// semantic — the new "tenants parameter cannot be used with
+			// semantic migrations" validation short-circuits before the
+			// per-tenant existence check, so the "does not exist" path is
+			// only reachable for format-only migrations. The semantic-vs-
+			// tenants rejection has its own pin
+			// ("tenants on semantic change-algorithm" below).
+			name:       "tenants=<nonexistent> on MT class with format-only migration",
 			collection: mtClass, property: "text_word",
-			body:        `{"searchable":{"algorithm":"blockmax"}}`,
+			body:        `{"filterable":{"rebuild":true}}`,
 			tenantsQS:   "?tenants=nonexistent_tenant_xyz",
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: "does not exist",
+		},
+		{
+			name:       "tenants on semantic change-algorithm rejected",
+			collection: mtClass, property: "text_word",
+			body:        `{"searchable":{"algorithm":"blockmax"}}`,
+			tenantsQS:   "?tenants=t1",
+			wantStatus:  http.StatusBadRequest,
+			wantBodyHas: "semantic migrations",
 		},
 		{
 			name:       "change-tokenization same value (word -> word) rejected",

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -157,15 +157,8 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 			wantBodyHas: "multi-tenant",
 		},
 		{
-			// repair-filterable is format-only (per-tenant supported);
-			// algorithm:blockmax used to fit here but
-			// weaviate/0-weaviate-issues#254 promoted change-algorithm to
-			// semantic — the new "tenants parameter cannot be used with
-			// semantic migrations" validation short-circuits before the
-			// per-tenant existence check, so the "does not exist" path is
-			// only reachable for format-only migrations. The semantic-vs-
-			// tenants rejection has its own pin
-			// ("tenants on semantic change-algorithm" below).
+			// Format-only body so the per-tenant existence check is reached
+			// (semantic bodies short-circuit on the semantic-vs-tenants gate).
 			name:       "tenants=<nonexistent> on MT class with format-only migration",
 			collection: mtClass, property: "text_word",
 			body:        `{"filterable":{"rebuild":true}}`,


### PR DESCRIPTION
**Fixes weaviate/0-weaviate-issues#254 finding 3** (and the related silent wrong-query-path race noted in QA Claude's 10:36Z follow-up).

## Problem

`MapToBlockmaxStrategy.OnMigrationComplete` flipped the class-level `UsingBlockMaxWAND` flag from a per-shard hook. The first shard to finish would call `updateToBlockMaxInvertedIndexConfig` → `UpdateClassInternal` → `executor.UpdateClass`, which unconditionally calls `UpdateVectorIndexConfig` even when only `InvertedIndexConfig.UsingBlockMaxWAND` changed in the diff. That cascades into `Shard.UpdateVectorIndexConfig` → `SetStatusReadonly` → `store.UpdateBucketsStatus(ReadOnly)` on **every loaded shard on every node**, including the `__blockmax_reindex_<gen>` / `__blockmax_ingest_<gen>` sidecar buckets that other shards (or other sub-tasks on the same shard) are still iterating into. The next `MapSet` on the still-iterating writer returns `ErrStatusReadOnly` — the recurring `store is read-only` failure on `TestMultiNode_HappyPath/MapToBlockmax` in the kpop-flake soak.

The same shard-local flip also opens a silent **wrong-query-path race**: a query routed to a still-migrating shard executes the new BM25 path against old-format buckets after the class flag has flipped cluster-wide.

The strategy's own godoc already states the invariant the broken flow violates:

> "the class-level flag must stay off until [all properties on all shards] are migrated too — otherwise BM25 queries over the still-map properties would hit the wrong query path."

But the gate was implemented shard-local, so a first-finishing shard could flip the flag while siblings still iterated.

## Fix

Promote MapToBlockmax to a semantic migration. The class-level flip now lives in `ReindexProvider.flipSemanticMigrationSchema` and fires from `OnTaskCompleted` after every node's swap has been acknowledged by the cluster-wide barrier — same orchestration that change-tokenization / enable-searchable / enable-filterable already use.

| | Before | After |
|---|---|---|
| Class-flag flip site | `MapToBlockmaxStrategy.OnMigrationComplete` (per-shard) | `flipSemanticMigrationSchema` (`OnTaskCompleted`, post-barrier) |
| Barrier flag on the RAFT task | `false` (format-only path) | `true` (driven by `IsSemanticMigration`) |
| Read-only cascade race window | Open: first shard's flip cascades onto still-iterating sibling shards | Closed: flip fires only after every replica's swap is acknowledged |
| Wrong-query-path race window | Open: class flag flips while a shard is still on the source bucket strategy | Closed: same — every shard has swapped before the class flag flips |

Specifically:

- `IsSemanticMigration` now includes `ReindexTypeChangeAlgorithm` — drives the barrier flag set on the RAFT task at submit time (`handlers_indexes.go:621`) and the `OnSwapRequested` / `LocalCallbacksDone` / `flipSemanticMigrationSchema` dispatches.
- `semanticMigrationIndexTypes` returns `["searchable"]` for ChangeAlgorithm — drives the swap-barrier recovery check in `LocalCallbacksDone`.
- `flipSemanticMigrationSchema` gains a `case ReindexTypeChangeAlgorithm` that calls `updateToBlockMaxInvertedIndexConfig`. Idempotent at the RAFT layer (already-set short-circuit), so safe to fire from `OnTaskCompleted` on multiple nodes.
- `MapToBlockmaxStrategy.OnMigrationComplete` becomes a no-op (the canonical pattern for semantic strategies — change-tokenization and enable-searchable also have no-op `OnMigrationComplete`).

## Why this is not just option (1)

The discussion on weaviate/0-weaviate-issues#254 enumerated three fix candidates: (1) short-circuit `Shard.UpdateVectorIndexConfig` when the vector-config didn't change, (2) route the flag flip through `UpdateProperty` instead of `UpdateClass`, (3) promote to a semantic migration. (1) closes the read-only symptom but leaves the wrong-query-path race; only (3) closes both. Etienne's 10:35Z call: "I'm thinking this is the only clean solution. Even if it wasn't for the read-only bug, it wouldn't be clean to flip the schema before all shards are done."

## Verification

- Full `adapters/repos/db` unit suite green (43s).
- `golangci-lint` 0 issues, `linter_go_routines.sh` clean.
- 3× fresh `TestMultiNode_HappyPath/MapToBlockmax` + 3× `TestMultiNode_QueryConsistencyDuringReindex` green locally on the rebuilt docker image. These were the two previously-red multinode reindex jobs in the soak.

## Test updates

- `TestSemanticMigrationIndexTypes`: the ChangeAlgorithm row now expects `["searchable"]` instead of `nil`.
- `TestLogOperatorRepairGuidanceOnFailedSemanticMigration_FormatOnlyMigrationIsNoOp`: ChangeAlgorithm removed from the no-op set (it now produces repair guidance like the other semantic migrations).
