### PR TITLE
fix(shard): make initTargetVector idempotent to prevent double-create

### DIFF
--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -355,6 +355,13 @@ func (s *Shard) initTargetVector(ctx context.Context, targetVector string, cfg s
 }
 
 func (s *Shard) initTargetVectorWithLock(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
+	// Recreating an existing target would orphan the current index+queue (never
+	// Dropped). Returning early also makes concurrent UpdateVectorIndexConfigs
+	// calls that both saw the target absent safe.
+	if _, exists := s.vectorIndexes[targetVector]; exists {
+		return nil
+	}
+
 	vectorIndex, err := s.initVectorIndex(ctx, targetVector, cfg, lazyLoadSegments)
 	if err != nil {
 		return fmt.Errorf("cannot create vector index for %q: %w", targetVector, err)

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -1,0 +1,67 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// Re-initialising an existing target vector must not replace and orphan its
+// queue. This is the outcome of two concurrent UpdateVectorIndexConfigs calls
+// that both observe the target absent before either creates it; reproduced here
+// sequentially.
+func TestInitTargetVector_Idempotent_DoesNotOrphanQueue(t *testing.T) {
+	ctx := context.Background()
+	shardLike, _ := testShard(t, ctx, "ToctouDoubleCreate")
+	shard := underlyingShard(t, shardLike)
+
+	cfg := enthnsw.UserConfig{Skip: true}
+
+	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
+	shard.vectorIndexMu.RLock()
+	q1 := shard.queues["v1"]
+	shard.vectorIndexMu.RUnlock()
+	require.NotNil(t, q1)
+
+	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
+
+	shard.vectorIndexMu.RLock()
+	q2 := shard.queues["v1"]
+	shard.vectorIndexMu.RUnlock()
+
+	assert.Same(t, q1, q2,
+		"re-initialising an existing target vector must not silently replace and "+
+			"orphan its queue; the first queue is leaked (never Dropped)")
+}
+
+// underlyingShard returns the concrete *Shard behind a ShardLike, loading it if
+// the test helper handed back a lazy-load wrapper (the default differs across
+// release branches, so handle both).
+func underlyingShard(t *testing.T, sl ShardLike) *Shard {
+	t.Helper()
+	switch s := sl.(type) {
+	case *Shard:
+		return s
+	case *LazyLoadShard:
+		require.NoError(t, s.Load(context.Background()))
+		return s.shard
+	default:
+		t.Fatalf("unexpected ShardLike type %T", sl)
+		return nil
+	}
+}


### PR DESCRIPTION
In UpdateVectorIndexConfigs the existence check (GetVectorIndex) and the create (initTargetVector) are separate critical sections, so two concurrent config updates adding the same target vector both create it; initTargetVectorWithLock overwrote the map entries, orphaning the first index+queue.

Fix: return early if the target already exists, under the held vectorIndexMu.Lock.

Test: `TestInitTargetVector_Idempotent_DoesNotOrphanQueue`.

Base: `stable/v1.36`. Forward-port to v1.37/v1.38/main.