### PR TITLE
fix(reindex): atomic tokenization overlay swap

### DIFF
--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -42,12 +42,24 @@
 //
 // 2a — tight loop, microseconds: per property, call
 // store.SwapBucketPointer(mainName, ingestName) followed by
-// rt.markSwappedProp(propName). The tight loop bounds the per-shard
-// "mixed-state" subwindow (some props swapped, others not) to a few
-// microseconds total. Queries during this subwindow that hit
-// not-yet-swapped props would tokenize input with the new value
-// against an old-tokenized bucket — wrong — so the subwindow MUST
-// stay microseconds.
+// rt.markSwappedProp(propName), then the [onPropSwapped] hook (which
+// sets the per-shard tokenization overlay for tokenization-changing
+// migrations). The tight loop bounds the per-shard "mixed-state"
+// subwindow (some props swapped, others not) to a few microseconds
+// total. Queries during this subwindow that hit not-yet-swapped props
+// would tokenize input with the new value against an old-tokenized
+// bucket — wrong — so the subwindow MUST stay microseconds.
+//
+// The overlay set MUST be co-located here, adjacent to this prop's
+// pointer flip, NOT once-for-the-whole-shard before Phase 2. Setting
+// it earlier (e.g. before [RunSwapOnShard]'s tracker/sentinel/prop
+// preamble) opens a disk-I/O-sized window where overlay=NEW while the
+// bucket is still OLD: a query in that window tokenizes input with the
+// new analyzer and looks it up in the still-old bucket, returning the
+// wrong count (e.g. 0 for a field→word reverse migration). Pairing the
+// overlay set with the flip makes the only residual exposure a single
+// in-memory map write, symmetric in both directions (word→field and
+// field→word).
 //
 // 2b — post-atomic inline tidy (slow but correctness-safe):
 // oldMainBucket.Shutdown(ctx) + os.Rename(oldMainDir, backupDir) per
@@ -200,6 +212,30 @@ type ShardReindexTaskGeneric struct {
 	// [processOneSwapPropFn] — defaults to the [processOneTidyProp]
 	// method; tests substitute a wrapper.
 	processOneTidyPropFn func(propIdx int, propName, lsmPath string) error
+
+	// onPropSwapped, when non-nil, is invoked per property IMMEDIATELY
+	// after that property's bucket pointer has been flipped — both on
+	// the in-process happy path ([runtimeSwap] Phase 2a) and on the
+	// post-restart dir-rename recovery path ([recoverRuntimeSwapBuckets]).
+	// It runs inside the Phase 2a tight loop, adjacent to the flip and
+	// before any other prop is processed, so the only work between the
+	// bucket-pointer flip and the callback is a single in-memory map
+	// write.
+	//
+	// Production wiring: [reindex_provider.runShardSwapPhase] sets this
+	// to the per-shard tokenization-overlay setter for
+	// tokenization-changing migrations, so a query can never observe
+	// overlay=NEW while the bucket is still OLD (nor the reverse) for
+	// more than the in-memory swap latency. nil for every other
+	// migration type — the callback is skipped entirely.
+	//
+	// Set on the shared task instance before [RunSwapOnShard]; read on
+	// the same goroutine that runs the swap, so no extra
+	// synchronization is needed beyond the SetTokenizationOverlay call's
+	// own lock. The target shard is captured by the closure at wiring
+	// time (the provider already holds the unwrapped *Shard), so the
+	// callback takes only the prop name.
+	onPropSwapped func(propName string)
 }
 
 // NewShardReindexTaskGeneric creates a new generic reindex task.
@@ -1767,6 +1803,17 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 		if oldMainBucket != nil {
 			oldMainBuckets[propName] = oldMainBucket
 		}
+		// Co-locate the per-shard query-path alignment (tokenization
+		// overlay) with this prop's pointer flip. Setting it here — in
+		// the tight loop, immediately after the flip and before the
+		// next prop — bounds the overlay≠bucket window to a single
+		// in-memory map write. processOneSwapPropFn returns (nil, nil)
+		// for props whose per-prop sentinel was already on disk
+		// (recovery idempotency); fire the hook regardless so a resumed
+		// swap re-establishes the overlay for already-flipped props.
+		if t.onPropSwapped != nil {
+			t.onPropSwapped(propName)
+		}
 	}
 	logger.Debug("runtime swap: all props in-memory swapped")
 
@@ -2191,6 +2238,14 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 
 		if err := rt.markSwappedProp(propName); err != nil {
 			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
+		}
+		// Keep the recovery path direction-symmetric with the in-process
+		// happy path: re-establish the per-shard query-path alignment for
+		// this prop right after its swap converges. The callback is the
+		// same overlay setter wired by [reindex_provider.runShardSwapPhase]
+		// (nil for non-tokenization migrations).
+		if t.onPropSwapped != nil {
+			t.onPropSwapped(propName)
 		}
 	}
 

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -41,25 +41,18 @@
 // Implemented by [ShardReindexTaskGeneric.runtimeSwap].
 //
 // 2a — tight loop, microseconds: per property, call
-// store.SwapBucketPointer(mainName, ingestName) followed by
+// store.SwapBucketPointer(mainName, ingestName), then
 // rt.markSwappedProp(propName), then the [onPropSwapped] hook (which
 // sets the per-shard tokenization overlay for tokenization-changing
 // migrations). The tight loop bounds the per-shard "mixed-state"
-// subwindow (some props swapped, others not) to a few microseconds
-// total. Queries during this subwindow that hit not-yet-swapped props
-// would tokenize input with the new value against an old-tokenized
-// bucket — wrong — so the subwindow MUST stay microseconds.
+// subwindow (some props swapped, others not) to microseconds. Queries
+// hitting a not-yet-swapped prop would tokenize input with the new
+// value against an old-tokenized bucket, so the subwindow MUST stay
+// microseconds.
 //
-// The overlay set MUST be co-located here, adjacent to this prop's
-// pointer flip, NOT once-for-the-whole-shard before Phase 2. Setting
-// it earlier (e.g. before [RunSwapOnShard]'s tracker/sentinel/prop
-// preamble) opens a disk-I/O-sized window where overlay=NEW while the
-// bucket is still OLD: a query in that window tokenizes input with the
-// new analyzer and looks it up in the still-old bucket, returning the
-// wrong count (e.g. 0 for a field→word reverse migration). Pairing the
-// overlay set with the flip makes the only residual exposure a single
-// in-memory map write, symmetric in both directions (word→field and
-// field→word).
+// The overlay set is co-located with this prop's pointer flip so the
+// only residual overlay≠bucket exposure is a single in-memory map
+// write, in both directions (word→field and field→word).
 //
 // 2b — post-atomic inline tidy (slow but correctness-safe):
 // oldMainBucket.Shutdown(ctx) + os.Rename(oldMainDir, backupDir) per
@@ -213,28 +206,22 @@ type ShardReindexTaskGeneric struct {
 	// method; tests substitute a wrapper.
 	processOneTidyPropFn func(propIdx int, propName, lsmPath string) error
 
-	// onPropSwapped, when non-nil, is invoked per property IMMEDIATELY
-	// after that property's bucket pointer has been flipped — both on
-	// the in-process happy path ([runtimeSwap] Phase 2a) and on the
-	// post-restart dir-rename recovery path ([recoverRuntimeSwapBuckets]).
-	// It runs inside the Phase 2a tight loop, adjacent to the flip and
-	// before any other prop is processed, so the only work between the
-	// bucket-pointer flip and the callback is a single in-memory map
-	// write.
+	// onPropSwapped, when non-nil, is invoked per property immediately
+	// after that property's bucket pointer is flipped, on both the
+	// in-process happy path ([runtimeSwap] Phase 2a) and the post-restart
+	// dir-rename recovery path ([recoverRuntimeSwapBuckets]). It runs
+	// inside the Phase 2a tight loop, adjacent to the flip, so the only
+	// work between flip and callback is a single in-memory map write.
 	//
-	// Production wiring: [reindex_provider.runShardSwapPhase] sets this
-	// to the per-shard tokenization-overlay setter for
-	// tokenization-changing migrations, so a query can never observe
-	// overlay=NEW while the bucket is still OLD (nor the reverse) for
-	// more than the in-memory swap latency. nil for every other
-	// migration type — the callback is skipped entirely.
+	// [reindex_provider.runShardSwapPhase] wires this to the per-shard
+	// tokenization-overlay setter for tokenization-changing migrations,
+	// so a query can never observe overlay≠bucket for more than the
+	// in-memory swap latency; nil (skipped) for every other migration.
 	//
-	// Set on the shared task instance before [RunSwapOnShard]; read on
-	// the same goroutine that runs the swap, so no extra
-	// synchronization is needed beyond the SetTokenizationOverlay call's
-	// own lock. The target shard is captured by the closure at wiring
-	// time (the provider already holds the unwrapped *Shard), so the
-	// callback takes only the prop name.
+	// Read on the same goroutine that runs the swap, so no extra
+	// synchronization is needed beyond SetTokenizationOverlay's own lock.
+	// The target shard is captured by the closure, so the callback takes
+	// only the prop name.
 	onPropSwapped func(propName string)
 }
 
