### PR TITLE
fix: increase retry wait time and reduce timeout for Docker Hub login

### DIFF
--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -15,7 +15,11 @@ runs:
         DOCKER_USERNAME: ${{ inputs.username }}
         DOCKER_PASSWORD: ${{ inputs.password }}
       with:
+        # Wide window to ride out sustained Docker Hub reachability dips: docker's own
+        # client timeout fires per attempt, so attempts × wait is the only effective lever.
+        # timeout_minutes is just a backstop to kill an attempt that hangs past docker's
+        # own timeout, so retries cycle promptly.
         max_attempts: 5
-        timeout_minutes: 5
-        retry_wait_seconds: 15
+        timeout_minutes: 2
+        retry_wait_seconds: 30
         command: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -15,10 +15,6 @@ runs:
         DOCKER_USERNAME: ${{ inputs.username }}
         DOCKER_PASSWORD: ${{ inputs.password }}
       with:
-        # Wide window to ride out sustained Docker Hub reachability dips: docker's own
-        # client timeout fires per attempt, so attempts × wait is the only effective lever.
-        # timeout_minutes is just a backstop to kill an attempt that hangs past docker's
-        # own timeout, so retries cycle promptly.
         max_attempts: 5
         timeout_minutes: 2
         retry_wait_seconds: 30


### PR DESCRIPTION
### What's being changed:

- bump wait time to 30 seconds

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
