### PR TITLE
Concurrent namespace test

### DIFF
--- a/test/acceptance/namespace/auto_schema_test.go
+++ b/test/acceptance/namespace/auto_schema_test.go
@@ -31,6 +31,7 @@ import (
 // A global principal on the same cluster cannot trigger auto-schema and
 // must be rejected with 403.
 func TestNamespaces_AutoSchema(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("auto-create class on first object insert", func(t *testing.T) {

--- a/test/acceptance/namespace/auto_schema_test.go
+++ b/test/acceptance/namespace/auto_schema_test.go
@@ -31,11 +31,11 @@ import (
 // A global principal on the same cluster cannot trigger auto-schema and
 // must be rejected with 403.
 func TestNamespaces_AutoSchema(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("auto-create class on first object insert", func(t *testing.T) {
 		const class = "AutoCreated"
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+class, adminKey) })
 
 		id := strfmt.UUID("11111111-aaaa-bbbb-cccc-111111111111")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -52,8 +52,8 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		assert.Equal(t, "Inception", got.Properties.(map[string]any)["title"])
 
 		// Admin's raw schema view confirms a single-qualified class exists.
-		gotClass := helper.GetClassAuth(t, "customer1:"+class, adminKey)
-		assert.Equal(t, "customer1:"+class, gotClass.Class)
+		gotClass := helper.GetClassAuth(t, ns1+":"+class, adminKey)
+		assert.Equal(t, ns1+":"+class, gotClass.Class)
 
 		// Same short name in a second namespace creates an independent class.
 		_, err = helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -62,15 +62,15 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 			Properties: map[string]any{"title": "Memento"},
 		}, user2Key)
 		require.NoError(t, err)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer2:"+class, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns2+":"+class, adminKey) })
 
-		gotClass2 := helper.GetClassAuth(t, "customer2:"+class, adminKey)
-		assert.Equal(t, "customer2:"+class, gotClass2.Class)
+		gotClass2 := helper.GetClassAuth(t, ns2+":"+class, adminKey)
+		assert.Equal(t, ns2+":"+class, gotClass2.Class)
 	})
 
 	t.Run("auto-add property on object insert", func(t *testing.T) {
 		const class = "AutoProp"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		id := strfmt.UUID("22222222-aaaa-bbbb-cccc-222222222222")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -90,20 +90,20 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		assert.Equal(t, "Tenet", props["title"])
 		assert.NotNil(t, props["runtime"])
 
-		gotNs1 := helper.GetClassAuth(t, "customer1:"+class, adminKey)
+		gotNs1 := helper.GetClassAuth(t, ns1+":"+class, adminKey)
 		assert.True(t, hasProperty(gotNs1, "runtime"),
-			"runtime property should have been auto-added to customer1:%s", class)
+			"runtime property should have been auto-added to %s:%s", ns1, class)
 
-		// The schema change is namespace-local: customer2's class with the
-		// same short name must not inherit "runtime".
-		gotNs2 := helper.GetClassAuth(t, "customer2:"+class, adminKey)
+		// The schema change is namespace-local: the second namespace's class with
+		// the same short name must not inherit "runtime".
+		gotNs2 := helper.GetClassAuth(t, ns2+":"+class, adminKey)
 		assert.False(t, hasProperty(gotNs2, "runtime"),
-			"runtime property must not appear on customer2:%s", class)
+			"runtime property must not appear on %s:%s", ns2, class)
 	})
 
 	t.Run("auto-add property via PUT", func(t *testing.T) {
 		const class = "AutoPropPut"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		id := strfmt.UUID("33333333-aaaa-bbbb-cccc-333333333333")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -125,14 +125,14 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		gotClass := helper.GetClassAuth(t, "customer1:"+class, adminKey)
+		gotClass := helper.GetClassAuth(t, ns1+":"+class, adminKey)
 		assert.True(t, hasProperty(gotClass, "rating"),
 			"rating property should have been auto-added via PUT")
 	})
 
 	t.Run("auto-add property via PATCH", func(t *testing.T) {
 		const class = "AutoPropPatch"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		id := strfmt.UUID("44444444-aaaa-bbbb-cccc-444444444444")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -152,7 +152,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		gotClass := helper.GetClassAuth(t, "customer1:"+class, adminKey)
+		gotClass := helper.GetClassAuth(t, ns1+":"+class, adminKey)
 		assert.True(t, hasProperty(gotClass, "director"),
 			"director property should have been auto-added via PATCH")
 	})
@@ -160,7 +160,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 	t.Run("auto-create tenant on single-object insert", func(t *testing.T) {
 		const class = "AutoTenantSingle"
 		mustCreateMTClass(t, class, user1Key, mtAutoCreate)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+class, adminKey) })
 
 		id := strfmt.UUID("55555555-aaaa-bbbb-cccc-555555555555")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -180,7 +180,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 	t.Run("auto-create tenant on batch insert", func(t *testing.T) {
 		const class = "AutoTenantBatch"
 		mustCreateMTClass(t, class, user1Key, mtAutoCreate)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+class, adminKey) })
 
 		id1 := strfmt.UUID("66666666-aaaa-bbbb-cccc-666666666666")
 		id2 := strfmt.UUID("66666666-aaaa-bbbb-cccc-777777777777")
@@ -200,7 +200,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 	t.Run("auto-activate cold tenant on insert", func(t *testing.T) {
 		const class = "AutoTenantActivate"
 		mustCreateMTClass(t, class, user1Key, mtAutoActivate)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+class, adminKey) })
 
 		// Pre-create tenant HOT, then deactivate.
 		helper.CreateTenantsAuth(t, class,
@@ -230,14 +230,14 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		// Auto-schema detects a beacon-shaped value in the payload and adds a
 		// cross-ref property whose DataType is the SHORT target class. The
 		// schema handler then namespaces that DataType via
-		// QualifyPropertyDataTypes, so storage holds "customer1:Target".
+		// QualifyPropertyDataTypes, so storage holds the qualified target class.
 		// Pinned here because the path crosses three NS-aware seams:
 		//   1. The validator's QualifyRefTarget call on the beacon's class.
 		//   2. The schema handler qualifying the auto-added DataType.
 		//   3. The class-response stripping back to short on read.
 		const source, target = "AutoRefSource", "AutoRefTarget"
-		setupClassInNs1(t, source, user1Key)
-		setupClassInNs1(t, target, user1Key)
+		setupClassInNs1(t, ns1, source, user1Key)
+		setupClassInNs1(t, ns1, target, user1Key)
 
 		targetID := strfmt.UUID("88888888-aaaa-bbbb-cccc-111111111111")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -258,7 +258,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		// Admin sees the qualified DataType in storage.
-		gotAdmin := helper.GetClassAuth(t, "customer1:"+source, adminKey)
+		gotAdmin := helper.GetClassAuth(t, ns1+":"+source, adminKey)
 		var foundDT []string
 		for _, p := range gotAdmin.Properties {
 			if p.Name == "linkedTo" {
@@ -266,7 +266,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 			}
 		}
 		require.Len(t, foundDT, 1, "linkedTo should have been auto-added with one DataType entry")
-		assert.Equal(t, "customer1:"+target, foundDT[0],
+		assert.Equal(t, ns1+":"+target, foundDT[0],
 			"auto-schema must qualify the cross-ref DataType under the caller's namespace")
 
 		// Namespaced caller reads it back as the short form (response stripping).
@@ -279,7 +279,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		}
 
 		// And the stored beacon is short (portability invariant).
-		got, err := helper.GetObjectAuth(t, "customer1:"+source, sourceID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":"+source, sourceID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["linkedTo"].([]interface{})
 		require.Len(t, refs, 1)

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -13,6 +13,7 @@ package namespace
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,10 +85,9 @@ func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
 // caller's namespace; on top of that sits the handler-level
 // IsGlobalOperator/Namespace check plus the entity-name validators.
 func TestNamespaces_CollectionAndAlias(t *testing.T) {
-	const (
-		ns1 = "customer1"
-		ns2 = "customer2"
-	)
+	ns1 := uniqueNS()
+	ns2 := uniqueNS()
+	upperNS := func(ns string) string { return strings.ToUpper(ns[:1]) + ns[1:] }
 
 	helper.CreateNamespace(t, ns1, adminKey)
 	helper.CreateNamespace(t, ns2, adminKey)
@@ -104,30 +104,30 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	t.Run("namespace-local alias create succeeds and is independent across namespaces", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
 		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user2Key)
-		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
-		defer helper.DeleteClassAuth(t, "customer2:Movies", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
+		defer helper.DeleteClassAuth(t, ns2+":Movies", adminKey)
 
 		// Admin (global) sees both qualified collections.
-		gotClass1 := helper.GetClassAuth(t, "customer1:Movies", adminKey)
-		require.Equal(t, "customer1:Movies", gotClass1.Class)
-		gotClass2 := helper.GetClassAuth(t, "customer2:Movies", adminKey)
-		require.Equal(t, "customer2:Movies", gotClass2.Class)
+		gotClass1 := helper.GetClassAuth(t, ns1+":Movies", adminKey)
+		require.Equal(t, ns1+":Movies", gotClass1.Class)
+		gotClass2 := helper.GetClassAuth(t, ns2+":Movies", adminKey)
+		require.Equal(t, ns2+":Movies", gotClass2.Class)
 
-		// user1: Films -> Movies. The handler qualifies both to customer1:.
+		// user1: Films -> Movies. The handler qualifies both to ns1:.
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Films", Class: "Movies"}, user1Key)
 		// user2 can independently create the same short alias name.
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Films", Class: "Movies"}, user2Key)
 
 		// Admin can see both qualified aliases exist.
-		got1 := helper.GetAliasWithAuthz(t, "customer1:Films", helper.CreateAuth(adminKey))
-		require.Equal(t, "customer1:Films", got1.Alias)
-		require.Equal(t, "customer1:Movies", got1.Class)
-		got2 := helper.GetAliasWithAuthz(t, "customer2:Films", helper.CreateAuth(adminKey))
-		require.Equal(t, "customer2:Films", got2.Alias)
-		require.Equal(t, "customer2:Movies", got2.Class)
+		got1 := helper.GetAliasWithAuthz(t, ns1+":Films", helper.CreateAuth(adminKey))
+		require.Equal(t, ns1+":Films", got1.Alias)
+		require.Equal(t, ns1+":Movies", got1.Class)
+		got2 := helper.GetAliasWithAuthz(t, ns2+":Films", helper.CreateAuth(adminKey))
+		require.Equal(t, ns2+":Films", got2.Alias)
+		require.Equal(t, ns2+":Movies", got2.Class)
 
-		defer helper.DeleteAliasWithAuthz(t, "customer1:Films", helper.CreateAuth(adminKey))
-		defer helper.DeleteAliasWithAuthz(t, "customer2:Films", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Films", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns2+":Films", helper.CreateAuth(adminKey))
 	})
 
 	t.Run("end-to-end: insert and get object via alias, with cross-namespace isolation", func(t *testing.T) {
@@ -143,17 +143,17 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 				},
 			}, key)
 		}
-		defer helper.DeleteClassAuth(t, "customer1:E2EFilmsTarget", adminKey)
-		defer helper.DeleteClassAuth(t, "customer2:E2EFilmsTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":E2EFilmsTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns2+":E2EFilmsTarget", adminKey)
 
 		// Both namespaces get the same short alias name pointing at their own copy.
 		for _, key := range []string{user1Key, user2Key} {
 			helper.CreateAliasAuth(t, &models.Alias{Alias: "E2EFilmsAlias", Class: "E2EFilmsTarget"}, key)
 		}
-		defer helper.DeleteAliasWithAuthz(t, "customer1:E2EFilmsAlias", helper.CreateAuth(adminKey))
-		defer helper.DeleteAliasWithAuthz(t, "customer2:E2EFilmsAlias", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":E2EFilmsAlias", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns2+":E2EFilmsAlias", helper.CreateAuth(adminKey))
 
-		// user1 inserts via the alias name; on disk it lands as customer1:E2EFilmsTarget.
+		// user1 inserts via the alias name; on disk it lands as ns1:E2EFilmsTarget.
 		// retryOnAliasLag absorbs the brief window where the alias entry has
 		// been applied on the leader but the follower we are talking to has
 		// not yet replicated it, so local alias resolution would 500.
@@ -180,7 +180,7 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 
 		// Cross-namespace isolation: user2 asks for the same id under the same
 		// short class name and the same short alias name. Both qualify to
-		// customer2:* — different shard, no such object → 404.
+		// ns2:* — different shard, no such object → 404.
 		_, err = helper.GetObjectAuth(t, "E2EFilmsTarget", obj.ID, user2Key)
 		require.Error(t, err)
 		var nfClass *objectsCli.ObjectsClassGetNotFound
@@ -199,7 +199,7 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	})
 
 	t.Run("namespaced caller submitting class name with ':' rejected", func(t *testing.T) {
-		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{Class: "Customer2:Movies"}, user1Key)
+		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{Class: upperNS(ns2) + ":Movies"}, user1Key)
 		require.Error(t, err)
 		var unproc *schema.SchemaObjectsCreateUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected SchemaObjectsCreateUnprocessableEntity, got %T: %v", err, err)
@@ -207,14 +207,14 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	})
 
 	t.Run("namespaced caller submitting alias with ':' in target rejected", func(t *testing.T) {
-		_, err := helper.CreateAliasAuthWithReturn(t, &models.Alias{Alias: "Films", Class: "Customer2:Movies"}, user1Key)
+		_, err := helper.CreateAliasAuthWithReturn(t, &models.Alias{Alias: "Films", Class: upperNS(ns2) + ":Movies"}, user1Key)
 		require.Error(t, err)
 		var unproc *schema.AliasesCreateUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected AliasesCreateUnprocessableEntity, got %T: %v", err, err)
 	})
 
 	t.Run("namespaced caller submitting alias with ':' in alias name rejected", func(t *testing.T) {
-		_, err := helper.CreateAliasAuthWithReturn(t, &models.Alias{Alias: "Customer2:Films", Class: "Movies"}, user1Key)
+		_, err := helper.CreateAliasAuthWithReturn(t, &models.Alias{Alias: upperNS(ns2) + ":Films", Class: "Movies"}, user1Key)
 		require.Error(t, err)
 		var unproc *schema.AliasesCreateUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected AliasesCreateUnprocessableEntity, got %T: %v", err, err)
@@ -231,13 +231,13 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "DeleteMe"}, user1Key)
 
 		// Confirm the qualified class exists before delete.
-		got := helper.GetClassAuth(t, "customer1:DeleteMe", adminKey)
-		require.Equal(t, "customer1:DeleteMe", got.Class)
+		got := helper.GetClassAuth(t, ns1+":DeleteMe", adminKey)
+		require.Equal(t, ns1+":DeleteMe", got.Class)
 
-		// Short-name delete from user1 must qualify to customer1:DeleteMe.
+		// Short-name delete from user1 must qualify to ns1:DeleteMe.
 		helper.DeleteClassAuth(t, "DeleteMe", user1Key)
 
-		_, err := helper.GetClassAuthWithReturn(t, "customer1:DeleteMe", adminKey)
+		_, err := helper.GetClassAuthWithReturn(t, ns1+":DeleteMe", adminKey)
 		require.Error(t, err)
 	})
 
@@ -246,30 +246,30 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		for _, key := range []string{user1Key, user2Key} {
 			helper.CreateClassAuth(t, &models.Class{Class: "Shared"}, key)
 		}
-		defer helper.DeleteClassAuth(t, "customer2:Shared", adminKey)
+		defer helper.DeleteClassAuth(t, ns2+":Shared", adminKey)
 
-		// user1 deletes via the short name — only customer1:Shared should go.
+		// user1 deletes via the short name — only ns1:Shared should go.
 		helper.DeleteClassAuth(t, "Shared", user1Key)
 
-		_, err := helper.GetClassAuthWithReturn(t, "customer1:Shared", adminKey)
+		_, err := helper.GetClassAuthWithReturn(t, ns1+":Shared", adminKey)
 		require.Error(t, err)
 
-		got := helper.GetClassAuth(t, "customer2:Shared", adminKey)
-		require.Equal(t, "customer2:Shared", got.Class)
+		got := helper.GetClassAuth(t, ns2+":Shared", adminKey)
+		require.Equal(t, ns2+":Shared", got.Class)
 	})
 
 	t.Run("global admin deletes by qualified class name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminDelete"}, user1Key)
 
-		helper.DeleteClassAuth(t, "customer1:AdminDelete", adminKey)
+		helper.DeleteClassAuth(t, ns1+":AdminDelete", adminKey)
 
-		_, err := helper.GetClassAuthWithReturn(t, "customer1:AdminDelete", adminKey)
+		_, err := helper.GetClassAuthWithReturn(t, ns1+":AdminDelete", adminKey)
 		require.Error(t, err)
 	})
 
 	t.Run("namespaced caller updates its class via short path name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "UpdateMe", Description: "v1"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:UpdateMe", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":UpdateMe", adminKey)
 
 		// GET as the namespaced caller returns the stripped (short) class
 		// name; round-trip the same short name through both URL and body.
@@ -279,7 +279,7 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 
 		helper.UpdateClassAuth(t, "UpdateMe", got, user1Key)
 
-		after := helper.GetClassAuth(t, "customer1:UpdateMe", adminKey)
+		after := helper.GetClassAuth(t, ns1+":UpdateMe", adminKey)
 		assert.Equal(t, "v2", after.Description)
 	})
 
@@ -287,31 +287,31 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		for _, key := range []string{user1Key, user2Key} {
 			helper.CreateClassAuth(t, &models.Class{Class: "SharedUpdate", Description: "v1"}, key)
 		}
-		defer helper.DeleteClassAuth(t, "customer1:SharedUpdate", adminKey)
-		defer helper.DeleteClassAuth(t, "customer2:SharedUpdate", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":SharedUpdate", adminKey)
+		defer helper.DeleteClassAuth(t, ns2+":SharedUpdate", adminKey)
 
-		// user1's short-name update must only touch customer1:SharedUpdate.
+		// user1's short-name update must only touch ns1:SharedUpdate.
 		// GET as the namespaced caller so the round-tripped body carries
 		// the stripped short class name.
 		toUpdate := helper.GetClassAuth(t, "SharedUpdate", user1Key)
 		toUpdate.Description = "v2"
 		helper.UpdateClassAuth(t, "SharedUpdate", toUpdate, user1Key)
 
-		after1 := helper.GetClassAuth(t, "customer1:SharedUpdate", adminKey)
+		after1 := helper.GetClassAuth(t, ns1+":SharedUpdate", adminKey)
 		assert.Equal(t, "v2", after1.Description)
-		after2 := helper.GetClassAuth(t, "customer2:SharedUpdate", adminKey)
+		after2 := helper.GetClassAuth(t, ns2+":SharedUpdate", adminKey)
 		assert.Equal(t, "v1", after2.Description)
 	})
 
 	t.Run("global admin updates by qualified class name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminUpdate", Description: "v1"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AdminUpdate", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AdminUpdate", adminKey)
 
-		cls := helper.GetClassAuth(t, "customer1:AdminUpdate", adminKey)
+		cls := helper.GetClassAuth(t, ns1+":AdminUpdate", adminKey)
 		cls.Description = "by-admin"
-		helper.UpdateClassAuth(t, "customer1:AdminUpdate", cls, adminKey)
+		helper.UpdateClassAuth(t, ns1+":AdminUpdate", cls, adminKey)
 
-		after := helper.GetClassAuth(t, "customer1:AdminUpdate", adminKey)
+		after := helper.GetClassAuth(t, ns1+":AdminUpdate", adminKey)
 		assert.Equal(t, "by-admin", after.Description)
 	})
 
@@ -321,52 +321,52 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	// a namespaced cluster.
 	t.Run("namespaced caller cannot delete its class via an alias name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasDeleteTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasDeleteTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasDeleteTarget", adminKey)
 
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasDeleter", Class: "AliasDeleteTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasDeleter", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasDeleter", helper.CreateAuth(adminKey))
 
 		// DELETE by alias name must be a no-op on the underlying class.
 		// The HTTP delete returns 200 even for non-existent classes, so we
 		// verify the underlying class still exists afterwards.
 		helper.DeleteClassAuth(t, "AliasDeleter", user1Key)
 
-		got := helper.GetClassAuth(t, "customer1:AliasDeleteTarget", adminKey)
-		require.Equal(t, "customer1:AliasDeleteTarget", got.Class)
+		got := helper.GetClassAuth(t, ns1+":AliasDeleteTarget", adminKey)
+		require.Equal(t, ns1+":AliasDeleteTarget", got.Class)
 	})
 
 	t.Run("namespaced caller cannot update its class via an alias name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasUpdateTarget", Description: "v1"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasUpdateTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasUpdateTarget", adminKey)
 
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasUpdater", Class: "AliasUpdateTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasUpdater", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasUpdater", helper.CreateAuth(adminKey))
 
 		// Body carries the underlying class name (mimicking a caller that
 		// fetched the qualified class and only swapped the URL path to the
 		// alias). The handler must reject regardless because the URL path
-		// resolves to "customer1:AliasUpdater", which is an alias, not a
+		// resolves to ns1+":AliasUpdater", which is an alias, not a
 		// class.
-		body := helper.GetClassAuth(t, "customer1:AliasUpdateTarget", adminKey)
+		body := helper.GetClassAuth(t, ns1+":AliasUpdateTarget", adminKey)
 		body.Description = "v2"
 		_, err := helper.UpdateClassAuthWithReturn(t, "AliasUpdater", body, user1Key)
 		require.Error(t, err)
 
-		after := helper.GetClassAuth(t, "customer1:AliasUpdateTarget", adminKey)
+		after := helper.GetClassAuth(t, ns1+":AliasUpdateTarget", adminKey)
 		assert.Equal(t, "v1", after.Description)
 	})
 
 	t.Run("global admin cannot delete a class via a qualified alias name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminAliasDeleteTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AdminAliasDeleteTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AdminAliasDeleteTarget", adminKey)
 
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminAliasDeleter", Class: "AdminAliasDeleteTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AdminAliasDeleter", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AdminAliasDeleter", helper.CreateAuth(adminKey))
 
-		helper.DeleteClassAuth(t, "customer1:AdminAliasDeleter", adminKey)
+		helper.DeleteClassAuth(t, ns1+":AdminAliasDeleter", adminKey)
 
-		got := helper.GetClassAuth(t, "customer1:AdminAliasDeleteTarget", adminKey)
-		require.Equal(t, "customer1:AdminAliasDeleteTarget", got.Class)
+		got := helper.GetClassAuth(t, ns1+":AdminAliasDeleteTarget", adminKey)
+		require.Equal(t, ns1+":AdminAliasDeleteTarget", got.Class)
 	})
 
 	// A delete with a wrong-case namespace prefix must be rejected at the
@@ -375,17 +375,17 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	// directory, and left the schema entry behind — blocking recreation.
 	t.Run("delete with wrong-case namespace prefix is rejected and class is untouched", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "CaseDelete"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:CaseDelete", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":CaseDelete", adminKey)
 
-		err := helper.DeleteClassAuthWithReturn(t, "Customer1:CaseDelete", adminKey)
+		err := helper.DeleteClassAuthWithReturn(t, upperNS(ns1)+":CaseDelete", adminKey)
 		require.Error(t, err)
 
-		got := helper.GetClassAuth(t, "customer1:CaseDelete", adminKey)
-		require.Equal(t, "customer1:CaseDelete", got.Class)
+		got := helper.GetClassAuth(t, ns1+":CaseDelete", adminKey)
+		require.Equal(t, ns1+":CaseDelete", got.Class)
 
 		// Caller can still recreate after attempted bad-case delete fails,
 		// confirming no partial deletion occurred.
-		helper.DeleteClassAuth(t, "customer1:CaseDelete", adminKey)
+		helper.DeleteClassAuth(t, ns1+":CaseDelete", adminKey)
 		helper.CreateClassAuth(t, &models.Class{Class: "CaseDelete"}, user1Key)
 	})
 
@@ -394,17 +394,17 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	// coverage on the read side too.
 	t.Run("get with wrong-case namespace prefix returns 422", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "CaseGet"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:CaseGet", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":CaseGet", adminKey)
 
-		_, err := helper.GetClassAuthWithReturn(t, "Customer1:CaseGet", adminKey)
+		_, err := helper.GetClassAuthWithReturn(t, upperNS(ns1)+":CaseGet", adminKey)
 		require.Error(t, err)
 		var unproc *schema.SchemaObjectsGetUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected SchemaObjectsGetUnprocessableEntity, got %T: %v", err, err)
 		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
 
 		// Correct casing still works — the class is reachable as registered.
-		got := helper.GetClassAuth(t, "customer1:CaseGet", adminKey)
-		require.Equal(t, "customer1:CaseGet", got.Class)
+		got := helper.GetClassAuth(t, ns1+":CaseGet", adminKey)
+		require.Equal(t, ns1+":CaseGet", got.Class)
 	})
 
 	// Alias update/delete inherit the same namespace-aware qualification as
