### PR TITLE
Skip malformed runtime config values

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2314,9 +2314,23 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 			registered.OIDCSkipTLSVerify = appState.ServerConfig.Config.Authentication.OIDC.SkipTLSVerify
 		}
 
+		// parser decodes the overrides file field-by-field. A value that fails to
+		// decode is logged and skipped so the remaining valid fields still apply;
+		// only a malformed document aborts the whole load.
+		parser := func(b []byte) (*config.WeaviateRuntimeConfig, error) {
+			cfg, fieldErrs, err := config.ParseRuntimeConfigPartial(b)
+			for _, fe := range fieldErrs {
+				appState.Logger.WithFields(logrus.Fields{
+					"action": "runtime_overrides_parse",
+					"field":  fe.Field,
+				}).Error(fe.Err)
+			}
+			return cfg, err
+		}
+
 		cm, err := configRuntime.NewConfigManager(
 			appState.ServerConfig.Config.RuntimeOverrides.Path,
-			config.ParseRuntimeConfig,
+			parser,
 			config.UpdateRuntimeConfig,
 			registered,
 			appState.ServerConfig.Config.RuntimeOverrides.LoadInterval,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2337,7 +2337,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 			appState.Logger,
 			prometheus.DefaultRegisterer)
 		if err != nil {
-			appState.Logger.WithField("action", "startup").Errorf("could not create runtime config manager: %v", err)
+			appState.Logger.WithField("action", "runtime_overrides_parse").Errorf("could not create runtime config manager: %v", err)
 		}
 		return cm
 	}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2314,24 +2314,9 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 			registered.OIDCSkipTLSVerify = appState.ServerConfig.Config.Authentication.OIDC.SkipTLSVerify
 		}
 
-		// parser decodes the overrides file field-by-field. A value that fails to
-		// decode is logged and recorded in skipped so the remaining valid fields
-		// still apply; only a malformed document aborts the whole load.
-		parser := func(b []byte, skipped map[string]struct{}) (*config.WeaviateRuntimeConfig, error) {
-			cfg, fieldErrs, err := config.ParseRuntimeConfigPartial(b)
-			for _, fe := range fieldErrs {
-				skipped[fe.Field] = struct{}{}
-				appState.Logger.WithFields(logrus.Fields{
-					"action": "runtime_overrides_parse",
-					"field":  fe.Field,
-				}).Error(fe.Err)
-			}
-			return cfg, err
-		}
-
 		cm, err := configRuntime.NewConfigManager(
 			appState.ServerConfig.Config.RuntimeOverrides.Path,
-			parser,
+			config.NewRuntimeConfigParser(appState.Logger),
 			config.UpdateRuntimeConfig,
 			registered,
 			appState.ServerConfig.Config.RuntimeOverrides.LoadInterval,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2315,11 +2315,12 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		}
 
 		// parser decodes the overrides file field-by-field. A value that fails to
