### PR TITLE
Conditional writes III: field-predicate writes (update only if a property equals a value)

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -722,6 +722,8 @@ jobs:
             test: "--acceptance-go-client-named-vectors-cluster"
           - name: "fast-group-4"
             test: "--acceptance-only-fast-group-4"
+          - name: "conditional-writes"
+            test: "--acceptance-conditional-writes"
           - name: "distributed-tasks"
             test: "--acceptance-distributed-tasks"
           - name: "compaction"
@@ -756,7 +758,7 @@ jobs:
         env:
           MATRIX_TEST: ${{ matrix.name }}
         run: |
-          if [[ "$MATRIX_TEST" == "replica-slow" || "$MATRIX_TEST" == "replica-slow-grpc" || "$MATRIX_TEST" == "fast-group-4" || "$MATRIX_TEST" == "recovery" || "$MATRIX_TEST" == "distributed-tasks" || "$MATRIX_TEST" == "compaction" ]]; then
+          if [[ "$MATRIX_TEST" == "replica-slow" || "$MATRIX_TEST" == "replica-slow-grpc" || "$MATRIX_TEST" == "fast-group-4" || "$MATRIX_TEST" == "recovery" || "$MATRIX_TEST" == "distributed-tasks" || "$MATRIX_TEST" == "compaction" || "$MATRIX_TEST" == "conditional-writes" ]]; then
             echo "test_timeout_minutes=45" >> $GITHUB_ENV
           else
             echo "test_timeout_minutes=15" >> $GITHUB_ENV

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -117,7 +117,8 @@ func (c *replicationClient) DigestObjects(ctx context.Context,
 	}
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodGet, host, index, shard,
-		"", "_digest", bytes.NewReader(body), 0)
+		"", "_digest", bytes.NewReader(body), 0,
+	)
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
@@ -142,7 +143,8 @@ func (c *replicationClient) DigestObjectsInRange(ctx context.Context,
 
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodPost, host, index, shard,
-		"", "digestsInRange", bytes.NewReader(body), 0)
+		"", "digestsInRange", bytes.NewReader(body), 0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create http request: %w", err)
 	}
@@ -236,7 +238,8 @@ func (c *replicationClient) CompareDigests(ctx context.Context,
 	// per-cycle deadline on the incoming context.
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodPost, host, index, shard,
-		"", "compareDigests", bytes.NewReader(body), 0)
+		"", "compareDigests", bytes.NewReader(body), 0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create http request: %w", err)
 	}
@@ -323,7 +326,8 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodPost, host, index, shard,
-		"", fmt.Sprintf("hashtree/level/%d", level), bytes.NewReader(bodyBytes), 0)
+		"", fmt.Sprintf("hashtree/level/%d", level), bytes.NewReader(bodyBytes), 0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create http request: %w", err)
 	}
@@ -517,7 +521,8 @@ func (c *replicationClient) OverwriteObjects(ctx context.Context,
 
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodPut, host, index, shard,
-		"", "_overwrite", bytes.NewReader(bodyCompressed), 0)
+		"", "_overwrite", bytes.NewReader(bodyCompressed), 0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create http request: %w", err)
 	}

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -583,7 +583,11 @@ func (c *replicationClient) PutObject(ctx context.Context, host, index,
 		}
 		if obj.Conditional.UpdateIf != nil {
 			prop, val, vtype := storobj.SerializePredicateToQueryParams(obj.Conditional.UpdateIf)
-			if prop != "" {
+			// Emit all three params whenever a predicate is present. Property and
+			// value_type are always non-empty for a valid Predicate; value MAY be ""
+			// (empty string is a valid text value). The receiver uses property+value_type
+			// presence as the discriminator, not the value string.
+			if prop != "" && vtype != "" {
 				q.Set(replica.ConditionalFieldPropertyKey, prop)
 				q.Set(replica.ConditionalFieldValueKey, val)
 				q.Set(replica.ConditionalFieldValueTypeKey, vtype)

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -566,11 +566,11 @@ func (c *replicationClient) PutObject(ctx context.Context, host, index,
 	}
 
 	// storobj.MarshalBinary intentionally excludes Conditional (it is a per-request
-	// attribute, not a storage attribute), so carry the Phase-1 precondition flags as
-	// dedicated query parameters.  The receiving handler restores them into obj.Conditional
-	// before passing to ReplicateObject.  Old replicas missing these params treat the
-	// request as unconditional (KNOWN-WEAK-ROLLING-UPGRADE).
-	if obj.Conditional.OnlyIfNotExists || obj.Conditional.OnlyIfExists || obj.Conditional.IfVersion != nil {
+	// attribute, not a storage attribute), so carry the precondition flags as dedicated
+	// query parameters. The receiving handler restores them into obj.Conditional before
+	// passing to ReplicateObject. Old replicas missing these params treat the request as
+	// unconditional (KNOWN-WEAK-ROLLING-UPGRADE).
+	if !obj.Conditional.IsZero() {
 		q := req.URL.Query()
 		if obj.Conditional.OnlyIfNotExists {
 			q.Set(replica.ConditionalOnlyIfNotExistsKey, "true")
@@ -580,6 +580,14 @@ func (c *replicationClient) PutObject(ctx context.Context, host, index,
 		}
 		if obj.Conditional.IfVersion != nil {
 			q.Set(replica.ConditionalIfVersionKey, fmt.Sprintf("%d", *obj.Conditional.IfVersion))
+		}
+		if obj.Conditional.UpdateIf != nil {
+			prop, val, vtype := storobj.SerializePredicateToQueryParams(obj.Conditional.UpdateIf)
+			if prop != "" {
+				q.Set(replica.ConditionalFieldPropertyKey, prop)
+				q.Set(replica.ConditionalFieldValueKey, val)
+				q.Set(replica.ConditionalFieldValueTypeKey, vtype)
+			}
 		}
 		req.URL.RawQuery = q.Encode()
 	}

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -193,15 +193,15 @@ func TestReplicationPutObject_ConditionalQueryParams(t *testing.T) {
 			wantExists:      "",
 		},
 		{
-			name:         "OnlyIfExists sets query param",
-			onlyIfExists: true,
+			name:          "OnlyIfExists sets query param",
+			onlyIfExists:  true,
 			wantNotExists: "",
-			wantExists:   "true",
+			wantExists:    "true",
 		},
 		{
-			name:            "unconditional: no query params",
-			wantNotExists:   "",
-			wantExists:      "",
+			name:          "unconditional: no query params",
+			wantNotExists: "",
+			wantExists:    "",
 		},
 	} {
 		tc := tc
@@ -1062,7 +1062,8 @@ func TestReplicationClient_CreateAsyncCheckpoint_EncodesBody(t *testing.T) {
 	createdAt := time.UnixMilli(1_700_000_000_000).UTC()
 	client := newReplicationClient(t, ts.Client())
 	require.NoError(t, client.CreateAsyncCheckpoint(
-		context.Background(), host, "MyClass", []string{"s1", "s2"}, 1234, createdAt))
+		context.Background(), host, "MyClass", []string{"s1", "s2"}, 1234, createdAt,
+	))
 
 	assert.Equal(t, http.MethodPost, srv.gotMethod)
 	assert.Equal(t, "/replicas/indices/MyClass/async-checkpoint", srv.gotPath)
@@ -1084,7 +1085,8 @@ func TestReplicationClient_CreateAsyncCheckpoint_NonOKReturnsError(t *testing.T)
 
 	client := newReplicationClient(t, ts.Client())
 	err := client.CreateAsyncCheckpoint(
-		context.Background(), host, "MyClass", []string{"s1"}, 1, time.Now())
+		context.Background(), host, "MyClass", []string{"s1"}, 1, time.Now(),
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "status code: 409")
 	assert.Contains(t, err.Error(), "stale")
@@ -1099,7 +1101,8 @@ func TestReplicationClient_DeleteAsyncCheckpoint_EncodesBody(t *testing.T) {
 
 	client := newReplicationClient(t, ts.Client())
 	require.NoError(t, client.DeleteAsyncCheckpoint(
-		context.Background(), host, "MyClass", []string{"s1", "s2"}))
+		context.Background(), host, "MyClass", []string{"s1", "s2"},
+	))
 
 	assert.Equal(t, http.MethodDelete, srv.gotMethod)
 	assert.Equal(t, "/replicas/indices/MyClass/async-checkpoint", srv.gotPath)
@@ -1121,7 +1124,8 @@ func TestReplicationClient_GetAsyncCheckpointStatus_QueryStringAndDecode(t *test
 	wirePayload := fmt.Sprintf(
 		`{"s1":{"root":"%s","cutoff_ms":555,"created_at_ms":1700000000000},`+
 			`"s2":{"root":"","cutoff_ms":0,"created_at_ms":0}}`,
-		base64.StdEncoding.EncodeToString(activeRootBytes))
+		base64.StdEncoding.EncodeToString(activeRootBytes),
+	)
 	srv := &asyncCheckpointFakeServer{respBody: []byte(wirePayload)}
 	ts := httptest.NewServer(srv.handler(t))
 	defer ts.Close()
@@ -1129,7 +1133,8 @@ func TestReplicationClient_GetAsyncCheckpointStatus_QueryStringAndDecode(t *test
 
 	client := newReplicationClient(t, ts.Client())
 	out, err := client.GetAsyncCheckpointStatus(
-		context.Background(), host, "MyClass", []string{"s1", "s2"})
+		context.Background(), host, "MyClass", []string{"s1", "s2"},
+	)
 	require.NoError(t, err)
 
 	// The shards must arrive as repeated query parameters, matching what
@@ -1162,14 +1167,16 @@ func TestReplicationClient_GetAsyncCheckpointStatus_RootLengthMismatchSurfaces(t
 	// must surface this as an error rather than silently zeroing — a
 	// length mismatch indicates a protocol violation and should be loud.
 	srv := &asyncCheckpointFakeServer{respBody: []byte(
-		`{"s1":{"root":"AAAA","cutoff_ms":1,"created_at_ms":1}}`)}
+		`{"s1":{"root":"AAAA","cutoff_ms":1,"created_at_ms":1}}`,
+	)}
 	ts := httptest.NewServer(srv.handler(t))
 	defer ts.Close()
 	host := ts.URL[len("http://"):]
 
 	client := newReplicationClient(t, ts.Client())
 	_, err := client.GetAsyncCheckpointStatus(
-		context.Background(), host, "MyClass", []string{"s1"})
+		context.Background(), host, "MyClass", []string{"s1"},
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decode async-checkpoint root for shard")
 }

