### PR TITLE
security(modules): validate X-*-BaseURL request headers to close SSRF bypass

### DIFF
--- a/modules/generative-anthropic/clients/anthropic.go
+++ b/modules/generative-anthropic/clients/anthropic.go
@@ -230,12 +230,9 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 }
 
 func (a *anthropic) getAnthropicURL(ctx context.Context, baseURL string) (string, error) {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Anthropic-Baseurl"); headerBaseURL != "" {
-		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
-			return "", err
-		}
-		passedBaseURL = headerBaseURL
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Anthropic-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
 	return url.JoinPath(passedBaseURL, "/v1/messages")
 }

--- a/modules/generative-anthropic/clients/anthropic.go
+++ b/modules/generative-anthropic/clients/anthropic.go
@@ -232,6 +232,9 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 func (a *anthropic) getAnthropicURL(ctx context.Context, baseURL string) (string, error) {
 	passedBaseURL := baseURL
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Anthropic-Baseurl"); headerBaseURL != "" {
+		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
+			return "", err
+		}
 		passedBaseURL = headerBaseURL
 	}
 	return url.JoinPath(passedBaseURL, "/v1/messages")

--- a/modules/generative-anyscale/clients/anyscale.go
+++ b/modules/generative-anyscale/clients/anyscale.go
@@ -87,6 +87,9 @@ func (v *anyscale) Generate(ctx context.Context, cfg moduletools.ClassConfig, pr
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Anyscale-Baseurl"); err != nil {
+		return nil, err
+	}
 	anyscaleUrl := v.getAnyscaleUrl(ctx, params.BaseURL)
 	anyscalePrompt := []map[string]string{
 		{"role": "system", "content": "You are a helpful assistant."},

--- a/modules/generative-anyscale/clients/anyscale.go
+++ b/modules/generative-anyscale/clients/anyscale.go
@@ -87,10 +87,10 @@ func (v *anyscale) Generate(ctx context.Context, cfg moduletools.ClassConfig, pr
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Anyscale-Baseurl"); err != nil {
+	anyscaleUrl, err := v.getAnyscaleUrl(ctx, params.BaseURL)
+	if err != nil {
 		return nil, err
 	}
-	anyscaleUrl := v.getAnyscaleUrl(ctx, params.BaseURL)
 	anyscalePrompt := []map[string]string{
 		{"role": "system", "content": "You are a helpful assistant."},
 		{"role": "user", "content": prompt},
@@ -149,12 +149,12 @@ func (v *anyscale) Generate(ctx context.Context, cfg moduletools.ClassConfig, pr
 	}, nil
 }
 
-func (v *anyscale) getAnyscaleUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Anyscale-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (v *anyscale) getAnyscaleUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Anyscale-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL)
+	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL), nil
 }
 
 func (v *anyscale) getApiKey(ctx context.Context) (string, error) {

--- a/modules/generative-anyscale/clients/anyscale_test.go
+++ b/modules/generative-anyscale/clients/anyscale_test.go
@@ -91,7 +91,8 @@ func TestGetAnswer(t *testing.T) {
 	t.Run("when X-Anyscale-BaseURL header is passed", func(t *testing.T) {
 		c := New("apiKey", 5*time.Second, nullLogger())
 		baseUrl := "https://api.endpoints.anyscale.com"
-		buildURL := c.getAnyscaleUrl(context.Background(), baseUrl)
+		buildURL, err := c.getAnyscaleUrl(context.Background(), baseUrl)
+		assert.NoError(t, err)
 		assert.Equal(t, "https://api.endpoints.anyscale.com/v1/chat/completions", buildURL)
 	})
 }

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -221,6 +221,9 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 func (v *cohere) getCohereUrl(ctx context.Context, baseURL string) (string, error) {
 	passedBaseURL := baseURL
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
+		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
+			return "", err
+		}
 		passedBaseURL = headerBaseURL
 	}
 	return url.JoinPath(passedBaseURL, "/v2/chat")

--- a/modules/generative-cohere/clients/cohere.go
+++ b/modules/generative-cohere/clients/cohere.go
@@ -219,12 +219,9 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 }
 
 func (v *cohere) getCohereUrl(ctx context.Context, baseURL string) (string, error) {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
-		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
-			return "", err
-		}
-		passedBaseURL = headerBaseURL
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Cohere-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
 	return url.JoinPath(passedBaseURL, "/v2/chat")
 }

--- a/modules/generative-contextualai/clients/contextualai.go
+++ b/modules/generative-contextualai/clients/contextualai.go
@@ -249,24 +249,12 @@ func (c *contextualai) extractKnowledge(properties []*modulecapabilities.Generat
 }
 
 func (c *contextualai) getContextualAIURL(ctx context.Context) (string, error) {
-	baseURL := "https://api.contextual.ai"
-	if value := ctx.Value(contextKey("X-ContextualAI-Baseurl")); value != nil {
-		if urls, ok := value.([]string); ok && len(urls) > 0 {
-			if err := modulecomponents.ValidateBaseURL(urls[0]); err != nil {
-				return "", err
-			}
-			baseURL = urls[0]
-		}
-	} else if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-ContextualAI-Baseurl"); headerBaseURL != "" {
-		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
-			return "", err
-		}
-		baseURL = headerBaseURL
+	baseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-ContextualAI-Baseurl", "https://api.contextual.ai")
+	if err != nil {
+		return "", err
 	}
 	return url.JoinPath(baseURL, "/v1/generate")
 }
