### PR TITLE
EXPERIMENT: Add REST search/aggregate endpoints (GraphQL replacement)

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -129,6 +129,9 @@ func CreateGRPCServer(state *state.State, clientTracker *telemetry.ClientTracker
 	s := grpc.NewServer(o...)
 	weaviateV0 := v0.NewService()
 	weaviateV1, drainBatch := v1.NewService(allowAnonymous, authComposer, state)
+	// Expose the search/aggregate pipeline to non-gRPC transports (REST query
+	// endpoints) so they reuse the exact same parse → traverse → reply path.
+	state.GRPCQuerier = weaviateV1
 	pbv0.RegisterWeaviateServer(s, weaviateV0)
 	pbv1.RegisterWeaviateServer(s, weaviateV1)
 

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/grpc/v1/auth"
 	"github.com/weaviate/weaviate/adapters/handlers/grpc/v1/batch"
 	restCtx "github.com/weaviate/weaviate/adapters/handlers/rest/context"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/filterext"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
@@ -97,7 +98,7 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
-	return s.AggregateWithPrincipal(ctx, principal, req)
+	return s.AggregateWithPrincipal(ctx, principal, req, nil)
 }
 
 // AggregateWithPrincipal runs an aggregation on behalf of an already-authenticated
@@ -105,7 +106,10 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 // metadata and delegates here; transports that authenticate before reaching the
 // service (e.g. the REST /v1/{collection}/aggregate endpoint) call this directly
 // so they reuse the exact same parse → aggregate → reply pipeline.
