### PR TITLE
test(reindex-backup): fix BackupRefusedDuringInFlightMigration flake

### DIFF
--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -152,6 +152,38 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 
 // AwaitReindexLive blocks until the task reaches a live status.
 //
+// fetchReindexTask does one GET /v1/tasks poll and returns the reindex task
+// with the given ID. ok is false when the request, status, decode, or lookup
+// hasn't yielded that task yet, so pollers keep retrying. A non-200 is logged
+// rather than decoded as JSON, so a flake surfaces the actual status instead
+// of a generic decode/timeout failure.
+func fetchReindexTask(t *testing.T, restURI, taskID string) (models.DistributedTask, bool) {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
+	if err != nil {
+		return models.DistributedTask{}, false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return models.DistributedTask{}, false
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Logf("GET /v1/tasks returned status %d: %s", resp.StatusCode, string(body))
+		return models.DistributedTask{}, false
+	}
+	var tasks models.DistributedTasks
+	if err := json.Unmarshal(body, &tasks); err != nil {
+		return models.DistributedTask{}, false
+	}
+	for _, task := range tasks["reindex"] {
+		if task.ID == taskID {
+			return task, true
+		}
+	}
+	return models.DistributedTask{}, false
+}
+
 // Sync here, not on GET /v1/schema/<class>/indexes: the backup gate reads
 // DTM liveness, and the two can lag ~1s, so index-status races the gate.
 func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
@@ -159,36 +191,22 @@ func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 	o := applyOptions(opts)
 
 	require.Eventually(t, func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-		if err != nil {
+		task, ok := fetchReindexTask(t, restURI, taskID)
+		if !ok {
 			return false
 		}
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return false
-		}
-		var tasks models.DistributedTasks
-		if err := json.Unmarshal(body, &tasks); err != nil {
-			return false
-		}
-		for _, task := range tasks["reindex"] {
-			if task.ID != taskID {
-				continue
-			}
-			t.Logf("task %s status: %s", taskID, task.Status)
-			switch task.Status {
-			case "FAILED", "CANCELLED":
-				t.Fatalf("reindex task %s reached terminal status %s before going live: %s",
-					taskID, task.Status, task.Error)
-			case "FINISHED":
-				// Drained before a live status was observed (fixture too small).
-				t.Fatalf("reindex task %s reached FINISHED before a live status was observed; "+
-					"increase the import corpus so the migration outlives the gate-arming poll",
-					taskID)
-			case "STARTED", "PREPARING", "SWAPPING":
-				return true
-			}
+		t.Logf("task %s status: %s", taskID, task.Status)
+		switch task.Status {
+		case "FAILED", "CANCELLED":
+			t.Fatalf("reindex task %s reached terminal status %s before going live: %s",
+				taskID, task.Status, task.Error)
+		case "FINISHED":
+			// Drained before a live status was observed (fixture too small).
+			t.Fatalf("reindex task %s reached FINISHED before a live status was observed; "+
+				"increase the import corpus so the migration outlives the gate-arming poll",
+				taskID)
+		case "STARTED", "PREPARING", "SWAPPING":
+			return true
 		}
 		return false
 	}, o.timeout, 200*time.Millisecond,
@@ -202,29 +220,15 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 	o := applyOptions(opts)
 
 	require.Eventually(t, func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-		if err != nil {
+		task, ok := fetchReindexTask(t, restURI, taskID)
+		if !ok {
 			return false
 		}
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return false
+		t.Logf("task %s status: %s", taskID, task.Status)
+		if task.Status == "FAILED" {
+			t.Fatalf("reindex task failed: %s", task.Error)
 		}
-		var tasks models.DistributedTasks
-		if err := json.Unmarshal(body, &tasks); err != nil {
-			return false
-		}
-		for _, task := range tasks["reindex"] {
-			if task.ID == taskID {
-				t.Logf("task %s status: %s", taskID, task.Status)
-				if task.Status == "FAILED" {
-					t.Fatalf("reindex task failed: %s", task.Error)
-				}
-				return task.Status == "FINISHED"
-			}
-		}
-		return false
+		return task.Status == "FINISHED"
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
 }
 

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -150,15 +150,11 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 	return &result
 }
 
-// AwaitReindexLive polls /v1/tasks until the named reindex task reaches a
-// live (non-terminal) status: STARTED, PREPARING, or SWAPPING.
+// AwaitReindexLive blocks until the task is live (STARTED/PREPARING/SWAPPING).
 //
-// Tests needing a reindex in flight must sync on this DTM surface, not the
-// GET /v1/schema/<class>/indexes status: the backup admission gate reads
-// DTM task liveness ([DB.AnyLiveReindexForShard]), and the two surfaces
-// can disagree by ~1s, so waiting on index-status races the gate.
-//
-// Fails on FAILED/CANCELLED or on timeout (default 120s).
+// Sync on this DTM surface, not GET /v1/schema/<class>/indexes: the backup
+// gate reads DTM liveness, and the two can disagree by ~1s, so waiting on
+// index-status races the gate.
 func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -150,11 +150,10 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 	return &result
 }
 
