### PR TITLE
test: deflake TestReplicationDigestObjectsInRange/TruncatedBinaryRecord (backport #11511 to v1.36)

### DIFF
--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -793,6 +793,7 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		_, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read digest in range record")


### PR DESCRIPTION
Backport of #11511 to `stable/v1.36`.

## Summary

Deflakes `TestReplicationDigestObjectsInRange/TruncatedBinaryRecord`, which flakes in CI with:

```
Error: "connect: Post \".../digestsInRange?...\": context deadline exceeded"
       does not contain "read digest in range record"
```

The subtest writes 10 raw bytes (less than the 24-byte record length) and expects the client to surface the truncation as `"read digest in range record: unexpected EOF"`. With the test helper's default `timeoutUnit=20ms`, the per-request deadline of `timeoutUnit*20 = 400ms` can be exceeded by a localhost HTTP round-trip under parallel `-race` CI load — the client returns the connection-level deadline error before the body-parse branch that produces the expected error message is ever reached.

The fix bumps `c.timeoutUnit` to `time.Second` to match the sibling binary-stream subtests (`BinaryResponse`, `JSONFallback`, `EmptyBinaryResponse`), which already set the same value.

Test-only change; cherry-picked cleanly from a93162ba81eda984a06b6c9de080933c7f494507.

## Test plan

- [x] `go test -count 1 -run 'TestReplicationDigestObjectsInRange/TruncatedBinaryRecord' ./adapters/clients/` — pass
