### PR TITLE
test(reindex-singlenode): poll DeleteClass past the in-flight migration guard (APIValidation flake)

### DIFF
--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -92,10 +92,9 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		if cancelResp, err := http.DefaultClient.Do(cancelReq); err == nil {
 			cancelResp.Body.Close()
 		}
-		// The cancel is best-effort and may land while the task is past
-		// STARTED (e.g. SWAPPING), where it doesn't terminalize synchronously.
-		// Poll the delete until the MutationGuard clears (task terminal)
-		// rather than a single delete that races the in-flight migration.
+		// The best-effort cancel may not terminalize a task already past
+		// STARTED (e.g. SWAPPING), so poll the delete until the MutationGuard
+		// clears rather than racing it with one shot.
 		require.Eventuallyf(t, func() bool {
 			delReq, _ := http.NewRequest(http.MethodDelete,
 				fmt.Sprintf("http://%s/v1/schema/%s", restURI, mtClass), nil)

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -92,19 +92,38 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		if cancelResp, err := http.DefaultClient.Do(cancelReq); err == nil {
 			cancelResp.Body.Close()
 		}
-		// A best-effort cancel may not terminalize a task already in
-		// SWAPPING, so poll the delete until the MutationGuard clears.
-		require.Eventuallyf(t, func() bool {
+		// A best-effort cancel may not terminalize a task already in SWAPPING,
+		// so poll the delete until the MutationGuard clears. The guard returns
+		// 400 while a reindex task is still in flight; retry only on that (and
+		// transient transport errors) and surface any other status immediately
+		// rather than masking a real failure for the whole timeout. Manual
+		// loop, not require.Eventually, because the latter runs its closure in
+		// a separate goroutine where t.Fatalf/require are unsafe.
+		deadline := time.Now().Add(60 * time.Second)
+		var lastInfo string
+		for {
 			delReq, _ := http.NewRequest(http.MethodDelete,
 				fmt.Sprintf("http://%s/v1/schema/%s", restURI, mtClass), nil)
 			delResp, err := http.DefaultClient.Do(delReq)
 			if err != nil {
-				return false
+				lastInfo = fmt.Sprintf("transport error: %v", err)
+			} else {
+				body, _ := io.ReadAll(delResp.Body)
+				delResp.Body.Close()
+				if delResp.StatusCode == http.StatusOK {
+					break
+				}
+				require.Equalf(t, http.StatusBadRequest, delResp.StatusCode,
+					"DeleteClass(%s) returned unexpected status %d (expected 200, or 400 from the in-flight MutationGuard): %s",
+					mtClass, delResp.StatusCode, string(body))
+				lastInfo = fmt.Sprintf("400 MutationGuard: %s", string(body))
 			}
-			delResp.Body.Close()
-			return delResp.StatusCode == http.StatusOK
-		}, 60*time.Second, 500*time.Millisecond,
-			"DeleteClass(%s) kept being rejected by the MutationGuard — reindex task never left in-flight", mtClass)
+			if time.Now().After(deadline) {
+				t.Fatalf("DeleteClass(%s) did not succeed within 60s — reindex task never left in-flight; last response: %s",
+					mtClass, lastInfo)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
 	}()
 	helper.CreateTenants(t, mtClass, []*models.Tenant{
 		{Name: "tenant-a"}, {Name: "tenant-b"},

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -92,9 +92,8 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		if cancelResp, err := http.DefaultClient.Do(cancelReq); err == nil {
 			cancelResp.Body.Close()
 		}
-		// The best-effort cancel may not terminalize a task already past
-		// STARTED (e.g. SWAPPING), so poll the delete until the MutationGuard
-		// clears rather than racing it with one shot.
+		// A best-effort cancel may not terminalize a task already in
+		// SWAPPING, so poll the delete until the MutationGuard clears.
 		require.Eventuallyf(t, func() bool {
 			delReq, _ := http.NewRequest(http.MethodDelete,
 				fmt.Sprintf("http://%s/v1/schema/%s", restURI, mtClass), nil)

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -92,12 +92,10 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		if cancelResp, err := http.DefaultClient.Do(cancelReq); err == nil {
 			cancelResp.Body.Close()
 		}
-		// The cancel above is best-effort and may land while the task is
-		// past STARTED (e.g. SWAPPING), where it does not terminalize the
-		// task synchronously. Poll the delete until the MutationGuard
-		// clears — i.e. until the task reaches a terminal state (cancelled
-		// or completed) — rather than a single delete that races the
-		// in-flight migration and fails with a 400.
+		// The cancel is best-effort and may land while the task is past
+		// STARTED (e.g. SWAPPING), where it doesn't terminalize synchronously.
+		// Poll the delete until the MutationGuard clears (task terminal)
+		// rather than a single delete that races the in-flight migration.
 		require.Eventuallyf(t, func() bool {
 			delReq, _ := http.NewRequest(http.MethodDelete,
 				fmt.Sprintf("http://%s/v1/schema/%s", restURI, mtClass), nil)

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -35,6 +35,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,7 +92,23 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		if cancelResp, err := http.DefaultClient.Do(cancelReq); err == nil {
 			cancelResp.Body.Close()
 		}
-		helper.DeleteClass(t, mtClass)
+		// The cancel above is best-effort and may land while the task is
+		// past STARTED (e.g. SWAPPING), where it does not terminalize the
+		// task synchronously. Poll the delete until the MutationGuard
+		// clears — i.e. until the task reaches a terminal state (cancelled
+		// or completed) — rather than a single delete that races the
+		// in-flight migration and fails with a 400.
+		require.Eventuallyf(t, func() bool {
+			delReq, _ := http.NewRequest(http.MethodDelete,
+				fmt.Sprintf("http://%s/v1/schema/%s", restURI, mtClass), nil)
+			delResp, err := http.DefaultClient.Do(delReq)
+			if err != nil {
+				return false
+			}
+			delResp.Body.Close()
+			return delResp.StatusCode == http.StatusOK
+		}, 60*time.Second, 500*time.Millisecond,
+			"DeleteClass(%s) kept being rejected by the MutationGuard — reindex task never left in-flight", mtClass)
 	}()
 	helper.CreateTenants(t, mtClass, []*models.Tenant{
 		{Name: "tenant-a"}, {Name: "tenant-b"},


### PR DESCRIPTION
## What

`TestSingleNode_ReindexSuite/APIValidationContract` flakes: its deferred cleanup best-effort-cancels the in-flight `repair-filterable` task on `APIValidationMTClass.text_word`, then calls `helper.DeleteClass` once. The cancel assumes the task is **STARTED**, but by cleanup time it can already be **SWAPPING** (it progressed faster than the positive-path subtest left it), where the cancel doesn't terminalize it synchronously. The schema FSM's MutationGuard then (correctly) rejects the delete:

> `[DELETE /schema/{className}][400]` *"reindex task ...repair-filterable... is in flight (status=SWAPPING); deleting this class would destroy the migration's working state"*

→ `t.Fatalf`. **The server is right** (the guard protects against the bucket↔schema-inversion Sev-1 family). The test races its own teardown.

Fix (test-only): poll the delete until the MutationGuard clears (task reaches a terminal state — cancelled or completed), instead of a single racy delete. Cannot mask a real bug — it only retries on the guard's 400, fails loudly at 60s otherwise.

## Evidence

Surfaced by the reindex soak on current `main` (f17b11b016), round 2. Not the torn-resume flake (#11507-fixed; `TornResumeReindexedNotTidied` passed in the same run).

QA Claude — forced-window proof (server swap delay → task reliably SWAPPING at cleanup) in progress on the reproducer VM.