### PR TITLE
Reuse testcontainers in tests for fast group 3

### DIFF
--- a/test/acceptance/aliases/aliases_api_backup_test.go
+++ b/test/acceptance/aliases/aliases_api_backup_test.go
@@ -12,33 +12,16 @@
 package test
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/books"
 )
 
-func Test_AliasesAPI_Backup(t *testing.T) {
-	ctx := context.Background()
-	compose, err := docker.New().
-		WithBackendFilesystem().
-		WithWeaviate().
-		WithText2VecModel2Vec().
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
-
-	defer helper.SetupClient(fmt.Sprintf("%s:%s", helper.ServerHost, helper.ServerPort))
-	helper.SetupClient(compose.GetWeaviate().URI())
-
+func testAliasesAPIBackup(t *testing.T) {
 	// Three options for the test:
 	// 1. full: backup and restore collection after deleting both collection and the alias, will pass as of 1.32
 	// 2. overwrite: backup and restore after deleting the collection but not the alias, should pass only if "overwrite option is set"
@@ -69,15 +52,15 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 				}{
 					{
 						name:  books.DefaultClassName,
-						alias: &models.Alias{Alias: "BookAlias", Class: books.DefaultClassName},
+						alias: &models.Alias{Alias: "BackupBookAlias", Class: books.DefaultClassName},
 					},
 					{
 						name:  books.DefaultClassName,
-						alias: &models.Alias{Alias: "BookAliasToBeDeleted", Class: books.DefaultClassName},
+						alias: &models.Alias{Alias: "BackupBookAliasToBeDeleted", Class: books.DefaultClassName},
 					},
 					{
 						name:  books.DefaultClassName,
-						alias: &models.Alias{Alias: "BookAliasOverwrite", Class: books.DefaultClassName},
+						alias: &models.Alias{Alias: "BackupBookAliasOverwrite", Class: books.DefaultClassName},
 					},
 				}
 				for _, tt := range tests {
@@ -105,17 +88,15 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 					helper.DeleteAlias(t, alias.Alias)
 				}
 				helper.DeleteClass(t, books.DefaultClassName)
+				helper.DeleteClass(t, "Books2")
 			}()
 
 			t.Run("delete alias", func(t *testing.T) {
 				checkAliasesCount := func(t *testing.T, count int) {
-					resp := helper.GetAliases(t, nil)
-					require.NotNil(t, resp)
-					require.NotEmpty(t, resp.Aliases)
-					require.Equal(t, count, len(resp.Aliases))
+					require.Equal(t, count, countAliasesWithPrefix(t, "Backup"))
 				}
 				checkAliasesCount(t, 3)
-				helper.DeleteAlias(t, "BookAliasToBeDeleted")
+				helper.DeleteAlias(t, "BackupBookAliasToBeDeleted")
 				checkAliasesCount(t, 2)
 			})
 
@@ -131,7 +112,7 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 
 			if tt.option == "overwrite" {
 				t.Run("reassign BookAliasOverwrite from Books to Books2 class", func(t *testing.T) {
-					alias := helper.GetAlias(t, "BookAliasOverwrite")
+					alias := helper.GetAlias(t, "BackupBookAliasOverwrite")
 					assert.Equal(t, "Books", alias.Class)
 					// create Books2 class
 					books2Class := books.ClassModel2VecVectorizerWithName("Books2")
@@ -140,7 +121,7 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 						helper.CreateObject(t, book)
 						helper.AssertGetObjectEventually(t, book.Class, book.ID)
 					}
-					helper.UpdateAlias(t, "BookAliasOverwrite", "Books2")
+					helper.UpdateAlias(t, "BackupBookAliasOverwrite", "Books2")
 				})
 			}
 
