### PR TITLE
fix(backup): return 422 instead of 500 when backend module is missing

### DIFF
--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -428,7 +428,8 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 
 	backupBackend, err := s.backends.BackupBackend(backend, modulecapabilities.BackendUseCaseBackup)
 	if err != nil {
-		return nil, err
+		err = fmt.Errorf("no backup backend %q: %w, did you enable the right module?", backend, err)
+		return nil, backup.NewErrUnprocessable(err)
 	}
 
 	backups, err := backupBackend.AllBackups(ctx)

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -919,6 +919,9 @@ func TestSchedulerList(t *testing.T) {
 		fs.backendErr = ErrAny
 		_, err := fs.scheduler().List(ctx, nil, backendName, defaultListOrdering, false)
 		assert.NotNil(t, err)
+		assert.ErrorAs(t, err, &backup.ErrUnprocessable{}, "missing backend module should map to 422 unprocessable")
+		assert.Contains(t, err.Error(), backendName)
+		assert.Contains(t, err.Error(), ErrAny.Error())
 	})
 
 	t.Run("AllBackupsFails", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
