### PR TITLE
Add env vars to disable bucket access check

### DIFF
--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -49,6 +49,39 @@ func TestInitialize_SkipAccessCheck(t *testing.T) {
 	}
 }
 
+func TestInit_SkipAccessCheckWiring(t *testing.T) {
+	// Init must route Backup.SkipAccessCheck to the backup client and
+	// Export.SkipAccessCheck to the export client, without crossing them.
+	t.Setenv("BACKUP_AZURE_CONTAINER", "test")
+	t.Setenv("AZURE_STORAGE_ACCOUNT", "test")
+
+	tests := []struct {
+		name       string
+		backupFlag bool
+		exportFlag bool
+	}{
+		{name: "backup only", backupFlag: true, exportFlag: false},
+		{name: "export only", backupFlag: false, exportFlag: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Backup.SkipAccessCheck = tt.backupFlag
+			cfg.Export.SkipAccessCheck = tt.exportFlag
+
+			params := moduletools.NewMockModuleInitParams(t)
+			params.EXPECT().GetLogger().Return(logrus.New())
+			params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+			params.EXPECT().GetConfig().Return(cfg)
+
+			m := New()
+			require.NoError(t, m.Init(context.Background(), params))
+			assert.Equal(t, tt.backupFlag, m.config.SkipAccessCheck, "backup client")
+			assert.Equal(t, tt.exportFlag, m.exportClient.config.SkipAccessCheck, "export client")
+		})
+	}
+}
+
 // Test user overrides
 func TestUploadParams(t *testing.T) {
 	defaultBlockSize := int64(40 * 1024 * 1024)

--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -22,7 +22,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/config"
 )