-
-type contextKey string
 
 func (c *contextualai) getAPIKey(ctx context.Context) (string, error) {
 	if apiKey := modulecomponents.GetValueFromContext(ctx, "X-ContextualAI-Api-Key"); apiKey != "" {

--- a/modules/generative-contextualai/clients/contextualai.go
+++ b/modules/generative-contextualai/clients/contextualai.go
@@ -252,9 +252,15 @@ func (c *contextualai) getContextualAIURL(ctx context.Context) (string, error) {
 	baseURL := "https://api.contextual.ai"
 	if value := ctx.Value(contextKey("X-ContextualAI-Baseurl")); value != nil {
 		if urls, ok := value.([]string); ok && len(urls) > 0 {
+			if err := modulecomponents.ValidateBaseURL(urls[0]); err != nil {
+				return "", err
+			}
 			baseURL = urls[0]
 		}
 	} else if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-ContextualAI-Baseurl"); headerBaseURL != "" {
+		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
+			return "", err
+		}
 		baseURL = headerBaseURL
 	}
 	return url.JoinPath(baseURL, "/v1/generate")

--- a/modules/generative-contextualai/clients/contextualai_test.go
+++ b/modules/generative-contextualai/clients/contextualai_test.go
@@ -28,10 +28,10 @@ import (
 )
 
 const (
-	baseURLKey        contextKey = "X-ContextualAI-Baseurl"
-	testAPIKey        string     = "test-key"
-	contentTypeHeader string     = "Content-Type"
-	applicationJSON   string     = "application/json"
+	baseURLKey        string = "X-ContextualAI-Baseurl"
+	testAPIKey        string = "test-key"
+	contentTypeHeader string = "Content-Type"
+	applicationJSON   string = "application/json"
 )
 
 func nullLogger() logrus.FieldLogger {

--- a/modules/generative-databricks/clients/databricks.go
+++ b/modules/generative-databricks/clients/databricks.go
@@ -207,10 +207,11 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 }
 
 func (v *databricks) buildDatabricksEndpoint(ctx context.Context, endpoint string) (string, error) {
-	if headerEndpoint := modulecomponents.GetValueFromContext(ctx, "X-Databricks-Endpoint"); headerEndpoint != "" {
-		if err := modulecomponents.ValidateBaseURL(headerEndpoint); err != nil {
-			return "", err
-		}
+	headerEndpoint, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Databricks-Endpoint", "")
+	if err != nil {
+		return "", err
+	}
+	if headerEndpoint != "" {
 		return headerEndpoint, nil
 	}
 	return v.buildEndpoint(endpoint)

--- a/modules/generative-databricks/clients/databricks.go
+++ b/modules/generative-databricks/clients/databricks.go
@@ -208,6 +208,9 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 
 func (v *databricks) buildDatabricksEndpoint(ctx context.Context, endpoint string) (string, error) {
 	if headerEndpoint := modulecomponents.GetValueFromContext(ctx, "X-Databricks-Endpoint"); headerEndpoint != "" {
+		if err := modulecomponents.ValidateBaseURL(headerEndpoint); err != nil {
+			return "", err
+		}
 		return headerEndpoint, nil
 	}
 	return v.buildEndpoint(endpoint)

--- a/modules/generative-deepseek/clients/deepseek.go
+++ b/modules/generative-deepseek/clients/deepseek.go
@@ -41,11 +41,9 @@ type client struct {
 
 func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *client {
 	return &client{
-		apiKey: apiKey,
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
-		logger: logger,
+		apiKey:     apiKey,
+		httpClient: modulecomponents.NewBaseHttpClient(timeout),
+		logger:     logger,
 	}
 }
 
@@ -227,8 +225,9 @@ func GetResponseParams(result map[string]any) *responseParams {
 }
 
 func (c *client) url(ctx context.Context, base string) (string, error) {
-	if override := modulecomponents.GetValueFromContext(ctx, "X-Deepseek-Baseurl"); override != "" {
-		return url.JoinPath(override, "/chat/completions")
+	base, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Deepseek-Baseurl", base)
+	if err != nil {
+		return "", err
 	}
 	return url.JoinPath(base, "/chat/completions")
 }

--- a/modules/generative-deepseek/config/class_settings.go
+++ b/modules/generative-deepseek/config/class_settings.go
@@ -73,6 +73,10 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		return errors.New("empty config")
 	}
 
+	if err := ic.propertyValuesHelper.ValidateBaseURL(ic.BaseURL()); err != nil {
+		return err
+	}
+
 	temperature := ic.Temperature()
 	if temperature != nil && (*temperature < 0 || *temperature > 2) {
 		return errors.Errorf("Wrong temperature configuration, values are between 0.0 and 2.0")

--- a/modules/generative-friendliai/clients/friendliai.go
+++ b/modules/generative-friendliai/clients/friendliai.go
@@ -65,6 +65,9 @@ func (v *friendliai) Generate(ctx context.Context, cfg moduletools.ClassConfig, 
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Friendli-Baseurl"); err != nil {
+		return nil, err
+	}
 	friendliUrl := v.getFriendliUrl(ctx, params.BaseURL)
 	friendliPrompt := []map[string]string{
 		{"role": "user", "content": prompt},

--- a/modules/generative-friendliai/clients/friendliai.go
+++ b/modules/generative-friendliai/clients/friendliai.go
@@ -65,10 +65,10 @@ func (v *friendliai) Generate(ctx context.Context, cfg moduletools.ClassConfig, 
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Friendli-Baseurl"); err != nil {
+	friendliUrl, err := v.getFriendliUrl(ctx, params.BaseURL)
+	if err != nil {
 		return nil, err
 	}
-	friendliUrl := v.getFriendliUrl(ctx, params.BaseURL)
 	friendliPrompt := []map[string]string{
 		{"role": "user", "content": prompt},
 	}
@@ -182,12 +182,12 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 	return nil
 }
 
-func (v *friendliai) getFriendliUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Friendli-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (v *friendliai) getFriendliUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Friendli-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL)
+	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL), nil
 }
 
 func (v *friendliai) getApiKey(ctx context.Context) (string, error) {

--- a/modules/generative-friendliai/clients/friendliai_test.go
+++ b/modules/generative-friendliai/clients/friendliai_test.go
@@ -99,10 +99,12 @@ func TestGetAnswer(t *testing.T) {
 
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Friendli-Baseurl", []string{"https://inference.friendli.ai/dedicated"})
-		buildURL := c.getFriendliUrl(ctxWithValue, baseUrl)
+		buildURL, err := c.getFriendliUrl(ctxWithValue, baseUrl)
+		assert.NoError(t, err)
 		assert.Equal(t, "https://inference.friendli.ai/dedicated/v1/chat/completions", buildURL)
 
-		buildURL = c.getFriendliUrl(context.Background(), baseUrl)
+		buildURL, err = c.getFriendliUrl(context.Background(), baseUrl)
+		assert.NoError(t, err)
 		assert.Equal(t, "https://inference.friendli.ai/v1/chat/completions", buildURL)
 	})
 }

--- a/modules/generative-mistral/clients/mistral.go
+++ b/modules/generative-mistral/clients/mistral.go
@@ -184,12 +184,9 @@ func (v *mistral) getDebugInformation(debug bool, prompt string) *modulecapabili
 }
 
 func (v *mistral) getMistralUrl(ctx context.Context, baseURL string) (string, error) {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Mistral-Baseurl"); headerBaseURL != "" {
-		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
-			return "", err
-		}
-		passedBaseURL = headerBaseURL
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Mistral-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
 	return url.JoinPath(passedBaseURL, "/v1/chat/completions")
 }

--- a/modules/generative-mistral/clients/mistral.go
+++ b/modules/generative-mistral/clients/mistral.go
@@ -186,6 +186,9 @@ func (v *mistral) getDebugInformation(debug bool, prompt string) *modulecapabili
 func (v *mistral) getMistralUrl(ctx context.Context, baseURL string) (string, error) {
 	passedBaseURL := baseURL
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Mistral-Baseurl"); headerBaseURL != "" {
+		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
+			return "", err
+		}
 		passedBaseURL = headerBaseURL
 	}
 	return url.JoinPath(passedBaseURL, "/v1/chat/completions")

--- a/modules/generative-nvidia/clients/nvidia.go
+++ b/modules/generative-nvidia/clients/nvidia.go
@@ -65,10 +65,10 @@ func (v *nvidia) generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Nvidia-Baseurl"); err != nil {
+	nvidiaUrl, err := v.getNvidiaUrl(ctx, params.BaseURL)
+	if err != nil {
 		return nil, err
 	}
-	nvidiaUrl := v.getNvidiaUrl(ctx, params.BaseURL)
 	input := v.getRequest(prompt, params)
 
 	body, err := json.Marshal(input)
@@ -181,12 +181,12 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 	return nil
 }
 
-func (v *nvidia) getNvidiaUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Nvidia-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (v *nvidia) getNvidiaUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Nvidia-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL)
+	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL), nil
 }
 
 func (v *nvidia) getApiKey(ctx context.Context) (string, error) {

--- a/modules/generative-nvidia/clients/nvidia.go
+++ b/modules/generative-nvidia/clients/nvidia.go
@@ -65,6 +65,9 @@ func (v *nvidia) generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Nvidia-Baseurl"); err != nil {
+		return nil, err
+	}
 	nvidiaUrl := v.getNvidiaUrl(ctx, params.BaseURL)
 	input := v.getRequest(prompt, params)
 