@@ -414,60 +414,60 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	// short name, exactly mirroring the create path.
 	t.Run("global admin alias delete with wrong-case namespace prefix returns 422", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseDeleteTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasCaseDeleteTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasCaseDeleteTarget", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasCaseDelete", Class: "AliasCaseDeleteTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasCaseDelete", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasCaseDelete", helper.CreateAuth(adminKey))
 
-		_, err := helper.DeleteAliasAuthWithReturn(t, "Customer1:AliasCaseDelete", adminKey)
+		_, err := helper.DeleteAliasAuthWithReturn(t, upperNS(ns1)+":AliasCaseDelete", adminKey)
 		require.Error(t, err)
 		var unproc *schema.AliasesDeleteUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected AliasesDeleteUnprocessableEntity, got %T: %v", err, err)
 		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
 
 		// Alias survives the malformed-prefix attempt.
-		got := helper.GetAliasWithAuthz(t, "customer1:AliasCaseDelete", helper.CreateAuth(adminKey))
-		require.Equal(t, "customer1:AliasCaseDelete", got.Alias)
+		got := helper.GetAliasWithAuthz(t, ns1+":AliasCaseDelete", helper.CreateAuth(adminKey))
+		require.Equal(t, ns1+":AliasCaseDelete", got.Alias)
 	})
 
 	t.Run("global admin alias update with wrong-case namespace prefix returns 422", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseUpdateA"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasCaseUpdateA", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasCaseUpdateA", adminKey)
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseUpdateB"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasCaseUpdateB", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasCaseUpdateB", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasCaseUpdate", Class: "AliasCaseUpdateA"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasCaseUpdate", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasCaseUpdate", helper.CreateAuth(adminKey))
 
 		// Wrong case in the alias path component is rejected.
-		_, err := helper.UpdateAliasAuthWithReturn(t, "Customer1:AliasCaseUpdate", "customer1:AliasCaseUpdateB", adminKey)
+		_, err := helper.UpdateAliasAuthWithReturn(t, upperNS(ns1)+":AliasCaseUpdate", ns1+":AliasCaseUpdateB", adminKey)
 		require.Error(t, err)
 		var unproc *schema.AliasesUpdateUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected AliasesUpdateUnprocessableEntity, got %T: %v", err, err)
 		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
 
 		// Wrong case in the target class is also rejected.
-		_, err = helper.UpdateAliasAuthWithReturn(t, "customer1:AliasCaseUpdate", "Customer1:AliasCaseUpdateB", adminKey)
+		_, err = helper.UpdateAliasAuthWithReturn(t, ns1+":AliasCaseUpdate", upperNS(ns1)+":AliasCaseUpdateB", adminKey)
 		require.Error(t, err)
 		require.True(t, errors.As(err, &unproc), "expected AliasesUpdateUnprocessableEntity, got %T: %v", err, err)
 		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
 
 		// Alias still points at its original target.
-		got := helper.GetAliasWithAuthz(t, "customer1:AliasCaseUpdate", helper.CreateAuth(adminKey))
-		require.Equal(t, "customer1:AliasCaseUpdateA", got.Class)
+		got := helper.GetAliasWithAuthz(t, ns1+":AliasCaseUpdate", helper.CreateAuth(adminKey))
+		require.Equal(t, ns1+":AliasCaseUpdateA", got.Class)
 	})
 
 	t.Run("namespaced caller deletes its own alias via short name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortDeleteTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasShortDeleteTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasShortDeleteTarget", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasShortDelete", Class: "AliasShortDeleteTarget"}, user1Key)
 
 		// Short name path is qualified by the principal's namespace, so the
-		// underlying "customer1:AliasShortDelete" alias is found and removed.
+		// underlying ns1+":AliasShortDelete" alias is found and removed.
 		_, err := helper.DeleteAliasAuthWithReturn(t, "AliasShortDelete", user1Key)
 		require.NoError(t, err)
 
 		// Lookup against the qualified name returns 404 after delete.
 		_, err = helper.Client(t).Schema.AliasesGetAlias(
-			schema.NewAliasesGetAliasParams().WithAliasName("customer1:AliasShortDelete"),
+			schema.NewAliasesGetAliasParams().WithAliasName(ns1+":AliasShortDelete"),
 			helper.CreateAuth(adminKey),
 		)
 		require.Error(t, err)
@@ -475,19 +475,19 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 
 	t.Run("namespaced caller updates its own alias via short name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortUpdateA"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasShortUpdateA", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasShortUpdateA", adminKey)
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortUpdateB"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasShortUpdateB", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasShortUpdateB", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasShortUpdate", Class: "AliasShortUpdateA"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasShortUpdate", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasShortUpdate", helper.CreateAuth(adminKey))
 
 		// Short names on both the alias and target are qualified with the
 		// caller's namespace; the alias re-points to the qualified target.
 		_, err := helper.UpdateAliasAuthWithReturn(t, "AliasShortUpdate", "AliasShortUpdateB", user1Key)
 		require.NoError(t, err)
 
-		got := helper.GetAliasWithAuthz(t, "customer1:AliasShortUpdate", helper.CreateAuth(adminKey))
-		require.Equal(t, "customer1:AliasShortUpdateB", got.Class)
+		got := helper.GetAliasWithAuthz(t, ns1+":AliasShortUpdate", helper.CreateAuth(adminKey))
+		require.Equal(t, ns1+":AliasShortUpdateB", got.Class)
 	})
 
 	// Global operators do not have a namespace, so qualification is a no-op
@@ -495,14 +495,14 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	// lookup. These tests confirm that path works end-to-end.
 	t.Run("global admin deletes alias via qualified name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminAliasQualifiedDeleteTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AdminAliasQualifiedDeleteTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AdminAliasQualifiedDeleteTarget", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminAliasQualifiedDelete", Class: "AdminAliasQualifiedDeleteTarget"}, user1Key)
 
-		_, err := helper.DeleteAliasAuthWithReturn(t, "customer1:AdminAliasQualifiedDelete", adminKey)
+		_, err := helper.DeleteAliasAuthWithReturn(t, ns1+":AdminAliasQualifiedDelete", adminKey)
 		require.NoError(t, err)
 
 		_, err = helper.Client(t).Schema.AliasesGetAlias(
-			schema.NewAliasesGetAliasParams().WithAliasName("customer1:AdminAliasQualifiedDelete"),
+			schema.NewAliasesGetAliasParams().WithAliasName(ns1+":AdminAliasQualifiedDelete"),
 			helper.CreateAuth(adminKey),
 		)
 		require.Error(t, err)
@@ -510,17 +510,17 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 
 	t.Run("global admin updates alias via qualified name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminAliasQualifiedUpdateA"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AdminAliasQualifiedUpdateA", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AdminAliasQualifiedUpdateA", adminKey)
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminAliasQualifiedUpdateB"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AdminAliasQualifiedUpdateB", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AdminAliasQualifiedUpdateB", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminAliasQualifiedUpdate", Class: "AdminAliasQualifiedUpdateA"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AdminAliasQualifiedUpdate", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AdminAliasQualifiedUpdate", helper.CreateAuth(adminKey))
 
-		_, err := helper.UpdateAliasAuthWithReturn(t, "customer1:AdminAliasQualifiedUpdate", "customer1:AdminAliasQualifiedUpdateB", adminKey)
+		_, err := helper.UpdateAliasAuthWithReturn(t, ns1+":AdminAliasQualifiedUpdate", ns1+":AdminAliasQualifiedUpdateB", adminKey)
 		require.NoError(t, err)
 
-		got := helper.GetAliasWithAuthz(t, "customer1:AdminAliasQualifiedUpdate", helper.CreateAuth(adminKey))
-		require.Equal(t, "customer1:AdminAliasQualifiedUpdateB", got.Class)
+		got := helper.GetAliasWithAuthz(t, ns1+":AdminAliasQualifiedUpdate", helper.CreateAuth(adminKey))
+		require.Equal(t, ns1+":AdminAliasQualifiedUpdateB", got.Class)
 	})
 
 	// Read paths (GET /aliases/{name} and GET /aliases?class=) qualify in
@@ -529,9 +529,9 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	// malformed prefixes surface as 422.
 	t.Run("namespaced caller gets its own alias via short name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortGetTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasShortGetTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasShortGetTarget", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasShortGet", Class: "AliasShortGetTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasShortGet", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasShortGet", helper.CreateAuth(adminKey))
 
 		// Short name is qualified with the principal's namespace, and the
 		// response is stripped back to the short form for namespaced callers.
@@ -541,40 +541,40 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		require.Equal(t, "AliasShortGetTarget", resp.Payload.Class)
 
 		// Admin sees qualified Alias/Class verbatim (strip is a no-op).
-		respAdmin, err := helper.GetAliasAuthWithReturn(t, "customer1:AliasShortGet", adminKey)
+		respAdmin, err := helper.GetAliasAuthWithReturn(t, ns1+":AliasShortGet", adminKey)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:AliasShortGet", respAdmin.Payload.Alias,
+		assert.Equal(t, ns1+":AliasShortGet", respAdmin.Payload.Alias,
 			"global admin must see the qualified Alias unchanged")
