### PR TITLE
test: deflake replication client tests via generous default timeoutUnit

### DIFF
--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -628,7 +628,6 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		c.timeoutUnit = time.Second
 		got, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.NoError(t, err)
 		require.Equal(t, expected, got)
@@ -643,7 +642,6 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		c.timeoutUnit = time.Second
 		got, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.NoError(t, err)
 		require.Equal(t, expected, got)
@@ -663,7 +661,6 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		c.timeoutUnit = time.Second
 		_, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "status code")
@@ -677,7 +674,6 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		c.timeoutUnit = time.Second
 		_, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read digest")
@@ -719,9 +715,6 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		// timeoutUnit*20 is the per-request deadline; set it large enough to
-		// survive CI scheduling jitter without relying on retry.
-		c.timeoutUnit = time.Second
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
@@ -740,7 +733,6 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		c.timeoutUnit = time.Second
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
@@ -759,7 +751,6 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		c.timeoutUnit = time.Second
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		assert.Empty(t, got)
@@ -793,7 +784,6 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
-		c.timeoutUnit = time.Second
 		_, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read digest in range record")
@@ -941,6 +931,8 @@ func newReplicationClient(t *testing.T, httpClient *http.Client) *replicationCli
 	require.NoError(t, err)
 	c.minBackOff = time.Millisecond * 1
 	c.maxBackOff = time.Millisecond * 8
-	c.timeoutUnit = time.Millisecond * 20
+	// Generous deadline: a localhost round-trip under -race CI load otherwise
+	// loses to it, surfacing "context deadline exceeded" instead of the real error.
+	c.timeoutUnit = time.Second
 	return c
 }

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -366,11 +366,9 @@ func TestReplicationAbort(t *testing.T) {
 	ts := fs.server(t)
 	defer ts.Close()
 	client := newReplicationClient(t, ts.Client())
-	// Abort's per-request deadline is timeoutUnit*ABORT_TIMEOUT_VALUE. With the
-	// default 20ms timeoutUnit that is only 100ms, which races a localhost
-	// round-trip and loses under parallel -race CPU load. Bump timeoutUnit so
-	// the deadline (4s) dwarfs both the round-trip and the retry budget (72ms),
-	// for every subtest below — not just ServerInternalError.
+	// Pin timeoutUnit to the retry budget so Abort's deadline
+	// (timeoutUnit*ABORT_TIMEOUT_VALUE = 4s) dwarfs the round-trip and retries
+	// for every subtest below, independent of the helper default.
 	client.timeoutUnit = client.maxBackOff * 100
 
 	t.Run("ConnectionError", func(t *testing.T) {


### PR DESCRIPTION
## Motivation

CI surfaced a flake in `TestReplicationDigestObjectsInRange/ServerError`:

```
"connect: Post \"http://127.0.0.1:.../digestsInRange?...\": context deadline exceeded" does not contain "status code"
```

The test helper `newReplicationClient` set `timeoutUnit = 20ms`. The client derives each request's context deadline as `timeoutUnit * MULTIPLIER` (e.g. `QUERY_TIMEOUT_VALUE = 20` → 400ms). Under parallel `-race` CI load a localhost round-trip can exceed that deadline, so the client returns `context deadline exceeded` from the deadline *before* it reads the real server response/error — exactly what the assertions check against.

This is the same root cause already patched piecemeal in earlier deflake work (#11511 for `TruncatedBinaryRecord`, the `TestReplicationAbort` override, and the per-subtest `c.timeoutUnit = time.Second` bumps in the binary-stream tests). `ServerError` was simply never bumped.

## Change

Rather than keep adding per-subtest bumps (and risk the next new test re-introducing the flake by forgetting one), raise the default `timeoutUnit` to `1s` in the `newReplicationClient` helper and remove the now-redundant scattered overrides.

- `timeoutUnit` only governs the per-request **context deadline**. On a healthy localhost response the deadline never fires, so a generous value is harmless and only affects genuinely stuck requests.
- `minBackOff` / `maxBackOff` are **unchanged** — they bound the retry budget (`MaxElapsedTime = n * maxBackOff`), which is independent of the deadline. The 1s deadline comfortably dwarfs the retry budget, which is the desired relationship.
- `TestReplicationAbort` is left as-is: it sets its own `timeoutUnit` explicitly to exercise a specific deadline/backoff relationship.

Net `-8` lines; the helper now owns the deadline for every server-backed test.

## Target branch

Opened against `stable/v1.36` so the fix flows up to v1.37 / v1.38 via the normal merge-forward, where the same `ServerError` flake exists.

## Test

`go test -race -count 1 ./adapters/clients/` passes locally.