### PR TITLE
[MCP] Align hybrid default alpha with GraphQL/gRPC (0.5 → 0.75)

### DIFF
--- a/adapters/handlers/mcp/search/hybrid.go
+++ b/adapters/handlers/mcp/search/hybrid.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/filterext"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
@@ -69,8 +70,7 @@ func (s *WeaviateSearcher) Hybrid(ctx context.Context, req mcp.CallToolRequest, 
 	// Build additional properties from return_metadata
 	additionalProps := buildAdditionalProperties(args.ReturnMetadata)
 
-	// Set alpha with default of 0.5
-	alpha := 0.5
+	alpha := common_filters.DefaultAlpha
 	if args.Alpha != nil {
 		alpha = *args.Alpha
 	}

--- a/adapters/handlers/mcp/search/schema.go
+++ b/adapters/handlers/mcp/search/schema.go
@@ -24,7 +24,7 @@ type QueryHybridArgs struct {
 	Query            string         `json:"query" jsonschema:"required" jsonschema_description:"The plain-text query to search the collection on"`
 	CollectionName   string         `json:"collection_name" jsonschema:"required" jsonschema_description:"Name of collection to search from"`
 	TenantName       string         `json:"tenant_name,omitempty" jsonschema_description:"Name of the tenant to search within"`
-	Alpha            *float64       `json:"alpha,omitempty" jsonschema_description:"Semantic weight (0.0 = pure keyword, 1.0 = pure vector). Default is 0.5 if not specified"`
+	Alpha            *float64       `json:"alpha,omitempty" jsonschema_description:"Semantic weight (0.0 = pure keyword, 1.0 = pure vector). Default is 0.75 if not specified"`
 	Limit            *int           `json:"limit,omitempty" jsonschema_description:"Maximum number of results to return"`
 	TargetVectors    []string       `json:"target_vectors,omitempty" jsonschema_description:"Target vectors to use in vector search"`
 	TargetProperties []string       `json:"target_properties,omitempty" jsonschema_description:"Properties to perform BM25 keyword search on. If not specified, searches all text properties"`

--- a/tools/dev/config.mcp.json
+++ b/tools/dev/config.mcp.json
@@ -17,7 +17,7 @@
       "arguments": {
         "query": "The natural language search query to find relevant objects.",
         "collection_name": "The name of the collection to search in.",
-        "alpha": "Controls the balance between vector and keyword search: 0.0 = pure keyword (BM25), 1.0 = pure vector, 0.5 = equal weight (default)."
+        "alpha": "Controls the balance between vector and keyword search: 0.0 = pure keyword (BM25), 1.0 = pure vector. Default is 0.75 (vector-leaning)."
       }
     },
     "weaviate-objects-upsert": {

--- a/tools/dev/config.mcp.yaml
+++ b/tools/dev/config.mcp.yaml
@@ -30,7 +30,7 @@ tools:
     arguments:
       query: "The natural language search query to find relevant objects."
       collection_name: "The name of the collection to search in."
-      alpha: "Controls the balance between vector and keyword search: 0.0 = pure keyword (BM25), 1.0 = pure vector, 0.5 = equal weight (default)."
+      alpha: "Controls the balance between vector and keyword search: 0.0 = pure keyword (BM25), 1.0 = pure vector. Default is 0.75 (vector-leaning)."
 
   weaviate-objects-upsert:
     description: "Upserts (inserts or updates) one or more objects into a collection in batch. Supports efficient bulk operations - provide an array of objects to insert or update multiple objects at once. Each object can optionally specify a UUID; if provided and exists, the object is updated, otherwise a new object is created. Returns results for each object including success/failure status and generated UUIDs. Use this for adding or modifying data in Weaviate collections."


### PR DESCRIPTION
Aligns MCP hybrid-search default `alpha` with the rest of the Weaviate API — now imports `common_filters.DefaultAlpha` (0.75) instead of hardcoding `0.5`. GraphQL and gRPC already default to 0.75; MCP was the odd one out.