-		// decode is logged and skipped so the remaining valid fields still apply;
-		// only a malformed document aborts the whole load.
-		parser := func(b []byte) (*config.WeaviateRuntimeConfig, error) {
+		// decode is logged and recorded in skipped so the remaining valid fields
+		// still apply; only a malformed document aborts the whole load.
+		parser := func(b []byte, skipped map[string]struct{}) (*config.WeaviateRuntimeConfig, error) {
 			cfg, fieldErrs, err := config.ParseRuntimeConfigPartial(b)
 			for _, fe := range fieldErrs {
+				skipped[fe.Field] = struct{}{}
 				appState.Logger.WithFields(logrus.Fields{
 					"action": "runtime_overrides_parse",
 					"field":  fe.Field,

--- a/usecases/config/runtime/manager.go
+++ b/usecases/config/runtime/manager.go
@@ -36,12 +36,14 @@ var (
 	ErrUnregisteredConfigFound = errors.New("unregistered config found")
 )
 
-// Parser takes care of unmarshaling a config struct
-// from given raw bytes(e.g: YAML, JSON, etc).
-type Parser[T any] func([]byte) (*T, error)
+// Parser takes care of unmarshaling a config struct from given raw bytes (e.g:
+// YAML, JSON, etc). Keys that fail to decode are recorded in skipped so the
+// updater can leave those fields untouched instead of resetting them.
+type Parser[T any] func(buf []byte, skipped map[string]struct{}) (*T, error)
 
-// Updater try to update `source` config with newly `parsed` config.
-type Updater[T any] func(log logrus.FieldLogger, source, parsed *T, hooks map[string]func() error) error
+// Updater try to update `source` config with newly `parsed` config. Fields named
+// in skipped are left as-is (neither applied nor reset to default).
+type Updater[T any] func(log logrus.FieldLogger, source, parsed *T, skipped map[string]struct{}, hooks map[string]func() error) error
 
 // ConfigManager takes care of periodically loading the config from
 // given filepath for every interval period.
@@ -157,13 +159,14 @@ func (cm *ConfigManager[T]) reloadConfig(forceReloadOverrides bool) error {
 		return nil // same file. no change
 	}
 
-	cfg, err := cm.parse(b)
+	skipped := make(map[string]struct{})
+	cfg, err := cm.parse(b, skipped)
 	if err != nil {
 		cm.lastLoadSuccess.Set(0)
 		return errors.Join(ErrFailedToParseConfig, err)
 	}
 
-	if err := cm.update(cm.log, cm.currentConfig, cfg, cm.hooks); err != nil {
+	if err := cm.update(cm.log, cm.currentConfig, cfg, skipped, cm.hooks); err != nil {
 		return err
 	}
 

--- a/usecases/config/runtime/manager_test.go
+++ b/usecases/config/runtime/manager_test.go
@@ -36,7 +36,7 @@ type testConfig struct {
 	BackupInterval *DynamicValue[time.Duration] `yaml:"backup_interval"`
 }
 
-func parseYaml(buf []byte) (*testConfig, error) {
+func parseYaml(buf []byte, _ map[string]struct{}) (*testConfig, error) {
 	var c testConfig
 	dec := yaml.NewDecoder(bytes.NewReader(buf))
 	dec.KnownFields(true)
@@ -47,7 +47,7 @@ func parseYaml(buf []byte) (*testConfig, error) {
 	return &c, nil
 }
 
-func updater(_ logrus.FieldLogger, source, parsed *testConfig, _ map[string]func() error) error {
+func updater(_ logrus.FieldLogger, source, parsed *testConfig, _ map[string]struct{}, _ map[string]func() error) error {
 	source.BackupInterval.SetValue(parsed.BackupInterval.Get())
 	return nil
 }
@@ -129,9 +129,9 @@ func TestConfigManager_loadConfig(t *testing.T) {
 
 		// calling parser => reloading the config
 		loadCount := 0
-		trackedParser := func(buf []byte) (*testConfig, error) {
+		trackedParser := func(buf []byte, skipped map[string]struct{}) (*testConfig, error) {
 			loadCount++
-			return parseYaml(buf)
+			return parseYaml(buf, skipped)
 		}
 
 		tmp, err := os.CreateTemp("", "valid_config.yaml")
@@ -201,9 +201,9 @@ func TestConfigManager_loadConfig(t *testing.T) {
 
 		// calling parser => reloading the config
 		loadCount := 0
-		trackedParser := func(buf []byte) (*testConfig, error) {
+		trackedParser := func(buf []byte, skipped map[string]struct{}) (*testConfig, error) {
 			loadCount++
-			return parseYaml(buf)
+			return parseYaml(buf, skipped)
 		}
 
 		tmp, err := os.CreateTemp("", "valid_config.yaml")
@@ -268,9 +268,9 @@ func TestConfigManager_loadConfig(t *testing.T) {
 
 		// calling parser => reloading the config
 		var loadCount atomic.Int64
-		trackedParser := func(buf []byte) (*testConfig, error) {
+		trackedParser := func(buf []byte, skipped map[string]struct{}) (*testConfig, error) {
 			loadCount.Add(1)
-			return parseYaml(buf)
+			return parseYaml(buf, skipped)
 		}
 
 		tmp, err := os.CreateTemp("", "valid_config.yaml")

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -163,6 +163,24 @@ func ParseRuntimeConfigPartial(buf []byte) (*WeaviateRuntimeConfig, []FieldError
 	return conf, fieldErrs, nil
 }
 
+// NewRuntimeConfigParser returns a Parser that decodes the overrides file
+// field-by-field. A value that fails to decode is logged and recorded in skipped
+// so the remaining valid fields still apply; only a malformed document aborts the
+// whole load.
+func NewRuntimeConfigParser(log logrus.FieldLogger) runtime.Parser[WeaviateRuntimeConfig] {
+	return func(b []byte, skipped map[string]struct{}) (*WeaviateRuntimeConfig, error) {
+		cfg, fieldErrs, err := ParseRuntimeConfigPartial(b)
+		for _, fe := range fieldErrs {
+			skipped[fe.Field] = struct{}{}
+			log.WithFields(logrus.Fields{
+				"action": "runtime_overrides_parse",
+				"field":  fe.Field,
+			}).Error(fe.Err)
+		}
+		return cfg, err
+	}
+}
+
 // yamlKey returns the YAML name of a struct field (tag value minus options).
 func yamlKey(sf reflect.StructField) string {
 	tag := sf.Tag.Get("yaml")

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -102,20 +102,84 @@ type WeaviateRuntimeConfig struct {
 	OIDCCertificate       *runtime.DynamicValue[string]   `yaml:"authentication_oidc_certificate" json:"authentication_oidc_certificate"`
 	OIDCJWKSUrl           *runtime.DynamicValue[string]   `yaml:"authentication_oidc_jwks_url" json:"authentication_oidc_jwks_url"`
 	OIDCSkipTLSVerify     *runtime.DynamicValue[bool]     `yaml:"authentication_oidc_insecure_skip_tls_verify" json:"authentication_oidc_insecure_skip_tls_verify"`
+
+	// skippedFields holds the YAML keys that failed to decode in this parse. Such
+	// a field is left untouched on update (neither applied nor reset), so a
+	// malformed value keeps whatever was already in effect instead of reverting
+	// to the default. Unexported so it is not (un)marshaled.
+	skippedFields map[string]struct{}
 }
 
-// ParseRuntimeConfig decode WeaviateRuntimeConfig from raw bytes of YAML.
+// FieldError reports a single runtime-config key that failed to decode into its
+// target type. The remaining keys in the document are still applied.
+type FieldError struct {
+	Field string
+	Err   error
+}
+
+func (e FieldError) Error() string { return fmt.Sprintf("%s: %v", e.Field, e.Err) }
+
+// ParseRuntimeConfig decodes WeaviateRuntimeConfig from raw YAML bytes. Per-field
+// decode failures are dropped here; use ParseRuntimeConfigPartial to observe them.
 func ParseRuntimeConfig(buf []byte) (*WeaviateRuntimeConfig, error) {
-	var conf WeaviateRuntimeConfig
+	conf, _, err := ParseRuntimeConfigPartial(buf)
+	return conf, err
+}
+
+// ParseRuntimeConfigPartial decodes WeaviateRuntimeConfig key-by-key so a single
+// malformed value (wrong type, out of the type's range, overflow) is skipped and
+// reported instead of rejecting the whole file. A document-level YAML error (one
+// not attributable to a single key, e.g. malformed syntax) is still returned as a
+// fatal error so the manager keeps the previous config.
+func ParseRuntimeConfigPartial(buf []byte) (*WeaviateRuntimeConfig, []FieldError, error) {
+	var raw map[string]yaml.Node
 
 	dec := yaml.NewDecoder(bytes.NewReader(buf))
 
-	// Am empty runtime yaml file is still a valid file. So treating io.EOF as
+	// An empty runtime yaml file is still a valid file. So treating io.EOF as
 	// non-error case returns default values of config.
-	if err := dec.Decode(&conf); err != nil && !errors.Is(err, io.EOF) {
-		return nil, err
+	if err := dec.Decode(&raw); err != nil && !errors.Is(err, io.EOF) {
+		return nil, nil, err
 	}
-	return &conf, nil
+
+	conf := &WeaviateRuntimeConfig{}
+	v := reflect.ValueOf(conf).Elem()
+	t := v.Type()
+
+	var fieldErrs []FieldError
+	for i := range t.NumField() {
+		key := yamlKey(t.Field(i))
+		if key == "" || key == "-" {
+			continue
+		}
+		node, ok := raw[key]
+		if !ok {
+			continue // absent key keeps the registered default
+		}
+		// Each field is a *runtime.DynamicValue[T]; decode the node into a fresh
+		// one so DynamicValue.UnmarshalYAML still runs (comma-split coercion etc.).
+		fp := reflect.New(t.Field(i).Type.Elem())
+		if err := node.Decode(fp.Interface()); err != nil {
+			fieldErrs = append(fieldErrs, FieldError{Field: key, Err: err})
+			if conf.skippedFields == nil {
+				conf.skippedFields = make(map[string]struct{})
+			}
+			conf.skippedFields[key] = struct{}{}
+			continue
+		}
+		v.Field(i).Set(fp)
+	}
+
+	return conf, fieldErrs, nil
+}
+
+// yamlKey returns the YAML name of a struct field (tag value minus options).
+func yamlKey(sf reflect.StructField) string {
+	tag := sf.Tag.Get("yaml")
+	if tag == "" {
+		return ""
+	}
+	return strings.SplitN(tag, ",", 2)[0]
 }
 
 // UpdateConfig does in-place update of `source` config based on values available in
@@ -125,7 +189,7 @@ func UpdateRuntimeConfig(log logrus.FieldLogger, source, parsed *WeaviateRuntime
 		return fmt.Errorf("source and parsed cannot be nil")
 	}
 
-	updateRuntimeConfig(log, reflect.ValueOf(*source), reflect.ValueOf(*parsed), hooks)
+	updateRuntimeConfig(log, reflect.ValueOf(*source), reflect.ValueOf(*parsed), parsed.skippedFields, hooks)
 	return nil
 }
 
@@ -165,7 +229,7 @@ With this reflection method, we avoided that extra step from the consumer. This 
 See "runtimeconfig_test.go" for more examples.
 */
 
-func updateRuntimeConfig(log logrus.FieldLogger, source, parsed reflect.Value, hooks map[string]func() error) {
+func updateRuntimeConfig(log logrus.FieldLogger, source, parsed reflect.Value, skipped map[string]struct{}, hooks map[string]func() error) {
 	// Basically we do following
 	//
 	// 1. Loop through all the `source` fields
@@ -177,11 +241,22 @@ func updateRuntimeConfig(log logrus.FieldLogger, source, parsed reflect.Value, h
 	logRecords := make([]updateLogRecord, 0)
 
 	for i := range source.NumField() {
+		sfType := source.Type().Field(i)
+		// Unexported bookkeeping fields (e.g. skippedFields) are not config values.
+		if !sfType.IsExported() {
+			continue
+		}
+		// A field whose value failed to decode is left as-is: don't apply the bad
+		// value, but don't reset it to the default either.
+		if _, skip := skipped[yamlKey(sfType)]; skip {
+			continue
+		}
+
 		sf := source.Field(i)
 		pf := parsed.Field(i)
 
 		r := updateLogRecord{
-			field: source.Type().Field(i).Name,
+			field: sfType.Name,
 		}
 
 		si := sf.Interface()

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -102,12 +102,6 @@ type WeaviateRuntimeConfig struct {
 	OIDCCertificate       *runtime.DynamicValue[string]   `yaml:"authentication_oidc_certificate" json:"authentication_oidc_certificate"`
 	OIDCJWKSUrl           *runtime.DynamicValue[string]   `yaml:"authentication_oidc_jwks_url" json:"authentication_oidc_jwks_url"`
 	OIDCSkipTLSVerify     *runtime.DynamicValue[bool]     `yaml:"authentication_oidc_insecure_skip_tls_verify" json:"authentication_oidc_insecure_skip_tls_verify"`
-
-	// skippedFields holds the YAML keys that failed to decode in this parse. Such
-	// a field is left untouched on update (neither applied nor reset), so a
-	// malformed value keeps whatever was already in effect instead of reverting
-	// to the default. Unexported so it is not (un)marshaled.
-	skippedFields map[string]struct{}
 }
 
 // FieldError reports a single runtime-config key that failed to decode into its
@@ -161,10 +155,6 @@ func ParseRuntimeConfigPartial(buf []byte) (*WeaviateRuntimeConfig, []FieldError
 		fp := reflect.New(t.Field(i).Type.Elem())
 		if err := node.Decode(fp.Interface()); err != nil {
 			fieldErrs = append(fieldErrs, FieldError{Field: key, Err: err})
-			if conf.skippedFields == nil {
-				conf.skippedFields = make(map[string]struct{})
-			}
-			conf.skippedFields[key] = struct{}{}
 			continue
 		}
 		v.Field(i).Set(fp)
@@ -184,12 +174,12 @@ func yamlKey(sf reflect.StructField) string {
 
 // UpdateConfig does in-place update of `source` config based on values available in
 // `parsed` config.
-func UpdateRuntimeConfig(log logrus.FieldLogger, source, parsed *WeaviateRuntimeConfig, hooks map[string]func() error) error {
+func UpdateRuntimeConfig(log logrus.FieldLogger, source, parsed *WeaviateRuntimeConfig, skipped map[string]struct{}, hooks map[string]func() error) error {
 	if source == nil || parsed == nil {
 		return fmt.Errorf("source and parsed cannot be nil")
 	}
 
-	updateRuntimeConfig(log, reflect.ValueOf(*source), reflect.ValueOf(*parsed), parsed.skippedFields, hooks)
+	updateRuntimeConfig(log, reflect.ValueOf(*source), reflect.ValueOf(*parsed), skipped, hooks)
 	return nil
 }
 
@@ -242,10 +232,6 @@ func updateRuntimeConfig(log logrus.FieldLogger, source, parsed reflect.Value, s
 
 	for i := range source.NumField() {
 		sfType := source.Type().Field(i)
-		// Unexported bookkeeping fields (e.g. skippedFields) are not config values.
-		if !sfType.IsExported() {
-			continue
-		}
 		// A field whose value failed to decode is left as-is: don't apply the bad
 		// value, but don't reset it to the default either.
 		if _, skip := skipped[yamlKey(sfType)]; skip {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -188,7 +188,7 @@ replica_movement_minimum_async_wait: 10s`)
 		assert.Equal(t, 0, colCount.Get())
 		assert.Equal(t, 0*time.Second, minFinWait.Get())
 
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 
 		// after update (reflect from parsed values)
 		assert.Equal(t, true, autoSchema.Get())
@@ -209,7 +209,7 @@ replica_movement_minimum_async_wait: 10s`)
 		// 1. apply a valid override (13 differs from the default 0)
 		parsed, err := ParseRuntimeConfig([]byte(`maximum_allowed_collections_count: 13`))
 		require.NoError(t, err)
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Equal(t, 13, colCount.Get())
 
 		// 2. reload where that same field is malformed, alongside a valid sibling
@@ -219,7 +219,8 @@ autoschema_enabled: true`))
 		require.Len(t, fieldErrs, 1)
 		assert.Equal(t, "maximum_allowed_collections_count", fieldErrs[0].Field)
 
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		skipped := map[string]struct{}{fieldErrs[0].Field: {}}
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, skipped, nil))
 
 		// malformed field keeps the previously-applied 13: not reset to the
 		// default 0, and not the bad value
@@ -261,7 +262,7 @@ autoschema_enabled: true`))
 		assert.Nil(t, parsed.TenantActivityWriteLogLevel)
 		assert.Nil(t, parsed.RevectorizeCheckDisabled)
 
-		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil, nil))
 		assert.Equal(t, 10, source.MaximumAllowedCollectionsCount.Get())
 		assert.Equal(t, true, source.AutoschemaEnabled.Get())
 		assert.Equal(t, true, source.AsyncReplicationDisabled.Get())
@@ -275,7 +276,7 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
 
-		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil, nil))
 		assert.Equal(t, 13, source.MaximumAllowedCollectionsCount.Get()) // changed
 		assert.Equal(t, false, source.AutoschemaEnabled.Get())           // changed
 		assert.Equal(t, true, source.AsyncReplicationDisabled.Get())
@@ -288,7 +289,7 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
 
-		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil, nil))
 		assert.Equal(t, 10, source.MaximumAllowedCollectionsCount.Get())
 		assert.Equal(t, true, source.AutoschemaEnabled.Get())
 		assert.Equal(t, true, source.AsyncReplicationDisabled.Get())
@@ -320,7 +321,7 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		assert.Equal(t, false, autoSchema.Get())
 		assert.Equal(t, 0, colCount.Get())
 
-		require.NotPanics(t, func() { UpdateRuntimeConfig(log, reg, parsed, nil) })
+		require.NotPanics(t, func() { UpdateRuntimeConfig(log, reg, parsed, nil, nil) })
 
 		// after update (reflect from parsed values)
 		assert.Equal(t, true, autoSchema.Get())
@@ -352,7 +353,7 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		assert.Equal(t, false, autoSchema.Get())
 		assert.Equal(t, 7, colCount.Get())
 
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '7' to '13'" action=runtime_overrides_changed field=MaximumAllowedCollectionsCount new_value=13 old_value=7`)
 		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'AutoschemaEnabled' changed from 'false' to 'true'" action=runtime_overrides_changed field=AutoschemaEnabled new_value=true old_value=false`)
 		logs.Reset()
@@ -363,7 +364,7 @@ maximum_allowed_collections_count: 10`)
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
 
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '13' to '10'" action=runtime_overrides_changed field=MaximumAllowedCollectionsCount new_value=10 old_value=13`)
 		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'AutoschemaEnabled' changed from 'true' to 'false'" action=runtime_overrides_changed field=AutoschemaEnabled new_value=false old_value=true`)
 		logs.Reset()
@@ -373,7 +374,7 @@ maximum_allowed_collections_count: 10`)
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
 
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Contains(t, logs.String(), `level=info msg="runtime overrides: config 'MaximumAllowedCollectionsCount' changed from '10' to '7'" action=runtime_overrides_changed field=MaximumAllowedCollectionsCount new_value=7 old_value=10`)
 	})
 
@@ -415,7 +416,7 @@ replica_movement_minimum_async_wait: 10s`)
 		assert.Equal(t, false, asyncRep.Get()) // this field doesn't exist in original config file.
 		assert.Equal(t, 0*time.Second, minFinWait.Get())
 
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 
 		// after update (reflect from parsed values)
 		assert.Equal(t, true, autoSchema.Get())
@@ -433,7 +434,7 @@ replica_movement_minimum_async_wait: 10s`)
 		assert.Equal(t, 13, colCount.Get())
 		assert.Equal(t, false, asyncRep.Get()) // this field doesn't exist in original config file, should return default value.
 
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 
 		// after update.
 		assert.Equal(t, false, autoSchema.Get())
@@ -455,21 +456,21 @@ replica_movement_minimum_async_wait: 10s`)
 		buf := []byte(`raft_drain_sleep: 5s`)
 		parsed, err := ParseRuntimeConfig(buf)
 		require.NoError(t, err)
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Equal(t, 5*time.Second, raftDrainSleep.Get())
 
 		// update to 10s
 		buf = []byte(`raft_drain_sleep: 10s`)
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Equal(t, 10*time.Second, raftDrainSleep.Get())
 
 		// remove -> back to default
 		buf = []byte(``)
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Equal(t, 0*time.Second, raftDrainSleep.Get())
 	})
 
@@ -487,21 +488,21 @@ replica_movement_minimum_async_wait: 10s`)
 		buf := []byte(`raft_timeouts_multiplier: 2`)
 		parsed, err := ParseRuntimeConfig(buf)
 		require.NoError(t, err)
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Equal(t, 2, raftTimeoutsMultiplier.Get())
 
 		// update to 3
 		buf = []byte(`raft_timeouts_multiplier: 3`)
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Equal(t, 3, raftTimeoutsMultiplier.Get())
 
 		// remove -> back to default
 		buf = []byte(``)
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
-		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 		assert.Equal(t, 0, raftTimeoutsMultiplier.Get())
 	})
 
@@ -532,25 +533,25 @@ replica_movement_minimum_async_wait: 10s`)
 			// set to 2h (without seconds)
 			parsed, err := ParseRuntimeConfig(buf("0 */2 * * *"))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, "0 */2 * * *", deleteSchedule.Get())
 
 			// try set invalid value
 			parsed, err = ParseRuntimeConfig(buf("* * * *"))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, "0 */2 * * *", deleteSchedule.Get())
 
 			// update to 3h (with seconds)
 			parsed, err = ParseRuntimeConfig(buf("0 0 */3 * * *"))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, "0 0 */3 * * *", deleteSchedule.Get())
 
 			// remove -> back to default
 			parsed, err = ParseRuntimeConfig(emptyBuf)
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, "@every 1h", deleteSchedule.Get())
 		})
 
@@ -565,25 +566,25 @@ replica_movement_minimum_async_wait: 10s`)
 			// set to 20k
 			parsed, err := ParseRuntimeConfig(buf(20_000))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 20_000, batchSize.Get())
 
 			// try set invalid value
 			parsed, err = ParseRuntimeConfig(buf(-10_000))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 20_000, batchSize.Get())
 
 			// update to 30k
 			parsed, err = ParseRuntimeConfig(buf(30_000))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 30_000, batchSize.Get())
 
 			// remove -> back to default
 			parsed, err = ParseRuntimeConfig(emptyBuf)
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, DefaultObjectsTTLBatchSize, batchSize.Get())
 		})
 
@@ -598,25 +599,25 @@ replica_movement_minimum_async_wait: 10s`)
 			// set to 20
 			parsed, err := ParseRuntimeConfig(buf(20))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 20, pauseEveryNoBatches.Get())
 
 			// try set invalid value
 			parsed, err = ParseRuntimeConfig(buf(-10))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 20, pauseEveryNoBatches.Get())
 
 			// update to 30
 			parsed, err = ParseRuntimeConfig(buf(30))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 30, pauseEveryNoBatches.Get())
 
 			// remove -> back to default
 			parsed, err = ParseRuntimeConfig(emptyBuf)
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, DefaultObjectsTTLPauseEveryNoBatches, pauseEveryNoBatches.Get())
 		})
 
