### PR TITLE
inverted: clear error for len()/isNull filter on non-indexed property (#11015)

### DIFF
--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -933,12 +933,27 @@ func (s *Searcher) extractPropertyLength(prop *models.Property, propType schema.
 			"failed to extract length of prop, unsupported type '%T' for length of prop '%s'", propType, prop.Name)
 	}
 
+	hasFilterableIndex := HasFilterableIndexPropLength && HasAnyInvertedIndex(prop)
+	hasSearchableIndex := HasSearchableIndexPropLength && HasAnyInvertedIndex(prop)
+
+	// The property-length bucket is only created when length indexing is enabled
+	// globally AND the property itself has an inverted index (see
+	// Shard.createPropertyLengthIndex, gated by HasAnyInvertedIndex). When length
+	// indexing is off globally, readFromBucket already returns a dedicated error.
+	// The remaining gap — enabled globally but the property has no inverted index
+	// (e.g. indexFilterable=false) — would read a non-existent bucket, so return
+	// a clear error here, mirroring extractReferenceCount.
+	indexPropertyLength := class.InvertedIndexConfig != nil && class.InvertedIndexConfig.IndexPropertyLength
+	if indexPropertyLength && !hasFilterableIndex && !hasSearchableIndex {
+		return nil, inverted.NewMissingFilterableIndexError(prop.Name)
+	}
+
 	return &propValuePair{
 		value:              byteValue,
 		prop:               helpers.PropLength(prop.Name),
 		operator:           operator,
-		hasFilterableIndex: HasFilterableIndexPropLength, // TODO text_rbm_inverted_index & with settings
-		hasSearchableIndex: HasSearchableIndexPropLength, // TODO text_rbm_inverted_index & with settings
+		hasFilterableIndex: hasFilterableIndex, // TODO text_rbm_inverted_index & with settings
+		hasSearchableIndex: hasSearchableIndex, // TODO text_rbm_inverted_index & with settings
 		Class:              class,
 	}, nil
 }
@@ -960,12 +975,27 @@ func (s *Searcher) extractPropertyNull(prop *models.Property, propType schema.Da
 			"failed to extract null prop, unsupported type '%T' for null prop '%s'", propType, prop.Name)
 	}
 
+	hasFilterableIndex := HasFilterableIndexPropNull && HasAnyInvertedIndex(prop)
+	hasSearchableIndex := HasSearchableIndexPropNull && HasAnyInvertedIndex(prop)
+
+	// The property-null bucket is only created when null-state indexing is enabled
+	// globally AND the property itself has an inverted index (see
+	// Shard.createPropertyNullIndex, gated by HasAnyInvertedIndex). When null-state
+	// indexing is off globally, readFromBucket already returns a dedicated error.
+	// The remaining gap — enabled globally but the property has no inverted index
+	// (e.g. indexFilterable=false) — would read a non-existent bucket, so return a
+	// clear error here, mirroring extractReferenceCount.
+	indexNullState := class.InvertedIndexConfig != nil && class.InvertedIndexConfig.IndexNullState
+	if indexNullState && !hasFilterableIndex && !hasSearchableIndex {
+		return nil, inverted.NewMissingFilterableIndexError(prop.Name)
+	}
+
 	return &propValuePair{
 		value:              valResult,
 		prop:               helpers.PropNull(prop.Name),
 		operator:           operator,
-		hasFilterableIndex: HasFilterableIndexPropNull, // TODO text_rbm_inverted_index & with settings
-		hasSearchableIndex: HasSearchableIndexPropNull, // TODO text_rbm_inverted_index & with settings
+		hasFilterableIndex: hasFilterableIndex, // TODO text_rbm_inverted_index & with settings
+		hasSearchableIndex: hasSearchableIndex, // TODO text_rbm_inverted_index & with settings
 		Class:              class,
 	}, nil
 }

--- a/adapters/repos/db/inverted/searcher_length_test.go
+++ b/adapters/repos/db/inverted/searcher_length_test.go
@@ -121,7 +121,7 @@ func TestSearcher_extractPropertyNull_missingInvertedIndex(t *testing.T) {
 		}
 
 		pv, err := s.extractPropertyNull(prop, schema.DataTypeBoolean, true,
-			filters.OperatorEqual, class)
+			filters.OperatorIsNull, class)
 
 		require.Error(t, err)
 		assert.Nil(t, pv)
@@ -138,7 +138,7 @@ func TestSearcher_extractPropertyNull_missingInvertedIndex(t *testing.T) {
 		}
 
 		pv, err := s.extractPropertyNull(prop, schema.DataTypeBoolean, true,
-			filters.OperatorEqual, class)
+			filters.OperatorIsNull, class)
 
 		require.NoError(t, err)
 		require.NotNil(t, pv)
@@ -158,7 +158,7 @@ func TestSearcher_extractPropertyNull_missingInvertedIndex(t *testing.T) {
 		}
 
 		_, err := s.extractPropertyNull(prop, schema.DataTypeBoolean, true,
-			filters.OperatorEqual, class)
+			filters.OperatorIsNull, class)
 
 		require.NoError(t, err)
 	})