@@ -150,20 +131,18 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 
 			if tt.option != "overwrite" {
 				t.Run("delete alias", func(t *testing.T) {
-					helper.DeleteAlias(t, "BookAlias")
-					helper.DeleteAlias(t, "BookAliasOverwrite")
+					helper.DeleteAlias(t, "BackupBookAlias")
+					helper.DeleteAlias(t, "BackupBookAliasOverwrite")
 				})
 
 				t.Run("check alias count after deletion", func(t *testing.T) {
-					resp := helper.GetAliases(t, nil)
-					require.NotNil(t, resp)
-					require.Empty(t, resp.Aliases)
+					require.Equal(t, 0, countAliasesWithPrefix(t, "Backup"))
 				})
 			}
 
 			if tt.option == "overwrite" {
 				t.Run("check BookAliasOverwrite alias that it points to Books2 before restore", func(t *testing.T) {
-					alias := helper.GetAlias(t, "BookAliasOverwrite")
+					alias := helper.GetAlias(t, "BackupBookAliasOverwrite")
 					assert.Equal(t, "Books2", alias.Class)
 				})
 			}
@@ -186,17 +165,11 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 			})
 
 			t.Run("check alias count after restore", func(t *testing.T) {
-				checkAliasesCount := func(t *testing.T, count int) {
-					resp := helper.GetAliases(t, nil)
-					require.NotNil(t, resp)
-					require.NotEmpty(t, resp.Aliases)
-					require.Equal(t, count, len(resp.Aliases))
-				}
-				checkAliasesCount(t, 2)
+				require.Equal(t, 2, countAliasesWithPrefix(t, "Backup"))
 			})
 
 			t.Run("check BookAliasOverwrite alias that it points to Books", func(t *testing.T) {
-				alias := helper.GetAlias(t, "BookAliasOverwrite")
+				alias := helper.GetAlias(t, "BackupBookAliasOverwrite")
 				assert.Equal(t, books.DefaultClassName, alias.Class)
 			})
 		})

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -44,9 +44,14 @@ func testAliasesAPIgRPC(t *testing.T, grpcURI string) {
 	booksAliasName := "GrpcBooksAlias"
 
 	// Shared container: leave no class/alias behind so the other suites'
-	// instance-wide alias counts stay correct.
+	// instance-wide alias counts stay correct. Delete only aliases that exist so
+	// a failure before the alias is created can't mask the original error.
 	defer func() {
-		helper.DeleteAlias(t, booksAliasName)
+		resp := helper.GetAliases(t, nil)
+		require.NotNil(t, resp)
+		for _, alias := range resp.Aliases {
+			helper.DeleteAlias(t, alias.Alias)
+		}
 		helper.DeleteClass(t, books.DefaultClassName)
 	}()
 

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -13,7 +13,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -22,23 +21,14 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/books"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func Test_AliasesAPI_gRPC(t *testing.T) {
+func testAliasesAPIgRPC(t *testing.T, grpcURI string) {
 	ctx := context.Background()
-	compose, err := docker.New().
-		WithWeaviateWithGRPC().
-		WithText2VecModel2Vec().
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
 
 	gRPCClient := func(t *testing.T, addr string) (pb.WeaviateClient, *grpc.ClientConn) {
 		conn, err := helper.CreateGrpcConnectionClient(addr)
@@ -49,13 +39,16 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 		return grpcClient, conn
 	}
 
-	defer helper.SetupClient(fmt.Sprintf("%s:%s", helper.ServerHost, helper.ServerPort))
+	grpcClient, _ := gRPCClient(t, grpcURI)
 
-	helper.SetupClient(compose.GetWeaviate().URI())
-	grpcClient, _ := gRPCClient(t, compose.GetWeaviate().GrpcURI())
-	require.NotNil(t, gRPCClient)
+	booksAliasName := "GrpcBooksAlias"
 
-	booksAliasName := "BooksAlias"
+	// Shared container: leave no class/alias behind so the other suites'
+	// instance-wide alias counts stay correct.
+	defer func() {
+		helper.DeleteAlias(t, booksAliasName)
+		helper.DeleteClass(t, books.DefaultClassName)
+	}()
 
 	t.Run("create schema", func(t *testing.T) {
 		booksClass := books.ClassModel2VecVectorizer()

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -12,7 +12,6 @@
 package test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,27 +24,13 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/books"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/documents"
 )
 
-func Test_AliasesAPI(t *testing.T) {
-	ctx := context.Background()
-	compose, err := docker.New().
-		WithWeaviate().
-		WithText2VecModel2Vec().
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
-
-	defer helper.SetupClient(fmt.Sprintf("%s:%s", helper.ServerHost, helper.ServerPort))
-	helper.SetupClient(compose.GetWeaviate().URI())
-
+func testAliasesAPI(t *testing.T) {
 	t.Run("create schema", func(t *testing.T) {
 		t.Run("Books", func(t *testing.T) {
 			booksClass := books.ClassModel2VecVectorizer()
@@ -74,36 +59,36 @@ func Test_AliasesAPI(t *testing.T) {
 		}{
 			{
 				name:  books.DefaultClassName,
-				alias: &models.Alias{Alias: "BookAlias", Class: books.DefaultClassName},
+				alias: &models.Alias{Alias: "RestBookAlias", Class: books.DefaultClassName},
 			},
 			{
 				name:  documents.Document,
-				alias: &models.Alias{Alias: "DocumentAlias", Class: documents.Document},
+				alias: &models.Alias{Alias: "RestDocumentAlias", Class: documents.Document},
 			},
 			{
 				name:  documents.Document,
-				alias: &models.Alias{Alias: "PassageAlias", Class: documents.Document},
+				alias: &models.Alias{Alias: "RestPassageAlias", Class: documents.Document},
 			},
 			{
 				name:  documents.Passage,
-				alias: &models.Alias{Alias: "PassageAlias1", Class: documents.Passage},
+				alias: &models.Alias{Alias: "RestPassageAlias1", Class: documents.Passage},
 			},
 			{
 				name:  documents.Passage,
-				alias: &models.Alias{Alias: "PassageAlias2", Class: documents.Passage},
+				alias: &models.Alias{Alias: "RestPassageAlias2", Class: documents.Passage},
 			},
 			{
 				name:  documents.Passage,
-				alias: &models.Alias{Alias: "PassageAlias3", Class: documents.Passage},
+				alias: &models.Alias{Alias: "RestPassageAlias3", Class: documents.Passage},
 			},
 			{
 				name:  documents.Passage,
-				alias: &models.Alias{Alias: "AliasThatWillBeReplaced", Class: documents.Passage},
+				alias: &models.Alias{Alias: "RestAliasThatWillBeReplaced", Class: documents.Passage},
 			},
 			{
 				name: "create with different case",
-				// passing in `aliasThatCreated` but should transform into `AliasThatCreated`.
-				alias: &models.Alias{Alias: "aliasThatCreated", Class: documents.Passage},
+				// passing in `restAliasThatCreated` but should transform into `AliasThatCreated`.
+				alias: &models.Alias{Alias: "restAliasThatCreated", Class: documents.Passage},
 			},
 		}
 		for _, tt := range tests {
@@ -166,22 +151,19 @@ func Test_AliasesAPI(t *testing.T) {
 	})
 
 	t.Run("get aliases", func(t *testing.T) {
-		resp := helper.GetAliases(t, nil)
-		require.NotNil(t, resp)
-		require.NotEmpty(t, resp.Aliases)
-		require.Equal(t, 8, len(resp.Aliases))
+		require.Equal(t, 8, countAliasesWithPrefix(t, "Rest"))
 	})
 
 	t.Run("get alias", func(t *testing.T) {
-		resp := helper.GetAlias(t, "BookAlias")
+		resp := helper.GetAlias(t, "RestBookAlias")
 		require.NotNil(t, resp)
-		require.Equal(t, "BookAlias", resp.Alias)
+		require.Equal(t, "RestBookAlias", resp.Alias)
 	})
 
 	t.Run("get alias different case", func(t *testing.T) {
-		resp := helper.GetAlias(t, "bookAlias") // first letter is different case.
+		resp := helper.GetAlias(t, "restBookAlias") // first letter is different case.
 		require.NotNil(t, resp)
-		require.Equal(t, "BookAlias", resp.Alias)
+		require.Equal(t, "RestBookAlias", resp.Alias)
 	})
 
 	t.Run("get alias not found", func(t *testing.T) {
@@ -196,7 +178,7 @@ func Test_AliasesAPI(t *testing.T) {
 			require.Equal(t, aliasName, resp.Alias)
 			require.Equal(t, expectedClass, resp.Class)
 		}
-		aliasName := "AliasThatWillBeReplaced"
+		aliasName := "RestAliasThatWillBeReplaced"
 		checkAlias(t, aliasName, documents.Passage)
 		helper.UpdateAlias(t, aliasName, documents.Document)
 		checkAlias(t, aliasName, documents.Document)
@@ -209,8 +191,8 @@ func Test_AliasesAPI(t *testing.T) {
 			require.Equal(t, aliasName, resp.Alias)
 			require.Equal(t, expectedClass, resp.Class)
 		}
-		aliasName := "AliasThatWillBeReplaced"
-		dAliasName := "aliasThatWillBeReplaced" // same with first lower case
+		aliasName := "RestAliasThatWillBeReplaced"
+		dAliasName := "restAliasThatWillBeReplaced" // same with first lower case
 		checkAlias(t, aliasName, documents.Document)
 		helper.UpdateAlias(t, dAliasName, documents.Passage)
 		checkAlias(t, aliasName, documents.Passage)
@@ -236,7 +218,7 @@ func Test_AliasesAPI(t *testing.T) {
 			require.Equal(t, aliasName, resp.Alias)
 			require.Equal(t, expectedClass, resp.Class)
 		}
-		aliasName := "AliasThatWillBeReplaced"
+		aliasName := "RestAliasThatWillBeReplaced"
 		checkAlias(t, aliasName, documents.Passage)
 		resp, err := helper.UpdateAliasWithReturn(t, aliasName, "errorCollection")
 		require.Error(t, err)
@@ -251,30 +233,24 @@ func Test_AliasesAPI(t *testing.T) {
 
 	t.Run("delete alias", func(t *testing.T) {
 		checkAliasesCount := func(t *testing.T, count int) {
-			resp := helper.GetAliases(t, nil)
-			require.NotNil(t, resp)
-			require.NotEmpty(t, resp.Aliases)
-			require.Equal(t, count, len(resp.Aliases))
+			require.Equal(t, count, countAliasesWithPrefix(t, "Rest"))
 		}
 		checkAliasesCount(t, 8)
-		helper.DeleteAlias(t, "AliasThatWillBeReplaced")
+		helper.DeleteAlias(t, "RestAliasThatWillBeReplaced")
 		checkAliasesCount(t, 7)
 	})
 
 	t.Run("delete alias different case", func(t *testing.T) {
 		checkAliasesCount := func(t *testing.T, count int) {
-			resp := helper.GetAliases(t, nil)
-			require.NotNil(t, resp)
-			require.NotEmpty(t, resp.Aliases)
-			require.Equal(t, count, len(resp.Aliases))
+			require.Equal(t, count, countAliasesWithPrefix(t, "Rest"))
 		}
 		checkAliasesCount(t, 7)
-		helper.DeleteAlias(t, "aliasThatCreated") // note first letter is small
+		helper.DeleteAlias(t, "restAliasThatCreated") // note first letter is small
 		checkAliasesCount(t, 6)
 	})
 
 	t.Run("delete alias that doesn't exist", func(t *testing.T) {
-		resp, err := helper.DeleteAliasWithReturn(t, "AliasThatWillBeReplaced")
+		resp, err := helper.DeleteAliasWithReturn(t, "RestAliasThatWillBeReplaced")
 		require.Error(t, err)
 		require.Nil(t, resp)
 	})
@@ -295,8 +271,8 @@ func Test_AliasesAPI(t *testing.T) {
 				},
 				{
 					name:             "clashing alias name",
-					alias:            &models.Alias{Alias: "BookAlias", Class: documents.Passage},
-					expectedErrorMsg: fmt.Sprintf("create alias: %s, alias already exists", "BookAlias"),
+					alias:            &models.Alias{Alias: "RestBookAlias", Class: documents.Passage},
+					expectedErrorMsg: fmt.Sprintf("create alias: %s, alias already exists", "RestBookAlias"),
 				},
 			}
 			for _, tt := range tests {
@@ -326,8 +302,8 @@ func Test_AliasesAPI(t *testing.T) {
 				// trying to create class with existing alias name.
 				{
 					name:             "with existing alias name",
-					class:            books.ClassModel2VecVectorizerWithName("BookAlias"),
-					expectedErrorMsg: fmt.Sprintf("alias name %s already exists", "BookAlias"),
+					class:            books.ClassModel2VecVectorizerWithName("RestBookAlias"),
+					expectedErrorMsg: fmt.Sprintf("alias name %s already exists", "RestBookAlias"),
 				},
 			}
 			for _, tt := range tests {
@@ -350,8 +326,8 @@ func Test_AliasesAPI(t *testing.T) {
 		require.Nil(t, resp)
 	})
 
-	t.Run("tests with BookAlias", func(t *testing.T) {
-		aliasName := "BookAlias"
+	t.Run("tests with RestBookAlias", func(t *testing.T) {
+		aliasName := "RestBookAlias"
 
 		assertGetObject := func(t *testing.T, id strfmt.UUID) {
 			objWithClassName, err := helper.GetObject(t, books.DefaultClassName, id)
@@ -370,7 +346,7 @@ func Test_AliasesAPI(t *testing.T) {
 		}
 
 		// Properties test via alias. Any collection properties manipulation needs
-		// original class name, not the alias. Assumes we have collection: Book, alias: BookAlias.
+		// original class name, not the alias. Assumes we have collection: Book, alias: RestBookAlias.
 		t.Run("update class property with alias - should fail", func(t *testing.T) {
 			c := &models.Class{
 				Class: aliasName, // using alias name to add property
@@ -402,7 +378,7 @@ func Test_AliasesAPI(t *testing.T) {
 		})
 
 		// Tenants test via alias. Any collection tenants manipulation needs
-		// original class name, not the alias. Assumes we have collection: Book, alias: BookAlias.
+		// original class name, not the alias. Assumes we have collection: Book, alias: RestBookAlias.
 		t.Run("add_update_delete tenants withalias - should fail", func(t *testing.T) {
 			className := "MultiTenantClass"
 			testClass := models.Class{

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -87,7 +87,7 @@ func testAliasesAPI(t *testing.T) {
 			},
 			{
 				name: "create with different case",
-				// passing in `restAliasThatCreated` but should transform into `AliasThatCreated`.
+				// passing in `restAliasThatCreated` but should transform into `RestAliasThatCreated`.
 				alias: &models.Alias{Alias: "restAliasThatCreated", Class: documents.Passage},
 			},
 		}

--- a/test/acceptance/aliases/aliases_test.go
+++ b/test/acceptance/aliases/aliases_test.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestAliases boots a single Weaviate container shared across the REST, gRPC and
+// backup suites. Each suite uses a unique alias-name prefix (Rest/Grpc/Backup)
+// and cleans up after itself so the instance-wide alias counts stay exact.
+func TestAliases(t *testing.T) {
+	ctx := context.Background()
+	compose, err := docker.New().
+		WithBackendFilesystem().
+		WithWeaviateWithGRPC().
+		WithText2VecModel2Vec().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	t.Run("rest", func(t *testing.T) {
+		testAliasesAPI(t)
+	})
+	t.Run("grpc", func(t *testing.T) {
+		testAliasesAPIgRPC(t, compose.GetWeaviate().GrpcURI())
+	})
+	t.Run("backup", func(t *testing.T) {
+		testAliasesAPIBackup(t)
+	})
+}
+
+// countAliasesWithPrefix returns how many instance-wide aliases start with the
+// given prefix. Each suite scopes its count assertions to its own prefix so a
+// sibling suite's aliases can't throw the numbers off.
+func countAliasesWithPrefix(t *testing.T, prefix string) int {
+	resp := helper.GetAliases(t, nil)
+	require.NotNil(t, resp)
+	count := 0
+	for _, alias := range resp.Aliases {
+		if strings.HasPrefix(alias.Alias, prefix) {
+			count++
+		}
+	}
+	return count
+}

--- a/test/acceptance/authn/dynamic_users_test.go
+++ b/test/acceptance/authn/dynamic_users_test.go
@@ -26,28 +26,23 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-func TestCreateUser(t *testing.T) {
-	adminKey := "admin-key"
-	adminUser := "admin-user"
-
-	otherUser := "custom-user"
-	otherKey := "custom-key"
-
-	otherUser2 := "custom-user2"
-	otherKey2 := "custom-key2"
-
-	otherUser3 := "custom-user3"
-	otherKey3 := "custom-key3"
-
-	otherUser4 := "custom-user4"
-	otherKey4 := "custom-key4"
-
-	otherUser5 := "custom-user5"
-	otherKey5 := "custom-key5"
+// TestDynamicUsers boots a single Weaviate container shared across the dynamic
+// user suites. The RBAC config is a superset: the admin key is a root user so
+// the non-RBAC suites' admin operations still work. Each suite uses a disjoint
+// set of user names so they don't clobber each other on the shared instance.
+func TestDynamicUsers(t *testing.T) {
+	adminUser, adminKey := "admin-user", "admin-key"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	compose, err := docker.New().WithWeaviate().
-		WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(otherUser, otherKey).WithUserApiKey(otherUser2, otherKey2).WithUserApiKey(otherUser3, otherKey3).WithUserApiKey(otherUser4, otherKey4).WithUserApiKey(otherUser5, otherKey5).
+		WithApiKey().
+		WithUserApiKey(adminUser, adminKey).
+		WithUserApiKey("custom-user", "custom-key").
+		WithUserApiKey("custom-user2", "custom-key2").
+		WithUserApiKey("custom-user3", "custom-key3").
+		WithUserApiKey("custom-user4", "custom-key4").
+		WithUserApiKey("custom-user5", "custom-key5").
+		WithUserApiKey("static-user", "static-key").
 		WithDbUsers().
 		WithRBAC().WithRbacRoots(adminUser).
 		Start(ctx)
@@ -58,6 +53,29 @@ func TestCreateUser(t *testing.T) {
 		require.NoError(t, compose.Terminate(ctx))
 		cancel()
 	}()
+
+	t.Run("create_user", testCreateUser)
+	t.Run("with_static_user", testWithStaticUser)
+	t.Run("suspend_and_activate", testSuspendAndActivate)
+}
+
+func testCreateUser(t *testing.T) {
+	adminKey := "admin-key"
+
+	otherUser := "custom-user"
+	otherKey := "custom-key"
+
+	otherUser2 := "custom-user2"
+
+	otherUser3 := "custom-user3"
+	otherKey3 := "custom-key3"
+
+	otherUser4 := "custom-user4"
+	otherKey4 := "custom-key4"
+
+	otherUser5 := "custom-user5"
+	otherKey5 := "custom-key5"
+
 	userName := "CreateUserTestUser"
 
 	t.Run("create and delete user", func(t *testing.T) {
@@ -221,26 +239,12 @@ func TestCreateUser(t *testing.T) {
 	})
 }
 
-func TestWithStaticUser(t *testing.T) {
+func testWithStaticUser(t *testing.T) {
 	adminKey := "admin-key"
-	adminUser := "admin-user"
-
-	otherKey := "custom-key"
-	otherUser := "custom-user"
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithUserApiKey(otherUser, otherKey).WithDbUsers().Start(ctx)
-	require.Nil(t, err)
-	helper.SetupClient(compose.GetWeaviate().URI())
-
-	defer func() {
-		helper.ResetClient()
-		require.NoError(t, compose.Terminate(ctx))
-		cancel()
-	}()
+	staticUser := "static-user"
 
 	t.Run("create with existing static user name", func(t *testing.T) {
-		resp, err := helper.Client(t).Users.CreateUser(users.NewCreateUserParams().WithUserID(otherUser), helper.CreateAuth(adminKey))
+		resp, err := helper.Client(t).Users.CreateUser(users.NewCreateUserParams().WithUserID(staticUser), helper.CreateAuth(adminKey))
 		require.Error(t, err)
 		require.Nil(t, resp)
 		var parsed *users.CreateUserConflict
@@ -248,7 +252,7 @@ func TestWithStaticUser(t *testing.T) {
 	})
 
 	t.Run("delete existing static user name", func(t *testing.T) {
-		resp, err := helper.Client(t).Users.DeleteUser(users.NewDeleteUserParams().WithUserID(otherUser), helper.CreateAuth(adminKey))
+		resp, err := helper.Client(t).Users.DeleteUser(users.NewDeleteUserParams().WithUserID(staticUser), helper.CreateAuth(adminKey))
 		require.Error(t, err)
 		require.Nil(t, resp)
 		var parsed *users.DeleteUserUnprocessableEntity
@@ -256,7 +260,7 @@ func TestWithStaticUser(t *testing.T) {
 	})
 
 	t.Run("rotate existing static user name", func(t *testing.T) {
-		resp, err := helper.Client(t).Users.RotateUserAPIKey(users.NewRotateUserAPIKeyParams().WithUserID(otherUser), helper.CreateAuth(adminKey))
+		resp, err := helper.Client(t).Users.RotateUserAPIKey(users.NewRotateUserAPIKeyParams().WithUserID(staticUser), helper.CreateAuth(adminKey))
 		require.Error(t, err)
 		require.Nil(t, resp)
 		var parsed *users.RotateUserAPIKeyUnprocessableEntity
@@ -264,21 +268,8 @@ func TestWithStaticUser(t *testing.T) {
 	})
 }
 
-func TestSuspendAndActivate(t *testing.T) {
+func testSuspendAndActivate(t *testing.T) {
 	adminKey := "admin-key"
-	adminUser := "admin-user"
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	compose, err := docker.New().WithWeaviate().WithApiKey().WithUserApiKey(adminUser, adminKey).WithDbUsers().Start(ctx)
-	require.Nil(t, err)
-	helper.SetupClient(compose.GetWeaviate().URI())
-
-	defer func() {
-		helper.ResetClient()
-		require.NoError(t, compose.Terminate(ctx))
-		cancel()
-	}()
-	helper.SetupClient(compose.GetWeaviate().URI())
 
 	dynamicUser := "dynamic-user"
 


### PR DESCRIPTION
### What's being changed:

title

Before:
- github.com/weaviate/weaviate/test/acceptance/authn	222.589s
- github.com/weaviate/weaviate/test/acceptance/aliases	82.699s

After
- github.com/weaviate/weaviate/test/acceptance/authn	198.758s
- github.com/weaviate/weaviate/test/acceptance/aliases	43.912s


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
