### PR TITLE
Namespace: Round of bugfixes

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -368,7 +368,6 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 	resourceFilter := filter.New[*models.Role](h.authorizer, h.rbacconfig)
 	filteredRoles := resourceFilter.Filter(
 		ctx,
-		h.logger,
 		principal,
 		response,
 		authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_ALL),
@@ -380,7 +379,6 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 		// try match if all was none
 		filteredRoles = resourceFilter.Filter(
 			ctx,
-			h.logger,
 			principal,
 			response,
 			authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH),
@@ -1033,7 +1031,6 @@ func (h *authZHandlers) getGroups(params authz.GetGroupsParams, principal *model
 	resourceFilter := filter.New[string](h.authorizer, h.rbacconfig)
 	filteredGroups := resourceFilter.Filter(
 		ctx,
-		h.logger,
 		principal,
 		groups,
 		authorization.READ,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -902,6 +902,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	namespaceCleanupCoordinator := namespacecleanup.NewCoordinator(
 		appState.NamespacesController,
 		rCluster.NewSchemaNamespaceLister(appState.ClusterService.SchemaReader()),
+		appState.APIKey.Dynamic,
 		appState.ClusterService.Raft,
 		appState.ClusterService.IsLeader,
 		appState.Logger,

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -118,7 +118,6 @@ func (h *dynUserHandler) listUsers(params users.ListAllUsersParams, principal *m
 	resourceFilter := filter.New[*apikey.User](h.authorizer, h.rbacConfig)
 	filteredUsers := resourceFilter.Filter(
 		ctx,
-		h.logger,
 		principal,
 		allUsers,
 		authorization.READ,

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -856,6 +856,9 @@ func (h *objectHandlers) extendReferenceWithAPILink(ref *models.SingleRef) *mode
 		// ignore return unchanged
 		return ref
 	}
+	// Defensive: beacons are written short, but strip here so a stray qualified
+	// class doesn't leak into the Href URL.
+	parsed.Class = namespacing.StripQualification(parsed.Class)
 	href := fmt.Sprintf("%s/v1/objects/%s/%s", h.config.Origin, parsed.Class, parsed.TargetID)
 	if parsed.Class == "" {
 		href = fmt.Sprintf("%s/v1/objects/%s", h.config.Origin, parsed.TargetID)

--- a/adapters/handlers/rest/handlers_objects_test.go
+++ b/adapters/handlers/rest/handlers_objects_test.go
@@ -1050,6 +1050,39 @@ func TestEnrichObjectsWithLinks(t *testing.T) {
 	})
 }
 
+// A stray qualified class on a beacon never leaks into the Href URL.
+func TestExtendReferenceWithAPILink_StripsQualifiedClass(t *testing.T) {
+	cases := []struct {
+		name     string
+		beacon   string
+		wantHref string
+	}{
+		{
+			name:     "short class passes through",
+			beacon:   "weaviate://localhost/Movies/85f78e29-5937-4390-a121-5379f262b4e5",
+			wantHref: "https://awesomehost.com/v1/objects/Movies/85f78e29-5937-4390-a121-5379f262b4e5",
+		},
+		{
+			name:     "qualified class is stripped to short",
+			beacon:   "weaviate://localhost/customer1:Movies/85f78e29-5937-4390-a121-5379f262b4e5",
+			wantHref: "https://awesomehost.com/v1/objects/Movies/85f78e29-5937-4390-a121-5379f262b4e5",
+		},
+		{
+			name:     "beacon without class stays classless",
+			beacon:   "weaviate://localhost/85f78e29-5937-4390-a121-5379f262b4e5",
+			wantHref: "https://awesomehost.com/v1/objects/85f78e29-5937-4390-a121-5379f262b4e5",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &objectHandlers{config: config.Config{Origin: "https://awesomehost.com"}}
+			ref := &models.SingleRef{Beacon: strfmt.URI(tc.beacon)}
+			got := h.extendReferenceWithAPILink(ref)
+			assert.Equal(t, strfmt.URI(tc.wantHref), got.Href)
+		})
+	}
+}
+
 type fakeManager struct {
 	getObjectReturn *models.Object
 	getObjectErr    error

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -12,14 +12,18 @@
 package namespace
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/client/batch"
 	"github.com/weaviate/weaviate/client/namespaces"
 	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -236,6 +240,104 @@ func TestNamespaces_ConcurrentDeleteAndAddClass(t *testing.T) {
 	// Post-condition: no class with the qualified name survives.
 	_, err := helper.GetClassWithoutAssert(t, qualifiedClass, adminKey)
 	require.Error(t, err, "class %q must not survive namespace removal", qualifiedClass)
+}
+
+// TestNamespaces_DeleteWhileBatchInsertInFlight runs a sustained batch
+// insert against a namespaced class, issues DELETE on the namespace, and
+// asserts: the race is actually exercised (writes succeed before DELETE
+// and fail after), the namespace is fully gone, and a fresh namespace +
+// class can be created cleanly — the latter is the proxy for "no torn
+// state was left behind".
+func TestNamespaces_DeleteWhileBatchInsertInFlight(t *testing.T) {
+	const (
+		ns        = "delbatch"
+		userID    = "dave"
+		className = "Tickets"
+	)
+	qualifiedClass := ns + ":" + className
+
+	helper.CreateNamespace(t, ns, adminKey)
+	userKey := createNamespacedUser(t, userID, ns, adminKey)
+	helper.CreateClassAuth(t, &models.Class{
+		Class:      className,
+		Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
+	}, userKey)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		batchOK, batchFailed atomic.Int64
+		lastErrMu            sync.Mutex
+		lastErr              error
+	)
+
+	var wg sync.WaitGroup
+	for w := 0; w < 2; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; ctx.Err() == nil; i++ {
+				_, err := helper.Client(t).Batch.BatchObjectsCreate(
+					batch.NewBatchObjectsCreateParams().WithBody(batch.BatchObjectsCreateBody{
+						Objects: []*models.Object{{
+							Class:      className,
+							Properties: map[string]any{"title": fmt.Sprintf("w%d-%d", workerID, i)},
+						}},
+					}),
+					helper.CreateAuth(userKey),
+				)
+				if err != nil {
+					batchFailed.Add(1)
+					lastErrMu.Lock()
+					lastErr = err
+					lastErrMu.Unlock()
+				} else {
+					batchOK.Add(1)
+				}
+			}
+		}(w)
+	}
+
+	// Pre-condition: let a few batches commit so the test actually
+	// exercises the race instead of issuing DELETE before any data lands.
+	require.Eventually(t, func() bool { return batchOK.Load() >= 4 },
+		10*time.Second, 50*time.Millisecond,
+		"batch loop should commit some objects before DELETE")
+
+	helper.DeleteNamespace(t, ns, adminKey)
+	cancel()
+	wg.Wait()
+
+	// (a) The batch loop must have seen failures once the class was deleted
+	// — otherwise the test never actually overlapped DELETE with writes.
+	require.Greater(t, batchFailed.Load(), int64(0),
+		"expected at least one batch failure after class delete; ok=%d failed=%d",
+		batchOK.Load(), batchFailed.Load())
+
+	// The last failure must be a typed REST error (any 4xx is fine), not
+	// a 500 from torn state.
+	lastErrMu.Lock()
+	le := lastErr
+	lastErrMu.Unlock()
+	require.Error(t, le)
+	var internal *batch.BatchObjectsCreateInternalServerError
+	require.False(t, errors.As(le, &internal),
+		"post-delete batch failure must not be a 500; got %T: %v", le, le)
+
+	// (b) Post-condition: class is gone.
+	_, err := helper.GetClassWithoutAssert(t, qualifiedClass, adminKey)
+	require.Error(t, err, "class %q must not survive namespace removal", qualifiedClass)
+
+	// (c) Namespace can be recreated cleanly with the same class name —
+	// a torn cleanup would surface here as a create failure or stale state.
+	helper.CreateNamespace(t, ns, adminKey)
+	t.Cleanup(func() { helper.DeleteNamespace(t, ns, adminKey) })
+	userKey2 := createNamespacedUser(t, userID, ns, adminKey)
+	helper.CreateClassAuth(t, &models.Class{
+		Class:      className,
+		Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
+	}, userKey2)
 }
 
 // TestNamespaces_DeleteMissingReturns404FromEveryReplica drives DELETE

