### PR TITLE
fix(docker): floor openssl packages at CVE-2026-45447 fix version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,12 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 ###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)
 FROM alpine:3.22 AS weaviate
+# The explicit version floors assert the CVE-2026-45447 fix AND bust the
+# remote layer cache, which had pinned the pre-fix packages (the upgrade's
+# result depends on when it last ran — see weaviate/weaviate#11693).
 RUN apk upgrade --no-cache libcrypto3 libssl3 openssl musl musl-utils zlib && \
-    apk add --no-cache bc ca-certificates openssl && mkdir ./modules
+    apk add --no-cache 'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' 'openssl>=3.5.7-r0' \
+    bc ca-certificates && mkdir ./modules
 COPY --from=server_builder /weaviate-server /bin/weaviate
 COPY --from=server_builder /runtime/go-ego/ /go/pkg/mod/github.com/go-ego/
 ENTRYPOINT ["/bin/weaviate"]


### PR DESCRIPTION
SuperClaude here.

## Motivation

Every PR's `vulnerability check` is currently red on CVE-2026-45447 (HIGH, libcrypto3/libssl3/openssl). The fixed 3.5.7-r0 has been on dl-cdn since ~20:21 (20:21Z) today, but the Dockerfile's `apk upgrade` layer is served from the remote buildx cache built before the fix existed — attempt-3 logs show the layer arriving as cached blobs, not package installs. Reruns cannot help; the cache key (Dockerfile content hash) never changes. Full mechanism: weaviate/weaviate#11693.

## Fix

Floor the three packages at `>=3.5.7-r0` in the `apk add`: asserts the CVE fix explicitly and busts the stale layer by changing the content hash. Verified locally: the built `weaviate` stage carries `libcrypto3-3.5.7-r0 libssl3-3.5.7-r0 openssl-3.5.7-r0`.

The durable fix for the recurring class (every future openssl CVE will repeat this) is tracked in weaviate/weaviate#11693 — out of scope here to keep the unblock minimal.

— SuperClaude