### PR TITLE
feat: add async replication compatibility layer

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -59,6 +59,7 @@ import (
 	rest_namespaces "github.com/weaviate/weaviate/adapters/handlers/rest/namespaces"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations"
 	replicationHandlers "github.com/weaviate/weaviate/adapters/handlers/rest/replication"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/restcompat"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/tenantactivity"
 	"github.com/weaviate/weaviate/adapters/repos/classifications"
@@ -570,6 +571,8 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	}
 
 	appState.DB = repo
+	// Seed the REST asyncEnabled shim; the runtime-config hook below keeps it live.
+	restcompat.SetAsyncReplicationGloballyDisabled(appState.ServerConfig.Config.Replication.AsyncReplicationDisabled.Get())
 	// Construct the usage-limits Manager now that its ObjectCounter (the
 	// DB) exists, then install it on the DB so each Index inherits it
 	// when loaded (init.go) or created at runtime (migrator.go). Both
@@ -1314,6 +1317,8 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	api.ServeError = openapierrors.ServeError
 
 	api.JSONConsumer = runtime.JSONConsumer()
+	// REST-only asyncEnabled shim — see adapters/handlers/rest/restcompat.
+	api.JSONProducer = restcompat.NewJSONProducer()
 
 	api.OidcAuth = composer.New(
 		appState.ServerConfig.Config.Authentication,
@@ -2635,6 +2640,7 @@ func postInitRuntimeOverrides(appState *state.State, serverShutdownCtx context.C
 		// config reload loop. serverShutdownCtx makes it cancellable on shutdown;
 		// errors are logged here and surfaced via the reconcileFailures metric.
 		hooks["AsyncReplicationDisabled"] = func() error {
+			restcompat.SetAsyncReplicationGloballyDisabled(appState.ServerConfig.Config.Replication.AsyncReplicationDisabled.Get())
 			enterrors.GoWrapper(func() {
 				if err := appState.DB.ReconcileAsyncReplication(serverShutdownCtx); err != nil {
 					appState.Logger.WithField("action", "reconcile_async_replication").Error(err)

--- a/adapters/handlers/rest/restcompat/flag.go
+++ b/adapters/handlers/rest/restcompat/flag.go
@@ -1,0 +1,27 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package restcompat synthesises legacy fields on REST responses only.
+// Internal JSON paths (RAFT, snapshots, backups) keep using the bare
+// entities/models types.
+package restcompat
+
+import "sync/atomic"
+
+// asyncReplicationGloballyDisabled mirrors ASYNC_REPLICATION_DISABLED so the
+// producer can derive the legacy replicationConfig.asyncEnabled field.
+var asyncReplicationGloballyDisabled atomic.Bool
+
+// SetAsyncReplicationGloballyDisabled must be called at startup and from the
+// AsyncReplicationDisabled runtime-config hook.
+func SetAsyncReplicationGloballyDisabled(disabled bool) {
+	asyncReplicationGloballyDisabled.Store(disabled)
+}

--- a/adapters/handlers/rest/restcompat/producer.go
+++ b/adapters/handlers/rest/restcompat/producer.go
@@ -1,0 +1,37 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package restcompat
+
+import (
+	"io"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// NewJSONProducer wraps the default JSON producer to inject the legacy
+// asyncEnabled field on *models.Class and *models.Schema payloads. Other
+// payloads pass through unchanged.
+func NewJSONProducer() runtime.Producer {
+	base := runtime.JSONProducer()
+	return runtime.ProducerFunc(func(w io.Writer, v interface{}) error {
+		switch t := v.(type) {
+		case *models.Class:
+			return base.Produce(w, wrapClass(t))
+		case *models.Schema:
+			return base.Produce(w, wrapSchema(t))
+		default:
+			return base.Produce(w, v)
+		}
+	})
+}

--- a/adapters/handlers/rest/restcompat/producer_test.go
+++ b/adapters/handlers/rest/restcompat/producer_test.go
@@ -1,0 +1,147 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package restcompat
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestJSONProducer_ClassEmitsDerivedAsyncEnabled(t *testing.T) {
+	original := asyncReplicationGloballyDisabled.Load()
+	t.Cleanup(func() { asyncReplicationGloballyDisabled.Store(original) })
+
+	cases := []struct {
+		name             string
+		factor           int64
+		globallyDisabled bool
+		want             bool
+	}{
+		{"factor 1 always false", 1, false, false},
+		{"factor 1 globally disabled stays false", 1, true, false},
+		{"factor 3 default true", 3, false, true},
+		{"factor 3 global override wins", 3, true, false},
+		{"factor 0 (omitted) stays false", 0, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetAsyncReplicationGloballyDisabled(tc.globallyDisabled)
+			class := &models.Class{
+				Class:             "Foo",
+				ReplicationConfig: &models.ReplicationConfig{Factor: tc.factor},
+			}
+
+			buf := encode(t, class)
+			var got struct {
+				Class             string `json:"class"`
+				ReplicationConfig struct {
+					Factor       int64 `json:"factor"`
+					AsyncEnabled bool  `json:"asyncEnabled"`
+				} `json:"replicationConfig"`
+			}
+			require.NoError(t, json.Unmarshal(buf, &got))
+			assert.Equal(t, "Foo", got.Class)
+			assert.Equal(t, tc.factor, got.ReplicationConfig.Factor)
+			assert.Equal(t, tc.want, got.ReplicationConfig.AsyncEnabled,
+				"factor=%d globalDisabled=%v", tc.factor, tc.globallyDisabled)
+		})
+	}
+}
+
+func TestJSONProducer_SchemaWrapsEveryClass(t *testing.T) {
+	original := asyncReplicationGloballyDisabled.Load()
+	t.Cleanup(func() { asyncReplicationGloballyDisabled.Store(original) })
+	SetAsyncReplicationGloballyDisabled(false)
+
+	schema := &models.Schema{
+		Classes: []*models.Class{
+			{Class: "A", ReplicationConfig: &models.ReplicationConfig{Factor: 1}},
+			{Class: "B", ReplicationConfig: &models.ReplicationConfig{Factor: 3}},
+		},
+	}
+
+	buf := encode(t, schema)
+	var got struct {
+		Classes []struct {
+			Class             string `json:"class"`
+			ReplicationConfig struct {
+				Factor       int64 `json:"factor"`
+				AsyncEnabled bool  `json:"asyncEnabled"`
+			} `json:"replicationConfig"`
+		} `json:"classes"`
+	}
+	require.NoError(t, json.Unmarshal(buf, &got))
+	require.Len(t, got.Classes, 2)
+	assert.Equal(t, "A", got.Classes[0].Class)
+	assert.Equal(t, int64(1), got.Classes[0].ReplicationConfig.Factor)
+	assert.False(t, got.Classes[0].ReplicationConfig.AsyncEnabled)
+	assert.Equal(t, "B", got.Classes[1].Class)
+	assert.Equal(t, int64(3), got.Classes[1].ReplicationConfig.Factor)
+	assert.True(t, got.Classes[1].ReplicationConfig.AsyncEnabled)
+}
+
+func TestJSONProducer_PassesThroughUnrelatedTypes(t *testing.T) {
+	type errPayload struct {
+		Error []map[string]string `json:"error"`
+	}
+	payload := &errPayload{Error: []map[string]string{{"message": "boom"}}}
+
+	buf := encode(t, payload)
+	assert.NotContains(t, string(buf), "asyncEnabled")
+}
+
+func TestJSONProducer_NilReplicationConfig(t *testing.T) {
+	original := asyncReplicationGloballyDisabled.Load()
+	t.Cleanup(func() { asyncReplicationGloballyDisabled.Store(original) })
+	SetAsyncReplicationGloballyDisabled(false)
+
+	class := &models.Class{Class: "NoRep"}
+	buf := encode(t, class)
+	assert.NotContains(t, string(buf), "replicationConfig")
+	assert.NotContains(t, string(buf), "asyncEnabled")
+}
+
+func TestJSONProducer_NilPayload(t *testing.T) {
+	var class *models.Class
+	buf := encode(t, class)
+	assert.JSONEq(t, "null", string(buf))
+}
+
+func TestJSONProducer_SchemaPreservesClassesNilness(t *testing.T) {
+	// models.Schema.Classes has no omitempty, so nil must marshal as
+	// "classes":null while an empty (non-nil) slice marshals as
+	// "classes":[].
+	t.Run("nil slice stays null", func(t *testing.T) {
+		buf := encode(t, &models.Schema{Classes: nil})
+		assert.Contains(t, string(buf), `"classes":null`)
+	})
+	t.Run("empty slice stays []", func(t *testing.T) {
+		buf := encode(t, &models.Schema{Classes: []*models.Class{}})
+		assert.Contains(t, string(buf), `"classes":[]`)
+		assert.NotContains(t, string(buf), `"classes":null`)
+	})
+}
+
+func encode(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, NewJSONProducer().Produce(&buf, v))
+	// Trim the trailing newline the base producer appends.
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}

--- a/adapters/handlers/rest/restcompat/wrappers.go
+++ b/adapters/handlers/rest/restcompat/wrappers.go
@@ -1,0 +1,71 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package restcompat
+
+import "github.com/weaviate/weaviate/entities/models"
+
+// Outer-field-wins JSON encoding: an outer field with the same json tag as a
+// field on an embedded type takes precedence, so the embedded model is
+// emitted verbatim plus the outer additions.
+type replicationConfigOut struct {
+	*models.ReplicationConfig
+	AsyncEnabled bool `json:"asyncEnabled"`
+}
+
+type classOut struct {
+	*models.Class
+	ReplicationConfig *replicationConfigOut `json:"replicationConfig,omitempty"`
+}
+
+type schemaOut struct {
+	*models.Schema
+	Classes []*classOut `json:"classes"`
+}
+
+func wrapReplicationConfig(rc *models.ReplicationConfig) *replicationConfigOut {
+	if rc == nil {
+		return nil
+	}
+	return &replicationConfigOut{
+		ReplicationConfig: rc,
+		AsyncEnabled:      rc.Factor > 1 && !asyncReplicationGloballyDisabled.Load(),
+	}
+}
+
+func wrapClass(c *models.Class) *classOut {
+	if c == nil {
+		return nil
+	}
+	return &classOut{
+		Class:             c,
+		ReplicationConfig: wrapReplicationConfig(c.ReplicationConfig),
+	}
+}
+
+func wrapSchema(s *models.Schema) *schemaOut {
+	if s == nil {
+		return nil
+	}
+	// Preserve nilness — models.Schema.Classes has no omitempty, so a nil
+	// slice must marshal as "classes":null, not "classes":[].
+	var classes []*classOut
+	if s.Classes != nil {
+		classes = make([]*classOut, len(s.Classes))
+		for i, c := range s.Classes {
+			classes[i] = wrapClass(c)
+		}
+	}
+	return &schemaOut{
+		Schema:  s,
+		Classes: classes,
+	}
+}

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -102,6 +102,7 @@ func testGetSchemaWithoutClient(t *testing.T) {
 				"replicationConfig": map[string]interface{}{
 					"factor":           float64(1),
 					"deletionStrategy": "TimeBasedResolution",
+					"asyncEnabled":     false,
 				},
 				"vectorizer": "text2vec-contextionary", // global default from env var, see docker-compose-test.yml
 				"invertedIndexConfig": map[string]interface{}{


### PR DESCRIPTION
### What's being changed

This PR adds a **REST-output compatibility shim** for the `replicationConfig.asyncEnabled` field that was removed in #11214. Released SDK versions (Java's Gson record in particular) deserialise a missing `asyncEnabled` as `null`, leading to NPEs on unbox; less strict SDKs (Python, JS, C#) silently default to `false`, which would misreport every `factor > 1` collection as async-off post-upgrade. The shim emits a derived `asyncEnabled` value on REST responses so SDKs see what they expect.

The shim lives **on the REST egress path only** — it does not modify the `entities/models.ReplicationConfig` struct or its JSON encoding. Internal callers that `json.Marshal` a `*models.ReplicationConfig` directly (RAFT log subcommands, FSM snapshots, backups) are unaffected.

#### Implementation

New package `adapters/handlers/rest/restcompat/`:

* **`producer.go`** — `NewJSONProducer()` returns a `runtime.Producer` that wraps the default JSON producer. For `*models.Class` and `*models.Schema` payloads it injects the legacy `asyncEnabled` field via wrapper structs; every other payload (errors, shard status, tenants, …) passes through unchanged.
* **`wrappers.go`** — three small wrapper structs (`replicationConfigOut`, `classOut`, `schemaOut`) that embed the canonical model and add `asyncEnabled` at the outer struct level. Go's outer-field-wins JSON encoding rule keeps the rest of the payload byte-identical to the unwrapped form.
* **`flag.go`** — package-level `atomic.Bool` mirroring `ASYNC_REPLICATION_DISABLED`, plus a `SetAsyncReplicationGloballyDisabled` setter that the producer reads when deriving the field.

Derivation rule: `asyncEnabled = factor > 1 && !globally_disabled`.

#### Wiring (`adapters/handlers/rest/configure_api.go`)

* `api.JSONProducer = restcompat.NewJSONProducer()` at the existing `JSONConsumer` initialisation site.
* Initial seed of the global flag right after `appState.DB = repo`.
* Runtime hook update on every `AsyncReplicationDisabled` change, alongside the existing reconcile call.

#### Why REST-only

Two reasons for confining the shim to the REST producer rather than putting `MarshalJSON` on `*models.ReplicationConfig`:
1. A model-level `MarshalJSON` would also fire on every internal `json.Marshal` — RAFT log entries, FSM snapshot bytes, backup payloads — baking the derived field into persistent on-disk artefacts. That's a wider blast radius than the SDK-compat goal requires.
2. Hand-written sibling files under `entities/models/` are deleted on every `./tools/gen-code-from-swagger.sh` run (the script does `rm -rf entities/models`). Keeping the shim outside the generated package sidesteps the codegen guard.

#### Testing

* Unit tests in `adapters/handlers/rest/restcompat/producer_test.go` cover: derived value across `factor`/global combinations, schema-wide wrapping, pass-through for unrelated payloads, nil payload and nil `ReplicationConfig` handling, and preservation of `s.Classes` nilness (so empty `Schema.Classes` still marshals as `"classes":null`, not `"classes":[]`).
* Updated `test/acceptance/schema/get_schema_without_client_test.go` to expect `asyncEnabled: false` on the test class (`factor=1`).
* Live cross-language validation: latest official Python (`weaviate-client` 4.21.0) and Java (`io.weaviate:client6` 6.2.1) clients exercised against a freshly built 3-node `weaviate-test:shim` cluster — 3/3 PASS each, covering factor=1, factor=3, and the user-supplied-false-on-factor=3 override case (shim still reports `true`).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

### Cross-functional impact

Client coordination issues filed:
- Python — weaviate/weaviate-python-client#2047
- TypeScript — weaviate/typescript-client#435
- Go — weaviate/weaviate-go-client#406
- Java — weaviate/java-client#571
- C# — weaviate/csharp-client#343
