### PR TITLE
Fix race in dynamic users with concurrent pointer access

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -59,7 +59,7 @@ type authZHandlers struct {
 
 type ControllerAndGetUsers interface {
 	authorization.Controller
-	GetUsers(userIds ...string) (map[string]*apikey.User, error)
+	GetUsers(userIds ...string) (map[string]apikey.UserView, error)
 }
 
 func SetupHandlers(api *operations.WeaviateAPI, controller ControllerAndGetUsers, schemaReader schemaUC.SchemaGetter,

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -515,7 +515,7 @@ func TestAssignRoleToUserInternalServerError(t *testing.T) {
 			authorizer.On("Authorize", mock.Anything, tt.principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Users(tt.params.ID)[0]).Return(nil)
 			controller.On("GetRoles", tt.params.Body.Roles[0]).Return(map[string][]authorization.Policy{tt.params.Body.Roles[0]: {}}, tt.getRolesErr)
 			if tt.getRolesErr == nil {
-				controller.On("GetUsers", "testUser").Return(map[string]*apikey.User{"testUser": {}}, nil)
+				controller.On("GetUsers", "testUser").Return(map[string]apikey.UserView{"testUser": {}}, nil)
 				controller.On("AddRolesForUser", conv.UserNameWithTypeFromId(tt.params.ID, authentication.AuthType(tt.params.Body.UserType)), tt.params.Body.Roles).Return(tt.assignErr)
 			}
 

--- a/adapters/handlers/rest/authz/handlers_authz_get_roles_for_group_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_get_roles_for_group_test.go
@@ -99,7 +99,7 @@ func TestGetRolesForGroupSuccess(t *testing.T) {
 				}
 			}
 			controller.On("GetRolesForUserOrGroup", tt.params.ID, authentication.AuthTypeOIDC, true).Return(returnedPolices, nil)
-			// controller.On("GetUsers", tt.params.ID).Return(map[string]*apikey.User{"testUser": {}}, nil)
+			// controller.On("GetUsers", tt.params.ID).Return(map[string]apikey.UserView{"testUser": {}}, nil)
 
 			h := &authZHandlers{
 				authorizer: authorizer,

--- a/adapters/handlers/rest/authz/handlers_authz_get_roles_for_user_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_get_roles_for_user_test.go
@@ -98,7 +98,7 @@ func TestGetRolesForUserSuccess(t *testing.T) {
 				}
 			}
 			controller.On("GetRolesForUserOrGroup", tt.params.ID, authentication.AuthTypeDb, false).Return(returnedPolices, nil)
-			controller.On("GetUsers", tt.params.ID).Return(map[string]*apikey.User{"testUser": {}}, nil)
+			controller.On("GetUsers", tt.params.ID).Return(map[string]apikey.UserView{"testUser": {}}, nil)
 
 			h := &authZHandlers{
 				authorizer: authorizer,
@@ -177,7 +177,7 @@ func TestGetRolesForUserForbidden(t *testing.T) {
 				authorizer.On("Authorize", mock.Anything, tt.principal, authorization.VerbWithScope(authorization.READ, authorization.ROLE_SCOPE_MATCH), authorization.Roles("testRole")[0]).Return(tt.authorizeErr)
 			}
 			controller.On("GetRolesForUserOrGroup", tt.params.ID, authentication.AuthType(userType), false).Return(returnedPolices, nil)
-			controller.On("GetUsers", tt.params.ID).Return(map[string]*apikey.User{tt.params.ID: {}}, nil)
+			controller.On("GetUsers", tt.params.ID).Return(map[string]apikey.UserView{tt.params.ID: {}}, nil)
 			h := &authZHandlers{
 				authorizer: authorizer,
 				controller: controller,
@@ -226,7 +226,7 @@ func TestGetRolesForUserInternalServerError(t *testing.T) {
 
 			authorizer.On("Authorize", mock.Anything, tt.principal, authorization.READ, authorization.Users(tt.params.ID)[0]).Return(nil)
 			controller.On("GetRolesForUserOrGroup", tt.params.ID, authentication.AuthType(userType), false).Return(nil, tt.getRolesErr)
-			controller.On("GetUsers", tt.params.ID).Return(map[string]*apikey.User{tt.params.ID: {}}, nil)
+			controller.On("GetUsers", tt.params.ID).Return(map[string]apikey.UserView{tt.params.ID: {}}, nil)
 
 			h := &authZHandlers{
 				authorizer: authorizer,

--- a/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_revoke_roles_test.go
@@ -613,7 +613,7 @@ func TestRevokeRoleFromUserInternalServerError(t *testing.T) {
 			authorizer.On("Authorize", mock.Anything, tt.principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Users(tt.params.ID)[0]).Return(nil)
 			controller.On("GetRoles", tt.params.Body.Roles[0]).Return(map[string][]authorization.Policy{tt.params.Body.Roles[0]: {}}, tt.getRolesErr)
 			if tt.getRolesErr == nil {
-				controller.On("GetUsers", "testUser").Return(map[string]*apikey.User{"testUser": {}}, nil)
+				controller.On("GetUsers", "testUser").Return(map[string]apikey.UserView{"testUser": {}}, nil)
 				controller.On("RevokeRolesForUser", conv.UserNameWithTypeFromId(tt.params.ID, authentication.AuthType(tt.params.Body.UserType)), tt.params.Body.Roles[0]).Return(tt.revokeErr)
 			}
 

--- a/adapters/handlers/rest/authz/mock_controller_and_get_users.go
+++ b/adapters/handlers/rest/authz/mock_controller_and_get_users.go
@@ -319,7 +319,7 @@ func (_c *MockControllerAndGetUsers_GetRolesForUserOrGroup_Call) RunAndReturn(ru
 }
 
 // GetUsers provides a mock function with given fields: userIds
-func (_m *MockControllerAndGetUsers) GetUsers(userIds ...string) (map[string]*apikey.User, error) {
+func (_m *MockControllerAndGetUsers) GetUsers(userIds ...string) (map[string]apikey.UserView, error) {
 	_va := make([]interface{}, len(userIds))
 	for _i := range userIds {
 		_va[_i] = userIds[_i]
@@ -332,16 +332,16 @@ func (_m *MockControllerAndGetUsers) GetUsers(userIds ...string) (map[string]*ap
 		panic("no return value specified for GetUsers")
 	}
 
-	var r0 map[string]*apikey.User
+	var r0 map[string]apikey.UserView
 	var r1 error
-	if rf, ok := ret.Get(0).(func(...string) (map[string]*apikey.User, error)); ok {
+	if rf, ok := ret.Get(0).(func(...string) (map[string]apikey.UserView, error)); ok {
 		return rf(userIds...)
 	}
-	if rf, ok := ret.Get(0).(func(...string) map[string]*apikey.User); ok {
+	if rf, ok := ret.Get(0).(func(...string) map[string]apikey.UserView); ok {
 		r0 = rf(userIds...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]*apikey.User)
+			r0 = ret.Get(0).(map[string]apikey.UserView)
 		}
 	}
 
@@ -379,12 +379,12 @@ func (_c *MockControllerAndGetUsers_GetUsers_Call) Run(run func(userIds ...strin
 	return _c
 }
 
-func (_c *MockControllerAndGetUsers_GetUsers_Call) Return(_a0 map[string]*apikey.User, _a1 error) *MockControllerAndGetUsers_GetUsers_Call {
+func (_c *MockControllerAndGetUsers_GetUsers_Call) Return(_a0 map[string]apikey.UserView, _a1 error) *MockControllerAndGetUsers_GetUsers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockControllerAndGetUsers_GetUsers_Call) RunAndReturn(run func(...string) (map[string]*apikey.User, error)) *MockControllerAndGetUsers_GetUsers_Call {
+func (_c *MockControllerAndGetUsers_GetUsers_Call) RunAndReturn(run func(...string) (map[string]apikey.UserView, error)) *MockControllerAndGetUsers_GetUsers_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -724,7 +724,8 @@ func (_c *MockControllerAndGetUsers_UpdateRolesPermissions_Call) RunAndReturn(ru
 func NewMockControllerAndGetUsers(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockControllerAndGetUsers {
+},
+) *MockControllerAndGetUsers {
 	mock := &MockControllerAndGetUsers{}
 	mock.Mock.Test(t)
 

--- a/adapters/handlers/rest/db_users/activate_user_test.go
+++ b/adapters/handlers/rest/db_users/activate_user_test.go
@@ -34,7 +34,7 @@ func TestSuccessActivate(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {Id: "user", Active: false}}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{"user": {Id: "user", Active: false}}, nil)
 	dynUser.On("ActivateUser", "user").Return(nil)
 
 	h := dynUserHandler{
@@ -51,7 +51,7 @@ func TestActivateNotFound(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,
@@ -102,7 +102,7 @@ func TestDoubleActivate(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users(user)[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", user).Return(map[string]*apikey.User{user: {Id: user, Active: true}}, nil)
+	dynUser.On("GetUsers", user).Return(map[string]apikey.UserView{user: {Id: user, Active: true}}, nil)
 
 	h := dynUserHandler{
 		dbUsers:              dynUser,

--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -117,7 +117,7 @@ func TestCreateConflict(t *testing.T) {
 			dynUser := NewMockDbUserAndRolesGetter(t)
 			authorizer.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Users("user")[0]).Return(nil)
 			if !tt.rbacConf.Enabled {
-				dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {}}, nil)
+				dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{"user": {}}, nil)
 			}
 
 			h := dynUserHandler{
@@ -142,7 +142,7 @@ func TestCreateSuccess(t *testing.T) {
 	authorizer.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Users(user)[0]).Return(nil)
 
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", user).Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", user).Return(map[string]apikey.UserView{}, nil)
 	dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
 	dynUser.On("CreateUser", user, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 

--- a/adapters/handlers/rest/db_users/deactivate_user_test.go
+++ b/adapters/handlers/rest/db_users/deactivate_user_test.go
@@ -39,7 +39,7 @@ func TestSuccessDeactivate(t *testing.T) {
 			authorizer := authorization.NewMockAuthorizer(t)
 			authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 			dynUser := NewMockDbUserAndRolesGetter(t)
-			dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {Id: "user", Active: true}}, nil)
+			dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{"user": {Id: "user", Active: true}}, nil)
 			dynUser.On("DeactivateUser", "user", test.revokeKey).Return(nil)
 
 			h := dynUserHandler{
@@ -59,7 +59,7 @@ func TestDeactivateNotFound(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,
@@ -112,7 +112,7 @@ func TestDoubleDeactivate(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users(user)[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", user).Return(map[string]*apikey.User{user: {Id: user, Active: false}}, nil)
+	dynUser.On("GetUsers", user).Return(map[string]apikey.UserView{user: {Id: user, Active: false}}, nil)
 
 	h := dynUserHandler{
 		dbUsers:              dynUser,

--- a/adapters/handlers/rest/db_users/delete_user_test.go
+++ b/adapters/handlers/rest/db_users/delete_user_test.go
@@ -39,7 +39,7 @@ func TestDeleteSuccess(t *testing.T) {
 	dynUser.On("GetRolesForUserOrGroup", "user", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{"role": {}}, nil)
 	dynUser.On("RevokeRolesForUser", conv.UserNameWithTypeFromId("user", authentication.AuthType(models.UserTypeInputDb)), "role").Return(nil)
 	dynUser.On("DeleteUser", "user").Return(nil)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {}}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{"user": {}}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,
@@ -75,7 +75,7 @@ func TestDeleteUnprocessableEntityStaticUser(t *testing.T) {
 	authorizer.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Users("user")[0]).Return(nil)
 
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,

--- a/adapters/handlers/rest/db_users/get_user_test.go
+++ b/adapters/handlers/rest/db_users/get_user_test.go
@@ -66,9 +66,9 @@ func TestSuccessGetUser(t *testing.T) {
 			dynUser := NewMockDbUserAndRolesGetter(t)
 			schemaGetter := schema.NewMockSchemaGetter(t)
 			if test.userType == models.UserTypeOutputDbUser {
-				dynUser.On("GetUsers", test.userId).Return(map[string]*apikey.User{test.userId: {Id: test.userId, ApiKeyFirstLetters: "abc"}}, nil)
+				dynUser.On("GetUsers", test.userId).Return(map[string]apikey.UserView{test.userId: {Id: test.userId, ApiKeyFirstLetters: "abc"}}, nil)
 			} else {
-				dynUser.On("GetUsers", test.userId).Return(map[string]*apikey.User{}, nil)
+				dynUser.On("GetUsers", test.userId).Return(map[string]apikey.UserView{}, nil)
 			}
 			dynUser.On("GetRolesForUserOrGroup", test.userId, authentication.AuthTypeDb, false).Return(
 				map[string][]authorization.Policy{"role": {}}, nil)
@@ -127,7 +127,7 @@ func TestSuccessGetUserMultiNode(t *testing.T) {
 			dynUser := NewMockDbUserAndRolesGetter(t)
 			schemaGetter := schema.NewMockSchemaGetter(t)
 
-			dynUser.On("GetUsers", userId).Return(map[string]*apikey.User{userId: {Id: userId, LastUsedAt: returnedTime}}, nil)
+			dynUser.On("GetUsers", userId).Return(map[string]apikey.UserView{userId: {Id: userId, LastUsedAt: returnedTime}}, nil)
 			dynUser.On("GetRolesForUserOrGroup", userId, authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{"role": {}}, nil)
 
 			var nodes []string
@@ -166,7 +166,7 @@ func TestNotFound(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.READ, authorization.Users("static")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "static").Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", "static").Return(map[string]apikey.UserView{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,
@@ -185,7 +185,7 @@ func TestNotFoundStatic(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.READ, authorization.Users("user")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,
@@ -202,11 +202,11 @@ func TestGetUserInternalServerError(t *testing.T) {
 	tests := []struct {
 		name               string
 		GetUserReturnErr   error
-		GetUserReturnValue map[string]*apikey.User
+		GetUserReturnValue map[string]apikey.UserView
 		GetRolesReturn     error
 	}{
 		{name: "get user error", GetUserReturnErr: errors.New("some error"), GetUserReturnValue: nil},
-		{name: "create user error", GetUserReturnErr: nil, GetUserReturnValue: map[string]*apikey.User{"user": {Id: "user"}}, GetRolesReturn: errors.New("some error")},
+		{name: "create user error", GetUserReturnErr: nil, GetUserReturnValue: map[string]apikey.UserView{"user": {Id: "user"}}, GetRolesReturn: errors.New("some error")},
 	}
 
 	for _, tt := range tests {
@@ -272,7 +272,7 @@ func TestGetUserWithNoPrincipal(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.READ, authorization.Users(userID)[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", userID).Return(map[string]*apikey.User{userID: {Id: userID, ApiKeyFirstLetters: "abc"}}, nil)
+	dynUser.On("GetUsers", userID).Return(map[string]apikey.UserView{userID: {Id: userID, ApiKeyFirstLetters: "abc"}}, nil)
 	dynUser.On("GetRolesForUserOrGroup", userID, authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{"role": {}}, nil)
 
 	h := dynUserHandler{dbUsers: dynUser, authorizer: authorizer, dbUserEnabled: true}

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -105,19 +105,19 @@ func (h *dynUserHandler) listUsers(params users.ListAllUsersParams, principal *m
 		return users.NewListAllUsersInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	allUsers := make([]*apikey.User, 0, len(allDbUsers))
+	allUsers := make([]apikey.UserView, 0, len(allDbUsers))
 	for _, dbUser := range allDbUsers {
 		allUsers = append(allUsers, dbUser)
 	}
 
-	resourceFilter := filter.New[*apikey.User](h.authorizer, h.rbacConfig)
+	resourceFilter := filter.New[apikey.UserView](h.authorizer, h.rbacConfig)
 	filteredUsers := resourceFilter.Filter(
 		ctx,
 		h.logger,
 		principal,
 		allUsers,
 		authorization.READ,
-		func(user *apikey.User) string {
+		func(user apikey.UserView) string {
 			return authorization.Users(user.Id)[0]
 		},
 	)
@@ -223,7 +223,7 @@ func (h *dynUserHandler) getUser(params users.GetUserInfoParams, principal *mode
 		}
 
 		if params.IncludeLastUsedTime != nil && *params.IncludeLastUsedTime {
-			usersWithTime := h.getLastUsed([]*apikey.User{user})
+			usersWithTime := h.getLastUsed([]apikey.UserView{user})
 			response.LastUsedAt = strfmt.DateTime(usersWithTime[params.UserID])
 		}
 		userType = string(models.UserTypeOutputDbUser)
@@ -248,7 +248,7 @@ func (h *dynUserHandler) getUser(params users.GetUserInfoParams, principal *mode
 	return users.NewGetUserInfoOK().WithPayload(response)
 }
 
-func (h *dynUserHandler) getLastUsed(users []*apikey.User) map[string]time.Time {
+func (h *dynUserHandler) getLastUsed(users []apikey.UserView) map[string]time.Time {
 	usersWithTime := make(map[string]time.Time, len(users))
 	for _, user := range users {
 		usersWithTime[user.Id] = user.LastUsedAt

--- a/adapters/handlers/rest/db_users/list_all_users_test.go
+++ b/adapters/handlers/rest/db_users/list_all_users_test.go
@@ -63,7 +63,7 @@ func TestSuccessListAll(t *testing.T) {
 			authorizer := authorization.NewMockAuthorizer(t)
 			authorizer.On("Authorize", mock.Anything, tt.principal, authorization.READ, authorization.Users()[0]).Return(nil)
 			dynUser := NewMockDbUserAndRolesGetter(t)
-			dynUser.On("GetUsers").Return(map[string]*apikey.User{dbUser: {Id: dbUser}}, nil)
+			dynUser.On("GetUsers").Return(map[string]apikey.UserView{dbUser: {Id: dbUser}}, nil)
 			dynUser.On("GetRolesForUserOrGroup", dbUser, authentication.AuthTypeDb, false).Return(
 				map[string][]authorization.Policy{"role": {}}, nil)
 			if tt.includeStatic {
@@ -98,7 +98,7 @@ func TestSuccessListAllAfterImport(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, &models.Principal{Username: "root"}, authorization.READ, authorization.Users()[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers").Return(map[string]*apikey.User{exStaticUser: {Id: exStaticUser, Active: true}}, nil)
+	dynUser.On("GetUsers").Return(map[string]apikey.UserView{exStaticUser: {Id: exStaticUser, Active: true}}, nil)
 	dynUser.On("GetRolesForUserOrGroup", exStaticUser, authentication.AuthTypeDb, false).Return(
 		map[string][]authorization.Policy{"role": {}}, nil)
 
@@ -195,9 +195,9 @@ func TestSuccessListAllUserMultiNode(t *testing.T) {
 			dynUser := NewMockDbUserAndRolesGetter(t)
 			schemaGetter := schema.NewMockSchemaGetter(t)
 
-			usersRet := make(map[string]*apikey.User)
+			usersRet := make(map[string]apikey.UserView)
 			for _, user := range tt.userIds {
-				usersRet[user] = &apikey.User{Id: user, LastUsedAt: baseTime}
+				usersRet[user] = apikey.UserView{Id: user, LastUsedAt: baseTime}
 			}
 
 			dynUser.On("GetUsers").Return(usersRet, nil)
@@ -243,7 +243,7 @@ func TestSuccessListForbidden(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.READ, mock.Anything).Return(errors.New("some error"))
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers").Return(map[string]*apikey.User{"test": {Id: "test"}}, nil)
+	dynUser.On("GetUsers").Return(map[string]apikey.UserView{"test": {Id: "test"}}, nil)
 
 	log, _ := test.NewNullLogger()
 	h := dynUserHandler{

--- a/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
+++ b/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
@@ -392,7 +392,7 @@ func (_c *MockDbUserAndRolesGetter_GetRolesForUserOrGroup_Call) RunAndReturn(run
 }
 
 // GetUsers provides a mock function with given fields: userIds
-func (_m *MockDbUserAndRolesGetter) GetUsers(userIds ...string) (map[string]*apikey.User, error) {
+func (_m *MockDbUserAndRolesGetter) GetUsers(userIds ...string) (map[string]apikey.UserView, error) {
 	_va := make([]interface{}, len(userIds))
 	for _i := range userIds {
 		_va[_i] = userIds[_i]
@@ -405,16 +405,16 @@ func (_m *MockDbUserAndRolesGetter) GetUsers(userIds ...string) (map[string]*api
 		panic("no return value specified for GetUsers")
 	}
 
-	var r0 map[string]*apikey.User
+	var r0 map[string]apikey.UserView
 	var r1 error
-	if rf, ok := ret.Get(0).(func(...string) (map[string]*apikey.User, error)); ok {
+	if rf, ok := ret.Get(0).(func(...string) (map[string]apikey.UserView, error)); ok {
 		return rf(userIds...)
 	}
-	if rf, ok := ret.Get(0).(func(...string) map[string]*apikey.User); ok {
+	if rf, ok := ret.Get(0).(func(...string) map[string]apikey.UserView); ok {
 		r0 = rf(userIds...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]*apikey.User)
+			r0 = ret.Get(0).(map[string]apikey.UserView)
 		}
 	}
 
@@ -452,12 +452,12 @@ func (_c *MockDbUserAndRolesGetter_GetUsers_Call) Run(run func(userIds ...string
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_GetUsers_Call) Return(_a0 map[string]*apikey.User, _a1 error) *MockDbUserAndRolesGetter_GetUsers_Call {
+func (_c *MockDbUserAndRolesGetter_GetUsers_Call) Return(_a0 map[string]apikey.UserView, _a1 error) *MockDbUserAndRolesGetter_GetUsers_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_GetUsers_Call) RunAndReturn(run func(...string) (map[string]*apikey.User, error)) *MockDbUserAndRolesGetter_GetUsers_Call {
+func (_c *MockDbUserAndRolesGetter_GetUsers_Call) RunAndReturn(run func(...string) (map[string]apikey.UserView, error)) *MockDbUserAndRolesGetter_GetUsers_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -578,7 +578,8 @@ func (_c *MockDbUserAndRolesGetter_RotateKey_Call) RunAndReturn(run func(string,
 func NewMockDbUserAndRolesGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockDbUserAndRolesGetter {
+},
+) *MockDbUserAndRolesGetter {
 	mock := &MockDbUserAndRolesGetter{}
 	mock.Mock.Test(t)
 

--- a/adapters/handlers/rest/db_users/rotate_key_test.go
+++ b/adapters/handlers/rest/db_users/rotate_key_test.go
@@ -32,7 +32,7 @@ func TestSuccessRotate(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {Id: "user"}}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{"user": {Id: "user"}}, nil)
 	dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
 	dynUser.On("RotateKey", "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -55,11 +55,11 @@ func TestRotateInternalServerError(t *testing.T) {
 	tests := []struct {
 		name               string
 		GetUserReturnErr   error
-		GetUserReturnValue map[string]*apikey.User
+		GetUserReturnValue map[string]apikey.UserView
 		RotateKeyError     error
 	}{
 		{name: "get user error", GetUserReturnErr: errors.New("some error"), GetUserReturnValue: nil},
-		{name: "rotate key error", GetUserReturnErr: nil, GetUserReturnValue: map[string]*apikey.User{"user": {Id: "user", InternalIdentifier: "abc"}}, RotateKeyError: errors.New("some error")},
+		{name: "rotate key error", GetUserReturnErr: nil, GetUserReturnValue: map[string]apikey.UserView{"user": {Id: "user", InternalIdentifier: "abc"}}, RotateKeyError: errors.New("some error")},
 	}
 
 	for _, tt := range tests {
@@ -90,7 +90,7 @@ func TestRotateNotFound(t *testing.T) {
 	authorizer := authorization.NewMockAuthorizer(t)
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,
@@ -125,7 +125,7 @@ func TestRotateUnprocessableEntity(t *testing.T) {
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{}, nil)
+	dynUser.On("GetUsers", "user").Return(map[string]apikey.UserView{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -119,7 +119,21 @@ func (m *Manager) GetUsers(req *cmd.QueryRequest) ([]byte, error) {
 		return []byte{}, fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	response := cmd.QueryGetUsersResponse{Users: users}
+	// Rebuild *apikey.User for the wire to keep the response shape stable;
+	// these pointers are local and never shared.
+	wireUsers := make(map[string]*apikey.User, len(users))
+	for id, v := range users {
+		wireUsers[id] = &apikey.User{
+			Id:                 v.Id,
+			Active:             v.Active,
+			InternalIdentifier: v.InternalIdentifier,
+			ApiKeyFirstLetters: v.ApiKeyFirstLetters,
+			CreatedAt:          v.CreatedAt,
+			LastUsedAt:         v.LastUsedAt,
+			ImportedWithKey:    v.ImportedWithKey,
+		}
+	}
+	response := cmd.QueryGetUsersResponse{Users: wireUsers}
 	payload, err := json.Marshal(response)
 	if err != nil {
 		return []byte{}, fmt.Errorf("could not marshal query response: %w", err)

--- a/cluster/raft_dynuser_query_endpoints.go
+++ b/cluster/raft_dynuser_query_endpoints.go
@@ -20,7 +20,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 )
 
-func (s *Raft) GetUsers(userIds ...string) (map[string]*apikey.User, error) {
+func (s *Raft) GetUsers(userIds ...string) (map[string]apikey.UserView, error) {
 	req := cmd.QueryGetUsersRequest{
 		UserIds: userIds,
 	}
@@ -45,7 +45,22 @@ func (s *Raft) GetUsers(userIds ...string) (map[string]*apikey.User, error) {
 		return nil, fmt.Errorf("failed to unmarshal query result: %w", err)
 	}
 
-	return response.Users, nil
+	out := make(map[string]apikey.UserView, len(response.Users))
+	for id, u := range response.Users {
+		if u == nil {
+			continue
+		}
+		out[id] = apikey.UserView{
+			Id:                 u.Id,
+			Active:             u.Active,
+			InternalIdentifier: u.InternalIdentifier,
+			ApiKeyFirstLetters: u.ApiKeyFirstLetters,
+			CreatedAt:          u.CreatedAt,
+			LastUsedAt:         u.LastUsedAt,
+			ImportedWithKey:    u.ImportedWithKey,
+		}
+	}
+	return out, nil
 }
 
 func (s *Raft) CheckUserIdentifierExists(userIdentifier string) (bool, error) {

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -53,6 +54,81 @@ func TestDynUserConcurrency(t *testing.T) {
 	users, err := dynUsers.GetUsers(userNames...)
 	require.NoError(t, err)
 	require.Equal(t, len(userNames), len(users))
+}
+
+// Pins UserView's data fields to User's. Adding a field to User without
+// mirroring it in UserView (and view()) would silently drop it from the
+// GetUsers snapshot.
+func TestUserView_MirrorsUserFields(t *testing.T) {
+	collect := func(typ reflect.Type) map[string]string {
+		out := make(map[string]string, typ.NumField())
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if f.Anonymous || !f.IsExported() {
+				continue
+			}
+			out[f.Name] = f.Type.String()
+		}
+		return out
+	}
+
+	require.Equal(t, collect(reflect.TypeOf(User{})), collect(reflect.TypeOf(UserView{})),
+		"User and UserView must expose the same exported data fields; update UserView and (*User).view() when adding fields to User")
+}
+
+// Concurrent Activate/Deactivate vs GetUsers field reads must stay race-free under -race.
+func TestGetUsers_NoRaceWithMutators(t *testing.T) {
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	require.NoError(t, err)
+
+	const numUsers = 5
+	userIds := make([]string, 0, numUsers)
+	for i := 0; i < numUsers; i++ {
+		id := fmt.Sprintf("u%d", i)
+		require.NoError(t, dynUsers.CreateUser(id, "h", id, "", time.Now()))
+		userIds = append(userIds, id)
+	}
+
+	const iterations = 200
+	done := make(chan struct{})
+	wg := sync.WaitGroup{}
+
+	// Mutator: flips Active under c.lock.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			id := userIds[i%numUsers]
+			if i%2 == 0 {
+				_ = dynUsers.DeactivateUser(id, false)
+			} else {
+				_ = dynUsers.ActivateUser(id)
+			}
+		}
+		close(done)
+	}()
+
+	// Reader: GetUsers + read .Active.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			users, err := dynUsers.GetUsers(userIds...)
+			require.NoError(t, err)
+			for _, u := range users {
+				_ = u.Active
+				_ = u.LastUsedAt
+				_ = u.InternalIdentifier
+			}
+		}
+	}()
+
+	wg.Wait()
 }
 
 func TestConcurrentValidate(t *testing.T) {

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
@@ -119,7 +120,7 @@ func TestGetUsers_NoRaceWithMutators(t *testing.T) {
 			default:
 			}
 			users, err := dynUsers.GetUsers(userIds...)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			for _, u := range users {
 				_ = u.Active
 				_ = u.LastUsedAt

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -43,7 +43,7 @@ type DBUsers interface {
 	DeleteUser(userId string) error
 	ActivateUser(userId string) error
 	DeactivateUser(userId string, revokeKey bool) error
-	GetUsers(userIds ...string) (map[string]*User, error)
+	GetUsers(userIds ...string) (map[string]UserView, error)
 	RotateKey(userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error
 	CheckUserIdentifierExists(userIdentifier string) (bool, error)
 }
@@ -57,6 +57,33 @@ type User struct {
 	CreatedAt          time.Time
 	LastUsedAt         time.Time
 	ImportedWithKey    bool
+}
+
+// UserView is a race-free snapshot of [User] returned by [DBUser.GetUsers].
+type UserView struct {
+	Id                 string
+	Active             bool
+	InternalIdentifier string
+	ApiKeyFirstLetters string
+	CreatedAt          time.Time
+	LastUsedAt         time.Time
+	ImportedWithKey    bool
+}
+
+// view returns a snapshot. Caller must hold c.lock for read; this method
+// also takes the per-user RLock to block LastUsedAt updaters.
+func (u *User) view() UserView {
+	u.RLock()
+	defer u.RUnlock()
+	return UserView{
+		Id:                 u.Id,
+		Active:             u.Active,
+		InternalIdentifier: u.InternalIdentifier,
+		ApiKeyFirstLetters: u.ApiKeyFirstLetters,
+		CreatedAt:          u.CreatedAt,
+		LastUsedAt:         u.LastUsedAt,
+		ImportedWithKey:    u.ImportedWithKey,
+	}
 }
 
 type DBUser struct {
@@ -284,19 +311,22 @@ func (c *DBUser) DeactivateUser(userId string, revokeKey bool) error {
 	return c.storeToFile()
 }
 
-func (c *DBUser) GetUsers(userIds ...string) (map[string]*User, error) {
+func (c *DBUser) GetUsers(userIds ...string) (map[string]UserView, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
 	if len(userIds) == 0 {
-		return c.data.Users, nil
+		users := make(map[string]UserView, len(c.data.Users))
+		for id, user := range c.data.Users {
+			users[id] = user.view()
+		}
+		return users, nil
 	}
 
-	users := make(map[string]*User, len(userIds))
+	users := make(map[string]UserView, len(userIds))
 	for _, id := range userIds {
-		user, ok := c.data.Users[id]
-		if ok {
-			users[id] = user
+		if user, ok := c.data.Users[id]; ok {
+			users[id] = user.view()
 		}
 	}
 	return users, nil

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -318,6 +318,9 @@ func (c *DBUser) GetUsers(userIds ...string) (map[string]UserView, error) {
 	if len(userIds) == 0 {
 		users := make(map[string]UserView, len(c.data.Users))
 		for id, user := range c.data.Users {
+			if user == nil {
+				continue
+			}
 			users[id] = user.view()
 		}
 		return users, nil
@@ -325,7 +328,7 @@ func (c *DBUser) GetUsers(userIds ...string) (map[string]UserView, error) {
 
 	users := make(map[string]UserView, len(userIds))
 	for _, id := range userIds {
-		if user, ok := c.data.Users[id]; ok {
+		if user, ok := c.data.Users[id]; ok && user != nil {
 			users[id] = user.view()
 		}
 	}

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -59,7 +59,8 @@ type User struct {
 	ImportedWithKey    bool
 }
 
-// UserView is a race-free snapshot of [User] returned by [DBUser.GetUsers].
+// UserView is an independent snapshot of [User] returned by [DBUser.GetUsers]
+// so callers can read fields without racing in-place mutators.
 type UserView struct {
 	Id                 string
 	Active             bool
@@ -70,8 +71,8 @@ type UserView struct {
 	ImportedWithKey    bool
 }
 
-// view returns a snapshot. Caller must hold c.lock for read; this method
-// also takes the per-user RLock to block LastUsedAt updaters.
+// view returns a snapshot taken under the per-user RLock so it cannot
+// observe a torn write from UpdateLastUsedTimestamp.
 func (u *User) view() UserView {
 	u.RLock()
 	defer u.RUnlock()


### PR DESCRIPTION
### What's being changed:

`DBUser.GetUsers` used to return `map[string]*apikey.User` — shared pointers into the in-memory user map. Callers could then read fields like `LastUsedAt` concurrently with mutators (e.g. `UpdateLastUsedTimestamp`, `ActivateUser`).

In practice, the **only call site that actually raced** was `RemoteApiKey.GetUserStatus` (`usecases/auth/authentication/apikey/remote.go`), which calls `DBUser.GetUsers` directly on the local instance — and even calls `UpdateLastUsedTimestamp` immediately before it.

All other callers (REST `db_users` handlers, REST `authz` handlers) go through `Raft.GetUsers`, which `json.Marshal`s on the server and `json.Unmarshal`s on the client. That round-trip already produces fresh allocations, so those paths were never racing on the shared pointers.

This PR introduces an `apikey.UserView` value type and changes `DBUser.GetUsers` to return `map[string]UserView` snapshots taken under the per-user `RLock`. The wire shape is preserved (`*apikey.User` on the RAFT response) by rebuilding the pointer on the server side and converting back to `UserView` on the client side.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See \`.github/workflows/create-cross-functional-issues.yml\`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->