### PR TITLE
use the same update time for batch references everywhere

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1417,6 +1417,15 @@ func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchRefere
 	if replProps == nil {
 		replProps = defaultConsistency()
 	}
+	// Stamp once so all replicas write the same LastUpdateTime; otherwise
+	// per-replica time.Now() diverges and triggers spurious async-replication
+	// repairs. Pre-set values (forwarded batches) are kept.
+	nowMs := time.Now().UnixMilli()
+	for idx := range refs {
+		if refs[idx].UpdateTime == 0 {
+			refs[idx].UpdateTime = nowMs
+		}
+	}
 	if schemaVersion > 0 {
 		if err := i.schemaReader.WaitForUpdate(ctx, schemaVersion); err != nil {
 			return duplicateErr(fmt.Errorf("wait for schema version %d: %w", schemaVersion, err), len(refs))

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -311,10 +311,16 @@ func (b *referencesBatcher) setErrorAtIndex(err error, i int) {
 }
 
 func mergeDocFromBatchReference(ref objects.BatchReference) objects.MergeDocument {
+	// Use the coordinator-assigned stamp so all replicas converge on the
+	// same LastUpdateTime; fall back when the field is unset.
+	updateTime := ref.UpdateTime
+	if updateTime == 0 {
+		updateTime = time.Now().UnixMilli()
+	}
 	return objects.MergeDocument{
 		Class:      ref.From.Class.String(),
 		ID:         ref.From.TargetID,
-		UpdateTime: time.Now().UnixMilli(),
+		UpdateTime: updateTime,
 		References: objects.BatchReferences{ref},
 	}
 }

--- a/adapters/repos/db/shard_write_batch_references_test.go
+++ b/adapters/repos/db/shard_write_batch_references_test.go
@@ -1,0 +1,60 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+func TestMergeDocFromBatchReference_UsesCoordinatorUpdateTime(t *testing.T) {
+	const stamped int64 = 1_700_000_000_000
+
+	ref := objects.BatchReference{
+		From: &crossref.RefSource{
+			Class:    schema.ClassName("Authors"),
+			TargetID: strfmt.UUID("11111111-1111-1111-1111-111111111111"),
+			Property: schema.PropertyName("wroteBooks"),
+		},
+		To:         &crossref.Ref{Class: "Books"},
+		UpdateTime: stamped,
+	}
+
+	got := mergeDocFromBatchReference(ref)
+
+	assert.Equal(t, stamped, got.UpdateTime,
+		"replica must apply the coordinator-assigned UpdateTime")
+}
+
+func TestMergeDocFromBatchReference_FallsBackWhenUpdateTimeUnset(t *testing.T) {
+	ref := objects.BatchReference{
+		From: &crossref.RefSource{
+			Class:    schema.ClassName("Authors"),
+			TargetID: strfmt.UUID("22222222-2222-2222-2222-222222222222"),
+			Property: schema.PropertyName("wroteBooks"),
+		},
+		To: &crossref.Ref{Class: "Books"},
+	}
+
+	before := time.Now().UnixMilli()
+	got := mergeDocFromBatchReference(ref)
+	after := time.Now().UnixMilli()
+
+	assert.GreaterOrEqual(t, got.UpdateTime, before)
+	assert.LessOrEqual(t, got.UpdateTime, after)
+}

--- a/usecases/objects/batch_types.go
+++ b/usecases/objects/batch_types.go
@@ -57,6 +57,9 @@ type BatchReference struct {
 	From          *crossref.RefSource `json:"from"`
 	To            *crossref.Ref       `json:"to"`
 	Tenant        string              `json:"tenant"`
+	// UpdateTime is stamped by the coordinator so all replicas apply the
+	// same LastUpdateTime. Zero means unset; replicas fall back to time.Now().
+	UpdateTime int64 `json:"updateTime,omitempty"`
 }
 
 // BatchReferences groups many Reference items together. The order matches the


### PR DESCRIPTION
### What's being changed:

Fixes that batch references do not use the same update time on ever node

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