-func (s *Service) AggregateWithPrincipal(ctx context.Context, principal *models.Principal, req *pb.AggregateRequest) (reply *pb.AggregateReply, retErr error) {
+//
+// where is an optional filter in the REST WhereFilter syntax. When non-nil it is
+// resolved server-side and overrides req.Filters. gRPC callers pass nil.
+func (s *Service) AggregateWithPrincipal(ctx context.Context, principal *models.Principal, req *pb.AggregateRequest, where *models.WhereFilter) (reply *pb.AggregateReply, retErr error) {
 	before := time.Now()
 	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
@@ -125,6 +129,14 @@ func (s *Service) AggregateWithPrincipal(ctx context.Context, principal *models.
 	params, err := parser.Aggregate(req)
 	if err != nil {
 		return nil, fmt.Errorf("parse params: %w", err)
+	}
+
+	if where != nil {
+		filter, err := filterext.Parse(where, req.Collection, s.config.Namespaces.Enabled, principal)
+		if err != nil {
+			return nil, err
+		}
+		params.Filters = filter
 	}
 
 	res, err := s.traverser.Aggregate(restCtx.AddPrincipalToContext(ctx, principal), principal, params)
@@ -296,7 +308,7 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
-	return s.SearchWithPrincipal(ctx, principal, req)
+	return s.SearchWithPrincipal(ctx, principal, req, nil)
 }
 
 // SearchWithPrincipal executes a search on behalf of an already-authenticated
@@ -304,7 +316,12 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 // metadata and delegates here; transports that authenticate before reaching the
 // service (e.g. the REST /v1/{collection}/query endpoint) call this directly so
 // they reuse the exact same parse → traverse → reply pipeline.
-func (s *Service) SearchWithPrincipal(ctx context.Context, principal *models.Principal, req *pb.SearchRequest) (reply *pb.SearchReply, retErr error) {
+//
+// where is an optional filter in the REST WhereFilter syntax. When non-nil it is
+// resolved server-side and overrides req.Filters, letting REST callers use the
+// familiar where syntax instead of the protobuf Filters shape. gRPC callers pass
+// nil.
+func (s *Service) SearchWithPrincipal(ctx context.Context, principal *models.Principal, req *pb.SearchRequest, where *models.WhereFilter) (reply *pb.SearchReply, retErr error) {
 	before := time.Now()
 	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
@@ -331,6 +348,14 @@ func (s *Service) SearchWithPrincipal(ctx context.Context, principal *models.Pri
 	searchParams, err := parser.Search(req, s.config)
 	if err != nil {
 		return nil, err
+	}
+
+	if where != nil {
+		filter, err := filterext.Parse(where, req.Collection, s.config.Namespaces.Enabled, principal)
+		if err != nil {
+			return nil, err
+		}
+		searchParams.Filters = filter
 	}
 
 	if err := s.validateClassAndProperty(searchParams); err != nil {

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -92,19 +92,29 @@ func (s *Service) Aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	return result, errInner
 }
 
-func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (reply *pb.AggregateReply, retErr error) {
-	before := time.Now()
-
+func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.AggregateReply, error) {
 	principal, err := s.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	return s.AggregateWithPrincipal(ctx, principal, req)
+}
+
+// AggregateWithPrincipal runs an aggregation on behalf of an already-authenticated
+// principal. The gRPC Aggregate entrypoint resolves the principal from request
+// metadata and delegates here; transports that authenticate before reaching the
+// service (e.g. the REST /v1/{collection}/aggregate endpoint) call this directly
+// so they reuse the exact same parse → aggregate → reply pipeline.
+func (s *Service) AggregateWithPrincipal(ctx context.Context, principal *models.Principal, req *pb.AggregateRequest) (reply *pb.AggregateReply, retErr error) {
+	before := time.Now()
 	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+	collection, _, err := namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
+	if err != nil {
 		return nil, err
 	}
+	req.Collection = collection
 
 	parser := NewAggregateParser(
 		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
@@ -281,19 +291,29 @@ func (s *Service) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	return result, errInner
 }
 
-func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (reply *pb.SearchReply, retErr error) {
-	before := time.Now()
-
+func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.SearchReply, error) {
 	principal, err := s.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	return s.SearchWithPrincipal(ctx, principal, req)
+}
+
+// SearchWithPrincipal executes a search on behalf of an already-authenticated
+// principal. The gRPC Search entrypoint resolves the principal from request
+// metadata and delegates here; transports that authenticate before reaching the
+// service (e.g. the REST /v1/{collection}/query endpoint) call this directly so
+// they reuse the exact same parse → traverse → reply pipeline.
+func (s *Service) SearchWithPrincipal(ctx context.Context, principal *models.Principal, req *pb.SearchRequest) (reply *pb.SearchReply, retErr error) {
+	before := time.Now()
 	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+	collection, _, err := namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
+	if err != nil {
 		return nil, err
 	}
+	req.Collection = collection
 
 	parser := NewParser(
 		req.Uses_127Api,

--- a/adapters/handlers/rest/handlers_query.go
+++ b/adapters/handlers/rest/handlers_query.go
@@ -1,0 +1,270 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/entities/models"
+	pbv1 "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/usecases/auth/authentication/composer"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/restrictions"
+	"github.com/weaviate/weaviate/usecases/usagelimits"
+)
+
+// restQueryHandler serves the pure-REST search/aggregate endpoints that mirror
+// the gRPC Search/Aggregate RPCs:
+//
+//	POST /v1/{collection}/query      → Search
+//	POST /v1/{collection}/aggregate  → Aggregate
+//
+// The JSON request body is the protojson encoding of the gRPC SearchRequest /
+// AggregateRequest message, and the response is the protojson encoding of the
+// corresponding reply. An empty body is treated as an empty request (i.e. a
+// default search/aggregate over the collection). The collection name is taken
+// from the path and always overrides any value carried in the body.
+//
+// These endpoints are the GraphQL replacement. Unlike GraphQL they are
+// namespace-compatible, because they delegate to the same gRPC pipeline
+// (SearchWithPrincipal/AggregateWithPrincipal) which resolves
+// namespace-qualified collections and strips namespace details from errors.
+//
+// They are registered as a custom route in the global middleware chain (see
+// makeAddRESTQueryHandlers, wired from makeSetupGlobalMiddleware) rather than as
+// go-swagger operations: the body is opaque protojson and does not belong in the
+// OpenAPI model surface, and this mirrors how module routes (makeAddModuleHandlers)
+// are attached. As a result authentication is performed here rather than by the
+// swagger security middleware, matching the gRPC handler's own auth flow.
+type restQueryHandler struct {
+	querier              state.GRPCQuerier
+	authComposer         composer.TokenFunc
+	allowAnonymousAccess bool
+	disabled             bool
+	maxBodyBytes         int64
+	logger               logrus.FieldLogger
+}
+
+type restQueryKind int
+
+const (
+	restQueryKindSearch restQueryKind = iota
+	restQueryKindAggregate
+)
+
+// makeAddRESTQueryHandlers builds the middleware that intercepts the REST
+// query/aggregate routes and falls through to next for everything else.
+func makeAddRESTQueryHandlers(appState *state.State) func(http.Handler) http.Handler {
+	h := &restQueryHandler{
+		querier: appState.GRPCQuerier,
+		authComposer: composer.New(
+			appState.ServerConfig.Config.Authentication,
+			appState.APIKey, appState.OIDC),
+		allowAnonymousAccess: appState.ServerConfig.Config.Authentication.AnonymousAccess.Enabled,
+		disabled:             appState.ServerConfig.Config.DisableRESTQuery,
+		maxBodyBytes:         int64(appState.ServerConfig.Config.GRPC.MaxMsgSize),
+		logger:               appState.Logger,
+	}
+	return h.middleware
+}
+
+func (h *restQueryHandler) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		collection, kind, ok := matchRESTQueryPath(r.URL.Path)
+		if !ok || r.Method != http.MethodPost {
+			next.ServeHTTP(w, r)
+			return
+		}
+		h.serve(w, r, collection, kind)
+	})
+}
+
+// matchRESTQueryPath returns the (url-decoded) collection and the query kind for
+// paths of the exact shape /v1/{collection}/query or /v1/{collection}/aggregate.
+// ok is false for anything else so the caller falls through to the next handler.
+// No existing REST route has the {x}/query or {x}/aggregate shape, so this never
+// shadows another endpoint.
+func matchRESTQueryPath(path string) (collection string, kind restQueryKind, ok bool) {
+	const prefix = "/v1/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", 0, false
+	}
+	rest := strings.TrimPrefix(path, prefix)
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		return "", 0, false
+	}
+	col, verb := rest[:slash], rest[slash+1:]
+	// Require exactly two segments: a non-empty collection and a verb with no
+	// further path elements.
+	if col == "" || verb == "" || strings.ContainsRune(verb, '/') {
+		return "", 0, false
+	}
+	switch verb {
+	case "query":
+		kind = restQueryKindSearch
+	case "aggregate":
+		kind = restQueryKindAggregate
+	default:
+		return "", 0, false
+	}
+	decoded, err := url.PathUnescape(col)
+	if err != nil {
+		decoded = col
+	}
+	return decoded, kind, true
+}
+
+func (h *restQueryHandler) serve(w http.ResponseWriter, r *http.Request, collection string, kind restQueryKind) {
+	if h.disabled {
+		h.writeError(w, http.StatusUnprocessableEntity, nil, fmt.Errorf("rest query api is disabled"))
+		return
+	}
+	if h.querier == nil {
+		// Defensive: the querier is set when the gRPC server is created, which
+		// always happens during startup. If it is somehow unset, fail loudly
+		// rather than panic.
+		h.writeError(w, http.StatusInternalServerError, nil, fmt.Errorf("query pipeline is not available"))
+		return
+	}
+
+	principal, err := h.principalFromRequest(r)
+	if err != nil {
+		h.writeError(w, http.StatusUnauthorized, nil, err)
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, h.maxBodyBytes))
+	if err != nil {
+		h.writeError(w, http.StatusRequestEntityTooLarge, principal,
+			fmt.Errorf("read request body: %w", err))
+		return
+	}
+
+	switch kind {
+	case restQueryKindSearch:
+		req := &pbv1.SearchRequest{}
+		if err := unmarshalRequestBody(body, req); err != nil {
+			h.writeError(w, http.StatusUnprocessableEntity, principal,
+				fmt.Errorf("parse request body: %w", err))
+			return
+		}
+		req.Collection = collection
+		reply, err := h.querier.SearchWithPrincipal(r.Context(), principal, req)
+		if err != nil {
+			h.writeError(w, httpStatusForQueryError(err), principal, err)
+			return
+		}
+		h.writeProto(w, principal, reply)
+	case restQueryKindAggregate:
+		req := &pbv1.AggregateRequest{}
+		if err := unmarshalRequestBody(body, req); err != nil {
+			h.writeError(w, http.StatusUnprocessableEntity, principal,
+				fmt.Errorf("parse request body: %w", err))
+			return
+		}
+		req.Collection = collection
+		reply, err := h.querier.AggregateWithPrincipal(r.Context(), principal, req)
+		if err != nil {
+			h.writeError(w, httpStatusForQueryError(err), principal, err)
+			return
+		}
+		h.writeProto(w, principal, reply)
+	}
+}
+
+// unmarshalRequestBody decodes a protojson request body, treating an empty or
+// whitespace-only body as an empty (zero-value) request.
+func unmarshalRequestBody(body []byte, msg proto.Message) error {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	return protojson.Unmarshal(body, msg)
+}
+
+// principalFromRequest authenticates the request exactly like the gRPC auth
+// handler (adapters/handlers/grpc/v1/auth): a Bearer token is validated via the
+// shared composer; a missing/invalid token falls back to anonymous access when
+// it is enabled, otherwise the composer rejects it.
+func (h *restQueryHandler) principalFromRequest(r *http.Request) (*models.Principal, error) {
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		if h.allowAnonymousAccess {
+			return nil, nil
+		}
+		return h.authComposer("", nil)
+	}
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	return h.authComposer(token, nil)
+}
+
+// httpStatusForQueryError maps an error from the gRPC search/aggregate pipeline
+// to an HTTP status. It mirrors the gRPC code mapping in
+// adapters/handlers/grpc/server.go (translateTypedError): typed auth, usage-limit
+// and restriction errors get precise statuses. Any other error is treated as a
+// client/query error (422), consistent with how the GraphQL endpoint surfaces
+// query-resolution failures.
+func httpStatusForQueryError(err error) int {
+	switch {
+	case errors.As(err, &authzerrors.Unauthenticated{}):
+		return http.StatusUnauthorized
+	case errors.As(err, &authzerrors.Forbidden{}):
+		return http.StatusForbidden
+	}
+	if _, ok := usagelimits.AsLimitExceeded(err); ok {
+		return http.StatusTooManyRequests
+	}
+	if _, ok := restrictions.AsViolation(err); ok {
+		return http.StatusUnprocessableEntity
+	}
+	return http.StatusUnprocessableEntity
+}
+
+func (h *restQueryHandler) writeProto(w http.ResponseWriter, principal *models.Principal, msg proto.Message) {
+	out, err := protojson.Marshal(msg)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, principal,
+			fmt.Errorf("marshal response: %w", err))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(out); err != nil {
+		h.logger.WithField("action", "rest_query_write_response").Warnf("write response: %v", err)
+	}
+}
+
+func (h *restQueryHandler) writeError(w http.ResponseWriter, status int, principal *models.Principal, err error) {
+	payload := errPayloadFromSingleErr(principal, err)
+	out, marshalErr := json.Marshal(payload)
+	if marshalErr != nil {
+		http.Error(w, err.Error(), status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, writeErr := w.Write(out); writeErr != nil {
+		h.logger.WithField("action", "rest_query_write_error").Warnf("write error response: %v", writeErr)
+	}
+}

--- a/adapters/handlers/rest/handlers_query.go
+++ b/adapters/handlers/rest/handlers_query.go
@@ -162,9 +162,9 @@ func (h *restQueryHandler) serve(w http.ResponseWriter, r *http.Request, collect
 		return
 	}
 
-	// Peel off the optional REST `where` filter before the strict protojson
-	// parse (it is not part of the protobuf request).
-	reqBody, where, err := splitWhereFilter(body)
+	// Adapt REST-friendly conveniences (`where` filter, consistency-level
+	// shorthand) before the strict protojson parse.
+	reqBody, where, err := preprocessQueryBody(body)
 	if err != nil {
 		h.writeError(w, http.StatusUnprocessableEntity, principal, err)
 		return
@@ -221,37 +221,70 @@ func unmarshalRequestBody(body []byte, msg proto.Message) error {
 	return protojson.Unmarshal(body, msg)
 }
 
-// splitWhereFilter peels an optional top-level `where` filter (in the REST
-// WhereFilter syntax) off the JSON body. It returns the remaining JSON — to be
-// parsed as the protobuf request — and the parsed WhereFilter (nil if absent).
-// The `where` field is a REST-only convenience that is not part of the protobuf
-// request, so it must be removed before the strict protojson parse; the gRPC
-// pipeline resolves it server-side via filterext.Parse and it overrides the
-// protobuf `filters` field.
-func splitWhereFilter(body []byte) (rest []byte, where *models.WhereFilter, err error) {
+// consistencyLevelAliases maps the short REST consistency-level names to the
+// canonical protobuf enum names, so callers can write the familiar
+// "ONE"/"QUORUM"/"ALL" instead of "CONSISTENCY_LEVEL_ONE" etc.
+var consistencyLevelAliases = map[string]string{
+	"ONE":    "CONSISTENCY_LEVEL_ONE",
+	"QUORUM": "CONSISTENCY_LEVEL_QUORUM",
+	"ALL":    "CONSISTENCY_LEVEL_ALL",
+}
+
+// preprocessQueryBody adapts a couple of REST-friendly conveniences in the JSON
+// body into the canonical protobuf JSON before the strict protojson parse:
+//
+//   - a top-level `where` filter (REST WhereFilter syntax) is peeled off and
+//     returned separately. It is not part of the protobuf request; the pipeline
+//     resolves it server-side via filterext.Parse and it overrides the protobuf
+//     `filters` field.
+//   - a `consistencyLevel` given in the short form ("ONE"/"QUORUM"/"ALL",
+//     case-insensitive) is rewritten to the protobuf enum name so protojson can
+//     decode it.
+//
+// It returns the (possibly rewritten) body to hand to protojson and the parsed
+// WhereFilter (nil if absent). A non-object body is returned untouched so the
+// protojson parse surfaces the error.
+func preprocessQueryBody(body []byte) (rest []byte, where *models.WhereFilter, err error) {
 	if len(bytes.TrimSpace(body)) == 0 {
 		return body, nil, nil
 	}
 	var top map[string]json.RawMessage
 	if err := json.Unmarshal(body, &top); err != nil {
-		// Not a JSON object; leave the body untouched and let the protojson
-		// parse surface the error.
 		return body, nil, nil
 	}
-	raw, ok := top["where"]
-	if !ok {
-		return body, nil, nil
+
+	changed := false
+
+	if raw, ok := top["where"]; ok {
+		var wf models.WhereFilter
+		if err := json.Unmarshal(raw, &wf); err != nil {
+			return nil, nil, fmt.Errorf("parse `where` filter: %w", err)
+		}
+		where = &wf
+		delete(top, "where")
+		changed = true
 	}
-	delete(top, "where")
-	var wf models.WhereFilter
-	if err := json.Unmarshal(raw, &wf); err != nil {
-		return nil, nil, fmt.Errorf("parse `where` filter: %w", err)
+
+	if raw, ok := top["consistencyLevel"]; ok {
+		var s string
+		if json.Unmarshal(raw, &s) == nil {
+			if full, ok := consistencyLevelAliases[strings.ToUpper(s)]; ok && full != s {
+				if enc, err := json.Marshal(full); err == nil {
+					top["consistencyLevel"] = enc
+					changed = true
+				}
+			}
+		}
+	}
+
+	if !changed {
+		return body, where, nil
 	}
 	rest, err = json.Marshal(top)
 	if err != nil {
 		return nil, nil, err
 	}
-	return rest, &wf, nil
+	return rest, where, nil
 }
 
 // principalFromRequest authenticates the request exactly like the gRPC auth

--- a/adapters/handlers/rest/handlers_query.go
+++ b/adapters/handlers/rest/handlers_query.go
@@ -162,16 +162,28 @@ func (h *restQueryHandler) serve(w http.ResponseWriter, r *http.Request, collect
 		return
 	}
 
+	// Peel off the optional REST `where` filter before the strict protojson
+	// parse (it is not part of the protobuf request).
+	reqBody, where, err := splitWhereFilter(body)
+	if err != nil {
+		h.writeError(w, http.StatusUnprocessableEntity, principal, err)
+		return
+	}
+
 	switch kind {
 	case restQueryKindSearch:
 		req := &pbv1.SearchRequest{}
-		if err := unmarshalRequestBody(body, req); err != nil {
+		if err := unmarshalRequestBody(reqBody, req); err != nil {
 			h.writeError(w, http.StatusUnprocessableEntity, principal,
 				fmt.Errorf("parse request body: %w", err))
 			return
 		}
 		req.Collection = collection
-		reply, err := h.querier.SearchWithPrincipal(r.Context(), principal, req)
+		if where != nil && req.Filters != nil {
+			h.writeError(w, http.StatusUnprocessableEntity, principal, errWhereAndFilters)
+			return
+		}
+		reply, err := h.querier.SearchWithPrincipal(r.Context(), principal, req, where)
 		if err != nil {
 			h.writeError(w, httpStatusForQueryError(err), principal, err)
 			return
@@ -179,13 +191,17 @@ func (h *restQueryHandler) serve(w http.ResponseWriter, r *http.Request, collect
 		h.writeProto(w, principal, reply)
 	case restQueryKindAggregate:
 		req := &pbv1.AggregateRequest{}
-		if err := unmarshalRequestBody(body, req); err != nil {
+		if err := unmarshalRequestBody(reqBody, req); err != nil {
 			h.writeError(w, http.StatusUnprocessableEntity, principal,
 				fmt.Errorf("parse request body: %w", err))
 			return
 		}
 		req.Collection = collection
-		reply, err := h.querier.AggregateWithPrincipal(r.Context(), principal, req)
+		if where != nil && req.Filters != nil {
+			h.writeError(w, http.StatusUnprocessableEntity, principal, errWhereAndFilters)
+			return
+		}
+		reply, err := h.querier.AggregateWithPrincipal(r.Context(), principal, req, where)
 		if err != nil {
 			h.writeError(w, httpStatusForQueryError(err), principal, err)
 			return
@@ -194,6 +210,8 @@ func (h *restQueryHandler) serve(w http.ResponseWriter, r *http.Request, collect
 	}
 }
 
+var errWhereAndFilters = errors.New("set either `where` or `filters` in the body, not both")
+
 // unmarshalRequestBody decodes a protojson request body, treating an empty or
 // whitespace-only body as an empty (zero-value) request.
 func unmarshalRequestBody(body []byte, msg proto.Message) error {
@@ -201,6 +219,39 @@ func unmarshalRequestBody(body []byte, msg proto.Message) error {
 		return nil
 	}
 	return protojson.Unmarshal(body, msg)
+}
+
+// splitWhereFilter peels an optional top-level `where` filter (in the REST
+// WhereFilter syntax) off the JSON body. It returns the remaining JSON — to be
+// parsed as the protobuf request — and the parsed WhereFilter (nil if absent).
+// The `where` field is a REST-only convenience that is not part of the protobuf
+// request, so it must be removed before the strict protojson parse; the gRPC
+// pipeline resolves it server-side via filterext.Parse and it overrides the
+// protobuf `filters` field.
+func splitWhereFilter(body []byte) (rest []byte, where *models.WhereFilter, err error) {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return body, nil, nil
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(body, &top); err != nil {
+		// Not a JSON object; leave the body untouched and let the protojson
+		// parse surface the error.
+		return body, nil, nil
+	}
+	raw, ok := top["where"]
+	if !ok {
+		return body, nil, nil
+	}
+	delete(top, "where")
+	var wf models.WhereFilter
+	if err := json.Unmarshal(raw, &wf); err != nil {
+		return nil, nil, fmt.Errorf("parse `where` filter: %w", err)
+	}
+	rest, err = json.Marshal(top)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rest, &wf, nil
 }
 
 // principalFromRequest authenticates the request exactly like the gRPC auth

--- a/adapters/handlers/rest/handlers_query_test.go
+++ b/adapters/handlers/rest/handlers_query_test.go
@@ -37,6 +37,7 @@ type fakeQuerier struct {
 	gotSearchReq    *pbv1.SearchRequest
 	gotAggregateReq *pbv1.AggregateRequest
 	gotPrincipal    *models.Principal
+	gotWhere        *models.WhereFilter
 
 	searchReply    *pbv1.SearchReply
 	searchErr      error
@@ -44,17 +45,19 @@ type fakeQuerier struct {
 	aggregateErr   error
 }
 
-func (f *fakeQuerier) SearchWithPrincipal(_ context.Context, principal *models.Principal, req *pbv1.SearchRequest) (*pbv1.SearchReply, error) {
+func (f *fakeQuerier) SearchWithPrincipal(_ context.Context, principal *models.Principal, req *pbv1.SearchRequest, where *models.WhereFilter) (*pbv1.SearchReply, error) {
 	f.calledSearch = true
 	f.gotSearchReq = req
 	f.gotPrincipal = principal
+	f.gotWhere = where
 	return f.searchReply, f.searchErr
 }
 
-func (f *fakeQuerier) AggregateWithPrincipal(_ context.Context, principal *models.Principal, req *pbv1.AggregateRequest) (*pbv1.AggregateReply, error) {
+func (f *fakeQuerier) AggregateWithPrincipal(_ context.Context, principal *models.Principal, req *pbv1.AggregateRequest, where *models.WhereFilter) (*pbv1.AggregateReply, error) {
 	f.calledAggregate = true
 	f.gotAggregateReq = req
 	f.gotPrincipal = principal
+	f.gotWhere = where
 	return f.aggregateReply, f.aggregateErr
 }
 
@@ -252,6 +255,65 @@ func TestRESTQuery_BearerTokenIsValidated(t *testing.T) {
 	assert.Equal(t, "s3cret", gotToken)
 	require.NotNil(t, q.gotPrincipal)
 	assert.Equal(t, "alice", q.gotPrincipal.Username)
+}
+
+func TestRESTQuery_WhereFilterParsedAndPassed(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query",
+		`{"limit":5,"where":{"operator":"Equal","path":["category"],"valueText":"fantasy"}}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, q.calledSearch)
+	// The `where` field is stripped before the protojson parse, so the gRPC
+	// request still parses (limit=5) and carries no protobuf filter.
+	assert.Equal(t, uint32(5), q.gotSearchReq.Limit)
+	assert.Nil(t, q.gotSearchReq.Filters)
+	// The WhereFilter is parsed and handed to the pipeline.
+	require.NotNil(t, q.gotWhere)
+	assert.Equal(t, "Equal", q.gotWhere.Operator)
+	assert.Equal(t, []string{"category"}, q.gotWhere.Path)
+	require.NotNil(t, q.gotWhere.ValueText)
+	assert.Equal(t, "fantasy", *q.gotWhere.ValueText)
+}
+
+func TestRESTQuery_WhereOnAggregate(t *testing.T) {
+	q := &fakeQuerier{aggregateReply: &pbv1.AggregateReply{}}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/aggregate",
+		`{"objectsCount":true,"where":{"operator":"Equal","path":["category"],"valueText":"scifi"}}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, q.calledAggregate)
+	require.NotNil(t, q.gotWhere)
+	assert.Equal(t, "Equal", q.gotWhere.Operator)
+}
+
+func TestRESTQuery_WhereAndFiltersConflict(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", `{
+		"where":{"operator":"Equal","path":["category"],"valueText":"fantasy"},
+		"filters":{"operator":"OPERATOR_EQUAL","valueText":"fantasy","target":{"property":"category"}}
+	}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "not both")
+	assert.False(t, q.calledSearch, "querier must not be called when both filter forms are set")
+}
+
+func TestRESTQuery_MalformedWhere(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+	h := newTestQueryHandler(q)
+
+	// `where` must be an object; a scalar fails to parse into a WhereFilter.
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", `{"where":123}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.False(t, q.calledSearch)
 }
 
 func TestRESTQuery_NonMatchingRequestsFallThrough(t *testing.T) {

--- a/adapters/handlers/rest/handlers_query_test.go
+++ b/adapters/handlers/rest/handlers_query_test.go
@@ -316,6 +316,30 @@ func TestRESTQuery_MalformedWhere(t *testing.T) {
 	assert.False(t, q.calledSearch)
 }
 
+func TestRESTQuery_ConsistencyLevelShorthand(t *testing.T) {
+	cases := []struct {
+		in   string
+		want pbv1.ConsistencyLevel
+	}{
+		{"ONE", pbv1.ConsistencyLevel_CONSISTENCY_LEVEL_ONE},
+		{"QUORUM", pbv1.ConsistencyLevel_CONSISTENCY_LEVEL_QUORUM},
+		{"all", pbv1.ConsistencyLevel_CONSISTENCY_LEVEL_ALL},                         // case-insensitive
+		{"CONSISTENCY_LEVEL_QUORUM", pbv1.ConsistencyLevel_CONSISTENCY_LEVEL_QUORUM}, // full form still works
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+			h := newTestQueryHandler(q)
+			rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query",
+				`{"consistencyLevel":"`+tc.in+`"}`)
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.True(t, q.calledSearch)
+			require.NotNil(t, q.gotSearchReq.ConsistencyLevel)
+			assert.Equal(t, tc.want, *q.gotSearchReq.ConsistencyLevel)
+		})
+	}
+}
+
 func TestRESTQuery_NonMatchingRequestsFallThrough(t *testing.T) {
 	q := &fakeQuerier{}
 	h := newTestQueryHandler(q)

--- a/adapters/handlers/rest/handlers_query_test.go
+++ b/adapters/handlers/rest/handlers_query_test.go
@@ -1,0 +1,278 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	pbv1 "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/restrictions"
+	"github.com/weaviate/weaviate/usecases/usagelimits"
+)
+
+// fakeQuerier records what it was called with and returns canned results.
+type fakeQuerier struct {
+	calledSearch    bool
+	calledAggregate bool
+	gotSearchReq    *pbv1.SearchRequest
+	gotAggregateReq *pbv1.AggregateRequest
+	gotPrincipal    *models.Principal
+
+	searchReply    *pbv1.SearchReply
+	searchErr      error
+	aggregateReply *pbv1.AggregateReply
+	aggregateErr   error
+}
+
+func (f *fakeQuerier) SearchWithPrincipal(_ context.Context, principal *models.Principal, req *pbv1.SearchRequest) (*pbv1.SearchReply, error) {
+	f.calledSearch = true
+	f.gotSearchReq = req
+	f.gotPrincipal = principal
+	return f.searchReply, f.searchErr
+}
+
+func (f *fakeQuerier) AggregateWithPrincipal(_ context.Context, principal *models.Principal, req *pbv1.AggregateRequest) (*pbv1.AggregateReply, error) {
+	f.calledAggregate = true
+	f.gotAggregateReq = req
+	f.gotPrincipal = principal
+	return f.aggregateReply, f.aggregateErr
+}
+
+func newTestQueryHandler(querier *fakeQuerier) *restQueryHandler {
+	return &restQueryHandler{
+		querier: querier,
+		// Composer that rejects everything; tests that exercise the happy path
+		// use anonymous access so the composer is never consulted.
+		authComposer: func(token string, _ []string) (*models.Principal, error) {
+			return nil, fmt.Errorf("auth not configured for token %q", token)
+		},
+		allowAnonymousAccess: true,
+		disabled:             false,
+		maxBodyBytes:         1 << 20,
+		logger:               logrus.New(),
+	}
+}
+
+func TestMatchRESTQueryPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		wantCol  string
+		wantKind restQueryKind
+		wantOK   bool
+	}{
+		{"/v1/Article/query", "Article", restQueryKindSearch, true},
+		{"/v1/Article/aggregate", "Article", restQueryKindAggregate, true},
+		{"/v1/My%20Class/query", "My Class", restQueryKindSearch, true},
+		{"/v1/Article/query/extra", "", 0, false},
+		{"/v1/Article", "", 0, false},
+		{"/v1/Article/get", "", 0, false},
+		{"/v1//query", "", 0, false},
+		{"/v1/graphql", "", 0, false},
+		{"/v1/objects/validate", "", 0, false},
+		{"/v2/Article/query", "", 0, false},
+		{"/Article/query", "", 0, false},
+		{"", "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			col, kind, ok := matchRESTQueryPath(tt.path)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantCol, col)
+				assert.Equal(t, tt.wantKind, kind)
+			}
+		})
+	}
+}
+
+func TestHTTPStatusForQueryError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"unauthenticated", authzerrors.NewUnauthenticated(), http.StatusUnauthorized},
+		{"forbidden", authzerrors.NewForbidden(&models.Principal{Username: "u"}, "read", "X"), http.StatusForbidden},
+		{"wrapped forbidden", fmt.Errorf("outer: %w", authzerrors.NewForbidden(&models.Principal{Username: "u"}, "read", "X")), http.StatusForbidden},
+		{"limit exceeded", usagelimits.NewLimitExceededError("", usagelimits.LimitObjects, 10), http.StatusTooManyRequests},
+		{"restriction violation", restrictions.NewViolationError("", restrictions.RestrictionCompression, "pq", []string{"none"}), http.StatusUnprocessableEntity},
+		{"generic", fmt.Errorf("could not find class Foo"), http.StatusUnprocessableEntity},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, httpStatusForQueryError(tt.err))
+		})
+	}
+}
+
+func doQueryRequest(t *testing.T, h *restQueryHandler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusTeapot) // sentinel for "fell through"
+	})
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.middleware(next).ServeHTTP(rec, req)
+	if rec.Code == http.StatusTeapot && nextCalled {
+		t.Logf("request fell through to next handler")
+	}
+	return rec
+}
+
+func TestRESTQuery_SearchHappyPath_CollectionFromPathOverridesBody(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{Took: 0.5}}
+	h := newTestQueryHandler(q)
+
+	// Body sets a different collection and a limit; path must win for collection.
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/RightName/query", `{"collection":"WrongName","limit":7}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	require.True(t, q.calledSearch)
+	assert.Equal(t, "RightName", q.gotSearchReq.Collection, "path collection must override body")
+	assert.Equal(t, uint32(7), q.gotSearchReq.Limit, "body fields must be parsed")
+	assert.Contains(t, rec.Body.String(), "took")
+}
+
+func TestRESTQuery_EmptyBodyIsEmptyRequest(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", "")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, q.calledSearch)
+	assert.Equal(t, "Article", q.gotSearchReq.Collection)
+	assert.Equal(t, uint32(0), q.gotSearchReq.Limit)
+}
+
+func TestRESTQuery_AggregateHappyPath(t *testing.T) {
+	q := &fakeQuerier{aggregateReply: &pbv1.AggregateReply{Took: 0.1}}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/aggregate", `{}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, q.calledAggregate)
+	assert.Equal(t, "Article", q.gotAggregateReq.Collection)
+}
+
+func TestRESTQuery_MalformedBody(t *testing.T) {
+	q := &fakeQuerier{}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", `{not valid json`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.False(t, q.calledSearch, "querier must not be called on parse failure")
+}
+
+func TestRESTQuery_Disabled(t *testing.T) {
+	q := &fakeQuerier{}
+	h := newTestQueryHandler(q)
+	h.disabled = true
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", `{}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "rest query api is disabled")
+	assert.False(t, q.calledSearch)
+}
+
+func TestRESTQuery_ErrorMappingFromPipeline(t *testing.T) {
+	q := &fakeQuerier{searchErr: authzerrors.NewForbidden(&models.Principal{Username: "u"}, "read", "Article")}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", `{}`)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestRESTQuery_AnonymousAllowed_PassesNilPrincipal(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+	h := newTestQueryHandler(q)
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", `{}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, q.calledSearch)
+	assert.Nil(t, q.gotPrincipal)
+}
+
+func TestRESTQuery_AnonymousDisabled_RejectsMissingToken(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+	h := newTestQueryHandler(q)
+	h.allowAnonymousAccess = false // composer will reject the empty token
+
+	rec := doQueryRequest(t, h, http.MethodPost, "/v1/Article/query", `{}`)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.False(t, q.calledSearch)
+}
+
+func TestRESTQuery_BearerTokenIsValidated(t *testing.T) {
+	q := &fakeQuerier{searchReply: &pbv1.SearchReply{}}
+	h := newTestQueryHandler(q)
+	h.allowAnonymousAccess = false
+	gotToken := ""
+	h.authComposer = func(token string, _ []string) (*models.Principal, error) {
+		gotToken = token
+		return &models.Principal{Username: "alice"}, nil
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { t.Fatal("should not fall through") })
+	req := httptest.NewRequest(http.MethodPost, "/v1/Article/query", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer s3cret")
+	rec := httptest.NewRecorder()
+	h.middleware(next).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "s3cret", gotToken)
+	require.NotNil(t, q.gotPrincipal)
+	assert.Equal(t, "alice", q.gotPrincipal.Username)
+}
+
+func TestRESTQuery_NonMatchingRequestsFallThrough(t *testing.T) {
+	q := &fakeQuerier{}
+	h := newTestQueryHandler(q)
+
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/v1/Article/query"},   // right path, wrong method
+		{http.MethodPost, "/v1/objects"},        // unrelated route
+		{http.MethodPost, "/v1/Article/get"},    // wrong verb
+		{http.MethodPost, "/v1/schema/Article"}, // unrelated route
+	}
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			rec := doQueryRequest(t, h, tc.method, tc.path, `{}`)
+			assert.Equal(t, http.StatusTeapot, rec.Code, "should fall through to next")
+			assert.False(t, q.calledSearch)
+			assert.False(t, q.calledAggregate)
+		})
+	}
+}

