### PR TITLE
fix(rbac): pass principal to prettyPermissionsResources (main is red)

### DIFF
--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -116,7 +116,7 @@ func (m *Manager) authorize(ctx context.Context, principal *models.Principal, ve
 		if !allowed {
 			if !skipAudit {
 				logger.WithFields(logrus.Fields{
-					"resource":    prettyPermissionsResources(perm),
+					"resource":    prettyPermissionsResources(principal, perm),
 					"perm":        prettyPermissionsActions(perm),
 					"permissions": permResults,
 				}).Error("authorization denied")


### PR DESCRIPTION
## main does not compile

```
usecases/auth/authorization/rbac/authorizer.go:119:48: not enough arguments in
call to prettyPermissionsResources
	have (*models.Permission)
	want (*models.Principal, *models.Permission)
```

`prettyPermissionsResources` has required `(principal, perm)` since `f6ab160bff1` (2026-05-11). The denied-log audit block calls it with one arg.

## Root cause — semantic merge conflict

The 1-arg call was introduced by #11517 ("Add more info to RBAC denied log"), which was **based on `stable/v1.36`** where `prettyPermissionsResources` is still 1-arg — so it compiled there and CI was green. When `stable/v1.36` was merged forward into `main` (2-arg signature), the new 1-arg call collided with it. Neither side's CI caught it because each compiled in isolation.

## Fix

Thread the in-scope `principal` into the call (line 119), matching the other three call sites in the same function. One line.

## Verification

- `go build ./usecases/auth/authorization/rbac/` now succeeds (was the failing package).
- `gofmt` clean; no other 1-arg call sites remain in the package.

One-line, build-verified — marked draft per request, but safe to mark ready/merge immediately; `main` is currently red for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)