### PR TITLE
Remove flaky dynamic index latency assertion

### DIFF
--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -121,7 +121,6 @@ func TestDynamic(t *testing.T) {
 	recall2, latency2 := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
 	t.Logf("recall: %f, latency %f\n", recall2, latency2)
 	assert.True(t, recall2 > 0.9)
-	assert.True(t, latency1 > latency2)
 }
 
 func TestDynamicReturnsErrorIfNoAsync(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

This removes a flaky assertion from the dynamic index tests. The assertion can't be properly verified on CI given the limited resources of the workers, and doesn't add much value to the test.

```
--- FAIL: TestDynamic (15.83s)
    index_test.go:110: recall: 1.000000, latency 25176.599609
    index_test.go:122: recall: 1.000000, latency 40340.898438
    index_test.go:124:
        	Error Trace:	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/dynamic/index_test.go:124
        	Error:      	Should be true
        	Test:       	TestDynamic
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
