### PR TITLE
test(reindex-multinode): use atomic Container.Restart for rolling-restart cycles

### DIFF
--- a/test/acceptance/reindex_multinode/finalizing_crash_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_crash_test.go
@@ -270,13 +270,8 @@ func TestMultiNode_UngracefulStopDuringFinalizing_PerReplicaConsistency(t *testi
 			"Consider increasing totalObjects to widen the window.")
 	}
 
-	// Kill + restart node 3 ungracefully — `docker restart -t 0` sends
-	// SIGKILL immediately, skipping the on-shutdown bucket flush. This
-	// is the k8s OOM / node-hardware-failure shape. The post-restart
-	// path must reconcile node 3's half-finalized .migrations/ directory
-	// and re-emit the ack via the rehydrate path if its pre-kill ack
-	// hadn't landed in RAFT.
-	t.Log("SIGKILL + restart node 3 (timeout=0)")
+	// SIGKILL + restart node 3 — k8s OOM / node-hardware-failure shape.
+	t.Log("SIGKILL + restart node 3")
 	cycleNodeFastKill(ctx, t, compose, 2)
 
 	// Wait for FINISHED. Without the ack barrier, the schema flip

--- a/test/acceptance/reindex_multinode/finalizing_crash_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_crash_test.go
@@ -270,18 +270,14 @@ func TestMultiNode_UngracefulStopDuringFinalizing_PerReplicaConsistency(t *testi
 			"Consider increasing totalObjects to widen the window.")
 	}
 
-	// Kill node 3 ungracefully — 0s timeout means Docker SIGKILLs
-	// immediately, skipping the on-shutdown bucket flush. This is the
-	// k8s OOM / node-hardware-failure shape.
-	killTimeout := 0 * time.Second
-	t.Log("SIGKILL on node 3 (timeout=0)")
-	require.NoError(t, compose.StopAt(ctx, 2, &killTimeout))
-
-	// Restart node 3. The post-restart path must reconcile its
-	// half-finalized .migrations/ directory and re-emit the ack via
-	// the rehydrate path if its pre-kill ack hadn't landed in RAFT.
-	t.Log("restarting node 3")
-	require.NoError(t, compose.StartAt(ctx, 2))
+	// Kill + restart node 3 ungracefully — `docker restart -t 0` sends
+	// SIGKILL immediately, skipping the on-shutdown bucket flush. This
+	// is the k8s OOM / node-hardware-failure shape. The post-restart
+	// path must reconcile node 3's half-finalized .migrations/ directory
+	// and re-emit the ack via the rehydrate path if its pre-kill ack
+	// hadn't landed in RAFT.
+	t.Log("SIGKILL + restart node 3 (timeout=0)")
+	cycleNodeFastKill(ctx, t, compose, 2)
 
 	// Wait for FINISHED. Without the ack barrier, the schema flip
 	// could already have committed before the kill, leaving node 3

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -541,6 +541,41 @@ func restartCluster(ctx context.Context, t *testing.T, compose *docker.DockerCom
 	rollingRestartCluster(ctx, t, compose)
 }
 
