### PR TITLE
[DRAFT/do-not-merge] vector-index config-update race & correctness fixes (combined, for e2e+chaos)

### DIFF
--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -159,6 +159,13 @@ func (db *DB) setShardsReadOnly(reason string) {
 	db.indexLock.Lock()
 	for _, index := range db.indices {
 		index.ForEachShard(func(name string, shard ShardLike) error {
+			// Don't overwrite the reason of an already read-only shard: it may be
+			// read-only for a non-resource reason (e.g. a vector-index config
+			// update), and relabeling it would let setShardsReady flip it back to
+			// READY mid-operation.
+			if shard.GetStatus() == storagestate.StatusReadOnly {
+				return nil
+			}
 			err := shard.SetStatusReadonly(statusReasonResourcePressure)
 			if err != nil {
 				db.logger.WithField("action", "set_shard_read_only").

--- a/adapters/repos/db/resource_use_test.go
+++ b/adapters/repos/db/resource_use_test.go
@@ -14,6 +14,8 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -70,8 +72,48 @@ func testResourceDB(t *testing.T, diskROPercent, memROPercent uint64, shards map
 	}
 }
 
+// newStatefulShardMock returns a MockShardLike whose GetStatus/GetStatusReason
+// reflect the mutations made by SetStatusReadonly/UpdateStatus. The mutex guards
+// reads from the test goroutine.
+func newStatefulShardMock(t *testing.T, initial ShardStatus) (*MockShardLike, *ShardStatus, *sync.Mutex) {
+	t.Helper()
+	mu := &sync.Mutex{}
+	status := &initial
+	shard := NewMockShardLike(t)
+	shard.EXPECT().GetStatus().RunAndReturn(func() storagestate.Status {
+		mu.Lock()
+		defer mu.Unlock()
+		return status.Status
+	}).Maybe()
+	shard.EXPECT().GetStatusReason().RunAndReturn(func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return status.Reason
+	}).Maybe()
+	shard.EXPECT().SetStatusReadonly(mock.AnythingOfType("string")).RunAndReturn(func(reason string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		status.Status = storagestate.StatusReadOnly
+		status.Reason = reason
+		return nil
+	}).Maybe()
+	shard.EXPECT().UpdateStatus(mock.AnythingOfType("string"), mock.AnythingOfType("string")).RunAndReturn(func(in, reason string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		st, err := storagestate.ValidateStatus(strings.ToUpper(in))
+		if err != nil {
+			return err
+		}
+		status.Status = st
+		status.Reason = reason
+		return nil
+	}).Maybe()
+	return shard, status, mu
+}
+
 func TestDiskUseReadonly_OverThreshold(t *testing.T) {
 	shard := NewMockShardLike(t)
+	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
 	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
 
 	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
@@ -86,6 +128,7 @@ func TestDiskUseReadonly_OverThreshold(t *testing.T) {
 
 func TestMemUseReadonly_OverThreshold(t *testing.T) {
 	shard := NewMockShardLike(t)
+	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
 	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
 
 	db := testResourceDB(t, 0, 90, map[string]*MockShardLike{"shard1": shard})
@@ -103,6 +146,7 @@ func TestResourceUseReadonly_BothOverThreshold(t *testing.T) {
 	// May be called twice (once for disk, once for memory). The second call is
 	// technically redundant since isReadOnly is already true, but setShardsReadOnly
 	// is called for both.
+	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
 	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
 
 	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
@@ -293,37 +337,40 @@ func TestReadonlyRecoveryCycle(t *testing.T) {
 	// 2. Usage drops below threshold → shards recover to READY
 	// 3. Usage goes over threshold again → shards become READONLY again
 
-	shard := NewMockShardLike(t)
-
-	// Step 1: Expect SetStatusReadonly to be called
-	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil).Once()
+	// Stateful mock so GetStatus reflects the actual transitions across the
+	// cycle (setShardsReadOnly now skips shards that are already read-only).
+	shard, status, mu := newStatefulShardMock(t, ShardStatus{Status: storagestate.StatusReady})
 
 	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
 
-	// Step 1: Disk usage exceeds threshold
+	// Step 1: Disk usage exceeds threshold → READONLY (resource pressure)
 	du := diskUse{total: 100, free: 5, avail: 5}
 	mon := newTestMemMonitor(0, 100)
 	db.resourceUseReadonly(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly, "should be readonly after exceeding threshold")
+	mu.Lock()
+	assert.Equal(t, storagestate.StatusReadOnly, status.Status)
+	assert.Equal(t, statusReasonResourcePressure, status.Reason)
+	mu.Unlock()
 
-	// Step 2: Disk usage drops below threshold → recovery
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly).Once()
-	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure).Once()
-	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil).Once()
-
+	// Step 2: Disk usage drops below threshold → recovery to READY
 	du = diskUse{total: 100, free: 50, avail: 50}
 	db.resourceUseRecovery(mon, du)
 
 	assert.False(t, db.resourceScanState.isReadOnly, "should recover after usage drops below threshold")
+	mu.Lock()
+	assert.Equal(t, storagestate.StatusReady, status.Status)
+	mu.Unlock()
 
-	// Step 3: Disk usage exceeds threshold again → readonly again
-	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil).Once()
-
+	// Step 3: Disk usage exceeds threshold again → READONLY again
 	du = diskUse{total: 100, free: 5, avail: 5}
 	db.resourceUseReadonly(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly, "should be readonly again after re-exceeding threshold")
+	mu.Lock()
+	assert.Equal(t, storagestate.StatusReadOnly, status.Status)
+	mu.Unlock()
 }
 
 func TestSetShardsReady_MultipleIndices(t *testing.T) {
@@ -401,6 +448,30 @@ func TestSetShardsReady_SkipsNonResourcePressureReadonly(t *testing.T) {
 	assert.False(t, db.resourceScanState.isReadOnly)
 	configUpdateShard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
 	resourcePressureShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+}
+
+// A shard that is READONLY for a vector-index config update must stay READONLY
+// across a resource readonly→recovery cycle: the resource scanner must not
+// relabel it as resource-pressure and then recover it mid-update.
+func TestResourceCycle_DoesNotRecoverConfigUpdateShard(t *testing.T) {
+	// Simulate UpdateVectorIndexConfig having marked the shard READONLY.
+	shard, status, mu := newStatefulShardMock(t,
+		ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate})
+
+	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"config_update_shard": shard})
+
+	// Resource pressure trips while the config update is in flight.
+	mon := newTestMemMonitor(0, 100)
+	db.resourceUseReadonly(mon, diskUse{total: 100, free: 5, avail: 5})
+
+	// Resource pressure clears → recovery pass runs.
+	db.resourceUseRecovery(mon, diskUse{total: 100, free: 50, avail: 50})
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, storagestate.StatusReadOnly, status.Status,
+		"config-update shard must stay READONLY across a resource readonly→recovery cycle; "+
+			"resource recovery must not re-admit writes while the vector-index config update is still in flight")
 }
 
 func TestSetShardsReady_SkipsUserInitiatedReadonly(t *testing.T) {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -359,6 +359,13 @@ func (s *Shard) initTargetVector(ctx context.Context, targetVector string, cfg s
 }
 
 func (s *Shard) initTargetVectorWithLock(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
+	// Recreating an existing target would orphan the current index+queue (never
+	// Dropped). Returning early also makes concurrent UpdateVectorIndexConfigs
+	// calls that both saw the target absent safe.
+	if _, exists := s.vectorIndexes[targetVector]; exists {
+		return nil
+	}
+
 	vectorIndex, err := s.initVectorIndex(ctx, targetVector, cfg, lazyLoadSegments)
 	if err != nil {
 		return fmt.Errorf("cannot create vector index for %q: %w", targetVector, err)

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -1,0 +1,67 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// Re-initialising an existing target vector must not replace and orphan its
+// queue. This is the outcome of two concurrent UpdateVectorIndexConfigs calls
+// that both observe the target absent before either creates it; reproduced here
+// sequentially.
+func TestInitTargetVector_Idempotent_DoesNotOrphanQueue(t *testing.T) {
+	ctx := context.Background()
+	shardLike, _ := testShard(t, ctx, "ToctouDoubleCreate")
+	shard := underlyingShard(t, shardLike)
+
+	cfg := enthnsw.UserConfig{Skip: true}
+
+	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
+	shard.vectorIndexMu.RLock()
+	q1 := shard.queues["v1"]
+	shard.vectorIndexMu.RUnlock()
+	require.NotNil(t, q1)
+
+	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
+
+	shard.vectorIndexMu.RLock()
+	q2 := shard.queues["v1"]
+	shard.vectorIndexMu.RUnlock()
+
+	assert.Same(t, q1, q2,
+		"re-initialising an existing target vector must not silently replace and "+
+			"orphan its queue; the first queue is leaked (never Dropped)")
+}
+
+// underlyingShard returns the concrete *Shard behind a ShardLike, loading it if
+// the test helper handed back a lazy-load wrapper (the default differs across
+// release branches, so handle both).
+func underlyingShard(t *testing.T, sl ShardLike) *Shard {
+	t.Helper()
+	switch s := sl.(type) {
+	case *Shard:
+		return s
+	case *LazyLoadShard:
+		require.NoError(t, s.Load(context.Background()))
+		return s.shard
+	default:
+		t.Fatalf("unexpected ShardLike type %T", sl)
+		return nil
+	}
+}

--- a/adapters/repos/db/vector/dynamic/config_update_race_test.go
+++ b/adapters/repos/db/vector/dynamic/config_update_race_test.go
@@ -1,0 +1,199 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package dynamic
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// newDynamicAboveThreshold builds an async dynamic index seeded past its upgrade
+// threshold, so a subsequent Upgrade() copies enough vectors to overlap a
+// concurrent accessor.
+func newDynamicAboveThreshold(t *testing.T) (*dynamic, ent.UserConfig, [][]float32) {
+	t.Helper()
+	ctx := context.Background()
+	dimensions := 20
+	vectorsSize := 1_000
+	threshold := 100
+
+	db, err := bbolt.Open(filepath.Join(t.TempDir(), "index.db"), 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	vectors, _ := testinghelpers.RandomVecs(vectorsSize, 0, dimensions)
+	dist := distancer.NewL2SquaredProvider()
+
+	fuc := flatent.UserConfig{}
+	fuc.SetDefaults()
+	hnswuc := hnswent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 1_000_000,
+	}
+	hnswuc.SetDefaults()
+
+	uc := ent.UserConfig{
+		Threshold: uint64(threshold),
+		Distance:  dist.Type(),
+		HnswUC:    hnswuc,
+		FlatUC:    fuc,
+	}
+
+	idx, err := New(Config{
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		RootPath:              t.TempDir(),
+		ID:                    "race-uc-test",
+		MakeCommitLoggerThunk: hnsw.MakeNoopCommitLogger,
+		DistanceProvider:      dist,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			vec := vectors[int(id)]
+			if vec == nil {
+				return nil, storobj.NewErrNotFoundf(id, "nil vec")
+			}
+			return vec, nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		TombstoneCallbacks:           cyclemanager.NewCallbackGroupNoop(),
+		SharedDB:                     db,
+		MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+		AsyncIndexingEnabled:         true, // required: New() errors otherwise
+	}, uc, testinghelpers.NewDummyStore(t))
+	require.NoError(t, err)
+
+	compressionhelpers.Concurrently(logger, uint64(vectorsSize), func(i uint64) {
+		require.NoError(t, idx.Add(ctx, i, vectors[i]))
+	})
+	return idx, uc, vectors
+}
+
+// UpdateUserConfig writes dynamic.uc while doUpgrade reads it; the write must be
+// synchronized. A single continuous writer keeps the reported race unambiguous.
+func TestUpdateUserConfig_RacesDoUpgrade(t *testing.T) {
+	idx, uc, _ := newDynamicAboveThreshold(t)
+
+	done := make(chan struct{})
+	require.NoError(t, idx.Upgrade(func() { close(done) }))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ef := 0
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				updated := uc
+				updated.HnswUC.EF = ef // vary so each call is a real update
+				ef++
+				_ = idx.UpdateUserConfig(updated, func() {})
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+// Iterate reads dynamic.index without a lock; it must be synchronized against
+// the upgrade swap. Several readers so a read is in flight during the one-shot
+// swap; fn returns true to keep each call cheap and the read frequent.
+func TestIterate_RacesDoUpgrade(t *testing.T) {
+	idx, _, _ := newDynamicAboveThreshold(t)
+
+	done := make(chan struct{})
+	require.NoError(t, idx.Upgrade(func() { close(done) }))
+
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					idx.Iterate(func(id uint64) bool { return true })
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// A config update must reach the active index whether it runs before or after
+// the upgrade swaps flat->hnsw — not get routed into the wrong index type.
+//
+// Known gap (not fixed here): an update landing inside doUpgrade's read->swap
+// window still applies to the discarded flat index, not the new hnsw one.
+func TestUpdateUserConfig_RoutesToActiveIndexType(t *testing.T) {
+	const newEF = int64(99)
+
+	t.Run("after upgrade routes HnswUC to the hnsw index", func(t *testing.T) {
+		idx, uc, _ := newDynamicAboveThreshold(t)
+		require.NotEqual(t, newEF, int64(uc.HnswUC.EF))
+
+		upgradeDone := make(chan struct{})
+		require.NoError(t, idx.Upgrade(func() { close(upgradeDone) }))
+		<-upgradeDone
+
+		updated := uc
+		updated.HnswUC.EF = int(newEF)
+		require.NoError(t, idx.UpdateUserConfig(updated, func() {}))
+
+		require.True(t, idx.upgraded.Load())
+		hnswIdx, ok := idx.index.(interface{ EF() int64 })
+		require.True(t, ok, "post-upgrade active index should be *hnsw")
+		assert.Equal(t, newEF, hnswIdx.EF(),
+			"a post-upgrade config update must be applied to the active HNSW index")
+	})
+
+	t.Run("before upgrade the update is carried into the hnsw index", func(t *testing.T) {
+		idx, uc, _ := newDynamicAboveThreshold(t)
+		require.NotEqual(t, newEF, int64(uc.HnswUC.EF))
+
+		updated := uc
+		updated.HnswUC.EF = int(newEF)
+		require.NoError(t, idx.UpdateUserConfig(updated, func() {}))
+
+		upgradeDone := make(chan struct{})
+		require.NoError(t, idx.Upgrade(func() { close(upgradeDone) }))
+		<-upgradeDone
+
+		require.True(t, idx.upgraded.Load())
+		hnswIdx, ok := idx.index.(interface{ EF() int64 })
+		require.True(t, ok, "post-upgrade active index should be *hnsw")
+		assert.Equal(t, newEF, hnswIdx.EF(),
+			"a config update applied before the upgrade must be carried into the new HNSW index via uc")
+	})
+}

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -358,17 +358,16 @@ func (dynamic *dynamic) UpdateUserConfig(updated schemaconfig.VectorIndexConfig,
 		callback()
 		return errors.Errorf("config is not UserConfig, but %T", updated)
 	}
+	// doUpgrade swaps dynamic.index and flips upgraded under the exclusive lock;
+	// hold it across the check and the use so an upgrade can't land in between
+	// and route the wrong sub-config into the swapped index.
+	dynamic.Lock()
+	defer dynamic.Unlock()
 	if dynamic.upgraded.Load() {
-		dynamic.RLock()
-		defer dynamic.RUnlock()
-		dynamic.index.UpdateUserConfig(parsed.HnswUC, callback)
-	} else {
-		dynamic.uc = parsed
-		dynamic.RLock()
-		defer dynamic.RUnlock()
-		dynamic.index.UpdateUserConfig(parsed.FlatUC, callback)
+		return dynamic.index.UpdateUserConfig(parsed.HnswUC, callback)
 	}
-	return nil
+	dynamic.uc = parsed
+	return dynamic.index.UpdateUserConfig(parsed.FlatUC, callback)
 }
 
 func (dynamic *dynamic) Drop(ctx context.Context, keepFiles bool) error {
@@ -683,6 +682,8 @@ func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 }
 
 func (dynamic *dynamic) Iterate(fn func(id uint64) bool) {
+	dynamic.RLock()
+	defer dynamic.RUnlock()
 	dynamic.index.Iterate(fn)
 }
 

--- a/adapters/repos/db/vector/hnsw/accessors.go
+++ b/adapters/repos/db/vector/hnsw/accessors.go
@@ -1,0 +1,19 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import "sync/atomic"
+
+// EF returns the configured query-time ef.
+func (h *hnsw) EF() int64 {
+	return atomic.LoadInt64(&h.ef)
+}

--- a/adapters/repos/db/vector/hnsw/compress_multivector_concurrency_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_multivector_concurrency_test.go
@@ -1,0 +1,109 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// AddMultiBatch reads the compression trio in two spots — the PreloadMulti
+// branch and growIndexToAccomodateNode (index growth) — now both taken under
+// compressActionLock, like the rest of the insert/search paths.
+//
+// This runs many multivector inserts (which grow the index) concurrently with
+// enabling compression, asserting liveness and deadlock-freedom under the added
+// locking. The data race itself is gated by the atomic h.compressed flag, so
+// -race does not deterministically reproduce it; the fix rests on lock
+// discipline. BQ is used because it is training-free (no cache sampling).
+func TestAddMultiBatch_ConcurrentWithCompression(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	doc := func(id uint64) [][]float32 {
+		return testMultiVectors[id%uint64(len(testMultiVectors))]
+	}
+
+	uc := ent.UserConfig{
+		VectorCacheMaxObjects: 1e12,
+		MaxConnections:        8,
+		EFConstruction:        64,
+		EF:                    64,
+		Multivector:           ent.MultivectorConfig{Enabled: true},
+	}
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "multivec-compress-concurrency",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewDotProductProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		MakeBucketOptions:     lsmkv.MakeNoopBucketOptions,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{0}, errors.New("can not use VectorForIDThunk with multivector")
+		},
+		MultiVectorForIDThunk: func(ctx context.Context, id uint64) ([][]float32, error) {
+			return doc(id), nil
+		},
+		GetViewThunk: func() common.BucketView { return &noopBucketView{} },
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	t.Cleanup(func() { index.Shutdown(context.Background()) })
+
+	ctx := context.Background()
+	const seed = 500
+	for id := uint64(0); id < seed; id++ {
+		require.NoError(t, index.AddMulti(ctx, id, doc(id)))
+	}
+	index.cachePrefilled.Store(true)
+
+	// Writers add new docs (growing the index) throughout the rebuild.
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(start uint64) {
+			defer wg.Done()
+			id := start
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = index.AddMulti(ctx, id, doc(id))
+					id++
+				}
+			}
+		}(uint64(seed + w*1_000_000))
+	}
+
+	// Enable BQ compression; Upgrade runs compress() on its goroutine.
+	bq := uc
+	bq.BQ = ent.BQConfig{Enabled: true}
+	cbDone := make(chan struct{})
+	require.NoError(t, index.UpdateUserConfig(bq, func() { close(cbDone) }))
+	<-cbDone
+
+	close(done)
+	wg.Wait()
+}

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -168,13 +168,18 @@ func (h *hnsw) Upgrade(callback func()) error {
 		return err
 	}
 
