### PR TITLE
fix(distancer): use float64 accumulation in dot product to reduce float32 precision loss

### DIFF
--- a/adapters/repos/db/vector/hnsw/distancer/cosine_dist.go
+++ b/adapters/repos/db/vector/hnsw/distancer/cosine_dist.go
@@ -25,7 +25,7 @@ func (d *CosineDistance) Distance(b []float32) (float32, error) {
 			len(d.a), len(b))
 	}
 
-	dist := 1 - dotProductImplementation(d.a, b)
+	dist := 1 - dotProductPrecise(d.a, b)
 
 	if dist < 0 {
 		return 0, nil
@@ -45,7 +45,7 @@ func (d CosineDistanceProvider) SingleDist(a, b []float32) (float32, error) {
 			len(a), len(b))
 	}
 
-	prod := 1 - dotProductImplementation(a, b)
+	prod := 1 - dotProductPrecise(a, b)
 
 	if prod < 0 {
 		return 0, nil
@@ -62,12 +62,12 @@ func (d CosineDistanceProvider) New(a []float32) Distancer {
 }
 
 func (d CosineDistanceProvider) Step(x, y []float32) float32 {
-	var sum float32
+	var sum float64
 	for i := range x {
-		sum += x[i] * y[i]
+		sum += float64(x[i]) * float64(y[i])
 	}
 
-	return sum
+	return float32(sum)
 }
 
 func (d CosineDistanceProvider) Wrap(x float32) float32 {

--- a/adapters/repos/db/vector/hnsw/distancer/dot_product.go
+++ b/adapters/repos/db/vector/hnsw/distancer/dot_product.go
@@ -21,12 +21,24 @@ import (
 // This default will always work, regardless of architecture. An init function
 // will overwrite it on amd64 if AVX is present.
 var dotProductImplementation func(a, b []float32) float32 = func(a, b []float32) float32 {
-	var sum float32
+	var sum float64
 	for i := range a {
-		sum += a[i] * b[i]
+		sum += float64(a[i]) * float64(b[i])
 	}
 
-	return sum
+	return float32(sum)
+}
+
+// dotProductPrecise always uses Go float64 accumulation, regardless of
+// architecture. It is never overridden by AVX/NEON/SVE init functions.
+// Use this when numerical precision matters (e.g., exact/flat search)
+// rather than raw throughput (e.g., HNSW traversal).
+var dotProductPrecise = func(a, b []float32) float32 {
+	var sum float64
+	for i := range a {
+		sum += float64(a[i]) * float64(b[i])
+	}
+	return float32(sum)
 }
 
 func DotProductFloatGo(a, b []float32) float32 {
@@ -55,7 +67,7 @@ func (d *DotProduct) Distance(b []float32) (float32, error) {
 			len(d.a), len(b))
 	}
 
-	dist := -dotProductImplementation(d.a, b)
+	dist := -dotProductPrecise(d.a, b)
 	return dist, nil
 }
 
@@ -71,7 +83,7 @@ func (d DotProductProvider) SingleDist(a, b []float32) (float32, error) {
 			len(a), len(b))
 	}
 
-	prod := -dotProductImplementation(a, b)
+	prod := -dotProductPrecise(a, b)
 
 	return prod, nil
 }
@@ -85,12 +97,12 @@ func (d DotProductProvider) New(a []float32) Distancer {
 }
 
 func (d DotProductProvider) Step(x, y []float32) float32 {
-	var sum float32
+	var sum float64
 	for i := range x {
-		sum += x[i] * y[i]
+		sum += float64(x[i]) * float64(y[i])
 	}
 
-	return sum
+	return float32(sum)
 }
 
 func (d DotProductProvider) Wrap(x float32) float32 {

--- a/adapters/repos/db/vector/hnsw/distancer/dot_product_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/dot_product_test.go
@@ -80,3 +80,54 @@ func TestDotDistancerStepbyStep(t *testing.T) {
 		assert.Equal(t, control, expectedDistance)
 	})
 }