--- a/modules/generative-nvidia/clients/nvidia_test.go
+++ b/modules/generative-nvidia/clients/nvidia_test.go
@@ -90,10 +90,12 @@ func TestGetAnswer(t *testing.T) {
 
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Nvidia-BaseURL", []string{"https://integrate.api.nvidia.com"})
-		buildURL := c.getNvidiaUrl(ctxWithValue, baseUrl)
+		buildURL, err := c.getNvidiaUrl(ctxWithValue, baseUrl)
+		assert.NoError(t, err)
 		assert.Equal(t, "https://integrate.api.nvidia.com/v1/chat/completions", buildURL)
 
-		buildURL = c.getNvidiaUrl(context.Background(), baseUrl)
+		buildURL, err = c.getNvidiaUrl(context.Background(), baseUrl)
+		assert.NoError(t, err)
 		assert.Equal(t, "https://integrate.api.nvidia.com/v1/chat/completions", buildURL)
 	})
 }

--- a/modules/generative-ollama/clients/ollama.go
+++ b/modules/generative-ollama/clients/ollama.go
@@ -63,6 +63,9 @@ func (v *ollama) generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	params := v.getParameters(cfg, options, imageProperties)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Ollama-BaseURL"); err != nil {
+		return nil, err
+	}
 	ollamaUrl := v.getOllamaUrl(ctx, params.ApiEndpoint)
 	input := generateInput{
 		Model:  params.Model,

--- a/modules/generative-ollama/clients/ollama.go
+++ b/modules/generative-ollama/clients/ollama.go
@@ -63,10 +63,10 @@ func (v *ollama) generate(ctx context.Context, cfg moduletools.ClassConfig, prom
 	params := v.getParameters(cfg, options, imageProperties)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Ollama-BaseURL"); err != nil {
+	ollamaUrl, err := v.getOllamaUrl(ctx, params.ApiEndpoint)
+	if err != nil {
 		return nil, err
 	}
-	ollamaUrl := v.getOllamaUrl(ctx, params.ApiEndpoint)
 	input := generateInput{
 		Model:  params.Model,
 		Prompt: prompt,
@@ -151,12 +151,12 @@ func (v *ollama) getDebugInformation(debug bool, prompt string) *modulecapabilit
 	return nil
 }
 
-func (v *ollama) getOllamaUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Ollama-BaseURL"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (v *ollama) getOllamaUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Ollama-BaseURL", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s/api/generate", passedBaseURL)
+	return fmt.Sprintf("%s/api/generate", passedBaseURL), nil
 }
 
 type generateInput struct {

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -290,6 +290,9 @@ func (v *openai) buildOpenAIUrl(ctx context.Context, params openaiparams.Params)
 	resourceName := params.ResourceName
 
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
+		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
+			return "", err
+		}
 		baseURL = headerBaseURL
 	}
 

--- a/modules/generative-openai/clients/openai.go
+++ b/modules/generative-openai/clients/openai.go
@@ -284,16 +284,12 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 }
 
 func (v *openai) buildOpenAIUrl(ctx context.Context, params openaiparams.Params) (string, error) {
-	baseURL := params.BaseURL
-
 	deploymentID := params.DeploymentID
 	resourceName := params.ResourceName
 
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
-		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
-			return "", err
-		}
-		baseURL = headerBaseURL
+	baseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Openai-Baseurl", params.BaseURL)
+	if err != nil {
+		return "", err
 	}
 
 	if headerDeploymentID := modulecomponents.GetValueFromContext(ctx, "X-Azure-Deployment-Id"); headerDeploymentID != "" {

--- a/modules/generative-xai/clients/xai.go
+++ b/modules/generative-xai/clients/xai.go
@@ -66,6 +66,9 @@ func (v *xai) generate(ctx context.Context, cfg moduletools.ClassConfig, prompt 
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Xai-Baseurl"); err != nil {
+		return nil, err
+	}
 	xaiUrl := v.getXaiUrl(ctx, params.BaseURL)
 	input := v.getRequest(prompt, params)
 

--- a/modules/generative-xai/clients/xai.go
+++ b/modules/generative-xai/clients/xai.go
@@ -66,10 +66,10 @@ func (v *xai) generate(ctx context.Context, cfg moduletools.ClassConfig, prompt 
 	params := v.getParameters(cfg, options)
 	debugInformation := v.getDebugInformation(debug, prompt)
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Xai-Baseurl"); err != nil {
+	xaiUrl, err := v.getXaiUrl(ctx, params.BaseURL)
+	if err != nil {
 		return nil, err
 	}
-	xaiUrl := v.getXaiUrl(ctx, params.BaseURL)
 	input := v.getRequest(prompt, params)
 
 	body, err := json.Marshal(input)
@@ -210,12 +210,12 @@ func GetResponseParams(result map[string]interface{}) *responseParams {
 	return nil
 }
 
-func (v *xai) getXaiUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Xai-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (v *xai) getXaiUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Xai-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL)
+	return fmt.Sprintf("%s/v1/chat/completions", passedBaseURL), nil
 }
 
 func (v *xai) getApiKey(ctx context.Context) (string, error) {

--- a/modules/generative-xai/clients/xai_test.go
+++ b/modules/generative-xai/clients/xai_test.go
@@ -90,10 +90,12 @@ func TestGetAnswer(t *testing.T) {
 
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Xai-BaseURL", []string{"https://integrate.api.xai.com"})
-		buildURL := c.getXaiUrl(ctxWithValue, baseUrl)
+		buildURL, err := c.getXaiUrl(ctxWithValue, baseUrl)
+		assert.NoError(t, err)
 		assert.Equal(t, "https://integrate.api.xai.com/v1/chat/completions", buildURL)
 
-		buildURL = c.getXaiUrl(context.Background(), baseUrl)
+		buildURL, err = c.getXaiUrl(context.Background(), baseUrl)
+		assert.NoError(t, err)
 		assert.Equal(t, "https://integrate.api.xai.com/v1/chat/completions", buildURL)
 	})
 }

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -165,6 +165,9 @@ func (v *qna) buildOpenAIUrl(ctx context.Context, baseURL, resourceName, deploym
 	passedBaseURL := baseURL
 
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
+		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
+			return "", err
+		}
 		passedBaseURL = headerBaseURL
 	}
 

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -162,13 +162,9 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 }
 
 func (v *qna) buildOpenAIUrl(ctx context.Context, baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
-	passedBaseURL := baseURL
-
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
-		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
-			return "", err
-		}
-		passedBaseURL = headerBaseURL
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Openai-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
 
 	if headerDeploymentID := modulecomponents.GetValueFromContext(ctx, "X-Azure-Deployment-Id"); headerDeploymentID != "" {

--- a/modules/reranker-cohere/clients/ranker.go
+++ b/modules/reranker-cohere/clients/ranker.go
@@ -94,10 +94,10 @@ func (c *client) performRank(ctx context.Context, query string, documents []stri
 ) ([]ent.DocumentScore, error) {
 	settings := config.NewClassSettings(cfg)
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Cohere-Baseurl"); err != nil {
+	cohereUrl, err := c.getCohereUrl(ctx, settings.BaseURL())
+	if err != nil {
 		return nil, err
 	}
-	cohereUrl := c.getCohereUrl(ctx, settings.BaseURL())
 	input := RankInput{
 		Documents:       documents,
 		Query:           query,
@@ -202,12 +202,12 @@ func (c *client) getApiKey(ctx context.Context) (string, error) {
 		"nor in environment variable under COHERE_APIKEY")
 }
 
-func (c *client) getCohereUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (c *client) getCohereUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Cohere-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return c.urlBuilder.URL(passedBaseURL)
+	return c.urlBuilder.URL(passedBaseURL), nil
 }
 
 type RankInput struct {

--- a/modules/reranker-cohere/clients/ranker.go
+++ b/modules/reranker-cohere/clients/ranker.go
@@ -94,6 +94,9 @@ func (c *client) performRank(ctx context.Context, query string, documents []stri
 ) ([]ent.DocumentScore, error) {
 	settings := config.NewClassSettings(cfg)
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Cohere-Baseurl"); err != nil {
+		return nil, err
+	}
 	cohereUrl := c.getCohereUrl(ctx, settings.BaseURL())
 	input := RankInput{
 		Documents:       documents,

--- a/modules/reranker-cohere/clients/ranker_test.go
+++ b/modules/reranker-cohere/clients/ranker_test.go
@@ -227,8 +227,12 @@ func TestRank_client_getCohereUrl(t *testing.T) {
 	ctx := context.Background()
 	c := New("", 1*time.Second, nil)
 
-	assert.Equal(t, "baseurl/v1/rerank", c.getCohereUrl(ctx, "baseurl"))
+	url, err := c.getCohereUrl(ctx, "baseurl")
+	assert.NoError(t, err)
+	assert.Equal(t, "baseurl/v1/rerank", url)
 
 	ctxWithBaseURL := context.WithValue(ctx, "X-Cohere-Baseurl", []string{"base-url-from-ctx"})
-	assert.Equal(t, "base-url-from-ctx/v1/rerank", c.getCohereUrl(ctxWithBaseURL, "base-url"))
+	url, err = c.getCohereUrl(ctxWithBaseURL, "base-url")
+	assert.NoError(t, err)
+	assert.Equal(t, "base-url-from-ctx/v1/rerank", url)
 }

--- a/modules/reranker-nvidia/clients/ranker.go
+++ b/modules/reranker-nvidia/clients/ranker.go
@@ -105,6 +105,9 @@ func (c *client) performRank(ctx context.Context,
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshal body")
 	}
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Nvidia-Baseurl"); err != nil {
+		return nil, err
+	}
 	url := c.getNvidiaUrl(ctx, settings.BaseURL())
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))

