### PR TITLE
Interpret empty string as empty for slices in dynamic runtime config

### DIFF
--- a/usecases/config/runtime/values.go
+++ b/usecases/config/runtime/values.go
@@ -14,6 +14,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -115,6 +116,15 @@ func (dv *DynamicValue[T]) SetValue(val T) error {
 func (dv *DynamicValue[T]) UnmarshalYAML(node *yaml.Node) error {
 	var val T
 	if err := node.Decode(&val); err != nil {
+		// `key: ""` errors against slice T in yaml.v3; coerce to nil so a
+		// quoted-empty doesn't fail the whole push. Scalars stay strict —
+		// their zero is field-dependent.
+		if node.Kind == yaml.ScalarNode && node.Value == "" && reflect.TypeOf(val).Kind() == reflect.Slice {
+			dv.mu.Lock()
+			defer dv.mu.Unlock()
+			dv.def = val
+			return nil
+		}
 		return err
 	}
 	dv.mu.Lock()

--- a/usecases/config/runtime/values_test.go
+++ b/usecases/config/runtime/values_test.go
@@ -69,6 +69,35 @@ slice: ["one", "two", "three"]
 		assert.Equal(t, []string{"one", "two", "three"}, val.Slice.Get())
 		assert.Nil(t, val.Slice.val)
 	})
+
+	t.Run("empty scalar decodes to nil for slice T", func(t *testing.T) {
+		val := struct {
+			Slice *DynamicValue[[]string] `yaml:"slice"`
+		}{}
+		require.NoError(t, yaml.NewDecoder(strings.NewReader(`slice: ""`)).Decode(&val))
+		assert.Nil(t, val.Slice.Get())
+	})
+
+	t.Run("empty scalar still errors for non-slice T", func(t *testing.T) {
+		cases := map[string]any{
+			`foo: ""`:   &struct{ Foo *DynamicValue[int] }{},
+			`bar: ""`:   &struct{ Bar *DynamicValue[float64] }{},
+			`alice: ""`: &struct{ Alice *DynamicValue[bool] }{},
+			`dave: ""`:  &struct{ Dave *DynamicValue[time.Duration] }{},
+		}
+		for input, target := range cases {
+			err := yaml.NewDecoder(strings.NewReader(input)).Decode(target)
+			require.Error(t, err, "expected %q to error", input)
+		}
+	})
+
+	t.Run("non-empty scalar with wrong type still errors", func(t *testing.T) {
+		val := struct {
+			Slice *DynamicValue[[]string] `yaml:"slice"`
+		}{}
+		err := yaml.NewDecoder(strings.NewReader(`slice: "abc"`)).Decode(&val)
+		require.Error(t, err)
+	})
 }
 
 func TestDynamicValue_JSON(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -49,6 +49,20 @@ maximum_allowed_collections_count: 13
 		assert.Equal(t, 13, cfg.MaximumAllowedCollectionsCount.Get())
 	})
 
+	t.Run("empty-string scalar for slice fields is equivalent to empty list", func(t *testing.T) {
+		buf := []byte(`allowed_vector_index_types: ""
+allowed_compression_types: ""`)
+		cfg, err := ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+		assert.Empty(t, cfg.AllowedVectorIndexTypes.Get())
+		assert.Empty(t, cfg.AllowedCompressionTypes.Get())
+	})
+
+	t.Run("empty-string scalar for non-slice fields still errors", func(t *testing.T) {
+		_, err := ParseRuntimeConfig([]byte(`maximum_allowed_collections_count: ""`))
+		require.Error(t, err)
+	})
+
 	t.Run("YAML tag should be lower_snake_case", func(t *testing.T) {
 		var r WeaviateRuntimeConfig
 


### PR DESCRIPTION
### What's being changed:

title

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