--- a/adapters/repos/db/inverted/searcher_length_test.go
+++ b/adapters/repos/db/inverted/searcher_length_test.go
@@ -1,0 +1,165 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// Regression test for https://github.com/weaviate/weaviate/issues/11015
+//
+// Filtering by the length of a property whose inverted index is disabled
+// (e.g. an int[] with indexFilterable=false) used to read a property-length
+// bucket that was never created, surfacing as a confusing "bucket not found"
+// error. When length indexing is enabled globally but the property has no
+// inverted index, it should instead return the same MissingFilterableIndex
+// error that other meta properties (e.g. reference count) already return.
+func TestSearcher_extractPropertyLength_missingInvertedIndex(t *testing.T) {
+	s := &Searcher{}
+
+	classWithLengthIndex := func() *models.Class {
+		return &models.Class{
+			Class: "BugReportLengthIndex",
+			InvertedIndexConfig: &models.InvertedIndexConfig{
+				IndexPropertyLength: true,
+			},
+		}
+	}
+
+	t.Run("returns clear error when property has no inverted index", func(t *testing.T) {
+		notFilterable := false
+		class := classWithLengthIndex()
+		prop := &models.Property{
+			Name:            "ints_non_filterable",
+			DataType:        []string{"int[]"},
+			IndexFilterable: &notFilterable,
+		}
+
+		pv, err := s.extractPropertyLength(prop, schema.DataTypeInt, 2,
+			filters.OperatorEqual, class)
+
+		require.Error(t, err)
+		assert.Nil(t, pv)
+		assert.Contains(t, err.Error(), "requires inverted index")
+	})
+
+	t.Run("succeeds when property is filterable", func(t *testing.T) {
+		filterable := true
+		class := classWithLengthIndex()
+		prop := &models.Property{
+			Name:            "ints_filterable",
+			DataType:        []string{"int[]"},
+			IndexFilterable: &filterable,
+		}
+
+		pv, err := s.extractPropertyLength(prop, schema.DataTypeInt, 2,
+			filters.OperatorEqual, class)
+
+		require.NoError(t, err)
+		require.NotNil(t, pv)
+		assert.True(t, pv.hasFilterableIndex)
+	})
+
+	t.Run("defers to downstream global-config error when length indexing is off", func(t *testing.T) {
+		notFilterable := false
+		// IndexPropertyLength is off globally; this is reported with a dedicated
+		// message later in readFromBucket, so the extractor must not shadow it.
+		class := &models.Class{
+			Class:               "BugReportLengthIndex",
+			InvertedIndexConfig: &models.InvertedIndexConfig{IndexPropertyLength: false},
+		}
+		prop := &models.Property{
+			Name:            "ints_non_filterable",
+			DataType:        []string{"int[]"},
+			IndexFilterable: &notFilterable,
+		}
+
+		_, err := s.extractPropertyLength(prop, schema.DataTypeInt, 2,
+			filters.OperatorEqual, class)
+
+		require.NoError(t, err)
+	})
+}
+
+// Same defect family as #11015 on the adjacent null-state journey: a `null`/
+// `isNull` filter on a property with no inverted index read a property-null
+// bucket that was never created. It must return the same clear error.
+func TestSearcher_extractPropertyNull_missingInvertedIndex(t *testing.T) {
+	s := &Searcher{}
+
+	classWithNullState := func() *models.Class {
+		return &models.Class{
+			Class: "BugReportNullIndex",
+			InvertedIndexConfig: &models.InvertedIndexConfig{
+				IndexNullState: true,
+			},
+		}
+	}
+
+	t.Run("returns clear error when property has no inverted index", func(t *testing.T) {
+		notFilterable := false
+		class := classWithNullState()
+		prop := &models.Property{
+			Name:            "ints_non_filterable",
+			DataType:        []string{"int[]"},
+			IndexFilterable: &notFilterable,
+		}
+
+		pv, err := s.extractPropertyNull(prop, schema.DataTypeBoolean, true,
+			filters.OperatorEqual, class)
+
+		require.Error(t, err)
+		assert.Nil(t, pv)
+		assert.Contains(t, err.Error(), "requires inverted index")
+	})
+
+	t.Run("succeeds when property is filterable", func(t *testing.T) {
+		filterable := true
+		class := classWithNullState()
+		prop := &models.Property{
+			Name:            "ints_filterable",
+			DataType:        []string{"int[]"},
+			IndexFilterable: &filterable,
+		}
+
+		pv, err := s.extractPropertyNull(prop, schema.DataTypeBoolean, true,
+			filters.OperatorEqual, class)
+
+		require.NoError(t, err)
+		require.NotNil(t, pv)
+		assert.True(t, pv.hasFilterableIndex)
+	})
+
+	t.Run("defers to downstream global-config error when null-state indexing is off", func(t *testing.T) {
+		notFilterable := false
+		class := &models.Class{
+			Class:               "BugReportNullIndex",
+			InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: false},
+		}
+		prop := &models.Property{
+			Name:            "ints_non_filterable",
+			DataType:        []string{"int[]"},
+			IndexFilterable: &notFilterable,
+		}
+
+		_, err := s.extractPropertyNull(prop, schema.DataTypeBoolean, true,
+			filters.OperatorEqual, class)
+
+		require.NoError(t, err)
+	})
+}

