### PR TITLE
fix(reindex-tests): plant torn sentinels across restart boundary

### DIFF
--- a/test/acceptance/reindex_singlenode/suite_test.go
+++ b/test/acceptance/reindex_singlenode/suite_test.go
@@ -252,7 +252,7 @@ func TestSingleNode_ReindexSuite(t *testing.T) {
 	// either finish the swap or rebuild from scratch. If RED, schema
 	// reports ready while queries return zero hits (Sev 1).
 	t.Run("TornResumeReindexedNotTidied", func(t *testing.T) {
-		testTornResumeReindexedNotTidied(t, restURI, compose)
+		testTornResumeReindexedNotTidied(t, compose)
 	})
 
 	// --- Shared restart: verify all deferred finalizations ---

--- a/test/acceptance/reindex_singlenode/suite_test.go
+++ b/test/acceptance/reindex_singlenode/suite_test.go
@@ -252,7 +252,7 @@ func TestSingleNode_ReindexSuite(t *testing.T) {
 	// either finish the swap or rebuild from scratch. If RED, schema
 	// reports ready while queries return zero hits (Sev 1).
 	t.Run("TornResumeReindexedNotTidied", func(t *testing.T) {
-		testTornResumeReindexedNotTidied(t, restURI, container)
+		testTornResumeReindexedNotTidied(t, restURI, compose)
 	})
 
 	// --- Shared restart: verify all deferred finalizations ---

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -255,34 +255,18 @@ func testTornResumeEnableFilterable(t *testing.T, restURI string, compose *docke
 		tornResumeObjectCount, hits)
 }
 
-// plantTornSentinelsAcrossRestart plants the on-disk sentinel files that
-// simulate a prior reindex run which reached markReindexed() and then
-// crashed before any of the swap-phase sentinels were written, then restarts
-// the weaviate container. Specifically the layout written is:
+// plantTornSentinelsAcrossRestart plants the on-disk sentinel files for a
+// run that reached markReindexed() and then crashed before any swap-phase
+// sentinel was written, then restarts the container. Layout:
 //
 //	.migrations/<migDir>/started.mig    — RFC3339Nano timestamp
 //	.migrations/<migDir>/reindexed.mig  — RFC3339Nano timestamp
 //	.migrations/<migDir>/properties.mig — comma-joined prop names
 //
-// This is the shape a real failure-mid-runtimeSwap would leave behind.
-// We do NOT plant __reindex / __ingest sidecar dirs; the legitimate
-// resume path should create or load them via CreateOrLoadBucket and
-// re-iterate.
-//
-// The function follows a strict stop → plant → start sequence because the
-// naive plant-while-running approach raced with the server's async
-// cleanStaleMigrationDirs(prop, indexType) call from
-// adapters/repos/db/shard_init_properties.go (lines 134-152, 336): the
-// cleaner walks every property × indexType pair during shard init and
-// deletes .migrations/<dir> for the pairs that don't match the freshly-
-// created class's current shape. The test's printf could then land in a
-// now-disappeared directory and exit 1, triggering a Zero-exit-code
-// assertion failure inside the per-file loop. Stopping the server first
-// closes the only writer to the .migrations tree, so the plant happens on
-// an at-rest filesystem with no concurrent mutator.
-//
-// Returns the new REST URI (the host port mapping changes across container
-// restart). The global helper.SetupClient is also refreshed.
+// Stop → plant → start avoids racing the server's async
+// cleanStaleMigrationDirs (shard_init_properties.go:134-152, 336); see
+// weaviate/0-weaviate-issues#254. Returns the new REST URI; host port
+// mapping changes across restart.
 func plantTornSentinelsAcrossRestart(
 	t *testing.T,
 	compose *docker.DockerCompose,
@@ -294,28 +278,16 @@ func plantTornSentinelsAcrossRestart(
 
 	container := compose.GetWeaviate().Container()
 
-	// Locate the shard while the server is up — the lookup needs the LSM
-	// layout to be visible, and we want a fast fail if it isn't. The path
-	// is stable across the restart because the data dir lives inside the
-	// container's writable layer (not a fresh tmpfs on restart).
+	// Locate the shard while the server is up — path is stable across restart.
 	shardPath := findShardPathInContainer(t, container, class)
 	containerMigDir := fmt.Sprintf("%s/lsm/.migrations/%s", shardPath, migDir)
 	lsmPath := fmt.Sprintf("%s/lsm", shardPath)
 
-	// Stop the weaviate container gracefully. nil timeout uses Docker's
-	// default (10s) SIGTERM grace period — long enough for in-flight RAFT
-	// barriers and LSM flushes to drain so the filesystem is quiescent
-	// before we touch it.
 	require.NoError(t, compose.StopAt(ctx, 0, nil),
 		"plantTornSentinelsAcrossRestart: graceful stop before planting must succeed")
 
-	// Build a host-side staging dir matching the in-container target layout
-	// (<lsm>/.migrations/<migDir>/{started,reindexed,properties}.mig) and
-	// ship it across via CopyDirToContainer. docker exec is not an option
-	// against a stopped container; CopyDirToContainer uses Docker's archive
-	// API, which works on stopped containers and includes parent directory
-	// entries in the tar so the intermediate ".migrations" and "<migDir>"
-	// dirs are created if absent.
+	// CopyDirToContainer works against stopped containers via Docker's archive
+	// API; docker exec does not.
 	stagingRoot := t.TempDir()
 	stagedDotMigrations := filepath.Join(stagingRoot, ".migrations")
 	stagedMigDir := filepath.Join(stagedDotMigrations, migDir)
@@ -334,35 +306,21 @@ func plantTornSentinelsAcrossRestart(
 			"plantTornSentinelsAcrossRestart: staging %s on host must succeed", fname)
 	}
 
-	// CopyDirToContainer extracts the contents of stagedDotMigrations into
-	// filepath.Dir(containerParentPath). Pointing containerParentPath at
-	// <lsm>/.migrations therefore extracts at <lsm>/, materialising
-	// .migrations/<migDir>/*.mig. <lsm>/ exists because the shard has been
-	// fully initialised, including LSM root creation, before this call.
-	//
-	// Mode is 0o755: testcontainers applies the same mode to every entry in
-	// the tarball (files + directories), so we need the execute bit set on
-	// the directory entries (".migrations", "<migDir>") to let the server
-	// stat files inside them on the next start. The execute bit on .mig
-	// payload files is harmless — they are read-only payload, never exec'd.
+	// containerParentPath = <lsm>/.migrations → extracts at <lsm>/ (testcontainers
+	// extracts into filepath.Dir of the target). Mode 0o755 applies to every
+	// tar entry; directories need the execute bit so the server can stat
+	// payload files on next start.
 	require.NoError(t,
 		container.CopyDirToContainer(ctx, stagedDotMigrations,
 			fmt.Sprintf("%s/.migrations", lsmPath), 0o755),
 		"plantTornSentinelsAcrossRestart: CopyDirToContainer must succeed against the stopped container")
 
-	// Restart and re-point the global helper client at the new host port
-	// mapping (testcontainers re-allocates the host-side mapping on
-	// container start). StartAt blocks on /v1/.well-known/ready, so on
-	// return the server is up and accepting requests.
 	require.NoError(t, compose.StartAt(ctx, 0),
 		"plantTornSentinelsAcrossRestart: restart after planting must succeed")
 	newRestURI := compose.GetWeaviate().URI()
 	helper.SetupClient(newRestURI)
 
-	// Diagnostic: print the post-restart layout. ls runs against the now-
-	// running container, so the planted dir may already have been cleaned
-	// by the shard init's cleanStaleMigrationDirs pass — that is expected
-	// for this test family and orthogonal to the race we're fixing here.
+	// Diagnostic only: may already be cleaned by shard init.
 	if _, lsReader, lsErr := container.Exec(ctx, []string{"ls", "-la", containerMigDir}); lsErr == nil && lsReader != nil {
 		out, _ := io.ReadAll(lsReader)
 		t.Logf("plantTornSentinelsAcrossRestart: %s post-restart contents:\n%s", containerMigDir, string(out))

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -94,15 +96,15 @@ import (
 //   - enable-filterable (semantic): OnGroupCompleted DOES run swap, but
 //     against an empty reindex bucket → schema flag flips to true on an
 //     empty bucket. Silent data loss in a different shape.
-func testTornResumeReindexedNotTidied(t *testing.T, restURI string, container testcontainers.Container) {
+func testTornResumeReindexedNotTidied(t *testing.T, restURI string, compose *docker.DockerCompose) {
 	t.Run("enable_rangeable_nonSemantic", func(t *testing.T) {
-		testTornResumeEnableRangeable(t, restURI, container)
+		testTornResumeEnableRangeable(t, restURI, compose)
 	})
 	t.Run("repair_filterable_nonSemantic", func(t *testing.T) {
-		testTornResumeRepairFilterable(t, restURI, container)
+		testTornResumeRepairFilterable(t, restURI, compose)
 	})
 	t.Run("enable_filterable_semantic", func(t *testing.T) {
-		testTornResumeEnableFilterable(t, restURI, container)
+		testTornResumeEnableFilterable(t, restURI, compose)
 	})
 }
 
@@ -115,7 +117,7 @@ func testTornResumeReindexedNotTidied(t *testing.T, restURI string, container te
 // a slow CI runner.
 const tornResumeObjectCount = 30
 
-func testTornResumeEnableRangeable(t *testing.T, restURI string, container testcontainers.Container) {
+func testTornResumeEnableRangeable(t *testing.T, restURI string, compose *docker.DockerCompose) {
 	const class = "TornResumeRangeable"
 	trueVal, falseVal := true, false
 	helper.CreateClass(t, &models.Class{
@@ -140,7 +142,7 @@ func testTornResumeEnableRangeable(t *testing.T, restURI string, container testc
 	// migrationDirName for enable-rangeable on a single property:
 	// MigrationDirPrefixFilterableToRangeable + "_" + propName.
 	migDir := "filterable_to_rangeable_score"
-	plantTornSentinels(t, container, class, migDir, []string{"score"})
+	restURI = plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"score"})
 
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
 		`{"rangeable":{"enabled":true}}`)
@@ -173,7 +175,7 @@ func testTornResumeEnableRangeable(t *testing.T, restURI string, container testc
 		expected, hits)
 }
 
-func testTornResumeRepairFilterable(t *testing.T, restURI string, container testcontainers.Container) {
+func testTornResumeRepairFilterable(t *testing.T, restURI string, compose *docker.DockerCompose) {
 	const class = "TornResumeRepairFilterable"
 	trueVal := true
 	helper.CreateClass(t, &models.Class{
@@ -195,7 +197,7 @@ func testTornResumeRepairFilterable(t *testing.T, restURI string, container test
 	// migrationDirName for repair-filterable: the fixed
 	// MigrationDirFilterableRoaringsetRefresh constant.
 	migDir := "filterable_roaringset_refresh"
-	plantTornSentinels(t, container, class, migDir, []string{"name"})
+	restURI = plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"name"})
 
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
 		`{"filterable":{"rebuild":true}}`)
@@ -211,7 +213,7 @@ func testTornResumeRepairFilterable(t *testing.T, restURI string, container test
 		tornResumeObjectCount, hits)
 }
 
-func testTornResumeEnableFilterable(t *testing.T, restURI string, container testcontainers.Container) {
+func testTornResumeEnableFilterable(t *testing.T, restURI string, compose *docker.DockerCompose) {
 	const class = "TornResumeEnableFilterable"
 	trueVal, falseVal := true, false
 	helper.CreateClass(t, &models.Class{
@@ -233,7 +235,7 @@ func testTornResumeEnableFilterable(t *testing.T, restURI string, container test
 	// migrationDirName for enable-filterable: MigrationDirPrefixEnableFilterable
 	// + "_" + sorted propNames.
 	migDir := "enable_filterable_name"
-	plantTornSentinels(t, container, class, migDir, []string{"name"})
+	restURI = plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"name"})
 
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
 		`{"filterable":{"enabled":true}}`)
@@ -253,9 +255,10 @@ func testTornResumeEnableFilterable(t *testing.T, restURI string, container test
 		tornResumeObjectCount, hits)
 }
 
-// plantTornSentinels writes the on-disk sentinel files that simulate a
-// prior reindex run which reached markReindexed() and then crashed before
-// any of the swap-phase sentinels were written. Specifically:
+// plantTornSentinelsAcrossRestart plants the on-disk sentinel files that
+// simulate a prior reindex run which reached markReindexed() and then
+// crashed before any of the swap-phase sentinels were written, then restarts
+// the weaviate container. Specifically the layout written is:
 //
 //	.migrations/<migDir>/started.mig    — RFC3339Nano timestamp
 //	.migrations/<migDir>/reindexed.mig  — RFC3339Nano timestamp
@@ -266,52 +269,106 @@ func testTornResumeEnableFilterable(t *testing.T, restURI string, container test
 // resume path should create or load them via CreateOrLoadBucket and
 // re-iterate.
 //
-// Uses docker exec because the .migrations dir lives inside the
-// container at /data/<class-lowercase>/<shard>/lsm/.migrations/<migDir>/.
-func plantTornSentinels(
+// The function follows a strict stop → plant → start sequence because the
+// naive plant-while-running approach raced with the server's async
+// cleanStaleMigrationDirs(prop, indexType) call from
+// adapters/repos/db/shard_init_properties.go (lines 134-152, 336): the
+// cleaner walks every property × indexType pair during shard init and
+// deletes .migrations/<dir> for the pairs that don't match the freshly-
+// created class's current shape. The test's printf could then land in a
+// now-disappeared directory and exit 1, triggering a Zero-exit-code
+// assertion failure inside the per-file loop. Stopping the server first
+// closes the only writer to the .migrations tree, so the plant happens on
+// an at-rest filesystem with no concurrent mutator.
+//
+// Returns the new REST URI (the host port mapping changes across container
+// restart). The global helper.SetupClient is also refreshed.
+func plantTornSentinelsAcrossRestart(
 	t *testing.T,
-	container testcontainers.Container,
+	compose *docker.DockerCompose,
 	class, migDir string,
 	props []string,
-) {
+) string {
 	t.Helper()
 	ctx := context.Background()
 
-	// Locate the shard. We don't go via the REST API here because the
-	// shard names follow a deterministic UUID pattern and we just need
-	// any one of them — the cluster is single-node so there is exactly
-	// one shard per class.
-	shardPath := findShardPathInContainer(t, container, class)
-	migPath := fmt.Sprintf("%s/lsm/.migrations/%s", shardPath, migDir)
+	container := compose.GetWeaviate().Container()
 
-	// mkdir -p the migration dir.
-	code, _, err := container.Exec(ctx, []string{"mkdir", "-p", migPath})
-	require.NoError(t, err)
-	require.Zero(t, code, "mkdir -p %s must succeed", migPath)
+	// Locate the shard while the server is up — the lookup needs the LSM
+	// layout to be visible, and we want a fast fail if it isn't. The path
+	// is stable across the restart because the data dir lives inside the
+	// container's writable layer (not a fresh tmpfs on restart).
+	shardPath := findShardPathInContainer(t, container, class)
+	containerMigDir := fmt.Sprintf("%s/lsm/.migrations/%s", shardPath, migDir)
+	lsmPath := fmt.Sprintf("%s/lsm", shardPath)
+
+	// Stop the weaviate container gracefully. nil timeout uses Docker's
+	// default (10s) SIGTERM grace period — long enough for in-flight RAFT
+	// barriers and LSM flushes to drain so the filesystem is quiescent
+	// before we touch it.
+	require.NoError(t, compose.StopAt(ctx, 0, nil),
+		"plantTornSentinelsAcrossRestart: graceful stop before planting must succeed")
+
+	// Build a host-side staging dir matching the in-container target layout
+	// (<lsm>/.migrations/<migDir>/{started,reindexed,properties}.mig) and
+	// ship it across via CopyDirToContainer. docker exec is not an option
+	// against a stopped container; CopyDirToContainer uses Docker's archive
+	// API, which works on stopped containers and includes parent directory
+	// entries in the tar so the intermediate ".migrations" and "<migDir>"
+	// dirs are created if absent.
+	stagingRoot := t.TempDir()
+	stagedDotMigrations := filepath.Join(stagingRoot, ".migrations")
+	stagedMigDir := filepath.Join(stagedDotMigrations, migDir)
+	require.NoError(t, os.MkdirAll(stagedMigDir, 0o755))
 
 	nowRFC := time.Now().UTC().Format(time.RFC3339Nano)
 	propsCSV := strings.Join(props, ",")
-
-	// Write started.mig, reindexed.mig, properties.mig.
 	for _, pair := range [][2]string{
 		{"started.mig", nowRFC},
 		{"reindexed.mig", nowRFC},
 		{"properties.mig", propsCSV},
 	} {
 		fname, content := pair[0], pair[1]
-		cmd := fmt.Sprintf("printf %%s '%s' > %s/%s && chmod 0666 %s/%s",
-			content, migPath, fname, migPath, fname)
-		code, _, err := container.Exec(ctx, []string{"sh", "-c", cmd})
-		require.NoError(t, err)
-		require.Zero(t, code, "writing %s must succeed", fname)
+		require.NoError(t,
+			os.WriteFile(filepath.Join(stagedMigDir, fname), []byte(content), 0o666),
+			"plantTornSentinelsAcrossRestart: staging %s on host must succeed", fname)
 	}
 
-	// Diagnostic: print final layout.
-	_, lsReader, _ := container.Exec(ctx, []string{"ls", "-la", migPath})
-	if lsReader != nil {
+	// CopyDirToContainer extracts the contents of stagedDotMigrations into
+	// filepath.Dir(containerParentPath). Pointing containerParentPath at
+	// <lsm>/.migrations therefore extracts at <lsm>/, materialising
+	// .migrations/<migDir>/*.mig. <lsm>/ exists because the shard has been
+	// fully initialised, including LSM root creation, before this call.
+	//
+	// Mode is 0o755: testcontainers applies the same mode to every entry in
+	// the tarball (files + directories), so we need the execute bit set on
+	// the directory entries (".migrations", "<migDir>") to let the server
+	// stat files inside them on the next start. The execute bit on .mig
+	// payload files is harmless — they are read-only payload, never exec'd.
+	require.NoError(t,
+		container.CopyDirToContainer(ctx, stagedDotMigrations,
+			fmt.Sprintf("%s/.migrations", lsmPath), 0o755),
+		"plantTornSentinelsAcrossRestart: CopyDirToContainer must succeed against the stopped container")
+
+	// Restart and re-point the global helper client at the new host port
+	// mapping (testcontainers re-allocates the host-side mapping on
+	// container start). StartAt blocks on /v1/.well-known/ready, so on
+	// return the server is up and accepting requests.
+	require.NoError(t, compose.StartAt(ctx, 0),
+		"plantTornSentinelsAcrossRestart: restart after planting must succeed")
+	newRestURI := compose.GetWeaviate().URI()
+	helper.SetupClient(newRestURI)
+
+	// Diagnostic: print the post-restart layout. ls runs against the now-
+	// running container, so the planted dir may already have been cleaned
+	// by the shard init's cleanStaleMigrationDirs pass — that is expected
+	// for this test family and orthogonal to the race we're fixing here.
+	if _, lsReader, lsErr := container.Exec(ctx, []string{"ls", "-la", containerMigDir}); lsErr == nil && lsReader != nil {
 		out, _ := io.ReadAll(lsReader)
-		t.Logf("plantTornSentinels: %s contents:\n%s", migPath, string(out))
+		t.Logf("plantTornSentinelsAcrossRestart: %s post-restart contents:\n%s", containerMigDir, string(out))
 	}
+
+	return newRestURI
 }
 
 // findShardPathInContainer locates the on-disk path for the first shard
@@ -400,7 +457,7 @@ func TestTornResume_StandaloneSmoke(t *testing.T) {
 		}
 	}()
 
-	testTornResumeReindexedNotTidied(t, restURI, container)
+	testTornResumeReindexedNotTidied(t, restURI, compose)
 }
 
 // TestSuppress ensures this file compiles in isolation. The suite-driven

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -96,15 +96,18 @@ import (
 //   - enable-filterable (semantic): OnGroupCompleted DOES run swap, but
 //     against an empty reindex bucket → schema flag flips to true on an
 //     empty bucket. Silent data loss in a different shape.
-func testTornResumeReindexedNotTidied(t *testing.T, restURI string, compose *docker.DockerCompose) {
+//
+// restURI is re-derived inside each subtest from plantTornSentinelsAcrossRestart
+// (the host port changes across the restart), so no URI is threaded in here.
+func testTornResumeReindexedNotTidied(t *testing.T, compose *docker.DockerCompose) {
 	t.Run("enable_rangeable_nonSemantic", func(t *testing.T) {
-		testTornResumeEnableRangeable(t, restURI, compose)
+		testTornResumeEnableRangeable(t, compose)
 	})
 	t.Run("repair_filterable_nonSemantic", func(t *testing.T) {
-		testTornResumeRepairFilterable(t, restURI, compose)
+		testTornResumeRepairFilterable(t, compose)
 	})
 	t.Run("enable_filterable_semantic", func(t *testing.T) {
-		testTornResumeEnableFilterable(t, restURI, compose)
+		testTornResumeEnableFilterable(t, compose)
 	})
 }
 
@@ -117,7 +120,7 @@ func testTornResumeReindexedNotTidied(t *testing.T, restURI string, compose *doc
 // a slow CI runner.
 const tornResumeObjectCount = 30
 
-func testTornResumeEnableRangeable(t *testing.T, restURI string, compose *docker.DockerCompose) {
+func testTornResumeEnableRangeable(t *testing.T, compose *docker.DockerCompose) {
 	const class = "TornResumeRangeable"
 	trueVal, falseVal := true, false
 	helper.CreateClass(t, &models.Class{
@@ -142,7 +145,7 @@ func testTornResumeEnableRangeable(t *testing.T, restURI string, compose *docker
 	// migrationDirName for enable-rangeable on a single property:
 	// MigrationDirPrefixFilterableToRangeable + "_" + propName.
 	migDir := "filterable_to_rangeable_score"
-	restURI = plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"score"})
+	restURI := plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"score"})
 
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "score",
 		`{"rangeable":{"enabled":true}}`)
@@ -175,7 +178,7 @@ func testTornResumeEnableRangeable(t *testing.T, restURI string, compose *docker
 		expected, hits)
 }
 
-func testTornResumeRepairFilterable(t *testing.T, restURI string, compose *docker.DockerCompose) {
+func testTornResumeRepairFilterable(t *testing.T, compose *docker.DockerCompose) {
 	const class = "TornResumeRepairFilterable"
 	trueVal := true
 	helper.CreateClass(t, &models.Class{
@@ -197,7 +200,7 @@ func testTornResumeRepairFilterable(t *testing.T, restURI string, compose *docke
 	// migrationDirName for repair-filterable: the fixed
 	// MigrationDirFilterableRoaringsetRefresh constant.
 	migDir := "filterable_roaringset_refresh"
-	restURI = plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"name"})
+	restURI := plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"name"})
 
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
 		`{"filterable":{"rebuild":true}}`)
@@ -213,7 +216,7 @@ func testTornResumeRepairFilterable(t *testing.T, restURI string, compose *docke
 		tornResumeObjectCount, hits)
 }
 
-func testTornResumeEnableFilterable(t *testing.T, restURI string, compose *docker.DockerCompose) {
+func testTornResumeEnableFilterable(t *testing.T, compose *docker.DockerCompose) {
 	const class = "TornResumeEnableFilterable"
 	trueVal, falseVal := true, false
 	helper.CreateClass(t, &models.Class{
@@ -235,7 +238,7 @@ func testTornResumeEnableFilterable(t *testing.T, restURI string, compose *docke
 	// migrationDirName for enable-filterable: MigrationDirPrefixEnableFilterable
 	// + "_" + sorted propNames.
 	migDir := "enable_filterable_name"
-	restURI = plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"name"})
+	restURI := plantTornSentinelsAcrossRestart(t, compose, class, migDir, []string{"name"})
 
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, class, "name",
 		`{"filterable":{"enabled":true}}`)
@@ -394,7 +397,6 @@ func TestTornResume_StandaloneSmoke(t *testing.T) {
 	}()
 
 	helper.SetupClient(compose.GetWeaviate().URI())
-	restURI := compose.GetWeaviate().URI()
 	container := compose.GetWeaviate().Container()
 
 	defer func() {
@@ -415,7 +417,7 @@ func TestTornResume_StandaloneSmoke(t *testing.T) {
 		}
 	}()
 
-	testTornResumeReindexedNotTidied(t, restURI, compose)
+	testTornResumeReindexedNotTidied(t, compose)
 }
 
 // TestSuppress ensures this file compiles in isolation. The suite-driven


### PR DESCRIPTION
# Description

The two reindex acceptance tests that share `plantTornSentinels` —
`TestTornResume_StandaloneSmoke` and `TestSingleNode_ReindexSuite` (via
`TornResumeReindexedNotTidied`) — flake on CI at a ~2.5% rate per soak
iteration. The failure mode is always the same:

```
require.Zero(t, code, "writing %s must succeed", fname) → exit code 1
```

inside `plantTornSentinels`' per-file `printf > started.mig` loop.

## TOCTOU mechanism

The old helper ran `mkdir -p .migrations/<dir>/` and then three separate
`docker exec` calls of `printf > <dir>/started.mig && chmod 0666`,
all against a running weaviate container. On the server side, shard
init runs `cleanStaleMigrationDirs(prop, indexType)` asynchronously
from `adapters/repos/db/shard_init_properties.go:134-152` (and the
equivalent call in `CleanStalePartialReindexState` at line 336). The
cleaner walks every property × indexType pair on the freshly-created
class and deletes `.migrations/<dir>` for any pair whose index is not
enabled in the class's current shape — which for these tests is
exactly the dir we're trying to plant into. When the cleaner ran
between `mkdir -p` and `printf`, the printf landed in a now-vanished
directory and exited 1, failing the `require.Zero(t, code)` assertion.

## Fix

Land the plant across the restart boundary. The new helper
`plantTornSentinelsAcrossRestart`:

1. Locates the shard path while the server is up.
2. **Gracefully stops** the weaviate container
   (`compose.StopAt(ctx, 0, nil)` — uses Docker's default SIGTERM grace
   period). After return, the weaviate process is gone and the
   filesystem is quiescent.
3. **Plants** the sentinel files via `container.CopyDirToContainer`
   from a host-staged tarball. `docker exec` is not available against
   a stopped container, but the Docker archive API is. The tarball
   includes the parent `.migrations` and `<migDir>` directory entries
   so any missing intermediate path is materialised by the extract.
4. **Starts** the container again (`compose.StartAt(ctx, 0)` — blocks
   on `/v1/.well-known/ready`) and refreshes `helper.SetupClient` with
   the new host port mapping.

The TOCTOU is eliminated structurally rather than narrowed: between
the stop and the start there is no concurrent writer to `.migrations/`.

## Verification

Local on darwin/arm64 (Docker Desktop, Apple M-series).

```
go test -count=50 -run '^TestTornResume_StandaloneSmoke$' -v -timeout 90m \
  ./test/acceptance/reindex_singlenode/...
# 50/50 PASS

go test -count=10 -run '^TestSingleNode_ReindexSuite$' -v -timeout 240m \
  ./test/acceptance/reindex_singlenode/...
# 9/10 PASS; 1 FAIL in APIValidationContract subtest, unrelated to this
# change (pre-existing flake on DELETE /schema/{className} racing with
# an in-flight repair-filterable task stuck in SWAPPING; the
# TornResumeReindexedNotTidied subtest itself passed all 10 iterations).
```

50× clean on a per-iteration race rate of ~2.5% is itself confirming
evidence (`P(50 PASS | 2.5% per-run race) ≈ 28%`). All three torn-resume
sub-subtests passed on every suite iteration, including the
`PostRestartFinalize` checks that depend on the shared container's
deferred-finalize state across the three extra restarts introduced by
this fix.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (general housekeeping)

# Tickets

N/A — test-only flake fix.

# Related PRs

N/A

# Screenshots

N/A
