### PR TITLE
test: fix data race in TestAsyncRepairMultiTenancyColdTenantConfigUpdate

### DIFF
--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -281,11 +281,28 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 		// The peers fetched the throttled config on activation; its propagation
 		// delay exceeds this window, so no cycle can repair node 2 regardless of
 		// timing. Stale defaults would repair within the window, failing this.
-		require.Never(t, func() bool {
+		//
+		// Poll synchronously rather than with require.Never, whose condition
+		// goroutine can outlive the assertion and race the global helper client.
+		assertNotFullyRepaired := func() {
 			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
-			return len(resp) == objectCount
-		}, asyncRepairObservationWindow, 5*time.Second,
-			"restarted node received all objects despite async replication being throttled — the peers did not pick up the COLD-time config update")
+			require.NotEqual(t, objectCount, len(resp),
+				"restarted node received all objects despite async replication being throttled — the peers did not pick up the COLD-time config update")
+		}
+		timer := time.NewTimer(asyncRepairObservationWindow)
+		defer timer.Stop()
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		assertNotFullyRepaired()
+		for {
+			select {
+			case <-timer.C:
+				assertNotFullyRepaired() // also assert at the window boundary, not only on ticks
+				return
+			case <-ticker.C:
+				assertNotFullyRepaired()
+			}
+		}
 	})
 
 	t.Run("restore async replication frequency", func(t *testing.T) {


### PR DESCRIPTION
## Motivation

`TestAsyncRepairMultiTenancyColdTenantConfigUpdate` was racy under `-race`. The defect was not in product code but in the test's use of the shared test-helper client — a `DATA RACE` between the "validate restarted node does not repair while throttled" subtest and the one that runs right after it.

## The race

The throttled-repair check used `require.Never`, whose condition closure is evaluated on a **background goroutine**. The closure called `common.GQLTenantGet(... node 2 ...)`, which calls `helper.SetupClient` — a **write** to the package-global `helper.ServerHost` / `helper.ServerPort` ([objects.go:38](https://github.com/weaviate/weaviate/blob/1a28e93d64758cd8a5c4c61e917636cf80493d6a/test/helper/objects.go#L38)). Those globals are unsynchronized.

`require.Never` returns once its window elapses, but it does not join the condition goroutine, so that goroutine can still be mid-`SetupClient` when the assertion returns. The next subtest ("restore async replication frequency") calls `helper.Client(t)`, which **reads** the same globals ([client.go:47](https://github.com/weaviate/weaviate/blob/1a28e93d64758cd8a5c4c61e917636cf80493d6a/test/helper/client.go#L47)). Write-on-outliving-goroutine vs. read-on-test-goroutine = data race.

## Approach

Replace `require.Never` with a synchronous poll on the test goroutine over the same `asyncRepairObservationWindow` (90s), asserting `len(resp) != objectCount`. A `time.Timer` (window) + `time.Ticker` (5s) `select` drives the loop — checking on each tick and once more when the timer fires — so the whole window, including its final interval, is covered and total runtime is **bounded to the window** (no sleep overshoot). This keeps **all** global-client access on a single goroutine — eliminating the race — while preserving the two behaviors the original relied on:

- the negative control (node 2 must *not* reach `objectCount` while repair is throttled), and
- the periodic node-2 query, which keeps node 2's lazily-loaded tenant shard warm during the window (so a regression that lets defaults repair node 2 is still observable).

Tightening `require.Never`'s timing wouldn't fix this — the defect is the cross-goroutine access to mutable global state, not the window length. Removing the second goroutine is the fix.

## Key areas for review

- [`async_repair_multi_tenancy_test.go:280`](https://github.com/weaviate/weaviate/blob/1a28e93d64758cd8a5c4c61e917636cf80493d6a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go#L280) — the poll loop. Confirm it is equivalent to the old `require.Never`: same window, the same assertion (`require.NotEqual(objectCount, len(resp))`) on every tick and at the window boundary, same node-2 endpoint, and total runtime bounded to the window.

## Risks and mitigations

- **Equivalence with `require.Never`**: `require.Never` fails if the condition is *ever* true within the window; the loop achieves the same by asserting the negation every tick and failing immediately on a match. Async repair only adds objects, so the count is monotonic and the per-tick check is sufficient. Test-only change, no product behavior affected.

## Testing

- `go test -race` for `TestAsyncRepairMultiTenancyColdTenantConfigUpdate` — **PASS, 0 data races** (previously flagged a `DATA RACE` on the helper-client globals). The synchronous-poll approach was exercised across multiple `-race` runs; the negative-control subtest runs the full **90.0s** window with no overshoot.
- `go vet ./test/acceptance/replication/async_replication/` — clean.
- `gofumpt -l` on the file — clean.
- `./tools/linter_go_routines.sh` — clean.