@@ -1803,14 +1790,12 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 		if oldMainBucket != nil {
 			oldMainBuckets[propName] = oldMainBucket
 		}
-		// Co-locate the per-shard query-path alignment (tokenization
-		// overlay) with this prop's pointer flip. Setting it here — in
-		// the tight loop, immediately after the flip and before the
-		// next prop — bounds the overlay≠bucket window to a single
-		// in-memory map write. processOneSwapPropFn returns (nil, nil)
-		// for props whose per-prop sentinel was already on disk
-		// (recovery idempotency); fire the hook regardless so a resumed
-		// swap re-establishes the overlay for already-flipped props.
+		// Set the overlay co-located with this prop's flip, bounding the
+		// overlay≠bucket window to a single in-memory map write.
+		// processOneSwapPropFn returns (nil, nil) for props whose
+		// sentinel was already on disk (recovery idempotency); fire the
+		// hook regardless so a resumed swap re-establishes the overlay
+		// for already-flipped props.
 		if t.onPropSwapped != nil {
 			t.onPropSwapped(propName)
 		}
@@ -2239,11 +2224,10 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 		if err := rt.markSwappedProp(propName); err != nil {
 			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
 		}
-		// Keep the recovery path direction-symmetric with the in-process
-		// happy path: re-establish the per-shard query-path alignment for
-		// this prop right after its swap converges. The callback is the
-		// same overlay setter wired by [reindex_provider.runShardSwapPhase]
-		// (nil for non-tokenization migrations).
+		// Re-establish the overlay for this prop after its swap converges,
+		// matching the in-process happy path. Same hook wired by
+		// [reindex_provider.runShardSwapPhase] (nil for non-tokenization
+		// migrations).
 		if t.onPropSwapped != nil {
 			t.onPropSwapped(propName)
 		}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -40,19 +40,10 @@
 // ------------------------------------------------------------
 // Implemented by [ShardReindexTaskGeneric.runtimeSwap].
 //
-// 2a — tight loop, microseconds: per property, call
-// store.SwapBucketPointer(mainName, ingestName), then
-// rt.markSwappedProp(propName), then the [onPropSwapped] hook (which
-// sets the per-shard tokenization overlay for tokenization-changing
-// migrations). The tight loop bounds the per-shard "mixed-state"
-// subwindow (some props swapped, others not) to microseconds. Queries
-// hitting a not-yet-swapped prop would tokenize input with the new
-// value against an old-tokenized bucket, so the subwindow MUST stay
-// microseconds.
-//
-// The overlay set is co-located with this prop's pointer flip so the
-// only residual overlay≠bucket exposure is a single in-memory map
-// write, in both directions (word→field and field→word).
+// 2a — tight loop, MUST stay microseconds: a query hitting a
+// not-yet-swapped prop tokenizes new-analyzer input against the old
+// bucket. The [onPropSwapped] overlay hook fires per-flip (not once up
+// front) so the overlay≠bucket exposure stays one in-memory map write.
 //
 // 2b — post-atomic inline tidy (slow but correctness-safe):
 // oldMainBucket.Shutdown(ctx) + os.Rename(oldMainDir, backupDir) per
@@ -206,22 +197,11 @@ type ShardReindexTaskGeneric struct {
 	// method; tests substitute a wrapper.
 	processOneTidyPropFn func(propIdx int, propName, lsmPath string) error
 
-	// onPropSwapped, when non-nil, is invoked per property immediately
-	// after that property's bucket pointer is flipped, on both the
-	// in-process happy path ([runtimeSwap] Phase 2a) and the post-restart
-	// dir-rename recovery path ([recoverRuntimeSwapBuckets]). It runs
-	// inside the Phase 2a tight loop, adjacent to the flip, so the only
-	// work between flip and callback is a single in-memory map write.
-	//
-	// [reindex_provider.runShardSwapPhase] wires this to the per-shard
-	// tokenization-overlay setter for tokenization-changing migrations,
-	// so a query can never observe overlay≠bucket for more than the
-	// in-memory swap latency; nil (skipped) for every other migration.
-	//
-	// Read on the same goroutine that runs the swap, so no extra
-	// synchronization is needed beyond SetTokenizationOverlay's own lock.
-	// The target shard is captured by the closure, so the callback takes
-	// only the prop name.
+	// onPropSwapped runs inside the Phase 2a tight loop right after each
+	// bucket-pointer flip, so a query never observes overlay≠bucket for
+	// longer than one in-memory map write. Runs on the swap goroutine, so
+	// SetTokenizationOverlay's own lock is enough. Wired only for
+	// tokenization-changing migrations.
 	onPropSwapped func(propName string)
 }
 
@@ -1790,12 +1770,8 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 		if oldMainBucket != nil {
 			oldMainBuckets[propName] = oldMainBucket
 		}
-		// Set the overlay co-located with this prop's flip, bounding the
-		// overlay≠bucket window to a single in-memory map write.
-		// processOneSwapPropFn returns (nil, nil) for props whose
-		// sentinel was already on disk (recovery idempotency); fire the
-		// hook regardless so a resumed swap re-establishes the overlay
-		// for already-flipped props.
+		// Fire even when processOneSwapPropFn no-ops an already-swapped prop
+		// (sentinel on disk), so a resumed swap re-establishes the overlay.
 		if t.onPropSwapped != nil {
 			t.onPropSwapped(propName)
 		}
@@ -2224,10 +2200,7 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 		if err := rt.markSwappedProp(propName); err != nil {
 			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
 		}
-		// Re-establish the overlay for this prop after its swap converges,
-		// matching the in-process happy path. Same hook wired by
-		// [reindex_provider.runShardSwapPhase] (nil for non-tokenization
-		// migrations).
+		// Recovery re-establishes the overlay for the same reason as the happy path.
 		if t.onPropSwapped != nil {
 			t.onPropSwapped(propName)
 		}

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1162,11 +1162,13 @@ func (p *ReindexProvider) runShardPrepPhase(
 	return ok, out
 }
 