+	h.compressWg.Add(1)
 	enterrors.GoWrapper(func() { h.compressThenCallback(callback) }, h.logger)
 
 	return nil
 }
 
 func (h *hnsw) compressThenCallback(callback func()) {
+	// Done() must run before the callback: the callback may call Drop/Shutdown,
+	// which Wait on compressWg, so decrement first to avoid waiting on ourselves.
+	// compress()'s cache and commit-log work is already complete by this point.
 	defer callback()
+	defer h.compressWg.Done()
 
 	uc := ent.UserConfig{
 		PQ: h.pqConfig,

--- a/adapters/repos/db/vector/hnsw/config_update_race_test.go
+++ b/adapters/repos/db/vector/hnsw/config_update_race_test.go
@@ -1,0 +1,136 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// validatePQSegments reads h.pqConfig from the insert-validation path
+// (ValidateBeforeInsert / ValidateMultiBeforeInsert) while UpdateUserConfig
+// writes it under compressActionLock; the read must take the same lock.
+func TestValidateBeforeInsert_RacesUpdateUserConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		multivector bool
+		validate    func(h *hnsw) error
+	}{
+		{
+			name:        "single-vector ValidateBeforeInsert",
+			multivector: false,
+			validate:    func(h *hnsw) error { return h.ValidateBeforeInsert(testVectors[0]) },
+		},
+		{
+			name:        "multi-vector ValidateMultiBeforeInsert",
+			multivector: true,
+			validate:    func(h *hnsw) error { return h.ValidateMultiBeforeInsert(testMultiVectors[0]) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			index, base := buildConfigRaceIndex(t, tt.multivector)
+			// Make UpdateUserConfig write the compression config and return early
+			// instead of kicking off a full rebuild.
+			index.cachePrefilled.Store(false)
+
+			done := make(chan struct{})
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 5000; i++ {
+					updated := base
+					updated.PQ.Enabled = true
+					updated.PQ.Segments = 1 + (i % 2) // vary -> real struct write each time
+					_ = index.UpdateUserConfig(updated, func() {})
+				}
+				close(done)
+			}()
+
+			timeout := time.After(60 * time.Second)
+			for {
+				select {
+				case <-done:
+					wg.Wait()
+					return
+				case <-timeout:
+					t.Fatal("UpdateUserConfig writer did not finish; possible hang")
+				default:
+					// reader side: validate reads pqConfig under compressActionLock
+					_ = tt.validate(index)
+					runtime.Gosched()
+				}
+			}
+		})
+	}
+}
+
+func buildConfigRaceIndex(t *testing.T, multivector bool) (*hnsw, ent.UserConfig) {
+	t.Helper()
+	store := testinghelpers.NewDummyStore(t)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	uc := ent.UserConfig{
+		VectorCacheMaxObjects: 1e12,
+		MaxConnections:        8,
+		EFConstruction:        64,
+		EF:                    64,
+	}
+	cfg := Config{
+		RootPath:              t.TempDir(),
+		ID:                    "config-race",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewL2SquaredProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		MakeBucketOptions:     lsmkv.MakeNoopBucketOptions,
+		GetViewThunk:          func() common.BucketView { return &noopBucketView{} },
+	}
+	if multivector {
+		uc.Multivector = ent.MultivectorConfig{Enabled: true}
+		cfg.DistanceProvider = distancer.NewDotProductProvider()
+		cfg.VectorForIDThunk = func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{0}, errors.New("can not use VectorForIDThunk with multivector")
+		}
+		cfg.MultiVectorForIDThunk = testMultiVectorForID
+	} else {
+		cfg.VectorForIDThunk = testVectorForID
+	}
+
+	index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	t.Cleanup(func() { index.Shutdown(context.Background()) })
+
+	// Seed one element so h.dims is set and the non-empty validate path runs.
+	if multivector {
+		require.NoError(t, index.AddMulti(context.Background(), 0, testMultiVectors[0]))
+	} else {
+		require.NoError(t, index.Add(context.Background(), 0, testVectors[0]))
+	}
+	return index, uc
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -187,7 +187,9 @@ type hnsw struct {
 	// to define the rescoring concurrency.
 	rescoreConcurrency int
 
-	compressActionLock    *sync.RWMutex
+	compressActionLock *sync.RWMutex
+	// compressWg lets Drop/Shutdown join the async compression goroutine Upgrade spawns.
+	compressWg            sync.WaitGroup
 	className             string
 	shardName             string
 	VectorForIDThunk      common.VectorForID[float32]
@@ -733,6 +735,10 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 }
 
 func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