--- a/adapters/repos/db/searcher_gh11015_integration_test.go
+++ b/adapters/repos/db/searcher_gh11015_integration_test.go
@@ -1,0 +1,92 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/dto"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// Regression test for https://github.com/weaviate/weaviate/issues/11015
+//
+// With IndexPropertyLength enabled globally but indexFilterable disabled on an
+// array property, the property has no inverted index, so its length bucket is
+// never created (Shard.createPropertyLengthIndex is gated by HasAnyInvertedIndex).
+// Filtering by len() of that property must return a clear, actionable error
+// rather than reading a non-existent bucket.
+func TestFilterPropertyLengthNonFilterable_GH11015(t *testing.T) {
+	notFilterable := false
+	class := &models.Class{
+		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			CleanupIntervalSeconds: 60,
+			Stopwords:              &models.StopwordConfig{Preset: "none"},
+			IndexPropertyLength:    true,
+			IndexNullState:         true,
+			UsingBlockMaxWAND:      config.DefaultUsingBlockMaxWAND,
+		},
+		Class: "GH11015Class",
+		Properties: []*models.Property{
+			{
+				Name:            "ints_non_filterable",
+				DataType:        []string{"int[]"},
+				IndexFilterable: &notFilterable,
+			},
+		},
+	}
+
+	migrator, repo, schemaGetter := createRepo(t)
+	defer repo.Shutdown(context.Background())
+	require.Nil(t, migrator.AddClass(context.Background(), class))
+	schemaGetter.schema = schema.Schema{
+		Objects: &models.Schema{Classes: []*models.Class{class}},
+	}
+
+	search := func(propertyPath string, op filters.Operator, value interface{}, valueType schema.DataType) error {
+		params := dto.GetParams{
+			ClassName:  class.Class,
+			Pagination: &filters.Pagination{Limit: 5},
+			Filters: &filters.LocalFilter{Root: &filters.Clause{
+				Operator: op,
+				On: &filters.Path{
+					Class:    schema.ClassName(class.Class),
+					Property: schema.PropertyName(propertyPath),
+				},
+				Value: &filters.Value{Value: value, Type: valueType},
+			}},
+		}
+		_, err := repo.Search(context.Background(), params)
+		return err
+	}
+
+	t.Run("filter by length", func(t *testing.T) {
+		err := search("len(ints_non_filterable)", filters.OperatorEqual, 2, schema.DataTypeInt)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requires inverted index")
+	})
+
+	t.Run("filter by null state", func(t *testing.T) {
+		err := search("ints_non_filterable", filters.OperatorIsNull, true, schema.DataTypeBoolean)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requires inverted index")
+	})
+}

--- a/adapters/repos/db/searcher_gh11015_integration_test.go
+++ b/adapters/repos/db/searcher_gh11015_integration_test.go
@@ -56,7 +56,7 @@ func TestFilterPropertyLengthNonFilterable_GH11015(t *testing.T) {
 
 	migrator, repo, schemaGetter := createRepo(t)
 	defer repo.Shutdown(context.Background())
-	require.Nil(t, migrator.AddClass(context.Background(), class))
+	require.NoError(t, migrator.AddClass(context.Background(), class))
 	schemaGetter.schema = schema.Schema{
 		Objects: &models.Schema{Classes: []*models.Class{class}},
 	}


### PR DESCRIPTION
## What

Filtering by `len(prop)` or `isNull` on a property with `indexFilterable=false`,
while `IndexPropertyLength`/`IndexNullState` is enabled globally, returned a
confusing internal error:

```
bucket for prop <name>_propertyLength not found - is it indexed?
```

The property has no inverted index, so its length/null bucket is never created
(`shard_init_properties.go` skips the property via `!HasAnyInvertedIndex(prop)`),
but `extractPropertyLength`/`extractPropertyNull` assumed the bucket always
exists.

## Fix

Mirror the existing `extractReferenceCount` handling: when the feature is enabled
globally but the property has no inverted index, return a clear
`MissingFilterableIndexError`. The global-disabled case keeps its existing
dedicated message — the new guard only fires for the per-property gap, so it does
not shadow the global-config errors in `readFromBucket`.

Closes #11015.

## Tests

- Unit (`searcher_length_test.go`): both extractors return the error for a
  non-indexed property, still succeed for filterable ones, and defer to the
  downstream global-config error when the feature is off globally.
- Integration (`searcher_gh11015_integration_test.go`): end-to-end length + null
  filter on a non-filterable property.
- Existing `TestFiltersNoLengthIndex`, `TestFilterPropertyLengthError`,
  `TestFilterNullStateError` still pass.