--- a/modules/reranker-nvidia/clients/ranker.go
+++ b/modules/reranker-nvidia/clients/ranker.go
@@ -105,10 +105,10 @@ func (c *client) performRank(ctx context.Context,
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshal body")
 	}
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Nvidia-Baseurl"); err != nil {
+	url, err := c.getNvidiaUrl(ctx, settings.BaseURL())
+	if err != nil {
 		return nil, err
 	}
-	url := c.getNvidiaUrl(ctx, settings.BaseURL())
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))
 	if err != nil {
@@ -182,12 +182,12 @@ func (c *client) chunkDocuments(documents []string, chunkSize int) [][]string {
 	return requests
 }
 
-func (c *client) getNvidiaUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Nvidia-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (c *client) getNvidiaUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Nvidia-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s/v1/retrieval/nvidia/reranking", passedBaseURL)
+	return fmt.Sprintf("%s/v1/retrieval/nvidia/reranking", passedBaseURL), nil
 }
 
 func (c *client) getApiKey(ctx context.Context) (string, error) {

--- a/modules/text2vec-databricks/clients/databricks.go
+++ b/modules/text2vec-databricks/clients/databricks.go
@@ -144,14 +144,7 @@ func (v *client) vectorize(ctx context.Context, input []string, config ent.Vecto
 }
 
 func (v *client) buildURL(ctx context.Context, config ent.VectorizationConfig) (string, error) {
-	endpoint := config.Endpoint
-	if headerEndpoint := modulecomponents.GetValueFromContext(ctx, "X-Databricks-Endpoint"); headerEndpoint != "" {
-		if err := modulecomponents.ValidateBaseURL(headerEndpoint); err != nil {
-			return "", err
-		}
-		endpoint = headerEndpoint
-	}
-	return endpoint, nil
+	return modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Databricks-Endpoint", config.Endpoint)
 }
 
 func (v *client) getError(statusCode int, resBody embedding) error {

--- a/modules/text2vec-databricks/clients/databricks.go
+++ b/modules/text2vec-databricks/clients/databricks.go
@@ -146,6 +146,9 @@ func (v *client) vectorize(ctx context.Context, input []string, config ent.Vecto
 func (v *client) buildURL(ctx context.Context, config ent.VectorizationConfig) (string, error) {
 	endpoint := config.Endpoint
 	if headerEndpoint := modulecomponents.GetValueFromContext(ctx, "X-Databricks-Endpoint"); headerEndpoint != "" {
+		if err := modulecomponents.ValidateBaseURL(headerEndpoint); err != nil {
+			return "", err
+		}
 		endpoint = headerEndpoint
 	}
 	return endpoint, nil

--- a/modules/text2vec-digitalocean/clients/digitalocean.go
+++ b/modules/text2vec-digitalocean/clients/digitalocean.go
@@ -211,6 +211,9 @@ func (c *Client) vectorize(ctx context.Context, input []string, cfg moduletools.
 
 func buildURL(ctx context.Context, baseURL string) (string, error) {
 	if header := modulecomponents.GetValueFromContext(ctx, "X-Digitalocean-Baseurl"); header != "" {
+		if err := modulecomponents.ValidateBaseURL(header); err != nil {
+			return "", err
+		}
 		baseURL = header
 	}
 	return url.JoinPath(baseURL, "/v1/embeddings")

--- a/modules/text2vec-digitalocean/clients/digitalocean.go
+++ b/modules/text2vec-digitalocean/clients/digitalocean.go
@@ -210,11 +210,9 @@ func (c *Client) vectorize(ctx context.Context, input []string, cfg moduletools.
 }
 
 func buildURL(ctx context.Context, baseURL string) (string, error) {
-	if header := modulecomponents.GetValueFromContext(ctx, "X-Digitalocean-Baseurl"); header != "" {
-		if err := modulecomponents.ValidateBaseURL(header); err != nil {
-			return "", err
-		}
-		baseURL = header
+	baseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Digitalocean-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
 	return url.JoinPath(baseURL, "/v1/embeddings")
 }

--- a/usecases/modulecomponents/base_client.go
+++ b/usecases/modulecomponents/base_client.go
@@ -12,17 +12,51 @@
 package modulecomponents
 
 import (
+	"fmt"
+	"net"
 	"net/http"
+	"syscall"
 	"time"
 )
 
-// NewBaseHttpClient creates an http.Client with the given timeout
-// and a redirect policy that prevents automatic redirect following.
+// NewBaseHttpClient creates an http.Client with the given timeout that does not
+// follow redirects. When MODULES_VALIDATE_BASE_URL is enabled it also installs
+// a dial guard rejecting internal addresses — the network-layer SSRF backstop
+// covering every client and baseURL source (config, headers, redirects).
 func NewBaseHttpClient(timeout time.Duration) *http.Client {
-	return &http.Client{
+	client := &http.Client{
 		Timeout: timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
+
+	if BaseURLValidationEnabled() {
+		// DefaultTransport's dialer settings plus a Control hook that runs
+		// after DNS resolution with the concrete IP about to be dialed.
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			Control:   ssrfDialGuard,
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = dialer.DialContext
+		client.Transport = transport
+	}
+
+	return client
+}
+
+// ssrfDialGuard blocks connections to internal addresses. address is the
+// resolved "ip:port", so a host that resolves to an internal IP is caught here
+// even if it slipped past ValidateBaseURL's string-level checks.
+func ssrfDialGuard(network, address string, c syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("invalid dial address %q: %w", address, err)
+	}
+	if ip := net.ParseIP(host); ip != nil && isDisallowedIP(ip) {
+		return fmt.Errorf("refusing to dial internal address %q", address)
+	}
+	return nil
 }

--- a/usecases/modulecomponents/clients/cohere/cohere.go
+++ b/usecases/modulecomponents/clients/cohere/cohere.go
@@ -113,10 +113,10 @@ func (c *Client) Vectorize(ctx context.Context,
 		return nil, errors.Wrapf(err, "marshal body")
 	}
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Cohere-Baseurl"); err != nil {
+	url, err := c.getCohereUrl(ctx, settings.BaseURL)
+	if err != nil {
 		return nil, err
 	}
-	url := c.getCohereUrl(ctx, settings.BaseURL)
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))
 	if err != nil {
@@ -191,12 +191,12 @@ func (c *Client) getEmbeddingRequest(inputs []string, settings Settings) embeddi
 	}
 }
 
-func (c *Client) getCohereUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Cohere-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (c *Client) getCohereUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Cohere-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return c.urlBuilder.URL(passedBaseURL)
+	return c.urlBuilder.URL(passedBaseURL), nil
 }
 
 func (c *Client) GetApiKeyHash(ctx context.Context, config moduletools.ClassConfig) [32]byte {

--- a/usecases/modulecomponents/clients/cohere/cohere.go
+++ b/usecases/modulecomponents/clients/cohere/cohere.go
@@ -113,6 +113,9 @@ func (c *Client) Vectorize(ctx context.Context,
 		return nil, errors.Wrapf(err, "marshal body")
 	}
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Cohere-Baseurl"); err != nil {
+		return nil, err
+	}
 	url := c.getCohereUrl(ctx, settings.BaseURL)
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))

--- a/usecases/modulecomponents/clients/cohere/cohere_test.go
+++ b/usecases/modulecomponents/clients/cohere/cohere_test.go
@@ -208,10 +208,12 @@ func TestClient(t *testing.T) {
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Cohere-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
-		buildURL := c.getCohereUrl(ctxWithValue, baseURL)
+		buildURL, err := c.getCohereUrl(ctxWithValue, baseURL)
+		assert.NoError(t, err)
 		assert.Equal(t, "http://base-url-passed-in-header.com/v2/embed", buildURL)
 
-		buildURL = c.getCohereUrl(context.TODO(), baseURL)
+		buildURL, err = c.getCohereUrl(context.TODO(), baseURL)
+		assert.NoError(t, err)
 		assert.Equal(t, "http://default-url.com/v2/embed", buildURL)
 	})
 

--- a/usecases/modulecomponents/clients/nvidia/nvidia.go
+++ b/usecases/modulecomponents/clients/nvidia/nvidia.go
@@ -107,10 +107,10 @@ func (c *Client) Vectorize(ctx context.Context,
 		return nil, errors.Wrapf(err, "marshal body")
 	}
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Nvidia-Baseurl"); err != nil {
+	url, err := c.getNvidiaUrl(ctx, settings.BaseURL)
+	if err != nil {
 		return nil, err
 	}
-	url := c.getNvidiaUrl(ctx, settings.BaseURL)
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))
 	if err != nil {
@@ -169,12 +169,12 @@ func (c *Client) getEmbeddingRequest(inputs []string, settings Settings) embeddi
 	}
 }
 
