### PR TITLE
ci(docker): switch docker pipelines to use Ubicloud's premium runners

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   Multi-Arch-Docker-Build:
     name: docker build (multi-arch)
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-premium-2
     if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && (startsWith(github.ref, 'refs/tags') || startsWith(github.head_ref, 'build') || github.head_ref == '') }} # no PRs from fork
     timeout-minutes: 45
     env:
@@ -140,7 +140,7 @@ jobs:
       matrix:
         include:
           - arch: "amd64"
-            runner: ubicloud-standard-2
+            runner: ubicloud-premium-2
             push-args: "--amd64-only"
           - arch: "arm64"
             runner: ubuntu-24.04-arm


### PR DESCRIPTION
### What's being changed:

This PR switches docker pipelines to use Ubicloud's premium runners

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
