### PR TITLE
fix(schema): don't 404 class config updates routed to a lagging follower

### DIFF
--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -468,20 +468,31 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 		if err := namespacing.QualifyPropertyDataTypes(principal, h.config.Namespaces.Enabled, updated.Properties); err != nil {
 			return fmt.Errorf("%w: %w", ErrValidation, err)
 		}
+	} else if updated != nil && updated.Class != "" {
+		// Auth is on the path but the RAFT command keys on updated.Class; pin
+		// them together so the body can't redirect the update to another class.
+		if schema.UppercaseClassName(updated.Class) != className {
+			return fmt.Errorf("%w: class name in body %q does not match path %q", ErrValidation, updated.Class, className)
+		}
+		updated.Class = className
 	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil || updated == nil {
 		return err
 	}
 
-	// Require DELETE permission on data when any TTL setting is being changed,
-	// but not when the user is updating other collection settings without
-	// touching TTL configuration.
+	// ReadOnlyClass is a local, no-wait read; on a lagging follower confirm
+	// against the leader before 404ing (also gates the TTL permission below).
 	initial := h.schemaReader.ReadOnlyClass(className)
 	if initial == nil {
-		// Reject here so the body's Class field can't redirect the
-		// update to a different, existing class.
-		return fmt.Errorf("class %q: %w", className, ErrNotFound)
+		vclasses, err := h.schemaManager.QueryReadOnlyClasses(className)
+		if err != nil {
+			return err
+		}
+		initial = vclasses[className].Class
+		if initial == nil {
+			return fmt.Errorf("class %q: %w", className, ErrNotFound)
+		}
 	}
 	if ttl.IsTtlConfigChanged(initial.ObjectTTLConfig, updated.ObjectTTLConfig) {
 		if err := h.Authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.CollectionsData(className)...); err != nil {

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/cluster/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/config/runtime"
@@ -1419,10 +1420,42 @@ func Test_UpdateClass(t *testing.T) {
 	t.Run("class not found", func(t *testing.T) {
 		handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 		fakeSchemaManager.On("ReadOnlyClass", "WrongClass", mock.Anything).Return(nil)
+		fakeSchemaManager.On("QueryReadOnlyClasses", []string{"WrongClass"}).
+			Return(map[string]versioned.Class{}, nil)
 
 		err := handler.UpdateClass(context.Background(), nil, "WrongClass", &models.Class{ReplicationConfig: &models.ReplicationConfig{Factor: 1}})
 		require.ErrorIs(t, err, ErrNotFound)
 		fakeSchemaManager.AssertExpectations(t)
+	})
+
+	t.Run("stale local view falls back to leader and proceeds", func(t *testing.T) {
+		// Regression: a lagging follower must defer to the leader, not 404.
+		handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+		existing := &models.Class{
+			Class:             "Article",
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+		fakeSchemaManager.On("ReadOnlyClass", "Article", mock.Anything).Return(nil)
+		fakeSchemaManager.On("QueryReadOnlyClasses", []string{"Article"}).
+			Return(map[string]versioned.Class{"Article": {Class: existing}}, nil)
+		fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
+
+		err := handler.UpdateClass(context.Background(), nil, "Article", &models.Class{
+			Class:             "Article",
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		})
+		require.NoError(t, err)
+		fakeSchemaManager.AssertExpectations(t)
+	})
+
+	t.Run("body class name must match path", func(t *testing.T) {
+		handler, _ := newTestHandler(t, &fakeDB{})
+		err := handler.UpdateClass(context.Background(), nil, "Article", &models.Class{
+			Class:             "OtherClass",
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		})
+		require.ErrorIs(t, err, ErrValidation)
+		require.Contains(t, err.Error(), "does not match path")
 	})
 
 	t.Run("immutable vectorizer properties", func(t *testing.T) {
@@ -1556,12 +1589,12 @@ func Test_UpdateClass(t *testing.T) {
 			expectedError error
 		}{
 			{
+				// Rejected by the path-vs-body guard, which fires before the immutable-fields check.
 				name:    "ChangeName",
 				initial: &models.Class{Class: "InitialName", Vectorizer: "none", ReplicationConfig: &models.ReplicationConfig{Factor: 1}},
 				update:  &models.Class{Class: "UpdatedName", Vectorizer: "none", ReplicationConfig: &models.ReplicationConfig{Factor: 1}},
 				expectedError: fmt.Errorf(
-					"class name is immutable: " +
-						"attempted change from \"InitialName\" to \"UpdatedName\""),
+					"class name in body \"UpdatedName\" does not match path \"InitialName\""),
 			},
 			{
 				name:    "ModifyVectorizer",


### PR DESCRIPTION
## What's the problem

`UpdateClass` (the handler behind `PUT /v1/schema/{class}`, i.e. collection config updates) used this node's **local** schema view as a hard existence gate:

```go
initial := h.schemaReader.ReadOnlyClass(className) // version 0, no wait, local only
if initial == nil {
    return ErrNotFound // -> HTTP 404
}
```

`ReadOnlyClass` reads only the local RAFT FSM at version 0 with no wait. On a follower that has not yet applied the class-create command, this transiently returns `nil` for a class that already exists cluster-wide. A config update routed to that lagging follower then 404s even though the class is real. This surfaces under concurrent schema churn — e.g. the autotenant e2e suite under `pytest-xdist`. It's a regression from a91f1325cd ("Fix inconsistency in class update between path and body"), which introduced the local-read existence gate.

The tricky part: that same gate was quietly doing **double duty**. It was also the only thing stopping a request body whose `Class` field names a *different* class than the path from redirecting the update. The RAFT update command is keyed on `updated.Class`, but authorization is keyed on the path's class name — so the leader's FSM can't catch that redirect (it validates against the body's target, not the authorized path). Simply relaxing the existence check would reopen that hole.

## Approach

Split the two concerns the old gate was conflating:

1. **Path-vs-body guard, independent of any schema read.** Non-namespaced callers now get an explicit check that `updated.Class` matches the path (namespaced callers already had one), and `updated.Class` is canonicalized to the path name. The body can no longer redirect the update regardless of what any node's schema view says.

2. **Leader-consistent existence fallback.** On a local-read miss, confirm existence via `QueryReadOnlyClasses` before deciding. This routes to the leader (`raft_query_endpoints.go` `Query` — local if leader, forwarded otherwise), so a lagging follower proceeds to the leader (which authoritatively enforces existence and all immutable-field validation via `schema.updateClass` / `ParseClassUpdate`), while a class the leader confirms absent still returns `ErrNotFound` (404).

The local read stays as the fast path; the leader round-trip only happens on a miss, so the common case is unchanged.

## Key areas for review

- The new path-vs-body guard in `UpdateClass`. Verify it can't be bypassed and that canonicalization (`UppercaseClassName` + assign) matches what the namespaced branch above does.
- The leader-consistent fallback. Confirm the ordering: the guard runs *before* the existence check, so even the leader fallback can't be used to smuggle a mismatched body through.

## Risks and mitigations

- **Extra leader round-trip on the update path**: only incurred on a local-read miss (the lagging-follower case), not the steady state. The hot path (`ReadOnlyClass` hit) is unchanged.
- **Reopening the body-redirect hole** that the original gate plugged: explicitly prevented — the path-vs-body guard now enforces this directly and independently of the schema view, which is strictly stronger than relying on a `nil` local read.
- **Behavioral change to the "rename via body" error**: renaming a class through the body now fails with `class name in body ... does not match path` (from the new guard, which fires earlier) instead of the old `class name is immutable` message. Same rejection, earlier and clearer; mirrors what namespaced callers already get.

## Testing

Unit tests in `class_test.go`:
- **`stale local view falls back to leader and proceeds`** — regression test for the spurious 404: local `ReadOnlyClass` returns `nil`, leader-consistent read finds the class, update routes to RAFT instead of 404ing.
- **`body class name must match path`** — the redirect guard rejects a mismatched body with `ErrValidation`, independent of the schema view.
- **`class not found`** (updated) — now mocks the leader-consistent read returning empty, asserting a genuinely-absent class still yields `ErrNotFound`.

## Test changes

- `Test_UpdateClass/class not found`: added a `QueryReadOnlyClasses` mock returning an empty map. With the new fallback the handler also consults the leader before returning `ErrNotFound`. The assertion (`ErrorIs ErrNotFound`) is unchanged — the genuine-404 path is preserved, just with the new code path mocked.
- `Test_UpdateClass` immutable-fields table, `ChangeName` case: expected error updated from `class name is immutable: attempted change from "InitialName" to "UpdatedName"` to `class name in body "UpdatedName" does not match path "InitialName"`. The path-vs-body guard now rejects a body/path class mismatch *before* the immutable-fields check. Coverage of "renaming a class is rejected" is preserved, with the more specific error (mirrors the namespaced-caller path).

Tracking issue: weaviate/0-weaviate-issues#257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
