### PR TITLE
chore: lower async replication scheduler defaults

### DIFF
--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1808,14 +1808,14 @@ const (
 	DefaultGRPCIdleConnTimeout                 = 5 * time.Minute
 	DefaultMinimumReplicationFactor            = 1
 	DefaultMaximumReplicationFactor            = 0 // 0 / negative = no cap
-	DefaultAsyncReplicationSchedulerWorkers    = 10
+	DefaultAsyncReplicationSchedulerWorkers    = 3
 	// MaxAsyncReplicationSchedulerWorkers is the hard ceiling on the worker
 	// pool size. The scheduler's internal channel buffers (workCh, resultCh,
 	// scaleDownCh) are all sized relative to this value; exceeding it requires
 	// a code change, so we enforce it at config parse time rather than silently
 	// capping.
 	MaxAsyncReplicationSchedulerWorkers            = 100
-	DefaultAsyncReplicationHashtreeInitConcurrency = 100
+	DefaultAsyncReplicationHashtreeInitConcurrency = 10
 	DefaultMaximumAllowedCollectionsCount          = -1 // unlimited
 	DefaultMaximumAllowedObjectsCount              = -1 // unlimited
 	DefaultMaximumAllowedTenantsPerCollection      = -1 // unlimited


### PR DESCRIPTION
## Summary

Lowers two async-replication default configuration values to reduce baseline resource usage:

| Constant | Old | New |
|---|---|---|
| `DefaultAsyncReplicationSchedulerWorkers` | 10 | 3 |
| `DefaultAsyncReplicationHashtreeInitConcurrency` | 100 | 10 |

Both remain fully overridable at runtime via the existing env vars:
- `ASYNC_REPLICATION_SCHEDULER_WORKERS`
- `ASYNC_REPLICATION_HASHTREE_INIT_CONCURRENCY`

The `MaxAsyncReplicationSchedulerWorkers` hard ceiling (100) is unchanged, so no channel-buffer sizing is affected.

## Test plan

- `go test ./usecases/config/...` — passes
- `go test -race ./adapters/repos/db/` (async replication scheduler unit tests) — passes