@@ -631,25 +632,25 @@ replica_movement_minimum_async_wait: 10s`)
 			// set to 2 mins
 			parsed, err := ParseRuntimeConfig(buf("2m"))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 2*time.Minute, pauseDuration.Get())
 
 			// try set invalid value
 			parsed, err = ParseRuntimeConfig(buf("-1h"))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 2*time.Minute, pauseDuration.Get())
 
 			// update to 3 hours
 			parsed, err = ParseRuntimeConfig(buf("3h"))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 3*time.Hour, pauseDuration.Get())
 
 			// remove -> back to default
 			parsed, err = ParseRuntimeConfig(emptyBuf)
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, DefaultObjectsTTLPauseDuration, pauseDuration.Get())
 		})
 
@@ -664,25 +665,25 @@ replica_movement_minimum_async_wait: 10s`)
 			// set to 2
 			parsed, err := ParseRuntimeConfig(buf(2))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 2., concurrencyFactor.Get())
 
 			// try set invalid value
 			parsed, err = ParseRuntimeConfig(buf(-1))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 2., concurrencyFactor.Get())
 
 			// update to 3
 			parsed, err = ParseRuntimeConfig(buf(3))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, 3., concurrencyFactor.Get())
 
 			// remove -> back to default
 			parsed, err = ParseRuntimeConfig(emptyBuf)
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, float64(DefaultObjectsTTLConcurrencyFactor), concurrencyFactor.Get())
 		})
 	})