+	// Wait for in-flight async compression to finish before teardown: it drops
+	// the cache and writes the commit log.
+	h.compressWg.Wait()
+
 	// cancel tombstone cleanup goroutine
 	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")
@@ -760,6 +766,10 @@ func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
 
 func (h *hnsw) Shutdown(ctx context.Context) error {
 	h.shutdownCtxCancel()
+
+	// Wait for in-flight async compression to finish before teardown: it drops
+	// the cache and writes the commit log.
+	h.compressWg.Wait()
 
 	if err := h.commitLog.Shutdown(ctx); err != nil {
 		return errors.Wrap(err, "hnsw shutdown")

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -162,6 +162,29 @@ func (h *hnsw) checkAndCompress() error {
 	return err
 }
 
+// growIndexToAccomodateNodeUnderCompressLock grows the index from the batch
+// insert paths, which (unlike addOne) don't already hold compressActionLock.
+// growIndexToAccomodateNode grows the cache/compressor too, reading the
+// compression trio, so take the read lock to exclude a concurrent compress().
+func (h *hnsw) growIndexToAccomodateNodeUnderCompressLock(maxId uint64) error {
+	h.compressActionLock.RLock()
+	defer h.compressActionLock.RUnlock()
+
+	h.RLock()
+	if maxId < uint64(len(h.nodes)) {
+		h.RUnlock()
+		return nil
+	}
+	h.RUnlock()
+
+	h.Lock()
+	defer h.Unlock()
+	if maxId >= uint64(len(h.nodes)) {
+		return h.growIndexToAccomodateNode(maxId, h.logger)
+	}
+	return nil
+}
+
 func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -212,20 +235,8 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 		}
 		levels[i] = h.generateLevel()
 	}