-// AwaitReindexLive blocks until the task is live (STARTED/PREPARING/SWAPPING).
+// AwaitReindexLive blocks until the task reaches a live status.
 //
-// Sync on this DTM surface, not GET /v1/schema/<class>/indexes: the backup
-// gate reads DTM liveness, and the two can disagree by ~1s, so waiting on
-// index-status races the gate.
+// Sync here, not on GET /v1/schema/<class>/indexes: the backup gate reads
+// DTM liveness, and the two can lag ~1s, so index-status races the gate.
 func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -150,22 +150,13 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 	return &result
 }
 
-// AwaitReindexLive polls /v1/tasks until the named reindex task is
-// reported in a LIVE (non-terminal) status — STARTED, PREPARING, or
-// SWAPPING — i.e. exactly the states the server-side backup gate
-// ([DB.AnyLiveReindexForShard] via IsLiveReindexTaskStatus) treats as
-// "a reindex is in flight on this shard".
+// AwaitReindexLive polls /v1/tasks until the named reindex task reaches a
+// live (non-terminal) status: STARTED, PREPARING, or SWAPPING.
 //
-// Why this and not the index-status surface: the backup admission gate
-// reads DTM task liveness, NOT GET /v1/schema/<class>/indexes. Those are
-// two different surfaces with no ordering guarantee and, with
-// DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS=1, up to ~1s of skew
-// between them. A test that arms "expect the backup to be refused" by
-// waiting on the index-status surface can fire the backup in a window
-// where index-status already reads "indexing" but DTM has not yet
-// registered the task as live (or has already flipped it terminal) — the
-// gate then admits the backup and the expected 422 never arrives. Syncing
-// on the same DTM surface the gate consults removes that TOCTOU.
+// Tests needing a reindex in flight must sync on this DTM surface, not the
+// GET /v1/schema/<class>/indexes status: the backup admission gate reads
+// DTM task liveness ([DB.AnyLiveReindexForShard]), and the two surfaces
+// can disagree by ~1s, so waiting on index-status races the gate.
 //
 // Fails on FAILED/CANCELLED or on timeout (default 120s).
 func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
@@ -196,10 +187,7 @@ func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 				t.Fatalf("reindex task %s reached terminal status %s before going live: %s",
 					taskID, task.Status, task.Error)
 			case "FINISHED":
-				// Drained before we could observe a live status. Treat as a
-				// fixture sizing problem rather than a gate regression: the
-				// caller's "expect refusal" assertion can no longer be
-				// satisfied, so fail loudly with an actionable message.
+				// Drained before a live status was observed (fixture too small).
 				t.Fatalf("reindex task %s reached FINISHED before a live status was observed; "+
 					"increase the import corpus so the migration outlives the gate-arming poll",
 					taskID)

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -150,6 +150,68 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 	return &result
 }
 