-// runShardSwapPhase runs OVERLAY SET + atomic per-task SWAP + defensive
-// overlay clear. Assumes PREP succeeded (merged.mig on disk per task).
-// Partial-success (some swapped, some not) leaves the overlay in place:
-// swapped buckets match the new tokenization; un-swapped buckets need
-// operator rebuild.
+// runShardSwapPhase wires the per-prop OVERLAY SET hook + runs the
+// atomic per-task SWAP (which fires that hook per prop, co-located with
+// each bucket-pointer flip) + the defensive overlay clear. Assumes PREP
+// succeeded (merged.mig on disk per task). Partial-success (some
+// swapped, some not) leaves the overlay in place for the flipped props
+// only: swapped buckets match the new tokenization; un-swapped buckets
+// keep the live (old) tokenization and need operator rebuild.
 func (p *ReindexProvider) runShardSwapPhase(
 	ctx context.Context,
 	payload *ReindexTaskPayload,
@@ -1179,14 +1181,19 @@ func (p *ReindexProvider) runShardSwapPhase(
 	allSwapped := true
 	anySwapped := false
 
-	// Overlay-before-swap: queries observing the SWAPPING window need the
-	// new analyzer alignment for buckets that flip.
+	// Overlay-with-swap: queries observing the SWAPPING window need the
+	// new analyzer alignment for buckets that flip. We wire a per-prop
+	// hook (instead of setting the overlay once up front) so each prop's
+	// overlay set lands atomically with that prop's bucket-pointer flip
+	// inside the swap's Phase 2a tight loop — see
+	// [maybeWirePerPropOverlaySet] for why the once-up-front variant was
+	// a correctness bug.
 	setShard, setUnwrapErr := unwrapShard(ctx, shard)
 	if setUnwrapErr != nil && IsTokenizationChangingMigration(payload.MigrationType) {
 		logger.WithField("unit", unitID).WithField("shard", shardName).
-			Warnf("reindex provider: cannot set tokenization overlay — shard unwrap failed; queries during SWAPPING window may observe stale-tokenization results: %v", setUnwrapErr)
+			Warnf("reindex provider: cannot wire tokenization overlay — shard unwrap failed; queries during SWAPPING window may observe stale-tokenization results: %v", setUnwrapErr)
 	}
-	overlayWasSet := maybeSetTokenizationOverlayPreSwap(setShard, payload)
+	overlayWasSet := maybeWirePerPropOverlaySet(setShard, payload, unitTasks)
 
 	for _, reindexTask := range unitTasks {
 		if err := reindexTask.RunSwapOnShard(ctx, shard); err != nil {
@@ -1388,10 +1395,15 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 	//
 	//   1. PREP (RunPrepareOnShard, per task) — disk-I/O-heavy work:
 	//      FlushAndSwitch reindex bucket, ShutdownBucket, Prepend.
-	//   2. OVERLAY SET — maybeSetTokenizationOverlayPreSwap. After
-	//      every task on this shard has its prep merged.
+	//   2. OVERLAY WIRING — maybeWirePerPropOverlaySet. Installs the
+	//      per-prop onPropSwapped hook on each task so the overlay is
+	//      SET atomically with that prop's bucket-pointer flip in
+	//      phase 3 (NOT once-for-the-whole-shard up front, which would
+	//      open a disk-I/O-sized overlay≠bucket window across
+	//      RunSwapOnShard's tracker/sentinel/prop preamble).
 	//   3. ATOMIC SWAP (RunSwapOnShard, per task) — in-memory
-	//      bucket-pointer flip + per-prop sentinel fsync. The disk
+	//      bucket-pointer flip + per-prop sentinel fsync + per-prop
+	//      overlay set, all in the Phase 2a tight loop. The disk
 	//      dirs aren't renamed here; that's deferred to next startup
 	//      via OnBeforeLsmInit's recoverRuntimeSwapBuckets path.
 	//
@@ -2149,11 +2161,36 @@ func IsTokenizationChangingMigration(mt ReindexMigrationType) bool {
 		mt == ReindexTypeChangeTokenizationFilterable
 }
 
-// maybeSetTokenizationOverlayPreSwap sets the per-shard tokenization
-// overlay before the swap loop on a tokenization-changing migration.
-// Returns true iff the overlay was written, so the caller can match
+// maybeWirePerPropOverlaySet installs the per-prop onPropSwapped hook
+// on every task of a tokenization-changing migration so the per-shard
+// tokenization overlay is SET atomically with each property's
+// bucket-pointer flip, inside the swap's Phase 2a tight loop. Returns
+// true iff the hook was wired (i.e. this is a tokenization-changing
+// migration with a non-empty target), so the caller can match
 // [maybeClearTokenizationOverlayOnAllFailed]'s clear decision.
-func maybeSetTokenizationOverlayPreSwap(shard *Shard, payload *ReindexTaskPayload) bool {
+//
+// Why per-prop-atomic and not once-up-front: the previous design set
+// the overlay for the whole shard BEFORE the per-task RunSwapOnShard
+// loop. But RunSwapOnShard has a non-trivial preamble between that set
+// and the actual in-memory bucket-pointer flip — newReindexTracker
+// (os.MkdirAll), IsReindexed/IsMerged sentinel stats, readPropsToReindex
+// (file read). During that disk-I/O-sized window the overlay already
+// reported NEW while the bucket was still OLD, so a BM25 query
+// tokenized input with the new analyzer and looked it up in the
+// still-old bucket — returning a transiently wrong count (the reverse
+// field→word case returns 0). Pairing the set with the flip per prop
+// collapses the window to a single in-memory map write and is
+// direction-symmetric (word→field and field→word both only ever expose
+// the microsecond flip-then-set gap, never the disk-I/O preamble).
+//
+// The target shard is captured by the closure so the task-side hook
+// signature stays shard-free. Wiring (not invoking) here is safe under
+// the partial-failure contract: a task whose swap fails before any flip
+// never invokes the hook for any prop, so the overlay is never set for
+// an un-flipped prop — which is exactly what
+// [maybeClearTokenizationOverlayOnAllFailed]'s all-failed branch relies
+// on.
+func maybeWirePerPropOverlaySet(shard *Shard, payload *ReindexTaskPayload, tasks []*ShardReindexTaskGeneric) bool {
 	if shard == nil || payload == nil {
 		return false
 	}
@@ -2163,8 +2200,14 @@ func maybeSetTokenizationOverlayPreSwap(shard *Shard, payload *ReindexTaskPayloa
 	if payload.TargetTokenization == "" {
 		return false
 	}
-	for _, propName := range payload.Properties {
-		shard.SetTokenizationOverlay(propName, payload.TargetTokenization)
+	target := payload.TargetTokenization
+	for _, task := range tasks {
+		if task == nil {
+			continue
+		}
+		task.onPropSwapped = func(propName string) {
+			shard.SetTokenizationOverlay(propName, target)
+		}
 	}
 	return true
 }
@@ -2172,18 +2215,22 @@ func maybeSetTokenizationOverlayPreSwap(shard *Shard, payload *ReindexTaskPayloa
 // maybeClearTokenizationOverlayOnAllFailed is the defensive CLEAR
 // hook — called by [OnGroupCompleted] AFTER the per-task swap loop
 // on a shard. It clears the per-shard tokenization overlay iff (a)
-// the overlay was set pre-swap by
-// [maybeSetTokenizationOverlayPreSwap] (the `wasSet` argument) AND
+// the per-prop overlay hook was wired by
+// [maybeWirePerPropOverlaySet] (the `wasSet` argument) AND
 // (b) every per-task swap failed before flipping its bucket pointer
 // (the `anySwapped` argument is false).
 //
-// Without this clear, an all-failed swap path leaves the overlay set
-// against unchanged OLD buckets — the migration's FAILED transition
-// then skips the cluster-wide schema flip, so neither
-// [OnTaskCompleted]'s explicit clear nor [Shard.TokenizationFor]'s
-// self-clear-on-catchup will ever fire (the live schema stays OLD
-// and never matches the overlay's NEW value). Permanent misalignment
-// until operator repair.
+// Under the per-prop-atomic set, a fully-failed swap loop never
+// invokes the onPropSwapped hook (no prop flipped → no overlay set),
+// so this clear is now idempotent rather than load-bearing on the
+// all-failed path. It is retained as a backstop: if any prop's hook
+// did fire (which only happens after a successful flip+sentinel, i.e.
+// anySwapped would be true), and the migration nonetheless transitions
+// to FAILED, the overlay would otherwise stay set against buckets
+// while the FAILED transition skips the cluster-wide schema flip —
+// so neither [OnTaskCompleted]'s explicit clear nor
+// [Shard.TokenizationFor]'s self-clear-on-catchup would fire (the live
+// schema stays OLD and never matches the overlay's NEW value).
 //
 // Partial success (≥ 1 per-task swap returned nil → ≥ 1 bucket
 // pointer flipped) is intentionally left intact: the overlay aligns

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1165,10 +1165,9 @@ func (p *ReindexProvider) runShardPrepPhase(
 // runShardSwapPhase wires the per-prop OVERLAY SET hook + runs the
 // atomic per-task SWAP (which fires that hook per prop, co-located with
 // each bucket-pointer flip) + the defensive overlay clear. Assumes PREP
-// succeeded (merged.mig on disk per task). Partial-success (some
-// swapped, some not) leaves the overlay in place for the flipped props
-// only: swapped buckets match the new tokenization; un-swapped buckets
-// keep the live (old) tokenization and need operator rebuild.
+// succeeded (merged.mig on disk per task). Partial-success leaves the
+// overlay in place for the flipped props only; un-swapped buckets keep
+// the live (old) tokenization and need operator rebuild.
 func (p *ReindexProvider) runShardSwapPhase(
 	ctx context.Context,
 	payload *ReindexTaskPayload,
@@ -1181,13 +1180,12 @@ func (p *ReindexProvider) runShardSwapPhase(
 	allSwapped := true
 	anySwapped := false
 
-	// Overlay-with-swap: queries observing the SWAPPING window need the
-	// new analyzer alignment for buckets that flip. We wire a per-prop
-	// hook (instead of setting the overlay once up front) so each prop's
-	// overlay set lands atomically with that prop's bucket-pointer flip
-	// inside the swap's Phase 2a tight loop — see
-	// [maybeWirePerPropOverlaySet] for why the once-up-front variant was
-	// a correctness bug.
+	// Queries observing the SWAPPING window need the new analyzer
+	// alignment for buckets that flip. Wire a per-prop hook so each
+	// prop's overlay set lands atomically with that prop's bucket-pointer
+	// flip inside the swap's Phase 2a tight loop. See
+	// [maybeWirePerPropOverlaySet] for why setting it once up front was a
+	// correctness bug.
 	setShard, setUnwrapErr := unwrapShard(ctx, shard)
 	if setUnwrapErr != nil && IsTokenizationChangingMigration(payload.MigrationType) {
 		logger.WithField("unit", unitID).WithField("shard", shardName).
@@ -1398,9 +1396,7 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 	//   2. OVERLAY WIRING — maybeWirePerPropOverlaySet. Installs the
 	//      per-prop onPropSwapped hook on each task so the overlay is
 	//      SET atomically with that prop's bucket-pointer flip in
-	//      phase 3 (NOT once-for-the-whole-shard up front, which would
-	//      open a disk-I/O-sized overlay≠bucket window across
-	//      RunSwapOnShard's tracker/sentinel/prop preamble).
+	//      phase 3.
 	//   3. ATOMIC SWAP (RunSwapOnShard, per task) — in-memory
 	//      bucket-pointer flip + per-prop sentinel fsync + per-prop
 	//      overlay set, all in the Phase 2a tight loop. The disk
@@ -2169,27 +2165,22 @@ func IsTokenizationChangingMigration(mt ReindexMigrationType) bool {
 // migration with a non-empty target), so the caller can match
 // [maybeClearTokenizationOverlayOnAllFailed]'s clear decision.
 //
-// Why per-prop-atomic and not once-up-front: the previous design set
-// the overlay for the whole shard BEFORE the per-task RunSwapOnShard
-// loop. But RunSwapOnShard has a non-trivial preamble between that set
-// and the actual in-memory bucket-pointer flip — newReindexTracker
-// (os.MkdirAll), IsReindexed/IsMerged sentinel stats, readPropsToReindex
-// (file read). During that disk-I/O-sized window the overlay already
-// reported NEW while the bucket was still OLD, so a BM25 query
-// tokenized input with the new analyzer and looked it up in the
-// still-old bucket — returning a transiently wrong count (the reverse
-// field→word case returns 0). Pairing the set with the flip per prop
-// collapses the window to a single in-memory map write and is
-// direction-symmetric (word→field and field→word both only ever expose
-// the microsecond flip-then-set gap, never the disk-I/O preamble).
+// Why per-prop-atomic and not once-up-front: RunSwapOnShard has a
+// disk-I/O preamble (newReindexTracker os.MkdirAll, sentinel stats,
+// readPropsToReindex) between the start of the loop and the in-memory
+// bucket-pointer flip. Setting the overlay before that loop reports NEW
+// while the bucket is still OLD for the whole preamble, so a BM25 query
+// tokenizes input with the new analyzer against the old bucket and
+// returns a transiently wrong count (0 for the reverse field→word
+// case). Pairing the set with the flip per prop collapses the window to
+// a single in-memory map write, symmetric in both directions.
 //
 // The target shard is captured by the closure so the task-side hook
 // signature stays shard-free. Wiring (not invoking) here is safe under
 // the partial-failure contract: a task whose swap fails before any flip
-// never invokes the hook for any prop, so the overlay is never set for
-// an un-flipped prop — which is exactly what
-// [maybeClearTokenizationOverlayOnAllFailed]'s all-failed branch relies
-// on.
+// never invokes the hook, so the overlay is never set for an un-flipped
+// prop, which is what [maybeClearTokenizationOverlayOnAllFailed]'s
+// all-failed branch relies on.
 func maybeWirePerPropOverlaySet(shard *Shard, payload *ReindexTaskPayload, tasks []*ShardReindexTaskGeneric) bool {
 	if shard == nil || payload == nil {
 		return false
@@ -2220,17 +2211,15 @@ func maybeWirePerPropOverlaySet(shard *Shard, payload *ReindexTaskPayload, tasks
 // (b) every per-task swap failed before flipping its bucket pointer
 // (the `anySwapped` argument is false).
 //
-// Under the per-prop-atomic set, a fully-failed swap loop never
-// invokes the onPropSwapped hook (no prop flipped → no overlay set),
-// so this clear is now idempotent rather than load-bearing on the
-// all-failed path. It is retained as a backstop: if any prop's hook
-// did fire (which only happens after a successful flip+sentinel, i.e.
-// anySwapped would be true), and the migration nonetheless transitions
-// to FAILED, the overlay would otherwise stay set against buckets
-// while the FAILED transition skips the cluster-wide schema flip —
-// so neither [OnTaskCompleted]'s explicit clear nor
-// [Shard.TokenizationFor]'s self-clear-on-catchup would fire (the live
-// schema stays OLD and never matches the overlay's NEW value).
+// Under the per-prop-atomic set, a fully-failed swap loop never invokes
+// the onPropSwapped hook (no flip, no overlay set), so this clear is an
+// idempotent backstop rather than load-bearing. It still guards the case
+// where a hook fired (anySwapped true) yet the migration transitions to
+// FAILED: the overlay would otherwise stay set while the FAILED
+// transition skips the cluster-wide schema flip, so neither
+// [OnTaskCompleted]'s explicit clear nor [Shard.TokenizationFor]'s
+// self-clear-on-catchup would fire (live schema stays OLD, never matches
+// the overlay's NEW value).
 //
 // Partial success (≥ 1 per-task swap returned nil → ≥ 1 bucket
 // pointer flipped) is intentionally left intact: the overlay aligns

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1162,12 +1162,9 @@ func (p *ReindexProvider) runShardPrepPhase(
 	return ok, out
 }
 
-// runShardSwapPhase wires the per-prop OVERLAY SET hook + runs the
-// atomic per-task SWAP (which fires that hook per prop, co-located with
-// each bucket-pointer flip) + the defensive overlay clear. Assumes PREP
-// succeeded (merged.mig on disk per task). Partial-success leaves the
-// overlay in place for the flipped props only; un-swapped buckets keep
-// the live (old) tokenization and need operator rebuild.
+// runShardSwapPhase. Partial success leaves the overlay set for the
+// flipped props only; un-swapped buckets keep the old tokenization and
+// need operator rebuild.
 func (p *ReindexProvider) runShardSwapPhase(
 	ctx context.Context,
 	payload *ReindexTaskPayload,
@@ -1180,12 +1177,8 @@ func (p *ReindexProvider) runShardSwapPhase(
 	allSwapped := true
 	anySwapped := false
 
-	// Queries observing the SWAPPING window need the new analyzer
-	// alignment for buckets that flip. Wire a per-prop hook so each
-	// prop's overlay set lands atomically with that prop's bucket-pointer
-	// flip inside the swap's Phase 2a tight loop. See
-	// [maybeWirePerPropOverlaySet] for why setting it once up front was a
-	// correctness bug.
+	// Wire a per-prop hook rather than setting the overlay once up front;
+	// see [maybeWirePerPropOverlaySet] for why the latter is a correctness bug.
 	setShard, setUnwrapErr := unwrapShard(ctx, shard)
 	if setUnwrapErr != nil && IsTokenizationChangingMigration(payload.MigrationType) {
 		logger.WithField("unit", unitID).WithField("shard", shardName).
@@ -2165,22 +2158,13 @@ func IsTokenizationChangingMigration(mt ReindexMigrationType) bool {
 // migration with a non-empty target), so the caller can match
 // [maybeClearTokenizationOverlayOnAllFailed]'s clear decision.
 //
-// Why per-prop-atomic and not once-up-front: RunSwapOnShard has a
-// disk-I/O preamble (newReindexTracker os.MkdirAll, sentinel stats,
-// readPropsToReindex) between the start of the loop and the in-memory
-// bucket-pointer flip. Setting the overlay before that loop reports NEW
-// while the bucket is still OLD for the whole preamble, so a BM25 query
-// tokenizes input with the new analyzer against the old bucket and
-// returns a transiently wrong count (0 for the reverse field→word
-// case). Pairing the set with the flip per prop collapses the window to
-// a single in-memory map write, symmetric in both directions.
-//
-// The target shard is captured by the closure so the task-side hook
-// signature stays shard-free. Wiring (not invoking) here is safe under
-// the partial-failure contract: a task whose swap fails before any flip
-// never invokes the hook, so the overlay is never set for an un-flipped
-// prop, which is what [maybeClearTokenizationOverlayOnAllFailed]'s
-// all-failed branch relies on.
+// Why per-prop, not once up front: RunSwapOnShard's disk-I/O preamble
+// (MkdirAll, sentinel stats, prop read) runs between the loop start and
+// the flip. Setting the overlay before the loop exposes overlay=NEW /
+// bucket=OLD for that whole window, so a BM25 query returns a wrong
+// count (0 for reverse field→word). Per-flip wiring collapses it to one
+// map write; a swap that fails before any flip never sets it, keeping
+// the all-failed path clean.
 func maybeWirePerPropOverlaySet(shard *Shard, payload *ReindexTaskPayload, tasks []*ShardReindexTaskGeneric) bool {
 	if shard == nil || payload == nil {
 		return false
@@ -2211,15 +2195,10 @@ func maybeWirePerPropOverlaySet(shard *Shard, payload *ReindexTaskPayload, tasks
 // (b) every per-task swap failed before flipping its bucket pointer
 // (the `anySwapped` argument is false).
 //
-// Under the per-prop-atomic set, a fully-failed swap loop never invokes
-// the onPropSwapped hook (no flip, no overlay set), so this clear is an
-// idempotent backstop rather than load-bearing. It still guards the case
-// where a hook fired (anySwapped true) yet the migration transitions to
-// FAILED: the overlay would otherwise stay set while the FAILED
-// transition skips the cluster-wide schema flip, so neither
-// [OnTaskCompleted]'s explicit clear nor [Shard.TokenizationFor]'s
-// self-clear-on-catchup would fire (live schema stays OLD, never matches
-// the overlay's NEW value).
+// Idempotent backstop: with per-prop wiring a fully-failed swap never
+// sets the overlay. It still matters if a flip succeeded but the
+// migration then went FAILED, since the skipped cluster-wide schema flip
+// means nothing else would ever clear the overlay.
 //
 // Partial success (≥ 1 per-task swap returned nil → ≥ 1 bucket
 // pointer flipped) is intentionally left intact: the overlay aligns

--- a/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
+++ b/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
@@ -18,35 +18,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test*TokenizationOverlay* pin the per-shard tokenization overlay
-// lifecycle that [ReindexProvider.OnGroupCompleted] orchestrates for
-// https://github.com/weaviate/0-weaviate-issues/issues/216 Gap B. The helpers
-// [maybeWirePerPropOverlaySet] and
-// [maybeClearTokenizationOverlayOnAllFailed] encapsulate the SET (per
-// prop, atomic with the bucket-pointer flip via the task's
-// onPropSwapped hook) and the defensive CLEAR (post-loop, all-failed) so
-// the Gap B failure modes can be regression-tested without standing up a
-// full provider + DB + index.
-//
-// The per-prop-atomic wiring is itself a correctness fix: these tests
-// pin that the overlay is established only when the per-prop hook fires
-// (production invokes it immediately after each store.SwapBucketPointer),
-// not eagerly at wiring time.
-//
-// The most important regression to guard against is the original
-// Copilot-review finding (PR https://github.com/weaviate/weaviate/pull/11322 review comment 3254170106):
-// if every per-task RunSwapOnShard fails before flipping its bucket
-// pointer, the migration transitions to FAILED, the cluster-wide
-// schema flip is skipped, OnTaskCompleted's explicit clear hook
-// never runs, and TokenizationFor's self-clear-on-catchup never
-// fires (because the live schema stays at the pre-migration value
-// and never matches the overlay's target). Under per-prop-atomic
-// wiring the all-failed path never invokes the hook (no flip, no
-// set), so the defensive clear is an idempotent backstop.
+// Unit coverage for the #216 Gap B overlay set/clear lifecycle without a
+// full provider+DB+index. Key invariant: the overlay is set only when
+// the per-prop hook fires, never eagerly at wiring time. The all-failed
+// case (orig. Copilot finding, PR https://github.com/weaviate/weaviate/pull/11322 review comment 3254170106)
+// is the subtle one; see [maybeClearTokenizationOverlayOnAllFailed].
 
-// fireAllPropHooks invokes the wired onPropSwapped hook for every prop
-// on every task, simulating a swap loop where every prop's bucket
-// pointer flipped. Returns the number of hooks fired.
+// fireAllPropHooks simulates a swap loop where every prop flipped.
 func fireAllPropHooks(tasks []*ShardReindexTaskGeneric, props []string) int {
 	fired := 0
 	for _, task := range tasks {
@@ -246,32 +224,25 @@ func TestTokenizationOverlay_AllFailedSwap_EndToEndLifecycle(t *testing.T) {
 		Properties:         []string{"name"},
 	}
 
-	// Step 1: runShardSwapPhase wires the per-prop hook.
 	wasSet := maybeWirePerPropOverlaySet(s, payload, tasks)
 	require.True(t, wasSet)
 
-	// Step 2: simulate every per-task RunSwapOnShard returning an error
-	// BEFORE flipping any bucket pointer, so the hook never fires.
+	// No flip happens, so the hook never fires.
 	const anySwapped = false
 
-	// Step 3: runShardSwapPhase's post-loop defensive CLEAR.
 	cleared := maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped)
 	require.True(t, cleared,
 		"end-to-end: defensive clear must fire on all-failed path")
 
-	// Final state: overlay empty, query path returns the live schema
-	// value untouched. This is what prevents the permanent
-	// misalignment the migration's FAILED transition would otherwise
-	// leave behind.
+	// Overlay cleared, so the query returns the untouched OLD value
+	// rather than the misalignment the FAILED migration would leave.
 	assert.Equal(t, "word", s.TokenizationFor("name", "word"),
 		"end-to-end: post all-failed clear, TokenizationFor returns live (untouched OLD) value")
 }
 
-// TestTokenizationOverlay_AnySwapped_EndToEndLifecycle pins the
-// partial-success path: per-prop hook wired, ≥ 1 per-task swap
-// succeeded (hook fired), post-loop CLEAR is a no-op so the overlay
-// stays for the swapped index types. Mirrors the same
-// runShardSwapPhase branch.
+// TestTokenizationOverlay_AnySwapped_EndToEndLifecycle: a partial
+// success (≥1 flip) must leave the overlay set, so the defensive clear
+// is a no-op.
 func TestTokenizationOverlay_AnySwapped_EndToEndLifecycle(t *testing.T) {
 	s := &Shard{}
 	tasks := []*ShardReindexTaskGeneric{{}}
@@ -284,8 +255,6 @@ func TestTokenizationOverlay_AnySwapped_EndToEndLifecycle(t *testing.T) {
 	wasSet := maybeWirePerPropOverlaySet(s, payload, tasks)
 	require.True(t, wasSet)
 
-	// At least one per-task swap succeeded → bucket pointer flipped
-	// for that index type → its hook fired. anySwapped = true.
 	fireAllPropHooks(tasks, payload.Properties)
 	const anySwapped = true
 

--- a/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
+++ b/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
@@ -28,16 +28,10 @@ import (
 // the Gap B failure modes can be regression-tested without standing up a
 // full provider + DB + index.
 //
-// The per-prop-atomic wiring is itself a correctness fix: the previous
-// design set the overlay once-for-the-whole-shard BEFORE the per-task
-// RunSwapOnShard loop, opening a disk-I/O-sized window (across
-// RunSwapOnShard's tracker/sentinel/prop preamble) where overlay=NEW
-// while the bucket was still OLD. A BM25 query in that window tokenized
-// input with the new analyzer and looked it up in the still-old bucket,
-// returning a transiently wrong count (0 for the reverse field→word
-// case). These tests pin that the overlay is now established only when
-// the per-prop hook fires — which production invokes immediately after
-// each store.SwapBucketPointer.
+// The per-prop-atomic wiring is itself a correctness fix: these tests
+// pin that the overlay is established only when the per-prop hook fires
+// (production invokes it immediately after each store.SwapBucketPointer),
+// not eagerly at wiring time.
 //
 // The most important regression to guard against is the original
 // Copilot-review finding (PR https://github.com/weaviate/weaviate/pull/11322 review comment 3254170106):
@@ -47,9 +41,8 @@ import (
 // never runs, and TokenizationFor's self-clear-on-catchup never
 // fires (because the live schema stays at the pre-migration value
 // and never matches the overlay's target). Under per-prop-atomic
-// wiring the all-failed path never invokes the hook (no flip → no
-// set), so the overlay is never written in the first place; the
-// defensive clear remains as an idempotent backstop.
+// wiring the all-failed path never invokes the hook (no flip, no
+// set), so the defensive clear is an idempotent backstop.
 
 // fireAllPropHooks invokes the wired onPropSwapped hook for every prop
 // on every task, simulating a swap loop where every prop's bucket
@@ -79,9 +72,8 @@ func TestMaybeWirePerPropOverlaySet_TokenizationChange_WiresAndSets(t *testing.T
 	require.True(t, maybeWirePerPropOverlaySet(s, payload, tasks),
 		"change-tokenization migration with non-empty target must wire the per-prop hook")
 
-	// Wiring alone must NOT set the overlay — the disk-I/O-sized window
-	// the fix closes only exists when the overlay is set BEFORE the
-	// flip. The overlay is established only when the hook fires.
+	// Wiring alone must NOT set the overlay; it is established only when
+	// the hook fires. Setting it before the flip is the bug being fixed.
 	assert.Equal(t, "word", s.TokenizationFor("name", "word"),
 		"wiring must not pre-set the overlay; that's the bug being fixed")
 
@@ -259,7 +251,7 @@ func TestTokenizationOverlay_AllFailedSwap_EndToEndLifecycle(t *testing.T) {
 	require.True(t, wasSet)
 
 	// Step 2: simulate every per-task RunSwapOnShard returning an error
-	// BEFORE flipping any bucket pointer — the hook never fires.
+	// BEFORE flipping any bucket pointer, so the hook never fires.
 	const anySwapped = false
 
 	// Step 3: runShardSwapPhase's post-loop defensive CLEAR.

--- a/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
+++ b/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
@@ -21,11 +21,23 @@ import (
 // Test*TokenizationOverlay* pin the per-shard tokenization overlay
 // lifecycle that [ReindexProvider.OnGroupCompleted] orchestrates for
 // https://github.com/weaviate/0-weaviate-issues/issues/216 Gap B. The helpers
-// [maybeSetTokenizationOverlayPreSwap] and
-// [maybeClearTokenizationOverlayOnAllFailed] encapsulate the SET (pre-
-// per-task-swap) and the defensive CLEAR (post-loop, all-failed) so
-// the Gap B failure modes can be regression-tested without standing
-// up a full provider + DB + index.
+// [maybeWirePerPropOverlaySet] and
+// [maybeClearTokenizationOverlayOnAllFailed] encapsulate the SET (per
+// prop, atomic with the bucket-pointer flip via the task's
+// onPropSwapped hook) and the defensive CLEAR (post-loop, all-failed) so
+// the Gap B failure modes can be regression-tested without standing up a
+// full provider + DB + index.
+//
+// The per-prop-atomic wiring is itself a correctness fix: the previous
+// design set the overlay once-for-the-whole-shard BEFORE the per-task
+// RunSwapOnShard loop, opening a disk-I/O-sized window (across
+// RunSwapOnShard's tracker/sentinel/prop preamble) where overlay=NEW
+// while the bucket was still OLD. A BM25 query in that window tokenized
+// input with the new analyzer and looked it up in the still-old bucket,
+// returning a transiently wrong count (0 for the reverse field→word
+// case). These tests pin that the overlay is now established only when
+// the per-prop hook fires — which production invokes immediately after
+// each store.SwapBucketPointer.
 //
 // The most important regression to guard against is the original
 // Copilot-review finding (PR https://github.com/weaviate/weaviate/pull/11322 review comment 3254170106):
@@ -34,107 +46,152 @@ import (
 // schema flip is skipped, OnTaskCompleted's explicit clear hook
 // never runs, and TokenizationFor's self-clear-on-catchup never
 // fires (because the live schema stays at the pre-migration value
-// and never matches the overlay's target). Without the all-failed
-// defensive clear, the overlay would stay set permanently, leaving
-// queries to tokenize input against the target value while every
-// bucket still has the source-tokenized content — wrong results
-// until operator repair.
+// and never matches the overlay's target). Under per-prop-atomic
+// wiring the all-failed path never invokes the hook (no flip → no
+// set), so the overlay is never written in the first place; the
+// defensive clear remains as an idempotent backstop.
 
-func TestMaybeSetTokenizationOverlayPreSwap_TokenizationChange_Sets(t *testing.T) {
+// fireAllPropHooks invokes the wired onPropSwapped hook for every prop
+// on every task, simulating a swap loop where every prop's bucket
+// pointer flipped. Returns the number of hooks fired.
+func fireAllPropHooks(tasks []*ShardReindexTaskGeneric, props []string) int {
+	fired := 0
+	for _, task := range tasks {
+		if task == nil || task.onPropSwapped == nil {
+			continue
+		}
+		for _, propName := range props {
+			task.onPropSwapped(propName)
+			fired++
+		}
+	}
+	return fired
+}
+
+func TestMaybeWirePerPropOverlaySet_TokenizationChange_WiresAndSets(t *testing.T) {
 	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{{}}
 	payload := &ReindexTaskPayload{
 		MigrationType:      ReindexTypeChangeTokenization,
 		TargetTokenization: "field",
 		Properties:         []string{"name", "description"},
 	}
-	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload),
-		"change-tokenization migration with non-empty target must set the overlay")
+	require.True(t, maybeWirePerPropOverlaySet(s, payload, tasks),
+		"change-tokenization migration with non-empty target must wire the per-prop hook")
 
+	// Wiring alone must NOT set the overlay — the disk-I/O-sized window
+	// the fix closes only exists when the overlay is set BEFORE the
+	// flip. The overlay is established only when the hook fires.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"),
+		"wiring must not pre-set the overlay; that's the bug being fixed")
+
+	require.Equal(t, len(payload.Properties), fireAllPropHooks(tasks, payload.Properties),
+		"hook must be wired on the task")
 	assert.Equal(t, "field", s.TokenizationFor("name", "word"),
-		"overlay should override the live schema value")
+		"after the per-prop hook fires, the overlay overrides the live schema value")
 	assert.Equal(t, "field", s.TokenizationFor("description", "word"))
 }
 
-func TestMaybeSetTokenizationOverlayPreSwap_FilterableVariant_Sets(t *testing.T) {
+func TestMaybeWirePerPropOverlaySet_FilterableVariant_WiresAndSets(t *testing.T) {
 	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{{}}
 	payload := &ReindexTaskPayload{
 		MigrationType:      ReindexTypeChangeTokenizationFilterable,
 		TargetTokenization: "word",
 		Properties:         []string{"name"},
 	}
-	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload),
-		"change-tokenization-filterable migration must also set the overlay")
+	require.True(t, maybeWirePerPropOverlaySet(s, payload, tasks),
+		"change-tokenization-filterable migration must also wire the hook")
+	fireAllPropHooks(tasks, payload.Properties)
 	assert.Equal(t, "word", s.TokenizationFor("name", "field"))
 }
 
-func TestMaybeSetTokenizationOverlayPreSwap_NonTokenizationMigration_NoOp(t *testing.T) {
-	s := &Shard{}
+func TestMaybeWirePerPropOverlaySet_NonTokenizationMigration_NoOp(t *testing.T) {
 	for _, mt := range []ReindexMigrationType{
 		ReindexTypeEnableFilterable,
 		ReindexTypeEnableSearchable,
 		ReindexTypeEnableRangeable,
 	} {
 		t.Run(string(mt), func(t *testing.T) {
+			s := &Shard{}
+			tasks := []*ShardReindexTaskGeneric{{}}
 			payload := &ReindexTaskPayload{
 				MigrationType:      mt,
 				TargetTokenization: "field",
 				Properties:         []string{"name"},
 			}
-			require.False(t, maybeSetTokenizationOverlayPreSwap(s, payload),
-				"non-tokenization-changing migration must NOT set the overlay")
-			// Overlay should still be empty (no entries for "name").
+			require.False(t, maybeWirePerPropOverlaySet(s, payload, tasks),
+				"non-tokenization-changing migration must NOT wire the hook")
+			assert.Nil(t, tasks[0].onPropSwapped,
+				"no hook should be installed for a non-tokenization migration")
 			assert.Equal(t, "word", s.TokenizationFor("name", "word"),
 				"no overlay set → fall back to live schema")
 		})
 	}
 }
 
-func TestMaybeSetTokenizationOverlayPreSwap_EmptyTargetTokenization_NoOp(t *testing.T) {
+func TestMaybeWirePerPropOverlaySet_EmptyTargetTokenization_NoOp(t *testing.T) {
 	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{{}}
 	payload := &ReindexTaskPayload{
 		MigrationType:      ReindexTypeChangeTokenization,
 		TargetTokenization: "", // payload missing target
 		Properties:         []string{"name"},
 	}
-	require.False(t, maybeSetTokenizationOverlayPreSwap(s, payload),
-		"empty target tokenization must skip the SET — better than writing an empty override")
+	require.False(t, maybeWirePerPropOverlaySet(s, payload, tasks),
+		"empty target tokenization must skip wiring — better than writing an empty override")
+	assert.Nil(t, tasks[0].onPropSwapped)
 	assert.Equal(t, "word", s.TokenizationFor("name", "word"))
 }
 
-func TestMaybeSetTokenizationOverlayPreSwap_NilInputs_NoOp(t *testing.T) {
+func TestMaybeWirePerPropOverlaySet_NilInputs_NoOp(t *testing.T) {
 	// Pure guard against nil-deref under unexpected call sites; both
 	// inputs are non-nil in production but defensive checks let the
 	// helper be tested via unit tests without bringing up a real
 	// shard.
-	require.False(t, maybeSetTokenizationOverlayPreSwap(nil, &ReindexTaskPayload{}))
-	require.False(t, maybeSetTokenizationOverlayPreSwap(&Shard{}, nil))
+	require.False(t, maybeWirePerPropOverlaySet(nil, &ReindexTaskPayload{}, nil))
+	require.False(t, maybeWirePerPropOverlaySet(&Shard{}, nil, nil))
+}
+
+func TestMaybeWirePerPropOverlaySet_NilTaskInSlice_Skipped(t *testing.T) {
+	// A nil task entry must not panic — defensive, mirrors the
+	// production loop's nil guard.
+	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{nil, {}}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenization,
+		TargetTokenization: "field",
+		Properties:         []string{"name"},
+	}
+	require.True(t, maybeWirePerPropOverlaySet(s, payload, tasks))
+	require.NotNil(t, tasks[1].onPropSwapped, "non-nil task must get the hook")
+	fireAllPropHooks(tasks, payload.Properties)
+	assert.Equal(t, "field", s.TokenizationFor("name", "word"))
 }
 
 func TestMaybeClearTokenizationOverlayOnAllFailed_AllFailed_Clears(t *testing.T) {
-	// This is the central #216 Gap B regression: every per-task swap
-	// failed → no bucket pointer flipped → overlay must be cleared so
-	// the FAILED migration doesn't leave the shard permanently
-	// misaligned.
+	// #216 Gap B regression. Under per-prop-atomic wiring the all-failed
+	// path never fires the hook, so the overlay is never set. The
+	// defensive clear is an idempotent backstop that must leave the
+	// shard aligned with the live (OLD) schema either way.
 	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{{}}
 	payload := &ReindexTaskPayload{
 		MigrationType:      ReindexTypeChangeTokenization,
 		TargetTokenization: "field",
 		Properties:         []string{"name", "description"},
 	}
-	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload))
-	require.Equal(t, "field", s.TokenizationFor("name", "word"),
-		"sanity: SET should have written the overlay")
+	wasSet := maybeWirePerPropOverlaySet(s, payload, tasks)
+	require.True(t, wasSet)
 
-	// Simulate the all-failed swap loop outcome.
-	const wasSet, anySwapped = true, false
+	// All swaps failed → no hook fired → overlay never set.
+	require.Equal(t, "word", s.TokenizationFor("name", "word"),
+		"all-failed: overlay must not have been set (no flip → no hook)")
+
+	const anySwapped = false
 	require.True(t, maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped),
 		"defensive clear must apply when wasSet=true and anySwapped=false")
 
-	// The overlay is gone → TokenizationFor falls back to the live
-	// schema value. The migration's FAILED transition skipped the
-	// cluster-wide schema flip, so live is still the OLD value, and
-	// the bucket is also still OLD → query correctly tokenizes input
-	// for the OLD bucket content.
 	assert.Equal(t, "word", s.TokenizationFor("name", "word"),
 		"after all-failed clear: TokenizationFor must return live (OLD) value")
 	assert.Equal(t, "word", s.TokenizationFor("description", "word"))
@@ -142,17 +199,18 @@ func TestMaybeClearTokenizationOverlayOnAllFailed_AllFailed_Clears(t *testing.T)
 
 func TestMaybeClearTokenizationOverlayOnAllFailed_AnySwapped_NoOp(t *testing.T) {
 	// Partial success path: at least one per-task swap returned nil
-	// → at least one bucket pointer flipped. The overlay must STAY
-	// set so the swapped index type's bucket content stays aligned
-	// with the query analyzer. The half-applied state surfaces via
-	// #221's FAILED-task repair_command for operator repair.
+	// → at least one bucket pointer flipped → its hook fired and set
+	// the overlay. The overlay must STAY set so the swapped index
+	// type's bucket content stays aligned with the query analyzer.
 	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{{}}
 	payload := &ReindexTaskPayload{
 		MigrationType:      ReindexTypeChangeTokenization,
 		TargetTokenization: "field",
 		Properties:         []string{"name"},
 	}
-	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload))
+	require.True(t, maybeWirePerPropOverlaySet(s, payload, tasks))
+	fireAllPropHooks(tasks, payload.Properties) // a swap succeeded → hook fired
 
 	const wasSet, anySwapped = true, true
 	require.False(t, maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped),
@@ -163,8 +221,8 @@ func TestMaybeClearTokenizationOverlayOnAllFailed_AnySwapped_NoOp(t *testing.T) 
 }
 
 func TestMaybeClearTokenizationOverlayOnAllFailed_WasNotSet_NoOp(t *testing.T) {
-	// Symmetric to the SET helper's no-op cases (non-tokenization
-	// migrations, empty target): if SET was skipped, CLEAR must also
+	// Symmetric to the wiring helper's no-op cases (non-tokenization
+	// migrations, empty target): if wiring was skipped, CLEAR must also
 	// be a no-op regardless of anySwapped — there's nothing to clear.
 	s := &Shard{}
 	payload := &ReindexTaskPayload{
@@ -185,25 +243,26 @@ func TestMaybeClearTokenizationOverlayOnAllFailed_NilInputs_NoOp(t *testing.T) {
 
 // TestTokenizationOverlay_AllFailedSwap_EndToEndLifecycle pins the
 // end-to-end behavior on the shard for the canonical #216 Gap B
-// failure scenario: pre-swap SET, every swap fails, post-loop CLEAR.
-// Mirrors OnGroupCompleted's per-shard branch exactly.
+// failure scenario: per-prop hook wired, every swap fails (so no hook
+// fires), post-loop CLEAR. Mirrors runShardSwapPhase's per-shard branch.
 func TestTokenizationOverlay_AllFailedSwap_EndToEndLifecycle(t *testing.T) {
 	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{{}}
 	payload := &ReindexTaskPayload{
 		MigrationType:      ReindexTypeChangeTokenization,
 		TargetTokenization: "field",
 		Properties:         []string{"name"},
 	}
 
-	// Step 1: OnGroupCompleted's pre-swap SET.
-	wasSet := maybeSetTokenizationOverlayPreSwap(s, payload)
+	// Step 1: runShardSwapPhase wires the per-prop hook.
+	wasSet := maybeWirePerPropOverlaySet(s, payload, tasks)
 	require.True(t, wasSet)
 
-	// Step 2: simulate every per-task RunSwapOnShard returning an
-	// error. anySwapped stays false.
+	// Step 2: simulate every per-task RunSwapOnShard returning an error
+	// BEFORE flipping any bucket pointer — the hook never fires.
 	const anySwapped = false
 
-	// Step 3: OnGroupCompleted's post-loop defensive CLEAR.
+	// Step 3: runShardSwapPhase's post-loop defensive CLEAR.
 	cleared := maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped)
 	require.True(t, cleared,
 		"end-to-end: defensive clear must fire on all-failed path")
@@ -217,22 +276,25 @@ func TestTokenizationOverlay_AllFailedSwap_EndToEndLifecycle(t *testing.T) {
 }
 
 // TestTokenizationOverlay_AnySwapped_EndToEndLifecycle pins the
-// partial-success path: pre-swap SET, ≥ 1 per-task swap succeeded,
-// post-loop CLEAR is a no-op so the overlay stays for the swapped
-// index types. Mirrors the same OnGroupCompleted branch.
+// partial-success path: per-prop hook wired, ≥ 1 per-task swap
+// succeeded (hook fired), post-loop CLEAR is a no-op so the overlay
+// stays for the swapped index types. Mirrors the same
+// runShardSwapPhase branch.
 func TestTokenizationOverlay_AnySwapped_EndToEndLifecycle(t *testing.T) {
 	s := &Shard{}
+	tasks := []*ShardReindexTaskGeneric{{}}
 	payload := &ReindexTaskPayload{
 		MigrationType:      ReindexTypeChangeTokenization,
 		TargetTokenization: "field",
 		Properties:         []string{"name"},
 	}
 
-	wasSet := maybeSetTokenizationOverlayPreSwap(s, payload)
+	wasSet := maybeWirePerPropOverlaySet(s, payload, tasks)
 	require.True(t, wasSet)
 
 	// At least one per-task swap succeeded → bucket pointer flipped
-	// for that index type. anySwapped = true.
+	// for that index type → its hook fired. anySwapped = true.
+	fireAllPropHooks(tasks, payload.Properties)
 	const anySwapped = true
 
 	cleared := maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped)

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -418,20 +418,14 @@ type Shard struct {
 	// Lifecycle (see reindex_provider.go's OnGroupCompleted +
 	// OnTaskCompleted):
 	//   1. SET: per property, ATOMICALLY with that property's
-	//      bucket-pointer flip — inside the swap's Phase 2a tight loop,
+	//      bucket-pointer flip, inside the swap's Phase 2a tight loop,
 	//      immediately after store.SwapBucketPointer, via the task's
 	//      onPropSwapped hook wired by reindex_provider's
 	//      maybeWirePerPropOverlaySet. Co-locating the set with the flip
-	//      bounds the overlay≠bucket window (in BOTH directions:
-	//      word→field and field→word) to a single in-memory map write —
-	//      the genuine in-memory swap latency. An earlier design set the
-	//      overlay once-for-the-whole-shard BEFORE the per-task
-	//      RunSwapOnShard loop; that opened a disk-I/O-sized window
-	//      across RunSwapOnShard's tracker/sentinel/prop preamble where
-	//      overlay=NEW while the bucket was still OLD, so a query
-	//      tokenized input with the new analyzer against the old bucket
-	//      and returned a transiently wrong count (e.g. 0 for the
-	//      reverse field→word case).
+	//      bounds the overlay≠bucket window (in both directions,
+	//      word→field and field→word) to a single in-memory map write.
+	//      See maybeWirePerPropOverlaySet for why setting it once up
+	//      front was a correctness bug.
 	//   2. CLEAR (defensive, all-failed path): if every per-task swap on
 	//      this shard fails before flipping its bucket pointer (e.g.
 	//      ctx.Canceled during graceful shutdown), the post-loop branch

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -417,11 +417,21 @@ type Shard struct {
 	//
 	// Lifecycle (see reindex_provider.go's OnGroupCompleted +
 	// OnTaskCompleted):
-	//   1. SET: pre-swap, just BEFORE the per-task RunSwapOnShard loop
-	//      kicks off on this shard. Setting pre-swap means the brief
-	//      in-flight window between bucket-pointer flip and overlay
-	//      visibility is bounded by the in-memory swap latency
-	//      (microseconds) rather than the cluster-wide cutover spread.
+	//   1. SET: per property, ATOMICALLY with that property's
+	//      bucket-pointer flip — inside the swap's Phase 2a tight loop,
+	//      immediately after store.SwapBucketPointer, via the task's
+	//      onPropSwapped hook wired by reindex_provider's
+	//      maybeWirePerPropOverlaySet. Co-locating the set with the flip
+	//      bounds the overlay≠bucket window (in BOTH directions:
+	//      word→field and field→word) to a single in-memory map write —
+	//      the genuine in-memory swap latency. An earlier design set the
+	//      overlay once-for-the-whole-shard BEFORE the per-task
+	//      RunSwapOnShard loop; that opened a disk-I/O-sized window
+	//      across RunSwapOnShard's tracker/sentinel/prop preamble where
+	//      overlay=NEW while the bucket was still OLD, so a query
+	//      tokenized input with the new analyzer against the old bucket
+	//      and returned a transiently wrong count (e.g. 0 for the
+	//      reverse field→word case).
 	//   2. CLEAR (defensive, all-failed path): if every per-task swap on
 	//      this shard fails before flipping its bucket pointer (e.g.
 	//      ctx.Canceled during graceful shutdown), the post-loop branch

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -417,15 +417,10 @@ type Shard struct {
 	//
 	// Lifecycle (see reindex_provider.go's OnGroupCompleted +
 	// OnTaskCompleted):
-	//   1. SET: per property, ATOMICALLY with that property's
-	//      bucket-pointer flip, inside the swap's Phase 2a tight loop,
-	//      immediately after store.SwapBucketPointer, via the task's
-	//      onPropSwapped hook wired by reindex_provider's
-	//      maybeWirePerPropOverlaySet. Co-locating the set with the flip
-	//      bounds the overlay≠bucket window (in both directions,
-	//      word→field and field→word) to a single in-memory map write.
-	//      See maybeWirePerPropOverlaySet for why setting it once up
-	//      front was a correctness bug.
+	//   1. SET: per prop, atomic with each bucket-pointer flip (onPropSwapped
+	//      hook), so the overlay≠bucket window is one in-memory map write.
+	//      See maybeWirePerPropOverlaySet for why setting it once up front
+	//      was a correctness bug.
 	//   2. CLEAR (defensive, all-failed path): if every per-task swap on
 	//      this shard fails before flipping its bucket pointer (e.g.
 	//      ctx.Canceled during graceful shutdown), the post-loop branch

--- a/adapters/repos/db/tokenization_overlay_write_path_test.go
+++ b/adapters/repos/db/tokenization_overlay_write_path_test.go
@@ -69,9 +69,10 @@ func TestTokenizationOverlay_WritePath_IgnoresOverlay(t *testing.T) {
 	defer shard.Shutdown(ctx)
 
 	// Simulate the SWAPPING window: set overlay to TARGET (field).
-	// Production sets this in maybeSetTokenizationOverlayPreSwap; the
-	// schema's prop.Tokenization stays at SOURCE (word) until the
-	// cluster-wide flip lands.
+	// Production sets this per prop, atomically with the bucket-pointer
+	// flip, via the onPropSwapped hook wired by
+	// maybeWirePerPropOverlaySet; the schema's prop.Tokenization stays at
+	// SOURCE (word) until the cluster-wide flip lands.
 	shard.SetTokenizationOverlay(propName, models.PropertyTokenizationField)
 
 	// Issue a PUT during the overlay-active window. With field

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -1100,12 +1100,10 @@ Lifecycle:
    `OnGroupCompleted`, between PREP and ATOMIC SWAP, installing a
    per-prop `onPropSwapped` hook on each task. The overlay for a prop
    is then SET inside the swap's Phase 2a tight loop, ATOMICALLY with
-   that prop's `store.SwapBucketPointer` flip — not once-for-the-whole-
-   shard up front. (Setting it up front opened a disk-I/O-sized window
-   across `RunSwapOnShard`'s tracker/sentinel/prop preamble where
-   overlay=NEW while the bucket was still OLD, so a query returned a
-   transiently wrong count, e.g. 0 for the reverse field→word case.)
-   Only for tokenization-changing migrations (`change-tokenization`,
+   that prop's `store.SwapBucketPointer` flip, not once-for-the-whole-
+   shard up front (which opens a disk-I/O-sized `overlay=NEW`,
+   `bucket=OLD` window across `RunSwapOnShard`'s preamble). Only for
+   tokenization-changing migrations (`change-tokenization`,
    `change-tokenization-filterable`).
 2. **Cover** — the entire Phase 2 (atomic swap + post-atomic tidy +
    `OnMigrationComplete`) runs with the overlay active. Queries see

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -1096,10 +1096,17 @@ which consults the overlay before falling back to the schema value.
 
 Lifecycle:
 
-1. **Set** — `maybeSetTokenizationOverlayPreSwap` runs in Phase 2 of
-   `OnGroupCompleted`, between PREP and ATOMIC SWAP. Only for
-   tokenization-changing migrations (`change-tokenization`,
-   `change-tokenization-filterable`, `enable-searchable`).
+1. **Set** — `maybeWirePerPropOverlaySet` runs in Phase 2 of
+   `OnGroupCompleted`, between PREP and ATOMIC SWAP, installing a
+   per-prop `onPropSwapped` hook on each task. The overlay for a prop
+   is then SET inside the swap's Phase 2a tight loop, ATOMICALLY with
+   that prop's `store.SwapBucketPointer` flip — not once-for-the-whole-
+   shard up front. (Setting it up front opened a disk-I/O-sized window
+   across `RunSwapOnShard`'s tracker/sentinel/prop preamble where
+   overlay=NEW while the bucket was still OLD, so a query returned a
+   transiently wrong count, e.g. 0 for the reverse field→word case.)
+   Only for tokenization-changing migrations (`change-tokenization`,
+   `change-tokenization-filterable`).
 2. **Cover** — the entire Phase 2 (atomic swap + post-atomic tidy +
    `OnMigrationComplete`) runs with the overlay active. Queries see
    NEW-tokenized analyzer input against NEW-tokenized bucket content.


### PR DESCRIPTION
## The bug

`TestLiveQueriesDuringChangeTokenization/reverse_field_to_word_searchable`
intermittently returns **count=0** from a live BM25 query during the
SWAPPING window (valid range `[1,1500]`). Transient and self-healing, but
a real correctness defect.

Root cause is an overlay/bucket window misalignment:

- The per-shard tokenization overlay was set **once-for-the-whole-shard**
  in `reindex_provider.runShardSwapPhase` (`maybeSetTokenizationOverlayPreSwap`),
  **before** the per-task `RunSwapOnShard` loop.
- The actual in-memory bucket-pointer flip (`store.SwapBucketPointer`)
  happens later, inside `runtimeSwap`'s Phase 2a, after `RunSwapOnShard`'s
  preamble: `newReindexTracker` (`os.MkdirAll`), `IsReindexed`/`IsMerged`
  sentinel stats, `readPropsToReindex` (file read).
- During that **disk-I/O-sized** window the overlay reported NEW
  (`word`) while the bucket was still OLD (`field`, keyed by full
  phrases). A BM25 query in the window tokenized the phrase into words
  and looked them up in the still-FIELD bucket -> 0 matches -> `count=0`.

The pre-existing `shard.go` godoc claimed the residual window was
"bounded by in-memory swap latency (microseconds)" — true for the
direction it was designed for, but false for the symmetric inverse
(overlay-set-then-flip) because the preamble does disk I/O.

## The fix

Set the overlay **atomically per-prop with that prop's pointer flip**
instead of once up front:

- New `onPropSwapped func(propName string)` hook on `ShardReindexTaskGeneric`,
  invoked inside Phase 2a immediately after each `store.SwapBucketPointer`
  (and symmetrically in the `recoverRuntimeSwapBuckets` post-restart
  recovery path). The only work between flip and overlay set is now a
  single in-memory map write.
- `maybeSetTokenizationOverlayPreSwap` -> `maybeWirePerPropOverlaySet`:
  wires the hook on each task (capturing the unwrapped `*Shard` and
  target tokenization) instead of writing the overlay eagerly.
- **Direction-symmetric**: both `word->field` and `field->word` now only
  ever expose the microsecond flip-then-set gap, never the disk-I/O
  preamble.
- Non-tokenization migrations are unaffected (hook stays nil).
- The all-failed defensive clear (`maybeClearTokenizationOverlayOnAllFailed`)
  becomes an idempotent backstop since a fully-failed swap never fires
  the hook (no flip -> no set). Gap-B regression coverage preserved.

Godoc on `shard.go`, the file-level phase contract in
`inverted_reindex_task_generic.go`, and `docs/runtime-reindex.md` updated
to reflect the new atomic guarantee.

## Validation

- `gofmt` clean; `go vet` clean on touched packages (the one
  `helper_for_test.go` vet warning is pre-existing on `main`, not in this
  diff).
- `go build ./adapters/repos/db/...` passes.
- Unit tests pass: overlay set/clear lifecycle, shard overlay, write-path,
  recovery-convergence (exercises the recovery hook), and the
  `TestRuntimeSwap_Phase2a_AtomicTightLoop` atomic-window guard.

## PENDING — multinode proof

The reproducer VM was busy, so the full multinode acceptance proof is
**not yet run**. QA to run `TestLiveQueriesDuringChangeTokenization`
(esp. `reverse_field_to_word_searchable`) on the reproducer VM and confirm
the `OutOfRange == 0` assertion holds across the SWAPPING window.

## Review note

This is **delicate production concurrency** in the reindex swap path
(overlay set vs. bucket-pointer flip, two different locks
`Store.bucketAccessLock` and `Shard.tokenizationOverlayMu`, recovery
re-entry, barrier-mode re-wiring). Needs careful human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)