-func (c *Client) getNvidiaUrl(ctx context.Context, baseURL string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Nvidia-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (c *Client) getNvidiaUrl(ctx context.Context, baseURL string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Nvidia-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%s/v1/embeddings", passedBaseURL)
+	return fmt.Sprintf("%s/v1/embeddings", passedBaseURL), nil
 }
 
 func (c *Client) GetApiKeyHash(ctx context.Context, config moduletools.ClassConfig) [32]byte {

--- a/usecases/modulecomponents/clients/nvidia/nvidia.go
+++ b/usecases/modulecomponents/clients/nvidia/nvidia.go
@@ -107,6 +107,9 @@ func (c *Client) Vectorize(ctx context.Context,
 		return nil, errors.Wrapf(err, "marshal body")
 	}
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Nvidia-Baseurl"); err != nil {
+		return nil, err
+	}
 	url := c.getNvidiaUrl(ctx, settings.BaseURL)
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))

--- a/usecases/modulecomponents/clients/nvidia/nvidia_test.go
+++ b/usecases/modulecomponents/clients/nvidia/nvidia_test.go
@@ -180,10 +180,12 @@ func TestClient(t *testing.T) {
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Nvidia-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
-		buildURL := c.getNvidiaUrl(ctxWithValue, baseURL)
+		buildURL, err := c.getNvidiaUrl(ctxWithValue, baseURL)
+		assert.NoError(t, err)
 		assert.Equal(t, "http://base-url-passed-in-header.com/v1/embeddings", buildURL)
 
-		buildURL = c.getNvidiaUrl(context.TODO(), baseURL)
+		buildURL, err = c.getNvidiaUrl(context.TODO(), baseURL)
+		assert.NoError(t, err)
 		assert.Equal(t, "http://default-url.com/v1/embeddings", buildURL)
 	})
 

--- a/usecases/modulecomponents/clients/openai/openai.go
+++ b/usecases/modulecomponents/clients/openai/openai.go
@@ -259,11 +259,9 @@ func (v *Client) vectorize(ctx context.Context, input []string, model string, se
 func (v *Client) buildURL(ctx context.Context, config Settings) (string, error) {
 	baseURL, resourceName, deploymentID, apiVersion, endpoint, isAzure := config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure
 
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
-		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
-			return "", err
-		}
-		baseURL = headerBaseURL
+	baseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Openai-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
 
 	if headerDeploymentID := modulecomponents.GetValueFromContext(ctx, "X-Azure-Deployment-Id"); headerDeploymentID != "" {

--- a/usecases/modulecomponents/clients/openai/openai.go
+++ b/usecases/modulecomponents/clients/openai/openai.go
@@ -260,6 +260,9 @@ func (v *Client) buildURL(ctx context.Context, config Settings) (string, error) 
 	baseURL, resourceName, deploymentID, apiVersion, endpoint, isAzure := config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure
 
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
+		if err := modulecomponents.ValidateBaseURL(headerBaseURL); err != nil {
+			return "", err
+		}
 		baseURL = headerBaseURL
 	}
 

--- a/usecases/modulecomponents/clients/openai/openai_test.go
+++ b/usecases/modulecomponents/clients/openai/openai_test.go
@@ -362,6 +362,26 @@ func TestClient(t *testing.T) {
 		assert.Equal(t, "http://default-url.com/v1/embeddings", buildURL)
 	})
 
+	// Regression for the SSRF via X-Openai-Baseurl (hackerone #3768976).
+	t.Run("when X-Openai-Baseurl header targets an internal address it is rejected", func(t *testing.T) {
+		t.Setenv("MODULES_VALIDATE_BASE_URL", "true")
+		c := New("", "", "", 0, nullLogger())
+		config := Settings{Model: "ada", Type: "text", BaseURL: "https://api.openai.com"}
+
+		for _, internal := range []string{
+			"http://169.254.169.254/",
+			"https://169.254.169.254/",
+			"https://127.0.0.1/",
+			"https://10.0.0.5/",
+			"https://localhost/",
+		} {
+			ctxWithValue := context.WithValue(context.Background(),
+				"X-Openai-Baseurl", []string{internal})
+			_, err := c.buildURL(ctxWithValue, config)
+			assert.Error(t, err, internal)
+		}
+	})
+
 	t.Run("when X-Azure-* headers are passed", func(t *testing.T) {
 		c := New("", "", "", 0, nullLogger())
 

--- a/usecases/modulecomponents/clients/voyageai/voyageai.go
+++ b/usecases/modulecomponents/clients/voyageai/voyageai.go
@@ -280,10 +280,10 @@ func (c *Client) vectorize(ctx context.Context, baseURL, model string, request i
 		return nil, errors.Wrap(err, "marshal body")
 	}
 
-	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Voyageai-Baseurl"); err != nil {
+	url, err := c.getVoyageAIUrl(ctx, baseURL, model)
+	if err != nil {
 		return nil, err
 	}
-	url := c.getVoyageAIUrl(ctx, baseURL, model)
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))
 	if err != nil {
@@ -371,12 +371,12 @@ func (c *Client) getVectorizationResult(input []string, resBody *embeddingsRespo
 	}, modulecomponents.GetTotalTokens(resBody.Usage), nil
 }
 
