### PR TITLE
test/docker: per-network subnet with retry to fix concurrent network overlap

### DIFF
--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -106,6 +106,7 @@ const (
 )
 
 type Compose struct {
+	netOctet                    int // second octet of this cluster's subnet, set in Start
 	enableModules               []string
 	defaultVectorizerModule     string
 	withMinIO                   bool
@@ -705,15 +706,26 @@ func (d *Compose) WithAutoschema() *Compose {
 
 func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 	d.weaviateEnvs["DISABLE_TELEMETRY"] = "true"
-	network, err := tescontainersnetwork.New(
-		ctx,
-		tescontainersnetwork.WithAttachable(),
-		tescontainersnetwork.WithIPAM(&dockernetwork.IPAM{
-			Config: []dockernetwork.IPAMConfig{
-				{Subnet: TestSubnet, Gateway: TestGateway},
-			},
-		}),
-	)
+	// Each cluster gets its own subnet (10.<octet>.0.0/16). Two networks can
+	// still draw the same random octet — including several within one test
+	// binary — so re-roll and retry when Docker reports an overlap.
+	newNet := func() (*testcontainers.DockerNetwork, error) {
+		return tescontainersnetwork.New(
+			ctx,
+			tescontainersnetwork.WithAttachable(),
+			tescontainersnetwork.WithIPAM(&dockernetwork.IPAM{
+				Config: []dockernetwork.IPAMConfig{
+					{Subnet: subnetForOctet(d.netOctet), Gateway: gatewayForOctet(d.netOctet)},
+				},
+			}),
+		)
+	}
+	d.netOctet = pickNetOctet()
+	network, err := newNet()
+	for retries := 0; err != nil && retries < 9 && strings.Contains(err.Error(), "overlaps"); retries++ {
+		d.netOctet = pickNetOctet()
+		network, err = newNet()
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "connecting to network")
 	}
@@ -725,7 +737,7 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 	envSettings["DISABLE_TELEMETRY"] = "true"
 	containers := []*DockerContainer{}
 	if d.withMinIO {
-		container, err := startMinIO(ctx, networkName, d.withBackendS3Buckets)
+		container, err := startMinIO(ctx, networkName, d.netOctet, d.withBackendS3Buckets)
 		if err != nil {
 			return nil, errors.Wrapf(err, "start %s", MinIO)
 		}
@@ -937,7 +949,7 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 				containers = append(containers, c)
 			}
 		}
-		return &DockerCompose{network, containers}, err
+		return &DockerCompose{network: network, netOctet: d.netOctet, containers: containers}, err
 	}
 
 	if d.withSecondWeaviate {
@@ -955,17 +967,17 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 		delete(secondWeaviateSettings, "RAFT_PORT")
 		delete(secondWeaviateSettings, "RAFT_INTERNAL_PORT")
 		delete(secondWeaviateSettings, "RAFT_JOIN")
-		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, "/v1/.well-known/ready", d.weaviateFiles)
+		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, d.netOctet, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, "/v1/.well-known/ready", d.weaviateFiles)
 		if err != nil {
 			return nil, errors.Wrapf(err, "start %s", hostname)
 		}
 		containers = append(containers, container)
 		if err != nil {
-			return &DockerCompose{network, containers}, errors.Wrapf(err, "start %s", hostname)
+			return &DockerCompose{network: network, netOctet: d.netOctet, containers: containers}, errors.Wrapf(err, "start %s", hostname)
 		}
 	}
 
