### PR TITLE
fix(backup-azure): use delimiter listing in AllBackups to avoid full object scan

### DIFF
--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -13,15 +13,23 @@ package modstgazure
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/moduletools"
+	ubak "github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -263,6 +271,121 @@ func TestResolveContainer(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantContainer, container)
 			}
+		})
+	}
+}
+
+func TestAllBackupsSkipsMissingDescriptors(t *testing.T) {
+	const containerName = "test-container"
+
+	validDesc := []byte(`{"id":"backup-1"}`)
+
+	tests := []struct {
+		name             string
+		downloadResponse func(blobName string) (status int, headers map[string]string, body []byte)
+		wantIDs          []string
+		wantErr          bool
+	}{
+		{
+			name: "missing descriptor for one backup is skipped, other returned",
+			downloadResponse: func(blobName string) (int, map[string]string, []byte) {
+				switch blobName {
+				case "backup-1/" + ubak.GlobalBackupFile:
+					return http.StatusOK, nil, validDesc
+				case "backup-2/" + ubak.GlobalBackupFile:
+					return http.StatusNotFound,
+						map[string]string{"x-ms-error-code": "BlobNotFound"},
+						nil
+				}
+				return http.StatusNotFound,
+					map[string]string{"x-ms-error-code": "BlobNotFound"}, nil
+			},
+			wantIDs: []string{"backup-1"},
+		},
+		{
+			name: "non-not-found error on descriptor fetch fails the listing",
+			downloadResponse: func(blobName string) (int, map[string]string, []byte) {
+				if blobName == "backup-1/"+ubak.GlobalBackupFile {
+					return http.StatusOK, nil, validDesc
+				}
+				return http.StatusInternalServerError,
+					map[string]string{"x-ms-error-code": "InternalError"}, nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+
+			// Hierarchy list: GET /<container>?restype=container&comp=list&prefix=&delimiter=/
+			// Returns two BlobPrefix entries (one per backup ID).
+			mux.HandleFunc("/"+containerName, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("comp") != "list" {
+					// Treat as a blob download with empty name; reject.
+					http.Error(w, "unexpected", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/xml")
+				fmt.Fprint(w, `<?xml version="1.0" encoding="utf-8"?>`+
+					`<EnumerationResults ContainerName="`+containerName+`">`+
+					`<Blobs>`+
+					`<BlobPrefix><Name>backup-1/</Name></BlobPrefix>`+
+					`<BlobPrefix><Name>backup-2/</Name></BlobPrefix>`+
+					`</Blobs>`+
+					`<NextMarker/>`+
+					`</EnumerationResults>`)
+			})
+
+			// Blob download: GET /<container>/<blob path>
+			mux.HandleFunc("/"+containerName+"/", func(w http.ResponseWriter, r *http.Request) {
+				raw := strings.TrimPrefix(r.URL.Path, "/"+containerName+"/")
+				name, err := url.PathUnescape(raw)
+				if err != nil {
+					http.Error(w, "bad blob name", http.StatusBadRequest)
+					return
+				}
+				status, headers, body := tt.downloadResponse(name)
+				for k, v := range headers {
+					w.Header().Set(k, v)
+				}
+				w.WriteHeader(status)
+				w.Write(body)
+			})
+
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			// Disable retries so a 5xx surfaces immediately.
+			client, err := azblob.NewClientWithNoCredential(srv.URL+"/", &azblob.ClientOptions{
+				ClientOptions: policy.ClientOptions{
+					Retry: policy.RetryOptions{MaxRetries: -1},
+				},
+			})
+			require.NoError(t, err)
+
+			a := &azureClient{
+				client: client,
+				config: clientConfig{Container: containerName},
+				logger: logrus.New(),
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			got, err := a.AllBackups(ctx)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			ids := make([]string, 0, len(got))
+			for _, d := range got {
+				ids = append(ids, d.ID)
+			}
+			assert.ElementsMatch(t, tt.wantIDs, ids)
 		})
 	}
 }

--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -141,28 +142,31 @@ func (g *azureClient) makeObjectName(overridePath string, parts []string) string
 }
 
 func (a *azureClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackupDescriptor, error) {
-	var keys []string
+	prefix := a.config.BackupPath
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
 
-	blobs := a.client.NewListBlobsFlatPager(a.config.Container, &azblob.ListBlobsFlatOptions{Prefix: to.Ptr(a.config.BackupPath)})
-	for {
-		if !blobs.More() {
-			break
-		}
-		blob, err := blobs.NextPage(ctx)
+	containerClient := a.client.ServiceClient().NewContainerClient(a.config.Container)
+	pager := containerClient.NewListBlobsHierarchyPager("/", &container.ListBlobsHierarchyOptions{
+		Prefix: new(prefix),
+	})
+
+	var keys []string
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("get next blob: %w", err)
 		}
 
-		if blob.ListBlobsFlatSegmentResponse.Segment != nil {
-			for _, item := range blob.ListBlobsFlatSegmentResponse.Segment.BlobItems {
-				if item.Name == nil {
-					continue
-				}
-				// Only collect backup_config.json keys, skip all node data files.
-				if strings.HasSuffix(*item.Name, ubak.GlobalBackupFile) {
-					keys = append(keys, *item.Name)
-				}
+		if page.Segment == nil {
+			continue
+		}
+		for _, bp := range page.Segment.BlobPrefixes {
+			if bp == nil || bp.Name == nil {
+				continue
 			}
+			keys = append(keys, *bp.Name+ubak.GlobalBackupFile)
 		}
 	}
 


### PR DESCRIPTION
### What's being changed:

Copies similar logic with https://github.com/weaviate/weaviate/pull/11234 and adds the same unit test as https://github.com/weaviate/weaviate/pull/11389

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
