### PR TITLE
Fix flaky HNSW search test

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -209,8 +209,16 @@ func testDistributed(t *testing.T, dirName string, rnd *rand.Rand, batch bool) {
 				ClassName: distributedClass,
 			}, []string{""}, []models.Vector{query})
 			assert.Nil(t, err)
-			for i, obj := range res {
-				assert.Equal(t, groundTruth[i].ID, obj.ID, fmt.Sprintf("at pos %d", i))
+			// Compare as a set, not by position: each shard runs its own
+			// approximate HNSW search and the merged result at the K-th
+			// boundary is not guaranteed to match the brute-force order.
+			expectedIDs := make(map[strfmt.UUID]struct{}, len(res))
+			for i := 0; i < len(res); i++ {
+				expectedIDs[groundTruth[i].ID] = struct{}{}
+			}
+			for _, obj := range res {
+				_, ok := expectedIDs[obj.ID]
+				assert.True(t, ok, fmt.Sprintf("unexpected id %s in results", obj.ID))
 			}
 		}
 


### PR DESCRIPTION
### What's being changed:

Fixes a flaky test where object order was asserted. The test said that the recall (==all objects are found) is the goal, not a specific order

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
