### PR TITLE
More test speedups by reusing containers

### DIFF
--- a/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
+++ b/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
@@ -43,10 +43,37 @@ import (
 // (CLUSTER_DATA_BIND_PORT) — there is no public REST surface today.
 type AsyncCheckpointConvergenceTestSuite struct {
 	suite.Suite
+	compose *docker.DockerCompose
+	cancel  context.CancelFunc
 }
 
-func (suite *AsyncCheckpointConvergenceTestSuite) SetupTest() {
-	suite.T().Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+func (suite *AsyncCheckpointConvergenceTestSuite) SetupSuite() {
+	t := suite.T()
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	suite.cancel = cancel
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithText2VecContextionary().
+		Start(ctx)
+	require.NoError(t, err)
+	suite.compose = compose
+}
+
+func (suite *AsyncCheckpointConvergenceTestSuite) TearDownSuite() {
+	if suite.compose != nil {
+		require.NoError(suite.T(), suite.compose.Terminate(context.Background()))
+	}
+	if suite.cancel != nil {
+		suite.cancel()
+	}
+}
+
+func (suite *AsyncCheckpointConvergenceTestSuite) TearDownTest() {
+	helper.SetupClient(suite.compose.GetWeaviate().URI())
+	helper.DeleteClassWithoutAssert(suite.T(), "Paragraph", "")
 }
 
 func TestAsyncCheckpointConvergenceTestSuite(t *testing.T) {
@@ -157,21 +184,7 @@ func discoverShards(t *testing.T, restURI, className string) []string {
 // (frozen-clone invariant), and delete clears every node.
 func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_ConvergenceAcrossReplicas() {
 	t := suite.T()
-	mainCtx := context.Background()
-
-	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	nodeRESTs := []string{
 		compose.GetWeaviate().URI(),
@@ -337,20 +350,10 @@ func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_Convergenc
 // recreate is the operator's responsibility.
 func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_RestartDropsLocalCheckpoint() {
 	t := suite.T()
-	mainCtx := context.Background()
-	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	node1REST := compose.GetWeaviate().URI()
 	node1Cluster := compose.GetWeaviate().ClusterURI()

--- a/test/acceptance/replication/async_replication/async_repair_deletes_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_deletes_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -38,16 +37,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	paragraphClass := articles.ParagraphsClass()
 

--- a/test/acceptance/replication/async_replication/async_repair_insertions_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_insertions_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -38,16 +37,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	paragraphClass := articles.ParagraphsClass()
 

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -346,8 +346,8 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 // the toggle path through `runtime-overrides → AsyncReplicationDisabled hook
 // → DB.ReconcileAsyncReplication → per-tenant-shard apply` on a real
 // multi-tenant cluster.
-func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyRuntimeToggle() {
-	t := suite.T()
+func TestAsyncRepairMultiTenancyRuntimeToggle(t *testing.T) {
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
 	mainCtx := context.Background()
 
 	const (

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -59,16 +59,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	paragraphClass := articles.ParagraphsClass()
 
@@ -170,16 +161,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	paragraphClass := articles.ParagraphsClass()
 

--- a/test/acceptance/replication/async_replication/async_repair_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_test.go
@@ -61,10 +61,45 @@ var (
 
 type AsyncReplicationTestSuite struct {
 	suite.Suite
+	compose *docker.DockerCompose
+	cancel  context.CancelFunc
 }
 
-func (suite *AsyncReplicationTestSuite) SetupTest() {
-	suite.T().Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+// SetupSuite starts one shared 3-node cluster for the plain async-repair
+// scenarios. The methods run sequentially and each restarts the nodes it
+// stops, so the cluster stays healthy between them. Scenarios that need a
+// bespoke cluster env (e.g. the runtime-override toggle) start their own.
+func (suite *AsyncReplicationTestSuite) SetupSuite() {
+	t := suite.T()
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	suite.cancel = cancel
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithText2VecContextionary().
+		Start(ctx)
+	require.NoError(t, err)
+	suite.compose = compose
+}
+
+func (suite *AsyncReplicationTestSuite) TearDownSuite() {
+	if suite.compose != nil {
+		require.NoError(suite.T(), suite.compose.Terminate(context.Background()))
+	}
+	if suite.cancel != nil {
+		suite.cancel()
+	}
+}
+
+// TearDownTest drops the shared classes so the next test starts from a clean
+// schema. Every shared-cluster scenario restarts node 1 if it stops it, so it
+// is reachable here.
+func (suite *AsyncReplicationTestSuite) TearDownTest() {
+	helper.SetupClient(suite.compose.GetWeaviate().URI())
+	helper.DeleteClassWithoutAssert(suite.T(), "Article", "")
+	helper.DeleteClassWithoutAssert(suite.T(), "Paragraph", "")
 }
 
 func TestAsyncReplicationTestSuite(t *testing.T) {
@@ -78,16 +113,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/async_replication/async_repair_updates_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_updates_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -39,16 +38,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	paragraphClass := articles.ParagraphsClass()
 

--- a/test/acceptance/replication/read_repair/crud_test.go
+++ b/test/acceptance/replication/read_repair/crud_test.go
@@ -63,10 +63,43 @@ var (
 
 type ReplicationTestSuite struct {
 	suite.Suite
+	compose *docker.DockerCompose
+	cancel  context.CancelFunc
 }
 
-func (suite *ReplicationTestSuite) SetupTest() {
-	suite.T().Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+// SetupSuite starts one shared 3-node cluster for every test in the suite.
+// The methods run sequentially and each restarts the nodes it stops, so the
+// cluster stays healthy between them.
+func (suite *ReplicationTestSuite) SetupSuite() {
+	t := suite.T()
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	suite.cancel = cancel
+
+	compose, err := docker.New().
+		With3NodeCluster().
+		WithText2VecContextionary().
+		Start(ctx)
+	require.NoError(t, err)
+	suite.compose = compose
+}
+
+func (suite *ReplicationTestSuite) TearDownSuite() {
+	if suite.compose != nil {
+		require.NoError(suite.T(), suite.compose.Terminate(context.Background()))
+	}
+	if suite.cancel != nil {
+		suite.cancel()
+	}
+}
+
+// TearDownTest drops the shared classes so the next test starts from a clean
+// schema. Node 1 is never stopped, so it is always reachable here.
+func (suite *ReplicationTestSuite) TearDownTest() {
+	helper.SetupClient(suite.compose.GetWeaviate().URI())
+	helper.DeleteClassWithoutAssert(suite.T(), "Article", "")
+	helper.DeleteClassWithoutAssert(suite.T(), "Paragraph", "")
 }
 
 func TestReplicationTestSuite(t *testing.T) {
@@ -80,16 +113,8 @@ func (suite *ReplicationTestSuite) TestImmediateReplicaCRUD() {
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		With3NodeCluster().
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
+	var err error
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/graphql_test.go
+++ b/test/acceptance/replication/read_repair/graphql_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -35,16 +34,8 @@ func (suite *ReplicationTestSuite) TestGraphqlSearch() {
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
+	var err error
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/multi_tenancy_test.go
+++ b/test/acceptance/replication/read_repair/multi_tenancy_test.go
@@ -43,16 +43,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		With3NodeCluster().
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -34,16 +33,7 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		With3NodeCluster().
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/read_repair_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -34,16 +33,7 @@ func (suite *ReplicationTestSuite) TestReadRepair() {
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		With3NodeCluster().
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	helper.SetupClient(compose.ContainerURI(1))
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/replication/read_repair/read_repair_timebasedresolution_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_timebasedresolution_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -34,16 +33,7 @@ func (suite *ReplicationTestSuite) TestReadRepairTimebasedResolution() {
 	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		With3NodeCluster().
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+	compose := suite.compose
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()

--- a/test/acceptance/schema/default_quantization_test.go
+++ b/test/acceptance/schema/default_quantization_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/config/runtime"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -37,20 +38,51 @@ func TestAssignDynamic(t *testing.T) {
 	require.Equal(t, "rq-8", d.Get())
 }
 
-func TestDefaultQuantizationRQ8(t *testing.T) {
-	mainCtx := context.Background()
+// DefaultQuantizationRQ8TestSuite shares one cluster booted with
+// DEFAULT_QUANTIZATION=rq-8 across the scenarios that assert the rq-8 default.
+// Each scenario recreates the Paragraph class, so the shared cluster carries no
+// state between them. The rq-1 default needs a different startup env, so
+// TestDefaultQuantizationRQ1 keeps its own cluster.
+type DefaultQuantizationRQ8TestSuite struct {
+	suite.Suite
+	compose *docker.DockerCompose
+	cancel  context.CancelFunc
+}
+
+func (suite *DefaultQuantizationRQ8TestSuite) SetupSuite() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	suite.cancel = cancel
 
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
 		WithWeaviateEnv("DEFAULT_QUANTIZATION", "rq-8").
 		WithWeaviateEnv("ASYNC_INDEXING", "true").
-		Start(mainCtx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(mainCtx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+		Start(ctx)
+	require.Nil(suite.T(), err)
+	suite.compose = compose
+}
+
+func (suite *DefaultQuantizationRQ8TestSuite) TearDownSuite() {
+	if suite.compose != nil {
+		require.NoError(suite.T(), suite.compose.Terminate(context.Background()))
+	}
+	if suite.cancel != nil {
+		suite.cancel()
+	}
+}
+
+func (suite *DefaultQuantizationRQ8TestSuite) TearDownTest() {
+	helper.SetupClient(suite.compose.GetWeaviate().URI())
+	helper.DeleteClassWithoutAssert(suite.T(), "Paragraph", "")
+}
+
+func TestDefaultQuantizationRQ8TestSuite(t *testing.T) {
+	suite.Run(t, new(DefaultQuantizationRQ8TestSuite))
+}
+
+func (suite *DefaultQuantizationRQ8TestSuite) TestDefaultQuantizationRQ8() {
+	t := suite.T()
+	compose := suite.compose
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 
@@ -323,20 +355,9 @@ func TestDefaultQuantizationRQ1(t *testing.T) {
 	})
 }
 
-func TestDefaultQuantizationWithSkipDefaultQuantization(t *testing.T) {
-	mainCtx := context.Background()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithWeaviateEnv("DEFAULT_QUANTIZATION", "rq-8").
-		WithWeaviateEnv("ASYNC_INDEXING", "true").
-		Start(mainCtx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(mainCtx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+func (suite *DefaultQuantizationRQ8TestSuite) TestDefaultQuantizationWithSkipDefaultQuantization() {
+	t := suite.T()
+	compose := suite.compose
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 
@@ -430,20 +451,9 @@ func TestDefaultQuantizationWithSkipDefaultQuantization(t *testing.T) {
 	})
 }
 
-func TestDefaultQuantizationOverride(t *testing.T) {
-	mainCtx := context.Background()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithWeaviateEnv("DEFAULT_QUANTIZATION", "rq-8").
-		WithWeaviateEnv("ASYNC_INDEXING", "true").
-		Start(mainCtx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(mainCtx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
+func (suite *DefaultQuantizationRQ8TestSuite) TestDefaultQuantizationOverride() {
+	t := suite.T()
+	compose := suite.compose
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 	t.Run("BQ override with Hnsw index", func(t *testing.T) {

--- a/test/acceptance/snapshots/raft_snapshot_test.go
+++ b/test/acceptance/snapshots/raft_snapshot_test.go
@@ -30,14 +30,25 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
-func TestSchemaSnapshotRecovery(t *testing.T) {
+// TestSnapshotRecovery runs the schema and RBAC snapshot-recovery scenarios
+// on one shared RBAC-enabled 3-node cluster. Subtests run sequentially: each
+// stops, restarts, and re-heals node 3 before the next begins.
+func TestSnapshotRecovery(t *testing.T) {
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	testRole := "test_role"
+
 	ctx := context.Background()
-	// Start a 3-node cluster with a low snapshot threshold
+	// Low thresholds force a snapshot per change so node 3 recovers via snapshot.
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
-		WithWeaviateEnv("RAFT_SNAPSHOT_THRESHOLD", "1"). // Force snapshot after every change
-		WithWeaviateEnv("RAFT_SNAPSHOT_INTERVAL", "1").  // Force snapshot every second
-		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").      // Keep one trailing logs
+		WithApiKey().
+		WithUserApiKey(adminUser, adminKey).
+		WithRBAC().
+		WithRbacRoots(adminUser).
+		WithWeaviateEnv("RAFT_SNAPSHOT_THRESHOLD", "1").
+		WithWeaviateEnv("RAFT_SNAPSHOT_INTERVAL", "1").
+		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -46,13 +57,26 @@ func TestSchemaSnapshotRecovery(t *testing.T) {
 		}
 	}()
 
+	defer helper.ResetClient()
+
+	t.Run("schema", func(t *testing.T) {
+		testSchemaSnapshotRecovery(t, ctx, compose, adminKey)
+	})
+
+	t.Run("rbac", func(t *testing.T) {
+		testRBACSnapshotRecovery(t, ctx, compose, adminKey, testRole)
+	})
+}
+
+func testSchemaSnapshotRecovery(t *testing.T, ctx context.Context, compose *docker.DockerCompose, adminKey string) {
+	auth := helper.CreateAuth(adminKey)
+
 	// Stop node 3 directly to make sure it doesn't get any added classes
 	t.Run("stop node 3", func(t *testing.T) {
 		require.NoError(t, compose.StopAt(ctx, 2, nil))
 	})
 
 	helper.SetupClient(compose.GetWeaviate().URI())
-	defer helper.ResetClient()
 
 	// Create classes while node 3 is down
 	t.Run("create classes while node 3 is down", func(t *testing.T) {
@@ -62,13 +86,13 @@ func TestSchemaSnapshotRecovery(t *testing.T) {
 			class := &models.Class{
 				Class: className,
 			}
-			helper.CreateClass(t, class)
+			helper.CreateClassAuth(t, class, adminKey)
 		}
 
 		// Verify classes exist on running nodes
 		for idx := 0; idx < 100; idx++ {
 			className := fmt.Sprintf("TestClass_%d", idx)
-			class := helper.GetClass(t, className)
+			class := helper.GetClassAuth(t, className, adminKey)
 			require.NotNil(t, class)
 			require.Equal(t, className, class.Class)
 		}
@@ -86,15 +110,15 @@ func TestSchemaSnapshotRecovery(t *testing.T) {
 		assert.Eventually(t, func() bool {
 			// Get schema from all nodes
 			helper.SetupClient(compose.GetWeaviate().URI())
-			schema1, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams().WithConsistency(Bool(false)), nil)
+			schema1, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams().WithConsistency(Bool(false)), auth)
 			assert.NoError(t, err)
 
 			helper.SetupClient(compose.GetWeaviateNode2().URI())
-			schema2, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams().WithConsistency(Bool(false)), nil)
+			schema2, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams().WithConsistency(Bool(false)), auth)
 			assert.NoError(t, err)
 
 			helper.SetupClient(compose.GetWeaviateNode3().URI())
-			schema3, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams().WithConsistency(Bool(false)), nil)
+			schema3, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams().WithConsistency(Bool(false)), auth)
 			assert.NoError(t, err)
 
 			// All schemas should have the same number of classes
@@ -105,38 +129,13 @@ func TestSchemaSnapshotRecovery(t *testing.T) {
 	})
 }
 
-func TestRBACSnapshotRecovery(t *testing.T) {
-	// Set up test users and roles
-	adminUser := "admin-user"
-	adminKey := "admin-key"
-	testRole := "test_role"
-
-	ctx := context.Background()
-	// Start a 3-node cluster with RBAC enabled and a low snapshot threshold
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithApiKey().
-		WithUserApiKey(adminUser, adminKey).
-		WithRBAC().
-		WithRbacRoots(adminUser).
-		WithWeaviateEnv("RAFT_SNAPSHOT_THRESHOLD", "1"). // Force snapshot after every change
-		WithWeaviateEnv("RAFT_SNAPSHOT_INTERVAL", "1").  // Force snapshot every second
-		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").      // Keep one trailing logs
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %v", err)
-		}
-	}()
-
+func testRBACSnapshotRecovery(t *testing.T, ctx context.Context, compose *docker.DockerCompose, adminKey, testRole string) {
 	// Stop node 3 directly to make sure it doesn't get any added roles
 	t.Run("stop node 3", func(t *testing.T) {
 		require.NoError(t, compose.StopAt(ctx, 2, nil))
 	})
 
 	helper.SetupClient(compose.GetWeaviate().URI())
-	defer helper.ResetClient()
 
 	// Create all roles while node 3 is down
 	t.Run("create roles while node 3 is down", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Before:
- github.com/weaviate/weaviate/test/acceptance/snapshots	122.469s
- acceptance (replication): 12m 50s
- acceptance (replication-grpc): 12m 50s
- acceptance (async-replication): 19m 13s
- acceptance (async-replication-grpc): 18m 59s
- github.com/weaviate/weaviate/test/acceptance/schema	540.393s

After:
- github.com/weaviate/weaviate/test/acceptance/snapshots	108.036s
- acceptance (replication): 9m 30s
- acceptance (replication-grpc): 9m 45s
- acceptance (async-replication): 16m 40s
- acceptance (async-replication-grpc): 16m 22s
- github.com/weaviate/weaviate/test/acceptance/schema	460.411s

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
