### PR TITLE
Use flat index to assert brute force search

### DIFF
--- a/test/acceptance_with_python/test_generative.py
+++ b/test/acceptance_with_python/test_generative.py
@@ -94,6 +94,9 @@ def test_generative_hybrid(collection_factory: CollectionFactory) -> None:
     collection = collection_factory(
         vectorizer_config=Configure.Vectorizer.none(),
         generative_config=Configure.Generative.custom("generative-dummy"),
+        # Flat (exact) index: with 100 identical "other" vectors HNSW can miss the
+        # distinct targets, collapsing relative-score fusion + autocut to the default limit.
+        vector_index_config=Configure.VectorIndex.flat(),
         properties=[
             Property(name="prop", data_type=DataType.TEXT),
             Property(name="prop2", data_type=DataType.TEXT),


### PR DESCRIPTION
### What's being changed:

fixes this flake:
```
❯   FAILED test_generative.py::test_generative_hybrid - AssertionError: assert 20 == 2
     +  where 20 = len([GenerativeObject(uuid=_WeaviateUUIDInt('006f8558-af17-4667-bde9-e9a5a10facb8'), metadata=MetadataReturn(creation_time... properties={'prop2': 'other',
  'prop': 'other'}, references=None, vector={}, collection='Test_generative_hybrid'), ...])
     +    where [GenerativeObject(uuid=_WeaviateUUIDInt('006f8558-af17-4667-bde9-e9a5a10facb8'), metadata=MetadataReturn(creation_time... properties={'prop2': 'other', 'prop':
  'other'}, references=None, vector={}, collection='Test_generative_hybrid'), ...] = <weaviate.collections.classes.internal.GenerativeReturn object at 0x7ff42f1a7350>.objects
```

The test creates two clusters of results and HNSW can sometimes end up in a state where the two results we want to find are not connected. Use flat index so we do a brute force search that always finds the results we want 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