-	return &DockerCompose{network, containers}, nil
+	return &DockerCompose{network: network, netOctet: d.netOctet, containers: containers}, nil
 }
 
 func (d *Compose) With1NodeCluster() *Compose {
@@ -1119,7 +1131,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 			}
 			attemptCtx, cancel := context.WithTimeout(context.Background(), perAttemptTimeout)
 			c, err := startWeaviate(attemptCtx, d.enableModules, d.defaultVectorizerModule,
-				cfg, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, livenessEndpoint, d.weaviateFiles)
+				cfg, networkName, d.netOctet, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, livenessEndpoint, d.weaviateFiles)
 			cancel()
 			if err == nil {
 				if attempt > 0 {

--- a/test/docker/container.go
+++ b/test/docker/container.go
@@ -13,32 +13,54 @@ package docker
 
 import (
 	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 )
 
-// Subnet used by test clusters. All weaviate nodes get static IPs
-// derived from their hostname via [StaticIPForHostname].
-const (
-	TestSubnet  = "10.99.0.0/16"
-	TestGateway = "10.99.0.1"
-)
+// pickNetOctet returns a second octet for a test cluster's subnet
+// (10.<octet>.0.0/16). Was hardcoded to 99, so every network fought over
+// 10.99.0.0/16 and failed with "Pool overlaps" whenever two ran at once —
+// including multiple clusters within a single test binary. SOAK_NET_OCTET pins
+// it (the flake-soak sets one per worker); otherwise it's random and Compose
+// re-rolls on overlap, so each network lands on a free subnet. Avoids 128-255
+// (GCP's 10.128.0.0/9) and 0-15 (common host/Docker networks).
+func pickNetOctet() int {
+	if v := os.Getenv("SOAK_NET_OCTET"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 254 && n != 128 {
+			return n
+		}
+	}
+	return rand.Intn(112) + 16 // [16, 127]
+}
 
-// StaticIPForHostname returns a deterministic static IP for a weaviate node.
-// weaviate-0 → 10.99.0.10, weaviate-1 → 10.99.0.11, weaviate-2 → 10.99.0.12.
-// Returns empty string for non-weaviate containers.
-func StaticIPForHostname(hostname string) string {
+func subnetForOctet(octet int) string  { return fmt.Sprintf("10.%d.0.0/16", octet) }
+func gatewayForOctet(octet int) string { return fmt.Sprintf("10.%d.0.1", octet) }
+
+// staticIPForHostname gives each weaviate node a fixed IP in its cluster's
+// subnet; empty for non-weaviate containers.
+func staticIPForHostname(octet int, hostname string) string {
 	switch hostname {
 	case Weaviate0:
-		return "10.99.0.10"
+		return fmt.Sprintf("10.%d.0.10", octet)
 	case Weaviate1:
-		return "10.99.0.11"
+		return fmt.Sprintf("10.%d.0.11", octet)
 	case Weaviate2:
-		return "10.99.0.12"
+		return fmt.Sprintf("10.%d.0.12", octet)
 	default:
 		return ""
 	}
+}
+
+// minioContainerName must be unique per network: MinIO uses Reuse:true keyed on
+// name, so a shared "test-minio" binds to whichever network created it first
+// and leaves other clusters unable to resolve it. The network alias stays
+// MinIO, so weaviate's S3 endpoint config is unchanged.
+func minioContainerName(octet int) string {
+	return fmt.Sprintf("%s-%d", MinIO, octet)
 }
 
 type EndpointName string
@@ -61,25 +83,6 @@ type DockerContainer struct {
 	endpoints   map[EndpointName]endpoint
 	container   testcontainers.Container
 	envSettings map[string]string
-}
-
-// StaticIP returns the deterministic static IP for this container based on its name.
-func (d *DockerContainer) StaticIP() string {
-	return StaticIPForHostname(d.name)
-}
-
-// InternalAddress returns the static cluster-internal address (IP:gossipPort) for
-// this container, useful for logging and diagnostics.
-func (d *DockerContainer) InternalAddress() string {
-	ip := d.StaticIP()
-	if ip == "" {
-		return ""
-	}
-	port := d.envSettings["CLUSTER_GOSSIP_BIND_PORT"]
-	if port == "" {
-		return ip
-	}
-	return fmt.Sprintf("%s:%s", ip, port)
 }
 
 func (d *DockerContainer) Name() string {

--- a/test/docker/container_net_test.go
+++ b/test/docker/container_net_test.go
@@ -1,0 +1,67 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package docker
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestPickNetOctet(t *testing.T) {
+	t.Run("valid SOAK_NET_OCTET wins", func(t *testing.T) {
+		t.Setenv("SOAK_NET_OCTET", "42")
+		if got := pickNetOctet(); got != 42 {
+			t.Fatalf("want 42, got %d", got)
+		}
+	})
+	t.Run("invalid/excluded override falls back to a random in-range octet", func(t *testing.T) {
+		for _, v := range []string{"128", "0", "255", "300", "-1", "abc", " 42"} {
+			t.Setenv("SOAK_NET_OCTET", v)
+			if got := pickNetOctet(); got < 16 || got > 127 {
+				t.Fatalf("override %q: fallback octet %d not in [16,127]", v, got)
+			}
+		}
+	})
+	t.Run("unset always yields an octet in [16,127]", func(t *testing.T) {
+		t.Setenv("SOAK_NET_OCTET", "")
+		for i := 0; i < 2000; i++ {
+			if got := pickNetOctet(); got < 16 || got > 127 {
+				t.Fatalf("random octet %d not in [16,127]", got)
+			}
+		}
+	})
+}
+
+// subnet, gateway, node IPs, and MinIO name must all derive from the cluster's
+// octet, else the network is broken / MinIO unreachable.
+func TestOctetDerivedAddresses(t *testing.T) {
+	const octet = 73
+	prefix := fmt.Sprintf("10.%d.", octet)
+	for name, got := range map[string]string{
+		"subnet":    subnetForOctet(octet),
+		"gateway":   gatewayForOctet(octet),
+		"weaviate0": staticIPForHostname(octet, Weaviate0),
+		"weaviate1": staticIPForHostname(octet, Weaviate1),
+		"weaviate2": staticIPForHostname(octet, Weaviate2),
+	} {
+		if !strings.HasPrefix(got, prefix) {
+			t.Fatalf("%s=%q does not start with %q", name, got, prefix)
+		}
+	}
+	if got := staticIPForHostname(octet, "not-a-weaviate-node"); got != "" {
+		t.Fatalf("non-weaviate static IP should be empty, got %q", got)
+	}
+	if want := fmt.Sprintf("%s-%d", MinIO, octet); minioContainerName(octet) != want {
+		t.Fatalf("minioContainerName(%d)=%q, want %q", octet, minioContainerName(octet), want)
+	}
+}

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -28,6 +28,7 @@ import (
 
 type DockerCompose struct {
 	network    *testcontainers.DockerNetwork
+	netOctet   int // second octet of this cluster's subnet (10.<netOctet>.0.0/16)
 	containers []*DockerContainer
 }
 
@@ -323,7 +324,7 @@ func (d *DockerCompose) ConnectToNetwork(ctx context.Context, containerName stri
 	// pass --ip to preserve it — otherwise Docker assigns a new IP and Raft/memberlist
 	// can't resolve the rejoining node.
 	args := []string{"network", "connect"}
-	if ip := container.StaticIP(); ip != "" {
+	if ip := staticIPForHostname(d.netOctet, container.name); ip != "" {
 		args = append(args, "--ip", ip)
 	}
 	args = append(args, networkName, containerID)

--- a/test/docker/minio.go
+++ b/test/docker/minio.go
@@ -23,17 +23,18 @@ import (
 
 const MinIO = "test-minio"
 
-func startMinIO(ctx context.Context, networkName string, buckets map[string]string) (*DockerContainer, error) {
+func startMinIO(ctx context.Context, networkName string, netOctet int, buckets map[string]string) (*DockerContainer, error) {
 	port := nat.Port("9000/tcp")
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "minio/minio",
 			ExposedPorts: []string{"9000/tcp"},
-			Name:         MinIO,
+			Name:         minioContainerName(netOctet),
 			Hostname:     MinIO,
 			AutoRemove:   true,
 			Networks:     []string{networkName},
 			NetworkAliases: map[string][]string{
+				// alias stays MinIO even though the container is named per-process
 				networkName: {MinIO},
 			},
 			Env: map[string]string{

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -36,7 +36,7 @@ const (
 
 func startWeaviate(ctx context.Context,
 	enableModules []string, defaultVectorizerModule string,
-	extraEnvSettings map[string]string, networkName string,
+	extraEnvSettings map[string]string, networkName string, netOctet int,
 	weaviateImage, hostname string,
 	exposeGRPCPort, exposeDebugPort bool,
 	wellKnownEndpoint string,
@@ -172,7 +172,7 @@ func startWeaviate(ctx context.Context,
 			},
 		},
 	}
-	if ip := StaticIPForHostname(containerName); ip != "" && networkName != "" {
+	if ip := staticIPForHostname(netOctet, containerName); ip != "" && networkName != "" {
 		req.EndpointSettingsModifier = func(settings map[string]*dockernetwork.EndpointSettings) {
 			s := settings[networkName]
 			s.IPAMConfig = &dockernetwork.EndpointIPAMConfig{


### PR DESCRIPTION
## Problem

Test clusters hardcoded their Docker network to `10.99.0.0/16`. Any two clusters created at the same time collide on that single subnet and fail with:

```
create network: invalid pool request: Pool overlaps with other one on this address space
```

This hits CI whenever clusters run concurrently — notably **multiple suites within one test binary**, e.g. `test/acceptance/replication/replica_replication/fast` (`TestReplicationNotImplementedTestSuite`, `TestReplicationHappyPathTestSuite/...`), which is what was failing.

## Change

Each `Compose.Start` picks its **own** subnet octet (`10.<octet>.0.0/16`) and **re-rolls + retries** when Docker reports an overlap, so concurrent networks — across processes *and* within one process — always land on distinct, free subnets.

- `SOAK_NET_OCTET` (valid `1..254`, `!=128`) still pins the octet — the reindex flake-soak sets one per worker.
- otherwise random in `[16,127]`; on `"overlaps"` it retries with a fresh octet (up to 10 attempts). `128..255` avoided (GCP's internal `10.128.0.0/9`), `0..15` avoided (common host/Docker default networks).

The chosen octet lives on `DockerCompose` and drives the per-node static IPs (`staticIPForHostname`) and the network-reconnect (`ConnectToNetwork`) path, so a cluster's subnet, gateway, and node IPs always agree.

### MinIO

MinIO uses `Reuse: true`, which keys on the container **name**. With per-cluster networks, a shared `test-minio` would bind to whichever network created it first and leave other clusters unable to resolve it. The name is suffixed with the octet; the in-network **alias** stays `test-minio`, so weaviate's S3 endpoint config (`test-minio:9000`) and `GetMinIO`/`StopMinIO` are unchanged.

## Why retry (not just randomize)

Randomization alone still leaves a birthday-collision chance when many clusters run at once (~112 octets). Retry-on-overlap closes that: a loser of a race simply re-rolls onto a free subnet. This is what makes it robust enough for CI rather than just less-likely-to-fail.

## Risk

- Default test subnet is no longer a fixed `10.99.x`; it's `10.[16-127].x`. Only `test/docker/` consumes `TestSubnet`/`TestGateway` and node IPs flow through `staticIPForHostname`, so nothing outside the package is affected. The unused `DockerContainer.StaticIP`/`InternalAddress` helpers (no callers) were removed; the octet now lives on `DockerCompose`.
- MinIO container name changes to `test-minio-<octet>`; alias unchanged, nothing references the literal name.

## Tests

- `TestPickNetOctet` — env override wins; invalid/excluded values fall back to an in-range random octet; unset always yields `[16,127]`.
- `TestOctetDerivedAddresses` — subnet, gateway, all node IPs, and the MinIO name derive from the same octet; non-weaviate hosts get no static IP.

`gofmt`, `go vet ./test/docker/`, `go build ./test/docker/`, and the new tests pass locally. The concurrent-overlap behavior itself is validated by CI on this package.

Targeting `stable/v1.37`. Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)