+// cycleNodeFast restarts the node at nodeIdx atomically via the Docker
+// daemon's restart endpoint and waits for /v1/.well-known/ready. Use this
+// when a test just needs a clean restart cycle.
+//
+// Compared to compose.StopAt + compose.StartAt, this skips StopAt's
+// memberlist-departure poll (a 30s wait for the cluster to mark the node
+// unhealthy via /v1/nodes). That convergence is unnecessary for most
+// reindex tests — they just need the process down and back up — and the
+// 30s exited-state window has been observed to let the testcontainers
+// reaper remove the container, producing "No such container" on
+// StartAt. The daemon-side `docker restart` transitions exited → running
+// in one step, so the reaper never sees a long-stopped container.
+//
+// Use StopAt + StartAt instead when the test specifically needs cluster
+// membership to converge on "node X unhealthy" before proceeding (for
+// example, consistency_level=ALL writes against the remaining nodes
+// mid-restart).
+func cycleNodeFast(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int) {
+	t.Helper()
+	require.NoErrorf(t, compose.RestartAt(ctx, nodeIdx, nil),
+		"cycleNodeFast: restart node at index %d", nodeIdx)
+}
+
+// cycleNodeFastKill is the SIGKILL variant of cycleNodeFast — used by
+// crash-path tests that need to bypass the on-shutdown bucket flush.
+// `docker restart -t 0` sends SIGKILL immediately, matching
+// compose.StopAt(ctx, _, &killTimeout) semantics for the kill-then-resume
+// shape.
+func cycleNodeFastKill(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int) {
+	t.Helper()
+	zero := 0 * time.Second
+	require.NoErrorf(t, compose.RestartAt(ctx, nodeIdx, &zero),
+		"cycleNodeFastKill: restart (SIGKILL) node at index %d", nodeIdx)
+}
+
 // rollingRestartCluster stops + restarts each node ONE AT A TIME,
 // waiting for the node to be ready (and for RAFT to accept writes
 // again) before moving on. Mimics a Kubernetes StatefulSet rolling