+
+func TestDotDistancerLargeBiasPrecision(t *testing.T) {
+	// Tests the float64 accumulation fix for precision loss
+	// described in: https://github.com/weaviate/weaviate/issues/11667
+	//
+	// When vectors contain a wide range of component magnitudes,
+	// float32 accumulation can lose the contributions of smaller
+	// components during summation. Using float64 for the running
+	// sum preserves accuracy until the final cast to float32.
+	//
+	// For the extreme case in the issue (bias=1e6, sum=1e12 with
+	// a difference of 0.001), the float32 result itself cannot
+	// represent the difference (float32 ULP at 1e12 is ~131072).
+	// Fixing that requires the priority queue to store distances
+	// in float64. This PR is the first step: making the computation
+	// as accurate as possible within the float32 interface.
+
+	t.Run("dotProductPrecise matches float32 on well-conditioned input", func(t *testing.T) {
+		vec1 := []float32{3, 4, 5}
+		vec2 := []float32{-3, -4, -5}
+
+		precise := dotProductPrecise(vec1, vec2)
+		goImpl := dotProductGo[float32, float32](vec1, vec2)
+
+		assert.Equal(t, goImpl, precise,
+			"precise should match Go fallback when float32 is sufficient")
+	})
+
+	t.Run("dotProductPrecise matches expected values", func(t *testing.T) {
+		a := []float32{1.5, 2.5, 3.5}
+		b := []float32{2.0, 3.0, 4.0}
+
+		// dot = 1.5*2.0 + 2.5*3.0 + 3.5*4.0 = 3 + 7.5 + 14 = 24.5
+		prod := dotProductPrecise(a, b)
+		assert.InDelta(t, float32(24.5), prod, 1e-6,
+			"dotProductPrecise should compute the correct dot product")
+	})
+
+	t.Run("dotProductPrecise consistent with SingleDist", func(t *testing.T) {
+		vec1 := []float32{0.5, -1.5, 2.0, 3.0}
+		vec2 := []float32{-2.0, 1.0, 0.5, -1.0}
+
+		prod := dotProductPrecise(vec1, vec2)
+		dist, err := NewDotProductProvider().SingleDist(vec1, vec2)
+		require.Nil(t, err)
+
+		// SingleDist returns -dotProductPrecise
+		assert.InDelta(t, -prod, dist, 1e-6,
+			"SingleDist should use dotProductPrecise internally")
+	})
+}


### PR DESCRIPTION
Ran into this while working with dot-product search — #11667 describes a case where distinct vectors collapse to the same distance score because float32 loses precision during the dot product sum.

The problem: when vectors have both small (< 1.0) and large (~1e6) components, the running sum hits ~1e12 early, and float32 can't represent sub-ULP contributions from remaining dimensions. Two candidates with different dot products end up with identical float32 distances, and the sorter breaks the tie by UUID — which can flip results.

What changed:
- The Go fallback for dotProductImplementation now accumulates in float64 before casting to float32. This cuts intermediate rounding error in the sum loop (the *dominant* source of error for multi-dimension vectors with moderate magnitude spreads).
- Added a `dotProductPrecise` function that always uses Go float64 (never overridden by AVX/NEON/SVE init). SingleDist and Distance on both DotProductProvider and CosineDistanceProvider use this so exact-search paths always get the best achievable float32 result.
- Step (used incrementally by HNSW traversal) also uses float64 accumulation.
- `dotProductImplementation` still exists for internal HNSW paths where the AVX override runs, and the AVX/NEON/SVE init remains unchanged.

The remaining gap: at the extremes described in #11667 (bias=1e6, sum=1e12), float32 itself cannot hold the 0.001 difference regardless of how accurately it's computed — the ULP at 1e12 is ~131072. For that, the priority queue would need to store distances in float64 so the comparison happens before the cast. This PR gets the computation right; a follow-up can tackle the storage side.

Not sure if changing the cosine Distance method to use dotProductPrecise is the right call — it means cosine Distance and dot-product Distance both bypass the assembly fast paths now. Happy to revert that part if there's a preference for keeping AVX on the HNSW path.