### PR TITLE
Ensure that CCL is started when local schema is up-to-date with leader

### DIFF
--- a/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
@@ -177,7 +177,7 @@ func (fps *FileReplicationService) GetFile(req *pb.GetFileRequest, stream pb.Fil
 func (fps *FileReplicationService) StartChangeCapture(ctx context.Context, req *pb.StartChangeCaptureRequest) (*pb.StartChangeCaptureResponse, error) {
 	index, err := fps.indexForIncomingWrite(ctx, req.GetIndexName(), req.GetSchemaVersion())
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "local index %q not found: %v", req.IndexName, err)
+		return nil, status.Errorf(codes.Internal, "cannot start change capture for index %q: %v", req.GetIndexName(), err)
 	}
 
 	if err := index.IncomingStartChangeCapture(ctx, req.ShardName, req.OpId); err != nil {

--- a/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
@@ -175,9 +175,9 @@ func (fps *FileReplicationService) GetFile(req *pb.GetFileRequest, stream pb.Fil
 }
 
 func (fps *FileReplicationService) StartChangeCapture(ctx context.Context, req *pb.StartChangeCaptureRequest) (*pb.StartChangeCaptureResponse, error) {
-	index := fps.repo.GetIndexForIncomingSharding(schema.ClassName(req.IndexName))
-	if index == nil {
-		return nil, status.Errorf(codes.Internal, "local index %q not found", req.IndexName)
+	index, err := fps.indexForIncomingWrite(ctx, req.GetIndexName(), req.GetSchemaVersion())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "local index %q not found: %v", req.IndexName, err)
 	}
 
 	if err := index.IncomingStartChangeCapture(ctx, req.ShardName, req.OpId); err != nil {

--- a/adapters/handlers/rest/clusterapi/grpc/file_replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/file_replication_service_test.go
@@ -14,6 +14,9 @@ package grpc
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,6 +26,7 @@ import (
 
 	pb "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
 	"github.com/weaviate/weaviate/cluster/replication/changelog"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -110,9 +114,45 @@ func (r *fakeRepo) GetIndexForIncomingSharding(className schema.ClassName) shard
 	return idx
 }
 
+// fakeSchema implements sharding.RemoteIncomingSchema. ReadOnlyClassWithVersion
+// records every requested version and errors when asked for a version higher
+// than `applied`, simulating a source node that has not yet applied that schema
+// command — which is exactly the wait the StartChangeCapture barrier relies on.
+type fakeSchema struct {
+	mu        sync.Mutex
+	requested []uint64
+	applied   uint64 // highest applied schema version; requests above this fail
+	err       error  // forced error, overrides the applied check when set
+}
+
+func (s *fakeSchema) ReadOnlyClassWithVersion(_ context.Context, class string, version uint64) (*models.Class, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requested = append(s.requested, version)
+	if s.err != nil {
+		return nil, s.err
+	}
+	if version > s.applied {
+		return nil, fmt.Errorf("schema version %d not applied (have %d)", version, s.applied)
+	}
+	return &models.Class{Class: class}, nil
+}
+
+func (s *fakeSchema) requestedVersions() []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]uint64(nil), s.requested...)
+}
+
 func newService(t *testing.T, indices map[string]*fakeIndex) *FileReplicationService {
 	t.Helper()
-	return NewFileReplicationService(&fakeRepo{indices: indices}, nil, 64*1024)
+	// Permissive schema: every version is already applied, so the barrier never blocks.
+	return newServiceWithSchema(t, indices, &fakeSchema{applied: math.MaxUint64})
+}
+
+func newServiceWithSchema(t *testing.T, indices map[string]*fakeIndex, sc sharding.RemoteIncomingSchema) *FileReplicationService {
+	t.Helper()
+	return NewFileReplicationService(&fakeRepo{indices: indices}, sc, 64*1024)
 }
 
 func TestStartChangeCapture_HappyPath(t *testing.T) {
@@ -155,6 +195,47 @@ func TestStartChangeCapture_IndexError(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+// StartChangeCapture must wait for the source to apply the op's HOT-activation
+// schema version before opening the change-capture log. When the version is
+// already applied, the barrier passes and the log is activated.
+func TestStartChangeCapture_WaitsForSchemaVersion(t *testing.T) {
+	fi := &fakeIndex{}
+	sc := &fakeSchema{applied: 4}
+	svc := newServiceWithSchema(t, map[string]*fakeIndex{"MyClass": fi}, sc)
+
+	_, err := svc.StartChangeCapture(context.Background(), &pb.StartChangeCaptureRequest{
+		IndexName:     "MyClass",
+		ShardName:     "shard1",
+		OpId:          "op-1",
+		SchemaVersion: 4,
+	})
+	require.NoError(t, err)
+	require.Len(t, fi.startCalls, 1)
+	// The handler consulted the schema with the op's version before activating.
+	require.Equal(t, []uint64{4}, sc.requestedVersions())
+}
+
+// Regression for the auto-tenant-activation FINALIZING flake: when the source
+// has not yet applied the op's schema version (the tenant reactivation is still
+// queued), the barrier must fail BEFORE the change-capture log is opened — never
+// activate it on a shard instance a pending COLD→HOT reactivation will sweep.
+func TestStartChangeCapture_BlockedUntilSchemaVersionApplied(t *testing.T) {
+	fi := &fakeIndex{}
+	sc := &fakeSchema{applied: 3} // op needs v5 but only v3 is applied on the source
+	svc := newServiceWithSchema(t, map[string]*fakeIndex{"MyClass": fi}, sc)
+
+	_, err := svc.StartChangeCapture(context.Background(), &pb.StartChangeCaptureRequest{
+		IndexName:     "MyClass",
+		ShardName:     "shard1",
+		OpId:          "op-1",
+		SchemaVersion: 5,
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.Empty(t, fi.startCalls, "change-capture log must not be activated before the schema version is applied")
+	require.Equal(t, []uint64{5}, sc.requestedVersions())
 }
 
 func TestFinalizeChangeLog_HappyPath(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/file_replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/file_replication.pb.go
@@ -670,6 +670,7 @@ type StartChangeCaptureRequest struct {
 	IndexName     string                 `protobuf:"bytes,1,opt,name=index_name,json=indexName,proto3" json:"index_name,omitempty"`
 	ShardName     string                 `protobuf:"bytes,2,opt,name=shard_name,json=shardName,proto3" json:"shard_name,omitempty"`
 	OpId          string                 `protobuf:"bytes,3,opt,name=op_id,json=opId,proto3" json:"op_id,omitempty"`
+	SchemaVersion uint64                 `protobuf:"varint,4,opt,name=schema_version,json=schemaVersion,proto3" json:"schema_version,omitempty"` // source waits for this schema version (the tenant HOT activation) before opening the change-capture log
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -723,6 +724,13 @@ func (x *StartChangeCaptureRequest) GetOpId() string {
 		return x.OpId
 	}
 	return ""
+}
+
+func (x *StartChangeCaptureRequest) GetSchemaVersion() uint64 {
+	if x != nil {
+		return x.SchemaVersion
+	}
+	return 0
 }
 
 type StartChangeCaptureResponse struct {
@@ -1374,13 +1382,14 @@ const file_protocol_file_replication_proto_rawDesc = "" +
 	"\tFileChunk\x12\x16\n" +
 	"\x06offset\x18\x01 \x01(\x03R\x06offset\x12\x12\n" +
 	"\x04data\x18\x02 \x01(\fR\x04data\x12\x10\n" +
-	"\x03eof\x18\x03 \x01(\bR\x03eof\"n\n" +
+	"\x03eof\x18\x03 \x01(\bR\x03eof\"\x95\x01\n" +
 	"\x19StartChangeCaptureRequest\x12\x1d\n" +
 	"\n" +
 	"index_name\x18\x01 \x01(\tR\tindexName\x12\x1d\n" +
 	"\n" +
 	"shard_name\x18\x02 \x01(\tR\tshardName\x12\x13\n" +
-	"\x05op_id\x18\x03 \x01(\tR\x04opId\"o\n" +
+	"\x05op_id\x18\x03 \x01(\tR\x04opId\x12%\n" +
+	"\x0eschema_version\x18\x04 \x01(\x04R\rschemaVersion\"o\n" +
 	"\x1aStartChangeCaptureResponse\x12\x1d\n" +
 	"\n" +
 	"index_name\x18\x01 \x01(\tR\tindexName\x12\x1d\n" +

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/file_replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/file_replication.pb.go
@@ -670,7 +670,7 @@ type StartChangeCaptureRequest struct {
 	IndexName     string                 `protobuf:"bytes,1,opt,name=index_name,json=indexName,proto3" json:"index_name,omitempty"`
 	ShardName     string                 `protobuf:"bytes,2,opt,name=shard_name,json=shardName,proto3" json:"shard_name,omitempty"`
 	OpId          string                 `protobuf:"bytes,3,opt,name=op_id,json=opId,proto3" json:"op_id,omitempty"`
-	SchemaVersion uint64                 `protobuf:"varint,4,opt,name=schema_version,json=schemaVersion,proto3" json:"schema_version,omitempty"` // source waits for this schema version (the tenant HOT activation) before opening the change-capture log
+	SchemaVersion uint64                 `protobuf:"varint,4,opt,name=schema_version,json=schemaVersion,proto3" json:"schema_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/file_replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/file_replication.proto
@@ -94,6 +94,7 @@ message StartChangeCaptureRequest {
   string index_name = 1;
   string shard_name = 2;
   string op_id = 3;
+  uint64 schema_version = 4; // source waits for this schema version (the tenant HOT activation) before opening the change-capture log
 }
 
 message StartChangeCaptureResponse {

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/file_replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/file_replication.proto
@@ -94,7 +94,7 @@ message StartChangeCaptureRequest {
   string index_name = 1;
   string shard_name = 2;
   string op_id = 3;
-  uint64 schema_version = 4; // source waits for this schema version (the tenant HOT activation) before opening the change-capture log
+  uint64 schema_version = 4;
 }
 
 message StartChangeCaptureResponse {

--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -588,7 +588,7 @@ func (c *CopyOpConsumer) processHydratingOp(ctx context.Context, op ShardReplica
 
 	// Must precede CopyReplicaFiles: every write after this point lands in
 	// the log and is replayed during FINALIZING/DEHYDRATING.
-	if err := c.replicaCopier.StartChangeCapture(ctx, src, coll, shard, opID); err != nil {
+	if err := c.replicaCopier.StartChangeCapture(ctx, src, coll, shard, opID, op.Status.SchemaVersion); err != nil {
 		logger.WithError(err).Error("failure while starting change capture")
 		return api.ShardReplicationState(""), err
 	}

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -1636,7 +1636,7 @@ func TestConsumerCopyIntegratingRetryAfterSeal(t *testing.T) {
 // FSM-converge-and-drain primitives that pair with it during DEHYDRATING.
 // Tests that don't reach FINALIZING (cancellation, deletion) still pass.
 func expectChangeCaptureMocks(m *types.MockReplicaCopier, fsm *types.MockFSMUpdater) {
-	m.EXPECT().StartChangeCapture(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	m.EXPECT().StartChangeCapture(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	m.EXPECT().SnapshotChangeLogLSN(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
 	m.EXPECT().TailAndApply(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
 	m.EXPECT().FinalizeChangeLog(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()

--- a/cluster/replication/copier/copier_changelog.go
+++ b/cluster/replication/copier/copier_changelog.go
@@ -22,15 +22,16 @@ import (
 )
 
 // StartChangeCapture must be called before the source takes its file snapshot.
-func (c *Copier) StartChangeCapture(ctx context.Context, srcNodeId, indexName, shardName, opID string) error {
+func (c *Copier) StartChangeCapture(ctx context.Context, srcNodeId, indexName, shardName, opID string, schemaVersion uint64) error {
 	client, err := c.dialSource(ctx, srcNodeId)
 	if err != nil {
 		return err
 	}
 	_, err = client.StartChangeCapture(ctx, &protocol.StartChangeCaptureRequest{
-		IndexName: indexName,
-		ShardName: shardName,
-		OpId:      opID,
+		IndexName:     indexName,
+		ShardName:     shardName,
+		OpId:          opID,
+		SchemaVersion: schemaVersion,
 	})
 	if err != nil {
 		return fmt.Errorf("start change capture on %s: %w", srcNodeId, err)

--- a/cluster/replication/copier/copier_changelog_bufconn_test.go
+++ b/cluster/replication/copier/copier_changelog_bufconn_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/replication/changelog"
 	"github.com/weaviate/weaviate/cluster/replication/copier"
 	"github.com/weaviate/weaviate/cluster/replication/copier/internal/changelogdrain"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -74,6 +75,14 @@ func (r *bufconnFakeRepo) GetIndexForIncomingSharding(schema.ClassName) sharding
 	return r.idx
 }
 
+// bufconnFakeSchema satisfies the StartChangeCapture schema-version barrier;
+// these tests pass schemaVersion 0, so the barrier is always a no-op.
+type bufconnFakeSchema struct{}
+
+func (bufconnFakeSchema) ReadOnlyClassWithVersion(context.Context, string, uint64) (*models.Class, error) {
+	return nil, nil
+}
+
 // bufconnFixture wires a real FileReplicationService + *changelog.ChangeLog
 // over bufconn. tailAndApply bypasses Copier.TailAndApply (which would need a
 // real *db.Index) and runs the drain loop directly.
@@ -109,7 +118,7 @@ func newBufconnFixture(t *testing.T) *bufconnFixture {
 	require.NoError(t, err)
 
 	fakeIdx := &bufconnFakeIndex{log: log}
-	svc := grpchandlers.NewFileReplicationService(&bufconnFakeRepo{idx: fakeIdx}, nil, 64*1024)
+	svc := grpchandlers.NewFileReplicationService(&bufconnFakeRepo{idx: fakeIdx}, bufconnFakeSchema{}, 64*1024)
 
 	lis := bufconn.Listen(1 << 20)
 	server := grpc.NewServer()
@@ -174,7 +183,7 @@ func TestChangeCapture_SingleLogMovementFlow(t *testing.T) {
 	}
 
 	require.NoError(t, fx.copier.StartChangeCapture(context.Background(),
-		"source", "ClassOne", "shard1", "op1"))
+		"source", "ClassOne", "shard1", "op1", 0))
 
 	snap, err := fx.copier.SnapshotChangeLogLSN(context.Background(),
 		"source", "ClassOne", "shard1", "op1")
@@ -235,7 +244,7 @@ func TestChangeCapture_CappedDrainStopsAtCap(t *testing.T) {
 	}
 
 	require.NoError(t, fx.copier.StartChangeCapture(context.Background(),
-		"source", "ClassOne", "shard1", "op1"))
+		"source", "ClassOne", "shard1", "op1", 0))
 
 	const cap = 3
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -262,7 +271,7 @@ func TestChangeCapture_QuietShardSnapshotZeroCompletes(t *testing.T) {
 	fx := newBufconnFixture(t)
 
 	require.NoError(t, fx.copier.StartChangeCapture(context.Background(),
-		"source", "ClassOne", "shard1", "op1"))
+		"source", "ClassOne", "shard1", "op1", 0))
 
 	snap, err := fx.copier.SnapshotChangeLogLSN(context.Background(),
 		"source", "ClassOne", "shard1", "op1")

--- a/cluster/replication/types/mock_replica_copier.go
+++ b/cluster/replication/types/mock_replica_copier.go
@@ -505,17 +505,17 @@ func (_c *MockReplicaCopier_SnapshotChangeLogLSN_Call) RunAndReturn(run func(con
 	return _c
 }
 
-// StartChangeCapture provides a mock function with given fields: ctx, srcNodeId, indexName, shardName, opID
-func (_m *MockReplicaCopier) StartChangeCapture(ctx context.Context, srcNodeId string, indexName string, shardName string, opID string) error {
-	ret := _m.Called(ctx, srcNodeId, indexName, shardName, opID)
+// StartChangeCapture provides a mock function with given fields: ctx, srcNodeId, indexName, shardName, opID, schemaVersion
+func (_m *MockReplicaCopier) StartChangeCapture(ctx context.Context, srcNodeId string, indexName string, shardName string, opID string, schemaVersion uint64) error {
+	ret := _m.Called(ctx, srcNodeId, indexName, shardName, opID, schemaVersion)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartChangeCapture")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
-		r0 = rf(ctx, srcNodeId, indexName, shardName, opID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, uint64) error); ok {
+		r0 = rf(ctx, srcNodeId, indexName, shardName, opID, schemaVersion)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -534,13 +534,14 @@ type MockReplicaCopier_StartChangeCapture_Call struct {
 //   - indexName string
 //   - shardName string
 //   - opID string
-func (_e *MockReplicaCopier_Expecter) StartChangeCapture(ctx interface{}, srcNodeId interface{}, indexName interface{}, shardName interface{}, opID interface{}) *MockReplicaCopier_StartChangeCapture_Call {
-	return &MockReplicaCopier_StartChangeCapture_Call{Call: _e.mock.On("StartChangeCapture", ctx, srcNodeId, indexName, shardName, opID)}
+//   - schemaVersion uint64
+func (_e *MockReplicaCopier_Expecter) StartChangeCapture(ctx interface{}, srcNodeId interface{}, indexName interface{}, shardName interface{}, opID interface{}, schemaVersion interface{}) *MockReplicaCopier_StartChangeCapture_Call {
+	return &MockReplicaCopier_StartChangeCapture_Call{Call: _e.mock.On("StartChangeCapture", ctx, srcNodeId, indexName, shardName, opID, schemaVersion)}
 }
 
-func (_c *MockReplicaCopier_StartChangeCapture_Call) Run(run func(ctx context.Context, srcNodeId string, indexName string, shardName string, opID string)) *MockReplicaCopier_StartChangeCapture_Call {
+func (_c *MockReplicaCopier_StartChangeCapture_Call) Run(run func(ctx context.Context, srcNodeId string, indexName string, shardName string, opID string, schemaVersion uint64)) *MockReplicaCopier_StartChangeCapture_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(uint64))
 	})
 	return _c
 }
@@ -550,7 +551,7 @@ func (_c *MockReplicaCopier_StartChangeCapture_Call) Return(_a0 error) *MockRepl
 	return _c
 }
 
-func (_c *MockReplicaCopier_StartChangeCapture_Call) RunAndReturn(run func(context.Context, string, string, string, string) error) *MockReplicaCopier_StartChangeCapture_Call {
+func (_c *MockReplicaCopier_StartChangeCapture_Call) RunAndReturn(run func(context.Context, string, string, string, string, uint64) error) *MockReplicaCopier_StartChangeCapture_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/cluster/replication/types/replica_copier.go
+++ b/cluster/replication/types/replica_copier.go
@@ -42,7 +42,7 @@ type ReplicaCopier interface {
 	AsyncReplicationStatus(ctx context.Context, srcNodeId, targetNodeId, collectionName, shardName string) (models.AsyncReplicationStatus, error)
 
 	// StartChangeCapture see cluster/replication/copier.Copier.StartChangeCapture
-	StartChangeCapture(ctx context.Context, srcNodeId, indexName, shardName, opID string) error
+	StartChangeCapture(ctx context.Context, srcNodeId, indexName, shardName, opID string, schemaVersion uint64) error
 
 	// TailAndApply see cluster/replication/copier.Copier.TailAndApply
 	TailAndApply(ctx context.Context, srcNodeId, indexName, shardName, opID string, untilLSN uint64) (lastAppliedLSN uint64, err error)


### PR DESCRIPTION
### What's being changed:

- avoids race where CCL would be started on a HOT shard, the shard would then be deactivated, then reactivated thereby deleting the CCL

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