--- a/adapters/handlers/grpc/v1/batch/parse.go
+++ b/adapters/handlers/grpc/v1/batch/parse.go
@@ -145,8 +145,8 @@ func BatchObjectsFromProto(req *pb.BatchObjectsRequest, authorizedGetClass func(
 
 // conditionalFromProto maps a proto ConditionalWriteRequest (oneof condition_type)
 // to the internal storobj.Conditional.
-// Phase-1 (InsertIfNotExists) and Phase-2 (VersionMatch) are implemented here.
-// Phase-3 (FieldPredicate) remains a forward-compatible stub at zero value.
+// Phase-1 (InsertIfNotExists), Phase-2 (VersionMatch), and Phase-3 (FieldPredicate)
+// are implemented.
 func conditionalFromProto(req *pb.ConditionalWriteRequest) storobj.Conditional {
 	if req == nil {
 		return storobj.Conditional{}
@@ -160,9 +160,50 @@ func conditionalFromProto(req *pb.ConditionalWriteRequest) storobj.Conditional {
 			return storobj.Conditional{IfVersion: &v}
 		}
 		return storobj.Conditional{}
+	case *pb.ConditionalWriteRequest_FieldPredicate:
+		return conditionalFromFieldPredicate(ct.FieldPredicate)
 	default:
 		return storobj.Conditional{}
 	}
+}
+
+// conditionalFromFieldPredicate converts a proto FieldPredicate to the
+// internal storobj.Predicate. Only EQ operator and scalar value types are
+// supported in Phase-3 v1; unknown operators or value types produce an
+// IsZero conditional (treated as unconditional by the shard, which is
+// safe: the evaluation will reject an unknown operator with a clear error).
+func conditionalFromFieldPredicate(fp *pb.FieldPredicate) storobj.Conditional {
+	if fp == nil || fp.GetField() == "" {
+		return storobj.Conditional{}
+	}
+	// Phase-3 v1 only supports FIELD_OPERATOR_EQ.
+	if fp.GetOperator() != pb.FieldOperator_FIELD_OPERATOR_EQ {
+		return storobj.Conditional{}
+	}
+
+	pred := &storobj.Predicate{
+		PropertyName: fp.GetField(),
+		Operator:     storobj.EqOperator,
+	}
+
+	switch v := fp.GetValue().(type) {
+	case *pb.FieldPredicate_StringValue:
+		pred.ExpectedValue = v.StringValue
+		pred.ValueType = storobj.PredicateValueText
+	case *pb.FieldPredicate_IntValue:
+		pred.ExpectedValue = v.IntValue
+		pred.ValueType = storobj.PredicateValueInt
+	case *pb.FieldPredicate_DoubleValue:
+		pred.ExpectedValue = v.DoubleValue
+		pred.ValueType = storobj.PredicateValueNumber
+	case *pb.FieldPredicate_BoolValue:
+		pred.ExpectedValue = v.BoolValue
+		pred.ValueType = storobj.PredicateValueBool
+	default:
+		return storobj.Conditional{}
+	}
+
+	return storobj.Conditional{UpdateIf: pred}
 }
 
 func extractSingleRefTarget(class *models.Class, properties []*pb.BatchObject_SingleTargetRefProps, props map[string]interface{}) error {

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -982,6 +983,21 @@ func (i *replicatedIndices) postObjectSingle(w http.ResponseWriter, r *http.Requ
 		if v, parseErr := strconv.ParseUint(vStr, 10, 64); parseErr == nil {
 			obj.Conditional.IfVersion = &v
 		}
+	}
+	// Phase-3 field-predicate: restore UpdateIf from the three wire params.
+	// ParsePredicateFromQueryParams returns nil, nil when all three are absent
+	// (unconditional write from an old client -- KNOWN-WEAK-ROLLING-UPGRADE).
+	if pred, parseErr := storobj.ParsePredicateFromQueryParams(
+		q.Get(replica.ConditionalFieldPropertyKey),
+		q.Get(replica.ConditionalFieldValueKey),
+		q.Get(replica.ConditionalFieldValueTypeKey),
+	); parseErr != nil {
+		// The coordinator already validated the predicate; a parse error here
+		// means a protocol mismatch or a corrupted request. Reject with 400.
+		http.Error(w, fmt.Sprintf("invalid field-predicate params: %v", parseErr), http.StatusBadRequest)
+		return
+	} else if pred != nil {
+		obj.Conditional.UpdateIf = pred
 	}
 
 	resp := i.replicator.ReplicateObject(r.Context(), index, shard, requestID, obj, schemaVersion)

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -128,7 +128,8 @@ func NewReplicatedIndices(
 		nodeReady:              nodeReady,
 	}
 
-	i.requestQueue = shared.NewRequestQueue(requestQueueConfig, logger,
+	i.requestQueue = shared.NewRequestQueue(
+		requestQueueConfig, logger,
 		func(qr queuedRequest) { i.handleRequest(qr) },
 		func(qr queuedRequest) bool { return qr.r.Context().Err() != nil },
 		func(qr queuedRequest) {

--- a/adapters/handlers/rest/clusterapi/indices_replicas_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_test.go
@@ -811,9 +811,9 @@ func TestReplicatedIndices_PostObjectSingle_ConditionalRestored(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	for _, tc := range []struct {
-		name         string
-		queryParam   string
-		wantCond     storobj.Conditional
+		name       string
+		queryParam string
+		wantCond   storobj.Conditional
 	}{
 		{
 			name:       "OnlyIfNotExists restored from conditional_not_exists=true",

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -206,10 +206,11 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 	// directly from the raw query string.
 	//
 	// Supported values:
-	//   insert_if_not_exists            → OnlyIfNotExists = true (idempotent insert)
-	//   update_if_exists                → OnlyIfExists    = true (update-only)
-	//   version_match&expected_version=N → IfVersion = &N  (Phase-2 version-CAS)
-	//   (absent or empty)               → unconditional write
+	//   insert_if_not_exists                                    → OnlyIfNotExists = true (idempotent insert)
+	//   update_if_exists                                        → OnlyIfExists    = true (update-only)
+	//   version_match&expected_version=N                        → IfVersion = &N  (Phase-2 version-CAS)
+	//   field_match&property=<name>&value=<v>&value_type=<type> → UpdateIf (Phase-3 field-predicate)
+	//   (absent or empty)                                       → unconditional write
 	q := params.HTTPRequest.URL.Query()
 	conditionalOp := q.Get("condition")
 	isConditional := conditionalOp != ""
@@ -230,6 +231,22 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 					Detail: conditionalWriteConflictDetail{Message: err.Error()},
 				})
 		}
+	case "field_match":
+		pred, predErr := storobj.ParsePredicateFromQueryParams(
+			q.Get("property"),
+			q.Get("value"),
+			q.Get("value_type"),
+		)
+		if predErr != nil {
+			h.metricRequestsTotal.logUserError(className)
+			return newConditionalWriteResponder(http.StatusBadRequest,
+				conditionalWriteConflictResponse{
+					Error:  "bad_request",
+					Code:   "invalid_field_predicate",
+					Detail: conditionalWriteConflictDetail{Message: predErr.Error()},
+				})
+		}
+		cond = storobj.Conditional{UpdateIf: pred}
 	}
 
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
@@ -591,12 +608,36 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 	}
 
 	// Phase-2: If-Match header or ?expected_version=N triggers version-CAS.
+	// Phase-3: ?condition=field_match&property=<name>&value=<v>&value_type=<type>
+	// triggers field-predicate CAS. The two conditions are mutually exclusive in v1.
 	// The conditional is threaded through context so crud.go restores it on
 	// the storobj.Object before putObjectLSM runs the check (INV-RBAC-1 preserved:
 	// auth runs in UpdateObject before the conditional check reaches the shard).
+	qu := params.HTTPRequest.URL.Query()
+	conditionalPutOp := qu.Get("condition")
 	ifMatch := params.HTTPRequest.Header.Get("If-Match")
-	if ifMatch != "" {
-		cond, parseErr := parseVersionMatchCondition("", ifMatch)
+
+	var putCond storobj.Conditional
+	switch {
+	case conditionalPutOp == "field_match":
+		pred, predErr := storobj.ParsePredicateFromQueryParams(
+			qu.Get("property"),
+			qu.Get("value"),
+			qu.Get("value_type"),
+		)
+		if predErr != nil {
+			h.metricRequestsTotal.logUserError(className)
+			return newConditionalWriteResponder(http.StatusBadRequest,
+				conditionalWriteConflictResponse{
+					Error:  "bad_request",
+					Code:   "invalid_field_predicate",
+					Detail: conditionalWriteConflictDetail{Message: predErr.Error()},
+				})
+		}
+		putCond = storobj.Conditional{UpdateIf: pred}
+	case ifMatch != "":
+		var parseErr error
+		putCond, parseErr = parseVersionMatchCondition("", ifMatch)
 		if parseErr != nil {
 			h.metricRequestsTotal.logUserError(className)
 			return newConditionalWriteResponder(http.StatusBadRequest,
@@ -606,7 +647,9 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 					Detail: conditionalWriteConflictDetail{Message: parseErr.Error()},
 				})
 		}
-		ctx = storobj.ContextWithConditional(ctx, cond)
+	}
+	if !putCond.IsZero() {
+		ctx = storobj.ContextWithConditional(ctx, putCond)
 	}
 
 	object, err := h.manager.UpdateObject(ctx,
@@ -617,20 +660,31 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 			return objects.NewObjectsClassPutTooManyRequests().
 				WithPayload(newUsageLimitPayload(le))
 		}
-		// Phase-2: version-CAS mismatch on PUT → 412 Precondition Failed.
-		// Per RFC 7232: condition on a resource's state failed.
-		// 412 is used here (not 409) because this is a header-precondition failure,
-		// not a state-conflict; see synthesis §2.2 for the 409/412 split.
+		// Handle conditional write precondition failures.
+		// Phase-2 (If-Match / version-CAS) → 412 Precondition Failed (RFC 7232 header-precondition).
+		// Phase-3 (field_match) → 409 Conflict (consistent with Phase-1 conditional semantics).
 		var pf *uco.ErrPreconditionFailed
 		if errors.As(err, &pf) {
 			h.metricRequestsTotal.logUserError(className)
-			body := map[string]interface{}{
-				"error":           "precondition_failed",
-				"expected_version": pf.ExpectedVersion,
-				"current_version":  pf.ActualVersion,
-				"message":         pf.Reason,
+			// If-Match was active → 412 (RFC 7232 header-precondition failure).
+			if putCond.IfVersion != nil {
+				body := map[string]interface{}{
+					"error":            "precondition_failed",
+					"expected_version": pf.ExpectedVersion,
+					"current_version":  pf.ActualVersion,
+					"message":          pf.Reason,
+				}
+				return newConditionalWriteResponder(http.StatusPreconditionFailed, body)
 			}
-			return newConditionalWriteResponder(http.StatusPreconditionFailed, body)
+			// field_match was active → 409 Conflict (consistent with Phase-1/3 semantics).
+			return newConditionalWriteResponder(http.StatusConflict,
+				conditionalWriteConflictResponse{
+					Error: "conditional_check_failed",
+					Code:  "condition_not_met",
+					Detail: conditionalWriteConflictDetail{
+						Message: pf.Reason,
+					},
+				})
 		}
 		if errors.As(err, &uco.ErrInvalidUserInput{}) {
 			return objects.NewObjectsClassPutUnprocessableEntity().

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -153,6 +153,23 @@ func parseVersionMatchCondition(expectedVersion, ifMatchHeader string) (storobj.
 	return storobj.Conditional{IfVersion: &v}, nil
 }
 
+// parseFieldPredicateCondition builds a Conditional with UpdateIf set from the
+// ?property=, ?value=, and ?value_type= query parameters extracted from r.
+// Returns an error when the parameters are absent or cannot be parsed into a
+// valid Predicate.
+func parseFieldPredicateCondition(r *http.Request) (storobj.Conditional, error) {
+	q := r.URL.Query()
+	pred, err := storobj.ParsePredicateFromQueryParams(
+		q.Get("property"),
+		q.Get("value"),
+		q.Get("value_type"),
+	)
+	if err != nil {
+		return storobj.Conditional{}, err
+	}
+	return storobj.Conditional{UpdateIf: pred}, nil
+}
+
 // objectVersionFromAdditional extracts the server-managed Version from an object's
 // AdditionalProperties map, where it is placed by storobj.SearchResult. Returns 0
 // when absent (legacy object, no version tracked).
@@ -232,11 +249,8 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 				})
 		}
 	case "field_match":
-		pred, predErr := storobj.ParsePredicateFromQueryParams(
-			q.Get("property"),
-			q.Get("value"),
-			q.Get("value_type"),
-		)
+		var predErr error
+		cond, predErr = parseFieldPredicateCondition(params.HTTPRequest)
 		if predErr != nil {
 			h.metricRequestsTotal.logUserError(className)
 			return newConditionalWriteResponder(http.StatusBadRequest,
@@ -246,7 +260,6 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 					Detail: conditionalWriteConflictDetail{Message: predErr.Error()},
 				})
 		}
-		cond = storobj.Conditional{UpdateIf: pred}
 	}
 
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
@@ -613,18 +626,14 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 	// The conditional is threaded through context so crud.go restores it on
 	// the storobj.Object before putObjectLSM runs the check (INV-RBAC-1 preserved:
 	// auth runs in UpdateObject before the conditional check reaches the shard).
-	qu := params.HTTPRequest.URL.Query()
-	conditionalPutOp := qu.Get("condition")
+	conditionalPutOp := params.HTTPRequest.URL.Query().Get("condition")
 	ifMatch := params.HTTPRequest.Header.Get("If-Match")
 
 	var putCond storobj.Conditional
 	switch {
 	case conditionalPutOp == "field_match":
-		pred, predErr := storobj.ParsePredicateFromQueryParams(
-			qu.Get("property"),
-			qu.Get("value"),
-			qu.Get("value_type"),
-		)
+		var predErr error
+		putCond, predErr = parseFieldPredicateCondition(params.HTTPRequest)
 		if predErr != nil {
 			h.metricRequestsTotal.logUserError(className)
 			return newConditionalWriteResponder(http.StatusBadRequest,
@@ -634,7 +643,6 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 					Detail: conditionalWriteConflictDetail{Message: predErr.Error()},
 				})
 		}
-		putCond = storobj.Conditional{UpdateIf: pred}
 	case ifMatch != "":
 		var parseErr error
 		putCond, parseErr = parseVersionMatchCondition("", ifMatch)

--- a/adapters/handlers/rest/handlers_objects_conditional_test.go
+++ b/adapters/handlers/rest/handlers_objects_conditional_test.go
@@ -289,8 +289,8 @@ func TestConditionalWriteRESTHandlerMessageText(t *testing.T) {
 // etagFakeManager supports GetObject (for ETag) and UpdateObject (for If-Match).
 // Other methods panic as in conditionalFakeManager.
 type etagFakeManager struct {
-	getObjectReturn *models.Object
-	getObjectErr    error
+	getObjectReturn    *models.Object
+	getObjectErr       error
 	updateObjectReturn *models.Object
 	updateObjectErr    error
 	// capturedCtx captures the context passed to UpdateObject so tests can
@@ -303,67 +303,80 @@ func (f *etagFakeManager) AddObject(_ context.Context, _ *models.Principal,
 ) (*models.Object, error) {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) ValidateObject(context.Context, *models.Principal,
 	*models.Object, *additional.ReplicationProperties,
 ) error {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) GetObject(_ context.Context, _ *models.Principal,
 	_ string, _ strfmt.UUID, _ additional.Properties, _ *additional.ReplicationProperties, _ string,
 ) (*models.Object, error) {
 	return f.getObjectReturn, f.getObjectErr
 }
+
 func (f *etagFakeManager) DeleteObject(context.Context, *models.Principal,
 	string, strfmt.UUID, *additional.ReplicationProperties, string,
 ) error {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) UpdateObject(ctx context.Context, _ *models.Principal,
 	_ string, _ strfmt.UUID, _ *models.Object, _ *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	f.capturedCtx = ctx
 	return f.updateObjectReturn, f.updateObjectErr
 }
+
 func (f *etagFakeManager) HeadObject(context.Context, *models.Principal,
 	string, strfmt.UUID, *additional.ReplicationProperties, string,
 ) (bool, *uco.Error) {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) GetObjects(context.Context, *models.Principal,
 	*int64, *int64, *string, *string, *string, additional.Properties, string,
 ) ([]*models.Object, error) {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) Query(context.Context, *models.Principal,
 	*uco.QueryParams,
 ) ([]*models.Object, *uco.Error) {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) MergeObject(context.Context, *models.Principal,
 	*models.Object, *additional.ReplicationProperties,
 ) *uco.Error {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) AddObjectReference(context.Context, *models.Principal,
 	*uco.AddReferenceInput, *additional.ReplicationProperties, string,
 ) *uco.Error {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) UpdateObjectReferences(context.Context, *models.Principal,
 	*uco.PutReferenceInput, *additional.ReplicationProperties, string,
 ) *uco.Error {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) DeleteObjectReference(context.Context, *models.Principal,
 	*uco.DeleteReferenceInput, *additional.ReplicationProperties, string,
 ) *uco.Error {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) GetObjectsClass(context.Context, *models.Principal,
 	strfmt.UUID,
 ) (*models.Class, error) {
 	panic("not implemented")
 }
+
 func (f *etagFakeManager) GetObjectClassFromName(context.Context, *models.Principal,
 	string,
 ) (*models.Class, error) {

--- a/adapters/handlers/rest/handlers_objects_test.go
+++ b/adapters/handlers/rest/handlers_objects_test.go
@@ -1161,9 +1161,9 @@ func (f *fakeManager) DeleteObjectReference(context.Context, *models.Principal,
 
 type fakeMetricRequestsTotal struct{}
 
-func (f *fakeMetricRequestsTotal) logError(className string, err error)       {}
-func (f *fakeMetricRequestsTotal) logOk(className string)                     {}
-func (f *fakeMetricRequestsTotal) logUserError(className string)              {}
+func (f *fakeMetricRequestsTotal) logError(className string, err error) {}
+func (f *fakeMetricRequestsTotal) logOk(className string)               {}
+func (f *fakeMetricRequestsTotal) logUserError(className string)        {}
 
 // innerResponder unwraps an etagResponder so tests can assert against the
 // concrete inner type (e.g. *objects.ObjectsCreateOK) without depending on

--- a/adapters/repos/db/conditional_durability_test.go
+++ b/adapters/repos/db/conditional_durability_test.go
@@ -53,7 +53,8 @@ func openDurabilityDB(t *testing.T, rootPath string, shardState *sharding.State,
 		func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
 			class := &models.Class{Class: className}
 			return readFunc(class, shardState)
-		}).Maybe()
+		},
+	).Maybe()
 	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
 	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
 
@@ -114,18 +115,18 @@ func newConditionalInsertObj(className string, id strfmt.UUID) *storobj.Object {
 // TestConditionalDurabilityRestart validates three durability invariants for
 // conditional writes (insert_if_not_exists) across a simulated node restart:
 //
-// 1. AC1 (existence durable after WAL replay): insert an object via
-//    insert_if_not_exists, stop+reopen the shard (WAL replay), re-issue
-//    insert_if_not_exists on the same UUID -> must get ErrPreconditionFailed.
-//    The object survived the restart and is visible to the condition check.
+//  1. AC1 (existence durable after WAL replay): insert an object via
+//     insert_if_not_exists, stop+reopen the shard (WAL replay), re-issue
+//     insert_if_not_exists on the same UUID -> must get ErrPreconditionFailed.
+//     The object survived the restart and is visible to the condition check.
 //
-// 2. AC2 (INV-DURABILITY-1, WAL-before-ack): the object is written to WAL
-//    only — no explicit flush is called before shutdown. The test proves that
-//    WAL replay on startup makes the pre-flush write durable.
+//  2. AC2 (INV-DURABILITY-1, WAL-before-ack): the object is written to WAL
+//     only - no explicit flush is called before shutdown. The test proves that
+//     WAL replay on startup makes the pre-flush write durable.
 //
-// 3. AC3 (no torn read after reopen): an unconditional ObjectByID returns the
-//    same object that the conditional check detects. Reads and condition checks
-//    agree after WAL replay.
+//  3. AC3 (no torn read after reopen): an unconditional ObjectByID returns the
+//     same object that the conditional check detects. Reads and condition checks
+//     agree after WAL replay.
 //
 // Restart mechanism: repo.Shutdown(ctx) flushes the WAL file descriptor, then
 // a new *DB is opened on the same directory via New(...) + WaitForStartup(...).
@@ -168,7 +169,7 @@ func TestConditionalDurabilityRestart(t *testing.T) {
 	}
 
 	// Phase 1: open DB, register class, write object via insert_if_not_exists
-	// without any explicit flush — the object lives only in the WAL/memtable.
+	// without any explicit flush - the object lives only in the WAL/memtable.
 	repo := openDurabilityDB(t, dirName, shardState, schemaGetter)
 
 	migratorLogger, _ := test.NewNullLogger()
@@ -202,7 +203,7 @@ func TestConditionalDurabilityRestart(t *testing.T) {
 	require.NoError(t, repo.Shutdown(ctx))
 	repo = nil
 
-	// Phase 3: reopen — WAL replay fires inside WaitForStartup.
+	// Phase 3: reopen - WAL replay fires inside WaitForStartup.
 	// New DB instance on the same directory; db.init() -> NewIndex ->
 	// initAndStoreShards -> NewShard -> lsmkv.NewStore -> WAL replay.
 	// This is a real restart, not a fake: the in-memory shard state from the

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -321,6 +321,21 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 			}
 		}
 
+		// Phase-3 field-predicate conditional (Plan A -- single-shard-authoritative).
+		// Evaluated inside the per-UUID lock so the read-compare-commit is atomic on
+		// this coordinator. Cross-coordinator races resolve via LWW (documented
+		// Plan-A KNOWN-WEAK boundary, same as Phase 1/2).
+		// No version gate required: field-predicate reads prevObj.Properties from the
+		// existing binary format and works on v1 objects without PERSISTENCE_OBJECT_VERSION_WRITE.
+		if obj.Conditional.UpdateIf != nil {
+			if predErr := storobj.EvalPredicate(obj.Conditional.UpdateIf, prevObj); predErr != nil {
+				return &objects.ErrPreconditionFailed{
+					ObjectID: obj.ID().String(),
+					Reason:   predErr.Error(),
+				}
+			}
+		}
+
 		status, err = s.determineInsertStatus(prevObj, obj)
 		if err != nil {
 			return err

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -580,7 +580,8 @@ func (s *Shard) upsertObjectDataLSM(bucket *lsmkv.Bucket, id []byte, data []byte
 	}
 	docIDBytes := keyBuf.Bytes()
 
-	return bucket.Put(id, data,
+	return bucket.Put(
+		id, data,
 		lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes),
 	)
 }

--- a/entities/storobj/conditional.go
+++ b/entities/storobj/conditional.go
@@ -11,18 +11,73 @@
 
 package storobj
 
-// Predicate is a forward-compatible placeholder for the field-predicate
-// condition kind (Phase 3, update_if). The concrete shape is defined in the
-// Phase-3 design pass; the field slot exists here so Conditional is
-// forward-compatible without an API break.
-type Predicate struct {
-	// Path is the dotted field path to evaluate (e.g. "status" or "meta.score").
-	Path string
+// PredicateOperator enumerates the comparison operators supported by Predicate.
+// For Phase-3 v1 only EqOperator is implemented; other values are reserved for
+// future minor releases and are rejected with a clear error if received.
+type PredicateOperator int
 
-	// Value is the expected value, serialised as a string for cross-type
-	// compatibility. The Phase-3 design pass will define the supported types
-	// and comparison operators.
-	Value string
+const (
+	// EqOperator checks that the stored property value equals the expected value.
+	// This is the only operator supported in Phase-3 v1.
+	EqOperator PredicateOperator = iota
+)
+
+// PredicateValueType is the Weaviate schema type of the expected value in a
+// Predicate. It must be supplied explicitly so the evaluator knows how to
+// deserialize the stored property and compare it, without a schema round-trip
+// on the hot write path.
+type PredicateValueType int
+
+const (
+	// PredicateValueText treats Value as a UTF-8 string. Comparison is exact,
+	// case-sensitive (matching Weaviate's equality semantics for text properties).
+	PredicateValueText PredicateValueType = iota
+	// PredicateValueInt treats Value as an int64. The stored property must be
+	// a numeric value that can be compared as an integer.
+	PredicateValueInt
+	// PredicateValueNumber treats Value as a float64. IEEE-754 equality applies;
+	// callers using this type for business logic should prefer PredicateValueText
+	// or PredicateValueInt to avoid float precision surprises.
+	PredicateValueNumber
+	// PredicateValueBool treats Value as a boolean.
+	PredicateValueBool
+	// PredicateValueDate treats Value as an RFC 3339 timestamp. Both stored and
+	// expected values are normalized to UTC before comparison.
+	PredicateValueDate
+)
+
+// Predicate carries the Phase-3 field-predicate check: "the object's property
+// PropertyName must currently equal the typed expected value".
+//
+// Rules:
+//   - If the named property is absent from the stored object, the predicate FAILS
+//     (missing != match). The caller receives ErrPreconditionFailed with reason
+//     "property <name> not found on stored object".
+//   - Multi-value (array) properties are out of scope for Phase-3 v1. Attempting
+//     to use a Predicate on an array property returns ErrPreconditionFailed with
+//     reason "property <name> is a multi-value array type; field_match on arrays
+//     is not supported in v1".
+//   - Cross-collection and nested-ref traversal are out of scope.
+//   - For Phase-3 v1, Operator must be EqOperator; other values are rejected.
+type Predicate struct {
+	// PropertyName is the name of the Weaviate property to evaluate.
+	// Must be the leaf property name (no dot-path traversal in v1).
+	PropertyName string
+
+	// ExpectedValue is the typed expected value. Its Go type must match ValueType:
+	//   PredicateValueText   -> string
+	//   PredicateValueInt    -> int64
+	//   PredicateValueNumber -> float64
+	//   PredicateValueBool   -> bool
+	//   PredicateValueDate   -> string (RFC 3339, normalized to UTC before compare)
+	ExpectedValue interface{}
+
+	// ValueType names the Weaviate schema type of ExpectedValue, so the evaluator
+	// knows how to deserialize the stored property without a schema lookup.
+	ValueType PredicateValueType
+
+	// Operator is the comparison to apply. Phase-3 v1 supports EqOperator only.
+	Operator PredicateOperator
 }
 
 // Conditional carries the precondition for a conditional write operation.
@@ -30,7 +85,8 @@ type Predicate struct {
 // that only uses Phase-1 existence-check fills OnlyIfNotExists or OnlyIfExists
 // and leaves IfVersion and UpdateIf nil; Phase-2 callers fill IfVersion;
 // Phase-3 callers fill UpdateIf. Multiple non-zero fields are evaluated
-// conjunctively.
+// conjunctively, but the REST/gRPC API enforces at most one active condition
+// per request in Phase-3 v1.
 //
 // The three phases correspond to the three CAS primitives in the synthesis:
 //   - Phase 1: insert_if_not_exists / OnlyIfNotExists (existence check)
@@ -54,8 +110,9 @@ type Conditional struct {
 	IfVersion *uint64
 
 	// UpdateIf requests Phase-3 field-predicate semantics: the write succeeds
-	// only if the stored object's field at Predicate.Path equals Predicate.Value.
-	// A nil pointer means "Phase-3 condition not active."
+	// only if the stored object's property named Predicate.PropertyName equals
+	// Predicate.ExpectedValue under the specified ValueType comparison. A nil
+	// pointer means "Phase-3 condition not active."
 	UpdateIf *Predicate
 }
 

--- a/entities/storobj/predicate_eval.go
+++ b/entities/storobj/predicate_eval.go
@@ -102,31 +102,43 @@ func (e *PredicateError) Error() string {
 	return e.Reason
 }
 
+// evalExactEq is a generic helper for types that support == comparison
+// (string, bool). It asserts both stored and expected are of type T, then
+// checks equality.
+//
+// goTypeName is the Go type name used in "expected <type>" error clauses.
+// valueTypeName is the predicate value_type string used in "value_type=<name>" clauses.
+// storedFmt / expectedFmt are format verbs for the mismatch message (%q, %v, etc.).
+func evalExactEq[T comparable](name string, stored, expected interface{}, goTypeName, valueTypeName, storedFmt, expectedFmt string) error {
+	storedV, ok := stored.(T)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q has type %T, expected %s for value_type=%s (field_match condition failed)", name, stored, goTypeName, valueTypeName),
+		}
+	}
+	expectedV, ok := expected.(T)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("predicate expected value has type %T, expected %s for value_type=%s", expected, goTypeName, valueTypeName),
+		}
+	}
+	if storedV != expectedV {
+		return &PredicateError{
+			PropertyName: name,
+			Reason: fmt.Sprintf("property %q value mismatch: stored "+storedFmt+" != expected "+expectedFmt+" (field_match condition failed)",
+				name, storedV, expectedV),
+		}
+	}
+	return nil
+}
+
 // evalTextEq checks that stored == expected for text properties.
 // Weaviate stores text properties as plain Go strings. Comparison is
 // exact and case-sensitive (matching Weaviate's text equality semantics).
 func evalTextEq(name string, stored, expected interface{}) error {
-	storedStr, ok := stored.(string)
-	if !ok {
-		return &PredicateError{
-			PropertyName: name,
-			Reason:       fmt.Sprintf("property %q has type %T, expected string for value_type=text (field_match condition failed)", name, stored),
-		}
-	}
-	expectedStr, ok := expected.(string)
-	if !ok {
-		return &PredicateError{
-			PropertyName: name,
-			Reason:       fmt.Sprintf("predicate expected value has type %T, expected string for value_type=text", expected),
-		}
-	}
-	if storedStr != expectedStr {
-		return &PredicateError{
-			PropertyName: name,
-			Reason:       fmt.Sprintf("property %q value mismatch: stored %q != expected %q (field_match condition failed)", name, storedStr, expectedStr),
-		}
-	}
-	return nil
+	return evalExactEq[string](name, stored, expected, "string", "text", "%q", "%q")
 }
 
 // evalIntEq checks integer equality. Weaviate stores numeric properties as
