### PR TITLE
Dynamic runtime list parsing

### DIFF
--- a/usecases/config/runtime/values.go
+++ b/usecases/config/runtime/values.go
@@ -117,11 +117,10 @@ func (dv *DynamicValue[T]) SetValue(val T) error {
 func (dv *DynamicValue[T]) UnmarshalYAML(node *yaml.Node) error {
 	var val T
 	if err := node.Decode(&val); err != nil {
-		// yaml.v3 errors decoding a scalar into a slice T. Accept it here:
-		// empty → nil, otherwise split on comma to match the env-var path
-		// (e.g. ALLOWED_VECTOR_INDEX_TYPES=hnsw,flat,dynamic). Non-slice
-		// scalars stay strict — their zero is field-dependent.
-		if node.Kind == yaml.ScalarNode && reflect.TypeOf(val).Kind() == reflect.Slice {
+		// yaml.v3 errors decoding a scalar into a slice T. Coerce only a string
+		// scalar (empty → nil, else comma-split like the env-var path); non-string
+		// scalars fall through to err so a mistyped config doesn't become ["123"].
+		if node.Kind == yaml.ScalarNode && node.ShortTag() == "!!str" && reflect.TypeOf(val).Kind() == reflect.Slice {
 			if ptr, ok := any(&val).(*[]string); ok {
 				if node.Value != "" {
 					*ptr = strings.Split(node.Value, ",")

--- a/usecases/config/runtime/values.go
+++ b/usecases/config/runtime/values.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -116,14 +117,20 @@ func (dv *DynamicValue[T]) SetValue(val T) error {
 func (dv *DynamicValue[T]) UnmarshalYAML(node *yaml.Node) error {
 	var val T
 	if err := node.Decode(&val); err != nil {
-		// `key: ""` errors against slice T in yaml.v3; coerce to nil so a
-		// quoted-empty doesn't fail the whole push. Scalars stay strict —
-		// their zero is field-dependent.
-		if node.Kind == yaml.ScalarNode && node.Value == "" && reflect.TypeOf(val).Kind() == reflect.Slice {
-			dv.mu.Lock()
-			defer dv.mu.Unlock()
-			dv.def = val
-			return nil
+		// yaml.v3 errors decoding a scalar into a slice T. Accept it here:
+		// empty → nil, otherwise split on comma to match the env-var path
+		// (e.g. ALLOWED_VECTOR_INDEX_TYPES=hnsw,flat,dynamic). Non-slice
+		// scalars stay strict — their zero is field-dependent.
+		if node.Kind == yaml.ScalarNode && reflect.TypeOf(val).Kind() == reflect.Slice {
+			if ptr, ok := any(&val).(*[]string); ok {
+				if node.Value != "" {
+					*ptr = strings.Split(node.Value, ",")
+				}
+				dv.mu.Lock()
+				defer dv.mu.Unlock()
+				dv.def = val
+				return nil
+			}
 		}
 		return err
 	}

--- a/usecases/config/runtime/values_test.go
+++ b/usecases/config/runtime/values_test.go
@@ -91,12 +91,19 @@ slice: ["one", "two", "three"]
 		}
 	})
 
-	t.Run("non-empty scalar with wrong type still errors", func(t *testing.T) {
-		val := struct {
-			Slice *DynamicValue[[]string] `yaml:"slice"`
-		}{}
-		err := yaml.NewDecoder(strings.NewReader(`slice: "abc"`)).Decode(&val)
-		require.Error(t, err)
+	t.Run("comma-separated scalar splits into slice T", func(t *testing.T) {
+		cases := map[string][]string{
+			`slice: "hfresh,hnsw,dynamic,flat"`: {"hfresh", "hnsw", "dynamic", "flat"},
+			`slice: "hnsw"`:                     {"hnsw"},
+			`slice: "a,b,"`:                     {"a", "b", ""},
+		}
+		for input, want := range cases {
+			val := struct {
+				Slice *DynamicValue[[]string] `yaml:"slice"`
+			}{}
+			require.NoError(t, yaml.NewDecoder(strings.NewReader(input)).Decode(&val), "input %q", input)
+			assert.Equal(t, want, val.Slice.Get(), "input %q", input)
+		}
 	})
 }
 

--- a/usecases/config/runtime/values_test.go
+++ b/usecases/config/runtime/values_test.go
@@ -105,6 +105,21 @@ slice: ["one", "two", "three"]
 			assert.Equal(t, want, val.Slice.Get(), "input %q", input)
 		}
 	})
+
+	t.Run("non-string scalar errors for slice T", func(t *testing.T) {
+		cases := []string{
+			`slice: 123`,
+			`slice: true`,
+			`slice: 1.5`,
+		}
+		for _, input := range cases {
+			val := struct {
+				Slice *DynamicValue[[]string] `yaml:"slice"`
+			}{}
+			err := yaml.NewDecoder(strings.NewReader(input)).Decode(&val)
+			require.Error(t, err, "expected %q to error", input)
+		}
+	})
 }
 
 func TestDynamicValue_JSON(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -49,36 +49,46 @@ maximum_allowed_collections_count: 13
 		assert.Equal(t, 13, cfg.MaximumAllowedCollectionsCount.Get())
 	})
 
-	t.Run("empty-string scalar for slice fields is equivalent to empty list", func(t *testing.T) {
-		buf := []byte(`allowed_vector_index_types: ""
-allowed_compression_types: ""`)
-		cfg, err := ParseRuntimeConfig(buf)
-		require.NoError(t, err)
-		assert.Empty(t, cfg.AllowedVectorIndexTypes.Get())
-		assert.Empty(t, cfg.AllowedCompressionTypes.Get())
+	t.Run("slice fields accept multiple YAML shapes", func(t *testing.T) {
+		cases := []struct {
+			name            string
+			yaml            string
+			wantVector      []string
+			wantCompression []string
+		}{
+			{
+				name: "empty-string scalar is equivalent to empty list",
+				yaml: `allowed_vector_index_types: ""
+allowed_compression_types: ""`,
+			},
+			{
+				name: "comma-separated scalar splits into elements",
+				yaml: `allowed_vector_index_types: "hfresh,hnsw,dynamic,flat"
+allowed_compression_types: "pq,bq"`,
+				wantVector:      []string{"hfresh", "hnsw", "dynamic", "flat"},
+				wantCompression: []string{"pq", "bq"},
+			},
+			{
+				name: "explicit YAML list decodes as-is",
+				yaml: `allowed_vector_index_types: ["hfresh", "hnsw", "dynamic", "flat"]
+allowed_compression_types: ["pq", "bq"]`,
+				wantVector:      []string{"hfresh", "hnsw", "dynamic", "flat"},
+				wantCompression: []string{"pq", "bq"},
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg, err := ParseRuntimeConfig([]byte(tc.yaml))
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantVector, cfg.AllowedVectorIndexTypes.Get())
+				assert.Equal(t, tc.wantCompression, cfg.AllowedCompressionTypes.Get())
+			})
+		}
 	})
 
 	t.Run("empty-string scalar for non-slice fields still errors", func(t *testing.T) {
 		_, err := ParseRuntimeConfig([]byte(`maximum_allowed_collections_count: ""`))
 		require.Error(t, err)
-	})
-
-	t.Run("comma-separated scalar for slice fields splits into elements", func(t *testing.T) {
-		buf := []byte(`allowed_vector_index_types: "hfresh,hnsw,dynamic,flat"
-allowed_compression_types: "pq,bq"`)
-		cfg, err := ParseRuntimeConfig(buf)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"hfresh", "hnsw", "dynamic", "flat"}, cfg.AllowedVectorIndexTypes.Get())
-		assert.Equal(t, []string{"pq", "bq"}, cfg.AllowedCompressionTypes.Get())
-	})
-
-	t.Run("explicit YAML list for slice fields decodes as-is", func(t *testing.T) {
-		buf := []byte(`allowed_vector_index_types: ["hfresh", "hnsw", "dynamic", "flat"]
-allowed_compression_types: ["pq", "bq"]`)
-		cfg, err := ParseRuntimeConfig(buf)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"hfresh", "hnsw", "dynamic", "flat"}, cfg.AllowedVectorIndexTypes.Get())
-		assert.Equal(t, []string{"pq", "bq"}, cfg.AllowedCompressionTypes.Get())
 	})
 
 	t.Run("YAML tag should be lower_snake_case", func(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -63,6 +63,15 @@ allowed_compression_types: ""`)
 		require.Error(t, err)
 	})
 
+	t.Run("comma-separated scalar for slice fields splits into elements", func(t *testing.T) {
+		buf := []byte(`allowed_vector_index_types: "hfresh,hnsw,dynamic,flat"
+allowed_compression_types: "pq,bq"`)
+		cfg, err := ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"hfresh", "hnsw", "dynamic", "flat"}, cfg.AllowedVectorIndexTypes.Get())
+		assert.Equal(t, []string{"pq", "bq"}, cfg.AllowedCompressionTypes.Get())
+	})
+
 	t.Run("YAML tag should be lower_snake_case", func(t *testing.T) {
 		var r WeaviateRuntimeConfig
 

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -72,6 +72,15 @@ allowed_compression_types: "pq,bq"`)
 		assert.Equal(t, []string{"pq", "bq"}, cfg.AllowedCompressionTypes.Get())
 	})
 
+	t.Run("explicit YAML list for slice fields decodes as-is", func(t *testing.T) {
+		buf := []byte(`allowed_vector_index_types: ["hfresh", "hnsw", "dynamic", "flat"]
+allowed_compression_types: ["pq", "bq"]`)
+		cfg, err := ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"hfresh", "hnsw", "dynamic", "flat"}, cfg.AllowedVectorIndexTypes.Get())
+		assert.Equal(t, []string{"pq", "bq"}, cfg.AllowedCompressionTypes.Get())
+	})
+
 	t.Run("YAML tag should be lower_snake_case", func(t *testing.T) {
 		var r WeaviateRuntimeConfig
 


### PR DESCRIPTION
### What's being changed:

This allows to set dynamic runtime lists in the same format as env vars `"entry1,entry2"` => `[]string{entry1,entry2}`. The parsing of lists ("[entry1,entry2]") stays like it is

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