-func (c *Client) getVoyageAIUrl(ctx context.Context, baseURL, model string) string {
-	passedBaseURL := baseURL
-	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Voyageai-Baseurl"); headerBaseURL != "" {
-		passedBaseURL = headerBaseURL
+func (c *Client) getVoyageAIUrl(ctx context.Context, baseURL, model string) (string, error) {
+	passedBaseURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Voyageai-Baseurl", baseURL)
+	if err != nil {
+		return "", err
 	}
-	return c.urlBuilder.URL(passedBaseURL, model)
+	return c.urlBuilder.URL(passedBaseURL, model), nil
 }
 
 func (c *Client) getErrorMessage(statusCode int, resBodyError string) string {

--- a/usecases/modulecomponents/clients/voyageai/voyageai.go
+++ b/usecases/modulecomponents/clients/voyageai/voyageai.go
@@ -280,6 +280,9 @@ func (c *Client) vectorize(ctx context.Context, baseURL, model string, request i
 		return nil, errors.Wrap(err, "marshal body")
 	}
 
+	if err := modulecomponents.ValidateBaseURLHeader(ctx, "X-Voyageai-Baseurl"); err != nil {
+		return nil, err
+	}
 	url := c.getVoyageAIUrl(ctx, baseURL, model)
 	req, err := http.NewRequestWithContext(ctx, "POST", url,
 		bytes.NewReader(body))

--- a/usecases/modulecomponents/clients/voyageai/voyageai_test.go
+++ b/usecases/modulecomponents/clients/voyageai/voyageai_test.go
@@ -185,10 +185,12 @@ func TestClient(t *testing.T) {
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Voyageai-Baseurl", []string{"http://base-url-passed-in-header.com"})
 
-		buildURL := c.getVoyageAIUrl(ctxWithValue, baseURL, "test-model")
+		buildURL, err := c.getVoyageAIUrl(ctxWithValue, baseURL, "test-model")
+		assert.NoError(t, err)
 		assert.Equal(t, "http://base-url-passed-in-header.com/embeddings", buildURL)
 
-		buildURL = c.getVoyageAIUrl(context.TODO(), baseURL, "test-model")
+		buildURL, err = c.getVoyageAIUrl(context.TODO(), baseURL, "test-model")
+		assert.NoError(t, err)
 		assert.Equal(t, "http://default-url.com/embeddings", buildURL)
 	})
 }

--- a/usecases/modulecomponents/clients/weaviateembed/weaviate_embed.go
+++ b/usecases/modulecomponents/clients/weaviateembed/weaviate_embed.go
@@ -147,6 +147,9 @@ func getToken(ctx context.Context) (string, error) {
 
 func getClusterURL(ctx context.Context) (string, error) {
 	if clusterURL := modulecomponents.GetValueFromContext(ctx, "X-Weaviate-Cluster-Url"); clusterURL != "" {
+		if err := modulecomponents.ValidateBaseURL(clusterURL); err != nil {
+			return "", err
+		}
 		return clusterURL, nil
 	}
 	return "", errors.New("no cluster URL found in request header: X-Weaviate-Cluster-Url")

--- a/usecases/modulecomponents/clients/weaviateembed/weaviate_embed.go
+++ b/usecases/modulecomponents/clients/weaviateembed/weaviate_embed.go
@@ -146,13 +146,14 @@ func getToken(ctx context.Context) (string, error) {
 }
 
 func getClusterURL(ctx context.Context) (string, error) {
-	if clusterURL := modulecomponents.GetValueFromContext(ctx, "X-Weaviate-Cluster-Url"); clusterURL != "" {
-		if err := modulecomponents.ValidateBaseURL(clusterURL); err != nil {
-			return "", err
-		}
-		return clusterURL, nil
+	clusterURL, err := modulecomponents.ValidatedBaseURLFromHeader(ctx, "X-Weaviate-Cluster-Url", "")
+	if err != nil {
+		return "", err
 	}
-	return "", errors.New("no cluster URL found in request header: X-Weaviate-Cluster-Url")
+	if clusterURL == "" {
+		return "", errors.New("no cluster URL found in request header: X-Weaviate-Cluster-Url")
+	}
+	return clusterURL, nil
 }
 
 func getErrorMessage(statusCode int, resBodyError string, errorTemplate string) string {

--- a/usecases/modulecomponents/settings/class_settings_property_helper.go
+++ b/usecases/modulecomponents/settings/class_settings_property_helper.go
@@ -12,18 +12,12 @@
 package settings
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/url"
-	"os"
 	"strconv"
-	"strings"
-	"time"
 
-	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
 )
 
 type PropertyValuesHelper interface {
@@ -40,19 +34,6 @@ type PropertyValuesHelper interface {
 	GetNumber(in any) (float32, error)
 	GetPropertyAsListOfStrings(cfg moduletools.ClassConfig, name string, defaultValue []string) []string
 	ValidateBaseURL(baseURL string) error
-}
-
-// blockedHostnames is the set of hostname patterns that are always rejected
-// regardless of whether they resolve to a private IP.
-var blockedHostnames = []string{
-	"localhost",
-}
-
-// blockedHostSuffixes are hostname suffixes that are always rejected.
-var blockedHostSuffixes = []string{
-	".local",
-	".internal",
-	".localdomain",
 }
 
 type classPropertyValuesHelper struct {
@@ -218,76 +199,9 @@ func (h *classPropertyValuesHelper) GetPropertyAsListOfStrings(cfg moduletools.C
 	}
 }
 
+// ValidateBaseURL validates a class-config baseURL; see modulecomponents.ValidateBaseURL.
 func (h *classPropertyValuesHelper) ValidateBaseURL(baseURL string) error {
-	if !entcfg.Enabled(os.Getenv("MODULES_VALIDATE_BASE_URL")) {
-		return nil
-	}
-
-	// We accept that baseURL might be empty
-	if baseURL == "" {
-		return nil
-	}
-
-	parsed, err := url.Parse(baseURL)
-	if err != nil {
-		return fmt.Errorf("invalid baseURL: %w", err)
-	}
-
-	// 1. Require HTTPS
-	if parsed.Scheme != "https" {
-		return fmt.Errorf("baseURL must use HTTPS")
-	}
-
-	// 2. Reject empty host (handles "https://", "https:///path", etc.)
-	host := parsed.Hostname()
-	if host == "" {
-		return fmt.Errorf("baseURL must have a non-empty host")
-	}
-
-	// 3. If host is an IP literal, reject internal/loopback/link-local ranges
-	if ip := net.ParseIP(host); ip != nil {
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
-			return fmt.Errorf("baseURL cannot target internal addresses")
-		}
-		return nil
-	}
-
-	// 4. For hostnames: reject well-known internal names and suffixes
-	lower := strings.ToLower(host)
-	for _, blocked := range blockedHostnames {
-		if lower == blocked {
-			return fmt.Errorf("baseURL cannot target internal addresses")
-		}
-	}
-	for _, suffix := range blockedHostSuffixes {
-		if strings.HasSuffix(lower, suffix) {
-			return fmt.Errorf("baseURL cannot target internal addresses")
-		}
-	}
-
-	// 5. DNS resolution check: resolve the hostname and verify none of the
-	//    returned IPs are in a private/loopback/link-local range.
-	//    Use a short timeout to avoid blocking the validation path.
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	resolver := &net.Resolver{}
-	addrs, err := resolver.LookupHost(ctx, host)
-	if err != nil {
-		// If DNS resolution fails we reject the URL — a resolvable public
-		// hostname is required.
-		return fmt.Errorf("baseURL host could not be resolved: %w", err)
-	}
-	for _, addr := range addrs {
-		ip := net.ParseIP(addr)
-		if ip == nil {
-			continue
-		}
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
-			return fmt.Errorf("baseURL cannot target internal addresses")
-		}
-	}
-
-	return nil
+	return modulecomponents.ValidateBaseURL(baseURL)
 }
 
 func (h *classPropertyValuesHelper) GetSettings(cfg moduletools.ClassConfig) map[string]any {

--- a/usecases/modulecomponents/validate_baseurl.go
+++ b/usecases/modulecomponents/validate_baseurl.go
@@ -1,0 +1,113 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modulecomponents
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	entcfg "github.com/weaviate/weaviate/entities/config"
+)
+
+// Hostnames and suffixes that are always rejected, independent of DNS.
+var (
+	blockedHostnames    = []string{"localhost"}
+	blockedHostSuffixes = []string{".local", ".internal", ".localdomain"}
+)
+
+// BaseURLValidationEnabled reports whether SSRF hardening of module baseURLs is
+// on. Gated behind MODULES_VALIDATE_BASE_URL so operators that legitimately
+// target HTTP proxies or private-network gateways are not broken by default.
+func BaseURLValidationEnabled() bool {
+	return entcfg.Enabled(os.Getenv("MODULES_VALIDATE_BASE_URL"))
+}
+
+// ValidateBaseURLHeader validates the baseURL carried in the given request
+// header (e.g. "X-Openai-Baseurl"). It is the call-site guard for module
+// clients; a no-op when the header is absent or validation is disabled.
+func ValidateBaseURLHeader(ctx context.Context, headerKey string) error {
+	return ValidateBaseURL(GetValueFromContext(ctx, headerKey))
+}
+
+// isDisallowedIP reports whether an IP points at the local host or an internal
+// network. Used both by ValidateBaseURL and by the dial guard, where it sees
+// the actually-resolved IP and so also defeats DNS rebinding (TOCTOU).
+func isDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified()
+}
+
+// ValidateBaseURL validates a module baseURL (class config or X-*-Baseurl
+// header) against SSRF abuse: https-only, non-empty host, and not pointing at
+// an internal address (by IP literal, by blocked hostname/suffix, or by DNS
+// resolution). It is a no-op unless MODULES_VALIDATE_BASE_URL is enabled; an
+// empty baseURL means "use the module default" and is allowed.
+func ValidateBaseURL(baseURL string) error {
+	if !BaseURLValidationEnabled() || baseURL == "" {
+		return nil
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid baseURL: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("baseURL must use HTTPS")
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("baseURL must have a non-empty host")
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if isDisallowedIP(ip) {
+			return fmt.Errorf("baseURL cannot target internal addresses")
+		}
+		return nil
+	}
+
+	lower := strings.ToLower(host)
+	for _, blocked := range blockedHostnames {
+		if lower == blocked {
+			return fmt.Errorf("baseURL cannot target internal addresses")
+		}
+	}
+	for _, suffix := range blockedHostSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return fmt.Errorf("baseURL cannot target internal addresses")
+		}
+	}
+
+	// Resolve and reject if any resolved IP is internal; a resolvable public
+	// host is required. Short timeout so validation can't block.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	addrs, err := (&net.Resolver{}).LookupHost(ctx, host)
+	if err != nil {
+		return fmt.Errorf("baseURL host could not be resolved: %w", err)
+	}
+	for _, addr := range addrs {
+		if ip := net.ParseIP(addr); ip != nil && isDisallowedIP(ip) {
+			return fmt.Errorf("baseURL cannot target internal addresses")
+		}
+	}
+
+	return nil
+}

