### PR TITLE
fix: move strip to outside ref loop

### DIFF
--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -139,15 +139,18 @@ func (h *batchObjectHandlers) referencesResponse(principal *models.Principal, in
 		var errorResponse *models.ErrorResponse
 		var reference models.BatchReference
 
+		// Echo beacons on every row so clients can correlate failures back
+		// to the input. Strip helpers tolerate nil inputs (return ""), so
+		// unconditional invocation is safe when the upstream rejected the
+		// row before populating From/To. resolveNS qualifies the From class
+		// upstream; To strip is defense in depth.
+		reference.From = namespacing.StripRefSourceBeacon(principal, ref.From)
+		reference.To = namespacing.StripRefBeacon(principal, ref.To)
+
 		status := models.BatchReferenceResponseAO1ResultStatusSUCCESS
 		if ref.Err != nil {
 			errorResponse = errPayloadFromSingleErr(principal, ref.Err)
 			status = models.BatchReferenceResponseAO1ResultStatusFAILED
-		} else {
-			// From class is qualified by resolveNS upstream; strip before
-			// emitting. To strip is defense in depth.
-			reference.From = namespacing.StripRefSourceBeacon(principal, ref.From)
-			reference.To = namespacing.StripRefBeacon(principal, ref.To)
 		}
 
 		response[i] = &models.BatchReferenceResponse{

--- a/adapters/handlers/rest/handlers_batch_objects_test.go
+++ b/adapters/handlers/rest/handlers_batch_objects_test.go
@@ -1,0 +1,83 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+// Pins that referencesResponse echoes From/To on every row regardless of
+// ref.Err — clients correlate failures back to the input by beacon, not
+// by slice index (the slice can be reordered upstream).
+func TestReferencesResponse_FailedRowsCarryBeacons(t *testing.T) {
+	const uuid = "11111111-2222-3333-4444-555555555555"
+	from := crossref.NewSource(schema.ClassName("Zoo"), "hasAnimals", strfmt.UUID(uuid))
+	to := &crossref.Ref{
+		Local:    true,
+		PeerName: "localhost",
+		Class:    "Animal",
+		TargetID: strfmt.UUID(uuid),
+	}
+
+	input := objects.BatchReferences{
+		{From: from, To: to}, // succeeds
+		{From: from, To: to, Err: errors.New("validation: ref target missing")}, // fails
+	}
+
+	h := &batchObjectHandlers{}
+	got := h.referencesResponse(nil, input)
+
+	require.Len(t, got, 2)
+
+	// Both rows must carry beacons.
+	assert.NotEmpty(t, got[0].From, "success row must carry From beacon")
+	assert.NotEmpty(t, got[0].To, "success row must carry To beacon")
+	assert.NotEmpty(t, got[1].From, "FAILED row must still carry From beacon for correlation")
+	assert.NotEmpty(t, got[1].To, "FAILED row must still carry To beacon for correlation")
+
+	// Statuses are as expected.
+	require.NotNil(t, got[0].Result.Status)
+	require.NotNil(t, got[1].Result.Status)
+	assert.Equal(t, models.BatchReferenceResponseAO1ResultStatusSUCCESS, *got[0].Result.Status)
+	assert.Equal(t, models.BatchReferenceResponseAO1ResultStatusFAILED, *got[1].Result.Status)
+	assert.Nil(t, got[0].Result.Errors)
+	assert.NotNil(t, got[1].Result.Errors)
+}
+
+// Pins that nil From/To on a failed row don't panic — the strip helpers
+// must tolerate nil inputs (return ""). This covers the rejection path
+// where upstream fails before populating From/To.
+func TestReferencesResponse_FailedRowWithNilBeaconsDoesNotPanic(t *testing.T) {
+	input := objects.BatchReferences{
+		{Err: errors.New("rejected before From/To set")},
+	}
+
+	h := &batchObjectHandlers{}
+	got := h.referencesResponse(nil, input)
+
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].Result.Status)
+	assert.Equal(t, models.BatchReferenceResponseAO1ResultStatusFAILED, *got[0].Result.Status)
+	// Empty beacons are acceptable here — what matters is no panic and the
+	// failure is preserved in Result.Errors.
+	assert.NotNil(t, got[0].Result.Errors)
+}


### PR DESCRIPTION
### What's being changed:

- moved the reference.From / reference.To assignments out of the else branch. They now run unconditionally so every response row (success and failure) carries the input beacons.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
