### PR TITLE
test: drop flaky RegisterAssignsMonotoneSeq subtest

### DIFF
--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -272,31 +272,6 @@ func TestRegisterDeregisterLifecycle(t *testing.T) {
 		sched := newSchedulerForUnitTest(t)
 		assert.NoError(t, sched.Deregister(&Shard{}))
 	})
-
-	t.Run("RegisterAssignsMonotoneSeq", func(t *testing.T) {
-		// Successive Register calls must stamp strictly increasing seq values
-		// so the FIFO tie-break in heap ordering is well-defined.
-		sched := newSchedulerForUnitTest(t)
-		const n = 5
-		shards := make([]*Shard, n)
-		for i := range shards {
-			shards[i] = &Shard{}
-			require.NoError(t, sched.Register(shards[i]))
-		}
-
-		sched.mu.Lock()
-		seqs := make([]uint64, n)
-		for i, s := range shards {
-			require.NotNil(t, sched.entries[s], "shard %d must be registered", i)
-			seqs[i] = sched.entries[s].seq
-		}
-		sched.mu.Unlock()
-
-		for i := 1; i < n; i++ {
-			assert.Less(t, seqs[i-1], seqs[i],
-				"seq must increase monotonically with each Register call (pos %d)", i)
-		}
-	})
 }
 
 // TestHeapFIFOTieBreakingSeq verifies that when multiple entries share the same


### PR DESCRIPTION
## Summary

- Removes the flaky `TestRegisterDeregisterLifecycle/RegisterAssignsMonotoneSeq` subtest in [`adapters/repos/db/async_replication_scheduler_test.go`](adapters/repos/db/async_replication_scheduler_test.go).
- No production code changes.

## Why

`newSchedulerForUnitTest` returns a fully-running scheduler (dispatcher + 1 worker, `AsyncReplicationDisabled=false`). `onAddLocked` stamps `nextRunAt = time.Now()`, so every newly registered shard is immediately due. After enough `Register` calls in the loop the dispatcher's timer fires, the worker picks up an entry, errors out on `&Shard{}` (`ctx==nil` -> `"shard not yet initialized"`), and `onResultLocked` re-pushes the same entry with a fresh `seq = sched.nextSeq++`.

The test then read `sched.entries[s].seq` and asserted strict monotonicity across shards, but some entries carried their original registration seq while others carried the post-result re-push seq. Observed failure: `"2" is not less than "1"` at pos 1 (shard[0]'s seq was the re-push seq, shard[1]'s was the original).

The `seq` field's documented role is "last heap-push order", not "registration order" -- re-assignment on re-push is intended. The test's premise was wrong.

## Coverage

The actual heap invariant the subtest was *meant* to protect -- entries with equal `nextRunAt` pop in ascending `seq` (FIFO) -- is already covered by `TestHeapFIFOTieBreakingSeq` in the same file, which exercises `Less()` directly without any timing-sensitive dispatcher interaction. The per-call `seq = nextSeq; nextSeq++` stamp inside `onAddLocked` is trivial enough to read off the code; a dedicated assertion adds little value over the existing FIFO test.

## Test plan

- [x] `go test -race -count=1 -run 'TestRegisterDeregisterLifecycle' ./adapters/repos/db/` passes.
- [x] `go test -race -count=1 -run 'TestHeapFIFOTieBreakingSeq' ./adapters/repos/db/` passes (the test that already covers the FIFO seq invariant).