### PR TITLE
[DRAFT/do-not-merge] bmw performance improvements (combined, for e2e+chaos)

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -263,11 +263,23 @@ func (b *BM25Searcher) wandBlock(
 }
 
 func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int) ([]*storobj.Object, []float32) {
+	// Preallocate by the real upper bound (total result rows across
+	// properties/segments), not limit*len(allIds): for unlimited (limit==0)
+	// queries the caller inflates limit to the sum of all term counts, which
+	// would over-allocate these slices by orders of magnitude.
+	totalRows, totalTerms := 0, 0
+	for i := range allIds {
+		for j := range allIds[i] {
+			totalRows += len(allIds[i][j])
+		}
+		totalTerms += len(queryTerms[i])
+	}
+
 	// combine all results
-	combinedIds := make([]uint64, 0, limit*len(allIds))
-	combinedScores := make([]float32, 0, limit*len(allIds))
-	combinedExplanations := make([][]*terms.DocPointerWithScore, 0, limit*len(allIds))
-	combinedTerms := make([]string, 0, limit*len(allIds))
+	combinedIds := make([]uint64, 0, totalRows)
+	combinedScores := make([]float32, 0, totalRows)
+	combinedExplanations := make([][]*terms.DocPointerWithScore, 0, totalRows)
+	combinedTerms := make([]string, 0, totalTerms)
 
 	// combine all results
 	for i := range allIds {

--- a/adapters/repos/db/inverted/terms/terms_block.go
+++ b/adapters/repos/db/inverted/terms/terms_block.go
@@ -43,12 +43,19 @@ func (b *BlockEntry) Encode() []byte {
 }
 
 func DecodeBlockEntry(data []byte) *BlockEntry {
-	return &BlockEntry{
-		MaxId:               binary.LittleEndian.Uint64(data),
-		Offset:              binary.LittleEndian.Uint32(data[8:]),
-		MaxImpactTf:         binary.LittleEndian.Uint32(data[12:]),
-		MaxImpactPropLength: binary.LittleEndian.Uint32(data[16:]),
-	}
+	b := &BlockEntry{}
+	DecodeBlockEntryInto(data, b)
+	return b
+}
+
+// DecodeBlockEntryInto decodes a block entry into an existing value, letting
+// callers decode a whole []BlockEntry contiguously without a heap allocation per
+// block.
+func DecodeBlockEntryInto(data []byte, b *BlockEntry) {
+	b.MaxId = binary.LittleEndian.Uint64(data)
+	b.Offset = binary.LittleEndian.Uint32(data[8:])
+	b.MaxImpactTf = binary.LittleEndian.Uint32(data[12:])
+	b.MaxImpactPropLength = binary.LittleEndian.Uint32(data[16:])
 }
 
 type BlockDataDecoded struct {

--- a/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
@@ -624,6 +624,13 @@ func bmwBaseRunLean(ctx context.Context, b *Bucket, query []string, N, avgPropLe
 		return 0
 	}
 	defer release()
+	for _, seg := range diskTerms {
+		for _, t := range seg {
+			if t != nil {
+				t.SetIdf(t.Idf())
+			}
+		}
+	}
 	n := 0
 	for _, seg := range diskTerms {
 		if len(seg) == 0 {

--- a/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
@@ -345,6 +345,13 @@ func bmwBaseRunQuery(ctx context.Context, b *Bucket, query []string, N, avgPropL
 		return nil
 	}
 	defer release()
+	for _, seg := range diskTerms {
+		for _, t := range seg {
+			if t != nil {
+				t.SetIdf(t.Idf())
+			}
+		}
+	}
 
 	best := map[uint64]float64{}
 	for _, seg := range diskTerms {

--- a/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
@@ -126,6 +126,10 @@ func TestBMWBaseline(t *testing.T) {
 	defer bucket.Shutdown(ctx)
 	require.Equal(t, StrategyInverted, bucket.Strategy())
 
+	// dump and compare may run with different BMW_DEFER_TOMBSTONE values; both must
+	// yield the same top-K, which is what this baseline proves.
+	applyDeferTombstoneEnv()
+
 	cfg := schema.BM25Config{K1: bEnvF("BMW_K1", 1.2), B: bEnvF("BMW_B", 0.75)}
 	limit := bEnvI("BMW_LIMIT", 10)
 	andOp := strings.EqualFold(bEnv("BMW_OPERATOR", "or"), "and")
@@ -140,6 +144,8 @@ func TestBMWBaseline(t *testing.T) {
 	if N <= 0 {
 		N = 1
 	}
+	tombPct := bEnvF("BMW_TOMBSTONE_PCT", 0)
+	injectSyntheticTombstones(t, bucket, tombPct, N)
 	filter := bmwBaseFilter(t, bEnvF("BMW_FILTER", 0), N)
 
 	results := make(map[string][]bmwDocScore, len(queries))
@@ -153,6 +159,7 @@ func TestBMWBaseline(t *testing.T) {
 		"sample": bEnv("BMW_SAMPLE", "4000"), "filter": bEnv("BMW_FILTER", "0"),
 		"operator": bEnv("BMW_OPERATOR", "or"), "k1": fmt.Sprintf("%g", cfg.K1), "b": fmt.Sprintf("%g", cfg.B),
 		"N": fmt.Sprintf("%.0f", N), "avgPropLen": fmt.Sprintf("%.4f", avgPropLen),
+		"tombstonePct": fmt.Sprintf("%g", tombPct),
 	}
 
 	switch mode {
@@ -413,6 +420,8 @@ func BenchmarkBMWCompare(b *testing.B) {
 	if N <= 0 {
 		N = 1
 	}
+	applyDeferTombstoneEnv()
+	injectSyntheticTombstones(b, bucket, bEnvF("BMW_TOMBSTONE_PCT", 0), N)
 	filter := bmwBaseFilter(b, bEnvF("BMW_FILTER", 0), N)
 
 	// warm caches

--- a/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_baseline_test.go
@@ -1,0 +1,836 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+// BlockMax WAND scores/rankings baseline harness.
+//
+// Runs a deterministic set of queries against an on-disk inverted bucket and
+// records, per query, the ranked top-K (docID, score). In `dump` mode it writes
+// that to a file; in `compare` mode it loads a baseline and diffs it against the
+// current code, reporting ranking / set / score changes. Used to prove an
+// optimization branch returns the same results as main.
+//
+// This file is intentionally self-contained (no dependency on the profiling
+// harness) and uses only APIs present on main, so the SAME file can be dropped
+// into a `main` worktree to generate the baseline.
+//
+//	# 1) baseline from main (in a clean worktree of main):
+//	BMW_SEGMENTS_DIR=/…/property_text_searchable BMW_BASELINE=/tmp/bmw_base.json \
+//	  BMW_BASELINE_MODE=dump go test -tags integrationTest -run TestBMWBaseline -v ./adapters/repos/db/lsmkv/
+//
+//	# 2) compare current branch against it:
+//	BMW_SEGMENTS_DIR=/…/property_text_searchable BMW_BASELINE=/tmp/bmw_base.json \
+//	  BMW_BASELINE_MODE=compare go test -tags integrationTest -run TestBMWBaseline -v ./adapters/repos/db/lsmkv/
+//
+// Reuses the BMW_QUERY_SIZE / BMW_NUM_QUERIES / BMW_SEED / BMW_LIMIT / BMW_SAMPLE
+// / BMW_FILTER / BMW_OPERATOR / BMW_K1 / BMW_B knobs (must match between the two
+// runs). BMW_SCORE_EPS (default 1e-6) is the score-drift tolerance;
+// BMW_BASELINE_STRICT=false turns the comparison into a report instead of a
+// test failure.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+type bmwDocScore struct {
+	DocID uint64  `json:"d"`
+	Score float64 `json:"s"`
+}
+
+type bmwBaselineFile struct {
+	Params  map[string]string        `json:"params"`
+	Results map[string][]bmwDocScore `json:"results"`
+}
+
+func bEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func bEnvI(key string, def int) int {
+	if v, err := strconv.Atoi(os.Getenv(key)); err == nil {
+		return v
+	}
+	return def
+}
+
+func bEnvF(key string, def float64) float64 {
+	if v, err := strconv.ParseFloat(os.Getenv(key), 64); err == nil {
+		return v
+	}
+	return def
+}
+
+func TestBMWBaseline(t *testing.T) {
+	mode := os.Getenv("BMW_BASELINE_MODE")
+	if mode == "" {
+		t.Skip("set BMW_BASELINE_MODE=dump|compare (and BMW_SEGMENTS_DIR, BMW_BASELINE)")
+	}
+	dir := os.Getenv("BMW_SEGMENTS_DIR")
+	require.NotEmpty(t, dir, "BMW_SEGMENTS_DIR required")
+	basePath := os.Getenv("BMW_BASELINE")
+	require.NotEmpty(t, basePath, "BMW_BASELINE (file path) required")
+
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	// open a copy so the source segments are never mutated
+	openDir := dir
+	if !strings.EqualFold(bEnv("BMW_COPY", "true"), "false") {
+		tmp := t.TempDir()
+		require.NoError(t, bmwBaseCopyDir(dir, tmp))
+		openDir = tmp
+	}
+	bucket, err := NewBucketCreator().NewBucket(ctx, openDir, openDir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	require.Equal(t, StrategyInverted, bucket.Strategy())
+
+	cfg := schema.BM25Config{K1: bEnvF("BMW_K1", 1.2), B: bEnvF("BMW_B", 0.75)}
+	limit := bEnvI("BMW_LIMIT", 10)
+	andOp := strings.EqualFold(bEnv("BMW_OPERATOR", "or"), "and")
+	avgPropLen, docCount := bucket.GetAveragePropertyLength()
+	if avgPropLen == 0 {
+		avgPropLen = 1
+	}
+	N := float64(docCount)
+
+	queries := bmwBaseQueries(t, ctx, bucket, cfg, N)
+	require.NotEmpty(t, queries, "no queries built")
+	if N <= 0 {
+		N = 1
+	}
+	filter := bmwBaseFilter(t, bEnvF("BMW_FILTER", 0), N)
+
+	results := make(map[string][]bmwDocScore, len(queries))
+	for _, q := range queries {
+		results[strings.Join(q, " ")] = bmwBaseRunQuery(ctx, bucket, q, N, avgPropLen, limit, cfg, filter, andOp, logger)
+	}
+
+	params := map[string]string{
+		"querySize": bEnv("BMW_QUERY_SIZE", "3"), "numQueries": strconv.Itoa(len(queries)),
+		"seed": bEnv("BMW_SEED", "42"), "limit": strconv.Itoa(limit),
+		"sample": bEnv("BMW_SAMPLE", "4000"), "filter": bEnv("BMW_FILTER", "0"),
+		"operator": bEnv("BMW_OPERATOR", "or"), "k1": fmt.Sprintf("%g", cfg.K1), "b": fmt.Sprintf("%g", cfg.B),
+		"N": fmt.Sprintf("%.0f", N), "avgPropLen": fmt.Sprintf("%.4f", avgPropLen),
+	}
+
+	switch mode {
+	case "dump":
+		f, err := os.Create(basePath)
+		require.NoError(t, err)
+		enc := json.NewEncoder(f)
+		enc.SetEscapeHTML(false)
+		require.NoError(t, enc.Encode(bmwBaselineFile{Params: params, Results: results}))
+		require.NoError(t, f.Close())
+		t.Logf("wrote baseline: %d queries -> %s (params: %v)", len(results), basePath, params)
+	case "compare":
+		raw, err := os.ReadFile(basePath)
+		require.NoError(t, err)
+		var base bmwBaselineFile
+		require.NoError(t, json.Unmarshal(raw, &base))
+		bmwBaseCompare(t, base, results, params)
+	default:
+		t.Fatalf("unknown BMW_BASELINE_MODE %q (want dump|compare)", mode)
+	}
+}
+
+func bmwBaseCompare(t *testing.T, base bmwBaselineFile, cur map[string][]bmwDocScore, curParams map[string]string) {
+	eps := bEnvF("BMW_SCORE_EPS", 1e-6)
+	strict := !strings.EqualFold(bEnv("BMW_BASELINE_STRICT", "true"), "false")
+
+	t.Logf("\n=== baseline compare ===")
+	t.Logf("baseline params: %v", base.Params)
+	t.Logf("current  params: %v", curParams)
+	if !bmwParamsComparable(base.Params, curParams) {
+		t.Fatalf("baseline and current params differ on query generation — set identical BMW_QUERY_SIZE/NUM_QUERIES/SEED/LIMIT/SAMPLE/FILTER/OPERATOR/K1/B")
+	}
+
+	var nQueries, identical, rankingChanged, setChanged, scoreDrift, missingQuery int
+	var maxAbs, maxRel float64
+	var samples []string
+
+	keys := make([]string, 0, len(base.Results))
+	for k := range base.Results {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		nQueries++
+		b := base.Results[k]
+		c, ok := cur[k]
+		if !ok {
+			missingQuery++
+			continue
+		}
+		setEq, orderEq, absDiff, relDiff := bmwDiffRanked(b, c)
+		if absDiff > maxAbs {
+			maxAbs = absDiff
+		}
+		if relDiff > maxRel {
+			maxRel = relDiff
+		}
+		switch {
+		case !setEq:
+			setChanged++
+			if len(samples) < 10 {
+				samples = append(samples, fmt.Sprintf("[%q] doc-set changed\n    base=%s\n    cur =%s", k, bmwFmt(b), bmwFmt(c)))
+			}
+		case !orderEq:
+			rankingChanged++
+			if len(samples) < 10 {
+				samples = append(samples, fmt.Sprintf("[%q] ranking changed (same docs)\n    base=%s\n    cur =%s", k, bmwFmt(b), bmwFmt(c)))
+			}
+		case absDiff > eps:
+			scoreDrift++
+			if len(samples) < 10 {
+				samples = append(samples, fmt.Sprintf("[%q] score drift |Δ|=%.3g", k, absDiff))
+			}
+		default:
+			identical++
+		}
+	}
+
+	t.Logf("queries compared:     %d", nQueries)
+	t.Logf("identical:            %d", identical)
+	t.Logf("ranking changed:      %d", rankingChanged)
+	t.Logf("doc-set changed:      %d", setChanged)
+	t.Logf("score drift > %.0e:    %d", eps, scoreDrift)
+	t.Logf("missing in current:   %d", missingQuery)
+	t.Logf("max |Δscore|=%.3g  max relΔ=%.3g", maxAbs, maxRel)
+	for _, s := range samples {
+		t.Logf("  %s", s)
+	}
+
+	regressions := rankingChanged + setChanged + missingQuery
+	if strict {
+		require.Zerof(t, regressions, "result regressions vs baseline (ranking/set/missing); see log")
+		require.Zerof(t, scoreDrift, "score drift beyond %g vs baseline; see log", eps)
+	} else if regressions > 0 || scoreDrift > 0 {
+		t.Logf("NOTE: differences found but BMW_BASELINE_STRICT=false, not failing")
+	}
+}
+
+// bmwDiffRanked compares two ranked result lists. Returns whether the doc set is
+// equal, whether the order is identical, and the max absolute/relative score
+// delta over docs present in both.
+func bmwDiffRanked(b, c []bmwDocScore) (setEq, orderEq bool, maxAbs, maxRel float64) {
+	orderEq = len(b) == len(c)
+	if orderEq {
+		for i := range b {
+			if b[i].DocID != c[i].DocID {
+				orderEq = false
+				break
+			}
+		}
+	}
+	bset := make(map[uint64]float64, len(b))
+	for _, d := range b {
+		bset[d.DocID] = d.Score
+	}
+	cset := make(map[uint64]float64, len(c))
+	for _, d := range c {
+		cset[d.DocID] = d.Score
+	}
+	setEq = len(bset) == len(cset)
+	if setEq {
+		for id := range bset {
+			if _, ok := cset[id]; !ok {
+				setEq = false
+				break
+			}
+		}
+	}
+	for id, bs := range bset {
+		if cs, ok := cset[id]; ok {
+			abs := math.Abs(bs - cs)
+			if abs > maxAbs {
+				maxAbs = abs
+			}
+			if bs != 0 {
+				if rel := abs / math.Abs(bs); rel > maxRel {
+					maxRel = rel
+				}
+			}
+		}
+	}
+	return setEq, orderEq, maxAbs, maxRel
+}
+
+func bmwFmt(ds []bmwDocScore) string {
+	var sb strings.Builder
+	n := len(ds)
+	if n > 8 {
+		n = 8
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d:%.4g ", ds[i].DocID, ds[i].Score)
+	}
+	if len(ds) > n {
+		sb.WriteString("…")
+	}
+	return sb.String()
+}
+
+func bmwParamsComparable(a, b map[string]string) bool {
+	for _, k := range []string{"querySize", "seed", "limit", "sample", "filter", "operator", "k1", "b"} {
+		if a[k] != b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// bmwBaseRunQuery runs one query and returns the merged top-K ranked by score
+// desc then docID asc (deterministic), taking the max score per doc across
+// segments. Score precision is float32 (as stored in the heap).
+func bmwBaseRunQuery(ctx context.Context, b *Bucket, query []string, N, avgPropLen float64, limit int, cfg schema.BM25Config, filter helpers.AllowList, andOp bool, logger logrus.FieldLogger) []bmwDocScore {
+	boosts := make([]int, len(query))
+	for i := range boosts {
+		boosts[i] = 1
+	}
+	diskTerms, _, release, err := b.CreateDiskTerm(N, filter, query, "", 1, boosts, cfg, ctx)
+	if err != nil || diskTerms == nil {
+		if release != nil {
+			release()
+		}
+		return nil
+	}
+	defer release()
+
+	best := map[uint64]float64{}
+	for _, seg := range diskTerms {
+		if len(seg) == 0 {
+			continue
+		}
+		var heap *priorityqueue.Queue[[]*terms.DocPointerWithScore]
+		if andOp {
+			heap = DoBlockMaxAnd(ctx, limit, seg, avgPropLen, false, len(query), len(query), logger)
+		} else {
+			heap, _ = DoBlockMaxWand(ctx, limit, seg, avgPropLen, false, len(query), 1, logger)
+		}
+		for heap != nil && heap.Len() > 0 {
+			item := heap.Pop()
+			s := float64(item.Dist)
+			if cur, ok := best[item.ID]; !ok || s > cur {
+				best[item.ID] = s
+			}
+		}
+	}
+	out := make([]bmwDocScore, 0, len(best))
+	for id, s := range best {
+		out = append(out, bmwDocScore{DocID: id, Score: s})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].DocID < out[j].DocID
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// BenchmarkBMWCompare times the search path (CreateDiskTerm + DoBlockMax* per
+// segment, draining the heap) over the deterministic query set. It is
+// self-contained and main-compatible, so the identical benchmark can be run in a
+// `main` worktree and on the branch for a whole-branch-vs-main comparison. Pin
+// BMW_SEGMENTS_DIR / BMW_QUERY_SIZE / BMW_NUM_QUERIES / BMW_SEED / BMW_LIMIT /
+// BMW_FILTER / BMW_OPERATOR identically across the two runs.
+func BenchmarkBMWCompare(b *testing.B) {
+	dir := os.Getenv("BMW_SEGMENTS_DIR")
+	if dir == "" {
+		b.Skip("set BMW_SEGMENTS_DIR to a searchable/inverted bucket directory")
+	}
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	openDir := dir
+	if !strings.EqualFold(bEnv("BMW_COPY", "true"), "false") {
+		tmp := b.TempDir()
+		require.NoError(b, bmwBaseCopyDir(dir, tmp))
+		openDir = tmp
+	}
+	bucket, err := NewBucketCreator().NewBucket(ctx, openDir, openDir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyInverted))
+	require.NoError(b, err)
+	defer bucket.Shutdown(ctx)
+
+	cfg := schema.BM25Config{K1: bEnvF("BMW_K1", 1.2), B: bEnvF("BMW_B", 0.75)}
+	limit := bEnvI("BMW_LIMIT", 10)
+	andOp := strings.EqualFold(bEnv("BMW_OPERATOR", "or"), "and")
+	avgPropLen, docCount := bucket.GetAveragePropertyLength()
+	if avgPropLen == 0 {
+		avgPropLen = 1
+	}
+	N := float64(docCount)
+	queries := bmwBaseQueries(b, ctx, bucket, cfg, N)
+	require.NotEmpty(b, queries)
+	if N <= 0 {
+		N = 1
+	}
+	filter := bmwBaseFilter(b, bEnvF("BMW_FILTER", 0), N)
+
+	// warm caches
+	for i := 0; i < len(queries) && i < 500; i++ {
+		bmwBaseRunLean(ctx, bucket, queries[i], N, avgPropLen, limit, cfg, filter, andOp, logger)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for i := 0; i < b.N; i++ {
+		sink += bmwBaseRunLean(ctx, bucket, queries[i%len(queries)], N, avgPropLen, limit, cfg, filter, andOp, logger)
+	}
+	_ = sink
+}
+
+// TestBMWConcurrentLoad models N concurrent clients (default 100) hammering one
+// shared read-only bucket for a fixed duration, with GOMAXPROCS left at the
+// machine default — i.e. heavy oversubscription, the regime where lock/GC
+// contention and tail latency surface. Reports throughput and latency
+// percentiles. Self-contained, so the same test runs in a main worktree and on
+// the branch. Gate with BMW_LOAD=true; tune with BMW_WORKERS / BMW_LOAD_SECONDS.
+func TestBMWConcurrentLoad(t *testing.T) {
+	if os.Getenv("BMW_LOAD") == "" {
+		t.Skip("set BMW_LOAD=true (and BMW_SEGMENTS_DIR) to run the concurrent load test")
+	}
+	dir := os.Getenv("BMW_SEGMENTS_DIR")
+	require.NotEmpty(t, dir, "BMW_SEGMENTS_DIR required")
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	openDir := dir
+	if !strings.EqualFold(bEnv("BMW_COPY", "true"), "false") {
+		tmp := t.TempDir()
+		require.NoError(t, bmwBaseCopyDir(dir, tmp))
+		openDir = tmp
+	}
+	bucket, err := NewBucketCreator().NewBucket(ctx, openDir, openDir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+
+	cfg := schema.BM25Config{K1: bEnvF("BMW_K1", 1.2), B: bEnvF("BMW_B", 0.75)}
+	limit := bEnvI("BMW_LIMIT", 10)
+	andOp := strings.EqualFold(bEnv("BMW_OPERATOR", "or"), "and")
+	avgPropLen, docCount := bucket.GetAveragePropertyLength()
+	if avgPropLen == 0 {
+		avgPropLen = 1
+	}
+	N := float64(docCount)
+	queries := bmwBaseQueries(t, ctx, bucket, cfg, N)
+	require.NotEmpty(t, queries)
+	if N <= 0 {
+		N = 1
+	}
+	filter := bmwBaseFilter(t, bEnvF("BMW_FILTER", 0), N)
+
+	for i := 0; i < len(queries) && i < 500; i++ { // warm caches
+		bmwBaseRunLean(ctx, bucket, queries[i], N, avgPropLen, limit, cfg, filter, andOp, logger)
+	}
+
+	workers := bEnvI("BMW_WORKERS", 100)
+	dur := time.Duration(bEnvF("BMW_LOAD_SECONDS", 8) * float64(time.Second))
+	lats := make([][]time.Duration, workers)
+	counts := make([]int64, workers)
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	deadline := start.Add(dur)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			i := w*7919 + 1
+			local := make([]time.Duration, 0, 8192)
+			for time.Now().Before(deadline) {
+				t0 := time.Now()
+				bmwBaseRunLean(ctx, bucket, queries[i%len(queries)], N, avgPropLen, limit, cfg, filter, andOp, logger)
+				local = append(local, time.Since(t0))
+				i++
+			}
+			lats[w] = local
+			counts[w] = int64(len(local))
+		}(w)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	var total int64
+	all := make([]time.Duration, 0, 1<<16)
+	for w := 0; w < workers; w++ {
+		total += counts[w]
+		all = append(all, lats[w]...)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+	pct := func(q float64) time.Duration {
+		if len(all) == 0 {
+			return 0
+		}
+		idx := int(float64(len(all)) * q)
+		if idx >= len(all) {
+			idx = len(all) - 1
+		}
+		return all[idx]
+	}
+	var sum time.Duration
+	for _, d := range all {
+		sum += d
+	}
+	avg := time.Duration(0)
+	if len(all) > 0 {
+		avg = sum / time.Duration(len(all))
+	}
+
+	t.Logf("\n=== concurrent load: workers=%d GOMAXPROCS=%d limit=%d filter=%v dur=%s ===",
+		workers, runtime.GOMAXPROCS(0), limit, filter != nil, elapsed.Round(time.Millisecond))
+	t.Logf("total queries=%d  throughput=%.0f q/s", total, float64(total)/elapsed.Seconds())
+	t.Logf("latency  avg=%s  p50=%s  p90=%s  p95=%s  p99=%s  p99.9=%s  max=%s",
+		avg.Round(time.Microsecond), pct(0.50).Round(time.Microsecond), pct(0.90).Round(time.Microsecond),
+		pct(0.95).Round(time.Microsecond), pct(0.99).Round(time.Microsecond), pct(0.999).Round(time.Microsecond),
+		all[len(all)-1].Round(time.Microsecond))
+}
+
+// BenchmarkBMWCompareParallel runs the search across GOMAXPROCS goroutines
+// (vary with -cpu=1,4,8,…) sharing one read-only bucket+filter, exactly as
+// concurrent queries do in production. ns/op falls as parallelism scales; compare
+// main vs branch at each -cpu level to see both absolute throughput and how well
+// each scales (the atomic refcount + lower allocations help the branch here).
+func BenchmarkBMWCompareParallel(b *testing.B) {
+	dir := os.Getenv("BMW_SEGMENTS_DIR")
+	if dir == "" {
+		b.Skip("set BMW_SEGMENTS_DIR to a searchable/inverted bucket directory")
+	}
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	openDir := dir
+	if !strings.EqualFold(bEnv("BMW_COPY", "true"), "false") {
+		tmp := b.TempDir()
+		require.NoError(b, bmwBaseCopyDir(dir, tmp))
+		openDir = tmp
+	}
+	bucket, err := NewBucketCreator().NewBucket(ctx, openDir, openDir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyInverted))
+	require.NoError(b, err)
+	defer bucket.Shutdown(ctx)
+
+	cfg := schema.BM25Config{K1: bEnvF("BMW_K1", 1.2), B: bEnvF("BMW_B", 0.75)}
+	limit := bEnvI("BMW_LIMIT", 10)
+	andOp := strings.EqualFold(bEnv("BMW_OPERATOR", "or"), "and")
+	avgPropLen, docCount := bucket.GetAveragePropertyLength()
+	if avgPropLen == 0 {
+		avgPropLen = 1
+	}
+	N := float64(docCount)
+	queries := bmwBaseQueries(b, ctx, bucket, cfg, N)
+	require.NotEmpty(b, queries)
+	if N <= 0 {
+		N = 1
+	}
+	filter := bmwBaseFilter(b, bEnvF("BMW_FILTER", 0), N)
+
+	for i := 0; i < len(queries) && i < 500; i++ {
+		bmwBaseRunLean(ctx, bucket, queries[i], N, avgPropLen, limit, cfg, filter, andOp, logger)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var ctr int64
+	b.RunParallel(func(pb *testing.PB) {
+		i := int(atomic.AddInt64(&ctr, 1)) * 7919 // distinct phase per worker
+		for pb.Next() {
+			bmwBaseRunLean(ctx, bucket, queries[i%len(queries)], N, avgPropLen, limit, cfg, filter, andOp, logger)
+			i++
+		}
+	})
+}
+
+// bmwBaseRunLean runs one query and returns the result count, without building a
+// result map — the leanest representation of the search hot path.
+func bmwBaseRunLean(ctx context.Context, b *Bucket, query []string, N, avgPropLen float64, limit int, cfg schema.BM25Config, filter helpers.AllowList, andOp bool, logger logrus.FieldLogger) int {
+	boosts := make([]int, len(query))
+	for i := range boosts {
+		boosts[i] = 1
+	}
+	diskTerms, _, release, err := b.CreateDiskTerm(N, filter, query, "", 1, boosts, cfg, ctx)
+	if err != nil || diskTerms == nil {
+		if release != nil {
+			release()
+		}
+		return 0
+	}
+	defer release()
+	n := 0
+	for _, seg := range diskTerms {
+		if len(seg) == 0 {
+			continue
+		}
+		var heap *priorityqueue.Queue[[]*terms.DocPointerWithScore]
+		if andOp {
+			heap = DoBlockMaxAnd(ctx, limit, seg, avgPropLen, false, len(query), len(query), logger)
+		} else {
+			heap, _ = DoBlockMaxWand(ctx, limit, seg, avgPropLen, false, len(query), 1, logger)
+		}
+		if heap != nil {
+			n += heap.Len()
+		}
+	}
+	return n
+}
+
+// bmwBaseQueries deterministically builds the query set. Terms are sampled from
+// the segment quantile keys then SORTED before any rng use, so the set is
+// identical across processes (a Go map's iteration order is not).
+func bmwBaseQueries(t testing.TB, ctx context.Context, bucket *Bucket, cfg schema.BM25Config, N float64) [][]string {
+	if explicit := os.Getenv("BMW_TERMS"); explicit != "" {
+		var qs [][]string
+		for _, g := range strings.Split(explicit, ";") {
+			var q []string
+			for _, tk := range strings.Split(g, ",") {
+				if tk = strings.TrimSpace(tk); tk != "" {
+					q = append(q, tk)
+				}
+			}
+			if len(q) > 0 {
+				qs = append(qs, q)
+			}
+		}
+		return qs
+	}
+
+	maxSample := bEnvI("BMW_SAMPLE", 4000)
+	seed := int64(bEnvI("BMW_SEED", 42))
+	size := bEnvI("BMW_QUERY_SIZE", 3)
+	count := bEnvI("BMW_NUM_QUERIES", 500)
+
+	view := bucket.GetConsistentView()
+	set := map[string]struct{}{}
+	for _, seg := range view.Disk {
+		for _, k := range seg.quantileKeys(maxSample) {
+			set[string(k)] = struct{}{}
+		}
+	}
+	view.ReleaseView()
+	sampled := make([]string, 0, len(set))
+	for k := range set {
+		sampled = append(sampled, k)
+	}
+	sort.Strings(sampled) // determinism across processes
+	rng := rand.New(rand.NewSource(seed))
+	if maxSample > 0 && len(sampled) > maxSample {
+		rng.Shuffle(len(sampled), func(i, j int) { sampled[i], sampled[j] = sampled[j], sampled[i] })
+		sampled = sampled[:maxSample]
+		sort.Strings(sampled)
+	}
+
+	// document frequencies (deterministic: data-derived)
+	freqs := map[string]uint64{}
+	const batch = 200
+	for i := 0; i < len(sampled); i += batch {
+		end := i + batch
+		if end > len(sampled) {
+			end = len(sampled)
+		}
+		grp := sampled[i:end]
+		boosts := make([]int, len(grp))
+		for j := range boosts {
+			boosts[j] = 1
+		}
+		_, idf, release, err := bucket.CreateDiskTerm(maxF64(N, 1), nil, grp, "", 1, boosts, cfg, ctx)
+		require.NoError(t, err)
+		for term, n := range idf {
+			freqs[term] = n
+		}
+		release()
+	}
+
+	present := make([]string, 0, len(sampled))
+	for _, term := range sampled {
+		if freqs[term] > 0 {
+			present = append(present, term)
+		}
+	}
+	// stable tiering: by freq desc, term asc
+	sort.Slice(present, func(i, j int) bool {
+		if freqs[present[i]] != freqs[present[j]] {
+			return freqs[present[i]] > freqs[present[j]]
+		}
+		return present[i] < present[j]
+	})
+	if len(present) == 0 {
+		return nil
+	}
+
+	nHigh := len(present) / 10
+	if nHigh < 1 {
+		nHigh = 1
+	}
+	high := present[:nHigh]
+	rest := present[nHigh:]
+	if len(rest) == 0 {
+		rest = high
+	}
+
+	queries := make([][]string, 0, count)
+	for i := 0; i < count; i++ {
+		var q []string
+		switch i % 4 {
+		case 0:
+			q = bmwPick(rng, high, size)
+		case 3:
+			q = bmwPick(rng, rest, size)
+		default:
+			q = bmwPick(rng, high, 1)
+			q = append(q, bmwPick(rng, rest, size-1)...)
+		}
+		q = bmwDedupe(q)
+		if len(q) > 0 {
+			queries = append(queries, q)
+		}
+	}
+	return queries
+}
+
+func bmwPick(rng *rand.Rand, pool []string, k int) []string {
+	if k <= 0 || len(pool) == 0 {
+		return nil
+	}
+	if k >= len(pool) {
+		out := append([]string{}, pool...)
+		rng.Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+		return out
+	}
+	idx := rng.Perm(len(pool))[:k]
+	out := make([]string, 0, k)
+	for _, i := range idx {
+		out = append(out, pool[i])
+	}
+	return out
+}
+
+func bmwDedupe(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func bmwBaseFilter(t testing.TB, selectivity, N float64) helpers.AllowList {
+	if selectivity <= 0 || selectivity >= 1 {
+		return nil
+	}
+	upper := uint64(N)
+	if upper == 0 {
+		upper = 1 << 20
+	}
+	step := uint64(1 / selectivity)
+	if step < 1 {
+		step = 1
+	}
+	bm := sroar.NewBitmap()
+	for id := uint64(0); id < upper; id += step {
+		bm.Set(id)
+	}
+	return helpers.NewAllowListFromBitmap(bm)
+}
+
+func maxF64(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func bmwBaseCopyDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		s := filepath.Join(src, e.Name())
+		d := filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := bmwBaseCopyDir(s, d); err != nil {
+				return err
+			}
+			continue
+		}
+		if !e.Type().IsRegular() {
+			continue
+		}
+		in, err := os.Open(s)
+		if err != nil {
+			return err
+		}
+		out, err := os.Create(d)
+		if err != nil {
+			in.Close()
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			in.Close()
+			out.Close()
+			return err
+		}
+		in.Close()
+		out.Close()
+	}
+	return nil
+}

--- a/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
@@ -66,6 +66,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -692,6 +693,66 @@ func BenchmarkBlockMaxWand(b *testing.B) {
 // the slowest set with their terms, doc-frequencies and per-query work. The
 // slowest queries are also emitted as a BMW_TERMS string for replay.
 //
+// TestBMWTombstoneStats prints, per disk segment, the tombstone cardinality vs
+// the segment's stored doc count, plus the bucket-wide union — i.e. how much
+// deleted-doc filtering a search on this bucket actually does. Gate with
+// BMW_TOMBSTONE_STATS=true.
+func TestBMWTombstoneStats(t *testing.T) {
+	if !envBool("BMW_TOMBSTONE_STATS") {
+		t.Skip("set BMW_TOMBSTONE_STATS=true (and BMW_SEGMENTS_DIR) to run")
+	}
+	dir := os.Getenv("BMW_SEGMENTS_DIR")
+	require.NotEmpty(t, dir, "BMW_SEGMENTS_DIR required")
+	bucket, cleanup := openBMWBucket(t, dir)
+	defer cleanup()
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+
+	union := sroar.NewBitmap()
+	var totalDocs uint64
+	t.Logf("%-55s %12s %12s %8s %14s %8s", "segment", "docs", "tombstones", "deleted%", "docID span", "density")
+	for _, seg := range view.Disk {
+		docs := uint64(0)
+		span := uint64(0)
+		if pl, err := seg.getPropertyLengths(); err == nil {
+			docs = uint64(len(pl))
+			if docs > 0 {
+				minID, maxID := uint64(math.MaxUint64), uint64(0)
+				for id := range pl {
+					if id < minID {
+						minID = id
+					}
+					if id > maxID {
+						maxID = id
+					}
+				}
+				span = maxID - minID + 1
+			}
+		}
+		totalDocs += docs
+		card := 0
+		if tombs, err := seg.ReadOnlyTombstones(); err == nil && tombs != nil && !tombs.IsEmpty() {
+			card = tombs.GetCardinality()
+			union.Or(tombs)
+		}
+		pct := 0.0
+		if docs > 0 {
+			pct = 100 * float64(card) / float64(docs)
+		}
+		density := 0.0
+		if span > 0 {
+			density = 100 * float64(docs) / float64(span)
+		}
+		t.Logf("%-55s %12d %12d %7.3f%% %14d %7.2f%%", filepath.Base(seg.getPath()), docs, card, pct, span, density)
+	}
+
+	avgPropLen, n := bucket.GetAveragePropertyLength()
+	uc := union.GetCardinality()
+	t.Logf("bucket: N=%d (prop-length docs=%d, avgPropLen=%.1f)", n, totalDocs, avgPropLen)
+	t.Logf("tombstone union: %d distinct docIDs = %.3f%% of N", uc, 100*float64(uc)/maxF(float64(n), 1))
+}
+
 // TestBMWTopTerms lists the BMW_TOP_TERMS most frequent sampled terms, plus a
 // ready-to-paste BMW_TERMS string — for building common-term stress queries.
 func TestBMWTopTerms(t *testing.T) {

--- a/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
@@ -504,6 +504,7 @@ func setupBMW(tb testing.TB) *bmwSetup {
 	// the BlockMetrics counters are gated off in production; turn them on so the
 	// harness can report per-query docsScored/blocksDecoded.
 	collectBlockMetrics = true
+	applyDeferTombstoneEnv()
 
 	bucket, cleanup := openBMWBucket(tb, dir)
 
@@ -535,6 +536,8 @@ func setupBMW(tb testing.TB) *bmwSetup {
 		}
 		N = float64(mx) + 1
 	}
+
+	injectSyntheticTombstones(tb, bucket, envFloat("BMW_TOMBSTONE_PCT", 0), N)
 
 	present := make([]string, 0, len(sampled))
 	for _, t := range sampled {
@@ -578,6 +581,39 @@ func buildFilter(tb testing.TB, selectivity, N float64) helpers.AllowList {
 	}
 	tb.Logf("filter: selectivity=%.4f (~%d of %d docIDs allowed; every %dth)", selectivity, count, upper, step)
 	return helpers.NewAllowListFromBitmap(bm)
+}
+
+// applyDeferTombstoneEnv leaves the shipping default in place unless
+// BMW_DEFER_TOMBSTONE is explicitly set (=false forces advance-time for A/B).
+func applyDeferTombstoneEnv() {
+	if v, ok := os.LookupEnv("BMW_DEFER_TOMBSTONE"); ok {
+		deferTombstoneToScore = strings.EqualFold(v, "true")
+	}
+}
+
+// injectSyntheticTombstones marks ~pct of [0,N) deleted on the active memtable,
+// whose tombstones createDiskTermFromCV ORs into memTombstones for every disk
+// segment — simulating deletes without rewriting any segment. Strided so separate
+// dump/compare processes build the identical set the bit-identical check needs.
+func injectSyntheticTombstones(tb testing.TB, b *Bucket, pct, N float64) int {
+	if pct <= 0 || N <= 0 {
+		return 0
+	}
+	if pct >= 1 {
+		pct = 0.99
+	}
+	upper := uint64(N)
+	step := uint64(1 / pct)
+	if step < 1 {
+		step = 1
+	}
+	n := 0
+	for id := uint64(0); id < upper; id += step {
+		require.NoError(tb, b.active.SetTombstone(id))
+		n++
+	}
+	tb.Logf("synthetic tombstones: pct=%.4f (~%d of %d docIDs deleted; every %dth)", pct, n, upper, step)
+	return n
 }
 
 func (s *bmwSetup) queriesOfSize(tb testing.TB, size, count int) [][]string {

--- a/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
@@ -692,6 +692,26 @@ func BenchmarkBlockMaxWand(b *testing.B) {
 // the slowest set with their terms, doc-frequencies and per-query work. The
 // slowest queries are also emitted as a BMW_TERMS string for replay.
 //
+// TestBMWTopTerms lists the BMW_TOP_TERMS most frequent sampled terms, plus a
+// ready-to-paste BMW_TERMS string — for building common-term stress queries.
+func TestBMWTopTerms(t *testing.T) {
+	n := envInt("BMW_TOP_TERMS", 0)
+	if n <= 0 {
+		t.Skip("set BMW_TOP_TERMS=N to list the N most frequent sampled terms")
+	}
+	s := setupBMW(t)
+	defer s.cleanup()
+	top := append([]string(nil), s.present...)
+	sort.Slice(top, func(i, j int) bool { return s.freqs[top[i]] > s.freqs[top[j]] })
+	if len(top) > n {
+		top = top[:n]
+	}
+	for _, term := range top {
+		t.Logf("%9d  %s", s.freqs[term], term)
+	}
+	t.Logf("BMW_TERMS=%s", strings.Join(top, ","))
+}
+
 //	BMW_SEGMENTS_DIR=… BMW_SLOW=true BMW_QUERY_SIZE=15 \
 //	  go test -tags integrationTest -run TestBMWSlowQueries -v ./adapters/repos/db/lsmkv/
 func TestBMWSlowQueries(t *testing.T) {

--- a/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
@@ -397,6 +397,13 @@ func runQuery(ctx context.Context, s *bmwSetup, query []string) queryStats {
 		return st
 	}
 	defer release()
+	for _, seg := range diskTerms {
+		for _, t := range seg {
+			if t != nil {
+				t.SetIdf(t.Idf())
+			}
+		}
+	}
 
 	matched := false
 	for _, seg := range diskTerms {

--- a/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
+++ b/adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go
@@ -1,0 +1,1063 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+// BlockMax WAND profiling harness.
+//
+// Points the real query path (CreateDiskTerm -> DoBlockMaxWand/DoBlockMaxAnd) at
+// an on-disk searchable (inverted) bucket and runs many multi-term queries built
+// from terms that actually exist in those segments. It captures CPU + allocation
+// profiles and parses them in-process to print a ranked list of the hottest
+// BlockMax functions, so you can see what to optimize first without leaving the
+// test.
+//
+// Usage:
+//
+//	# A folder holding ONE searchable property's segment files (*.db etc).
+//	# Copy a property dir out of a Weaviate data dir, e.g.
+//	#   <data>/<class>/<shard>/lsm/property_<name>_searchable
+//	BMW_SEGMENTS_DIR=/path/to/property_searchable \
+//	  go test -tags integrationTest -run TestProfileBlockMaxWand -v -timeout 30m \
+//	  ./adapters/repos/db/lsmkv/
+//
+//	# Standard Go benchmark (works with the usual pprof flags):
+//	BMW_SEGMENTS_DIR=/path/to/property_searchable \
+//	  go test -tags integrationTest -run x -bench BenchmarkBlockMaxWand -benchmem \
+//	  -cpuprofile cpu.prof -memprofile mem.prof ./adapters/repos/db/lsmkv/
+//	go tool pprof -http=: cpu.prof
+//
+// Tunables (env vars):
+//
+//	BMW_SEGMENTS_DIR     required; folder with the bucket's segments
+//	BMW_QUERY_SIZE       terms per query; CSV for the benchmark (default "1,2,3,5"), single int for the test (default 3)
+//	BMW_NUM_QUERIES      distinct query combinations to generate (default 500)
+//	BMW_PROFILE_SECONDS  wall-clock to drive the profiler in the test (default 15); ignored if BMW_PROFILE_QUERIES is set
+//	BMW_PROFILE_QUERIES  fixed query-execution cap under the profiler (overrides BMW_PROFILE_SECONDS)
+//	BMW_LIMIT            top-K limit (default 10)
+//	BMW_SAMPLE           max terms reservoir-sampled from the bucket (default 4000)
+//	BMW_TERMS            explicit query groups, ';'-separated groups of ','-separated terms (overrides sampling)
+//	BMW_OPERATOR         "or" (BlockMaxWand, default) or "and" (BlockMaxAnd)
+//	BMW_FILTER           filter selectivity in (0,1): builds an AllowList passing ~that fraction of docIDs, exercising the filtered-search path (default 0 = no filter)
+//	BMW_CONCURRENCY      goroutines running queries during the profiled run (default 1); >1 also captures mutex/block profiles
+//	BMW_SCALING          CSV concurrency levels for a contention sweep, e.g. "1,2,4,8,16" (put 1 first); prints throughput + scaling efficiency
+//	BMW_SCALING_SECONDS  duration per scaling level (default 4)
+//	BMW_BLOCK_RATE_NS    block-profile rate in ns when concurrent (default 10000)
+//	BMW_EXPLAIN          "true" to request additionalExplanations (heavier scoring path)
+//	BMW_PREAD            "true" to force pread instead of the default mmap path
+//	BMW_COPY             "false" to open the dir in place instead of copying to temp (default copies)
+//	BMW_PROFILE_OUT      dir for the written profiles (default <tmp>/bmw-profiles)
+//	BMW_TOPN             hotspot rows to print (default 40)
+//	BMW_SEED             rng seed for sampling/combinations (default 42)
+//	BMW_K1, BMW_B        BM25 params (default 1.2 / 0.75)
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/pprof/profile"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// bmwQuietLogger silences the per-100k-iteration timeout warnings; with a
+// background context that path is never hit anyway.
+var bmwQuietLogger = func() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetLevel(logrus.PanicLevel)
+	return l
+}()
+
+// packages whose functions are worth ranking; everything else (runtime, GC,
+// syscall) is shown only in the unfiltered "context" view.
+var bmwPackages = []string{
+	"adapters/repos/db/lsmkv",
+	"adapters/repos/db/inverted",
+	"adapters/repos/db/priorityqueue",
+	"usecases/byteops",
+	"weaviate/sroar",
+	"lsmkv/varenc",
+	"lsmkv/gobenc",
+}
+
+type queryStats struct {
+	queries      int
+	emptyQueries int
+	results      int
+	docsScored   uint64
+	blocksDocIds uint64
+	blocksFreqs  uint64
+	docsDecoded  uint64
+}
+
+func (s *queryStats) add(o queryStats) {
+	s.queries += o.queries
+	s.emptyQueries += o.emptyQueries
+	s.results += o.results
+	s.docsScored += o.docsScored
+	s.blocksDocIds += o.blocksDocIds
+	s.blocksFreqs += o.blocksFreqs
+	s.docsDecoded += o.docsDecoded
+}
+
+func bm25ConfigFromEnv() schema.BM25Config {
+	return schema.BM25Config{
+		K1: envFloat("BMW_K1", 1.2),
+		B:  envFloat("BMW_B", 0.75),
+	}
+}
+
+func envStr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func envFloat(key string, def float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
+}
+
+func envBool(key string) bool {
+	return strings.EqualFold(os.Getenv(key), "true")
+}
+
+// openBMWBucket loads an inverted bucket from dir. By default the dir is copied
+// into a temp location first so the source segments are never mutated (NewBucket
+// may recover a WAL or compact in place).
+func openBMWBucket(tb testing.TB, dir string) (*Bucket, func()) {
+	tb.Helper()
+
+	openDir := dir
+	if !strings.EqualFold(envStr("BMW_COPY", "true"), "false") {
+		tmp := tb.TempDir()
+		require.NoError(tb, bmwCopyDir(dir, tmp), "copy segments dir")
+		openDir = tmp
+		tb.Logf("opened a copy of the segments at %s (set BMW_COPY=false to open in place)", openDir)
+	}
+
+	opts := []BucketOption{WithStrategy(StrategyInverted)}
+	if envBool("BMW_PREAD") {
+		opts = append(opts, WithPread(true))
+	}
+
+	b, err := NewBucketCreator().NewBucket(context.Background(), openDir, openDir, bmwQuietLogger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+	require.NoError(tb, err, "open inverted bucket")
+	require.Equal(tb, StrategyInverted, b.Strategy(),
+		"BMW_SEGMENTS_DIR must point at a searchable/inverted bucket directory")
+
+	cleanup := func() { _ = b.Shutdown(context.Background()) }
+	return b, cleanup
+}
+
+func bmwCopyDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		s := filepath.Join(src, e.Name())
+		d := filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := bmwCopyDir(s, d); err != nil {
+				return err
+			}
+			continue
+		}
+		if !e.Type().IsRegular() {
+			continue
+		}
+		if err := bmwCopyFile(s, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func bmwCopyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+// sampleTermKeys collects a spread of term keys across the keyspace using the
+// segment index's quantile keys, which walk the tree without decoding any
+// posting lists (cheap even on huge buckets). Keys are gathered from every disk
+// segment, deduped, and trimmed to max. NOTE: MapCursorKeyOnly cannot be used
+// here — its keyOnly path drops every key because it merges empty value lists.
+func sampleTermKeys(tb testing.TB, b *Bucket, max int, rng *rand.Rand) []string {
+	tb.Helper()
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+
+	q := max
+	if q < 1 {
+		q = 1
+	}
+	set := make(map[string]struct{}, max)
+	for _, seg := range view.Disk {
+		for _, k := range seg.quantileKeys(q) {
+			set[string(k)] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	if max > 0 && len(keys) > max {
+		rng.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+		keys = keys[:max]
+	}
+	tb.Logf("sampled %d terms across %d disk segments", len(keys), len(view.Disk))
+	return keys
+}
+
+// termFrequencies returns the document frequency (postings count) per term,
+// read cheaply from CreateDiskTerm's idf counts. Doubles as a warmup that loads
+// the per-segment property lengths.
+func termFrequencies(tb testing.TB, ctx context.Context, b *Bucket, terms []string, N float64, cfg schema.BM25Config) map[string]uint64 {
+	tb.Helper()
+	out := make(map[string]uint64, len(terms))
+	const batch = 200
+	for i := 0; i < len(terms); i += batch {
+		end := i + batch
+		if end > len(terms) {
+			end = len(terms)
+		}
+		grp := terms[i:end]
+		boosts := ones(len(grp))
+		_, idfCounts, release, err := b.CreateDiskTerm(N, nil, grp, "", 1, boosts, cfg, ctx)
+		require.NoError(tb, err)
+		for t, n := range idfCounts {
+			out[t] = n
+		}
+		release()
+	}
+	return out
+}
+
+func ones(n int) []int {
+	s := make([]int, n)
+	for i := range s {
+		s[i] = 1
+	}
+	return s
+}
+
+// buildQueries forms `count` query groups of the requested size. WAND cost is
+// dominated by the term-frequency mix, so queries deliberately span tiers:
+// some all-frequent (heavy postings, lots of block skipping), most a frequent
+// term plus rarer ones (the common case), some all-rare (cheap).
+func buildQueries(tb testing.TB, present []string, freqs map[string]uint64, size, count int, rng *rand.Rand) [][]string {
+	tb.Helper()
+	if size < 1 {
+		size = 1
+	}
+	sorted := make([]string, len(present))
+	copy(sorted, present)
+	sort.Slice(sorted, func(i, j int) bool { return freqs[sorted[i]] > freqs[sorted[j]] })
+
+	nHigh := len(sorted) / 10
+	if nHigh < 1 {
+		nHigh = 1
+	}
+	nMid := len(sorted) * 4 / 10
+	high := sorted[:nHigh]
+	mid := sorted[nHigh : nHigh+nMid]
+	low := sorted[nHigh+nMid:]
+	rest := append(append([]string{}, mid...), low...)
+	if len(rest) == 0 {
+		rest = high
+	}
+
+	queries := make([][]string, 0, count)
+	for i := 0; i < count; i++ {
+		var q []string
+		switch i % 4 {
+		case 0: // stress: all frequent
+			q = sampleDistinct(rng, high, size)
+		case 3: // light: all rare/mid
+			q = sampleDistinct(rng, rest, size)
+		default: // typical: one frequent + rest mixed
+			q = sampleDistinct(rng, high, 1)
+			q = append(q, sampleDistinct(rng, rest, size-1)...)
+		}
+		q = dedupe(q)
+		if len(q) > 0 {
+			queries = append(queries, q)
+		}
+	}
+	return queries
+}
+
+func sampleDistinct(rng *rand.Rand, pool []string, k int) []string {
+	if k <= 0 || len(pool) == 0 {
+		return nil
+	}
+	if k >= len(pool) {
+		out := append([]string{}, pool...)
+		rng.Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+		return out
+	}
+	idx := rng.Perm(len(pool))[:k]
+	out := make([]string, 0, k)
+	for _, i := range idx {
+		out = append(out, pool[i])
+	}
+	return out
+}
+
+func dedupe(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// runQuery executes one query exactly like the production block path: build the
+// per-segment term iterators, then run WAND/AND once per segment. Safe to call
+// concurrently — each call builds its own iterators and accumulates into its own
+// returned queryStats; only the (read-only) filter/bucket are shared.
+func runQuery(ctx context.Context, s *bmwSetup, query []string) queryStats {
+	b, N, avgPropLen, limit, cfg := s.bucket, s.N, s.avgPropLen, s.limit, s.cfg
+	st := queryStats{queries: 1}
+	boosts := ones(len(query))
+	diskTerms, _, release, err := b.CreateDiskTerm(N, s.filter, query, "", 1, boosts, cfg, ctx)
+	if err != nil || diskTerms == nil {
+		st.emptyQueries = 1
+		if release != nil {
+			release()
+		}
+		return st
+	}
+	defer release()
+
+	matched := false
+	for _, seg := range diskTerms {
+		if len(seg) == 0 {
+			continue
+		}
+		matched = true
+		var heap *priorityqueue.Queue[[]*terms.DocPointerWithScore]
+		if s.andOp {
+			heap = DoBlockMaxAnd(ctx, limit, seg, avgPropLen, s.explain, len(query), len(query), bmwQuietLogger)
+		} else {
+			heap, _ = DoBlockMaxWand(ctx, limit, seg, avgPropLen, s.explain, len(query), 1, bmwQuietLogger)
+		}
+		if heap != nil {
+			st.results += heap.Len()
+		}
+		for _, t := range seg {
+			if t == nil {
+				continue
+			}
+			st.docsScored += t.Metrics.DocCountScored
+			st.blocksDocIds += t.Metrics.BlockCountDecodedDocIds
+			st.blocksFreqs += t.Metrics.BlockCountDecodedFreqs
+			st.docsDecoded += t.Metrics.DocCountDecodedDocIds
+		}
+	}
+	if !matched {
+		st.emptyQueries = 1
+	}
+	return st
+}
+
+// runConcurrent drives queries across `workers` goroutines until `dur` elapses
+// (when maxExec<=0) or `maxExec` total executions are reached. Each worker
+// accumulates into its own queryStats so the harness adds no shared-write
+// contention of its own — only the bucket and filter (read-only) are shared,
+// exactly as in production. Returns total executions, wall time, merged stats.
+func runConcurrent(ctx context.Context, s *bmwSetup, queries [][]string, workers int, dur time.Duration, maxExec int) (int, time.Duration, queryStats) {
+	if workers < 1 {
+		workers = 1
+	}
+	stats := make([]queryStats, workers)
+	useDeadline := maxExec <= 0
+	var counter int64
+	start := time.Now()
+	deadline := start.Add(dur)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			local := &stats[w]
+			i := w*7919 + 1 // distinct phase per worker so they don't run in lockstep
+			for {
+				if useDeadline {
+					if time.Now().After(deadline) {
+						return
+					}
+				} else if atomic.AddInt64(&counter, 1) > int64(maxExec) {
+					return
+				}
+				local.add(runQuery(ctx, s, queries[i%len(queries)]))
+				i++
+			}
+		}(w)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	var agg queryStats
+	for w := range stats {
+		agg.add(stats[w])
+	}
+	return agg.queries, elapsed, agg
+}
+
+// bmwSetup loads the bucket and prepares the query set shared by the benchmark
+// and the profiling test.
+type bmwSetup struct {
+	bucket     *Bucket
+	cleanup    func()
+	terms      []string
+	freqs      map[string]uint64
+	present    []string
+	N          float64
+	avgPropLen float64
+	cfg        schema.BM25Config
+	andOp      bool
+	explain    bool
+	limit      int
+	filter     helpers.AllowList
+	rng        *rand.Rand
+}
+
+func setupBMW(tb testing.TB) *bmwSetup {
+	tb.Helper()
+	dir := os.Getenv("BMW_SEGMENTS_DIR")
+	if dir == "" {
+		tb.Skip("set BMW_SEGMENTS_DIR to a searchable/inverted bucket directory to run")
+	}
+	ctx := context.Background()
+	cfg := bm25ConfigFromEnv()
+	rng := rand.New(rand.NewSource(int64(envInt("BMW_SEED", 42))))
+
+	// the BlockMetrics counters are gated off in production; turn them on so the
+	// harness can report per-query docsScored/blocksDecoded.
+	collectBlockMetrics = true
+
+	bucket, cleanup := openBMWBucket(tb, dir)
+
+	avgPropLen, docCount := bucket.GetAveragePropertyLength()
+	if avgPropLen == 0 {
+		avgPropLen = 1
+	}
+	N := float64(docCount)
+
+	explicit := os.Getenv("BMW_TERMS")
+	var sampled []string
+	if explicit == "" {
+		sampled = sampleTermKeys(tb, bucket, envInt("BMW_SAMPLE", 4000), rng)
+		require.NotEmpty(tb, sampled, "no terms found in bucket")
+	}
+
+	freqs := map[string]uint64{}
+	if explicit == "" {
+		freqs = termFrequencies(tb, ctx, bucket, sampled, maxF(N, 1), cfg)
+	}
+
+	// derive N from the data if the bucket didn't report a doc count
+	if N <= 0 {
+		var mx uint64
+		for _, n := range freqs {
+			if n > mx {
+				mx = n
+			}
+		}
+		N = float64(mx) + 1
+	}
+
+	present := make([]string, 0, len(sampled))
+	for _, t := range sampled {
+		if freqs[t] > 0 {
+			present = append(present, t)
+		}
+	}
+
+	return &bmwSetup{
+		bucket: bucket, cleanup: cleanup,
+		terms: sampled, freqs: freqs, present: present,
+		N: N, avgPropLen: avgPropLen, cfg: cfg,
+		andOp:   strings.EqualFold(envStr("BMW_OPERATOR", "or"), "and"),
+		explain: envBool("BMW_EXPLAIN"),
+		limit:   envInt("BMW_LIMIT", 10),
+		filter:  buildFilter(tb, envFloat("BMW_FILTER", 0), N),
+		rng:     rng,
+	}
+}
+
+// buildFilter constructs a filter AllowList that passes ~selectivity of the
+// docID space, so the filtered-search path (SegmentBlockMax.advanceOnTombstoneOrFilter
+// -> AllowList.Contains -> sroar) is exercised. selectivity<=0 means no filter.
+func buildFilter(tb testing.TB, selectivity, N float64) helpers.AllowList {
+	if selectivity <= 0 || selectivity >= 1 {
+		return nil
+	}
+	upper := uint64(N)
+	if upper == 0 {
+		upper = 1 << 20
+	}
+	step := uint64(1 / selectivity)
+	if step < 1 {
+		step = 1
+	}
+	bm := sroar.NewBitmap()
+	count := 0
+	for id := uint64(0); id < upper; id += step {
+		bm.Set(id)
+		count++
+	}
+	tb.Logf("filter: selectivity=%.4f (~%d of %d docIDs allowed; every %dth)", selectivity, count, upper, step)
+	return helpers.NewAllowListFromBitmap(bm)
+}
+
+func (s *bmwSetup) queriesOfSize(tb testing.TB, size, count int) [][]string {
+	if explicit := os.Getenv("BMW_TERMS"); explicit != "" {
+		var qs [][]string
+		for _, g := range strings.Split(explicit, ";") {
+			var q []string
+			for _, t := range strings.Split(g, ",") {
+				if t = strings.TrimSpace(t); t != "" {
+					q = append(q, t)
+				}
+			}
+			if len(q) > 0 {
+				qs = append(qs, q)
+			}
+		}
+		require.NotEmpty(tb, qs, "BMW_TERMS produced no queries")
+		return qs
+	}
+	qs := buildQueries(tb, s.present, s.freqs, size, count, s.rng)
+	require.NotEmpty(tb, qs, "could not build queries; not enough terms")
+	return qs
+}
+
+func maxF(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func parseSizes(csv string) []int {
+	var out []int
+	for _, p := range strings.Split(csv, ",") {
+		if n, err := strconv.Atoi(strings.TrimSpace(p)); err == nil && n > 0 {
+			out = append(out, n)
+		}
+	}
+	if len(out) == 0 {
+		out = []int{3}
+	}
+	return out
+}
+
+// BenchmarkBlockMaxWand drives the search path under the standard Go benchmark
+// flags. Use -cpuprofile/-memprofile to capture profiles for `go tool pprof`.
+func BenchmarkBlockMaxWand(b *testing.B) {
+	s := setupBMW(b)
+	defer s.cleanup()
+	ctx := context.Background()
+	numQueries := envInt("BMW_NUM_QUERIES", 500)
+
+	for _, size := range parseSizes(envStr("BMW_QUERY_SIZE", "1,2,3,5")) {
+		queries := s.queriesOfSize(b, size, numQueries)
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			var agg queryStats
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				agg.add(runQuery(ctx, s, queries[i%len(queries)]))
+			}
+			b.StopTimer()
+			if b.N > 0 {
+				b.ReportMetric(float64(agg.docsScored)/float64(b.N), "docsScored/op")
+				b.ReportMetric(float64(agg.blocksDocIds)/float64(b.N), "blocksDecoded/op")
+				b.ReportMetric(float64(agg.results)/float64(b.N), "results/op")
+			}
+		})
+	}
+}
+
+// TestBMWSlowQueries searches for the consistently-slowest queries on the given
+// segments. It builds many candidate queries from the highest-document-frequency
+// terms (the worst case for WAND: little block skipping, almost everything gets
+// scored), times each over several repeats (median, to be robust), and reports
+// the slowest set with their terms, doc-frequencies and per-query work. The
+// slowest queries are also emitted as a BMW_TERMS string for replay.
+//
+//	BMW_SEGMENTS_DIR=… BMW_SLOW=true BMW_QUERY_SIZE=15 \
+//	  go test -tags integrationTest -run TestBMWSlowQueries -v ./adapters/repos/db/lsmkv/
+func TestBMWSlowQueries(t *testing.T) {
+	if os.Getenv("BMW_SLOW") == "" {
+		t.Skip("set BMW_SLOW=true to search for high-latency queries")
+	}
+	s := setupBMW(t)
+	defer s.cleanup()
+	ctx := context.Background()
+
+	size := envInt("BMW_QUERY_SIZE", 15)
+	candidates := envInt("BMW_SLOW_CANDIDATES", 400)
+	repeats := envInt("BMW_SLOW_REPEATS", 9)
+	topK := envInt("BMW_SLOW_TOPK", 20)
+
+	// candidate pool = the most frequent terms (≈ top 5%, at least 4× the query
+	// size), where WAND prunes least.
+	present := append([]string(nil), s.present...)
+	sort.Slice(present, func(i, j int) bool { return s.freqs[present[i]] > s.freqs[present[j]] })
+	poolSize := envInt("BMW_SLOW_POOL", 0)
+	if poolSize <= 0 {
+		poolSize = len(present) / 20
+		if poolSize < size*4 {
+			poolSize = size * 4
+		}
+	}
+	if poolSize > len(present) {
+		poolSize = len(present)
+	}
+	pool := present[:poolSize]
+	require.GreaterOrEqual(t, len(pool), size, "not enough terms for the requested query size")
+	t.Logf("pool: top %d terms by freq (%d..%d docs); building %d candidate %d-term queries",
+		len(pool), s.freqs[pool[len(pool)-1]], s.freqs[pool[0]], candidates, size)
+
+	type qstat struct {
+		q          []string
+		medianUs   float64
+		spreadUs   float64
+		docsScored uint64
+		blocks     uint64
+		results    int
+		minFreq    uint64
+		maxFreq    uint64
+	}
+
+	built := make([][]string, 0, candidates)
+	seen := map[string]struct{}{}
+	for len(built) < candidates {
+		q := dedupe(sampleDistinct(s.rng, pool, size))
+		if len(q) < size {
+			continue
+		}
+		key := strings.Join(q, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		built = append(built, q)
+	}
+
+	// warm the page cache for every term involved
+	for _, q := range built {
+		runQuery(ctx, s, q)
+	}
+
+	stats := make([]qstat, 0, len(built))
+	for _, q := range built {
+		lats := make([]float64, repeats)
+		var st queryStats
+		for r := 0; r < repeats; r++ {
+			t0 := time.Now()
+			st = runQuery(ctx, s, q)
+			lats[r] = float64(time.Since(t0).Microseconds())
+		}
+		sort.Float64s(lats)
+		var minF, maxF uint64 = ^uint64(0), 0
+		for _, term := range q {
+			f := s.freqs[term]
+			if f < minF {
+				minF = f
+			}
+			if f > maxF {
+				maxF = f
+			}
+		}
+		stats = append(stats, qstat{
+			q: q, medianUs: lats[len(lats)/2], spreadUs: lats[len(lats)-1] - lats[0],
+			docsScored: st.docsScored, blocks: st.blocksDocIds, results: st.results, minFreq: minF, maxFreq: maxF,
+		})
+	}
+	sort.Slice(stats, func(i, j int) bool { return stats[i].medianUs > stats[j].medianUs })
+
+	var allMed float64
+	for _, st := range stats {
+		allMed += st.medianUs
+	}
+	t.Logf("\n=== %d candidates: median-latency distribution ===", len(stats))
+	t.Logf("slowest=%.0fµs  median-of-candidates=%.0fµs  fastest=%.0fµs  mean=%.0fµs",
+		stats[0].medianUs, stats[len(stats)/2].medianUs, stats[len(stats)-1].medianUs, allMed/float64(len(stats)))
+
+	t.Logf("\n=== top %d slowest queries (median over %d repeats) ===", topK, repeats)
+	var replay []string
+	for i := 0; i < topK && i < len(stats); i++ {
+		st := stats[i]
+		t.Logf("#%2d  median=%6.0fµs (spread %.0fµs)  docsScored=%d  blocksDecoded=%d  results=%d  termFreq=%d..%d\n      terms: %s",
+			i+1, st.medianUs, st.spreadUs, st.docsScored, st.blocks, st.results, st.minFreq, st.maxFreq, strings.Join(st.q, " "))
+		replay = append(replay, strings.Join(st.q, ","))
+	}
+	t.Logf("\nreplay the slow set with:\n  BMW_TERMS='%s'", strings.Join(replay, ";"))
+}
+
+// TestProfileBlockMaxWand runs a fixed batch of queries under the CPU profiler,
+// writes CPU + allocation profiles, then parses them and prints a ranked list of
+// the hottest BlockMax functions — i.e. what to optimize first.
+func TestProfileBlockMaxWand(t *testing.T) {
+	s := setupBMW(t)
+	defer s.cleanup()
+	ctx := context.Background()
+
+	size := envInt("BMW_QUERY_SIZE", 3)
+	numQueries := envInt("BMW_NUM_QUERIES", 500)
+	queries := s.queriesOfSize(t, size, numQueries)
+
+	outDir := envStr("BMW_PROFILE_OUT", filepath.Join(os.TempDir(), "bmw-profiles"))
+	require.NoError(t, os.MkdirAll(outDir, 0o755))
+	cpuPath := filepath.Join(outDir, "bmw_cpu.prof")
+	memPath := filepath.Join(outDir, "bmw_mem.prof")
+
+	// warm caches (property lengths, OS page cache) so the profile reflects steady state
+	for i := 0; i < min(len(queries), 500); i++ {
+		runQuery(ctx, s, queries[i])
+	}
+
+	// Drive the profiler for a target wall-clock duration by default so CPU
+	// sampling is meaningful regardless of dataset size/speed. An explicit
+	// BMW_PROFILE_QUERIES caps by query count instead.
+	maxExec := envInt("BMW_PROFILE_QUERIES", 0)
+	targetDur := time.Duration(envFloat("BMW_PROFILE_SECONDS", 15) * float64(time.Second))
+	conc := envInt("BMW_CONCURRENCY", 1)
+
+	// Optional scaling sweep: run the same workload at several concurrency levels
+	// and report how per-worker throughput degrades as queries contend. efficiency
+	// = per-worker q/s at this level / per-worker q/s at the first level (stays at
+	// 100% if the search scales perfectly; drops as contention bites). Put the
+	// lowest level (e.g. 1) first to anchor the baseline.
+	if scaling := os.Getenv("BMW_SCALING"); scaling != "" {
+		levels := parseSizes(scaling)
+		phaseDur := time.Duration(envFloat("BMW_SCALING_SECONDS", 4) * float64(time.Second))
+		t.Logf("\n=== concurrency scaling (each level ~%.0fs, GOMAXPROCS=%d) ===", phaseDur.Seconds(), runtime.GOMAXPROCS(0))
+		t.Logf("%8s  %12s  %16s  %11s", "workers", "queries/s", "per-worker q/s", "efficiency")
+		base := 0.0
+		for _, lvl := range levels {
+			n, el, _ := runConcurrent(ctx, s, queries, lvl, phaseDur, 0)
+			qps := float64(n) / el.Seconds()
+			per := qps / float64(lvl)
+			if base == 0 {
+				base = per
+			}
+			t.Logf("%8d  %12.0f  %16.0f  %10.0f%%", lvl, qps, per, 100*per/base)
+		}
+		conc = levels[len(levels)-1]
+	}
+
+	// mutex + block profiling exposes lock contention when running concurrently
+	if conc > 1 {
+		runtime.SetMutexProfileFraction(1)
+		runtime.SetBlockProfileRate(envInt("BMW_BLOCK_RATE_NS", 10000))
+		defer runtime.SetMutexProfileFraction(0)
+		defer runtime.SetBlockProfileRate(0)
+	}
+
+	cpuFile, err := os.Create(cpuPath)
+	require.NoError(t, err)
+	require.NoError(t, pprof.StartCPUProfile(cpuFile))
+
+	exec, elapsed, agg := runConcurrent(ctx, s, queries, conc, targetDur, maxExec)
+
+	pprof.StopCPUProfile()
+	require.NoError(t, cpuFile.Close())
+
+	runtime.GC()
+	memFile, err := os.Create(memPath)
+	require.NoError(t, err)
+	require.NoError(t, pprof.Lookup("allocs").WriteTo(memFile, 0))
+	require.NoError(t, memFile.Close())
+
+	op := "OR/BlockMaxWand"
+	if s.andOp {
+		op = "AND/BlockMaxAnd"
+	}
+	t.Logf("\n=== BlockMax run summary (%s) ===", op)
+	t.Logf("terms/query=%d  distinct queries=%d  executions=%d  concurrency=%d  limit=%d  N=%.0f  avgPropLen=%.2f  filter=%v",
+		size, len(queries), exec, conc, s.limit, s.N, s.avgPropLen, s.filter != nil)
+	t.Logf("wall=%s  throughput=%.0f queries/s  empty=%d",
+		elapsed.Round(time.Millisecond), float64(exec)/elapsed.Seconds(), agg.emptyQueries)
+	t.Logf("per-query: docsScored=%.1f  blocksDecoded(docIds)=%.1f  blocksDecoded(freqs)=%.1f  docsDecoded=%.1f  results=%.1f",
+		perQ(agg.docsScored, exec), perQ(agg.blocksDocIds, exec), perQ(agg.blocksFreqs, exec),
+		perQ(agg.docsDecoded, exec), perQ(uint64(agg.results), exec))
+
+	reportHotspots(t, cpuPath, "cpu", "ms", 1e6, envInt("BMW_TOPN", 40))
+	reportHotspots(t, memPath, "alloc_space", "MB", 1e6, envInt("BMW_TOPN", 40))
+
+	written := fmt.Sprintf("  go tool pprof -http=: %s\n  go tool pprof -http=: %s", cpuPath, memPath)
+	if conc > 1 {
+		mutexPath := filepath.Join(outDir, "bmw_mutex.prof")
+		blockPath := filepath.Join(outDir, "bmw_block.prof")
+		writeLookup(t, "mutex", mutexPath)
+		writeLookup(t, "block", blockPath)
+		// "delay" = nanoseconds blocked; the CUM view filtered to BMW packages
+		// shows which lock-protected sections serialize concurrent queries.
+		reportHotspots(t, mutexPath, "delay", "ms", 1e6, envInt("BMW_TOPN", 40))
+		reportHotspots(t, blockPath, "delay", "ms", 1e6, envInt("BMW_TOPN", 40))
+		written += fmt.Sprintf("\n  go tool pprof -http=: %s\n  go tool pprof -http=: %s", mutexPath, blockPath)
+	}
+	t.Logf("\nprofiles written:\n%s", written)
+}
+
+func writeLookup(t *testing.T, name, path string) {
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	if p := pprof.Lookup(name); p != nil {
+		require.NoError(t, p.WriteTo(f, 0))
+	}
+}
+
+// TestGenerateBMWFixture builds a synthetic on-disk inverted bucket with a
+// Zipf-skewed vocabulary spread over several segments, so the profiling harness
+// can be exercised without a real Weaviate data dir. Point BMW_SEGMENTS_DIR at
+// BMW_GEN_DIR afterwards.
+//
+//	BMW_GEN_DIR=/tmp/bmwfix go test -tags integrationTest -run TestGenerateBMWFixture ./adapters/repos/db/lsmkv/
+func TestGenerateBMWFixture(t *testing.T) {
+	dir := os.Getenv("BMW_GEN_DIR")
+	if dir == "" {
+		t.Skip("set BMW_GEN_DIR to generate a synthetic inverted bucket")
+	}
+	docs := envInt("BMW_GEN_DOCS", 50000)
+	vocab := envInt("BMW_GEN_VOCAB", 2000)
+	segments := envInt("BMW_GEN_SEGMENTS", 4)
+	rng := rand.New(rand.NewSource(int64(envInt("BMW_GEN_SEED", 7))))
+	zipf := rand.NewZipf(rng, 1.2, 1, uint64(vocab-1))
+
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	b, err := NewBucketCreator().NewBucket(context.Background(), dir, dir, bmwQuietLogger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	b.SetMemtableThreshold(1 << 30)
+	defer func() { require.NoError(t, b.Shutdown(context.Background())) }()
+
+	segBoundary := docs / maxI(segments, 1)
+	for docID := 0; docID < docs; docID++ {
+		nTerms := 5 + rng.Intn(45)
+		used := make(map[uint64]struct{}, nTerms)
+		for j := 0; j < nTerms; j++ {
+			tid := zipf.Uint64()
+			if _, ok := used[tid]; ok {
+				continue
+			}
+			used[tid] = struct{}{}
+			pair := NewMapPairFromDocIdAndTf(uint64(docID), float32(1+rng.Intn(8)), float32(nTerms), false)
+			require.NoError(t, b.MapSet([]byte(fmt.Sprintf("term%06d", tid)), pair))
+		}
+		if segBoundary > 0 && docID > 0 && docID%segBoundary == 0 {
+			require.NoError(t, b.FlushAndSwitch())
+		}
+	}
+	require.NoError(t, b.FlushAndSwitch())
+	t.Logf("generated synthetic inverted bucket at %s (docs=%d vocab=%d segments~=%d)", dir, docs, vocab, segments)
+}
+
+func maxI(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func perQ(v uint64, n int) float64 {
+	if n == 0 {
+		return 0
+	}
+	return float64(v) / float64(n)
+}
+
+// reportHotspots parses a pprof profile and prints flat (self) and cumulative
+// rankings, filtered to the BlockMax-relevant packages, then a short unfiltered
+// view for context (GC, syscalls, etc.).
+func reportHotspots(t *testing.T, path, valueType, unit string, divisor float64, topN int) {
+	f, err := os.Open(path)
+	if err != nil {
+		t.Logf("cannot open profile %s: %v", path, err)
+		return
+	}
+	defer f.Close()
+	p, err := profile.Parse(f)
+	if err != nil {
+		t.Logf("cannot parse profile %s: %v", path, err)
+		return
+	}
+
+	flat, cum, total := aggregateProfile(p, valueType)
+	if total == 0 {
+		t.Logf("profile %s has no %s samples (run longer or raise BMW_PROFILE_QUERIES)", path, valueType)
+		return
+	}
+
+	if valueType == "cpu" && total < 5_000_000_000 { // < ~5s of CPU samples
+		t.Logf("WARNING: only %.0fms of CPU samples — low confidence. Raise BMW_PROFILE_QUERIES and/or point at a larger BMW_SEGMENTS_DIR for a meaningful CPU profile (the alloc profile below is exact regardless).", float64(total)/1e6)
+	}
+	t.Logf("\n========== HOTSPOTS: %s (total %.1f %s) ==========", valueType, float64(total)/divisor, unit)
+	printTable(t, fmt.Sprintf("BlockMax FLAT (self %s) — optimize these first", unit), flat, total, unit, divisor, topN, isBMWFunc)
+	printTable(t, fmt.Sprintf("BlockMax CUMULATIVE (%s incl. callees)", unit), cum, total, unit, divisor, topN, isBMWFunc)
+	printTable(t, "All packages FLAT (context: GC/syscall/runtime)", flat, total, unit, divisor, 15, nil)
+}
+
+func isBMWFunc(name string) bool {
+	for _, p := range bmwPackages {
+		if strings.Contains(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func aggregateProfile(p *profile.Profile, valueType string) (flat, cum map[string]int64, total int64) {
+	idx := -1
+	for i, st := range p.SampleType {
+		if st.Type == valueType {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		idx = len(p.SampleType) - 1
+	}
+
+	flat = map[string]int64{}
+	cum = map[string]int64{}
+	for _, s := range p.Sample {
+		if idx >= len(s.Value) {
+			continue
+		}
+		v := s.Value[idx]
+		if v <= 0 {
+			continue
+		}
+		total += v
+
+		// leaf (self): innermost frame of the top location
+		if len(s.Location) > 0 && len(s.Location[0].Line) > 0 {
+			if fn := s.Location[0].Line[0].Function; fn != nil {
+				flat[fn.Name] += v
+			}
+		}
+
+		// cumulative: each distinct function appearing anywhere in the stack
+		seen := map[string]struct{}{}
+		for _, loc := range s.Location {
+			for _, ln := range loc.Line {
+				if ln.Function == nil {
+					continue
+				}
+				if _, ok := seen[ln.Function.Name]; ok {
+					continue
+				}
+				seen[ln.Function.Name] = struct{}{}
+				cum[ln.Function.Name] += v
+			}
+		}
+	}
+	return flat, cum, total
+}
+
+func printTable(t *testing.T, title string, m map[string]int64, total int64, unit string, divisor float64, topN int, filter func(string) bool) {
+	type row struct {
+		name string
+		v    int64
+	}
+	rows := make([]row, 0, len(m))
+	for name, v := range m {
+		if filter != nil && !filter(name) {
+			continue
+		}
+		rows = append(rows, row{name, v})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].v > rows[j].v })
+	if len(rows) > topN {
+		rows = rows[:topN]
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "\n--- %s ---\n", title)
+	fmt.Fprintf(&sb, "%8s  %7s  %s\n", unit, "%", "function")
+	for _, r := range rows {
+		fmt.Fprintf(&sb, "%8.1f  %6.2f%%  %s\n", float64(r.v)/divisor, 100*float64(r.v)/float64(total), shortFunc(r.name))
+	}
+	t.Log(sb.String())
+}
+
+func shortFunc(name string) string {
+	name = strings.TrimPrefix(name, "github.com/weaviate/weaviate/")
+	name = strings.TrimPrefix(name, "github.com/weaviate/")
+	return name
+}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1155,9 +1155,9 @@ func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsi
 
 		segmentStrategy := segmentsDisk[i].getStrategy()
 
-		propLengths := make(map[uint64]uint32)
+		var propLengths propLengthsView
 		if segmentStrategy == segmentindex.StrategyInverted {
-			propLengths, err = segmentsDisk[i].getPropertyLengths()
+			propLengths, err = segmentsDisk[i].propLengthsView()
 			if err != nil {
 				return nil, err
 			}
@@ -1180,7 +1180,7 @@ func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsi
 					}
 				}
 				// put the property length in the value from the "external" property lengths
-				binary.LittleEndian.PutUint32(segmentDecoded[j].Value[4:], math.Float32bits(float32(propLengths[docId])))
+				binary.LittleEndian.PutUint32(segmentDecoded[j].Value[4:], math.Float32bits(float32(propLengths.get(docId))))
 
 			} else {
 				if err := segmentDecoded[j].FromBytes(v.value, false); err != nil {
@@ -2045,9 +2045,9 @@ func (b *Bucket) docPointerWithScoreListFromConsistentView(ctx context.Context, 
 
 		segmentStrategy := segmentsDisk[i].getStrategy()
 
-		propLengths := make(map[uint64]uint32)
+		var propLengths propLengthsView
 		if segmentStrategy == segmentindex.StrategyInverted {
-			propLengths, err = segmentsDisk[i].getPropertyLengths()
+			propLengths, err = segmentsDisk[i].propLengthsView()
 			if err != nil {
 				return nil, err
 			}
@@ -2057,7 +2057,7 @@ func (b *Bucket) docPointerWithScoreListFromConsistentView(ctx context.Context, 
 		for j, v := range plist {
 			if segmentStrategy == segmentindex.StrategyInverted {
 				docId := binary.BigEndian.Uint64(v.value[:8])
-				propLen := propLengths[docId]
+				propLen := propLengths.get(docId)
 				if err := segmentDecoded[j].FromBytesInverted(v.value, propBoost, float32(propLen)); err != nil {
 					return nil, err
 				}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2157,70 +2157,100 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 	// active memtable
 	output[len(view.Disk)+1] = make([]*SegmentBlockMax, 0, len(query))
 
+	// memtable tombstones are invariant within a consistent view; read them once
+	// per query instead of cloning + OR-ing the same bitmaps for every term.
 	memTombstones := sroar.NewBitmap()
+	var activeTombstones *sroar.Bitmap
+	if view.Active != nil {
+		activeTombstones, err = view.Active.ReadOnlyTombstones()
+		if err != nil {
+			view.ReleaseView()
+			return nil, nil, func() {}, fmt.Errorf("active tombstones: %w", err)
+		}
+		memTombstones.Or(activeTombstones)
+	}
+	if view.Flushing != nil {
+		flushingTombstones, err := view.Flushing.ReadOnlyTombstones()
+		if err != nil {
+			view.ReleaseView()
+			return nil, nil, func() {}, fmt.Errorf("flushing tombstones: %w", err)
+		}
+		memTombstones.Or(flushingTombstones)
+	}
+
+	// per-(segment, term) index nodes prefetched together with the doc counts in
+	// a single index descent (hasKey, getDocCount and the term constructor each
+	// did their own before). diskSkip marks inverted segments where the key is
+	// definitively absent, so construction is not attempted at all.
+	qn := len(query)
+	diskNodes := make([]segmentindex.Node, len(view.Disk)*qn)
+	diskNodeOk := make([]bool, len(view.Disk)*qn)
+	diskSkip := make([]bool, len(view.Disk)*qn)
 
 	for i, queryTerm := range query {
 		key := []byte(queryTerm)
 		n := uint64(0)
 
-		active := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
-		flushing := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
-
-		var activeTombstones *sroar.Bitmap
+		// memtable terms are built only when the memtable actually holds the key
+		// (the common case is that it doesn't — or there is no memtable at all).
+		var active, flushing *SegmentBlockMax
 		if view.Active != nil {
-			n2, _ := fillTerm(view.Active, key, active, filterDocIds)
-			if active.Count() > 0 {
-				output[len(view.Disk)+1] = append(output[len(view.Disk)+1], active)
-			}
-			n += n2
+			if mapPairs, err := view.Active.getMap(key); err == nil {
+				if active = NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config); active != nil {
+					n2, _ := addDataToTerm(mapPairs, filterDocIds, active)
+					if active.Count() > 0 {
+						output[len(view.Disk)+1] = append(output[len(view.Disk)+1], active)
+					}
+					n += n2
 
-			activeTombstones, err = view.Active.ReadOnlyTombstones()
-			if err != nil {
-				view.ReleaseView()
-				return nil, nil, func() {}, fmt.Errorf("active tombstones: %w", err)
-			}
-			memTombstones.Or(activeTombstones)
-
-			if !active.Exhausted() {
-				active.advanceOnTombstoneOrFilter()
+					if !active.Exhausted() {
+						active.advanceOnTombstoneOrFilter()
+					}
+				}
 			}
 		}
 
 		if view.Flushing != nil {
-			n2, _ := fillTerm(view.Flushing, key, flushing, filterDocIds)
-			if flushing.Count() > 0 {
-				output[len(view.Disk)] = append(output[len(view.Disk)], flushing)
-			}
-			n += n2
+			if mapPairs, err := view.Flushing.getMap(key); err == nil {
+				if flushing = NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config); flushing != nil {
+					n2, _ := addDataToTerm(mapPairs, filterDocIds, flushing)
+					if flushing.Count() > 0 {
+						output[len(view.Disk)] = append(output[len(view.Disk)], flushing)
+					}
+					n += n2
 
-			tombstones, err := view.Flushing.ReadOnlyTombstones()
-			if err != nil {
-				view.ReleaseView()
-				return nil, nil, func() {}, fmt.Errorf("flushing tombstones: %w", err)
+					if !flushing.Exhausted() {
+						flushing.tombstones = activeTombstones
+						flushing.advanceOnTombstoneOrFilter()
+					}
+				}
 			}
-			memTombstones.Or(tombstones)
-
-			if !flushing.Exhausted() {
-				flushing.tombstones = activeTombstones
-				flushing.advanceOnTombstoneOrFilter()
-			}
-
 		}
 
-		for _, segment := range view.Disk {
-			if segment.getStrategy() == segmentindex.StrategyInverted && segment.hasKey(key) {
-				n += segment.getDocCount(key)
+		for j, segment := range view.Disk {
+			if segment.getStrategy() != segmentindex.StrategyInverted {
+				continue
+			}
+			if node, docCount, ok := segment.getInvertedNodeAndDocCount(key); ok {
+				n += docCount
+				diskNodes[j*qn+i] = node
+				diskNodeOk[j*qn+i] = true
+			} else {
+				diskSkip[j*qn+i] = true
 			}
 		}
 
 		// we can only know the full n after we have checked all segments and all memtables
 		idfs[i] = math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateTextBoosts[i])
 
-		active.idf = idfs[i]
-		active.currentBlockImpact = float32(idfs[i])
-
-		flushing.idf = idfs[i]
-		flushing.currentBlockImpact = float32(idfs[i])
+		if active != nil {
+			active.idf = idfs[i]
+			active.currentBlockImpact = float32(idfs[i])
+		}
+		if flushing != nil {
+			flushing.idf = idfs[i]
+			flushing.currentBlockImpact = float32(idfs[i])
+		}
 
 		idfCounts[queryTerm] = n
 	}
@@ -2243,7 +2273,17 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		}
 
 		for i, key := range query {
-			term := segment.newSegmentBlockMax([]byte(key), i, idfs[i], propertyBoost, segTombstones, memTombstones, filterDocIds, averagePropLength, config)
+			idx := j*qn + i
+			if diskSkip[idx] {
+				continue
+			}
+			// non-inverted segments have no prefetched node; the constructor
+			// falls back to its own index lookup exactly as before.
+			var node *segmentindex.Node
+			if diskNodeOk[idx] {
+				node = &diskNodes[idx]
+			}
+			term := segment.newSegmentBlockMax(node, []byte(key), i, idfs[i], propertyBoost, segTombstones, memTombstones, filterDocIds, averagePropLength, config)
 			if term != nil {
 				output[j] = append(output[j], term)
 			}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2301,8 +2301,8 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		return n, nil
 	}
 	term.exhausted = false
-	term.blockEntries = make([]*terms.BlockEntry, 1)
-	term.blockEntries[0] = &terms.BlockEntry{
+	term.blockEntries = make([]terms.BlockEntry, 1)
+	term.blockEntries[0] = terms.BlockEntry{
 		MaxId:  term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],
 		Offset: 0,
 	}

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -2463,7 +2463,7 @@ func validateMapPairListVsBlockMaxSearchFromSegments(ctx context.Context, segmen
 		duplicateTextBoosts[0] = 1
 		diskTerms := make([][]*SegmentBlockMax, 0, len(segments))
 		for _, segment := range segments {
-			bmws := segment.newSegmentBlockMax(mapKey, 0, 1, 1, nil, nil, nil, 3, bm25config)
+			bmws := segment.newSegmentBlockMax(nil, mapKey, 0, 1, 1, nil, nil, nil, 3, bm25config)
 			diskTerms = append(diskTerms, []*SegmentBlockMax{bmws})
 		}
 

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -19,20 +19,14 @@ import (
 )
 
 type segmentCursorInvertedReusable struct {
-	segment     *segment
-	nextOffset  uint64
-	nodeBuf     binarySearchNodeMap
-	propLengths map[uint64]uint32
+	segment    *segment
+	nextOffset uint64
+	nodeBuf    binarySearchNodeMap
 }
 
 func (s *segment) newInvertedCursorReusable() *segmentCursorInvertedReusable {
-	propLengths, err := s.getPropertyLengths()
-	if err != nil {
-		return nil
-	}
 	return &segmentCursorInvertedReusable{
-		segment:     s,
-		propLengths: propLengths,
+		segment: s,
 	}
 }
 

--- a/adapters/repos/db/lsmkv/gobenc/gobenc.go
+++ b/adapters/repos/db/lsmkv/gobenc/gobenc.go
@@ -133,6 +133,104 @@ func Decode(data []byte) (map[uint64]uint32, error) {
 	return m, nil
 }
 
+// DecodePairs deserializes gob-encoded map[uint64]uint32 bytes into two
+// parallel slices, pre-allocated at the exact entry count from the stream —
+// the map is never materialized. Entries are returned in stream order (gob
+// writes map iteration order, i.e. effectively random); callers sort.
+func DecodePairs(data []byte) ([]uint64, []uint32, error) {
+	ids, lens, err := decodePairsFast(data)
+	if err == nil {
+		return ids, lens, nil
+	}
+
+	// Fallback to stdlib gob for unexpected formats
+	dec := gob.NewDecoder(bytes.NewReader(data))
+	m := map[uint64]uint32{}
+	if gobErr := dec.Decode(&m); gobErr != nil {
+		return nil, nil, fmt.Errorf("gobenc: fast decode failed (%w), gob fallback also failed: %w", err, gobErr)
+	}
+	ids = make([]uint64, 0, len(m))
+	lens = make([]uint32, 0, len(m))
+	for k, v := range m {
+		ids = append(ids, k)
+		lens = append(lens, v)
+	}
+	return ids, lens, nil
+}
+
+func decodePairsFast(data []byte) ([]uint64, []uint32, error) {
+	preambleLen, typeID, err := parseGobMapPreamble(data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pos := preambleLen
+
+	msgLen, n, err := readGobUint(data, pos)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read message length: %w", err)
+	}
+	pos += n
+
+	if msgLen > uint64(len(data)-pos) {
+		return nil, nil, fmt.Errorf("message length %d exceeds data (%d bytes remaining)", msgLen, len(data)-pos)
+	}
+	msgEnd := pos + int(msgLen)
+
+	prefixID, n, err := readGobInt(data, pos)
+	if err != nil || pos+n >= msgEnd {
+		return nil, nil, fmt.Errorf("data prefix truncated")
+	}
+	if prefixID != typeID {
+		return nil, nil, fmt.Errorf("data prefix mismatch")
+	}
+	pos += n
+	if data[pos] != 0x00 {
+		return nil, nil, fmt.Errorf("data prefix mismatch")
+	}
+	pos++
+
+	count, n, err := readGobUint(data, pos)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read map count: %w", err)
+	}
+	pos += n
+
+	// Each entry is at least 2 bytes (1 byte key + 1 byte value).
+	if count > uint64(msgEnd-pos)/2 {
+		return nil, nil, fmt.Errorf("count %d too large for remaining %d bytes", count, msgEnd-pos)
+	}
+
+	ids := make([]uint64, count)
+	lens := make([]uint32, count)
+
+	for i := range count {
+		key, n, err := readGobUint(data, pos)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read key %d: %w", i, err)
+		}
+		pos += n
+
+		val, n, err := readGobUint(data, pos)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read value %d: %w", i, err)
+		}
+		pos += n
+
+		if val > math.MaxUint32 {
+			return nil, nil, fmt.Errorf("value %d at index %d overflows uint32", val, i)
+		}
+		ids[i] = key
+		lens[i] = uint32(val)
+	}
+
+	if pos != msgEnd {
+		return nil, nil, fmt.Errorf("trailing bytes: decoded to offset %d, expected %d", pos, msgEnd)
+	}
+
+	return ids, lens, nil
+}
+
 func decodeFast(data []byte) (map[uint64]uint32, error) {
 	preambleLen, typeID, err := parseGobMapPreamble(data)
 	if err != nil {

--- a/adapters/repos/db/lsmkv/lazy_segment.go
+++ b/adapters/repos/db/lsmkv/lazy_segment.go
@@ -369,17 +369,22 @@ func (s *lazySegment) newInvertedCursorReusable() *segmentCursorInvertedReusable
 	return s.segment.newInvertedCursorReusable()
 }
 
-func (s *lazySegment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64,
+func (s *lazySegment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64,
 	propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList,
 	averagePropLength float64, config schema.BM25Config,
 ) *SegmentBlockMax {
 	s.mustLoad()
-	return s.segment.newSegmentBlockMax(key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+	return s.segment.newSegmentBlockMax(node, key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
 }
 
 func (s *lazySegment) getDocCount(key []byte) uint64 {
 	s.mustLoad()
 	return s.segment.getDocCount(key)
+}
+
+func (s *lazySegment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	s.mustLoad()
+	return s.segment.getInvertedNodeAndDocCount(key)
 }
 
 func (s *lazySegment) getCountNetAdditions() int {

--- a/adapters/repos/db/lsmkv/lazy_segment.go
+++ b/adapters/repos/db/lsmkv/lazy_segment.go
@@ -364,6 +364,13 @@ func (s *lazySegment) getPropertyLengths() (map[uint64]uint32, error) {
 	return s.segment.getPropertyLengths()
 }
 
+func (s *lazySegment) propLengthsView() (propLengthsView, error) {
+	if err := s.load(); err != nil {
+		return propLengthsView{}, fmt.Errorf("lazySegment::propLengthsView: %w", err)
+	}
+	return s.segment.propLengthsView()
+}
+
 func (s *lazySegment) newInvertedCursorReusable() *segmentCursorInvertedReusable {
 	s.mustLoad()
 	return s.segment.newInvertedCursorReusable()

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -111,11 +111,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		upperBound = float32(0)
-		for i := 0; i <= pivotPoint; i++ {
+		// reslice to [0,pivotPoint] (pivotPoint < len, guaranteed by the pivotID
+		// check above) so the compiler drops the per-iteration bounds check.
+		candidates := results[:pivotPoint+1]
+		for i := range candidates {
 			// exhausted terms carry currentBlockMaxId==MaxUint64 (so the shallow
 			// advance is skipped) and currentBlockImpact==0 (so the add is a no-op),
 			// so no explicit exhausted guard is needed here.
-			t := results[i]
+			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
 				t.AdvanceAtLeastShallow(pivotID)
 			}
@@ -123,14 +126,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
-			if additionalExplanations {
-				docInfos = make([]*terms.DocPointerWithScore, termCount)
-			}
-			if pivotID == results[firstNonExhausted].idPointer {
+			firstTerm := results[firstNonExhausted]
+			if pivotID == firstTerm.idPointer {
 				// a deferred tombstone hit: advance the aligned terms past the pivot
 				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
-				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
+				pivotTombstoned := deferTombstoneToScore && firstTerm.tombstoned(pivotID)
 				if !pivotTombstoned {
+					if additionalExplanations {
+						docInfos = make([]*terms.DocPointerWithScore, termCount)
+					}
 					score := 0.0
 					termsMatched := 0
 					for _, term := range results {
@@ -180,13 +184,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			maxWeight := results[nextList].idf
 			next := uint64(math.MaxUint64) // max uint
 
-			for i := 0; i <= pivotPoint; i++ {
-				if i < pivotPoint && results[i].idf > maxWeight {
+			candidates := results[:pivotPoint+1]
+			for i := range candidates {
+				t := candidates[i]
+				if i < pivotPoint && t.idf > maxWeight {
 					nextList = i
-					maxWeight = results[i].idf
+					maxWeight = t.idf
 				}
-				if results[i].currentBlockMaxId < next {
-					next = results[i].currentBlockMaxId
+				if t.currentBlockMaxId < next {
+					next = t.currentBlockMaxId
 				}
 			}
 
@@ -230,40 +236,41 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 		return topKHeap
 	}
 
+	ctxCheck := 0
 	for {
 		iterations++
 
-		if iterations%100000 == 0 && ctx != nil && ctx.Err() != nil {
-			segmentPath := ""
-			terms := ""
-			filterCardinality := -1
-			for _, r := range results {
-				if r == nil {
-					continue
-				}
-				if r.segment != nil {
-					segmentPath = r.segment.path
-					if r.filterDocIds != nil {
-						filterCardinality = r.filterDocIds.Len()
+		// periodic cancellation check; countdown instead of a 64-bit modulo on the
+		// hot loop (same change as DoBlockMaxWand), same every-100000 cadence.
+		ctxCheck++
+		if ctxCheck == 100000 {
+			ctxCheck = 0
+			if ctx != nil && ctx.Err() != nil {
+				segmentPath := ""
+				terms := ""
+				filterCardinality := -1
+				for _, r := range results {
+					if r == nil {
+						continue
 					}
+					if r.segment != nil {
+						segmentPath = r.segment.path
+						if r.filterDocIds != nil {
+							filterCardinality = r.filterDocIds.Len()
+						}
+					}
+					terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
 				}
-				terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
-			}
-			logger.WithFields(logrus.Fields{
-				"segment":           segmentPath,
-				"iterations":        iterations,
-				"pivotID":           pivotID,
-				"lenResults":        len(results),
-				"upperBound":        upperBound,
-				"terms":             terms,
-				"filterCardinality": filterCardinality,
-				"limit":             limit,
-			}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
-			return topKHeap
-		}
-
-		for i := 0; i < len(results); i++ {
-			if results[i].exhausted {
+				logger.WithFields(logrus.Fields{
+					"segment":           segmentPath,
+					"iterations":        iterations,
+					"pivotID":           pivotID,
+					"lenResults":        len(results),
+					"upperBound":        upperBound,
+					"terms":             terms,
+					"filterCardinality": filterCardinality,
+					"limit":             limit,
+				}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
 				return topKHeap
 			}
 		}
@@ -276,12 +283,17 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 
 		pivotID = results[0].idPointer
 
+		// AND is terminal the instant any term exhausts: no higher doc id can align
+		// across every term, so the heap is frozen and we return at the advance site
+		// rather than rescanning all terms at the top of each iteration. results[0]
+		// is covered just above; the others can only exhaust here or in the
+		// candidate-advance loop below.
+		upperBound = results[0].currentBlockImpact
 		for i := 1; i < len(results); i++ {
 			results[i].AdvanceAtLeastShallow(pivotID)
-		}
-
-		upperBound = float32(0)
-		for i := 0; i < len(results); i++ {
+			if results[i].exhausted {
+				return topKHeap
+			}
 			upperBound += results[i].currentBlockImpact
 		}
 
@@ -289,6 +301,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 			isCandidate := true
 			for i := 1; i < len(results); i++ {
 				results[i].AdvanceAtLeast(pivotID)
+				if results[i].exhausted {
+					return topKHeap
+				}
 				if results[i].idPointer != pivotID {
 					isCandidate = false
 					break

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -127,29 +127,34 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 				docInfos = make([]*terms.DocPointerWithScore, termCount)
 			}
 			if pivotID == results[firstNonExhausted].idPointer {
-				score := 0.0
-				termsMatched := 0
-				for _, term := range results {
-					if term.idPointer != pivotID {
-						break
-					}
-					termsMatched++
-					_, s, d := term.Score(averagePropLength, additionalExplanations)
-					score += s
+				// a deferred tombstone hit: advance the aligned terms past the pivot
+				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
+				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
+				if !pivotTombstoned {
+					score := 0.0
+					termsMatched := 0
+					for _, term := range results {
+						if term.idPointer != pivotID {
+							break
+						}
+						termsMatched++
+						_, s, d := term.Score(averagePropLength, additionalExplanations)
+						score += s
 
-					if additionalExplanations {
-						docInfos[term.QueryTermIndex()] = d
-					}
+						if additionalExplanations {
+							docInfos[term.QueryTermIndex()] = d
+						}
 
+					}
+					if topKHeap.ShouldEnqueue(float32(score), limit) && termsMatched >= minimumOrTokensMatch {
+						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+					}
 				}
 				for _, term := range results {
 					if !term.exhausted && term.idPointer != pivotID {
 						break
 					}
 					term.Advance()
-				}
-				if topKHeap.ShouldEnqueue(float32(score), limit) && termsMatched >= minimumOrTokensMatch {
-					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 				}
 
 				results.sortByID()
@@ -290,20 +295,28 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 				}
 			}
 			if isCandidate {
-				score := 0.0
-				if additionalExplanations {
-					docInfos = make([]*terms.DocPointerWithScore, termCount)
-				}
-				for _, term := range results {
-					_, s, d := term.Score(averagePropLength, additionalExplanations)
-					score += s
-					if additionalExplanations {
-						docInfos[term.QueryTermIndex()] = d
+				// deferred tombstone hit (see deferTombstoneToScore): advance past the
+				// candidate without scoring it.
+				if deferTombstoneToScore && results[0].tombstoned(pivotID) {
+					for _, term := range results {
+						term.Advance()
 					}
-					term.Advance()
-				}
-				if topKHeap.ShouldEnqueue(float32(score), limit) {
-					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+				} else {
+					score := 0.0
+					if additionalExplanations {
+						docInfos = make([]*terms.DocPointerWithScore, termCount)
+					}
+					for _, term := range results {
+						_, s, d := term.Score(averagePropLength, additionalExplanations)
+						score += s
+						if additionalExplanations {
+							docInfos[term.QueryTermIndex()] = d
+						}
+						term.Advance()
+					}
+					if topKHeap.ShouldEnqueue(float32(score), limit) {
+						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+					}
 				}
 			} else {
 				pivotID += 1

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -38,6 +38,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	pivotID := uint64(0)
 	var pivotPoint int
 	upperBound := float32(0)
+	// needFullSort tracks whether shallow advances have run since the last full
+	// sortByID. Shallow advances move idPointers (and can exhaust terms) in place,
+	// so the slice may hold inversions or mis-placed exhausted sentinels that only
+	// a full sort repairs. While false, the matched branch can restore order with
+	// a per-advanced-term re-insertion instead of re-sorting all terms — matched
+	// iterations themselves never shallow-advance (their live prefix is already
+	// aligned, so currentBlockMaxId >= pivotID), so matched-dense queries stay on
+	// the cheap path.
+	needFullSort := false
 
 	done := ctx.Done()
 	ctxCheck := 0
@@ -123,6 +132,10 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
 				t.AdvanceAtLeastShallow(pivotID)
+				// a shallow advance moves idPointer without re-sorting (and may even
+				// exhaust mid-array), so the slice may now hold inversions that only
+				// a full sortByID repairs — see the matched branch.
+				needFullSort = true
 			}
 			upperBound += t.currentBlockImpact
 		}
@@ -156,14 +169,29 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 					}
 				}
+				advanced := 0
 				for _, term := range results {
 					if !term.exhausted && term.idPointer != pivotID {
 						break
 					}
 					term.Advance()
+					advanced++
 				}
 
-				results.sortByID()
+				if needFullSort {
+					results.sortByID()
+					needFullSort = false
+				} else {
+					// only the advanced prefix moved (each idPointer increased) and the
+					// suffix is inversion-free, so re-inserting the prefix right-to-left
+					// yields the exact permutation a full stable sortByID would: at each
+					// step the suffix is already sorted, and reinsertRight's strict `<`
+					// settles equal ids in original index order, matching insertion-sort
+					// stability.
+					for i := advanced - 1; i >= 0; i-- {
+						results.reinsertRight(i)
+					}
+				}
 
 			} else {
 				nextList := pivotPoint

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -30,7 +30,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	var docInfos []*terms.DocPointerWithScore
 	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
 	worstDist := float64(-10000) // tf score can be negative
-	sort.Sort(results)
+	results.sortByID()
 	iterations := 0
 	var firstNonExhausted int
 	pivotID := uint64(0)
@@ -130,7 +130,6 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 					termsMatched++
 					_, s, d := term.Score(averagePropLength, additionalExplanations)
 					score += s
-					upperBound -= term.currentBlockImpact - float32(s)
 
 					if additionalExplanations {
 						docInfos[term.QueryTermIndex()] = d
@@ -147,7 +146,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 				}
 
-				sort.Sort(results)
+				results.sortByID()
 
 			} else {
 				nextList := pivotPoint
@@ -168,20 +167,18 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 
 			}
 		} else {
+			// single pass over [0, pivotPoint] computing both the heaviest term to
+			// advance (over [0, pivotPoint)) and the smallest block-max id (over
+			// [0, pivotPoint]) — formerly two separate scans.
 			nextList := pivotPoint
 			maxWeight := results[nextList].Idf()
+			next := uint64(math.MaxUint64) // max uint
 
-			for i := 0; i < pivotPoint; i++ {
-				if results[i].Idf() > maxWeight {
+			for i := 0; i <= pivotPoint; i++ {
+				if i < pivotPoint && results[i].Idf() > maxWeight {
 					nextList = i
 					maxWeight = results[i].Idf()
 				}
-			}
-
-			// max uint
-			next := uint64(math.MaxUint64)
-
-			for i := 0; i <= pivotPoint; i++ {
 				if results[i].currentBlockMaxId < next {
 					next = results[i].currentBlockMaxId
 				}
@@ -372,6 +369,24 @@ func (t Terms) Less(i, j int) bool {
 
 func (t Terms) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
+}
+
+// sortByID sorts the terms ascending by idPointer with a concrete insertion
+// sort. It replaces sort.Sort on the WAND hot path: the term list is small
+// (query-term count) and, after the first pass, nearly sorted — the regime where
+// insertion sort wins — and comparing idPointer directly avoids the
+// sort.Interface Less/Swap dispatch that showed up as ~5% self time.
+func (t Terms) sortByID() {
+	for i := 1; i < len(t); i++ {
+		cur := t[i]
+		id := cur.idPointer
+		j := i - 1
+		for j >= 0 && t[j].idPointer > id {
+			t[j+1] = t[j]
+			j--
+		}
+		t[j+1] = cur
+	}
 }
 
 type TermsBySize []*SegmentBlockMax

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -38,10 +38,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	upperBound := float32(0)
 
 	done := ctx.Done()
+	ctxCheck := 0
 	for {
 		iterations++
 
-		if iterations%100000 == 0 {
+		// periodic cancellation check; a countdown avoids a 64-bit modulo on the
+		// hottest loop in BMW (the modulo was ~1.5% of self time).
+		ctxCheck++
+		if ctxCheck == 100000 {
+			ctxCheck = 0
 			select {
 			case <-done:
 				segmentPath := ""
@@ -88,7 +93,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			if firstNonExhausted == -1 {
 				firstNonExhausted = pivotPoint
 			}
-			cumScore += float64(results[pivotPoint].Idf())
+			cumScore += results[pivotPoint].idf
 			if cumScore >= worstDist {
 				pivotID = results[pivotPoint].idPointer
 				for i := pivotPoint + 1; i < len(results); i++ {
@@ -107,13 +112,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 
 		upperBound = float32(0)
 		for i := 0; i <= pivotPoint; i++ {
-			if results[i].exhausted {
-				continue
+			// exhausted terms carry currentBlockMaxId==MaxUint64 (so the shallow
+			// advance is skipped) and currentBlockImpact==0 (so the add is a no-op),
+			// so no explicit exhausted guard is needed here.
+			t := results[i]
+			if t.currentBlockMaxId < pivotID {
+				t.AdvanceAtLeastShallow(pivotID)
 			}
-			if results[i].currentBlockMaxId < pivotID {
-				results[i].AdvanceAtLeastShallow(pivotID)
-			}
-			upperBound += results[i].currentBlockImpact
+			upperBound += t.currentBlockImpact
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
@@ -155,15 +161,10 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 				}
 				results[nextList].AdvanceAtLeast(pivotID)
 
-				// sort partial
-				for i := nextList + 1; i < len(results); i++ {
-					if results[i].idPointer < results[i-1].idPointer {
-						// swap
-						results[i], results[i-1] = results[i-1], results[i]
-					} else {
-						break
-					}
-				}
+				// only results[nextList] moved (rightward), so a single re-insertion
+				// restores order — same permutation as the old swap bubble, one move
+				// per step instead of a two-write swap.
+				results.reinsertRight(nextList)
 
 			}
 		} else {
@@ -171,13 +172,13 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			// advance (over [0, pivotPoint)) and the smallest block-max id (over
 			// [0, pivotPoint]) — formerly two separate scans.
 			nextList := pivotPoint
-			maxWeight := results[nextList].Idf()
+			maxWeight := results[nextList].idf
 			next := uint64(math.MaxUint64) // max uint
 
 			for i := 0; i <= pivotPoint; i++ {
-				if i < pivotPoint && results[i].Idf() > maxWeight {
+				if i < pivotPoint && results[i].idf > maxWeight {
 					nextList = i
-					maxWeight = results[i].Idf()
+					maxWeight = results[i].idf
 				}
 				if results[i].currentBlockMaxId < next {
 					next = results[i].currentBlockMaxId
@@ -195,14 +196,13 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			}
 			results[nextList].AdvanceAtLeast(next)
 
-			for i := nextList + 1; i < len(results); i++ {
-				if results[i].idPointer < results[i-1].idPointer {
-					// swap
-					results[i], results[i-1] = results[i-1], results[i]
-				} else if results[i].exhausted && i < len(results)-1 {
-					results[i], results[i+1] = results[i+1], results[i]
-				}
-			}
+			// AdvanceAtLeast only ever increases results[nextList].idPointer (or
+			// exhausts it to MaxUint64), so the slice is sorted everywhere except
+			// that one element, which must move right. Re-insert it and stop the
+			// instant it settles — the old loop had no early break and rescanned the
+			// whole tail every iteration (its exhausted-swap branch only ever
+			// reordered MaxUint64 sentinels, which no reader observes).
+			results.reinsertRight(nextList)
 
 		}
 
@@ -369,6 +369,21 @@ func (t Terms) Less(i, j int) bool {
 
 func (t Terms) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
+}
+
+// reinsertRight restores ascending-by-idPointer order when exactly one element
+// (at index i) has had its idPointer increased and everything else is already
+// sorted. It shifts the element rightward to its slot and stops as soon as it
+// settles — O(displacement), with one move per step instead of a two-write swap.
+func (t Terms) reinsertRight(i int) {
+	cur := t[i]
+	id := cur.idPointer
+	j := i
+	for j+1 < len(t) && t[j+1].idPointer < id {
+		t[j] = t[j+1]
+		j++
+	}
+	t[j] = cur
 }
 
 // sortByID sorts the terms ascending by idPointer with a concrete insertion

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -131,11 +131,17 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			// so no explicit exhausted guard is needed here.
 			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
+				// a real shallow advance moves idPointer without re-sorting (and may
+				// even exhaust mid-array), so the slice may then hold inversions that
+				// only a full sortByID repairs — see the matched branch. blockEntryIdx
+				// changes on every actual move/exhaust but not on the early-return
+				// no-op (docCount==1 terms never initialize currentBlockMaxId, so the
+				// guard over-fires for them; the no-op must not defeat the fast path).
+				prevBlockIdx := t.blockEntryIdx
 				t.AdvanceAtLeastShallow(pivotID)
-				// a shallow advance moves idPointer without re-sorting (and may even
-				// exhaust mid-array), so the slice may now hold inversions that only
-				// a full sortByID repairs — see the matched branch.
-				needFullSort = true
+				if t.blockEntryIdx != prevBlockIdx {
+					needFullSort = true
+				}
 			}
 			upperBound += t.currentBlockImpact
 		}

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -28,7 +28,9 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	termCount, minimumOrTokensMatch int, logger logrus.FieldLogger,
 ) (*priorityqueue.Queue[[]*terms.DocPointerWithScore], error) {
 	var docInfos []*terms.DocPointerWithScore
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	results.sortByID()
 	iterations := 0
@@ -225,7 +227,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 ) *priorityqueue.Queue[[]*terms.DocPointerWithScore] {
 	results := TermsBySize(resultsByTerm)
 	var docInfos []*terms.DocPointerWithScore
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	sort.Sort(results)
 	iterations := 0
@@ -355,7 +359,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 func DoWand(ctx context.Context, limit int, results *terms.Terms, averagePropLength float64, additionalExplanations bool,
 	minimumOrTokensMatch int, logger logrus.FieldLogger,
 ) *priorityqueue.Queue[[]*terms.DocPointerWithScore] {
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	sort.Sort(results)
 	iterations := 0

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -87,9 +87,10 @@ type Segment interface {
 	// map/bmw specific
 	hasKey(key []byte) bool
 	getDocCount(key []byte) uint64
+	getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool)
 	getPropertyLengths() (map[uint64]uint32, error)
 	newInvertedCursorReusable() *segmentCursorInvertedReusable
-	newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
+	newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
 
 	// replace specific
 	getCountNetAdditions() int

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -89,6 +89,7 @@ type Segment interface {
 	getDocCount(key []byte) uint64
 	getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool)
 	getPropertyLengths() (map[uint64]uint32, error)
+	propLengthsView() (propLengthsView, error)
 	newInvertedCursorReusable() *segmentCursorInvertedReusable
 	newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
 
@@ -409,8 +410,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 			return nil, fmt.Errorf("load tombstones: %w", err)
 		}
 
-		_, err = seg.loadPropertyLengths()
-		if err != nil {
+		if err := seg.loadPropertyLengths(); err != nil {
 			return nil, fmt.Errorf("load property lengths: %w", err)
 		}
 

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -128,7 +129,7 @@ type segment struct {
 	invertedData   *segmentInvertedData
 
 	observeMetaWrite diskio.MeteredWriterCallback // used for precomputing meta (cna + bloom)
-	refCount         int
+	refCount         atomic.Int64
 
 	deleteMarkerSuffix string
 }
@@ -765,32 +766,21 @@ func (c *readObserverCache) GetOrCreate(key string, metrics *Metrics) BytesReadO
 	return observer
 }
 
-// WARNING: This method is NOT thread-safe on its own. The caller must ensure
-// that it is safe to read and manipulate the refs. In practice, this is done
-// using a SegmentGroup.segmentRefCounterLock which both protects against racy
-// access, as well as guarantees a consistent view across refs of ALL segments
-// in the group.
+// refCount is an atomic, so incRef/decRef/getRefs are individually thread-safe
+// and need no external lock. Acquiring a consistent view of refs across ALL
+// segments in a group is still serialized against compaction via the
+// SegmentGroup.maintenanceLock: incRef happens under its RLock, segment swaps
+// under its write lock, and segments awaiting drop only ever see refs decrease.
 func (s *segment) incRef() {
-	s.refCount++
+	s.refCount.Add(1)
 }
 
-// WARNING: This method is NOT thread-safe on its own. The caller must ensure
-// that it is safe to read and manipulate the refs. In practice, this is done
-// using a SegmentGroup.segmentRefCounterLock which both protects against racy
-// access, as well as guarantees a consistent view across refs of ALL segments
-// in the group.
 func (s *segment) decRef() {
-	if s.refCount <= 0 {
+	if s.refCount.Add(-1) < 0 {
 		panic("refCount already zero")
 	}
-	s.refCount--
 }
 
-// WARNING: This method is NOT thread-safe on its own. The caller must ensure
-// that it is safe to read and manipulate the refs. In practice, this is done
-// using a SegmentGroup.segmentRefCounterLock which both protects against racy
-// access, as well as guarantees a consistent view across refs of ALL segments
-// in the group.
 func (s *segment) getRefs() int {
-	return s.refCount
+	return int(s.refCount.Load())
 }

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -145,6 +145,16 @@ type BlockMetrics struct {
 }
 
 type SegmentBlockMax struct {
+	// Hot scalars read on every WAND scan iteration — kept together at the top so
+	// they share a cache line (the gated-off Metrics block sits at the tail).
+	idPointer          uint64
+	idf                float64
+	currentBlockMaxId  uint64
+	currentBlockImpact float32
+	exhausted          bool
+	decoded            bool
+	freqDecoded        bool
+
 	segment               *segment
 	node                  segmentindex.Node
 	docCount              uint64
@@ -158,23 +168,15 @@ type SegmentBlockMax struct {
 	blockDataSize         int
 	blockDataStartOffset  uint64
 	blockDataEndOffset    uint64
-	idPointer             uint64
-	idf                   float64
-	exhausted             bool
-	decoded               bool
-	freqDecoded           bool
 	queryTermIndex        int
-	Metrics               BlockMetrics
 	averagePropLength     float64
 	b                     float64
 	k1                    float64
 	propertyBoost         float64
 
-	currentBlockImpact float32
-	currentBlockMaxId  uint64
-	tombstones         *sroar.Bitmap
-	memTombstones      *sroar.Bitmap
-	filterDocIds       helpers.AllowList
+	tombstones    *sroar.Bitmap
+	memTombstones *sroar.Bitmap
+	filterDocIds  helpers.AllowList
 
 	// stateless reusable-decode functions, resolved once from the segment's
 	// codecs (doc ids and term frequencies). Func values, not an encoder
@@ -188,6 +190,10 @@ type SegmentBlockMax struct {
 	blockDatasTest   []*terms.BlockData
 
 	sectionReader *io.SectionReader
+
+	// cold: only written under collectBlockMetrics (off in production); kept last
+	// so it never separates the hot scalars above.
+	Metrics BlockMetrics
 }
 
 func (s *segment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
@@ -204,6 +210,17 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	// we can skip it and return nil for the segment
 	if filterDocIds != nil && filterDocIds.IsEmpty() {
 		return nil
+	}
+
+	// Normalize empty-but-non-nil tombstone bitmaps to nil so advanceOnTombstoneOrFilter
+	// short-circuits them instead of paying a sroar.Contains per advanced doc.
+	// memTombstones is built as a fresh sroar.NewBitmap() and is non-nil even with
+	// no in-memory deletes (the common case), which otherwise costs a probe per doc.
+	if tombstones != nil && tombstones.IsEmpty() {
+		tombstones = nil
+	}
+	if memTombstones != nil && memTombstones.IsEmpty() {
+		memTombstones = nil
 	}
 
 	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(s.invertedHeader.DataFields)

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -77,7 +77,15 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]terms.BlockEntry, 
 	if docCount <= uint64(terms.ENCODE_AS_FULL_BYTES) {
 		data := convertFixedLengthFromMemory(buf, int(docCount))
 		entries := make([]terms.BlockEntry, 1)
-		propLength := s.invertedData.propertyLengths[data.DocIds[0]]
+		// single lookup through the segment view (same unlocked read as before —
+		// prop lengths are loaded and frozen at segment open)
+		v := propLengthsView{
+			dense: s.invertedData.propLengthsDense,
+			min:   s.invertedData.propLengthsMin,
+			ids:   s.invertedData.propLengthIds,
+			lens:  s.invertedData.propLengthLens,
+		}
+		propLength := v.get(data.DocIds[0])
 		tf := data.Tfs[0]
 		entries[0] = terms.BlockEntry{
 			Offset:              0,
@@ -192,10 +200,12 @@ type SegmentBlockMax struct {
 	decodeDocIds func(data []byte, values []uint64)
 	decodeTfs    func(data []byte, values []uint64)
 
-	propLengths      map[uint64]uint32
-	propLengthsDense []uint32
-	propLengthsMin   uint64
-	blockDatasTest   []*terms.BlockData
+	// disk terms read property lengths through the cursor view over the
+	// segment's sorted pairs; the map remains only for memtable-decoded terms
+	// (addDataToTerm) and the in-memory test constructor.
+	plView         propLengthsView
+	propLengths    map[uint64]uint32
+	blockDatasTest []*terms.BlockData
 
 	sectionReader *io.SectionReader
 
@@ -400,13 +410,12 @@ func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
 func (s *SegmentBlockMax) reset() error {
 	var err error
 
-	s.propLengths, err = s.segment.getPropertyLengths()
+	// the view is a no-IO cursor over the segment's sorted pairs —
+	// getPropertyLengths would reconstruct the whole map per query.
+	s.plView, err = s.segment.propLengthsView()
 	if err != nil {
 		return err
 	}
-	// getPropertyLengths just (re)loaded and froze these; safe to read directly.
-	s.propLengthsDense = s.segment.invertedData.propLengthsDense
-	s.propLengthsMin = s.segment.invertedData.propLengthsMin
 
 	s.blockEntries, s.docCount, s.blockDataDecoded, err = s.segment.loadBlockEntries(s.node)
 	if err != nil {
@@ -595,16 +604,13 @@ func (s *SegmentBlockMax) QueryTerm() string {
 	return string(s.node.Key)
 }
 
-// propLengthOf returns the property length for a docID. It prefers the dense
-// array (a single bounds-checked index) and falls back to the map for sparse
-// segments. A docID without an entry yields 0 in both paths, so results match
-// the plain map lookup exactly.
+// propLengthOf returns the property length for a docID: the segment view for
+// disk terms (dense indexed load, or the pairs cursor — scoring visits docIDs
+// in ascending order, so the cursor is amortized O(1)), the map for
+// memtable-decoded terms. A docID without an entry yields 0 in all paths.
 func (s *SegmentBlockMax) propLengthOf(docID uint64) uint32 {
-	if s.propLengthsDense != nil {
-		if idx := docID - s.propLengthsMin; idx < uint64(len(s.propLengthsDense)) {
-			return s.propLengthsDense[idx]
-		}
-		return 0
+	if s.plView.dense != nil || s.plView.ids != nil {
+		return s.plView.get(docID)
 	}
 	return s.propLengths[docID]
 }

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -493,16 +493,23 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		return
 	}
 
-	for s.blockEntryIdx < len(s.blockEntries) && docId > s.blockEntries[s.blockEntryIdx].MaxId {
-		s.blockEntryIdx++
+	// scan with locals so the index stays in a register and the decoded/freqDecoded
+	// stores happen once after the loop instead of on every skipped block.
+	entries := s.blockEntries
+	idx := s.blockEntryIdx
+	for idx < len(entries) && docId > entries[idx].MaxId {
+		idx++
+	}
+	if idx != s.blockEntryIdx {
+		s.blockEntryIdx = idx
 		s.decoded = false
 		s.freqDecoded = false
 	}
 
-	// the loop only stops when blockEntryIdx hits the end or docId <= this
-	// block's MaxId, so the "last block, still past it" case the old condition
-	// also tested can never hold here — a bounds check is enough.
-	if s.blockEntryIdx >= len(s.blockEntries) {
+	// the loop only stops when idx hits the end or docId <= this block's MaxId,
+	// so the "last block, still past it" case the old condition also tested can
+	// never hold here — a bounds check is enough.
+	if idx >= len(entries) {
 		s.exhaust()
 		return
 	}
@@ -511,9 +518,15 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		s.decodeBlock()
 	}
 
-	for s.blockDataIdx < s.blockDataSize-1 && docId > s.blockDataDecoded.DocIds[s.blockDataIdx] {
-		s.blockDataIdx++
+	// read after decodeBlock: it rewrites the decoded buffer in place and updates
+	// blockDataSize.
+	docIDs := s.blockDataDecoded.DocIds
+	last := s.blockDataSize - 1
+	j := s.blockDataIdx
+	for j < last && docId > docIDs[j] {
+		j++
 	}
+	s.blockDataIdx = j
 
 	s.advanceOnTombstoneOrFilter()
 }
@@ -526,8 +539,9 @@ func (s *SegmentBlockMax) AdvanceAtLeastShallow(docId uint64) {
 		return
 	}
 
-	for s.blockEntryIdx < len(s.blockEntries) && docId > s.blockEntries[s.blockEntryIdx].MaxId {
-
+	// the in-loop bounds return below guarantees blockEntryIdx < len on every
+	// condition re-eval, so the index is always valid here — no length guard needed.
+	for docId > s.blockEntries[s.blockEntryIdx].MaxId {
 		s.blockEntryIdx++
 		s.blockDataIdx = 0
 		s.decoded = false

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -204,8 +204,17 @@ type SegmentBlockMax struct {
 	Metrics BlockMetrics
 }
 
-func (s *segment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
-	return NewSegmentBlockMax(s, key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+// node may carry the term's index node prefetched by getInvertedNodeAndDocCount
+// (one descent for docCount + construction); nil means look it up here.
+func (s *segment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
+	if node == nil {
+		n, err := s.index.Get(key)
+		if err != nil {
+			return nil
+		}
+		node = &n
+	}
+	return newSegmentBlockMaxFromNode(s, *node, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
 }
 
 func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
@@ -213,7 +222,10 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	if err != nil {
 		return nil
 	}
+	return newSegmentBlockMaxFromNode(s, node, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+}
 
+func newSegmentBlockMaxFromNode(s *segment, node segmentindex.Node, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	// if filter is empty after checking for tombstones,
 	// we can skip it and return nil for the segment
 	if filterDocIds != nil && filterDocIds.IsEmpty() {
@@ -257,8 +269,7 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 		sectionReader: sectionReader,
 	}
 
-	err = output.reset()
-	if err != nil {
+	if err := output.reset(); err != nil {
 		return nil
 	}
 	output.Metrics.BlockCountTotal += uint64(len(output.blockEntries))

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -26,7 +26,26 @@ import (
 
 var blockMaxBufferSize = 4096
 
-func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
+// collectBlockMetrics gates the per-doc/per-block BlockMetrics bookkeeping in the
+// scoring hot path. No production code reads these counters; the profiling
+// harness sets this true to populate them. Default false keeps Score/decodeBlock
+// free of the counter writes.
+var collectBlockMetrics = false
+
+// decodeFuncsFromCodecs resolves the stateless doc-id and tf decode functions for
+// a segment's codecs once, so per-term iterators carry func values instead of
+// allocating decoder instances.
+func decodeFuncsFromCodecs(codecs []varenc.VarEncDataType) (docIds, tfs func(data []byte, values []uint64)) {
+	if len(codecs) > 0 {
+		docIds = varenc.GetDecodeFunc(codecs[0])
+	}
+	if len(codecs) > 1 {
+		tfs = varenc.GetDecodeFunc(codecs[1])
+	}
+	return docIds, tfs
+}
+
+func (s *segment) loadBlockEntries(node segmentindex.Node) ([]terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
 	var buf []byte
 	if s.readFromMemory {
 		buf = s.contents[node.Start : node.Start+uint64(8+12*terms.ENCODE_AS_FULL_BYTES)]
@@ -49,10 +68,10 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry,
 
 	if docCount <= uint64(terms.ENCODE_AS_FULL_BYTES) {
 		data := convertFixedLengthFromMemory(buf, int(docCount))
-		entries := make([]*terms.BlockEntry, 1)
+		entries := make([]terms.BlockEntry, 1)
 		propLength := s.invertedData.propertyLengths[data.DocIds[0]]
 		tf := data.Tfs[0]
-		entries[0] = &terms.BlockEntry{
+		entries[0] = terms.BlockEntry{
 			Offset:              0,
 			MaxId:               data.DocIds[len(data.DocIds)-1],
 			MaxImpactTf:         uint32(tf),
@@ -64,7 +83,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry,
 
 	blockCount := (docCount + uint64(terms.BLOCK_SIZE-1)) / uint64(terms.BLOCK_SIZE)
 
-	entries := make([]*terms.BlockEntry, blockCount)
+	entries := make([]terms.BlockEntry, blockCount)
 	if s.readFromMemory {
 		buf = s.contents[node.Start+16 : node.Start+16+uint64(blockCount*20)]
 	} else {
@@ -82,7 +101,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry,
 	}
 
 	for i := 0; i < int(blockCount); i++ {
-		entries[i] = terms.DecodeBlockEntry(buf[i*20 : (i+1)*20])
+		terms.DecodeBlockEntryInto(buf[i*20:(i+1)*20], &entries[i])
 	}
 
 	return entries, docCount, nil, nil
@@ -129,7 +148,7 @@ type SegmentBlockMax struct {
 	segment               *segment
 	node                  segmentindex.Node
 	docCount              uint64
-	blockEntries          []*terms.BlockEntry
+	blockEntries          []terms.BlockEntry
 	blockEntryIdx         int
 	blockDataBufferOffset uint64
 	blockDataBuffer       []byte
@@ -157,11 +176,16 @@ type SegmentBlockMax struct {
 	memTombstones      *sroar.Bitmap
 	filterDocIds       helpers.AllowList
 
-	// at position 0 we have the doc ids decoder, at position 1 is the tfs decoder
-	decoders []varenc.VarEncEncoder[uint64]
+	// stateless reusable-decode functions, resolved once from the segment's
+	// codecs (doc ids and term frequencies). Func values, not an encoder
+	// interface slice, so the query path allocates no per-term decoder buffers.
+	decodeDocIds func(data []byte, values []uint64)
+	decodeTfs    func(data []byte, values []uint64)
 
-	propLengths    map[uint64]uint32
-	blockDatasTest []*terms.BlockData
+	propLengths      map[uint64]uint32
+	propLengthsDense []uint32
+	propLengthsMin   uint64
+	blockDatasTest   []*terms.BlockData
 
 	sectionReader *io.SectionReader
 }
@@ -182,13 +206,7 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 		return nil
 	}
 
-	codecs := s.invertedHeader.DataFields
-	decoders := make([]varenc.VarEncEncoder[uint64], len(codecs))
-
-	for i, codec := range codecs {
-		decoders[i] = varenc.GetVarEncEncoder64(codec)
-		decoders[i].Init(terms.BLOCK_SIZE)
-	}
+	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(s.invertedHeader.DataFields)
 
 	var sectionReader *io.SectionReader
 
@@ -205,7 +223,8 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 
 		b:             config.B,
 		k1:            config.K1,
-		decoders:      decoders,
+		decodeDocIds:  decodeDocIds,
+		decodeTfs:     decodeTfs,
 		propertyBoost: float64(propertyBoost),
 		filterDocIds:  filterDocIds,
 		tombstones:    tombstones,
@@ -224,12 +243,8 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	return output
 }
 
-func NewSegmentBlockMaxTest(docCount uint64, blockEntries []*terms.BlockEntry, blockDatas []*terms.BlockData, propLengths map[uint64]uint32, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config, codecs []varenc.VarEncDataType) *SegmentBlockMax {
-	decoders := make([]varenc.VarEncEncoder[uint64], len(codecs))
-
-	for i, codec := range codecs {
-		decoders[i] = varenc.GetVarEncEncoder64(codec)
-	}
+func NewSegmentBlockMaxTest(docCount uint64, blockEntries []terms.BlockEntry, blockDatas []*terms.BlockData, propLengths map[uint64]uint32, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config, codecs []varenc.VarEncDataType) *SegmentBlockMax {
+	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(codecs)
 
 	// if filter is empty after checking for tombstones,
 	// we can skip it and return nil for the segment
@@ -245,7 +260,8 @@ func NewSegmentBlockMaxTest(docCount uint64, blockEntries []*terms.BlockEntry, b
 		averagePropLength: averagePropLength,
 		b:                 config.B,
 		k1:                config.K1,
-		decoders:          decoders,
+		decodeDocIds:      decodeDocIds,
+		decodeTfs:         decodeTfs,
 		propertyBoost:     float64(propertyBoost),
 		filterDocIds:      filterDocIds,
 		tombstones:        tombstones,
@@ -307,9 +323,16 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		return
 	}
 
-	for (s.filterDocIds != nil && !s.filterDocIds.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) ||
-		(s.tombstones != nil && s.tombstones.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) ||
-		(s.memTombstones != nil && s.memTombstones.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) {
+	for {
+		// read the current doc id once instead of re-indexing the slice in each
+		// of the up-to-three membership checks below
+		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
+		passes := (s.filterDocIds == nil || s.filterDocIds.Contains(docID)) &&
+			(s.tombstones == nil || !s.tombstones.Contains(docID)) &&
+			(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		if passes {
+			break
+		}
 		s.blockDataIdx++
 		if s.blockDataIdx > s.blockDataSize-1 {
 			if s.blockEntryIdx >= len(s.blockEntries)-1 {
@@ -334,6 +357,9 @@ func (s *SegmentBlockMax) reset() error {
 	if err != nil {
 		return err
 	}
+	// getPropertyLengths just (re)loaded and froze these; safe to read directly.
+	s.propLengthsDense = s.segment.invertedData.propLengthsDense
+	s.propLengthsMin = s.segment.invertedData.propLengthsMin
 
 	s.blockEntries, s.docCount, s.blockDataDecoded, err = s.segment.loadBlockEntries(s.node)
 	if err != nil {
@@ -341,7 +367,12 @@ func (s *SegmentBlockMax) reset() error {
 	}
 
 	if s.blockDataDecoded == nil {
-		s.blockDataBuffer = make([]byte, blockMaxBufferSize)
+		// blockDataBuffer is only read in the non-mmap path of
+		// loadBlockDataReusable; when readFromMemory we decode straight from
+		// s.contents, so allocating it would be pure dead weight per term.
+		if !s.segment.readFromMemory {
+			s.blockDataBuffer = make([]byte, blockMaxBufferSize)
+		}
 		s.blockDataDecoded = &terms.BlockDataDecoded{
 			DocIds: make([]uint64, terms.BLOCK_SIZE),
 			Tfs:    make([]uint64, terms.BLOCK_SIZE),
@@ -383,8 +414,10 @@ func (s *SegmentBlockMax) decodeBlock() error {
 		s.blockDataSize = int(s.docCount)
 		s.freqDecoded = true
 		s.decoded = true
-		s.Metrics.BlockCountDecodedDocIds++
-		s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+		if collectBlockMetrics {
+			s.Metrics.BlockCountDecodedDocIds++
+			s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+		}
 		return nil
 	}
 	if s.segment != nil {
@@ -406,9 +439,11 @@ func (s *SegmentBlockMax) decodeBlock() error {
 	if s.blockEntryIdx == len(s.blockEntries)-1 {
 		s.blockDataSize = int(s.docCount) - terms.BLOCK_SIZE*s.blockEntryIdx
 	}
-	s.decoders[0].DecodeReusable(s.blockDataEncoded.DocIds, s.blockDataDecoded.DocIds[:s.blockDataSize])
-	s.Metrics.BlockCountDecodedDocIds++
-	s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+	s.decodeDocIds(s.blockDataEncoded.DocIds, s.blockDataDecoded.DocIds[:s.blockDataSize])
+	if collectBlockMetrics {
+		s.Metrics.BlockCountDecodedDocIds++
+		s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+	}
 	s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 	s.freqDecoded = false
 	s.decoded = true
@@ -428,7 +463,10 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		s.freqDecoded = false
 	}
 
-	if (s.blockEntryIdx == len(s.blockEntries)-1 && docId > s.blockEntries[s.blockEntryIdx].MaxId) || s.blockEntryIdx >= len(s.blockEntries) {
+	// the loop only stops when blockEntryIdx hits the end or docId <= this
+	// block's MaxId, so the "last block, still past it" case the old condition
+	// also tested can never hold here — a bounds check is enough.
+	if s.blockEntryIdx >= len(s.blockEntries) {
 		s.exhaust()
 		return
 	}
@@ -464,10 +502,9 @@ func (s *SegmentBlockMax) AdvanceAtLeastShallow(docId uint64) {
 		}
 	}
 
-	if (s.blockEntryIdx == len(s.blockEntries)-1 && docId > s.blockEntries[s.blockEntryIdx].MaxId) || s.blockEntryIdx >= len(s.blockEntries) {
-		s.exhaust()
-		return
-	}
+	// the loop exits only by reaching a block with docId <= MaxId (the >= len
+	// case returns inside the loop above), so no further exhaustion check is
+	// needed here.
 	s.idPointer = s.blockEntries[s.blockEntryIdx-1].MaxId
 	s.currentBlockMaxId = s.blockEntries[s.blockEntryIdx].MaxId
 	s.currentBlockImpact = s.computeCurrentBlockImpact()
@@ -497,6 +534,20 @@ func (s *SegmentBlockMax) QueryTerm() string {
 	return string(s.node.Key)
 }
 
+// propLengthOf returns the property length for a docID. It prefers the dense
+// array (a single bounds-checked index) and falls back to the map for sparse
+// segments. A docID without an entry yields 0 in both paths, so results match
+// the plain map lookup exactly.
+func (s *SegmentBlockMax) propLengthOf(docID uint64) uint32 {
+	if s.propLengthsDense != nil {
+		if idx := docID - s.propLengthsMin; idx < uint64(len(s.propLengthsDense)) {
+			return s.propLengthsDense[idx]
+		}
+		return 0
+	}
+	return s.propLengths[docID]
+}
+
 func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation bool) (uint64, float64, *terms.DocPointerWithScore) {
 	if s.exhausted {
 		return 0, 0, nil
@@ -505,18 +556,20 @@ func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation
 	var doc *terms.DocPointerWithScore
 
 	if !s.freqDecoded {
-		s.decoders[1].DecodeReusable(s.blockDataEncoded.Tfs, s.blockDataDecoded.Tfs[:s.blockDataSize])
+		s.decodeTfs(s.blockDataEncoded.Tfs, s.blockDataDecoded.Tfs[:s.blockDataSize])
 		s.freqDecoded = true
 	}
 
 	freq := float64(s.blockDataDecoded.Tfs[s.blockDataIdx])
-	propLength := s.propLengths[s.idPointer]
+	propLength := s.propLengthOf(s.idPointer)
 	tf := freq / (freq + s.k1*((1-s.b)+s.b*(float64(propLength)/s.averagePropLength)))
-	s.Metrics.DocCountScored++
-	if s.blockEntryIdx != s.Metrics.LastAddedBlock {
-		s.Metrics.BlockCountDecodedFreqs++
-		s.Metrics.DocCountDecodedFreqs += uint64(s.blockDataSize)
-		s.Metrics.LastAddedBlock = s.blockEntryIdx
+	if collectBlockMetrics {
+		s.Metrics.DocCountScored++
+		if s.blockEntryIdx != s.Metrics.LastAddedBlock {
+			s.Metrics.BlockCountDecodedFreqs++
+			s.Metrics.DocCountDecodedFreqs += uint64(s.blockDataSize)
+			s.Metrics.LastAddedBlock = s.blockEntryIdx
+		}
 	}
 
 	if additionalExplanation {

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -32,6 +32,14 @@ var blockMaxBufferSize = 4096
 // free of the counter writes.
 var collectBlockMetrics = false
 
+// deferTombstoneToScore rejects tombstoned (deleted) docs in the DoBlockMax*
+// scoring branch rather than skipping them per advance. Filters stay at advance
+// time because they prune the WAND candidate space; a tombstone does not (the
+// deleted doc still occupies its posting slot and is still visited), so probing it
+// per advanced doc is pure overhead. Bit-identical either way — a doc dropped at
+// scoring affects neither other scores nor the heap threshold.
+var deferTombstoneToScore = true
+
 // decodeFuncsFromCodecs resolves the stateless doc-id and tf decode functions for
 // a segment's codecs once, so per-term iterators carry func values instead of
 // allocating decoder instances.
@@ -333,7 +341,8 @@ func NewSegmentBlockMaxDecoded(key []byte, queryTermIndex int, propertyBoost flo
 }
 
 func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
-	if (s.filterDocIds == nil && s.tombstones == nil && s.memTombstones == nil) || s.exhausted {
+	checkTomb := !deferTombstoneToScore && (s.tombstones != nil || s.memTombstones != nil)
+	if (s.filterDocIds == nil && !checkTomb) || s.exhausted {
 		if !s.exhausted {
 			s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 		}
@@ -344,9 +353,11 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		// read the current doc id once instead of re-indexing the slice in each
 		// of the up-to-three membership checks below
 		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
-		passes := (s.filterDocIds == nil || s.filterDocIds.Contains(docID)) &&
-			(s.tombstones == nil || !s.tombstones.Contains(docID)) &&
-			(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		passes := s.filterDocIds == nil || s.filterDocIds.Contains(docID)
+		if passes && checkTomb {
+			passes = (s.tombstones == nil || !s.tombstones.Contains(docID)) &&
+				(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		}
 		if passes {
 			break
 		}
@@ -365,6 +376,14 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 	if !s.exhausted {
 		s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 	}
+}
+
+// tombstoned reports whether docID is deleted in this iterator's view. All terms
+// in a segment share its tombstone bitmaps, so any aligned term answers for the
+// pivot.
+func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
+	return (s.tombstones != nil && s.tombstones.Contains(docID)) ||
+		(s.memTombstones != nil && s.memTombstones.Contains(docID))
 }
 
 func (s *SegmentBlockMax) reset() error {

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
@@ -98,7 +99,7 @@ type fakeSegment struct {
 	roaringRangeAdditions map[uint64]*sroar.Bitmap
 	roaringRangeDeletions *sroar.Bitmap
 	collectionStore       map[string][]value
-	refs                  int
+	refs                  atomic.Int64
 	path                  string
 	getCounter            int
 
@@ -137,15 +138,15 @@ func (f *fakeSegment) setSize(size int64) {
 }
 
 func (f *fakeSegment) incRef() {
-	f.refs++
+	f.refs.Add(1)
 }
 
 func (f *fakeSegment) decRef() {
-	f.refs--
+	f.refs.Add(-1)
 }
 
 func (f *fakeSegment) getRefs() int {
-	return f.refs
+	return int(f.refs.Load())
 }
 
 func (f *fakeSegment) indexSize() int {

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -385,6 +385,19 @@ func (s *fakeSegment) getDocCount(key []byte) uint64 {
 	return uint64(len(s.collectionStore[string(key)]))
 }
 
+func (s *fakeSegment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.strategy != segmentindex.StrategyInverted {
+		return segmentindex.Node{}, 0, false
+	}
+	pairs, ok := s.collectionStore[string(key)]
+	if !ok {
+		return segmentindex.Node{}, 0, false
+	}
+	// the fake's newSegmentBlockMax rebuilds terms from collectionStore and
+	// ignores the node, so a zero node with the right count is sufficient
+	return segmentindex.Node{Key: key}, uint64(len(pairs)), true
+}
+
 func (s *fakeSegment) getCountNetAdditions() int {
 	// NOTE: This oversimplified fake implementation ignores deletes and updates,
 	// it pretends every write is a unique insert.
@@ -429,7 +442,7 @@ func (s *fakeSegment) stripTmpExtensions(leftSegmentID, rightSegmentID string) e
 	return nil
 }
 
-func (s *fakeSegment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
+func (s *fakeSegment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	// we're taking a bit of a creative route to make this work with a fake
 	// segment. We have existing functions to create a SegmentBlockMax from a
 	// memtable which are used with real memtables. So if we convert the fake

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -221,13 +221,11 @@ func (f *fakeSegment) getCollectionBytes(key []byte) ([][]byte, error) {
 func (f *fakeSegment) getInvertedData() *segmentInvertedData {
 	return &segmentInvertedData{
 		tombstones: sroar.NewBitmap(),
-		propertyLengths: map[uint64]uint32{
-			// NOTE: we are returning hardcoded fake data here which is good enough
-			// for the purpose of this test. This could be extended to return real
-			// data if necessary in the future.
-			0: 3,
-			1: 3,
-		},
+		// NOTE: we are returning hardcoded fake data here which is good enough
+		// for the purpose of this test. This could be extended to return real
+		// data if necessary in the future.
+		propLengthIds:           []uint64{0, 1},
+		propLengthLens:          []uint32{3, 3},
 		propertyLengthsLoaded:   true,
 		tombstonesLoaded:        true,
 		avgPropertyLengthsAvg:   3.0,
@@ -411,6 +409,10 @@ func (s *fakeSegment) getCountNetAdditions() int {
 }
 
 func (s *fakeSegment) getPropertyLengths() (map[uint64]uint32, error) {
+	panic("not implemented")
+}
+
+func (s *fakeSegment) propLengthsView() (propLengthsView, error) {
 	panic("not implemented")
 }
 

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -40,8 +40,7 @@ import (
 )
 
 type SegmentGroup struct {
-	segments              []Segment
-	segmentRefCounterLock sync.Mutex
+	segments []Segment
 
 	// Holds compacted / cleaned up segments meant to be closed and removed from disk
 	// after their's refs counter drops to 0.
@@ -592,19 +591,18 @@ func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, relea
 	segments = make([]Segment, len(sg.segments))
 	copy(segments, sg.segments)
 
-	sg.segmentRefCounterLock.Lock()
+	// incRef under the RLock so the refs are taken before any compaction (which
+	// holds the write lock) can swap these segments out. refCount is atomic, so no
+	// separate refcount lock is needed.
 	for _, seg := range segments {
 		seg.incRef()
 	}
-	sg.segmentRefCounterLock.Unlock()
 	sg.maintenanceLock.RUnlock()
 
 	return segments, func() {
-		sg.segmentRefCounterLock.Lock()
 		for _, seg := range segments {
 			seg.decRef()
 		}
-		sg.segmentRefCounterLock.Unlock()
 	}
 }
 

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -552,8 +552,8 @@ func (sg *SegmentGroup) waitForReferenceCountToReachZero(segments ...Segment) {
 	var lastWarn time.Time
 	t := time.NewTicker(tickerInterval)
 	for {
-		sg.segmentRefCounterLock.Lock()
-
+		// these segments are already swapped out of the active set, so their refs
+		// only decrease; an atomic read per segment is sufficient.
 		allZero := true
 		var pos, count int
 		for i, seg := range segments {
@@ -564,8 +564,6 @@ func (sg *SegmentGroup) waitForReferenceCountToReachZero(segments ...Segment) {
 				break
 			}
 		}
-
-		sg.segmentRefCounterLock.Unlock()
 
 		if allZero {
 			return
@@ -623,33 +621,30 @@ func (sg *SegmentGroup) dropSegmentsAwaiting() (dropped int, err error) {
 	var maxWaitingSegment Segment
 	var maxWaitingRefs int
 
+	// segmentsAwaitingDrop is only touched by the (serial) compaction/cleanup
+	// cycle, and getRefs is an atomic read, so no lock is needed here.
 	toDrop := []Segment{}
-	func() {
-		sg.segmentRefCounterLock.Lock()
-		defer sg.segmentRefCounterLock.Unlock()
+	i := 0
+	for _, st := range sg.segmentsAwaitingDrop {
+		if refs := st.seg.getRefs(); refs == 0 {
+			toDrop = append(toDrop, st.seg)
+		} else {
+			sg.segmentsAwaitingDrop[i] = st
+			i++
 
-		i := 0
-		for _, st := range sg.segmentsAwaitingDrop {
-			if refs := st.seg.getRefs(); refs == 0 {
-				toDrop = append(toDrop, st.seg)
-			} else {
-				sg.segmentsAwaitingDrop[i] = st
-				i++
-
-				if !skipWarning {
-					if d := now.Sub(st.time); d >= warnThreshold {
-						waitingCount++
-						if d > maxWaitingDuration {
-							maxWaitingDuration = d
-							maxWaitingSegment = st.seg
-							maxWaitingRefs = refs
-						}
+			if !skipWarning {
+				if d := now.Sub(st.time); d >= warnThreshold {
+					waitingCount++
+					if d > maxWaitingDuration {
+						maxWaitingDuration = d
+						maxWaitingSegment = st.seg
+						maxWaitingRefs = refs
 					}
 				}
 			}
 		}
-		sg.segmentsAwaitingDrop = sg.segmentsAwaitingDrop[:i]
-	}()
+	}
+	sg.segmentsAwaitingDrop = sg.segmentsAwaitingDrop[:i]
 
 	if !skipWarning && maxWaitingDuration > 0 {
 		sg.segmentsAwaitingLastWarn = now

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -251,3 +251,25 @@ func (s *segment) getDocCount(key []byte) uint64 {
 
 	return binary.LittleEndian.Uint64(buffer)
 }
+
+// getInvertedNodeAndDocCount resolves a term's index node and posting doc count
+// with a single index descent, so the BMW setup path can reuse the node instead
+// of descending again in hasKey/getDocCount/the term constructor. Inverted
+// segments only; callers check the strategy.
+func (s *segment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.useBloomFilter && !s.bloomFilter.Test(key) {
+		return segmentindex.Node{}, 0, false
+	}
+
+	node, err := s.index.Get(key)
+	if err != nil {
+		return segmentindex.Node{}, 0, false
+	}
+
+	var buf [8]byte
+	if err = s.copyNode(buf[:], nodeOffset{node.Start, node.Start + 8}); err != nil {
+		return segmentindex.Node{}, 0, false
+	}
+
+	return node, binary.LittleEndian.Uint64(buf[:]), true
+}

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -29,16 +29,20 @@ type segmentInvertedData struct {
 	tombstones       *sroar.Bitmap
 	tombstonesLoaded bool
 
-	propertyLengths       map[uint64]uint32
+	// Property lengths in one of two representations replacing the old
+	// ~33B/entry map (exactly one is non-nil once loaded, both nil when the
+	// segment has none): a dense array indexed by docID-propLengthsMin when the
+	// docID range is ≥1/3 occupied (4B×span ≤ 12B×count — smaller than pairs AND
+	// O(1) to read), or parallel pair arrays sorted by docID for sparser
+	// segments, read through propLengthsView's cursor (amortized O(1) on the
+	// ascending-docID access pattern of scoring and posting iteration; measured
+	// 3× slower than dense on dense-shaped data, hence the split). Full-map
+	// consumers (compaction) reconstruct a transient map via getPropertyLengths.
+	propLengthsDense      []uint32
+	propLengthsMin        uint64
+	propLengthIds         []uint64
+	propLengthLens        []uint32
 	propertyLengthsLoaded bool
-
-	// Dense view of propertyLengths for the scoring hot path: indexed by
-	// docID-propLengthsMin, avoiding a per-scored-doc map probe. Built only when
-	// the docID range is dense enough to bound the extra memory (see
-	// loadPropertyLengths); nil otherwise, in which case the map is used. The map
-	// is always kept — compaction copies it wholesale.
-	propLengthsDense []uint32
-	propLengthsMin   uint64
 
 	avgPropertyLengthsAvg   float64
 	avgPropertyLengthsCount uint64
@@ -78,21 +82,21 @@ func (s *segment) loadTombstones() (*sroar.Bitmap, error) {
 	return bitmap, nil
 }
 
-func (s *segment) loadPropertyLengths() (map[uint64]uint32, error) {
+func (s *segment) loadPropertyLengths() error {
 	s.invertedData.lockInvertedData.Lock()
 	defer s.invertedData.lockInvertedData.Unlock()
 	if s.strategy != segmentindex.StrategyInverted {
-		return nil, fmt.Errorf("property only supported for inverted strategy")
+		return fmt.Errorf("property only supported for inverted strategy")
 	}
 
 	if s.invertedData.propertyLengthsLoaded {
-		return s.invertedData.propertyLengths, nil
+		return nil
 	}
 
 	buffer := make([]byte, 8*3)
 
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.PropertyLengthsOffset, s.invertedHeader.PropertyLengthsOffset + 8*3}); err != nil {
-		return nil, fmt.Errorf("copy node: %w", err)
+		return fmt.Errorf("copy node: %w", err)
 	}
 
 	s.invertedData.avgPropertyLengthsAvg = math.Float64frombits(binary.LittleEndian.Uint64(buffer))
@@ -101,52 +105,41 @@ func (s *segment) loadPropertyLengths() (map[uint64]uint32, error) {
 
 	if propertyLengthsSize == 0 {
 		s.invertedData.propertyLengthsLoaded = true
-		return s.invertedData.propertyLengths, nil
+		return nil
 	}
 
 	propertyLengthsStart := s.invertedHeader.PropertyLengthsOffset + 16 + 8
 	propertyLengthsEnd := propertyLengthsStart + propertyLengthsSize
 
 	buffer = make([]byte, propertyLengthsSize)
-
 	if err := s.copyNode(buffer, nodeOffset{propertyLengthsStart, propertyLengthsEnd}); err != nil {
-		return nil, fmt.Errorf("copy node: %w", err)
+		return fmt.Errorf("copy node: %w", err)
 	}
-	propLengths, err := gobenc.Decode(buffer)
+	ids, lens, err := gobenc.DecodePairs(buffer)
 	if err != nil {
-		return s.invertedData.propertyLengths, fmt.Errorf("decode property lengths: %w", err)
+		return fmt.Errorf("decode property lengths: %w", err)
 	}
 
 	if math.IsNaN(s.invertedData.avgPropertyLengthsAvg) || math.IsInf(s.invertedData.avgPropertyLengthsAvg, 0) {
 		// recompute property lengths average
 		var totalLength uint64
-		for _, length := range propLengths {
+		for _, length := range lens {
 			totalLength += uint64(length)
 		}
-		if s.invertedData.avgPropertyLengthsCount > 0 && len(propLengths) > 0 {
-			s.invertedData.avgPropertyLengthsAvg = float64(totalLength) / float64(len(propLengths))
+		if s.invertedData.avgPropertyLengthsCount > 0 && len(lens) > 0 {
+			s.invertedData.avgPropertyLengthsAvg = float64(totalLength) / float64(len(lens))
 		} else {
 			s.invertedData.avgPropertyLengthsAvg = 0
 		}
 	}
 
 	s.invertedData.propertyLengthsLoaded = true
-	s.invertedData.propertyLengths = propLengths
-	s.buildDensePropertyLengths(propLengths)
-	return s.invertedData.propertyLengths, nil
-}
-
-// buildDensePropertyLengths populates the dense docID->propLength view used by
-// the scoring hot path, but only when the docID range is dense enough that the
-// array stays within ~4/3 of the entry count (≈75% dense). Sparse segments keep
-// using the map so a few scattered docIDs can't blow up memory. Must be called
-// with lockInvertedData held.
-func (s *segment) buildDensePropertyLengths(propLengths map[uint64]uint32) {
-	if len(propLengths) == 0 {
-		return
+	if len(ids) == 0 {
+		return nil
 	}
-	minID, maxID := uint64(math.MaxUint64), uint64(0)
-	for id := range propLengths {
+
+	minID, maxID := ids[0], ids[0]
+	for _, id := range ids[1:] {
 		if id < minID {
 			minID = id
 		}
@@ -155,15 +148,73 @@ func (s *segment) buildDensePropertyLengths(propLengths map[uint64]uint32) {
 		}
 	}
 	span := maxID - minID + 1
-	if span > uint64(len(propLengths))/3*4 {
-		return // too sparse — keep the map only
+	if span/3 <= uint64(len(ids)) {
+		// dense enough (≥1/3 occupancy): the dense array is both smaller than the
+		// pairs (4B×span ≤ 12B×count) and O(1) to read. Fill needs no sort.
+		dense := make([]uint32, span)
+		for i, id := range ids {
+			dense[id-minID] = lens[i]
+		}
+		s.invertedData.propLengthsDense = dense
+		s.invertedData.propLengthsMin = minID
+		return nil
 	}
-	dense := make([]uint32, span)
-	for id, l := range propLengths {
-		dense[id-minID] = l
+
+	sortPropLenPairs(ids, lens)
+	s.invertedData.propLengthIds = ids
+	s.invertedData.propLengthLens = lens
+	return nil
+}
+
+// sortPropLenPairs sorts both arrays in tandem by docID using an LSD radix sort
+// over only the bytes the largest docID needs (~4 passes for realistic ID
+// ranges). Entries arrive in gob map-iteration order (random), so a comparison
+// sort would pay ~n log n interface-dispatched swaps — radix is linear and
+// allocation-bounded to one scratch copy of each array.
+func sortPropLenPairs(ids []uint64, lens []uint32) {
+	n := len(ids)
+	if n < 2 {
+		return
 	}
-	s.invertedData.propLengthsDense = dense
-	s.invertedData.propLengthsMin = minID
+	var maxID uint64
+	for _, id := range ids {
+		if id > maxID {
+			maxID = id
+		}
+	}
+
+	srcIds, srcLens := ids, lens
+	dstIds := make([]uint64, n)
+	dstLens := make([]uint32, n)
+
+	var counts [256]int
+	for shift := uint(0); maxID>>shift > 0; shift += 8 {
+		for i := range counts {
+			counts[i] = 0
+		}
+		for _, id := range srcIds {
+			counts[byte(id>>shift)]++
+		}
+		sum := 0
+		for i, c := range counts {
+			counts[i] = sum
+			sum += c
+		}
+		for i, id := range srcIds {
+			j := counts[byte(id>>shift)]
+			counts[byte(id>>shift)]++
+			dstIds[j] = id
+			dstLens[j] = srcLens[i]
+		}
+		srcIds, dstIds = dstIds, srcIds
+		srcLens, dstLens = dstLens, srcLens
+	}
+
+	// after an odd number of passes the sorted data sits in the scratch arrays
+	if &srcIds[0] != &ids[0] {
+		copy(ids, srcIds)
+		copy(lens, srcLens)
+	}
 }
 
 // ReadOnlyTombstones returns segment's tombstones
@@ -202,23 +253,177 @@ func (s *segment) MergeTombstones(other *sroar.Bitmap) (*sroar.Bitmap, error) {
 	return s.invertedData.tombstones, nil
 }
 
+// getPropertyLengths reconstructs the segment's full docID->propLength map from
+// the sorted pair arrays on every call. Full-map consumers are
+// compaction-frequency; per-query lookups go through propLengthsView instead.
 func (s *segment) getPropertyLengths() (map[uint64]uint32, error) {
 	if s.strategy != segmentindex.StrategyInverted {
 		return nil, fmt.Errorf("property length only supported for inverted strategy")
 	}
 
+	if err := s.ensurePropertyLengthsLoaded(); err != nil {
+		return nil, err
+	}
+
+	s.invertedData.lockInvertedData.RLock()
+	dense, minID := s.invertedData.propLengthsDense, s.invertedData.propLengthsMin
+	ids, lens := s.invertedData.propLengthIds, s.invertedData.propLengthLens
+	s.invertedData.lockInvertedData.RUnlock()
+
+	if dense != nil {
+		// stored lengths are always >= 1, so zero slots are exactly the absent
+		// docIDs and the reconstruction reproduces the stored key set
+		m := make(map[uint64]uint32)
+		for i, l := range dense {
+			if l != 0 {
+				m[minID+uint64(i)] = l
+			}
+		}
+		return m, nil
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	m := make(map[uint64]uint32, len(ids))
+	for i, id := range ids {
+		m[id] = lens[i]
+	}
+	return m, nil
+}
+
+func (s *segment) ensurePropertyLengthsLoaded() error {
 	s.invertedData.lockInvertedData.RLock()
 	loaded := s.invertedData.propertyLengthsLoaded
 	s.invertedData.lockInvertedData.RUnlock()
 
-	if !loaded {
-		return s.loadPropertyLengths()
+	if loaded {
+		return nil
+	}
+	return s.loadPropertyLengths()
+}
+
+// propLengthsView is a no-IO per-docID lookup over a segment's property
+// lengths: a single indexed load for dense segments, a cursor over the sorted
+// pairs otherwise. A miss returns 0, matching the map semantics this replaced.
+// The cursor exploits ascending docID access (scoring and posting iteration
+// order): lookups gallop forward from the last hit, so monotone scans are
+// amortized O(1); a backward jump restarts the search from the front.
+type propLengthsView struct {
+	dense []uint32
+	min   uint64
+	ids   []uint64
+	lens  []uint32
+	cur   int
+}
+
+func (v *propLengthsView) get(docID uint64) uint32 {
+	if v.dense != nil {
+		if idx := docID - v.min; idx < uint64(len(v.dense)) {
+			return v.dense[idx]
+		}
+		return 0
+	}
+
+	ids := v.ids
+	n := len(ids)
+	c := v.cur
+
+	if c >= n || ids[c] > docID {
+		// went backward relative to the cursor (or cursor exhausted): restart
+		c = 0
+	}
+	// short linear probe from the cursor covers the small gaps of
+	// frequent-term scans
+	for k := 0; k < 4 && c < n; k++ {
+		if ids[c] >= docID {
+			if ids[c] == docID {
+				v.cur = c + 1
+				return v.lens[c]
+			}
+			v.cur = c
+			return 0
+		}
+		c++
+	}
+	if c >= n {
+		v.cur = n
+		return 0
+	}
+
+	lo := c - 1 // ids[lo] < docID by the loop above
+	hi := n - 1
+	if ids[hi] < docID {
+		v.cur = n
+		return 0
+	}
+	// invariant: ids[lo] < docID <= ids[hi].
+	// bounded gallop first: frequent-term scans advance by small-to-medium gaps
+	// where a couple of near-cursor probes settle the window (measured faster
+	// than going straight to interpolation there)
+	for step := 4; step <= 64; step *= 4 {
+		p := lo + step
+		if p >= hi {
+			break
+		}
+		if ids[p] < docID {
+			lo = p
+		} else {
+			hi = p
+			break
+		}
+	}
+	// interpolation for the rest: the pairs are a near-uniformly thinned docID
+	// sequence, so the predicted position lands within a few entries of the
+	// target no matter how large the jump — a pure gallop paid ~log(gap)
+	// cache-missing probes there (measured +30% on rare-term queries). The
+	// budget bounds adversarial distributions; binary search finishes the rest.
+	for budget := 0; budget < 8 && hi-lo > 1; budget++ {
+		span := ids[hi] - ids[lo]
+		p := lo + 1 + int(float64(docID-ids[lo])/float64(span)*float64(hi-lo-1))
+		if p <= lo {
+			p = lo + 1
+		} else if p >= hi {
+			p = hi - 1
+		}
+		if ids[p] < docID {
+			lo = p
+		} else {
+			hi = p
+		}
+	}
+	for hi-lo > 1 {
+		mid := int(uint(lo+hi) >> 1)
+		if ids[mid] < docID {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	if ids[hi] == docID {
+		v.cur = hi + 1
+		return v.lens[hi]
+	}
+	v.cur = hi
+	return 0
+}
+
+func (s *segment) propLengthsView() (propLengthsView, error) {
+	if s.strategy != segmentindex.StrategyInverted {
+		return propLengthsView{}, fmt.Errorf("property length only supported for inverted strategy")
+	}
+
+	if err := s.ensurePropertyLengthsLoaded(); err != nil {
+		return propLengthsView{}, err
 	}
 
 	s.invertedData.lockInvertedData.RLock()
 	defer s.invertedData.lockInvertedData.RUnlock()
-
-	return s.invertedData.propertyLengths, nil
+	return propLengthsView{
+		dense: s.invertedData.propLengthsDense,
+		min:   s.invertedData.propLengthsMin,
+		ids:   s.invertedData.propLengthIds,
+		lens:  s.invertedData.propLengthLens,
+	}, nil
 }
 
 func (s *segment) hasKey(key []byte) bool {

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -32,6 +32,14 @@ type segmentInvertedData struct {
 	propertyLengths       map[uint64]uint32
 	propertyLengthsLoaded bool
 
+	// Dense view of propertyLengths for the scoring hot path: indexed by
+	// docID-propLengthsMin, avoiding a per-scored-doc map probe. Built only when
+	// the docID range is dense enough to bound the extra memory (see
+	// loadPropertyLengths); nil otherwise, in which case the map is used. The map
+	// is always kept — compaction copies it wholesale.
+	propLengthsDense []uint32
+	propLengthsMin   uint64
+
 	avgPropertyLengthsAvg   float64
 	avgPropertyLengthsCount uint64
 }
@@ -124,7 +132,38 @@ func (s *segment) loadPropertyLengths() (map[uint64]uint32, error) {
 
 	s.invertedData.propertyLengthsLoaded = true
 	s.invertedData.propertyLengths = propLengths
+	s.buildDensePropertyLengths(propLengths)
 	return s.invertedData.propertyLengths, nil
+}
+
+// buildDensePropertyLengths populates the dense docID->propLength view used by
+// the scoring hot path, but only when the docID range is dense enough that the
+// array stays within ~4/3 of the entry count (≈75% dense). Sparse segments keep
+// using the map so a few scattered docIDs can't blow up memory. Must be called
+// with lockInvertedData held.
+func (s *segment) buildDensePropertyLengths(propLengths map[uint64]uint32) {
+	if len(propLengths) == 0 {
+		return
+	}
+	minID, maxID := uint64(math.MaxUint64), uint64(0)
+	for id := range propLengths {
+		if id < minID {
+			minID = id
+		}
+		if id > maxID {
+			maxID = id
+		}
+	}
+	span := maxID - minID + 1
+	if span > uint64(len(propLengths))/3*4 {
+		return // too sparse — keep the map only
+	}
+	dense := make([]uint32, span)
+	for id, l := range propLengths {
+		dense[id-minID] = l
+	}
+	s.invertedData.propLengthsDense = dense
+	s.invertedData.propLengthsMin = minID
 }
 
 // ReadOnlyTombstones returns segment's tombstones

--- a/adapters/repos/db/lsmkv/segment_refcount_test.go
+++ b/adapters/repos/db/lsmkv/segment_refcount_test.go
@@ -1,0 +1,96 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSegmentRefCountAtomic verifies the lock-free atomic refcount: concurrent
+// incRef/decRef neither lose updates nor race. Run with -race to catch the
+// latter; the count assertions catch the former (a plain int would under-count).
+func TestSegmentRefCountAtomic(t *testing.T) {
+	t.Parallel()
+
+	s := &segment{}
+	const goroutines = 64
+	const perGoroutine = 20000
+
+	// wave 1: everyone incRefs — total must be exact (no lost increments)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				s.incRef()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, goroutines*perGoroutine, s.getRefs())
+
+	// wave 2: everyone decRefs — must land back exactly at zero
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				s.decRef()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 0, s.getRefs())
+}
+
+func TestSegmentDecRefBelowZeroPanics(t *testing.T) {
+	t.Parallel()
+	s := &segment{}
+	require.Panics(t, func() { s.decRef() })
+}
+
+// TestSegmentGroupConsistentViewConcurrent hammers the now lock-free
+// getConsistentViewOfSegments + release from many goroutines. -race proves the
+// refcount access is data-race-free without segmentRefCounterLock; the final
+// assertion proves every acquire is balanced by its release (refs return to 0).
+func TestSegmentGroupConsistentViewConcurrent(t *testing.T) {
+	t.Parallel()
+
+	segs := make([]Segment, 0, 4)
+	for i := 0; i < 4; i++ {
+		segs = append(segs, newFakeReplaceSegment(map[string][]byte{"k": []byte("v")}))
+	}
+	sg := &SegmentGroup{strategy: StrategyReplace, segments: segs}
+
+	const readers = 32
+	const iters = 10000
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_, release := sg.getConsistentViewOfSegments()
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, s := range sg.segments {
+		require.Equalf(t, 0, s.getRefs(), "segment %d should have no outstanding refs", i)
+	}
+}

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -51,41 +51,36 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 		return Node{}, lsmkv.NotFound
 	}
 	var out Node
-	rw := byteops.NewReadWriter(t.data)
+	data := t.data
+	pos := uint64(0)
 
-	// jump to the buffer until the node with _key_ is found or return a NotFound error.
-	// This function avoids allocations by reusing the same buffer for all keys and avoids memory reads by only
-	// extracting the necessary pieces of information while skipping the rest
-	NodeKeyBuffer := make([]byte, len(key))
+	// jump through the buffer until the node with _key_ is found or return a
+	// NotFound error. Node keys are compared in place against the tree data, so
+	// the descent allocates nothing; only the matched node's key is materialized
+	// (callers may keep it beyond the underlying segment's lifetime).
 	for {
 		// detect if there is no node with the wanted key.
-		if rw.Position+4 > uint64(len(t.data)) || rw.Position+4 < 4 {
+		if pos+4 > uint64(len(data)) || pos+4 < 4 {
 			return out, lsmkv.NotFound
 		}
 
-		keyLen := rw.ReadUint32()
-		if int(keyLen) > len(NodeKeyBuffer) {
-			NodeKeyBuffer = make([]byte, int(keyLen))
-		} else if int(keyLen) < len(NodeKeyBuffer) {
-			NodeKeyBuffer = NodeKeyBuffer[:keyLen]
-		}
-		_, err := rw.CopyBytesFromBuffer(uint64(keyLen), NodeKeyBuffer)
-		if err != nil {
-			return out, fmt.Errorf("copy node key: %w", err)
+		keyLen := uint64(binary.LittleEndian.Uint32(data[pos:]))
+		pos += 4
+		if pos+keyLen > uint64(len(data)) {
+			return out, fmt.Errorf("copy node key: key at %d len %d out of range", pos, keyLen)
 		}
 
-		keyEqual := bytes.Compare(key, NodeKeyBuffer)
+		keyEqual := bytes.Compare(key, data[pos:pos+keyLen])
+		pos += keyLen
 		if keyEqual == 0 {
-			out.Key = NodeKeyBuffer
-			out.Start = rw.ReadUint64()
-			out.End = rw.ReadUint64()
+			out.Key = bytes.Clone(data[pos-keyLen : pos])
+			out.Start = binary.LittleEndian.Uint64(data[pos:])
+			out.End = binary.LittleEndian.Uint64(data[pos+8:])
 			return out, nil
 		} else if keyEqual < 0 {
-			rw.MoveBufferPositionForward(2 * 8) // jump over start+end position
-			rw.Position = rw.ReadUint64()       // left child
+			pos = binary.LittleEndian.Uint64(data[pos+16:]) // skip start+end, read left child
 		} else {
-			rw.MoveBufferPositionForward(3 * 8) // jump over start+end position and left child
-			rw.Position = rw.ReadUint64()       // right child
+			pos = binary.LittleEndian.Uint64(data[pos+24:]) // skip start+end+left, read right child
 		}
 	}
 }

--- a/adapters/repos/db/lsmkv/varenc/simple.go
+++ b/adapters/repos/db/lsmkv/varenc/simple.go
@@ -84,6 +84,15 @@ func (e SimpleEncoder[T]) DecodeReusable(data []byte, values []T) {
 	}
 }
 
+// decodeSimpleUint64 is the stateless uint64 variant of DecodeReusable, used by
+// GetDecodeFunc so the read path needs no SimpleEncoder instance.
+func decodeSimpleUint64(data []byte, values []uint64) {
+	count := binary.LittleEndian.Uint64(data)
+	for i := 0; i < int(count); i++ {
+		values[i] = binary.LittleEndian.Uint64(data[8+i*8 : 8+(i+1)*8])
+	}
+}
+
 func (e *SimpleEncoder[T]) Encode(values []T) []byte {
 	e.EncodeReusable(values, e.buf)
 	return e.buf

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding.go
@@ -46,3 +46,21 @@ func GetVarEncEncoder64(t VarEncDataType) VarEncEncoder[uint64] {
 		return nil
 	}
 }
+
+// GetDecodeFunc returns a stateless reusable-decode function for the query read
+// path. Unlike GetVarEncEncoder64 it allocates no per-call buffers and needs no
+// encoder instance — DecodeReusable writes straight into the caller's slice — so
+// callers avoid one heap allocation per term and the interface dispatch. Returns
+// nil for codecs without a uint64 decoder (same contract as GetVarEncEncoder64).
+func GetDecodeFunc(t VarEncDataType) func(data []byte, values []uint64) {
+	switch t {
+	case VarIntUint64:
+		return func(data []byte, values []uint64) { decodeReusable(values, data, false) }
+	case DeltaVarIntUint64:
+		return func(data []byte, values []uint64) { decodeReusable(values, data, true) }
+	case SimpleUint64:
+		return decodeSimpleUint64
+	default:
+		return nil
+	}
+}

--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -17,12 +17,17 @@ import (
 )
 
 func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
-	if len(packed) < 8 {
+	if len(packed) < 9 {
 		return // Error handling: insufficient input or output space
 	}
 
 	// Read the first delta using BigEndian to handle byte order explicitly
 	deltas[0] = binary.BigEndian.Uint64(packed[0:8])
+
+	n := len(deltas)
+	if n <= 1 {
+		return
+	}
 
 	// Read bitsNeeded (6 bits starting from bit 2 of packed[8])
 	bitsNeeded := int((packed[8] >> 2) & 0x3F)
@@ -31,37 +36,168 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 		return
 	}
 
-	// Starting bit position after reading bitsNeeded
-	bitPos := 6
-	bytePos := 8 // Start from packed[8]
+	bnu := uint(bitsNeeded)
+	bitsMask := uint64(1)<<bnu - 1
 
-	// Initialize the bit buffer with the remaining bits in packed[8], if any
-	bitsLeft := 8 - bitPos
-	bitBuffer := uint64(packed[bytePos] & ((1 << bitsLeft) - 1))
+	bits := packed[8:]
+	bitsLen := len(bits)
 
-	bytePos++
+	// High-aligned bit reservoir:
+	//   - `buf` holds the next bits to extract in its MSB; the very next bit
+	//     to read is at position 63.
+	//   - `bitsAvail` counts valid bits, which occupy positions 63..64-bitsAvail.
+	//   - Extract: value = buf >> (64 - bnu); buf <<= bnu; bitsAvail -= bnu.
+	//   - Refill: buf |= newBits << (64 - bitsAvail - chunkBits).
+	//
+	// The 6-bit header was consumed via `packed[8]>>2`; the low 2 bits of
+	// bits[0] are the start of the first delta and seed the reservoir.
+	buf := uint64(bits[0]&0x3) << 62
+	bitsAvail := 2
+	bytePos := 1
 
-	// Precompute the mask for bitsNeeded bits
-	bitsMask := uint64((1 << bitsNeeded) - 1)
+	if bnu <= 32 {
+		// Refill 32 bits per chunk. We refill only when bitsAvail < bnu, so
+		// bitsAvail is at most 31 when we refill (bnu <= 32), keeping
+		// bitsAvail+32 <= 63 — safe to store in the reservoir.
+		if deltaDiff {
+			prev := deltas[0]
+			i := 1
+			for ; i < n; i++ {
+				if bitsAvail < int(bnu) {
+					if bytePos+4 > bitsLen {
+						break
+					}
+					buf |= uint64(binary.BigEndian.Uint32(bits[bytePos:])) << uint(32-bitsAvail)
+					bytePos += 4
+					bitsAvail += 32
+				}
+				prev += buf >> (64 - bnu)
+				buf <<= bnu
+				bitsAvail -= int(bnu)
+				deltas[i] = prev
+			}
+			decodeTailDelta(deltas, bits, bytePos, bitsLen, buf, bitsAvail, bnu, i, n, &prev)
+		} else {
+			i := 1
+			for ; i < n; i++ {
+				if bitsAvail < int(bnu) {
+					if bytePos+4 > bitsLen {
+						break
+					}
+					buf |= uint64(binary.BigEndian.Uint32(bits[bytePos:])) << uint(32-bitsAvail)
+					bytePos += 4
+					bitsAvail += 32
+				}
+				deltas[i] = buf >> (64 - bnu)
+				buf <<= bnu
+				bitsAvail -= int(bnu)
+			}
+			decodeTail(deltas, bits, bytePos, bitsLen, buf, bitsAvail, bnu, i, n)
+		}
+		return
+	}
 
-	// Read the deltas
-	for i := 1; i < len(deltas); i++ {
-		// Ensure we have enough bits in the buffer
+	// bnu > 32: per-iteration uint64 load. The reservoir state above is unused
+	// here; we recompute from bitPos.
+	//
+	// Fast path: read 8 bytes at a time and extract bitsNeeded bits with a
+	// single shift+mask. Safe only when bnu <= 57 (so that bitOffset+bnu <= 64
+	// for any bitOffset in [0,7]) and when we have 8 bytes available.
+	bitPos := uint(6)
+	fastEnd := 1
+	if bnu <= 57 && bitsLen >= 8 {
+		room := 8*bitsLen - 63
+		fastEnd = 2 + room/bitsNeeded
+		if fastEnd > n {
+			fastEnd = n
+		}
+	}
+
+	if deltaDiff {
+		prev := deltas[0]
+		for i := 1; i < fastEnd; i++ {
+			bytePos := bitPos >> 3
+			bitOffset := bitPos & 7
+			val := binary.BigEndian.Uint64(bits[bytePos:])
+			d := (val >> (64 - bitOffset - bnu)) & bitsMask
+			prev += d
+			deltas[i] = prev
+			bitPos += bnu
+		}
+	} else {
+		for i := 1; i < fastEnd; i++ {
+			bytePos := bitPos >> 3
+			bitOffset := bitPos & 7
+			val := binary.BigEndian.Uint64(bits[bytePos:])
+			deltas[i] = (val >> (64 - bitOffset - bnu)) & bitsMask
+			bitPos += bnu
+		}
+	}
+
+	if fastEnd >= n {
+		return
+	}
+
+	// Tail: byte-by-byte for the remaining values where a uint64 read would
+	// run past the end of the input.
+	bytePosT := int(bitPos >> 3)
+	bitOffset := int(bitPos & 7)
+	bitsLeft := 8 - bitOffset
+	bitBuffer := uint64(bits[bytePosT]) & (uint64(1)<<uint(bitsLeft) - 1)
+	bytePosT++
+
+	for i := fastEnd; i < n; i++ {
 		for bitsLeft < bitsNeeded {
-			if bytePos >= len(packed) {
-				// Handle insufficient data
+			if bytePosT >= bitsLen {
 				return
 			}
-			bitBuffer = (bitBuffer << 8) | uint64(packed[bytePos])
+			bitBuffer = (bitBuffer << 8) | uint64(bits[bytePosT])
 			bitsLeft += 8
-			bytePos++
+			bytePosT++
 		}
-		// Extract bitsNeeded bits from the buffer
 		bitsLeft -= bitsNeeded
-		deltas[i] = (bitBuffer >> bitsLeft) & bitsMask
+		deltas[i] = (bitBuffer >> uint(bitsLeft)) & bitsMask
 		if deltaDiff {
 			deltas[i] += deltas[i-1]
 		}
+	}
+}
+
+// decodeTail finishes the reservoir-style decode for the last few values, where
+// a 32-bit refill would run past the end of the input. Refills one byte at a
+// time. Called from the bnu <= 32 fast paths.
+func decodeTail(deltas []uint64, bits []byte, bytePos, bitsLen int, buf uint64, bitsAvail int, bnu uint, i, n int) {
+	for ; i < n; i++ {
+		for bitsAvail < int(bnu) {
+			if bytePos >= bitsLen {
+				return
+			}
+			buf |= uint64(bits[bytePos]) << uint(56-bitsAvail)
+			bytePos++
+			bitsAvail += 8
+		}
+		deltas[i] = buf >> (64 - bnu)
+		buf <<= bnu
+		bitsAvail -= int(bnu)
+	}
+}
+
+// decodeTailDelta is the delta variant of decodeTail.
+func decodeTailDelta(deltas []uint64, bits []byte, bytePos, bitsLen int, buf uint64, bitsAvail int, bnu uint, i, n int, prev *uint64) {
+	p := *prev
+	for ; i < n; i++ {
+		for bitsAvail < int(bnu) {
+			if bytePos >= bitsLen {
+				return
+			}
+			buf |= uint64(bits[bytePos]) << uint(56-bitsAvail)
+			bytePos++
+			bitsAvail += 8
+		}
+		p += buf >> (64 - bnu)
+		buf <<= bnu
+		bitsAvail -= int(bnu)
+		deltas[i] = p
 	}
 }
 

--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -141,6 +141,9 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 	// Tail: byte-by-byte for the remaining values where a uint64 read would
 	// run past the end of the input.
 	bytePosT := int(bitPos >> 3)
+	if bytePosT >= bitsLen {
+		return
+	}
 	bitOffset := int(bitPos & 7)
 	bitsLeft := 8 - bitOffset
 	bitBuffer := uint64(bits[bytePosT]) & (uint64(1)<<uint(bitsLeft) - 1)

--- a/adapters/repos/db/lsmkv/varenc/varint_test.go
+++ b/adapters/repos/db/lsmkv/varenc/varint_test.go
@@ -1,0 +1,339 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package varenc
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The encoded format stores bitsNeeded in a 6-bit header field, so the largest
+// per-value bit width it can name is 63. The current decoder also loses bits
+// for bnu >= 59 because its byte-refill loop overflows the 64-bit buffer. The
+// tests below therefore cover bnu in [1, 58], which is the safely supported
+// range. Realistic delta/TF values are far below this ceiling.
+const maxSupportedBnu = 58
+
+// roundtripSizes covers small, boundary, and block-aligned sizes plus a few
+// large counts to exercise the fast and tail paths in decodeReusable.
+var roundtripSizes = []int{1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 200, 511, 512}
+
+func TestVarIntRoundtripFixedWidth(t *testing.T) {
+	// For each bit width in [1, maxSupportedBnu], generate values that exactly
+	// fit that width (including the boundary value 2^bnu - 1) and verify a
+	// full encode/decode roundtrip.
+	rng := rand.New(rand.NewPCG(0xdeadbeef, 0x12345678))
+
+	for bnu := 1; bnu <= maxSupportedBnu; bnu++ {
+		maxVal := uint64(1)<<uint(bnu) - 1
+		for _, n := range roundtripSizes {
+			t.Run(fmt.Sprintf("bnu=%d_n=%d", bnu, n), func(t *testing.T) {
+				values := make([]uint64, n)
+				values[0] = rng.Uint64() // first value is stored verbatim, can be anything
+				for i := 1; i < n; i++ {
+					if maxVal == 0 {
+						values[i] = 0
+					} else {
+						values[i] = rng.Uint64N(maxVal + 1)
+					}
+				}
+				// Force at least one boundary value so bitsNeeded is exactly bnu.
+				if n > 1 {
+					values[n-1] = maxVal
+				}
+
+				enc := &VarIntEncoder{}
+				enc.Init(n)
+				packed := enc.Encode(values)
+				decoded := enc.Decode(packed)
+				assert.Equal(t, values, decoded[:n])
+			})
+		}
+	}
+}
+
+func TestVarIntDeltaRoundtripFixedWidth(t *testing.T) {
+	// Same shape, but values are a non-decreasing cumulative sum so the deltas
+	// have a known bit width.
+	rng := rand.New(rand.NewPCG(0xc0ffee, 0xfeedface))
+
+	for bnu := 1; bnu <= maxSupportedBnu; bnu++ {
+		// Cap per-delta size by bnu and the count to keep the cumulative sum
+		// within uint64.
+		maxDelta := uint64(1)<<uint(bnu) - 1
+		for _, n := range roundtripSizes {
+			// Guard against overflow when n*maxDelta would wrap.
+			if maxDelta != 0 && uint64(n) > ^uint64(0)/maxDelta {
+				continue
+			}
+			t.Run(fmt.Sprintf("bnu=%d_n=%d", bnu, n), func(t *testing.T) {
+				values := make([]uint64, n)
+				values[0] = rng.Uint64N(1 << 30)
+				for i := 1; i < n; i++ {
+					var d uint64
+					if maxDelta == 0 {
+						d = 0
+					} else {
+						d = rng.Uint64N(maxDelta + 1)
+					}
+					values[i] = values[i-1] + d
+				}
+				if n > 1 {
+					// Force one boundary delta so bitsNeeded = bnu.
+					values[n-1] = values[n-2] + maxDelta
+				}
+
+				enc := &VarIntDeltaEncoder{}
+				enc.Init(n)
+				packed := enc.Encode(values)
+				decoded := enc.Decode(packed)
+				assert.Equal(t, values, decoded[:n])
+			})
+		}
+	}
+}
+
+func TestVarIntEdgeCases(t *testing.T) {
+	t.Run("single value", func(t *testing.T) {
+		// Only the first value, no deltas; should roundtrip unchanged.
+		for _, v := range []uint64{0, 1, 42, math.MaxUint32, math.MaxUint64} {
+			enc := &VarIntEncoder{}
+			enc.Init(1)
+			packed := enc.Encode([]uint64{v})
+			decoded := enc.Decode(packed)
+			assert.Equal(t, []uint64{v}, decoded[:1])
+		}
+	})
+
+	t.Run("all zero deltas", func(t *testing.T) {
+		// Non-delta encoder: all-zero values means bitsNeeded=1 (encoder enforces a
+		// minimum of 1 bit).
+		n := 128
+		values := make([]uint64, n)
+		// First value can be anything; the rest are zero.
+		values[0] = 1234
+
+		enc := &VarIntEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+
+	t.Run("delta encoder constant value", func(t *testing.T) {
+		// All values equal → all deltas zero → bitsNeeded=1.
+		n := 128
+		values := make([]uint64, n)
+		for i := range values {
+			values[i] = 42
+		}
+
+		enc := &VarIntDeltaEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+
+	t.Run("delta encoder strictly increasing by 1", func(t *testing.T) {
+		// The bnu=1 case in the fast reservoir path: maximum loads-per-refill.
+		n := 128
+		values := make([]uint64, n)
+		values[0] = 1000
+		for i := 1; i < n; i++ {
+			values[i] = values[i-1] + 1
+		}
+
+		enc := &VarIntDeltaEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+
+	t.Run("delta encoder max representable deltas", func(t *testing.T) {
+		// Deltas at the boundary of the supported bit width.
+		n := 64
+		maxDelta := uint64(1)<<maxSupportedBnu - 1
+		values := make([]uint64, n)
+		values[0] = 0
+		for i := 1; i < n; i++ {
+			values[i] = values[i-1] + maxDelta
+		}
+
+		enc := &VarIntDeltaEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+}
+
+func TestVarIntFastAndTailPathCoverage(t *testing.T) {
+	// Force the decoder through both the reservoir fast path and the
+	// byte-by-byte tail by choosing block sizes such that the 32-bit refill
+	// runs out of room before processing every value.
+	//
+	// For bnu=8 and n=128, the encoded payload past the header is 127*8=1016
+	// bits = 127 bytes. Reservoir refills 4 bytes at a time, so the last few
+	// values are guaranteed to land in the tail. The roundtrip must still
+	// succeed.
+	for _, bnu := range []int{1, 2, 4, 8, 16, 24, 32} {
+		t.Run(fmt.Sprintf("reservoir_bnu=%d", bnu), func(t *testing.T) {
+			n := 128
+			maxVal := uint64(1)<<uint(bnu) - 1
+			rng := rand.New(rand.NewPCG(uint64(bnu), 0))
+			values := make([]uint64, n)
+			values[0] = rng.Uint64()
+			for i := 1; i < n; i++ {
+				values[i] = rng.Uint64N(maxVal + 1)
+			}
+			values[n-1] = maxVal // anchor bitsNeeded
+
+			enc := &VarIntEncoder{}
+			enc.Init(n)
+			packed := enc.Encode(values)
+			decoded := enc.Decode(packed)
+			require.Equal(t, values, decoded[:n])
+		})
+	}
+
+	// Same exercise for the uint64-load path (bnu in (32, 57]).
+	for _, bnu := range []int{33, 40, 48, 56} {
+		t.Run(fmt.Sprintf("uint64_load_bnu=%d", bnu), func(t *testing.T) {
+			n := 64
+			maxVal := uint64(1)<<uint(bnu) - 1
+			rng := rand.New(rand.NewPCG(uint64(bnu), 1))
+			values := make([]uint64, n)
+			values[0] = rng.Uint64()
+			for i := 1; i < n; i++ {
+				values[i] = rng.Uint64N(maxVal + 1)
+			}
+			values[n-1] = maxVal
+
+			enc := &VarIntEncoder{}
+			enc.Init(n)
+			packed := enc.Encode(values)
+			decoded := enc.Decode(packed)
+			require.Equal(t, values, decoded[:n])
+		})
+	}
+}
+
+func TestDecodeReusableReusesOutputBuffer(t *testing.T) {
+	// The Reusable variants are expected to write into a caller-provided slice
+	// without allocating. Verify two consecutive calls with different inputs
+	// produce the correct outputs in the same buffer.
+	enc := VarIntEncoder{}
+	enc1 := &VarIntEncoder{}
+	enc1.Init(32)
+
+	v1 := make([]uint64, 32)
+	v1[0] = 100
+	for i := 1; i < 32; i++ {
+		v1[i] = uint64(i * 3)
+	}
+	p1 := enc1.Encode(v1)
+
+	v2 := make([]uint64, 32)
+	v2[0] = 999_999
+	for i := 1; i < 32; i++ {
+		v2[i] = uint64(i)
+	}
+	p2 := enc1.Encode(v2)
+
+	out := make([]uint64, 32)
+	enc.DecodeReusable(p1, out)
+	assert.Equal(t, v1, out)
+	enc.DecodeReusable(p2, out)
+	assert.Equal(t, v2, out)
+}
+
+func TestVarIntBitsNeededHeaderHasExpectedValue(t *testing.T) {
+	// Confirm that the encoder writes the bitsNeeded value we expect for a
+	// known input, and that the decoder reads it back identically. This pins
+	// down the on-disk format so future format changes can't silently break
+	// readers in other segments.
+	for _, tc := range []struct {
+		name      string
+		values    []uint64
+		expectBnu int
+	}{
+		{"all_zero_deltas", []uint64{0, 0, 0, 0, 0, 0, 0, 0}, 1},
+		{"max_delta_3_bits", []uint64{0, 5, 7, 3, 0, 2}, 3},
+		{"max_delta_8_bits", []uint64{0, 255, 100, 200}, 8},
+		{"max_delta_16_bits", []uint64{0, 65535, 32000}, 16},
+		{"max_delta_32_bits", []uint64{0, math.MaxUint32, 1234}, 32},
+		{"max_delta_56_bits", []uint64{0, 1<<56 - 1, 0}, 56},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := &VarIntEncoder{}
+			enc.Init(len(tc.values))
+			packed := enc.Encode(tc.values)
+
+			// Header is the high 6 bits of packed[8].
+			require.GreaterOrEqual(t, len(packed), 9)
+			gotBnu := int((packed[8] >> 2) & 0x3F)
+			if tc.expectBnu == 0 {
+				// Encoder enforces a minimum of 1 bit even for all-zero deltas.
+				assert.Equal(t, 1, gotBnu)
+			} else {
+				assert.Equal(t, tc.expectBnu, gotBnu)
+			}
+
+			decoded := enc.Decode(packed)
+			assert.Equal(t, tc.values, decoded[:len(tc.values)])
+		})
+	}
+}
+
+// TestVarIntLargeBitWidthLimitation documents a known limitation in the
+// encoded format: bitsNeeded values above 58 are not safely supported.
+//   - The 6-bit header field can name at most 63 (so bnu=64 silently truncates
+//     to 0 and the decoder returns nothing).
+//   - For bnu in [59, 63] the decoder's byte-refill loop shifts a uint64 buffer
+//     left by 8 when it already holds >= 56 bits, losing the oldest 2 bits.
+//
+// In practice deltas requiring >= 59 bits never occur in the BM25 inverted
+// index use case (doc IDs and term frequencies fit comfortably below 2^40),
+// so this is documented rather than fixed. If a future caller starts feeding
+// values that need >= 59 bits, the format itself needs to change (wider
+// header, different refill strategy).
+func TestVarIntLargeBitWidthLimitation(t *testing.T) {
+	t.Run("bnu_64_truncated_to_zero", func(t *testing.T) {
+		// A delta requiring 64 bits would have bitsNeeded=64, which doesn't
+		// fit in the 6-bit header.
+		require.Equal(t, 64, bits.Len64(math.MaxUint64))
+
+		values := []uint64{0, math.MaxUint64}
+		enc := &VarIntEncoder{}
+		enc.Init(2)
+		packed := enc.Encode(values)
+
+		// The encoder wrote 64 in 6 bits, which is 0.
+		require.GreaterOrEqual(t, len(packed), 9)
+		gotBnu := int((packed[8] >> 2) & 0x3F)
+		assert.Equal(t, 0, gotBnu, "bnu=64 is truncated to 0 in the header")
+
+		// The decoder treats bnu=0 as invalid and returns without touching the
+		// remaining slots — only the first value comes through correctly.
+		decoded := enc.Decode(packed)
+		assert.Equal(t, uint64(0), decoded[0])
+		assert.Equal(t, uint64(0), decoded[1])
+	})
+}

--- a/adapters/repos/db/priorityqueue/queue.go
+++ b/adapters/repos/db/priorityqueue/queue.go
@@ -66,7 +66,9 @@ func NewMax[T supportedValueType](capacity int) *Queue[T] {
 }
 
 func (q *Queue[T]) ShouldEnqueue(distance float32, limit int) bool {
-	return q.Len() < limit || q.Top().Dist < distance
+	// read items[0].Dist directly rather than via Top(), which returns the whole
+	// Item by value (a multi-word copy) on this hot path.
+	return len(q.items) < limit || q.items[0].Dist < distance
 }
 
 func (q *Queue[T]) InsertAndPop(id uint64, score float64, limit int, worstDist *float64, val T) {

--- a/docs/bmw_perf_plan.md
+++ b/docs/bmw_perf_plan.md
@@ -1,0 +1,945 @@
+# BlockMax WAND query-time performance plan
+
+Prioritized improvements to the BlockMax WAND (BMW) keyword-search hot path,
+ordered by measured impact and gated by adversarial verification of correctness.
+
+## Combined result: whole branch vs main
+
+Same machine, same 897MB `climate_fever` `property_text_searchable` segments,
+identical deterministic queries, `BenchmarkBMWCompare` (`bm25_blockmax_baseline_test.go`)
+run in a `main` git worktree vs this branch, `-count=6` (variance <3%):
+
+| workload | metric | main | branch | Δ |
+|----------|--------|------|--------|---|
+| 10-term OR, no filter | ns/op | 480,425 | 327,370 | **−31.9%** |
+|                       | B/op  | 251,300 | 71,060  | **−71.7%** |
+|                       | allocs/op | 2,170 | 863  | **−60.2%** |
+| 10-term OR, filter 0.1 | ns/op | 272,176 | 227,558 | **−16.4%** |
+|                        | B/op  | 233,800 | 70,245  | **−70.0%** |
+|                        | allocs/op | 1,475 | 862 | **−41.6%** |
+
+Results are bit-for-bit identical to main (7000 queries across OR/filtered/AND;
+see Validation). The aggregate is the sum of Tier 1 (allocations), Tier 2 (sort +
+branches), the atomic refcount, and Tier 3 (dense propLengths).
+
+### Re-benchmark after rounds 3–4 (2026-06-09)
+
+Same data (now at `data-weaviate-0/`), fresh `main` worktree (`a746884eb6`, the
+established comparison base), interleaved **min-of-5 × 2s** per config (machine
+under background load, so minimums; the direct main↔branch dump/compare was re-run
+first — bit-identical incl. the 2%-tombstone config where main checks at advance
+and the branch defers to scoring):
+
+| workload | main | branch | Δ |
+|----------|------|--------|---|
+| OR typical (size 5, limit 10) | 254 µs | 113 µs | **−55%** (2.2×) |
+| OR worst-case 10-term, limit 10 | 25.4 ms | 15.9 ms | **−37%** (1.6×) |
+| OR worst-case 10-term, limit 100 | 29.8 ms | 16.6 ms | **−44%** (1.8×) |
+| OR worst-case + filter 10% | 12.5 ms | 10.2 ms | **−18%** |
+| OR worst-case + tombstones 2% | 30.3 ms | 16.9 ms | **−44%** (1.8×) |
+| AND typical (size 5, limit 10) | 33.1 µs | 23.2 µs | **−30%** (1.4×) |
+
+The tombstone row shows the deferred-tombstone change at work: with 2% deletes the
+branch stays at its no-tombstone speed (16.9 vs 15.9 ms) while main pays the
+per-advanced-doc probe (30.3 vs 25.4 ms).
+
+### Higher limit (top-100) — gains grow with limit
+
+Same setup, `BMW_LIMIT=100` (lower WAND threshold → more docs scored/enqueued):
+
+| metric | main | branch | Δ |
+|--------|------|--------|---|
+| serial ns/op | 954,131 | 482,504 | **−49.4%** |
+| serial B/op | 325,000 | 92,985 | −71.4% |
+| serial allocs/op | 4,334 | 863 | **−80.1%** |
+| parallel q/s @14 cores | 9,679 | 22,771 | **2.35×** |
+
+The branch's edge is *bigger* at limit 100 than at limit 10 (−49% vs −32%
+serial). Reason: `main`'s allocs/op scale with limit (2,170 → 4,334) because the
+old per-match `sort.Sort` boxed the slice into a `sort.Interface` on every
+accepted doc; more accepted docs ⇒ more allocations/GC. The branch's `sortByID`
+allocates nothing, so allocs/op stay flat at 863 regardless of limit. Results
+remain bit-identical to main at limit 100.
+
+### Parallel (concurrent queries)
+
+`BenchmarkBMWCompareParallel` (`b.RunParallel`) at increasing `-cpu`, 10-term OR,
+no filter, sequential main/branch runs (no cross-contention), avg of 2:
+
+| cores | main ns/op | branch ns/op | branch latency Δ | main q/s | branch q/s |
+|-------|-----------|-------------|------------------|----------|------------|
+| 1  | 522,922 | 335,361 | −35.9% | 1,912 | 2,982 |
+| 4  | 132,013 | 81,658  | −38.1% | 7,575 | 12,246 |
+| 8  | 70,223  | 42,253  | −39.8% | 14,240 | 23,667 |
+| 14 | 57,869  | 30,747  | **−46.9%** | 17,280 | **32,523** |
+
+The branch's lead widens with parallelism (1.56× single-thread → 1.88× at 14
+cores) and it scales better — 1→14-core speedup 9.0× (main) vs 10.9× (branch),
+i.e. 65% → 78% scaling efficiency. That extra headroom is the atomic refcount
+(no per-query segment-refcount mutex) plus ~70% fewer bytes / ~60% fewer allocs
+(less GC/runtime-lock contention). Peak throughput at 14 cores: **1.88×** main.
+
+### 100 concurrent clients (oversubscribed)
+
+`TestBMWConcurrentLoad`, 100 worker goroutines on GOMAXPROCS=14 (the realistic
+"100 simultaneous queries" regime), 8s, no filter:
+
+| | main q/s | branch q/s | main p50 | branch p50 | main p95 | branch p95 | main p99 | branch p99 |
+|--|---------|-----------|---------|-----------|---------|-----------|---------|-----------|
+| limit 10  | 15,876 | **30,342** (1.91×) | 433µs | 161µs | 5.5ms | 2.2ms | 55ms | 39ms |
+| limit 100 | 9,407  | **19,761** (2.10×) | 666µs | 261µs | 27ms | 3.6ms | 206ms | 75ms |
+
+~2× throughput and 30–87% lower median/p95/p99 latency — the allocation cut
+sharply reduces GC pressure, which dominates under oversubscription. The extreme
+tail (p99.9 ~0.8–1.1s, max ~2–3.7s) stays high on *both* — Go stop-the-world GC
+pauses + scheduler latency at 100:14 oversubscription, which these changes don't
+target (would need GOGC/GOMEMLIMIT tuning or bounding in-flight queries).
+
+## Worst-case queries
+
+`TestBMWSlowQueries` searches for consistently-slow queries by drawing terms from
+the highest-document-frequency pool (where WAND prunes least) and timing each
+over repeats. On `climate_fever`:
+
+- **Mixed queries** (terms across freq tiers): median ~2ms, slowest ~9ms.
+- **All-high-frequency** 15-term queries (pool = top ~40 terms, 8k–119k docs
+  each, `BMW_SLOW_POOL=40`): **consistently 12–28ms (median ~18ms)** — ~10× a
+  typical query. Each scores 20k–29k docs and decodes ~5k blocks; the block-max
+  upper bounds never drop below the heap threshold so almost nothing is skipped.
+
+Recurring high-frequency drivers: `since` (278k), `census` (168k), `women`
+(119k), plus `films/present/complete/level/lord/21/turkey/fund/1912/1974`. These
+are the queries to watch for tail latency; cost grows with query length and with
+the frequency of the included terms (and with limit). The slow set is emitted as
+a `BMW_TERMS=…` string for replay.
+
+## How this was measured
+
+Profiles come from the harness in
+[`adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go`](../adapters/repos/db/lsmkv/bm25_blockmax_profile_test.go),
+which drives the real query path (`CreateDiskTerm` → `DoBlockMaxWand`) against a
+folder of on-disk segments, samples representative terms, and prints a ranked
+hotspot table.
+
+Reference run: `climate_fever` `property_text_searchable`, 5.4M docs, 10-term OR
+queries, no filter, tombstones present, 20s CPU profile.
+
+```
+BMW_SEGMENTS_DIR=/…/property_text_searchable BMW_QUERY_SIZE=10 \
+BMW_NUM_QUERIES=1000 BMW_SEED=42 BMW_PROFILE_SECONDS=20 \
+  go test -tags integrationTest -run TestProfileBlockMaxWand -v -timeout 30m ./adapters/repos/db/lsmkv/
+```
+
+Top self-time: `DoBlockMaxWand` 21%, `AdvanceAtLeast` 7.5%, `decodeReusable`
+4.9%, `advanceOnTombstoneOrFilter` 3.3% (+ `sroar.*` ~6%), `sort.insertionSort`
+5.1%, `runtime.mapaccess1_fast64` 2.9%, allocation/zeroing (`memclr`+`mallocgc`)
+~16%. `CreateDiskTerm` (per-query term setup) is ~17% cumulative.
+
+A separate multi-agent review verified 9 of 32 candidates as real; the rest were
+dropped as not-real, off-hot-path, or unsafe-as-proposed.
+
+## Priority table
+
+| # | Change | Measured signal | Impact | Effort | Risk | Status |
+|---|--------|-----------------|--------|--------|------|--------|
+| 1 | Drop dead per-term decoder allocations (devirtualize decode) | alloc churn; `CreateDiskTerm` 17% cum + GC ~16% | High | Low | None | Tier 1 |
+| 2 | `[]*BlockEntry` → `[]BlockEntry` value slice | alloc/zeroing ~16% | Med-High | Low | Low | Tier 1 |
+| 3 | Devirtualize block decoders (folded into #1) | `decodeReusable` dispatch | Med | Low | Low | Tier 1 |
+| 4 | Gate per-doc `Metrics` bookkeeping | `Score` per-doc writes | Low | Low | None | Tier 1 |
+| 5 | Cap `combineResults` prealloc when `limit==0` | memory cliff (off hot-path) | Med (mem) | Low | None | Tier 1 |
+| 6 | Replace in-loop `sort.Sort` with bounded re-insertion | `sort.insertionSort` 5.1% | Med | Med | Med | Tier 2 |
+| 7 | `propLengths` map → dense/sorted slice | `mapaccess1_fast64` 2.9% | Med | High | Med | Tier 3 |
+| 8 | Cheaper tombstone/filter probing | `advanceOnTombstoneOrFilter`+`sroar.*` ~10% | Med | High | Med | Stretch |
+
+## Tier 1 — status: DONE
+
+Implemented and measured. A/B on `climate_fever` `property_text_searchable`,
+10-term OR, `BMW_SEED=42`, `BenchmarkBlockMaxWand/size=10 -benchmem -benchtime=5s`:
+
+| Metric | Before | After | Δ |
+|--------|--------|-------|---|
+| ns/op | 524,910 | 468,783 | −10.7% |
+| B/op | 251,441 | 153,780 | −38.8% |
+| allocs/op | 2,199 | 1,828 | −16.9% |
+
+The allocation profile confirms `VarInt*.Init` and per-block `DecodeBlockEntry`
+allocations are gone. The profile then showed `SegmentBlockMax.reset` dominating
+allocations (~59%) via its per-term scratch buffers.
+
+### Follow-up (DONE): skip dead `blockDataBuffer` on the mmap path
+
+`mmapContents` defaults to true, so `readFromMemory` is true on the common path,
+where `loadBlockDataReusable` decodes straight from `s.contents` and never reads
+`blockDataBuffer`. The 4KB-per-term buffer was pure dead weight; `reset` now only
+allocates it when `!readFromMemory`. Cumulative A/B vs the pre-Tier-1 baseline:
+
+| Metric | Before (HEAD) | After Tier 1 + mmap-skip | Δ |
+|--------|---------------|--------------------------|---|
+| ns/op | 524,910 | 464,262 | −11.6% |
+| B/op | 251,441 | 90,865 | −63.9% |
+| allocs/op | 2,199 | 1,778 | −19.1% |
+
+Remaining `reset` allocations are the two `BLOCK_SIZE` `uint64` decode slices
+(`DocIds`/`Tfs`, ~2KB/term) + two small structs — a `sync.Pool` candidate, but it
+needs lifecycle wiring (return buffers via the `CreateDiskTerm` release callback)
+and carries use-after-release risk, so it is deferred behind Tier 2.
+
+## Tier 1 (low/no risk — implemented together)
+
+### 1 + 3. Devirtualize decoders, kill per-term decoder allocations
+`NewSegmentBlockMax` built a fresh `[]VarEncEncoder[uint64]` and called
+`Init(BLOCK_SIZE)` on each per *(term × segment)* per query. `Init` allocates
+`values []uint64` and `buf []byte` (~1KB each, ×2) that the query path never
+reads — `DecodeReusable` writes into the caller's buffers. The interface call
+also blocked inlining.
+
+Fix: a stateless `varenc.GetDecodeFunc(codec) func([]byte, []uint64)`; store two
+`decodeDocIds`/`decodeTfs` func fields on `SegmentBlockMax` assigned once. No
+per-term encoder instance, no `Init`, no interface dispatch. Write/compaction
+path (separate encoders, which do need `Init`) is untouched.
+
+Correctness: none — the decode funcs delegate to the same `decodeReusable`.
+
+### 2. `[]*terms.BlockEntry` → `[]terms.BlockEntry`
+`loadBlockEntries` allocated one heap `*BlockEntry` per 128-doc block
+(~7,800 for a 1M-doc term), scattered and pointer-chased in the WAND skip loop.
+
+Fix: one contiguous `make([]terms.BlockEntry, blockCount)` + in-place
+`terms.DecodeBlockEntryInto`. Indexed field reads are unchanged. Serialization
+helpers keep their own pointer slices (write path).
+
+Correctness: low — no pointer identity / nil-entry sentinels relied upon.
+
+### 4. Gate per-doc `Metrics` bookkeeping
+`Score` incremented `BlockMetrics` counters per scored doc; no production code
+reads them. Guard behind an unexported `collectBlockMetrics` bool (default
+false; the profiling harness sets it true for its per-query stats).
+
+Correctness: none.
+
+### 5. Cap `combineResults` prealloc for unlimited queries
+With `limit==0`, `wandBlock` sets `limit` to the sum of all term counts
+(millions); `combineResults` then preallocated four slices at
+`limit*len(allIds)` → multi-GB spike. Bound capacity by the actual row count.
+
+Correctness: none — capacity hints don't change results.
+
+## Tier 2 — WAND loop (status: DONE)
+
+CPU-focused loop/branch pass over `DoBlockMaxWand` + `SegmentBlockMax`:
+
+1. **`sort.Sort(results)` → `Terms.sortByID()` (concrete insertion sort).**
+   `sort.Sort` dispatched `Less`/`Swap` through `sort.Interface` *and* boxed the
+   `Terms` slice into an interface value — a heap allocation on **every matched
+   doc**. The concrete insertion sort (term list is small + nearly-sorted)
+   inlines the `idPointer` compares and allocates nothing.
+2. **Dead store removed:** `upperBound -= …` in the match branch (the value was
+   never read before `upperBound` is reset the next iteration).
+3. **`AdvanceAtLeast`:** the "last block, still past it" disjunct is provably
+   always-false after the skip loop → reduced to a single `>= len` bounds check.
+4. **`AdvanceAtLeastShallow`:** the post-loop exhaustion `if` is dead (the loop
+   returns internally on overrun) → removed.
+
+A/B isolating #1 (climate_fever, 10-term OR, same seed): **421,628 → 381,936
+ns/op (−9.4%), 1,776 → 862 allocs/op (−51%)** — the ~914 fewer allocs/op are the
+per-match interface boxing. Combined with #2–#4, the turn moved ~464µs→382µs/op
+(~18%). CPU profile confirms `sort.insertionSort`/`Terms.Less`/`Terms.Swap` are
+gone (replaced by `Terms.sortByID` at 3.71%). Correctness: BM25F block + inverted
+suites pass under `-race`.
+
+Follow-up safe loop/branch wins:
+
+5. **`advanceOnTombstoneOrFilter`:** read the doc id once per skipped doc instead
+   of re-indexing the slice in each of the up-to-three membership checks — helps
+   the filtered/tombstoned path (where this method is ~40% cumulative).
+6. **`DoBlockMaxWand` prune branch:** fused the two `[0, pivotPoint]` scans
+   (heaviest-term + smallest block-max-id) into one pass.
+
+## Validation: main-vs-branch baseline (scores + rankings)
+
+`bm25_blockmax_baseline_test.go` (`TestBMWBaseline`, dump/compare modes) records
+the ranked top-K (docID, score) for a deterministic query set and diffs a
+baseline against the current code. It is self-contained and uses only APIs
+present on main, so the same file runs in a `main` git worktree to produce the
+baseline. Determinism across processes comes from sorting sampled terms before
+any rng use (a Go map's iteration order is not stable).
+
+Ran on `climate_fever` (5.4M docs), comparing this whole branch (Tier 1 + atomic
+refcount + Tier 2 + #5/#6) against `main`:
+
+| set | queries | identical | ranking Δ | doc-set Δ | max \|Δscore\| |
+|-----|---------|-----------|-----------|-----------|----------------|
+| OR, size 5, no filter | 3000 | 3000 | 0 | 0 | 0 |
+| OR, size 10, filter 0.1 | 2000 | 2000 | 0 | 0 | 0 |
+| AND, size 4 | 2000 | 2000 | 0 | 0 | 0 |
+
+Bit-for-bit identical — the optimizations are pure performance, no result change.
+
+## DoBlockMaxWand deep-dive (status: DONE)
+
+Line-profiled the worst case (10 all-high-frequency terms — block-max pruning
+fails, ~900k docs decoded/query) and applied verified, bit-identical changes:
+
+1. **Inline `Idf()` → `.idf`** in the pivot/prune scans (it wasn't inlining; ~3% self).
+2. **`iterations%100000` → countdown** (removes a per-iteration 64-bit modulo, ~1.5%).
+3. **Prune-branch re-sort → `Terms.reinsertRight`** (search_segment.go): the old
+   loop had **no early break** and rescanned the whole tail every iteration (its
+   `exhausted`-swap branch, 8.7s self, only shuffled MaxUint64 sentinels). After
+   `AdvanceAtLeast` only one element moved, and only rightward, so a break-on-settle
+   re-insertion suffices. Verified bit-identical by exhaustive enumeration (n≤6) +
+   20M random trials.
+4. **Tombstone empty→nil normalization** in `NewSegmentBlockMax`: `memTombstones`
+   is always a non-nil `sroar.NewBitmap()`, so with no in-memory deletes it's a
+   non-nil **empty** bitmap that paid a `Contains` per advanced doc (~8.4s). Nil-ing
+   genuinely-empty bitmaps lets the existing guard skip them — eliminated ~13% of
+   self time (all `sroar.*` probes) on this dataset.
+5. **upperBound loop**: dropped the per-element `exhausted` guard (exhausted terms
+   contribute `currentBlockMaxId==MaxUint64` → no shallow advance, and
+   `currentBlockImpact==0` → no-op add).
+6. **Struct field reorder**: hot scalars (`idPointer/idf/currentBlockMaxId/
+   currentBlockImpact/exhausted/decoded/freqDecoded`) co-located at the top, gated-off
+   `Metrics` pushed to the tail.
+
+Results, climate_fever, vs the pre-deep-dive branch:
+- **Worst-case** (10 high-freq, conc=14): **446 → 628 q/s (+41%)**.
+- **Normal** (10-term mixed, no filter): **~327 → ~273 µs/op (−16.5%)**.
+- Bit-identical to main across 8000 queries (OR/filtered/AND/limit=100); BM25F +
+  inverted + refcount suites pass under `-race`.
+
+(Dropped as speculative/unsafe by the verifier: full struct-of-arrays, galloping
+block search, the 2-bitmap merge — deferred, redundant with #4 here.)
+
+## DoBlockMaxWand deep-dive, round 2 (status: DONE)
+
+Re-profiled the worst case after round 1 (`AdvanceAtLeast` 15%, `reinsertRight`
+12%, pivot scan still dominant) and ran a second agent deep-dive. Kept:
+
+1. **`ShouldEnqueue` reads `items[0].Dist` directly** instead of via `Top()`,
+   which returned the whole `Item` by value (a multi-word copy) on a path hit per
+   scored doc + per iteration (priorityqueue/queue.go).
+2. **Unify the matched-*else* swap-bubble into `reinsertRight`** (move-based, same
+   permutation as the old break-on-settle swap bubble).
+
+Result vs the post-round-1 branch: normal 10-term **273 → ~255 µs/op (−6.5%)**,
+worst case **617 → 665 q/s (+7.8%)**, bit-identical to main (8000 queries),
+`-race` clean.
+
+**Reverted (negative result, documented):** binary-searching the `AdvanceAtLeast`
+in-block doc scan and block-entry skip loop. Both were verified bit-identical and
+the line profile made them look like obvious wins (~8.7s + ~1.8s linear scans),
+but they **regressed the worst case 617 → 474 q/s (−23%)**. Reason: in dense
+all-high-frequency scanning the advances are mostly *small* (1–2 docs), so the
+linear scan touches a couple of *sequential* cache-warm elements, whereas binary
+search does log(N) *random* accesses — disastrous for the block-entry array
+(~156KB, cache misses) and net-negative even within a 128-doc block. The profile
+line was hot from *call-count × tiny-work*, not work-per-call; binary search adds
+per-call overhead exactly where the work per call is already minimal. Lesson:
+"linear scan is hot → binary search" is wrong when the hotness is call frequency,
+not scan length — measure, don't assume.
+
+**Attempted + reverted (negative result): dense filter bitset.** The per-advanced-doc
+`filterDocIds.Contains` (a sroar keys-b-tree search) is the residual filtered-path
+cost. Tried converting the filter `AllowList` to a dense `[]uint64` (O(1) membership,
+built once per query). Measured (filter 0.1, limit 100): worst-case filtered serial
+**12.0 → 8.6 ms (−29%)** ✓, but a typical filtered query **132 µs → 3,034 µs (23×
+slower)** ✗ — the O(cardinality) build (~2.9 ms to materialize a 540k-bit set) dwarfs
+a light query's actual work. Same trap as the binary searches: an unconditional build
+only pays off when #probes ≫ cardinality. A non-regressing version needs lazy/adaptive
+building (build only after a query proves heavy), which is concurrency-delicate (a
+query's per-segment terms run in parallel goroutines) — a larger, separate change, or
+better a monotonic-cursor `Contains` added to sroar itself (its container internals are
+unexported, so it can't be done from lsmkv). Reverted; the filter probe stays as-is.
+
+Deferred (verifier-flagged marginal / cache-miss-bound): pivot-scan `liveCount`
+(the L90 `exhausted` load shares a cache line with the `idf` read, so removing it
+saves a branch, not the miss), and `reinsertRight` binary-search+memmove (same
+small-displacement trap as the reverted searches).
+
+## Loop & conditional opt, round 3 (status: DONE)
+
+Ran a 52-agent workflow (6 finders by lens — WAND main loop, AND loop, advance
+methods, score/decode, compiler BCE, sort/ordering — each finding refuted by a
+3-lens adversarial panel: bit-identical-vs-main, perf-reality, edge-cases). 15
+findings, 13 rejected. **Kept (all bit-identical, validated vs HEAD≡main over 2000
+queries each: AND/OR, limit 10/100, tombstones 0/2%, ±filter — 0 doc-set changes,
+0 score drift; integration `-race` incl. real deletes):**
+
+1. **Drop `DoBlockMaxAnd`'s per-iteration O(n) exhausted scan.** AND is terminal
+   the instant any term exhausts (an exhausted term sits at `MaxUint64` forever, so
+   `isCandidate` can never be true again and the heap is frozen) — so return at the
+   advance sites (shallow-advance loop + candidate loop; `results[0]` was already
+   guarded) instead of rescanning all terms each iteration. **AND +2.2–2.5%.**
+2. **BCE reslice + redundant-load removal in the two `DoBlockMaxWand`
+   `[0,pivotPoint]` loops** (`candidates := results[:pivotPoint+1]`; the prune loop
+   also stops re-loading `results[i]` twice). **OR worst-case ~2%** (4/5 interleaved
+   rounds faster, min −2.5%).
+3. **Drop the provably-always-true `blockEntryIdx < len` conjunct** from
+   `AdvanceAtLeastShallow`'s block-scan loop (the in-loop bounds return guarantees
+   it) — dead-code removal.
+4. **Cache `results[firstNonExhausted]`** in the WAND matched-branch tombstone gate.
+
+**Reverted (negative result):** scan-then-`copy()`(memmove) `reinsertRight` — split
+the interleaved compare+move into a scan plus a bulk shift. **Regressed worst-case
+17.0 → 18.2 ms (+7%).** The interleaved compare+move loop is already optimal; the
+moves were never the cost, and the extra `copy()` call + branch hurt. Same
+measure-first lesson as the binary-search/dense-bitset reverts.
+
+**Rejected by verifiers (don't re-explore):** cache `results[pivotPoint]` in the
+pivot loop (compiler no-op — already loaded once); hoist tombstone/filter checks
+into cached struct bools (premise false — `deferTombstoneToScore` is L1-resident;
+plus a placement bug under `BMW_DEFER_TOMBSTONE=false`); precompute `1-b` /
+`k1*(1-b)` into a struct field (off the critical path — fuses as the FMA additive
+operand under the divide; decode-frequency only); fold the else-branch block-max-min
+into the fused loop (pessimizes candidate iters). All instruction-level; no
+end-to-end gain.
+
+**Deeper profile finding (open).** On the OR worst case, `Terms.reinsertRight` is
+**21% self** (the re-sort after each advance) and `DoBlockMaxWand` itself 34%, while
+`sortByID` is only **1.86%** — so the verifier-"measure-first" rank (matched-branch
+prefix-reinsert replacing `sortByID`) was **skipped**: the target is too small to
+justify its subtlety. `reinsertRight` is the real lever but is already near-optimal
+(the 30 `SegmentBlockMax` structs are L1-resident, so an SoA parallel-id array would
+not cut the deref cost, and the memmove rewrite regressed); its cost is inherent
+re-sort work × call frequency. Reducing it needs an algorithmic change to advance
+fewer times, not a cheaper per-call sort.
+
+## Loop & conditional opt, round 4 (status: DONE)
+
+Follow-up review pass after round 3. **Kept (bit-identical vs HEAD≡main over the
+full 7-config matrix — AND/OR, limit 10/100, tombstones 0/2%, 10% filter,
+worst-case query: 0 doc-set changes, 0 score drift; `-race` + linters clean):**
+
+1. **`DoBlockMaxAnd` ctx check: modulo → countdown** (same change the WAND loop
+   already had; the 64-bit `iterations%100000` ran every iteration).
+2. **`AdvanceAtLeast` scan hoisting**: both scan loops now run on locals (index in
+   a register, slice headers loaded once) and the `decoded=false/freqDecoded=false`
+   stores happen once after the block-skip loop instead of on every skipped block.
+   The in-block scan's `docIDs`/`blockDataSize` are read *after* `decodeBlock`
+   (it rewrites the buffer in place and updates the size).
+3. **`docInfos` allocation moved into the scoring path** — it was allocated for
+   every `ShouldEnqueue`-passing iteration, including non-aligned ones that never
+   use it (explain-mode-only effect).
+
+Measured (min-of-N interleaved, machine under background load so minimums used):
+OR worst-case **23.09 → 22.09 ms (−4.3%)**; AND size-8 **−4.5%**, AND size-5
+**−11.5%** (countdown + the AND loop's heavy `AdvanceAtLeast` use both helping).
+
+**Reverted (negative result):** `reinsertRight` body restructure caching the
+`t[j+1]` load (`nxt := t[j+1]; if nxt.idPointer >= id break`) — min-of-6 showed it
+*slower* than the interleaved compare+move original (22.46 vs 22.09 ms). Third
+confirmation that `reinsertRight`'s loop is already optimal per-call; do not
+revisit its body.
+
+**Dropped during review (false premise — documented so it isn't re-derived):**
+the "exhausted terms always sit at the tail" invariant is FALSE.
+`AdvanceAtLeastShallow` in the upperBound loop can exhaust a term *in place*, and
+the prune branches' `reinsertRight(nextList)` only re-sorts the advanced element —
+so exhausted sentinels can sit mid-array until the next matched-branch `sortByID`.
+Two candidate optimizations died on this: simplifying the matched-branch advance
+loop's `!term.exhausted &&` condition, and fusing the score+advance loops (their
+break conditions differ precisely in these mid-array-exhausted states; main's
+behaviour there must be preserved verbatim).
+
+## Round 5: full profiling + benchmark sweep (2026-06-10)
+
+Six 20s CPU/alloc profiles (`/tmp/bmwprof_r5/`: OR_WC, OR_typical, OR_filtered,
+OR_tomb2, AND_size5, OR_WC_conc14 incl. mutex/block), analyzed line-level by a
+7-agent workflow, plus a fresh main-vs-branch benchmark sweep (min-of-N
+interleaved, main worktree `a746884eb6`):
+
+| benchmark | main | branch | Δ |
+|---|---|---|---|
+| serial OR typical (size 5, limit 10) | 280.7 µs | 119.6 µs | **−57%** |
+| serial OR worst-case 10-term | 25.45 ms | 15.23 ms | **−40%** |
+| serial AND typical (size 5) | 35.2 µs | 24.4 µs | **−31%** |
+| parallel RunParallel (GOMAXPROCS=14) | 33.4 µs/op | 13.3 µs/op | **2.5×** |
+| 100-worker load (8s) | 27,631 q/s | 65,802 q/s | **2.38×** |
+| — p50 / p99 / p99.9 latency | 294µs / 26.7ms / 698ms | 107µs / 11.9ms / 344ms | ~2× better |
+
+**Profile regimes.** The code has split into three cost regimes:
+
+1. **Worst-case OR** (WC/tomb2/conc14): the WAND core is 58–64% flat
+   (DoBlockMaxWand 33–36%, reinsertRight 21–26%, AdvanceAtLeast 12–14%,
+   decodeReusable 8–9%) and is now **memory-bound on dependent pointer derefs**
+   through `[]*SegmentBlockMax` + GC write barriers (disasm-confirmed). Every
+   in-layout restructure tried in rounds 1–4 regressed → instruction-level
+   headroom is spent; remaining levers are a data-layout change (SoA hot-field
+   mirror) or fewer iterations (algorithmic).
+2. **Setup-bound** (AND_size5 is ~75% setup, OR_typical ~26%): term construction
+   does **three DiskTree descents per (term, segment)** for the same key
+   (hasKey, getDocCount, NewSegmentBlockMax), reallocates `NodeKeyBuffer` per
+   visited node (a cap-vs-len growth check at `disk_tree.go:68` — **62% of ALL
+   allocated objects**), and builds memtable terms even when memtables are empty.
+   AND allocates 30GB/20s; all of it setup, zero in the scoring loop.
+3. **Filtered**: sroar `Contains` is 34.7% of CPU (~1.8B probes); 86% of each
+   probe is a redundant key→container binary search although probes are monotonic
+   ascending with a 99.97% same-container hit rate → a container-cursor cache in
+   the sroar fork would amortize it (distinct from the rejected dense bitset:
+   zero build cost).
+
+**Concurrency: closed.** 0.11% mutex delay at conc 14, 100% of it runtime
+allocator locks reached from setup allocations; zero application mutexes (the
+atomic refcount holds under load); 10.1× parallelism on 10 P-cores.
+
+**Deferred-tombstone validation in the profile:** OR_tomb2's
+advanceOnTombstoneOrFilter is at OR_WC levels (3.8% vs 3.2% — no per-advance
+probes); the residual tomb2 gap (61 vs 66 q/s) is the per-term
+`ReadOnlyTombstones Clone+Or` in createDiskTermFromCV, hoistable to per-query.
+
+**Ranked next targets** (1–4 are measured-confident; 7 is the only remaining
+WAND-core lever and is prototype-gated):
+1. Dedupe DiskTree descents: 1 `Get` per (term,segment) instead of 3 (est. −25–30%
+   AND, −8% typical).
+2. Zero-copy DiskTree.Get descent + fix the NodeKeyBuffer cap-vs-len growth check
+   (est. −10–15% AND; removes 62% of allocated objects).
+3. Cache decoded `[]terms.BlockEntry` per (segment, node) + pool the reset
+   buffers (attacks 60–80% of alloc bytes everywhere; est. −8–12% OR_WC).
+4. Hoist the memtable-tombstone Clone+Or out of the per-term loop (−3–5% tomb2,
+   >90% of its alloc volume).
+5. Container-cursor `Contains` in the sroar fork (est. −25–30% filtered).
+6. Setup trivia: skip empty-memtable terms; `NewMinWithId` off-by-one regrow
+   (queue.go:159).
+7. SoA hot-field mirror for Terms (ids as contiguous `[]uint64`) — the only
+   remaining lever on the memory-bound WAND core; high revert-risk, prototype.
+8. advanceOnTombstoneOrFilter fast-path inlining via outlined slow loop (~1%).
+9. Per-bitwidth decode kernels / fused decode-until-target (defer; complexity).
+
+## Round 6: setup-path optimization (status: DONE)
+
+Implements round-5 targets 1, 2, 4, 6 — the query-SETUP path (term construction),
+which round-5 profiling showed dominates AND (~75%) and weighs on typical OR
+(~26%). The WAND scoring loop is untouched. Deferred: target 3 (BlockEntry cache —
+compaction lifecycle needs its own round), 5 (sroar fork), 7 (SoA prototype).
+
+1. **One index descent per (term, segment) instead of three**
+   (`getInvertedNodeAndDocCount`: bloom + `index.Get` + docCount read fused;
+   `newSegmentBlockMax` accepts the prefetched node, nil = old path). Inverted
+   segments where the key is absent skip construction outright; non-inverted
+   segments keep the constructor-does-its-own-Get path verbatim (mixed-strategy
+   buckets unaffected).
+2. **Zero-copy `DiskTree.Get`**: node keys compared in place against the tree
+   data; only the matched node's key is materialized (`bytes.Clone`). Kills both
+   the per-Get buffer alloc and the per-node regrow (the old growth check
+   compared len, not cap — 62% of ALL allocated objects on setup-bound loads).
+   Serves all strategies; full lsmkv integration suite passed under `-race`.
+3. **Memtable tombstones hoisted out of the per-term loop** — one
+   `ReadOnlyTombstones` Clone+Or per query instead of per term (the bitmaps are
+   invariant within a consistent view; all flushing terms share one read-only
+   clone).
+4. **Memtable terms built only when `getMap` finds the key** (was:
+   always-construct + fillTerm; empty-memtable construction was 11%+ of typical's
+   alloc bytes).
+5. **topK heaps preallocate `limit+1`** (`InsertAndPop` holds limit+1 items
+   between insert and pop; exact-limit capacity forced one regrow per query).
+
+Measured (min-of-6 interleaved vs pre-change HEAD `1b5c9990eb`):
+
+| workload | before | after | Δ ns/op | Δ B/op |
+|---|---|---|---|---|
+| AND typical (size 5) | 23.2 µs / 37.5 KB | 12.6 µs / 28.9 KB | **−46%** | −23% |
+| OR typical (size 5) | 114.4 µs / 39.5 KB | 103.7 µs / 28.9 KB | **−9.4%** | −27% |
+| OR worst-case + tombstones 2% | 16.87 ms / 6.12 MB | 16.37 ms / 0.96 MB | −2.9% | **−84%** |
+| OR worst-case | 15.31 ms | ±noise | neutral | −8% |
+
+(OR worst-case deltas are within the ±11% same-binary machine noise; setup is
+~0.7% of that query, so neutrality is expected.)
+
+**30-common-term stress, limit 1000** (top-30 most frequent sampled terms via the
+new `TestBMWTopTerms` helper — incl. "that" at 938k docs ≈ 17% of the corpus, so
+WAND pruning barely engages and this approximates a full-scoring scan;
+min-of-5 interleaved):
+
+| | time | B/op | allocs/op |
+|---|---|---|---|
+| main `a746884eb6` | 131.4 ms | 5.45 MB | 165,923 |
+| branch (round 6) | 53.9 ms | 0.87 MB | **906** |
+| Δ | **−59% (2.4×)** | **−84%** | **−99.5%** |
+
+main's 166k allocs/op at limit 1000 is the per-accepted-doc `sort.Sort` boxing
+plus per-query setup churn; the branch holds a flat ~900 allocs regardless of
+limit. vs the pre-round-6 branch, time is neutral (setup ≈0.3% of a 50ms query)
+and B/op drops a further −23% (1.13 → 0.87 MB). Bit-identical vs main confirmed
+at this config (0 doc-set changes, 0 score drift).
+
+QPS under concurrent load (`TestBMWConcurrentLoad`, same 30-term limit-1000
+query, 10s):
+
+| workers | side | q/s | p50 | p99 |
+|---|---|---|---|---|
+| 14 (cores) | main | 77 | 177 ms | 255 ms |
+| 14 | branch | **190 (2.5×)** | 70 ms | 119 ms |
+| 100 | main | 78 | 1.22 s | 1.98 s |
+| 100 | branch | **201 (2.6×)** | 445 ms | 853 ms |
+
+Throughput saturates at core count on both sides (CPU-bound; 100 workers only
+multiply queue latency), so the 2.5–2.6× is pure per-query CPU reduction.
+
+### Second dataset: ltk_desc (3GB single segment, multilingual product text)
+
+Same 30-common-term limit-1000 shape on a structurally different corpus (one
+3GB level-15 segment vs climate_fever's three; head term "eignet" 220k docs with
+a fast Zipf drop-off vs climate_fever's 938k/17%-of-corpus head). Bit-identical
+vs main (0 doc-set changes, 0 score drift). min-of-5 interleaved:
+
+| | main | branch | Δ |
+|---|---|---|---|
+| serial time | 30.0 ms | 15.3 ms | **−49% (2.0×)** |
+| serial B/op | 1.84 MB | 0.23 MB | **−88%** |
+| serial allocs/op | 56,465 | 354 | **−99.4%** |
+| QPS @14 workers | 181 q/s | 315 q/s | **1.74×** |
+| p50 / p99 | 47.8 ms / 498 ms | 23.3 ms / 171 ms | p99 **−66%** |
+
+main's concurrent p99 degrades far past its serial time (~10M allocs/s of GC
+pressure at 181 q/s); the branch's flat ~350 allocs keeps the tail tight.
+
+**Hotspot cross-check (20s profile, same shape):** identical hotspot *set* to
+climate_fever — the five WAND-core functions, no new entries, no I/O/memmove,
+setup negligible — but the ranking shifts with corpus shape:
+
+| function | ltk_desc | climate_fever T30 |
+|---|---|---|
+| Terms.sortByID | **20.4% (#1)** | 13.5% (#3) |
+| DoBlockMaxWand | 16.9% | 31.4% |
+| Terms.reinsertRight | 9.8% | 18.3% |
+| AdvanceAtLeast | 6.4% | 9.4% |
+| decodeReusable | 4.1% | 6.9% |
+| priorityqueue (insert/heapify/swap/Less) | ~3.9% | ~1.5% |
+
+On ltk_desc the matched branch dominates (steeper Zipf → terms align constantly;
+58.8k docs scored/query), so the per-match full `sortByID` of 30 terms becomes
+the single largest cost. Two corpora now independently rank the matched-branch
+re-sort as the top remaining target — prioritize the prefix-reinsert re-measure
+and the SoA id-mirror (both make the re-sort cheaper or unnecessary).
+
+### I/O & memory-copy attribution (30-term limit-1000 shape)
+
+Is I/O or copying a bottleneck? **No, neither — measured:**
+
+- **I/O: zero on the default path.** Segments this size are mmap'd
+  (`readFromMemory`), and the whole disk→decoder chain is zero-copy:
+  `loadBlockDataReusable` decodes straight from `s.contents`,
+  `DecodeBlockDataReusable` just reslices. The 20s CPU profile contains **no
+  read-syscall and no `runtime.memmove` frames at all**. Steady-state the 897MB
+  segment is page-cache resident.
+- **Forcing the syscall path (`BMW_PREAD=true`) costs only ~5%** (19 → 18 q/s)
+  despite ~20k preads + 4KB kernel→user copies per query (~80MB/query,
+  ~1.4GB/s of forced copying) — even deliberate I/O+copy barely moves this
+  workload. (The pread profile shows 96% in `syscall.pread`; that is Darwin
+  SIGPROF attribution skew at ~366k syscalls/s — trust the wall-clock delta.)
+- **Intrinsic data movement is small**: varint decode (the actual decompression,
+  2.59M docIDs/query) is 6.9%; GC traffic (madvise+memclr) ~3.5% after round 6.
+  Decode-output bandwidth ≈ 0.4GB/s — nowhere near memory bandwidth.
+
+The bottleneck is the WAND core's compare/sort logic, **memory-latency-bound**
+(dependent pointer derefs), not bandwidth: DoBlockMaxWand 31.4% + reinsertRight
+18.3% + sortByID 13.5% + AdvanceAtLeast 9.4% ≈ 79%.
+
+**New shape-specific finding:** `sortByID` is 13.5% here vs 1.9% on the 10-term
+worst case — 30 common terms co-occur in nearly every doc, so the matched branch
+fires per scored doc and full-sorts 30 elements each time. The round-3
+"matched-branch prefix reinsert" idea was skipped when sortByID measured 1.9%;
+at 13.5% on this shape it deserves a re-measure, and it strengthens the SoA
+hot-field-mirror target (round-5 rank 7).
+
+**Validation:** bit-identical vs pre-change HEAD across 8 configs × 2000 queries
+(OR/AND × tombstones 0/2% × limit 10/100, filter 10%, filter+tombstone combined) —
+0 doc-set changes, 0 score drift; segmentindex + lsmkv unit suites; **full** lsmkv
+integration suite `-race` (covers the new `DiskTree.Get` under every strategy);
+inverted suite `-race`; linters clean. A 4-lens adversarial review workflow
+(aliasing/ownership, lifecycle/concurrency, strategy/error paths, non-BMW
+`DiskTree.Get` callers) confirmed zero critical/major findings.
+
+Known intentional divergences from main (unobservable in valid use): a shared
+read-only tombstone clone across flushing terms (was per-term clones; nothing
+mutates them); inverted-absent-key terms skip construction instead of failing
+inside the constructor; the empty-filter + key-in-memtable case no longer
+nil-panics into the recover handler.
+
+## Tombstone density of the test datasets (`TestBMWTombstoneStats`)
+
+| dataset | docs stored | distinct tombstoned docIDs | deleted share |
+|---|---|---|---|
+| ltk_desc (6 segments, 14GB) | 244.5M | 63.7M | **26.1%** |
+| climate_fever | 5.4M | 0 | 0% |
+
+ltk per segment (a segment's bitmap targets *older* segments' docs, merged
+forward — hence ratios >100% against its own doc count): l18 63.7M, l16 63.7M,
+l15 40.3M, l13 29.9M, l12 26.6M, l5 80,192 — the newest segment's tombstones
+exactly equal its own doc count, the signature of a pure-update workload (every
+insert deletes a prior version). Implications: (a) real-world tombstone density
+here is **13× the 2% synthetic rate** used to validate the deferred-tombstone
+change — on main every advanced doc probes a 63.7M-entry sroar bitmap, on the
+branch only scored candidates do, and that effect is already baked into the ltk
+main-vs-branch numbers; (b) side observation (main behaviour, untouched): this
+bucket's `GetAveragePropertyLength` count — used as N in idf — reports 2.18B vs
+244.5M actually stored docs, i.e. the cached averagePropCount appears to
+accumulate across updates/compactions without subtracting; worth a separate
+look since it skews idf.
+
+## Heap usage during querying (post-round-7)
+
+inuse_space after `runtime.GC()`, T30 limit-1000 workload:
+
+| | ltk (14GB, 244M docs) | climate_fever (5.4M docs) |
+|---|---|---|
+| total live heap | **8.75 GB** | 178 MB |
+| propLengths maps (`gobenc.decodeFast`) | **8.04 GB (92%)** | 144.5 MB (81%) |
+| dense propLengths arrays | 511 MB | 20.4 MB |
+| tombstone bitmaps | 150 MB | — |
+| per-query churn | ~500 objs / few MB | ~350 objs / 0.87 MB |
+
+The live heap while querying is almost entirely **bucket-open state**: the
+per-segment `map[uint64]uint32` property-lengths maps (~33B/entry of Go map
+overhead for 244M entries). Per-query allocation is invisible after round 6.
+The round-3 dense arrays only get built when a segment's docID span is ≤4/3 of
+its entry count (`buildDensePropertyLengths`); on ltk only ~128M of span
+qualified — the update-heavy history (26% deleted, survivors scattered across a
+2.18B docID space) makes most segments too sparse — **and even when dense is
+built, the map is retained as fallback**, so dense adds memory instead of
+replacing it.
+
+Ranked follow-ups (memory, not query-CPU): (1) free the map when the dense
+array fully covers its key range (easy; recovers the entire map for dense
+segments); (2) a compact sparse representation for the rest — sorted
+docID+length pairs (12B/entry ≈ 2.9GB for ltk, 2.8× less than the map) or a
+paged two-level array; trade a binary search per first-scored-doc against the
+current map probe (propLengthOf was ~3% CPU — measure); (3) note that
+compaction-time docID compaction would fix the sparsity at the root.
+
+## Rounds 8–10: property-lengths memory overhaul (status: DONE)
+
+The heap analysis showed 92% of live query-time heap was the per-segment
+`map[uint64]uint32` property-lengths maps (~33B/entry; 8.04GB on ltk). Three
+iterations, each measured:
+
+**r8 (dense + map-drop):** widened the round-3 dense gate to 12.5% density and
+released the map once dense was built (compaction re-decodes from disk on
+demand; an audit workflow traced every consumer first — notable finds: the
+reusable inverted cursor loaded the map and NEVER used it (dead code, removed —
+every Like/range filter paid a full map load), zero-length entries provably
+cannot exist, and `getPropertyLengths` must never return an empty map for a
+non-empty segment or compaction silently writes corrupt block-max metadata).
+Result: ltk 8.75 → 3.08GB, bit-identical, all suites green.
+
+**r9 (pairs-only, dense removed) — NEGATIVE RESULT:** sorted parallel arrays
+(`ids []uint64` + `lens []uint32`, 12B/entry exact) for ALL segments, decoded
+straight into pre-allocated arrays by `gobenc.DecodePairs` (the map never
+exists, even at open) and sorted by an LSD radix sort (insertion sort is O(n²)
+here — gob emits random map order). Pairs beat the maps (ltk neutral) but lost
+3.2× to dense on dense-shaped data (cf typical 173→527µs): scoring skips
+hundreds of pairs entries per lookup, and ~log(gap) cache-missing probes can't
+compete with dense's single indexed load. Dense is also *smaller* than pairs
+above 33% occupancy.
+
+**r10 (hybrid, shipped):** per segment, dense when span/3 ≤ count (≥33%
+occupancy — no sort needed, fill from unsorted pairs), sorted pairs below; the
+map never retained; both representations behind one `propLengthsView`.
+Pairs lookup evolution (each step measured): cursor+gallop (+30% on rare-term
+queries: huge gaps → ~30 probes), pure interpolation (fixed rare terms, hurt
+frequent ones), final = linear-4 → bounded gallop (+4/+16/+64) → budgeted
+interpolation → binary. The pairs are near-uniformly thinned docID sequences,
+so interpolation lands within a few entries regardless of jump size.
+
+| | main/r7 (maps+old dense) | r10 hybrid |
+|---|---|---|
+| ltk live heap | 8.55 GB | **2.01 GB (4.3×)** |
+| ltk bucket open | minutes (map decode) | seconds (pairs decode + radix/dense fill) |
+| cf typical / T30 / WC10 | — | parity with r7 (dense again) |
+| ltk typical (rare terms) | 3.45 ms | **2.13 ms (−38%)** |
+| ltk T30 (frequent terms) | — | ±5% (noise band) |
+
+Validated: bit-identical matrix (9 configs × both datasets) vs r7, full lsmkv +
+inverted suites `-race`, linters. `getPropertyLengths` reconstructs a transient
+exact map from either representation for compaction-frequency callers.
+
+## Round 7: matched-branch sort elision (status: DONE)
+
+Both datasets' 30-common-term profiles ranked the matched branch's unconditional
+`sortByID` as the top remaining cost (ltk 20.4%, cf 13.5%): matched-dense queries
+re-sort all n terms per scored doc when only the advanced prefix moved.
+
+**Change** (`DoBlockMaxWand`): a function-local `needFullSort` flag. It is set
+when an `AdvanceAtLeastShallow` in the upperBound loop *actually moves*
+(`blockEntryIdx` changed — moves and exhausts always increment it, the
+early-return no-op never does), because shallow advances mutate idPointers (and
+can exhaust terms) in place, leaving inversions/mis-placed sentinels that only a
+full sort repairs. While the flag is clear, the matched branch restores order
+with right-to-left `reinsertRight` over just the `advanced` prefix instead of
+`sortByID`. Matched iterations never *really* shallow-advance (their live prefix
+is aligned, so true block-max ≥ pivot), so matched-dense runs stay on the cheap
+path; prune-heavy runs fall back to the full sort and lose nothing but a branch.
+
+**Adversarial verification (3-agent refuter panel) found a real flaw in the
+first version**: `decodeBlock`'s ENCODE_AS_FULL_BYTES path (docCount==1 terms)
+never initializes `currentBlockMaxId` (stays 0), so the shallow guard over-fires
+for live singleton terms in matched iterations — a *conservative* failure
+(no-op call, but the naive flag-set defeated the fast path for any query with a
+rare term). Fixed by the `blockEntryIdx`-change detection above. The panel also
+*proved* the permutation-equivalence claim with a 2M-case property test
+(right-to-left reinsertRight over a dirty prefix + sorted suffix == stable
+insertion sort, incl. equal-id and sentinel cases) and traced every
+idPointer/exhaust writer to confirm flag coverage. Two pre-existing main quirks
+recorded (not touched): stale `currentBlockMaxId=0` makes prune-branch `next`
+computations conservative for singleton terms; memtable terms' MaxImpactTf=0
+zeroes their currentBlockImpact via SetIdf.
+
+**Measured (min-of-N interleaved, r6 → r7):**
+
+| workload | r6 | r7 | Δ |
+|---|---|---|---|
+| ltk 6-segment (14GB) T30, limit 1000 | 549.7 ms | 367.2 ms | **−33%** |
+| cf T30, limit 1000 | 54.8 ms | 51.2 ms | **−6.5%** |
+| ltk 6-segment typical (size 5) | 1.93 ms | 1.82 ms | −5.6% |
+| cf typical (size 5) | 101.5 µs | 98.5 µs | −2.9% |
+| cf worst-case 10-term (prune-heavy) | 15.84 ms | 15.53 ms | ~neutral |
+
+**Validation:** bit-identical vs r6 across 10 configs × 2 datasets — including
+the full 6-segment ltk corpus opened in place — twice (pre- and post-amendment;
+~28k queries total, 0 doc-set changes, 0 score drift); full lsmkv + inverted
+suites `-race`; linters clean.
+
+## Tier 3 (status: DONE)
+
+### 7. `propLengths` map → dense slice
+Per-scored-doc `s.propLengths[s.idPointer]` was a `runtime.mapaccess1_fast64`
+probe. Now each segment also builds, once, a dense `[]uint32` indexed by
+`docID - propLengthsMin` (`buildDensePropertyLengths` in segment_inverted.go);
+`SegmentBlockMax.propLengthOf` uses a single bounds-checked index and falls back
+to the map only for sparse segments. Holes yield 0 in both paths, so results are
+unchanged.
+
+The map is **kept** (compaction `maps.Copy`s it wholesale, plus cursor/merge
+readers), so the dense array is additive memory. To bound it, it is built only
+when the docID range is ≥~75% dense (`span ≤ 4/3·entries`); sparse segments stay
+map-only. Cost when built: `span·4` bytes/segment (≈4·entries when dense) —
+roughly +25% on the property-length memory, a one-time per-segment allocation
+(per-query allocs/op unchanged at ~860).
+
+A/B isolating the Score lookup (climate_fever, 10-term OR, ~1000 docs scored per
+query): **~420µs → ~354µs/op (≈ −16%)** (map: 433/407µs; dense: 367/342µs).
+Correctness: BM25F + inverted pass under `-race`, and the main-vs-branch baseline
+(OR/filtered/AND) stays **bit-identical**.
+
+Note: the win scales with docs-scored-per-query; it is smaller for highly-pruned
+queries. If per-segment memory is tight, the density gate can be tightened or the
+dense build made opt-in.
+
+### 8. Cheaper tombstone/filter probing
+`advanceOnTombstoneOrFilter` → `sroar.Bitmap.Contains` per advanced doc. The
+naive "skip nil-checks" fix was rejected (nil-checks are cheap; the bitmap probe
+is the cost). A dense bitset representation was also prototyped and **rejected**
+— it regressed typical filtered queries ~23× (the O(cardinality) build cost
+dwarfs the per-probe saving).
+
+#### 8a. Defer tombstone checks to scoring time (status: DONE)
+Key insight: a **filter** prunes the WAND candidate space (a disallowed doc is
+genuinely absent), so filter probes at advance time pay for themselves. A
+**tombstone** does *not* — a deleted doc still occupies its slot in every posting
+list and is still visited by the pivot logic; skipping it during advance just
+forces *another* advance, so the per-advanced-doc `Contains` probe is pure
+overhead. The check can therefore move out of `advanceOnTombstoneOrFilter` and
+into the scoring branch of `DoBlockMaxWand`/`DoBlockMaxAnd`: a tombstoned pivot is
+advanced past but never scored or enqueued. This is **bit-identical** to
+advance-time skipping (rejecting a doc at scoring touches neither other docs'
+scores nor the heap threshold `worstDist`), trades ~one-probe-per-advanced-doc for
+~one-probe-per-scored-candidate (far fewer), and is a no-op when there are no
+tombstones. Gated by `deferTombstoneToScore` (default **true**); filters stay at
+advance time.
+
+Measured on `climate_fever` (5.4M docs) with synthetic tombstones injected via the
+active memtable (`BMW_TOMBSTONE_PCT`); advance-time forced with
+`BMW_DEFER_TOMBSTONE=false`:
+
+| scenario (10-term OR worst-case unless noted) | advance-time | deferred | Δ |
+|---|---|---|---|
+| no tombstones (production common case) | 16.92 ms | 16.97 ms | ~0 (neutral) |
+| 2% tombstones | 24.19 ms | 17.95 ms | **−26%** |
+| 5% tombstones | 22.84 ms | 17.69 ms | **−23%** |
+| 10% filter + 2% tombstones | 11.49 ms | 11.15 ms | −3% |
+| typical set (size 5, 2000q), 2% tombstones | 700 µs | 669 µs | −4.5% |
+
+Allocations identical in every case. Deferred latency tracks the no-tombstone
+baseline regardless of tombstone rate (the advance side no longer probes).
+
+**Correctness:** bit-identical (2000-query baseline, OR + AND, limit 10/100,
+±filter, 0 doc-set changes / 0 score drift); the no-tombstone case is also
+bit-identical to forced advance-time, so flipping the default is provably a no-op
+on tombstone-free data. The gate-off code path reduces to the pre-change code
+(`DoBlockMaxWand` only reorders `InsertAndPop` ahead of the independent advance
+loop), which was already == `main`. Real-tombstone path verified with
+`TestTombstonesInverted_Compaction` (delete + compact + `DoBlockMaxWand`) and the
+`inverted` search suite under `-race`. Every `SegmentBlockMax` consumer (disk
+segments + flushing-memtable iterators carrying `activeTombstones`) flows through
+`DoBlockMax*`, so the scoring-time re-check covers the whole production path.
+
+Harness: `BMW_TOMBSTONE_PCT` injects synthetic deletes; `BMW_DEFER_TOMBSTONE`
+overrides the default only when set, so dump/compare can A/B the two strategies.
+
+## Filtered search + concurrency (harness extensions)
+
+The harness now supports `BMW_FILTER` (build an `AllowList` of given selectivity),
+`BMW_CONCURRENCY`, and a `BMW_SCALING` sweep that also captures mutex/block
+profiles. Findings on `climate_fever` (5.4M docs, 10-term OR, GOMAXPROCS=14):
+
+### Filter path
+With a 10%-selectivity filter, `SegmentBlockMax.advanceOnTombstoneOrFilter →
+sroar.Bitmap.Contains` is **~31% of CPU** (sroar `node.search`/`getContainer`/
+`keyOffset`/`getValue` traversal) — the per-advanced-doc bitmap membership check
+dominates. This reproduces the customer's residual BM25 cost (their
+`generateSingleFilter`/`sroar` time) and matches Tier-3 item #8 (tombstone/filter
+probing). A per-block filter short-circuit or a cheaper membership structure is
+the lever; the naive nil-check removal does not help (the cost is the probe).
+
+### Concurrency contention
+Scaling efficiency (per-worker q/s vs single-worker):
+
+| workers | q/s | efficiency |
+|---------|-----|-----------|
+| 1 | 4,521 | 100% |
+| 8 | 33,766 | 93% |
+| 14 | 42,117 | 67% |
+| 28 | 42,930 | 34% |
+| 56 | 39,745 | 16% |
+
+Scales well to ~core count, then plateaus (CPU saturation) and *declines* past it
+(real contention overhead). Mutex/block profiles pinpoint two sources:
+
+1. **`segmentRefCounterLock` (`sync.Mutex`)** — `getConsistentViewOfSegments` and
+   `ReleaseView` took it twice per query to inc/decRef every segment.
+   **DONE:** `segment.refCount` is now an `atomic.Int64`; the mutex is removed.
+   incRef still happens under `maintenanceLock.RLock` (ordering vs compaction
+   preserved), and awaiting-drop segments only see refs decrease, so the
+   lock-free atomic reads are safe. Verified: new `-race` unit tests
+   (`TestSegmentRefCountAtomic`, `TestSegmentGroupConsistentViewConcurrent`),
+   compaction/inverted/BM25F regression under `-race`, and the mutex profile no
+   longer shows the lock. Scaling efficiency improved at/below core count
+   (8 workers 93%→99%, 14 workers 67%→73%); past GOMAXPROCS the residual is CPU
+   saturation + #2 below, not this lock.
+2. **`runtime._LostContendedRuntimeLock`** (~73% of mutex delay at 28 workers) —
+   NOT a located call site and not addressed by any change here. It is a Go
+   runtime synthetic frame: each M can keep only one runtime-internal-lock
+   contention stack, and the overflow is bucketed under this sentinel
+   (runtime/mprof.go). It is a *symptom of oversubscription* — many more runnable
+   goroutines than cores contending on scheduler/allocator/GC locks — and only
+   shows up past GOMAXPROCS, where efficiency is already CPU-bound. Levers, none
+   verified to move this frame: (a) bound concurrent queries to ≈ core count
+   (the only thing that removes the oversubscription); (b) re-profile unfiltered
+   in `go tool pprof` to see which real runtime stacks accompany it (the harness
+   top-N hides them); (c) lower allocation/GC traffic *may* shrink the
+   allocator-lock portion, but this is unproven for this frame.
+
+## Measuring each change
+
+Pin inputs and compare throughput (queries/s), the target function's flat %, and
+`-benchmem` alloc/op for #1/#2/#5:
+
+```
+BASE="BMW_SEGMENTS_DIR=/…/property_text_searchable BMW_QUERY_SIZE=10 BMW_NUM_QUERIES=1000 BMW_SEED=42 BMW_PROFILE_SECONDS=20"
+env $BASE go test -tags integrationTest -run TestProfileBlockMaxWand -v -timeout 30m ./adapters/repos/db/lsmkv/
+env $BASE go test -tags integrationTest -run x -bench 'BenchmarkBlockMaxWand/size=10' -benchmem ./adapters/repos/db/lsmkv/
+```
+
+For per-function isolation, add in-memory micro-benchmarks built on the existing
+`NewSegmentBlockMaxTest` (`segment==nil`, no disk) + `createBlocks` with
+realistic Zipf postings: `BenchmarkDoBlockMaxWand`, `BenchmarkSegmentBlockMaxScore`,
+`BenchmarkSegmentBlockMaxAdvance`, `BenchmarkSegmentBlockMaxDecodeBlock`.


### PR DESCRIPTION
### What's being changed:

Test on local 5.4M dataset (limit=10, random terms)
Metric | main | this PR | Δ
-- | -- | -- | --
Latency / query (serial) | 485 µs | 275 µs | −43 %
Allocations / query | 2,173 | 863 | −60 %
Bytes allocated / query | 251 KB | 71 KB | −72 %
Throughput @ 14 cores | 17.9k q/s | 39.3k q/s | 2.2×
Throughput @ 100 concurrent clients | 15.6k q/s | 36.8k q/s | 2.4×
p50 latency @ 100 clients | 450 µs | 157 µs | −65 %
p99 latency @ 100 clients | 63 ms | 46 ms | −27 %

Test on local 5.4M dataset (limit=100, 10-term query of common terms)
Metric | main | this PR | Δ
-- | -- | -- | --
Latency / query (serial) | 31.3 ms | 18.5 ms | −41 %
Allocations / query | 36,129 | 1,129 | −97 % (32× fewer)
Bytes allocated / query | 1.29 MB | 322 KB | −75 %
Throughput @ 14 cores | 353 q/s | 611 q/s | 1.73×
Throughput @ 100 concurrent clients | 358 q/s | 538 q/s | 1.50×
p50 latency @ 100 clients | 216 ms | 183 ms | −15 %
p99 latency @ 100 clients | 987 ms | 602 ms | −39 %



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