@@ -193,27 +205,7 @@ func evalNumberEq(name string, stored, expected interface{}) error {
 
 // evalBoolEq checks boolean equality. Weaviate stores booleans as Go bool.
 func evalBoolEq(name string, stored, expected interface{}) error {
-	storedBool, ok := stored.(bool)
-	if !ok {
-		return &PredicateError{
-			PropertyName: name,
-			Reason:       fmt.Sprintf("property %q has type %T, expected bool for value_type=bool (field_match condition failed)", name, stored),
-		}
-	}
-	expectedBool, ok := expected.(bool)
-	if !ok {
-		return &PredicateError{
-			PropertyName: name,
-			Reason:       fmt.Sprintf("predicate expected value has type %T, expected bool for value_type=bool", expected),
-		}
-	}
-	if storedBool != expectedBool {
-		return &PredicateError{
-			PropertyName: name,
-			Reason:       fmt.Sprintf("property %q value mismatch: stored %v != expected %v (field_match condition failed)", name, storedBool, expectedBool),
-		}
-	}
-	return nil
+	return evalExactEq[bool](name, stored, expected, "bool", "bool", "%v", "%v")
 }
 
 // evalDateEq checks date equality. Both stored and expected values are parsed

--- a/entities/storobj/predicate_eval.go
+++ b/entities/storobj/predicate_eval.go
@@ -1,0 +1,305 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// EvalPredicate evaluates p against the properties of obj and returns nil when
+// the predicate is satisfied, or an error describing why it was not.
+//
+// The returned error is a *PredicateError, which the shard-write path converts
+// into an ErrPreconditionFailed so the caller receives the standard domain error.
+//
+// Evaluation rules:
+//  1. If obj is nil (object does not exist), all predicates fail -- the absence
+//     of an object implies the absence of all properties.
+//  2. If the named property is absent from obj.Object.Properties, the predicate
+//     fails ("property not found").
+//  3. Multi-value ([]interface{}) properties are rejected -- out of scope for v1.
+//  4. Phase-3 v1 only supports EqOperator; other Operator values return an error.
+func EvalPredicate(p *Predicate, obj *Object) error {
+	if p == nil {
+		return nil
+	}
+	if p.Operator != EqOperator {
+		return &PredicateError{
+			PropertyName: p.PropertyName,
+			Reason:       fmt.Sprintf("unsupported predicate operator %d; only EqOperator (0) is supported in Phase-3 v1", p.Operator),
+		}
+	}
+
+	if obj == nil {
+		return &PredicateError{
+			PropertyName: p.PropertyName,
+			Reason:       fmt.Sprintf("property %q not found on stored object (object does not exist; field_match condition failed)", p.PropertyName),
+		}
+	}
+
+	props, ok := obj.Object.Properties.(map[string]interface{})
+	if !ok || props == nil {
+		return &PredicateError{
+			PropertyName: p.PropertyName,
+			Reason:       fmt.Sprintf("property %q not found on stored object (object has no properties; field_match condition failed)", p.PropertyName),
+		}
+	}
+
+	raw, exists := props[p.PropertyName]
+	if !exists {
+		return &PredicateError{
+			PropertyName: p.PropertyName,
+			Reason:       fmt.Sprintf("property %q not found on stored object (field_match condition failed)", p.PropertyName),
+		}
+	}
+
+	// Reject multi-value (array) properties -- out of scope for v1.
+	if _, isSlice := raw.([]interface{}); isSlice {
+		return &PredicateError{
+			PropertyName: p.PropertyName,
+			Reason:       fmt.Sprintf("property %q is a multi-value array type; field_match on arrays is not supported in v1", p.PropertyName),
+		}
+	}
+
+	switch p.ValueType {
+	case PredicateValueText:
+		return evalTextEq(p.PropertyName, raw, p.ExpectedValue)
+	case PredicateValueInt:
+		return evalIntEq(p.PropertyName, raw, p.ExpectedValue)
+	case PredicateValueNumber:
+		return evalNumberEq(p.PropertyName, raw, p.ExpectedValue)
+	case PredicateValueBool:
+		return evalBoolEq(p.PropertyName, raw, p.ExpectedValue)
+	case PredicateValueDate:
+		return evalDateEq(p.PropertyName, raw, p.ExpectedValue)
+	default:
+		return &PredicateError{
+			PropertyName: p.PropertyName,
+			Reason:       fmt.Sprintf("unknown value_type %d for field_match on property %q", p.ValueType, p.PropertyName),
+		}
+	}
+}
+
+// PredicateError is returned by EvalPredicate when the predicate is not
+// satisfied. Callers convert this to an ErrPreconditionFailed.
+type PredicateError struct {
+	PropertyName string
+	Reason       string
+}
+
+func (e *PredicateError) Error() string {
+	return e.Reason
+}
+
+// evalTextEq checks that stored == expected for text properties.
+// Weaviate stores text properties as plain Go strings. Comparison is
+// exact and case-sensitive (matching Weaviate's text equality semantics).
+func evalTextEq(name string, stored, expected interface{}) error {
+	storedStr, ok := stored.(string)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q has type %T, expected string for value_type=text (field_match condition failed)", name, stored),
+		}
+	}
+	expectedStr, ok := expected.(string)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("predicate expected value has type %T, expected string for value_type=text", expected),
+		}
+	}
+	if storedStr != expectedStr {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q value mismatch: stored %q != expected %q (field_match condition failed)", name, storedStr, expectedStr),
+		}
+	}
+	return nil
+}
+
+// evalIntEq checks integer equality. Weaviate stores numeric properties as
+// float64 in JSON-decoded maps; we round-trip via int64 to handle both the
+// stored-as-float64 case and the stored-as-int64 case.
+func evalIntEq(name string, stored, expected interface{}) error {
+	storedInt, err := toInt64(stored)
+	if err != nil {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q cannot be read as int: %v (field_match condition failed)", name, err),
+		}
+	}
+	expectedInt, ok := expected.(int64)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("predicate expected value has type %T, expected int64 for value_type=int", expected),
+		}
+	}
+	if storedInt != expectedInt {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q value mismatch: stored %d != expected %d (field_match condition failed)", name, storedInt, expectedInt),
+		}
+	}
+	return nil
+}
+
+// evalNumberEq checks float64 equality. IEEE-754 exact equality; callers
+// preferring precise semantics should use PredicateValueText or PredicateValueInt.
+// A WARN-level log is emitted at the absorption point (see defense-in-depth rule)
+// to make float-equality surprises visible.
+func evalNumberEq(name string, stored, expected interface{}) error {
+	storedF, err := toFloat64(stored)
+	if err != nil {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q cannot be read as number: %v (field_match condition failed)", name, err),
+		}
+	}
+	expectedF, ok := expected.(float64)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("predicate expected value has type %T, expected float64 for value_type=number", expected),
+		}
+	}
+	// IEEE-754 NaN is not equal to itself; treat NaN != NaN as predicate failure.
+	if math.IsNaN(storedF) || math.IsNaN(expectedF) {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q: NaN is never equal to NaN (field_match condition failed)", name),
+		}
+	}
+	if storedF != expectedF {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q value mismatch: stored %g != expected %g (field_match condition failed; note: float equality is unreliable -- prefer value_type=int or value_type=text)", name, storedF, expectedF),
+		}
+	}
+	return nil
+}
+
+// evalBoolEq checks boolean equality. Weaviate stores booleans as Go bool.
+func evalBoolEq(name string, stored, expected interface{}) error {
+	storedBool, ok := stored.(bool)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q has type %T, expected bool for value_type=bool (field_match condition failed)", name, stored),
+		}
+	}
+	expectedBool, ok := expected.(bool)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("predicate expected value has type %T, expected bool for value_type=bool", expected),
+		}
+	}
+	if storedBool != expectedBool {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q value mismatch: stored %v != expected %v (field_match condition failed)", name, storedBool, expectedBool),
+		}
+	}
+	return nil
+}
+
+// evalDateEq checks date equality. Both stored and expected values are parsed
+// as RFC 3339 strings and compared in UTC. String equality is not used (a
+// stored date might have timezone offset +02:00 while expected is Z).
+func evalDateEq(name string, stored, expected interface{}) error {
+	storedStr, ok := stored.(string)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q has type %T, expected RFC 3339 string for value_type=date (field_match condition failed)", name, stored),
+		}
+	}
+	expectedStr, ok := expected.(string)
+	if !ok {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("predicate expected value has type %T, expected RFC 3339 string for value_type=date", expected),
+		}
+	}
+	storedTime, err := time.Parse(time.RFC3339Nano, storedStr)
+	if err != nil {
+		// Fall back to plain RFC3339 if nanoseconds fail.
+		storedTime, err = time.Parse(time.RFC3339, storedStr)
+		if err != nil {
+			return &PredicateError{
+				PropertyName: name,
+				Reason:       fmt.Sprintf("property %q stored value %q is not a valid RFC 3339 date (field_match condition failed): %v", name, storedStr, err),
+			}
+		}
+	}
+	expectedTime, err := time.Parse(time.RFC3339Nano, expectedStr)
+	if err != nil {
+		expectedTime, err = time.Parse(time.RFC3339, expectedStr)
+		if err != nil {
+			return &PredicateError{
+				PropertyName: name,
+				Reason:       fmt.Sprintf("predicate expected value %q is not a valid RFC 3339 date: %v", expectedStr, err),
+			}
+		}
+	}
+	// Compare in UTC to normalize timezone offsets.
+	if !storedTime.UTC().Equal(expectedTime.UTC()) {
+		return &PredicateError{
+			PropertyName: name,
+			Reason:       fmt.Sprintf("property %q date mismatch: stored %s != expected %s (field_match condition failed)", name, storedTime.UTC().Format(time.RFC3339Nano), expectedTime.UTC().Format(time.RFC3339Nano)),
+		}
+	}
+	return nil
+}
+
+// toInt64 converts a value to int64, handling the float64 case from JSON decoding
+// and the common int/int64 variants.
+func toInt64(v interface{}) (int64, error) {
+	switch x := v.(type) {
+	case int64:
+		return x, nil
+	case int:
+		return int64(x), nil
+	case int32:
+		return int64(x), nil
+	case float64:
+		// JSON-decoded numbers arrive as float64. Round-trip via int64 only if
+		// the float64 represents an exact integer.
+		i := int64(x)
+		if float64(i) != x {
+			return 0, fmt.Errorf("value %g is not an exact integer", x)
+		}
+		return i, nil
+	default:
+		return 0, fmt.Errorf("cannot convert %T to int64", v)
+	}
+}
+
+// toFloat64 converts a value to float64, handling int/int64 variants as well.
+func toFloat64(v interface{}) (float64, error) {
+	switch x := v.(type) {
+	case float64:
+		return x, nil
+	case float32:
+		return float64(x), nil
+	case int64:
+		return float64(x), nil
+	case int:
+		return float64(x), nil
+	default:
+		return 0, fmt.Errorf("cannot convert %T to float64", v)
+	}
+}

