### PR TITLE
Fix race in usage module startup

### DIFF
--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -70,10 +70,25 @@ func NewBaseModule(moduleName string, storage StorageBackend) *BaseModule {
 }
 
 func (b *BaseModule) SetUsageService(usageService any) {
-	if service, ok := usageService.(clusterusage.Service); ok {
-		b.usageService = service
-		service.SetJitterInterval(b.shardJitter)
+	service, ok := usageService.(clusterusage.Service)
+	if !ok {
+		return
 	}
+
+	b.mu.Lock()
+	if b.usageService != nil {
+		// already set, the collector is running
+		b.mu.Unlock()
+		return
+	}
+	b.usageService = service
+	b.mu.Unlock()
+
+	service.SetJitterInterval(b.shardJitter)
+	// Start the collector only once the service it depends on is set.
+	enterrors.GoWrapper(func() {
+		b.collectAndUploadPeriodically(context.Background())
+	}, b.logger)
 }
 
 func (b *BaseModule) Name() string {
@@ -136,11 +151,6 @@ func (b *BaseModule) InitializeCommon(ctx context.Context, config *config.Config
 	if err := b.adjustInitialInterval(config); err != nil {
 		b.logger.Errorf("cannot adjust initial interval, falling back to: %v: %v", b.interval, err)
 	}
-
-	// Start periodic collection and upload
-	enterrors.GoWrapper(func() {
-		b.collectAndUploadPeriodically(context.Background())
-	}, b.logger)
 
 	b.logger.Infof("%s module initialized successfully", b.moduleName)
 	return nil

--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -75,14 +75,19 @@ func (b *BaseModule) SetUsageService(usageService any) {
 		return
 	}
 
-	b.mu.Lock()
-	if b.usageService != nil {
-		// already set, the collector is running
-		b.mu.Unlock()
+	alreadySet := func() bool {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if b.usageService != nil {
+			// already set, the collector is running
+			return true
+		}
+		b.usageService = service
+		return false
+	}()
+	if alreadySet {
 		return
 	}
-	b.usageService = service
-	b.mu.Unlock()
 
 	service.SetJitterInterval(b.shardJitter)
 	// Start the collector only once the service it depends on is set.

--- a/usecases/modulecomponents/usage/common_test.go
+++ b/usecases/modulecomponents/usage/common_test.go
@@ -14,6 +14,7 @@ package usage
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -365,4 +366,70 @@ func TestModule_ZeroIntervalProtection(t *testing.T) {
 	assert.Greater(t, baseModule.interval, time.Duration(0))
 
 	mockStorage.AssertExpectations(t)
+}
+
+// TestSetUsageService_StartsCollectorExactlyOnce tests that the collector only
+// starts after a valid service is provided, and that repeated calls neither
+// replace the service nor start additional collectors
+func TestSetUsageService_StartsCollectorExactlyOnce(t *testing.T) {
+	logger := logrus.New()
+
+	mockStorage := NewMockStorageBackend(t)
+	mockUsageService := clusterusage.NewMockService(t)
+
+	uploads := make(chan struct{}, 16)
+	mockUsageService.EXPECT().SetJitterInterval(mock.Anything).Return().Once()
+	mockUsageService.EXPECT().Usage(mock.Anything, mock.Anything).Return(&types.Report{Node: "test-node"}, nil)
+	mockStorage.EXPECT().UploadUsageData(mock.Anything, mock.Anything).RunAndReturn(func(context.Context, *types.Report) error {
+		uploads <- struct{}{}
+		return nil
+	})
+	mockStorage.EXPECT().UpdateConfig(mock.Anything).Return(false, nil).Maybe()
+
+	baseModule := NewBaseModule("test-module", mockStorage)
+	// short initial interval with a long base interval: each collector fires
+	// exactly one collection cycle during the test window, so a duplicate
+	// collector would show up as a second upload
+	baseModule.interval = time.Hour
+	baseModule.initialInterval = 10 * time.Millisecond
+	baseModule.nodeID = "test-node"
+	baseModule.policyVersion = "2025-06-01"
+	baseModule.metrics = NewMetrics(prometheus.NewRegistry(), "test-module")
+	baseModule.logger = logger.WithField("component", "test-module")
+	baseModule.lastPushDateFilePath = filepath.Join(t.TempDir(), "usage.module.last.push")
+	baseModule.config = &config.Config{
+		Usage: usagetypes.UsageConfig{
+			// matches the module's jitter so reloadConfig does not call
+			// SetJitterInterval again
+			ShardJitterInterval: runtime.NewDynamicValue(DefaultShardJitterInterval),
+		},
+		RuntimeOverrides: config.RuntimeOverrides{
+			LoadInterval: 2 * time.Minute,
+		},
+	}
+	defer close(baseModule.stopChan)
+
+	// an invalid service must not be set and must not start the collector
+	baseModule.SetUsageService("not a usage service")
+	assert.Nil(t, baseModule.usageService)
+
+	baseModule.SetUsageService(mockUsageService)
+
+	// a second call must keep the original service and not start another
+	// collector - any call on this mock fails the test
+	baseModule.SetUsageService(clusterusage.NewMockService(t))
+	assert.Same(t, mockUsageService, baseModule.usageService)
+
+	select {
+	case <-uploads:
+	case <-time.After(5 * time.Second):
+		t.Fatal("collector did not start after setting a valid usage service")
+	}
+
+	// a duplicate collector would fire its own initial collection right away
+	select {
+	case <-uploads:
+		t.Fatal("second collection cycle fired - collector started more than once")
+	case <-time.After(200 * time.Millisecond):
+	}
 }


### PR DESCRIPTION
### What's being changed:

the usage modules are initialized in two phases:
- InitializeCommon runs during module init, but the usage service ( what actually collects the data) is only injected later, in postInitModules, after the DB and schema manager are ready
- The collector goroutine (collectAndUploadPeriodically) was started at the end of InitializeCommon, i.e. before the service existed. If a collection tick fired in that window, collectUsageData hit a nil b.usageService and failed with "usage service not initialized". 
 
The fix moved the goroutine launch out of InitializeCommon into SetUsageService, so the collector can only start once its dependency is actually set.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
