### PR TITLE
[Reindex Fixes A] fix: class DELETE racing a draining reindex worker re-created the class dir

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3306,8 +3306,8 @@ func (i *Index) drop() error {
 // Scope: the guard covers whole-index drops only. Per-shard tenant deletes
 // (dropShards) run under closeLock.RLock themselves and never set i.closed,
 // so the guard is blind to them — a guarded MkdirAll can still re-create a
-// tenant shard dir that dropShards just removed. Tracked in a separate
-// to-be-filed issue.
+// tenant shard dir that dropShards just removed. Tracked in
+// https://github.com/weaviate/0-weaviate-issues/issues/288.
 func (i *Index) withCloseRLockGuard(fn func() error) error {
 	i.closeLock.RLock()
 	defer i.closeLock.RUnlock()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3293,6 +3293,47 @@ func (i *Index) drop() error {
 	return nil
 }
 
+// withCloseRLockGuard runs fn while holding i.closeLock.RLock(), but only
+// after confirming the index is not closing/closed. If the index is already
+// closing (drop() or Shutdown() has set i.closed), it returns
+// context.Canceled WITHOUT running fn.
+//
+// The point of this helper is to make a filesystem-mutating operation (today:
+// the reindex tracker's os.MkdirAll, which re-materializes a shard's LSM path)
+// mutually exclusive with drop()'s rename-away of the index directory.
+//
+// drop() takes i.closeLock.Lock() across the whole tear-down — it sets
+// i.closed=true AND performs renameForAsyncDelete(i.path()) under the same
+// write lock (see drop() above). Therefore, for any fn run through this guard,
+// exactly one of these holds:
+//
+//   - fn runs entirely before drop() acquires the write lock. drop() then
+//     renames the directory away (carrying anything fn created into the
+//     .deleteme dir, which the async RemoveAll later reaps). Safe.
+//   - drop() already holds (or has passed through) the write lock, so by the
+//     time this guard takes the RLock it observes i.closed==true and bails
+//     with context.Canceled. fn never runs, so it cannot re-materialize the
+//     just-renamed directory. Safe.
+//
+// A lock-free flag/ctx check is deliberately NOT sufficient here: a stale read
+// of i.closed could let fn proceed AFTER the rename, re-creating the path that
+// drop() already moved away. The RLock is what closes that window.
+//
+// fn runs while the RLock is held, so it must be short and must not attempt to
+// acquire i.closeLock for writing, nor any lock that drop() holds inside the
+// write-locked region in an inverting order (backupLock / shardCreateLocks).
+// See the lock-order documentation on the Index struct.
+func (i *Index) withCloseRLockGuard(fn func() error) error {
+	i.closeLock.RLock()
+	defer i.closeLock.RUnlock()
+
+	if i.closed {
+		return context.Canceled
+	}
+
+	return fn()
+}
+
 func (i *Index) dropShards(names []string) error {
 	i.closeLock.RLock()
 	defer i.closeLock.RUnlock()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3302,6 +3302,12 @@ func (i *Index) drop() error {
 // runs. A lock-free i.closed check is NOT sufficient: a stale read would let
 // fn re-create the just-renamed path. fn must be short and must not acquire
 // i.closeLock for writing or any lock drop() holds in an inverting order.
+//
+// Scope: the guard covers whole-index drops only. Per-shard tenant deletes
+// (dropShards) run under closeLock.RLock themselves and never set i.closed,
+// so the guard is blind to them — a guarded MkdirAll can still re-create a
+// tenant shard dir that dropShards just removed. Tracked in a separate
+// to-be-filed issue.
 func (i *Index) withCloseRLockGuard(fn func() error) error {
 	i.closeLock.RLock()
 	defer i.closeLock.RUnlock()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3293,36 +3293,15 @@ func (i *Index) drop() error {
 	return nil
 }
 
-// withCloseRLockGuard runs fn while holding i.closeLock.RLock(), but only
-// after confirming the index is not closing/closed. If the index is already
-// closing (drop() or Shutdown() has set i.closed), it returns
-// context.Canceled WITHOUT running fn.
+// withCloseRLockGuard runs fn under i.closeLock.RLock, returning
+// context.Canceled WITHOUT running fn if the index is closing/closed.
 //
-// The point of this helper is to make a filesystem-mutating operation (today:
-// the reindex tracker's os.MkdirAll, which re-materializes a shard's LSM path)
-// mutually exclusive with drop()'s rename-away of the index directory.
-//
-// drop() takes i.closeLock.Lock() across the whole tear-down — it sets
-// i.closed=true AND performs renameForAsyncDelete(i.path()) under the same
-// write lock (see drop() above). Therefore, for any fn run through this guard,
-// exactly one of these holds:
-//
-//   - fn runs entirely before drop() acquires the write lock. drop() then
-//     renames the directory away (carrying anything fn created into the
-//     .deleteme dir, which the async RemoveAll later reaps). Safe.
-//   - drop() already holds (or has passed through) the write lock, so by the
-//     time this guard takes the RLock it observes i.closed==true and bails
-//     with context.Canceled. fn never runs, so it cannot re-materialize the
-//     just-renamed directory. Safe.
-//
-// A lock-free flag/ctx check is deliberately NOT sufficient here: a stale read
-// of i.closed could let fn proceed AFTER the rename, re-creating the path that
-// drop() already moved away. The RLock is what closes that window.
-//
-// fn runs while the RLock is held, so it must be short and must not attempt to
-// acquire i.closeLock for writing, nor any lock that drop() holds inside the
-// write-locked region in an inverting order (backupLock / shardCreateLocks).
-// See the lock-order documentation on the Index struct.
+// drop() sets i.closed AND renames the index dir away under the same write
+// lock, so fn — today the reindex tracker's MkdirAll — either completes
+// before the rename (its output is carried into the .deleteme dir) or never
+// runs. A lock-free i.closed check is NOT sufficient: a stale read would let
+// fn re-create the just-renamed path. fn must be short and must not acquire
+// i.closeLock for writing or any lock drop() holds in an inverting order.
 func (i *Index) withCloseRLockGuard(fn func() error) error {
 	i.closeLock.RLock()
 	defer i.closeLock.RUnlock()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3294,19 +3294,12 @@ func (i *Index) drop() error {
 }
 
 // withCloseRLockGuard runs fn under i.closeLock.RLock, returning
-// context.Canceled WITHOUT running fn if the index is closing/closed.
+// context.Canceled WITHOUT running fn if the index is closing/closed. fn
+// must be short and must not acquire i.closeLock for writing or any lock
+// drop() holds in an inverting order.
 //
-// drop() sets i.closed AND renames the index dir away under the same write
-// lock, so fn — today the reindex tracker's MkdirAll — either completes
-// before the rename (its output is carried into the .deleteme dir) or never
-// runs. A lock-free i.closed check is NOT sufficient: a stale read would let
-// fn re-create the just-renamed path. fn must be short and must not acquire
-// i.closeLock for writing or any lock drop() holds in an inverting order.
-//
-// Scope: the guard covers whole-index drops only. Per-shard tenant deletes
-// (dropShards) run under closeLock.RLock themselves and never set i.closed,
-// so the guard is blind to them — a guarded MkdirAll can still re-create a
-// tenant shard dir that dropShards just removed. Tracked in
+// Covers whole-index drops only: dropShards never sets i.closed, so tenant
+// deletes are invisible to the guard. Tracked in
 // https://github.com/weaviate/0-weaviate-issues/issues/288.
 func (i *Index) withCloseRLockGuard(fn func() error) error {
 	i.closeLock.RLock()

--- a/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
+++ b/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
@@ -1,0 +1,147 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	stderrors "errors"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestModeADrainRematerialize is the deterministic, single-process
+// reproduction + proof for the "draining cancelled reindex worker
+// re-materializes a just-DELETEd class dir" race
+// (TestBackupVsReindexSuite/CancelClearsTrackerDirsViaOnTaskCompleted).
+//
+// Scenario the integration test exercises:
+//
+//  1. A reindex worker is mid drain loop, repeatedly calling
+//     OnAfterLsmInitAsync, whose first action is to (re)create the reindex
+//     tracker dir via os.MkdirAll(shard.pathLSM()/.migrations/...).
+//  2. A DELETE class arrives → Index.drop() sets i.closed=true and renames
+//     i.path() away to a <...>.deleteme dir under i.closeLock.Lock(), then
+//     spawns an async RemoveAll.
+//  3. The cancelled-but-still-draining worker re-enters OnAfterLsmInitAsync
+//     AFTER the rename. pathLSM() is re-resolved live to the ORIGINAL
+//     (renamed-away) path, so an unguarded MkdirAll re-creates it — leaving
+//     an orphaned class dir the DELETE was supposed to remove.
+//
+// The fix routes the drain-loop tracker creation through
+// newReindexTrackerGuarded → Index.withCloseRLockGuard, so the MkdirAll is
+// mutually exclusive with drop()'s rename: it either runs before the rename
+// (carried into .deleteme) or observes i.closed under closeLock.RLock and
+// bails with context.Canceled WITHOUT MkdirAll.
+//
+// The test drives the exact post-rename interleaving deterministically using
+// the TEST-ONLY reindexTrackerInitHook, which parks the worker at the top of
+// fileReindexTracker.init() (before the MkdirAll, before any closeLock) until
+// the test has driven Index.drop() to completion.
+//
+// Behavior proof:
+//   - WITHOUT the fix (drain loop uses the unguarded
+//     t.newReindexTracker(shard.pathLSM())): init() runs MkdirAll after the
+//     rename → i.path() re-materializes → this test FAILS at the final
+//     os.Stat assertion.
+//   - WITH the fix (newReindexTrackerGuarded): init() bails with
+//     context.Canceled → i.path() stays absent → this test PASSES.
+//
+// To exercise both, build the tracker exactly as the production drain path
+// does. The drain path is newReindexTrackerGuarded; stashing the fix reverts
+// that callsite to the unguarded factory and turns this green test red.
+func TestModeADrainRematerialize(t *testing.T) {
+	ctx := testCtx()
+	className := "ModeADrain_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"title"})
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+
+	idxPath := idx.path()
+	require.DirExists(t, idxPath, "class dir must exist before drop")
+
+	// The task is the vehicle for the production drain-path tracker creation
+	// (newReindexTrackerGuarded → MigrationDirName / keyParser). Same
+	// MapToBlockmax setup the other reindex tests use.
+	strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
+	task := newTestTask(idx.logger, strategy)
+
+	// inHook fires once the simulated worker reaches the top of init(); the
+	// worker then blocks on releaseHook until the test has run drop() to
+	// completion. This makes the drop-vs-MkdirAll interleaving deterministic
+	// with no sleeps.
+	inHook := make(chan struct{})
+	releaseHook := make(chan struct{})
+	var hookOnce sync.Once
+
+	reindexTrackerInitHook = func() {
+		hookOnce.Do(func() { close(inHook) })
+		<-releaseHook
+	}
+	t.Cleanup(func() { reindexTrackerInitHook = nil })
+
+	// Simulated worker: build the tracker exactly as the production drain path
+	// (OnAfterLsmInitAsync) does. With the fix this is the guarded factory;
+	// stashing the fix reverts it to the unguarded t.newReindexTracker.
+	var initErr error
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		initErr = buildDrainTracker(task, shard)
+	}()
+
+	// Wait until the worker is parked at the top of init() (pre-MkdirAll).
+	<-inHook
+
+	// Drive the DELETE to completion while the worker is held. drop() renames
+	// idxPath away under i.closeLock.Lock() and spawns async RemoveAll.
+	require.NoError(t, idx.drop())
+	require.NoFileExists(t, idxPath,
+		"drop() must have renamed the class dir away before the worker proceeds")
+
+	// Release the worker so its MkdirAll runs AFTER the rename — the race
+	// window. With the fix it bails under closeLock.RLock; without it,
+	// MkdirAll re-materializes the path.
+	close(releaseHook)
+	<-workerDone
+
+	// With the fix, init bails with context.Canceled (index closing) and never
+	// runs MkdirAll.
+	if initErr != nil {
+		assert.Truef(t, stderrors.Is(initErr, context.Canceled),
+			"drain tracker init failed with an unexpected error (want context.Canceled): %v", initErr)
+	}
+
+	// The load-bearing assertion: the class dir DELETE renamed away must stay
+	// absent. Without the fix the draining worker re-materializes it here.
+	_, statErr := os.Stat(idxPath)
+	assert.Truef(t, os.IsNotExist(statErr),
+		"draining reindex worker re-materialized class dir %q after DELETE renamed it away (stat err: %v)",
+		idxPath, statErr)
+}
+
+// buildDrainTracker builds the reindex tracker the way the production worker
+// drain loop (OnAfterLsmInitAsync) does. It is a thin indirection so the OLD
+// (unguarded) vs NEW (guarded) behavior is selected purely by which factory
+// the drain loop is wired to — no test-side branching on the fix.
+func buildDrainTracker(task *ShardReindexTaskGeneric, shard ShardLike) error {
+	_, err := task.newReindexTrackerGuarded(shard)
+	return err
+}

--- a/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
+++ b/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
@@ -25,23 +25,9 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// TestModeADrainRematerialize deterministically reproduces the race where a
-// cancelled-but-still-draining DTM reindex goroutine re-enters a tracker
-// init after a concurrent DELETE: Index.drop renamed the class dir away, but
-// pathLSM() re-resolves to the ORIGINAL path and an unguarded tracker
-// MkdirAll re-creates it — an orphaned class dir the DELETE was supposed to
-// remove. The TEST-ONLY reindexTrackerInitHook parks the goroutine just
-// before the MkdirAll until drop() completes — no sleeps.
-//
-// Each subtest drives a REAL production entry point (not the tracker factory
-// directly), so reverting the guard wiring at either callsite turns the
-// corresponding subtest red at the final os.Stat:
-//
-//   - the worker drain path: OnAfterLsmInitAsync, the per-iteration re-entry
-//     a cancelled worker takes with no ctx check before the tracker MkdirAll;
-//   - the DTM lifecycle path: RunReindexOnlyOnShard → runShardLifecycle →
-//     onAfterLsmInitGuarded — the same route enterDTMPhase's iteration
-//     resume ladder takes (and RunOnShard shares).
+// TestModeADrainRematerialize pins the race where a draining reindex
+// goroutine's tracker MkdirAll re-creates the class dir a concurrent DELETE
+// (Index.drop) just renamed away.
 func TestModeADrainRematerialize(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -78,8 +64,6 @@ func TestModeADrainRematerialize(t *testing.T) {
 			strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
 			task := newTestTask(idx.logger, strategy)
 
-			// The worker signals inHook at the top of the first tracker init,
-			// then blocks on releaseHook until drop() has completed — no sleeps.
 			inHook := make(chan struct{})
 			releaseHook := make(chan struct{})
 			var hookOnce sync.Once
@@ -107,14 +91,12 @@ func TestModeADrainRematerialize(t *testing.T) {
 			close(releaseHook)
 			<-workerDone
 
-			// The guard bails with context.Canceled (clean stop); a nil error
-			// would also be acceptable if a future refactor swallows the stop.
+			// nil is also fine: only a clean stop is acceptable.
 			if driveErr != nil {
 				assert.Truef(t, errors.Is(driveErr, context.Canceled),
 					"production entry failed with an unexpected error (want context.Canceled): %v", driveErr)
 			}
 
-			// The load-bearing assertion.
 			_, statErr := os.Stat(idxPath)
 			assert.Truef(t, os.IsNotExist(statErr),
 				"draining reindex goroutine re-materialized class dir %q after DELETE renamed it away (stat err: %v)",

--- a/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
+++ b/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
@@ -68,11 +68,18 @@ func TestModeADrainRematerialize(t *testing.T) {
 			releaseHook := make(chan struct{})
 			var hookOnce sync.Once
 
-			reindexTrackerInitHook = func() {
-				hookOnce.Do(func() { close(inHook) })
-				<-releaseHook
+			// Interpose a barrier at the tracker's pre-MkdirAll point (before
+			// the real close-lock guard runs, holding no lock) so the DELETE
+			// lands between the worker parking and its guarded MkdirAll.
+			realGuardFor := task.trackerMkdirGuard
+			task.trackerMkdirGuard = func(s ShardLike) func(func() error) error {
+				guard := realGuardFor(s)
+				return func(mkdir func() error) error {
+					hookOnce.Do(func() { close(inHook) })
+					<-releaseHook
+					return guard(mkdir)
+				}
 			}
-			t.Cleanup(func() { reindexTrackerInitHook = nil })
 
 			var driveErr error
 			workerDone := make(chan struct{})

--- a/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
+++ b/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
@@ -25,46 +25,15 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// TestModeADrainRematerialize is the deterministic, single-process
-// reproduction + proof for the "draining cancelled reindex worker
-// re-materializes a just-DELETEd class dir" race
-// (TestBackupVsReindexSuite/CancelClearsTrackerDirsViaOnTaskCompleted).
-//
-// Scenario the integration test exercises:
-//
-//  1. A reindex worker is mid drain loop, repeatedly calling
-//     OnAfterLsmInitAsync, whose first action is to (re)create the reindex
-//     tracker dir via os.MkdirAll(shard.pathLSM()/.migrations/...).
-//  2. A DELETE class arrives → Index.drop() sets i.closed=true and renames
-//     i.path() away to a <...>.deleteme dir under i.closeLock.Lock(), then
-//     spawns an async RemoveAll.
-//  3. The cancelled-but-still-draining worker re-enters OnAfterLsmInitAsync
-//     AFTER the rename. pathLSM() is re-resolved live to the ORIGINAL
-//     (renamed-away) path, so an unguarded MkdirAll re-creates it — leaving
-//     an orphaned class dir the DELETE was supposed to remove.
-//
-// The fix routes the drain-loop tracker creation through
-// newReindexTrackerGuarded → Index.withCloseRLockGuard, so the MkdirAll is
-// mutually exclusive with drop()'s rename: it either runs before the rename
-// (carried into .deleteme) or observes i.closed under closeLock.RLock and
-// bails with context.Canceled WITHOUT MkdirAll.
-//
-// The test drives the exact post-rename interleaving deterministically using
-// the TEST-ONLY reindexTrackerInitHook, which parks the worker at the top of
-// fileReindexTracker.init() (before the MkdirAll, before any closeLock) until
-// the test has driven Index.drop() to completion.
-//
-// Behavior proof:
-//   - WITHOUT the fix (drain loop uses the unguarded
-//     t.newReindexTracker(shard.pathLSM())): init() runs MkdirAll after the
-//     rename → i.path() re-materializes → this test FAILS at the final
-//     os.Stat assertion.
-//   - WITH the fix (newReindexTrackerGuarded): init() bails with
-//     context.Canceled → i.path() stays absent → this test PASSES.
-//
-// To exercise both, build the tracker exactly as the production drain path
-// does. The drain path is newReindexTrackerGuarded; stashing the fix reverts
-// that callsite to the unguarded factory and turns this green test red.
+// TestModeADrainRematerialize deterministically reproduces the race where a
+// cancelled-but-still-draining reindex worker re-enters OnAfterLsmInitAsync
+// after a concurrent DELETE: Index.drop renamed the class dir away, but
+// pathLSM() re-resolves to the ORIGINAL path and an unguarded tracker
+// MkdirAll re-creates it — an orphaned class dir the DELETE was supposed to
+// remove. The TEST-ONLY reindexTrackerInitHook parks the worker just before
+// the MkdirAll until drop() completes. With the guarded factory init bails
+// with context.Canceled and the dir stays absent; reverting the drain loop
+// to the unguarded factory turns this test red at the final os.Stat.
 func TestModeADrainRematerialize(t *testing.T) {
 	ctx := testCtx()
 	className := "ModeADrain_" + uuid.NewString()[:8]
@@ -77,16 +46,11 @@ func TestModeADrainRematerialize(t *testing.T) {
 	idxPath := idx.path()
 	require.DirExists(t, idxPath, "class dir must exist before drop")
 
-	// The task is the vehicle for the production drain-path tracker creation
-	// (newReindexTrackerGuarded → MigrationDirName / keyParser). Same
-	// MapToBlockmax setup the other reindex tests use.
 	strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
 	task := newTestTask(idx.logger, strategy)
 
-	// inHook fires once the simulated worker reaches the top of init(); the
-	// worker then blocks on releaseHook until the test has run drop() to
-	// completion. This makes the drop-vs-MkdirAll interleaving deterministic
-	// with no sleeps.
+	// The worker signals inHook at the top of init(), then blocks on
+	// releaseHook until drop() has completed — no sleeps.
 	inHook := make(chan struct{})
 	releaseHook := make(chan struct{})
 	var hookOnce sync.Once
@@ -97,9 +61,6 @@ func TestModeADrainRematerialize(t *testing.T) {
 	}
 	t.Cleanup(func() { reindexTrackerInitHook = nil })
 
-	// Simulated worker: build the tracker exactly as the production drain path
-	// (OnAfterLsmInitAsync) does. With the fix this is the guarded factory;
-	// stashing the fix reverts it to the unguarded t.newReindexTracker.
 	var initErr error
 	workerDone := make(chan struct{})
 	go func() {
@@ -107,40 +68,30 @@ func TestModeADrainRematerialize(t *testing.T) {
 		initErr = buildDrainTracker(task, shard)
 	}()
 
-	// Wait until the worker is parked at the top of init() (pre-MkdirAll).
+	// Worker parked pre-MkdirAll; drive the DELETE to completion.
 	<-inHook
-
-	// Drive the DELETE to completion while the worker is held. drop() renames
-	// idxPath away under i.closeLock.Lock() and spawns async RemoveAll.
 	require.NoError(t, idx.drop())
 	require.NoFileExists(t, idxPath,
 		"drop() must have renamed the class dir away before the worker proceeds")
 
-	// Release the worker so its MkdirAll runs AFTER the rename — the race
-	// window. With the fix it bails under closeLock.RLock; without it,
-	// MkdirAll re-materializes the path.
+	// Release the worker so its MkdirAll runs AFTER the rename.
 	close(releaseHook)
 	<-workerDone
 
-	// With the fix, init bails with context.Canceled (index closing) and never
-	// runs MkdirAll.
 	if initErr != nil {
 		assert.Truef(t, stderrors.Is(initErr, context.Canceled),
 			"drain tracker init failed with an unexpected error (want context.Canceled): %v", initErr)
 	}
 
-	// The load-bearing assertion: the class dir DELETE renamed away must stay
-	// absent. Without the fix the draining worker re-materializes it here.
+	// The load-bearing assertion.
 	_, statErr := os.Stat(idxPath)
 	assert.Truef(t, os.IsNotExist(statErr),
 		"draining reindex worker re-materialized class dir %q after DELETE renamed it away (stat err: %v)",
 		idxPath, statErr)
 }
 
-// buildDrainTracker builds the reindex tracker the way the production worker
-// drain loop (OnAfterLsmInitAsync) does. It is a thin indirection so the OLD
-// (unguarded) vs NEW (guarded) behavior is selected purely by which factory
-// the drain loop is wired to — no test-side branching on the fix.
+// buildDrainTracker builds the tracker exactly as the production drain loop
+// does, so reverting that callsite to the unguarded factory turns the test red.
 func buildDrainTracker(task *ShardReindexTaskGeneric, shard ShardLike) error {
 	_, err := task.newReindexTrackerGuarded(shard)
 	return err

--- a/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
+++ b/adapters/repos/db/inverted_reindex_drain_rematerialize_test.go
@@ -13,7 +13,7 @@ package db
 
 import (
 	"context"
-	stderrors "errors"
+	"errors"
 	"os"
 	"sync"
 	"testing"
@@ -26,73 +26,99 @@ import (
 )
 
 // TestModeADrainRematerialize deterministically reproduces the race where a
-// cancelled-but-still-draining reindex worker re-enters OnAfterLsmInitAsync
-// after a concurrent DELETE: Index.drop renamed the class dir away, but
+// cancelled-but-still-draining DTM reindex goroutine re-enters a tracker
+// init after a concurrent DELETE: Index.drop renamed the class dir away, but
 // pathLSM() re-resolves to the ORIGINAL path and an unguarded tracker
 // MkdirAll re-creates it — an orphaned class dir the DELETE was supposed to
-// remove. The TEST-ONLY reindexTrackerInitHook parks the worker just before
-// the MkdirAll until drop() completes. With the guarded factory init bails
-// with context.Canceled and the dir stays absent; reverting the drain loop
-// to the unguarded factory turns this test red at the final os.Stat.
+// remove. The TEST-ONLY reindexTrackerInitHook parks the goroutine just
+// before the MkdirAll until drop() completes — no sleeps.
+//
+// Each subtest drives a REAL production entry point (not the tracker factory
+// directly), so reverting the guard wiring at either callsite turns the
+// corresponding subtest red at the final os.Stat:
+//
+//   - the worker drain path: OnAfterLsmInitAsync, the per-iteration re-entry
+//     a cancelled worker takes with no ctx check before the tracker MkdirAll;
+//   - the DTM lifecycle path: RunReindexOnlyOnShard → runShardLifecycle →
+//     onAfterLsmInitGuarded — the same route enterDTMPhase's iteration
+//     resume ladder takes (and RunOnShard shares).
 func TestModeADrainRematerialize(t *testing.T) {
-	ctx := testCtx()
-	className := "ModeADrain_" + uuid.NewString()[:8]
-	class := newTestClassWithProps(className, []string{"title"})
-
-	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-		false, false, false)
-	shard := shd.(*Shard)
-
-	idxPath := idx.path()
-	require.DirExists(t, idxPath, "class dir must exist before drop")
-
-	strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
-	task := newTestTask(idx.logger, strategy)
-
-	// The worker signals inHook at the top of init(), then blocks on
-	// releaseHook until drop() has completed — no sleeps.
-	inHook := make(chan struct{})
-	releaseHook := make(chan struct{})
-	var hookOnce sync.Once
-
-	reindexTrackerInitHook = func() {
-		hookOnce.Do(func() { close(inHook) })
-		<-releaseHook
-	}
-	t.Cleanup(func() { reindexTrackerInitHook = nil })
-
-	var initErr error
-	workerDone := make(chan struct{})
-	go func() {
-		defer close(workerDone)
-		initErr = buildDrainTracker(task, shard)
-	}()
-
-	// Worker parked pre-MkdirAll; drive the DELETE to completion.
-	<-inHook
-	require.NoError(t, idx.drop())
-	require.NoFileExists(t, idxPath,
-		"drop() must have renamed the class dir away before the worker proceeds")
-
-	// Release the worker so its MkdirAll runs AFTER the rename.
-	close(releaseHook)
-	<-workerDone
-
-	if initErr != nil {
-		assert.Truef(t, stderrors.Is(initErr, context.Canceled),
-			"drain tracker init failed with an unexpected error (want context.Canceled): %v", initErr)
+	cases := []struct {
+		name  string
+		drive func(ctx context.Context, task *ShardReindexTaskGeneric, shard *Shard) error
+	}{
+		{
+			name: "worker drain via OnAfterLsmInitAsync",
+			drive: func(ctx context.Context, task *ShardReindexTaskGeneric, shard *Shard) error {
+				_, _, err := task.OnAfterLsmInitAsync(ctx, shard)
+				return err
+			},
+		},
+		{
+			name: "DTM lifecycle via RunReindexOnlyOnShard",
+			drive: func(ctx context.Context, task *ShardReindexTaskGeneric, shard *Shard) error {
+				return task.RunReindexOnlyOnShard(ctx, shard)
+			},
+		},
 	}
 
-	// The load-bearing assertion.
-	_, statErr := os.Stat(idxPath)
-	assert.Truef(t, os.IsNotExist(statErr),
-		"draining reindex worker re-materialized class dir %q after DELETE renamed it away (stat err: %v)",
-		idxPath, statErr)
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			className := "ModeADrain_" + uuid.NewString()[:8]
+			class := newTestClassWithProps(className, []string{"title"})
 
-// buildDrainTracker builds the tracker exactly as the production drain loop
-// does, so reverting that callsite to the unguarded factory turns the test red.
-func buildDrainTracker(task *ShardReindexTaskGeneric, shard ShardLike) error {
-	_, err := task.newReindexTrackerGuarded(shard)
-	return err
+			shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+				false, false, false)
+			shard := shd.(*Shard)
+
+			idxPath := idx.path()
+			require.DirExists(t, idxPath, "class dir must exist before drop")
+
+			strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
+			task := newTestTask(idx.logger, strategy)
+
+			// The worker signals inHook at the top of the first tracker init,
+			// then blocks on releaseHook until drop() has completed — no sleeps.
+			inHook := make(chan struct{})
+			releaseHook := make(chan struct{})
+			var hookOnce sync.Once
+
+			reindexTrackerInitHook = func() {
+				hookOnce.Do(func() { close(inHook) })
+				<-releaseHook
+			}
+			t.Cleanup(func() { reindexTrackerInitHook = nil })
+
+			var driveErr error
+			workerDone := make(chan struct{})
+			go func() {
+				defer close(workerDone)
+				driveErr = tc.drive(ctx, task, shard)
+			}()
+
+			// Worker parked pre-MkdirAll; drive the DELETE to completion.
+			<-inHook
+			require.NoError(t, idx.drop())
+			require.NoFileExists(t, idxPath,
+				"drop() must have renamed the class dir away before the worker proceeds")
+
+			// Release the worker so its MkdirAll runs AFTER the rename.
+			close(releaseHook)
+			<-workerDone
+
+			// The guard bails with context.Canceled (clean stop); a nil error
+			// would also be acceptable if a future refactor swallows the stop.
+			if driveErr != nil {
+				assert.Truef(t, errors.Is(driveErr, context.Canceled),
+					"production entry failed with an unexpected error (want context.Canceled): %v", driveErr)
+			}
+
+			// The load-bearing assertion.
+			_, statErr := os.Stat(idxPath)
+			assert.Truef(t, os.IsNotExist(statErr),
+				"draining reindex goroutine re-materialized class dir %q after DELETE renamed it away (stat err: %v)",
+				idxPath, statErr)
+		})
+	}
 }

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -414,23 +414,11 @@ func (t *ShardReindexTaskGeneric) runShardLifecycle(ctx context.Context, shard S
 // consistent with ongoing writes). Callbacks are disabled only at
 // the end of [runtimeSwap] after the atomic pointer flip.
 func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard ShardLike) error {
-	concreteShard, err := unwrapShard(ctx, shard)
+	entry, err := t.enterDTMPhase(ctx, shard, "RunPrepareOnShard")
 	if err != nil {
-		return fmt.Errorf("unwrapping shard %q: %w", shard.Name(), err)
+		return err
 	}
-
-	logger := t.logger.WithFields(map[string]any{
-		"collection": concreteShard.Index().Config.ClassName.String(),
-		"shard":      concreteShard.Name(),
-		"method":     "RunPrepareOnShard",
-	})
-
-	// Guarded: PREP is DTM-scheduler-driven (never under closeLock) — same
-	// DELETE-race exposure as the worker drain path.
-	rt, err := t.newReindexTrackerGuarded(concreteShard)
-	if err != nil {
-		return fmt.Errorf("creating reindex tracker: %w", err)
-	}
+	concreteShard, logger, rt := entry.shard, entry.logger, entry.rt
 
 	// Idempotent fast-path: already merged means prep was already
 	// completed (either by an earlier call in this process or by a
@@ -438,27 +426,6 @@ func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard S
 	if rt.IsMerged() {
 		logger.Debug("RunPrepareOnShard: already merged on disk; no-op")
 		return nil
-	}
-
-	// Re-entry path: state-on-disk vs state-in-RAFT race (mirrors the
-	// same check in RunSwapOnShard). If we land here with state
-	// "started but not reindexed", resume the iteration before
-	// preparing.
-	if !rt.IsReindexed() {
-		if !rt.IsStarted() {
-			return fmt.Errorf("shard %q is not in reindexed state and has no started sentinel — no in-flight migration on disk", concreteShard.Name())
-		}
-		logger.Info("RunPrepareOnShard: state not yet reindexed on disk; resuming iteration before prep")
-		if err := t.RunReindexOnlyOnShard(ctx, shard); err != nil {
-			return fmt.Errorf("resume iteration before prep: %w", err)
-		}
-		rt, err = t.newReindexTrackerGuarded(concreteShard)
-		if err != nil {
-			return fmt.Errorf("creating reindex tracker after iteration resume: %w", err)
-		}
-		if !rt.IsReindexed() {
-			return fmt.Errorf("shard %q: iteration resume returned but IsReindexed still false", concreteShard.Name())
-		}
 	}
 
 	props, err := t.readPropsToReindex(rt)
@@ -474,6 +441,64 @@ func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard S
 	}
 
 	return t.runtimePrepare(ctx, logger, shard, rt, props)
+}
+
+// dtmPhaseEntry is the shared entry state of the DTM-scheduler-driven phase
+// callbacks (RunPrepareOnShard / RunSwapOnShard).
+type dtmPhaseEntry struct {
+	shard  *Shard
+	logger logrus.FieldLogger
+	rt     reindexTracker
+}
+
+// enterDTMPhase unwraps the shard and opens the guarded tracker (both phase
+// callbacks are DTM-scheduler-driven — never under closeLock — so they share
+// the worker drain path's DELETE-race exposure; see newReindexTrackerGuarded).
+//
+// It also handles the state-on-disk vs state-in-RAFT race: a rolling restart
+// inside the FINALIZING window can leave the unit's terminal state replicated
+// in RAFT while the on-disk markReindexed sentinel is lost (or the iteration
+// was still running when RAFT replicated another node's vote). Post-restart
+// recovery only loads buckets — it does not run the iteration. If the state
+// is "started but not reindexed", resume the iteration via
+// RunReindexOnlyOnShard and re-read the tracker.
+func (t *ShardReindexTaskGeneric) enterDTMPhase(ctx context.Context, shard ShardLike, method string) (*dtmPhaseEntry, error) {
+	concreteShard, err := unwrapShard(ctx, shard)
+	if err != nil {
+		return nil, fmt.Errorf("unwrapping shard %q: %w", shard.Name(), err)
+	}
+
+	logger := t.logger.WithFields(map[string]any{
+		"collection": concreteShard.Index().Config.ClassName.String(),
+		"shard":      concreteShard.Name(),
+		"method":     method,
+	})
+
+	rt, err := t.newReindexTrackerGuarded(concreteShard)
+	if err != nil {
+		return nil, fmt.Errorf("creating reindex tracker: %w", err)
+	}
+
+	if !rt.IsReindexed() {
+		if !rt.IsStarted() {
+			// Migration never started on this shard. Shouldn't happen via
+			// OnGroupCompleted (units are node-assigned); surface it cleanly.
+			return nil, fmt.Errorf("shard %q is not in reindexed state and has no started sentinel — no in-flight migration on disk", concreteShard.Name())
+		}
+		logger.Info(method + ": state not yet reindexed on disk; resuming iteration")
+		if err := t.RunReindexOnlyOnShard(ctx, shard); err != nil {
+			return nil, fmt.Errorf("resume iteration: %w", err)
+		}
+		rt, err = t.newReindexTrackerGuarded(concreteShard)
+		if err != nil {
+			return nil, fmt.Errorf("creating reindex tracker after iteration resume: %w", err)
+		}
+		if !rt.IsReindexed() {
+			return nil, fmt.Errorf("shard %q: iteration resume returned but IsReindexed still false", concreteShard.Name())
+		}
+	}
+
+	return &dtmPhaseEntry{shard: concreteShard, logger: logger, rt: rt}, nil
 }
 
 // RunSwapOnShard runs the swap+tidy+OnMigrationComplete phase.
@@ -524,72 +549,11 @@ func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard S
 // swapped their buckets — producing the cluster-wide schema↔bucket
 // inversion this dispatch is here to prevent.
 func (t *ShardReindexTaskGeneric) RunSwapOnShard(ctx context.Context, shard ShardLike) error {
-	concreteShard, err := unwrapShard(ctx, shard)
+	entry, err := t.enterDTMPhase(ctx, shard, "RunSwapOnShard")
 	if err != nil {
-		return fmt.Errorf("unwrapping shard %q: %w", shard.Name(), err)
+		return err
 	}
-
-	logger := t.logger.WithFields(map[string]any{
-		"collection": concreteShard.Index().Config.ClassName.String(),
-		"shard":      concreteShard.Name(),
-		"method":     "RunSwapOnShard",
-	})
-
-	// Guarded: SWAP is DTM-scheduler-driven (never under closeLock), same
-	// DELETE-race exposure as the worker drain path.
-	rt, err := t.newReindexTrackerGuarded(concreteShard)
-	if err != nil {
-		return fmt.Errorf("creating reindex tracker: %w", err)
-	}
-
-	// State-on-disk vs state-in-RAFT race: a rolling restart that
-	// landed inside the FINALIZING window can leave a node with the
-	// unit's terminal state replicated in RAFT (the unit-completion
-	// record landed before the crash) but the on-disk markReindexed
-	// sentinel lost (file write didn't persist before SIGTERM, or the
-	// race went the other way and the iteration was still running when
-	// RAFT replicated some OTHER node's vote that flipped the group to
-	// FINALIZING). The recovered task's [OnAfterLsmInit] (fired at
-	// shard init by [shardReindexerV3RecoveryOnly]) only loads buckets
-	// — it does NOT run the iteration. The iteration lives in
-	// [OnAfterLsmInitAsync], which the recovery-only reindexer
-	// intentionally no-ops.
-	//
-	// If we land here with state "started but not reindexed", we need
-	// to resume the iteration before swapping. Calling
-	// [RunReindexOnlyOnShard] is the right entry point: it runs
-	// OnAfterLsmInit (idempotent for already-loaded buckets) and then
-	// loops OnAfterLsmInitAsync until the iteration terminates and
-	// markReindexed fires. After the call returns, we re-read the
-	// tracker and continue with the sentinel-aware swap dispatch.
-	//
-	// This is the local repro path where the iteration didn't reach
-	// markReindexed but the scheduler still scheduled the swap (e.g.
-	// rolling restart caught the unit mid-iteration).
-	if !rt.IsReindexed() {
-		if !rt.IsStarted() {
-			// Migration never started on this shard. This shouldn't
-			// happen via OnGroupCompleted (the scheduler only invokes
-			// this for units that were assigned to this node), but
-			// surface it cleanly rather than silently completing.
-			return fmt.Errorf("shard %q is not in reindexed state and has no started sentinel — no in-flight migration on disk", concreteShard.Name())
-		}
-		logger.Info("RunSwapOnShard: state not yet reindexed on disk; resuming iteration before swap")
-		if err := t.RunReindexOnlyOnShard(ctx, shard); err != nil {
-			return fmt.Errorf("resume iteration before swap: %w", err)
-		}
-		// Re-read tracker. The iteration should have set IsReindexed
-		// (and possibly more — runtimeSwap MAY have run inline if
-		// skipSwapOnFinish was somehow not honored, though it's set in
-		// runShardLifecycle).
-		rt, err = t.newReindexTrackerGuarded(concreteShard)
-		if err != nil {
-			return fmt.Errorf("creating reindex tracker after iteration resume: %w", err)
-		}
-		if !rt.IsReindexed() {
-			return fmt.Errorf("shard %q: iteration resume returned but IsReindexed still false", concreteShard.Name())
-		}
-	}
+	concreteShard, logger, rt := entry.shard, entry.logger, entry.rt
 
 	props, err := t.readPropsToReindex(rt)
 	if err != nil {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -361,11 +361,8 @@ func (t *ShardReindexTaskGeneric) runShardLifecycle(ctx context.Context, shard S
 		return fmt.Errorf("unwrapping shard %q: %w", shard.Name(), err)
 	}
 
-	// DTM route: runShardLifecycle runs on scheduler/worker goroutines that
-	// hold no closeLock, so the hook's tracker init must be guarded against a
-	// concurrent DELETE (see newReindexTrackerGuarded). context.Canceled from
-	// the guard means the index is closing — propagate unwrapped so callers
-	// treat it as a clean stop, consistent with OnAfterLsmInitAsync.
+	// context.Canceled means the index is closing — propagate unwrapped so
+	// callers treat it as a clean stop, consistent with OnAfterLsmInitAsync.
 	if err := t.onAfterLsmInitGuarded(ctx, concreteShard); err != nil {
 		if errors.Is(err, context.Canceled) {
 			return err
@@ -459,17 +456,10 @@ type dtmPhaseEntry struct {
 	rt     reindexTracker
 }
 
-// enterDTMPhase unwraps the shard and opens the guarded tracker (both phase
-// callbacks are DTM-scheduler-driven — never under closeLock — so they share
-// the worker drain path's DELETE-race exposure; see newReindexTrackerGuarded).
-//
-// It also handles the state-on-disk vs state-in-RAFT race: a rolling restart
-// inside the FINALIZING window can leave the unit's terminal state replicated
-// in RAFT while the on-disk markReindexed sentinel is lost (or the iteration
-// was still running when RAFT replicated another node's vote). Post-restart
-// recovery only loads buckets — it does not run the iteration. If the state
-// is "started but not reindexed", resume the iteration via
-// RunReindexOnlyOnShard and re-read the tracker.
+// enterDTMPhase unwraps the shard, opens the guarded tracker (DTM callbacks
+// run under no closeLock; see newReindexTrackerGuarded), and — if on-disk
+// state trails RAFT ("started but not reindexed" after a rolling restart) —
+// resumes the iteration before returning.
 func (t *ShardReindexTaskGeneric) enterDTMPhase(ctx context.Context, shard ShardLike, method string) (*dtmPhaseEntry, error) {
 	concreteShard, err := unwrapShard(ctx, shard)
 	if err != nil {
@@ -487,21 +477,17 @@ func (t *ShardReindexTaskGeneric) enterDTMPhase(ctx context.Context, shard Shard
 		return nil, fmt.Errorf("creating reindex tracker: %w", err)
 	}
 
-	// IsMerged fast-path — MUST stay ahead of the iteration-resume ladder
-	// below. merged.mig can only be written after the iteration completed, so
-	// on a torn sentinel state (IsMerged && !IsReindexed — e.g. partial
-	// sentinel loss or operator surgery) re-running the iteration would run
-	// against an already-merged migration (or error out on !IsStarted). Both
-	// callers handle the merged state downstream: RunPrepareOnShard no-ops,
-	// RunSwapOnShard's dispatch has an IsMerged branch.
+	// MUST stay ahead of the iteration-resume ladder below: merged implies
+	// the iteration completed, so on a torn sentinel state (IsMerged &&
+	// !IsReindexed) resuming would re-run the iteration against an
+	// already-merged migration. Both callers handle merged downstream.
 	if rt.IsMerged() {
 		return &dtmPhaseEntry{shard: concreteShard, logger: logger, rt: rt}, nil
 	}
 
 	if !rt.IsReindexed() {
 		if !rt.IsStarted() {
-			// Migration never started on this shard. Shouldn't happen via
-			// OnGroupCompleted (units are node-assigned); surface it cleanly.
+			// Shouldn't happen via OnGroupCompleted (units are node-assigned).
 			return nil, fmt.Errorf("shard %q is not in reindexed state and has no started sentinel — no in-flight migration on disk", concreteShard.Name())
 		}
 		logger.Info(method + ": state not yet reindexed on disk; resuming iteration")
@@ -820,9 +806,6 @@ func (t *ShardReindexTaskGeneric) logPhase(collectionName, shardName, method str
 		case err == nil:
 			logger.Info("finished")
 		case errors.Is(err, context.Canceled):
-			// Clean stop (index closing / request cancelled): the scheduler
-			// already logs the cancelled unit, so keep this at debug to avoid
-			// a duplicate ERROR line per clean stop.
 			logger.Debugf("finished after cancellation: %v", err)
 		default:
 			logger.Errorf("finished with error: %v", err)
@@ -842,12 +825,9 @@ func (t *ShardReindexTaskGeneric) OnBeforeLsmInit(ctx context.Context, shard *Sh
 		return nil
 	}
 
-	// Deliberately UNguarded: OnBeforeLsmInit is only reachable from the
-	// shard-init route (ShardReindexerV3.RunBeforeLsmInit via shard_init.go —
-	// no DTM-goroutine caller exists), and some of those routes run under an
-	// outer closeLock.RLock (see newReindexTrackerGuarded) — a nested RLock
-	// here deadlocks against a queued drop() writer. If a DTM-driven caller
-	// is ever added, it needs a guarded variant like onAfterLsmInitGuarded.
+	// Deliberately unguarded: only reachable from shard init, where some
+	// routes hold closeLock.RLock — a nested RLock would deadlock against a
+	// queued drop() writer (see newReindexTrackerGuarded).
 	rt, err := t.newReindexTracker(shard.pathLSM())
 	if err != nil {
 		err = fmt.Errorf("creating reindex tracker: %w", err)
@@ -1054,13 +1034,10 @@ func (t *ShardReindexTaskGeneric) OnBeforeLsmInit(ctx context.Context, shard *Sh
 	return nil
 }
 
-// OnAfterLsmInit is the shard-init entry into the after-LSM-init hook
-// (ShardReindexerV3.RunAfterLsmInit via shard_init.go, including the
-// recovery-only reindexer). It builds the PLAIN tracker because some NewShard
-// routes hold closeLock.RLock on the calling goroutine (see
-// newReindexTrackerGuarded). DTM-driven callers MUST use
-// onAfterLsmInitGuarded instead — an unguarded tracker init on a goroutine
-// holding no closeLock can re-materialize a just-DELETEd class dir.
+// OnAfterLsmInit is the shard-init entry into the after-LSM-init hook. It
+// uses the plain tracker because some NewShard routes hold closeLock.RLock
+// (see newReindexTrackerGuarded); DTM-driven callers MUST use
+// onAfterLsmInitGuarded instead.
 func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Shard) error {
 	return t.onAfterLsmInitWithTracker(ctx, shard, func(s *Shard) (reindexTracker, error) {
 		return t.newReindexTracker(s.pathLSM())
@@ -1068,12 +1045,9 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 }
 
 // onAfterLsmInitGuarded is the DTM-route entry into the after-LSM-init hook:
-// runShardLifecycle (RunOnShard / RunReindexOnlyOnShard, including
-// enterDTMPhase's iteration resume) runs on scheduler/worker goroutines that
-// hold no closeLock, so the tracker's init()-time MkdirAll must be guarded
-// against a concurrent Index.drop — the same DELETE-race exposure as
-// OnAfterLsmInitAsync. Returns context.Canceled unwrapped when the index is
-// closing (clean stop).
+// scheduler/worker goroutines hold no closeLock, so the tracker init must be
+// guarded against a concurrent Index.drop. Returns context.Canceled
+// unwrapped when the index is closing (clean stop).
 func (t *ShardReindexTaskGeneric) onAfterLsmInitGuarded(ctx context.Context, shard *Shard) error {
 	return t.onAfterLsmInitWithTracker(ctx, shard, func(s *Shard) (reindexTracker, error) {
 		return t.newReindexTrackerGuarded(s)
@@ -1081,9 +1055,7 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitGuarded(ctx context.Context, sha
 }
 
 // onAfterLsmInitWithTracker is the shared body of OnAfterLsmInit /
-// onAfterLsmInitGuarded. newTracker selects the plain (shard-init route) or
-// guarded (DTM route) tracker factory — see newReindexTrackerGuarded for why
-// the two routes must differ.
+// onAfterLsmInitGuarded; newTracker selects the plain or guarded factory.
 func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context, shard *Shard,
 	newTracker func(*Shard) (reindexTracker, error),
 ) (err error) {
@@ -1101,14 +1073,10 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 		return nil
 	}
 
-	// Tracker factory selected per route (plain on shard init, guarded on the
-	// DTM route) — see OnAfterLsmInit / onAfterLsmInitGuarded above.
 	rt, err := newTracker(shard)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			// Guarded route: the index is closing and the tracker dir was
-			// deliberately not created. Clean stop; return unwrapped so
-			// callers can errors.Is on it.
+			// Guarded route: return unwrapped so callers can errors.Is on it.
 			logger.Debug("index is closing, stopping after-LSM-init hook")
 			return err
 		}
@@ -1243,21 +1211,14 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 	return nil
 }
 
-// newReindexTrackerGuarded builds a tracker whose init()-time MkdirAll is
-// serialized against Index.drop via withCloseRLockGuard: DTM-driven callers
-// (worker drain loop, runShardLifecycle via onAfterLsmInitGuarded,
-// RunPrepareOnShard, RunSwapOnShard) can race a concurrent DELETE, and an
-// unguarded MkdirAll would re-create the class dir drop() just renamed away.
-// The guard makes it complete-before-rename or bail with context.Canceled
-// (treated as a clean stop).
+// newReindexTrackerGuarded serializes the tracker's init()-time MkdirAll
+// against Index.drop: DTM-driven callers hold no closeLock, and an unguarded
+// MkdirAll would re-create the class dir a concurrent DELETE just renamed
+// away. context.Canceled means the index is closing (clean stop).
 //
-// The shard-init hooks (OnBeforeLsmInit / OnAfterLsmInit) MUST keep the
-// plain factory: SOME NewShard call routes hold closeLock.RLock on the same
-// goroutine (eager index init and the background lazy-load hold none, but
-// the factory has to be safe on ALL of them), and sync.RWMutex is
-// non-reentrant — a nested RLock on the lock-holding routes deadlocks
-// against a queued drop() writer. On those routes the outer RLock excludes
-// drop() for their whole duration anyway.
+// The shard-init hooks MUST keep the plain factory: some NewShard routes
+// hold closeLock.RLock, and a nested RLock (sync.RWMutex is non-reentrant)
+// deadlocks against a queued drop() writer.
 func (t *ShardReindexTaskGeneric) newReindexTrackerGuarded(shard ShardLike) (reindexTracker, error) {
 	rt := NewFileReindexTracker(shard.pathLSM(), t.strategy.MigrationDirName(), t.keyParser)
 	rt.mkdirGuard = shard.Index().withCloseRLockGuard
@@ -1281,9 +1242,8 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		return zerotime, false, nil
 	}
 
-	// Guarded: per-iteration WORKER drain path — a cancelled worker re-enters
-	// here with no ctx check before the tracker's MkdirAll. context.Canceled
-	// means the index is closing; treat as a clean stop.
+	// Guarded: a cancelled worker re-enters here with no ctx check before the
+	// tracker's MkdirAll (see newReindexTrackerGuarded).
 	rt, err := t.newReindexTrackerGuarded(shard)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -425,9 +425,8 @@ func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard S
 		"method":     "RunPrepareOnShard",
 	})
 
-	// Guarded: PREP is DTM-scheduler-driven (never under closeLock), so the
-	// tracker's MkdirAll must be serialized against a concurrent DELETE the
-	// same way as the worker drain path — see newReindexTrackerGuarded.
+	// Guarded: PREP is DTM-scheduler-driven (never under closeLock) — same
+	// DELETE-race exposure as the worker drain path.
 	rt, err := t.newReindexTrackerGuarded(concreteShard)
 	if err != nil {
 		return fmt.Errorf("creating reindex tracker: %w", err)
@@ -1214,35 +1213,18 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 	return nil
 }
 
-// newReindexTrackerGuarded builds a reindex tracker for DTM-scheduler-driven
-// paths (worker drain loop, RunPrepareOnShard, RunSwapOnShard) whose
-// init()-time os.MkdirAll is serialized against the owning Index's drop()
-// via Index.closeLock.
+// newReindexTrackerGuarded builds a tracker whose init()-time MkdirAll is
+// serialized against Index.drop via withCloseRLockGuard: DTM-driven callers
+// (worker drain loop, RunPrepareOnShard, RunSwapOnShard) can race a
+// concurrent DELETE, and an unguarded MkdirAll would re-create the class dir
+// drop() just renamed away. The guard makes it complete-before-rename or
+// bail with context.Canceled (treated as a clean stop).
 //
-// The plain t.newReindexTracker factory creates the tracker dir with an
-// unguarded MkdirAll. That is correct — and REQUIRED — for the shard-init
-// hooks (OnBeforeLsmInit / OnAfterLsmInit): those run inside NewShard, which
-// two of its call routes reach while ALREADY holding closeLock.RLock on the
-// same goroutine (initLocalShardWithForcedLoading, getOptInitLocalShard);
-// sync.RWMutex is non-reentrant, so taking the guard's RLock there deadlocks
-// against a queued drop() writer. Those routes are also already excluded
-// from drop() for their whole duration by that outer RLock. DTM-driven
-// paths, by contrast, provably never hold closeLock (they reach the shard
-// via ForEachShard/GetShard, whose RLocks are released before the callback),
-// and they ARE reachable while a concurrent DELETE runs: a cancelled reindex
-// keeps executing with NO ctx check before the MkdirAll. If Index.drop has
-// renamed the shard's LSM path away, the unguarded MkdirAll re-materializes
-// the original directory AFTER the rename, leaving an orphaned class dir
-// that the DELETE was supposed to remove.
-//
-// Routing the MkdirAll through index.withCloseRLockGuard makes it mutually
-// exclusive with drop()'s rename: it either completes before drop() takes the
-// write lock (rename then carries it into the .deleteme dir) or observes
-// i.closed and bails with context.Canceled (no MkdirAll). The caller treats
-// context.Canceled as a clean stop of the drain loop.
-//
-// shard.Index() is valid for both *Shard and *LazyLoadShard, so no unwrap is
-// needed to reach the owning Index.
+// The shard-init hooks (OnBeforeLsmInit / OnAfterLsmInit) MUST keep the
+// plain factory: two NewShard call routes already hold closeLock.RLock on
+// the same goroutine, and sync.RWMutex is non-reentrant — the guard would
+// deadlock against a queued drop() writer. That outer RLock already excludes
+// drop() for their whole duration anyway.
 func (t *ShardReindexTaskGeneric) newReindexTrackerGuarded(shard ShardLike) (reindexTracker, error) {
 	rt := NewFileReindexTracker(shard.pathLSM(), t.strategy.MigrationDirName(), t.keyParser)
 	rt.mkdirGuard = shard.Index().withCloseRLockGuard
@@ -1278,12 +1260,9 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		return zerotime, false, nil
 	}
 
-	// Guarded tracker: this is the per-iteration WORKER drain path. A
-	// cancelled-but-draining worker re-enters here with no ctx check before the
-	// tracker's MkdirAll; the guard serializes that MkdirAll against a
-	// concurrent DELETE (Index.drop) so it cannot re-materialize a renamed-away
-	// shard path. A closing index yields context.Canceled, which the worker
-	// loop treats as a clean stop.
+	// Guarded: per-iteration WORKER drain path — a cancelled worker re-enters
+	// here with no ctx check before the tracker's MkdirAll. context.Canceled
+	// means the index is closing; treat as a clean stop.
 	rt, err := t.newReindexTrackerGuarded(shard)
 	if err != nil {
 		if stderrors.Is(err, context.Canceled) {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -204,6 +204,15 @@ type ShardReindexTaskGeneric struct {
 	// SetTokenizationOverlay's own lock is enough. Wired only for
 	// tokenization-changing migrations.
 	onPropSwapped func(propName string)
+
+	// trackerMkdirGuard yields the close-lock guard serializing a reindex
+	// tracker's init() MkdirAll against a concurrent Index.drop (see
+	// newReindexTrackerGuarded). Defaults to Index.withCloseRLockGuard in
+	// NewShardReindexTaskGeneric; the drain-rematerialize test wraps it to
+	// interpose a barrier at the exact pre-MkdirAll point that makes the
+	// drop()-vs-MkdirAll race deterministic. Always set — no test-only
+	// branch runs in production.
+	trackerMkdirGuard func(shard ShardLike) func(func() error) error
 }
 
 // NewShardReindexTaskGeneric creates a new generic reindex task.
@@ -233,6 +242,9 @@ func NewShardReindexTaskGeneric(name string, logger logrus.FieldLogger,
 	}
 	t.processOneSwapPropFn = t.processOneSwapProp
 	t.processOneTidyPropFn = t.processOneTidyProp
+	t.trackerMkdirGuard = func(shard ShardLike) func(func() error) error {
+		return shard.Index().withCloseRLockGuard
+	}
 	return t
 }
 
@@ -1221,7 +1233,7 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 // deadlocks against a queued drop() writer.
 func (t *ShardReindexTaskGeneric) newReindexTrackerGuarded(shard ShardLike) (reindexTracker, error) {
 	rt := NewFileReindexTracker(shard.pathLSM(), t.strategy.MigrationDirName(), t.keyParser)
-	rt.mkdirGuard = shard.Index().withCloseRLockGuard
+	rt.mkdirGuard = t.trackerMkdirGuard(shard)
 	if err := rt.init(); err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -122,7 +122,7 @@ package db
 import (
 	"bytes"
 	"context"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -361,7 +361,15 @@ func (t *ShardReindexTaskGeneric) runShardLifecycle(ctx context.Context, shard S
 		return fmt.Errorf("unwrapping shard %q: %w", shard.Name(), err)
 	}
 
-	if err := t.OnAfterLsmInit(ctx, concreteShard); err != nil {
+	// DTM route: runShardLifecycle runs on scheduler/worker goroutines that
+	// hold no closeLock, so the hook's tracker init must be guarded against a
+	// concurrent DELETE (see newReindexTrackerGuarded). context.Canceled from
+	// the guard means the index is closing — propagate unwrapped so callers
+	// treat it as a clean stop, consistent with OnAfterLsmInitAsync.
+	if err := t.onAfterLsmInitGuarded(ctx, concreteShard); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
 		return fmt.Errorf("after LSM init: %w", err)
 	}
 
@@ -477,6 +485,17 @@ func (t *ShardReindexTaskGeneric) enterDTMPhase(ctx context.Context, shard Shard
 	rt, err := t.newReindexTrackerGuarded(concreteShard)
 	if err != nil {
 		return nil, fmt.Errorf("creating reindex tracker: %w", err)
+	}
+
+	// IsMerged fast-path — MUST stay ahead of the iteration-resume ladder
+	// below. merged.mig can only be written after the iteration completed, so
+	// on a torn sentinel state (IsMerged && !IsReindexed — e.g. partial
+	// sentinel loss or operator surgery) re-running the iteration would run
+	// against an already-merged migration (or error out on !IsStarted). Both
+	// callers handle the merged state downstream: RunPrepareOnShard no-ops,
+	// RunSwapOnShard's dispatch has an IsMerged branch.
+	if rt.IsMerged() {
+		return &dtmPhaseEntry{shard: concreteShard, logger: logger, rt: rt}, nil
 	}
 
 	if !rt.IsReindexed() {
@@ -807,9 +826,12 @@ func (t *ShardReindexTaskGeneric) OnBeforeLsmInit(ctx context.Context, shard *Sh
 		return nil
 	}
 
-	// Deliberately UNguarded: shard-init hooks can run under an outer
-	// closeLock.RLock (see newReindexTrackerGuarded) — a nested RLock here
-	// deadlocks against a queued drop() writer.
+	// Deliberately UNguarded: OnBeforeLsmInit is only reachable from the
+	// shard-init route (ShardReindexerV3.RunBeforeLsmInit via shard_init.go —
+	// no DTM-goroutine caller exists), and some of those routes run under an
+	// outer closeLock.RLock (see newReindexTrackerGuarded) — a nested RLock
+	// here deadlocks against a queued drop() writer. If a DTM-driven caller
+	// is ever added, it needs a guarded variant like onAfterLsmInitGuarded.
 	rt, err := t.newReindexTracker(shard.pathLSM())
 	if err != nil {
 		err = fmt.Errorf("creating reindex tracker: %w", err)
@@ -1016,7 +1038,39 @@ func (t *ShardReindexTaskGeneric) OnBeforeLsmInit(ctx context.Context, shard *Sh
 	return nil
 }
 
-func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Shard) (err error) {
+// OnAfterLsmInit is the shard-init entry into the after-LSM-init hook
+// (ShardReindexerV3.RunAfterLsmInit via shard_init.go, including the
+// recovery-only reindexer). It builds the PLAIN tracker because some NewShard
+// routes hold closeLock.RLock on the calling goroutine (see
+// newReindexTrackerGuarded). DTM-driven callers MUST use
+// onAfterLsmInitGuarded instead — an unguarded tracker init on a goroutine
+// holding no closeLock can re-materialize a just-DELETEd class dir.
+func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Shard) error {
+	return t.onAfterLsmInitWithTracker(ctx, shard, func(s *Shard) (reindexTracker, error) {
+		return t.newReindexTracker(s.pathLSM())
+	})
+}
+
+// onAfterLsmInitGuarded is the DTM-route entry into the after-LSM-init hook:
+// runShardLifecycle (RunOnShard / RunReindexOnlyOnShard, including
+// enterDTMPhase's iteration resume) runs on scheduler/worker goroutines that
+// hold no closeLock, so the tracker's init()-time MkdirAll must be guarded
+// against a concurrent Index.drop — the same DELETE-race exposure as
+// OnAfterLsmInitAsync. Returns context.Canceled unwrapped when the index is
+// closing (clean stop).
+func (t *ShardReindexTaskGeneric) onAfterLsmInitGuarded(ctx context.Context, shard *Shard) error {
+	return t.onAfterLsmInitWithTracker(ctx, shard, func(s *Shard) (reindexTracker, error) {
+		return t.newReindexTrackerGuarded(s)
+	})
+}
+
+// onAfterLsmInitWithTracker is the shared body of OnAfterLsmInit /
+// onAfterLsmInitGuarded. newTracker selects the plain (shard-init route) or
+// guarded (DTM route) tracker factory — see newReindexTrackerGuarded for why
+// the two routes must differ.
+func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context, shard *Shard,
+	newTracker func(*Shard) (reindexTracker, error),
+) (err error) {
 	collectionName := shard.Index().Config.ClassName.String()
 	shardName := shard.Name()
 	logger := t.logger.WithFields(map[string]any{
@@ -1027,10 +1081,16 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 	logger.Info("starting")
 	defer func(started time.Time) {
 		logger = logger.WithField("took", time.Since(started))
-		if err != nil {
-			logger.Errorf("finished with error: %v", err)
-		} else {
+		switch {
+		case err == nil:
 			logger.Info("finished")
+		case errors.Is(err, context.Canceled):
+			// Clean stop (index closing / request cancelled): the scheduler
+			// already logs the cancelled unit, so keep this at debug to avoid
+			// a duplicate ERROR line per clean stop.
+			logger.Debugf("finished after cancellation: %v", err)
+		default:
+			logger.Errorf("finished with error: %v", err)
 		}
 	}(time.Now())
 
@@ -1043,9 +1103,17 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 		return nil
 	}
 
-	// Deliberately UNguarded: shard-init hook, see comment in OnBeforeLsmInit.
-	rt, err := t.newReindexTracker(shard.pathLSM())
+	// Tracker factory selected per route (plain on shard init, guarded on the
+	// DTM route) — see OnAfterLsmInit / onAfterLsmInitGuarded above.
+	rt, err := newTracker(shard)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			// Guarded route: the index is closing and the tracker dir was
+			// deliberately not created. Clean stop; return unwrapped so
+			// callers can errors.Is on it.
+			logger.Debug("index is closing, stopping after-LSM-init hook")
+			return err
+		}
 		err = fmt.Errorf("creating reindex tracker: %w", err)
 		return err
 	}
@@ -1179,15 +1247,18 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 
 // newReindexTrackerGuarded builds a tracker whose init()-time MkdirAll is
 // serialized against Index.drop via withCloseRLockGuard: DTM-driven callers
-// (worker drain loop, RunPrepareOnShard, RunSwapOnShard) can race a
-// concurrent DELETE, and an unguarded MkdirAll would re-create the class dir
-// drop() just renamed away. The guard makes it complete-before-rename or
-// bail with context.Canceled (treated as a clean stop).
+// (worker drain loop, runShardLifecycle via onAfterLsmInitGuarded,
+// RunPrepareOnShard, RunSwapOnShard) can race a concurrent DELETE, and an
+// unguarded MkdirAll would re-create the class dir drop() just renamed away.
+// The guard makes it complete-before-rename or bail with context.Canceled
+// (treated as a clean stop).
 //
 // The shard-init hooks (OnBeforeLsmInit / OnAfterLsmInit) MUST keep the
-// plain factory: two NewShard call routes already hold closeLock.RLock on
-// the same goroutine, and sync.RWMutex is non-reentrant — the guard would
-// deadlock against a queued drop() writer. That outer RLock already excludes
+// plain factory: SOME NewShard call routes hold closeLock.RLock on the same
+// goroutine (eager index init and the background lazy-load hold none, but
+// the factory has to be safe on ALL of them), and sync.RWMutex is
+// non-reentrant — a nested RLock on the lock-holding routes deadlocks
+// against a queued drop() writer. On those routes the outer RLock excludes
 // drop() for their whole duration anyway.
 func (t *ShardReindexTaskGeneric) newReindexTrackerGuarded(shard ShardLike) (reindexTracker, error) {
 	rt := NewFileReindexTracker(shard.pathLSM(), t.strategy.MigrationDirName(), t.keyParser)
@@ -1210,10 +1281,16 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	logger.Info("starting")
 	defer func(started time.Time) {
 		logger = logger.WithField("took", time.Since(started))
-		if err != nil {
-			logger.Errorf("finished with error: %v", err)
-		} else {
+		switch {
+		case err == nil:
 			logger.Info("finished")
+		case errors.Is(err, context.Canceled):
+			// Clean stop (index closing / request cancelled): the scheduler
+			// already logs the cancelled unit, so keep this at debug to avoid
+			// a duplicate ERROR line per clean stop.
+			logger.Debugf("finished after cancellation: %v", err)
+		default:
+			logger.Errorf("finished with error: %v", err)
 		}
 	}(time.Now())
 
@@ -1229,7 +1306,7 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	// means the index is closing; treat as a clean stop.
 	rt, err := t.newReindexTrackerGuarded(shard)
 	if err != nil {
-		if stderrors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) {
 			logger.Debug("index is closing, stopping reindex drain")
 			return zerotime, false, err
 		}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -803,23 +803,39 @@ func unwrapShard(ctx context.Context, shard ShardLike) (*Shard, error) {
 	}
 }
 
-func (t *ShardReindexTaskGeneric) OnBeforeLsmInit(ctx context.Context, shard *Shard) (err error) {
-	collectionName := shard.Index().Config.ClassName.String()
-	shardName := shard.Name()
+// logPhase builds the per-invocation logger and the finished-lifecycle
+// callback shared by the LSM-init hooks. context.Canceled logs at Debug —
+// the scheduler already logs the cancelled unit.
+func (t *ShardReindexTaskGeneric) logPhase(collectionName, shardName, method string,
+) (logrus.FieldLogger, func(started time.Time, err error)) {
 	logger := t.logger.WithFields(map[string]any{
 		"collection": collectionName,
 		"shard":      shardName,
-		"method":     "OnBeforeLsmInit",
+		"method":     method,
 	})
 	logger.Info("starting")
-	defer func(started time.Time) {
-		logger = logger.WithField("took", time.Since(started))
-		if err != nil {
-			logger.Errorf("finished with error: %v", err)
-		} else {
+	done := func(started time.Time, err error) {
+		logger := logger.WithField("took", time.Since(started))
+		switch {
+		case err == nil:
 			logger.Info("finished")
+		case errors.Is(err, context.Canceled):
+			// Clean stop (index closing / request cancelled): the scheduler
+			// already logs the cancelled unit, so keep this at debug to avoid
+			// a duplicate ERROR line per clean stop.
+			logger.Debugf("finished after cancellation: %v", err)
+		default:
+			logger.Errorf("finished with error: %v", err)
 		}
-	}(time.Now())
+	}
+	return logger, done
+}
+
+func (t *ShardReindexTaskGeneric) OnBeforeLsmInit(ctx context.Context, shard *Shard) (err error) {
+	collectionName := shard.Index().Config.ClassName.String()
+	shardName := shard.Name()
+	logger, done := t.logPhase(collectionName, shardName, "OnBeforeLsmInit")
+	defer func(started time.Time) { done(started, err) }(time.Now())
 
 	if !t.isShardSelected(collectionName, shardName) {
 		logger.Debug("different collection/shard selected. nothing to do")
@@ -1073,26 +1089,8 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 ) (err error) {
 	collectionName := shard.Index().Config.ClassName.String()
 	shardName := shard.Name()
-	logger := t.logger.WithFields(map[string]any{
-		"collection": collectionName,
-		"shard":      shardName,
-		"method":     "OnAfterLsmInit",
-	})
-	logger.Info("starting")
-	defer func(started time.Time) {
-		logger = logger.WithField("took", time.Since(started))
-		switch {
-		case err == nil:
-			logger.Info("finished")
-		case errors.Is(err, context.Canceled):
-			// Clean stop (index closing / request cancelled): the scheduler
-			// already logs the cancelled unit, so keep this at debug to avoid
-			// a duplicate ERROR line per clean stop.
-			logger.Debugf("finished after cancellation: %v", err)
-		default:
-			logger.Errorf("finished with error: %v", err)
-		}
-	}(time.Now())
+	logger, done := t.logPhase(collectionName, shardName, "OnAfterLsmInit")
+	defer func(started time.Time) { done(started, err) }(time.Now())
 
 	// skip shard only if not started or rollback requested
 	// otherwise double writes have to be enabled if migration was already started
@@ -1273,26 +1271,8 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 ) (rerunAt time.Time, reloadShard bool, err error) {
 	collectionName := shard.Index().Config.ClassName.String()
 	shardName := shard.Name()
-	logger := t.logger.WithFields(map[string]any{
-		"collection": collectionName,
-		"shard":      shardName,
-		"method":     "OnAfterLsmInitAsync",
-	})
-	logger.Info("starting")
-	defer func(started time.Time) {
-		logger = logger.WithField("took", time.Since(started))
-		switch {
-		case err == nil:
-			logger.Info("finished")
-		case errors.Is(err, context.Canceled):
-			// Clean stop (index closing / request cancelled): the scheduler
-			// already logs the cancelled unit, so keep this at debug to avoid
-			// a duplicate ERROR line per clean stop.
-			logger.Debugf("finished after cancellation: %v", err)
-		default:
-			logger.Errorf("finished with error: %v", err)
-		}
-	}(time.Now())
+	logger, done := t.logPhase(collectionName, shardName, "OnAfterLsmInitAsync")
+	defer func(started time.Time) { done(started, err) }(time.Now())
 
 	zerotime := time.Time{}
 

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -122,6 +122,7 @@ package db
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1204,6 +1205,36 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 	return nil
 }
 
+// newReindexTrackerGuarded builds a reindex tracker for the WORKER drain path
+// whose init()-time os.MkdirAll is serialized against the owning Index's
+// drop() via Index.closeLock.
+//
+// The plain t.newReindexTracker factory creates the tracker dir with an
+// unguarded MkdirAll. That is correct for setup/recovery callers that run
+// before the worker loop, but it is UNSAFE for the per-iteration call inside
+// the worker loop (OnAfterLsmInitAsync): a cancelled reindex worker keeps
+// draining and re-enters this function with NO ctx check before the MkdirAll.
+// If a concurrent DELETE (Index.drop) has renamed the shard's LSM path away,
+// the unguarded MkdirAll re-materializes the original directory AFTER the
+// rename, leaving an orphaned class dir that the DELETE was supposed to remove.
+//
+// Routing the MkdirAll through index.withCloseRLockGuard makes it mutually
+// exclusive with drop()'s rename: it either completes before drop() takes the
+// write lock (rename then carries it into the .deleteme dir) or observes
+// i.closed and bails with context.Canceled (no MkdirAll). The caller treats
+// context.Canceled as a clean stop of the drain loop.
+//
+// shard.Index() is valid for both *Shard and *LazyLoadShard, so no unwrap is
+// needed to reach the owning Index.
+func (t *ShardReindexTaskGeneric) newReindexTrackerGuarded(shard ShardLike) (reindexTracker, error) {
+	rt := NewFileReindexTracker(shard.pathLSM(), t.strategy.MigrationDirName(), t.keyParser)
+	rt.mkdirGuard = shard.Index().withCloseRLockGuard
+	if err := rt.init(); err != nil {
+		return nil, err
+	}
+	return rt, nil
+}
+
 func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard ShardLike,
 ) (rerunAt time.Time, reloadShard bool, err error) {
 	collectionName := shard.Index().Config.ClassName.String()
@@ -1230,8 +1261,18 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		return zerotime, false, nil
 	}
 
-	rt, err := t.newReindexTracker(shard.pathLSM())
+	// Guarded tracker: this is the per-iteration WORKER drain path. A
+	// cancelled-but-draining worker re-enters here with no ctx check before the
+	// tracker's MkdirAll; the guard serializes that MkdirAll against a
+	// concurrent DELETE (Index.drop) so it cannot re-materialize a renamed-away
+	// shard path. A closing index yields context.Canceled, which the worker
+	// loop treats as a clean stop.
+	rt, err := t.newReindexTrackerGuarded(shard)
 	if err != nil {
+		if stderrors.Is(err, context.Canceled) {
+			logger.Debug("index is closing, stopping reindex drain")
+			return zerotime, false, err
+		}
 		err = fmt.Errorf("creating reindex tracker: %w", err)
 		return zerotime, false, err
 	}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -425,7 +425,10 @@ func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard S
 		"method":     "RunPrepareOnShard",
 	})
 
-	rt, err := t.newReindexTracker(concreteShard.pathLSM())
+	// Guarded: PREP is DTM-scheduler-driven (never under closeLock), so the
+	// tracker's MkdirAll must be serialized against a concurrent DELETE the
+	// same way as the worker drain path — see newReindexTrackerGuarded.
+	rt, err := t.newReindexTrackerGuarded(concreteShard)
 	if err != nil {
 		return fmt.Errorf("creating reindex tracker: %w", err)
 	}
@@ -450,7 +453,7 @@ func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard S
 		if err := t.RunReindexOnlyOnShard(ctx, shard); err != nil {
 			return fmt.Errorf("resume iteration before prep: %w", err)
 		}
-		rt, err = t.newReindexTracker(concreteShard.pathLSM())
+		rt, err = t.newReindexTrackerGuarded(concreteShard)
 		if err != nil {
 			return fmt.Errorf("creating reindex tracker after iteration resume: %w", err)
 		}
@@ -533,7 +536,9 @@ func (t *ShardReindexTaskGeneric) RunSwapOnShard(ctx context.Context, shard Shar
 		"method":     "RunSwapOnShard",
 	})
 
-	rt, err := t.newReindexTracker(concreteShard.pathLSM())
+	// Guarded: SWAP is DTM-scheduler-driven (never under closeLock), same
+	// DELETE-race exposure as the worker drain path.
+	rt, err := t.newReindexTrackerGuarded(concreteShard)
 	if err != nil {
 		return fmt.Errorf("creating reindex tracker: %w", err)
 	}
@@ -578,7 +583,7 @@ func (t *ShardReindexTaskGeneric) RunSwapOnShard(ctx context.Context, shard Shar
 		// (and possibly more — runtimeSwap MAY have run inline if
 		// skipSwapOnFinish was somehow not honored, though it's set in
 		// runShardLifecycle).
-		rt, err = t.newReindexTracker(concreteShard.pathLSM())
+		rt, err = t.newReindexTrackerGuarded(concreteShard)
 		if err != nil {
 			return fmt.Errorf("creating reindex tracker after iteration resume: %w", err)
 		}
@@ -839,6 +844,9 @@ func (t *ShardReindexTaskGeneric) OnBeforeLsmInit(ctx context.Context, shard *Sh
 		return nil
 	}
 
+	// Deliberately UNguarded: shard-init hooks can run under an outer
+	// closeLock.RLock (see newReindexTrackerGuarded) — a nested RLock here
+	// deadlocks against a queued drop() writer.
 	rt, err := t.newReindexTracker(shard.pathLSM())
 	if err != nil {
 		err = fmt.Errorf("creating reindex tracker: %w", err)
@@ -1072,6 +1080,7 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 		return nil
 	}
 
+	// Deliberately UNguarded: shard-init hook, see comment in OnBeforeLsmInit.
 	rt, err := t.newReindexTracker(shard.pathLSM())
 	if err != nil {
 		err = fmt.Errorf("creating reindex tracker: %w", err)
@@ -1205,18 +1214,26 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInit(ctx context.Context, shard *Sha
 	return nil
 }
 
-// newReindexTrackerGuarded builds a reindex tracker for the WORKER drain path
-// whose init()-time os.MkdirAll is serialized against the owning Index's
-// drop() via Index.closeLock.
+// newReindexTrackerGuarded builds a reindex tracker for DTM-scheduler-driven
+// paths (worker drain loop, RunPrepareOnShard, RunSwapOnShard) whose
+// init()-time os.MkdirAll is serialized against the owning Index's drop()
+// via Index.closeLock.
 //
 // The plain t.newReindexTracker factory creates the tracker dir with an
-// unguarded MkdirAll. That is correct for setup/recovery callers that run
-// before the worker loop, but it is UNSAFE for the per-iteration call inside
-// the worker loop (OnAfterLsmInitAsync): a cancelled reindex worker keeps
-// draining and re-enters this function with NO ctx check before the MkdirAll.
-// If a concurrent DELETE (Index.drop) has renamed the shard's LSM path away,
-// the unguarded MkdirAll re-materializes the original directory AFTER the
-// rename, leaving an orphaned class dir that the DELETE was supposed to remove.
+// unguarded MkdirAll. That is correct — and REQUIRED — for the shard-init
+// hooks (OnBeforeLsmInit / OnAfterLsmInit): those run inside NewShard, which
+// two of its call routes reach while ALREADY holding closeLock.RLock on the
+// same goroutine (initLocalShardWithForcedLoading, getOptInitLocalShard);
+// sync.RWMutex is non-reentrant, so taking the guard's RLock there deadlocks
+// against a queued drop() writer. Those routes are also already excluded
+// from drop() for their whole duration by that outer RLock. DTM-driven
+// paths, by contrast, provably never hold closeLock (they reach the shard
+// via ForEachShard/GetShard, whose RLocks are released before the callback),
+// and they ARE reachable while a concurrent DELETE runs: a cancelled reindex
+// keeps executing with NO ctx check before the MkdirAll. If Index.drop has
+// renamed the shard's LSM path away, the unguarded MkdirAll re-materializes
+// the original directory AFTER the rename, leaving an orphaned class dir
+// that the DELETE was supposed to remove.
 //
 // Routing the MkdirAll through index.withCloseRLockGuard makes it mutually
 // exclusive with drop()'s rename: it either completes before drop() takes the

--- a/adapters/repos/db/inverted_reindex_tracker.go
+++ b/adapters/repos/db/inverted_reindex_tracker.go
@@ -99,6 +99,20 @@ type fileReindexTracker struct {
 	progressCheckpoint int
 	keyParser          indexKeyParser
 	config             fileReindexTrackerConfig
+
+	// mkdirGuard, when non-nil, wraps the os.MkdirAll in init() so the
+	// directory creation is serialized against the owning Index's drop().
+	// Wired by newReindexTrackerGuarded for trackers created on the reindex
+	// WORKER drain path, where a cancelled-but-still-draining worker must not
+	// re-materialize a shard LSM path that a concurrent DELETE (Index.drop)
+	// has just renamed away. nil for all other (non-worker) callers, which
+	// keeps their behavior byte-for-byte identical to a direct MkdirAll.
+	//
+	// The guard receives the MkdirAll as a closure and is expected to run it
+	// under Index.closeLock.RLock() with an i.closed pre-check (see
+	// (*Index).withCloseRLockGuard). If it returns context.Canceled the
+	// directory is intentionally NOT created and init() propagates that error.
+	mkdirGuard func(func() error) error
 }
 
 type fileReindexTrackerConfig struct {
@@ -118,8 +132,36 @@ type fileReindexTrackerConfig struct {
 	migrationPath      string
 }
 
+// reindexTrackerInitHook is a TEST-ONLY hook fired at the very top of
+// fileReindexTracker.init(), BEFORE the (optionally guarded) os.MkdirAll and
+// before any closeLock is taken. Production leaves it nil, which compiles to a
+// single nil-check on a cold path. Tests set it to widen the drop()-vs-MkdirAll
+// race window deterministically: the hook can block until a concurrent
+// Index.drop() has renamed the directory away, proving that the guard (and only
+// the guard) prevents re-materialization.
+var reindexTrackerInitHook func()
+
 func (t *fileReindexTracker) init() error {
-	if err := os.MkdirAll(t.config.migrationPath, 0o777); err != nil {
+	if reindexTrackerInitHook != nil {
+		reindexTrackerInitHook()
+	}
+
+	mkdir := func() error {
+		return os.MkdirAll(t.config.migrationPath, 0o777)
+	}
+
+	if t.mkdirGuard != nil {
+		// Guarded worker path: the MkdirAll runs under Index.closeLock.RLock()
+		// with an i.closed pre-check, so it is mutually exclusive with the
+		// rename-away inside Index.drop(). A context.Canceled return means the
+		// index is closing and the directory was deliberately not created.
+		if err := t.mkdirGuard(mkdir); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if err := mkdir(); err != nil {
 		return err
 	}
 	return nil

--- a/adapters/repos/db/inverted_reindex_tracker.go
+++ b/adapters/repos/db/inverted_reindex_tracker.go
@@ -100,18 +100,11 @@ type fileReindexTracker struct {
 	keyParser          indexKeyParser
 	config             fileReindexTrackerConfig
 
-	// mkdirGuard, when non-nil, wraps the os.MkdirAll in init() so the
-	// directory creation is serialized against the owning Index's drop().
-	// Wired by newReindexTrackerGuarded for trackers created on the reindex
-	// WORKER drain path, where a cancelled-but-still-draining worker must not
-	// re-materialize a shard LSM path that a concurrent DELETE (Index.drop)
-	// has just renamed away. nil for all other (non-worker) callers, which
-	// keeps their behavior byte-for-byte identical to a direct MkdirAll.
-	//
-	// The guard receives the MkdirAll as a closure and is expected to run it
-	// under Index.closeLock.RLock() with an i.closed pre-check (see
-	// (*Index).withCloseRLockGuard). If it returns context.Canceled the
-	// directory is intentionally NOT created and init() propagates that error.
+	// mkdirGuard, when non-nil, wraps init()'s os.MkdirAll (expected:
+	// Index.withCloseRLockGuard) so directory creation is serialized against
+	// Index.drop and cannot re-materialize a renamed-away class dir.
+	// context.Canceled means the index is closing and the dir was
+	// deliberately not created. nil = plain MkdirAll, behavior unchanged.
 	mkdirGuard func(func() error) error
 }
 
@@ -132,13 +125,9 @@ type fileReindexTrackerConfig struct {
 	migrationPath      string
 }
 
-// reindexTrackerInitHook is a TEST-ONLY hook fired at the very top of
-// fileReindexTracker.init(), BEFORE the (optionally guarded) os.MkdirAll and
-// before any closeLock is taken. Production leaves it nil, which compiles to a
-// single nil-check on a cold path. Tests set it to widen the drop()-vs-MkdirAll
-// race window deterministically: the hook can block until a concurrent
-// Index.drop() has renamed the directory away, proving that the guard (and only
-// the guard) prevents re-materialization.
+// reindexTrackerInitHook is a TEST-ONLY hook fired at the top of init(),
+// before the (optionally guarded) MkdirAll. Tests block in it to widen the
+// drop()-vs-MkdirAll race window deterministically. Production leaves it nil.
 var reindexTrackerInitHook func()
 
 func (t *fileReindexTracker) init() error {
@@ -151,20 +140,9 @@ func (t *fileReindexTracker) init() error {
 	}
 
 	if t.mkdirGuard != nil {
-		// Guarded worker path: the MkdirAll runs under Index.closeLock.RLock()
-		// with an i.closed pre-check, so it is mutually exclusive with the
-		// rename-away inside Index.drop(). A context.Canceled return means the
-		// index is closing and the directory was deliberately not created.
-		if err := t.mkdirGuard(mkdir); err != nil {
-			return err
-		}
-		return nil
+		return t.mkdirGuard(mkdir)
 	}
-
-	if err := mkdir(); err != nil {
-		return err
-	}
-	return nil
+	return mkdir()
 }
 
 func (t *fileReindexTracker) HasStartCondition() bool {

--- a/adapters/repos/db/inverted_reindex_tracker.go
+++ b/adapters/repos/db/inverted_reindex_tracker.go
@@ -123,15 +123,7 @@ type fileReindexTrackerConfig struct {
 	migrationPath      string
 }
 
-// reindexTrackerInitHook is a TEST-ONLY hook fired before init()'s MkdirAll;
-// tests block in it to make the drop()-vs-MkdirAll race deterministic.
-var reindexTrackerInitHook func()
-
 func (t *fileReindexTracker) init() error {
-	if reindexTrackerInitHook != nil {
-		reindexTrackerInitHook()
-	}
-
 	mkdir := func() error {
 		return os.MkdirAll(t.config.migrationPath, 0o777)
 	}

--- a/adapters/repos/db/inverted_reindex_tracker.go
+++ b/adapters/repos/db/inverted_reindex_tracker.go
@@ -100,11 +100,9 @@ type fileReindexTracker struct {
 	keyParser          indexKeyParser
 	config             fileReindexTrackerConfig
 
-	// mkdirGuard, when non-nil, wraps init()'s os.MkdirAll (expected:
-	// Index.withCloseRLockGuard) so directory creation is serialized against
-	// Index.drop and cannot re-materialize a renamed-away class dir.
-	// context.Canceled means the index is closing and the dir was
-	// deliberately not created. nil = plain MkdirAll, behavior unchanged.
+	// mkdirGuard, when non-nil (expected: Index.withCloseRLockGuard), wraps
+	// init()'s MkdirAll so it cannot re-create a class dir Index.drop just
+	// renamed away; context.Canceled means the index is closing.
 	mkdirGuard func(func() error) error
 }
 
@@ -125,9 +123,8 @@ type fileReindexTrackerConfig struct {
 	migrationPath      string
 }
 
-// reindexTrackerInitHook is a TEST-ONLY hook fired at the top of init(),
-// before the (optionally guarded) MkdirAll. Tests block in it to widen the
-// drop()-vs-MkdirAll race window deterministically. Production leaves it nil.
+// reindexTrackerInitHook is a TEST-ONLY hook fired before init()'s MkdirAll;
+// tests block in it to make the drop()-vs-MkdirAll race deterministic.
 var reindexTrackerInitHook func()
 
 func (t *fileReindexTracker) init() error {

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -555,7 +555,22 @@ func (p *ReindexProvider) processOneUnit(
 	// arriving between shard init and OnGroupCompleted's swap go only to
 	// the old main bucket (no ingest double-write) and are lost on swap.
 	// See [ReindexProvider.persistRecoveryRecord] for the on-disk shape.
-	if err := p.persistRecoveryRecord(task, payload, unitID, concreteShard.pathLSM(), tasks); err != nil {
+	//
+	// Guarded against Index.drop: SaveRecoveryPayload MkdirAll's the
+	// migration dir, so an unguarded write racing a DELETE re-materializes
+	// the renamed-away class dir — the same shape newReindexTrackerGuarded
+	// closes on the tracker paths. This goroutine (GoWrapper worker) never
+	// holds closeLock, so the RLock is safe.
+	if err := concreteShard.Index().withCloseRLockGuard(func() error {
+		return p.persistRecoveryRecord(task, payload, unitID, concreteShard.pathLSM(), tasks)
+	}); err != nil {
+		if errors.Is(err, context.Canceled) {
+			// Index is closing (concurrent DELETE): the cascade-cancel will
+			// terminate this task; stop quietly instead of failing the unit.
+			p.logger.WithField("unit", unitID).
+				Debug("index closing during recovery-record persist; stopping unit")
+			return
+		}
 		// A failure to persist the recovery record means a restart in the
 		// next few seconds would lose the in-flight reindex's double-write
 		// callbacks. That is bad enough to fail the unit explicitly rather

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -557,10 +557,8 @@ func (p *ReindexProvider) processOneUnit(
 	// See [ReindexProvider.persistRecoveryRecord] for the on-disk shape.
 	//
 	// Guarded against Index.drop: SaveRecoveryPayload MkdirAll's the
-	// migration dir, so an unguarded write racing a DELETE re-materializes
-	// the renamed-away class dir — the same shape newReindexTrackerGuarded
-	// closes on the tracker paths. This goroutine (GoWrapper worker) never
-	// holds closeLock, so the RLock is safe.
+	// migration dir — same re-materialization race the tracker paths guard
+	// via newReindexTrackerGuarded. This goroutine never holds closeLock.
 	if err := concreteShard.Index().withCloseRLockGuard(func() error {
 		return p.persistRecoveryRecord(task, payload, unitID, concreteShard.pathLSM(), tasks)
 	}); err != nil {

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -556,15 +556,14 @@ func (p *ReindexProvider) processOneUnit(
 	// the old main bucket (no ingest double-write) and are lost on swap.
 	// See [ReindexProvider.persistRecoveryRecord] for the on-disk shape.
 	//
-	// Guarded against Index.drop: SaveRecoveryPayload MkdirAll's the
-	// migration dir — same re-materialization race the tracker paths guard
-	// via newReindexTrackerGuarded. This goroutine never holds closeLock.
+	// Guarded: SaveRecoveryPayload MkdirAll's the migration dir on a
+	// goroutine holding no closeLock — same re-materialization race as
+	// newReindexTrackerGuarded.
 	if err := concreteShard.Index().withCloseRLockGuard(func() error {
 		return p.persistRecoveryRecord(task, payload, unitID, concreteShard.pathLSM(), tasks)
 	}); err != nil {
 		if errors.Is(err, context.Canceled) {
-			// Index is closing (concurrent DELETE): the cascade-cancel will
-			// terminate this task; stop quietly instead of failing the unit.
+			// Index is closing: cascade-cancel ends the task; don't fail the unit.
 			p.logger.WithField("unit", unitID).
 				Debug("index closing during recovery-record persist; stopping unit")
 			return


### PR DESCRIPTION
## What

A cancelled reindex keeps executing briefly after a DELETE class: DTM-driven code paths create the reindex tracker with an unguarded `os.MkdirAll(<class>/<shard>/lsm/.migrations/…)` and no ctx check first, so if `Index.drop()` has just renamed the class dir away, the MkdirAll re-creates it — an orphaned class dir the DELETE was supposed to remove. Observed as `TestBackupVsReindexSuite/CancelClearsTrackerDirsViaOnTaskCompleted` and `TestMultiNode_DeleteRecreateCleansReindexTasks` soak flakes.

## Design

**`Index.withCloseRLockGuard`** runs a short fn under `closeLock.RLock` with an `i.closed` pre-check. `drop()` sets `i.closed` AND renames the dir under the same write lock, so a guarded MkdirAll either completes before the rename (its output is carried into the `.deleteme` dir) or never runs (`context.Canceled`, treated as a clean stop). A lock-free flag check would not close the window — a stale read could run the MkdirAll after the rename.

**Route split — the load-bearing decision.** Every DTM-scheduler route takes the guarded tracker factory: the worker drain loop (`OnAfterLsmInitAsync`), the phase callbacks (`RunPrepareOnShard`/`RunSwapOnShard` via `enterDTMPhase`), the DTM entry into the LSM-init hook (`onAfterLsmInitGuarded`, used by `runShardLifecycle`), and the recovery-record persist. The shard-init routes keep the plain factory: some `NewShard` call paths already hold `closeLock.RLock` on the same goroutine, and `sync.RWMutex` is non-reentrant — guarding there deadlocks against a queued `drop()` writer (they're excluded from drop by that outer RLock anyway). `OnBeforeLsmInit` was traced to shard-init-only callers and stays plain.

## Proof

`TestModeADrainRematerialize` drives both production entries (`OnAfterLsmInitAsync`, `RunReindexOnlyOnShard`) with a hook that parks the goroutine pre-MkdirAll until `drop()` completes: both subtests verified red with the guard wiring reverted, green with it.

## Known blind spot (filed, not in scope)

Per-shard tenant deletes (`dropShards`) run under `closeLock.RLock` and never set `i.closed`, so this guard is blind to them — weaviate/0-weaviate-issues#288.
