### PR TITLE
fix(inverted): index references provided as untyped JSON beacons

### DIFF
--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -473,17 +474,25 @@ func (a *Analyzer) extendPropertiesWithReference(properties *[]Property,
 	var asRefs models.MultipleRef
 	asRefs, ok = value.(models.MultipleRef)
 	if !ok {
-		// due to the fix introduced in https://github.com/weaviate/weaviate/pull/2320,
-		// MultipleRef's can appear as empty []any when no actual refs are provided for
-		// an object's reference property.
-		//
-		// if we encounter []any, assume it indicates an empty ref prop, and skip it.
-		_, ok := value.([]any)
-		if !ok {
-			return fmt.Errorf("expected property %q to be of type models.MutlipleRef,"+
+		// A reference can also arrive as a generic []any of beacon
+		// maps — e.g. an object decoded from JSON during async-replication
+		// repair. Per PR #2320 an *empty* []any means "no refs". A *populated*
+		// one carries real beacons and must be parsed and indexed: silently
+		// skipping it drops the refs from the filterable bucket and makes
+		// by-reference filters miss the object.
+		untyped, isUntyped := value.([]any)
+		if !isUntyped {
+			return fmt.Errorf("expected property %q to be of type models.MultipleRef,"+
 				" but got %T", prop.Name, value)
 		}
-		return nil
+		if len(untyped) == 0 {
+			return nil
+		}
+		parsed, err := refsFromUntyped(untyped)
+		if err != nil {
+			return fmt.Errorf("reference property %q: %w", prop.Name, err)
+		}
+		asRefs = parsed
 	}
 
 	property, err := a.analyzeRefPropCount(prop, asRefs)
@@ -504,6 +513,26 @@ func (a *Analyzer) extendPropertiesWithReference(properties *[]Property,
 
 	*properties = append(*properties, *property)
 	return nil
+}
+
+// refsFromUntyped converts a reference property decoded from generic JSON
+// ([]interface{} of {"beacon": ...} maps) into models.MultipleRef, so it can be
+// indexed like a natively-typed reference. Used when an object reaches the
+// analyzer without the typed-coercion the read path normally applies.
+func refsFromUntyped(value []interface{}) (models.MultipleRef, error) {
+	refs := make(models.MultipleRef, len(value))
+	for i, elem := range value {
+		asMap, ok := elem.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected ref element %d to be a map, got %T", i, elem)
+		}
+		beacon, ok := asMap["beacon"].(string)
+		if !ok {
+			return nil, fmt.Errorf("expected ref element %d to have a string %q, got %T", i, "beacon", asMap["beacon"])
+		}
+		refs[i] = &models.SingleRef{Beacon: strfmt.URI(beacon)}
+	}
+	return refs, nil
 }
 
 func (a *Analyzer) analyzeRefPropCount(prop *models.Property,

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -516,10 +516,10 @@ func (a *Analyzer) extendPropertiesWithReference(properties *[]Property,
 }
 
 // refsFromUntyped converts a reference property decoded from generic JSON
-// ([]interface{} of {"beacon": ...} maps) into models.MultipleRef, so it can be
+// ([]any of {"beacon": ...} maps) into models.MultipleRef, so it can be
 // indexed like a natively-typed reference. Used when an object reaches the
 // analyzer without the typed-coercion the read path normally applies.
-func refsFromUntyped(value []interface{}) (models.MultipleRef, error) {
+func refsFromUntyped(value []any) (models.MultipleRef, error) {
 	refs := make(models.MultipleRef, len(value))
 	for i, elem := range value {
 		asMap, ok := elem.(map[string]interface{})

--- a/adapters/repos/db/inverted/objects_ref_index_test.go
+++ b/adapters/repos/db/inverted/objects_ref_index_test.go
@@ -1,0 +1,61 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// Regression: a reference property arriving as generic JSON ([]interface{} of
+// beacon maps) — as it does for an object decoded during async-replication
+// repair — must be indexed into the filterable bucket, not silently skipped.
+func TestAnalyzer_ReferenceFromUntypedBeaconsIsIndexed(t *testing.T) {
+	filterable := true
+	refProp := &models.Property{
+		Name:            "wroteBooks",
+		DataType:        []string{"Books"},
+		IndexFilterable: &filterable,
+	}
+	a := NewAnalyzer(nil, "Authors")
+	uuid := strfmt.UUID("33333333-3333-3333-3333-333333333333")
+
+	hasRefValueProp := func(props []Property) bool {
+		for _, p := range props {
+			if p.Name == "wroteBooks" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("populated []interface{} beacons are indexed", func(t *testing.T) {
+		input := map[string]any{"wroteBooks": []interface{}{
+			map[string]interface{}{"beacon": "weaviate://localhost/Books/11111111-1111-1111-1111-111111111111"},
+			map[string]interface{}{"beacon": "weaviate://localhost/Books/22222222-2222-2222-2222-222222222222"},
+		}}
+		props, _, err := a.Object(input, []*models.Property{refProp}, uuid)
+		require.NoError(t, err)
+		require.True(t, hasRefValueProp(props),
+			"populated []interface{} ref must be indexed into the filterable bucket")
+	})
+
+	t.Run("empty []interface{} is treated as no refs", func(t *testing.T) {
+		input := map[string]any{"wroteBooks": []interface{}{}}
+		props, _, err := a.Object(input, []*models.Property{refProp}, uuid)
+		require.NoError(t, err)
+		require.False(t, hasRefValueProp(props), "empty ref must not produce a ref value entry")
+	})
+}

--- a/adapters/repos/db/inverted/objects_ref_index_test.go
+++ b/adapters/repos/db/inverted/objects_ref_index_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -42,19 +43,19 @@ func TestAnalyzer_ReferenceFromUntypedBeaconsIsIndexed(t *testing.T) {
 	}
 
 	t.Run("populated []interface{} beacons are indexed", func(t *testing.T) {
-		input := map[string]any{"wroteBooks": []interface{}{
+		input := map[string]any{"wroteBooks": []any{
 			map[string]interface{}{"beacon": "weaviate://localhost/Books/11111111-1111-1111-1111-111111111111"},
 			map[string]interface{}{"beacon": "weaviate://localhost/Books/22222222-2222-2222-2222-222222222222"},
 		}}
-		props, _, err := a.Object(input, []*models.Property{refProp}, uuid)
+		props, err := a.Object(input, []*models.Property{refProp}, uuid)
 		require.NoError(t, err)
 		require.True(t, hasRefValueProp(props),
 			"populated []interface{} ref must be indexed into the filterable bucket")
 	})
 
 	t.Run("empty []interface{} is treated as no refs", func(t *testing.T) {
-		input := map[string]any{"wroteBooks": []interface{}{}}
-		props, _, err := a.Object(input, []*models.Property{refProp}, uuid)
+		input := map[string]any{"wroteBooks": []any{}}
+		props, err := a.Object(input, []*models.Property{refProp}, uuid)
 		require.NoError(t, err)
 		require.False(t, hasRefValueProp(props), "empty ref must not produce a ref value entry")
 	})


### PR DESCRIPTION
## Problem
`Filter.by_ref(...).by_property(...).equal(...)` misses objects when async replication is enabled (e.g. after a rolling restart): the referenced objects keep their refs in the body (forward resolution works) but the reference's **filterable inverted index is empty**, so by-reference filters return ~0.

## Root cause
`extendPropertiesWithReference` only indexes a reference property when its value is `models.MultipleRef`. When an object reaches the analyzer with the reference as a generic `[]interface{}` of beacon maps — which happens when the object was decoded from JSON (e.g. async-replication repair) rather than going through the read path's type coercion — the analyzer hits this branch:

```go
_, ok := value.([]any)
if !ok { return error }
return nil   // []any => silently skip indexing
```

So the beacons are never written to the filterable bucket. The skip was intended for *empty* `[]any` ("no refs", PR #2320), but it also silently drops *populated* ones.

## Fix
Stop the silent skip: an empty `[]any` still means "no refs", but a populated one is parsed into `models.MultipleRef` and indexed like a native reference. Single chokepoint, so it covers every path that can feed untyped refs.

## Tests
`TestAnalyzer_ReferenceFromUntypedBeaconsIsIndexed` — populated `[]interface{}` beacons are now indexed; empty stays "no refs".


chaos runs : 
- upgrade test only : https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/26764005882
- whole pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/26765665112