### PR TITLE
fix(hnsw): guard insert-path compression-state reads under compressActionLock

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress_multivector_concurrency_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_multivector_concurrency_test.go
@@ -1,0 +1,109 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// AddMultiBatch reads the compression trio in two spots — the PreloadMulti
+// branch and growIndexToAccomodateNode (index growth) — now both taken under
+// compressActionLock, like the rest of the insert/search paths.
+//
+// This runs many multivector inserts (which grow the index) concurrently with
+// enabling compression, asserting liveness and deadlock-freedom under the added
+// locking. The data race itself is gated by the atomic h.compressed flag, so
+// -race does not deterministically reproduce it; the fix rests on lock
+// discipline. BQ is used because it is training-free (no cache sampling).
+func TestAddMultiBatch_ConcurrentWithCompression(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	doc := func(id uint64) [][]float32 {
+		return testMultiVectors[id%uint64(len(testMultiVectors))]
+	}
+
+	uc := ent.UserConfig{
+		VectorCacheMaxObjects: 1e12,
+		MaxConnections:        8,
+		EFConstruction:        64,
+		EF:                    64,
+		Multivector:           ent.MultivectorConfig{Enabled: true},
+	}
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "multivec-compress-concurrency",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewDotProductProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		MakeBucketOptions:     lsmkv.MakeNoopBucketOptions,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{0}, errors.New("can not use VectorForIDThunk with multivector")
+		},
+		MultiVectorForIDThunk: func(ctx context.Context, id uint64) ([][]float32, error) {
+			return doc(id), nil
+		},
+		GetViewThunk: func() common.BucketView { return &noopBucketView{} },
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	t.Cleanup(func() { index.Shutdown(context.Background()) })
+
+	ctx := context.Background()
+	const seed = 500
+	for id := uint64(0); id < seed; id++ {
+		require.NoError(t, index.AddMulti(ctx, id, doc(id)))
+	}
+	index.cachePrefilled.Store(true)
+
+	// Writers add new docs (growing the index) throughout the rebuild.
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(start uint64) {
+			defer wg.Done()
+			id := start
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = index.AddMulti(ctx, id, doc(id))
+					id++
+				}
+			}
+		}(uint64(seed + w*1_000_000))
+	}
+
+	// Enable BQ compression; Upgrade runs compress() on its goroutine.
+	bq := uc
+	bq.BQ = ent.BQConfig{Enabled: true}
+	cbDone := make(chan struct{})
+	require.NoError(t, index.UpdateUserConfig(bq, func() { close(cbDone) }))
+	<-cbDone
+
+	close(done)
+	wg.Wait()
+}

--- a/adapters/repos/db/vector/hnsw/compress_multivector_concurrency_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_multivector_concurrency_test.go
@@ -80,6 +80,8 @@ func TestAddMultiBatch_ConcurrentWithCompression(t *testing.T) {
 	// Writers add new docs (growing the index) throughout the rebuild.
 	done := make(chan struct{})
 	var wg sync.WaitGroup
+	var writeErr error
+	var writeErrOnce sync.Once
 	for w := 0; w < 4; w++ {
 		wg.Add(1)
 		go func(start uint64) {
@@ -90,7 +92,10 @@ func TestAddMultiBatch_ConcurrentWithCompression(t *testing.T) {
 				case <-done:
 					return
 				default:
-					_ = index.AddMulti(ctx, id, doc(id))
+					if err := index.AddMulti(ctx, id, doc(id)); err != nil {
+						writeErrOnce.Do(func() { writeErr = err })
+						return
+					}
 					id++
 				}
 			}
@@ -106,4 +111,5 @@ func TestAddMultiBatch_ConcurrentWithCompression(t *testing.T) {
 
 	close(done)
 	wg.Wait()
+	require.NoError(t, writeErr)
 }

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -159,6 +159,29 @@ func (h *hnsw) checkAndCompress() error {
 	return err
 }
 
+// growIndexToAccomodateNodeUnderCompressLock grows the index from the batch
+// insert paths, which (unlike addOne) don't already hold compressActionLock.
+// growIndexToAccomodateNode grows the cache/compressor too, reading the
+// compression trio, so take the read lock to exclude a concurrent compress().
+func (h *hnsw) growIndexToAccomodateNodeUnderCompressLock(maxId uint64) error {
+	h.compressActionLock.RLock()
+	defer h.compressActionLock.RUnlock()
+
+	h.RLock()
+	if maxId < uint64(len(h.nodes)) {
+		h.RUnlock()
+		return nil
+	}
+	h.RUnlock()
+
+	h.Lock()
+	defer h.Unlock()
+	if maxId >= uint64(len(h.nodes)) {
+		return h.growIndexToAccomodateNode(maxId, h.logger)
+	}
+	return nil
+}
+
 func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -210,20 +233,8 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 		}
 		levels[i] = int(h.generateLevel()) // TODO: represent level as uint8
 	}
