### PR TITLE
gh-11523 reject negative GraphQL Get offsets

### DIFF
--- a/adapters/handlers/graphql/local/get/get_test.go
+++ b/adapters/handlers/graphql/local/get/get_test.go
@@ -1738,6 +1738,15 @@ func TestExtractPaginationWithOnlyOffset(t *testing.T) {
 	resolver.AssertResolve(t, query)
 }
 
+func TestExtractPaginationWithNegativeOffset(t *testing.T) {
+	t.Parallel()
+
+	resolver := newMockResolver()
+
+	query := "{ Get { SomeAction(offset: -1 limit: 3) { intField } } }"
+	resolver.AssertFailToResolve(t, query, "offset must be non-negative")
+}
+
 func TestExtractCursor(t *testing.T) {
 	t.Parallel()
 

--- a/entities/filters/pagination.go
+++ b/entities/filters/pagination.go
@@ -11,6 +11,8 @@
 
 package filters
 
+import "errors"
+
 const (
 	// LimitFlagSearchByDist indicates that the
 	// vector search should be conducted by
@@ -34,6 +36,9 @@ func ExtractPaginationFromArgs(args map[string]interface{}) (*Pagination, error)
 	offset, offsetOk := args["offset"]
 	if !offsetOk {
 		offset = 0
+	}
+	if offset.(int) < 0 {
+		return nil, errors.New("offset must be non-negative")
 	}
 
 	limit, limitOk := args["limit"]

--- a/entities/filters/pagination_test.go
+++ b/entities/filters/pagination_test.go
@@ -55,4 +55,13 @@ func TestExtractPagination(t *testing.T) {
 		assert.Equal(t, 11, p.Offset)
 		assert.Equal(t, 25, p.Limit)
 	})
+
+	t.Run("with a negative offset", func(t *testing.T) {
+		p, err := ExtractPaginationFromArgs(map[string]interface{}{
+			"offset": -1,
+			"limit":  25,
+		})
+		require.Nil(t, p)
+		require.EqualError(t, err, "offset must be non-negative")
+	})
 }


### PR DESCRIPTION
### What's being changed:

Fixes #11523.

GraphQL `Get` now rejects negative `offset` values during pagination argument extraction instead of passing them into the retrieval path.

Previously, `ExtractPaginationFromArgs()` accepted `offset:-1`, which allowed a `filters.Pagination{Offset:-1}` to reach downstream code and trigger a recovered runtime panic (`slice bounds out of range [-1:]`). The shared pagination helper now returns a user-facing validation error: `offset must be non-negative`.

Added regression coverage at both levels:

- `entities/filters`: verifies negative offsets are rejected by the shared pagination extractor.
- `adapters/handlers/graphql/local/get`: verifies a GraphQL `Get` query with `offset:-1` fails before the resolver is called.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: Not necessary; this is validation behavior for an invalid request.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: Not necessary; GraphQL argument validation only.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. Not necessary; this adds a single integer validation branch.

Validation:

- `go test ./entities/filters -run TestExtractPagination -count=1`
- `go test ./adapters/handlers/graphql/local/get -run TestExtractPaginationWithNegativeOffset -count=1`
- `go test ./entities/filters -count=1`
- `go test ./adapters/handlers/graphql/local/get -count=1`
- `git diff --check`