@@ -729,7 +730,7 @@ func TestExportDefaultPathRuntimeOverride(t *testing.T) {
 
 			parsed, err := ParseRuntimeConfig([]byte(tt.runtimeConfig))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil, nil))
 
 			assert.Equal(t, tt.expectedPath, defaultPath.Get())
 		})

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -86,8 +86,33 @@ allowed_compression_types: ["pq", "bq"]`,
 		}
 	})
 
-	t.Run("empty-string scalar for non-slice fields still errors", func(t *testing.T) {
-		_, err := ParseRuntimeConfig([]byte(`maximum_allowed_collections_count: ""`))
+	t.Run("a malformed field is skipped and reported, valid fields still apply", func(t *testing.T) {
+		// empty-string into an int field cannot decode; it must be skipped and
+		// reported, while the other valid keys in the same document are applied.
+		in := []byte(`maximum_allowed_collections_count: ""
+maximum_allowed_objects_count: 42
+autoschema_enabled: true`)
+
+		cfg, fieldErrs, err := ParseRuntimeConfigPartial(in)
+		require.NoError(t, err)
+
+		require.Len(t, fieldErrs, 1)
+		assert.Equal(t, "maximum_allowed_collections_count", fieldErrs[0].Field)
+
+		// bad field left unset (nil pointer → Get() returns zero value)
+		assert.Equal(t, 0, cfg.MaximumAllowedCollectionsCount.Get())
+		// sibling valid fields still applied
+		assert.Equal(t, 42, cfg.MaximumAllowedObjectsCount.Get())
+		assert.Equal(t, true, cfg.AutoschemaEnabled.Get())
+
+		// back-compat wrapper drops field errors and does not fail the load
+		_, werr := ParseRuntimeConfig(in)
+		require.NoError(t, werr)
+	})
+
+	t.Run("malformed document is still a fatal error", func(t *testing.T) {
+		// a top-level scalar (no mapping) can't be decoded field-by-field
+		_, _, err := ParseRuntimeConfigPartial([]byte(`maximum_allowed_collections_count=13`))
 		require.Error(t, err)
 	})
 
@@ -169,6 +194,38 @@ replica_movement_minimum_async_wait: 10s`)
 		assert.Equal(t, true, autoSchema.Get())
 		assert.Equal(t, 13, colCount.Get())
 		assert.Equal(t, 10*time.Second, minFinWait.Get())