-	h.RLock()
-	if maxId >= uint64(len(h.nodes)) {
-		h.RUnlock()
-		h.Lock()
-		if maxId >= uint64(len(h.nodes)) {
-			err := h.growIndexToAccomodateNode(maxId, h.logger)
-			if err != nil {
-				h.Unlock()
-				return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
-			}
-		}
-		h.Unlock()
-	} else {
-		h.RUnlock()
+	if err := h.growIndexToAccomodateNodeUnderCompressLock(maxId); err != nil {
+		return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
 	}
 
 	for i := range ids {
@@ -333,31 +344,24 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 
 		maxId := counter + uint64(numVectors)
 
-		h.RLock()
-		if maxId >= uint64(len(h.nodes)) {
-			h.RUnlock()
-			h.Lock()
-			if maxId >= uint64(len(h.nodes)) {
-				err := h.growIndexToAccomodateNode(maxId, h.logger)
-				if err != nil {
-					h.Unlock()
-					return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
-				}
-			}
-			h.Unlock()
-		} else {
-			h.RUnlock()
+		if err := h.growIndexToAccomodateNodeUnderCompressLock(maxId); err != nil {
+			return errors.Wrapf(err, "grow HNSW index to accommodate node %d", maxId)
 		}
 
 		ids := make([]uint64, numVectors)
 		for id := range ids {
 			ids[id] = counter + uint64(id)
 		}
+		// Read the compression trio under compressActionLock, like addOne, so a
+		// concurrent compress() (which holds the write lock) can't swap the
+		// compressor / drop the cache underneath this preload.
+		h.compressActionLock.RLock()
 		if h.compressed.Load() {
 			h.compressor.PreloadMulti(docID, ids, vectors[i])
 		} else {
 			h.cache.PreloadMulti(docID, ids, vectors[i])
 		}
+		h.compressActionLock.RUnlock()
 		for j := range numVectors {
 			if err := ctx.Err(); err != nil {
 				return err


### PR DESCRIPTION
AddMultiBatch reads the compression trio (h.compressed/h.compressor/h.cache) in two spots that did not hold compressActionLock: the PreloadMulti branch, and growIndexToAccomodateNode (index growth, reached from the AddBatch/AddMultiBatch grow blocks). compress() writes that trio under compressActionLock, so a concurrent batch insert could read a half-swapped compressor / dropped cache.

Fix: take compressActionLock.RLock around the PreloadMulti read, and route the batch grow blocks through a helper that holds the read lock (addOne and the search/delete paths already do this). The single-vector addOne path was already safe.

Test: TestAddMultiBatch_ConcurrentWithCompression runs multivector inserts (which grow the index) concurrently with enabling BQ compression, asserting liveness/deadlock-freedom under the added locking. The race is gated by the atomic h.compressed flag, so -race does not deterministically reproduce it; the fix rests on matching the lock discipline of the rest of the insert/search paths.

Base: stable/v1.36. Forward-port to v1.37/v1.38/main.