### PR TITLE
fix: add support for strfmt.URI in reference aggregation and strip NS

### DIFF
--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
@@ -77,11 +77,7 @@ func (r *AggregateReplier) Aggregate(res interface{}, isGroupby bool) (*pb.Aggre
 
 		if len(result.Groups) > 0 {
 			groups = make([]*pb.AggregateReply_Group, len(result.Groups))
-			// All groups share the same group-by property, so resolve its
-			// ref-ness once. Keyed on the schema rather than the bucket
-			// value's dynamic type: remote-shard results arrive with the
-			// beacon as a plain string (JSON-collapsed from strfmt.URI), so a
-			// type check would miss them and skip the NS strip.
+			// All groups share one group-by property; resolve ref-ness once.
 			var groupByIsRef bool
 			if gb := result.Groups[0].GroupedBy; gb != nil {
 				groupByIsRef = r.groupByIsRef(gb.Path)
@@ -108,11 +104,11 @@ func (r *AggregateReplier) Aggregate(res interface{}, isGroupby bool) (*pb.Aggre
 	return &pb.AggregateReply{}, nil
 }
 
-// groupByIsRef reports whether the group-by property at path is a
-// cross-reference, i.e. its bucket values are beacon URIs (from
-// MultipleRef.Beacon) rather than user text. Resolved from the schema, not
-// the value's dynamic type, so it holds for remote-shard buckets that arrive
-// as plain strings after the shard→coordinator JSON round-trip.
+// groupByIsRef reports whether the group-by property is a cross-reference
+// (its buckets are beacon URIs, not user text). Keyed on the schema, not the
+// value's type: remote-shard buckets arrive as plain strings after the
+// shard→coordinator JSON round-trip collapses strfmt.URI, so a type check
+// would miss them.
 func (r *AggregateReplier) groupByIsRef(path []string) bool {
 	if r.authorizedGetDataTypeOfProp == nil || len(path) == 0 {
 		return false
@@ -124,18 +120,14 @@ func (r *AggregateReplier) groupByIsRef(path []string) bool {
 	return schema.IsRefDataType([]string{dataType})
 }
 
-// beaconScheme is the URI scheme of a Weaviate cross-ref beacon. crossref.Parse
-// validates only the path shape + UUID, not the scheme, and Ref.String()
-// re-serializes as weaviate:// dropping any query/fragment — so we gate on the
-// scheme before rewriting to avoid mangling a non-beacon "/Class/<uuid>" URI.
 const beaconScheme = "weaviate://"
 
-// groupedByText builds a text bucket. For ref group-by (isRef) the value is a
-// beacon URI: strip the embedded class of the caller's own "<ns>:" so it
-// doesn't ride along, leaving foreign prefixes intact. Anything that isn't a
-// weaviate:// beacon passes through untouched. Non-ref values are arbitrary
-// user text and are never rewritten. Defense in depth — the write path already
-// stores beacons short, so the strip only fires if a qualified one slips through.
+// groupedByText builds a text bucket. For a ref beacon it strips the caller's
+// own "<ns>:" from the embedded class (foreign prefixes stay). The scheme
+// guard matters: crossref.Parse ignores the scheme and Ref.String() rewrites
+// to weaviate:// dropping any query/fragment, so without it a non-beacon
+// "/Class/<uuid>" URI would be mangled. Defense in depth — writes already
+// store beacons short.
 func (r *AggregateReplier) groupedByText(path []string, val string, isRef bool) *pb.AggregateReply_Group_GroupedBy {
 	if isRef && strings.HasPrefix(val, beaconScheme) {
 		if ref, err := crossref.Parse(val); err == nil {
@@ -155,10 +147,8 @@ func (r *AggregateReplier) parseAggregateGroupedBy(in *aggregation.GroupedBy, is
 		case string:
 			return r.groupedByText(in.Path, val, isRef), nil
 		case strfmt.URI:
-			// Defensive: the grouper normalizes ref beacons to plain string,
-			// so this fires only if some path still hands us the named type
-			// (e.g. a local shard whose value skipped JSON). Normalize so a
-			// stray strfmt.URI can't fall through to the default 500.
+			// Defensive: the grouper emits beacons as plain string; this only
+			// catches a stray named type so it can't fall through to the 500.
 			return r.groupedByText(in.Path, string(val), isRef), nil
 		case bool:
 			return &pb.AggregateReply_Group_GroupedBy{

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
@@ -14,9 +14,11 @@ package v1
 import (
 	"fmt"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
@@ -103,6 +105,20 @@ func (r *AggregateReplier) parseAggregateGroupedBy(in *aggregation.GroupedBy) (*
 			return &pb.AggregateReply_Group_GroupedBy{
 				Path:  in.Path,
 				Value: &pb.AggregateReply_Group_GroupedBy_Text{Text: val},
+			}, nil
+		case strfmt.URI:
+			// Ref-target group-by: bucket value is the beacon URI from
+			// MultipleRef.Beacon. Parse + strip embedded class so the
+			// caller's "<ns>:" doesn't ride along; unparseable URIs pass
+			// through unchanged.
+			s := string(val)
+			if ref, err := crossref.Parse(s); err == nil {
+				ref.Class = namespacing.StripOwnNamespace(r.principal, ref.Class)
+				s = ref.String()
+			}
+			return &pb.AggregateReply_Group_GroupedBy{
+				Path:  in.Path,
+				Value: &pb.AggregateReply_Group_GroupedBy_Text{Text: s},
 			}, nil
 		case bool:
 			return &pb.AggregateReply_Group_GroupedBy{

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
@@ -76,13 +76,22 @@ func (r *AggregateReplier) Aggregate(res interface{}, isGroupby bool) (*pb.Aggre
 
 		if len(result.Groups) > 0 {
 			groups = make([]*pb.AggregateReply_Group, len(result.Groups))
+			// All groups share the same group-by property, so resolve its
+			// ref-ness once. Keyed on the schema rather than the bucket
+			// value's dynamic type: remote-shard results arrive with the
+			// beacon as a plain string (JSON-collapsed from strfmt.URI), so a
+			// type check would miss them and skip the NS strip.
+			var groupByIsRef bool
+			if gb := result.Groups[0].GroupedBy; gb != nil {
+				groupByIsRef = r.groupByIsRef(gb.Path)
+			}
 			for i := range result.Groups {
 				count := int64(result.Groups[i].Count)
 				aggregations, err := r.parseAggregatedProperties(result.Groups[i].Properties)
 				if err != nil {
 					return nil, fmt.Errorf("aggregations: %w", err)
 				}
-				groupedBy, err := r.parseAggregateGroupedBy(result.Groups[i].GroupedBy)
+				groupedBy, err := r.parseAggregateGroupedBy(result.Groups[i].GroupedBy, groupByIsRef)
 				if err != nil {
 					return nil, fmt.Errorf("groupedBy: %w", err)
 				}
@@ -98,28 +107,52 @@ func (r *AggregateReplier) Aggregate(res interface{}, isGroupby bool) (*pb.Aggre
 	return &pb.AggregateReply{}, nil
 }
 
-func (r *AggregateReplier) parseAggregateGroupedBy(in *aggregation.GroupedBy) (*pb.AggregateReply_Group_GroupedBy, error) {
+// groupByIsRef reports whether the group-by property at path is a
+// cross-reference, i.e. its bucket values are beacon URIs (from
+// MultipleRef.Beacon) rather than user text. Resolved from the schema, not
+// the value's dynamic type, so it holds for remote-shard buckets that arrive
+// as plain strings after the shard→coordinator JSON round-trip.
+func (r *AggregateReplier) groupByIsRef(path []string) bool {
+	if r.authorizedGetDataTypeOfProp == nil || len(path) == 0 {
+		return false
+	}
+	dataType, err := r.authorizedGetDataTypeOfProp(path[len(path)-1])
+	if err != nil {
+		return false
+	}
+	return schema.IsRefDataType([]string{dataType})
+}
+
+// groupedByText builds a text bucket. For ref group-by (isRef) the value is a
+// beacon URI: strip the embedded class of the caller's own "<ns>:" so it
+// doesn't ride along, leaving foreign prefixes intact; unparseable beacons
+// pass through. Non-ref values are arbitrary user text and are never
+// rewritten. Defense in depth — the write path already stores beacons short,
+// so the strip only fires if a qualified one ever slips through.
+func (r *AggregateReplier) groupedByText(path []string, val string, isRef bool) *pb.AggregateReply_Group_GroupedBy {
+	if isRef {
+		if ref, err := crossref.Parse(val); err == nil {
+			ref.Class = namespacing.StripOwnNamespace(r.principal, ref.Class)
+			val = ref.String()
+		}
+	}
+	return &pb.AggregateReply_Group_GroupedBy{
+		Path:  path,
+		Value: &pb.AggregateReply_Group_GroupedBy_Text{Text: val},
+	}
+}
+
+func (r *AggregateReplier) parseAggregateGroupedBy(in *aggregation.GroupedBy, isRef bool) (*pb.AggregateReply_Group_GroupedBy, error) {
 	if in != nil {
 		switch val := in.Value.(type) {
 		case string:
-			return &pb.AggregateReply_Group_GroupedBy{
-				Path:  in.Path,
-				Value: &pb.AggregateReply_Group_GroupedBy_Text{Text: val},
-			}, nil
+			return r.groupedByText(in.Path, val, isRef), nil
 		case strfmt.URI:
-			// Ref-target group-by: bucket value is the beacon URI from
-			// MultipleRef.Beacon. Parse + strip embedded class so the
-			// caller's "<ns>:" doesn't ride along; unparseable URIs pass
-			// through unchanged.
-			s := string(val)
-			if ref, err := crossref.Parse(s); err == nil {
-				ref.Class = namespacing.StripOwnNamespace(r.principal, ref.Class)
-				s = ref.String()
-			}
-			return &pb.AggregateReply_Group_GroupedBy{
-				Path:  in.Path,
-				Value: &pb.AggregateReply_Group_GroupedBy_Text{Text: s},
-			}, nil
+			// Defensive: the grouper normalizes ref beacons to plain string,
+			// so this fires only if some path still hands us the named type
+			// (e.g. a local shard whose value skipped JSON). Normalize so a
+			// stray strfmt.URI can't fall through to the default 500.
+			return r.groupedByText(in.Path, string(val), isRef), nil
 		case bool:
 			return &pb.AggregateReply_Group_GroupedBy{
 				Path:  in.Path,

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
@@ -13,6 +13,7 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -123,14 +124,20 @@ func (r *AggregateReplier) groupByIsRef(path []string) bool {
 	return schema.IsRefDataType([]string{dataType})
 }
 
+// beaconScheme is the URI scheme of a Weaviate cross-ref beacon. crossref.Parse
+// validates only the path shape + UUID, not the scheme, and Ref.String()
+// re-serializes as weaviate:// dropping any query/fragment — so we gate on the
+// scheme before rewriting to avoid mangling a non-beacon "/Class/<uuid>" URI.
+const beaconScheme = "weaviate://"
+
 // groupedByText builds a text bucket. For ref group-by (isRef) the value is a
 // beacon URI: strip the embedded class of the caller's own "<ns>:" so it
-// doesn't ride along, leaving foreign prefixes intact; unparseable beacons
-// pass through. Non-ref values are arbitrary user text and are never
-// rewritten. Defense in depth — the write path already stores beacons short,
-// so the strip only fires if a qualified one ever slips through.
+// doesn't ride along, leaving foreign prefixes intact. Anything that isn't a
+// weaviate:// beacon passes through untouched. Non-ref values are arbitrary
+// user text and are never rewritten. Defense in depth — the write path already
+// stores beacons short, so the strip only fires if a qualified one slips through.
 func (r *AggregateReplier) groupedByText(path []string, val string, isRef bool) *pb.AggregateReply_Group_GroupedBy {
-	if isRef {
+	if isRef && strings.HasPrefix(val, beaconScheme) {
 		if ref, err := crossref.Parse(val); err == nil {
 			ref.Class = namespacing.StripOwnNamespace(r.principal, ref.Class)
 			val = ref.String()

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
@@ -73,79 +73,85 @@ func TestGRPCAggregateReply_ReferenceAggregationStripsPointingTo(t *testing.T) {
 	}
 }
 
-// Pins the ref-target group-by case (in.Value is strfmt.URI from
-// MultipleRef.Beacon). Pre-fix the type switch's `case string` didn't
-// match the named strfmt.URI type → 500. Fix adds the case and strips
-// the caller's own NS from the embedded class.
+// Pins the ref-target group-by strip (isRef=true). The bucket value is a
+// beacon URI from MultipleRef.Beacon. The grouper normalizes it to a plain
+// string (`in`), but a stray strfmt.URI (local shard that skipped JSON) must
+// strip identically, so each case is run through both dynamic types. The
+// caller's own "<ns>:" is stripped from the embedded class; foreign prefixes
+// and short beacons are left intact.
 func TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace(t *testing.T) {
 	const uuid = "11111111-2222-3333-4444-555555555555"
-	mkURI := func(class string) strfmt.URI {
-		return strfmt.URI("weaviate://localhost/" + class + "/" + uuid)
+	mk := func(class string) string {
+		return "weaviate://localhost/" + class + "/" + uuid
 	}
 	cases := []struct {
 		name      string
 		principal *models.Principal
-		in        strfmt.URI
+		in        string
 		wantText  string
 	}{
 		{
 			name:      "namespaced caller: own-NS stripped from embedded class",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			in:        mkURI("customer1:Animal"),
-			wantText:  "weaviate://localhost/Animal/" + uuid,
+			in:        mk("customer1:Animal"),
+			wantText:  mk("Animal"),
 		},
 		{
 			name:      "namespaced caller: foreign-NS preserved",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			in:        mkURI("customer2:Animal"),
-			wantText:  "weaviate://localhost/customer2:Animal/" + uuid,
+			in:        mk("customer2:Animal"),
+			wantText:  mk("customer2:Animal"),
 		},
 		{
 			name:      "namespaced caller: already-short beacon unchanged",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			in:        mkURI("Animal"),
-			wantText:  "weaviate://localhost/Animal/" + uuid,
+			in:        mk("Animal"),
+			wantText:  mk("Animal"),
 		},
 		{
 			name:      "global principal: qualified beacon preserved",
 			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			in:        mkURI("customer1:Animal"),
-			wantText:  "weaviate://localhost/customer1:Animal/" + uuid,
+			in:        mk("customer1:Animal"),
+			wantText:  mk("customer1:Animal"),
 		},
 		{
 			name:      "nil principal: pass-through (NS-disabled cluster)",
 			principal: nil,
-			in:        mkURI("customer1:Animal"),
-			wantText:  "weaviate://localhost/customer1:Animal/" + uuid,
+			in:        mk("customer1:Animal"),
+			wantText:  mk("customer1:Animal"),
 		},
 		{
 			name:      "unparseable URI: passed through unchanged",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			in:        strfmt.URI("not-a-real-beacon"),
+			in:        "not-a-real-beacon",
 			wantText:  "not-a-real-beacon",
 		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			replier := NewAggregateReplier(tc.principal, nil, nil)
-			got, err := replier.parseAggregateGroupedBy(&aggregation.GroupedBy{
-				Path:  []string{"hasAnimals"},
-				Value: tc.in,
+		// string is the grouper's normalized output (and the remote-shard
+		// JSON shape); strfmt.URI is the defensive local-shard path.
+		for _, val := range []interface{}{tc.in, strfmt.URI(tc.in)} {
+			t.Run(tc.name, func(t *testing.T) {
+				replier := NewAggregateReplier(tc.principal, nil, nil)
+				got, err := replier.parseAggregateGroupedBy(&aggregation.GroupedBy{
+					Path:  []string{"hasAnimals"},
+					Value: val,
+				}, true)
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				textVal, ok := got.Value.(*pb.AggregateReply_Group_GroupedBy_Text)
+				require.True(t, ok, "expected Text value, got %T", got.Value)
+				assert.Equal(t, tc.wantText, textVal.Text)
 			})
-			require.NoError(t, err)
-			require.NotNil(t, got)
-			textVal, ok := got.Value.(*pb.AggregateReply_Group_GroupedBy_Text)
-			require.True(t, ok, "expected Text value, got %T", got.Value)
-			assert.Equal(t, tc.wantText, textVal.Text)
-		})
+		}
 	}
 }
 
-// TestGRPCAggregateReply_GroupByPassesValuesThrough pins that bucket
-// values flow unchanged for string / []string. Group-by values can be
-// arbitrary user text (e.g. "customer1:foo"), so we must not rewrite
-// them — ref-target buckets carry a strfmt.URI value (not plain string)
-// and go through TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace.
+// TestGRPCAggregateReply_GroupByPassesValuesThrough pins that non-ref bucket
+// values flow unchanged (isRef=false). Group-by values can be arbitrary user
+// text (e.g. "customer1:foo"), so we must not rewrite them — including a
+// value that merely looks like a beacon, which proves the strip keys off
+// schema ref-ness, not value shape.
 func TestGRPCAggregateReply_GroupByPassesValuesThrough(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -163,6 +169,11 @@ func TestGRPCAggregateReply_GroupByPassesValuesThrough(t *testing.T) {
 			wantValue: &pb.AggregateReply_Group_GroupedBy_Text{Text: "Tigger"},
 		},
 		{
+			name:      "beacon-shaped user text is NOT stripped when prop is non-ref",
+			in:        aggregation.GroupedBy{Path: []string{"title"}, Value: "weaviate://localhost/customer1:Foo/11111111-2222-3333-4444-555555555555"},
+			wantValue: &pb.AggregateReply_Group_GroupedBy_Text{Text: "weaviate://localhost/customer1:Foo/11111111-2222-3333-4444-555555555555"},
+		},
+		{
 			name:      "[]string preserves every entry verbatim",
 			in:        aggregation.GroupedBy{Path: []string{"tags"}, Value: []string{"customer1:tag", "Global", "customer2:tag"}},
 			wantValue: &pb.AggregateReply_Group_GroupedBy_Texts{Texts: &pb.TextArray{Values: []string{"customer1:tag", "Global", "customer2:tag"}}},
@@ -170,14 +181,34 @@ func TestGRPCAggregateReply_GroupByPassesValuesThrough(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			replier := NewAggregateReplier(nil, nil, nil)
-			got, err := replier.parseAggregateGroupedBy(&tc.in)
+			replier := NewAggregateReplier(&models.Principal{Username: "u", Namespace: "customer1"}, nil, nil)
+			got, err := replier.parseAggregateGroupedBy(&tc.in, false)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			assert.Equal(t, tc.wantValue, got.Value)
 			assert.Equal(t, tc.in.Path, got.Path)
 		})
 	}
+}
+
+// Pins that ref-ness is resolved from the schema (so it survives the
+// remote-shard JSON round-trip that collapses strfmt.URI → string), not from
+// the bucket value's dynamic type.
+func TestGRPCAggregateReply_GroupByIsRef(t *testing.T) {
+	class := &models.Class{
+		Class: "Zoo",
+		Properties: []*models.Property{
+			{Name: "hasAnimals", DataType: []string{"Animal"}},
+			{Name: "name", DataType: []string{"text"}},
+		},
+	}
+	getClass := func(string) (*models.Class, error) { return class, nil }
+	replier := NewAggregateReplier(nil, getClass, &aggregation.Params{ClassName: "Zoo"})
+
+	assert.True(t, replier.groupByIsRef([]string{"hasAnimals"}), "ref prop")
+	assert.False(t, replier.groupByIsRef([]string{"name"}), "text prop")
+	assert.False(t, replier.groupByIsRef([]string{"missing"}), "unknown prop fails closed")
+	assert.False(t, replier.groupByIsRef(nil), "empty path fails closed")
 }
 
 func TestGRPCAggregateReply(t *testing.T) {

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
@@ -126,6 +126,15 @@ func TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace(t *testing.T) {
 			in:        "not-a-real-beacon",
 			wantText:  "not-a-real-beacon",
 		},
+		{
+			// crossref.Parse accepts this shape (path + UUID) but it isn't a
+			// weaviate:// beacon, so the scheme guard must leave it verbatim
+			// rather than re-serialize it as weaviate:// (dropping the query).
+			name:      "non-beacon URI with beacon-shaped path: not rewritten",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			in:        "http://example.com/customer1:Animal/" + uuid + "?q=1",
+			wantText:  "http://example.com/customer1:Animal/" + uuid + "?q=1",
+		},
 	}
 	for _, tc := range cases {
 		// string is the grouper's normalized output (and the remote-shard

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
@@ -73,12 +73,10 @@ func TestGRPCAggregateReply_ReferenceAggregationStripsPointingTo(t *testing.T) {
 	}
 }
 
-// Pins the ref-target group-by strip (isRef=true). The bucket value is a
-// beacon URI from MultipleRef.Beacon. The grouper normalizes it to a plain
-// string (`in`), but a stray strfmt.URI (local shard that skipped JSON) must
-// strip identically, so each case is run through both dynamic types. The
-// caller's own "<ns>:" is stripped from the embedded class; foreign prefixes
-// and short beacons are left intact.
+// Pins the ref-target group-by strip (isRef=true): own "<ns>:" stripped from
+// the embedded class, foreign prefixes and short beacons left intact. Each
+// case runs through both string (grouper/remote shape) and strfmt.URI (the
+// defensive local-shard path) so they strip identically.
 func TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace(t *testing.T) {
 	const uuid = "11111111-2222-3333-4444-555555555555"
 	mk := func(class string) string {
@@ -137,8 +135,6 @@ func TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		// string is the grouper's normalized output (and the remote-shard
-		// JSON shape); strfmt.URI is the defensive local-shard path.
 		for _, val := range []interface{}{tc.in, strfmt.URI(tc.in)} {
 			t.Run(tc.name, func(t *testing.T) {
 				replier := NewAggregateReplier(tc.principal, nil, nil)
@@ -156,11 +152,9 @@ func TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace(t *testing.T) {
 	}
 }
 
-// TestGRPCAggregateReply_GroupByPassesValuesThrough pins that non-ref bucket
-// values flow unchanged (isRef=false). Group-by values can be arbitrary user
-// text (e.g. "customer1:foo"), so we must not rewrite them — including a
-// value that merely looks like a beacon, which proves the strip keys off
-// schema ref-ness, not value shape.
+// Pins that non-ref buckets (isRef=false) flow through unchanged — including
+// user text that looks like a beacon, proving the strip keys off schema
+// ref-ness, not value shape.
 func TestGRPCAggregateReply_GroupByPassesValuesThrough(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply_test.go
@@ -14,6 +14,7 @@ package v1
 import (
 	"testing"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/aggregation"
@@ -72,11 +73,79 @@ func TestGRPCAggregateReply_ReferenceAggregationStripsPointingTo(t *testing.T) {
 	}
 }
 
+// Pins the ref-target group-by case (in.Value is strfmt.URI from
+// MultipleRef.Beacon). Pre-fix the type switch's `case string` didn't
+// match the named strfmt.URI type → 500. Fix adds the case and strips
+// the caller's own NS from the embedded class.
+func TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace(t *testing.T) {
+	const uuid = "11111111-2222-3333-4444-555555555555"
+	mkURI := func(class string) strfmt.URI {
+		return strfmt.URI("weaviate://localhost/" + class + "/" + uuid)
+	}
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		in        strfmt.URI
+		wantText  string
+	}{
+		{
+			name:      "namespaced caller: own-NS stripped from embedded class",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			in:        mkURI("customer1:Animal"),
+			wantText:  "weaviate://localhost/Animal/" + uuid,
+		},
+		{
+			name:      "namespaced caller: foreign-NS preserved",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			in:        mkURI("customer2:Animal"),
+			wantText:  "weaviate://localhost/customer2:Animal/" + uuid,
+		},
+		{
+			name:      "namespaced caller: already-short beacon unchanged",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			in:        mkURI("Animal"),
+			wantText:  "weaviate://localhost/Animal/" + uuid,
+		},
+		{
+			name:      "global principal: qualified beacon preserved",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			in:        mkURI("customer1:Animal"),
+			wantText:  "weaviate://localhost/customer1:Animal/" + uuid,
+		},
+		{
+			name:      "nil principal: pass-through (NS-disabled cluster)",
+			principal: nil,
+			in:        mkURI("customer1:Animal"),
+			wantText:  "weaviate://localhost/customer1:Animal/" + uuid,
+		},
+		{
+			name:      "unparseable URI: passed through unchanged",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			in:        strfmt.URI("not-a-real-beacon"),
+			wantText:  "not-a-real-beacon",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			replier := NewAggregateReplier(tc.principal, nil, nil)
+			got, err := replier.parseAggregateGroupedBy(&aggregation.GroupedBy{
+				Path:  []string{"hasAnimals"},
+				Value: tc.in,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			textVal, ok := got.Value.(*pb.AggregateReply_Group_GroupedBy_Text)
+			require.True(t, ok, "expected Text value, got %T", got.Value)
+			assert.Equal(t, tc.wantText, textVal.Text)
+		})
+	}
+}
+
 // TestGRPCAggregateReply_GroupByPassesValuesThrough pins that bucket
 // values flow unchanged for string / []string. Group-by values can be
 // arbitrary user text (e.g. "customer1:foo"), so we must not rewrite
-// them — ref-target buckets, the one case where a class name could
-// appear, surface as beacon URIs ("weaviate://.../") not bare names.
+// them — ref-target buckets carry a strfmt.URI value (not plain string)
+// and go through TestGRPCAggregateReply_GroupByOnRefTargetStripsOwnNamespace.
 func TestGRPCAggregateReply_GroupByPassesValuesThrough(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -955,7 +955,7 @@ func testNumericalAggregationsWithGrouping(repo *DB, exact bool) func(t *testing
 						Count: 10,
 						GroupedBy: &aggregation.GroupedBy{
 							Path:  []string{"makesProduct"},
-							Value: strfmt.URI("weaviate://localhost/1295c052-263d-4aae-99dd-920c5a370d06"),
+							Value: "weaviate://localhost/1295c052-263d-4aae-99dd-920c5a370d06",
 						},
 						Properties: map[string]aggregation.Property{
 							"dividendYield": {

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -198,7 +198,15 @@ func (g *grouper) addElementById(s *models.PropertySchema, docID uint64) error {
 		}
 	case models.MultipleRef:
 		for i := range val {
-			g.addItem(val[i].Beacon, docID)
+			// Emit the beacon as a plain string, not strfmt.URI. The grouped
+			// value is an interface{} that crosses the shard→coordinator
+			// boundary as JSON for remote shards, which decodes a strfmt.URI
+			// back into a plain string; local shards keep the named type.
+			// Different dynamic types for the same beacon are unequal
+			// interface keys, so ShardCombiner.getPosOfGroup would split one
+			// ref target into two buckets with halved counts. Normalizing to
+			// string here keeps the key identical on both paths.
+			g.addItem(string(val[i].Beacon), docID)
 		}
 	default:
 		g.addItem(val, docID)

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -198,14 +198,10 @@ func (g *grouper) addElementById(s *models.PropertySchema, docID uint64) error {
 		}
 	case models.MultipleRef:
 		for i := range val {
-			// Emit the beacon as a plain string, not strfmt.URI. The grouped
-			// value is an interface{} that crosses the shard→coordinator
-			// boundary as JSON for remote shards, which decodes a strfmt.URI
-			// back into a plain string; local shards keep the named type.
-			// Different dynamic types for the same beacon are unequal
-			// interface keys, so ShardCombiner.getPosOfGroup would split one
-			// ref target into two buckets with halved counts. Normalizing to
-			// string here keeps the key identical on both paths.
+			// Emit a plain string, not strfmt.URI: remote shards JSON-decode
+			// the beacon back to string while local shards keep the named
+			// type, and the two are unequal interface keys — so ShardCombiner
+			// would split one ref target into two buckets with halved counts.
 			g.addItem(string(val[i].Beacon), docID)
 		}
 	default:

--- a/adapters/repos/db/aggregator/grouper_test.go
+++ b/adapters/repos/db/aggregator/grouper_test.go
@@ -1,0 +1,50 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/aggregation"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// Pins that a ref group-by emits its beacon as a plain string. The grouped
+// value is an interface{} that JSON-collapses strfmt.URI → string when it
+// crosses shard→coordinator on multi-node clusters. If the grouper emitted
+// the named strfmt.URI type instead, a local shard's bucket and a remote
+// shard's bucket for the same target would be unequal interface keys in
+// ShardCombiner.getPosOfGroup and split into two groups with halved counts.
+func TestGrouper_RefBeaconEmittedAsString(t *testing.T) {
+	const beacon = "weaviate://localhost/Animal/11111111-2222-3333-4444-555555555555"
+	g := newGrouper(&Aggregator{
+		params: aggregation.Params{
+			GroupBy: &filters.Path{Property: "hasAnimals"},
+		},
+	}, 10)
+
+	var schema models.PropertySchema = map[string]interface{}{
+		"hasAnimals": models.MultipleRef{{Beacon: strfmt.URI(beacon)}},
+	}
+	require.NoError(t, g.addElementById(&schema, 0))
+
+	require.Len(t, g.values, 1)
+	for key := range g.values {
+		_, ok := key.(string)
+		assert.Truef(t, ok, "ref group-by key must be string, got %T", key)
+		assert.Equal(t, beacon, key)
+	}
+}

--- a/adapters/repos/db/aggregator/grouper_test.go
+++ b/adapters/repos/db/aggregator/grouper_test.go
@@ -22,12 +22,10 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// Pins that a ref group-by emits its beacon as a plain string. The grouped
-// value is an interface{} that JSON-collapses strfmt.URI → string when it
-// crosses shard→coordinator on multi-node clusters. If the grouper emitted
-// the named strfmt.URI type instead, a local shard's bucket and a remote
-// shard's bucket for the same target would be unequal interface keys in
-// ShardCombiner.getPosOfGroup and split into two groups with halved counts.
+// Pins that a ref group-by emits its beacon as a plain string. Remote shards
+// JSON-collapse strfmt.URI → string; if the grouper kept the named type,
+// local and remote buckets for the same target would be unequal interface
+// keys in ShardCombiner and split into two groups with halved counts.
 func TestGrouper_RefBeaconEmittedAsString(t *testing.T) {
 	const beacon = "weaviate://localhost/Animal/11111111-2222-3333-4444-555555555555"
 	g := newGrouper(&Aggregator{

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -419,7 +419,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 		const (
 			zoo     = "ZooGroupByRef"
 			animal  = "AnimalGroupByRef"
-			numZoos = 5
+			numZoos = 30
 		)
 		helper.CreateClassAuth(t, &models.Class{
 			Class:      animal,

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -410,12 +410,11 @@ func TestNamespaces_GRPC(t *testing.T) {
 			"admin's aggregate over the qualified class must return the same shape")
 	})
 
-	// End-to-end check: ref-target group-by emits a short bucket URI (own-NS
-	// stripped) and merges all source objects pointing at the same target
-	// into one bucket. Several zoo objects reference the same animal so, on a
-	// multi-node cluster, sources spread across shards: the grouper must emit
-	// the beacon as a plain string on every shard (local and remote) or the
-	// combiner splits the target into multiple buckets with divided counts.
+	// End-to-end: ref-target group-by emits a short bucket URI (own-NS
+	// stripped) and merges every source into one bucket. Many zoos reference
+	// one animal so sources spread across shards on a multi-node cluster — if
+	// the beacon type differs per shard the combiner splits the target into
+	// multiple buckets with divided counts.
 	t.Run("Aggregate GroupBy on a ref property: short, merged bucket for namespaced caller", func(t *testing.T) {
 		const (
 			zoo     = "ZooGroupByRef"
@@ -454,12 +453,10 @@ func TestNamespaces_GRPC(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// short, namespace-free target beacon all sources point at
 		shortBeacon := "weaviate://localhost/" + animal + "/" + string(animalID)
 
-		// Poll: on multi-node clusters the refs may not all be visible to the
-		// aggregator immediately after AddReference returns. Retry until the
-		// counts add up to every source object.
+		// Poll: refs may not be visible to the aggregator immediately after
+		// AddReference returns on multi-node clusters.
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := grpcClient.Aggregate(authCtx(user1Key), &pb.AggregateRequest{
 				Collection:   zoo,
@@ -473,10 +470,8 @@ func TestNamespaces_GRPC(t *testing.T) {
 			if !assert.NotEmpty(c, groups, "refs not replicated to aggregate node yet") {
 				return
 			}
-			// One target referenced by every zoo → exactly one merged bucket,
-			// short-form, holding all sources. More than one bucket means the
-			// combiner split a single target across shards (strfmt.URI vs
-			// string keys).
+			// One target referenced by every zoo → one merged bucket. More
+			// than one means the combiner split it across shards.
 			if !assert.Len(c, groups, 1, "single ref target must yield one bucket, not a per-shard split") {
 				return
 			}

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -410,13 +410,17 @@ func TestNamespaces_GRPC(t *testing.T) {
 			"admin's aggregate over the qualified class must return the same shape")
 	})
 
-	// End-to-end check: ref-target group-by reaches the strfmt.URI case in
-	// parseAggregateGroupedBy, strips the embedded class of the caller's
-	// own NS, and emits a short bucket URI.
-	t.Run("Aggregate GroupBy on a ref property: short bucket URI for namespaced caller", func(t *testing.T) {
+	// End-to-end check: ref-target group-by emits a short bucket URI (own-NS
+	// stripped) and merges all source objects pointing at the same target
+	// into one bucket. Several zoo objects reference the same animal so, on a
+	// multi-node cluster, sources spread across shards: the grouper must emit
+	// the beacon as a plain string on every shard (local and remote) or the
+	// combiner splits the target into multiple buckets with divided counts.
+	t.Run("Aggregate GroupBy on a ref property: short, merged bucket for namespaced caller", func(t *testing.T) {
 		const (
-			zoo    = "ZooGroupByRef"
-			animal = "AnimalGroupByRef"
+			zoo     = "ZooGroupByRef"
+			animal  = "AnimalGroupByRef"
+			numZoos = 5
 		)
 		helper.CreateClassAuth(t, &models.Class{
 			Class:      animal,
@@ -434,23 +438,28 @@ func TestNamespaces_GRPC(t *testing.T) {
 			helper.DeleteClassAuth(t, "customer1:"+animal, adminKey)
 		})
 
-		zooID := strfmt.UUID(uuid.New().String())
 		animalID := strfmt.UUID(uuid.New().String())
 		_, err := helper.CreateObjectWithResponseAuth(t,
 			&models.Object{ID: animalID, Class: animal, Properties: map[string]any{"name": "tigger"}}, user1Key)
 		require.NoError(t, err)
-		_, err = helper.CreateObjectWithResponseAuth(t,
-			&models.Object{ID: zooID, Class: zoo, Properties: map[string]any{"name": "z1"}}, user1Key)
-		require.NoError(t, err)
 
-		_, err = helper.AddReferenceReturn(t,
-			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/" + animal + "/" + string(animalID))},
-			zooID, zoo, "hasAnimals", "", helper.CreateAuth(user1Key))
-		require.NoError(t, err)
+		for i := 0; i < numZoos; i++ {
+			zooID := strfmt.UUID(uuid.New().String())
+			_, err = helper.CreateObjectWithResponseAuth(t,
+				&models.Object{ID: zooID, Class: zoo, Properties: map[string]any{"name": "z"}}, user1Key)
+			require.NoError(t, err)
+			_, err = helper.AddReferenceReturn(t,
+				&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/" + animal + "/" + string(animalID))},
+				zooID, zoo, "hasAnimals", "", helper.CreateAuth(user1Key))
+			require.NoError(t, err)
+		}
 
-		// Poll: on multi-node clusters the ref may not be visible to the
-		// aggregator immediately after AddReference returns. Retry until
-		// non-empty groups come back, then validate the bucket URI is short.
+		// short, namespace-free target beacon all sources point at
+		shortBeacon := "weaviate://localhost/" + animal + "/" + string(animalID)
+
+		// Poll: on multi-node clusters the refs may not all be visible to the
+		// aggregator immediately after AddReference returns. Retry until the
+		// counts add up to every source object.
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := grpcClient.Aggregate(authCtx(user1Key), &pb.AggregateRequest{
 				Collection:   zoo,
@@ -461,17 +470,22 @@ func TestNamespaces_GRPC(t *testing.T) {
 				return
 			}
 			groups := resp.GetGroupedResults().GetGroups()
-			if !assert.NotEmpty(c, groups, "ref not replicated to aggregate node yet") {
+			if !assert.NotEmpty(c, groups, "refs not replicated to aggregate node yet") {
 				return
 			}
-			const qualified = "customer1:" + animal
-			for _, g := range groups {
-				val := g.GroupedBy.GetText()
-				assert.NotContains(c, val, qualified,
-					"bucket URI must be short-form, got %q", val)
+			// One target referenced by every zoo → exactly one merged bucket,
+			// short-form, holding all sources. More than one bucket means the
+			// combiner split a single target across shards (strfmt.URI vs
+			// string keys).
+			if !assert.Len(c, groups, 1, "single ref target must yield one bucket, not a per-shard split") {
+				return
 			}
+			assert.Equal(c, shortBeacon, groups[0].GroupedBy.GetText(),
+				"bucket URI must be short-form")
+			assert.Equal(c, int64(numZoos), groups[0].GetObjectsCount(),
+				"merged bucket must hold every source object")
 		}, 30*time.Second, 200*time.Millisecond,
-			"ref-target group-by must return short-form bucket URIs once the ref replicates")
+			"ref-target group-by must return one short-form, fully-merged bucket once the refs replicate")
 	})
 
 	t.Run("Search and Aggregate via alias resolve per namespace", func(t *testing.T) {

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -410,12 +410,10 @@ func TestNamespaces_GRPC(t *testing.T) {
 			"admin's aggregate over the qualified class must return the same shape")
 	})
 
-	// Pins a pre-existing gRPC bug: parseAggregateGroupedBy's `case string`
-	// doesn't match strfmt.URI, so ref-target buckets (MultipleRef.Beacon)
-	// never reach the strip path — confirming the aggregate-replier revert
-	// is safe. Swap the error check for the URI assertion below once the
-	// type switch is fixed.
-	t.Run("Aggregate GroupBy on a ref property: pins broken gRPC type switch", func(t *testing.T) {
+	// End-to-end check: ref-target group-by reaches the strfmt.URI case in
+	// parseAggregateGroupedBy, strips the embedded class of the caller's
+	// own NS, and emits a short bucket URI.
+	t.Run("Aggregate GroupBy on a ref property: short bucket URI for namespaced caller", func(t *testing.T) {
 		const (
 			zoo    = "ZooGroupByRef"
 			animal = "AnimalGroupByRef"
@@ -451,36 +449,29 @@ func TestNamespaces_GRPC(t *testing.T) {
 		require.NoError(t, err)
 
 		// Poll: on multi-node clusters the ref may not be visible to the
-		// aggregator immediately after AddReference returns. The bug only
-		// fires when the grouper produces a bucket, so retry until either
-		// the strfmt.URI error surfaces (bug present) or the call returns
-		// non-empty groups (bug fixed) — never trust a "no groups, no error"
-		// snapshot, which just means the ref isn't replicated yet.
+		// aggregator immediately after AddReference returns. Retry until
+		// non-empty groups come back, then validate the bucket URI is short.
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := grpcClient.Aggregate(authCtx(user1Key), &pb.AggregateRequest{
 				Collection:   zoo,
 				ObjectsCount: true,
 				GroupBy:      &pb.AggregateRequest_GroupBy{Collection: zoo, Property: "hasAnimals"},
 			})
-			if err != nil {
-				// Bug present (current state): pin that the type switch is
-				// the source. Loose substring match tolerates small wording
-				// changes around the same bug.
-				assert.Contains(c, err.Error(), "strfmt.URI",
-					"error must come from the prepare-reply type switch")
+			if !assert.NoError(c, err, "ref-target group-by must not error") {
 				return
 			}
-			// Bug fixed: validate the short-form bucket URI premise.
 			groups := resp.GetGroupedResults().GetGroups()
-			assert.NotEmpty(c, groups, "ref not replicated to aggregate node yet")
+			if !assert.NotEmpty(c, groups, "ref not replicated to aggregate node yet") {
+				return
+			}
 			const qualified = "customer1:" + animal
 			for _, g := range groups {
 				val := g.GroupedBy.GetText()
 				assert.NotContains(c, val, qualified,
-					"ref-target bucket URI must be short-form, got %q", val)
+					"bucket URI must be short-form, got %q", val)
 			}
 		}, 30*time.Second, 200*time.Millisecond,
-			"ref-target group-by must either error with the strfmt.URI bug or return short-form bucket URIs once the ref replicates")
+			"ref-target group-by must return short-form bucket URIs once the ref replicates")
 	})
 
 	t.Run("Search and Aggregate via alias resolve per namespace", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

- Added a case strfmt.URI: arm to parseAggregateGroupedBy. It coerces to string, runs the URI through crossref.Parse, strips the Class field via namespacing.StripOwnNamespace, and reconstructs via Ref.String(). Parse failures pass through unchanged so non-beacon URI shapes don't get mangled.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