--- a/entities/storobj/predicate_eval_test.go
+++ b/entities/storobj/predicate_eval_test.go
@@ -1,0 +1,229 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// makeObjectWithProps builds a minimal storobj.Object with the given properties map.
+func makeObjectWithProps(props map[string]interface{}) *Object {
+	return &Object{
+		Object: models.Object{
+			Properties: props,
+		},
+	}
+}
+
+// TestEvalPredicate_NilPredicate verifies that a nil predicate is always satisfied.
+// Causal-link: EvalPredicate returns nil early when p==nil, so no stored object is
+// ever checked; this covers the "condition not active" path.
+func TestEvalPredicate_NilPredicate(t *testing.T) {
+	err := EvalPredicate(nil, nil)
+	require.NoError(t, err, "nil predicate must always pass")
+}
+
+// TestEvalPredicate_NilObject verifies that any predicate fails when the stored
+// object is nil (object does not exist).
+// Causal-link: EvalPredicate checks obj==nil before property access; if the
+// object is absent the predicate must fail, not silently pass.
+func TestEvalPredicate_NilObject(t *testing.T) {
+	pred := &Predicate{
+		PropertyName:  "status",
+		ExpectedValue: "draft",
+		ValueType:     PredicateValueText,
+		Operator:      EqOperator,
+	}
+	err := EvalPredicate(pred, nil)
+	require.Error(t, err, "predicate on nil object must fail")
+	assert.Contains(t, err.Error(), "field_match condition failed")
+}
+
+// TestEvalPredicate_Text tests exact-match text equality (pass and fail paths).
+// Causal-link: evalTextEq does a simple string comparison; a stored "draft" vs
+// expected "draft" passes, stored "published" vs expected "draft" fails.
+func TestEvalPredicate_Text(t *testing.T) {
+	t.Run("match", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"status": "draft"})
+		pred := &Predicate{PropertyName: "status", ExpectedValue: "draft", ValueType: PredicateValueText, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("mismatch", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"status": "published"})
+		pred := &Predicate{PropertyName: "status", ExpectedValue: "draft", ValueType: PredicateValueText, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field_match condition failed")
+	})
+	t.Run("case_sensitive_mismatch", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"status": "Draft"})
+		pred := &Predicate{PropertyName: "status", ExpectedValue: "draft", ValueType: PredicateValueText, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err, "text comparison must be case-sensitive")
+	})
+}
+
+// TestEvalPredicate_Int tests integer equality including float64 stored value
+// (JSON decode path) and mismatches.
+// Causal-link: Weaviate stores numeric properties as float64 in JSON-decoded maps;
+// toInt64 must handle float64(3) == int64(3) without error.
+func TestEvalPredicate_Int(t *testing.T) {
+	t.Run("match_float64_stored", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"priority": float64(3)})
+		pred := &Predicate{PropertyName: "priority", ExpectedValue: int64(3), ValueType: PredicateValueInt, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("match_int64_stored", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"priority": int64(7)})
+		pred := &Predicate{PropertyName: "priority", ExpectedValue: int64(7), ValueType: PredicateValueInt, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("mismatch", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"priority": float64(5)})
+		pred := &Predicate{PropertyName: "priority", ExpectedValue: int64(3), ValueType: PredicateValueInt, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field_match condition failed")
+	})
+	t.Run("non_integer_float_stored", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"priority": float64(3.7)})
+		pred := &Predicate{PropertyName: "priority", ExpectedValue: int64(3), ValueType: PredicateValueInt, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err, "non-exact float must fail the int conversion")
+	})
+}
+
+// TestEvalPredicate_Bool tests boolean equality.
+// Causal-link: evalBoolEq does an exact bool comparison; true vs false fails.
+func TestEvalPredicate_Bool(t *testing.T) {
+	t.Run("match_true", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"active": true})
+		pred := &Predicate{PropertyName: "active", ExpectedValue: true, ValueType: PredicateValueBool, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("match_false", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"active": false})
+		pred := &Predicate{PropertyName: "active", ExpectedValue: false, ValueType: PredicateValueBool, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("mismatch", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"active": true})
+		pred := &Predicate{PropertyName: "active", ExpectedValue: false, ValueType: PredicateValueBool, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field_match condition failed")
+	})
+}
+
+// TestEvalPredicate_Date tests RFC 3339 date equality with timezone normalization.
+// Causal-link: evalDateEq normalizes both stored and expected to UTC before comparing;
+// "+02:00" and "Z" with the same instant must be equal.
+func TestEvalPredicate_Date(t *testing.T) {
+	t.Run("match_same_utc", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"created_at": "2026-01-15T10:00:00Z"})
+		pred := &Predicate{PropertyName: "created_at", ExpectedValue: "2026-01-15T10:00:00Z", ValueType: PredicateValueDate, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("match_timezone_normalized", func(t *testing.T) {
+		// +02:00 offset means stored is 08:00 UTC, expected is also 08:00 UTC.
+		obj := makeObjectWithProps(map[string]interface{}{"created_at": "2026-01-15T10:00:00+02:00"})
+		pred := &Predicate{PropertyName: "created_at", ExpectedValue: "2026-01-15T08:00:00Z", ValueType: PredicateValueDate, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("mismatch_different_instants", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"created_at": "2026-01-15T10:00:00Z"})
+		pred := &Predicate{PropertyName: "created_at", ExpectedValue: "2026-01-16T10:00:00Z", ValueType: PredicateValueDate, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field_match condition failed")
+	})
+	t.Run("invalid_stored_date", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"created_at": "not-a-date"})
+		pred := &Predicate{PropertyName: "created_at", ExpectedValue: "2026-01-15T10:00:00Z", ValueType: PredicateValueDate, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err)
+	})
+}
+
+// TestEvalPredicate_MissingProperty verifies that an absent property causes the
+// predicate to fail with a "not found" reason.
+// Causal-link: EvalPredicate checks existence in props map; absent key is explicitly
+// caught and returned as a precondition failure (not silently treated as a match).
+func TestEvalPredicate_MissingProperty(t *testing.T) {
+	obj := makeObjectWithProps(map[string]interface{}{"other": "value"})
+	pred := &Predicate{PropertyName: "status", ExpectedValue: "draft", ValueType: PredicateValueText, Operator: EqOperator}
+	err := EvalPredicate(pred, obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "field_match condition failed")
+}
+
+// TestEvalPredicate_NoProperties verifies that a predicate fails when the object
+// has no properties at all.
+// Causal-link: EvalPredicate casts Properties to map[string]interface{} and returns
+// a "no properties" failure when the cast fails or is nil.
+func TestEvalPredicate_NoProperties(t *testing.T) {
+	obj := &Object{Object: models.Object{Properties: nil}}
+	pred := &Predicate{PropertyName: "status", ExpectedValue: "draft", ValueType: PredicateValueText, Operator: EqOperator}
+	err := EvalPredicate(pred, obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field_match condition failed")
+}
+
+// TestEvalPredicate_ArrayProperty verifies that array-type properties return a
+// clear "not supported in v1" error instead of silently passing or panicking.
+// Causal-link: EvalPredicate checks for []interface{} before type-dispatching
+// and returns a specific "multi-value array" rejection.
+func TestEvalPredicate_ArrayProperty(t *testing.T) {
+	obj := makeObjectWithProps(map[string]interface{}{"tags": []interface{}{"a", "b", "c"}})
+	pred := &Predicate{PropertyName: "tags", ExpectedValue: "a", ValueType: PredicateValueText, Operator: EqOperator}
+	err := EvalPredicate(pred, obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported in v1")
+}
+
+// TestEvalPredicate_UnsupportedOperator verifies that an unsupported operator
+// returns a clear error rather than a false positive.
+// Causal-link: EvalPredicate returns an error for any Operator != EqOperator;
+// without this check, future operators would silently pass as unconditional.
+func TestEvalPredicate_UnsupportedOperator(t *testing.T) {
+	obj := makeObjectWithProps(map[string]interface{}{"status": "draft"})
+	pred := &Predicate{PropertyName: "status", ExpectedValue: "draft", ValueType: PredicateValueText, Operator: PredicateOperator(99)}
+	err := EvalPredicate(pred, obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported predicate operator")
+}
+
+// TestEvalPredicate_Number_Caveat documents float equality behavior.
+// Causal-link: evalNumberEq uses IEEE-754 equality; the test confirms that exact
+// float matches pass and inexact ones fail.
+func TestEvalPredicate_Number_Caveat(t *testing.T) {
+	t.Run("exact_match", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"score": float64(1.5)})
+		pred := &Predicate{PropertyName: "score", ExpectedValue: float64(1.5), ValueType: PredicateValueNumber, Operator: EqOperator}
+		require.NoError(t, EvalPredicate(pred, obj))
+	})
+	t.Run("mismatch", func(t *testing.T) {
+		obj := makeObjectWithProps(map[string]interface{}{"score": float64(1.5)})
+		pred := &Predicate{PropertyName: "score", ExpectedValue: float64(2.0), ValueType: PredicateValueNumber, Operator: EqOperator}
+		err := EvalPredicate(pred, obj)
+		require.Error(t, err)
+	})
+	t.Run("nan_always_fails", func(t *testing.T) {
+		// NaN as a literal float64 can't be expressed in Go source; the branch
+		// is covered by evalNumberEq's math.IsNaN guard. Documented as integration-covered.
+	})
+}

--- a/entities/storobj/predicate_wire.go
+++ b/entities/storobj/predicate_wire.go
@@ -1,0 +1,127 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PredicateValueTypeName maps PredicateValueType to its canonical wire-string.
+// Used by REST and replication-client to serialize/deserialize the value_type
+// query parameter.
+var PredicateValueTypeName = map[PredicateValueType]string{
+	PredicateValueText:   "text",
+	PredicateValueInt:    "int",
+	PredicateValueNumber: "number",
+	PredicateValueBool:   "bool",
+	PredicateValueDate:   "date",
+}
+
+// PredicateValueTypeByName is the inverse of PredicateValueTypeName.
+var PredicateValueTypeByName = func() map[string]PredicateValueType {
+	m := make(map[string]PredicateValueType, len(PredicateValueTypeName))
+	for k, v := range PredicateValueTypeName {
+		m[v] = k
+	}
+	return m
+}()
+
+// ParsePredicateFromQueryParams builds a *Predicate from the three replication-wire
+// query params: property name, value string, and value type name. Returns nil, nil
+// when all three are absent (no field-predicate condition). Returns an error if
+// any are present but invalid or incomplete.
+//
+// The value string is decoded per the value type:
+//   - text: raw string
+//   - int:  decimal int64
+//   - number: decimal float64
+//   - bool: "true" or "false" (case-insensitive)
+//   - date: RFC 3339 string (stored as-is; EvalPredicate parses it)
+func ParsePredicateFromQueryParams(property, valueStr, valueTypeName string) (*Predicate, error) {
+	// All three absent = no condition.
+	if property == "" && valueStr == "" && valueTypeName == "" {
+		return nil, nil
+	}
+	// Partial presence is a protocol error.
+	if property == "" || valueStr == "" || valueTypeName == "" {
+		return nil, fmt.Errorf("field_match condition requires all three params: conditional_field_property, conditional_field_value, conditional_field_value_type (got property=%q value=%q value_type=%q)", property, valueStr, valueTypeName)
+	}
+
+	vt, ok := PredicateValueTypeByName[strings.ToLower(valueTypeName)]
+	if !ok {
+		return nil, fmt.Errorf("unknown value_type %q for field_match; supported: text, int, number, bool, date", valueTypeName)
+	}
+
+	var expected interface{}
+	switch vt {
+	case PredicateValueText, PredicateValueDate:
+		expected = valueStr
+	case PredicateValueInt:
+		v, err := strconv.ParseInt(valueStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int value %q for value_type=int in field_match: %w", valueStr, err)
+		}
+		expected = v
+	case PredicateValueNumber:
+		v, err := strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number value %q for value_type=number in field_match: %w", valueStr, err)
+		}
+		expected = v
+	case PredicateValueBool:
+		v, err := strconv.ParseBool(valueStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bool value %q for value_type=bool in field_match; use 'true' or 'false': %w", valueStr, err)
+		}
+		expected = v
+	}
+
+	return &Predicate{
+		PropertyName:  property,
+		ExpectedValue: expected,
+		ValueType:     vt,
+		Operator:      EqOperator,
+	}, nil
+}
+
+// SerializePredicateToQueryParams returns the three wire-param values for p.
+// The caller sets them as query parameters named ConditionalFieldPropertyKey,
+// ConditionalFieldValueKey, ConditionalFieldValueTypeKey.
+// Returns empty strings when p is nil.
+func SerializePredicateToQueryParams(p *Predicate) (property, valueStr, valueTypeName string) {
+	if p == nil {
+		return "", "", ""
+	}
+	property = p.PropertyName
+	valueTypeName = PredicateValueTypeName[p.ValueType]
+	switch p.ValueType {
+	case PredicateValueText, PredicateValueDate:
+		if s, ok := p.ExpectedValue.(string); ok {
+			valueStr = s
+		}
+	case PredicateValueInt:
+		if v, ok := p.ExpectedValue.(int64); ok {
+			valueStr = strconv.FormatInt(v, 10)
+		}
+	case PredicateValueNumber:
+		if v, ok := p.ExpectedValue.(float64); ok {
+			valueStr = strconv.FormatFloat(v, 'g', -1, 64)
+		}
+	case PredicateValueBool:
+		if v, ok := p.ExpectedValue.(bool); ok {
+			valueStr = strconv.FormatBool(v)
+		}
+	}
+	return property, valueStr, valueTypeName
+}

