### PR TITLE
[Reindex Fixes A] test: tolerate transient /v1/tasks 500s after node restarts

### DIFF
--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -150,30 +150,53 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 	return &result
 }
 
-// AwaitReindexLive blocks until the task reaches a live status.
-//
-// fetchReindexTask does one GET /v1/tasks poll and returns the reindex task
-// with the given ID. ok is false when the request, status, decode, or lookup
-// hasn't yielded that task yet, so pollers keep retrying. A non-200 is logged
-// rather than decoded as JSON, so a flake surfaces the actual status instead
-// of a generic decode/timeout failure.
-func fetchReindexTask(t *testing.T, restURI, taskID string) (models.DistributedTask, bool) {
-	t.Helper()
+// TryFetchTasks does one tolerant GET /v1/tasks: ok=false on any transport /
+// non-200 / decode error so Eventually polls retry post-restart transients
+// (gRPC reconnect). Deliberately takes no *testing.T — require inside an
+// Eventually condition goroutine would runtime.Goexit the wrong goroutine.
+func TryFetchTasks(restURI string) (models.DistributedTasks, bool) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 	if err != nil {
-		return models.DistributedTask{}, false
+		return nil, false
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return models.DistributedTask{}, false
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Logf("GET /v1/tasks returned status %d: %s", resp.StatusCode, string(body))
-		return models.DistributedTask{}, false
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, false
 	}
 	var tasks models.DistributedTasks
-	if err := json.Unmarshal(body, &tasks); err != nil {
+	if json.Unmarshal(body, &tasks) != nil {
+		return nil, false
+	}
+	return tasks, true
+}
+
+// TryGetIndexes is the GET /v1/schema/{collection}/indexes counterpart of
+// TryFetchTasks: tolerant and goroutine-safe, for Eventually polls that must
+// ride out the same post-restart reconnect window.
+func TryGetIndexes(restURI, collection string) (*IndexesResponse, bool) {
+	resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s/indexes", restURI, collection))
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, false
+	}
+	var out IndexesResponse
+	if json.Unmarshal(body, &out) != nil {
+		return nil, false
+	}
+	return &out, true
+}
+
+// fetchReindexTask does one tolerant GET /v1/tasks poll and returns the
+// reindex task with the given ID. ok is false when the request, status,
+// decode, or lookup hasn't yielded that task yet, so pollers keep retrying.
+func fetchReindexTask(restURI, taskID string) (models.DistributedTask, bool) {
+	tasks, ok := TryFetchTasks(restURI)
+	if !ok {
 		return models.DistributedTask{}, false
 	}
 	for _, task := range tasks["reindex"] {
@@ -184,52 +207,71 @@ func fetchReindexTask(t *testing.T, restURI, taskID string) (models.DistributedT
 	return models.DistributedTask{}, false
 }
 
+// AwaitReindexLive blocks until the task reaches a live status.
+//
 // Sync here, not on GET /v1/schema/<class>/indexes: the backup gate reads
 // DTM liveness, and the two can lag ~1s, so index-status races the gate.
+//
+// A terminal status is captured inside the Eventually condition (which runs
+// on its own goroutine, so it must never Fatalf) and reported from the test
+// goroutine after Eventually returns.
 func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)
 
+	var terminalErr error
 	require.Eventually(t, func() bool {
-		task, ok := fetchReindexTask(t, restURI, taskID)
+		task, ok := fetchReindexTask(restURI, taskID)
 		if !ok {
 			return false
 		}
 		t.Logf("task %s status: %s", taskID, task.Status)
 		switch task.Status {
 		case "FAILED", "CANCELLED":
-			t.Fatalf("reindex task %s reached terminal status %s before going live: %s",
+			terminalErr = fmt.Errorf("reindex task %s reached terminal status %s before going live: %s",
 				taskID, task.Status, task.Error)
+			return true // exit Eventually; Fatalf below on the test goroutine
 		case "FINISHED":
 			// Drained before a live status was observed (fixture too small).
-			t.Fatalf("reindex task %s reached FINISHED before a live status was observed; "+
+			terminalErr = fmt.Errorf("reindex task %s reached FINISHED before a live status was observed; "+
 				"increase the import corpus so the migration outlives the gate-arming poll",
 				taskID)
+			return true
 		case "STARTED", "PREPARING", "SWAPPING":
 			return true
 		}
 		return false
 	}, o.timeout, 200*time.Millisecond,
 		"reindex task %s should reach a live (STARTED/PREPARING/SWAPPING) status", taskID)
+	if terminalErr != nil {
+		t.Fatal(terminalErr)
+	}
 }
 
 // AwaitReindexFinished polls /v1/tasks until the named reindex task
-// reaches FINISHED. Fails on FAILED or on timeout (default 120s).
+// reaches FINISHED. Fails on FAILED or on timeout (default 120s). FAILED is
+// captured inside the Eventually condition and reported from the test
+// goroutine after — the condition goroutine must never Fatalf.
 func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)
 
+	var terminalErr error
 	require.Eventually(t, func() bool {
-		task, ok := fetchReindexTask(t, restURI, taskID)
+		task, ok := fetchReindexTask(restURI, taskID)
 		if !ok {
 			return false
 		}
 		t.Logf("task %s status: %s", taskID, task.Status)
 		if task.Status == "FAILED" {
-			t.Fatalf("reindex task failed: %s", task.Error)
+			terminalErr = fmt.Errorf("reindex task failed: %s", task.Error)
+			return true // exit Eventually; Fatalf below on the test goroutine
 		}
 		return task.Status == "FINISHED"
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
+	if terminalErr != nil {
+		t.Fatal(terminalErr)
+	}
 }
 
 // AwaitReindexViaIndexes polls GET /v1/schema/{collection}/indexes until
@@ -244,7 +286,10 @@ func AwaitReindexViaIndexes(t *testing.T, restURI, collection, property, indexTy
 	var sawIndexing bool
 
 	require.Eventually(t, func() bool {
-		resp := GetIndexes(t, restURI, collection)
+		resp, ok := TryGetIndexes(restURI, collection)
+		if !ok {
+			return false // transient read (e.g. post-restart gRPC reconnect) — retry
+		}
 		for _, prop := range resp.Properties {
 			if prop.Name == property {
 				for _, idx := range prop.Indexes {

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -151,10 +151,9 @@ func GetIndexes(t *testing.T, restURI, collection string) *IndexesResponse {
 	return &result
 }
 
-// TryFetchTasks does one tolerant GET /v1/tasks: ok=false on any transport /
-// non-200 / decode error so Eventually polls retry post-restart transients
-// (gRPC reconnect). Deliberately takes no *testing.T — require inside an
-// Eventually condition goroutine would runtime.Goexit the wrong goroutine.
+// TryFetchTasks does one tolerant GET /v1/tasks: ok=false on any error so
+// Eventually polls can retry post-restart transients. No *testing.T: require
+// in an Eventually condition would runtime.Goexit the wrong goroutine.
 func TryFetchTasks(restURI string) (models.DistributedTasks, bool) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 	if err != nil {
@@ -173,8 +172,7 @@ func TryFetchTasks(restURI string) (models.DistributedTasks, bool) {
 }
 
 // TryGetIndexes is the GET /v1/schema/{collection}/indexes counterpart of
-// TryFetchTasks: tolerant and goroutine-safe, for Eventually polls that must
-// ride out the same post-restart reconnect window.
+// TryFetchTasks: same tolerant, no-*testing.T contract.
 func TryGetIndexes(restURI, collection string) (*IndexesResponse, bool) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s/indexes", restURI, collection))
 	if err != nil {
@@ -192,9 +190,8 @@ func TryGetIndexes(restURI, collection string) (*IndexesResponse, bool) {
 	return &out, true
 }
 
-// fetchReindexTask does one tolerant GET /v1/tasks poll and returns the
-// reindex task with the given ID. ok is false when the request, status,
-// decode, or lookup hasn't yielded that task yet, so pollers keep retrying.
+// fetchReindexTask returns the reindex task with the given ID; ok=false
+// means keep polling.
 func fetchReindexTask(restURI, taskID string) (models.DistributedTask, bool) {
 	tasks, ok := TryFetchTasks(restURI)
 	if !ok {
@@ -212,18 +209,13 @@ func fetchReindexTask(restURI, taskID string) (models.DistributedTask, bool) {
 //
 // Sync here, not on GET /v1/schema/<class>/indexes: the backup gate reads
 // DTM liveness, and the two can lag ~1s, so index-status races the gate.
-//
-// A terminal status is captured inside the Eventually condition (which runs
-// on its own goroutine, so it must never Fatalf) and reported from the test
-// goroutine after Eventually returns.
 func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)
 
-	// atomic.Pointer, not a plain var: correct today because
-	// require.Eventually's cross-goroutine send/receive orders the write
-	// before the read, but a future switch to assert.Eventually (returns on
-	// timeout) would turn a plain capture into a live race.
+	// atomic.Pointer: require.Eventually's channel sync makes a plain var
+	// safe today, but a switch to assert.Eventually (returns on timeout)
+	// would make a plain capture a live race.
 	var terminalErr atomic.Pointer[error]
 	require.Eventually(t, func() bool {
 		task, ok := fetchReindexTask(restURI, taskID)
@@ -256,9 +248,7 @@ func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 }
 
 // AwaitReindexFinished polls /v1/tasks until the named reindex task
-// reaches FINISHED. Fails on FAILED or on timeout (default 120s). FAILED is
-// captured inside the Eventually condition and reported from the test
-// goroutine after — the condition goroutine must never Fatalf.
+// reaches FINISHED. Fails on FAILED or on timeout (default 120s).
 func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -219,7 +220,11 @@ func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)
 
-	var terminalErr error
+	// atomic.Pointer, not a plain var: correct today because
+	// require.Eventually's cross-goroutine send/receive orders the write
+	// before the read, but a future switch to assert.Eventually (returns on
+	// timeout) would turn a plain capture into a live race.
+	var terminalErr atomic.Pointer[error]
 	require.Eventually(t, func() bool {
 		task, ok := fetchReindexTask(restURI, taskID)
 		if !ok {
@@ -228,14 +233,16 @@ func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 		t.Logf("task %s status: %s", taskID, task.Status)
 		switch task.Status {
 		case "FAILED", "CANCELLED":
-			terminalErr = fmt.Errorf("reindex task %s reached terminal status %s before going live: %s",
+			err := fmt.Errorf("reindex task %s reached terminal status %s before going live: %s",
 				taskID, task.Status, task.Error)
+			terminalErr.Store(&err)
 			return true // exit Eventually; Fatalf below on the test goroutine
 		case "FINISHED":
 			// Drained before a live status was observed (fixture too small).
-			terminalErr = fmt.Errorf("reindex task %s reached FINISHED before a live status was observed; "+
+			err := fmt.Errorf("reindex task %s reached FINISHED before a live status was observed; "+
 				"increase the import corpus so the migration outlives the gate-arming poll",
 				taskID)
+			terminalErr.Store(&err)
 			return true
 		case "STARTED", "PREPARING", "SWAPPING":
 			return true
@@ -243,8 +250,8 @@ func AwaitReindexLive(t *testing.T, restURI, taskID string, opts ...Option) {
 		return false
 	}, o.timeout, 200*time.Millisecond,
 		"reindex task %s should reach a live (STARTED/PREPARING/SWAPPING) status", taskID)
-	if terminalErr != nil {
-		t.Fatal(terminalErr)
+	if errp := terminalErr.Load(); errp != nil {
+		t.Fatal(*errp)
 	}
 }
 
@@ -256,7 +263,8 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 	t.Helper()
 	o := applyOptions(opts)
 
-	var terminalErr error
+	// atomic.Pointer for the same future-proofing as AwaitReindexLive.
+	var terminalErr atomic.Pointer[error]
 	require.Eventually(t, func() bool {
 		task, ok := fetchReindexTask(restURI, taskID)
 		if !ok {
@@ -264,13 +272,14 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 		}
 		t.Logf("task %s status: %s", taskID, task.Status)
 		if task.Status == "FAILED" {
-			terminalErr = fmt.Errorf("reindex task failed: %s", task.Error)
+			err := fmt.Errorf("reindex task failed: %s", task.Error)
+			terminalErr.Store(&err)
 			return true // exit Eventually; Fatalf below on the test goroutine
 		}
 		return task.Status == "FINISHED"
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
-	if terminalErr != nil {
-		t.Fatal(terminalErr)
+	if errp := terminalErr.Load(); errp != nil {
+		t.Fatal(*errp)
 	}
 }
 
@@ -282,8 +291,9 @@ func AwaitReindexViaIndexes(t *testing.T, restURI, collection, property, indexTy
 	t.Helper()
 	o := applyOptions(opts)
 
-	var lastProgress float32
-	var sawIndexing bool
+	// Atomics for the same future-proofing as AwaitReindexLive.
+	var lastProgress atomic.Value // float32
+	var sawIndexing atomic.Bool
 
 	require.Eventually(t, func() bool {
 		resp, ok := TryGetIndexes(restURI, collection)
@@ -296,8 +306,8 @@ func AwaitReindexViaIndexes(t *testing.T, restURI, collection, property, indexTy
 					if idx.Type == indexType {
 						switch idx.Status {
 						case "indexing":
-							sawIndexing = true
-							lastProgress = idx.Progress
+							sawIndexing.Store(true)
+							lastProgress.Store(idx.Progress)
 							return false
 						case "ready":
 							return true
@@ -311,8 +321,8 @@ func AwaitReindexViaIndexes(t *testing.T, restURI, collection, property, indexTy
 		return false
 	}, o.timeout, 1*time.Second, "expected property %s index %s to reach ready status", property, indexType)
 
-	if sawIndexing {
-		t.Logf("index monitoring: saw indexing->ready for %s/%s (final progress: %f)", property, indexType, lastProgress)
+	if sawIndexing.Load() {
+		t.Logf("index monitoring: saw indexing->ready for %s/%s (final progress: %f)", property, indexType, lastProgress.Load())
 	} else {
 		t.Logf("index monitoring: task completed too fast for %s/%s", property, indexType)
 	}

--- a/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
@@ -147,8 +147,7 @@ func assertTaskGone(t *testing.T, restURI, taskID, label string) {
 	t.Helper()
 	// /v1/tasks is served from the coordinator's FSM-replicated view — the
 	// cascade applies inside the same FSM, so absence is visible immediately.
-	// The tolerant read retries post-restart transient non-200s (gRPC
-	// reconnect); only a successful read with the task absent passes.
+	// A failed read is a retry, not absence.
 	require.Eventuallyf(t, func() bool {
 		exists, ok := taskExists(t, restURI, taskID)
 		return ok && !exists

--- a/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
@@ -13,10 +13,7 @@ package reindex_multinode
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"testing"
 	"time"
 
@@ -134,7 +131,7 @@ func TestMultiNode_DeleteRecreateCleansReindexTasks(t *testing.T) {
 // so callers can pin per-replica behaviour.
 func taskExists(t *testing.T, restURI, taskID string) (exists, ok bool) {
 	t.Helper()
-	tasks, ok := tryFetchTasks(restURI)
+	tasks, ok := reindexhelpers.TryFetchTasks(restURI)
 	if !ok {
 		return false, false
 	}
@@ -163,7 +160,7 @@ func assertTaskGone(t *testing.T, restURI, taskID, label string) {
 func assertIndexesReady(t *testing.T, restURI, className, label string) {
 	t.Helper()
 	require.Eventuallyf(t, func() bool {
-		indexes, ok := tryGetIndexes(restURI, className)
+		indexes, ok := reindexhelpers.TryGetIndexes(restURI, className)
 		if !ok {
 			return false // transient post-restart read (gRPC reconnect) — retry
 		}
@@ -194,45 +191,4 @@ func assertIndexesReady(t *testing.T, restURI, className, label string) {
 				label, p.Name, idx.Type, idx.Status)
 		}
 	}
-}
-
-// tryFetchTasks does one tolerant GET /v1/tasks: ok=false on any transport /
-// non-200 / decode error so Eventually polls retry post-restart transients
-// (gRPC reconnect). Deliberately takes no *testing.T — require inside an
-// Eventually condition goroutine would runtime.Goexit the wrong goroutine.
-func tryFetchTasks(restURI string) (models.DistributedTasks, bool) {
-	resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-	if err != nil {
-		return nil, false
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return nil, false
-	}
-	var tasks models.DistributedTasks
-	if json.Unmarshal(body, &tasks) != nil {
-		return nil, false
-	}
-	return tasks, true
-}
-
-// tryGetIndexes is the GET /v1/schema/{class}/indexes counterpart of
-// tryFetchTasks: tolerant and goroutine-safe, for Eventually polls that must
-// ride out the same post-restart reconnect window.
-func tryGetIndexes(restURI, className string) (*reindexhelpers.IndexesResponse, bool) {
-	resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s/indexes", restURI, className))
-	if err != nil {
-		return nil, false
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return nil, false
-	}
-	var out reindexhelpers.IndexesResponse
-	if json.Unmarshal(body, &out) != nil {
-		return nil, false
-	}
-	return &out, true
 }

--- a/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
@@ -150,10 +150,8 @@ func assertTaskGone(t *testing.T, restURI, taskID, label string) {
 	t.Helper()
 	// /v1/tasks is served from the coordinator's FSM-replicated view — the
 	// cascade applies inside the same FSM, so absence is visible immediately.
-	// The Eventually + tolerant read absorb the post-rolling-restart window
-	// where the queried node's ListDistributedTasks gRPC connection is still
-	// reconnecting and /v1/tasks transiently returns non-200: a read that did
-	// not succeed is retried, never read as "task still present".
+	// The tolerant read retries post-restart transient non-200s (gRPC
+	// reconnect); only a successful read with the task absent passes.
 	require.Eventuallyf(t, func() bool {
 		exists, ok := taskExists(t, restURI, taskID)
 		return ok && !exists
@@ -198,14 +196,10 @@ func assertIndexesReady(t *testing.T, restURI, className, label string) {
 	}
 }
 
-// tryFetchTasks does one tolerant GET /v1/tasks, returning ok=false on any
-// transport / non-200 / decode error so a caller polling inside
-// require.Eventually retries instead of hard-failing. Right after a rolling
-// restart the queried node's internal gRPC connection for ListDistributedTasks
-// can still be reconnecting, so /v1/tasks transiently returns a non-200
-// ("client connection is closing") that must be ridden out. Takes no
-// *testing.T: it runs inside an Eventually condition goroutine, where
-// require/t.Fatal would runtime.Goexit the wrong goroutine.
+// tryFetchTasks does one tolerant GET /v1/tasks: ok=false on any transport /
+// non-200 / decode error so Eventually polls retry post-restart transients
+// (gRPC reconnect). Deliberately takes no *testing.T — require inside an
+// Eventually condition goroutine would runtime.Goexit the wrong goroutine.
 func tryFetchTasks(restURI string) (models.DistributedTasks, bool) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
 	if err != nil {

--- a/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
@@ -68,8 +68,9 @@ func TestMultiNode_DeleteRecreateCleansReindexTasks(t *testing.T) {
 	t.Logf("first migration FINISHED: task=%s", task1)
 
 	// Spot-check pre-delete: task record is present on this node's view.
-	require.True(t, taskExists(t, uri, task1),
-		"pre-delete: reindex task %s must be in /v1/tasks", task1)
+	existsPre, okPre := taskExists(t, uri, task1)
+	require.Truef(t, okPre && existsPre,
+		"pre-delete: reindex task %s must be in /v1/tasks (fetch ok=%v)", task1, okPre)
 
 	deleteCollection(t, uri, className)
 	t.Logf("deleted class %s", className)
@@ -131,25 +132,31 @@ func TestMultiNode_DeleteRecreateCleansReindexTasks(t *testing.T) {
 // taskExists returns true if the reindex namespace contains a task with
 // the given ID on the queried node. Per-node scope (no /v1/tasks fan-out)
 // so callers can pin per-replica behaviour.
-func taskExists(t *testing.T, restURI, taskID string) bool {
+func taskExists(t *testing.T, restURI, taskID string) (exists, ok bool) {
 	t.Helper()
-	tasks := fetchTasks(t, restURI)
+	tasks, ok := tryFetchTasks(restURI)
+	if !ok {
+		return false, false
+	}
 	for _, task := range tasks["reindex"] {
 		if task.ID == taskID {
-			return true
+			return true, true
 		}
 	}
-	return false
+	return false, true
 }
 
 func assertTaskGone(t *testing.T, restURI, taskID, label string) {
 	t.Helper()
-	// /v1/tasks is served from the coordinator's FSM-replicated view —
-	// the cascade applies inside the same FSM, so the absence is visible
-	// immediately. Eventually wrap absorbs the (rare) raft-leader catch-up
-	// race after a rolling restart but not behavioural divergence.
+	// /v1/tasks is served from the coordinator's FSM-replicated view — the
+	// cascade applies inside the same FSM, so absence is visible immediately.
+	// The Eventually + tolerant read absorb the post-rolling-restart window
+	// where the queried node's ListDistributedTasks gRPC connection is still
+	// reconnecting and /v1/tasks transiently returns non-200: a read that did
+	// not succeed is retried, never read as "task still present".
 	require.Eventuallyf(t, func() bool {
-		return !taskExists(t, restURI, taskID)
+		exists, ok := taskExists(t, restURI, taskID)
+		return ok && !exists
 	}, 20*time.Second, 50*time.Millisecond,
 		"%s: reindex task %s must NOT be in /v1/tasks (cascade deleted on DELETE_CLASS)",
 		label, taskID)
@@ -158,7 +165,10 @@ func assertTaskGone(t *testing.T, restURI, taskID, label string) {
 func assertIndexesReady(t *testing.T, restURI, className, label string) {
 	t.Helper()
 	require.Eventuallyf(t, func() bool {
-		indexes := reindexhelpers.GetIndexes(t, restURI, className)
+		indexes, ok := tryGetIndexes(restURI, className)
+		if !ok {
+			return false // transient post-restart read (gRPC reconnect) — retry
+		}
 		for _, p := range indexes.Properties {
 			for _, idx := range p.Indexes {
 				// Anything other than "ready" on a freshly-recreated class
@@ -188,15 +198,47 @@ func assertIndexesReady(t *testing.T, restURI, className, label string) {
 	}
 }
 
-func fetchTasks(t *testing.T, restURI string) models.DistributedTasks {
-	t.Helper()
+// tryFetchTasks does one tolerant GET /v1/tasks, returning ok=false on any
+// transport / non-200 / decode error so a caller polling inside
+// require.Eventually retries instead of hard-failing. Right after a rolling
+// restart the queried node's internal gRPC connection for ListDistributedTasks
+// can still be reconnecting, so /v1/tasks transiently returns a non-200
+// ("client connection is closing") that must be ridden out. Takes no
+// *testing.T: it runs inside an Eventually condition goroutine, where
+// require/t.Fatal would runtime.Goexit the wrong goroutine.
+func tryFetchTasks(restURI string) (models.DistributedTasks, bool) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-	require.NoError(t, err)
+	if err != nil {
+		return nil, false
+	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "GET /v1/tasks failed: %s", string(body))
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, false
+	}
 	var tasks models.DistributedTasks
-	require.NoError(t, json.Unmarshal(body, &tasks))
-	return tasks
+	if json.Unmarshal(body, &tasks) != nil {
+		return nil, false
+	}
+	return tasks, true
+}
+
+// tryGetIndexes is the GET /v1/schema/{class}/indexes counterpart of
+// tryFetchTasks: tolerant and goroutine-safe, for Eventually polls that must
+// ride out the same post-restart reconnect window.
+func tryGetIndexes(restURI, className string) (*reindexhelpers.IndexesResponse, bool) {
+	resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s/indexes", restURI, className))
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, false
+	}
+	var out reindexhelpers.IndexesResponse
+	if json.Unmarshal(body, &out) != nil {
+		return nil, false
+	}
+	return &out, true
 }

--- a/test/acceptance/reindex_multinode/dtm_cascade_transient_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_transient_test.go
@@ -21,14 +21,10 @@ import (
 )
 
 // Regression guard for the post-rolling-restart flake in
-// TestMultiNode_DeleteRecreateCleansReindexTasks: right after a node restarts,
-// its internal gRPC connection for ListDistributedTasks is briefly
-// reconnecting, so GET /v1/tasks transiently returns a non-200 ("the client
-// connection is closing"). assertTaskGone's Eventually is meant to ride that
-// out, but previously its inner read hard-asserted status==200 and so
-// FailNow'd from the Eventually condition goroutine on the first transient.
-// This drives assertTaskGone against a server that returns the transient for
-// the first few polls and then a clean empty task list; it must pass.
+// TestMultiNode_DeleteRecreateCleansReindexTasks: assertTaskGone's inner read
+// used to hard-assert status==200 and FailNow'd from the Eventually condition
+// goroutine on the first transient non-200 (gRPC reconnect after restart).
+// Drives assertTaskGone against a server replaying that transient; must pass.
 func TestAssertTaskGone_ToleratesTransientReadError(t *testing.T) {
 	var polls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/acceptance/reindex_multinode/dtm_cascade_transient_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_transient_test.go
@@ -1,0 +1,49 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_multinode
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Regression guard for the post-rolling-restart flake in
+// TestMultiNode_DeleteRecreateCleansReindexTasks: right after a node restarts,
+// its internal gRPC connection for ListDistributedTasks is briefly
+// reconnecting, so GET /v1/tasks transiently returns a non-200 ("the client
+// connection is closing"). assertTaskGone's Eventually is meant to ride that
+// out, but previously its inner read hard-asserted status==200 and so
+// FailNow'd from the Eventually condition goroutine on the first transient.
+// This drives assertTaskGone against a server that returns the transient for
+// the first few polls and then a clean empty task list; it must pass.
+func TestAssertTaskGone_ToleratesTransientReadError(t *testing.T) {
+	var polls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&polls, 1) <= 3 {
+			// The post-restart reconnect window.
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"error":[{"message":"list distributed tasks: failed to execute query: rpc error: code = Canceled desc = grpc: the client connection is closing"}]}`)
+			return
+		}
+		// gRPC connection re-established: the cascade-deleted task is absent.
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"reindex":[]}`)
+	}))
+	defer srv.Close()
+
+	restURI := strings.TrimPrefix(srv.URL, "http://")
+	assertTaskGone(t, restURI, "DTMCascadeDelete:change-tokenization:text:dead", "transient-tolerance proof")
+}

--- a/test/acceptance/reindex_multinode/dtm_cascade_transient_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_transient_test.go
@@ -20,11 +20,7 @@ import (
 	"testing"
 )
 
-// Regression guard for the post-rolling-restart flake in
-// TestMultiNode_DeleteRecreateCleansReindexTasks: assertTaskGone's inner read
-// used to hard-assert status==200 and FailNow'd from the Eventually condition
-// goroutine on the first transient non-200 (gRPC reconnect after restart).
-// Drives assertTaskGone against a server replaying that transient; must pass.
+// pins: assertTaskGone retries transient /v1/tasks non-200s (post-restart gRPC reconnect) instead of failing.
 func TestAssertTaskGone_ToleratesTransientReadError(t *testing.T) {
 	var polls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

`TestMultiNode_DeleteRecreateCleansReindexTasks` flaked (~0.4% on the soak) because its `/v1/tasks` and `/v1/schema/{class}/indexes` polls hard-asserted inside `require.Eventually` conditions. testify runs the condition on its own goroutine, so the first transient non-200 — the post-rolling-restart window where a node's internal gRPC connection for `ListDistributedTasks` is still reconnecting (`grpc: the client connection is closing`) — `FailNow`'d the wrong goroutine and killed the test instead of retrying.

## Design

- `reindexhelpers.TryFetchTasks` / `TryGetIndexes`: tolerant, `*testing.T`-free readers returning `ok=false` on any transport / non-200 / decode error. They are the canonical pattern for any poll that must ride out a restart window.
- All three `Await*` pollers (`AwaitReindexLive`, `AwaitReindexFinished`, `AwaitReindexViaIndexes`) are goroutine-safe: terminal statuses are captured in the condition and `Fatalf` fires from the test goroutine after `Eventually` exits. Failure messages unchanged.
- `assertTaskGone` still requires an eventual **successful 200 read with the task absent** — a permanently failing endpoint or a still-present task both still fail, so the tolerance cannot mask a real cascade bug.

## Proof

`TestAssertTaskGone_ToleratesTransientReadError` replays the exact production 500 body for 3 polls then a clean empty list: red with the pre-fix hard-assert, green with the tolerant read.

## Notes for review

The transient itself is a product defect (leader conn closed under in-flight RPCs), filed as weaviate/0-weaviate-issues#284 — this PR only makes the test's read semantics correct.