--- a/usecases/modulecomponents/validate_baseurl.go
+++ b/usecases/modulecomponents/validate_baseurl.go
@@ -36,11 +36,19 @@ func BaseURLValidationEnabled() bool {
 	return entcfg.Enabled(os.Getenv("MODULES_VALIDATE_BASE_URL"))
 }
 
-// ValidateBaseURLHeader validates the baseURL carried in the given request
-// header (e.g. "X-Openai-Baseurl"). It is the call-site guard for module
-// clients; a no-op when the header is absent or validation is disabled.
-func ValidateBaseURLHeader(ctx context.Context, headerKey string) error {
-	return ValidateBaseURL(GetValueFromContext(ctx, headerKey))
+// ValidatedBaseURLFromHeader returns the baseURL carried in the given request
+// header if present and valid, otherwise fallback. Validation is a no-op unless
+// MODULES_VALIDATE_BASE_URL is enabled. It folds the recurring
+// fetch-check-validate-assign block in module URL builders into one call.
+func ValidatedBaseURLFromHeader(ctx context.Context, headerKey, fallback string) (string, error) {
+	headerBaseURL := GetValueFromContext(ctx, headerKey)
+	if headerBaseURL == "" {
+		return fallback, nil
+	}
+	if err := ValidateBaseURL(headerBaseURL); err != nil {
+		return "", err
+	}
+	return headerBaseURL, nil
 }
 
 // isDisallowedIP reports whether an IP points at the local host or an internal

--- a/usecases/modulecomponents/validate_baseurl_test.go
+++ b/usecases/modulecomponents/validate_baseurl_test.go
@@ -72,21 +72,25 @@ func TestValidateBaseURLHeader(t *testing.T) {
 	ctxWith := func(v string) context.Context {
 		return context.WithValue(context.Background(), key, []string{v})
 	}
+	validate := func(ctx context.Context) error {
+		_, err := ValidatedBaseURLFromHeader(ctx, key, "")
+		return err
+	}
 
 	t.Run("validation enabled", func(t *testing.T) {
 		t.Setenv("MODULES_VALIDATE_BASE_URL", "true")
 
-		assert.NoError(t, ValidateBaseURLHeader(context.Background(), key)) // absent
-		assert.NoError(t, ValidateBaseURLHeader(ctxWith("https://8.8.8.8"), key))
-		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://169.254.169.254/"), key))
-		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://127.0.0.1/"), key))
-		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://10.0.0.5/"), key))
-		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://localhost/"), key))
-		assert.Error(t, ValidateBaseURLHeader(ctxWith("http://169.254.169.254/"), key))
+		assert.NoError(t, validate(context.Background())) // absent
+		assert.NoError(t, validate(ctxWith("https://8.8.8.8")))
+		assert.Error(t, validate(ctxWith("https://169.254.169.254/")))
+		assert.Error(t, validate(ctxWith("https://127.0.0.1/")))
+		assert.Error(t, validate(ctxWith("https://10.0.0.5/")))
+		assert.Error(t, validate(ctxWith("https://localhost/")))
+		assert.Error(t, validate(ctxWith("http://169.254.169.254/")))
 	})
 
 	t.Run("validation disabled is a no-op even for internal headers", func(t *testing.T) {
-		assert.NoError(t, ValidateBaseURLHeader(ctxWith("http://169.254.169.254/"), key))
+		assert.NoError(t, validate(ctxWith("http://169.254.169.254/")))
 	})
 }
 

--- a/usecases/modulecomponents/validate_baseurl_test.go
+++ b/usecases/modulecomponents/validate_baseurl_test.go
@@ -1,0 +1,118 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modulecomponents
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Cases use IP literals and blocked hostnames/suffixes (which short-circuit
+// before the DNS step) so the test stays hermetic — no live DNS.
+func TestValidateBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr bool
+	}{
+		{name: "empty baseURL is allowed", baseURL: "", wantErr: false},
+		{name: "http scheme rejected", baseURL: "http://example.com", wantErr: true},
+		{name: "no scheme rejected", baseURL: "example.com", wantErr: true},
+		{name: "empty host rejected", baseURL: "https://", wantErr: true},
+		{name: "loopback IPv4 rejected", baseURL: "https://127.0.0.1", wantErr: true},
+		{name: "loopback IPv6 rejected", baseURL: "https://[::1]", wantErr: true},
+		{name: "private 10/8 rejected", baseURL: "https://10.0.0.1", wantErr: true},
+		{name: "private 192.168 rejected", baseURL: "https://192.168.1.1:8080", wantErr: true},
+		{name: "private 172.16 rejected", baseURL: "https://172.16.0.5", wantErr: true},
+		{name: "cloud metadata IP rejected", baseURL: "https://169.254.169.254", wantErr: true},
+		{name: "unspecified addr rejected", baseURL: "https://0.0.0.0", wantErr: true},
+		{name: "localhost rejected", baseURL: "https://localhost", wantErr: true},
+		{name: ".local suffix rejected", baseURL: "https://myhost.local", wantErr: true},
+		{name: ".internal suffix rejected", baseURL: "https://svc.internal", wantErr: true},
+		{name: ".localdomain suffix rejected", baseURL: "https://box.localdomain", wantErr: true},
+		// A routable public IP literal is allowed (no DNS needed).
+		{name: "public IP literal allowed", baseURL: "https://8.8.8.8", wantErr: false},
+	}
+
+	t.Run("validation disabled (default) is a no-op", func(t *testing.T) {
+		// Unset → every URL is accepted, preserving backwards compatibility.
+		for _, tt := range tests {
+			assert.NoError(t, ValidateBaseURL(tt.baseURL), tt.name)
+		}
+		assert.NoError(t, ValidateBaseURL("http://169.254.169.254"))
+	})
+
+	t.Run("validation enabled", func(t *testing.T) {
+		t.Setenv("MODULES_VALIDATE_BASE_URL", "true")
+		for _, tt := range tests {
+			err := ValidateBaseURL(tt.baseURL)
+			if tt.wantErr {
+				assert.Error(t, err, tt.name)
+			} else {
+				assert.NoError(t, err, tt.name)
+			}
+		}
+	})
+}
+
+// Guards the SSRF-via-header vector from hackerone #3768976.
+func TestValidateBaseURLHeader(t *testing.T) {
+	const key = "X-Openai-Baseurl"
+	ctxWith := func(v string) context.Context {
+		return context.WithValue(context.Background(), key, []string{v})
+	}
+
+	t.Run("validation enabled", func(t *testing.T) {
+		t.Setenv("MODULES_VALIDATE_BASE_URL", "true")
+
+		assert.NoError(t, ValidateBaseURLHeader(context.Background(), key)) // absent
+		assert.NoError(t, ValidateBaseURLHeader(ctxWith("https://8.8.8.8"), key))
+		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://169.254.169.254/"), key))
+		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://127.0.0.1/"), key))
+		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://10.0.0.5/"), key))
+		assert.Error(t, ValidateBaseURLHeader(ctxWith("https://localhost/"), key))
+		assert.Error(t, ValidateBaseURLHeader(ctxWith("http://169.254.169.254/"), key))
+	})
+
+	t.Run("validation disabled is a no-op even for internal headers", func(t *testing.T) {
+		assert.NoError(t, ValidateBaseURLHeader(ctxWith("http://169.254.169.254/"), key))
+	})
+}
+
+func TestSSRFDialGuard(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{name: "loopback blocked", address: "127.0.0.1:80", wantErr: true},
+		{name: "private 10/8 blocked", address: "10.1.2.3:443", wantErr: true},
+		{name: "private 192.168 blocked", address: "192.168.0.1:443", wantErr: true},
+		{name: "cloud metadata blocked", address: "169.254.169.254:80", wantErr: true},
+		{name: "unspecified blocked", address: "0.0.0.0:80", wantErr: true},
+		{name: "IPv6 loopback blocked", address: "[::1]:80", wantErr: true},
+		{name: "public address allowed", address: "8.8.8.8:443", wantErr: false},
+		{name: "invalid address rejected", address: "not-an-address", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ssrfDialGuard("tcp", tt.address, nil)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the unauthenticated SSRF reported in **hackerone #3768976**.

PR #10878 hardened the **class-config** baseURL path (`moduleConfig.<module>.baseURL`) behind `MODULES_VALIDATE_BASE_URL`, but the runtime **`X-*-Baseurl` request headers** were copied straight into `baseURL` inside each client's URL builder and never validated. On a default anonymous deployment, an unauthenticated caller could:

- redirect outbound model-provider calls to any host — internal services, cloud metadata (`169.254.169.254`), etc.;
- have the operator's `OPENAI_APIKEY` (or an attacker-supplied `X-*-Api-Key`) forwarded to that host as `Authorization: Bearer …`.

The header path bypassed `ValidateBaseURL()` even with `MODULES_VALIDATE_BASE_URL=true`.

## Approach

Validate the header path with the **same policy**, gated behind the **same flag**, so default behaviour is unchanged (operators that legitimately target HTTP proxies or private-network gateways are not broken).

- **Centralized validator** — moved the logic into `modulecomponents.ValidateBaseURL` (the `settings` helper now delegates) and added a `ValidateBaseURLHeader(ctx, key)` call-site guard.
- **Per-client guard** — every module client validates the header before building its outbound URL.
- **Dial-layer backstop** — when validation is enabled, `NewBaseHttpClient` installs a `net.Dialer` `Control` hook that refuses to connect to loopback/private/link-local/unspecified IPs. It inspects the *resolved* IP at connect time, so it covers redirects, future clients, and **DNS-rebinding (TOCTOU)** that a URL-string check can't catch.

### Coverage (21 URL builders)
openai, cohere, voyageai, nvidia, weaviateembed, generative-{openai,cohere,xai,contextualai,friendliai,mistral,nvidia,anyscale,anthropic,ollama,databricks}, qna-openai, reranker-{cohere,nvidia}, text2vec-{databricks,digitalocean}.

### Note for reviewers
Two patterns, intentionally: builders that **already returned `(string, error)`** validate inline; builders that returned a **bare `string`** are guarded at the call site to avoid a signature change. Both call the same validator and are backstopped by the dial guard. A good chunk of the "added" lines are the validator **relocated** out of `settings` (see the matching removals there) plus the two new test files.

## Default-posture caveat
Per the chosen design, this stays gated behind `MODULES_VALIDATE_BASE_URL` (default **off**) — so an out-of-the-box deployment remains exploitable until an operator opts in. This matches #10878's posture and breaks no one, but does **not** fix the default deployment the report targets. If we want to close the default, the lowest-breakage next step is making *just* the metadata/link-local block default-on while leaving the HTTPS+RFC1918 strictness opt-in. **Flagging for the security team before we respond on the HackerOne report.**

Also note: with the flag on, the header path performs a synchronous DNS `LookupHost` (3s timeout) per request carrying a baseURL header.

## Testing
- Hermetic unit tests for `ValidateBaseURL`, `ValidateBaseURLHeader`, and the dial guard (IP literals + blocked hostnames, no live DNS).
- openai client regression test for the exact reported vector.
- `go vet` clean, `gofumpt` clean, touched-package tests pass.

Thanks to HackerOne user Duong Tran (https://hackerone.com/duongtt) for finding this issue. 