### PR TITLE
Increase timeout for ObjectTTL test in case multi node cluster is not ready yet

### DIFF
--- a/test/acceptance/multi_node/object_ttl_test.go
+++ b/test/acceptance/multi_node/object_ttl_test.go
@@ -97,11 +97,15 @@ func TestObjectTTLMultiNodeTicker(t *testing.T) {
 		}))
 	}
 
+	// On a cold cluster, TTL deletion can stall on a not-yet-ready peer until the
+	// internal request times out (~30s), blocking all deletion until then.
+	const ttlDeletionTimeout = 60 * time.Second
+
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		objs, err := helper.GetObjects(t, class.Class)
 		require.NoError(ct, err)
 		require.Len(ct, objs, numNotExpiredObjs)
-	}, time.Second*15, 500*time.Millisecond)
+	}, ttlDeletionTimeout, 500*time.Millisecond)
 
 	// add more expired objects to see that the ticker continues to work
 	// add objects that are already expired so that the TTL process should delete them
@@ -120,7 +124,7 @@ func TestObjectTTLMultiNodeTicker(t *testing.T) {
 		objs, err := helper.GetObjects(t, class.Class)
 		require.NoError(ct, err)
 		require.Len(ct, objs, numNotExpiredObjs)
-	}, time.Second*15, 500*time.Millisecond)
+	}, ttlDeletionTimeout, 500*time.Millisecond)
 }
 
 func TestObjectTTLMultiNode(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

  The test intermittently failed (~1–2% of runs) with the expired-object count not reaching the expected value `object_ttl_test.go:122: should have 11 item(s), but has 20`

  Root cause: Object TTL deletion is leader-coordinated and skips a round while the previously-targeted node is still deleting. On a freshly-formed cluster, that node can stall on
  a not-yet-ready peer until the internal request times out (MINIMUM_INTERNAL_TIMEOUT, ~30s). Because the coordinator stays pinned to the stuck node, all TTL deletion is blocked
  for that window. The test's 15s assertion windows were shorter than this ~30s cold-start recovery, so deletion legitimately hadn't caught up yet when the assertion fired.

Increasing the wait window to 60s makes this test always pass (Did 60 runs locally without a flake)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