--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -108,6 +108,11 @@ func makeSetupGlobalMiddleware(appState *state.State, context *middleware.Contex
 		handler = addLiveAndReadyness(appState, handler)
 		handler = addHandleRoot(handler)
 		handler = makeAddModuleHandlers(appState.Modules)(handler)
+		// REST query/aggregate endpoints (the GraphQL replacement). Attached as
+		// a custom route, like the module handlers, so it benefits from the
+		// cross-cutting middleware below (panic recovery, operational mode,
+		// monitoring, tracing) while doing its own auth.
+		handler = makeAddRESTQueryHandlers(appState)(handler)
 		// Add client tracking middleware early in the chain to capture all requests
 		if telemeter != nil {
 			handler = telemetry.ClientTrackingMiddleware(telemeter.GetClientTracker())(handler)
@@ -262,19 +267,25 @@ func addLiveAndReadyness(state *state.State, next http.Handler) http.Handler {
 
 func addOperationalMode(state *state.State, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The REST query/aggregate endpoints are POSTs but are semantically
+		// reads (they mirror the gRPC Search/Aggregate RPCs). Classify them as
+		// reads so they behave like reads under operational mode — allowed in
+		// read-only/scale-out, blocked in write-only — consistent with
+		// IsGRPCRead for the equivalent RPCs.
+		isQueryRead := isRESTQueryReadPath(r.URL.Path)
 		switch state.ServerConfig.Config.OperationalMode.Get() {
 		case config.READ_ONLY:
-			if config.IsHTTPWrite(r.Method) && !whitelist(r.URL.Path, config.ReadOnlyWhitelist) {
+			if config.IsHTTPWrite(r.Method) && !isQueryRead && !whitelist(r.URL.Path, config.ReadOnlyWhitelist) {
 				writeOperationalModeErrorResponse(w, config.ErrReadOnlyModeEnabled)
 				return
 			}
 		case config.SCALE_OUT:
-			if config.IsHTTPWrite(r.Method) && !whitelist(r.URL.Path, config.ScaleOutWhitelist) {
+			if config.IsHTTPWrite(r.Method) && !isQueryRead && !whitelist(r.URL.Path, config.ScaleOutWhitelist) {
 				writeOperationalModeErrorResponse(w, config.ErrScaleOutModeEnabled)
 				return
 			}
 		case config.WRITE_ONLY:
-			if config.IsHTTPRead(r.Method) && !whitelist(r.URL.Path, config.WriteOnlyWhitelist) {
+			if (config.IsHTTPRead(r.Method) || isQueryRead) && !whitelist(r.URL.Path, config.WriteOnlyWhitelist) {
 				writeOperationalModeErrorResponse(w, config.ErrWriteOnlyModeEnabled)
 				return
 			}
@@ -283,6 +294,13 @@ func addOperationalMode(state *state.State, next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isRESTQueryReadPath reports whether the path is one of the REST query/aggregate
+// read endpoints (POST /v1/{collection}/query|aggregate).
+func isRESTQueryReadPath(path string) bool {
+	_, _, ok := matchRESTQueryPath(path)
+	return ok
 }
 
 func writeOperationalModeErrorResponse(w http.ResponseWriter, err error) {

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -162,8 +162,8 @@ type State struct {
 // (*grpc/v1.Service) satisfies it; the REST query handlers consume it so that
 // REST and gRPC share one parse → traverse → reply implementation.
 type GRPCQuerier interface {
-	SearchWithPrincipal(ctx context.Context, principal *models.Principal, req *pbv1.SearchRequest) (*pbv1.SearchReply, error)
-	AggregateWithPrincipal(ctx context.Context, principal *models.Principal, req *pbv1.AggregateRequest) (*pbv1.AggregateReply, error)
+	SearchWithPrincipal(ctx context.Context, principal *models.Principal, req *pbv1.SearchRequest, where *models.WhereFilter) (*pbv1.SearchReply, error)
+	AggregateWithPrincipal(ctx context.Context, principal *models.Principal, req *pbv1.AggregateRequest, where *models.WhereFilter) (*pbv1.AggregateReply, error)
 }
 
 // GetGraphQL is the safe way to retrieve GraphQL from the state as it can be

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -27,7 +27,9 @@ import (
 	rCluster "github.com/weaviate/weaviate/cluster"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/cluster/fsm"
+	"github.com/weaviate/weaviate/entities/models"
 	grpcconn "github.com/weaviate/weaviate/grpc/conn"
+	pbv1 "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/anonymous"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/oidc"
@@ -148,6 +150,20 @@ type State struct {
 	GRPCConnManager *grpcconn.ConnManager
 	// ReplGRPCConnManager is a separate connection manager that implements retry logic to each RPC call on top of connection pooling, specifically for replication traffic.
 	ReplGRPCConnManager *grpcconn.ConnManager
+
+	// GRPCQuerier exposes the gRPC search/aggregate pipeline so non-gRPC
+	// transports (the REST /v1/{collection}/query and /aggregate endpoints)
+	// can reuse it. Set when the gRPC server is created.
+	GRPCQuerier GRPCQuerier
+}
+
+// GRPCQuerier runs the gRPC search/aggregate pipeline for a principal that has
+// already been authenticated by the calling transport. The gRPC service
+// (*grpc/v1.Service) satisfies it; the REST query handlers consume it so that
+// REST and gRPC share one parse → traverse → reply implementation.
+type GRPCQuerier interface {
+	SearchWithPrincipal(ctx context.Context, principal *models.Principal, req *pbv1.SearchRequest) (*pbv1.SearchReply, error)
+	AggregateWithPrincipal(ctx context.Context, principal *models.Principal, req *pbv1.AggregateRequest) (*pbv1.AggregateReply, error)
 }
 
 // GetGraphQL is the safe way to retrieve GraphQL from the state as it can be

--- a/docs/rest-query-endpoints.md
+++ b/docs/rest-query-endpoints.md
@@ -1,0 +1,120 @@
+# REST query & aggregate endpoints
+
+Two REST endpoints expose search and aggregation over HTTP as the replacement
+for GraphQL data queries:
+
+```
+POST /v1/{collection}/query       → gRPC Search
+POST /v1/{collection}/aggregate   → gRPC Aggregate
+```
+
+GraphQL is being deprecated (it is incompatible with Namespaces — schema
+leakage, no per-namespace RBAC — and introspection exposes the schema). Every
+other dedicated vector database exposes querying over REST; these endpoints give
+HTTP-only integrations a first-class path and converge on that norm. Because they
+delegate to the gRPC pipeline, they are **namespace-compatible** (unlike GraphQL).
+
+## Core design: one pipeline, two transports
+
+The request and response bodies are the **canonical proto-JSON encoding of the
+gRPC `SearchRequest`/`AggregateRequest` and `SearchReply`/`AggregateReply`
+messages**. REST and gRPC therefore share a single `parse → traverse → reply`
+implementation — there is no second query parser, no hand-maintained REST query
+model, and automatic feature parity (hybrid, bm25, nearVector/nearText, filters,
+groupBy, generative, rerank, …).
+
+```
+gRPC client ─► Search()/Aggregate() ─┐
+                                      ├─► SearchWithPrincipal / AggregateWithPrincipal ─► traverser ─► reply
+REST client ─► /v1/{collection}/query ┘        (parse_search_request, prepare_reply, …)
+```
+
+The gRPC entrypoints (`adapters/handlers/grpc/v1/service.go`) resolve the
+principal from request metadata, then delegate to the exported
+`SearchWithPrincipal` / `AggregateWithPrincipal`. The REST handler authenticates
+itself and calls the same methods. The split is a pure extraction — gRPC behavior
+is unchanged and is guarded by the existing parser test suite.
+
+A REST-vs-gRPC **parity acceptance test** (`test/acceptance/rest_query/`) asserts
+the REST results are `proto.Equal` to gRPC for the same request.
+
+## Routing (custom middleware, not go-swagger)
+
+The endpoints are registered as a custom route in the global middleware chain
+(`adapters/handlers/rest/handlers_query.go`, wired from `middlewares.go`'s
+`makeSetupGlobalMiddleware`), mirroring how module routes
+(`makeAddModuleHandlers`) are attached — **not** as go-swagger operations. The
+body is opaque proto-JSON that doesn't belong in the OpenAPI model surface, and
+this avoids generating/committing a parallel REST model layer. Non-matching
+paths/methods fall through to the swagger router. `matchRESTQueryPath` matches
+exactly `/v1/{collection}/query|aggregate`; no existing route has that shape, so
+nothing is shadowed.
+
+Consequences of being outside go-swagger:
+- **Auth** is performed in the handler, mirroring the gRPC auth handler: a Bearer
+  token is validated via the shared `composer`; a missing/invalid token falls
+  back to anonymous access when enabled.
+- **Errors** from the pipeline are mapped to HTTP status by
+  `httpStatusForQueryError` (mirroring the gRPC typed-error translation):
+  Unauthenticated→401, Forbidden→403, usage-limit→429, restriction/other→422.
+- **Operational mode**: these POSTs are classified as reads (`isRESTQueryReadPath`
+  in `middlewares.go`) — allowed in read-only/scale-out, blocked in write-only —
+  consistent with `IsGRPCRead` for the equivalent RPCs.
+
+## Request conveniences
+
+The handler pre-processes the JSON body (`preprocessQueryBody`) before the strict
+proto-JSON parse to smooth over the parts that are awkward to hand-write over raw
+HTTP:
+
+- **`where`** — an optional top-level filter in the familiar REST `WhereFilter`
+  syntax (`operator: "Equal"`, `path`, `operands`), an alternative to the
+  protobuf `filters`. It is resolved server-side via the existing
+  `adapters/handlers/rest/filterext.Parse` (reused, not reimplemented) and
+  overrides `filters`. Setting both `where` and `filters` returns 422.
+- **`consistencyLevel`** — accepts the short form (`ONE`/`QUORUM`/`ALL`,
+  case-insensitive) and rewrites it to the protobuf enum name; unknown values
+  fall through to the strict parser.
+- Plain **`vector`** float arrays (nearVector/hybrid) and a simple **`alpha`**
+  (hybrid) are accepted directly by the underlying parser — no base64 or
+  `useAlphaParam` needed. These are documented but require no special handling.
+
+The collection always comes from the path and overrides any `collection` in the
+body; an empty body runs a default query.
+
+## Gating
+
+Enabled by default; set `DISABLE_REST_QUERY=true` to turn the endpoints off (they
+then return 422). In the Namespaces world this is the supported query surface, so
+its default is the opposite of GraphQL's.
+
+## OpenAPI documentation
+
+The endpoints and their request/response schemas are documented in
+`openapi-specs/schema.json` for the docs site, with the body schemas derived from
+the proto messages. Because that file is also go-swagger's code-generation source
+(and CI regenerates + diffs it), these documentation entries are marked
+`"x-doc-only": true` and stripped from the spec fed to `swagger generate` by
+`tools/swagger_strip_doc_only` (wired into `tools/gen-code-from-swagger.sh`). The
+docs keep the full surface; the generated/committed Go is unchanged.
+
+## Not included
+
+`Explore` (cross-class search) has no gRPC RPC and is intentionally not exposed.
+`nearText` and other vectorizer-dependent searches work only when the collection
+has a vectorizer module configured (the endpoint accepts the request and returns
+the module's error otherwise).
+
+## Key files
+
+| Area | File |
+|---|---|
+| Shared pipeline entrypoints | `adapters/handlers/grpc/v1/service.go` |
+| REST handler (routing, auth, where/consistency, errors) | `adapters/handlers/rest/handlers_query.go` |
+| Middleware wiring + operational-mode read classification | `adapters/handlers/rest/middlewares.go` |
+| `Querier` interface | `adapters/handlers/rest/state/state.go` |
+| Gating flag | `usecases/config/config_handler.go`, `usecases/config/environment.go` |
+| WhereFilter → internal filter converter (reused) | `adapters/handlers/rest/filterext/parse.go` |
+| OpenAPI doc-only strip for codegen | `tools/swagger_strip_doc_only/main.go` |
+| Unit tests | `adapters/handlers/rest/handlers_query_test.go` |
+| REST-vs-gRPC parity acceptance test | `test/acceptance/rest_query/parity_test.go` |

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -5243,6 +5243,14 @@
             }
           ]
         },
+        "where": {
+          "description": "Alternative to `filters`, using the REST where syntax (operator \"Equal\", `path`, `operands`). Resolved server-side. Provide either `where` or `filters`, not both.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WhereFilter"
+            }
+          ]
+        },
         "hybridSearch": {
           "description": "Hybrid (keyword + vector) search.",
           "allOf": [
@@ -5397,6 +5405,14 @@
           "allOf": [
             {
               "$ref": "#/definitions/Filters"
+            }
+          ]
+        },
+        "where": {
+          "description": "Alternative to `filters`, using the REST where syntax (operator \"Equal\", `path`, `operands`). Resolved server-side. Provide either `where` or `filters`, not both.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WhereFilter"
             }
           ]
         },

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -4102,6 +4102,14 @@
             "$ref": "#/definitions/QueryVectors"
           }
         },
+        "vector": {
+          "type": "array",
+          "description": "Convenience: the query vector as a plain array of float32 values, e.g. [0.1, 0.2, 0.3]. An alternative to `vectors`/`vectorBytes` for a single (non-named) vector — no base64 needed.",
+          "items": {
+            "type": "number",
+            "format": "float"
+          }
+        },
         "certainty": {
           "type": "number",
           "description": "Minimum certainty (0..1). Mutually exclusive with distance."
@@ -4424,6 +4432,11 @@
           ],
           "description": "How keyword and vector result sets are fused."
         },
+        "alpha": {
+          "type": "number",
+          "format": "float",
+          "description": "Balance between keyword (0.0) and vector (1.0) results. Simpler alternative to `alphaParam` (no `useAlphaParam` needed)."
+        },
         "nearText": {
           "description": "Use a nearText search as the vector side (targets here are ignored).",
           "allOf": [
@@ -4481,6 +4494,14 @@
           "description": "Explicit query vector(s) for the vector side.",
           "items": {
             "$ref": "#/definitions/QueryVectors"
+          }
+        },
+        "vector": {
+          "type": "array",
+          "description": "Convenience: the query vector for the vector side as a plain array of float32 values. An alternative to `vectors` — no base64 needed.",
+          "items": {
+            "type": "number",
+            "format": "float"
           }
         }
       }
@@ -5184,9 +5205,12 @@
             "CONSISTENCY_LEVEL_UNSPECIFIED",
             "CONSISTENCY_LEVEL_ONE",
             "CONSISTENCY_LEVEL_QUORUM",
-            "CONSISTENCY_LEVEL_ALL"
+            "CONSISTENCY_LEVEL_ALL",
+            "ONE",
+            "QUORUM",
+            "ALL"
           ],
-          "description": "Read consistency level."
+          "description": "Read consistency level. Accepts either the short form (ONE, QUORUM, ALL) or the full enum name (CONSISTENCY_LEVEL_*)."
         },
         "properties": {
           "description": "Which object properties to return.",

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3805,6 +3805,2010 @@
       "items": {
         "$ref": "#/definitions/Namespace"
       }
+    },
+    "TextArray": {
+      "type": "object",
+      "description": "A list of text values.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The text values.",
+          "items": {
+            "type": "string",
+            "description": "A text value."
+          }
+        }
+      }
+    },
+    "IntArray": {
+      "type": "object",
+      "description": "A list of int64 values.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The int64 values.",
+          "items": {
+            "type": "integer",
+            "format": "int64",
+            "description": "An int64 value. (int64; serialized as a string in responses)"
+          }
+        }
+      }
+    },
+    "NumberArray": {
+      "type": "object",
+      "description": "A list of float64 values.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The float64 values.",
+          "items": {
+            "type": "number",
+            "description": "A float64 value."
+          }
+        }
+      }
+    },
+    "BooleanArray": {
+      "type": "object",
+      "description": "A list of boolean values.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "description": "The boolean values.",
+          "items": {
+            "type": "boolean",
+            "description": "A boolean value."
+          }
+        }
+      }
+    },
+    "GeoCoordinatesFilter": {
+      "type": "object",
+      "description": "A geo-coordinate reference point plus radius used with OPERATOR_WITHIN_GEO_RANGE.",
+      "properties": {
+        "latitude": {
+          "type": "number",
+          "description": "Latitude of the reference point, in degrees."
+        },
+        "longitude": {
+          "type": "number",
+          "description": "Longitude of the reference point, in degrees."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum distance from the reference point, in meters."
+        }
+      }
+    },
+    "QueryVectors": {
+      "type": "object",
+      "description": "A vector value encoded as bytes, optionally named for multi/named-vector collections.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the (named) vector this entry refers to. Empty for the legacy/default vector."
+        },
+        "vectorBytes": {
+          "type": "string",
+          "format": "byte",
+          "description": "The vector encoded as little-endian float32 bytes. For multi-vectors, the flattened matrix. (base64-encoded bytes)"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "VECTOR_TYPE_UNSPECIFIED",
+            "VECTOR_TYPE_SINGLE_FP32",
+            "VECTOR_TYPE_MULTI_FP32"
+          ],
+          "description": "Whether this is a single (SINGLE_FP32) or multi (MULTI_FP32) vector."
+        }
+      }
+    },
+    "WeightsForTarget": {
+      "type": "object",
+      "description": "Per-target weight used when combining multiple target vectors.",
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "The target (named) vector this weight applies to."
+        },
+        "weight": {
+          "type": "number",
+          "description": "The weight applied to this target's score during multi-target fusion."
+        }
+      }
+    },
+    "Targets": {
+      "type": "object",
+      "description": "Selects and combines multiple target (named) vectors for a single search.",
+      "properties": {
+        "targetVectors": {
+          "type": "array",
+          "description": "The named vectors to search against in a multi-target query.",
+          "items": {
+            "type": "string",
+            "description": "A target (named) vector to search."
+          }
+        },
+        "combination": {
+          "type": "string",
+          "enum": [
+            "COMBINATION_METHOD_UNSPECIFIED",
+            "COMBINATION_METHOD_TYPE_SUM",
+            "COMBINATION_METHOD_TYPE_MIN",
+            "COMBINATION_METHOD_TYPE_AVERAGE",
+            "COMBINATION_METHOD_TYPE_RELATIVE_SCORE",
+            "COMBINATION_METHOD_TYPE_MANUAL"
+          ],
+          "description": "How per-target scores are combined into a single score."
+        },
+        "weightsForTargets": {
+          "type": "array",
+          "description": "Per-target weights, used when combination is COMBINATION_METHOD_TYPE_MANUAL/RELATIVE_SCORE.",
+          "items": {
+            "$ref": "#/definitions/WeightsForTarget"
+          }
+        }
+      }
+    },
+    "VectorForTarget": {
+      "type": "object",
+      "description": "A query vector bound to a specific target (named) vector.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the target vector."
+        },
+        "vectors": {
+          "type": "array",
+          "description": "The query vector(s) for this target.",
+          "items": {
+            "$ref": "#/definitions/QueryVectors"
+          }
+        }
+      }
+    },
+    "SelectionMMR": {
+      "type": "object",
+      "description": "Maximal Marginal Relevance selection parameters.",
+      "properties": {
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of candidates considered for MMR re-selection."
+        },
+        "balance": {
+          "type": "number",
+          "description": "Trade-off between relevance and diversity (0..1)."
+        }
+      }
+    },
+    "Selection": {
+      "type": "object",
+      "description": "Post-retrieval selection strategy applied to the candidate set.",
+      "properties": {
+        "mmr": {
+          "$ref": "#/definitions/SelectionMMR"
+        }
+      }
+    },
+    "SearchOperatorOptions": {
+      "type": "object",
+      "description": "Keyword (BM25) token-matching operator options.",
+      "properties": {
+        "operator": {
+          "type": "string",
+          "enum": [
+            "OPERATOR_UNSPECIFIED",
+            "OPERATOR_OR",
+            "OPERATOR_AND"
+          ],
+          "description": "Whether matched tokens are combined with OR or AND."
+        },
+        "minimumOrTokensMatch": {
+          "type": "integer",
+          "description": "When operator is OR, the minimum number of query tokens that must match."
+        }
+      }
+    },
+    "NearTextMove": {
+      "type": "object",
+      "description": "Biases a nearText query vector toward or away from concepts/objects.",
+      "properties": {
+        "force": {
+          "type": "number",
+          "description": "Strength of the move (0..1)."
+        },
+        "concepts": {
+          "type": "array",
+          "description": "Concepts that bias the query vector.",
+          "items": {
+            "type": "string",
+            "description": "A concept to move toward/away from."
+          }
+        },
+        "uuids": {
+          "type": "array",
+          "description": "Objects whose vectors bias the query.",
+          "items": {
+            "type": "string",
+            "description": "An object UUID to move toward/away from."
+          }
+        }
+      }
+    },
+    "NearTextSearch": {
+      "type": "object",
+      "description": "A semantic (nearText) search; requires a text vectorizer module on the collection.",
+      "properties": {
+        "query": {
+          "type": "array",
+          "description": "The search concepts; vectorized by the collection's text module.",
+          "items": {
+            "type": "string",
+            "description": "A search concept/phrase."
+          }
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1). Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance. Mutually exclusive with certainty."
+        },
+        "moveTo": {
+          "description": "Bias the query vector toward these concepts/objects.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearTextMove"
+            }
+          ]
+        },
+        "moveAway": {
+          "description": "Bias the query vector away from these concepts/objects.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearTextMove"
+            }
+          ]
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearVector": {
+      "type": "object",
+      "description": "A raw-vector (nearVector) search. Provide vectors directly without a vectorizer.",
+      "properties": {
+        "vectors": {
+          "type": "array",
+          "description": "The query vector(s). Preferred over the deprecated vector/vectorBytes fields.",
+          "items": {
+            "$ref": "#/definitions/QueryVectors"
+          }
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1). Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "vectorForTargets": {
+          "type": "array",
+          "description": "Per-target query vectors for multi-target search.",
+          "items": {
+            "$ref": "#/definitions/VectorForTarget"
+          }
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearObject": {
+      "type": "object",
+      "description": "A nearObject search using an existing object's vector as the query.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The UUID of the object whose vector is used as the query."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1). Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearImageSearch": {
+      "type": "object",
+      "description": "A near-image vector search; requires a module that vectorizes image input.",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Base64-encoded image used as the query."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1) a result must meet. Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance a result may have. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearAudioSearch": {
+      "type": "object",
+      "description": "A near-audio vector search; requires a module that vectorizes audio input.",
+      "properties": {
+        "audio": {
+          "type": "string",
+          "description": "Base64-encoded audio used as the query."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1) a result must meet. Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance a result may have. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearVideoSearch": {
+      "type": "object",
+      "description": "A near-video vector search; requires a module that vectorizes video input.",
+      "properties": {
+        "video": {
+          "type": "string",
+          "description": "Base64-encoded video used as the query."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1) a result must meet. Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance a result may have. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearDepthSearch": {
+      "type": "object",
+      "description": "A near-depth vector search; requires a module that vectorizes depth input.",
+      "properties": {
+        "depth": {
+          "type": "string",
+          "description": "Base64-encoded depth data used as the query."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1) a result must meet. Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance a result may have. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearThermalSearch": {
+      "type": "object",
+      "description": "A near-thermal vector search; requires a module that vectorizes thermal input.",
+      "properties": {
+        "thermal": {
+          "type": "string",
+          "description": "Base64-encoded thermal data used as the query."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1) a result must meet. Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance a result may have. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "NearIMUSearch": {
+      "type": "object",
+      "description": "A near-IMU vector search; requires a module that vectorizes IMU input.",
+      "properties": {
+        "imu": {
+          "type": "string",
+          "description": "Base64-encoded IMU data used as the query."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Minimum certainty (0..1) a result must meet. Mutually exclusive with distance."
+        },
+        "distance": {
+          "type": "number",
+          "description": "Maximum vector distance a result may have. Mutually exclusive with certainty."
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        }
+      }
+    },
+    "BM25": {
+      "type": "object",
+      "description": "A BM25 keyword (lexical) search.",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "The keyword query string."
+        },
+        "properties": {
+          "type": "array",
+          "description": "Properties to run the BM25 keyword search over.",
+          "items": {
+            "type": "string",
+            "description": "A property to search; empty means all text properties."
+          }
+        },
+        "searchOperator": {
+          "description": "Token-matching (OR/AND) options.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SearchOperatorOptions"
+            }
+          ]
+        }
+      }
+    },
+    "Hybrid": {
+      "type": "object",
+      "description": "A hybrid search combining BM25 keyword and vector search.",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "The query string (used for both the keyword and, if no vector is given, the vector side)."
+        },
+        "properties": {
+          "type": "array",
+          "description": "Properties for the keyword (BM25) side of the hybrid search.",
+          "items": {
+            "type": "string",
+            "description": "A property to include in the keyword side."
+          }
+        },
+        "fusionType": {
+          "type": "string",
+          "enum": [
+            "FUSION_TYPE_UNSPECIFIED",
+            "FUSION_TYPE_RANKED",
+            "FUSION_TYPE_RELATIVE_SCORE"
+          ],
+          "description": "How keyword and vector result sets are fused."
+        },
+        "nearText": {
+          "description": "Use a nearText search as the vector side (targets here are ignored).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearTextSearch"
+            }
+          ]
+        },
+        "nearVector": {
+          "description": "Use a nearVector search as the vector side (targets here are ignored).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearVector"
+            }
+          ]
+        },
+        "targets": {
+          "description": "The named vectors to search (multi-target).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Targets"
+            }
+          ]
+        },
+        "bm25SearchOperator": {
+          "description": "Token-matching (OR/AND) options for the keyword side.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SearchOperatorOptions"
+            }
+          ]
+        },
+        "alphaParam": {
+          "type": "number",
+          "description": "Balance between keyword (0.0) and vector (1.0) results. Requires useAlphaParam=true."
+        },
+        "useAlphaParam": {
+          "type": "boolean",
+          "description": "Use alphaParam instead of the deprecated alpha field."
+        },
+        "selection": {
+          "description": "Optional post-retrieval selection (e.g. MMR).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Selection"
+            }
+          ]
+        },
+        "vectorDistance": {
+          "type": "number",
+          "description": "Optional maximum vector distance threshold for the vector side."
+        },
+        "vectors": {
+          "type": "array",
+          "description": "Explicit query vector(s) for the vector side.",
+          "items": {
+            "$ref": "#/definitions/QueryVectors"
+          }
+        }
+      }
+    },
+    "FilterReferenceSingleTarget": {
+      "type": "object",
+      "description": "Filters across a single-target cross-reference.",
+      "properties": {
+        "on": {
+          "type": "string",
+          "description": "The cross-reference property to traverse."
+        },
+        "target": {
+          "description": "The filter target on the referenced collection.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FilterTarget"
+            }
+          ]
+        }
+      }
+    },
+    "FilterReferenceMultiTarget": {
+      "type": "object",
+      "description": "Filters across a multi-target cross-reference.",
+      "properties": {
+        "on": {
+          "type": "string",
+          "description": "The cross-reference property to traverse."
+        },
+        "target": {
+          "description": "The filter target on the referenced collection.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FilterTarget"
+            }
+          ]
+        },
+        "targetCollection": {
+          "type": "string",
+          "description": "The referenced collection to traverse into."
+        }
+      }
+    },
+    "FilterReferenceCount": {
+      "type": "object",
+      "description": "Filters on the number of cross-references on a property.",
+      "properties": {
+        "on": {
+          "type": "string",
+          "description": "The cross-reference property whose count is filtered."
+        }
+      }
+    },
+    "FilterTarget": {
+      "type": "object",
+      "description": "What a filter applies to: a property or a cross-reference path (exactly one).",
+      "properties": {
+        "property": {
+          "type": "string",
+          "description": "A direct property name to filter on."
+        },
+        "singleTarget": {
+          "description": "Filter through a single-target reference.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FilterReferenceSingleTarget"
+            }
+          ]
+        },
+        "multiTarget": {
+          "description": "Filter through a multi-target reference.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FilterReferenceMultiTarget"
+            }
+          ]
+        },
+        "count": {
+          "description": "Filter on a reference count.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FilterReferenceCount"
+            }
+          ]
+        }
+      }
+    },
+    "Filters": {
+      "type": "object",
+      "description": "A conditional filter (a tree). Leaf nodes set a value + target; AND/OR/NOT nodes set `filters`.",
+      "properties": {
+        "operator": {
+          "type": "string",
+          "enum": [
+            "OPERATOR_UNSPECIFIED",
+            "OPERATOR_EQUAL",
+            "OPERATOR_NOT_EQUAL",
+            "OPERATOR_GREATER_THAN",
+            "OPERATOR_GREATER_THAN_EQUAL",
+            "OPERATOR_LESS_THAN",
+            "OPERATOR_LESS_THAN_EQUAL",
+            "OPERATOR_AND",
+            "OPERATOR_OR",
+            "OPERATOR_WITHIN_GEO_RANGE",
+            "OPERATOR_LIKE",
+            "OPERATOR_IS_NULL",
+            "OPERATOR_CONTAINS_ANY",
+            "OPERATOR_CONTAINS_ALL",
+            "OPERATOR_CONTAINS_NONE",
+            "OPERATOR_NOT"
+          ],
+          "description": "The filter operator. AND/OR/NOT combine the nested `filters`."
+        },
+        "filters": {
+          "type": "array",
+          "description": "Nested filters, combined via the AND/OR/NOT operator.",
+          "items": {
+            "$ref": "#/definitions/Filters"
+          }
+        },
+        "target": {
+          "description": "What the comparison applies to (property or reference path).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FilterTarget"
+            }
+          ]
+        },
+        "valueText": {
+          "type": "string",
+          "description": "Comparison value (text)."
+        },
+        "valueInt": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Comparison value (int64). (int64; serialized as a string in responses)"
+        },
+        "valueBoolean": {
+          "type": "boolean",
+          "description": "Comparison value (boolean)."
+        },
+        "valueNumber": {
+          "type": "number",
+          "description": "Comparison value (float64)."
+        },
+        "valueTextArray": {
+          "description": "Comparison values for CONTAINS_ANY/ALL/NONE (text).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TextArray"
+            }
+          ]
+        },
+        "valueIntArray": {
+          "description": "Comparison values for CONTAINS_ANY/ALL/NONE (int64).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IntArray"
+            }
+          ]
+        },
+        "valueBooleanArray": {
+          "description": "Comparison values for CONTAINS_ANY/ALL/NONE (boolean).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BooleanArray"
+            }
+          ]
+        },
+        "valueNumberArray": {
+          "description": "Comparison values for CONTAINS_ANY/ALL/NONE (float64).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NumberArray"
+            }
+          ]
+        },
+        "valueGeo": {
+          "description": "Comparison value for OPERATOR_WITHIN_GEO_RANGE.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GeoCoordinatesFilter"
+            }
+          ]
+        }
+      }
+    },
+    "ObjectPropertiesRequest": {
+      "type": "object",
+      "description": "Selects which sub-properties of a nested object property to return.",
+      "properties": {
+        "propName": {
+          "type": "string",
+          "description": "The nested object property name."
+        },
+        "primitiveProperties": {
+          "type": "array",
+          "description": "Primitive sub-properties to return from this object.",
+          "items": {
+            "type": "string",
+            "description": "A primitive sub-property to return."
+          }
+        },
+        "objectProperties": {
+          "type": "array",
+          "description": "Further nested object sub-properties.",
+          "items": {
+            "$ref": "#/definitions/ObjectPropertiesRequest"
+          }
+        }
+      }
+    },
+    "RefPropertiesRequest": {
+      "type": "object",
+      "description": "Selects properties/metadata to return from a cross-referenced collection.",
+      "properties": {
+        "referenceProperty": {
+          "type": "string",
+          "description": "The cross-reference property to expand."
+        },
+        "properties": {
+          "description": "Which properties to return from the referenced objects.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PropertiesRequest"
+            }
+          ]
+        },
+        "metadata": {
+          "description": "Which metadata to return from the referenced objects.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetadataRequest"
+            }
+          ]
+        },
+        "targetCollection": {
+          "type": "string",
+          "description": "The referenced collection (for multi-target references)."
+        }
+      }
+    },
+    "PropertiesRequest": {
+      "type": "object",
+      "description": "Selects which object properties are returned in the response.",
+      "properties": {
+        "nonRefProperties": {
+          "type": "array",
+          "description": "Non-reference properties to return.",
+          "items": {
+            "type": "string",
+            "description": "A property name to return."
+          }
+        },
+        "refProperties": {
+          "type": "array",
+          "description": "Cross-reference properties to expand and return.",
+          "items": {
+            "$ref": "#/definitions/RefPropertiesRequest"
+          }
+        },
+        "objectProperties": {
+          "type": "array",
+          "description": "Nested object properties to return.",
+          "items": {
+            "$ref": "#/definitions/ObjectPropertiesRequest"
+          }
+        },
+        "returnAllNonrefProperties": {
+          "type": "boolean",
+          "description": "If true, return all non-reference properties (ignores nonRefProperties)."
+        }
+      }
+    },
+    "MetadataRequest": {
+      "type": "object",
+      "description": "Selects which per-object metadata is returned in the response.",
+      "properties": {
+        "uuid": {
+          "type": "boolean",
+          "description": "Return each object's UUID."
+        },
+        "vector": {
+          "type": "boolean",
+          "description": "Return each object's (legacy/default) vector. Deprecated; prefer `vectors`."
+        },
+        "creationTimeUnix": {
+          "type": "boolean",
+          "description": "Return the object creation timestamp."
+        },
+        "lastUpdateTimeUnix": {
+          "type": "boolean",
+          "description": "Return the object last-update timestamp."
+        },
+        "distance": {
+          "type": "boolean",
+          "description": "Return the vector distance (vector searches only)."
+        },
+        "certainty": {
+          "type": "boolean",
+          "description": "Return the certainty (vector searches only)."
+        },
+        "score": {
+          "type": "boolean",
+          "description": "Return the score (BM25/hybrid searches)."
+        },
+        "explainScore": {
+          "type": "boolean",
+          "description": "Return a human-readable score explanation."
+        },
+        "isConsistent": {
+          "type": "boolean",
+          "description": "Return whether the read was consistent."
+        },
+        "vectors": {
+          "type": "array",
+          "description": "Named vectors to return for each object.",
+          "items": {
+            "type": "string",
+            "description": "A named vector to return."
+          }
+        },
+        "queryProfile": {
+          "type": "boolean",
+          "description": "Return per-shard query profiling (timing breakdowns) in the reply."
+        }
+      }
+    },
+    "SearchGroupBy": {
+      "type": "object",
+      "description": "Groups search results by a property.",
+      "properties": {
+        "path": {
+          "type": "array",
+          "description": "The property path to group by.",
+          "items": {
+            "type": "string",
+            "description": "The property to group by (currently exactly one)."
+          }
+        },
+        "numberOfGroups": {
+          "type": "integer",
+          "description": "Maximum number of groups to return."
+        },
+        "objectsPerGroup": {
+          "type": "integer",
+          "description": "Maximum number of objects per group."
+        }
+      }
+    },
+    "SortBy": {
+      "type": "object",
+      "description": "Sorts results by a property. Cannot be combined with vector searches.",
+      "properties": {
+        "ascending": {
+          "type": "boolean",
+          "description": "Sort ascending when true, descending when false."
+        },
+        "path": {
+          "type": "array",
+          "description": "The property path to sort by.",
+          "items": {
+            "type": "string",
+            "description": "The property to sort by (currently exactly one)."
+          }
+        }
+      }
+    },
+    "Rerank": {
+      "type": "object",
+      "description": "Reranks results using a reranker module.",
+      "properties": {
+        "property": {
+          "type": "string",
+          "description": "The property whose values are reranked."
+        },
+        "query": {
+          "type": "string",
+          "description": "Optional rerank query; defaults to the search query."
+        }
+      }
+    },
+    "GenerativeSearch": {
+      "type": "object",
+      "description": "Retrieval-augmented generation (RAG) options.",
+      "properties": {
+        "single": {
+          "type": "object",
+          "description": "Single-prompt (per-object) generation.",
+          "properties": {
+            "prompt": {
+              "type": "string",
+              "description": "Per-object prompt; use {property} placeholders."
+            },
+            "debug": {
+              "type": "boolean",
+              "description": "Include provider debug info in the reply."
+            },
+            "queries": {
+              "type": "array",
+              "description": "Generative provider configuration(s).",
+              "items": {
+                "type": "object",
+                "description": "A generative provider configuration (model and parameters)."
+              }
+            }
+          }
+        },
+        "grouped": {
+          "type": "object",
+          "description": "Grouped (single result over all objects) generation.",
+          "properties": {
+            "task": {
+              "type": "string",
+              "description": "Grouped task prompt applied across all results."
+            },
+            "properties": {
+              "description": "Properties to feed into the grouped task.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/TextArray"
+                }
+              ]
+            },
+            "queries": {
+              "type": "array",
+              "description": "Generative provider configuration(s).",
+              "items": {
+                "type": "object",
+                "description": "A generative provider configuration (model and parameters)."
+              }
+            },
+            "debug": {
+              "type": "boolean",
+              "description": "Include provider debug info in the reply."
+            }
+          }
+        }
+      }
+    },
+    "AggregationInteger": {
+      "type": "object",
+      "description": "Aggregations available on an integer property.",
+      "properties": {
+        "count": {
+          "type": "boolean",
+          "description": "Return the count."
+        },
+        "type": {
+          "type": "boolean",
+          "description": "Return the data type."
+        },
+        "sum": {
+          "type": "boolean",
+          "description": "Return the sum."
+        },
+        "mean": {
+          "type": "boolean",
+          "description": "Return the mean."
+        },
+        "mode": {
+          "type": "boolean",
+          "description": "Return the mode."
+        },
+        "median": {
+          "type": "boolean",
+          "description": "Return the median."
+        },
+        "maximum": {
+          "type": "boolean",
+          "description": "Return the maximum."
+        },
+        "minimum": {
+          "type": "boolean",
+          "description": "Return the minimum."
+        }
+      }
+    },
+    "AggregationNumber": {
+      "type": "object",
+      "description": "Aggregations available on a number (float) property.",
+      "properties": {
+        "count": {
+          "type": "boolean",
+          "description": "Return the count."
+        },
+        "type": {
+          "type": "boolean",
+          "description": "Return the data type."
+        },
+        "sum": {
+          "type": "boolean",
+          "description": "Return the sum."
+        },
+        "mean": {
+          "type": "boolean",
+          "description": "Return the mean."
+        },
+        "mode": {
+          "type": "boolean",
+          "description": "Return the mode."
+        },
+        "median": {
+          "type": "boolean",
+          "description": "Return the median."
+        },
+        "maximum": {
+          "type": "boolean",
+          "description": "Return the maximum."
+        },
+        "minimum": {
+          "type": "boolean",
+          "description": "Return the minimum."
+        }
+      }
+    },
+    "AggregationText": {
+      "type": "object",
+      "description": "Aggregations available on a text property.",
+      "properties": {
+        "count": {
+          "type": "boolean",
+          "description": "Return the count."
+        },
+        "type": {
+          "type": "boolean",
+          "description": "Return the data type."
+        },
+        "topOccurences": {
+          "type": "boolean",
+          "description": "Return the most frequent values."
+        },
+        "topOccurencesLimit": {
+          "type": "integer",
+          "description": "Maximum number of top occurrences to return."
+        }
+      }
+    },
+    "AggregationBoolean": {
+      "type": "object",
+      "description": "Aggregations available on a boolean property.",
+      "properties": {
+        "count": {
+          "type": "boolean",
+          "description": "Return the count."
+        },
+        "type": {
+          "type": "boolean",
+          "description": "Return the data type."
+        },
+        "totalTrue": {
+          "type": "boolean",
+          "description": "Return the count of true values."
+        },
+        "totalFalse": {
+          "type": "boolean",
+          "description": "Return the count of false values."
+        },
+        "percentageTrue": {
+          "type": "boolean",
+          "description": "Return the percentage of true values."
+        },
+        "percentageFalse": {
+          "type": "boolean",
+          "description": "Return the percentage of false values."
+        }
+      }
+    },
+    "AggregationDate": {
+      "type": "object",
+      "description": "Aggregations available on a date property.",
+      "properties": {
+        "count": {
+          "type": "boolean",
+          "description": "Return the count."
+        },
+        "type": {
+          "type": "boolean",
+          "description": "Return the data type."
+        },
+        "median": {
+          "type": "boolean",
+          "description": "Return the median."
+        },
+        "mode": {
+          "type": "boolean",
+          "description": "Return the mode."
+        },
+        "maximum": {
+          "type": "boolean",
+          "description": "Return the maximum."
+        },
+        "minimum": {
+          "type": "boolean",
+          "description": "Return the minimum."
+        }
+      }
+    },
+    "AggregationReference": {
+      "type": "object",
+      "description": "Aggregations available on a cross-reference property.",
+      "properties": {
+        "type": {
+          "type": "boolean",
+          "description": "Return the reference type."
+        },
+        "pointingTo": {
+          "type": "boolean",
+          "description": "Return the collections referenced."
+        }
+      }
+    },
+    "Aggregation": {
+      "type": "object",
+      "description": "Requests aggregations for one property (set exactly one of int/number/text/boolean/date/reference).",
+      "properties": {
+        "property": {
+          "type": "string",
+          "description": "The property to aggregate."
+        },
+        "int": {
+          "description": "Integer-property aggregations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationInteger"
+            }
+          ]
+        },
+        "number": {
+          "description": "Number-property aggregations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationNumber"
+            }
+          ]
+        },
+        "text": {
+          "description": "Text-property aggregations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationText"
+            }
+          ]
+        },
+        "boolean": {
+          "description": "Boolean-property aggregations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationBoolean"
+            }
+          ]
+        },
+        "date": {
+          "description": "Date-property aggregations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationDate"
+            }
+          ]
+        },
+        "reference": {
+          "description": "Reference-property aggregations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationReference"
+            }
+          ]
+        }
+      }
+    },
+    "AggregateGroupBy": {
+      "type": "object",
+      "description": "Groups aggregation results by a property.",
+      "properties": {
+        "collection": {
+          "type": "string",
+          "description": "The collection to group by (usually the queried collection)."
+        },
+        "property": {
+          "type": "string",
+          "description": "The property to group by."
+        }
+      }
+    },
+    "SearchRequest": {
+      "type": "object",
+      "description": "The search request body. Field encoding: camelCase field names, enum values as strings, vectors and other bytes as base64-encoded strings, and 64-bit integers as strings. Set at most one search method (nearVector, nearText, hybridSearch, bm25Search, ...).",
+      "properties": {
+        "collection": {
+          "type": "string",
+          "description": "Ignored for the REST endpoint: the collection from the URL path is always used."
+        },
+        "tenant": {
+          "type": "string",
+          "description": "The tenant to query (multi-tenant collections only)."
+        },
+        "consistencyLevel": {
+          "type": "string",
+          "enum": [
+            "CONSISTENCY_LEVEL_UNSPECIFIED",
+            "CONSISTENCY_LEVEL_ONE",
+            "CONSISTENCY_LEVEL_QUORUM",
+            "CONSISTENCY_LEVEL_ALL"
+          ],
+          "description": "Read consistency level."
+        },
+        "properties": {
+          "description": "Which object properties to return.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PropertiesRequest"
+            }
+          ]
+        },
+        "metadata": {
+          "description": "Which per-object metadata to return.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetadataRequest"
+            }
+          ]
+        },
+        "groupBy": {
+          "description": "Group results by a property.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SearchGroupBy"
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of results to return. 0 means the server default."
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Number of results to skip (pagination)."
+        },
+        "autocut": {
+          "type": "integer",
+          "description": "Autocut: stop after N jumps in the result-score distribution. 0 disables."
+        },
+        "after": {
+          "type": "string",
+          "description": "Cursor for cursor-based pagination (object UUID)."
+        },
+        "sortBy": {
+          "type": "array",
+          "description": "Sort results by properties. Not compatible with vector searches.",
+          "items": {
+            "$ref": "#/definitions/SortBy"
+          }
+        },
+        "filters": {
+          "description": "Restrict results with a conditional filter.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Filters"
+            }
+          ]
+        },
+        "hybridSearch": {
+          "description": "Hybrid (keyword + vector) search.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Hybrid"
+            }
+          ]
+        },
+        "bm25Search": {
+          "description": "BM25 keyword search.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BM25"
+            }
+          ]
+        },
+        "nearVector": {
+          "description": "Raw-vector search.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearVector"
+            }
+          ]
+        },
+        "nearObject": {
+          "description": "Search by an existing object's vector.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearObject"
+            }
+          ]
+        },
+        "nearText": {
+          "description": "Semantic text search (requires a vectorizer).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearTextSearch"
+            }
+          ]
+        },
+        "nearImage": {
+          "description": "Image search (requires a multi-modal module).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearImageSearch"
+            }
+          ]
+        },
+        "nearAudio": {
+          "description": "Audio search (requires a multi-modal module).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearAudioSearch"
+            }
+          ]
+        },
+        "nearVideo": {
+          "description": "Video search (requires a multi-modal module).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearVideoSearch"
+            }
+          ]
+        },
+        "nearDepth": {
+          "description": "Depth search (requires a multi-modal module).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearDepthSearch"
+            }
+          ]
+        },
+        "nearThermal": {
+          "description": "Thermal search (requires a multi-modal module).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearThermalSearch"
+            }
+          ]
+        },
+        "nearImu": {
+          "description": "IMU search (requires a multi-modal module).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearIMUSearch"
+            }
+          ]
+        },
+        "generative": {
+          "description": "Retrieval-augmented generation (RAG) over the results.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GenerativeSearch"
+            }
+          ]
+        },
+        "rerank": {
+          "description": "Rerank the results with a reranker module.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Rerank"
+            }
+          ]
+        },
+        "uses127Api": {
+          "type": "boolean",
+          "description": "Use the 1.27+ response shape (recommended; nested object properties returned inline)."
+        }
+      }
+    },
+    "AggregateRequest": {
+      "type": "object",
+      "description": "The aggregation request body. Field encoding: camelCase field names, enum values as strings, vectors and other bytes as base64-encoded strings, and 64-bit integers as strings. Set at most one search method (nearVector, nearText, hybrid, bm25, ...).",
+      "properties": {
+        "collection": {
+          "type": "string",
+          "description": "Ignored for the REST endpoint: the collection from the URL path is always used."
+        },
+        "tenant": {
+          "type": "string",
+          "description": "The tenant to aggregate (multi-tenant collections only)."
+        },
+        "objectsCount": {
+          "type": "boolean",
+          "description": "Return the total number of matching objects."
+        },
+        "aggregations": {
+          "type": "array",
+          "description": "Per-property aggregations to compute.",
+          "items": {
+            "$ref": "#/definitions/Aggregation"
+          }
+        },
+        "objectLimit": {
+          "type": "integer",
+          "description": "When a search is set, only aggregate over the top N matching objects."
+        },
+        "groupBy": {
+          "description": "Group the aggregation by a property.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregateGroupBy"
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of groups to return (grouped aggregation)."
+        },
+        "filters": {
+          "description": "Restrict the aggregated set with a conditional filter.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Filters"
+            }
+          ]
+        },
+        "hybrid": {
+          "description": "Aggregate over a hybrid search result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Hybrid"
+            }
+          ]
+        },
+        "nearVector": {
+          "description": "Aggregate over a nearVector result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearVector"
+            }
+          ]
+        },
+        "nearObject": {
+          "description": "Aggregate over a nearObject result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearObject"
+            }
+          ]
+        },
+        "nearText": {
+          "description": "Aggregate over a nearText result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearTextSearch"
+            }
+          ]
+        },
+        "nearImage": {
+          "description": "Aggregate over a nearImage result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearImageSearch"
+            }
+          ]
+        },
+        "nearAudio": {
+          "description": "Aggregate over a nearAudio result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearAudioSearch"
+            }
+          ]
+        },
+        "nearVideo": {
+          "description": "Aggregate over a nearVideo result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearVideoSearch"
+            }
+          ]
+        },
+        "nearDepth": {
+          "description": "Aggregate over a nearDepth result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearDepthSearch"
+            }
+          ]
+        },
+        "nearThermal": {
+          "description": "Aggregate over a nearThermal result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearThermalSearch"
+            }
+          ]
+        },
+        "nearImu": {
+          "description": "Aggregate over a nearImu result set.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NearIMUSearch"
+            }
+          ]
+        }
+      }
+    },
+    "Properties": {
+      "type": "object",
+      "description": "A bag of returned property values, one entry per requested property.",
+      "properties": {
+        "fields": {
+          "type": "object",
+          "description": "Map of property name to its (typed) value."
+        }
+      }
+    },
+    "MetadataResult": {
+      "type": "object",
+      "description": "Per-object metadata. Each optional numeric field has a sibling `<field>Present` boolean indicating whether the value is set.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The object UUID."
+        },
+        "idAsBytes": {
+          "type": "string",
+          "format": "byte",
+          "description": "The object UUID as raw bytes. (base64-encoded bytes)"
+        },
+        "vectorBytes": {
+          "type": "string",
+          "format": "byte",
+          "description": "The (legacy/default) vector as little-endian float32 bytes. (base64-encoded bytes)"
+        },
+        "vectors": {
+          "type": "array",
+          "description": "Named vectors of the object (when requested).",
+          "items": {
+            "$ref": "#/definitions/QueryVectors"
+          }
+        },
+        "creationTimeUnix": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Creation timestamp (unix ms). (int64; serialized as a string in responses)"
+        },
+        "lastUpdateTimeUnix": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Last-update timestamp (unix ms). (int64; serialized as a string in responses)"
+        },
+        "distance": {
+          "type": "number",
+          "description": "Vector distance (vector searches)."
+        },
+        "certainty": {
+          "type": "number",
+          "description": "Certainty (vector searches)."
+        },
+        "score": {
+          "type": "number",
+          "description": "Score (BM25/hybrid searches)."
+        },
+        "explainScore": {
+          "type": "string",
+          "description": "Human-readable score explanation."
+        },
+        "rerankScore": {
+          "type": "number",
+          "description": "Score assigned by the reranker, if used."
+        },
+        "isConsistent": {
+          "type": "boolean",
+          "description": "Whether the read was consistent."
+        }
+      }
+    },
+    "RefPropertiesResult": {
+      "type": "object",
+      "description": "Returned cross-referenced objects for one reference property.",
+      "properties": {
+        "propName": {
+          "type": "string",
+          "description": "The cross-reference property name."
+        },
+        "properties": {
+          "type": "array",
+          "description": "The referenced objects' properties.",
+          "items": {
+            "$ref": "#/definitions/PropertiesResult"
+          }
+        }
+      }
+    },
+    "PropertiesResult": {
+      "type": "object",
+      "description": "The property values returned for one object.",
+      "properties": {
+        "nonRefProps": {
+          "description": "The non-reference property values.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Properties"
+            }
+          ]
+        },
+        "refProps": {
+          "type": "array",
+          "description": "Expanded cross-reference properties.",
+          "items": {
+            "$ref": "#/definitions/RefPropertiesResult"
+          }
+        },
+        "targetCollection": {
+          "type": "string",
+          "description": "The collection this result belongs to."
+        },
+        "refPropsRequested": {
+          "type": "boolean",
+          "description": "Whether reference properties were requested."
+        }
+      }
+    },
+    "GenerativeResult": {
+      "type": "object",
+      "description": "A generative (RAG) result."
+    },
+    "SearchResult": {
+      "type": "object",
+      "description": "A single search result object.",
+      "properties": {
+        "properties": {
+          "description": "The object's returned properties.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PropertiesResult"
+            }
+          ]
+        },
+        "metadata": {
+          "description": "The object's returned metadata.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetadataResult"
+            }
+          ]
+        },
+        "generative": {
+          "description": "Per-object generative (RAG) result, if requested.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GenerativeResult"
+            }
+          ]
+        }
+      }
+    },
+    "GroupByResult": {
+      "type": "object",
+      "description": "One group of a group-by search.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The group's value."
+        },
+        "minDistance": {
+          "type": "number",
+          "description": "Minimum distance within the group."
+        },
+        "maxDistance": {
+          "type": "number",
+          "description": "Maximum distance within the group."
+        },
+        "numberOfObjects": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of objects in the group. (int64; serialized as a string in responses)"
+        },
+        "objects": {
+          "type": "array",
+          "description": "The objects in this group.",
+          "items": {
+            "$ref": "#/definitions/SearchResult"
+          }
+        },
+        "generativeResult": {
+          "description": "Group-level generative (RAG) result, if requested.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GenerativeResult"
+            }
+          ]
+        }
+      }
+    },
+    "QueryProfile": {
+      "type": "object",
+      "description": "Per-shard query profiling; populated when metadata.queryProfile is true.",
+      "properties": {
+        "shards": {
+          "type": "array",
+          "description": "Per-shard query profiling entries.",
+          "items": {
+            "type": "object",
+            "description": "Per-shard profiling entry (name, node, per-search-type timings)."
+          }
+        }
+      }
+    },
+    "SearchReply": {
+      "type": "object",
+      "description": "The search response body.",
+      "properties": {
+        "took": {
+          "type": "number",
+          "description": "Server-side processing time, in seconds."
+        },
+        "results": {
+          "type": "array",
+          "description": "The matching objects.",
+          "items": {
+            "$ref": "#/definitions/SearchResult"
+          }
+        },
+        "groupByResults": {
+          "type": "array",
+          "description": "Groups, when groupBy was set.",
+          "items": {
+            "$ref": "#/definitions/GroupByResult"
+          }
+        },
+        "generativeGroupedResults": {
+          "description": "Grouped generative (RAG) result, if requested.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GenerativeResult"
+            }
+          ]
+        },
+        "queryProfile": {
+          "description": "Per-shard profiling, when requested.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/QueryProfile"
+            }
+          ]
+        }
+      }
+    },
+    "AggregateReplyAggregations": {
+      "type": "object",
+      "description": "Per-property aggregation results."
+    },
+    "AggregateReplySingle": {
+      "type": "object",
+      "description": "Ungrouped aggregation result.",
+      "properties": {
+        "objectsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total number of matching objects, when requested. (int64; serialized as a string in responses)"
+        },
+        "aggregations": {
+          "description": "The computed per-property aggregations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregateReplyAggregations"
+            }
+          ]
+        }
+      }
+    },
+    "AggregateReplyGroup": {
+      "type": "object",
+      "description": "One group of a grouped aggregation result.",
+      "properties": {
+        "objectsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of objects in the group. (int64; serialized as a string in responses)"
+        },
+        "aggregations": {
+          "description": "The computed per-property aggregations for the group.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregateReplyAggregations"
+            }
+          ]
+        },
+        "groupedBy": {
+          "type": "object",
+          "description": "The group's path and value."
+        }
+      }
+    },
+    "AggregateReplyGrouped": {
+      "type": "object",
+      "description": "Grouped aggregation result.",
+      "properties": {
+        "groups": {
+          "type": "array",
+          "description": "The groups.",
+          "items": {
+            "$ref": "#/definitions/AggregateReplyGroup"
+          }
+        }
+      }
+    },
+    "AggregateReply": {
+      "type": "object",
+      "description": "The aggregation response body.",
+      "properties": {
+        "took": {
+          "type": "number",
+          "description": "Server-side processing time, in seconds."
+        },
+        "singleResult": {
+          "description": "Set when no groupBy was requested.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregateReplySingle"
+            }
+          ]
+        },
+        "groupedResults": {
+          "description": "Set when a groupBy was requested.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregateReplyGrouped"
+            }
+          ]
+        }
+      }
     }
   },
   "externalDocs": {
@@ -3904,6 +5908,138 @@
     }
   },
   "paths": {
+    "/{collection}/query": {
+      "post": {
+        "summary": "Search a collection",
+        "description": "Runs a search against a single collection and returns the matching objects. The collection name is taken from the path and always overrides any `collection` field in the body. An empty body runs a default search over the collection.",
+        "operationId": "query.search",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "collection",
+            "in": "path",
+            "description": "The name of the collection (class) to search.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The search request body. Any `collection` field in the body is ignored in favor of the path parameter.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/SearchRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search executed successfully. The body contains the matching objects.",
+            "schema": {
+              "$ref": "#/definitions/SearchReply"
+            }
+          },
+          "401": {
+            "description": "Unauthorized or invalid credentials."
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the maximum allowed size."
+          },
+          "422": {
+            "description": "The request is well-formed but could not be processed (for example an unknown collection, invalid parameters, or the endpoint is disabled).",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "An internal server error occurred. Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "query"
+        ]
+      }
+    },
+    "/{collection}/aggregate": {
+      "post": {
+        "summary": "Aggregate over a collection",
+        "description": "Runs a aggregation against a single collection and returns the aggregation results. The collection name is taken from the path and always overrides any `collection` field in the body.",
+        "operationId": "query.aggregate",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "collection",
+            "in": "path",
+            "description": "The name of the collection (class) to aggregate over.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The aggregation request body. Any `collection` field in the body is ignored in favor of the path parameter.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/AggregateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregation executed successfully. The body contains the aggregation results.",
+            "schema": {
+              "$ref": "#/definitions/AggregateReply"
+            }
+          },
+          "401": {
+            "description": "Unauthorized or invalid credentials."
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "413": {
+            "description": "The request body exceeds the maximum allowed size."
+          },
+          "422": {
+            "description": "The request is well-formed but could not be processed (for example an unknown collection, invalid parameters, or the endpoint is disabled).",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "An internal server error occurred. Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "query"
+        ]
+      }
+    },
     "/": {
       "get": {
         "description": "Get links to other endpoints to help discover the REST API.",
@@ -10972,6 +13108,10 @@
     },
     {
       "name": "graphql"
+    },
+    {
+      "name": "query",
+      "description": "REST search and aggregation over a single collection (POST /v1/{collection}/query and /v1/{collection}/aggregate). The recommended way to query Weaviate over HTTP and the replacement for GraphQL data queries."
     },
     {
       "name": "meta"

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3818,7 +3818,8 @@
             "description": "A text value."
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "IntArray": {
       "type": "object",
@@ -3833,7 +3834,8 @@
             "description": "An int64 value. (int64; serialized as a string in responses)"
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NumberArray": {
       "type": "object",
@@ -3847,7 +3849,8 @@
             "description": "A float64 value."
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "BooleanArray": {
       "type": "object",
@@ -3861,7 +3864,8 @@
             "description": "A boolean value."
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "GeoCoordinatesFilter": {
       "type": "object",
@@ -3879,7 +3883,8 @@
           "type": "number",
           "description": "Maximum distance from the reference point, in meters."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "QueryVectors": {
       "type": "object",
@@ -3903,7 +3908,8 @@
           ],
           "description": "Whether this is a single (SINGLE_FP32) or multi (MULTI_FP32) vector."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "WeightsForTarget": {
       "type": "object",
@@ -3917,7 +3923,8 @@
           "type": "number",
           "description": "The weight applied to this target's score during multi-target fusion."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "Targets": {
       "type": "object",
@@ -3950,7 +3957,8 @@
             "$ref": "#/definitions/WeightsForTarget"
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "VectorForTarget": {
       "type": "object",
@@ -3967,7 +3975,8 @@
             "$ref": "#/definitions/QueryVectors"
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "SelectionMMR": {
       "type": "object",
@@ -3981,7 +3990,8 @@
           "type": "number",
           "description": "Trade-off between relevance and diversity (0..1)."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "Selection": {
       "type": "object",
@@ -3990,7 +4000,8 @@
         "mmr": {
           "$ref": "#/definitions/SelectionMMR"
         }
-      }
+      },
+      "x-doc-only": true
     },
     "SearchOperatorOptions": {
       "type": "object",
@@ -4009,7 +4020,8 @@
           "type": "integer",
           "description": "When operator is OR, the minimum number of query tokens that must match."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearTextMove": {
       "type": "object",
@@ -4035,7 +4047,8 @@
             "description": "An object UUID to move toward/away from."
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearTextSearch": {
       "type": "object",
@@ -4089,7 +4102,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearVector": {
       "type": "object",
@@ -4141,7 +4155,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearObject": {
       "type": "object",
@@ -4175,7 +4190,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearImageSearch": {
       "type": "object",
@@ -4209,7 +4225,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearAudioSearch": {
       "type": "object",
@@ -4243,7 +4260,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearVideoSearch": {
       "type": "object",
@@ -4277,7 +4295,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearDepthSearch": {
       "type": "object",
@@ -4311,7 +4330,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearThermalSearch": {
       "type": "object",
@@ -4345,7 +4365,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "NearIMUSearch": {
       "type": "object",
@@ -4379,7 +4400,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "BM25": {
       "type": "object",
@@ -4405,7 +4427,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "Hybrid": {
       "type": "object",
@@ -4504,7 +4527,8 @@
             "format": "float"
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "FilterReferenceSingleTarget": {
       "type": "object",
@@ -4522,7 +4546,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "FilterReferenceMultiTarget": {
       "type": "object",
@@ -4544,7 +4569,8 @@
           "type": "string",
           "description": "The referenced collection to traverse into."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "FilterReferenceCount": {
       "type": "object",
@@ -4554,7 +4580,8 @@
           "type": "string",
           "description": "The cross-reference property whose count is filtered."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "FilterTarget": {
       "type": "object",
@@ -4588,7 +4615,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "Filters": {
       "type": "object",
@@ -4688,7 +4716,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "ObjectPropertiesRequest": {
       "type": "object",
@@ -4713,7 +4742,8 @@
             "$ref": "#/definitions/ObjectPropertiesRequest"
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "RefPropertiesRequest": {
       "type": "object",
@@ -4743,7 +4773,8 @@
           "type": "string",
           "description": "The referenced collection (for multi-target references)."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "PropertiesRequest": {
       "type": "object",
@@ -4775,7 +4806,8 @@
           "type": "boolean",
           "description": "If true, return all non-reference properties (ignores nonRefProperties)."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "MetadataRequest": {
       "type": "object",
@@ -4829,7 +4861,8 @@
           "type": "boolean",
           "description": "Return per-shard query profiling (timing breakdowns) in the reply."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "SearchGroupBy": {
       "type": "object",
@@ -4851,7 +4884,8 @@
           "type": "integer",
           "description": "Maximum number of objects per group."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "SortBy": {
       "type": "object",
@@ -4869,7 +4903,8 @@
             "description": "The property to sort by (currently exactly one)."
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "Rerank": {
       "type": "object",
@@ -4883,7 +4918,8 @@
           "type": "string",
           "description": "Optional rerank query; defaults to the search query."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "GenerativeSearch": {
       "type": "object",
@@ -4941,7 +4977,8 @@
             }
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregationInteger": {
       "type": "object",
@@ -4979,7 +5016,8 @@
           "type": "boolean",
           "description": "Return the minimum."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregationNumber": {
       "type": "object",
@@ -5017,7 +5055,8 @@
           "type": "boolean",
           "description": "Return the minimum."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregationText": {
       "type": "object",
@@ -5039,7 +5078,8 @@
           "type": "integer",
           "description": "Maximum number of top occurrences to return."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregationBoolean": {
       "type": "object",
@@ -5069,7 +5109,8 @@
           "type": "boolean",
           "description": "Return the percentage of false values."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregationDate": {
       "type": "object",
@@ -5099,7 +5140,8 @@
           "type": "boolean",
           "description": "Return the minimum."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregationReference": {
       "type": "object",
@@ -5113,7 +5155,8 @@
           "type": "boolean",
           "description": "Return the collections referenced."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "Aggregation": {
       "type": "object",
@@ -5171,7 +5214,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregateGroupBy": {
       "type": "object",
@@ -5185,7 +5229,8 @@
           "type": "string",
           "description": "The property to group by."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "SearchRequest": {
       "type": "object",
@@ -5383,7 +5428,8 @@
           "type": "boolean",
           "description": "Use the 1.27+ response shape (recommended; nested object properties returned inline)."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregateRequest": {
       "type": "object",
@@ -5520,7 +5566,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "Properties": {
       "type": "object",
@@ -5530,7 +5577,8 @@
           "type": "object",
           "description": "Map of property name to its (typed) value."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "MetadataResult": {
       "type": "object",
@@ -5591,7 +5639,8 @@
           "type": "boolean",
           "description": "Whether the read was consistent."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "RefPropertiesResult": {
       "type": "object",
@@ -5608,7 +5657,8 @@
             "$ref": "#/definitions/PropertiesResult"
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "PropertiesResult": {
       "type": "object",
@@ -5637,11 +5687,13 @@
           "type": "boolean",
           "description": "Whether reference properties were requested."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "GenerativeResult": {
       "type": "object",
-      "description": "A generative (RAG) result."
+      "description": "A generative (RAG) result.",
+      "x-doc-only": true
     },
     "SearchResult": {
       "type": "object",
@@ -5671,7 +5723,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "GroupByResult": {
       "type": "object",
@@ -5709,7 +5762,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "QueryProfile": {
       "type": "object",
@@ -5723,7 +5777,8 @@
             "description": "Per-shard profiling entry (name, node, per-search-type timings)."
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "SearchReply": {
       "type": "object",
@@ -5763,11 +5818,13 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregateReplyAggregations": {
       "type": "object",
-      "description": "Per-property aggregation results."
+      "description": "Per-property aggregation results.",
+      "x-doc-only": true
     },
     "AggregateReplySingle": {
       "type": "object",
@@ -5786,7 +5843,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregateReplyGroup": {
       "type": "object",
@@ -5809,7 +5867,8 @@
           "type": "object",
           "description": "The group's path and value."
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregateReplyGrouped": {
       "type": "object",
@@ -5822,7 +5881,8 @@
             "$ref": "#/definitions/AggregateReplyGroup"
           }
         }
-      }
+      },
+      "x-doc-only": true
     },
     "AggregateReply": {
       "type": "object",
@@ -5848,7 +5908,8 @@
             }
           ]
         }
-      }
+      },
+      "x-doc-only": true
     }
   },
   "externalDocs": {
@@ -6011,7 +6072,8 @@
         },
         "tags": [
           "query"
-        ]
+        ],
+        "x-doc-only": true
       }
     },
     "/{collection}/aggregate": {
@@ -6077,7 +6139,8 @@
         },
         "tags": [
           "query"
-        ]
+        ],
+        "x-doc-only": true
       }
     },
     "/": {
@@ -13151,7 +13214,8 @@
     },
     {
       "name": "query",
-      "description": "REST search and aggregation over a single collection (POST /v1/{collection}/query and /v1/{collection}/aggregate). The recommended way to query Weaviate over HTTP and the replacement for GraphQL data queries."
+      "description": "REST search and aggregation over a single collection (POST /v1/{collection}/query and /v1/{collection}/aggregate). The recommended way to query Weaviate over HTTP and the replacement for GraphQL data queries.",
+      "x-doc-only": true
     },
     {
       "name": "meta"

--- a/test/acceptance/rest_query/parity_test.go
+++ b/test/acceptance/rest_query/parity_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -157,6 +158,33 @@ func TestRESTQueryParity(t *testing.T) {
 		})
 	}
 
+	// The REST `where` filter (operator/path syntax) must produce the same
+	// result as the equivalent gRPC pb.Filters.
+	t.Run("search/where filter equals pb.Filters", func(t *testing.T) {
+		grpcReply, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: parityClass,
+			Filters: &pb.Filters{
+				Operator:  pb.Filters_OPERATOR_EQUAL,
+				TestValue: &pb.Filters_ValueText{ValueText: "fantasy"},
+				Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "category"}},
+			},
+			Metadata:    &pb.MetadataRequest{Uuid: true},
+			Properties:  &pb.PropertiesRequest{NonRefProperties: []string{"title", "category"}},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+
+		// Same filter, expressed in the REST where syntax instead of pb.Filters.
+		restReply := restSearchBody(t, httpURI, parityClass,
+			`{"metadata":{"uuid":true},"properties":{"nonRefProperties":["title","category"]},"uses127Api":true,`+
+				`"where":{"operator":"Equal","path":["category"],"valueText":"fantasy"}}`)
+
+		normalizeSearch(grpcReply)
+		normalizeSearch(restReply)
+		require.Truef(t, proto.Equal(grpcReply, restReply),
+			"REST where and gRPC pb.Filters differ\ngRPC: %v\nREST: %v", grpcReply, restReply)
+	})
+
 	aggregateCases := []struct {
 		name string
 		req  *pb.AggregateRequest
@@ -208,6 +236,22 @@ func normalizeSearch(r *pb.SearchReply) {
 func restSearch(t *testing.T, httpURI string, req *pb.SearchRequest) *pb.SearchReply {
 	t.Helper()
 	data := restPost(t, httpURI, req.Collection, "query", req)
+	var reply pb.SearchReply
+	require.NoError(t, protojson.Unmarshal(data, &reply))
+	return &reply
+}
+
+// restSearchBody POSTs a raw JSON body to the query endpoint (used to send the
+// REST `where` syntax, which has no protobuf equivalent to marshal from).
+func restSearchBody(t *testing.T, httpURI, collection, body string) *pb.SearchReply {
+	t.Helper()
+	url := "http://" + httpURI + "/v1/" + collection + "/query"
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "unexpected status; body: %s", string(data))
 	var reply pb.SearchReply
 	require.NoError(t, protojson.Unmarshal(data, &reply))
 	return &reply

--- a/test/acceptance/rest_query/parity_test.go
+++ b/test/acceptance/rest_query/parity_test.go
@@ -1,0 +1,246 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package restquery verifies that the pure-REST query/aggregate endpoints
+// (POST /v1/{collection}/query and /aggregate) return exactly the same results
+// as the equivalent gRPC Search/Aggregate RPCs. Both transports delegate to the
+// same gRPC pipeline (SearchWithPrincipal/AggregateWithPrincipal), so any
+// divergence here is a regression in the REST plumbing.
+package restquery
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/byteops"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+const parityClass = "RestParity"
+
+func TestRESTQueryParity(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateWithGRPC().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	httpURI := compose.GetWeaviate().URI()
+	helper.SetupClient(httpURI)
+	grpcClient, conn := newGRPCClient(t, compose.GetWeaviate().GrpcURI())
+	defer conn.Close()
+
+	helper.DeleteClass(t, parityClass)
+	helper.CreateClass(t, &models.Class{
+		Class:      parityClass,
+		Vectorizer: "none",
+		Properties: []*models.Property{
+			{
+				Name:         "title",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+			},
+			{
+				Name:         "category",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationField,
+			},
+		},
+	})
+	defer helper.DeleteClass(t, parityClass)
+
+	objects := []struct {
+		title    string
+		category string
+		vector   []float32
+	}{
+		{"Dune", "scifi", []float32{1, 0, 0}},
+		{"Project Hail Mary", "scifi", []float32{0, 1, 0}},
+		{"The Hobbit", "fantasy", []float32{0, 0, 1}},
+		{"The Silmarillion", "fantasy", []float32{1, 1, 0}},
+	}
+	for _, o := range objects {
+		require.NoError(t, helper.CreateObject(t, &models.Object{
+			Class:  parityClass,
+			Vector: o.vector,
+			Properties: map[string]interface{}{
+				"title":    o.title,
+				"category": o.category,
+			},
+		}))
+	}
+	// Single-node create is synchronous, but allow a brief settle for the
+	// inverted index just in case the environment is slow.
+	time.Sleep(500 * time.Millisecond)
+
+	searchCases := []struct {
+		name string
+		req  *pb.SearchRequest
+	}{
+		{
+			name: "match all with uuid metadata",
+			req: &pb.SearchRequest{
+				Collection: parityClass,
+				Metadata:   &pb.MetadataRequest{Uuid: true},
+				Limit:      10,
+			},
+		},
+		{
+			name: "bm25 keyword search",
+			req: &pb.SearchRequest{
+				Collection:  parityClass,
+				Bm25Search:  &pb.BM25{Query: "Dune"},
+				Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+				Properties:  &pb.PropertiesRequest{NonRefProperties: []string{"title"}},
+				Uses_127Api: true,
+			},
+		},
+		{
+			name: "filter by category",
+			req: &pb.SearchRequest{
+				Collection: parityClass,
+				Filters: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_EQUAL,
+					TestValue: &pb.Filters_ValueText{ValueText: "fantasy"},
+					Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "category"}},
+				},
+				Metadata:    &pb.MetadataRequest{Uuid: true},
+				Properties:  &pb.PropertiesRequest{NonRefProperties: []string{"title", "category"}},
+				Uses_127Api: true,
+			},
+		},
+		{
+			name: "near vector",
+			req: &pb.SearchRequest{
+				Collection:  parityClass,
+				NearVector:  &pb.NearVector{Vectors: []*pb.Vectors{{VectorBytes: byteops.Fp32SliceToBytes([]float32{1, 0, 0}), Type: pb.Vectors_VECTOR_TYPE_SINGLE_FP32}}},
+				Metadata:    &pb.MetadataRequest{Uuid: true, Distance: true},
+				Limit:       2,
+				Uses_127Api: true,
+			},
+		},
+	}
+
+	for _, tc := range searchCases {
+		t.Run("search/"+tc.name, func(t *testing.T) {
+			grpcReply, err := grpcClient.Search(ctx, proto.Clone(tc.req).(*pb.SearchRequest))
+			require.NoError(t, err)
+
+			restReply := restSearch(t, httpURI, tc.req)
+
+			normalizeSearch(grpcReply)
+			normalizeSearch(restReply)
+			require.Truef(t, proto.Equal(grpcReply, restReply),
+				"REST and gRPC search results differ\ngRPC: %v\nREST: %v", grpcReply, restReply)
+		})
+	}
+
+	aggregateCases := []struct {
+		name string
+		req  *pb.AggregateRequest
+	}{
+		{
+			name: "objects count",
+			req: &pb.AggregateRequest{
+				Collection:   parityClass,
+				ObjectsCount: true,
+			},
+		},
+	}
+	for _, tc := range aggregateCases {
+		t.Run("aggregate/"+tc.name, func(t *testing.T) {
+			grpcReply, err := grpcClient.Aggregate(ctx, proto.Clone(tc.req).(*pb.AggregateRequest))
+			require.NoError(t, err)
+
+			restReply := restAggregate(t, httpURI, tc.req)
+
+			grpcReply.Took = 0
+			restReply.Took = 0
+			require.Truef(t, proto.Equal(grpcReply, restReply),
+				"REST and gRPC aggregate results differ\ngRPC: %v\nREST: %v", grpcReply, restReply)
+		})
+	}
+
+	t.Run("disabled endpoint returns error", func(t *testing.T) {
+		// The endpoint is enabled by default; this is a sanity check that the
+		// route exists (a 404 would indicate the route was never registered).
+		req := &pb.SearchRequest{Collection: parityClass}
+		body, err := protojson.Marshal(req)
+		require.NoError(t, err)
+		resp, err := http.Post("http://"+httpURI+"/v1/"+parityClass+"/query", "application/json", bytes.NewReader(body))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// normalizeSearch zeroes fields that legitimately differ between two otherwise
+// identical responses (wall-clock timing).
+func normalizeSearch(r *pb.SearchReply) {
+	if r == nil {
+		return
+	}
+	r.Took = 0
+}
+
+func restSearch(t *testing.T, httpURI string, req *pb.SearchRequest) *pb.SearchReply {
+	t.Helper()
+	data := restPost(t, httpURI, req.Collection, "query", req)
+	var reply pb.SearchReply
+	require.NoError(t, protojson.Unmarshal(data, &reply))
+	return &reply
+}
+
+func restAggregate(t *testing.T, httpURI string, req *pb.AggregateRequest) *pb.AggregateReply {
+	t.Helper()
+	data := restPost(t, httpURI, req.Collection, "aggregate", req)
+	var reply pb.AggregateReply
+	require.NoError(t, protojson.Unmarshal(data, &reply))
+	return &reply
+}
+
+func restPost(t *testing.T, httpURI, collection, verb string, msg proto.Message) []byte {
+	t.Helper()
+	body, err := protojson.Marshal(msg)
+	require.NoError(t, err)
+	url := "http://" + httpURI + "/v1/" + collection + "/" + verb
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "unexpected status; body: %s", string(data))
+	return data
+}
+
+func newGRPCClient(t *testing.T, host string) (pb.WeaviateClient, *grpc.ClientConn) {
+	t.Helper()
+	conn, err := helper.CreateGrpcConnectionClient(host)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	grpcClient := helper.CreateGrpcWeaviateClient(conn)
+	require.NotNil(t, grpcClient)
+	return grpcClient, conn
+}

--- a/tools/gen-code-from-swagger.sh
+++ b/tools/gen-code-from-swagger.sh
@@ -26,11 +26,21 @@ go install golang.org/x/tools/cmd/goimports@v0.1.12
 # Explicitly get yamplc package
 (go get github.com/go-openapi/runtime/yamlpc@v0.29.2)
 
+# Generate from a copy of the spec with documentation-only entries removed.
+# Entries marked `"x-doc-only": true` stay in openapi-specs/schema.json for the
+# docs site but are excluded from code generation — they document the REST
+# query/aggregate endpoints, which are served by custom middleware over the gRPC
+# pipeline rather than by generated handlers.
+CODEGEN_DIR="$(mktemp -d)"
+trap 'rm -rf "$CODEGEN_DIR"' EXIT
+CODEGEN_SPEC="$CODEGEN_DIR/schema.json"
+(cd "$DIR"/..; GO111MODULE=on go run ./tools/swagger_strip_doc_only openapi-specs/schema.json "$CODEGEN_SPEC")
+
 # Remove old stuff.
 (cd "$DIR"/..; rm -rf entities/models client adapters/handlers/rest/operations/)
 
-(cd "$DIR"/..; $SWAGGER generate server --name=weaviate --model-package=entities/models --server-package=adapters/handlers/rest --spec=openapi-specs/schema.json -P models.Principal --default-scheme=https --struct-tags=yaml --struct-tags=json)
-(cd "$DIR"/..; $SWAGGER generate client --name=weaviate --model-package=entities/models --spec=openapi-specs/schema.json -P models.Principal --default-scheme=https)
+(cd "$DIR"/..; $SWAGGER generate server --name=weaviate --model-package=entities/models --server-package=adapters/handlers/rest --spec="$CODEGEN_SPEC" -P models.Principal --default-scheme=https --struct-tags=yaml --struct-tags=json)
+(cd "$DIR"/..; $SWAGGER generate client --name=weaviate --model-package=entities/models --spec="$CODEGEN_SPEC" -P models.Principal --default-scheme=https)
 
 echo Generate Deprecation code...
 (cd "$DIR"/..; GO111MODULE=on GOWORK=off go generate ./deprecations)

--- a/tools/swagger_strip_doc_only/main.go
+++ b/tools/swagger_strip_doc_only/main.go
@@ -1,0 +1,143 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Command swagger_strip_doc_only reads an OpenAPI 2.0 spec and writes a copy
+// with every entry marked `"x-doc-only": true` removed — definitions, path
+// operations, and tags.
+//
+// These entries are kept in openapi-specs/schema.json so the documentation site
+// can render them, but they must NOT reach go-swagger code generation: they
+// describe endpoints (the REST query/aggregate endpoints) that are served by
+// custom middleware over the gRPC pipeline, not by generated handlers, and the
+// "swagger" CI job both regenerates from the spec and fails on any diff. Feeding
+// swagger this stripped copy keeps the generated/committed code unchanged.
+//
+// Usage: swagger_strip_doc_only <input-spec> <output-spec>
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// httpMethods are the OpenAPI 2.0 path-item keys that denote an operation.
+var httpMethods = []string{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: swagger_strip_doc_only <input-spec> <output-spec>")
+		os.Exit(2)
+	}
+	in, out := os.Args[1], os.Args[2]
+
+	raw, err := os.ReadFile(in)
+	if err != nil {
+		fatalf("read %s: %v", in, err)
+	}
+
+	// UseNumber keeps numeric literals byte-exact so the stripped spec the
+	// generator sees is otherwise identical to the input.
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var spec map[string]any
+	if err := dec.Decode(&spec); err != nil {
+		fatalf("parse %s: %v", in, err)
+	}
+
+	stripDefinitions(spec)
+	stripPaths(spec)
+	stripTags(spec)
+
+	enc, err := json.MarshalIndent(spec, "", "  ")
+	if err != nil {
+		fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(out, append(enc, '\n'), 0o644); err != nil {
+		fatalf("write %s: %v", out, err)
+	}
+}
+
+// docOnly reports whether the given spec node carries `"x-doc-only": true`.
+func docOnly(v any) bool {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return false
+	}
+	b, _ := m["x-doc-only"].(bool)
+	return b
+}
+
+func stripDefinitions(spec map[string]any) {
+	defs, ok := spec["definitions"].(map[string]any)
+	if !ok {
+		return
+	}
+	for name, def := range defs {
+		if docOnly(def) {
+			delete(defs, name)
+		}
+	}
+}
+
+func stripPaths(spec map[string]any) {
+	paths, ok := spec["paths"].(map[string]any)
+	if !ok {
+		return
+	}
+	for p, item := range paths {
+		pi, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if docOnly(pi) {
+			delete(paths, p)
+			continue
+		}
+		hasOp := false
+		for _, method := range httpMethods {
+			op, exists := pi[method]
+			if !exists {
+				continue
+			}
+			if docOnly(op) {
+				delete(pi, method)
+				continue
+			}
+			hasOp = true
+		}
+		// Drop a path item that has no operations left.
+		if !hasOp {
+			delete(paths, p)
+		}
+	}
+}
+
+func stripTags(spec map[string]any) {
+	tags, ok := spec["tags"].([]any)
+	if !ok {
+		return
+	}
+	kept := make([]any, 0, len(tags))
+	for _, t := range tags {
+		if docOnly(t) {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	spec["tags"] = kept
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -210,6 +210,7 @@ type Config struct {
 	ReindexMapToBlockmaxConfig          MapToBlockamaxConfig   `json:"reindex_map_to_blockmax_config" yaml:"reindex_map_to_blockmax_config"`
 	IndexMissingTextFilterableAtStartup bool                   `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
 	DisableGraphQL                      bool                   `json:"disable_graphql" yaml:"disable_graphql"`
+	DisableRESTQuery                    bool                   `json:"disable_rest_query" yaml:"disable_rest_query"`
 	AvoidMmap                           bool                   `json:"avoid_mmap" yaml:"avoid_mmap"`
 	CORS                                CORS                   `json:"cors" yaml:"cors"`
 	DisableTelemetry                    bool                   `json:"disable_telemetry" yaml:"disable_telemetry"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -970,6 +970,10 @@ func FromEnv(config *Config) error {
 
 	config.DisableGraphQL = entcfg.Enabled(os.Getenv("DISABLE_GRAPHQL"))
 
+	// The REST query/aggregate endpoints (the GraphQL replacement) are enabled
+	// by default; set DISABLE_REST_QUERY=true to turn them off.
+	config.DisableRESTQuery = entcfg.Enabled(os.Getenv("DISABLE_REST_QUERY"))
+
 	config.Namespaces.Enabled = entcfg.Enabled(os.Getenv("NAMESPACES_ENABLED"))
 	if config.Namespaces.Enabled {
 		config.Persistence.LSMSkipWriteClassNameEnabled = true


### PR DESCRIPTION
## Summary

Adds pure-REST **`POST /v1/{collection}/query`** and **`POST /v1/{collection}/aggregate`** as the GraphQL replacement. They reuse the existing gRPC search/aggregate pipeline verbatim — request/response bodies are the canonical proto-JSON encoding of the gRPC `SearchRequest`/`AggregateRequest` messages — so REST and gRPC share one `parse → traverse → reply` implementation, with no business-logic duplication and automatic feature parity (hybrid, bm25, nearVector/nearText, filters, groupBy, generative, rerank, …).

Architecture write-up: **`docs/rest-query-endpoints.md`**.

## Why

GraphQL is being deprecated — it's incompatible with Namespaces (schema leakage, no per-namespace RBAC) and its introspection exposes the schema. Every other dedicated vector DB exposes querying over REST; this gives HTTP-only integrations a first-class path and converges on that norm. Because the endpoints delegate to the gRPC pipeline, they are **namespace-compatible** (unlike GraphQL).

## Endpoints

- `POST /v1/{collection}/query` → gRPC `Search`
- `POST /v1/{collection}/aggregate` → gRPC `Aggregate`

Body = proto-JSON of the gRPC request. The collection comes from the **path** and overrides any `collection` in the body; an empty body runs a default query.

## What's in here

- **Shared pipeline:** extracted `SearchWithPrincipal` / `AggregateWithPrincipal` on the gRPC service. The gRPC entrypoints resolve the principal then delegate; the REST handler authenticates itself and calls the same methods. Pure extraction — gRPC behavior unchanged.
- **Routing:** custom route in the global middleware chain (like module handlers), not go-swagger — the proto-JSON body doesn't belong in the OpenAPI model surface and this avoids a redundant generated model layer. In-handler auth (mirrors the gRPC auth handler); pipeline errors mapped to HTTP (401/403/429/422); the POSTs are treated as **reads** under operational mode (consistent with `IsGRPCRead`).
- **`where` filter:** optional top-level filter in the familiar REST `WhereFilter` syntax as an alternative to the protobuf `filters`, resolved server-side via the existing `filterext.Parse` and overriding `filters` (setting both → 422). The gRPC `filters` JSON is awkward to hand-write; `where` is what existing REST/clients already know.
- **Conveniences:** short `consistencyLevel` (`ONE`/`QUORUM`/`ALL`); documented plain-array `vector` and simple `alpha` (no base64 / `useAlphaParam`).
- **Gating:** `DISABLE_REST_QUERY` env (default **enabled** — the supported query surface for Namespaces).
- **Docs:** both endpoints are documented in `openapi-specs/schema.json` with proto-derived request/response schemas. Since that file is also go-swagger's codegen source (CI regenerates + diffs), the doc entries are marked `x-doc-only` and stripped from the codegen copy by `tools/swagger_strip_doc_only` (wired into `gen-code-from-swagger.sh`), so generated code is unchanged.

## Testing

- **Unit** (`handlers_query_test.go`): routing/path matching, collection-override, empty/malformed body, gating, error mapping, anonymous + Bearer auth, `where` parse/conflict, consistency-level shorthand.
- **Parity acceptance** (`test/acceptance/rest_query/`): REST results are `proto.Equal` to gRPC for match-all, bm25, filter, nearVector, aggregate, and `where`-vs-`pb.Filters`.
- Manual e2e against a built image across the full surface (filters, hybrid alpha sweep, pagination, groupBy, aggregations, generative).

## Note for reviewers

REST query/aggregate are blocked in **write-only** operational mode (consistent with gRPC `IsGRPCRead`), slightly stricter than the legacy GraphQL POST path. `Explore` (cross-class) has no gRPC RPC and is intentionally not exposed.