### PR TITLE
test(reindex-backup): poll for orphan sidecar dir removal (Mode B flake)

### DIFF
--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -375,9 +375,16 @@ func testPostRestartOrphanAuditClearsTracker(t *testing.T, ctx context.Context, 
 	}, 60*time.Second, 500*time.Millisecond,
 		"orphan tracker dir was not cleaned up by the post-bootstrap audit")
 
-	code, _, _ := container.Exec(ctx, []string{"test", "-d", filepath.Join(lsmPath, sidecarBucket)})
-	assert.NotEqual(t, 0, code,
-		"orphan sidecar bucket dir was not cleaned up; got test -d exit %d", code)
+	// The sidecar bucket dir is removed by the same async audit, AFTER the
+	// tracker dir above (cleanUnloadedShardOrphans calls
+	// removeUnloadedSidecarsForOrphan after the tracker RemoveAll). Poll for
+	// it rather than asserting once, so the check can't fire in the window
+	// between the two removals.
+	require.Eventually(t, func() bool {
+		code, _, _ := container.Exec(ctx, []string{"test", "-d", filepath.Join(lsmPath, sidecarBucket)})
+		return code != 0
+	}, 60*time.Second, 500*time.Millisecond,
+		"orphan sidecar bucket dir was not cleaned up by the post-bootstrap audit")
 
 	assert.EqualValues(t, preCount, moduleshelper.GetClassCount(t, className, ""),
 		"canonical data must survive the audit")

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -375,11 +375,9 @@ func testPostRestartOrphanAuditClearsTracker(t *testing.T, ctx context.Context, 
 	}, 60*time.Second, 500*time.Millisecond,
 		"orphan tracker dir was not cleaned up by the post-bootstrap audit")
 
-	// The sidecar bucket dir is removed by the same async audit, AFTER the
-	// tracker dir above (cleanUnloadedShardOrphans calls
-	// removeUnloadedSidecarsForOrphan after the tracker RemoveAll). Poll for
-	// it rather than asserting once, so the check can't fire in the window
-	// between the two removals.
+	// The sidecar dir is removed by the same async audit, after the tracker
+	// dir above. Poll for it rather than asserting once, so the check can't
+	// fire in the window between the two removals.
 	require.Eventually(t, func() bool {
 		code, _, _ := container.Exec(ctx, []string{"test", "-d", filepath.Join(lsmPath, sidecarBucket)})
 		return code != 0

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -375,8 +375,8 @@ func testPostRestartOrphanAuditClearsTracker(t *testing.T, ctx context.Context, 
 	}, 60*time.Second, 500*time.Millisecond,
 		"orphan tracker dir was not cleaned up by the post-bootstrap audit")
 
-	// The audit removes the sidecar dir after the tracker dir; poll so the
-	// check can't fire in the gap between the two.
+	// The sidecar dir is removed just after the tracker, so poll instead of
+	// asserting once.
 	require.Eventually(t, func() bool {
 		code, _, _ := container.Exec(ctx, []string{"test", "-d", filepath.Join(lsmPath, sidecarBucket)})
 		return code != 0

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -380,7 +380,7 @@ func testPostRestartOrphanAuditClearsTracker(t *testing.T, ctx context.Context, 
 	require.Eventually(t, func() bool {
 		code, _, _ := container.Exec(ctx, []string{"test", "-d", filepath.Join(lsmPath, sidecarBucket)})
 		return code != 0
-	}, 60*time.Second, 500*time.Millisecond,
+	}, 60*time.Second, 50*time.Millisecond,
 		"orphan sidecar bucket dir was not cleaned up by the post-bootstrap audit")
 
 	assert.EqualValues(t, preCount, moduleshelper.GetClassCount(t, className, ""),

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -375,9 +375,8 @@ func testPostRestartOrphanAuditClearsTracker(t *testing.T, ctx context.Context, 
 	}, 60*time.Second, 500*time.Millisecond,
 		"orphan tracker dir was not cleaned up by the post-bootstrap audit")
 
-	// The sidecar dir is removed by the same async audit, after the tracker
-	// dir above. Poll for it rather than asserting once, so the check can't
-	// fire in the window between the two removals.
+	// The audit removes the sidecar dir after the tracker dir; poll so the
+	// check can't fire in the gap between the two.
 	require.Eventually(t, func() bool {
 		code, _, _ := container.Exec(ctx, []string{"test", "-d", filepath.Join(lsmPath, sidecarBucket)})
 		return code != 0


### PR DESCRIPTION
## What

`TestBackupVsReindexSuite/PostRestartOrphanAuditClearsTracker` polled (`require.Eventually`) for the orphan **tracker** dir removal, then did a single **un-polled** assert on the **sidecar** bucket dir. The post-bootstrap audit (`cleanUnloadedShardOrphans`) removes the tracker first (`os.RemoveAll(trackerPath)`) and the sidecar second (`removeUnloadedSidecarsForOrphan`), so the un-polled check can fire in the window between the two removals and see the sidecar still present (`test -d` exit 0).

Fix: wrap the sidecar check in `require.Eventually`, mirroring the adjacent tracker poll. Does **not** mask a real bug — if the sidecar is genuinely never removed, the Eventually still fails loudly at 60s.

## Evidence

Surfaced by the reindex soak on current `main` (f17b11b016): this is "Mode B", a sibling of the "Mode C" `BackupRefusedDuringInFlightMigration` flake in weaviate/weaviate#11512. Server logs in the failing run confirm `partial-reindex cleanup: sidecar dirs + migration dir cleaned` did fire — the test just checked before the async removal completed.

## Suggested fold

Candidate — recommend folding into weaviate/weaviate#11512 (both are `reindex_backup` orphan-audit/refusal test-races). Kept separate for now so it can be reviewed/proven independently.

QA Claude — forced-window proof (server delay between tracker and sidecar removal) in progress on the reproducer VM.