### PR TITLE
Harden replica movement gating before CCL sealing

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -705,6 +705,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 
 	appState.ClusterService = rCluster.New(rConfig, appState.AuthzController, appState.AuthzSnapshotter, appState.GRPCServerMetrics)
 	migrator.SetCluster(appState.ClusterService.Raft)
+	appState.ClusterService.SetInflightDrainer(repo.WaitForLocalInflightWrites)
 
 	// Wrap RestoreClassDir so each post-RAFT-apply class-dir move also
 	// fires the orphan-reindex audit on the restored on-disk state.

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -418,6 +418,18 @@ func (db *DB) GetIndex(className schema.ClassName) *Index {
 	return index
 }
 
+// WaitForLocalInflightWrites blocks until this node's in-flight coordinated
+// writes to the given shard have drained, or ctx is done.
+func (db *DB) WaitForLocalInflightWrites(ctx context.Context, class, shard string) error {
+	db.indexLock.RLock()
+	index := db.indices[indexID(schema.ClassName(class))]
+	db.indexLock.RUnlock()
+	if index == nil || index.replicator == nil {
+		return nil
+	}
+	return index.replicator.WaitForDrain(ctx, shard)
+}
+
 // GetLocalShardNames returns the names of all shards local to this node for
 // the given collection. Returns an error if the collection is not found or has
 // no local shards.

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -421,14 +421,16 @@ func (db *DB) GetIndex(className schema.ClassName) *Index {
 // WaitForLocalInflightWrites blocks until this node's in-flight coordinated
 // writes to the given shard have drained, or ctx is done.
 func (db *DB) WaitForLocalInflightWrites(ctx context.Context, class, shard string) error {
-	db.indexLock.RLock()
-	index := db.indices[indexID(schema.ClassName(class))]
-	if index == nil || index.replicator == nil {
-		db.indexLock.RUnlock()
-		return nil
-	}
-	index.dropIndex.RLock()
-	db.indexLock.RUnlock()
+	var index *Index
+	func() {
+		db.indexLock.RLock()
+		defer db.indexLock.RUnlock()
+		index = db.indices[indexID(schema.ClassName(class))]
+		if index == nil || index.replicator == nil {
+			return
+		}
+		index.dropIndex.RLock()
+	}()
 	defer index.dropIndex.RUnlock()
 	return index.replicator.WaitForDrain(ctx, shard)
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -423,10 +423,13 @@ func (db *DB) GetIndex(className schema.ClassName) *Index {
 func (db *DB) WaitForLocalInflightWrites(ctx context.Context, class, shard string) error {
 	db.indexLock.RLock()
 	index := db.indices[indexID(schema.ClassName(class))]
-	db.indexLock.RUnlock()
 	if index == nil || index.replicator == nil {
+		db.indexLock.RUnlock()
 		return nil
 	}
+	index.dropIndex.RLock()
+	db.indexLock.RUnlock()
+	defer index.dropIndex.RUnlock()
 	return index.replicator.WaitForDrain(ctx, shard)
 }
 

--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -131,6 +131,10 @@ func (s *Raft) ReplicationFsm() *replication.ShardReplicationFSM {
 	return s.store.replicationManager.GetReplicationFSM()
 }
 
+func (s *Raft) SetInflightDrainer(fn func(ctx context.Context, class, shard string) error) {
+	s.store.replicationManager.SetInflightDrainer(fn)
+}
+
 func (s *Raft) IsLeader() bool {
 	return s.store.IsLeader()
 }

--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -47,7 +47,10 @@ type Manager struct {
 	// know who reported.
 	localNodeID       string
 	submitNodeReached func(ctx context.Context, req *cmd.ReplicationNodeReachedStateRequest) error
+	inflightDrainer   func(ctx context.Context, class, shard string) error
 }
+
+const inflightDrainBackstop = 60 * time.Second
 
 func NewManager(schemaReader schema.SchemaReader, nodeSelector cluster.NodeSelector, reg prometheus.Registerer) *Manager {
 	replicationFSM := NewShardReplicationFSM(reg)
@@ -70,6 +73,10 @@ func (m *Manager) SetNodeReachedStateSubmitter(
 	m.submitNodeReached = submit
 }
 
+func (m *Manager) SetInflightDrainer(fn func(ctx context.Context, class, shard string) error) {
+	m.inflightDrainer = fn
+}
+
 // broadcastNodeReachedState submits a node-reached-state command async so
 // the FSM apply that triggered it can't block on RAFT. Bounded backoff;
 // idempotent on receipt (monotonic per peer).
@@ -77,11 +84,12 @@ func (m *Manager) broadcastNodeReachedState(opID uint64, state cmd.ShardReplicat
 	if m.submitNodeReached == nil || m.localNodeID == "" {
 		return
 	}
-	logger := m.logger
-	if logger == nil {
-		logger = logrus.New()
-	}
+
 	enterrors.GoWrapper(func() {
+		if state == cmd.INTEGRATING {
+			m.drainInflight(opID)
+		}
+
 		req := &cmd.ReplicationNodeReachedStateRequest{
 			Version: cmd.ReplicationCommandVersionV0,
 			Id:      opID,
@@ -94,13 +102,36 @@ func (m *Manager) broadcastNodeReachedState(opID uint64, state cmd.ShardReplicat
 			return m.submitNodeReached(context.Background(), req)
 		}, bo)
 		if err != nil {
-			logger.WithFields(logrus.Fields{
+			m.logger.WithFields(logrus.Fields{
 				"op_id":   opID,
 				"node_id": m.localNodeID,
 				"state":   state,
 			}).Error(fmt.Errorf("broadcast node-reached-state exhausted retries: %w", err))
 		}
-	}, logger)
+	}, m.logger)
+}
+
+func (m *Manager) drainInflight(opID uint64) {
+	if m.inflightDrainer == nil {
+		return
+	}
+	op, ok := m.replicationFSM.GetOpById(opID)
+	if !ok {
+		return
+	}
+	class := op.Op.SourceShard.CollectionId
+	shard := op.Op.SourceShard.ShardId
+
+	ctx, cancel := context.WithTimeout(context.Background(), inflightDrainBackstop)
+	defer cancel()
+	if err := m.inflightDrainer(ctx, class, shard); err != nil {
+		m.logger.WithFields(logrus.Fields{
+			"op_id":   opID,
+			"node_id": m.localNodeID,
+			"class":   class,
+			"shard":   shard,
+		}).Warnf("in-flight write drain before INTEGRATING did not complete, proceeding: %v", err)
+	}
 }
 
 func (m *Manager) GetReplicationFSM() *ShardReplicationFSM {

--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -45,9 +45,10 @@ type Manager struct {
 
 	// localNodeID is embedded in node-reached-state broadcasts so peers
 	// know who reported.
-	localNodeID       string
-	submitNodeReached func(ctx context.Context, req *cmd.ReplicationNodeReachedStateRequest) error
-	inflightDrainer   func(ctx context.Context, class, shard string) error
+	localNodeID                  string
+	submitNodeReached            func(ctx context.Context, req *cmd.ReplicationNodeReachedStateRequest) error
+	inflightDrainer              func(ctx context.Context, class, shard string) error
+	inflightDrainFailuresCounter prometheus.Counter
 }
 
 const inflightDrainBackstop = 60 * time.Second
@@ -58,6 +59,11 @@ func NewManager(schemaReader schema.SchemaReader, nodeSelector cluster.NodeSelec
 		replicationFSM: replicationFSM,
 		schemaReader:   schemaReader,
 		nodeSelector:   nodeSelector,
+		inflightDrainFailuresCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "weaviate",
+			Name:      "inflight_drain_failures_total",
+			Help:      "Total number of failures to drain in-flight writes before transitioning to INTEGRATING or DEHYDRATING state",
+		}),
 	}
 }
 
@@ -125,6 +131,7 @@ func (m *Manager) drainInflight(opID uint64) {
 	ctx, cancel := context.WithTimeout(context.Background(), inflightDrainBackstop)
 	defer cancel()
 	if err := m.inflightDrainer(ctx, class, shard); err != nil {
+		m.inflightDrainFailuresCounter.Inc()
 		m.logger.WithFields(logrus.Fields{
 			"op_id":   opID,
 			"node_id": m.localNodeID,

--- a/cluster/replication/manager.go
+++ b/cluster/replication/manager.go
@@ -86,7 +86,7 @@ func (m *Manager) broadcastNodeReachedState(opID uint64, state cmd.ShardReplicat
 	}
 
 	enterrors.GoWrapper(func() {
-		if state == cmd.INTEGRATING {
+		if state == cmd.INTEGRATING || state == cmd.DEHYDRATING {
 			m.drainInflight(opID)
 		}
 

--- a/cluster/replication/manager_inflight_test.go
+++ b/cluster/replication/manager_inflight_test.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/schema"
+)
+
+func newDrainTestManager(t *testing.T, opID uint64, coll, shard string) *Manager {
+	t.Helper()
+	// schemaReader/nodeSelector are unused on the broadcastNodeReachedState path.
+	m := NewManager(schema.SchemaReader{}, nil, prometheus.NewPedanticRegistry())
+	m.SetLogger(logrus.New())
+	require.NoError(t, m.GetReplicationFSM().Replicate(opID, &cmd.ReplicationReplicateShardRequest{
+		Version:          cmd.ReplicationCommandVersionV0,
+		Uuid:             strfmt.UUID("00000000-0000-0000-0000-000000000001"),
+		SourceNode:       "node1",
+		SourceCollection: coll,
+		SourceShard:      shard,
+		TargetNode:       "node2",
+		TransferType:     cmd.COPY.String(),
+	}))
+	return m
+}
+
+// The fix's wiring: a node must not report it reached INTEGRATING until its
+// in-flight coordinated writes to the moving shard have drained.
+func TestManager_HoldsIntegratingReportUntilDrained(t *testing.T) {
+	const opID = uint64(1)
+	m := newDrainTestManager(t, opID, "TestClass", "shard1")
+
+	submitted := make(chan cmd.ShardReplicationState, 4)
+	m.SetNodeReachedStateSubmitter("node1", func(ctx context.Context, req *cmd.ReplicationNodeReachedStateRequest) error {
+		submitted <- req.State
+		return nil
+	})
+
+	gate := make(chan struct{})
+	drainStarted := make(chan struct{}, 1)
+	var gotClass, gotShard string
+	m.SetInflightDrainer(func(ctx context.Context, class, shard string) error {
+		gotClass, gotShard = class, shard
+		select {
+		case drainStarted <- struct{}{}:
+		default:
+		}
+		select {
+		case <-gate:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	m.broadcastNodeReachedState(opID, cmd.INTEGRATING)
+
+	// The drainer is invoked with the op's source class/shard.
+	select {
+	case <-drainStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainer was not invoked for INTEGRATING")
+	}
+	require.Equal(t, "TestClass", gotClass)
+	require.Equal(t, "shard1", gotShard)
+
+	// While the drain is gated, the report must NOT go out.
+	select {
+	case s := <-submitted:
+		t.Fatalf("INTEGRATING reported before the drain completed: %v", s)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(gate)
+
+	select {
+	case s := <-submitted:
+		require.Equal(t, cmd.INTEGRATING, s)
+	case <-time.After(2 * time.Second):
+		t.Fatal("INTEGRATING was not reported after the drain completed")
+	}
+}
+
+// Only INTEGRATING is gated on the drain; every other state reports promptly
+// and never invokes the drainer.
+func TestManager_DoesNotDrainForNonIntegratingStates(t *testing.T) {
+	const opID = uint64(2)
+	m := newDrainTestManager(t, opID, "TestClass", "shard1")
+
+	submitted := make(chan cmd.ShardReplicationState, 4)
+	m.SetNodeReachedStateSubmitter("node1", func(ctx context.Context, req *cmd.ReplicationNodeReachedStateRequest) error {
+		submitted <- req.State
+		return nil
+	})
+
+	drained := make(chan struct{}, 1)
+	m.SetInflightDrainer(func(ctx context.Context, class, shard string) error {
+		select {
+		case drained <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+
+	for _, st := range []cmd.ShardReplicationState{cmd.HYDRATING, cmd.FINALIZING, cmd.READY} {
+		m.broadcastNodeReachedState(opID, st)
+		select {
+		case s := <-submitted:
+			require.Equal(t, st, s)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("state %v was not reported", st)
+		}
+	}
+
+	select {
+	case <-drained:
+		t.Fatal("the drainer must not be called for non-INTEGRATING states")
+	default:
+	}
+}

--- a/usecases/replica/inflight.go
+++ b/usecases/replica/inflight.go
@@ -1,0 +1,125 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// inflightWrites tracks, per shard, the write coordinations this node is
+// currently driving. It exists to close a replica-movement lost-write race:
+// during a COPY/MOVE, a coordinator whose op-state view is still FINALIZING
+// routes a write to the source only; if that write lands after the source's
+// change-capture log is sealed, it is captured by neither the log nor the
+// target.
+//
+// A write is registered here BEFORE it routes (reads op-state). So any write
+// that routed under the pre-INTEGRATING view was registered before the
+// INTEGRATING RAFT apply. WaitForDrain, called once a node has applied
+// INTEGRATING, snapshots the set and waits for exactly those writes — which is
+// provably every source-only write — so the node only reports INTEGRATING (and
+// the consumer only seals the log) once they have all committed into the still-
+// open log. No coordinator/routing changes are needed for this to be exact.
+type inflightWrites struct {
+	mu     sync.RWMutex
+	nextID atomic.Uint64
+	// byShard maps a shard to the set of in-flight registration ids for it.
+	byShard map[string]map[uint64]struct{}
+}
+
+func newInflightWrites() *inflightWrites {
+	return &inflightWrites{byShard: make(map[string]map[uint64]struct{})}
+}
+
+// register records a new in-flight write to shard and returns a release closure
+// that removes it. The release must be called exactly once (via defer) when the
+// write coordination returns. Safe for concurrent callers.
+func (w *inflightWrites) register(shard string) (release func()) {
+	id := w.nextID.Add(1)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	set := w.byShard[shard]
+	if set == nil {
+		set = make(map[uint64]struct{})
+		w.byShard[shard] = set
+	}
+	set[id] = struct{}{}
+
+	return func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if set := w.byShard[shard]; set != nil {
+			delete(set, id)
+			if len(set) == 0 {
+				delete(w.byShard, shard)
+			}
+		}
+	}
+}
+
+// snapshot returns the registration ids currently in flight for shard.
+func (w *inflightWrites) snapshot(shard string) []uint64 {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	set := w.byShard[shard]
+	if len(set) == 0 {
+		return nil
+	}
+	ids := make([]uint64, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// stillPending reports whether any of ids is still in flight for shard.
+func (w *inflightWrites) stillPending(shard string, ids []uint64) bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	set := w.byShard[shard]
+	if len(set) == 0 {
+		return false
+	}
+	for _, id := range ids {
+		if _, ok := set[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// WaitForDrain blocks until every write in flight to shard at call time has
+// completed, or ctx is done. Writes registered after the snapshot are ignored,
+// so it terminates under sustained write load: post-cutover writes do not hold the drain.
+func (w *inflightWrites) WaitForDrain(ctx context.Context, shard string) error {
+	pending := w.snapshot(shard)
+	if len(pending) == 0 {
+		return nil
+	}
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if !w.stillPending(shard, pending) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/usecases/replica/inflight_test.go
+++ b/usecases/replica/inflight_test.go
@@ -1,0 +1,111 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInflightWrites_WaitForDrain_Empty(t *testing.T) {
+	w := newInflightWrites()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, w.WaitForDrain(ctx, "shard1"))
+}
+
+func TestInflightWrites_WaitForDrain_BlocksUntilRelease(t *testing.T) {
+	w := newInflightWrites()
+	release := w.register("shard1")
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		done <- w.WaitForDrain(ctx, "shard1")
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("WaitForDrain returned while a write was still in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForDrain did not return after the in-flight write was released")
+	}
+}
+
+// The load-bearing property: writes registered AFTER WaitForDrain snapshots are
+// ignored, so the drain terminates under sustained write load (post-cutover
+// writes routed to both source and target do not hold the seal).
+func TestInflightWrites_WaitForDrain_IgnoresPostSnapshot(t *testing.T) {
+	w := newInflightWrites()
+	releaseA := w.register("shard1") // pre-snapshot: must be waited for
+
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		done <- w.WaitForDrain(ctx, "shard1")
+	}()
+
+	// Let WaitForDrain take its snapshot ({A}).
+	time.Sleep(30 * time.Millisecond)
+
+	// Post-snapshot write, left in flight on purpose: must NOT hold the drain.
+	releaseB := w.register("shard1")
+	defer releaseB()
+
+	select {
+	case <-done:
+		t.Fatal("WaitForDrain returned before the pre-snapshot write was released")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseA()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "drain must complete once the snapshot set drains, ignoring post-snapshot writes")
+	case <-time.After(2 * time.Second):
+		t.Fatal("a post-snapshot write wrongly held the drain")
+	}
+}
+
+func TestInflightWrites_WaitForDrain_CtxTimeout(t *testing.T) {
+	w := newInflightWrites()
+	release := w.register("shard1")
+	defer release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, w.WaitForDrain(ctx, "shard1"), context.DeadlineExceeded)
+}
+
+// A drain on one shard must not wait on writes to another — the MT case relies
+// on this (the physical shard name is the tenant).
+func TestInflightWrites_WaitForDrain_PerShardScoping(t *testing.T) {
+	w := newInflightWrites()
+	release := w.register("shard1")
+	defer release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, w.WaitForDrain(ctx, "shard2"))
+}

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -57,6 +57,7 @@ type Replicator struct {
 	client         Client
 	log            logrus.FieldLogger
 	requestCounter atomic.Uint64
+	inflight       *inflightWrites
 	*Finder
 }
 
@@ -80,6 +81,7 @@ func NewReplicator(className string,
 		router:   router,
 		client:   client,
 		log:      l,
+		inflight: newInflightWrites(),
 		Finder: NewFinder(
 			className,
 			router,
@@ -100,6 +102,8 @@ func (r *Replicator) PutObject(ctx context.Context,
 	schemaVersion uint64,
 ) error {
 	coord := NewWriteCoordinator[SimpleResponse, error](r.client, r.router, r.metrics, r.class, shard, r.requestID(opPutObject), r.log)
+	release := r.inflight.register(shard)
+	defer release()
 	isReady := func(ctx context.Context, host, requestID string) error {
 		resp, err := r.client.PutObject(ctx, host, r.class, shard, requestID, obj, schemaVersion)
 		if err == nil {
@@ -131,6 +135,8 @@ func (r *Replicator) MergeObject(ctx context.Context,
 	schemaVersion uint64,
 ) error {
 	coord := NewWriteCoordinator[SimpleResponse, error](r.client, r.router, r.metrics, r.class, shard, r.requestID(opMergeObject), r.log)
+	release := r.inflight.register(shard)
+	defer release()
 	op := func(ctx context.Context, host, requestID string) error {
 		resp, err := r.client.MergeObject(ctx, host, r.class, shard, requestID, doc, schemaVersion)
 		if err == nil {
@@ -167,6 +173,8 @@ func (r *Replicator) DeleteObject(ctx context.Context,
 	schemaVersion uint64,
 ) error {
 	coord := NewWriteCoordinator[SimpleResponse, error](r.client, r.router, r.metrics, r.class, shard, r.requestID(opDeleteObject), r.log)
+	release := r.inflight.register(shard)
+	defer release()
 	op := func(ctx context.Context, host, requestID string) error {
 		resp, err := r.client.DeleteObject(ctx, host, r.class, shard, requestID, id, deletionTime, schemaVersion)
 		if err == nil {
@@ -198,6 +206,8 @@ func (r *Replicator) PutObjects(ctx context.Context,
 	schemaVersion uint64,
 ) []error {
 	coord := NewWriteCoordinator[SimpleResponse, error](r.client, r.router, r.metrics, r.class, shard, r.requestID(opPutObjects), r.log)
+	release := r.inflight.register(shard)
+	defer release()
 	op := func(ctx context.Context, host, requestID string) error {
 		resp, err := r.client.PutObjects(ctx, host, r.class, shard, requestID, objs, schemaVersion)
 		if err == nil {
@@ -235,6 +245,8 @@ func (r *Replicator) DeleteObjects(ctx context.Context,
 	schemaVersion uint64,
 ) []objects.BatchSimpleObject {
 	coord := NewWriteCoordinator[DeleteBatchResponse, objects.BatchSimpleObject](r.client, r.router, r.metrics, r.class, shard, r.requestID(opDeleteObjects), r.log)
+	release := r.inflight.register(shard)
+	defer release()
 	op := func(ctx context.Context, host, requestID string) error {
 		resp, err := r.client.DeleteObjects(ctx, host, r.class, shard, requestID, uuids, deletionTime, dryRun, schemaVersion)
 		if err == nil {
@@ -281,6 +293,8 @@ func (r *Replicator) AddReferences(ctx context.Context,
 	schemaVersion uint64,
 ) []error {
 	coord := NewWriteCoordinator[SimpleResponse, error](r.client, r.router, r.metrics, r.class, shard, r.requestID(opAddReferences), r.log)
+	release := r.inflight.register(shard)
+	defer release()
 	op := func(ctx context.Context, host, requestID string) error {
 		resp, err := r.client.AddReferences(ctx, host, r.class, shard, requestID, refs, schemaVersion)
 		if err == nil {
@@ -307,6 +321,10 @@ func (r *Replicator) AddReferences(ctx context.Context,
 			WithField("shard", shard).Error(rs)
 	}
 	return rs
+}
+
+func (r *Replicator) WaitForDrain(ctx context.Context, shard string) error {
+	return r.inflight.WaitForDrain(ctx, shard)
 }
 
 // simpleCommit generate commit function for the coordinator


### PR DESCRIPTION
### What's being changed:

- followers only report `INTEGRATING` & `DEHYDRATING` back to leader once all their point-in-time in-flight coordinator replications have returned
- track all in-flight replication operations in the coordinator
- inject them into the replicationFSM
- (de)register per-shard ops in each replicator method

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
