### PR TITLE
chore: per-tenancy async replication frequency defaults

### DIFF
--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1382,7 +1382,7 @@ func TestEffectiveThreeTierPrecedence(t *testing.T) {
 		// distinct minFrequencyWhilePropagating minimum.
 		const fwpClassOverride = 10 * time.Second
 		cfg := AsyncReplicationConfig{
-			frequencyWhilePropagating: defaultFrequencyWhilePropagating,
+			frequencyWhilePropagating: defaultFrequencyWhilePropagatingSingleTenant,
 			classOverrides: asyncReplicationClassOverrides{
 				frequencyWhilePropagating: durationPtr(fwpClassOverride),
 			},

--- a/adapters/repos/db/index_async_replication.go
+++ b/adapters/repos/db/index_async_replication.go
@@ -54,11 +54,13 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 	// ---- Code defaults (tier 1) ----
 	if multiTenancyEnabled {
 		config.hashtreeHeight = defaultHashtreeHeightMultiTenant
+		config.frequency = defaultFrequencyMultiTenant
+		config.frequencyWhilePropagating = defaultFrequencyWhilePropagatingMultiTenant
 	} else {
 		config.hashtreeHeight = defaultHashtreeHeightSingleTenant
+		config.frequency = defaultFrequencySingleTenant
+		config.frequencyWhilePropagating = defaultFrequencyWhilePropagatingSingleTenant
 	}
-	config.frequency = defaultFrequency
-	config.frequencyWhilePropagating = defaultFrequencyWhilePropagating
 	config.loggingFrequency = defaultLoggingFrequency
 	config.diffBatchSize = defaultDiffBatchSize
 	config.diffPerNodeTimeout = defaultDiffPerNodeTimeout

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -46,17 +46,20 @@ import (
 const (
 	defaultHashtreeHeightSingleTenant = 16
 	defaultHashtreeHeightMultiTenant  = 10
-	defaultFrequency                  = 30 * time.Second
-	defaultFrequencyWhilePropagating  = 5 * time.Second
-	defaultLoggingFrequency           = 60 * time.Second
-	defaultDiffBatchSize              = 1_000
-	defaultDiffPerNodeTimeout         = 10 * time.Second
-	defaultPrePropagationTimeout      = 300 * time.Second
-	defaultPropagationTimeout         = 60 * time.Second
-	defaultPropagationLimit           = 1_000
-	defaultPropagationConcurrency     = 1
-	defaultPropagationBatchSize       = 100
-	defaultPropagationDelay           = 30 * time.Second
+	// Multi-tenant defaults are larger: a node may host ~1k tenant shards, each hashbeating.
+	defaultFrequencySingleTenant                 = 60 * time.Second
+	defaultFrequencyMultiTenant                  = 600 * time.Second
+	defaultFrequencyWhilePropagatingSingleTenant = 20 * time.Second
+	defaultFrequencyWhilePropagatingMultiTenant  = 120 * time.Second
+	defaultLoggingFrequency                      = 60 * time.Second
+	defaultDiffBatchSize                         = 1_000
+	defaultDiffPerNodeTimeout                    = 10 * time.Second
+	defaultPrePropagationTimeout                 = 300 * time.Second
+	defaultPropagationTimeout                    = 60 * time.Second
+	defaultPropagationLimit                      = 1_000
+	defaultPropagationConcurrency                = 1
+	defaultPropagationBatchSize                  = 100
+	defaultPropagationDelay                      = 30 * time.Second
 	// asyncReplicationWorkerDrainTimeout is the maximum time mayStopAsyncReplication
 	// will wait for in-flight hashbeat workers to exit after the per-shard context
 	// has been cancelled. Workers should unblock almost immediately once their

--- a/test/acceptance/replication/async_replication/async_repair_deletes_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_deletes_test.go
@@ -56,6 +56,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 			Factor:           int64(clusterSize),
 			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
 			AsyncEnabled:     true,
+			AsyncConfig:      fastAsyncReplicationConfig(),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_repair_insertions_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_insertions_test.go
@@ -55,6 +55,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor:       int64(clusterSize),
 			AsyncEnabled: true,
+			AsyncConfig:  fastAsyncReplicationConfig(),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -80,6 +80,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor:       int64(clusterSize),
 			AsyncEnabled: true,
+			AsyncConfig:  fastAsyncReplicationConfig(),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
@@ -210,6 +211,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 		// Update to enable async replication
 		class := res.Payload
 		class.ReplicationConfig.AsyncEnabled = true
+		class.ReplicationConfig.AsyncConfig = fastAsyncReplicationConfig()
 
 		// Update the class
 		helper.UpdateClass(t, class)

--- a/test/acceptance/replication/async_replication/async_repair_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_test.go
@@ -59,6 +59,18 @@ var (
 	}
 )
 
+// fastAsyncReplicationConfig pins per-class frequencies to the API floors so
+// read-repair converges in seconds, decoupling tests from the larger production
+// code defaults.
+func fastAsyncReplicationConfig() *models.ReplicationAsyncConfig {
+	freq := int64(5000)          // 5s == minFrequency
+	freqWhileProp := int64(1000) // 1s == minFrequencyWhilePropagating
+	return &models.ReplicationAsyncConfig{
+		Frequency:                 &freq,
+		FrequencyWhilePropagating: &freqWhileProp,
+	}
+}
+
 type AsyncReplicationTestSuite struct {
 	suite.Suite
 }
@@ -97,12 +109,14 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor:       3,
 			AsyncEnabled: true,
+			AsyncConfig:  fastAsyncReplicationConfig(),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor:       3,
 			AsyncEnabled: true,
+			AsyncConfig:  fastAsyncReplicationConfig(),
 		}
 		helper.CreateClass(t, articleClass)
 	})

