### PR TITLE
Fix flaky usage test

### DIFF
--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -358,6 +358,7 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	className := t.Name() + "Class"
+	tenantName := "tenant"
 	vector1 := "vector1"
 	vector2 := "vector2"
 	dimensions := 128
@@ -391,16 +392,21 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 				VectorIndexType: "flat",
 			},
 		},
+		// enables the COLD/HOT flush below for a stable on-disk baseline
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	}
 	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
+	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName}).Do(ctx))
 
 	// Insert 100 objects with both named vectors
 	const numObjects = 100
 	objs := make([]*models.Object, numObjects)
 	for i := range numObjects {
 		objs[i] = &models.Object{
-			Class: className,
-			ID:    strfmt.UUID(uuid.NewString()),
+			Class:  className,
+			ID:     strfmt.UUID(uuid.NewString()),
+			Tenant: tenantName,
 			Properties: map[string]any{
 				"name":        fmt.Sprintf("name %d", i),
 				"description": fmt.Sprintf("description %d", i),
@@ -420,6 +426,12 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	}
 
 	testAllObjectsIndexed(t, c, className)
+
+	// COLD/HOT cycle flushes to disk so the baseline is comparable post-drop
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx))
 
 	// Verify both named vectors appear in usage
 	colUsageBefore, err := GetDebugUsageForCollection(className)


### PR DESCRIPTION
### What's being changed:

Fixes

```
--- FAIL: TestAlterSchemaDropVectorIndex (30.76s)
    usage_test.go:453: 
        	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance_with_go_client/usage/usage_test.go:464
        	            				/opt/hostedtoolcache/go/1.26.3/x64/src/runtime/asm_amd64.s:1771
        	Error:      	"305243" is not less than "274825"
    usage_test.go:453: 
        	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance_with_go_client/usage/usage_test.go:453
        	Error:      	Condition never satisfied
        	Test:       	TestAlterSchemaDropVectorIndex
```

by re-activating a tenant to force flushing and a stable baseline. Repeated 100 times locally without a flake

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
