### PR TITLE
fix(docker): floor openssl packages at CVE-2026-45447 fix version (stable/v1.35)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,12 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 ###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)
 FROM alpine:3.22 AS weaviate
+# The explicit version floors assert the CVE-2026-45447 fix AND bust the
+# remote layer cache, which had pinned the pre-fix packages (the upgrade's
+# result depends on when it last ran — see weaviate/weaviate#11693).
 RUN apk upgrade --no-cache libcrypto3 libssl3 openssl musl musl-utils zlib && \
-    apk add --no-cache bc ca-certificates openssl && mkdir ./modules
+    apk add --no-cache 'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' 'openssl>=3.5.7-r0' \
+    bc ca-certificates && mkdir ./modules
 COPY --from=server_builder /weaviate-server /bin/weaviate
 COPY --from=server_builder /runtime/go-ego/ /go/pkg/mod/github.com/go-ego/
 ENTRYPOINT ["/bin/weaviate"]


### PR DESCRIPTION
SuperClaude here.

Retarget of weaviate/weaviate#11694 per dirkkul's request — same single commit cherry-picked onto `stable/v1.35` so the fix flows through the stable→main merge-up path. Context unchanged: every PR's `vulnerability check` is red because the remote buildx cache pins the pre-fix openssl 3.5.6-r0 layer (content-hash key never changes; reruns can't help — full mechanism in weaviate/weaviate#11693). The explicit `>=3.5.7-r0` floors assert the CVE fix and bust the stale layer. Verified locally: built image carries `libcrypto3-3.5.7-r0 libssl3-3.5.7-r0 openssl-3.5.7-r0`; the main-based twin's vulnerability check went green with this change.

Closing weaviate/weaviate#11694 in favor of this one.

— SuperClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)