### PR TITLE
gh-11401 reject negative replication factors

### DIFF
--- a/usecases/replica/config.go
+++ b/usecases/replica/config.go
@@ -42,6 +42,9 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 	}
 
 	if class.ReplicationConfig.Factor < 1 {
+		if class.ReplicationConfig.Factor < 0 {
+			return fmt.Errorf("replication factor must not be negative, got %d", class.ReplicationConfig.Factor)
+		}
 		class.ReplicationConfig.Factor = int64(globalCfg.MinimumFactor)
 	}
 

--- a/usecases/replica/config_test.go
+++ b/usecases/replica/config_test.go
@@ -52,8 +52,9 @@ func Test_ValidateConfig(t *testing.T) {
 		{
 			name:          "config provided, factor < 0",
 			initialconfig: &models.ReplicationConfig{Factor: -1},
-			resultConfig:  &models.ReplicationConfig{Factor: 1},
+			resultConfig:  &models.ReplicationConfig{Factor: -1},
 			globalConfig:  replication.GlobalConfig{MinimumFactor: 1},
+			expectedErr:   fmt.Errorf("replication factor must not be negative, got -1"),
 		},
 		{
 			name:          "config provided, valid factor",

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -729,6 +729,9 @@ func (h *Handler) setClassDefaults(class *models.Class, globalCfg replication.Gl
 	}
 
 	if class.ReplicationConfig.Factor < 1 {
+		if class.ReplicationConfig.Factor < 0 {
+			return fmt.Errorf("replication factor must not be negative, got %d", class.ReplicationConfig.Factor)
+		}
 		class.ReplicationConfig.Factor = int64(globalCfg.MinimumFactor)
 	}
 

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -2906,7 +2906,7 @@ func Test_SetClassDefaults(t *testing.T) {
 			expectedFactor: 2,
 		},
 		{
-			name: "ReplicationConfig factor less than 1",
+			name: "ReplicationConfig factor is zero",
 			class: &models.Class{
 				ReplicationConfig: &models.ReplicationConfig{
 					Factor: 0,
@@ -2914,6 +2914,16 @@ func Test_SetClassDefaults(t *testing.T) {
 			},
 			expectedError:  "",
 			expectedFactor: 3,
+		},
+		{
+			name: "ReplicationConfig factor is negative",
+			class: &models.Class{
+				ReplicationConfig: &models.ReplicationConfig{
+					Factor: -1,
+				},
+			},
+			expectedError:  "replication factor must not be negative, got -1",
+			expectedFactor: -1,
 		},
 		{
 			name: "ReplicationConfig factor greater than or equal to MinimumFactor",


### PR DESCRIPTION
### What's being changed:

Fixes #11401.

Reject explicit negative `replicationConfig.factor` values during collection creation instead of silently defaulting them to the configured minimum replication factor.

The defaulting behavior for omitted replication config and `factor: 0` is preserved. Negative factors are now rejected in both schema defaulting and the shared replica config validation helper so the invalid value does not pass through another validation path.

### Validation

- `go test -count=1 ./usecases/schema -run 'Test_AddClass/reject_negative_replication_factor|Test_SetClassDefaults'`
- `go test -count=1 ./usecases/schema/...`
- `go test -count=1 ./usecases/replica ./usecases/schema/...`
- `./tools/linter_go_routines.sh`

`golangci-lint run ./usecases/schema ./usecases/replica` was attempted by the local worker, but `golangci-lint` is not installed in this environment.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: Not necessary; this rejects invalid input without changing documented valid configuration.
- [x] Chaos pipeline run or not necessary. Link to pipeline: Not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary; validation-only change.