--- a/usecases/auth/authorization/filter/filter.go
+++ b/usecases/auth/authorization/filter/filter.go
@@ -15,12 +15,9 @@ import (
 	"context"
 	"slices"
 
-	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
 )
 
 // ResourceFilter handles filtering resources based on authorization
@@ -39,10 +36,10 @@ func New[T any](authorizer authorization.Authorizer, config rbacconf.Config) *Re
 // FilterFn defines a function that generates authorization resources for an item
 type FilterFn[T any] func(item T) string
 
-// Filter filters a slice of items based on authorization
+// Filter filters a slice of items based on authorization. Authz failures are
+// not logged here — the underlying authorizer emits the canonical audit entry.
 func (f *ResourceFilter[T]) Filter(
 	ctx context.Context,
-	logger logrus.FieldLogger,
 	principal *models.Principal,
 	items []T,
 	verb string,
@@ -54,11 +51,6 @@ func (f *ResourceFilter[T]) Filter(
 	if !f.config.Enabled {
 		// here it's either you have the permissions or not so 1 check is enough
 		if err := f.authorizer.Authorize(ctx, principal, verb, resourceFn(items[0])); err != nil {
-			logger.WithFields(logrus.Fields{
-				"username":  principal.Username,
-				"verb":      verb,
-				"resources": items,
-			}).Error(err)
 			return nil
 		}
 		return items
@@ -76,17 +68,7 @@ func (f *ResourceFilter[T]) Filter(
 
 	// If all items have the same parent, we can do a single authorization check
 	if allSameParent {
-		err := f.authorizer.Authorize(ctx, principal, verb, authorization.WildcardPath(firstResource))
-		if err != nil {
-			logger.WithFields(logrus.Fields{
-				"username": principal.Username,
-				"verb":     verb,
-				"resource": authorization.WildcardPath(firstResource),
-			}).Error(err)
-		}
-
-		if err == nil {
-			// user is authorized
+		if err := f.authorizer.Authorize(ctx, principal, verb, authorization.WildcardPath(firstResource)); err == nil {
 			return items
 		}
 	}
@@ -98,15 +80,7 @@ func (f *ResourceFilter[T]) Filter(
 		resources = append(resources, resourceFn(item))
 	}
 
-	allowedList, err := f.authorizer.FilterAuthorizedResources(ctx, principal, verb, resources...)
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"username":  principal.Username,
-			"verb":      verb,
-			"resources": resources,
-		}).Error(err)
-	}
-
+	allowedList, _ := f.authorizer.FilterAuthorizedResources(ctx, principal, verb, resources...)
 	if len(allowedList) == len(resources) {
 		// has permissions to all
 		return items

--- a/usecases/auth/authorization/filter/filter_test.go
+++ b/usecases/auth/authorization/filter/filter_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -41,15 +40,12 @@ func TestFilter(t *testing.T) {
 		},
 	}
 
-	l, _ := test.NewNullLogger()
-
 	authorizer := mocks.NewMockAuthorizer()
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			resourceFilter := New[*models.Object](authorizer, tt.Config)
 			filteredObjects := resourceFilter.Filter(
 				context.Background(),
-				l,
 				&models.Principal{Username: "user"},
 				tt.Items,
 				authorization.READ,

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -56,6 +56,7 @@ func nonNilCoordinator(t *testing.T) *namespacecleanup.Coordinator {
 		stubLister{},
 		stubLister{},
 		stubLister{},
+		stubLister{},
 		func() bool { return true },
 		logger,
 	)
@@ -68,6 +69,7 @@ type stubLister struct{}
 func (stubLister) ListDeleting() []string                               { return nil }
 func (stubLister) ClassesInNamespace(string) ([]string, error)          { return nil, nil }
 func (stubLister) AliasesInNamespace(string) []string                   { return nil }
+func (stubLister) UsersInNamespace(string) []string                     { return nil }
 func (stubLister) DeleteUsersInNamespace(context.Context, string) error { return nil }
 func (stubLister) DeleteAlias(context.Context, string) (uint64, error) {
 	return 0, nil

--- a/usecases/export/scheduler.go
+++ b/usecases/export/scheduler.go
@@ -157,7 +157,6 @@ func (s *Scheduler) Export(ctx context.Context, principal *models.Principal, id,
 
 	classes = filter.New[string](s.authorizer, s.rbacConfig).Filter(
 		ctx,
-		s.logger,
 		principal,
 		classes,
 		authorization.CREATE,

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -27,8 +27,8 @@
 // path exists, routing the bulk of the work through it is cheaper
 // than duplicating the logic in the request handler.
 //
-// The user delete is re-run on every tick as a safety net in case the
-// handler crashed between marking and the eager drain.
+// The user delete is re-run as a safety net whenever leftover users remain,
+// in case the handler crashed between marking and the eager drain.
 //
 // Every step is a separate replicated command, so any failure is
 // retried on the next tick. Because the coordinator's view of what
@@ -60,6 +60,11 @@ type schemaLister interface {
 	AliasesInNamespace(namespace string) []string
 }
 
+// userLister returns the DB users bound to a namespace.
+type userLister interface {
+	UsersInNamespace(namespace string) []string
+}
+
 // raftExecutor is the subset of cluster.Raft used here.
 type raftExecutor interface {
 	DeleteUsersInNamespace(ctx context.Context, name string) error
@@ -74,6 +79,7 @@ type raftExecutor interface {
 type Coordinator struct {
 	namespaces namespaceLister
 	schema     schemaLister
+	users      userLister
 	raft       raftExecutor
 	isLeader   func() bool
 	logger     logrus.FieldLogger
@@ -83,6 +89,7 @@ type Coordinator struct {
 func NewCoordinator(
 	nsLister namespaceLister,
 	schema schemaLister,
+	users userLister,
 	raft raftExecutor,
 	isLeader func() bool,
 	logger logrus.FieldLogger,
@@ -93,6 +100,9 @@ func NewCoordinator(
 	if schema == nil {
 		panic("namespacecleanup: schema lister must not be nil")
 	}
+	if users == nil {
+		panic("namespacecleanup: user lister must not be nil")
+	}
 	if raft == nil {
 		panic("namespacecleanup: raft executor must not be nil")
 	}
@@ -102,6 +112,7 @@ func NewCoordinator(
 	return &Coordinator{
 		namespaces: nsLister,
 		schema:     schema,
+		users:      users,
 		raft:       raft,
 		isLeader:   isLeader,
 		logger:     logger,
@@ -150,8 +161,11 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if err := c.raft.DeleteUsersInNamespace(ctx, ns); err != nil {
-		return err
+	// Skip the no-op RAFT entry when no users remain to redrain.
+	if len(c.users.UsersInNamespace(ns)) > 0 {
+		if err := c.raft.DeleteUsersInNamespace(ctx, ns); err != nil {
+			return err
+		}
 	}
 	for _, alias := range c.schema.AliasesInNamespace(ns) {
 		if !c.isLeader() {

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -46,6 +46,11 @@ func (s stubSchema) ClassesInNamespace(ns string) ([]string, error) {
 }
 func (s stubSchema) AliasesInNamespace(ns string) []string { return s.aliases[ns] }
 
+// stubUsers returns the configured per-namespace user IDs.
+type stubUsers struct{ users map[string][]string }
+
+func (s stubUsers) UsersInNamespace(ns string) []string { return s.users[ns] }
+
 // recordedCall captures a single RAFT call for ordering assertions.
 type recordedCall struct {
 	op   string
@@ -118,7 +123,15 @@ func newTestCoordinator(t *testing.T,
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
-	return NewCoordinator(nsLister, schema, raft, isLeader, logger)
+	// Default: one user per deleting namespace so the skip-on-empty branch
+	// stays inert. Skip-path tests build the Coordinator directly.
+	users := stubUsers{users: map[string][]string{}}
+	if listing, ok := nsLister.(stubNamespaces); ok {
+		for _, ns := range listing.deleting {
+			users.users[ns] = []string{ns + ":default-user"}
+		}
+	}
+	return NewCoordinator(nsLister, schema, users, raft, isLeader, logger)
 }
 
 func alwaysLeader() bool { return true }
@@ -127,24 +140,27 @@ func TestCoordinator_NewCoordinator_PanicsOnNilArgs(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	nsLister := stubNamespaces{}
 	schema := stubSchema{}
+	users := stubUsers{}
 	raft := newStubRaft()
 
 	tests := []struct {
 		name     string
 		ns       namespaceLister
 		schema   schemaLister
+		users    userLister
 		raft     raftExecutor
 		isLeader func() bool
 	}{
-		{name: "nil namespace lister", ns: nil, schema: schema, raft: raft, isLeader: alwaysLeader},
-		{name: "nil schema lister", ns: nsLister, schema: nil, raft: raft, isLeader: alwaysLeader},
-		{name: "nil raft executor", ns: nsLister, schema: schema, raft: nil, isLeader: alwaysLeader},
-		{name: "nil isLeader", ns: nsLister, schema: schema, raft: raft, isLeader: nil},
+		{name: "nil namespace lister", ns: nil, schema: schema, users: users, raft: raft, isLeader: alwaysLeader},
+		{name: "nil schema lister", ns: nsLister, schema: nil, users: users, raft: raft, isLeader: alwaysLeader},
+		{name: "nil user lister", ns: nsLister, schema: schema, users: nil, raft: raft, isLeader: alwaysLeader},
+		{name: "nil raft executor", ns: nsLister, schema: schema, users: users, raft: nil, isLeader: alwaysLeader},
+		{name: "nil isLeader", ns: nsLister, schema: schema, users: users, raft: raft, isLeader: nil},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Panics(t, func() {
-				NewCoordinator(tc.ns, tc.schema, tc.raft, tc.isLeader, logger)
+				NewCoordinator(tc.ns, tc.schema, tc.users, tc.raft, tc.isLeader, logger)
 			})
 		})
 	}
@@ -163,6 +179,45 @@ func TestCoordinator_Tick_NotLeaderReturnsBeforeAnyCall(t *testing.T) {
 	c := newTestCoordinator(t, ns, stubSchema{}, raft, func() bool { return false })
 	c.Tick(context.Background())
 	assert.Empty(t, raft.calls)
+}
+
+// Safety-net redrain fires only when leftover users remain.
+func TestCoordinator_Tick_RedrainOnlyWhenUsersRemain(t *testing.T) {
+	cases := []struct {
+		name             string
+		users            map[string][]string
+		wantUsersOpFired bool
+	}{
+		{
+			name:             "empty user set skips safety-net redrain",
+			users:            map[string][]string{},
+			wantUsersOpFired: false,
+		},
+		{
+			name:             "leftover users trigger safety-net redrain",
+			users:            map[string][]string{"alpha": {"alpha:leftover"}},
+			wantUsersOpFired: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raft := newStubRaft()
+			ns := stubNamespaces{deleting: []string{"alpha"}}
+			logger, _ := test.NewNullLogger()
+			c := NewCoordinator(ns, stubSchema{}, stubUsers{users: tc.users}, raft, alwaysLeader, logger)
+
+			c.Tick(context.Background())
+
+			fired := false
+			for _, call := range raft.calls {
+				if call.op == "users" {
+					fired = true
+					break
+				}
+			}
+			assert.Equal(t, tc.wantUsersOpFired, fired)
+		})
+	}
 }
 
 func TestCoordinator_Tick_OrderingAcrossPhases(t *testing.T) {

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -74,7 +74,6 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 		for i, nodeS := range status {
 			status[i].Shards = resourceFilter.Filter(
 				ctx,
-				m.logger,
 				principal,
 				nodeS.Shards,
 				authorization.READ,

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -84,7 +84,6 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	resourceFilter := filter.New[*models.Object](m.authorizer, m.config.Config.Authorization.Rbac)
 	filteredObjects := resourceFilter.Filter(
 		ctx,
-		m.logger,
 		principal,
 		objects,
 		authorization.READ,

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -93,7 +93,6 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 
 	filteredQuery := filter.New[*QueryInput](m.authorizer, m.config.Config.Authorization.Rbac).Filter(
 		ctx,
-		m.logger,
 		principal,
 		[]*QueryInput{q},
 		authorization.READ,

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -47,7 +47,6 @@ func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, a
 
 	filteredAliases := filter.New[*models.Alias](h.Authorizer, h.config.Authorization.Rbac).Filter(
 		ctx,
-		h.logger,
 		principal,
 		aliases,
 		authorization.READ,

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -306,7 +306,6 @@ func (h *Handler) GetConsistentSchema(ctx context.Context, principal *models.Pri
 
 	filteredClasses := filter.New[*models.Class](h.Authorizer, h.config.Authorization.Rbac).Filter(
 		ctx,
-		h.logger,
 		principal,
 		fullSchema.Objects.Classes,
 		authorization.READ,

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -215,7 +215,7 @@ func QualifyPropertyDataTypes(
 // or short input). A foreign prefix is left intact so downstream
 // ValidateClassName fails closed on the embedded ":".
 func StripOwnNamespace(principal *models.Principal, name string) string {
-	if principal == nil || principal.Namespace == "" {
+	if principal == nil || principal.IsGlobalOperator || principal.Namespace == "" {
 		return name
 	}
 	return strings.TrimPrefix(name, principal.Namespace+schema.NamespaceSeparator)
@@ -228,7 +228,7 @@ func StripOwnNamespace(principal *models.Principal, name string) string {
 // pass-through. The input is never mutated: callers can safely pass cached
 // schema pointers without affecting concurrent readers.
 func StripClassResponse(principal *models.Principal, src *models.Class) *models.Class {
-	if src == nil || principal == nil || principal.Namespace == "" {
+	if src == nil || principal == nil || principal.IsGlobalOperator || principal.Namespace == "" {
 		return src
 	}
 	out := *src
@@ -247,7 +247,7 @@ func StripClassResponse(principal *models.Principal, src *models.Class) *models.
 // namespace prefix. Primitive types (text, int, …) never carry a namespace
 // prefix, so StripOwnNamespace is a no-op on them. The input is never mutated.
 func StripPropertyResponse(principal *models.Principal, src *models.Property) *models.Property {
-	if src == nil || principal == nil || principal.Namespace == "" {
+	if src == nil || principal == nil || principal.IsGlobalOperator || principal.Namespace == "" {
 		return src
 	}
 	out := *src
@@ -292,7 +292,7 @@ func stripDataTypes(principal *models.Principal, src []string) []string {
 // mutated: callers can safely pass cached schema pointers without affecting
 // concurrent readers.
 func StripAliasResponse(principal *models.Principal, src *models.Alias) *models.Alias {
-	if src == nil || principal == nil || principal.Namespace == "" {
+	if src == nil || principal == nil || principal.IsGlobalOperator || principal.Namespace == "" {
 		return src
 	}
 	out := *src
@@ -306,7 +306,7 @@ func StripAliasResponse(principal *models.Principal, src *models.Alias) *models.
 // objects manager — there are no shared pointers to protect — so in-place
 // mutation is safe.
 func StripObjectResponseClass(principal *models.Principal, obj *models.Object) {
-	if obj == nil || principal == nil || principal.Namespace == "" {
+	if obj == nil || principal == nil || principal.IsGlobalOperator || principal.Namespace == "" {
 		return
 	}
 	obj.Class = StripOwnNamespace(principal, obj.Class)
@@ -316,7 +316,7 @@ func StripObjectResponseClass(principal *models.Principal, obj *models.Object) {
 // "<namespace>:" prefix from msg. Returns msg unchanged when principal is
 // nil or has no namespace.
 func StripErrorMessage(principal *models.Principal, msg string) string {
-	if principal == nil || principal.Namespace == "" {
+	if principal == nil || principal.IsGlobalOperator || principal.Namespace == "" {
 		return msg
 	}
 	return strings.ReplaceAll(msg, principal.Namespace+schema.NamespaceSeparator, "")

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -1099,6 +1099,42 @@ func TestStripOwnNamespace(t *testing.T) {
 	}
 }
 
+// TestStripHelpers_GlobalOperatorDominatesNamespace pins that every strip
+// helper short-circuits when IsGlobalOperator=true, even if Namespace is set.
+// Today's invariant is "globals have empty namespace"; this gate makes the
+// helpers safe if that invariant ever drifts.
+func TestStripHelpers_GlobalOperatorDominatesNamespace(t *testing.T) {
+	op := &models.Principal{Username: "admin", IsGlobalOperator: true, Namespace: "customer1"}
+
+	t.Run("StripOwnNamespace", func(t *testing.T) {
+		assert.Equal(t, "customer1:Movies", StripOwnNamespace(op, "customer1:Movies"))
+	})
+	t.Run("StripErrorMessage", func(t *testing.T) {
+		assert.Equal(t, "class customer1:Movies not found",
+			StripErrorMessage(op, "class customer1:Movies not found"))
+	})
+	t.Run("StripClassResponse", func(t *testing.T) {
+		got := StripClassResponse(op, &models.Class{Class: "customer1:Movies"})
+		assert.Equal(t, "customer1:Movies", got.Class)
+	})
+	t.Run("StripPropertyResponse", func(t *testing.T) {
+		got := StripPropertyResponse(op, &models.Property{
+			Name: "ref", DataType: []string{"customer1:Movies"},
+		})
+		assert.Equal(t, []string{"customer1:Movies"}, got.DataType)
+	})
+	t.Run("StripAliasResponse", func(t *testing.T) {
+		got := StripAliasResponse(op, &models.Alias{Alias: "customer1:Films", Class: "customer1:Movies"})
+		assert.Equal(t, "customer1:Films", got.Alias)
+		assert.Equal(t, "customer1:Movies", got.Class)
+	})
+	t.Run("StripObjectResponseClass", func(t *testing.T) {
+		obj := &models.Object{Class: "customer1:Movies"}
+		StripObjectResponseClass(op, obj)
+		assert.Equal(t, "customer1:Movies", obj.Class)
+	})
+}
+
 func TestQualifyRefTarget(t *testing.T) {
 	ns := &models.Principal{Username: "u", Namespace: "customer1"}
 	admin := &models.Principal{Username: "admin"}

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -301,8 +301,12 @@ func (h *Handler) DeleteClassVectorIndex(ctx context.Context, principal *models.
 func (h *Handler) DeleteClassProperty(ctx context.Context, principal *models.Principal,
 	class string, property string,
 ) error {
-	err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(class)...)
+	class, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
 	if err != nil {
+		return err
+	}
+
+	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(class)...); err != nil {
 		return err
 	}
 

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -1112,6 +1112,62 @@ func TestDeleteClassPropertyIndex_Namespacing(t *testing.T) {
 	}
 }
 
+// TestDeleteClassProperty_Namespacing pins that DeleteClassProperty qualifies
+// the class before authorize. The handler itself returns a stub "not supported"
+// error on the happy path (see https://github.com/weaviate/weaviate/issues/973),
+// so a non-stub error proves the qualify step rejected the input first.
+func TestDeleteClassProperty_Namespacing(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name            string
+		enabled         bool
+		principal       *models.Principal
+		inputName       string
+		wantErrContains string
+	}{
+		{
+			name:            "namespaced short input reaches stub after qualify+authorize",
+			enabled:         true,
+			principal:       namespacedPrincipal("customer1"),
+			inputName:       "Movies",
+			wantErrContains: "not supported",
+		},
+		{
+			name:            "namespaced qualified input is rejected by QualifyClass",
+			enabled:         true,
+			principal:       namespacedPrincipal("customer1"),
+			inputName:       "customer1:Movies",
+			wantErrContains: "is not a valid class name",
+		},
+		{
+			name:            "global qualified input reaches stub",
+			enabled:         true,
+			principal:       globalPrincipal(),
+			inputName:       "customer1:Movies",
+			wantErrContains: "not supported",
+		},
+		{
+			name:            "namespaces disabled reaches stub",
+			enabled:         false,
+			principal:       nil,
+			inputName:       "Movies",
+			wantErrContains: "not supported",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, _ := newTestHandlerWithNamespaces(t, tt.enabled)
+
+			err := handler.DeleteClassProperty(context.Background(), tt.principal,
+				tt.inputName, "title")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErrContains)
+		})
+	}
+}
+
 // TestDeleteClassPropertyIndex_NoLocalMutationOnUpdatePropertyError pins
 // the regression fixed in PR https://github.com/weaviate/weaviate/pull/11320 after Copilot's review on
 // `cluster/schema/manager.go:520`:

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -1112,10 +1112,9 @@ func TestDeleteClassPropertyIndex_Namespacing(t *testing.T) {
 	}
 }
 
-// TestDeleteClassProperty_Namespacing pins that DeleteClassProperty qualifies
-// the class before authorize. The handler itself returns a stub "not supported"
-// error on the happy path (see https://github.com/weaviate/weaviate/issues/973),
-// so a non-stub error proves the qualify step rejected the input first.
+// TestDeleteClassProperty_Namespacing pins that QualifyClass runs before
+// Authorize; the handler is stubbed (#973), so a non-stub error means the
+// qualify step rejected the input.
 func TestDeleteClassProperty_Namespacing(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -289,7 +289,6 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	resourceFilter := filter.New[*models.Tenant](h.Authorizer, h.config.Authorization.Rbac)
 	filteredTenants := resourceFilter.Filter(
 		ctx,
-		h.logger,
 		principal,
 		allTenants,
 		authorization.READ,


### PR DESCRIPTION
### What's being changed:

This PR fixes a couple of smaller issues that I found during a review:
- Fix auth and namespace resolving order for DeleteClassProperty. Before this commit we would auth on the unqualified class name
- Remove duplicated RBAC log messages
- Use global operator member to detect operators
- Only try to delete users in namespace cleanup if there are any users
- Add reference response stipping as defense in depth
- Add date insertion vs namespace deletion stress test

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