+
+func TestInitialize_SkipAccessCheck(t *testing.T) {
+	// With SkipAccessCheck set, Initialize must be a no-op: it returns
+	// before resolving the container or running the write+delete probe.
+	c := &azureClient{config: clientConfig{Container: "my-container", SkipAccessCheck: true}}
+	require.NoError(t, c.Initialize(context.Background(), "backup-1", "", ""))
+}
 
 // Test user overrides
 func TestUploadParams(t *testing.T) {
@@ -39,6 +47,7 @@ func TestUploadParams(t *testing.T) {
 	params := moduletools.NewMockModuleInitParams(t)
 	params.EXPECT().GetLogger().Return(logrus.New())
 	params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+	params.EXPECT().GetConfig().Return(&config.Config{})
 	err := azure.Init(testCtx, params)
 	require.Nil(t, err)
 
@@ -53,6 +62,7 @@ func TestUploadParams(t *testing.T) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 
@@ -66,6 +76,7 @@ func TestUploadParams(t *testing.T) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 
@@ -109,6 +120,7 @@ func TestUploadParams(t *testing.T) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 
@@ -122,6 +134,7 @@ func TestUploadParams(t *testing.T) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := azure.Init(testCtx, params)
 		assert.Nil(t, err)
 

--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestInitialize_SkipAccessCheck(t *testing.T) {
-	// With SkipAccessCheck set, Initialize must be a no-op: it returns
-	// before resolving the container or running the write+delete probe.
+	// With SkipAccessCheck set, Initialize validates the container name but
+	// skips the write+delete probe, so it returns nil without any network call.
 	c := &azureClient{config: clientConfig{Container: "my-container", SkipAccessCheck: true}}
 	require.NoError(t, c.Initialize(context.Background(), "backup-1", "", ""))
 }

--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -26,10 +26,27 @@ import (
 )
 
 func TestInitialize_SkipAccessCheck(t *testing.T) {
-	// With SkipAccessCheck set, Initialize validates the container name but
-	// skips the write+delete probe, so it returns nil without any network call.
-	c := &azureClient{config: clientConfig{Container: "my-container", SkipAccessCheck: true}}
-	require.NoError(t, c.Initialize(context.Background(), "backup-1", "", ""))
+	// Validation runs before the SkipAccessCheck short-circuit: a valid
+	// container skips the probe, an empty one still errors.
+	tests := []struct {
+		name      string
+		container string
+		wantErr   string
+	}{
+		{name: "valid container skips probe", container: "my-container"},
+		{name: "empty container still validates", container: "", wantErr: "container must not be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &azureClient{config: clientConfig{Container: tt.container, SkipAccessCheck: true}}
+			err := c.Initialize(context.Background(), "backup-1", "", "")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
 // Test user overrides

--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -227,6 +227,10 @@ func (a *azureClient) PutObject(ctx context.Context, backupID, key, overrideBuck
 }
 
 func (a *azureClient) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
+	if a.config.SkipAccessCheck {
+		return nil
+	}
+
 	containerName, err := a.resolveContainer(overrideBucket)
 	if err != nil {
 		return err

--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -227,13 +227,13 @@ func (a *azureClient) PutObject(ctx context.Context, backupID, key, overrideBuck
 }
 
 func (a *azureClient) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
-	if a.config.SkipAccessCheck {
-		return nil
-	}
-
 	containerName, err := a.resolveContainer(overrideBucket)
 	if err != nil {
 		return err
+	}
+
+	if a.config.SkipAccessCheck {
+		return nil
 	}
 
 	key := "access-check"

--- a/modules/backup-azure/module.go
+++ b/modules/backup-azure/module.go
@@ -43,6 +43,11 @@ type clientConfig struct {
 	// the backup to be stored in a specific
 	// directory inside the provided bucket
 	BackupPath string
+
+	// SkipAccessCheck disables the write+delete probe in Initialize.
+	// Set it when the credentials are intentionally restricted
+	// (e.g. a least-privilege role without delete permission).
+	SkipAccessCheck bool
 }
 
 type Module struct {
@@ -79,8 +84,9 @@ func (m *Module) Init(ctx context.Context,
 	m.dataPath = params.GetStorageProvider().DataPath()
 
 	config := &clientConfig{
-		Container:  os.Getenv(azureContainer),
-		BackupPath: os.Getenv(azurePath),
+		Container:       os.Getenv(azureContainer),
+		BackupPath:      os.Getenv(azurePath),
+		SkipAccessCheck: params.GetConfig().Backup.SkipAccessCheck,
 	}
 	if config.Container == "" {
 		return errors.Errorf("backup init: '%s' must be set", azureContainer)
@@ -93,8 +99,9 @@ func (m *Module) Init(ctx context.Context,
 	m.azureClient = client
 
 	exportConfig := &clientConfig{
-		Container:  "", // export scheduler provides bucket via EXPORT_DEFAULT_BUCKET
-		BackupPath: "", // export scheduler provides path via EXPORT_DEFAULT_PATH
+		Container:       "", // export scheduler provides bucket via EXPORT_DEFAULT_BUCKET
+		BackupPath:      "", // export scheduler provides path via EXPORT_DEFAULT_PATH
+		SkipAccessCheck: params.GetConfig().Export.SkipAccessCheck,
 	}
 	exportClient, err := newClient(ctx, exportConfig, m.dataPath, m.logger)
 	if err != nil {

--- a/modules/backup-azure/module.go
+++ b/modules/backup-azure/module.go
@@ -45,8 +45,6 @@ type clientConfig struct {
 	BackupPath string
 
 	// SkipAccessCheck disables the write+delete probe in Initialize.
-	// Set it when the credentials are intentionally restricted
-	// (e.g. a least-privilege role without delete permission).
 	SkipAccessCheck bool
 }
 

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -199,14 +199,21 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 	})
 }
 
-func (g *gcsClient) findBucket(ctx context.Context, bucketOverride string) (*storage.BucketHandle, error) {
+func (g *gcsClient) resolveBucketName(bucketOverride string) (string, error) {
 	b := g.config.Bucket
-
 	if bucketOverride != "" {
 		b = bucketOverride
 	}
 	if b == "" {
-		return nil, fmt.Errorf("bucket must not be empty")
+		return "", fmt.Errorf("bucket must not be empty")
+	}
+	return b, nil
+}
+
+func (g *gcsClient) findBucket(ctx context.Context, bucketOverride string) (*storage.BucketHandle, error) {
+	b, err := g.resolveBucketName(bucketOverride)
+	if err != nil {
+		return nil, err
 	}
 	bucket := g.client.Bucket(b)
 
@@ -282,6 +289,10 @@ func (g *gcsClient) PutObject(ctx context.Context, backupID, key, overrideBucket
 }
 
 func (g *gcsClient) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
+	if _, err := g.resolveBucketName(overrideBucket); err != nil {
+		return err
+	}
+
 	if g.config.SkipAccessCheck {
 		return nil
 	}

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -282,6 +282,10 @@ func (g *gcsClient) PutObject(ctx context.Context, backupID, key, overrideBucket
 }
 
 func (g *gcsClient) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
+	if g.config.SkipAccessCheck {
+		return nil
+	}
+
 	// Each call gets a unique access-check file so concurrent Initialize calls
 	// from different nodes (or the same node) never interfere with each other.
 	seq := g.counter.Add(1)

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -32,10 +32,27 @@ import (
 )
 
 func TestInitialize_SkipAccessCheck(t *testing.T) {
-	// With SkipAccessCheck set, Initialize must be a no-op: it returns
-	// before touching the (nil) GCS client or running the write+delete probe.
-	c := &gcsClient{config: clientConfig{Bucket: "my-bucket", SkipAccessCheck: true}}
-	require.NoError(t, c.Initialize(context.Background(), "backup-1", "", ""))
+	// Validation runs before the SkipAccessCheck short-circuit: a valid bucket
+	// skips the probe, an empty one still errors.
+	tests := []struct {
+		name    string
+		bucket  string
+		wantErr string
+	}{
+		{name: "valid bucket skips probe", bucket: "my-bucket"},
+		{name: "empty bucket still validates", bucket: "", wantErr: "bucket must not be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &gcsClient{config: clientConfig{Bucket: tt.bucket, SkipAccessCheck: true}}
+			err := c.Initialize(context.Background(), "backup-1", "", "")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
 func TestFindBucket_EmptyBucket(t *testing.T) {

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -31,6 +31,13 @@ import (
 	ubak "github.com/weaviate/weaviate/usecases/backup"
 )
 
+func TestInitialize_SkipAccessCheck(t *testing.T) {
+	// With SkipAccessCheck set, Initialize must be a no-op: it returns
+	// before touching the (nil) GCS client or running the write+delete probe.
+	c := &gcsClient{config: clientConfig{Bucket: "my-bucket", SkipAccessCheck: true}}
+	require.NoError(t, c.Initialize(context.Background(), "backup-1", "", ""))
+}
+
 func TestFindBucket_EmptyBucket(t *testing.T) {
 	// Note: cases where the resolved bucket is non-empty cannot be tested
 	// without a real GCS connection (client.Bucket panics on a nil client),

--- a/modules/backup-gcs/module.go
+++ b/modules/backup-gcs/module.go
@@ -43,6 +43,11 @@ type clientConfig struct {
 	// the backup to be stored in a specific
 	// directory inside the provided bucket
 	BackupPath string
+
+	// SkipAccessCheck disables the write+delete probe in Initialize.
+	// Set it when the credentials are intentionally restricted
+	// (e.g. a least-privilege role without delete permission).
+	SkipAccessCheck bool
 }
 
 type Module struct {
@@ -79,8 +84,9 @@ func (m *Module) Init(ctx context.Context,
 	m.dataPath = params.GetStorageProvider().DataPath()
 
 	config := &clientConfig{
-		Bucket:     os.Getenv(gcsBucket),
-		BackupPath: os.Getenv(gcsPath),
+		Bucket:          os.Getenv(gcsBucket),
+		BackupPath:      os.Getenv(gcsPath),
+		SkipAccessCheck: params.GetConfig().Backup.SkipAccessCheck,
 	}
 	if config.Bucket == "" {
 		return errors.Errorf("backup init: '%s' must be set", gcsBucket)
@@ -93,8 +99,9 @@ func (m *Module) Init(ctx context.Context,
 	m.gcsClient = client
 
 	exportConfig := &clientConfig{
-		Bucket:     "", // export scheduler provides bucket via EXPORT_DEFAULT_BUCKET
-		BackupPath: "", // export scheduler provides path via EXPORT_DEFAULT_PATH
+		Bucket:          "", // export scheduler provides bucket via EXPORT_DEFAULT_BUCKET
+		BackupPath:      "", // export scheduler provides path via EXPORT_DEFAULT_PATH
+		SkipAccessCheck: params.GetConfig().Export.SkipAccessCheck,
 	}
 	exportClient, err := newClient(ctx, exportConfig, m.dataPath, m.logger)
 	if err != nil {

--- a/modules/backup-gcs/module.go
+++ b/modules/backup-gcs/module.go
@@ -45,8 +45,6 @@ type clientConfig struct {
 	BackupPath string
 
 	// SkipAccessCheck disables the write+delete probe in Initialize.
-	// Set it when the credentials are intentionally restricted
-	// (e.g. a least-privilege role without delete permission).
 	SkipAccessCheck bool
 }
 

--- a/modules/backup-gcs/module_test.go
+++ b/modules/backup-gcs/module_test.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modstggcs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+func TestInit_SkipAccessCheckWiring(t *testing.T) {
+	// Init must route Backup.SkipAccessCheck to the backup client and
+	// Export.SkipAccessCheck to the export client, without crossing them.
+	t.Setenv("BACKUP_GCS_BUCKET", "test")
+	t.Setenv("BACKUP_GCS_USE_AUTH", "false")
+
+	tests := []struct {
+		name       string
+		backupFlag bool
+		exportFlag bool
+	}{
+		{name: "backup only", backupFlag: true, exportFlag: false},
+		{name: "export only", backupFlag: false, exportFlag: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Backup.SkipAccessCheck = tt.backupFlag
+			cfg.Export.SkipAccessCheck = tt.exportFlag
+
+			params := moduletools.NewMockModuleInitParams(t)
+			params.EXPECT().GetLogger().Return(logrus.New())
+			params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+			params.EXPECT().GetConfig().Return(cfg)
+
+			m := New()
+			require.NoError(t, m.Init(context.Background(), params))
+			assert.Equal(t, tt.backupFlag, m.config.SkipAccessCheck, "backup client")
+			assert.Equal(t, tt.exportFlag, m.exportClient.config.SkipAccessCheck, "export client")
+		})
+	}
+}
+
+type fakeStorageProvider struct {
+	dataPath string
+}
+
+func (f *fakeStorageProvider) Storage(name string) (moduletools.Storage, error) {
+	return nil, nil
+}
+
+func (f *fakeStorageProvider) DataPath() string {
+	return f.dataPath
+}

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -356,6 +356,10 @@ func (s *s3Client) PutObject(ctx context.Context, backupID, key, overrideBucket,
 }
 
 func (s *s3Client) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
+	if s.config.SkipAccessCheck {
+		return nil
+	}
+
 	client, err := s.getClient(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to get client")

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -356,6 +356,13 @@ func (s *s3Client) PutObject(ctx context.Context, backupID, key, overrideBucket,
 }
 
 func (s *s3Client) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
+	key := "access-check"
+
+	bucket, objectName, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	if err != nil {
+		return err
+	}
+
 	if s.config.SkipAccessCheck {
 		return nil
 	}
@@ -365,16 +372,10 @@ func (s *s3Client) Initialize(ctx context.Context, backupID, overrideBucket, ove
 		return errors.Wrap(err, "failed to get client")
 	}
 
-	key := "access-check"
-
 	if err := s.PutObject(ctx, backupID, key, overrideBucket, overridePath, []byte("")); err != nil {
 		return errors.Wrap(err, "failed to access-check s3 backup module")
 	}
 
-	bucket, objectName, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
-	if err != nil {
-		return err
-	}
 	opt := minio.RemoveObjectOptions{}
 	if err := client.RemoveObject(ctx, bucket, objectName, opt); err != nil {
 		return errors.Wrap(err, "failed to remove access-check s3 backup module")

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -21,12 +21,27 @@ import (
 )
 
 func TestInitialize_SkipAccessCheck(t *testing.T) {
-	// With SkipAccessCheck set, Initialize must be a no-op: no client is
-	// built and no PutObject/RemoveObject probe runs, so it returns nil
-	// even though the client has no working S3 connection.
-	c := &s3Client{config: &clientConfig{Bucket: "my-bucket", SkipAccessCheck: true}}
-	err := c.Initialize(context.Background(), "backup-1", "", "")
-	require.NoError(t, err)
+	// Validation runs before the SkipAccessCheck short-circuit: a valid bucket
+	// skips the probe, an empty one still errors.
+	tests := []struct {
+		name    string
+		bucket  string
+		wantErr string
+	}{
+		{name: "valid bucket skips probe", bucket: "my-bucket"},
+		{name: "empty bucket still validates", bucket: "", wantErr: "bucket must not be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &s3Client{config: &clientConfig{Bucket: tt.bucket, SkipAccessCheck: true}}
+			err := c.Initialize(context.Background(), "backup-1", "", "")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
 // setEnvVars sets environment variables and returns a cleanup function

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -12,12 +12,22 @@
 package modstgs3
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestInitialize_SkipAccessCheck(t *testing.T) {
+	// With SkipAccessCheck set, Initialize must be a no-op: no client is
+	// built and no PutObject/RemoveObject probe runs, so it returns nil
+	// even though the client has no working S3 connection.
+	c := &s3Client{config: &clientConfig{Bucket: "my-bucket", SkipAccessCheck: true}}
+	err := c.Initialize(context.Background(), "backup-1", "", "")
+	require.NoError(t, err)
+}
 
 // setEnvVars sets environment variables and returns a cleanup function
 // that restores the original values.

--- a/modules/backup-s3/config.go
+++ b/modules/backup-s3/config.go
@@ -28,8 +28,6 @@ type clientConfig struct {
 	RoleSessionName string
 
 	// SkipAccessCheck disables the write+delete probe in Initialize.
-	// Set it when the credentials are intentionally restricted (e.g. a
-	// least-privilege export role without DeleteObject).
 	SkipAccessCheck bool
 }
 

--- a/modules/backup-s3/config.go
+++ b/modules/backup-s3/config.go
@@ -26,6 +26,11 @@ type clientConfig struct {
 	ExternalID      string
 	STSEndpoint     string
 	RoleSessionName string
+
+	// SkipAccessCheck disables the write+delete probe in Initialize.
+	// Set it when the credentials are intentionally restricted (e.g. a
+	// least-privilege export role without DeleteObject).
+	SkipAccessCheck bool
 }
 
 func newConfig(endpoint, bucket, path string, useSSL bool) *clientConfig {

--- a/modules/backup-s3/module.go
+++ b/modules/backup-s3/module.go
@@ -88,6 +88,7 @@ func (m *Module) Init(ctx context.Context,
 	// SSL on by default
 	useSSL := strings.ToLower(os.Getenv(s3UseSSL)) != "false"
 	config := newConfig(os.Getenv(s3Endpoint), bucket, os.Getenv(s3Path), useSSL)
+	config.SkipAccessCheck = params.GetConfig().Backup.SkipAccessCheck
 	client, err := newClient(config, m.logger, m.dataPath)
 	if err != nil {
 		return errors.Wrap(err, "initialize S3 backup module")
@@ -108,6 +109,7 @@ func (m *Module) Init(ctx context.Context,
 			exportCfg.RoleSessionName = "weaviate-export-s3"
 		}
 	}
+	exportCfg.SkipAccessCheck = params.GetConfig().Export.SkipAccessCheck
 	exportClient, err := newClient(exportCfg, m.logger, m.dataPath)
 	if err != nil {
 		return errors.Wrap(err, "initialize S3 export client")

--- a/modules/backup-s3/module_test.go
+++ b/modules/backup-s3/module_test.go
@@ -1,0 +1,68 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modstgs3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+func TestInit_SkipAccessCheckWiring(t *testing.T) {
+	// Init must route Backup.SkipAccessCheck to the backup client and
+	// Export.SkipAccessCheck to the export client, without crossing them.
+	t.Setenv("BACKUP_S3_BUCKET", "test")
+
+	tests := []struct {
+		name       string
+		backupFlag bool
+		exportFlag bool
+	}{
+		{name: "backup only", backupFlag: true, exportFlag: false},
+		{name: "export only", backupFlag: false, exportFlag: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Backup.SkipAccessCheck = tt.backupFlag
+			cfg.Export.SkipAccessCheck = tt.exportFlag
+
+			params := moduletools.NewMockModuleInitParams(t)
+			params.EXPECT().GetLogger().Return(logrus.New())
+			params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+			params.EXPECT().GetConfig().Return(cfg)
+
+			m := New()
+			require.NoError(t, m.Init(context.Background(), params))
+			assert.Equal(t, tt.backupFlag, m.config.SkipAccessCheck, "backup client")
+			assert.Equal(t, tt.exportFlag, m.exportClient.config.SkipAccessCheck, "export client")
+		})
+	}
+}
+
+type fakeStorageProvider struct {
+	dataPath string
+}
+
+func (f *fakeStorageProvider) Storage(name string) (moduletools.Storage, error) {
+	return nil, nil
+}
+
+func (f *fakeStorageProvider) DataPath() string {
+	return f.dataPath
+}

--- a/test/modules/backup-azure/backup_backend_test.go
+++ b/test/modules/backup-azure/backup_backend_test.go
@@ -28,6 +28,7 @@ import (
 	mod "github.com/weaviate/weaviate/modules/backup-azure"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 // Environment variable names for Azure module configuration
@@ -127,6 +128,7 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath strin
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := azure.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -215,6 +217,7 @@ func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath string) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := azure.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -266,6 +269,7 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: dataDir})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err = azure.Init(testCtx, params)
 		require.Nil(t, err)
 

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -28,6 +28,7 @@ import (
 	mod "github.com/weaviate/weaviate/modules/backup-gcs"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 // Environment variable names for GCS module configuration
@@ -89,6 +90,7 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath strin
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := gcs.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -182,6 +184,7 @@ func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath string) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := gcs.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -234,6 +237,7 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: dataDir})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err = gcs.Init(testCtx, params)
 		require.Nil(t, err)
 

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -28,6 +28,7 @@ import (
 	mod "github.com/weaviate/weaviate/modules/backup-s3"
 	moduleshelper "github.com/weaviate/weaviate/test/helper/modules"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 // Environment variable names for S3 module configuration
@@ -101,6 +102,7 @@ func moduleLevelStoreBackupMeta(t *testing.T, override bool, containerName, over
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := s3.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -195,6 +197,7 @@ func moduleLevelCopyObjects(t *testing.T, override bool, containerName, override
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err := s3.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -235,6 +238,7 @@ func moduleLevelCopyFiles(t *testing.T, override bool, containerName, overrideBu
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: dataDir})
+		params.EXPECT().GetConfig().Return(&config.Config{})
 		err = s3.Init(testCtx, params)
 		require.Nil(t, err)
 

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -733,6 +733,12 @@ type Backup struct {
 	MinChunkSize    int64 `json:"min_chunk_size" yaml:"min_chunk_size"`
 	ChunkTargetSize int64 `json:"chunk_target_size" yaml:"chunk_target_size"`
 	SplitFileSize   int64 `json:"split_file_size" yaml:"split_file_size"`
+
+	// SkipAccessCheck disables the write+delete probe that the backup client
+	// runs on initialize. Set it when the backup credentials are
+	// intentionally restricted (e.g. lacking DeleteObject).
+	// Env: BACKUP_SKIP_ACCESS_CHECK.
+	SkipAccessCheck bool `json:"skip_access_check" yaml:"skip_access_check"`
 }
 
 // DefaultQueryDefaultsLimit is the default query limit when no limit is provided
@@ -929,6 +935,12 @@ type Export struct {
 	// so this value is used directly.
 	// Env: EXPORT_DEFAULT_PATH, runtime config: export_default_path.
 	DefaultPath *runtime.DynamicValue[string] `json:"default_path" yaml:"default_path"`
+
+	// SkipAccessCheck disables the write+delete probe that the export client
+	// runs on initialize. Set it when the export credentials are
+	// intentionally restricted (e.g. a least-privilege role without
+	// DeleteObject). Env: EXPORT_SKIP_ACCESS_CHECK.
+	SkipAccessCheck bool `json:"skip_access_check" yaml:"skip_access_check"`
 }
 
 const (

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -734,9 +734,9 @@ type Backup struct {
 	ChunkTargetSize int64 `json:"chunk_target_size" yaml:"chunk_target_size"`
 	SplitFileSize   int64 `json:"split_file_size" yaml:"split_file_size"`
 
-	// SkipAccessCheck disables the write+delete probe that the backup client
-	// runs on initialize. Set it when the backup credentials are
-	// intentionally restricted (e.g. lacking DeleteObject).
+	// SkipAccessCheck disables the write+delete probe the backup client runs on
+	// initialize, deferring write/permission errors to backup time. Use it for
+	// least-privilege credentials that can write but lack DeleteObject.
 	// Env: BACKUP_SKIP_ACCESS_CHECK.
 	SkipAccessCheck bool `json:"skip_access_check" yaml:"skip_access_check"`
 }
@@ -936,10 +936,10 @@ type Export struct {
 	// Env: EXPORT_DEFAULT_PATH, runtime config: export_default_path.
 	DefaultPath *runtime.DynamicValue[string] `json:"default_path" yaml:"default_path"`
 
-	// SkipAccessCheck disables the write+delete probe that the export client
-	// runs on initialize. Set it when the export credentials are
-	// intentionally restricted (e.g. a least-privilege role without
-	// DeleteObject). Env: EXPORT_SKIP_ACCESS_CHECK.
+	// SkipAccessCheck disables the write+delete probe the export client runs on
+	// initialize, deferring write/permission errors to export time. Use it for
+	// least-privilege credentials that can write but lack DeleteObject.
+	// Env: EXPORT_SKIP_ACCESS_CHECK.
 	SkipAccessCheck bool `json:"skip_access_check" yaml:"skip_access_check"`
 }
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -741,6 +741,10 @@ func FromEnv(config *Config) error {
 		config.Backup.SplitFileSize = DefaultBackupSplitFileSize
 	}
 
+	if entcfg.Enabled(os.Getenv("BACKUP_SKIP_ACCESS_CHECK")) {
+		config.Backup.SkipAccessCheck = true
+	}
+
 	if v := os.Getenv("QUERY_DEFAULTS_LIMIT_GRAPHQL"); v != "" {
 		asInt, err := strconv.Atoi(v)
 		if err != nil {
@@ -2220,5 +2224,9 @@ func (c *Config) parseExportConfig() {
 		c.Export.DefaultPath = configRuntime.NewDynamicValue(strings.TrimSpace(v))
 	} else if c.Export.DefaultPath == nil {
 		c.Export.DefaultPath = configRuntime.NewDynamicValue("")
+	}
+
+	if entcfg.Enabled(os.Getenv("EXPORT_SKIP_ACCESS_CHECK")) {
+		c.Export.SkipAccessCheck = true
 	}
 }

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -321,6 +321,33 @@ func TestEnvironmentDisableLazyLoadShardsBackwardCompat(t *testing.T) {
 	})
 }
 
+func TestEnvironmentSkipAccessCheck(t *testing.T) {
+	t.Run("unset defaults to false for both", func(t *testing.T) {
+		conf := Config{}
+		require.NoError(t, FromEnv(&conf))
+		assert.False(t, conf.Backup.SkipAccessCheck)
+		assert.False(t, conf.Export.SkipAccessCheck)
+	})
+
+	t.Run("BACKUP_SKIP_ACCESS_CHECK toggles only backup", func(t *testing.T) {
+		t.Setenv("BACKUP_SKIP_ACCESS_CHECK", "true")
+
+		conf := Config{}
+		require.NoError(t, FromEnv(&conf))
+		assert.True(t, conf.Backup.SkipAccessCheck)
+		assert.False(t, conf.Export.SkipAccessCheck)
+	})
+
+	t.Run("EXPORT_SKIP_ACCESS_CHECK toggles only export", func(t *testing.T) {
+		t.Setenv("EXPORT_SKIP_ACCESS_CHECK", "true")
+
+		conf := Config{}
+		require.NoError(t, FromEnv(&conf))
+		assert.False(t, conf.Backup.SkipAccessCheck)
+		assert.True(t, conf.Export.SkipAccessCheck)
+	})
+}
+
 func TestEnvironmentLazyLoadShardSizeThreshold(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -351,6 +351,16 @@ func TestEnvironmentSkipAccessCheck(t *testing.T) {
 		assert.False(t, conf.Backup.SkipAccessCheck)
 		assert.True(t, conf.Export.SkipAccessCheck)
 	})
+
+	t.Run("both set toggles both independently", func(t *testing.T) {
+		t.Setenv("BACKUP_SKIP_ACCESS_CHECK", "true")
+		t.Setenv("EXPORT_SKIP_ACCESS_CHECK", "true")
+
+		conf := Config{}
+		require.NoError(t, FromEnv(&conf))
+		assert.True(t, conf.Backup.SkipAccessCheck)
+		assert.True(t, conf.Export.SkipAccessCheck)
+	})
 }
 
 func TestEnvironmentLazyLoadShardSizeThreshold(t *testing.T) {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -323,6 +323,9 @@ func TestEnvironmentDisableLazyLoadShardsBackwardCompat(t *testing.T) {
 
 func TestEnvironmentSkipAccessCheck(t *testing.T) {
 	t.Run("unset defaults to false for both", func(t *testing.T) {
+		t.Setenv("BACKUP_SKIP_ACCESS_CHECK", "")
+		t.Setenv("EXPORT_SKIP_ACCESS_CHECK", "")
+
 		conf := Config{}
 		require.NoError(t, FromEnv(&conf))
 		assert.False(t, conf.Backup.SkipAccessCheck)
@@ -331,6 +334,7 @@ func TestEnvironmentSkipAccessCheck(t *testing.T) {
 
 	t.Run("BACKUP_SKIP_ACCESS_CHECK toggles only backup", func(t *testing.T) {
 		t.Setenv("BACKUP_SKIP_ACCESS_CHECK", "true")
+		t.Setenv("EXPORT_SKIP_ACCESS_CHECK", "")
 
 		conf := Config{}
 		require.NoError(t, FromEnv(&conf))
@@ -339,6 +343,7 @@ func TestEnvironmentSkipAccessCheck(t *testing.T) {
 	})
 
 	t.Run("EXPORT_SKIP_ACCESS_CHECK toggles only export", func(t *testing.T) {
+		t.Setenv("BACKUP_SKIP_ACCESS_CHECK", "")
 		t.Setenv("EXPORT_SKIP_ACCESS_CHECK", "true")
 
 		conf := Config{}


### PR DESCRIPTION
### What's being changed:

Adds new env vars:
- BACKUP_SKIP_ACCESS_CHECK
- EXPORT_SKIP_ACCESS_CHECK

to disable access check for new backups


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
