### PR TITLE
fix: enforce rate limiting in text2vec-google for all vectorization paths

### DIFF
--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -123,6 +123,9 @@ func (v *google) waitForQuota(ctx context.Context, n int) error {
 func (v *google) VectorizeWithTitleProperty(ctx context.Context,
 	input []string, titlePropertyValue string, cfg moduletools.ClassConfig,
 ) (*modulecomponents.VectorizationResult[[]float32], error) {
+	// reserve one rate-limit token per input text, NOT one per HTTP request:
+	// Gemini counts each embedding as a request against the RPM quota, even
+	// when multiple inputs are batched into a single HTTP call
 	if err := v.waitForQuota(ctx, len(input)); err != nil {
 		return nil, err
 	}
@@ -133,6 +136,9 @@ func (v *google) VectorizeWithTitleProperty(ctx context.Context,
 func (v *google) Vectorize(ctx context.Context,
 	input []string, cfg moduletools.ClassConfig,
 ) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
+	// reserve one rate-limit token per input text, NOT one per HTTP request:
+	// Gemini counts each embedding as a request against the RPM quota, even
+	// when multiple inputs are batched into a single HTTP call
 	if err := v.waitForQuota(ctx, len(input)); err != nil {
 		return nil, nil, 0, err
 	}

--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+
 	"github.com/weaviate/weaviate/modules/text2vec-google/vectorizer"
 )
 
@@ -83,6 +85,10 @@ type google struct {
 	httpClient    *http.Client
 	urlBuilderFn  func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string
 	logger        logrus.FieldLogger
+	// Google deducts embedding quota per input text (1 embedding = 1 request),
+	// not per HTTP request. The limiter therefore reserves one token per input
+	// so that all vectorization paths are paced against the actual quota.
+	rateLimiter *rate.Limiter
 }
 
 func New(apiKey string, useGoogleAuth bool, rpm int, timeout time.Duration, logger logrus.FieldLogger) *google {
@@ -94,12 +100,32 @@ func New(apiKey string, useGoogleAuth bool, rpm int, timeout time.Duration, logg
 		httpClient:    modulecomponents.NewBaseHttpClient(timeout),
 		urlBuilderFn:  buildURL,
 		logger:        logger,
+		rateLimiter:   rate.NewLimiter(rate.Limit(float64(rpm)/60.0), max(rpm/60, 1)),
 	}
+}
+
+// waitForQuota blocks until the rate limiter grants quota for n embeddings.
+// Requests larger than the limiter's burst size are reserved in chunks.
+func (v *google) waitForQuota(ctx context.Context, n int) error {
+	if v.rateLimiter == nil {
+		return nil
+	}
+	for n > 0 {
+		take := min(n, v.rateLimiter.Burst())
+		if err := v.rateLimiter.WaitN(ctx, take); err != nil {
+			return errors.Wrap(err, "wait for rate limit quota")
+		}
+		n -= take
+	}
+	return nil
 }
 
 func (v *google) VectorizeWithTitleProperty(ctx context.Context,
 	input []string, titlePropertyValue string, cfg moduletools.ClassConfig,
 ) (*modulecomponents.VectorizationResult[[]float32], error) {
+	if err := v.waitForQuota(ctx, len(input)); err != nil {
+		return nil, err
+	}
 	settings := v.getSettings(cfg)
 	return v.vectorize(ctx, input, v.getDocumentTaskType(settings.TaskType), titlePropertyValue, settings)
 }
@@ -107,6 +133,9 @@ func (v *google) VectorizeWithTitleProperty(ctx context.Context,
 func (v *google) Vectorize(ctx context.Context,
 	input []string, cfg moduletools.ClassConfig,
 ) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
+	if err := v.waitForQuota(ctx, len(input)); err != nil {
+		return nil, nil, 0, err
+	}
 	settings := v.getSettings(cfg)
 	res, err := v.vectorize(ctx, input, v.getDocumentTaskType(settings.TaskType), "", settings)
 	return res, nil, 0, err

--- a/modules/text2vec-google/clients/google_test.go
+++ b/modules/text2vec-google/clients/google_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/apikey"
+	"golang.org/x/time/rate"
 )
 
 func TestClient(t *testing.T) {
@@ -231,4 +232,69 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func nullLogger() logrus.FieldLogger {
 	l, _ := test.NewNullLogger()
 	return l
+}
+
+func TestWaitForQuota(t *testing.T) {
+	tests := []struct {
+		name        string
+		limiter     *rate.Limiter
+		n           int
+		ctxTimeout  time.Duration
+		expectError bool
+	}{
+		{
+			name:    "nil limiter is a no-op",
+			limiter: nil,
+			n:       1000,
+		},
+		{
+			name:    "request fitting in burst",
+			limiter: rate.NewLimiter(rate.Limit(1000), 100),
+			n:       50,
+		},
+		{
+			name:    "request larger than burst is chunked",
+			limiter: rate.NewLimiter(rate.Limit(1000), 10),
+			n:       150,
+		},
+		{
+			name:        "context deadline while waiting",
+			limiter:     rate.NewLimiter(rate.Limit(1), 1),
+			n:           10,
+			ctxTimeout:  10 * time.Millisecond,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.ctxTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+			v := &google{rateLimiter: tt.limiter}
+			err := v.waitForQuota(ctx, tt.n)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRateLimiterPacing(t *testing.T) {
+	// rpm of 600 = 10 embeddings/second. Sending 3 single-input requests after
+	// draining the burst should take at least ~200ms.
+	c := New("apiKey", false, 600, time.Minute, logrus.New())
+	require.NotNil(t, c.rateLimiter)
+	require.NoError(t, c.waitForQuota(context.Background(), c.rateLimiter.Burst())) // drain burst
+
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		require.NoError(t, c.waitForQuota(context.Background(), 1))
+	}
+	assert.GreaterOrEqual(t, time.Since(start), 200*time.Millisecond)
 }


### PR DESCRIPTION
Follow-up to #11279, which exposed `T2V_GOOGLE_BATCH_RPM` to control rate limiting against the Google gemini embedding API.

### Problem

`T2V_GOOGLE_BATCH_RPM` was only effective when using the batched Gemini embedding API (1 request → N embeddings, opt-in via `USE_T2V_GOOGLE_BATCH_SEND_OBJECTS_IN_BATCH`), but didn't work for the default Weaviate setup, where a batch of items gets parallelized into individual Gemini requests (1 request == 1 embedding). On that default path the configured RPM is never read, so traffic to the Google API is unthrottled and can exceed the caller's rate limit quota.

Since the Gemini API returns no rate-limit headers, the customer-configured RPM is the only available control and needs to be enforced reliably.

### Fix

This PR enforces the configured RPM at the HTTP client layer, which all document vectorization paths share. This is the same pattern `text2vec-mistral` already uses, with one adaptation: we reserve one token **per input text**, matching how Gemini counts quota (per embedding, not per HTTP request).

It would be great if this could also be backported to `stable/v1.35`, where #11279 landed.
