### PR TITLE
Use local HuggingFace cache for ann-datasets to avoid 429

### DIFF
--- a/adapters/repos/db/vector/datasets/dataset.go
+++ b/adapters/repos/db/vector/datasets/dataset.go
@@ -12,10 +12,19 @@
 package datasets
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/gomlx/go-huggingface/hub"
 )
+
+// hfRevision is the dataset revision this package downloads. It matches the
+// default ("main") used by hub.New, and is the key under which the resolved
+// commit hash is cached on disk (info/<revision>).
+const hfRevision = "main"
 
 type HubDataset struct {
 	repo      *hub.Repo
@@ -40,11 +49,49 @@ func NewHubDatasetWithToken(datasetID string, subset string, hfAuthToken string)
 
 func (h *HubDataset) downloadParquetFile(name string) (string, error) {
 	filePath := fmt.Sprintf("%s/%s/%s.parquet", h.subset, name, name)
+	// Reuse the file from the local HuggingFace cache when present. The library's
+	// DownloadFile always re-resolves the "main" revision against the API first,
+	// which is rate-limited and makes CI flaky with HTTP 429 even on a warm cache.
+	if cached, ok := h.cachedParquetPath(filePath); ok {
+		return cached, nil
+	}
 	localPath, err := h.repo.DownloadFile(filePath)
 	if err != nil {
 		return "", err
 	}
 	return localPath, nil
+}
+
+// cachedParquetPath returns the path to an already-downloaded parquet file in the
+// local HuggingFace cache, if present. It mirrors the on-disk layout that
+// go-huggingface shares with the Python huggingface_hub library: the resolved
+// commit hash for a revision lives in info/<revision>, and files are stored under
+// snapshots/<commitHash>/. This lets us serve a warm cache without any network
+// call. It assumes the default cache dir and revision used by this package's
+// constructor.
+func (h *HubDataset) cachedParquetPath(filePath string) (string, bool) {
+	flatName := strings.Join(
+		append([]string{string(hub.RepoTypeDataset)}, strings.Split(h.datasetID, "/")...),
+		hub.RepoIdSeparator,
+	)
+	repoDir := filepath.Join(hub.DefaultCacheDir(), flatName)
+
+	infoBytes, err := os.ReadFile(filepath.Join(repoDir, "info", hfRevision))
+	if err != nil {
+		return "", false
+	}
+	var info struct {
+		Sha string `json:"sha"`
+	}
+	if err := json.Unmarshal(infoBytes, &info); err != nil || info.Sha == "" {
+		return "", false
+	}
+
+	snapshotPath := filepath.Join(repoDir, "snapshots", info.Sha, filepath.FromSlash(filePath))
+	if _, err := os.Stat(snapshotPath); err != nil {
+		return "", false
+	}
+	return snapshotPath, true
 }
 
 const defaultRowBufferSize = 1000

--- a/adapters/repos/db/vector/datasets/dataset_cache_test.go
+++ b/adapters/repos/db/vector/datasets/dataset_cache_test.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package datasets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachedParquetPath(t *testing.T) {
+	const (
+		datasetID = "weaviate/ann-datasets"
+		subset    = "fiqa-st-minilm-384-dot-12k"
+		sha       = "1e437271d862b9ed45ebc169a1bcd0b39c16def7"
+	)
+	relFile := subset + "/train/train.parquet"
+
+	// seedCache lays out a HuggingFace-style cache under a temp XDG_CACHE_HOME and
+	// returns the repo directory. The caller decides which pieces to populate.
+	seedCache := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		t.Setenv("XDG_CACHE_HOME", root)
+		return filepath.Join(root, "huggingface", "hub", "datasets--weaviate--ann-datasets")
+	}
+	writeInfo := func(t *testing.T, repoDir, body string) {
+		t.Helper()
+		infoPath := filepath.Join(repoDir, "info", "main")
+		require.NoError(t, os.MkdirAll(filepath.Dir(infoPath), 0o755))
+		require.NoError(t, os.WriteFile(infoPath, []byte(body), 0o644))
+	}
+	writeSnapshot := func(t *testing.T, repoDir string) string {
+		t.Helper()
+		p := filepath.Join(repoDir, "snapshots", sha, filepath.FromSlash(relFile))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("parquet"), 0o644))
+		return p
+	}
+
+	t.Run("hit when info and snapshot present", func(t *testing.T) {
+		repoDir := seedCache(t)
+		writeInfo(t, repoDir, `{"sha":"`+sha+`"}`)
+		want := writeSnapshot(t, repoDir)
+
+		h := NewHubDataset(datasetID, subset)
+		got, ok := h.cachedParquetPath(relFile)
+		require.True(t, ok)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("miss when info file absent", func(t *testing.T) {
+		repoDir := seedCache(t)
+		writeSnapshot(t, repoDir)
+
+		h := NewHubDataset(datasetID, subset)
+		_, ok := h.cachedParquetPath(relFile)
+		require.False(t, ok)
+	})
+
+	t.Run("miss when snapshot absent", func(t *testing.T) {
+		repoDir := seedCache(t)
+		writeInfo(t, repoDir, `{"sha":"`+sha+`"}`)
+
+		h := NewHubDataset(datasetID, subset)
+		_, ok := h.cachedParquetPath(relFile)
+		require.False(t, ok)
+	})
+
+	t.Run("miss when sha empty", func(t *testing.T) {
+		repoDir := seedCache(t)
+		writeInfo(t, repoDir, `{"sha":""}`)
+		writeSnapshot(t, repoDir)
+
+		h := NewHubDataset(datasetID, subset)
+		_, ok := h.cachedParquetPath(relFile)
+		require.False(t, ok)
+	})
+}


### PR DESCRIPTION
## Summary
- Integration tests (`with vectors`) fail intermittently because `go-huggingface`'s `DownloadFile` always re-resolves the `main` revision against the HuggingFace API before serving cached files. That `GET /api/datasets/weaviate/ann-datasets/revision/main` is rate-limited and returns **HTTP 429** — even when the GitHub Actions cache (`~/.cache/huggingface/hub`) already has the dataset on disk.
- This change serves the parquet file directly from the local HF cache when present (reads the resolved commit hash from `info/main`, builds the `snapshots/<sha>/...` path, and returns it if it exists), falling back to the library download path on a cache miss. Cold-cache behavior is unchanged.

## Notes
- The cache-path logic mirrors the on-disk layout `go-huggingface` shares with the Python `huggingface_hub` library (stable), and assumes the default cache dir + `main` revision used by this package's constructor (documented in the helper comment).
- Does not address the cold-cache case (first run / cache key change), which still makes the API call; an `HF_TOKEN` in CI would raise the rate limit there if desired.

## Test plan
- [x] `go build` + `go vet ./adapters/repos/db/vector/datasets/` clean
- [x] New hermetic unit test `TestCachedParquetPath` (no network): covers hit, missing info, missing snapshot, empty sha
- [x] Existing `TestDataReader*` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)