--- a/test/acceptance/replication/async_replication/async_repair_updates_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_updates_test.go
@@ -56,6 +56,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor:       int64(clusterSize),
 			AsyncEnabled: true,
+			AsyncConfig:  fastAsyncReplicationConfig(),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 


### PR DESCRIPTION
## Motivation

The async-replication hashbeat scheduler ran with a single flat code default for both single- and multi-tenant collections (`frequency` 30s, `frequencyWhilePropagating` 5s). On multi-tenant nodes this scales badly: a node can host ~1k tenant shards, each running its own hashbeat cycle, so a flat 30s/5s baseline multiplies into heavy continuous background work. We already split `defaultHashtreeHeight` by tenancy for the same reason; the frequency defaults should follow the same pattern.

## Approach

Split `defaultFrequency`/`defaultFrequencyWhilePropagating` into `…SingleTenant`/`…MultiTenant` variants and select them in `asyncReplicationConfigFromModel` based on `multiTenancyEnabled`, mirroring the existing hashtree-height branch. Baselines were raised:

- single-tenant: frequency **60s**, while-propagating **20s**
- multi-tenant: frequency **600s**, while-propagating **120s**

This touches **tier-1 code defaults only**. The three-tier precedence is unchanged: per-class API/schema overrides and the global runtime `DynamicValue` resolution still take priority, and the `minFrequency` (5s) / `minFrequencyWhilePropagating` (1s) clamp floors are untouched. The only observable effect is the starting point when an operator sets nothing.

## Key areas for review

- `adapters/repos/db/shard_async_replication.go` — the renamed/retuned constants; confirm the MT vs ST values are intended and the gofmt re-alignment of the `const` block is purely mechanical.
- `adapters/repos/db/index_async_replication.go` (`asyncReplicationConfigFromModel`) — the frequency assignments moved inside the existing `if multiTenancyEnabled` branch; both branches set both fields.
- `test/acceptance/replication/async_replication/async_repair_test.go` (`fastAsyncReplicationConfig`) — the new helper and its application across the repair scenarios.

## Risks and mitigations

- **Slower default convergence**: raising the MT default to 600s means out-of-the-box read-repair on multi-tenant clusters lags further behind writes. This is intentional load-shedding; operators needing tighter convergence set a per-class or runtime override, which still wins over these defaults. Single-tenant only doubles (30s→60s).
- **Acceptance tests timing out**: the repair tests previously leaned on the code defaults and asserted convergence within fixed 60s/120s windows; under the new MT 600s default they would time out. Mitigated by pinning each test's `ReplicationConfig.AsyncConfig` to the API floors (5s / 1s) via `fastAsyncReplicationConfig()`, so repair converges in seconds independent of the production defaults — and the tests no longer silently depend on whatever the code defaults happen to be.

## Testing

- `golangci-lint` clean on both changed packages; targeted async-replication unit tests in `adapters/repos/db` pass (incl. the global-config sub-floor clamp test, which referenced the renamed constant).
- The async-replication repair acceptance suite (simple, insertions, updates, deletes, multi-tenancy incl. the cold-tenant-on-enable scenario) was run against a freshly built image with this code and passes — `PASS (353s)`.

```
go test -count 1 -race ./adapters/repos/db/ -run 'AsyncReplication|Effective|nextInterval'
go test -count 1 -timeout 20m ./test/acceptance/replication/async_replication/...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)