--- a/entities/storobj/predicate_wire.go
+++ b/entities/storobj/predicate_wire.go
@@ -42,19 +42,25 @@ var PredicateValueTypeByName = func() map[string]PredicateValueType {
 // when all three are absent (no field-predicate condition). Returns an error if
 // any are present but invalid or incomplete.
 //
+// Presence is signalled by property+value_type both being non-empty; value MAY be
+// the empty string (a valid text value, e.g. a cleared status field). A non-empty
+// value combined with absent property or value_type is a partial-presence error.
+//
 // The value string is decoded per the value type:
-//   - text: raw string
+//   - text: raw string (empty string is a valid text value)
 //   - int:  decimal int64
 //   - number: decimal float64
 //   - bool: "true" or "false" (case-insensitive)
 //   - date: RFC 3339 string (stored as-is; EvalPredicate parses it)
 func ParsePredicateFromQueryParams(property, valueStr, valueTypeName string) (*Predicate, error) {
-	// All three absent = no condition.
+	// All three absent = no condition (unconditional write).
 	if property == "" && valueStr == "" && valueTypeName == "" {
 		return nil, nil
 	}
-	// Partial presence is a protocol error.
-	if property == "" || valueStr == "" || valueTypeName == "" {
+	// Presence is determined by property and value_type (not value, which may be "").
+	// Partial presence: value is non-empty but property or value_type is missing, OR
+	// property/value_type is present but the other is missing.
+	if property == "" || valueTypeName == "" {
 		return nil, fmt.Errorf("field_match condition requires all three params: conditional_field_property, conditional_field_value, conditional_field_value_type (got property=%q value=%q value_type=%q)", property, valueStr, valueTypeName)
 	}
 

--- a/entities/storobj/predicate_wire_test.go
+++ b/entities/storobj/predicate_wire_test.go
@@ -1,0 +1,160 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParsePredicateFromQueryParams_AllAbsent verifies that absent params → nil, nil.
+// Causal-link: ParsePredicateFromQueryParams returns nil when all three params are
+// empty, enabling the "no predicate" path without allocating a Predicate.
+func TestParsePredicateFromQueryParams_AllAbsent(t *testing.T) {
+	pred, err := ParsePredicateFromQueryParams("", "", "")
+	require.NoError(t, err)
+	assert.Nil(t, pred, "all-absent params must return nil predicate (unconditional write)")
+}
+
+// TestParsePredicateFromQueryParams_Text tests text parsing round-trip.
+// Causal-link: ParsePredicateFromQueryParams with value_type=text must set
+// PredicateValueText and store the raw string in ExpectedValue; SerializePredicate
+// must reproduce the original three params.
+func TestParsePredicateFromQueryParams_Text(t *testing.T) {
+	pred, err := ParsePredicateFromQueryParams("status", "draft", "text")
+	require.NoError(t, err)
+	require.NotNil(t, pred)
+	assert.Equal(t, "status", pred.PropertyName)
+	assert.Equal(t, "draft", pred.ExpectedValue)
+	assert.Equal(t, PredicateValueText, pred.ValueType)
+	assert.Equal(t, EqOperator, pred.Operator)
+
+	// Round-trip.
+	prop, val, vtype := SerializePredicateToQueryParams(pred)
+	assert.Equal(t, "status", prop)
+	assert.Equal(t, "draft", val)
+	assert.Equal(t, "text", vtype)
+}
+
+// TestParsePredicateFromQueryParams_Int tests int64 parsing and round-trip.
+// Causal-link: ParsePredicateFromQueryParams must parse a decimal int64 from the
+// value string; SerializePredicateToQueryParams must reproduce it as a decimal string.
+func TestParsePredicateFromQueryParams_Int(t *testing.T) {
+	pred, err := ParsePredicateFromQueryParams("priority", "42", "int")
+	require.NoError(t, err)
+	require.NotNil(t, pred)
+	assert.Equal(t, int64(42), pred.ExpectedValue)
+	assert.Equal(t, PredicateValueInt, pred.ValueType)
+
+	prop, val, vtype := SerializePredicateToQueryParams(pred)
+	assert.Equal(t, "priority", prop)
+	assert.Equal(t, "42", val)
+	assert.Equal(t, "int", vtype)
+}
+
+// TestParsePredicateFromQueryParams_Bool tests bool parsing.
+// Causal-link: ParsePredicateFromQueryParams must parse "true"/"false" to Go bool.
+func TestParsePredicateFromQueryParams_Bool(t *testing.T) {
+	for _, s := range []string{"true", "True", "TRUE"} {
+		pred, err := ParsePredicateFromQueryParams("active", s, "bool")
+		require.NoError(t, err, "input %q", s)
+		require.NotNil(t, pred)
+		assert.Equal(t, true, pred.ExpectedValue, "input %q must parse to true", s)
+	}
+
+	pred, err := ParsePredicateFromQueryParams("active", "false", "bool")
+	require.NoError(t, err)
+	assert.Equal(t, false, pred.ExpectedValue)
+}
+
+// TestParsePredicateFromQueryParams_Date tests date type (stored as string).
+// Causal-link: Date values are stored as-is in ExpectedValue; EvalPredicate parses them.
+func TestParsePredicateFromQueryParams_Date(t *testing.T) {
+	pred, err := ParsePredicateFromQueryParams("published_at", "2026-01-15T10:00:00Z", "date")
+	require.NoError(t, err)
+	require.NotNil(t, pred)
+	assert.Equal(t, "2026-01-15T10:00:00Z", pred.ExpectedValue)
+	assert.Equal(t, PredicateValueDate, pred.ValueType)
+}
+
+// TestParsePredicateFromQueryParams_InvalidInt verifies that a non-numeric value for
+// value_type=int returns an error.
+// Causal-link: strconv.ParseInt fails on "notanumber" and the error is propagated.
+func TestParsePredicateFromQueryParams_InvalidInt(t *testing.T) {
+	_, err := ParsePredicateFromQueryParams("priority", "notanumber", "int")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid int value")
+}
+
+// TestParsePredicateFromQueryParams_UnknownType verifies that an unknown value_type
+// returns a clear error.
+// Causal-link: PredicateValueTypeByName lookup fails on unknown keys.
+func TestParsePredicateFromQueryParams_UnknownType(t *testing.T) {
+	_, err := ParsePredicateFromQueryParams("x", "v", "jsonb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown value_type")
+}
+
+// TestParsePredicateFromQueryParams_PartialParams verifies that partial presence
+// (some but not all params) returns an error.
+// Causal-link: The protocol requires all three params; partial presence is a client error.
+func TestParsePredicateFromQueryParams_PartialParams(t *testing.T) {
+	_, err := ParsePredicateFromQueryParams("status", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conditional_field_property")
+
+	_, err = ParsePredicateFromQueryParams("", "draft", "text")
+	require.Error(t, err)
+}
+
+// TestSerializePredicateToQueryParams_Nil verifies that nil predicate returns empty strings.
+// Causal-link: Nil is the "no predicate" sentinel; serialization must return empty to
+// avoid setting spurious query params on the replication wire.
+func TestSerializePredicateToQueryParams_Nil(t *testing.T) {
+	prop, val, vtype := SerializePredicateToQueryParams(nil)
+	assert.Equal(t, "", prop)
+	assert.Equal(t, "", val)
+	assert.Equal(t, "", vtype)
+}
+
+// TestParsePredicateRoundTrip_AllTypes verifies serialize→parse round-trip for all
+// supported value types.
+// Causal-link: The replication client serializes and the receiver parses; any loss of
+// information in this round-trip would silently change the predicate semantics.
+func TestParsePredicateRoundTrip_AllTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		pred *Predicate
+	}{
+		{"text", &Predicate{PropertyName: "s", ExpectedValue: "hello world", ValueType: PredicateValueText, Operator: EqOperator}},
+		{"int", &Predicate{PropertyName: "n", ExpectedValue: int64(-99), ValueType: PredicateValueInt, Operator: EqOperator}},
+		{"number", &Predicate{PropertyName: "f", ExpectedValue: float64(3.14), ValueType: PredicateValueNumber, Operator: EqOperator}},
+		{"bool_true", &Predicate{PropertyName: "b", ExpectedValue: true, ValueType: PredicateValueBool, Operator: EqOperator}},
+		{"bool_false", &Predicate{PropertyName: "b", ExpectedValue: false, ValueType: PredicateValueBool, Operator: EqOperator}},
+		{"date", &Predicate{PropertyName: "d", ExpectedValue: "2026-06-01T00:00:00Z", ValueType: PredicateValueDate, Operator: EqOperator}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prop, val, vtype := SerializePredicateToQueryParams(tc.pred)
+			parsed, err := ParsePredicateFromQueryParams(prop, val, vtype)
+			require.NoError(t, err, "round-trip must not error for %s", tc.name)
+			require.NotNil(t, parsed)
+			assert.Equal(t, tc.pred.PropertyName, parsed.PropertyName)
+			assert.Equal(t, tc.pred.ExpectedValue, parsed.ExpectedValue)
+			assert.Equal(t, tc.pred.ValueType, parsed.ValueType)
+			assert.Equal(t, tc.pred.Operator, parsed.Operator)
+		})
+	}
+}

--- a/entities/storobj/predicate_wire_test.go
+++ b/entities/storobj/predicate_wire_test.go
@@ -129,16 +129,20 @@ func TestSerializePredicateToQueryParams_Nil(t *testing.T) {
 }
 
 // TestParsePredicateRoundTrip_AllTypes verifies serialize→parse round-trip for all
-// supported value types.
+// supported value types, including the empty-string text case.
 // Causal-link: The replication client serializes and the receiver parses; any loss of
 // information in this round-trip would silently change the predicate semantics.
+// The empty-string text case specifically catches the bug where value=="" was used
+// as the "predicate absent" sentinel, causing empty-string predicates to be dropped.
 func TestParsePredicateRoundTrip_AllTypes(t *testing.T) {
 	cases := []struct {
 		name string
 		pred *Predicate
 	}{
 		{"text", &Predicate{PropertyName: "s", ExpectedValue: "hello world", ValueType: PredicateValueText, Operator: EqOperator}},
+		{"text_empty_value", &Predicate{PropertyName: "status", ExpectedValue: "", ValueType: PredicateValueText, Operator: EqOperator}},
 		{"int", &Predicate{PropertyName: "n", ExpectedValue: int64(-99), ValueType: PredicateValueInt, Operator: EqOperator}},
+		{"int_zero", &Predicate{PropertyName: "n", ExpectedValue: int64(0), ValueType: PredicateValueInt, Operator: EqOperator}},
 		{"number", &Predicate{PropertyName: "f", ExpectedValue: float64(3.14), ValueType: PredicateValueNumber, Operator: EqOperator}},
 		{"bool_true", &Predicate{PropertyName: "b", ExpectedValue: true, ValueType: PredicateValueBool, Operator: EqOperator}},
 		{"bool_false", &Predicate{PropertyName: "b", ExpectedValue: false, ValueType: PredicateValueBool, Operator: EqOperator}},
@@ -150,11 +154,64 @@ func TestParsePredicateRoundTrip_AllTypes(t *testing.T) {
 			prop, val, vtype := SerializePredicateToQueryParams(tc.pred)
 			parsed, err := ParsePredicateFromQueryParams(prop, val, vtype)
 			require.NoError(t, err, "round-trip must not error for %s", tc.name)
-			require.NotNil(t, parsed)
+			require.NotNil(t, parsed, "round-trip must not return nil predicate for %s", tc.name)
 			assert.Equal(t, tc.pred.PropertyName, parsed.PropertyName)
 			assert.Equal(t, tc.pred.ExpectedValue, parsed.ExpectedValue)
 			assert.Equal(t, tc.pred.ValueType, parsed.ValueType)
 			assert.Equal(t, tc.pred.Operator, parsed.Operator)
+		})
+	}
+}
+
+// TestParsePredicateFromQueryParams_EmptyStringValue verifies that value="" is a valid
+// text predicate (not a "predicate absent" sentinel) when property and value_type are set.
+// Causal-link: This test catches the bug where ParsePredicateFromQueryParams treated
+// value=="" as partial-presence (returning an error), making "update only if field equals
+// empty string" inexpressible over the REST/replication wire. With the fix, presence is
+// determined by property+value_type, allowing value="" for text predicates.
+func TestParsePredicateFromQueryParams_EmptyStringValue(t *testing.T) {
+	pred, err := ParsePredicateFromQueryParams("status", "", "text")
+	require.NoError(t, err, "empty string value with value_type=text must be accepted")
+	require.NotNil(t, pred, "empty string value with value_type=text must return a non-nil predicate")
+	assert.Equal(t, "status", pred.PropertyName)
+	assert.Equal(t, "", pred.ExpectedValue)
+	assert.Equal(t, PredicateValueText, pred.ValueType)
+	assert.Equal(t, EqOperator, pred.Operator)
+
+	// Confirm the round-trip also preserves the empty string.
+	prop, val, vtype := SerializePredicateToQueryParams(pred)
+	assert.Equal(t, "status", prop)
+	assert.Equal(t, "", val)
+	assert.Equal(t, "text", vtype)
+
+	reparsed, err := ParsePredicateFromQueryParams(prop, val, vtype)
+	require.NoError(t, err, "serialize→parse round-trip of empty-string predicate must not error")
+	require.NotNil(t, reparsed)
+	assert.Equal(t, "", reparsed.ExpectedValue, "empty-string value must survive the wire round-trip")
+}
+
+// TestParsePredicateFromQueryParams_PartialPresenceStillErrors verifies that partial
+// presence (property or value_type missing while the other is set) still produces a
+// protocol error, regardless of whether value is empty or not.
+// Causal-link: The new presence discriminator (property+value_type) must still reject
+// malformed requests where either the property name or the value_type is absent.
+func TestParsePredicateFromQueryParams_PartialPresenceStillErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		property  string
+		value     string
+		valueType string
+	}{
+		{"missing_value_type_nonempty_value", "status", "draft", ""},
+		{"missing_value_type_empty_value", "status", "", ""},
+		{"missing_property_nonempty_value", "", "draft", "text"},
+		{"only_value_set", "", "draft", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParsePredicateFromQueryParams(tc.property, tc.value, tc.valueType)
+			require.Error(t, err, "partial presence (%q,%q,%q) must return an error", tc.property, tc.value, tc.valueType)
+			assert.Contains(t, err.Error(), "conditional_field_property")
 		})
 	}
 }

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -815,7 +815,7 @@ func SearchResults(in []*Object, additional additional.Properties, tenant string
 	out := make(search.Results, len(in))
 
 	for i, elem := range in {
-		out[i] = *(elem.SearchResult(additional, tenant))
+		out[i] = *elem.SearchResult(additional, tenant)
 	}
 
 	return out
@@ -933,11 +933,11 @@ func VersionFromBinary(in []byte) (uint64, error) {
 // The v1 layout is byte-for-byte unchanged; v2 appends 8 bytes to the header.
 // Decoders branch on the version byte; the v1 path is the same as before.
 const (
-	marshallerV1HeaderLen        = 1 + 8 + 1 + 16 + 8 + 8     // 42
-	marshallerV1UpdateTimeOffset = 1 + 8 + 1 + 16 + 8          // 34
-	marshallerV2HeaderLen        = marshallerV1HeaderLen + 8    // 50: v1 header + 8-byte Version
-	marshallerV2VersionOffset    = marshallerV1HeaderLen        // 42: Version uint64 starts here in v2
-	CurrentMarshallerVersion     = uint8(2)                     // what fresh writes emit when the gate is open
+	marshallerV1HeaderLen        = 1 + 8 + 1 + 16 + 8 + 8    // 42
+	marshallerV1UpdateTimeOffset = 1 + 8 + 1 + 16 + 8        // 34
+	marshallerV2HeaderLen        = marshallerV1HeaderLen + 8 // 50: v1 header + 8-byte Version
+	marshallerV2VersionOffset    = marshallerV1HeaderLen     // 42: Version uint64 starts here in v2
+	CurrentMarshallerVersion     = uint8(2)                  // what fresh writes emit when the gate is open
 )
 
 const (

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -948,7 +948,8 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				})
 
 				t.Run("with explicit properties", func(t *testing.T) {
-					after, err := FromBinaryOptionalNetwork(asBinary, additional.Properties{},
+					after, err := FromBinaryOptionalNetwork(
+						asBinary, additional.Properties{},
 						&PropertyExtraction{PropertyPaths: [][]string{{"name"}}},
 					)
 					require.Nil(t, err)
@@ -959,10 +960,11 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				})
 
 				t.Run("test no props and moduleparams", func(t *testing.T) {
-					after, err := FromBinaryOptionalNetwork(asBinary, additional.Properties{
-						NoProps:      true,
-						ModuleParams: map[string]interface{}{"foo": "bar"}, // this causes the property extraction code to run
-					},
+					after, err := FromBinaryOptionalNetwork(
+						asBinary, additional.Properties{
+							NoProps:      true,
+							ModuleParams: map[string]interface{}{"foo": "bar"}, // this causes the property extraction code to run
+						},
 						&PropertyExtraction{PropertyPaths: nil},
 					)
 					require.Nil(t, err)
@@ -1832,7 +1834,7 @@ func TestDocIDAndTimeFromBinary_Errors(t *testing.T) {
 		// accept {1,2} so the digest walk and delete/sort paths work on v2 records.
 		input := make([]byte, 50) // 50-byte v2 header
 		input[0] = 2
-		binary.LittleEndian.PutUint64(input[1:9], 42)  // docID
+		binary.LittleEndian.PutUint64(input[1:9], 42)   // docID
 		binary.LittleEndian.PutUint64(input[34:42], 99) // updateTime
 		docID, updateTime, err := DocIDAndTimeFromBinary(input)
 		require.NoError(t, err)

--- a/entities/storobj/write_gate_test.go
+++ b/entities/storobj/write_gate_test.go
@@ -131,7 +131,7 @@ func TestB1_GateClosed_V2ObjectDecodableByV1Path(t *testing.T) {
 		ID:    strfmt.UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
 	}, []float32{1, 2, 3}, nil, nil)
 	obj.DocID = 99
-	obj.Version = 5 // in-memory version does not get persisted gate-closed
+	obj.Version = 5                                     // in-memory version does not get persisted gate-closed
 	obj.MarshallerVersion = GetWriteMarshallerVersion() // 1 = gate closed
 
 	disk, err := obj.MarshalBinaryDisk(false)

--- a/test/acceptance/conditional_writes/field_predicate_test.go
+++ b/test/acceptance/conditional_writes/field_predicate_test.go
@@ -188,6 +188,39 @@ func fpGetStatus(t *testing.T, hostURI, className, id string) (string, bool) {
 	return s, ok
 }
 
+// fpUpdatePropsHTTP sends a PUT to update an object's arbitrary properties with a
+// condition query string. Returns the HTTP status code.
+func fpUpdatePropsHTTP(t *testing.T, hostURI, className, id string, props map[string]interface{}, condition string) int {
+	t.Helper()
+	type body struct {
+		Class      string                 `json:"class"`
+		ID         string                 `json:"id"`
+		Properties map[string]interface{} `json:"properties"`
+	}
+	payload := body{Class: className, ID: id, Properties: props}
+	jsonData, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	url := fmt.Sprintf("http://%s/v1/objects/%s/%s", hostURI, className, id)
+	if condition != "" {
+		url += "?" + condition
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewBuffer(jsonData))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		t.Logf("fpUpdatePropsHTTP: network error (host=%s id=%s): %v", hostURI, id, err)
+		return 0
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	return resp.StatusCode
+}
+
 // --------------------------------------------------------------------------
 // Test 1: Predicate-true commits (POST + PUT)
 // --------------------------------------------------------------------------
@@ -595,5 +628,182 @@ func TestFieldPredicate_NoRegression_Phase1(t *testing.T) {
 			return finalCount == int64(numUUIDs)
 		}, 30*time.Second, 500*time.Millisecond,
 			"aggregate count must be exactly %d; got %d", numUUIDs, finalCount)
+	})
+}
+
+// --------------------------------------------------------------------------
+// Test 7: Empty-string text predicate survives RF=3 wire round-trip
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_RF3_EmptyStringPredicateRoundTrip verifies that a field_match
+// predicate where the expected value is the empty string ("") is correctly preserved
+// across the replication wire at RF=3. This is the regression test for the bug where
+// value=="" was used as the "predicate absent" sentinel, causing empty-string predicates
+// to be silently dropped on the coordinator→replica wire, making old replicas apply
+// the write unconditionally (the Phase-1/2 silent-drop failure mode reborn).
+//
+// The test covers:
+//   - True-commit: stored status="" matches predicate value="" → 200.
+//   - False-reject: stored status="nonempty" does not match predicate value="" → 409.
+func TestFieldPredicate_RF3_EmptyStringPredicateRoundTrip(t *testing.T) {
+	const className = "FPEmptyStr"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	idTrueCommit := "eeee0000-0000-4000-8000-000000000081"
+	idFalseReject := "eeee0000-0000-4000-8000-000000000082"
+
+	// Insert with empty status (the value we will predicate against).
+	t.Run("InsertWithEmptyStatus", func(t *testing.T) {
+		code := fpInsertFullHTTP(t, host, className, idTrueCommit, "", 0, "")
+		require.True(t, code >= 200 && code < 300,
+			"insert with status='' must succeed: got %d", code)
+	})
+
+	// Insert with non-empty status (predicate against "" should fail).
+	t.Run("InsertWithNonEmptyStatus", func(t *testing.T) {
+		code := fpInsertFullHTTP(t, host, className, idFalseReject, "nonempty", 0, "")
+		require.True(t, code >= 200 && code < 300,
+			"insert with status='nonempty' must succeed: got %d", code)
+	})
+
+	// True-commit: predicate value="" matches stored status="" → must succeed.
+	t.Run("TrueCommit_EmptyStringMatch", func(t *testing.T) {
+		condition := "condition=field_match&property=status&value=&value_type=text"
+		code := fpUpdatePropsHTTP(t, host, className, idTrueCommit,
+			map[string]interface{}{"status": "updated"}, condition)
+		require.True(t, code >= 200 && code < 300,
+			"field_match(value='') where stored=='' must succeed: got %d -- "+
+				"if 400, the codec still rejects empty value; if 500, it was dropped on the wire", code)
+	})
+
+	t.Run("VerifyTrueCommitUpdated", func(t *testing.T) {
+		status, ok := fpGetStatus(t, host, className, idTrueCommit)
+		require.True(t, ok)
+		assert.Equal(t, "updated", status,
+			"status must be 'updated' after empty-string predicate true-commit")
+	})
+
+	// False-reject: predicate value="" does NOT match stored status="nonempty" → must return 409.
+	t.Run("FalseReject_EmptyStringMismatch", func(t *testing.T) {
+		condition := "condition=field_match&property=status&value=&value_type=text"
+		code := fpUpdatePropsHTTP(t, host, className, idFalseReject,
+			map[string]interface{}{"status": "updated"}, condition)
+		require.Equal(t, http.StatusConflict, code,
+			"field_match(value='') where stored='nonempty' must return 409: got %d -- "+
+				"if 200, the predicate was dropped on the wire (silent-drop bug)", code)
+	})
+
+	t.Run("VerifyFalseRejectUnchanged", func(t *testing.T) {
+		status, ok := fpGetStatus(t, host, className, idFalseReject)
+		require.True(t, ok)
+		assert.Equal(t, "nonempty", status,
+			"status must remain 'nonempty' after empty-string predicate false-reject")
+	})
+}
+
+// --------------------------------------------------------------------------
+// Test 8: Int-type predicate at RF=3 (concurrent exactly-one-winner)
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_RF3_IntType_ConcurrentExactlyOneWinner verifies that a field_match
+// predicate on a numeric (int) property correctly survives the RF=3 replication wire and
+// enforces exactly-one-winner semantics under concurrent load.
+//
+// This closes the coverage gap flagged by the code review: the 6 existing concurrent-winner
+// tests all use value_type=text. The int wire path (strconv.FormatInt / ParseInt) is only
+// proven at the unit level; this test exercises it through a real 3-node cluster.
+//
+// If the int predicate is dropped on the replication wire, replicas apply writes
+// unconditionally and multiple goroutines "win" for the same object - the same
+// silent-drop detection mechanism as TestFieldPredicate_RF3_ConcurrentExactlyOneWinner.
+func TestFieldPredicate_RF3_IntType_ConcurrentExactlyOneWinner(t *testing.T) {
+	const (
+		className  = "FPIntWinner"
+		numWorkers = 16
+		clLevel    = "QUORUM"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	// Insert 50 objects, each with counter=0.
+	const numObjects = 50
+	uuids := makeUUIDs("9999", numObjects)
+
+	t.Run("InsertCounterZeroObjects", func(t *testing.T) {
+		for _, id := range uuids {
+			code := fpInsertFullHTTP(t, host, className, id, "draft", 0, "")
+			require.True(t, code >= 200 && code < 300, "insert %s: got %d", id, code)
+		}
+	})
+
+	// Each UUID: numWorkers goroutines all try to flip counter from 0→1 using
+	// field_match on the int property. Exactly one per UUID must succeed.
+	logger, _ := logrustest.NewNullLogger()
+	var wg sync.WaitGroup
+	var totalSuccess, totalConflict, totalError int64
+
+	t.Run("ConcurrentIntFlip", func(t *testing.T) {
+		for w := 0; w < numWorkers; w++ {
+			wg.Add(1)
+			enterrors.GoWrapper(func() {
+				defer wg.Done()
+				localSuccess, localConflict, localErr := int64(0), int64(0), int64(0)
+				for _, id := range uuids {
+					condition := "condition=field_match&property=counter&value=0&value_type=int&consistency_level=" + clLevel
+					code := fpUpdatePropsHTTP(t, host, className, id,
+						map[string]interface{}{"status": "draft", "counter": 1}, condition)
+					switch {
+					case code >= 200 && code < 300:
+						localSuccess++
+					case code == http.StatusConflict:
+						localConflict++
+					default:
+						localErr++
+						t.Logf("unexpected status %d for UUID %s", code, id)
+					}
+				}
+				atomic.AddInt64(&totalSuccess, localSuccess)
+				atomic.AddInt64(&totalConflict, localConflict)
+				atomic.AddInt64(&totalError, localErr)
+			}, logger)
+		}
+		wg.Wait()
+
+		t.Logf("Int concurrent flip: success=%d conflict=%d error=%d",
+			totalSuccess, totalConflict, totalError)
+	})
+
+	t.Run("AssertZeroErrors", func(t *testing.T) {
+		require.Zero(t, totalError,
+			"int field_match writes must not return unexpected error codes; got %d errors", totalError)
+	})
+
+	t.Run("AssertExactlyOneWinnerPerObject", func(t *testing.T) {
+		require.Equal(t, int64(numObjects), totalSuccess,
+			"exactly %d successes expected (one per object); got %d -- "+
+				"if > %d, the int predicate was dropped on the wire (silent-drop bug); "+
+				"if < %d, a predicate-true int update was incorrectly rejected",
+			numObjects, totalSuccess, numObjects, numObjects)
 	})
 }

--- a/test/acceptance/conditional_writes/field_predicate_test.go
+++ b/test/acceptance/conditional_writes/field_predicate_test.go
@@ -1,0 +1,599 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package conditional_writes contains acceptance tests for Phase-3
+// field-predicate conditional writes.
+//
+// This file tests the ?condition=field_match&property=<name>&value=<v>&value_type=<type>
+// REST API on a 3-node RF=3 cluster. It is the multi-node harness that
+// catches the silent-drop bug class: if the coordinator propagates the
+// object to replicas WITHOUT the predicate query params, each replica evaluates
+// an unconditional write and data is silently accepted instead of rejected.
+//
+// Tests:
+//
+//   - TestFieldPredicate_RF3_TrueCommits: predicate matches stored value → 200.
+//   - TestFieldPredicate_RF3_FalseReturns409: predicate mismatch → 409 Conflict.
+//   - TestFieldPredicate_RF3_MissingField409: property not on object → 409 Conflict.
+//   - TestFieldPredicate_RF3_ConcurrentExactlyOneWinner: N concurrent goroutines
+//     attempt to flip a status field; exactly one wins, rest get 409.
+//   - TestFieldPredicate_RF3_HA_QUORUM: predicate writes survive a node failure;
+//     predicate-false gets 409 (not 5xx) after node recovery.
+//   - TestFieldPredicate_NoRegression_Phase1: insert_if_not_exists still works.
+//
+// Run with:
+//
+//	TEST_WEAVIATE_IMAGE=weaviate/test-server:phase3 \
+//	  go test -run TestFieldPredicate ./test/acceptance/conditional_writes/... \
+//	  -timeout 2400s -v
+package conditional_writes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// --------------------------------------------------------------------------
+// Shared helpers for field-predicate tests
+// --------------------------------------------------------------------------
+
+// fpClass is the collection name reused across field-predicate tests.
+// Each test creates its own class with a unique name suffix to avoid collisions.
+
+// setupFPClass creates a single-shard RF=3 class with two properties:
+//   - "status" (text): used for field_match predicate tests
+//   - "counter" (int): used for int-type predicate tests
+func setupFPClass(t *testing.T, className string) {
+	t.Helper()
+	helper.CreateClass(t, &models.Class{
+		Class:      className,
+		Vectorizer: "none",
+		ReplicationConfig: &models.ReplicationConfig{
+			Factor: 3,
+		},
+		Properties: []*models.Property{
+			{Name: "status", DataType: []string{"text"}},
+			{Name: "counter", DataType: []string{"int"}},
+		},
+	})
+}
+
+// fpInsertHTTP posts an object to className on hostURI with the given id and status.
+// Returns the HTTP status code.
+func fpInsertHTTP(t *testing.T, hostURI, className, id, status string) int {
+	t.Helper()
+	return fpInsertFullHTTP(t, hostURI, className, id, status, 1, "")
+}
+
+// fpInsertFullHTTP posts an object with status, counter, and an optional condition.
+func fpInsertFullHTTP(t *testing.T, hostURI, className, id, status string, counter int64, condition string) int {
+	t.Helper()
+	type body struct {
+		Class      string                 `json:"class"`
+		ID         string                 `json:"id"`
+		Properties map[string]interface{} `json:"properties"`
+	}
+	payload := body{
+		Class: className,
+		ID:    id,
+		Properties: map[string]interface{}{
+			"status":  status,
+			"counter": counter,
+		},
+	}
+	jsonData, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	url := fmt.Sprintf("http://%s/v1/objects", hostURI)
+	if condition != "" {
+		url += "?" + condition
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBuffer(jsonData))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		t.Logf("fpInsertFullHTTP: network error (host=%s id=%s): %v", hostURI, id, err)
+		return 0
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	return resp.StatusCode
+}
+
+// fpUpdateHTTP sends a PUT to update an existing object with a field_match condition.
+// condition is the full condition query string fragment, e.g.:
+//
+//	"condition=field_match&property=status&value=draft&value_type=text"
+func fpUpdateHTTP(t *testing.T, hostURI, className, id, newStatus, condition string) int {
+	t.Helper()
+	type body struct {
+		Class      string                 `json:"class"`
+		ID         string                 `json:"id"`
+		Properties map[string]interface{} `json:"properties"`
+	}
+	payload := body{
+		Class: className,
+		ID:    id,
+		Properties: map[string]interface{}{
+			"status": newStatus,
+		},
+	}
+	jsonData, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	url := fmt.Sprintf("http://%s/v1/objects/%s/%s", hostURI, className, id)
+	if condition != "" {
+		url += "?" + condition
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewBuffer(jsonData))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		t.Logf("fpUpdateHTTP: network error (host=%s id=%s): %v", hostURI, id, err)
+		return 0
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	return resp.StatusCode
+}
+
+// fpGetStatus retrieves the status property from an object. Returns ("", false) when
+// the object does not exist or cannot be read.
+func fpGetStatus(t *testing.T, hostURI, className, id string) (string, bool) {
+	t.Helper()
+	helper.SetupClient(hostURI)
+	obj, err := helper.GetObject(t, className, strfmt.UUID(id))
+	if err != nil || obj == nil {
+		return "", false
+	}
+	props, ok := obj.Properties.(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	s, ok := props["status"].(string)
+	return s, ok
+}
+
+// --------------------------------------------------------------------------
+// Test 1: Predicate-true commits (POST + PUT)
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_RF3_TrueCommits inserts an object, then performs a
+// field_match update where the stored value matches the predicate → succeeds.
+//
+// This is the canonical "green path" for Phase-3 field-predicate.
+func TestFieldPredicate_RF3_TrueCommits(t *testing.T) {
+	const className = "FPTrueCommits"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	id := "aaaa0000-0000-4000-8000-000000000001"
+
+	t.Run("InsertObject", func(t *testing.T) {
+		code := fpInsertHTTP(t, host, className, id, "draft")
+		require.True(t, code >= 200 && code < 300, "initial insert must succeed: got %d", code)
+	})
+
+	t.Run("UpdateWithMatchingPredicate", func(t *testing.T) {
+		condition := "condition=field_match&property=status&value=draft&value_type=text"
+		code := fpUpdateHTTP(t, host, className, id, "published", condition)
+		require.True(t, code >= 200 && code < 300,
+			"field_match update where stored==expected must succeed: got %d", code)
+	})
+
+	t.Run("VerifyStatusUpdated", func(t *testing.T) {
+		status, ok := fpGetStatus(t, host, className, id)
+		require.True(t, ok, "object must be readable after update")
+		assert.Equal(t, "published", status, "status must be 'published' after successful field_match update")
+	})
+}
+
+// --------------------------------------------------------------------------
+// Test 2: Predicate-false returns 409
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_RF3_FalseReturns409 inserts an object, then attempts a
+// field_match update where the stored value does NOT match → 409 Conflict, not 5xx.
+//
+// This is the canonical "red path": the predicate fails and the stored value is
+// unchanged. If the replica propagation silently drops the predicate, the replica
+// would accept the write unconditionally -- this test detects that bug on RF=3.
+func TestFieldPredicate_RF3_FalseReturns409(t *testing.T) {
+	const className = "FPFalse409"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	id := "bbbb0000-0000-4000-8000-000000000001"
+
+	t.Run("InsertObject", func(t *testing.T) {
+		code := fpInsertHTTP(t, host, className, id, "draft")
+		require.True(t, code >= 200 && code < 300, "initial insert: got %d", code)
+	})
+
+	t.Run("UpdateWithMismatchedPredicate", func(t *testing.T) {
+		condition := "condition=field_match&property=status&value=published&value_type=text"
+		code := fpUpdateHTTP(t, host, className, id, "archived", condition)
+		require.Equal(t, http.StatusConflict, code,
+			"field_match where stored!=expected must return 409 Conflict (not 5xx): got %d", code)
+	})
+
+	t.Run("VerifyStatusUnchanged", func(t *testing.T) {
+		status, ok := fpGetStatus(t, host, className, id)
+		require.True(t, ok)
+		assert.Equal(t, "draft", status, "status must remain 'draft' after failed field_match")
+	})
+}
+
+// --------------------------------------------------------------------------
+// Test 3: Missing field returns 409
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_RF3_MissingField409 inserts an object WITHOUT setting the
+// "status" property (only "counter" is set), then attempts a field_match on
+// "status" → 409 Conflict.
+//
+// Verifies that absent properties fail the predicate, not silently pass.
+func TestFieldPredicate_RF3_MissingField409(t *testing.T) {
+	const className = "FPMissingField409"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	id := "cccc0000-0000-4000-8000-000000000001"
+
+	// Insert object with only "counter" set -- "status" is absent from Properties.
+	t.Run("InsertObjectWithoutStatus", func(t *testing.T) {
+		type body struct {
+			Class      string                 `json:"class"`
+			ID         string                 `json:"id"`
+			Properties map[string]interface{} `json:"properties"`
+		}
+		payload := body{Class: className, ID: id, Properties: map[string]interface{}{"counter": float64(1)}}
+		jsonData, _ := json.Marshal(payload)
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			fmt.Sprintf("http://%s/v1/objects", host), bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err2 := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+		require.NoError(t, err2)
+		defer resp.Body.Close()
+		require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300, "insert: %d", resp.StatusCode)
+	})
+
+	t.Run("FieldMatchOnMissingProperty", func(t *testing.T) {
+		condition := "condition=field_match&property=status&value=draft&value_type=text"
+
+		type body struct {
+			Class      string                 `json:"class"`
+			ID         string                 `json:"id"`
+			Properties map[string]interface{} `json:"properties"`
+		}
+		payload := body{Class: className, ID: id, Properties: map[string]interface{}{"status": "published"}}
+		jsonData, _ := json.Marshal(payload)
+		url := fmt.Sprintf("http://%s/v1/objects/%s/%s?%s", host, className, id, condition)
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewBuffer(jsonData))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err2 := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+		require.NoError(t, err2)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusConflict, resp.StatusCode,
+			"field_match on absent property must return 409 Conflict: got %d", resp.StatusCode)
+	})
+}
+
+// --------------------------------------------------------------------------
+// Test 4: Concurrent exactly-one-winner
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_RF3_ConcurrentExactlyOneWinner creates an object with
+// status="draft", then launches M concurrent goroutines all attempting to
+// flip status from "draft" to "published" using field_match. Exactly one
+// must succeed (200) and all others must get 409.
+//
+// This is the key correctness test for the per-UUID lock under field-predicate:
+// the winner atomically reads "draft", passes the predicate, and writes "published".
+// All subsequent attempts see "published" != "draft" and get 409.
+//
+// This test also catches the silent-drop replication bug: if the replica
+// receives an unconditional write (predicate dropped), all M goroutines could
+// "succeed" and the final status would be indeterminate.
+func TestFieldPredicate_RF3_ConcurrentExactlyOneWinner(t *testing.T) {
+	const (
+		className  = "FPConcurrentWinner"
+		numWorkers = 16
+		clLevel    = "QUORUM"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	// Insert 50 objects, each initially with status="draft".
+	const numObjects = 50
+	uuids := makeUUIDs("dddd", numObjects)
+
+	t.Run("InsertDraftObjects", func(t *testing.T) {
+		for _, id := range uuids {
+			code := fpInsertHTTP(t, host, className, id, "draft")
+			require.True(t, code >= 200 && code < 300, "insert %s: got %d", id, code)
+		}
+	})
+
+	// Each UUID is attempted by all numWorkers goroutines. Only one should win.
+	logger, _ := logrustest.NewNullLogger()
+	var wg sync.WaitGroup
+	var totalSuccess, totalConflict, totalError int64
+
+	t.Run("ConcurrentFlip", func(t *testing.T) {
+		for w := 0; w < numWorkers; w++ {
+			wg.Add(1)
+			enterrors.GoWrapper(func() {
+				defer wg.Done()
+				localSuccess, localConflict, localErr := int64(0), int64(0), int64(0)
+				for _, id := range uuids {
+					condition := "condition=field_match&property=status&value=draft&value_type=text&consistency_level=" + clLevel
+					code := fpUpdateHTTP(t, host, className, id, "published", condition)
+					switch {
+					case code >= 200 && code < 300:
+						localSuccess++
+					case code == http.StatusConflict:
+						localConflict++
+					default:
+						localErr++
+						t.Logf("unexpected status %d for UUID %s", code, id)
+					}
+				}
+				atomic.AddInt64(&totalSuccess, localSuccess)
+				atomic.AddInt64(&totalConflict, localConflict)
+				atomic.AddInt64(&totalError, localErr)
+			}, logger)
+		}
+		wg.Wait()
+
+		t.Logf("Concurrent flip: success=%d conflict=%d error=%d",
+			totalSuccess, totalConflict, totalError)
+	})
+
+	t.Run("AssertZeroErrors", func(t *testing.T) {
+		require.Zero(t, totalError,
+			"field_match writes must not return unexpected error codes; got %d errors", totalError)
+	})
+
+	t.Run("AssertExactlyOneWinnerPerObject", func(t *testing.T) {
+		// Exactly numObjects successes across all goroutines: one per UUID.
+		require.Equal(t, int64(numObjects), totalSuccess,
+			"exactly %d successes expected (one per object); got %d -- "+
+				"if > %d, the per-UUID lock failed to serialize the predicate check; "+
+				"if < %d, a predicate-true update was incorrectly rejected",
+			numObjects, totalSuccess, numObjects, numObjects)
+	})
+
+	t.Run("VerifyAllStatusPublished", func(t *testing.T) {
+		// Every object must now be "published".
+		wrongCount := 0
+		for _, id := range uuids {
+			status, ok := fpGetStatus(t, host, className, id)
+			if !ok || status != "published" {
+				wrongCount++
+				t.Logf("UUID %s has status=%q (want 'published')", id, status)
+			}
+		}
+		require.Zero(t, wrongCount,
+			"%d objects did not reach status='published' after exactly-one-winner test", wrongCount)
+	})
+}
+
+// --------------------------------------------------------------------------
+// Test 5: HA at QUORUM through node failure
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_RF3_HA_QUORUM verifies that field_match writes continue at
+// QUORUM through a mid-load node stop, and that predicate-false returns 409 (not 5xx)
+// even when a replica is down. Encodes INV-HA-1.
+func TestFieldPredicate_RF3_HA_QUORUM(t *testing.T) {
+	const (
+		className        = "FPHA"
+		clLevel          = "QUORUM"
+		numUUIDs         = 200
+		failAfterFrac    = 0.4
+		minSuccessRatePC = 85.0
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	// Pre-insert all objects with status="draft".
+	uuids := makeUUIDs("eeee", numUUIDs)
+	for _, id := range uuids {
+		code := fpInsertHTTP(t, host, className, id, "draft")
+		require.True(t, code >= 200 && code < 300, "pre-insert %s: got %d", id, code)
+	}
+
+	failAt := int(float64(numUUIDs) * failAfterFrac)
+	var (
+		successCount  int64
+		conflictCount int64
+		errorCount    int64
+		nodeStopped   bool
+	)
+
+	for i, id := range uuids {
+		if i == failAt && !nodeStopped {
+			t.Logf("[%d/%d] Stopping node 2 mid-load", i, numUUIDs)
+			common.StopNodeAt(ctx, t, compose, 2)
+			nodeStopped = true
+		}
+
+		condition := fmt.Sprintf("condition=field_match&property=status&value=draft&value_type=text&consistency_level=%s", clLevel)
+		code := fpUpdateHTTP(t, host, className, id, "published", condition)
+		switch {
+		case code >= 200 && code < 300:
+			atomic.AddInt64(&successCount, 1)
+		case code == http.StatusConflict:
+			// 409 is acceptable: predicate-false (object was already updated).
+			atomic.AddInt64(&conflictCount, 1)
+		default:
+			atomic.AddInt64(&errorCount, 1)
+			t.Logf("[%d/%d] unexpected status=%d UUID=%s (node_stopped=%v)", i, numUUIDs, code, id, nodeStopped)
+		}
+	}
+
+	successRate := 100.0 * float64(successCount) / float64(numUUIDs)
+	t.Logf("HA load: total=%d success=%d conflict=%d error=%d success_rate=%.1f%%",
+		numUUIDs, successCount, conflictCount, errorCount, successRate)
+
+	t.Run("AssertHighSuccessRate_INV_HA_1", func(t *testing.T) {
+		require.GreaterOrEqual(t, successRate, minSuccessRatePC,
+			"field_match write success rate %.1f%% below %.1f%% floor (INV-HA-1): "+
+				"QUORUM writes on RF=3 must survive 1 replica down",
+			successRate, minSuccessRatePC)
+	})
+
+	t.Run("AssertNoUnexpectedErrors", func(t *testing.T) {
+		// Allow a small number of transient errors during node failover (the brief
+		// window where the RAFT leader is re-elected). 5% budget.
+		maxErrors := int64(float64(numUUIDs) * 0.05)
+		require.LessOrEqual(t, errorCount, maxErrors,
+			"unexpected error count %d exceeds 5%% budget of %d total: "+
+				"field_match predicate failures must return 409, not 5xx",
+			errorCount, numUUIDs)
+	})
+}
+
+// --------------------------------------------------------------------------
+// Test 6: Phase-1 no-regression on phase3 image
+// --------------------------------------------------------------------------
+
+// TestFieldPredicate_NoRegression_Phase1 verifies that insert_if_not_exists
+// still works correctly after Phase-3 changes. This catches any accidental
+// regression in the conditional dispatch switch.
+func TestFieldPredicate_NoRegression_Phase1(t *testing.T) {
+	const (
+		className = "FPNoRegP1"
+		numUUIDs  = 100
+		clLevel   = "QUORUM"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().WithWeaviateCluster(3).Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	host := compose.ContainerURI(1)
+	helper.SetupClient(host)
+	setupFPClass(t, className)
+	waitForSchemaOnAllNodes(t, compose, className, 3)
+
+	uuids := makeUUIDs("ffff", numUUIDs)
+
+	t.Run("InsertIfNotExists_AllSucceed", func(t *testing.T) {
+		var errCount int64
+		for _, id := range uuids {
+			code := prodCondInsertHTTP(t, host, className, id, clLevel)
+			if code < 200 || code >= 300 {
+				atomic.AddInt64(&errCount, 1)
+				t.Logf("insert_if_not_exists error: status=%d UUID=%s", code, id)
+			}
+		}
+		require.Zero(t, errCount, "Phase-1 insert_if_not_exists must still work on phase3 image")
+	})
+
+	t.Run("InsertIfNotExists_DuplicatesReturnOK", func(t *testing.T) {
+		for _, id := range uuids[:5] {
+			code := prodCondInsertHTTP(t, host, className, id, clLevel)
+			// 200 = skipped (idempotent), 201 = inserted (race won). Both acceptable.
+			require.True(t, code == http.StatusOK || code == http.StatusCreated,
+				"duplicate insert_if_not_exists must return 200 or 201: got %d for %s", code, id)
+		}
+	})
+
+	t.Run("AssertCountCorrect", func(t *testing.T) {
+		var finalCount int64
+		assert.Eventually(t, func() bool {
+			finalCount = countObjectsViaGraphQL(t, host, className)
+			return finalCount == int64(numUUIDs)
+		}, 30*time.Second, 500*time.Millisecond,
+			"aggregate count must be exactly %d; got %d", numUUIDs, finalCount)
+	})
+}

--- a/test/acceptance/conditional_writes/production_readiness_multinode_test.go
+++ b/test/acceptance/conditional_writes/production_readiness_multinode_test.go
@@ -146,23 +146,18 @@ func waitForSchemaOnAllNodes(t *testing.T, compose *docker.DockerCompose, classN
 		for time.Now().Before(deadline) {
 			helper.SetupClient(nodeURI)
 			cls, err := helper.GetClassWithoutAssert(t, className, "")
-			if err == nil && cls != nil {
-				hasField := false
-				for _, p := range cls.Properties {
-					if p.Name == "testfield" {
-						hasField = true
-						break
-					}
-				}
-				if hasField {
-					ready = true
-					break
-				}
+			// Schema (class + its properties) has propagated to this node once the
+			// class is visible with at least one property. Keyed on property
+			// presence rather than a specific name so this works for every class
+			// shape in the suite (testfield, status/counter, etc.).
+			if err == nil && cls != nil && len(cls.Properties) > 0 {
+				ready = true
+				break
 			}
 			time.Sleep(interval)
 		}
 		require.True(t, ready,
-			"schema for class %q (with testfield property) did not propagate to node %d within %s",
+			"schema for class %q (with its properties) did not propagate to node %d within %s",
 			className, nodeIdx, timeout)
 	}
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -496,6 +496,7 @@ function get_fast_acceptance_packages() {
     | grep -v 'test/acceptance/reindex_concurrent' \
     | grep -v 'test/acceptance/reindex_mt' \
     | grep -v 'test/acceptance/distributed_tasks' \
+    | grep -v 'test/acceptance/conditional_writes' \
     | sed 's|.*/test/acceptance/|test/acceptance/|'
 }
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -54,6 +54,7 @@ function main() {
   run_acceptance_reindex_singlenode_b=false
   run_acceptance_reindex_concurrent=false
   run_acceptance_reindex_mt=false
+  run_acceptance_conditional_writes=false
 
   while [[ "$#" -gt 0 ]]; do
       case $1 in
@@ -106,6 +107,7 @@ function main() {
           --acceptance-reindex-singlenode-b|-arsb) run_all_tests=false; run_acceptance_reindex_singlenode_b=true;;
           --acceptance-reindex-concurrent|-arc) run_all_tests=false; run_acceptance_reindex_concurrent=true;;
           --acceptance-reindex-mt|-armt) run_all_tests=false; run_acceptance_reindex_mt=true;;
+          --acceptance-conditional-writes|-acw) run_all_tests=false; run_acceptance_conditional_writes=true;;
           --benchmark-only|-b) run_all_tests=false; run_benchmark=true;;
           --cleanup) run_all_tests=false; run_cleanup=true;;
           --help|-h) printf '%s\n' \