-	h.RLock()
-	if maxId >= uint64(len(h.nodes)) {
-		h.RUnlock()
-		h.Lock()
-		if maxId >= uint64(len(h.nodes)) {
-			err := h.growIndexToAccomodateNode(maxId, h.logger)
-			if err != nil {
-				h.Unlock()
-				return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
-			}
-		}
-		h.Unlock()
-	} else {
-		h.RUnlock()
+	if err := h.growIndexToAccomodateNodeUnderCompressLock(maxId); err != nil {
+		return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
 	}
 
 	for i := range ids {
@@ -335,31 +346,24 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 
 		maxId := counter + uint64(numVectors)
 
-		h.RLock()
-		if maxId >= uint64(len(h.nodes)) {
-			h.RUnlock()
-			h.Lock()
-			if maxId >= uint64(len(h.nodes)) {
-				err := h.growIndexToAccomodateNode(maxId, h.logger)
-				if err != nil {
-					h.Unlock()
-					return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
-				}
-			}
-			h.Unlock()
-		} else {
-			h.RUnlock()
+		if err := h.growIndexToAccomodateNodeUnderCompressLock(maxId); err != nil {
+			return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
 		}
 
 		ids := make([]uint64, numVectors)
 		for id := range ids {
 			ids[id] = counter + uint64(id)
 		}
+		// Read the compression trio under compressActionLock, like addOne, so a
+		// concurrent compress() (which holds the write lock) can't swap the
+		// compressor / drop the cache underneath this preload.
+		h.compressActionLock.RLock()
 		if h.compressed.Load() {
 			h.compressor.PreloadMulti(docID, ids, vectors[i])
 		} else {
 			h.cache.PreloadMulti(docID, ids, vectors[i])
 		}
+		h.compressActionLock.RUnlock()
 		for j := range numVectors {
 			if err := ctx.Err(); err != nil {
 				return err

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -97,6 +97,9 @@ func (h *hnsw) ValidateMultiBeforeInsert(vector [][]float32) error {
 }
 
 func (h *hnsw) validatePQSegments(dims int) error {
+	// pqConfig is written under compressActionLock; read it under the same lock.
+	h.compressActionLock.RLock()
+	defer h.compressActionLock.RUnlock()
 	if h.pqConfig.Enabled && h.pqConfig.Segments != 0 && dims%h.pqConfig.Segments != 0 {
 		return fmt.Errorf("pq segments must be a divisor of the vector dimensions")
 	}

--- a/adapters/repos/db/vector/hnsw/shutdown_compress_join_test.go
+++ b/adapters/repos/db/vector/hnsw/shutdown_compress_join_test.go
@@ -1,0 +1,101 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// newCompressReadyIndex builds an hnsw index seeded with data and with the cache
+// marked prefilled, so a subsequent UpdateUserConfig enabling SQ runs the
+// compression rebuild immediately on the Upgrade goroutine.
+func newCompressReadyIndex(t *testing.T) (*hnsw, ent.UserConfig) {
+	t.Helper()
+	store := testinghelpers.NewDummyStore(t)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	dim, n := 32, 2000
+	vectors, _ := testinghelpers.RandomVecs(n, 0, dim)
+	uc := ent.UserConfig{VectorCacheMaxObjects: 1e12, MaxConnections: 8, EFConstruction: 64, EF: 64}
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "shutdown-compress",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewL2SquaredProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		MakeBucketOptions:     lsmkv.MakeNoopBucketOptions,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			// compress() samples over the cache's padded length, which exceeds n;
+			// return NotFound for ids past the inserted range so it skips them.
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[int(id)], nil
+		},
+		GetViewThunk: func() common.BucketView { return &noopBucketView{} },
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, compressionhelpers.ConcurrentlyWithError(logger, uint64(n), func(id uint64) error {
+		return index.Add(ctx, id, vectors[id])
+	}))
+	index.cachePrefilled.Store(true)
+	return index, uc
+}
+
+func enableSQ(uc ent.UserConfig) ent.UserConfig {
+	uc.SQ = ent.SQConfig{Enabled: true, RescoreLimit: 20, TrainingLimit: 100}
+	return uc
+}
+
+// Shutdown must join the async compression goroutine Upgrade spawns before
+// tearing down; otherwise its cache.Drop()/commit-log teardown races the
+// in-flight compression. Run with -race.
+func TestShutdown_JoinsAsyncCompression(t *testing.T) {
+	index, uc := newCompressReadyIndex(t)
+	require.NoError(t, index.UpdateUserConfig(enableSQ(uc), func() {}))
+	require.NoError(t, index.Shutdown(context.Background()))
+}
+
+// The compression callback runs on the Upgrade goroutine; if it calls
+// Drop/Shutdown (which Wait on compressWg), compressWg.Done() must already have
+// run or the goroutine waits on itself forever.
+func TestCompressCallback_DoesNotDeadlockOnShutdown(t *testing.T) {
+	index, uc := newCompressReadyIndex(t)
+
+	done := make(chan struct{})
+	require.NoError(t, index.UpdateUserConfig(enableSQ(uc), func() {
+		_ = index.Shutdown(context.Background())
+		close(done)
+	}))
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("compression callback -> Shutdown deadlocked waiting on compressWg")
+	}
+}


### PR DESCRIPTION
Combined branch stacking all six vector-index config-update fixes, opened as a draft to exercise the e2e and chaos suites across the whole set in one run. Do not merge — each fix ships via its own PR against its floor branch:

- #11581 resource: do not auto-recover a shard read-only for a non-resource reason (base stable/v1.36)
- #11582 dynamic: serialize config updates and Iterate against the flat->hnsw upgrade (base stable/v1.35)
- #11583 hnsw: read compression config under compressActionLock in insert validation (base stable/v1.35)
- #11584 shard: make initTargetVector idempotent to prevent double-create (base stable/v1.35)
- #11585 hnsw: join async compression goroutine on Drop/Shutdown (base stable/v1.35)
- #11597 hnsw: guard insert-path compression-state reads under compressActionLock (base stable/v1.35)

Each carries -race / regression tests; cherry-picks verified clean onto their floor branches. Forward-port floor -> ... -> main after merge.