+	})
+
+	t.Run("a malformed field keeps the previously-applied value", func(t *testing.T) {
+		var (
+			colCount   runtime.DynamicValue[int]  // default 0
+			autoSchema runtime.DynamicValue[bool] // default false
+		)
+		reg := &WeaviateRuntimeConfig{
+			MaximumAllowedCollectionsCount: &colCount,
+			AutoschemaEnabled:              &autoSchema,
+		}
+
+		// 1. apply a valid override (13 differs from the default 0)
+		parsed, err := ParseRuntimeConfig([]byte(`maximum_allowed_collections_count: 13`))
+		require.NoError(t, err)
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+		assert.Equal(t, 13, colCount.Get())
+
+		// 2. reload where that same field is malformed, alongside a valid sibling
+		parsed, fieldErrs, err := ParseRuntimeConfigPartial([]byte(`maximum_allowed_collections_count: "not-an-int"
+autoschema_enabled: true`))
+		require.NoError(t, err)
+		require.Len(t, fieldErrs, 1)
+		assert.Equal(t, "maximum_allowed_collections_count", fieldErrs[0].Field)
+
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+
+		// malformed field keeps the previously-applied 13: not reset to the
+		// default 0, and not the bad value
+		assert.Equal(t, 13, colCount.Get())
+		// the valid sibling field still applies
+		assert.Equal(t, true, autoSchema.Get())
 	})
 
 	t.Run("Add and remove workflow", func(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -800,7 +800,7 @@ func TestUpdateRuntimeConfig_DefaultVectorIndex(t *testing.T) {
 			}
 			parsed, err := ParseRuntimeConfig([]byte(yaml))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+			require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil, nil))
 
 			assert.Equal(t, tt.expected, source.DefaultVectorIndexType.Get())
 		})

--- a/usecases/config/usage_limits_test.go
+++ b/usecases/config/usage_limits_test.go
@@ -69,7 +69,7 @@ usage_limits_error_message: "test {limit} {value}"
 	parsed, err := ParseRuntimeConfig(buf)
 	require.NoError(t, err)
 
-	require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil))
+	require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 
 	assert.Equal(t, 10, objects.Get())
 	assert.Equal(t, 2, tenants.Get())


### PR DESCRIPTION
### What's being changed:

Dont bail if a single entry in the dynamic runtime config is malformed and instead:
- log a message with error so we can alert on it
- still apply the other values

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
