### PR TITLE
[Reindex Fixes A] test: harden multinode reindex tests against weak-VM timing

### DIFF
--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -232,26 +232,37 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
 }
 
-// fetchLocalTokenization requires consistency:false: the default GET
-// proxies to the leader, not this node's local schema.
-func fetchLocalTokenization(restURI, className, propName string) (string, bool) {
+// FetchClass reads the class schema via the given node. local=true sends
+// consistency:false for the node's own FSM state; the default GET proxies
+// to the leader — fine for cluster assertions, useless as a per-node gate.
+func FetchClass(restURI, className string, local bool) (*models.Class, bool) {
 	req, err := http.NewRequest(http.MethodGet,
 		fmt.Sprintf("http://%s/v1/schema/%s", restURI, className), nil)
 	if err != nil {
-		return "", false
+		return nil, false
 	}
-	req.Header.Set("consistency", "false")
+	if local {
+		req.Header.Set("consistency", "false")
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", false
+		return nil, false
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil || resp.StatusCode != http.StatusOK {
-		return "", false
+		return nil, false
 	}
 	var class models.Class
 	if err := json.Unmarshal(body, &class); err != nil {
+		return nil, false
+	}
+	return &class, true
+}
+
+func fetchLocalTokenization(restURI, className, propName string) (string, bool) {
+	class, ok := FetchClass(restURI, className, true)
+	if !ok {
 		return "", false
 	}
 	for _, prop := range class.Properties {

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -232,9 +232,8 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
 }
 
-// fetchLocalTokenization reads propName's tokenization from the node's
-// LOCAL schema. The consistency:false header is load-bearing — the
-// default proxies GET /v1/schema/{class} to the leader.
+// fetchLocalTokenization requires consistency:false: the default GET
+// proxies to the leader, not this node's local schema.
 func fetchLocalTokenization(restURI, className, propName string) (string, bool) {
 	req, err := http.NewRequest(http.MethodGet,
 		fmt.Sprintf("http://%s/v1/schema/%s", restURI, className), nil)
@@ -263,10 +262,8 @@ func fetchLocalTokenization(restURI, className, propName string) (string, bool) 
 	return "", false
 }
 
-// AwaitTokenizationVisible blocks until propName's tokenization equals
-// wantTok in the node's LOCAL schema. /v1/tasks FINISHED is a leader-
-// forwarded read while the indexes PUT validates against the local
-// schema — gate on local visibility before resubmitting.
+// AwaitTokenizationVisible gates on the node's local schema: /v1/tasks
+// FINISHED is leader-forwarded, but the indexes PUT validates locally.
 func AwaitTokenizationVisible(t *testing.T, restURI, className, propName, wantTok string, opts ...Option) {
 	t.Helper()
 	o := applyOptions(opts)

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -232,9 +232,8 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
 }
 
-// FetchClass reads the class schema via the given node. local=true sends
-// consistency:false for the node's own FSM state; the default GET proxies
-// to the leader — fine for cluster assertions, useless as a per-node gate.
+// FetchClass: local=true sends consistency:false for the node's own FSM
+// state; the default GET proxies to the leader, not a per-node visibility gate.
 func FetchClass(restURI, className string, local bool) (*models.Class, bool) {
 	req, err := http.NewRequest(http.MethodGet,
 		fmt.Sprintf("http://%s/v1/schema/%s", restURI, className), nil)

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -232,6 +232,60 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)
 }
 
+// fetchLocalTokenization reads propName's tokenization from the node's
+// LOCAL schema. The consistency:false header is load-bearing — the
+// default proxies GET /v1/schema/{class} to the leader.
+func fetchLocalTokenization(restURI, className, propName string) (string, bool) {
+	req, err := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("http://%s/v1/schema/%s", restURI, className), nil)
+	if err != nil {
+		return "", false
+	}
+	req.Header.Set("consistency", "false")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	var class models.Class
+	if err := json.Unmarshal(body, &class); err != nil {
+		return "", false
+	}
+	for _, prop := range class.Properties {
+		if prop.Name == propName {
+			return prop.Tokenization, true
+		}
+	}
+	return "", false
+}
+
+// AwaitTokenizationVisible blocks until propName's tokenization equals
+// wantTok in the node's LOCAL schema. /v1/tasks FINISHED is a leader-
+// forwarded read while the indexes PUT validates against the local
+// schema — gate on local visibility before resubmitting.
+func AwaitTokenizationVisible(t *testing.T, restURI, className, propName, wantTok string, opts ...Option) {
+	t.Helper()
+	o := applyOptions(opts)
+
+	lastSeen := "(no successful read)"
+	deadline := time.Now().Add(o.timeout)
+	for time.Now().Before(deadline) {
+		if tok, ok := fetchLocalTokenization(restURI, className, propName); ok {
+			lastSeen = tok
+			if tok == wantTok {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("property %s.%s tokenization not %q in local schema of %s within %s (last seen: %q)",
+		className, propName, wantTok, restURI, o.timeout, lastSeen)
+}
+
 // AwaitReindexViaIndexes polls GET /v1/schema/{collection}/indexes until
 // the named (property, indexType) reports `ready`. Unlike
 // AwaitReindexFinished, this polls the index-status surface — useful for

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -679,10 +679,8 @@ func testCancelClearsTrackerDirsViaOnTaskCompleted(t *testing.T, ctx context.Con
 		delResp.StatusCode, string(delBody))
 	deletedByTest = true
 
-	// class-dir removal is async (`.deleteme` rename + background RemoveAll)
-	// and lags the DELETE 200 under load; poll instead of checking once.
-	// Mirrors the .migrations drain poll above: assert.Eventually drives it,
-	// and on timeout we t.Fatalf with an ls -la so a real leak stays loud.
+	// Class-dir removal is async and lags the DELETE 200 under load;
+	// poll instead of checking once.
 	removed := assert.Eventually(t, func() bool {
 		code, _, execErr := container.Exec(ctx, []string{"test", "-d", classPath})
 		require.NoError(t, execErr)

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -679,11 +679,27 @@ func testCancelClearsTrackerDirsViaOnTaskCompleted(t *testing.T, ctx context.Con
 		delResp.StatusCode, string(delBody))
 	deletedByTest = true
 
-	code, _, execErr := container.Exec(ctx, []string{"test", "-d", classPath})
-	require.NoError(t, execErr)
-	require.Equalf(t, 1, code,
-		"class dir %s must be removed by DELETE; got test -d exit %d",
-		classPath, code)
+	// class-dir removal is async (`.deleteme` rename + background RemoveAll)
+	// and lags the DELETE 200 under load; poll instead of checking once.
+	// Mirrors the .migrations drain poll above: assert.Eventually drives it,
+	// and on timeout we t.Fatalf with an ls -la so a real leak stays loud.
+	removed := assert.Eventually(t, func() bool {
+		code, _, execErr := container.Exec(ctx, []string{"test", "-d", classPath})
+		require.NoError(t, execErr)
+		return code == 1 // test -d exit 1 == class dir gone
+	}, 30*time.Second, 50*time.Millisecond)
+	if !removed {
+		_, reader, execErr := container.Exec(ctx, []string{
+			"sh", "-c", fmt.Sprintf("ls -la %s 2>&1", classPath),
+		})
+		require.NoError(t, execErr)
+		out := new(strings.Builder)
+		if reader != nil {
+			_, _ = io.Copy(out, reader)
+		}
+		t.Fatalf("class dir %s must be removed by DELETE within 30s; still present:\n%s",
+			classPath, strings.TrimSpace(out.String()))
+	}
 
 	_ = taskID
 }

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -265,15 +265,9 @@ func scanClassDirAllNodes(
 }
 
 // createS3Backup posts to /v1/backups/s3 and waits for a SUCCESS terminal
-// status. The caller waits for completion (not just acceptance) because the
-// subsequent DELETE must not run while a backup is in progress — an in-flight
-// backup makes Index.drop take the keepFiles path (rename-aside, not remove),
-// which would defeat the post-delete "class dir removed" assertion. The budget
-// is generous (not 120s) to absorb the deliberately-weak soak VM's S3 upload
-// throughput under multi-worker contention: the backup completes on ~92% of
-// runs and is not stuck — only the completion *timing* spikes under load. (A
-// future failure where the backup shows no upload progress would be a real
-// bug, not this timing case.)
+// status. Completion (not just acceptance) is load-bearing: an in-flight
+// backup makes Index.drop take the rename-aside keepFiles path, defeating the
+// post-delete "class dir removed" assertion. Budget sized for a starved VM.
 func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) error {
 	t.Helper()
 	body := map[string]interface{}{

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -264,8 +264,16 @@ func scanClassDirAllNodes(
 	return survivors
 }
 
-// createS3Backup posts to /v1/backups/s3 and waits up to 120s for a
-// SUCCESS terminal status.
+// createS3Backup posts to /v1/backups/s3 and waits for a SUCCESS terminal
+// status. The caller waits for completion (not just acceptance) because the
+// subsequent DELETE must not run while a backup is in progress — an in-flight
+// backup makes Index.drop take the keepFiles path (rename-aside, not remove),
+// which would defeat the post-delete "class dir removed" assertion. The budget
+// is generous (not 120s) to absorb the deliberately-weak soak VM's S3 upload
+// throughput under multi-worker contention: the backup completes on ~92% of
+// runs and is not stuck — only the completion *timing* spikes under load. (A
+// future failure where the backup shows no upload progress would be a real
+// bug, not this timing case.)
 func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) error {
 	t.Helper()
 	body := map[string]interface{}{
@@ -287,7 +295,7 @@ func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) e
 		return fmt.Errorf("backup create returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	deadline := time.Now().Add(120 * time.Second)
+	deadline := time.Now().Add(300 * time.Second)
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -309,7 +317,7 @@ func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) e
 			return fmt.Errorf("backup FAILED: %s", status.Error)
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("backup did not reach SUCCESS/FAILED in 120s; last status: %s", status.Status)
+			return fmt.Errorf("backup did not reach SUCCESS/FAILED in 300s; last status: %s", status.Status)
 		}
 		<-ticker.C
 	}

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -67,7 +67,7 @@ func TestMultiNode_CancelClearsAcrossReplicas(t *testing.T) {
 
 	uri := restURIOf(compose, 1)
 	trueVal := true
-	createCollection(t, uri, className, 3, 3, []*models.Property{
+	createCollection(t, compose, uri, className, 3, 3, []*models.Property{
 		{
 			Name:            propName,
 			DataType:        []string{"text"},

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -264,9 +264,8 @@ func scanClassDirAllNodes(
 	return survivors
 }
 
-// createS3Backup posts to /v1/backups/s3 and waits for a SUCCESS terminal
-// status. Completion (not just acceptance) is load-bearing: an in-flight
-// backup makes Index.drop take the rename-aside keepFiles path, defeating the
+// createS3Backup posts to /v1/backups/s3 and waits for SUCCESS: an in-flight
+// backup sends Index.drop down the rename-aside keepFiles path, defeating the
 // post-delete "class dir removed" assertion. Budget sized for a starved VM.
 func createS3Backup(t *testing.T, restURI, className, backupID, bucket string) error {
 	t.Helper()

--- a/test/acceptance/reindex_multinode/concurrent_migrations_test.go
+++ b/test/acceptance/reindex_multinode/concurrent_migrations_test.go
@@ -89,7 +89,7 @@ func TestMultiNode_ConcurrentDifferentMigrations_ExactCountsPostSettle(t *testin
 	// `category`: text, IndexFilterable=false → will be enable-filterable'd
 	// `path`: text, tokenization=field → will be change-tokenization'd to word
 	trueVal, falseVal := true, false
-	createCollection(t, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
 		{
 			Name:              "price",
 			DataType:          []string{"int"},

--- a/test/acceptance/reindex_multinode/cross_replica_barrier_test.go
+++ b/test/acceptance/reindex_multinode/cross_replica_barrier_test.go
@@ -91,7 +91,7 @@ func TestMultiNode_CrossReplicaPrepBarrier(t *testing.T) {
 	// This is the topology Etienne's design sketch on
 	// weaviate/0-weaviate-issues#225 (comment 4472712888) prescribes
 	// as the sharp cross-replica reproducer.
-	createCollection(t, restURI, className, 5, 1, []*models.Property{
+	createCollection(t, compose, restURI, className, 5, 1, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer deleteCollection(t, restURI, className)

--- a/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
+++ b/test/acceptance/reindex_multinode/dtm_cascade_delete_test.go
@@ -44,7 +44,7 @@ func TestMultiNode_DeleteRecreateCleansReindexTasks(t *testing.T) {
 	uri := restURIOf(compose, 1)
 
 	trueVal := true
-	createCollection(t, uri, className, 3, 3, []*models.Property{
+	createCollection(t, compose, uri, className, 3, 3, []*models.Property{
 		{
 			Name:            "text",
 			DataType:        []string{"text"},
@@ -82,7 +82,7 @@ func TestMultiNode_DeleteRecreateCleansReindexTasks(t *testing.T) {
 	}
 
 	// Same-name recreate must not inherit FAILED / FINISHED pills.
-	createCollection(t, uri, className, 3, 3, []*models.Property{
+	createCollection(t, compose, uri, className, 3, 3, []*models.Property{
 		{
 			Name:            "text",
 			DataType:        []string{"text"},

--- a/test/acceptance/reindex_multinode/finalizing_crash_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_crash_test.go
@@ -73,7 +73,7 @@ func TestMultiNode_RollingRestartDuringFinalizing_PerReplicaConsistency(t *testi
 	const expectedPathCount = totalObjects / 5 // exactly even bucketing
 
 	trueVal := true
-	createCollection(t, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
 		{
 			Name:            "path",
 			DataType:        []string{"text"},
@@ -249,7 +249,7 @@ func TestMultiNode_UngracefulStopDuringFinalizing_PerReplicaConsistency(t *testi
 	const expectedPathCount = totalObjects / 5
 
 	trueVal := true
-	createCollection(t, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
 		{
 			Name:            "path",
 			DataType:        []string{"text"},

--- a/test/acceptance/reindex_multinode/finalizing_window_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_window_test.go
@@ -188,7 +188,7 @@ func runLiveQueryDuringChangeTokenizationCase(
 
 	className := fmt.Sprintf("LiveQueryTok_%s_%s_%s", startTok, targetTok, indexType)
 
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, shardCount, rf,
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, shardCount, rf,
 		[]*models.Property{
 			{Name: "text", DataType: []string{"text"}, Tokenization: startTok},
 		})
@@ -415,7 +415,7 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 		queryLimit  = 2000 // Must exceed objectCount so all matches are returned.
 	)
 
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, shardCount, rf,
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, shardCount, rf,
 		[]*models.Property{
 			{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 		})

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -238,19 +238,27 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	}
 }
 
-// waitForClassOnAllNodes blocks until className is visible (GET
-// /v1/schema/<class> == 200, a per-node local read) on every node. After
-// createCollection a node still catching up on the RAFT schema log — e.g. one
-// tied up in a slow startup migration — may not yet have the class; a
-// consistency=ALL write then trips that replica's schema-version deadline
-// (got=N want=N+k). Gating writes on convergence avoids that without retrying
-// the write itself (objects get auto-UUIDs, so a retry would duplicate).
+// waitForClassOnAllNodes blocks until className is visible in every node's
+// LOCAL schema view. The `consistency: false` header is load-bearing: without
+// it the GET defaults to consistency=true and is proxied to the leader, so
+// the poll would return 200 immediately after create regardless of the lagging
+// follower — exactly the follower whose local RAFT catch-up (e.g. one tied up
+// in a slow startup migration) trips a consistency=ALL write's schema-version
+// deadline (got=N want=N+k). Gating writes on local convergence avoids that
+// without retrying the write itself (objects get auto-UUIDs, so a retry would
+// duplicate).
 func waitForClassOnAllNodes(t *testing.T, compose *docker.DockerCompose, className string) {
 	t.Helper()
 	for i := 1; i <= 3; i++ {
 		nodeURI := compose.GetWeaviateNode(i).URI()
 		require.Eventuallyf(t, func() bool {
-			resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s", nodeURI, className))
+			req, err := http.NewRequest(http.MethodGet,
+				fmt.Sprintf("http://%s/v1/schema/%s", nodeURI, className), nil)
+			if err != nil {
+				return false
+			}
+			req.Header.Set("consistency", "false")
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return false
 			}
@@ -258,7 +266,7 @@ func waitForClassOnAllNodes(t *testing.T, compose *docker.DockerCompose, classNa
 			_ = resp.Body.Close()
 			return resp.StatusCode == http.StatusOK
 		}, 60*time.Second, 100*time.Millisecond,
-			"class %s must be visible on node %d before consistency=ALL writes", className, i)
+			"class %s must be locally visible on node %d before consistency=ALL writes", className, i)
 	}
 }
 

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -103,10 +103,7 @@ func testMapToBlockmaxMultiPropertyDefersFlip(t *testing.T, compose *docker.Dock
 	className := "MultiNodeBlockmaxMultiProp"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "title", DataType: []string{"text"}, Tokenization: "word"},
-		{Name: "body", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("title", "body"))
 	defer deleteCollection(t, restURI, className)
 
 	// Baseline: flag off pre-migration.
@@ -156,9 +153,7 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeBlockmax"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("text"))
 	defer deleteCollection(t, restURI, className)
 
 	importObjects(t, restURI, className, testDocuments)
@@ -242,9 +237,7 @@ func testRoaringSetRefresh(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeRoaringSet"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("text"))
 	defer deleteCollection(t, restURI, className)
 
 	importObjects(t, restURI, className, testDocuments)
@@ -344,9 +337,7 @@ func testChangeTokenization(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeTokenize"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("text"))
 	defer deleteCollection(t, restURI, className)
 
 	importObjects(t, restURI, className, testDocuments)
@@ -409,9 +400,7 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 	className := "ConsistencyTest"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("text"))
 	defer deleteCollection(t, restURI, className)
 
 	importObjects(t, restURI, className, testDocuments)

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -238,6 +238,30 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	}
 }
 
+// waitForClassOnAllNodes blocks until className is visible (GET
+// /v1/schema/<class> == 200, a per-node local read) on every node. After
+// createCollection a node still catching up on the RAFT schema log — e.g. one
+// tied up in a slow startup migration — may not yet have the class; a
+// consistency=ALL write then trips that replica's schema-version deadline
+// (got=N want=N+k). Gating writes on convergence avoids that without retrying
+// the write itself (objects get auto-UUIDs, so a retry would duplicate).
+func waitForClassOnAllNodes(t *testing.T, compose *docker.DockerCompose, className string) {
+	t.Helper()
+	for i := 1; i <= 3; i++ {
+		nodeURI := compose.GetWeaviateNode(i).URI()
+		require.Eventuallyf(t, func() bool {
+			resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s", nodeURI, className))
+			if err != nil {
+				return false
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		}, 60*time.Second, 100*time.Millisecond,
+			"class %s must be visible on node %d before consistency=ALL writes", className, i)
+	}
+}
+
 func testRoaringSetRefresh(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeRoaringSet"
 	restURI := compose.GetWeaviateNode(1).URI()
@@ -246,6 +270,9 @@ func testRoaringSetRefresh(t *testing.T, compose *docker.DockerCompose) {
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer deleteCollection(t, restURI, className)
+
+	// Gate the first consistency=ALL write on schema convergence across nodes.
+	waitForClassOnAllNodes(t, compose, className)
 
 	importObjects(t, restURI, className, testDocuments)
 

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -103,7 +103,7 @@ func testMapToBlockmaxMultiPropertyDefersFlip(t *testing.T, compose *docker.Dock
 	className := "MultiNodeBlockmaxMultiProp"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "title", DataType: []string{"text"}, Tokenization: "word"},
 		{Name: "body", DataType: []string{"text"}, Tokenization: "word"},
 	})
@@ -156,7 +156,7 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeBlockmax"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer deleteCollection(t, restURI, className)
@@ -238,43 +238,14 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	}
 }
 
-// waitForClassOnAllNodes blocks until className is in every node's LOCAL
-// schema view: a lagging follower otherwise fails consistency=ALL writes, and
-// the write can't simply be retried (auto-UUIDs would duplicate). The
-// consistency:false header is load-bearing — the default proxies to the leader.
-func waitForClassOnAllNodes(t *testing.T, compose *docker.DockerCompose, className string) {
-	t.Helper()
-	for i := 1; i <= 3; i++ {
-		nodeURI := compose.GetWeaviateNode(i).URI()
-		require.Eventuallyf(t, func() bool {
-			req, err := http.NewRequest(http.MethodGet,
-				fmt.Sprintf("http://%s/v1/schema/%s", nodeURI, className), nil)
-			if err != nil {
-				return false
-			}
-			req.Header.Set("consistency", "false")
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				return false
-			}
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			return resp.StatusCode == http.StatusOK
-		}, 60*time.Second, 100*time.Millisecond,
-			"class %s must be locally visible on node %d before consistency=ALL writes", className, i)
-	}
-}
-
 func testRoaringSetRefresh(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeRoaringSet"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer deleteCollection(t, restURI, className)
-
-	waitForClassOnAllNodes(t, compose, className)
 
 	importObjects(t, restURI, className, testDocuments)
 
@@ -323,7 +294,7 @@ func testEnableRangeable(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeRangeable"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 		{Name: "score", DataType: []string{"int"}},
 	})
@@ -373,7 +344,7 @@ func testChangeTokenization(t *testing.T, compose *docker.DockerCompose) {
 	className := "MultiNodeTokenize"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer deleteCollection(t, restURI, className)
@@ -438,7 +409,7 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 	className := "ConsistencyTest"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer deleteCollection(t, restURI, className)

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -238,15 +238,10 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	}
 }
 
-// waitForClassOnAllNodes blocks until className is visible in every node's
-// LOCAL schema view. The `consistency: false` header is load-bearing: without
-// it the GET defaults to consistency=true and is proxied to the leader, so
-// the poll would return 200 immediately after create regardless of the lagging
-// follower — exactly the follower whose local RAFT catch-up (e.g. one tied up
-// in a slow startup migration) trips a consistency=ALL write's schema-version
-// deadline (got=N want=N+k). Gating writes on local convergence avoids that
-// without retrying the write itself (objects get auto-UUIDs, so a retry would
-// duplicate).
+// waitForClassOnAllNodes blocks until className is in every node's LOCAL
+// schema view: a lagging follower otherwise fails consistency=ALL writes, and
+// the write can't simply be retried (auto-UUIDs would duplicate). The
+// consistency:false header is load-bearing — the default proxies to the leader.
 func waitForClassOnAllNodes(t *testing.T, compose *docker.DockerCompose, className string) {
 	t.Helper()
 	for i := 1; i <= 3; i++ {
@@ -279,7 +274,6 @@ func testRoaringSetRefresh(t *testing.T, compose *docker.DockerCompose) {
 	})
 	defer deleteCollection(t, restURI, className)
 
-	// Gate the first consistency=ALL write on schema convergence across nodes.
 	waitForClassOnAllNodes(t, compose, className)
 
 	importObjects(t, restURI, className, testDocuments)

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -660,6 +660,12 @@ func filterMigrationLogLines(s string) []string {
 		"recovered untidied", "swap INCOMPLETE", "swap complete",
 		"runtime swap", "trim:",
 		"distributed task", "distributedtask",
+		// raft leadership evidence: a leader move between a task's
+		// FINISHED (leader read) and the local schema apply is a known
+		// flake shape. These lines are rare, so the dump stays small.
+		"entering follower state", "entering candidate state",
+		"entering leader state", "election won", "leadership",
+		"raft_node_state",
 	}
 	var out []string
 	for _, line := range strings.Split(s, "\n") {

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -62,8 +62,10 @@ func start3NodeReindexCluster(ctx context.Context, t *testing.T, extraEnv ...str
 }
 
 // createCollection creates a class with the given shard count and replication factor
-// via the REST API.
-func createCollection(t *testing.T, restURI, className string, shardCount, rf int, properties []*models.Property) {
+// via the REST API, then blocks until the class is in every node's LOCAL
+// schema view — a lagging follower otherwise fails consistency=ALL writes,
+// and the write can't simply be retried (auto-UUIDs would duplicate).
+func createCollection(t *testing.T, compose *docker.DockerCompose, restURI, className string, shardCount, rf int, properties []*models.Property) {
 	t.Helper()
 
 	class := map[string]interface{}{
@@ -91,6 +93,32 @@ func createCollection(t *testing.T, restURI, className string, shardCount, rf in
 
 	respBody, _ := io.ReadAll(resp.Body)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "create class failed: %s", string(respBody))
+
+	// The consistency:false header is load-bearing — the default proxies the
+	// read to the leader, which would hide a follower whose local schema view
+	// still lags behind the CREATE_CLASS apply.
+	for _, node := range compose.Containers() {
+		if !strings.HasPrefix(node.Name(), "weaviate-") {
+			continue
+		}
+		nodeURI := node.URI()
+		require.Eventuallyf(t, func() bool {
+			req, err := http.NewRequest(http.MethodGet,
+				fmt.Sprintf("http://%s/v1/schema/%s", nodeURI, className), nil)
+			if err != nil {
+				return false
+			}
+			req.Header.Set("consistency", "false")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return false
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		}, 60*time.Second, 100*time.Millisecond,
+			"class %s must be locally visible on node %s before consistency=ALL writes", className, node.Name())
+	}
 }
 
 // deleteCollection deletes a class via the REST API.

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -660,9 +660,8 @@ func filterMigrationLogLines(s string) []string {
 		"recovered untidied", "swap INCOMPLETE", "swap complete",
 		"runtime swap", "trim:",
 		"distributed task", "distributedtask",
-		// raft leadership evidence: a leader move between a task's
-		// FINISHED (leader read) and the local schema apply is a known
-		// flake shape. These lines are rare, so the dump stays small.
+		// raft leadership lines: correlate with the FINISHED vs
+		// local-schema race (see AwaitTokenizationVisible).
 		"entering follower state", "entering candidate state",
 		"entering leader state", "election won", "leadership",
 		"raft_node_state",

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -61,6 +61,20 @@ func start3NodeReindexCluster(ctx context.Context, t *testing.T, extraEnv ...str
 	return compose, func() { require.NoError(t, compose.Terminate(ctx)) }
 }
 
+// textProps builds word-tokenized text properties — the package's default
+// collection shape.
+func textProps(names ...string) []*models.Property {
+	props := make([]*models.Property, 0, len(names))
+	for _, name := range names {
+		props = append(props, &models.Property{
+			Name:         name,
+			DataType:     []string{"text"},
+			Tokenization: "word",
+		})
+	}
+	return props
+}
+
 // createCollection creates a class with the given shard count and replication factor
 // via the REST API, then blocks until the class is in every node's LOCAL
 // schema view — a lagging follower otherwise fails consistency=ALL writes,

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/docker"
 )
 
@@ -392,21 +393,15 @@ func assertQueryConsistency(t *testing.T, results [][]string) {
 	}
 }
 
-// getClassFromNode retrieves a class schema from a specific node.
+// getClassFromNode is LEADER-PROXIED (default GET consistency): fine for
+// cluster-level assertions, never a per-node visibility gate — use
+// reindexhelpers.AwaitTokenizationVisible for gating.
 func getClassFromNode(t *testing.T, restURI, className string) *models.Class {
 	t.Helper()
 
-	resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s", restURI, className))
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "get class failed: %s", string(body))
-
-	var class models.Class
-	require.NoError(t, json.Unmarshal(body, &class))
-	return &class
+	class, ok := reindexhelpers.FetchClass(restURI, className, false)
+	require.True(t, ok, "get class %s via %s failed", className, restURI)
+	return class
 }
 
 // tryImportObject attempts to import a single object and returns an error
@@ -441,29 +436,14 @@ func tryImportObject(restURI, className, text string) error {
 	return nil
 }
 
-// tryGetPropertyTokenization retrieves a property's tokenization from a node.
-// Returns "" if the request fails or the property is not found.
+// tryGetPropertyTokenization is LEADER-PROXIED (default GET consistency):
+// fine for cluster-level assertions, never a per-node visibility gate — use
+// reindexhelpers.AwaitTokenizationVisible for gating. "" = failed/not found.
 func tryGetPropertyTokenization(restURI, className, propName string) string {
-	resp, err := http.Get(fmt.Sprintf("http://%s/v1/schema/%s", restURI, className))
-	if err != nil {
+	class, ok := reindexhelpers.FetchClass(restURI, className, false)
+	if !ok {
 		return ""
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return ""
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return ""
-	}
-
-	var class models.Class
-	if err := json.Unmarshal(body, &class); err != nil {
-		return ""
-	}
-
 	for _, prop := range class.Properties {
 		if prop.Name == propName {
 			return prop.Tokenization

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -61,8 +61,6 @@ func start3NodeReindexCluster(ctx context.Context, t *testing.T, extraEnv ...str
 	return compose, func() { require.NoError(t, compose.Terminate(ctx)) }
 }
 
-// textProps builds word-tokenized text properties — the package's default
-// collection shape.
 func textProps(names ...string) []*models.Property {
 	props := make([]*models.Property, 0, len(names))
 	for _, name := range names {
@@ -75,10 +73,9 @@ func textProps(names ...string) []*models.Property {
 	return props
 }
 
-// createCollection creates a class with the given shard count and replication factor
-// via the REST API, then blocks until the class is in every node's LOCAL
-// schema view — a lagging follower otherwise fails consistency=ALL writes,
-// and the write can't simply be retried (auto-UUIDs would duplicate).
+// createCollection creates a class via the REST API, then blocks until it is
+// in every node's local schema view: a lagging follower fails consistency=ALL
+// writes, and retrying isn't safe (auto-UUIDs would duplicate).
 func createCollection(t *testing.T, compose *docker.DockerCompose, restURI, className string, shardCount, rf int, properties []*models.Property) {
 	t.Helper()
 
@@ -108,9 +105,8 @@ func createCollection(t *testing.T, compose *docker.DockerCompose, restURI, clas
 	respBody, _ := io.ReadAll(resp.Body)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "create class failed: %s", string(respBody))
 
-	// The consistency:false header is load-bearing — the default proxies the
-	// read to the leader, which would hide a follower whose local schema view
-	// still lags behind the CREATE_CLASS apply.
+	// consistency:false forces a local read; the default proxies to the
+	// leader, which would hide a lagging follower.
 	for _, node := range compose.Containers() {
 		if !strings.HasPrefix(node.Name(), "weaviate-") {
 			continue

--- a/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
+++ b/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
@@ -86,7 +86,7 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 	scoreFor := func(i int) int { return 10_000 + i*5 }
 
 	trueVal, falseVal := true, false
-	createCollection(t, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
 		{Name: "name", DataType: []string{"text"}},
 		{
 			Name:              "score",

--- a/test/acceptance/reindex_multinode/migration_journeys_test.go
+++ b/test/acceptance/reindex_multinode/migration_journeys_test.go
@@ -74,7 +74,7 @@ func TestMultiNode_BackToBackChangeTokenization_RoundTripCounts(t *testing.T) {
 	const totalObjects = 10_000
 
 	trueVal := true
-	createCollection(t, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
 		{
 			Name:            "path",
 			DataType:        []string{"text"},
@@ -250,7 +250,7 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 	)
 
 	trueVal, falseVal := true, false
-	createCollection(t, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
 		{
 			Name:              "price",
 			DataType:          []string{"int"},

--- a/test/acceptance/reindex_multinode/migration_journeys_test.go
+++ b/test/acceptance/reindex_multinode/migration_journeys_test.go
@@ -138,6 +138,9 @@ func TestMultiNode_BackToBackChangeTokenization_RoundTripCounts(t *testing.T) {
 		`{"searchable":{"tokenization":"field"}}`)
 	t.Logf("change-tokenization → field: task=%s", task1)
 	reindexhelpers.AwaitReindexFinished(t, uri1, task1, reindexhelpers.WithTimeout(180*time.Second))
+	// FINISHED is a leader read; the next PUT validates against node-1's
+	// local schema — gate on local visibility before resubmitting.
+	reindexhelpers.AwaitTokenizationVisible(t, uri1, className, "path", "field")
 
 	// === Step 5: every replica must serve the FIELD count.
 	// AwaitReindexFinished only confirms node-1; poll all replicas (50ms)
@@ -326,6 +329,9 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
+		// FINISHED is a leader read; cycle 1's PUT validates against
+		// node-1's local schema — gate on local visibility.
+		reindexhelpers.AwaitTokenizationVisible(t, uri, className, "path", "field")
 	}
 
 	// Repeated journey: rebuild + tokenization round-trip, N times. The
@@ -364,6 +370,8 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
+		// Gate the next cycle's PUT on node-1's local schema flip.
+		reindexhelpers.AwaitTokenizationVisible(t, uri, className, "path", nextTok)
 	}
 
 	// After preRestartCycles cycles, the path tokenization is:

--- a/test/acceptance/reindex_multinode/migration_journeys_test.go
+++ b/test/acceptance/reindex_multinode/migration_journeys_test.go
@@ -138,8 +138,7 @@ func TestMultiNode_BackToBackChangeTokenization_RoundTripCounts(t *testing.T) {
 		`{"searchable":{"tokenization":"field"}}`)
 	t.Logf("change-tokenization → field: task=%s", task1)
 	reindexhelpers.AwaitReindexFinished(t, uri1, task1, reindexhelpers.WithTimeout(180*time.Second))
-	// FINISHED is a leader read; the next PUT validates against node-1's
-	// local schema — gate on local visibility before resubmitting.
+	// FINISHED is leader-read; gate on local schema before the next PUT.
 	reindexhelpers.AwaitTokenizationVisible(t, uri1, className, "path", "field")
 
 	// === Step 5: every replica must serve the FIELD count.
@@ -329,8 +328,7 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
-		// FINISHED is a leader read; cycle 1's PUT validates against
-		// node-1's local schema — gate on local visibility.
+		// FINISHED is leader-read; gate on local schema before the next PUT.
 		reindexhelpers.AwaitTokenizationVisible(t, uri, className, "path", "field")
 	}
 
@@ -370,7 +368,7 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		reindexhelpers.AwaitReindexFinished(t, uri, tp, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tc, reindexhelpers.WithTimeout(180*time.Second))
 		reindexhelpers.AwaitReindexFinished(t, uri, tk, reindexhelpers.WithTimeout(180*time.Second))
-		// Gate the next cycle's PUT on node-1's local schema flip.
+		// FINISHED is leader-read; gate on local schema before the next PUT.
 		reindexhelpers.AwaitTokenizationVisible(t, uri, className, "path", nextTok)
 	}
 

--- a/test/acceptance/reindex_multinode/post_restart_test.go
+++ b/test/acceptance/reindex_multinode/post_restart_test.go
@@ -440,8 +440,7 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 	// OnAfterLsmInitAsync iterator path that #212 Issues C/D/G hit.
 	t.Log("submitting post-restart re-apply migrations (3 concurrent)")
 	uri1 = restURIOf(compose, 1)
-	// The tok→word PUT below validates against node-1's local schema;
-	// the pre-restart FINISHED was a leader read — gate on local visibility.
+	// FINISHED is leader-read; gate on local schema before the next PUT.
 	reindexhelpers.AwaitTokenizationVisible(t, uri1, className, "path", "field")
 	{
 		var (

--- a/test/acceptance/reindex_multinode/post_restart_test.go
+++ b/test/acceptance/reindex_multinode/post_restart_test.go
@@ -61,7 +61,7 @@ func TestMultiNode_PostRestartMigration_NoStallPlateau(t *testing.T) {
 
 	const className = "PostRestartPlateau"
 
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	// Re-resolve at defer time: rollingRestart replaces each container,
@@ -313,7 +313,7 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 	const totalObjects = 10_000
 
 	trueVal, falseVal := true, false
-	createCollection(t, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
 		{
 			Name:              "price",
 			DataType:          []string{"int"},

--- a/test/acceptance/reindex_multinode/post_restart_test.go
+++ b/test/acceptance/reindex_multinode/post_restart_test.go
@@ -440,6 +440,9 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 	// OnAfterLsmInitAsync iterator path that #212 Issues C/D/G hit.
 	t.Log("submitting post-restart re-apply migrations (3 concurrent)")
 	uri1 = restURIOf(compose, 1)
+	// The tok→word PUT below validates against node-1's local schema;
+	// the pre-restart FINISHED was a leader read — gate on local visibility.
+	reindexhelpers.AwaitTokenizationVisible(t, uri1, className, "path", "field")
 	{
 		var (
 			tp, tc, tk string

--- a/test/acceptance/reindex_multinode/post_restart_test.go
+++ b/test/acceptance/reindex_multinode/post_restart_test.go
@@ -61,9 +61,7 @@ func TestMultiNode_PostRestartMigration_NoStallPlateau(t *testing.T) {
 
 	const className = "PostRestartPlateau"
 
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	// Re-resolve at defer time: rollingRestart replaces each container,
 	// which testcontainers reallocates ports for. Capturing a URL at
 	// defer-registration time would bake in a pre-restart port and the

--- a/test/acceptance/reindex_multinode/restart_matrix_test.go
+++ b/test/acceptance/reindex_multinode/restart_matrix_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/docker"
 )
@@ -117,9 +116,7 @@ func testR0_RestartThenMigrate(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR0"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -156,9 +153,7 @@ func testR1_RestartAfter1Migration(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR1"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -197,9 +192,7 @@ func testR1b_RestartAfter1MigrationThenMigrate(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR1b"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -225,9 +218,7 @@ func testR2_RestartAfter2Migrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR2"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -251,9 +242,7 @@ func testR2b_RestartAfter2MigrationsThenMigrate(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR2b"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -289,9 +278,7 @@ func testR3_RestartAfter3Migrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR3"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -317,9 +304,7 @@ func testR5_RestartAfterManyMigrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR5"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -350,9 +335,7 @@ func TestMultiNode_RollingRestartMidMigration(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RollingMidMigration"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)
@@ -396,9 +379,7 @@ func TestMultiNode_RollingRestartBetweenMigrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RollingBetweenMigrations"
-	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, textProps("text"))
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
 
 	importObjects(t, compose.GetWeaviateNode(1).URI(), className, testDocuments)

--- a/test/acceptance/reindex_multinode/restart_matrix_test.go
+++ b/test/acceptance/reindex_multinode/restart_matrix_test.go
@@ -117,7 +117,7 @@ func testR0_RestartThenMigrate(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR0"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -156,7 +156,7 @@ func testR1_RestartAfter1Migration(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR1"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -197,7 +197,7 @@ func testR1b_RestartAfter1MigrationThenMigrate(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR1b"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -225,7 +225,7 @@ func testR2_RestartAfter2Migrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR2"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -251,7 +251,7 @@ func testR2b_RestartAfter2MigrationsThenMigrate(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR2b"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -289,7 +289,7 @@ func testR3_RestartAfter3Migrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR3"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -317,7 +317,7 @@ func testR5_RestartAfterManyMigrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RestartR5"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -350,7 +350,7 @@ func TestMultiNode_RollingRestartMidMigration(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RollingMidMigration"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()
@@ -396,7 +396,7 @@ func TestMultiNode_RollingRestartBetweenMigrations(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const className = "RollingBetweenMigrations"
-	createCollection(t, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
+	createCollection(t, compose, compose.GetWeaviateNode(1).URI(), className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() { deleteCollection(t, compose.GetWeaviateNode(1).URI(), className) }()

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -34,7 +34,7 @@ func setupRestartDuringReindex(
 
 	uri := restURIOf(compose, 1)
 	trueVal := true
-	createCollection(t, uri, className, 3, 3, []*models.Property{
+	createCollection(t, compose, uri, className, 3, 3, []*models.Property{
 		{
 			Name:            "path",
 			DataType:        []string{"text"},
@@ -162,7 +162,7 @@ func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 	className := "RollingRestart"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer func() {

--- a/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
@@ -230,7 +230,7 @@ func TestMultiNode_ChangeTokenization_RestartThenRoundTrip(t *testing.T) {
 	const className = "RestartRoundTrip"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	// Use a closure so the URI is re-resolved at defer-time. The
@@ -376,7 +376,7 @@ func TestMultiNode_ChangeTokenization_ConcurrentDifferentProps(t *testing.T) {
 	const className = "ConcurrentProps"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "title", DataType: []string{"text"}, Tokenization: "word"},
 		{Name: "body", DataType: []string{"text"}, Tokenization: "word"},
 	})
@@ -474,7 +474,7 @@ func testRoundTripNRounds(
 	t.Helper()
 
 	restURI := compose.GetWeaviateNode(1).URI()
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: startTok},
 	})
 	defer deleteCollection(t, restURI, className)
@@ -514,7 +514,7 @@ func testMultiPropertyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
 	const className = "MultiProp"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "title", DataType: []string{"text"}, Tokenization: "word"},
 		{Name: "body", DataType: []string{"text"}, Tokenization: "word"},
 	})
@@ -572,7 +572,7 @@ func testFilterableOnlyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
 	trueVal, falseVal := true, false
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{
 			Name: "text", DataType: []string{"text"},
 			Tokenization:    "word",
@@ -631,7 +631,7 @@ func testSearchableOnlyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
 	trueVal, falseVal := true, false
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{
 			Name: "text", DataType: []string{"text"},
 			Tokenization:    "word",
@@ -666,7 +666,7 @@ func testEnableFilterableThenChangeTok(t *testing.T, compose *docker.DockerCompo
 	trueVal, falseVal := true, false
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{
 			Name: "text", DataType: []string{"text"},
 			Tokenization:    "word",
@@ -720,7 +720,7 @@ func testEnableSearchableThenChangeTok(t *testing.T, compose *docker.DockerCompo
 	trueVal, falseVal := true, false
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{
 			Name: "text", DataType: []string{"text"},
 			Tokenization:    "word",

--- a/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_adjacent_test.go
@@ -230,9 +230,7 @@ func TestMultiNode_ChangeTokenization_RestartThenRoundTrip(t *testing.T) {
 	const className = "RestartRoundTrip"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("text"))
 	// Use a closure so the URI is re-resolved at defer-time. The
 	// rolling restart below replaces node-1's container; capturing
 	// compose.GetWeaviateNode(1).URI() at defer-registration time
@@ -376,10 +374,7 @@ func TestMultiNode_ChangeTokenization_ConcurrentDifferentProps(t *testing.T) {
 	const className = "ConcurrentProps"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "title", DataType: []string{"text"}, Tokenization: "word"},
-		{Name: "body", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("title", "body"))
 	defer deleteCollection(t, restURI, className)
 
 	// Each object has distinct content in title and body so we can
@@ -514,10 +509,7 @@ func testMultiPropertyRoundTrip(t *testing.T, compose *docker.DockerCompose) {
 	const className = "MultiProp"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
-		{Name: "title", DataType: []string{"text"}, Tokenization: "word"},
-		{Name: "body", DataType: []string{"text"}, Tokenization: "word"},
-	})
+	createCollection(t, compose, restURI, className, 3, 3, textProps("title", "body"))
 	defer deleteCollection(t, restURI, className)
 
 	importObjectsTwoProps(t, restURI, className, testDocuments)

--- a/test/acceptance/reindex_multinode/round_trip_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_test.go
@@ -133,20 +133,17 @@ func perNodeBM25Counts(t *testing.T, compose *docker.DockerCompose, className, q
 	return counts
 }
 
-// awaitTokenizationOnAllNodes polls each node's /v1/schema/{class} until
-// the named property's tokenization matches the target. The schema flip is
-// RAFT-replicated from the OnTaskCompleted commit, so it lands on every
-// node within RAFT propagation latency — typically tens of ms.
+// awaitTokenizationOnAllNodes blocks until the property's tokenization
+// matches the target in every node's LOCAL schema. Task FINISHED is a
+// leader-forwarded read while a follow-up indexes PUT validates against
+// the submit node's local schema, so this gate must not leader-proxy.
 func awaitTokenizationOnAllNodes(
 	t *testing.T, compose *docker.DockerCompose, className, propName, target string,
 ) {
 	t.Helper()
 
 	for i := 0; i < 3; i++ {
-		uri := compose.GetWeaviateNode(i + 1).URI()
-		require.Eventuallyf(t, func() bool {
-			return tryGetPropertyTokenization(uri, className, propName) == target
-		}, 30*time.Second, 50*time.Millisecond,
-			"node %d: property %q tokenization should be %q", i+1, propName, target)
+		reindexhelpers.AwaitTokenizationVisible(t,
+			compose.GetWeaviateNode(i+1).URI(), className, propName, target)
 	}
 }

--- a/test/acceptance/reindex_multinode/round_trip_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_test.go
@@ -133,10 +133,8 @@ func perNodeBM25Counts(t *testing.T, compose *docker.DockerCompose, className, q
 	return counts
 }
 
-// awaitTokenizationOnAllNodes blocks until the property's tokenization
-// matches the target in every node's LOCAL schema. Task FINISHED is a
-// leader-forwarded read while a follow-up indexes PUT validates against
-// the submit node's local schema, so this gate must not leader-proxy.
+// awaitTokenizationOnAllNodes gates each node's LOCAL schema; a leader-
+// proxied read here would just check the leader three times over.
 func awaitTokenizationOnAllNodes(
 	t *testing.T, compose *docker.DockerCompose, className, propName, target string,
 ) {

--- a/test/acceptance/reindex_multinode/round_trip_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_test.go
@@ -57,7 +57,7 @@ func TestMultiNode_ChangeTokenization_RoundTrip(t *testing.T) {
 	const className = "RoundTripTokenize"
 	restURI := compose.GetWeaviateNode(1).URI()
 
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
+	createCollection(t, compose, restURI, className, 3, 3, []*models.Property{
 		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
 	})
 	defer deleteCollection(t, restURI, className)


### PR DESCRIPTION
## What

Two weak-VM soak flakes in `reindex_multinode`, both timing, neither a product bug:

1. **Lagging-follower writes** (`TestMultiNode_HappyPath/RoaringSetRefresh`, ~0.3%): `createCollection` returns on leader ack, so a `consistency_level=ALL` import can hit a follower whose local RAFT log hasn't caught up (`got=N want=N+k` schema-version deadline). Objects get auto-UUIDs, so retrying the write would duplicate — the write must be gated, not retried.
2. **Backup-completion timing** (`TestMultiNode_CancelClearsAcrossReplicas`, S3 upload under multi-worker contention): the test must wait for backup *completion* (not acceptance) because an in-flight backup makes `Index.drop` take the rename-aside `keepFiles` path, defeating the post-delete "class dir removed" assertion.

## Design

- The schema-visibility gate lives in `createCollection` itself, covering every one of the 38 call sites in the package: after the create succeeds, poll `GET /v1/schema/{class}` on **every** node (derived from the compose object, not hardcoded) until 200. The `consistency: false` header is load-bearing — the default proxies the read to the leader, which answers 200 immediately and gates nothing.
- Backup deadline 120s → 300s. `FAILED` stays a hard error; only the completion timing budget widens.

## Notes for review

A backup that shows **no upload progress** within the budget would be a real bug, not this timing case — the wait is a budget, not a mask.