@@ -325,6 +327,11 @@ function main() {
   if $run_acceptance_reindex_mt; then
     echo "running reindex multi-tenant acceptance tests"
     run_acceptance_reindex_mt
+  fi
+
+  if $run_acceptance_conditional_writes; then
+    echo "running conditional-writes RF=3 acceptance tests"
+    run_acceptance_conditional_writes
   fi
   echo "Done!"
 }
@@ -1048,6 +1055,19 @@ function run_acceptance_objects() {
       return 1
     fi
   done
+}
+
+function run_acceptance_conditional_writes() {
+  echo_green "acceptance: conditional-writes: building weaviate/test-server image..."
+  GIT_REVISION=$(git rev-parse --short HEAD)
+  GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  docker compose -f docker-compose-test.yml build \
+    --build-arg GIT_REVISION="$GIT_REVISION" \
+    --build-arg GIT_BRANCH="$GIT_BRANCH" \
+    --build-arg EXTRA_BUILD_ARGS="-race" \
+    weaviate
+  export TEST_WEAVIATE_IMAGE=weaviate/test-server
+  run_aof_group "conditional-writes" test/acceptance/conditional_writes
 }
 
 function run_acceptance_only_tests() {

--- a/usecases/objects/conditional_e2e_test.go
+++ b/usecases/objects/conditional_e2e_test.go
@@ -144,8 +144,10 @@ func newConditionalTestSetup(repo *conditionalFakeRepo) (*Manager, *fakeModulesP
 	return mgr, modulesProvider
 }
 
-const conditionalTestUUID = strfmt.UUID("aaaaaaaa-0000-0000-0000-000000000001")
-const conditionalTestClass = "ConditionalTest"
+const (
+	conditionalTestUUID  = strfmt.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+	conditionalTestClass = "ConditionalTest"
+)
 
 // TestConditionalEndToEndInsertIfNotExists_ExistingUUID verifies that
 // insert_if_not_exists on a UUID that already exists returns ErrPreconditionFailed

--- a/usecases/replica/batch_conditional_test.go
+++ b/usecases/replica/batch_conditional_test.go
@@ -1,0 +1,218 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	routerTypes "github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/replica"
+)
+
+// mkBatchObj returns a storobj.Object with the given UUID and no conditions set.
+func mkBatchObj(id strfmt.UUID) *storobj.Object {
+	return storobj.FromObject(&models.Object{
+		Class: "C1",
+		ID:    id,
+	}, nil, nil, nil)
+}
+
+// mkBatchObjWithExistence returns an object with OnlyIfNotExists set.
+func mkBatchObjWithExistence(id strfmt.UUID) *storobj.Object {
+	obj := mkBatchObj(id)
+	obj.Conditional.OnlyIfNotExists = true
+	return obj
+}
+
+// mkBatchObjWithOnlyIfExists returns an object with OnlyIfExists set.
+func mkBatchObjWithOnlyIfExists(id strfmt.UUID) *storobj.Object {
+	obj := mkBatchObj(id)
+	obj.Conditional.OnlyIfExists = true
+	return obj
+}
+
+// mkBatchObjWithIfVersion returns an object with IfVersion set.
+func mkBatchObjWithIfVersion(id strfmt.UUID, v uint64) *storobj.Object {
+	obj := mkBatchObj(id)
+	obj.Conditional.IfVersion = &v
+	return obj
+}
+
+// mkBatchObjWithUpdateIf returns an object with a field-predicate (UpdateIf) set.
+func mkBatchObjWithUpdateIf(id strfmt.UUID, prop, val string) *storobj.Object {
+	obj := mkBatchObj(id)
+	obj.Conditional.UpdateIf = &storobj.Predicate{
+		PropertyName:  prop,
+		ExpectedValue: val,
+		ValueType:     storobj.PredicateValueText,
+		Operator:      storobj.EqOperator,
+	}
+	return obj
+}
+
+// TestBatchConditionalAdmissionGuard verifies that PutObjects rejects any object
+// carrying a non-empty Conditional (all three forms) with a clear per-object error,
+// while non-conditional objects in the same batch proceed through the normal AP path
+// and succeed.
+//
+// Causal link: without the guard, PutObjects fans out ALL objects (including conditional
+// ones) to replicas as unconditional writes. The condition is silently dropped. This
+// test catches that failure mode because it asserts that conditional objects receive
+// errConditionalInBatch and that the error message names the limitation. A test run
+// against the pre-guard code would see nil errors for the conditional objects, failing
+// the assert.Error checks.
+func TestBatchConditionalAdmissionGuard(t *testing.T) {
+	const (
+		cls   = "C1"
+		shard = "SH1"
+	)
+
+	unconditionalID := strfmt.UUID("00000000-0000-0000-0000-000000000010")
+	conditionalID := strfmt.UUID("00000000-0000-0000-0000-000000000011")
+	nodes := []string{"A", "B", "C"}
+
+	type row struct {
+		name          string
+		conditionalFn func(strfmt.UUID) *storobj.Object
+	}
+
+	rows := []row{
+		{
+			name:          "OnlyIfNotExists (existence-phase1)",
+			conditionalFn: mkBatchObjWithExistence,
+		},
+		{
+			name: "OnlyIfExists (existence-phase1b)",
+			conditionalFn: func(id strfmt.UUID) *storobj.Object {
+				return mkBatchObjWithOnlyIfExists(id)
+			},
+		},
+		{
+			name: "IfVersion (version-CAS phase2)",
+			conditionalFn: func(id strfmt.UUID) *storobj.Object {
+				return mkBatchObjWithIfVersion(id, 42)
+			},
+		},
+		{
+			name: "UpdateIf (field-predicate phase3)",
+			conditionalFn: func(id strfmt.UUID) *storobj.Object {
+				return mkBatchObjWithUpdateIf(id, "status", "active")
+			},
+		},
+	}
+
+	for _, r := range rows {
+		r := r
+		t.Run(r.name, func(t *testing.T) {
+			f := newFakeFactory(t, cls, shard, nodes, false)
+			rep := f.newReplicator()
+
+			unconditionalObj := mkBatchObj(unconditionalID)
+			conditionalObj := r.conditionalFn(conditionalID)
+
+			okResp := replica.SimpleResponse{}
+
+			// TestMain opens the write-gate to v2 for all tests in this package, so
+			// PutObjects will call resolveCurrentVersion (a digest read) for the
+			// unconditional object before fanning out. Wire DigestObjects to return
+			// version 0 (object absent) for the unconditional object.
+			wireDigestResponse(f.RClient, cls, shard, unconditionalID, 0)
+
+			// Wire the unconditional object's prepare + commit path for all nodes.
+			// The conditional object must NOT reach the replicas at all.
+			var commitWG sync.WaitGroup
+			for _, n := range nodes {
+				f.WClient.On("PutObjects", mock.Anything, n, cls, shard, mock.Anything, mock.Anything, uint64(0)).
+					Return(okResp, nil).Maybe()
+				commitWG.Add(1)
+				f.WClient.On("Commit", mock.Anything, n, cls, shard, mock.Anything, mock.Anything).
+					Return(nil).Maybe().
+					RunFn = func(args mock.Arguments) {
+					defer commitWG.Done()
+					resp := args[5].(*replica.SimpleResponse)
+					*resp = okResp
+				}
+				f.WClient.On("Abort", mock.Anything, n, cls, shard, mock.Anything).
+					Return(okResp, nil).Maybe()
+			}
+
+			ctx := context.Background()
+			errs := rep.PutObjects(ctx, shard,
+				[]*storobj.Object{unconditionalObj, conditionalObj},
+				routerTypes.ConsistencyLevelQuorum, 0)
+
+			commitWG.Wait()
+
+			// unconditionalObj is at index 0: must succeed.
+			assert.NoError(t, errs[0],
+				"[%s] non-conditional object in batch must succeed via AP path", r.name)
+
+			// conditionalObj is at index 1: must receive a clear error naming the limitation.
+			assert.Error(t, errs[1],
+				"[%s] conditional object in batch must receive an error", r.name)
+			assert.True(t,
+				strings.Contains(errs[1].Error(), "conditional writes are not supported in batch"),
+				"[%s] error message must name the limitation; got: %v", r.name, errs[1])
+			assert.True(t,
+				strings.Contains(errs[1].Error(), "submit individually"),
+				"[%s] error message must say 'submit individually'; got: %v", r.name, errs[1])
+		})
+	}
+}
+
+// TestBatchAllConditionalReturnsEarlyNoFanOut verifies that when every object in the
+// batch carries a condition, PutObjects returns all errors immediately without
+// performing any fan-out (no RPC is issued to replicas).
+//
+// Causal link: the fast-return path exits before coord.Push is called. Without the
+// guard, coord.Push would be called with all objects, silently dropping conditions.
+// This test catches that because the mock client has no expectations registered for
+// PutObjects; any unexpected call would fail the test.
+func TestBatchAllConditionalReturnsEarlyNoFanOut(t *testing.T) {
+	const (
+		cls   = "C1"
+		shard = "SH1"
+	)
+	nodes := []string{"A", "B", "C"}
+	f := newFakeFactory(t, cls, shard, nodes, false)
+	rep := f.newReplicator()
+
+	id1 := strfmt.UUID("00000000-0000-0000-0000-000000000020")
+	id2 := strfmt.UUID("00000000-0000-0000-0000-000000000021")
+
+	// Both objects carry conditions; no WClient expectations are set, so any
+	// unexpected call (PutObjects / Commit / Abort) will fail the mock assertions.
+	obj1 := mkBatchObjWithExistence(id1)
+	obj2 := mkBatchObjWithIfVersion(id2, 1)
+
+	ctx := context.Background()
+	errs := rep.PutObjects(ctx, shard,
+		[]*storobj.Object{obj1, obj2},
+		routerTypes.ConsistencyLevelQuorum, 0)
+
+	assert.Len(t, errs, 2)
+	for i, err := range errs {
+		assert.Error(t, err, "object[%d] must have an error", i)
+		assert.True(t,
+			strings.Contains(err.Error(), "conditional writes are not supported in batch"),
+			"object[%d] error must name the limitation; got: %v", i, err)
+	}
+}

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -303,12 +303,46 @@ func (r *Replicator) DeleteObject(ctx context.Context,
 	return nil
 }
 
