### PR TITLE
test: deflake TestReplicationDigestObjectsInRange/TruncatedBinaryRecord

### DIFF
--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -798,6 +798,7 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		_, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read digest in range record")


### PR DESCRIPTION
## Summary

`TestReplicationDigestObjectsInRange/TruncatedBinaryRecord` flakes in CI with:

```
Error: "connect: Post \".../digestsInRange?...\": context deadline exceeded"
       does not contain "read digest in range record"
```

The subtest writes 10 raw bytes (less than the 24-byte record length) and expects the client to surface the truncation as `"read digest in range record: unexpected EOF"`. With the test helper's default `timeoutUnit=20ms`, the per-request deadline of `timeoutUnit*20 = 400ms` can be exceeded by a localhost HTTP round-trip under parallel `-race` CI load — the client returns the connection-level deadline error before the body-parse branch that produces the expected error message is ever reached.

The fix bumps `c.timeoutUnit` to `time.Second` to match the sibling binary-stream subtests (`BinaryResponse`, `JSONFallback`, `EmptyBinaryResponse`), all of which already set the same value and document the rationale at `replication_test.go:730-732`:

> `timeoutUnit*20` is the per-request deadline; set it large enough to survive CI scheduling jitter without relying on retry.

No production-code change is needed — the truncation handling in `readDigestsInRangeBinaryStream` is already correct: `io.ReadFull` on the 10-byte body returns `ErrUnexpectedEOF`, which is wrapped with the `"read digest in range record"` prefix.

## Test plan

- [x] `go test -count 50 -race -run 'TestReplicationDigestObjectsInRange/TruncatedBinaryRecord' ./adapters/clients/` — 50/50 pass
- [x] `go test -count 5 -race -run 'TestReplicationDigestObjectsInRange' ./adapters/clients/` — all sibling subtests still pass
- [x] `go test -race -count 1 ./adapters/clients/...` — full package green