@@ -554,12 +589,18 @@ func restartCluster(ctx context.Context, t *testing.T, compose *docker.DockerCom
 // promoted canonical dir is present on disk. That manifested as a
 // per-replica `[6 6 0]`/`[0 0 0]` failure that looks identical to the
 // real #10675 prod data-loss bug but is just a missing test barrier.
+//
+// Uses cycleNodeFast so the per-node restart is atomic at the daemon
+// level — the testcontainers reaper does not see a long-stopped
+// container during the cycle. The follow-up `/v1/.well-known/ready` poll
+// is layered on top to wait for FinalizeCompletedMigrations and
+// shard-init to complete; RestartAt's own readiness wait covers the
+// process being up, but tests assert on routing being live too.
 func rollingRestartCluster(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
 	t.Helper()
 	for i := 1; i <= 3; i++ {
 		t.Logf("rolling restart: cycling node %d", i)
-		require.NoErrorf(t, compose.StopAt(ctx, i-1, nil), "stop node %d", i)
-		require.NoErrorf(t, compose.StartAt(ctx, i-1), "start node %d", i)
+		cycleNodeFast(ctx, t, compose, i-1)
 
 		// Wait for this node's HTTP endpoint to respond before moving
 		// on. tryGetSchema is cheap and exercises the same routing

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -541,34 +541,18 @@ func restartCluster(ctx context.Context, t *testing.T, compose *docker.DockerCom
 	rollingRestartCluster(ctx, t, compose)
 }
 
-// cycleNodeFast restarts the node at nodeIdx atomically via the Docker
-// daemon's restart endpoint and waits for /v1/.well-known/ready. Use this
-// when a test just needs a clean restart cycle.
-//
-// Compared to compose.StopAt + compose.StartAt, this skips StopAt's
-// memberlist-departure poll (a 30s wait for the cluster to mark the node
-// unhealthy via /v1/nodes). That convergence is unnecessary for most
-// reindex tests — they just need the process down and back up — and the
-// 30s exited-state window has been observed to let the testcontainers
-// reaper remove the container, producing "No such container" on
-// StartAt. The daemon-side `docker restart` transitions exited → running
-// in one step, so the reaper never sees a long-stopped container.
-//
-// Use StopAt + StartAt instead when the test specifically needs cluster
-// membership to converge on "node X unhealthy" before proceeding (for
-// example, consistency_level=ALL writes against the remaining nodes
-// mid-restart).
+// cycleNodeFast restarts a node via `docker restart` and waits for
+// /v1/.well-known/ready. Use compose.StopAt + StartAt instead when the
+// test needs cluster membership to converge on "node X unhealthy" first
+// (e.g. consistency_level=ALL writes mid-restart). See weaviate/0-weaviate-issues#254.
 func cycleNodeFast(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int) {
 	t.Helper()
 	require.NoErrorf(t, compose.RestartAt(ctx, nodeIdx, nil),
 		"cycleNodeFast: restart node at index %d", nodeIdx)
 }
 
-// cycleNodeFastKill is the SIGKILL variant of cycleNodeFast — used by
-// crash-path tests that need to bypass the on-shutdown bucket flush.
-// `docker restart -t 0` sends SIGKILL immediately, matching
-// compose.StopAt(ctx, _, &killTimeout) semantics for the kill-then-resume
-// shape.
+// cycleNodeFastKill is cycleNodeFast with SIGKILL (`docker restart -t 0`).
+// For crash-path tests that need to bypass the on-shutdown bucket flush.
 func cycleNodeFastKill(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int) {
 	t.Helper()
 	zero := 0 * time.Second
@@ -589,13 +573,6 @@ func cycleNodeFastKill(ctx context.Context, t *testing.T, compose *docker.Docker
 // promoted canonical dir is present on disk. That manifested as a
 // per-replica `[6 6 0]`/`[0 0 0]` failure that looks identical to the
 // real #10675 prod data-loss bug but is just a missing test barrier.
-//
-// Uses cycleNodeFast so the per-node restart is atomic at the daemon
-// level — the testcontainers reaper does not see a long-stopped
-// container during the cycle. The follow-up `/v1/.well-known/ready` poll
-// is layered on top to wait for FinalizeCompletedMigrations and
-// shard-init to complete; RestartAt's own readiness wait covers the
-// process being up, but tests assert on routing being live too.
 func rollingRestartCluster(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
 	t.Helper()
 	for i := 1; i <= 3; i++ {

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -85,10 +85,13 @@ func assertReindexCompleteAndConsistent(
 }
 
 // timeout=nil → graceful SIGTERM; non-nil → SIGKILL after expiry.
+//
+// Routes through RestartAt (one atomic daemon-side stop+start) instead of
+// StopAt+StartAt so the testcontainers reaper cannot remove the container
+// during a 30s memberlist-departure poll. See cycleNodeFast godoc.
 func stopStart(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int, timeout *time.Duration) {
 	t.Helper()
-	require.NoError(t, compose.StopAt(ctx, nodeIdx, timeout))
-	require.NoError(t, compose.StartAt(ctx, nodeIdx))
+	require.NoError(t, compose.RestartAt(ctx, nodeIdx, timeout))
 }
 
 func runRestartDuringReindex(
@@ -144,6 +147,13 @@ func TestMultiNode_CrashDuringReindex(t *testing.T) {
 func TestMultiNode_MajorityCrashDuringReindex(t *testing.T) {
 	runRestartDuringReindex(t, "MajorityCrash", 360*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
+			// Intentionally StopAt + StartAt (not RestartAt): this is an
+			// ordered TWO-node down → TWO-node up sequence to lose then
+			// restore RAFT quorum. RestartAt collapses stop+start into one
+			// daemon transition, so it cannot express "both nodes down at
+			// the same time". The reaper-removal risk is bounded here too
+			// because the cluster loses quorum within seconds; the surviving
+			// node has nothing to converge to in StopAt's membership poll.
 			require.NoError(t, compose.StopAt(ctx, 2, &sigkillFast))
 			require.NoError(t, compose.StopAt(ctx, 1, &sigkillFast))
 			// Node 2 first → restores quorum with node 1 before node 3.
@@ -188,10 +198,8 @@ func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 
 	// Rolling restart all 3 nodes one at a time.
 	for nodeIdx := 0; nodeIdx < 3; nodeIdx++ {
-		t.Logf("rolling restart: stopping node %d", nodeIdx+1)
-		require.NoError(t, compose.StopAt(ctx, nodeIdx, nil))
-		t.Logf("rolling restart: starting node %d", nodeIdx+1)
-		require.NoError(t, compose.StartAt(ctx, nodeIdx))
+		t.Logf("rolling restart: cycling node %d", nodeIdx+1)
+		cycleNodeFast(ctx, t, compose, nodeIdx)
 
 		// After restart, verify queries on the restarted node.
 		// Re-fetch URI since port mapping may change after restart.

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -85,10 +85,6 @@ func assertReindexCompleteAndConsistent(
 }
 
 // timeout=nil → graceful SIGTERM; non-nil → SIGKILL after expiry.
-//
-// Routes through RestartAt (one atomic daemon-side stop+start) instead of
-// StopAt+StartAt so the testcontainers reaper cannot remove the container
-// during a 30s memberlist-departure poll. See cycleNodeFast godoc.
 func stopStart(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int, timeout *time.Duration) {
 	t.Helper()
 	require.NoError(t, compose.RestartAt(ctx, nodeIdx, timeout))
@@ -147,13 +143,8 @@ func TestMultiNode_CrashDuringReindex(t *testing.T) {
 func TestMultiNode_MajorityCrashDuringReindex(t *testing.T) {
 	runRestartDuringReindex(t, "MajorityCrash", 360*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-			// Intentionally StopAt + StartAt (not RestartAt): this is an
-			// ordered TWO-node down → TWO-node up sequence to lose then
-			// restore RAFT quorum. RestartAt collapses stop+start into one
-			// daemon transition, so it cannot express "both nodes down at
-			// the same time". The reaper-removal risk is bounded here too
-			// because the cluster loses quorum within seconds; the surviving
-			// node has nothing to converge to in StopAt's membership poll.
+			// StopAt+StartAt (not RestartAt) — needs both nodes down at
+			// the same time to lose RAFT quorum.
 			require.NoError(t, compose.StopAt(ctx, 2, &sigkillFast))
 			require.NoError(t, compose.StopAt(ctx, 1, &sigkillFast))
 			// Node 2 first → restores quorum with node 1 before node 3.

--- a/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
@@ -265,9 +265,8 @@ func TestMultiNode_ChangeTokenization_RestartThenRoundTrip(t *testing.T) {
 	// Restart every node, one at a time, so FinalizeCompletedMigrations
 	// runs on each node's shard init.
 	for nodeIdx := 0; nodeIdx < 3; nodeIdx++ {
-		t.Logf("restarting node %d between rounds", nodeIdx+1)
-		require.NoError(t, compose.StopAt(ctx, nodeIdx, nil))
-		require.NoError(t, compose.StartAt(ctx, nodeIdx))
+		t.Logf("cycling node %d between rounds", nodeIdx+1)
+		cycleNodeFast(ctx, t, compose, nodeIdx)
 
 		restartedURI := compose.GetWeaviateNode(nodeIdx + 1).URI()
 		require.Eventually(t, func() bool {

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -203,7 +203,17 @@ func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *t
 
 	args := []string{"restart"}
 	if timeout != nil {
-		args = append(args, "-t", fmt.Sprintf("%d", int(timeout.Seconds())))
+		if *timeout < 0 {
+			return fmt.Errorf("RestartAt[%s]: negative timeout %s", c.name, *timeout)
+		}
+		// docker -t is integer seconds. Round a non-zero sub-second
+		// timeout up to 1s — truncating e.g. 500ms to 0 would force an
+		// unintended SIGKILL. An explicit 0 stays 0 (intentional SIGKILL).
+		secs := int(timeout.Seconds())
+		if *timeout > 0 && secs == 0 {
+			secs = 1
+		}
+		args = append(args, "-t", fmt.Sprintf("%d", secs))
 	}
 	args = append(args, containerID)
 	cmd := exec.CommandContext(ctx, "docker", args...)

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -191,29 +191,9 @@ func (d *DockerCompose) StartAt(ctx context.Context, nodeIndex int) error {
 	return nil
 }
 
-// RestartAt restarts the container at nodeIndex atomically via the Docker
-// daemon's restart endpoint (shell out to `docker restart`) and then
-// re-resolves its mapped host ports and waits for /v1/.well-known/ready.
-//
-// timeout controls the graceful-stop window before SIGKILL — nil uses
-// Docker's default (10s SIGTERM grace), and a non-nil pointer is passed
-// through as `-t <seconds>`. Passing &zero (0s) forces an immediate
-// SIGKILL, matching StopAt(ctx, _, &killTimeout) semantics for crash-path
-// tests.
-//
-// Compared to StopAt+StartAt, this skips the memberlist-departure poll in
-// StopAt. The daemon-side restart goes exited → running in one transition
-// from the daemon's perspective, so the testcontainers reaper (Ryuk) is
-// never given a window to observe a long-stopped container and remove it.
-// That is the failure mode this helper is designed to avoid; the reaper
-// has been observed to remove a Weaviate container during the 30s
-// convergence wait, causing a subsequent StartAt to fail with
-// "No such container".
-//
-// Use this when a test just needs a clean restart cycle. Use StopAt +
-// StartAt if the test specifically needs cluster membership to converge on
-// "node X unhealthy" before proceeding (for example, consistency_level=ALL
-// writes against the remaining nodes mid-restart).
+// RestartAt restarts a container via `docker restart` and waits for
+// /v1/.well-known/ready. timeout=nil uses Docker's default SIGTERM grace;
+// &zero forces SIGKILL. See weaviate/0-weaviate-issues#254.
 func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *time.Duration) error {
 	if nodeIndex >= len(d.containers) {
 		return errors.Errorf("node index is greater than available nodes")
@@ -221,9 +201,6 @@ func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *t
 	c := d.containers[nodeIndex]
 	containerID := c.container.GetContainerID()
 
-	// `docker restart` is atomic at the daemon level: the container goes
-	// through stop → start in one daemon-side transition. No client-side
-	// gap during which an external observer (reaper) can remove it.
 	args := []string{"restart"}
 	if timeout != nil {
 		args = append(args, "-t", fmt.Sprintf("%d", int(timeout.Seconds())))
@@ -235,9 +212,6 @@ func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *t
 			c.name, containerID, err, string(out))
 	}
 
-	// Re-resolve mapped host ports. Port bindings survive a Docker
-	// restart in practice, but this mirrors StartAt's behaviour and
-	// guards against any caller that cached an old endpoint string.
 	endPoints := map[EndpointName]endpoint{}
 	for name, e := range c.endpoints {
 		newURI, err := c.container.PortEndpoint(ctx, nat.Port(e.port), "")

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -191,6 +191,75 @@ func (d *DockerCompose) StartAt(ctx context.Context, nodeIndex int) error {
 	return nil
 }
 
+// RestartAt restarts the container at nodeIndex atomically via the Docker
+// daemon's restart endpoint (shell out to `docker restart`) and then
+// re-resolves its mapped host ports and waits for /v1/.well-known/ready.
+//
+// timeout controls the graceful-stop window before SIGKILL — nil uses
+// Docker's default (10s SIGTERM grace), and a non-nil pointer is passed
+// through as `-t <seconds>`. Passing &zero (0s) forces an immediate
+// SIGKILL, matching StopAt(ctx, _, &killTimeout) semantics for crash-path
+// tests.
+//
+// Compared to StopAt+StartAt, this skips the memberlist-departure poll in
+// StopAt. The daemon-side restart goes exited → running in one transition
+// from the daemon's perspective, so the testcontainers reaper (Ryuk) is
+// never given a window to observe a long-stopped container and remove it.
+// That is the failure mode this helper is designed to avoid; the reaper
+// has been observed to remove a Weaviate container during the 30s
+// convergence wait, causing a subsequent StartAt to fail with
+// "No such container".
+//
+// Use this when a test just needs a clean restart cycle. Use StopAt +
+// StartAt if the test specifically needs cluster membership to converge on
+// "node X unhealthy" before proceeding (for example, consistency_level=ALL
+// writes against the remaining nodes mid-restart).
+func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *time.Duration) error {
+	if nodeIndex >= len(d.containers) {
+		return errors.Errorf("node index is greater than available nodes")
+	}
+	c := d.containers[nodeIndex]
+	containerID := c.container.GetContainerID()
+
+	// `docker restart` is atomic at the daemon level: the container goes
+	// through stop → start in one daemon-side transition. No client-side
+	// gap during which an external observer (reaper) can remove it.
+	args := []string{"restart"}
+	if timeout != nil {
+		args = append(args, "-t", fmt.Sprintf("%d", int(timeout.Seconds())))
+	}
+	args = append(args, containerID)
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("RestartAt[%s]: docker restart %s failed: %w (output: %s)",
+			c.name, containerID, err, string(out))
+	}
+
+	// Re-resolve mapped host ports. Port bindings survive a Docker
+	// restart in practice, but this mirrors StartAt's behaviour and
+	// guards against any caller that cached an old endpoint string.
+	endPoints := map[EndpointName]endpoint{}
+	for name, e := range c.endpoints {
+		newURI, err := c.container.PortEndpoint(ctx, nat.Port(e.port), "")
+		if err != nil {
+			return fmt.Errorf("RestartAt[%s]: failed to resolve port %s: %w",
+				c.name, e.port, err)
+		}
+		endPoints[name] = endpoint{e.port, newURI}
+
+		if name != HTTP {
+			continue
+		}
+		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port))
+		if err := waitStrategy.WaitUntilReady(ctx, c.container); err != nil {
+			return fmt.Errorf("RestartAt[%s]: readiness check /v1/.well-known/ready failed: %w",
+				c.name, err)
+		}
+	}
+	c.endpoints = endPoints
+	return nil
+}
+
 func (d *DockerCompose) ContainerURI(index int) string {
 	return d.containers[index].URI()
 }


### PR DESCRIPTION
## Problem

`TestMultiNode_DeleteRecreateCleansReindexTasks` fails in the kpop-flake soak with `No such container: <id>` on container start (soak log dated `20260528T071324Z`). The reindex helper does `compose.StopAt() + StartAt()`, and `StopAt` polls a surviving node's `/v1/nodes` for up to 30 s waiting for memberlist to mark the stopped node unhealthy (`test/docker/docker.go:114-127`). During that 30 s window the test holds a reference to the stopped container — long enough for testcontainers' ryuk reaper (or another cleanup) to act. The reindex tests don't need that convergence wait; they just want a clean restart cycle.

## Change

- New `compose.RestartAt(ctx, nodeIdx, *time.Duration)` in `test/docker/docker.go` — `docker restart` shell-out (testcontainers-go v0.39/v0.41 doesn't expose `Container.Restart`), then re-resolve mapped ports and wait for `/v1/.well-known/ready`. Does not touch `StopAt`.
- New helpers in `reindex_multinode/helpers_test.go`: `cycleNodeFast` (graceful) and `cycleNodeFastKill` (SIGKILL semantics).
- Migrated reindex_multinode callers: `rollingRestartCluster`, `stopStart`, `TestMultiNode_RollingRestartAfterComplete`, `finalizing_crash_test.go` (SIGKILL path), `round_trip_adjacent_test.go`.

## Not migrated

- `TestMultiNode_MajorityCrashDuringReindex` (`restart_test.go:144-153`) — stops two nodes simultaneously; atomic restart can't express that. In-line comment explains.
- `reindex_concurrent`, `reindex_mt`, `reindex_backup`, `reindex_singlenode` — out of scope.

## Validation

Local: `go vet` + `gofmt` clean; build clean. Local `go test -count=10 -run …DeleteRecreate…` and `-count=5 -run …RestartMatrix…` not completed — Docker subnet `10.99.0.0/16` and build cache were occupied by a parallel agent's run when the validator launched. CI shards will exercise the migrated tests; opening as **draft** until CI confirms green.

Authored by QA Claude on Etienne's instruction.