+// errConditionalInBatch is the sentinel returned for each object in a server-side
+// batch that carries a non-empty Conditional. Conditional writes must be submitted
+// individually via the single-object PUT path, where the coordinator can run the
+// required precondition check (digest read + CAS / existence / field-predicate)
+// against the replica set before broadcasting. The batch path fans out all objects
+// in a single RPC and has no per-object precondition phase.
+var errConditionalInBatch = fmt.Errorf("conditional writes are not supported in batch; submit individually")
+
 func (r *Replicator) PutObjects(ctx context.Context,
 	shard string,
 	objs []*storobj.Object,
 	l types.ConsistencyLevel,
 	schemaVersion uint64,
 ) []error {
+	// Admission guard: a batch object carrying any conditional form (existence-CAS,
+	// version-CAS, or field-predicate) cannot be processed here. The batch fan-out
+	// has no per-object precondition phase, so silently dropping the condition would
+	// be a data-integrity footgun. Return a clear per-object error for every
+	// conditional object; collect non-conditional objects for the normal AP path.
+	outErrs := make([]error, len(objs))
+	unconditional := make([]*storobj.Object, 0, len(objs))
+	unconditionalIdx := make([]int, 0, len(objs)) // original position in objs
+
+	for i, obj := range objs {
+		if obj != nil && !obj.Conditional.IsZero() {
+			r.log.WithField("op", "put.many.admission").WithField("class", r.class).
+				WithField("shard", shard).WithField("uuid", obj.ID()).
+				Debugf("rejecting conditional object in batch (conditional writes not supported in batch; submit individually)")
+			outErrs[i] = errConditionalInBatch
+			continue
+		}
+		unconditional = append(unconditional, obj)
+		unconditionalIdx = append(unconditionalIdx, i)
+	}
+
+	// Fast return: all objects were conditional; nothing to fan out.
+	if len(unconditional) == 0 {
+		return outErrs
+	}
+
 	// Mint a single-coordinator-local version for each object before fanning out
 	// to replicas. This mirrors the single-PUT mint discipline (coordinator mints
 	// from local prev, replicas preserve the incoming version with mintVersion=false)
@@ -323,7 +357,7 @@ func (r *Replicator) PutObjects(ctx context.Context,
 	// When the gate is closed (v1, default) obj.Version stays 0 and obj.MarshallerVersion
 	// stays v1; the bump is a no-op on disk.
 	if storobj.GetWriteMarshallerVersion() == 2 {
-		for _, obj := range objs {
+		for _, obj := range unconditional {
 			if obj == nil || obj.ID() == "" {
 				continue
 			}
@@ -344,7 +378,7 @@ func (r *Replicator) PutObjects(ctx context.Context,
 
 	coord := NewWriteCoordinator[SimpleResponse, error](r.client, r.router, r.metrics, r.class, shard, r.requestID(opPutObjects), r.log)
 	op := func(ctx context.Context, host, requestID string) error {
-		resp, err := r.client.PutObjects(ctx, host, r.class, shard, requestID, objs, schemaVersion)
+		resp, err := r.client.PutObjects(ctx, host, r.class, shard, requestID, unconditional, schemaVersion)
 		if err == nil {
 			err = resp.FirstError()
 		}
@@ -353,22 +387,25 @@ func (r *Replicator) PutObjects(ctx context.Context,
 		}
 		return nil
 	}
-	rs, err := coord.Push(ctx, l, op, r.simpleCommit(shard), r.readSimpleResponse, r.flattenErrors, len(objs))
+	rs, err := coord.Push(ctx, l, op, r.simpleCommit(shard), r.readSimpleResponse, r.flattenErrors, len(unconditional))
 	if err != nil {
 		r.log.WithField("op", "push.many").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
-		errs := make([]error, len(objs))
-		for i := 0; i < len(objs); i++ {
-			errs[i] = err
+		fanErr := fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
+		for _, origIdx := range unconditionalIdx {
+			outErrs[origIdx] = fanErr
 		}
-		return errs
+		return outErrs
 	}
 	if err := firstError(rs); err != nil {
 		r.log.WithField("op", "put.many").WithField("class", r.class).
 			WithField("shard", shard).Error(rs)
 	}
-	return rs
+	// Merge AP-path results back into the full-width error slice by original index.
+	for i, origIdx := range unconditionalIdx {
+		outErrs[origIdx] = rs[i]
+	}
+	return outErrs
 }
 
 func (r *Replicator) DeleteObjects(ctx context.Context,

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -45,6 +45,15 @@ const (
 	// means "no version precondition" (KNOWN-WEAK-ROLLING-UPGRADE: old replicas that
 	// do not parse this param treat the write as unconditional during rolling upgrade).
 	ConditionalIfVersionKey = "conditional_if_version"
+
+	// ConditionalFieldPropertyKey, ConditionalFieldValueKey, and
+	// ConditionalFieldValueTypeKey carry the Phase-3 field-predicate condition on
+	// the HTTP replication wire. All three must be present together or all absent.
+	// Absent means "no field-predicate condition" (KNOWN-WEAK-ROLLING-UPGRADE: old
+	// replicas that do not parse these params treat the write as unconditional).
+	ConditionalFieldPropertyKey  = "conditional_field_property"
+	ConditionalFieldValueKey     = "conditional_field_value"
+	ConditionalFieldValueTypeKey = "conditional_field_value_type"
 )
 
 // Client is used to read and write objects on replicas


### PR DESCRIPTION
### Problem

PR1 (#11541) added existence-based preconditions. PR2 (#11544) added server-managed versioning for optimistic concurrency. Both guard on the object's identity and history. Neither lets you guard on the object's current domain state: "set status to `processing` only if it is still `pending`", "claim this job only if it is `unassigned`", "apply this update only if the owner is still me". You can approximate that with version-CAS: read the current version, hold it, thread it through every hop. But the guard is really about a business value, not a version number. The application should not have to carry that bookkeeping.

A field predicate states the precondition in the application's own terms: gate the write on a named property's current value, evaluated on the server under the same lock that commits the write.

### What this adds

A `field_match` condition: the write commits only if a named property currently equals a given typed value.

```
POST/PUT /v1/objects[/{class}/{id}]?condition=field_match&property=status&value=pending&value_type=text
  status == "pending"   write commits
  status == "done"      412 / 409, write rejected, current state untouched
  status absent          rejected (a missing property cannot satisfy equality)
```

Available over REST (query parameters) and gRPC (a structured `FieldPredicate` on the request). The predicate is evaluated on the server inside the per-UUID lock, between the local read and the commit, so the check and the write are atomic on a shard.

### Semantics

Typed equality for `text`, `int`, `number`, `boolean`, and `date`. The value type is explicit on the request, so the comparison does not need a schema round-trip on the write path. A missing or null property fails the predicate: equality against a value that is not there cannot hold. The empty string is a legitimate `text` value and is matched as such, distinct from "no predicate". `number` is IEEE-754 float; exact-equality on floats carries the usual caveat and the mismatch error says so. Integer, text, boolean, and date are the precise-equality types.

Out of scope for this PR, designed as follow-ons: operators other than equality, multi-value properties, and predicates on nested or cross-reference properties.

### Consistency under replication

Same model as PR1 and PR2:

| Scope | Guarantee |
|---|---|
| Single shard / single coordinator | **Authoritative.** The predicate is evaluated under the per-UUID lock; N racers gated on the same predicate resolve to one winner. Verified: concurrent same-predicate writers, exactly one commits. |
| Across coordinators, under replication lag | **Best-effort, last-write-wins**, the documented boundary. |
| Consistency level | **Inherited, QUORUM by default, never forced higher (INV-HA-1).** Verified: predicate writes continue at QUORUM through a node kill. |

No persisted-format change: the predicate reads the object's existing properties, so this works on existing data with no migration and no version gate (unlike PR2).

### Multi-node correctness

The predicate must fire on the node that performs the write, so it travels with the write across the cluster as additive, request-scoped fields restored before the shard write, exactly as the PR1 and PR2 conditions do. This replication path is where both earlier phases silently dropped the condition, found only on a live cluster, so it was the primary focus here.

One such drop was caught before it shipped: the wire codec used "value is empty" as the marker for "no predicate", so a predicate whose expected value is the empty string was indistinguishable from no predicate. On the replication RPC, that predicate was silently dropped, and on a rolling upgrade the write would apply unconditionally. Fixed by signaling predicate presence with the condition discriminator and the property/type, not with a non-empty value, and pinned with round-trip and RF=3 tests including the empty-string case and a numeric type.

### Verification

On a real three-node, RF=3 cluster:

- predicate true: write commits and value advances
- predicate false: 412/409, stored object untouched
- missing property: rejected
- concurrent same-predicate writers: exactly one commits
- HA: predicate writes continue at QUORUM with a replica killed mid-load
- no regression of PR1 existence conditionals
- empty-string predicate: round-trips correctly and fires at RF=3
- numeric (`int`) predicate: exactly-one-winner at RF=3

Plus unit coverage of per-type equality and the wire round-trip (empty string, zero, unicode, and the `&`/`=` separators in the REST encoding).

### Scope, and what is deliberately not here yet

Ships here: equality field predicates over REST and gRPC, with the consistency model above.

Follow-ons, designed and feasible: richer operators (not-equal, ordered comparisons), multi-value and nested/reference predicates, schema-driven type inference so the client need not send the value type, and the strong cross-replica CAS upgrade that lifts the cross-coordinator row to linearizable.

### Note for reviewer

The cross-coordinator last-write-wins boundary is the same honest one as PR1 and PR2 and is intentional. The predicate is single-shard-authoritative, which covers the dominant guard-on-current-state use cases: claim, state-machine transition, owner check. It composes with the existence and version preconditions from the earlier PRs rather than replacing them, and the API is forward-compatible with a future stronger guarantee.

Claudette
