### PR TITLE
fix: handle transient errors during namespaced user creation

### DIFF
--- a/test/acceptance_with_python/test_namespace_refs.py
+++ b/test/acceptance_with_python/test_namespace_refs.py
@@ -237,6 +237,7 @@ def _create_namespaced_user(http_port: int, user_id: str, namespace: str) -> str
                 d.raise_for_status()
             _wait_for_user_gone(http_port, qualified)
             deleted = True
+            deadline = time.time() + 10.0
             continue
         if r.status_code == 422 and "does not exist" in r.text:
             last = r

--- a/test/acceptance_with_python/test_namespace_refs.py
+++ b/test/acceptance_with_python/test_namespace_refs.py
@@ -203,17 +203,19 @@ def _assign_admin_role(http_port: int, qualified_user: str) -> None:
 
 
 def _create_namespaced_user(http_port: int, user_id: str, namespace: str) -> str:
-    """POST /users/db/{namespace:user}, then grant the admin role. Returns the apikey.
+    """POST /users/db/{namespace:user}, grant admin, return apikey.
 
-    Mirrors createNamespacedUser in test/acceptance/namespace/collection_alias_test.go.
-    On 409 (user already exists from a prior run) we delete and recreate so
-    the fixture is re-runnable against a long-lived cluster — the api key
-    isn't readable after creation, so reuse isn't an option. The DELETE is
-    RAFT-forwarded, so we poll until it's applied before re-POSTing — else
-    createUser's local existence check races it and 409s again.
+    Absorbs two transients:
+      - 409 (stale user from prior run): delete once + retry.
+      - 422 "namespace does not exist": local FSM hasn't applied the
+        create-namespace entry yet even though _wait_for_namespace got 200
+        from the RAFT-served GET; poll until local apply catches up.
     """
     qualified = f"{namespace}:{user_id}"
-    for _ in range(2):
+    deleted = False
+    deadline = time.time() + 10.0
+    last: Optional[_RestResponse] = None
+    while time.time() < deadline:
         r = _http(
             "POST",
             f"{_rest_base(http_port)}/users/db/{qualified}",
@@ -225,7 +227,7 @@ def _create_namespaced_user(http_port: int, user_id: str, namespace: str) -> str
             assert apikey, f"createUser returned no apikey: {r.text}"
             _assign_admin_role(http_port, qualified)
             return apikey
-        if r.status_code == 409:
+        if r.status_code == 409 and not deleted:
             d = _http(
                 "DELETE",
                 f"{_rest_base(http_port)}/users/db/{qualified}",
@@ -234,9 +236,17 @@ def _create_namespaced_user(http_port: int, user_id: str, namespace: str) -> str
             if d.status_code not in (200, 204, 404):
                 d.raise_for_status()
             _wait_for_user_gone(http_port, qualified)
+            deleted = True
+            continue
+        if r.status_code == 422 and "does not exist" in r.text:
+            last = r
+            time.sleep(0.05)
             continue
         r.raise_for_status()
-    raise AssertionError(f"could not create user {qualified} after delete+retry")
+    raise AssertionError(
+        f"could not create user {qualified} within 10s: "
+        f"{last.status_code if last else 'no response'}: {last.text if last else ''}"
+    )
 
 
 def _wait_for_user_gone(http_port: int, qualified: str) -> None:


### PR DESCRIPTION
### What's being changed:

- retry namespace creation if namespace does not exist on all nodes yet

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