-		assert.Equal(t, "customer1:AliasShortGetTarget", respAdmin.Payload.Class,
+		assert.Equal(t, ns1+":AliasShortGetTarget", respAdmin.Payload.Class,
 			"global admin must see the qualified Class unchanged")
 	})
 
 	t.Run("global admin alias get with wrong-case namespace prefix returns 422", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseGetTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasCaseGetTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasCaseGetTarget", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasCaseGet", Class: "AliasCaseGetTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasCaseGet", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasCaseGet", helper.CreateAuth(adminKey))
 
-		_, err := helper.GetAliasAuthWithReturn(t, "Customer1:AliasCaseGet", adminKey)
+		_, err := helper.GetAliasAuthWithReturn(t, upperNS(ns1)+":AliasCaseGet", adminKey)
 		require.Error(t, err)
 		var unproc *schema.AliasesGetAliasUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected AliasesGetAliasUnprocessableEntity, got %T: %v", err, err)
 		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
 
 		// Correct casing still resolves.
-		got := helper.GetAliasWithAuthz(t, "customer1:AliasCaseGet", helper.CreateAuth(adminKey))
-		require.Equal(t, "customer1:AliasCaseGet", got.Alias)
+		got := helper.GetAliasWithAuthz(t, ns1+":AliasCaseGet", helper.CreateAuth(adminKey))
+		require.Equal(t, ns1+":AliasCaseGet", got.Alias)
 	})
 
 	t.Run("namespaced caller submitting qualified alias name to GET is rejected", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasQualifiedGetTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasQualifiedGetTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasQualifiedGetTarget", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasQualifiedGet", Class: "AliasQualifiedGetTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasQualifiedGet", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasQualifiedGet", helper.CreateAuth(adminKey))
 
 		// Namespaced principals are not allowed to type a "<ns>:" prefix —
 		// the resolver adds their namespace automatically. Generic 422.
-		_, err := helper.GetAliasAuthWithReturn(t, "customer1:AliasQualifiedGet", user1Key)
+		_, err := helper.GetAliasAuthWithReturn(t, ns1+":AliasQualifiedGet", user1Key)
 		require.Error(t, err)
 		var unproc *schema.AliasesGetAliasUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected AliasesGetAliasUnprocessableEntity, got %T: %v", err, err)
@@ -583,13 +583,13 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 
 	t.Run("namespaced caller lists aliases filtered by short class name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasListByClass"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasListByClass", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasListByClass", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListByClassA", Class: "AliasListByClass"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListByClassA", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasListByClassA", helper.CreateAuth(adminKey))
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListByClassB", Class: "AliasListByClass"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListByClassB", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasListByClassB", helper.CreateAuth(adminKey))
 
-		// Short class filter must be qualified to customer1:AliasListByClass.
+		// Short class filter must be qualified to ns1:AliasListByClass.
 		// Response is stripped back to short names for the namespaced caller.
 		class := "AliasListByClass"
 		resp, err := helper.GetAliasesAuthWithReturn(t, &class, user1Key)
@@ -605,11 +605,11 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 
 	t.Run("global admin alias list with wrong-case class filter returns 422", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AliasListCaseTarget"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AliasListCaseTarget", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AliasListCaseTarget", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListCase", Class: "AliasListCaseTarget"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListCase", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AliasListCase", helper.CreateAuth(adminKey))
 
-		class := "Customer1:AliasListCaseTarget"
+		class := upperNS(ns1) + ":AliasListCaseTarget"
 		_, err := helper.GetAliasesAuthWithReturn(t, &class, adminKey)
 		require.Error(t, err)
 		var unproc *schema.AliasesGetUnprocessableEntity
@@ -619,13 +619,13 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 
 	t.Run("global admin lists aliases across namespaces", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminListA"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:AdminListA", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":AdminListA", adminKey)
 		helper.CreateClassAuth(t, &models.Class{Class: "AdminListB"}, user2Key)
-		defer helper.DeleteClassAuth(t, "customer2:AdminListB", adminKey)
+		defer helper.DeleteClassAuth(t, ns2+":AdminListB", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminListAlphaA", Class: "AdminListA"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AdminListAlphaA", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":AdminListAlphaA", helper.CreateAuth(adminKey))
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminListAlphaB", Class: "AdminListB"}, user2Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer2:AdminListAlphaB", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns2+":AdminListAlphaB", helper.CreateAuth(adminKey))
 
 		resp, err := helper.GetAliasesAuthWithReturn(t, nil, adminKey)
 		require.NoError(t, err)
@@ -633,7 +633,7 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		for _, a := range resp.Payload.Aliases {
 			seen[a.Alias] = true
 		}
-		assert.True(t, seen["customer1:AdminListAlphaA"], "admin should see customer1's alias")
-		assert.True(t, seen["customer2:AdminListAlphaB"], "admin should see customer2's alias")
+		assert.True(t, seen[ns1+":AdminListAlphaA"], "admin should see ns1's alias")
+		assert.True(t, seen[ns2+":AdminListAlphaB"], "admin should see ns2's alias")
 	})
 }

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -85,6 +85,7 @@ func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
 // caller's namespace; on top of that sits the handler-level
 // IsGlobalOperator/Namespace check plus the entity-name validators.
 func TestNamespaces_CollectionAndAlias(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 	ns2 := uniqueNS()
 	upperNS := func(ns string) string { return strings.ToUpper(ns[:1]) + ns[1:] }

--- a/test/acceptance/namespace/crud_test.go
+++ b/test/acceptance/namespace/crud_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestNamespaces_CRUD_HappyPath(t *testing.T) {
-	const name = "crudhappy"
+	name := uniqueNS()
 
 	helper.CreateNamespace(t, name, adminKey)
 
@@ -66,7 +66,7 @@ func TestNamespaces_CRUD_HappyPath(t *testing.T) {
 }
 
 func TestNamespaces_CreateDuplicate_Conflict(t *testing.T) {
-	const name = "duplicatens"
+	name := uniqueNS()
 
 	helper.CreateNamespace(t, name, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, name, adminKey) })
@@ -113,8 +113,8 @@ func TestNamespaces_CreateInvalid_UnprocessableEntity(t *testing.T) {
 // on the original node, and (c) a subsequently created collection lands on
 // the new home_node.
 func TestNamespaces_UpdateHomeNode(t *testing.T) {
+	ns := uniqueNS()
 	const (
-		ns    = "updatehomenode"
 		nodeA = "weaviate-0"
 		nodeB = "weaviate-2"
 	)
@@ -174,7 +174,7 @@ func TestNamespaces_UpdateHomeNode(t *testing.T) {
 // TestNamespaces_CreateUserInMissingNamespace pins that CreateUser rejects
 // with 422 when the target namespace does not exist.
 func TestNamespaces_CreateUserInMissingNamespace(t *testing.T) {
-	const ghost = "ghostns"
+	ghost := uniqueNS()
 
 	_, err := helper.Client(t).Namespaces.GetNamespace(
 		namespaces.NewGetNamespaceParams().WithNamespaceID(ghost),
@@ -199,7 +199,7 @@ func TestNamespaces_CreateUserInMissingNamespace(t *testing.T) {
 
 // TestNamespaces_UpdateHomeNode_Invalid rejects an unknown home_node with 422.
 func TestNamespaces_UpdateHomeNode_Invalid(t *testing.T) {
-	const name = "updatehomenodeinvalid"
+	name := uniqueNS()
 
 	helper.CreateNamespace(t, name, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, name, adminKey) })

--- a/test/acceptance/namespace/crud_test.go
+++ b/test/acceptance/namespace/crud_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestNamespaces_CRUD_HappyPath(t *testing.T) {
+	t.Parallel()
 	name := uniqueNS()
 
 	helper.CreateNamespace(t, name, adminKey)
@@ -66,6 +67,7 @@ func TestNamespaces_CRUD_HappyPath(t *testing.T) {
 }
 
 func TestNamespaces_CreateDuplicate_Conflict(t *testing.T) {
+	t.Parallel()
 	name := uniqueNS()
 
 	helper.CreateNamespace(t, name, adminKey)
@@ -81,6 +83,7 @@ func TestNamespaces_CreateDuplicate_Conflict(t *testing.T) {
 }
 
 func TestNamespaces_CreateInvalid_UnprocessableEntity(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		candidate string
@@ -113,6 +116,7 @@ func TestNamespaces_CreateInvalid_UnprocessableEntity(t *testing.T) {
 // on the original node, and (c) a subsequently created collection lands on
 // the new home_node.
 func TestNamespaces_UpdateHomeNode(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const (
 		nodeA = "weaviate-0"
@@ -174,6 +178,7 @@ func TestNamespaces_UpdateHomeNode(t *testing.T) {
 // TestNamespaces_CreateUserInMissingNamespace pins that CreateUser rejects
 // with 422 when the target namespace does not exist.
 func TestNamespaces_CreateUserInMissingNamespace(t *testing.T) {
+	t.Parallel()
 	ghost := uniqueNS()
 
 	_, err := helper.Client(t).Namespaces.GetNamespace(
@@ -199,6 +204,7 @@ func TestNamespaces_CreateUserInMissingNamespace(t *testing.T) {
 
 // TestNamespaces_UpdateHomeNode_Invalid rejects an unknown home_node with 422.
 func TestNamespaces_UpdateHomeNode_Invalid(t *testing.T) {
+	t.Parallel()
 	name := uniqueNS()
 
 	helper.CreateNamespace(t, name, adminKey)

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -46,8 +46,8 @@ func rawDeleteNamespace(t *testing.T, name, key string) (*namespaces.DeleteNames
 // alias, and a DB user, deletes it, and verifies that the namespace,
 // its class, its alias, and the user are all gone.
 func TestNamespaces_DeleteHappyPath(t *testing.T) {
+	ns := uniqueNS()
 	const (
-		ns        = "delhappy"
 		userID    = "alice"
 		className = "Movies"
 		aliasName = "Films"
@@ -85,10 +85,8 @@ func TestNamespaces_DeleteHappyPath(t *testing.T) {
 // the synchronous DeleteUsersInNamespace before returning 202; followers
 // apply asynchronously, so each node is polled until auth is rejected.
 func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
-	const (
-		ns     = "delauth"
-		userID = "bob"
-	)
+	ns := uniqueNS()
+	const userID = "bob"
 
 	helper.CreateNamespace(t, ns, adminKey)
 	userKey := createNamespacedUser(t, userID, ns, adminKey)
@@ -129,8 +127,8 @@ func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
 // 409 (still deleting) and success are acceptable; any other response
 // fails the test.
 func TestNamespaces_RecreateAfterDelete(t *testing.T) {
+	ns := uniqueNS()
 	const (
-		ns        = "delrecreate"
 		userID    = "creator"
 		className = "Movies"
 	)
@@ -176,7 +174,7 @@ func TestNamespaces_RecreateAfterDelete(t *testing.T) {
 // the namespace is still in the deleting state and asserts both return
 // 202. After cleanup completes, DELETE returns 404.
 func TestNamespaces_DeleteIsIdempotent(t *testing.T) {
-	const ns = "delidempotent"
+	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
 	// First DELETE: 202.
@@ -207,7 +205,7 @@ func TestNamespaces_DeleteIsIdempotent(t *testing.T) {
 // cleaned up — both outcomes are acceptable. The post-condition is that
 // no orphan class survives once the namespace entity is gone.
 func TestNamespaces_ConcurrentDeleteAndAddClass(t *testing.T) {
-	const ns = "delrace"
+	ns := uniqueNS()
 	const className = "Films"
 	qualifiedClass := ns + ":" + className
 
@@ -249,8 +247,8 @@ func TestNamespaces_ConcurrentDeleteAndAddClass(t *testing.T) {
 // class can be created cleanly — the latter is the proxy for "no torn
 // state was left behind".
 func TestNamespaces_DeleteWhileBatchInsertInFlight(t *testing.T) {
+	ns := uniqueNS()
 	const (
-		ns        = "delbatch"
 		userID    = "dave"
 		className = "Tickets"
 	)
@@ -348,7 +346,7 @@ func TestNamespaces_DeleteWhileBatchInsertInFlight(t *testing.T) {
 // must round-trip through gRPC and re-chain on the client so the
 // handler's errors.Is mapping returns 404 rather than 500.
 func TestNamespaces_DeleteMissingReturns404FromEveryReplica(t *testing.T) {
-	const ns = "neverexisted"
+	ns := uniqueNS()
 
 	originalURI := sharedCompose.GetWeaviate().URI()
 	t.Cleanup(func() { helper.SetupClient(originalURI) })

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -46,6 +46,7 @@ func rawDeleteNamespace(t *testing.T, name, key string) (*namespaces.DeleteNames
 // alias, and a DB user, deletes it, and verifies that the namespace,
 // its class, its alias, and the user are all gone.
 func TestNamespaces_DeleteHappyPath(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const (
 		userID    = "alice"
@@ -127,6 +128,7 @@ func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
 // 409 (still deleting) and success are acceptable; any other response
 // fails the test.
 func TestNamespaces_RecreateAfterDelete(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const (
 		userID    = "creator"
@@ -174,6 +176,7 @@ func TestNamespaces_RecreateAfterDelete(t *testing.T) {
 // the namespace is still in the deleting state and asserts both return
 // 202. After cleanup completes, DELETE returns 404.
 func TestNamespaces_DeleteIsIdempotent(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
@@ -205,6 +208,7 @@ func TestNamespaces_DeleteIsIdempotent(t *testing.T) {
 // cleaned up — both outcomes are acceptable. The post-condition is that
 // no orphan class survives once the namespace entity is gone.
 func TestNamespaces_ConcurrentDeleteAndAddClass(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const className = "Films"
 	qualifiedClass := ns + ":" + className
@@ -247,6 +251,7 @@ func TestNamespaces_ConcurrentDeleteAndAddClass(t *testing.T) {
 // class can be created cleanly — the latter is the proxy for "no torn
 // state was left behind".
 func TestNamespaces_DeleteWhileBatchInsertInFlight(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const (
 		userID    = "dave"

--- a/test/acceptance/namespace/endpoints_gone_test.go
+++ b/test/acceptance/namespace/endpoints_gone_test.go
@@ -29,6 +29,7 @@ import (
 // TestNamespaces_EndpointsGone locks in that endpoints incompatible with
 // namespace-enabled clusters return HTTP 410 Gone with an ErrorResponse body.
 func TestNamespaces_EndpointsGone(t *testing.T) {
+	t.Parallel()
 	t.Run("GET /v1/graphql returns 410", func(t *testing.T) {
 		_, err := helper.Client(t).Graphql.GraphqlPost(
 			gql.NewGraphqlPostParams().WithBody(&models.GraphQLQuery{Query: "{ Get { Foo { _additional { id } } } }"}),

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -63,13 +63,13 @@ func searchReq(collection string, limit uint32) *pb.SearchRequest {
 // short collection name; the handler must qualify it via namespacing.Resolve
 // so the request only ever touches the caller's namespace shard.
 func TestNamespaces_GRPC(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)
 	defer conn.Close()
 
 	const class = "MoviesGRPC"
-	setupClassInBothNamespaces(t, class, user1Key, user2Key)
+	setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 	id1 := strfmt.UUID("aaaaaaaa-1111-1111-1111-111111111111")
 	id2 := strfmt.UUID("bbbbbbbb-2222-2222-2222-222222222222")
@@ -90,7 +90,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 
 	t.Run("BatchObjects fans out per namespace", func(t *testing.T) {
 		// user1 inserts under the short class name; the handler qualifies
-		// to customer1:MoviesGRPC.
+		// to ns1:MoviesGRPC.
 		resp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
 			Objects: []*pb.BatchObject{
 				makeBatchObj(id1, class, "ns1-The Matrix"),
@@ -102,7 +102,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 		require.Empty(t, resp.Errors)
 
 		// user2 inserts the same UUIDs under the same short class name;
-		// the handler qualifies to customer2:MoviesGRPC, so there is no
+		// the handler qualifies to ns2:MoviesGRPC, so there is no
 		// id collision between the two namespaces.
 		resp, err = grpcClient.BatchObjects(authCtx(user2Key), &pb.BatchObjectsRequest{
 			Objects: []*pb.BatchObject{
@@ -131,7 +131,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// Self-contained against the rest of TestNamespaces_GRPC: own class,
 		// own UUIDs, no reliance on (or mutation of) the MoviesGRPC rows above.
 		const delClass = "BatchDeleteGRPC"
-		setupClassInBothNamespaces(t, delClass, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, delClass, user1Key, user2Key)
 
 		killID := strfmt.UUID("33333333-cccc-cccc-cccc-cccccccccccc")
 		keepID := strfmt.UUID("44444444-dddd-dddd-dddd-dddddddddddd")
@@ -188,12 +188,12 @@ func TestNamespaces_GRPC(t *testing.T) {
 			delClass = "BatchDeleteAliasGRPC"
 			alias    = "BDAliasGRPC"
 		)
-		setupClassInBothNamespaces(t, delClass, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, delClass, user1Key, user2Key)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: delClass}, user1Key)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: delClass}, user2Key)
 		t.Cleanup(func() {
-			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
-			helper.DeleteAliasWithAuthz(t, "customer2:"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns2+":"+alias, helper.CreateAuth(adminKey))
 		})
 
 		killID := strfmt.UUID("77777777-7777-7777-7777-777777777777")
@@ -250,7 +250,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// class portion: the qualified name flows through to storage and
 		// matches; the short name does not exist on disk.
 		const delClass = "BatchDeleteAdminGRPC"
-		setupClassInNs1(t, delClass, user1Key)
+		setupClassInNs1(t, ns1, delClass, user1Key)
 
 		killID := strfmt.UUID("bbbbbbbb-3333-3333-3333-333333333333")
 		keepID := strfmt.UUID("cccccccc-4444-4444-4444-444444444444")
@@ -279,7 +279,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 		require.Error(t, err)
 
 		// Qualified class name → resolves to storage, delete succeeds.
-		delResp, err := grpcClient.BatchDelete(authCtx(adminKey), mkReq("customer1:"+delClass))
+		delResp, err := grpcClient.BatchDelete(authCtx(adminKey), mkReq(ns1+":"+delClass))
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), delResp.Successful)
 		assert.Equal(t, int64(0), delResp.Failed)
@@ -401,9 +401,9 @@ func TestNamespaces_GRPC(t *testing.T) {
 			"buckets should differ between namespaces; got %v on both", buckets1)
 
 		respAdmin, err := grpcClient.Aggregate(authCtx(adminKey), &pb.AggregateRequest{
-			Collection:   "customer1:" + class,
+			Collection:   ns1 + ":" + class,
 			ObjectsCount: true,
-			GroupBy:      &pb.AggregateRequest_GroupBy{Collection: "customer1:" + class, Property: "title"},
+			GroupBy:      &pb.AggregateRequest_GroupBy{Collection: ns1 + ":" + class, Property: "title"},
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, respAdmin.GetGroupedResults().GetGroups(),
@@ -433,8 +433,8 @@ func TestNamespaces_GRPC(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+zoo, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+animal, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+zoo, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+animal, adminKey)
 		})
 
 		animalID := strfmt.UUID(uuid.New().String())
@@ -497,11 +497,11 @@ func TestNamespaces_GRPC(t *testing.T) {
 			require.NoError(t, err)
 		}
 		defer helper.Client(t).Schema.AliasesDelete(
-			schemaCli.NewAliasesDeleteParams().WithAliasName("customer1:"+aliasName),
+			schemaCli.NewAliasesDeleteParams().WithAliasName(ns1+":"+aliasName),
 			helper.CreateAuth(adminKey),
 		)
 		defer helper.Client(t).Schema.AliasesDelete(
-			schemaCli.NewAliasesDeleteParams().WithAliasName("customer2:"+aliasName),
+			schemaCli.NewAliasesDeleteParams().WithAliasName(ns2+":"+aliasName),
 			helper.CreateAuth(adminKey),
 		)
 
@@ -533,9 +533,9 @@ func TestNamespaces_GRPC(t *testing.T) {
 	})
 
 	t.Run("namespaced caller submitting :-qualified collection double-prefixes", func(t *testing.T) {
-		// user1 supplying "customer1:MoviesGRPC" gets qualified again to
-		// "customer1:customer1:MoviesGRPC" — no such class on disk.
-		qualified := "customer1:" + class
+		// user1 supplying "ns1:MoviesGRPC" gets qualified again to
+		// "ns1:ns1:MoviesGRPC" — no such class on disk.
+		qualified := ns1 + ":" + class
 
 		_, err := grpcClient.Search(authCtx(user1Key), searchReq(qualified, 1))
 		require.Error(t, err)
@@ -563,7 +563,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 			return grpcClient.Search(authCtx(adminKey), searchReq(class, 10))
 		}
 		qualifiedReq := func() (*pb.SearchReply, error) {
-			return grpcClient.Search(authCtx(adminKey), searchReq("customer1:"+class, 10))
+			return grpcClient.Search(authCtx(adminKey), searchReq(ns1+":"+class, 10))
 		}
 
 		_, err := shortReq()
@@ -572,8 +572,8 @@ func TestNamespaces_GRPC(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, searchResp.Results, 2)
 		// Admin sees the raw qualified class name in target_collection.
-		assert.Equal(t, "customer1:"+class, searchResp.Results[0].Properties.TargetCollection)
-		assert.Equal(t, "customer1:"+class, searchResp.Results[1].Properties.TargetCollection)
+		assert.Equal(t, ns1+":"+class, searchResp.Results[0].Properties.TargetCollection)
+		assert.Equal(t, ns1+":"+class, searchResp.Results[1].Properties.TargetCollection)
 
 		_, err = grpcClient.Aggregate(authCtx(adminKey), &pb.AggregateRequest{
 			Collection:   class,
@@ -581,7 +581,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 		})
 		require.Error(t, err)
 		aggResp, err := grpcClient.Aggregate(authCtx(adminKey), &pb.AggregateRequest{
-			Collection:   "customer1:" + class,
+			Collection:   ns1 + ":" + class,
 			ObjectsCount: true,
 		})
 		require.NoError(t, err)
@@ -598,14 +598,14 @@ func TestNamespaces_GRPC(t *testing.T) {
 
 		adminID := strfmt.UUID("ffffffff-6666-6666-6666-666666666666")
 		qualifiedBatch, err := grpcClient.BatchObjects(authCtx(adminKey), &pb.BatchObjectsRequest{
-			Objects: []*pb.BatchObject{makeBatchObj(adminID, "customer1:"+class, "admin-qualified")},
+			Objects: []*pb.BatchObject{makeBatchObj(adminID, ns1+":"+class, "admin-qualified")},
 		})
 		require.NoError(t, err)
 		require.Empty(t, qualifiedBatch.Errors)
 
-		got, err := helper.GetObjectAuth(t, "customer1:"+class, adminID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":"+class, adminID, adminKey)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, ns1+":"+class, got.Class)
 		assert.Equal(t, "admin-qualified", got.Properties.(map[string]any)["title"])
 	})
 
@@ -662,13 +662,13 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// Driving real traffic through the stream also locks in that the
 		// principal captured at Handle() is the one used per data message.
 		const streamClass = "MoviesGRPCStream"
-		setupClassInBothNamespaces(t, streamClass, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, streamClass, user1Key, user2Key)
 
 		streamID1 := strfmt.UUID("99999999-1111-1111-1111-111111111111")
 		streamID2 := strfmt.UUID("99999999-2222-2222-2222-222222222222")
 
 		// user1 inserts under the short class name; the stream receiver must
-		// qualify to customer1:MoviesGRPCStream for the schema pre-flight,
+		// qualify to ns1:MoviesGRPCStream for the schema pre-flight,
 		// and the worker must qualify again for the actual write.
 		successes, errs := runBatchStream(t, user1Key, []*pb.BatchObject{
 			{Uuid: streamID1.String(), Collection: streamClass, Properties: &pb.BatchObject_Properties{
@@ -721,18 +721,18 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// Each namespace registers the same short alias name for its own
 		// copy of the class. namespacing.Resolve in the receiver qualifies
 		// the alias with the principal's namespace before alias→target
-		// lookup, so user1's stream must land on customer1's class and
-		// user2's stream on customer2's.
+		// lookup, so user1's stream must land on ns1's class and
+		// user2's stream on ns2's.
 		const (
 			streamClass = "MoviesGRPCStreamAlias"
 			aliasName   = "StreamAlias"
 		)
-		setupClassInBothNamespaces(t, streamClass, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, streamClass, user1Key, user2Key)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: aliasName, Class: streamClass}, user1Key)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: aliasName, Class: streamClass}, user2Key)
 		t.Cleanup(func() {
-			helper.DeleteAliasWithAuthz(t, "customer1:"+aliasName, helper.CreateAuth(adminKey))
-			helper.DeleteAliasWithAuthz(t, "customer2:"+aliasName, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns1+":"+aliasName, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns2+":"+aliasName, helper.CreateAuth(adminKey))
 		})
 
 		id1 := strfmt.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
@@ -787,7 +787,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// class portion. Short names don't exist on disk; qualified names
 		// flow through to the namespaced shard.
 		const streamClass = "MoviesGRPCStreamAdmin"
-		setupClassInNs1(t, streamClass, user1Key)
+		setupClassInNs1(t, ns1, streamClass, user1Key)
 
 		adminShortID := strfmt.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
 		adminQualifiedID := strfmt.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
@@ -813,17 +813,17 @@ func TestNamespaces_GRPC(t *testing.T) {
 		require.Len(t, errs, 1)
 		assert.Equal(t, adminShortID.String(), errs[0].GetUuid())
 
-		// Qualified name: write lands on customer1's shard and is visible
+		// Qualified name: write lands on ns1's shard and is visible
 		// via REST to admin and to user1.
 		successes, errs = runBatchStream(t, adminKey, []*pb.BatchObject{
-			mkObj(adminQualifiedID, "customer1:"+streamClass, "admin-qualified"),
+			mkObj(adminQualifiedID, ns1+":"+streamClass, "admin-qualified"),
 		})
 		require.Empty(t, errs)
 		assert.Equal(t, 1, successes)
 
-		got, err := helper.GetObjectAuth(t, "customer1:"+streamClass, adminQualifiedID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":"+streamClass, adminQualifiedID, adminKey)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+streamClass, got.Class)
+		assert.Equal(t, ns1+":"+streamClass, got.Class)
 		assert.Equal(t, "admin-qualified", got.Properties.(map[string]any)["title"])
 
 		// The short-name row was never persisted under any class.
@@ -835,16 +835,16 @@ func TestNamespaces_GRPC(t *testing.T) {
 // TestNamespaces_GRPC_QueryProfile checks that a namespaced caller never sees
 // its own "<namespace>:" prefix in the per-shard query_profile. The shard ID
 // (shard.ID()) embeds the qualified class name, so the raw profile Name is
-// "customer1:moviesgrpcprofile_<shard>"; the replier strips the prefix via
+// "ns1:moviesgrpcprofile_<shard>"; the replier strips the prefix via
 // namespacing.StripOwnNamespace, the same helper used for target_collection.
 func TestNamespaces_GRPC_QueryProfile(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)
 	defer conn.Close()
 
 	const class = "MoviesGRPCProfile"
-	setupClassInBothNamespaces(t, class, user1Key, user2Key)
+	setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 	// Seed one row in ns1 so a shard is actually searched and profiled.
 	_, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
@@ -876,7 +876,7 @@ func TestNamespaces_GRPC_QueryProfile(t *testing.T) {
 		// prefix must not surface anywhere a future detail could embed a
 		// qualified name (search-type keys, detail keys, detail values).
 		notLeak := func(field, val string) {
-			assert.NotContainsf(t, val, "customer1:",
+			assert.NotContainsf(t, val, ns1+":",
 				"query_profile leaks the caller's namespace prefix via %s: %q", field, val)
 		}
 		for _, sh := range resp.QueryProfile.Shards {
@@ -894,21 +894,21 @@ func TestNamespaces_GRPC_QueryProfile(t *testing.T) {
 
 	t.Run("global admin keeps the raw profile (raw mode)", func(t *testing.T) {
 		// Admin has no namespace, so it keeps the raw internal names: at least
-		// one shard name must still carry the qualified "customer1:" prefix.
+		// one shard name must still carry the qualified "ns1:" prefix.
 		// This is the positive control for the stripping above — without it a
 		// regression that strips global names too would go unnoticed.
-		resp, err := grpcClient.Search(authCtx(adminKey), profReq("customer1:"+class))
+		resp, err := grpcClient.Search(authCtx(adminKey), profReq(ns1+":"+class))
 		require.NoError(t, err)
 		require.NotNil(t, resp.QueryProfile)
 		require.NotEmpty(t, resp.QueryProfile.Shards)
 		hasPrefix := false
 		for _, sh := range resp.QueryProfile.Shards {
-			if strings.Contains(sh.Name, "customer1:") {
+			if strings.Contains(sh.Name, ns1+":") {
 				hasPrefix = true
 			}
 		}
 		assert.True(t, hasPrefix,
-			"admin should see the raw qualified shard name with the customer1: prefix, got %v",
+			"admin should see the raw qualified shard name with the ns1: prefix, got %v",
 			resp.QueryProfile.Shards)
 	})
 }
@@ -918,10 +918,8 @@ func TestNamespaces_GRPC_QueryProfile(t *testing.T) {
 // The namespace is pinned to a node that is provably not the gRPC entry
 // (GetWeaviate() returns weaviate-0) so the hop is exercised every run.
 func TestNamespaces_GRPC_RemoteShardAggregate(t *testing.T) {
-	const (
-		ns       = "remoteshardns"
-		homeNode = "weaviate-2"
-	)
+	ns := uniqueNS()
+	const homeNode = "weaviate-2"
 	helper.CreateNamespaceWithHomeNode(t, ns, homeNode, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, ns, adminKey) })
 
@@ -974,13 +972,13 @@ func TestNamespaces_GRPC_RemoteShardAggregate(t *testing.T) {
 // qualify the object's collection so the auto-created collection and the write
 // agree on the qualified name.
 func TestNamespaces_GRPC_BatchAutoSchema(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, _, user1Key, _ := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)
 	defer conn.Close()
 
 	const class = "GrpcAutoSchema"
-	t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+	t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+class, adminKey) })
 
 	id := strfmt.UUID("99999999-aaaa-bbbb-cccc-999999999999")
 	resp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
@@ -1007,6 +1005,6 @@ func TestNamespaces_GRPC_BatchAutoSchema(t *testing.T) {
 	assert.Equal(t, "Inception", got.Properties.(map[string]any)["title"])
 
 	// Admin's raw view confirms auto-schema created a single-qualified class.
-	gotClass := helper.GetClassAuth(t, "customer1:"+class, adminKey)
-	assert.Equal(t, "customer1:"+class, gotClass.Class)
+	gotClass := helper.GetClassAuth(t, ns1+":"+class, adminKey)
+	assert.Equal(t, ns1+":"+class, gotClass.Class)
 }

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -63,6 +63,7 @@ func searchReq(collection string, limit uint32) *pb.SearchRequest {
 // short collection name; the handler must qualify it via namespacing.Resolve
 // so the request only ever touches the caller's namespace shard.
 func TestNamespaces_GRPC(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)
@@ -838,6 +839,7 @@ func TestNamespaces_GRPC(t *testing.T) {
 // "ns1:moviesgrpcprofile_<shard>"; the replier strips the prefix via
 // namespacing.StripOwnNamespace, the same helper used for target_collection.
 func TestNamespaces_GRPC_QueryProfile(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)
@@ -918,6 +920,7 @@ func TestNamespaces_GRPC_QueryProfile(t *testing.T) {
 // The namespace is pinned to a node that is provably not the gRPC entry
 // (GetWeaviate() returns weaviate-0) so the hop is exercised every run.
 func TestNamespaces_GRPC_RemoteShardAggregate(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const homeNode = "weaviate-2"
 	helper.CreateNamespaceWithHomeNode(t, ns, homeNode, adminKey)
@@ -972,6 +975,7 @@ func TestNamespaces_GRPC_RemoteShardAggregate(t *testing.T) {
 // qualify the object's collection so the auto-created collection and the write
 // agree on the qualified name.
 func TestNamespaces_GRPC_BatchAutoSchema(t *testing.T) {
+	t.Parallel()
 	ns1, _, user1Key, _ := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)

--- a/test/acceptance/namespace/indexes_test.go
+++ b/test/acceptance/namespace/indexes_test.go
@@ -28,9 +28,9 @@ import (
 // by short name reaches the resolved collection (200, not 404); a global admin uses the
 // qualified name.
 func TestNamespaces_IndexesGet(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, _, user1Key, _ := twoNamespaces(t)
 	const class = "IdxStatus"
-	setupClassInNs1(t, class, user1Key)
+	setupClassInNs1(t, ns1, class, user1Key)
 
 	t.Run("namespaced caller gets index status by short class name", func(t *testing.T) {
 		params := schema.NewSchemaObjectsIndexesGetParams().WithClassName(class)
@@ -46,19 +46,19 @@ func TestNamespaces_IndexesGet(t *testing.T) {
 			if p.Name == "title" {
 				titleSeen = true
 			}
-			assert.NotContains(t, p.DataType, "customer1:",
+			assert.NotContains(t, p.DataType, ns1+":",
 				"property DataType must not leak the caller's namespace prefix")
 		}
 		assert.True(t, titleSeen, "expected the 'title' property in the index status")
 	})
 
 	t.Run("global admin gets index status by qualified class name", func(t *testing.T) {
-		params := schema.NewSchemaObjectsIndexesGetParams().WithClassName("customer1:" + class)
+		params := schema.NewSchemaObjectsIndexesGetParams().WithClassName(ns1 + ":" + class)
 		resp, err := helper.Client(t).Schema.SchemaObjectsIndexesGet(params, helper.CreateAuth(adminKey))
 		require.NoError(t, err)
 		require.NotNil(t, resp.Payload)
 		// A global admin addressed the collection by its qualified name and sees it as-is.
-		assert.Equal(t, "customer1:"+class, resp.Payload.Collection)
+		assert.Equal(t, ns1+":"+class, resp.Payload.Collection)
 	})
 
 	t.Run("cross-reference DataType is stripped for namespaced caller, qualified for admin", func(t *testing.T) {
@@ -69,12 +69,12 @@ func TestNamespaces_IndexesGet(t *testing.T) {
 			Class: host,
 			Properties: []*models.Property{
 				{Name: "title", DataType: []string{"text"}},
-				{Name: "directedBy", DataType: []string{target}}, // qualified to customer1:IdxRefTarget on disk
+				{Name: "directedBy", DataType: []string{target}}, // qualified to ns1:IdxRefTarget on disk
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+host, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+target, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+host, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+target, adminKey)
 		})
 
 		nsResp, err := helper.Client(t).Schema.SchemaObjectsIndexesGet(
@@ -86,10 +86,10 @@ func TestNamespaces_IndexesGet(t *testing.T) {
 			"namespaced caller must see the short cross-ref target class name")
 
 		adminResp, err := helper.Client(t).Schema.SchemaObjectsIndexesGet(
-			schema.NewSchemaObjectsIndexesGetParams().WithClassName("customer1:"+host), helper.CreateAuth(adminKey))
+			schema.NewSchemaObjectsIndexesGetParams().WithClassName(ns1+":"+host), helper.CreateAuth(adminKey))
 		require.NoError(t, err)
 		require.NotNil(t, adminResp.Payload)
-		assert.Equal(t, "customer1:"+target, findIndexProp(t, adminResp.Payload, "directedBy").DataType,
+		assert.Equal(t, ns1+":"+target, findIndexProp(t, adminResp.Payload, "directedBy").DataType,
 			"global admin must see the qualified cross-ref target class name")
 	})
 }
@@ -112,7 +112,7 @@ func findIndexProp(t *testing.T, resp *models.IndexStatusResponse, name string) 
 // 404); a valid body submits a real reindex (202). Each subtest uses its own
 // class so in-flight reindexes don't conflict.
 func TestNamespaces_IndexesUpdate(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, _, user1Key, _ := twoNamespaces(t)
 
 	put := func(className, key string, body *models.IndexUpdateRequest) (*schema.SchemaObjectsIndexesUpdateAccepted, error) {
 		return helper.Client(t).Schema.SchemaObjectsIndexesUpdate(
@@ -147,7 +147,7 @@ func TestNamespaces_IndexesUpdate(t *testing.T) {
 			Class:      name,
 			Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
 		}, user1Key)
-		qualified := "customer1:" + name
+		qualified := ns1 + ":" + name
 		t.Cleanup(func() {
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				// Cancel only matches STARTED tasks; retry covers the window
@@ -162,7 +162,7 @@ func TestNamespaces_IndexesUpdate(t *testing.T) {
 
 	t.Run("namespaced caller: invalid body resolves to 400, not 404", func(t *testing.T) {
 		const class = "IdxPutNsResolve"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 		_, err := put(class, user1Key, invalidBody()) // short name
 		requireResolvedNot404(t, err)
 	})
@@ -175,25 +175,25 @@ func TestNamespaces_IndexesUpdate(t *testing.T) {
 		require.NotNil(t, resp)
 		// The task ID embeds the collection name; it must not leak the prefix.
 		require.NotEmpty(t, resp.Payload.TaskID)
-		assert.False(t, strings.HasPrefix(resp.Payload.TaskID, "customer1:"),
+		assert.False(t, strings.HasPrefix(resp.Payload.TaskID, ns1+":"),
 			"task ID must not leak the caller's namespace prefix: %q", resp.Payload.TaskID)
 	})
 
 	t.Run("global admin: invalid body resolves to 400, not 404", func(t *testing.T) {
 		const class = "IdxPutAdminResolve"
-		setupClassInNs1(t, class, user1Key)
-		_, err := put("customer1:"+class, adminKey, invalidBody()) // qualified name
+		setupClassInNs1(t, ns1, class, user1Key)
+		_, err := put(ns1+":"+class, adminKey, invalidBody()) // qualified name
 		requireResolvedNot404(t, err)
 	})
 
 	t.Run("global admin: valid reindex accepted (202)", func(t *testing.T) {
 		const class = "IdxPutAdminReindex"
 		setupReindexClassInNs1(t, class)
-		resp, err := put("customer1:"+class, adminKey, validBody()) // qualified name
+		resp, err := put(ns1+":"+class, adminKey, validBody()) // qualified name
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		// A global admin has no own namespace to strip, so the qualified task ID stands.
-		assert.True(t, strings.HasPrefix(resp.Payload.TaskID, "customer1:"),
+		assert.True(t, strings.HasPrefix(resp.Payload.TaskID, ns1+":"),
 			"global admin should see the qualified task ID: %q", resp.Payload.TaskID)
 	})
 }

--- a/test/acceptance/namespace/indexes_test.go
+++ b/test/acceptance/namespace/indexes_test.go
@@ -28,6 +28,7 @@ import (
 // by short name reaches the resolved collection (200, not 404); a global admin uses the
 // qualified name.
 func TestNamespaces_IndexesGet(t *testing.T) {
+	t.Parallel()
 	ns1, _, user1Key, _ := twoNamespaces(t)
 	const class = "IdxStatus"
 	setupClassInNs1(t, ns1, class, user1Key)
@@ -112,6 +113,7 @@ func findIndexProp(t *testing.T, resp *models.IndexStatusResponse, name string) 
 // 404); a valid body submits a real reindex (202). Each subtest uses its own
 // class so in-flight reindexes don't conflict.
 func TestNamespaces_IndexesUpdate(t *testing.T) {
+	t.Parallel()
 	ns1, _, user1Key, _ := twoNamespaces(t)
 
 	put := func(className, key string, body *models.IndexUpdateRequest) (*schema.SchemaObjectsIndexesUpdateAccepted, error) {

--- a/test/acceptance/namespace/mcp_test.go
+++ b/test/acceptance/namespace/mcp_test.go
@@ -36,16 +36,14 @@ const (
 // Per the namespace-prefix validator, a namespaced principal that submits a
 // qualified name is rejected up front with "is not a valid class name".
 func TestNamespaces_MCP(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, ns2, user1Key, _ := twoNamespaces(t)
 
 	alpha0 := 0.0
-	const (
-		short   = "Movies"
-		qualNs1 = "customer1:Movies"
-		qualNs2 = "customer2:Movies"
-	)
+	const short = "Movies"
+	qualNs1 := ns1 + ":" + short
+	qualNs2 := ns2 + ":" + short
 
-	setupClassInNs1(t, short, user1Key)
+	setupClassInNs1(t, ns1, short, user1Key)
 
 	t.Run("namespaced principal, short input works on single-tenant tools", func(t *testing.T) {
 		// upsert
@@ -90,7 +88,7 @@ func TestNamespaces_MCP(t *testing.T) {
 	// onto every other tool call above.
 	t.Run("namespaced principal, tenants-list with short input", func(t *testing.T) {
 		const mtShort = "Theaters"
-		setupMTClassInNs1(t, mtShort, user1Key)
+		setupMTClassInNs1(t, ns1, mtShort, user1Key)
 		require.NoError(t, addTenantsAuth(t, mtShort,
 			[]*models.Tenant{{Name: "t1", ActivityStatus: models.TenantActivityStatusHOT}}, user1Key))
 
@@ -194,8 +192,8 @@ func TestNamespaces_MCP(t *testing.T) {
 	})
 
 	// Global principals carry no namespace, so the resolver doesn't qualify
-	// "Movies" and the equality filter against the schema (which stores
-	// "customer1:Movies") returns the existing "not found" path. Hybrid hits
+	// "Movies" and the equality filter against the schema (which stores the
+	// namespaced "Movies" class) returns the existing "not found" path. Hybrid hits
 	// the traverser, which surfaces a class-missing error.
 	t.Run("global admin, short input does not resolve to namespaced class", func(t *testing.T) {
 		var cfg *read.GetCollectionConfigResp
@@ -217,7 +215,7 @@ func TestNamespaces_MCP(t *testing.T) {
 		const alias = "Films"
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: short}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
 		})
 
 		var hybridResp *search.QueryHybridResp
@@ -246,7 +244,7 @@ func TestNamespaces_MCP(t *testing.T) {
 			Query:          "Inception",
 			Alpha:          &alpha0,
 			Filters: map[string]any{
-				"path":      []any{"hasAuthor", "customer2:Author", "name"},
+				"path":      []any{"hasAuthor", ns2 + ":Author", "name"},
 				"operator":  "Equal",
 				"valueText": "Anyone",
 			},

--- a/test/acceptance/namespace/mcp_test.go
+++ b/test/acceptance/namespace/mcp_test.go
@@ -36,6 +36,7 @@ const (
 // Per the namespace-prefix validator, a namespaced principal that submits a
 // qualified name is rejected up front with "is not a valid class name".
 func TestNamespaces_MCP(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, _ := twoNamespaces(t)
 
 	alpha0 := 0.0

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -96,6 +96,7 @@ func seedTwo(t *testing.T, class string, id strfmt.UUID, ns1Title, ns2Title, k1,
 // the object REST endpoints (add/get/update/merge/delete/head/list/validate)
 // plus the contract for double-prefix and global-principal access.
 func TestNamespaces_ObjectLifecycle(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("add and get with short, lowercase class name", func(t *testing.T) {
@@ -313,6 +314,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 // TestNamespaces_BatchOperations exercises BatchManager fan-out under
 // namespace resolution.
 func TestNamespaces_BatchOperations(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("batch insert is namespace-scoped", func(t *testing.T) {

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -25,33 +25,31 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-// twoNamespaces brings up customer1+customer2 plus a single namespaced
-// DB user per namespace and returns their API keys. Cleanup is registered.
-func twoNamespaces(t *testing.T) (string, string) {
+// twoNamespaces brings up two unique namespaces plus a single namespaced
+// DB user per namespace and returns the namespace names and their API keys.
+// Cleanup is registered.
+func twoNamespaces(t *testing.T) (ns1, ns2, user1Key, user2Key string) {
 	t.Helper()
-	const (
-		ns1 = "customer1"
-		ns2 = "customer2"
-	)
+	ns1, ns2 = uniqueNS(), uniqueNS()
 	helper.CreateNamespace(t, ns1, adminKey)
 	helper.CreateNamespace(t, ns2, adminKey)
 	t.Cleanup(func() {
 		helper.DeleteNamespace(t, ns1, adminKey)
 		helper.DeleteNamespace(t, ns2, adminKey)
 	})
-	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
-	user2Key := createNamespacedUser(t, "u2", ns2, adminKey)
+	user1Key = createNamespacedUser(t, "u1", ns1, adminKey)
+	user2Key = createNamespacedUser(t, "u2", ns2, adminKey)
 	t.Cleanup(func() {
 		helper.DeleteUser(t, ns1+":u1", adminKey)
 		helper.DeleteUser(t, ns2+":u2", adminKey)
 	})
-	return user1Key, user2Key
+	return ns1, ns2, user1Key, user2Key
 }
 
 // setupClassInBothNamespaces creates a class with a single text "title"
 // property under each user's namespace and registers cleanup of the
 // qualified names.
-func setupClassInBothNamespaces(t *testing.T, name, k1, k2 string) {
+func setupClassInBothNamespaces(t *testing.T, ns1, ns2, name, k1, k2 string) {
 	t.Helper()
 	for _, key := range []string{k1, k2} {
 		helper.CreateClassAuth(t, &models.Class{
@@ -62,14 +60,14 @@ func setupClassInBothNamespaces(t *testing.T, name, k1, k2 string) {
 		}, key)
 	}
 	t.Cleanup(func() {
-		helper.DeleteClassAuth(t, "customer1:"+name, adminKey)
-		helper.DeleteClassAuth(t, "customer2:"+name, adminKey)
+		helper.DeleteClassAuth(t, ns1+":"+name, adminKey)
+		helper.DeleteClassAuth(t, ns2+":"+name, adminKey)
 	})
 }
 
 // setupClassInNs1 creates a class with a single text "title" property under
 // user1Key only and registers cleanup of the qualified name.
-func setupClassInNs1(t *testing.T, name, key string) {
+func setupClassInNs1(t *testing.T, ns1, name, key string) {
 	t.Helper()
 	helper.CreateClassAuth(t, &models.Class{
 		Class: name,
@@ -77,7 +75,7 @@ func setupClassInNs1(t *testing.T, name, key string) {
 			{Name: "title", DataType: []string{"text"}},
 		},
 	}, key)
-	t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+	t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+name, adminKey) })
 }
 
 // seedTwo writes the same UUID under the same short class name in both
@@ -98,7 +96,7 @@ func seedTwo(t *testing.T, class string, id strfmt.UUID, ns1Title, ns2Title, k1,
 // the object REST endpoints (add/get/update/merge/delete/head/list/validate)
 // plus the contract for double-prefix and global-principal access.
 func TestNamespaces_ObjectLifecycle(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("add and get with short, lowercase class name", func(t *testing.T) {
 		// Submit lowercased on every hop. UppercaseClassName runs before the
@@ -107,10 +105,10 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		const (
 			short      = "e2emovies"
 			shortClass = "E2emovies"
-			qualified1 = "customer1:E2emovies"
-			qualified2 = "customer2:E2emovies"
 		)
-		setupClassInBothNamespaces(t, short, user1Key, user2Key)
+		qualified1 := ns1 + ":" + shortClass
+		qualified2 := ns2 + ":" + shortClass
+		setupClassInBothNamespaces(t, ns1, ns2, short, user1Key, user2Key)
 
 		id := strfmt.UUID("11111111-2222-3333-4444-555555555555")
 		seedTwo(t, short, id, "The Matrix", "Inception", user1Key, user2Key)
@@ -133,7 +131,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 
 	t.Run("update / merge / delete on ns1 leave ns2 untouched", func(t *testing.T) {
 		const class = "MutationTarget"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		id := strfmt.UUID("aaaaaaaa-1111-1111-1111-111111111111")
 		seedTwo(t, class, id, "v1-ns1", "v1-ns2", user1Key, user2Key)
@@ -179,7 +177,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 
 	t.Run("head is namespace-scoped", func(t *testing.T) {
 		const class = "HeadTarget"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		// Insert only in ns1; ns2 has the class but no row.
 		id := strfmt.UUID("cccccccc-3333-3333-3333-333333333333")
@@ -205,7 +203,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 
 	t.Run("query (GET /objects?class=) is namespace-scoped", func(t *testing.T) {
 		const class = "ListTarget"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		id := strfmt.UUID("eeeeeeee-5555-5555-5555-555555555555")
 		seedTwo(t, class, id, "list-ns1", "list-ns2", user1Key, user2Key)
@@ -234,7 +232,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		// Class only in ns1. user1 validates → ok. user2 validates same short
 		// class → unresolved → error.
 		const class = "ValidateTarget"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		id := strfmt.UUID("ffffffff-6666-6666-6666-666666666666")
 		_, err := helper.Client(t).Objects.ObjectsValidate(
@@ -256,7 +254,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 
 	t.Run("namespaced caller submitting :-qualified class on read is rejected as 422", func(t *testing.T) {
 		const class = "DoublePrefix"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
 			Class:      class,
@@ -267,7 +265,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 
 		// user1 supplying the already-qualified name is rejected by namespace
 		// prefix validation — namespaced callers must use the short name.
-		_, err = helper.GetObjectAuth(t, "customer1:"+class, obj.ID, user1Key)
+		_, err = helper.GetObjectAuth(t, ns1+":"+class, obj.ID, user1Key)
 		require.Error(t, err)
 		var unproc *objects.ObjectsClassGetUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected ObjectsClassGetUnprocessableEntity, got %T: %v", err, err)
@@ -275,7 +273,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 
 	t.Run("global admin reads object via qualified class name", func(t *testing.T) {
 		const class = "AdminQualified"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
 			Class:      class,
@@ -286,15 +284,15 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 
 		// Admin has no namespace, so Resolve is a no-op and the qualified
 		// name flows through untouched.
-		got, err := helper.GetObjectAuth(t, "customer1:"+class, obj.ID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":"+class, obj.ID, adminKey)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, ns1+":"+class, got.Class)
 		assert.Equal(t, "Tenet", got.Properties.(map[string]any)["title"])
 	})
 
 	t.Run("global admin reading object via short name returns 404", func(t *testing.T) {
 		const class = "AdminShort"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
 			Class:      class,
@@ -304,7 +302,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		require.NotEmpty(t, obj.ID)
 
 		// Admin → no namespace → Resolve leaves the short name as-is. Storage
-		// only has "customer1:AdminShort" → 404.
+		// only has the qualified "<ns>:AdminShort" → 404.
 		_, err = helper.GetObjectAuth(t, class, obj.ID, adminKey)
 		require.Error(t, err)
 		var nf *objects.ObjectsClassGetNotFound
@@ -315,11 +313,11 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 // TestNamespaces_BatchOperations exercises BatchManager fan-out under
 // namespace resolution.
 func TestNamespaces_BatchOperations(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("batch insert is namespace-scoped", func(t *testing.T) {
 		const class = "BatchInsert"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		id1 := strfmt.UUID("11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 		id2 := strfmt.UUID("22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
@@ -346,7 +344,7 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 
 	t.Run("batch delete by filter is namespace-scoped", func(t *testing.T) {
 		const class = "BatchDelete"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		id1 := strfmt.UUID("33333333-cccc-cccc-cccc-cccccccccccc")
 		id2 := strfmt.UUID("44444444-dddd-dddd-dddd-dddddddddddd")
@@ -405,12 +403,12 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 			class = "BatchDeleteAlias"
 			alias = "BDAlias"
 		)
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user2Key)
 		t.Cleanup(func() {
-			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
-			helper.DeleteAliasWithAuthz(t, "customer2:"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns2+":"+alias, helper.CreateAuth(adminKey))
 		})
 
 		id1 := strfmt.UUID("55555555-eeee-eeee-eeee-eeeeeeeeeeee")
@@ -468,7 +466,7 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 		// class portion: the qualified name flows through to storage and
 		// matches; the short name does not exist on disk and 422s.
 		const class = "BatchDeleteAdmin"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		id1 := strfmt.UUID("99999999-1111-1111-1111-111111111111")
 		id2 := strfmt.UUID("aaaaaaaa-2222-2222-2222-222222222222")
@@ -500,7 +498,7 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 
 		// Admin with the qualified class name resolves directly to storage.
 		resp, err := helper.Client(t).Batch.BatchObjectsDelete(
-			batch.NewBatchObjectsDeleteParams().WithBody(mkBody("customer1:"+class)),
+			batch.NewBatchObjectsDeleteParams().WithBody(mkBody(ns1+":"+class)),
 			helper.CreateAuth(adminKey),
 		)
 		require.NoError(t, err)
@@ -520,12 +518,12 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 		// clusters: filterext.Parse qualifies each inner class segment against
 		// the source's namespace and then the filter is validated like any
 		// other. This fixture has no "Other" class, so QualifyRefTarget turns
-		// "Other" into "customer1:Other" and the downstream schema lookup then
+		// "Other" into "<ns>:Other" and the downstream schema lookup then
 		// rejects it with "could not find class ..." — proving the qualification
 		// path runs and the removed path-len > 1 upfront guard is gone (any
-		// "customer1:" in the message is stripped before reaching this caller).
+		// namespace prefix in the message is stripped before reaching this caller).
 		const class = "BatchDeleteRefPath"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		x := "x"
 		body := &models.BatchDelete{
@@ -553,7 +551,7 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 		assert.Contains(t, msg, "could not find class",
 			"must fail in the downstream schema lookup, not the removed upfront rejection")
 		assert.Contains(t, msg, "Other",
-			"the leaf class name (qualified to customer1:Other and stripped to Other) must appear in the message")
+			"the leaf class name (qualified to <ns>:Other and stripped to Other) must appear in the message")
 		assert.NotContains(t, msg, "reference-path filters",
 			"the upfront path-len > 1 rejection no longer exists")
 	})

--- a/test/acceptance/namespace/placement_test.go
+++ b/test/acceptance/namespace/placement_test.go
@@ -47,6 +47,7 @@ func homeNodeShards(t *testing.T, qualifiedClass, homeNode, key string) (homeSha
 // TestNamespaces_CollectionPinsToHomeNode places a namespaced collection
 // and asserts its shard lands only on the namespace's home_node.
 func TestNamespaces_CollectionPinsToHomeNode(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const homeNode = "weaviate-1"
 
@@ -75,6 +76,7 @@ func TestNamespaces_CollectionPinsToHomeNode(t *testing.T) {
 // namespaced MT class: every tenant's shard lands on the namespace's
 // home_node, and a tenant reactivated after freeze still pins there.
 func TestNamespaces_TenantPinsToHomeNode(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const homeNode = "weaviate-2"
 

--- a/test/acceptance/namespace/placement_test.go
+++ b/test/acceptance/namespace/placement_test.go
@@ -47,10 +47,8 @@ func homeNodeShards(t *testing.T, qualifiedClass, homeNode, key string) (homeSha
 // TestNamespaces_CollectionPinsToHomeNode places a namespaced collection
 // and asserts its shard lands only on the namespace's home_node.
 func TestNamespaces_CollectionPinsToHomeNode(t *testing.T) {
-	const (
-		ns       = "pincol"
-		homeNode = "weaviate-1"
-	)
+	ns := uniqueNS()
+	const homeNode = "weaviate-1"
 
 	helper.CreateNamespaceWithHomeNode(t, ns, homeNode, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, ns, adminKey) })
@@ -77,10 +75,8 @@ func TestNamespaces_CollectionPinsToHomeNode(t *testing.T) {
 // namespaced MT class: every tenant's shard lands on the namespace's
 // home_node, and a tenant reactivated after freeze still pins there.
 func TestNamespaces_TenantPinsToHomeNode(t *testing.T) {
-	const (
-		ns       = "pintnt"
-		homeNode = "weaviate-2"
-	)
+	ns := uniqueNS()
+	const homeNode = "weaviate-2"
 
 	helper.CreateNamespaceWithHomeNode(t, ns, homeNode, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, ns, adminKey) })

--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -40,6 +40,7 @@ const s3Backend = "s3"
 // env-var root accessing it successfully, proving the denies are real auth
 // denials — narrowing, not a missing grant or a disabled endpoint.
 func TestNamespaces_RBACSurfaces(t *testing.T) {
+	t.Parallel()
 	ns1, _, user1Key, _ := twoNamespaces(t)
 
 	const class = "Surfaces"

--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -40,13 +40,11 @@ const s3Backend = "s3"
 // env-var root accessing it successfully, proving the denies are real auth
 // denials — narrowing, not a missing grant or a disabled endpoint.
 func TestNamespaces_RBACSurfaces(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, _, user1Key, _ := twoNamespaces(t)
 
-	const (
-		class     = "Surfaces"
-		qualified = "customer1:" + class
-	)
-	setupClassInNs1(t, class, user1Key)
+	const class = "Surfaces"
+	qualified := ns1 + ":" + class
+	setupClassInNs1(t, ns1, class, user1Key)
 
 	// Positive control for the namespaced admin itself: prove the admin grant is
 	// live with real data permissions. Without this, the operator-surface 403s
@@ -135,7 +133,7 @@ func TestNamespaces_RBACSurfaces(t *testing.T) {
 
 	t.Run("create namespace: namespaced denied, root allowed", func(t *testing.T) {
 		// manage_namespaces is root-only; the narrowed admin lacks it.
-		const newNS = "ns-deny-create"
+		newNS := uniqueNS()
 		_, err := helper.Client(t).Namespaces.CreateNamespace(
 			clns.NewCreateNamespaceParams().WithNamespaceID(newNS),
 			helper.CreateAuth(user1Key))
@@ -149,8 +147,8 @@ func TestNamespaces_RBACSurfaces(t *testing.T) {
 
 	t.Run("delete namespace: namespaced denied, root allowed", func(t *testing.T) {
 		// Throwaway target so a regression letting the call through cannot
-		// remove customer1 mid-test; authz runs before existence checks.
-		const throwaway = "ns-root-delete"
+		// remove a live namespace mid-test; authz runs before existence checks.
+		throwaway := uniqueNS()
 		helper.CreateNamespace(t, throwaway, adminKey)
 
 		_, err := helper.Client(t).Namespaces.DeleteNamespace(

--- a/test/acceptance/namespace/references_test.go
+++ b/test/acceptance/namespace/references_test.go
@@ -40,6 +40,7 @@ import (
 //  3. update / delete resolve the same way add does
 //  4. global admin can address objects via qualified class names
 func TestNamespaces_References(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	// One Zoo and one Animal class per namespace. hasAnimals.DataType is

--- a/test/acceptance/namespace/references_test.go
+++ b/test/acceptance/namespace/references_test.go
@@ -40,13 +40,13 @@ import (
 //  3. update / delete resolve the same way add does
 //  4. global admin can address objects via qualified class names
 func TestNamespaces_References(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	// One Zoo and one Animal class per namespace. hasAnimals.DataType is
 	// submitted short (the schema validator rejects ":" in cross-ref data
 	// types from user input) but QualifyPropertyDataTypes mutates the slice
 	// to the qualified form before RAFT, and storage keeps it qualified —
-	// admin reads see ["customer1:Animal"] while namespaced reads strip
+	// admin reads see [ns1+":Animal"] while namespaced reads strip
 	// back to ["Animal"]. The reference handlers strip the stored
 	// qualified DataType at autodetect sites for beacon construction.
 	zooAnimal := func() (animal, zoo *models.Class) {
@@ -74,10 +74,10 @@ func TestNamespaces_References(t *testing.T) {
 	setup(t, user1Key)
 	setup(t, user2Key)
 	t.Cleanup(func() {
-		helper.DeleteClassAuth(t, "customer1:Zoo", adminKey)
-		helper.DeleteClassAuth(t, "customer1:Animal", adminKey)
-		helper.DeleteClassAuth(t, "customer2:Zoo", adminKey)
-		helper.DeleteClassAuth(t, "customer2:Animal", adminKey)
+		helper.DeleteClassAuth(t, ns1+":Zoo", adminKey)
+		helper.DeleteClassAuth(t, ns1+":Animal", adminKey)
+		helper.DeleteClassAuth(t, ns2+":Zoo", adminKey)
+		helper.DeleteClassAuth(t, ns2+":Animal", adminKey)
 	})
 
 	newID := func() strfmt.UUID { return strfmt.UUID(uuid.New().String()) }
@@ -102,7 +102,7 @@ func TestNamespaces_References(t *testing.T) {
 
 		// The object should now contain the reference (admin reads the
 		// qualified class to inspect raw storage).
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs, ok := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.True(t, ok, "hasAnimals should be a list, got %T", got.Properties.(map[string]any)["hasAnimals"])
@@ -125,11 +125,11 @@ func TestNamespaces_References(t *testing.T) {
 		// Admin addresses everything by qualified storage class. The handler
 		// must still write the beacon in short form so portability holds.
 		_, err := helper.AddReferenceReturn(t,
-			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/customer1:Animal/" + string(animalID))},
-			zooID, "customer1:Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
+			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/" + ns1 + ":Animal/" + string(animalID))},
+			zooID, ns1+":Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
 		require.NoError(t, err)
 
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1)
@@ -140,8 +140,8 @@ func TestNamespaces_References(t *testing.T) {
 	})
 
 	t.Run("source object in foreign namespace is invisible", func(t *testing.T) {
-		// Object lives only in customer2. user1 tries to add a reference on
-		// the same UUID via "Zoo" — that resolves to customer1:Zoo where the
+		// Object lives only in ns2. user1 tries to add a reference on
+		// the same UUID via "Zoo" — that resolves to ns1:Zoo where the
 		// object does not exist, so the call fails (404 from the source-object
 		// existence check, not a cross-namespace leak).
 		zooID, animalID := newID(), newID()
@@ -162,7 +162,7 @@ func TestNamespaces_References(t *testing.T) {
 		// Qualified target class — namespaced caller must not type "<ns>:" in
 		// the beacon. namespacing.Resolve rejects with 422.
 		_, err := helper.AddReferenceReturn(t,
-			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/customer2:Animal/" + string(animalID))},
+			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/" + ns2 + ":Animal/" + string(animalID))},
 			zooID, "Zoo", "hasAnimals", "", helper.CreateAuth(user1Key))
 		require.Error(t, err)
 		var unproc *objects.ObjectsClassReferencesCreateUnprocessableEntity
@@ -191,9 +191,9 @@ func TestNamespaces_References(t *testing.T) {
 		// Beacons must be short for the namespaced caller.
 		gotFrom := string(resp.Payload[0].From)
 		gotTo := string(resp.Payload[0].To)
-		assert.NotContains(t, gotFrom, "customer1:",
+		assert.NotContains(t, gotFrom, ns1+":",
 			"From beacon must not leak the caller's own namespace prefix: %s", gotFrom)
-		assert.NotContains(t, gotTo, "customer1:",
+		assert.NotContains(t, gotTo, ns1+":",
 			"To beacon must stay short for the caller's own namespace: %s", gotTo)
 		assert.Equal(t, "weaviate://localhost/Zoo/"+string(zooID)+"/hasAnimals", gotFrom)
 		assert.Equal(t, "weaviate://localhost/Animal/"+string(animalID), gotTo)
@@ -206,7 +206,7 @@ func TestNamespaces_References(t *testing.T) {
 
 		refs := []*models.BatchReference{{
 			From: strfmt.URI("weaviate://localhost/Zoo/" + string(zooID) + "/hasAnimals"),
-			To:   strfmt.URI("weaviate://localhost/customer2:Animal/" + string(badAnimalID)),
+			To:   strfmt.URI("weaviate://localhost/" + ns2 + ":Animal/" + string(badAnimalID)),
 		}}
 		resp, err := helper.Client(t).Batch.BatchReferencesCreate(
 			batch.NewBatchReferencesCreateParams().WithBody(refs),
@@ -236,14 +236,14 @@ func TestNamespaces_References(t *testing.T) {
 		require.NoError(t, err)
 
 		// DELETE the only remaining ref (passed in short form; the handler
-		// must resolve it to "customer1:Animal" so the stored qualified beacon
+		// must resolve it to ns1+":Animal" so the stored qualified beacon
 		// matches).
 		_, err = helper.DeleteReferenceReturn(t,
 			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/Animal/" + string(animalBID))},
 			zooID, "Zoo", "hasAnimals", "", helper.CreateAuth(user1Key))
 		require.NoError(t, err)
 
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs, ok := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		if ok {
@@ -256,7 +256,7 @@ func TestNamespaces_References(t *testing.T) {
 		// storage invariant. references_add normalises admin-submitted
 		// qualified beacons to short before storage; without the
 		// structural (Class, TargetID) compare in removeReference, an
-		// admin submitting "weaviate://localhost/customer1:Animal/<id>"
+		// admin submitting "weaviate://localhost/"+ns1+":Animal/<id>"
 		// would hit an exact-string compare against the stored short
 		// "weaviate://localhost/Animal/<id>", miss, and silently return
 		// 204 with the ref still present.
@@ -272,12 +272,12 @@ func TestNamespaces_References(t *testing.T) {
 
 		// Admin DELETE with the QUALIFIED beacon must remove the ref.
 		_, err = helper.DeleteReferenceReturn(t,
-			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/customer1:Animal/" + string(animalID))},
-			zooID, "customer1:Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
+			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/" + ns1 + ":Animal/" + string(animalID))},
+			zooID, ns1+":Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
 		require.NoError(t, err)
 
 		// Verify the ref is actually gone — admin reads via qualified class.
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs, ok := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		if ok {
@@ -291,7 +291,7 @@ func TestNamespaces_References(t *testing.T) {
 		// target via qualified beacon" but for the DELETE path. The
 		// ValidateNamespacePrefix gate in references_delete runs BEFORE
 		// any normalisation, so a namespaced user submitting
-		// "weaviate://localhost/customer2:Animal/<id>" is rejected with
+		// "weaviate://localhost/"+ns2+":Animal/<id>" is rejected with
 		// 422 — and the local ref is untouched.
 		zooID, animalID, foreignAnimalID := newID(), newID(), newID()
 		createIn(t, user1Key, "Zoo", zooID, map[string]any{"name": "z-foreign-del"})
@@ -306,7 +306,7 @@ func TestNamespaces_References(t *testing.T) {
 
 		// Namespaced user DELETE with a foreign-NS qualified beacon: 422.
 		_, err = helper.DeleteReferenceReturn(t,
-			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/customer2:Animal/" + string(foreignAnimalID))},
+			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/" + ns2 + ":Animal/" + string(foreignAnimalID))},
 			zooID, "Zoo", "hasAnimals", "", helper.CreateAuth(user1Key))
 		require.Error(t, err)
 		var unproc *objects.ObjectsClassReferencesDeleteUnprocessableEntity
@@ -315,7 +315,7 @@ func TestNamespaces_References(t *testing.T) {
 
 		// The legitimate stored ref must still be present — the 422 path
 		// must NOT mutate state.
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1, "cross-NS delete must not remove the local ref")
@@ -328,9 +328,9 @@ func TestNamespaces_References(t *testing.T) {
 	t.Run("admin delete with foreign-NS qualified beacon must not silently match by short class", func(t *testing.T) {
 		// Defense against the admin foot-gun in removeReference: the
 		// short-class-on-both-sides match would otherwise accept
-		// "weaviate://localhost/customer2:Animal/<uuid>" against a stored
+		// "weaviate://localhost/"+ns2+":Animal/<uuid>" against a stored
 		// "weaviate://localhost/Animal/<uuid>" (both strip to "Animal")
-		// and delete the customer1:Animal ref. QualifyRefTarget enforces
+		// and delete the ns1:Animal ref. QualifyRefTarget enforces
 		// "admin's qualified prefix must match the source's namespace"
 		// for the same reason the four write paths do.
 		zooID, animalID, foreignAnimalID := newID(), newID(), newID()
@@ -338,24 +338,24 @@ func TestNamespaces_References(t *testing.T) {
 		createIn(t, user1Key, "Animal", animalID, map[string]any{"name": "local"})
 		createIn(t, user2Key, "Animal", foreignAnimalID, map[string]any{"name": "foreign"})
 
-		// Seed: customer1:Zoo → customer1:Animal/animalID
+		// Seed: ns1:Zoo → ns1:Animal/animalID
 		_, err := helper.AddReferenceReturn(t,
 			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/Animal/" + string(animalID))},
 			zooID, "Zoo", "hasAnimals", "", helper.CreateAuth(user1Key))
 		require.NoError(t, err)
 
-		// Admin DELETE on customer1:Zoo with a customer2-prefixed target
+		// Admin DELETE on ns1:Zoo with a ns2-prefixed target
 		// against the LOCAL animalID. Without the cross-NS gate, both
 		// classes strip to "Animal" and the UUID matches, so the local
 		// ref would silently be deleted. Expect 422.
 		_, err = helper.DeleteReferenceReturn(t,
-			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/customer2:Animal/" + string(animalID))},
-			zooID, "customer1:Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
+			&models.SingleRef{Beacon: strfmt.URI("weaviate://localhost/" + ns2 + ":Animal/" + string(animalID))},
+			zooID, ns1+":Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
 		require.Error(t, err,
 			"admin foreign-NS delete must be rejected even when the short class + UUID would match locally")
 
 		// State unchanged: the local ref is still there.
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1, "admin foreign-NS delete must not have removed the local ref")
@@ -369,9 +369,9 @@ func TestNamespaces_References(t *testing.T) {
 		zooID := newID()
 		createIn(t, user1Key, "Zoo", zooID, map[string]any{"name": "admin-view"})
 
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:Zoo", got.Class)
+		assert.Equal(t, ns1+":Zoo", got.Class)
 	})
 
 	t.Run("identical UUIDs in two namespaces stay isolated through refs", func(t *testing.T) {
@@ -394,7 +394,7 @@ func TestNamespaces_References(t *testing.T) {
 		}
 
 		// Both rows have the same short beacon on disk — portability check.
-		for _, ns := range []string{"customer1", "customer2"} {
+		for _, ns := range []string{ns1, ns2} {
 			got, err := helper.GetObjectAuth(t, ns+":Zoo", zooID, adminKey)
 			require.NoError(t, err)
 			refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
@@ -421,7 +421,7 @@ func TestNamespaces_References(t *testing.T) {
 
 		// user1 sends a gRPC search using the short class name and asks for
 		// hasAnimals to be ref-resolved inline. The parser must qualify the
-		// linked Animal class via customer1:, otherwise the multi-get misses
+		// linked Animal class via ns1:, otherwise the multi-get misses
 		// the qualified storage.
 		req := searchReq("Zoo", 10)
 		req.Properties = &pb.PropertiesRequest{
@@ -433,7 +433,7 @@ func TestNamespaces_References(t *testing.T) {
 		}
 		// Search may return Zoos from earlier subtests too; the assertion is
 		// that *the one we just created* has its hasAnimals ref resolved
-		// inline to the customer1:Animal target with the expected name.
+		// inline to the ns1:Animal target with the expected name.
 		req.Limit = 100
 		resp, err := grpcClient.Search(authCtx(user1Key), req)
 		require.NoError(t, err)
@@ -462,12 +462,12 @@ func TestNamespaces_References(t *testing.T) {
 			}
 		}
 		assert.True(t, foundResolved,
-			"gRPC ref-resolve should inline the customer1:Animal target via the source namespace; got name=%q", resolvedName)
+			"gRPC ref-resolve should inline the ns1:Animal target via the source namespace; got name=%q", resolvedName)
 		assert.Equal(t, "Animal", resolvedTargetCollection,
 			"nested-ref TargetCollection must be stripped of the caller's own namespace prefix")
 
 		// Admin sees the qualified form (Strip is a no-op for globals).
-		adminReq := searchReq("customer1:Zoo", 100)
+		adminReq := searchReq(ns1+":Zoo", 100)
 		adminReq.Properties = &pb.PropertiesRequest{
 			NonRefProperties: []string{"name"},
 			RefProperties: []*pb.RefPropertiesRequest{{
@@ -489,7 +489,7 @@ func TestNamespaces_References(t *testing.T) {
 				}
 			}
 		}
-		assert.Equal(t, "customer1:Animal", adminResolvedTargetCollection,
+		assert.Equal(t, ns1+":Animal", adminResolvedTargetCollection,
 			"admin must see the qualified nested-ref TargetCollection unchanged")
 	})
 
@@ -499,7 +499,7 @@ func TestNamespaces_References(t *testing.T) {
 		// path normalizes via crossref.NewLocalhost. The by-ref filter must
 		// strip the qualified prefix off the nested-search ClassName before
 		// building its lookup beacon — otherwise the lookup value carries
-		// "customer1:Animal" and never matches the stored short value.
+		// ns1+":Animal" and never matches the stored short value.
 		// Pre-fix this returned 0 rows; we now assert the actual matching
 		// row is returned, not just that the call doesn't crash.
 		zooTiger, zooLion := newID(), newID()
@@ -563,7 +563,7 @@ func TestNamespaces_References(t *testing.T) {
 	t.Run("REST ref-path where filter resolves target via source namespace", func(t *testing.T) {
 		// REST ingress (batch-delete → filterext.Parse), independent of the
 		// gRPC path above. The short inner class "Animal" must qualify to
-		// "customer1:Animal" or the ref sub-search matches nothing. dryRun
+		// ns1+":Animal" or the ref sub-search matches nothing. dryRun
 		// keeps the shared Zoo class intact.
 		tigerID, lionID := newID(), newID()
 		zooTigerID, zooLionID := newID(), newID()
@@ -624,7 +624,7 @@ func TestNamespaces_References(t *testing.T) {
 					Class: "Zoo",
 					Where: &models.WhereFilter{
 						Operator:  models.WhereFilterOperatorEqual,
-						Path:      []string{"hasAnimals", "customer2:Animal", "name"},
+						Path:      []string{"hasAnimals", ns2 + ":Animal", "name"},
 						ValueText: &anyName,
 					},
 				},
@@ -665,7 +665,7 @@ func TestNamespaces_References(t *testing.T) {
 		require.NoError(t, err, "creating an object with a ref property in Properties must succeed on NS clusters")
 
 		// Stored shape: still short.
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1)
@@ -677,7 +677,7 @@ func TestNamespaces_References(t *testing.T) {
 
 	t.Run("AddProperty adds a cross-ref property to an existing namespaced class", func(t *testing.T) {
 		// Pre-WS9: AddClassProperty would call ReadOnlyClass("Animal") (short)
-		// while storage has "customer1:Animal" (qualified), hitting
+		// while storage has ns1+":Animal" (qualified), hitting
 		// ErrRefToNonexistentClass at the use-case validator.
 		// WS9: classGetterWithAuth stitches parent's namespace onto the short
 		// class name before lookup, so the cross-ref data type resolves.
@@ -696,13 +696,13 @@ func TestNamespaces_References(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+class, adminKey)
-			helper.DeleteClassAuth(t, "customer1:PostHocAnimal", adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+class, adminKey)
+			helper.DeleteClassAuth(t, ns1+":PostHocAnimal", adminKey)
 		})
 
 		// Now add the cross-ref property — user submits short DataType
 		// ("PostHocAnimal"); QualifyPropertyDataTypes mutates the slice
-		// to ["customer1:PostHocAnimal"] before RAFT, and storage keeps
+		// to [ns1+":PostHocAnimal"] before RAFT, and storage keeps
 		// that qualified form.
 		_, err := helper.Client(t).Schema.SchemaObjectsPropertiesAdd(
 			schemaCli.NewSchemaObjectsPropertiesAddParams().
@@ -716,12 +716,12 @@ func TestNamespaces_References(t *testing.T) {
 		// the empty-namespace admin principal, so DataType comes back in
 		// the qualified storage form. Reading as user1Key would strip
 		// back to the short form — both views are exercised together.
-		got := helper.GetClassAuth(t, "customer1:"+class, adminKey)
+		got := helper.GetClassAuth(t, ns1+":"+class, adminKey)
 		var sawHasAnimals bool
 		for _, p := range got.Properties {
 			if p.Name == "hasAnimals" {
 				sawHasAnimals = true
-				assert.Equal(t, []string{"customer1:PostHocAnimal"}, p.DataType,
+				assert.Equal(t, []string{ns1 + ":PostHocAnimal"}, p.DataType,
 					"admin view: stored DataType is qualified")
 			}
 		}
@@ -752,7 +752,7 @@ func TestNamespaces_References(t *testing.T) {
 				{Name: "relatedTo", DataType: []string{class}},
 			},
 		}, user1Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+class, adminKey) })
 
 		// And the self-ref works end-to-end: two instances, one referencing
 		// the other.
@@ -785,9 +785,9 @@ func TestNamespaces_References(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:MultiRefSource", adminKey)
-			helper.DeleteClassAuth(t, "customer1:MultiRefAlpha", adminKey)
-			helper.DeleteClassAuth(t, "customer1:MultiRefBeta", adminKey)
+			helper.DeleteClassAuth(t, ns1+":MultiRefSource", adminKey)
+			helper.DeleteClassAuth(t, ns1+":MultiRefAlpha", adminKey)
+			helper.DeleteClassAuth(t, ns1+":MultiRefBeta", adminKey)
 		})
 
 		// Reference each multi-target via an explicit class in the beacon.
@@ -807,7 +807,7 @@ func TestNamespaces_References(t *testing.T) {
 		}
 
 		// Stored beacons stay short for both targets.
-		got, err := helper.GetObjectAuth(t, "customer1:MultiRefSource", srcID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":MultiRefSource", srcID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasOther"].([]interface{})
 		require.Len(t, refs, 2)
@@ -815,7 +815,7 @@ func TestNamespaces_References(t *testing.T) {
 			beaconStr, _ := r.(map[string]any)["beacon"].(string)
 			// Beacon format: weaviate://localhost/<class>/<uuid>. The class
 			// segment must not carry a namespace prefix.
-			assert.NotContains(t, beaconStr, "customer1:",
+			assert.NotContains(t, beaconStr, ns1+":",
 				"stored multi-target beacon must be short (no namespace prefix in the class segment): %s", beaconStr)
 		}
 	})
@@ -846,9 +846,9 @@ func TestNamespaces_References(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:MTFilterSource", adminKey)
-			helper.DeleteClassAuth(t, "customer1:MTFilterAlpha", adminKey)
-			helper.DeleteClassAuth(t, "customer1:MTFilterBeta", adminKey)
+			helper.DeleteClassAuth(t, ns1+":MTFilterSource", adminKey)
+			helper.DeleteClassAuth(t, ns1+":MTFilterAlpha", adminKey)
+			helper.DeleteClassAuth(t, ns1+":MTFilterBeta", adminKey)
 		})
 
 		alphaWanted, alphaOther := newID(), newID()
@@ -877,7 +877,7 @@ func TestNamespaces_References(t *testing.T) {
 				Target: &pb.FilterTarget_MultiTarget{
 					MultiTarget: &pb.FilterReferenceMultiTarget{
 						On:               "linkedTo",
-						TargetCollection: "MTFilterAlpha", // short — qualifier stitches customer1
+						TargetCollection: "MTFilterAlpha", // short — qualifier stitches ns1
 						Target: &pb.FilterTarget{
 							Target: &pb.FilterTarget_Property{Property: "name"},
 						},
@@ -909,7 +909,7 @@ func TestNamespaces_References(t *testing.T) {
 				Target: &pb.FilterTarget_MultiTarget{
 					MultiTarget: &pb.FilterReferenceMultiTarget{
 						On:               "hasAnimals",
-						TargetCollection: "customer2:Animal", // foreign namespace
+						TargetCollection: ns2 + ":Animal", // foreign namespace
 						Target: &pb.FilterTarget{
 							Target: &pb.FilterTarget_Property{Property: "name"},
 						},
@@ -926,7 +926,7 @@ func TestNamespaces_References(t *testing.T) {
 	t.Run("gRPC by_ref_count filter on NS cluster", func(t *testing.T) {
 		// by_ref_count goes through the SOURCE's `property_<name>__meta_count`
 		// inverted bucket — no beacon construction, no linked-class lookup.
-		// The bucket lives under the source's qualified shard (customer1:Src)
+		// The bucket lives under the source's qualified shard (ns1:Src)
 		// which is keyed normally, so the only thing that has to work is
 		// the source class qualification done upstream by namespacing.Resolve.
 		// This subtest is the negative control for the namespace-strip
@@ -948,8 +948,8 @@ func TestNamespaces_References(t *testing.T) {
 			InvertedIndexConfig: &models.InvertedIndexConfig{IndexPropertyLength: indexLen},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+class, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+tgt, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+class, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+tgt, adminKey)
 		})
 
 		t1ID, tID := newID(), newID()
@@ -1001,7 +1001,7 @@ func TestNamespaces_References(t *testing.T) {
 		// N source rows × N target rows, batched via /v1/batch/references.
 		// Each src[i] links to tgt[i]. After the batch returns, a gRPC
 		// search with return_references inlines the linked object — must
-		// resolve to the customer1:Animal target matching index i, which
+		// resolve to the ns1:Animal target matching index i, which
 		// confirms the batch path qualifies the target class for the
 		// existence check and strips it back to short for storage.
 		const n = 5
@@ -1089,8 +1089,8 @@ func TestNamespaces_References(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+class, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+tgt, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+class, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+tgt, adminKey)
 		})
 
 		tID, s1, s2 := newID(), newID(), newID()
@@ -1180,7 +1180,7 @@ func TestNamespaces_References(t *testing.T) {
 		// beacon from Property.DataType. DataType is qualified by
 		// QualifyPropertyDataTypes upstream, so without StripQualification
 		// at the beacon-build site the produced beacon reads
-		// "weaviate://localhost/customer1:Animal/<id>" and trips
+		// "weaviate://localhost/"+ns1+":Animal/<id>" and trips
 		// ValidateNamespacePrefix in properties_validation.go's
 		// parseAndValidateSingleRef — the whole object insert 422s with
 		// "is not a valid class name". Untested before this commit; the
@@ -1215,7 +1215,7 @@ func TestNamespaces_References(t *testing.T) {
 			resp.Errors)
 
 		// Stored beacon must be SHORT — admin reads via qualified class.
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs, ok := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.True(t, ok, "hasAnimals should be a list, got %T",
@@ -1234,8 +1234,8 @@ func TestNamespaces_References(t *testing.T) {
 		// Pre-unification, properties_validation built the qualified
 		// target as QualifiedName(NamespaceFromQualified(sourceClass),
 		// ref.Class) without stripping first. An admin POSTing to
-		// customer1:Zoo with beacon ".../customer1:Animal/<id>" would
-		// produce "customer1:customer1:Animal" — the existence check
+		// ns1:Zoo with beacon ".../ns1:Animal/<id>" would
+		// produce "ns1:ns1:Animal" — the existence check
 		// hit a non-existent class and the insert 422'd. Untested
 		// before: the existing inline-ref test only uses a namespaced
 		// caller with a short beacon.
@@ -1248,17 +1248,17 @@ func TestNamespaces_References(t *testing.T) {
 		// schema" against the double-qualified target.
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
 			ID:    zooID,
-			Class: "customer1:Zoo",
+			Class: ns1 + ":Zoo",
 			Properties: map[string]any{
 				"name": "z-admin-inline",
 				"hasAnimals": []any{
-					map[string]any{"beacon": "weaviate://localhost/customer1:Animal/" + string(animalID)},
+					map[string]any{"beacon": "weaviate://localhost/" + ns1 + ":Animal/" + string(animalID)},
 				},
 			},
 		}, adminKey)
 		require.NoError(t, err)
 
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1)
@@ -1274,7 +1274,7 @@ func TestNamespaces_References(t *testing.T) {
 		// (validateReferenceMultiTenancy in references_add.go:159 and
 		// batch_references_add.go:142), but no test ever lit a tenant on
 		// a ref. Two cases:
-		//   1. Happy path: MT Zoo → MT Animal in customer1, tenant=t1.
+		//   1. Happy path: MT Zoo → MT Animal in ns1, tenant=t1.
 		//      ref-add must succeed, stored beacon short, ref resolves
 		//      to the matching tenant.
 		//   2. Mismatch: MT Zoo → non-MT Animal must be rejected via
@@ -1304,9 +1304,9 @@ func TestNamespaces_References(t *testing.T) {
 			Properties: []*models.Property{{Name: "name", DataType: []string{"text"}}},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+mtZoo, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+mtAnimal, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+plain, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+mtZoo, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+mtAnimal, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+plain, adminKey)
 		})
 
 		require.NoError(t, addTenantsAuth(t, mtZoo,
@@ -1340,7 +1340,7 @@ func TestNamespaces_References(t *testing.T) {
 		require.NoError(t, err, "MT ref-add same tenant on NS cluster must succeed")
 
 		// Stored beacon stays short.
-		got, err := helper.GetObjectAuthWithTenant(t, "customer1:"+mtZoo, zooID, tenantA, adminKey)
+		got, err := helper.GetObjectAuthWithTenant(t, ns1+":"+mtZoo, zooID, tenantA, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1)
@@ -1363,7 +1363,7 @@ func TestNamespaces_References(t *testing.T) {
 				{Name: "hasAnimals", DataType: []string{mtAnimal}},
 			},
 		}, user1Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+plainZoo, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+plainZoo, adminKey) })
 
 		plainZooID := newID()
 		_, err = helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -1382,10 +1382,10 @@ func TestNamespaces_References(t *testing.T) {
 	t.Run("admin POST with inline foreign-NS target on NS cluster is rejected", func(t *testing.T) {
 		// Companion to the previous test: QualifyRefTarget centralises
 		// the cross-namespace policy, so an admin's attempt to point a
-		// customer1:Zoo at customer2:Animal via inline beacon must
+		// ns1:Zoo at ns2:Animal via inline beacon must
 		// 422. Pre-unification this silently succeeded
 		// (resolveNS-based path stripped the prefix), then later read
-		// paths would resolve the link back to customer1:Animal
+		// paths would resolve the link back to ns1:Animal
 		// — a cross-tenant write that read as same-tenant. Now
 		// rejected at validation.
 		zooID, animalID := newID(), newID()
@@ -1393,11 +1393,11 @@ func TestNamespaces_References(t *testing.T) {
 
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
 			ID:    zooID,
-			Class: "customer1:Zoo",
+			Class: ns1 + ":Zoo",
 			Properties: map[string]any{
 				"name": "z-admin-cross-ns",
 				"hasAnimals": []any{
-					map[string]any{"beacon": "weaviate://localhost/customer2:Animal/" + string(animalID)},
+					map[string]any{"beacon": "weaviate://localhost/" + ns2 + ":Animal/" + string(animalID)},
 				},
 			},
 		}, adminKey)
@@ -1426,11 +1426,11 @@ func TestNamespaces_References(t *testing.T) {
 		// 1. Admin PUT replaces with a qualified-target beacon and
 		//    storage normalizes back to short.
 		_, err = helper.ReplaceReferencesReturn(t,
-			[]*models.SingleRef{{Beacon: strfmt.URI("weaviate://localhost/customer1:Animal/" + string(a2))}},
-			zooID, "customer1:Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
+			[]*models.SingleRef{{Beacon: strfmt.URI("weaviate://localhost/" + ns1 + ":Animal/" + string(a2))}},
+			zooID, ns1+":Zoo", "hasAnimals", "", helper.CreateAuth(adminKey))
 		require.NoError(t, err, "admin PUT with qualified-target beacon must succeed")
 
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1, "PUT must replace, not append")
@@ -1443,7 +1443,7 @@ func TestNamespaces_References(t *testing.T) {
 		//    QualifyRefTarget rejects qualified targets from namespaced
 		//    principals (422).
 		_, err = helper.ReplaceReferencesReturn(t,
-			[]*models.SingleRef{{Beacon: strfmt.URI("weaviate://localhost/customer2:Animal/" + string(a1))}},
+			[]*models.SingleRef{{Beacon: strfmt.URI("weaviate://localhost/" + ns2 + ":Animal/" + string(a1))}},
 			zooID, "Zoo", "hasAnimals", "", helper.CreateAuth(user1Key))
 		require.Error(t, err,
 			"namespaced PUT with foreign-NS qualified target must be rejected")
@@ -1477,9 +1477,9 @@ func TestNamespaces_References(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+src, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+a, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+b, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+src, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+a, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+b, adminKey)
 		})
 
 		aID := newID()
@@ -1512,7 +1512,7 @@ func TestNamespaces_References(t *testing.T) {
 			"gRPC BatchObjects with MultiTargetRefProps must succeed on NS clusters; got %+v",
 			resp.Errors)
 
-		got, err := helper.GetObjectAuth(t, "customer1:"+src, srcID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":"+src, srcID, adminKey)
 		require.NoError(t, err)
 		refs, ok := got.Properties.(map[string]any)["linkedTo"].([]interface{})
 		require.True(t, ok, "linkedTo should be a list, got %T",
@@ -1558,7 +1558,7 @@ func TestNamespaces_References(t *testing.T) {
 		require.NoError(t, err, "PUT with inline short ref from namespaced user must succeed")
 
 		// Namespace-handling focus: every stored beacon must be SHORT
-		// (no customer1: prefix), and the new target must be present.
+		// (no ns1: prefix), and the new target must be present.
 		// PUT's ref-cardinality semantics (whether it appends or
 		// replaces inline refs vs the prior stored refs) are a
 		// separate concern from namespace handling.
@@ -1568,7 +1568,7 @@ func TestNamespaces_References(t *testing.T) {
 			var found bool
 			for _, r := range refs {
 				b, _ := r.(map[string]any)["beacon"].(string)
-				assert.NotContains(t, b, "customer",
+				assert.NotContains(t, b, ns1+":",
 					"stored beacon must be SHORT (no namespace prefix); got %q", b)
 				if b == want {
 					found = true
@@ -1578,7 +1578,7 @@ func TestNamespaces_References(t *testing.T) {
 				"expected SHORT beacon %q to be present in %v", want, refs)
 		}
 
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		assertShortBeaconPresent(t, refs, "Animal", string(a1))
@@ -1599,7 +1599,7 @@ func TestNamespaces_References(t *testing.T) {
 		_, err = helper.Client(t).Objects.ObjectsClassPatch(patchParams, helper.CreateAuth(user1Key))
 		require.NoError(t, err, "PATCH with inline short ref from namespaced user must succeed")
 
-		got, err = helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err = helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs = got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		assertShortBeaconPresent(t, refs, "Animal", string(a2))
@@ -1607,12 +1607,12 @@ func TestNamespaces_References(t *testing.T) {
 		// Admin PATCH with qualified-target inline beacon — must
 		// normalize via QualifyRefTarget without double-qualifying.
 		adminPatch := objects.NewObjectsClassPatchParams().
-			WithClassName("customer1:Zoo").WithID(zooID).WithBody(&models.Object{
+			WithClassName(ns1 + ":Zoo").WithID(zooID).WithBody(&models.Object{
 			ID:    zooID,
-			Class: "customer1:Zoo",
+			Class: ns1 + ":Zoo",
 			Properties: map[string]any{
 				"hasAnimals": []any{
-					map[string]any{"beacon": "weaviate://localhost/customer1:Animal/" + string(a1)},
+					map[string]any{"beacon": "weaviate://localhost/" + ns1 + ":Animal/" + string(a1)},
 				},
 			},
 		})
@@ -1620,7 +1620,7 @@ func TestNamespaces_References(t *testing.T) {
 		require.NoError(t, err,
 			"admin PATCH with qualified inline ref must succeed (no double-qualify)")
 
-		got, err = helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err = helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs = got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		assertShortBeaconPresent(t, refs, "Animal", string(a1))
@@ -1632,7 +1632,7 @@ func TestNamespaces_References(t *testing.T) {
 			Class: "Zoo",
 			Properties: map[string]any{
 				"hasAnimals": []any{
-					map[string]any{"beacon": "weaviate://localhost/customer2:Animal/" + string(a1)},
+					map[string]any{"beacon": "weaviate://localhost/" + ns2 + ":Animal/" + string(a1)},
 				},
 			},
 		})
@@ -1664,7 +1664,7 @@ func TestNamespaces_References(t *testing.T) {
 		defer conn.Close()
 
 		animalTarget := "Animal"
-		foreignTarget := "customer2:Animal"
+		foreignTarget := ns2 + ":Animal"
 		resp, err := grpcClient.BatchReferences(authCtx(user1Key), &pb.BatchReferencesRequest{
 			References: []*pb.BatchReference{
 				{
@@ -1689,7 +1689,7 @@ func TestNamespaces_References(t *testing.T) {
 
 		// Happy path: confirm the short-target row landed and is short
 		// in storage.
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs, ok := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.True(t, ok)
@@ -1699,10 +1699,10 @@ func TestNamespaces_References(t *testing.T) {
 			if beaconStr == "weaviate://localhost/Animal/"+string(animalID) {
 				foundShort = true
 			}
-			// Beacon class segment must not carry a customer namespace
-			// prefix — beacon scheme is "weaviate://" so a bare `:`
-			// check would always fail.
-			assert.NotContains(t, beaconStr, "customer",
+			// Beacon class segment must not carry the namespace prefix —
+			// beacon scheme is "weaviate://" so a bare `:` check would
+			// always fail.
+			assert.NotContains(t, beaconStr, ns1+":",
 				"no stored beacon should carry a namespace prefix; got %q", beaconStr)
 		}
 		assert.True(t, foundShort,
@@ -1717,7 +1717,7 @@ func TestNamespaces_References(t *testing.T) {
 		// QualifyRefTarget, so the inferred toClass goes through
 		// the same qualification flow. This subtest pins:
 		//   1. namespaced user can submit a classless beacon and
-		//      autodetect resolves to the customer1 Animal target.
+		//      autodetect resolves to the ns1 Animal target.
 		//   2. stored beacon is SHORT (autodetect inferred class
 		//      should not leak the qualified form into storage).
 		zooID, animalID := newID(), newID()
@@ -1730,7 +1730,7 @@ func TestNamespaces_References(t *testing.T) {
 		require.NoError(t, err,
 			"namespaced classless beacon autodetect must succeed")
 
-		got, err := helper.GetObjectAuth(t, "customer1:Zoo", zooID, adminKey)
+		got, err := helper.GetObjectAuth(t, ns1+":Zoo", zooID, adminKey)
 		require.NoError(t, err)
 		refs := got.Properties.(map[string]any)["hasAnimals"].([]interface{})
 		require.Len(t, refs, 1)
@@ -1764,8 +1764,8 @@ func TestNamespaces_References(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+class, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+tgt, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+class, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+tgt, adminKey)
 		})
 
 		tID, srcWith, srcWithout := newID(), newID(), newID()

--- a/test/acceptance/namespace/response_stripping_errors_test.go
+++ b/test/acceptance/namespace/response_stripping_errors_test.go
@@ -33,14 +33,14 @@ import (
 // error messages surfaced to namespaced callers do not carry the caller's own
 // namespace prefix, while global admins still see qualified names.
 func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, _, user1Key, _ := twoNamespaces(t)
 	const class = "ErrStripREST"
-	setupClassInNs1(t, class, user1Key)
+	setupClassInNs1(t, ns1, class, user1Key)
 
 	t.Run("returned error: duplicate-class create surfaces stripped message", func(t *testing.T) {
 		// Creating the class a second time returns 422 with a body whose
 		// message contains the qualified name internally; the strip must
-		// remove the "customer1:" prefix before the response leaves the
+		// remove the namespace prefix before the response leaves the
 		// handler.
 		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{Class: class}, user1Key)
 		require.Error(t, err)
@@ -48,17 +48,17 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 		require.True(t, stderrors.As(err, &unproc), "expected SchemaObjectsCreateUnprocessableEntity, got %T: %v", err, err)
 		require.NotEmpty(t, unproc.Payload.Error)
 		msg := unproc.Payload.Error[0].Message
-		assert.NotContains(t, msg, "customer1:", "namespaced caller must not see own-prefix in error: %s", msg)
+		assert.NotContains(t, msg, ns1+":", "namespaced caller must not see own-prefix in error: %s", msg)
 	})
 
 	t.Run("returned error: global admin sees raw qualified name (control)", func(t *testing.T) {
 		// Admin adds a property whose name collides with the existing
 		// "title" prop on the qualified class. The 422 message names the
 		// qualified class, and the strip is a no-op for a global principal,
-		// so "customer1:" stays intact.
+		// so the namespace prefix stays intact.
 		_, err := helper.Client(t).Schema.SchemaObjectsPropertiesAdd(
 			schema.NewSchemaObjectsPropertiesAddParams().
-				WithClassName("customer1:"+class).
+				WithClassName(ns1+":"+class).
 				WithBody(&models.Property{Name: "title", DataType: []string{"text"}}),
 			helper.CreateAuth(adminKey),
 		)
@@ -66,12 +66,12 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 		var unproc *schema.SchemaObjectsPropertiesAddUnprocessableEntity
 		require.True(t, stderrors.As(err, &unproc), "expected SchemaObjectsPropertiesAddUnprocessableEntity, got %T: %v", err, err)
 		require.NotEmpty(t, unproc.Payload.Error)
-		assert.Contains(t, unproc.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", unproc.Payload.Error[0].Message)
+		assert.Contains(t, unproc.Payload.Error[0].Message, ns1+":", "admin must see qualified name: %s", unproc.Payload.Error[0].Message)
 	})
 
 	t.Run("indexes update on missing property surfaces stripped message", func(t *testing.T) {
 		// PUT on an existing class but a non-existent property returns 404 with a
-		// message naming the qualified collection internally; the strip removes "customer1:".
+		// message naming the qualified collection internally; the strip removes the namespace prefix.
 		body := &models.IndexUpdateRequest{Filterable: &models.IndexUpdateFilterable{Tokenization: "lowercase"}}
 		_, err := helper.Client(t).Schema.SchemaObjectsIndexesUpdate(
 			schema.NewSchemaObjectsIndexesUpdateParams().
@@ -86,14 +86,14 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 		require.NotEmpty(t, notFound.Payload.Error)
 		msg := notFound.Payload.Error[0].Message
 		assert.Contains(t, msg, "ghostprop", "sanity: error names the missing property: %s", msg)
-		assert.NotContains(t, msg, "customer1:", "namespaced caller must not see own-prefix in indexes error: %s", msg)
+		assert.NotContains(t, msg, ns1+":", "namespaced caller must not see own-prefix in indexes error: %s", msg)
 	})
 
 	t.Run("indexes update error: global admin sees raw qualified name (control)", func(t *testing.T) {
 		body := &models.IndexUpdateRequest{Filterable: &models.IndexUpdateFilterable{Tokenization: "lowercase"}}
 		_, err := helper.Client(t).Schema.SchemaObjectsIndexesUpdate(
 			schema.NewSchemaObjectsIndexesUpdateParams().
-				WithClassName("customer1:"+class). // qualified name
+				WithClassName(ns1+":"+class). // qualified name
 				WithPropertyName("ghostprop").
 				WithBody(body),
 			helper.CreateAuth(adminKey),
@@ -102,15 +102,15 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 		var notFound *schema.SchemaObjectsIndexesUpdateNotFound
 		require.True(t, stderrors.As(err, &notFound), "expected 404, got %T: %v", err, err)
 		require.NotEmpty(t, notFound.Payload.Error)
-		assert.Contains(t, notFound.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", notFound.Payload.Error[0].Message)
+		assert.Contains(t, notFound.Payload.Error[0].Message, ns1+":", "admin must see qualified name: %s", notFound.Payload.Error[0].Message)
 	})
 
 	t.Run("batch per-item error: object with type-mismatched property is stripped", func(t *testing.T) {
 		// Number value for a text property — auto-schema can't reconcile
 		// a type conflict on an existing prop, so the validator emits a
 		// per-item error naming the qualified class. The message lands in
-		// the success-shaped response's Result.Errors with "customer1:"
-		// stripped for the namespaced caller.
+		// the success-shaped response's Result.Errors with the namespace
+		// prefix stripped for the namespaced caller.
 		resp, err := helper.Client(t).Batch.BatchObjectsCreate(
 			batch.NewBatchObjectsCreateParams().WithBody(batch.BatchObjectsCreateBody{
 				Objects: []*models.Object{
@@ -125,7 +125,7 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 		for _, r := range resp.Payload {
 			if r.Result != nil && r.Result.Errors != nil && len(r.Result.Errors.Error) > 0 {
 				msg := r.Result.Errors.Error[0].Message
-				assert.NotContains(t, msg, "customer1:", "batch per-item error must be stripped: %s", msg)
+				assert.NotContains(t, msg, ns1+":", "batch per-item error must be stripped: %s", msg)
 				found = true
 			}
 		}
@@ -139,12 +139,12 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 // (PermissionDenied/Unauthenticated) — the test asserts the status code is
 // preserved, not collapsed to Unknown.
 func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, _, user1Key, _ := twoNamespaces(t)
 	grpcClient, conn := newGrpcClient(t)
 	defer conn.Close()
 
 	const class = "ErrStripGRPC"
-	setupClassInNs1(t, class, user1Key)
+	setupClassInNs1(t, ns1, class, user1Key)
 
 	t.Run("unary returned error: Search on non-existent collection stripped", func(t *testing.T) {
 		_, err := grpcClient.Search(authCtx(user1Key), searchReq("NonExistentClass", 1))
@@ -154,7 +154,7 @@ func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
 		// The status code must be preserved, not collapsed to Unknown by
 		// the strippedErr wrapper (Unwrap keeps the original typed error
 		// reachable for the interceptor's translateTypedError).
-		assert.NotContains(t, st.Message(), "customer1:", "namespaced caller must not see own-prefix in status message: %s", st.Message())
+		assert.NotContains(t, st.Message(), ns1+":", "namespaced caller must not see own-prefix in status message: %s", st.Message())
 	})
 
 	t.Run("batch reply per-item error: invalid object yields stripped per-item entry", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, resp.Errors)
 		for _, be := range resp.Errors {
-			assert.NotContains(t, be.Error, "customer1:", "batch reply per-item error must be stripped: %s", be.Error)
+			assert.NotContains(t, be.Error, ns1+":", "batch reply per-item error must be stripped: %s", be.Error)
 		}
 	})
 
@@ -214,7 +214,7 @@ func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
 			}
 			if r := msg.GetResults(); r != nil {
 				for _, e := range r.GetErrors() {
-					assert.NotContains(t, e.Error, "customer1:", "stream per-item error must be stripped: %s", e.Error)
+					assert.NotContains(t, e.Error, ns1+":", "stream per-item error must be stripped: %s", e.Error)
 					foundErr = true
 				}
 			}
@@ -224,21 +224,21 @@ func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
 
 	t.Run("control: global admin sees qualified name in unary error", func(t *testing.T) {
 		// Admin queries the qualified class form for a non-existent class —
-		// the message must keep "customer1:" intact.
-		_, err := grpcClient.Search(authCtx(adminKey), searchReq("customer1:NonExistentClass", 1))
+		// the message must keep the namespace prefix intact.
+		_, err := grpcClient.Search(authCtx(adminKey), searchReq(ns1+":NonExistentClass", 1))
 		require.Error(t, err)
 		st, ok := status.FromError(err)
 		require.True(t, ok)
-		assert.Contains(t, st.Message(), "customer1:", "admin must see qualified name: %s", st.Message())
+		assert.Contains(t, st.Message(), ns1+":", "admin must see qualified name: %s", st.Message())
 	})
 }
 
 // TestNamespaces_ResponseStripping_Errors_MCP pins the contract for MCP
 // tool-handler returned errors and per-item upsert error fields.
 func TestNamespaces_ResponseStripping_Errors_MCP(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	ns1, _, user1Key, _ := twoNamespaces(t)
 	const class = "ErrStripMCP"
-	setupClassInNs1(t, class, user1Key)
+	setupClassInNs1(t, ns1, class, user1Key)
 
 	t.Run("returned error: hybrid on non-existent collection is stripped", func(t *testing.T) {
 		alpha := 0.0
@@ -249,12 +249,12 @@ func TestNamespaces_ResponseStripping_Errors_MCP(t *testing.T) {
 			Alpha:          &alpha,
 		}, &resp, user1Key)
 		require.Error(t, err)
-		assert.NotContains(t, err.Error(), "customer1:", "namespaced caller must not see own-prefix in MCP error: %s", err.Error())
+		assert.NotContains(t, err.Error(), ns1+":", "namespaced caller must not see own-prefix in MCP error: %s", err.Error())
 	})
 
 	t.Run("upsert per-item error: invalid object yields stripped per-item entry", func(t *testing.T) {
 		// Mismatched UUID triggers a per-item failure; the resulting
-		// UpsertObjectResult.Error string must have no "customer1:" prefix.
+		// UpsertObjectResult.Error string must have no namespace prefix.
 		var resp *create.UpsertObjectResp
 		err := helper.CallToolOnce(t.Context(), t, mcpToolUpsert, &create.UpsertObjectArgs{
 			CollectionName: class,
@@ -267,12 +267,12 @@ func TestNamespaces_ResponseStripping_Errors_MCP(t *testing.T) {
 		// error. Accept either shape: top-level error OR per-item Error.
 		switch {
 		case err != nil:
-			assert.NotContains(t, err.Error(), "customer1:", "top-level MCP error must be stripped: %s", err.Error())
+			assert.NotContains(t, err.Error(), ns1+":", "top-level MCP error must be stripped: %s", err.Error())
 		case resp != nil:
 			require.NotEmpty(t, resp.Results)
 			for _, r := range resp.Results {
 				if r.Error != "" {
-					assert.NotContains(t, r.Error, "customer1:", "per-item MCP error must be stripped: %s", r.Error)
+					assert.NotContains(t, r.Error, ns1+":", "per-item MCP error must be stripped: %s", r.Error)
 				}
 			}
 		default:

--- a/test/acceptance/namespace/response_stripping_errors_test.go
+++ b/test/acceptance/namespace/response_stripping_errors_test.go
@@ -33,6 +33,7 @@ import (
 // error messages surfaced to namespaced callers do not carry the caller's own
 // namespace prefix, while global admins still see qualified names.
 func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
+	t.Parallel()
 	ns1, _, user1Key, _ := twoNamespaces(t)
 	const class = "ErrStripREST"
 	setupClassInNs1(t, ns1, class, user1Key)
@@ -139,6 +140,7 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 // (PermissionDenied/Unauthenticated) — the test asserts the status code is
 // preserved, not collapsed to Unknown.
 func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
+	t.Parallel()
 	ns1, _, user1Key, _ := twoNamespaces(t)
 	grpcClient, conn := newGrpcClient(t)
 	defer conn.Close()
@@ -236,6 +238,7 @@ func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
 // TestNamespaces_ResponseStripping_Errors_MCP pins the contract for MCP
 // tool-handler returned errors and per-item upsert error fields.
 func TestNamespaces_ResponseStripping_Errors_MCP(t *testing.T) {
+	t.Parallel()
 	ns1, _, user1Key, _ := twoNamespaces(t)
 	const class = "ErrStripMCP"
 	setupClassInNs1(t, ns1, class, user1Key)

--- a/test/acceptance/namespace/response_stripping_test.go
+++ b/test/acceptance/namespace/response_stripping_test.go
@@ -32,7 +32,7 @@ import (
 // global admin keeps the raw qualified form. Round-trip tests assert that a
 // stripped GET response can be PUT/PATCHed back unchanged.
 func TestNamespaces_ResponseStripping_REST(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("AddClass response strips Class and cross-ref DataType", func(t *testing.T) {
 		const name = "AddClassStripped"
@@ -41,9 +41,9 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
 		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+name, adminKey)
-			helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
-			helper.DeleteClassAuth(t, "customer1:Books", adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+name, adminKey)
+			helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
+			helper.DeleteClassAuth(t, ns1+":Books", adminKey)
 		})
 
 		resp, err := helper.CreateClassAuthWithReturn(t, &models.Class{
@@ -63,20 +63,20 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 		// Admin sees the raw qualified class + qualified cross-ref DataTypes
 		// via direct GET.
-		raw := helper.GetClassAuth(t, "customer1:"+name, adminKey)
-		assert.Equal(t, "customer1:"+name, raw.Class)
-		assert.Equal(t, []string{"customer1:Movies"}, findProp(raw, "watched").DataType)
-		assert.Equal(t, []string{"customer1:Movies", "customer1:Books"}, findProp(raw, "related").DataType)
+		raw := helper.GetClassAuth(t, ns1+":"+name, adminKey)
+		assert.Equal(t, ns1+":"+name, raw.Class)
+		assert.Equal(t, []string{ns1 + ":Movies"}, findProp(raw, "watched").DataType)
+		assert.Equal(t, []string{ns1 + ":Movies", ns1 + ":Books"}, findProp(raw, "related").DataType)
 	})
 
 	t.Run("addClassProperty response strips DataType cross-ref class names", func(t *testing.T) {
 		const host = "Library"
 		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
 		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user1Key)
-		setupClassInNs1(t, host, user1Key)
+		setupClassInNs1(t, ns1, host, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
-			helper.DeleteClassAuth(t, "customer1:Books", adminKey)
+			helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
+			helper.DeleteClassAuth(t, ns1+":Books", adminKey)
 		})
 
 		single, err := addPropertyAuthWithReturn(t, host,
@@ -90,19 +90,19 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		assert.Equal(t, []string{"Movies", "Books"}, multi.DataType)
 
 		// Admin sees the raw qualified DataTypes via direct GET.
-		raw := helper.GetClassAuth(t, "customer1:"+host, adminKey)
-		assert.Equal(t, []string{"customer1:Movies"}, findProp(raw, "watched").DataType)
-		assert.Equal(t, []string{"customer1:Movies", "customer1:Books"}, findProp(raw, "related").DataType)
+		raw := helper.GetClassAuth(t, ns1+":"+host, adminKey)
+		assert.Equal(t, []string{ns1 + ":Movies"}, findProp(raw, "watched").DataType)
+		assert.Equal(t, []string{ns1 + ":Movies", ns1 + ":Books"}, findProp(raw, "related").DataType)
 	})
 
 	t.Run("AddClass with already-qualified own-NS DataType rejected", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:Movies", adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":Movies", adminKey) })
 
 		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{
 			Class: "RejectQualifiedOwn",
 			Properties: []*models.Property{
-				{Name: "watched", DataType: []string{"customer1:Movies"}},
+				{Name: "watched", DataType: []string{ns1 + ":Movies"}},
 			},
 		}, user1Key)
 		require.Error(t, err)
@@ -110,14 +110,14 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 	})
 
 	t.Run("AddClass with cross-NS DataType rejected", func(t *testing.T) {
-		// customer2:Movies exists, but customer1's caller may not reference it.
+		// ns2's Movies exists, but ns1's caller may not reference it.
 		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user2Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer2:Movies", adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns2+":Movies", adminKey) })
 
 		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{
 			Class: "RejectCrossNS",
 			Properties: []*models.Property{
-				{Name: "watched", DataType: []string{"customer2:Movies"}},
+				{Name: "watched", DataType: []string{ns2 + ":Movies"}},
 			},
 		}, user1Key)
 		require.Error(t, err)
@@ -132,7 +132,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		// sides.
 		const name = "RoundTripMe"
 		helper.CreateClassAuth(t, &models.Class{Class: name, Description: "v1"}, user1Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+name, adminKey) })
 
 		// GET by short path — response is stripped.
 		got, err := helper.GetClassAuthWithReturn(t, name, user1Key)
@@ -147,7 +147,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		assert.Equal(t, name, putResp.Payload.Class)
 
 		// Confirm via admin: underlying class updated.
-		after := helper.GetClassAuth(t, "customer1:"+name, adminKey)
+		after := helper.GetClassAuth(t, ns1+":"+name, adminKey)
 		assert.Equal(t, "v2", after.Description)
 	})
 
@@ -167,8 +167,8 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 			},
 		}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteClassAuth(t, "customer1:"+host, adminKey)
-			helper.DeleteClassAuth(t, "customer1:"+target, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+host, adminKey)
+			helper.DeleteClassAuth(t, ns1+":"+target, adminKey)
 		})
 
 		got, err := helper.GetClassAuthWithReturn(t, host, user1Key)
@@ -187,18 +187,18 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 		// Admin GET confirms the stored cross-refs are still qualified and
 		// the Description update landed.
-		after := helper.GetClassAuth(t, "customer1:"+host, adminKey)
+		after := helper.GetClassAuth(t, ns1+":"+host, adminKey)
 		assert.Equal(t, "v2", after.Description)
-		assert.Equal(t, []string{"customer1:" + target}, findProp(after, "watched").DataType)
-		assert.Equal(t, []string{"customer1:" + target}, findProp(after, "related").DataType)
+		assert.Equal(t, []string{ns1 + ":" + target}, findProp(after, "watched").DataType)
+		assert.Equal(t, []string{ns1 + ":" + target}, findProp(after, "related").DataType)
 	})
 
 	t.Run("AddAlias response strips Alias and Class", func(t *testing.T) {
 		const class = "AliasCreateTarget"
 		const alias = "AliasCreateName"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
 		})
 
 		resp, err := helper.CreateAliasAuthWithReturn(t, &models.Alias{Alias: alias, Class: class}, user1Key)
@@ -211,12 +211,12 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		const classA = "AliasUpdateA"
 		const classB = "AliasUpdateB"
 		const alias = "AliasUpdateName"
-		setupClassInNs1(t, classA, user1Key)
+		setupClassInNs1(t, ns1, classA, user1Key)
 		helper.CreateClassAuth(t, &models.Class{Class: classB}, user1Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+classB, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+classB, adminKey) })
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: classA}, user1Key)
 		t.Cleanup(func() {
-			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
 		})
 
 		resp, err := helper.UpdateAliasAuthWithReturn(t, alias, classB, user1Key)
@@ -227,7 +227,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 	t.Run("AddObject response is stripped", func(t *testing.T) {
 		const class = "AddObjStripped"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
 			Class: class, Properties: map[string]any{"title": "first"},
 		}, user1Key)
@@ -237,7 +237,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 	t.Run("object GET → PUT round-trip succeeds with stripped body", func(t *testing.T) {
 		const class = "ObjPutRoundTrip"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		id := strfmt.UUID("aaaa1111-2222-3333-4444-aaaa11112222")
 		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -267,7 +267,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 	t.Run("object GET → PATCH round-trip succeeds with stripped body", func(t *testing.T) {
 		const class = "ObjPatchRoundTrip"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		id := strfmt.UUID("bbbb2222-3333-4444-5555-bbbb22223333")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
@@ -294,7 +294,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 	t.Run("batch create response strips per-item Class", func(t *testing.T) {
 		const class = "BatchCreateStrip"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 
 		resp, err := helper.Client(t).Batch.BatchObjectsCreate(
 			batch.NewBatchObjectsCreateParams().WithBody(batch.BatchObjectsCreateBody{
@@ -314,20 +314,20 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		respAdmin, err := helper.Client(t).Batch.BatchObjectsCreate(
 			batch.NewBatchObjectsCreateParams().WithBody(batch.BatchObjectsCreateBody{
 				Objects: []*models.Object{
-					{Class: "customer1:" + class, Properties: map[string]any{"title": "admin-a"}},
+					{Class: ns1 + ":" + class, Properties: map[string]any{"title": "admin-a"}},
 				},
 			}),
 			helper.CreateAuth(adminKey),
 		)
 		require.NoError(t, err)
 		require.Len(t, respAdmin.Payload, 1)
-		assert.Equal(t, "customer1:"+class, respAdmin.Payload[0].Class,
+		assert.Equal(t, ns1+":"+class, respAdmin.Payload[0].Class,
 			"global admin must see the qualified Class in the batch-create response")
 	})
 
 	t.Run("batch delete response strips Match.Class", func(t *testing.T) {
 		const class = "BatchDeleteStrip"
-		setupClassInNs1(t, class, user1Key)
+		setupClassInNs1(t, ns1, class, user1Key)
 		id := strfmt.UUID("cccc3333-4444-5555-6666-cccc33334444")
 		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
 			ID: id, Class: class, Properties: map[string]any{"title": "kill"},
@@ -362,7 +362,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		respAdmin, err := helper.Client(t).Batch.BatchObjectsDelete(
 			batch.NewBatchObjectsDeleteParams().WithBody(&models.BatchDelete{
 				Match: &models.BatchDeleteMatch{
-					Class: "customer1:" + class,
+					Class: ns1 + ":" + class,
 					Where: &models.WhereFilter{
 						Operator:  "Equal",
 						Path:      []string{"title"},
@@ -374,7 +374,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NotNil(t, respAdmin.Payload.Match)
-		assert.Equal(t, "customer1:"+class, respAdmin.Payload.Match.Class,
+		assert.Equal(t, ns1+":"+class, respAdmin.Payload.Match.Class,
 			"global admin must see the qualified Match.Class in the batch-delete response")
 	})
 
@@ -385,7 +385,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 			Class:      animal,
 			Properties: []*models.Property{{Name: "name", DataType: []string{"text"}}},
 		}, user1Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+animal, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+animal, adminKey) })
 		helper.CreateClassAuth(t, &models.Class{
 			Class: zoo,
 			Properties: []*models.Property{
@@ -393,7 +393,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 				{Name: "hasAnimals", DataType: []string{animal}},
 			},
 		}, user1Key)
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+zoo, adminKey) })
+		t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+zoo, adminKey) })
 
 		zooID := strfmt.UUID("bbbb1111-2222-3333-4444-bbbb11112222")
 		animalID := strfmt.UUID("bbbb3333-4444-5555-6666-bbbb33334444")
@@ -419,9 +419,9 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 		gotFrom := string(resp.Payload[0].From)
 		gotTo := string(resp.Payload[0].To)
-		assert.NotContains(t, gotFrom, "customer1:",
+		assert.NotContains(t, gotFrom, ns1+":",
 			"namespaced caller must see short From beacon: %s", gotFrom)
-		assert.NotContains(t, gotTo, "customer1:",
+		assert.NotContains(t, gotTo, ns1+":",
 			"namespaced caller must see short To beacon: %s", gotTo)
 		assert.Equal(t, "weaviate://localhost/"+zoo+"/"+string(zooID)+"/hasAnimals", gotFrom)
 		assert.Equal(t, "weaviate://localhost/"+animal+"/"+string(animalID), gotTo)
@@ -429,7 +429,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 
 	t.Run("cross-NS isolation: same short class name in both namespaces, each sees only own", func(t *testing.T) {
 		const class = "CrossNSStrip"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		// Each namespaced caller GETs by short name and sees only their own
 		// short form; admin sees both qualified forms exist.
@@ -438,13 +438,13 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		c2 := helper.GetClassAuth(t, class, user2Key)
 		assert.Equal(t, class, c2.Class)
 
-		assert.Equal(t, "customer1:"+class, helper.GetClassAuth(t, "customer1:"+class, adminKey).Class)
-		assert.Equal(t, "customer2:"+class, helper.GetClassAuth(t, "customer2:"+class, adminKey).Class)
+		assert.Equal(t, ns1+":"+class, helper.GetClassAuth(t, ns1+":"+class, adminKey).Class)
+		assert.Equal(t, ns2+":"+class, helper.GetClassAuth(t, ns2+":"+class, adminKey).Class)
 	})
 
 	t.Run("SchemaDump strips for namespaced caller and keeps qualified for admin", func(t *testing.T) {
 		const class = "SchemaDumpStrip"
-		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		dump := func(key string) []*models.Class {
 			resp, err := helper.Client(t).Schema.SchemaDump(clschema.NewSchemaDumpParams(), helper.CreateAuth(key))
@@ -475,17 +475,17 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		for _, c := range dump(adminKey) {
 			adminNames = append(adminNames, c.Class)
 		}
-		assert.Contains(t, adminNames, "customer1:"+class)
-		assert.Contains(t, adminNames, "customer2:"+class)
+		assert.Contains(t, adminNames, ns1+":"+class)
+		assert.Contains(t, adminNames, ns2+":"+class)
 	})
 }
 
 // TestNamespaces_ResponseStripping_OwnInfoUsername pins the Username strip
-// contract: namespaced DB users carry "customer1:apiuser" internally, and
+// contract: namespaced DB users carry a namespace-qualified username internally, and
 // /users/own-info must echo that as the short form. Role/permission strip
 // requires RBAC and is covered in the authz acceptance suite.
 func TestNamespaces_ResponseStripping_OwnInfoUsername(t *testing.T) {
-	user1Key, _ := twoNamespaces(t)
+	_, _, user1Key, _ := twoNamespaces(t)
 
 	t.Run("namespaced DB user sees short username", func(t *testing.T) {
 		resp, err := helper.Client(t).Users.GetOwnInfo(
@@ -494,7 +494,7 @@ func TestNamespaces_ResponseStripping_OwnInfoUsername(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Payload.Username)
 		assert.Equal(t, "u1", *resp.Payload.Username,
-			"namespaced caller's stored username is customer1:u1; response must strip")
+			"namespaced caller's stored username is qualified; response must strip")
 	})
 
 	t.Run("global admin sees raw username", func(t *testing.T) {

--- a/test/acceptance/namespace/response_stripping_test.go
+++ b/test/acceptance/namespace/response_stripping_test.go
@@ -32,6 +32,7 @@ import (
 // global admin keeps the raw qualified form. Round-trip tests assert that a
 // stripped GET response can be PUT/PATCHed back unchanged.
 func TestNamespaces_ResponseStripping_REST(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	t.Run("AddClass response strips Class and cross-ref DataType", func(t *testing.T) {
@@ -485,6 +486,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 // /users/own-info must echo that as the short form. Role/permission strip
 // requires RBAC and is covered in the authz acceptance suite.
 func TestNamespaces_ResponseStripping_OwnInfoUsername(t *testing.T) {
+	t.Parallel()
 	_, _, user1Key, _ := twoNamespaces(t)
 
 	t.Run("namespaced DB user sees short username", func(t *testing.T) {

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -90,10 +90,8 @@ func findProp(class *models.Class, name string) *models.Property {
 }
 
 func TestNamespaces_AddClassProperty(t *testing.T) {
-	const (
-		ns1 = "customer1"
-		ns2 = "customer2"
-	)
+	ns1 := uniqueNS()
+	ns2 := uniqueNS()
 	helper.CreateNamespace(t, ns1, adminKey)
 	helper.CreateNamespace(t, ns2, adminKey)
 	defer helper.DeleteNamespace(t, ns1, adminKey)
@@ -108,7 +106,7 @@ func TestNamespaces_AddClassProperty(t *testing.T) {
 
 	t.Run("namespaced user adds property by short name; lands on qualified class", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
 
 		err := addPropertyAuth(t, "Movies", &models.Property{
 			Name:     "genre",
@@ -116,7 +114,7 @@ func TestNamespaces_AddClassProperty(t *testing.T) {
 		}, user1Key)
 		require.NoError(t, err)
 
-		got := helper.GetClassAuth(t, "customer1:Movies", adminKey)
+		got := helper.GetClassAuth(t, ns1+":Movies", adminKey)
 		require.Len(t, got.Properties, 1)
 		assert.Equal(t, "genre", got.Properties[0].Name)
 	})
@@ -124,15 +122,15 @@ func TestNamespaces_AddClassProperty(t *testing.T) {
 	t.Run("each namespace mutates only its own class", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user1Key)
 		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user2Key)
-		defer helper.DeleteClassAuth(t, "customer1:Books", adminKey)
-		defer helper.DeleteClassAuth(t, "customer2:Books", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Books", adminKey)
+		defer helper.DeleteClassAuth(t, ns2+":Books", adminKey)
 
 		require.NoError(t, addPropertyAuth(t, "Books", &models.Property{
 			Name: "author", DataType: []string{"text"},
 		}, user2Key))
 
-		c1 := helper.GetClassAuth(t, "customer1:Books", adminKey)
-		c2 := helper.GetClassAuth(t, "customer2:Books", adminKey)
+		c1 := helper.GetClassAuth(t, ns1+":Books", adminKey)
+		c2 := helper.GetClassAuth(t, ns2+":Books", adminKey)
 		assert.Empty(t, c1.Properties)
 		require.Len(t, c2.Properties, 1)
 		assert.Equal(t, "author", c2.Properties[0].Name)
@@ -140,36 +138,36 @@ func TestNamespaces_AddClassProperty(t *testing.T) {
 
 	t.Run("global admin adds property by qualified name", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "Shows"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Shows", adminKey)
 
-		err := addPropertyAuth(t, "customer1:Shows", &models.Property{
+		err := addPropertyAuth(t, ns1+":Shows", &models.Property{
 			Name: "rating", DataType: []string{"text"},
 		}, adminKey)
 		require.NoError(t, err)
 
-		got := helper.GetClassAuth(t, "customer1:Shows", adminKey)
+		got := helper.GetClassAuth(t, ns1+":Shows", adminKey)
 		require.Len(t, got.Properties, 1)
 		assert.Equal(t, "rating", got.Properties[0].Name)
 	})
 
 	t.Run("alias is not a backdoor: AddClassProperty by alias name fails and underlying class unchanged", func(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "Concerts"}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Concerts", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Gigs", helper.CreateAuth(adminKey))
 
 		err := addPropertyAuth(t, "Gigs", &models.Property{
 			Name: "venue", DataType: []string{"text"},
 		}, user1Key)
 		require.Error(t, err, "AddClassProperty must not resolve aliases on namespaced clusters")
 
-		got := helper.GetClassAuth(t, "customer1:Concerts", adminKey)
+		got := helper.GetClassAuth(t, ns1+":Concerts", adminKey)
 		assert.Empty(t, got.Properties, "underlying class must be unchanged")
 	})
 }
 
 func TestNamespaces_DeleteClassPropertyIndex(t *testing.T) {
-	const ns1 = "customer1"
+	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
 	defer helper.DeleteNamespace(t, ns1, adminKey)
@@ -204,40 +202,40 @@ func TestNamespaces_DeleteClassPropertyIndex(t *testing.T) {
 
 	t.Run("namespaced user drops filterable index by short name", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithFilterable("Movies"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
-		requireFilterable(t, "customer1:Movies", true)
+		defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
+		requireFilterable(t, ns1+":Movies", true)
 
 		require.NoError(t, deletePropertyIndexAuth(t, "Movies", "title", "filterable", user1Key))
 
-		requireFilterable(t, "customer1:Movies", false)
+		requireFilterable(t, ns1+":Movies", false)
 	})
 
 	t.Run("global admin drops filterable index by qualified name", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithFilterable("Shows"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
-		requireFilterable(t, "customer1:Shows", true)
+		defer helper.DeleteClassAuth(t, ns1+":Shows", adminKey)
+		requireFilterable(t, ns1+":Shows", true)
 
-		require.NoError(t, deletePropertyIndexAuth(t, "customer1:Shows", "title", "filterable", adminKey))
+		require.NoError(t, deletePropertyIndexAuth(t, ns1+":Shows", "title", "filterable", adminKey))
 
-		requireFilterable(t, "customer1:Shows", false)
+		requireFilterable(t, ns1+":Shows", false)
 	})
 
 	t.Run("alias is not a backdoor: DeleteClassPropertyIndex by alias name fails and underlying class unchanged", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithFilterable("Concerts"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Concerts", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
-		requireFilterable(t, "customer1:Concerts", true)
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Gigs", helper.CreateAuth(adminKey))
+		requireFilterable(t, ns1+":Concerts", true)
 
 		err := deletePropertyIndexAuth(t, "Gigs", "title", "filterable", user1Key)
 		require.Error(t, err, "DeleteClassPropertyIndex must not resolve aliases on namespaced clusters")
 
-		requireFilterable(t, "customer1:Concerts", true)
+		requireFilterable(t, ns1+":Concerts", true)
 	})
 }
 
 func TestNamespaces_DeleteClassVectorIndex(t *testing.T) {
-	const ns1 = "customer1"
+	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
 	defer helper.DeleteNamespace(t, ns1, adminKey)
@@ -274,41 +272,41 @@ func TestNamespaces_DeleteClassVectorIndex(t *testing.T) {
 
 	t.Run("namespaced user drops named vector by short name", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithTwoVectors("Movies"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
-		require.Equal(t, "hnsw", vectorIndexType(t, "customer1:Movies", "vec1"))
+		defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
+		require.Equal(t, "hnsw", vectorIndexType(t, ns1+":Movies", "vec1"))
 
 		require.NoError(t, deleteVectorIndexAuth(t, "Movies", "vec1", user1Key))
 
-		assert.Equal(t, "none", vectorIndexType(t, "customer1:Movies", "vec1"))
-		assert.Equal(t, "hnsw", vectorIndexType(t, "customer1:Movies", "vec2"))
+		assert.Equal(t, "none", vectorIndexType(t, ns1+":Movies", "vec1"))
+		assert.Equal(t, "hnsw", vectorIndexType(t, ns1+":Movies", "vec2"))
 	})
 
 	t.Run("global admin drops named vector by qualified name", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithTwoVectors("Shows"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
-		require.Equal(t, "hnsw", vectorIndexType(t, "customer1:Shows", "vec1"))
+		defer helper.DeleteClassAuth(t, ns1+":Shows", adminKey)
+		require.Equal(t, "hnsw", vectorIndexType(t, ns1+":Shows", "vec1"))
 
-		require.NoError(t, deleteVectorIndexAuth(t, "customer1:Shows", "vec1", adminKey))
+		require.NoError(t, deleteVectorIndexAuth(t, ns1+":Shows", "vec1", adminKey))
 
-		assert.Equal(t, "none", vectorIndexType(t, "customer1:Shows", "vec1"))
+		assert.Equal(t, "none", vectorIndexType(t, ns1+":Shows", "vec1"))
 	})
 
 	t.Run("alias is not a backdoor: DeleteClassVectorIndex by alias name fails and underlying class unchanged", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithTwoVectors("Concerts"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Concerts", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
-		require.Equal(t, "hnsw", vectorIndexType(t, "customer1:Concerts", "vec1"))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Gigs", helper.CreateAuth(adminKey))
+		require.Equal(t, "hnsw", vectorIndexType(t, ns1+":Concerts", "vec1"))
 
 		err := deleteVectorIndexAuth(t, "Gigs", "vec1", user1Key)
 		require.Error(t, err, "DeleteClassVectorIndex must not resolve aliases on namespaced clusters")
 
-		assert.Equal(t, "hnsw", vectorIndexType(t, "customer1:Concerts", "vec1"))
+		assert.Equal(t, "hnsw", vectorIndexType(t, ns1+":Concerts", "vec1"))
 	})
 }
 
 func TestNamespaces_PropertyTokenize(t *testing.T) {
-	const ns1 = "customer1"
+	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
 	defer helper.DeleteNamespace(t, ns1, adminKey)
@@ -331,7 +329,7 @@ func TestNamespaces_PropertyTokenize(t *testing.T) {
 
 	t.Run("namespaced user tokenizes property by short class name", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithTokenizedTitle("Movies"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
 
 		got, err := tokenizePropertyAuth(t, "Movies", "title", "Hello World", user1Key)
 		require.NoError(t, err)
@@ -340,9 +338,9 @@ func TestNamespaces_PropertyTokenize(t *testing.T) {
 
 	t.Run("namespaced user tokenizes property via alias resolves to underlying class", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithTokenizedTitle("Concerts"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Concerts", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Gigs", helper.CreateAuth(adminKey))
 
 		// retryOnAliasLag absorbs the brief window where the alias entry has
 		// been applied on the leader but the follower has not yet replicated
@@ -358,9 +356,9 @@ func TestNamespaces_PropertyTokenize(t *testing.T) {
 
 	t.Run("global admin tokenizes property by qualified class name", func(t *testing.T) {
 		helper.CreateClassAuth(t, classWithTokenizedTitle("Shows"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Shows", adminKey)
 
-		got, err := tokenizePropertyAuth(t, "customer1:Shows", "title", "Hello World", adminKey)
+		got, err := tokenizePropertyAuth(t, ns1+":Shows", "title", "Hello World", adminKey)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"hello", "world"}, got.Indexed)
 	})
@@ -372,10 +370,8 @@ func TestNamespaces_PropertyTokenize(t *testing.T) {
 // i.e. weaviate-0), so the shard always lives remote and the request hops
 // the /indices/<ns>:<class>/shards/<sh>/status route every run.
 func TestNamespaces_ShardsStatus(t *testing.T) {
-	const (
-		ns1      = "shardsstatusns"
-		homeNode = "weaviate-2"
-	)
+	ns1 := uniqueNS()
+	const homeNode = "weaviate-2"
 
 	helper.CreateNamespaceWithHomeNode(t, ns1, homeNode, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, ns1, adminKey) })
@@ -454,10 +450,8 @@ func TestNamespaces_ShardsStatus(t *testing.T) {
 // names from a namespaced principal must hit "<ns>:<class>" and aliases
 // must not be a backdoor.
 func TestNamespaces_UpdateShardStatus(t *testing.T) {
-	const (
-		ns1 = "customer1"
-		ns2 = "customer2"
-	)
+	ns1 := uniqueNS()
+	ns2 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
 	defer helper.DeleteNamespace(t, ns1, adminKey)
@@ -523,7 +517,7 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 
 	t.Run("namespaced user updates shard status by short name; lands on qualified class", func(t *testing.T) {
 		helper.CreateClassAuth(t, newClass("Movies"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
 
 		shards, err := getShards(t, "Movies", user1Key)
 		require.NoError(t, err)
@@ -532,28 +526,28 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 
 		require.NoError(t, updateShard(t, "Movies", shardName, "READONLY", user1Key))
 
-		eventuallyShardStatus(t, "customer1:Movies", shardName, "READONLY", adminKey)
+		eventuallyShardStatus(t, ns1+":Movies", shardName, "READONLY", adminKey)
 	})
 
 	t.Run("global admin updates shard status by qualified name", func(t *testing.T) {
 		helper.CreateClassAuth(t, newClass("Shows"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Shows", adminKey)
 
-		shards, err := getShards(t, "customer1:Shows", adminKey)
+		shards, err := getShards(t, ns1+":Shows", adminKey)
 		require.NoError(t, err)
 		require.Len(t, shards, 1)
 		shardName := shards[0].Name
 
-		require.NoError(t, updateShard(t, "customer1:Shows", shardName, "READONLY", adminKey))
+		require.NoError(t, updateShard(t, ns1+":Shows", shardName, "READONLY", adminKey))
 
-		eventuallyShardStatus(t, "customer1:Shows", shardName, "READONLY", adminKey)
+		eventuallyShardStatus(t, ns1+":Shows", shardName, "READONLY", adminKey)
 	})
 
 	t.Run("alias is not a backdoor: UpdateShardStatus by alias name fails and underlying shard unchanged", func(t *testing.T) {
 		helper.CreateClassAuth(t, newClass("Concerts"), user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Concerts", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Gigs", helper.CreateAuth(adminKey))
 
 		shards, err := getShards(t, "Concerts", user1Key)
 		require.NoError(t, err)
@@ -575,7 +569,7 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 		err = updateShard(t, "Gigs", shardName, "READONLY", user1Key)
 		require.Error(t, err, "UpdateShardStatus must not resolve aliases on namespaced clusters")
 
-		after, err := getShards(t, "customer1:Concerts", adminKey)
+		after, err := getShards(t, ns1+":Concerts", adminKey)
 		require.NoError(t, err)
 		require.Len(t, after, 1)
 		assert.Equal(t, initialStatus, after[0].Status, "underlying shard status must be unchanged")
@@ -584,27 +578,27 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 	t.Run("each namespace updates only its own class", func(t *testing.T) {
 		helper.CreateClassAuth(t, newClass("Books"), user1Key)
 		helper.CreateClassAuth(t, newClass("Books"), user2Key)
-		defer helper.DeleteClassAuth(t, "customer1:Books", adminKey)
-		defer helper.DeleteClassAuth(t, "customer2:Books", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Books", adminKey)
+		defer helper.DeleteClassAuth(t, ns2+":Books", adminKey)
 
-		// Shard ids are per-class, so customer1:Books and customer2:Books
+		// Shard ids are per-class, so ns1:Books and ns2:Books
 		// have disjoint shard name sets.
-		shards2, err := getShards(t, "customer2:Books", adminKey)
+		shards2, err := getShards(t, ns2+":Books", adminKey)
 		require.NoError(t, err)
 		require.Len(t, shards2, 1)
 		shardName := shards2[0].Name
 
-		// user2 says "Books" + a shard id that exists only on customer2:Books.
+		// user2 says "Books" + a shard id that exists only on ns2:Books.
 		// If qualification were skipped the update would resolve to
-		// customer1:Books and fail with "shard not found".
+		// ns1:Books and fail with "shard not found".
 		require.NoError(t, updateShard(t, "Books", shardName, "READONLY", user2Key))
 
-		eventuallyShardStatus(t, "customer2:Books", shardName, "READONLY", adminKey)
+		eventuallyShardStatus(t, ns2+":Books", shardName, "READONLY", adminKey)
 
-		after1, err := getShards(t, "customer1:Books", adminKey)
+		after1, err := getShards(t, ns1+":Books", adminKey)
 		require.NoError(t, err)
 		require.Len(t, after1, 1)
-		assert.NotEqual(t, "READONLY", after1[0].Status, "customer1:Books must be untouched by user2's update")
+		assert.NotEqual(t, "READONLY", after1[0].Status, "ns1:Books must be untouched by user2's update")
 	})
 }
 
@@ -615,7 +609,7 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 // cluster-API URL routing through `regxNodesClass`, which only accepts
 // namespace-qualified names once it is built from IndexNameRegexCore.
 func TestNamespaces_NodesGetClass(t *testing.T) {
-	const ns1 = "customer1"
+	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, ns1, adminKey) })
@@ -629,7 +623,7 @@ func TestNamespaces_NodesGetClass(t *testing.T) {
 			{Name: "title", DataType: []string{"text"}},
 		},
 	}, user1Key)
-	defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+	defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
 
 	verbose := "verbose"
 
@@ -642,7 +636,7 @@ func TestNamespaces_NodesGetClass(t *testing.T) {
 	})
 
 	t.Run("global admin gets node status by qualified class name", func(t *testing.T) {
-		params := nodes.NewNodesGetClassParams().WithClassName("customer1:Movies").WithOutput(&verbose)
+		params := nodes.NewNodesGetClassParams().WithClassName(ns1 + ":Movies").WithOutput(&verbose)
 		resp, err := helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(adminKey))
 		require.NoError(t, err)
 		require.NotNil(t, resp.Payload)
@@ -656,9 +650,9 @@ func TestNamespaces_NodesGetClass(t *testing.T) {
 				{Name: "title", DataType: []string{"text"}},
 			},
 		}, user1Key)
-		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		defer helper.DeleteClassAuth(t, ns1+":Concerts", adminKey)
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Gigs", helper.CreateAuth(adminKey))
 
 		// A 403 is immediate (the authz deny precedes alias resolution), so no
 		// retryOnAliasLag wrapper is needed here.

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -90,6 +90,7 @@ func findProp(class *models.Class, name string) *models.Property {
 }
 
 func TestNamespaces_AddClassProperty(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 	ns2 := uniqueNS()
 	helper.CreateNamespace(t, ns1, adminKey)
@@ -167,6 +168,7 @@ func TestNamespaces_AddClassProperty(t *testing.T) {
 }
 
 func TestNamespaces_DeleteClassPropertyIndex(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
@@ -235,6 +237,7 @@ func TestNamespaces_DeleteClassPropertyIndex(t *testing.T) {
 }
 
 func TestNamespaces_DeleteClassVectorIndex(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
@@ -306,6 +309,7 @@ func TestNamespaces_DeleteClassVectorIndex(t *testing.T) {
 }
 
 func TestNamespaces_PropertyTokenize(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)
@@ -370,6 +374,7 @@ func TestNamespaces_PropertyTokenize(t *testing.T) {
 // i.e. weaviate-0), so the shard always lives remote and the request hops
 // the /indices/<ns>:<class>/shards/<sh>/status route every run.
 func TestNamespaces_ShardsStatus(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 	const homeNode = "weaviate-2"
 
@@ -450,6 +455,7 @@ func TestNamespaces_ShardsStatus(t *testing.T) {
 // names from a namespaced principal must hit "<ns>:<class>" and aliases
 // must not be a backdoor.
 func TestNamespaces_UpdateShardStatus(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 	ns2 := uniqueNS()
 
@@ -609,6 +615,7 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 // cluster-API URL routing through `regxNodesClass`, which only accepts
 // namespace-qualified names once it is built from IndexNameRegexCore.
 func TestNamespaces_NodesGetClass(t *testing.T) {
+	t.Parallel()
 	ns1 := uniqueNS()
 
 	helper.CreateNamespace(t, ns1, adminKey)

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -13,7 +13,9 @@ package namespace
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,6 +26,18 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
+
+// nsCounter backs uniqueNS. Tests must not hardcode namespace names: a shared
+// literal would collide once tests run in parallel against the shared cluster.
+var nsCounter atomic.Int64
+
+// uniqueNS returns a process-unique namespace name ("ns1", "ns2", ...) that
+// satisfies the name contract (lowercase alphanumeric, 3-36 chars). Each test
+// allocates its own so namespaced state (classes, users, objects) stays
+// isolated across concurrent tests.
+func uniqueNS() string {
+	return fmt.Sprintf("ns%d", nsCounter.Add(1))
+}
 
 // retryOnAliasLag retries op until it returns no error. Used after
 // CreateAliasAuth on the multi-node cluster: the create returns when the

--- a/test/acceptance/namespace/tenant_test.go
+++ b/test/acceptance/namespace/tenant_test.go
@@ -33,21 +33,21 @@ func mtClass(name string) *models.Class {
 
 // setupMTClassInBothNamespaces creates an MT-enabled class with the same short
 // name under each namespaced user and registers cleanup of the qualified names.
-func setupMTClassInBothNamespaces(t *testing.T, name, k1, k2 string) {
+func setupMTClassInBothNamespaces(t *testing.T, ns1, ns2, name, k1, k2 string) {
 	t.Helper()
 	for _, key := range []string{k1, k2} {
 		helper.CreateClassAuth(t, mtClass(name), key)
 	}
 	t.Cleanup(func() {
-		helper.DeleteClassAuth(t, "customer1:"+name, adminKey)
-		helper.DeleteClassAuth(t, "customer2:"+name, adminKey)
+		helper.DeleteClassAuth(t, ns1+":"+name, adminKey)
+		helper.DeleteClassAuth(t, ns2+":"+name, adminKey)
 	})
 }
 
-func setupMTClassInNs1(t *testing.T, name, key string) {
+func setupMTClassInNs1(t *testing.T, ns1, name, key string) {
 	t.Helper()
 	helper.CreateClassAuth(t, mtClass(name), key)
-	t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+	t.Cleanup(func() { helper.DeleteClassAuth(t, ns1+":"+name, adminKey) })
 }
 
 func addTenantsAuth(t *testing.T, class string, tenants []*models.Tenant, key string) error {
@@ -113,14 +113,14 @@ func tenantNames(tenants []*models.Tenant) []string {
 // shards land under the qualified class name and tenant lookups never bleed
 // across namespaces.
 func TestNamespaces_TenantOps(t *testing.T) {
-	user1Key, user2Key := twoNamespaces(t)
+	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)
 	defer conn.Close()
 
 	t.Run("REST mutations under namespaced principal land on qualified class", func(t *testing.T) {
 		const class = "TenantsCRUD"
-		setupMTClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupMTClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		// user1 adds two tenants by short name; user2 adds the same short
 		// "alpha" tenant under its own copy of the class.
@@ -134,19 +134,19 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 		// Admin's raw view of the qualified classes shows the per-namespace
 		// tenant sets exactly as written.
-		ns1, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		ns1Tenants, err := getTenantsAuth(t, ns1+":"+class, adminKey)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"alpha", "beta"}, tenantNames(ns1))
+		assert.ElementsMatch(t, []string{"alpha", "beta"}, tenantNames(ns1Tenants))
 
-		ns2, err := getTenantsAuth(t, "customer2:"+class, adminKey)
+		ns2Tenants, err := getTenantsAuth(t, ns2+":"+class, adminKey)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"alpha"}, tenantNames(ns2))
+		assert.ElementsMatch(t, []string{"alpha"}, tenantNames(ns2Tenants))
 
 		// user1 deactivates beta via the short class name.
 		require.NoError(t, updateTenantsAuth(t, class, []*models.Tenant{
 			{Name: "beta", ActivityStatus: models.TenantActivityStatusCOLD},
 		}, user1Key))
-		listed, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		listed, err := getTenantsAuth(t, ns1+":"+class, adminKey)
 		require.NoError(t, err)
 		var betaActivity string
 		for _, tt := range listed {
@@ -158,17 +158,17 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 		// user1 deletes alpha by short name; ns2's alpha is untouched.
 		require.NoError(t, deleteTenantsAuth(t, class, []string{"alpha"}, user1Key))
-		ns1after, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		ns1after, err := getTenantsAuth(t, ns1+":"+class, adminKey)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"beta"}, tenantNames(ns1after))
-		ns2after, err := getTenantsAuth(t, "customer2:"+class, adminKey)
+		ns2after, err := getTenantsAuth(t, ns2+":"+class, adminKey)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"alpha"}, tenantNames(ns2after))
 	})
 
 	t.Run("REST reads are namespace-scoped", func(t *testing.T) {
 		const class = "TenantsRead"
-		setupMTClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupMTClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
 			{Name: "shared"},
@@ -178,19 +178,19 @@ func TestNamespaces_TenantOps(t *testing.T) {
 			{Name: "ns2only"},
 		}, user2Key))
 
-		ns1, err := getTenantsAuth(t, class, user1Key)
+		ns1Tenants, err := getTenantsAuth(t, class, user1Key)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"shared"}, tenantNames(ns1))
+		assert.ElementsMatch(t, []string{"shared"}, tenantNames(ns1Tenants))
 
-		ns2, err := getTenantsAuth(t, class, user2Key)
+		ns2Tenants, err := getTenantsAuth(t, class, user2Key)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"shared", "ns2only"}, tenantNames(ns2))
+		assert.ElementsMatch(t, []string{"shared", "ns2only"}, tenantNames(ns2Tenants))
 
 		got, err := getOneTenantAuth(t, class, "shared", user1Key)
 		require.NoError(t, err)
 		assert.Equal(t, "shared", got.Name)
 
-		// ns2only is invisible to user1 — qualifies to customer1:TenantsRead
+		// ns2only is invisible to user1 — qualifies to user1's own namespace
 		// where no such tenant exists.
 		_, err = getOneTenantAuth(t, class, "ns2only", user1Key)
 		require.Error(t, err)
@@ -201,13 +201,13 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 	t.Run("global principal uses qualified names; short names do not resolve", func(t *testing.T) {
 		const class = "TenantsAdmin"
-		setupMTClassInNs1(t, class, user1Key)
+		setupMTClassInNs1(t, ns1, class, user1Key)
 
-		require.NoError(t, addTenantsAuth(t, "customer1:"+class, []*models.Tenant{
+		require.NoError(t, addTenantsAuth(t, ns1+":"+class, []*models.Tenant{
 			{Name: "byAdmin"},
 		}, adminKey))
 
-		listed, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		listed, err := getTenantsAuth(t, ns1+":"+class, adminKey)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"byAdmin"}, tenantNames(listed))
 
@@ -220,7 +220,7 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 	t.Run("gRPC TenantsGet under namespaced principal returns own tenants", func(t *testing.T) {
 		const class = "TenantsGRPC"
-		setupMTClassInBothNamespaces(t, class, user1Key, user2Key)
+		setupMTClassInBothNamespaces(t, ns1, ns2, class, user1Key, user2Key)
 
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "g1"}}, user1Key))
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "g2"}}, user2Key))
@@ -238,7 +238,7 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 	t.Run("gRPC TenantsGet with Names param filters to the requested subset", func(t *testing.T) {
 		const class = "TenantsGRPCNames"
-		setupMTClassInNs1(t, class, user1Key)
+		setupMTClassInNs1(t, ns1, class, user1Key)
 
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
 			{Name: "keep1"},
@@ -262,11 +262,11 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 	t.Run("gRPC TenantsGet under global principal uses qualified collection name", func(t *testing.T) {
 		const class = "TenantsGRPCAdmin"
-		setupMTClassInNs1(t, class, user1Key)
+		setupMTClassInNs1(t, ns1, class, user1Key)
 
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "ga1"}}, user1Key))
 
-		resp, err := grpcClient.TenantsGet(authCtx(adminKey), &pb.TenantsGetRequest{Collection: "customer1:" + class})
+		resp, err := grpcClient.TenantsGet(authCtx(adminKey), &pb.TenantsGetRequest{Collection: ns1 + ":" + class})
 		require.NoError(t, err)
 		require.Len(t, resp.Tenants, 1)
 		assert.Equal(t, "ga1", resp.Tenants[0].Name)
@@ -281,7 +281,7 @@ func TestNamespaces_TenantOps(t *testing.T) {
 			class = "AliasBackdoorTarget"
 			alias = "AliasBackdoor"
 		)
-		setupMTClassInNs1(t, class, user1Key)
+		setupMTClassInNs1(t, ns1, class, user1Key)
 
 		// Seed the underlying class with a known tenant so we can detect any
 		// state change after the rejected calls.
@@ -290,7 +290,7 @@ func TestNamespaces_TenantOps(t *testing.T) {
 		}, user1Key))
 
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
 
 		// Mutations qualify via QualifyClass, which does not resolve aliases.
 		// All three calls must fail.
@@ -304,7 +304,7 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 		// Underlying class state must be unchanged: same single tenant, still
 		// HOT, no leaked "viaAlias" tenant.
-		listed, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		listed, err := getTenantsAuth(t, ns1+":"+class, adminKey)
 		require.NoError(t, err)
 		require.Len(t, listed, 1)
 		assert.Equal(t, "seed", listed[0].Name)
@@ -313,16 +313,16 @@ func TestNamespaces_TenantOps(t *testing.T) {
 
 	t.Run("namespaced caller submitting namespace-qualified class double-prefixes", func(t *testing.T) {
 		const class = "TenantsDoublePrefix"
-		setupMTClassInNs1(t, class, user1Key)
+		setupMTClassInNs1(t, ns1, class, user1Key)
 
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "x"}}, user1Key))
 
-		// user1 supplying "customer1:TenantsDoublePrefix" qualifies again to
-		// "customer1:customer1:TenantsDoublePrefix" — no such class.
-		_, err := getTenantsAuth(t, "customer1:"+class, user1Key)
+		// user1 supplying the already-qualified "<ns>:TenantsDoublePrefix"
+		// qualifies again to "<ns>:<ns>:TenantsDoublePrefix" — no such class.
+		_, err := getTenantsAuth(t, ns1+":"+class, user1Key)
 		require.Error(t, err)
 
-		err = addTenantsAuth(t, "customer1:"+class, []*models.Tenant{{Name: "y"}}, user1Key)
+		err = addTenantsAuth(t, ns1+":"+class, []*models.Tenant{{Name: "y"}}, user1Key)
 		require.Error(t, err)
 	})
 
@@ -331,14 +331,14 @@ func TestNamespaces_TenantOps(t *testing.T) {
 			class = "AliasSingleTarget"
 			alias = "AliasSingle"
 		)
-		setupMTClassInNs1(t, class, user1Key)
+		setupMTClassInNs1(t, ns1, class, user1Key)
 
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
 			{Name: "present", ActivityStatus: models.TenantActivityStatusHOT},
 		}, user1Key))
 
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
 
 		// GetConsistentTenant via alias resolves to the underlying class.
 		// retryOnAliasLag absorbs the brief window where the alias entry
@@ -368,12 +368,12 @@ func TestNamespaces_TenantOps(t *testing.T) {
 			class = "TenantsAliasTarget"
 			alias = "TenantsAlias"
 		)
-		setupMTClassInNs1(t, class, user1Key)
+		setupMTClassInNs1(t, ns1, class, user1Key)
 
 		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "t1"}, {Name: "t2"}}, user1Key))
 
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, ns1+":"+alias, helper.CreateAuth(adminKey))
 
 		// retryOnAliasLag absorbs the brief window where the alias entry
 		// has been applied on the leader but the follower has not yet

--- a/test/acceptance/namespace/tenant_test.go
+++ b/test/acceptance/namespace/tenant_test.go
@@ -113,6 +113,7 @@ func tenantNames(tenants []*models.Tenant) []string {
 // shards land under the qualified class name and tenant lookups never bleed
 // across namespaces.
 func TestNamespaces_TenantOps(t *testing.T) {
+	t.Parallel()
 	ns1, ns2, user1Key, user2Key := twoNamespaces(t)
 
 	grpcClient, conn := newGrpcClient(t)

--- a/test/acceptance/namespace/user_mgmt_test.go
+++ b/test/acceptance/namespace/user_mgmt_test.go
@@ -73,6 +73,7 @@ func createNamespacedViewerUser(t *testing.T, userID, ns, adminKey string) strin
 // create / get / list / deactivate / activate / rotate / delete lifecycle
 // on a user in its own namespace, with responses stripped to the short form.
 func TestNamespacedAdminLifecycle(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
@@ -135,6 +136,7 @@ func TestNamespacedAdminLifecycle(t *testing.T) {
 // each namespace's admin sees only its own users, deletes only its own, and
 // every response (success or 404) is free of the namespace separator.
 func TestNamespacedUserCrossNamespaceIsolation(t *testing.T) {
+	t.Parallel()
 	ns1, ns2 := uniqueNS(), uniqueNS()
 	helper.CreateNamespace(t, ns1, adminKey)
 	helper.CreateNamespace(t, ns2, adminKey)
@@ -184,6 +186,7 @@ func TestNamespacedUserCrossNamespaceIsolation(t *testing.T) {
 // TestNamespacedViewerDeniedUserMutations — viewer in a namespace can read
 // users, cannot mutate.
 func TestNamespacedViewerDeniedUserMutations(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
@@ -230,6 +233,7 @@ func TestNamespacedViewerDeniedUserMutations(t *testing.T) {
 // revokes roles on a namespaced user (matcher blast-radius guard). The
 // deprecated role-read endpoint is gated off on NS clusters — 410.
 func TestGlobalOperatorReach(t *testing.T) {
+	t.Parallel()
 	ns1, ns2 := uniqueNS(), uniqueNS()
 	helper.CreateNamespace(t, ns1, adminKey)
 	helper.CreateNamespace(t, ns2, adminKey)
@@ -289,6 +293,7 @@ func TestGlobalOperatorReach(t *testing.T) {
 // the configured root user succeeds inside a namespace because the
 // resolver qualifies the storage key before the isRootUser check.
 func TestNamespacedAdminConflictsAndCollisions(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)
@@ -341,6 +346,7 @@ func TestNamespacedAdminConflictsAndCollisions(t *testing.T) {
 // (matcher cannot specialize the unqualified key), and assign/revoke fail at
 // authz on the qualified key (no AssignAndRevokeUsers in the widened admin).
 func TestNamespacedAdminAuthzSurface(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)
@@ -386,6 +392,7 @@ func TestNamespacedAdminAuthzSurface(t *testing.T) {
 // mid-delete is 422. A class makes cleanup non-instant so the race lands
 // somewhere between deleting and gone; both surface 422.
 func TestCreateUserAgainstDeletingNamespace(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
@@ -413,6 +420,7 @@ func TestCreateUserAgainstDeletingNamespace(t *testing.T) {
 // short name hits the self-target guard on the resolved key; the 422
 // message must not leak the ':' separator.
 func TestNamespacedAdminSelfTargetIs422(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)

--- a/test/acceptance/namespace/user_mgmt_test.go
+++ b/test/acceptance/namespace/user_mgmt_test.go
@@ -73,7 +73,7 @@ func createNamespacedViewerUser(t *testing.T, userID, ns, adminKey string) strin
 // create / get / list / deactivate / activate / rotate / delete lifecycle
 // on a user in its own namespace, with responses stripped to the short form.
 func TestNamespacedAdminLifecycle(t *testing.T) {
-	const ns = "umg-lifecycle"
+	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)
@@ -135,7 +135,7 @@ func TestNamespacedAdminLifecycle(t *testing.T) {
 // each namespace's admin sees only its own users, deletes only its own, and
 // every response (success or 404) is free of the namespace separator.
 func TestNamespacedUserCrossNamespaceIsolation(t *testing.T) {
-	const ns1, ns2 = "umg-iso-a", "umg-iso-b"
+	ns1, ns2 := uniqueNS(), uniqueNS()
 	helper.CreateNamespace(t, ns1, adminKey)
 	helper.CreateNamespace(t, ns2, adminKey)
 
@@ -184,7 +184,7 @@ func TestNamespacedUserCrossNamespaceIsolation(t *testing.T) {
 // TestNamespacedViewerDeniedUserMutations — viewer in a namespace can read
 // users, cannot mutate.
 func TestNamespacedViewerDeniedUserMutations(t *testing.T) {
-	const ns = "umg-deny"
+	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
 	helper.CreateUserWithNamespace(t, "bob", ns, adminKey)
@@ -230,7 +230,7 @@ func TestNamespacedViewerDeniedUserMutations(t *testing.T) {
 // revokes roles on a namespaced user (matcher blast-radius guard). The
 // deprecated role-read endpoint is gated off on NS clusters — 410.
 func TestGlobalOperatorReach(t *testing.T) {
-	const ns1, ns2 = "umg-reach-a", "umg-reach-b"
+	ns1, ns2 := uniqueNS(), uniqueNS()
 	helper.CreateNamespace(t, ns1, adminKey)
 	helper.CreateNamespace(t, ns2, adminKey)
 
@@ -289,7 +289,7 @@ func TestGlobalOperatorReach(t *testing.T) {
 // the configured root user succeeds inside a namespace because the
 // resolver qualifies the storage key before the isRootUser check.
 func TestNamespacedAdminConflictsAndCollisions(t *testing.T) {
-	const ns = "umg-edges"
+	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)
 
@@ -341,7 +341,7 @@ func TestNamespacedAdminConflictsAndCollisions(t *testing.T) {
 // (matcher cannot specialize the unqualified key), and assign/revoke fail at
 // authz on the qualified key (no AssignAndRevokeUsers in the widened admin).
 func TestNamespacedAdminAuthzSurface(t *testing.T) {
-	const ns = "umg-authz-deny"
+	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)
 
@@ -386,7 +386,7 @@ func TestNamespacedAdminAuthzSurface(t *testing.T) {
 // mid-delete is 422. A class makes cleanup non-instant so the race lands
 // somewhere between deleting and gone; both surface 422.
 func TestCreateUserAgainstDeletingNamespace(t *testing.T) {
-	const ns = "umg-deleting"
+	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)
@@ -413,7 +413,7 @@ func TestCreateUserAgainstDeletingNamespace(t *testing.T) {
 // short name hits the self-target guard on the resolved key; the 422
 // message must not leak the ':' separator.
 func TestNamespacedAdminSelfTargetIs422(t *testing.T) {
-	const ns = "umg-self"
+	ns := uniqueNS()
 	helper.CreateNamespace(t, ns, adminKey)
 	nsAdminKey := createNamespacedUser(t, "alice", ns, adminKey)
 	t.Cleanup(func() { helper.DeleteUser(t, ns+":alice", adminKey) })

--- a/test/acceptance/namespace_limits/grpc_batch_test.go
+++ b/test/acceptance/namespace_limits/grpc_batch_test.go
@@ -50,8 +50,8 @@ func authCtx(key string) context.Context {
 // keeping Limit/Value and unanimousLimitExceeded lifting the per-row
 // rejection to a top-level gRPC error.
 func TestGRPCBatchObjects_AtQuota(t *testing.T) {
+	ns := uniqueNS()
 	const (
-		ns       = "grpcbatch"
 		homeNode = "weaviate-1"
 		class    = "Items"
 	)

--- a/test/acceptance/namespace_limits/grpc_batch_test.go
+++ b/test/acceptance/namespace_limits/grpc_batch_test.go
@@ -50,6 +50,7 @@ func authCtx(key string) context.Context {
 // keeping Limit/Value and unanimousLimitExceeded lifting the per-row
 // rejection to a top-level gRPC error.
 func TestGRPCBatchObjects_AtQuota(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const (
 		homeNode = "weaviate-1"

--- a/test/acceptance/namespace_limits/object_limit_test.go
+++ b/test/acceptance/namespace_limits/object_limit_test.go
@@ -68,11 +68,8 @@ func fillUntilQuota(t *testing.T, class, key string) {
 // so the cap is per namespace, not per node: after alpha hits its cap,
 // beta can still write.
 func TestObjectLimitEnforcedPerNamespace(t *testing.T) {
-	const (
-		nsA      = "alpha"
-		nsB      = "beta"
-		homeNode = "weaviate-0"
-	)
+	nsA, nsB := uniqueNS(), uniqueNS()
+	const homeNode = "weaviate-0"
 
 	helper.CreateNamespaceWithHomeNode(t, nsA, homeNode, adminKey)
 	helper.CreateNamespaceWithHomeNode(t, nsB, homeNode, adminKey)
@@ -109,10 +106,8 @@ func TestObjectLimitEnforcedPerNamespace(t *testing.T) {
 // client is not bound to, so every insert is forwarded; the quota still
 // fires at the home node.
 func TestObjectLimitFromNonHomeNode(t *testing.T) {
-	const (
-		ns       = "forwarded"
-		homeNode = "weaviate-1"
-	)
+	ns := uniqueNS()
+	const homeNode = "weaviate-1"
 
 	// Guard against a future helper change that would silently make the
 	// test client bind to the home node and turn this into a local-write
@@ -136,10 +131,8 @@ func TestObjectLimitFromNonHomeNode(t *testing.T) {
 // TestUpdatesAtQuotaRejected regression-guards the documented behaviour
 // that PUTs also fail at full quota (the chokepoint covers updates).
 func TestUpdatesAtQuotaRejected(t *testing.T) {
-	const (
-		ns       = "updates"
-		homeNode = "weaviate-2"
-	)
+	ns := uniqueNS()
+	const homeNode = "weaviate-2"
 
 	helper.CreateNamespaceWithHomeNode(t, ns, homeNode, adminKey)
 	t.Cleanup(func() { helper.DeleteNamespace(t, ns, adminKey) })

--- a/test/acceptance/namespace_limits/object_limit_test.go
+++ b/test/acceptance/namespace_limits/object_limit_test.go
@@ -68,6 +68,7 @@ func fillUntilQuota(t *testing.T, class, key string) {
 // so the cap is per namespace, not per node: after alpha hits its cap,
 // beta can still write.
 func TestObjectLimitEnforcedPerNamespace(t *testing.T) {
+	t.Parallel()
 	nsA, nsB := uniqueNS(), uniqueNS()
 	const homeNode = "weaviate-0"
 
@@ -106,6 +107,7 @@ func TestObjectLimitEnforcedPerNamespace(t *testing.T) {
 // client is not bound to, so every insert is forwarded; the quota still
 // fires at the home node.
 func TestObjectLimitFromNonHomeNode(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const homeNode = "weaviate-1"
 
@@ -131,6 +133,7 @@ func TestObjectLimitFromNonHomeNode(t *testing.T) {
 // TestUpdatesAtQuotaRejected regression-guards the documented behaviour
 // that PUTs also fail at full quota (the chokepoint covers updates).
 func TestUpdatesAtQuotaRejected(t *testing.T) {
+	t.Parallel()
 	ns := uniqueNS()
 	const homeNode = "weaviate-2"
 

--- a/test/acceptance/namespace_limits/setup_test.go
+++ b/test/acceptance/namespace_limits/setup_test.go
@@ -17,8 +17,10 @@ package namespace_limits
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,6 +38,15 @@ const (
 	adminUser, adminKey = "admin-user", "admin-key"
 	objectCap           = 10
 )
+
+// nsCounter backs uniqueNS. Tests must not hardcode namespace names: a shared
+// compose runs every test against one cluster, so reused names collide.
+var nsCounter atomic.Int64
+
+// uniqueNS returns a process-unique, validator-legal namespace name.
+func uniqueNS() string {
+	return fmt.Sprintf("ns%d", nsCounter.Add(1))
+}
 
 var sharedCompose *docker.DockerCompose
 


### PR DESCRIPTION
### What's being changed:

Runs all namespace tests concurrently using t.Parallel()

Before:
- http://github.com/weaviate/weaviate/test/acceptance/namespace	285.898s
- http://github.com/weaviate/weaviate/test/acceptance/namespace_limits 71.626s

After:
- github.com/weaviate/weaviate/test/acceptance/namespace	117.793s
- github.com/weaviate/weaviate/test/acceptance/namespace_limits	50.379s


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