+// AwaitReindexLive polls /v1/tasks until the named reindex task is
+// reported in a LIVE (non-terminal) status — STARTED, PREPARING, or
+// SWAPPING — i.e. exactly the states the server-side backup gate
+// ([DB.AnyLiveReindexForShard] via IsLiveReindexTaskStatus) treats as
+// "a reindex is in flight on this shard".
+//
+// Why this and not the index-status surface: the backup admission gate
+// reads DTM task liveness, NOT GET /v1/schema/<class>/indexes. Those are
+// two different surfaces with no ordering guarantee and, with
+// DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS=1, up to ~1s of skew
+// between them. A test that arms "expect the backup to be refused" by
+// waiting on the index-status surface can fire the backup in a window
+// where index-status already reads "indexing" but DTM has not yet
+// registered the task as live (or has already flipped it terminal) — the
+// gate then admits the backup and the expected 422 never arrives. Syncing
+// on the same DTM surface the gate consults removes that TOCTOU.
+//
+// Fails on FAILED/CANCELLED or on timeout (default 120s).
+func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
+	t.Helper()
+	o := applyOptions(opts)
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		var tasks models.DistributedTasks
+		if err := json.Unmarshal(body, &tasks); err != nil {
+			return false
+		}
+		for _, task := range tasks["reindex"] {
+			if task.ID != taskID {
+				continue
+			}
+			t.Logf("task %s status: %s", taskID, task.Status)
+			switch task.Status {
+			case "FAILED", "CANCELLED":
+				t.Fatalf("reindex task %s reached terminal status %s before going live: %s",
+					taskID, task.Status, task.Error)
+			case "FINISHED":
+				// Drained before we could observe a live status. Treat as a
+				// fixture sizing problem rather than a gate regression: the
+				// caller's "expect refusal" assertion can no longer be
+				// satisfied, so fail loudly with an actionable message.
+				t.Fatalf("reindex task %s reached FINISHED before a live status was observed; "+
+					"increase the import corpus so the migration outlives the gate-arming poll",
+					taskID)
+			case "STARTED", "PREPARING", "SWAPPING":
+				return true
+			}
+		}
+		return false
+	}, o.timeout, 200*time.Millisecond,
+		"reindex task %s should reach a live (STARTED/PREPARING/SWAPPING) status", taskID)
+}
+
 // AwaitReindexFinished polls /v1/tasks until the named reindex task
 // reaches FINISHED. Fails on FAILED or on timeout (default 120s).
 func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) {

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -164,8 +164,7 @@ func testBackupRefusedDuringInFlightMigration(t *testing.T, ctx context.Context,
 	taskID := submitChangeTokenization(t, restURI, className, "body", "lowercase")
 	t.Logf("change-tokenization task submitted: %s", taskID)
 
-	// Arm the gate on the same DTM surface the server reads (see
-	// reindexhelpers.AwaitReindexLive); the index-status surface races it.
+	// Backup must land while the migration is live.
 	reindexhelpers.AwaitReindexLive(t, restURI, taskID,
 		reindexhelpers.WithTimeout(30*time.Second))
 
@@ -191,10 +190,9 @@ func testBackupRefusedDuringInFlightMigration(t *testing.T, ctx context.Context,
 	require.Contains(t, errMsg, "retry after the migration finishes",
 		"error body must include an actionable next step")
 
-	// The refusal must not leave a staging dir behind, or a same-id retry
-	// hits checkIfBackupExists's "Status != Cancelled" rejection. The 422
-	// gates all fire before the coordinator's first write, so no staging
-	// dir is created; Eventually is just a defensive settle guard.
+	// A leaked staging dir would block a same-id retry (checkIfBackupExists,
+	// "Status != Cancelled"). The 422 fires before any write so none exists;
+	// Eventually is just a defensive settle.
 	container := compose.GetWeaviate().Container()
 	stagingPath := "/tmp/backups/" + backupID
 	require.Eventually(t, func() bool {

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -164,9 +164,18 @@ func testBackupRefusedDuringInFlightMigration(t *testing.T, ctx context.Context,
 	taskID := submitChangeTokenization(t, restURI, className, "body", "lowercase")
 	t.Logf("change-tokenization task submitted: %s", taskID)
 
-	// Without this wait, a small corpus can finish the migration before
-	// the backup HTTP call lands, producing a spurious "backup succeeded".
-	awaitIndexingState(t, restURI, className, "body")
+	// Arm the gate on the SAME surface the server reads. The backup
+	// admission gate consults DTM task liveness
+	// ([DB.AnyLiveReindexForShard] / IsLiveReindexTaskStatus), not the
+	// GET /v1/schema/<class>/indexes status surface. Waiting on the
+	// index-status surface here (the prior awaitIndexingState approach)
+	// raced the gate: with DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_
+	// SECONDS=1 the two surfaces can disagree by ~1s, so a backup fired
+	// while index-status read "indexing" could still slip past a DTM gate
+	// that had not yet seen the task as live — and the expected 422 would
+	// never arrive. Polling /v1/tasks for a live status closes that TOCTOU.
+	reindexhelpers.AwaitReindexLive(t, restURI, taskID,
+		reindexhelpers.WithTimeout(30*time.Second))
 
 	backupID := "reindex-backup-refuse"
 
@@ -193,10 +202,20 @@ func testBackupRefusedDuringInFlightMigration(t *testing.T, ctx context.Context,
 	// The refusal must not leave a staging dir behind; otherwise a
 	// same-id retry hits checkIfBackupExists's "Status != Cancelled"
 	// rejection.
+	//
+	// On the refused (422) path the server creates no staging dir: every
+	// gate that yields this 422 (validateBackupRequest's Backupable, then
+	// OnCanCommit's Backupable) fires before the coordinator's first
+	// PutMeta, and the filesystem backend's Initialize is a no-op. The
+	// check is wrapped in Eventually purely as a defensive guard against
+	// any incidental async filesystem settling — it is not expected to
+	// need more than the first probe.
 	container := compose.GetWeaviate().Container()
 	stagingPath := "/tmp/backups/" + backupID
-	code, _, _ := container.Exec(ctx, []string{"test", "-d", stagingPath})
-	assert.NotEqual(t, 0, code,
+	require.Eventually(t, func() bool {
+		code, _, _ := container.Exec(ctx, []string{"test", "-d", stagingPath})
+		return code != 0
+	}, 10*time.Second, 200*time.Millisecond,
 		"refused backup must not leave a staging dir at %s", stagingPath)
 
 	// Wait via the index-status surface (status:"ready") rather than DTM

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -164,16 +164,8 @@ func testBackupRefusedDuringInFlightMigration(t *testing.T, ctx context.Context,
 	taskID := submitChangeTokenization(t, restURI, className, "body", "lowercase")
 	t.Logf("change-tokenization task submitted: %s", taskID)
 
-	// Arm the gate on the SAME surface the server reads. The backup
-	// admission gate consults DTM task liveness
-	// ([DB.AnyLiveReindexForShard] / IsLiveReindexTaskStatus), not the
-	// GET /v1/schema/<class>/indexes status surface. Waiting on the
-	// index-status surface here (the prior awaitIndexingState approach)
-	// raced the gate: with DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_
-	// SECONDS=1 the two surfaces can disagree by ~1s, so a backup fired
-	// while index-status read "indexing" could still slip past a DTM gate
-	// that had not yet seen the task as live — and the expected 422 would
-	// never arrive. Polling /v1/tasks for a live status closes that TOCTOU.
+	// Arm the gate on the same DTM surface the server reads (see
+	// reindexhelpers.AwaitReindexLive); the index-status surface races it.
 	reindexhelpers.AwaitReindexLive(t, restURI, taskID,
 		reindexhelpers.WithTimeout(30*time.Second))
 
@@ -199,17 +191,10 @@ func testBackupRefusedDuringInFlightMigration(t *testing.T, ctx context.Context,
 	require.Contains(t, errMsg, "retry after the migration finishes",
 		"error body must include an actionable next step")
 
-	// The refusal must not leave a staging dir behind; otherwise a
-	// same-id retry hits checkIfBackupExists's "Status != Cancelled"
-	// rejection.
-	//
-	// On the refused (422) path the server creates no staging dir: every
-	// gate that yields this 422 (validateBackupRequest's Backupable, then
-	// OnCanCommit's Backupable) fires before the coordinator's first
-	// PutMeta, and the filesystem backend's Initialize is a no-op. The
-	// check is wrapped in Eventually purely as a defensive guard against
-	// any incidental async filesystem settling — it is not expected to
-	// need more than the first probe.
+	// The refusal must not leave a staging dir behind, or a same-id retry
+	// hits checkIfBackupExists's "Status != Cancelled" rejection. The 422
+	// gates all fire before the coordinator's first write, so no staging
+	// dir is created; Eventually is just a defensive settle guard.
 	container := compose.GetWeaviate().Container()
 	stagingPath := "/tmp/backups/" + backupID
 	require.Eventually(t, func() bool {

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -196,7 +196,13 @@ func testBackupRefusedDuringInFlightMigration(t *testing.T, ctx context.Context,
 	container := compose.GetWeaviate().Container()
 	stagingPath := "/tmp/backups/" + backupID
 	require.Eventually(t, func() bool {
-		code, _, _ := container.Exec(ctx, []string{"test", "-d", stagingPath})
+		code, _, err := container.Exec(ctx, []string{"test", "-d", stagingPath})
+		if err != nil {
+			// A transient exec error tells us nothing about the dir; log it and
+			// keep polling so a persistent failure surfaces in the timeout.
+			t.Logf("exec test -d %s failed: %v", stagingPath, err)
+			return false
+		}
 		return code != 0
 	}, 10*time.Second, 200*time.Millisecond,
 		"refused backup must not leave a staging dir at %s", stagingPath)


### PR DESCRIPTION
## Summary

Fixes the `TestBackupVsReindexSuite/BackupRefusedDuringInFlightMigration` flake (Mode C), confirmed live on main.

## Root cause: a two-surface TOCTOU

The subtest submits a change-tokenization reindex, waits for it to be "in flight", then fires a backup it expects to be **refused with 422** while the reindex is live.

It armed that wait on the **index-status surface** (`GET /v1/schema/<class>/indexes` via `awaitIndexingState`, `status=="indexing"`). But the server's backup admission gate reads a **different surface** — DTM task liveness:

- `DB.Backupable` (`adapters/repos/db/backup.go:75`) → `Index.refuseIfReindexInFlight` (`reindex_inflight.go:124`) → `DB.AnyLiveReindexForShard` (`reindex_inflight.go:46`) → `IsLiveReindexTaskStatus` (`reindex_provider.go:1792`), which treats `STARTED`/`PREPARING`/`SWAPPING` as live.

These two surfaces have no ordering guarantee, and with `DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS=1` they can disagree by ~1s. A backup fired while index-status read `"indexing"` could slip past a DTM gate that had not yet registered the task as live (or had already flipped it terminal), so the expected 422 never arrived — and the subtest's downstream staging-dir assertion never even got a chance to mean what it claims.

## Server-vs-test determination: pure test race (no server leak)

I traced the full backup admission + execution path. On the genuinely-refused (422) path the server **creates no staging dir**:

- `Scheduler.validateBackupRequest` calls `Backupable` (`scheduler.go:530`) and returns the 422 **before** `coordinator.Backup` is ever invoked.
- `coordinator.Backup` writes nothing to the backend until `canCommit` succeeds; on a canCommit refusal it returns at `coordinator.go:201`, **before** the first `PutMeta` (`coordinator.go:206`).
- The filesystem backend's `Initialize` is a no-op (`modules/backup-filesystem/backup.go:137`); `/tmp/backups/<id>` is created lazily only by `PutObject`/`Write`, which run during `PutMeta`/`provider.all` — **after** both `Backupable` gates pass.

So there is **no code path** where a backup is refused with 422 *after* the staging dir was created. No server-side cleanup change is warranted for the refused path. The fix is test-side.

(Latent note, out of scope here: an *admitted* backup that later fails at the commit-phase `HaltForTransfer` gate has no staging-dir cleanup on the create path — `os.RemoveAll` exists only on the restore/write-temp path. That orphan only occurs when the gates passed, never on the 422 path this test asserts; flagging for separate follow-up.)

## Changes (test-only)

- **`test/acceptance/helpers/reindex/helpers.go`**: add `AwaitReindexLive`, which polls `/v1/tasks` until the task reports a live status (`STARTED`/`PREPARING`/`SWAPPING`) — the same DTM surface the gate consults — and fails loudly if the task drains to `FINISHED` first (fixture too small) or hits `FAILED`/`CANCELLED`.
- **`test/acceptance/reindex_backup/suite_test.go`**: arm the subtest with `AwaitReindexLive` instead of `awaitIndexingState`, closing the TOCTOU; wrap the staging-dir-absence check in `require.Eventually` as a defensive guard.

## Validation

- `gofmt`, `go vet ./test/acceptance/helpers/reindex/...`, `go vet ./test/acceptance/reindex_backup/...`, `go vet ./usecases/backup/...` clean.
- `go build ./test/acceptance/helpers/reindex/...` clean.
- `go test ./usecases/backup/...` and `go test -run TestAnyLiveReindexForShard ./adapters/repos/db/` pass.
- **Proof on the reproducer VM is PENDING** — the acceptance suite needs docker and the VM was busy; QA will run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)