### PR TITLE
Handle missing boost properties and property type validation

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -705,19 +705,19 @@ func (p *Parser) extractBoostCondition(cond *pb.Boost_Condition, className, tena
 		}
 		pc.Filter = &filters.LocalFilter{Root: &clause}
 	case *pb.Boost_Condition_TimeDecay:
-		decay, err := extractTimeDecayFunction(c.TimeDecay, idx)
+		decay, err := p.extractTimeDecayFunction(c.TimeDecay, className, idx)
 		if err != nil {
 			return filters.BoostCondition{}, err
 		}
 		pc.Decay = decay
 	case *pb.Boost_Condition_NumericDecay:
-		decay, err := extractNumericDecayFunction(c.NumericDecay, idx)
+		decay, err := p.extractNumericDecayFunction(c.NumericDecay, className, idx)
 		if err != nil {
 			return filters.BoostCondition{}, err
 		}
 		pc.Decay = decay
 	case *pb.Boost_Condition_PropertyValue:
-		fv, err := extractPropertyValueFunction(c.PropertyValue, idx)
+		fv, err := p.extractPropertyValueFunction(c.PropertyValue, className, idx)
 		if err != nil {
 			return filters.BoostCondition{}, err
 		}
@@ -729,7 +729,7 @@ func (p *Parser) extractBoostCondition(cond *pb.Boost_Condition, className, tena
 	return pc, nil
 }
 
-func extractPropertyValueFunction(fv *pb.Boost_PropertyValueFunction, condIdx int) (*filters.PropertyValue, error) {
+func (p *Parser) extractPropertyValueFunction(fv *pb.Boost_PropertyValueFunction, className string, condIdx int) (*filters.PropertyValue, error) {
 	if fv == nil {
 		return nil, nil
 	}
@@ -737,6 +737,15 @@ func extractPropertyValueFunction(fv *pb.Boost_PropertyValueFunction, condIdx in
 	prop := fv.GetProperty()
 	if prop == "" {
 		return nil, fmt.Errorf("boost condition[%d] property_value: property is required", condIdx)
+	}
+
+	dt, err := p.boostPropertyDataType(className, prop, "property_value", condIdx)
+	if err != nil {
+		return nil, err
+	}
+	if dt != schema.DataTypeInt && dt != schema.DataTypeNumber {
+		return nil, fmt.Errorf("boost condition[%d] property_value: property %q must be of type int or number, got %s",
+			condIdx, prop, dt)
 	}
 
 	modifier := filters.PropertyValueModifierNone
@@ -766,7 +775,21 @@ func extractDecayCurve(curve pb.Boost_DecayCurve) filters.DecayCurveType {
 	}
 }
 
-func extractTimeDecayFunction(d *pb.Boost_TimeDecayFunction, condIdx int) (*filters.Decay, error) {
+// boostPropertyDataType resolves the dataType of a property referenced by a
+// boost condition, erroring if the property does not exist on the class.
+func (p *Parser) boostPropertyDataType(className, propName, condName string, condIdx int) (schema.DataType, error) {
+	class, err := p.authorizedGetClass(className)
+	if err != nil {
+		return "", err
+	}
+	propDef, err := schema.GetPropertyByName(class, propName)
+	if err != nil {
+		return "", fmt.Errorf("boost condition[%d] %s: %w", condIdx, condName, err)
+	}
+	return schema.DataType(propDef.DataType[0]), nil
+}
+
+func (p *Parser) extractTimeDecayFunction(d *pb.Boost_TimeDecayFunction, className string, condIdx int) (*filters.Decay, error) {
 	if d == nil {
 		return nil, nil
 	}
@@ -774,6 +797,15 @@ func extractTimeDecayFunction(d *pb.Boost_TimeDecayFunction, condIdx int) (*filt
 	prop := d.GetProperty()
 	if prop == "" {
 		return nil, fmt.Errorf("boost condition[%d] time_decay: property is required", condIdx)
+	}
+
+	dt, err := p.boostPropertyDataType(className, prop, "time_decay", condIdx)
+	if err != nil {
+		return nil, err
+	}
+	if dt != schema.DataTypeDate {
+		return nil, fmt.Errorf("boost condition[%d] time_decay: property %q must be of type date, got %s",
+			condIdx, prop, dt)
 	}
 
 	decayValue := float32(0.5)
@@ -801,7 +833,7 @@ func extractTimeDecayFunction(d *pb.Boost_TimeDecayFunction, condIdx int) (*filt
 	}, nil
 }
 
-func extractNumericDecayFunction(d *pb.Boost_NumericDecayFunction, condIdx int) (*filters.Decay, error) {
+func (p *Parser) extractNumericDecayFunction(d *pb.Boost_NumericDecayFunction, className string, condIdx int) (*filters.Decay, error) {
 	if d == nil {
 		return nil, nil
 	}
@@ -809,6 +841,15 @@ func extractNumericDecayFunction(d *pb.Boost_NumericDecayFunction, condIdx int) 
 	prop := d.GetProperty()
 	if prop == "" {
 		return nil, fmt.Errorf("boost condition[%d] numeric_decay: property is required", condIdx)
+	}
+
+	dt, err := p.boostPropertyDataType(className, prop, "numeric_decay", condIdx)
+	if err != nil {
+		return nil, err
+	}
+	if dt != schema.DataTypeInt && dt != schema.DataTypeNumber {
+		return nil, fmt.Errorf("boost condition[%d] numeric_decay: property %q must be of type int or number, got %s",
+			condIdx, prop, dt)
 	}
 
 	if d.GetScale() <= 0 {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -14,6 +14,7 @@ package v1
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema/configvalidation"
@@ -778,6 +779,9 @@ func extractDecayCurve(curve pb.Boost_DecayCurve) filters.DecayCurveType {
 // boostPropertyDataType resolves the dataType of a property referenced by a
 // boost condition, erroring if the property does not exist on the class.
 func (p *Parser) boostPropertyDataType(className, propName, condName string, condIdx int) (schema.DataType, error) {
+	if strings.Contains(propName, ".") {
+		return "", fmt.Errorf("boost condition[%d] %s: nested property %q is not supported", condIdx, condName, propName)
+	}
 	class, err := p.authorizedGetClass(className)
 	if err != nil {
 		return "", err
@@ -785,6 +789,9 @@ func (p *Parser) boostPropertyDataType(className, propName, condName string, con
 	propDef, err := schema.GetPropertyByName(class, propName)
 	if err != nil {
 		return "", fmt.Errorf("boost condition[%d] %s: %w", condIdx, condName, err)
+	}
+	if len(propDef.DataType) == 0 {
+		return "", fmt.Errorf("boost condition[%d] %s: property %q has no data type", condIdx, condName, propName)
 	}
 	return schema.DataType(propDef.DataType[0]), nil
 }

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -62,6 +62,7 @@ var (
 	singleNamedVecClass      = "SingleNamedVecClass"
 	regularWithColBERTClass  = "RegularWithColBERTClass"
 	mixedVectorsClass        = "MixedVectorsClass"
+	boostClass               = "BoostClass"
 
 	scheme = schema.Schema{
 		Objects: &models.Schema{
@@ -76,6 +77,17 @@ var (
 						{Name: "uuid", DataType: schema.DataTypeUUID.PropString()},
 						{Name: "ref", DataType: []string{refClass1}},
 						{Name: "multiRef", DataType: []string{refClass1, refClass2}},
+					},
+					VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DefaultDistanceMetric},
+				},
+				{
+					Class: boostClass,
+					Properties: []*models.Property{
+						{Name: "name", DataType: schema.DataTypeText.PropString()},
+						{Name: "int", DataType: schema.DataTypeInt.PropString()},
+						{Name: "number", DataType: schema.DataTypeNumber.PropString()},
+						{Name: "floats", DataType: schema.DataTypeNumberArray.PropString()},
+						{Name: "date", DataType: schema.DataTypeDate.PropString()},
 					},
 					VectorIndexConfig: hnsw.UserConfig{Distance: vectorIndex.DefaultDistanceMetric},
 				},
@@ -2796,6 +2808,60 @@ func TestGRPCSearchRequest(t *testing.T) {
 				sortNamedVecs(out.AdditionalProperties.Vectors)
 				require.EqualValues(t, tt.out.Properties, out.Properties)
 				require.EqualValues(t, tt.out, out)
+			}
+		})
+	}
+}
+
+func TestGRPCSearchRequestBoostPropertyTypeValidation(t *testing.T) {
+	propertyValue := func(prop string) *pb.Boost_Condition {
+		return &pb.Boost_Condition{Condition: &pb.Boost_Condition_PropertyValue{
+			PropertyValue: &pb.Boost_PropertyValueFunction{Property: prop},
+		}}
+	}
+	timeDecay := func(prop string) *pb.Boost_Condition {
+		return &pb.Boost_Condition{Condition: &pb.Boost_Condition_TimeDecay{
+			TimeDecay: &pb.Boost_TimeDecayFunction{Property: prop, Scale: "7d"},
+		}}
+	}
+	numericDecay := func(prop string) *pb.Boost_Condition {
+		return &pb.Boost_Condition{Condition: &pb.Boost_Condition_NumericDecay{
+			NumericDecay: &pb.Boost_NumericDecayFunction{Property: prop, Scale: 10},
+		}}
+	}
+
+	tests := []struct {
+		name  string
+		cond  *pb.Boost_Condition
+		error bool
+	}{
+		{"property_value on number is valid", propertyValue("number"), false},
+		{"property_value on int is valid", propertyValue("int"), false},
+		{"property_value on text errors", propertyValue("name"), true},
+		{"property_value on number array errors", propertyValue("floats"), true},
+		{"property_value on nonexistent property errors", propertyValue("doesNotExist"), true},
+		{"time_decay on date is valid", timeDecay("date"), false},
+		{"time_decay on number errors", timeDecay("number"), true},
+		{"time_decay on text errors", timeDecay("name"), true},
+		{"time_decay on nonexistent property errors", timeDecay("doesNotExist"), true},
+		{"numeric_decay on number is valid", numericDecay("number"), false},
+		{"numeric_decay on int is valid", numericDecay("int"), false},
+		{"numeric_decay on date errors", numericDecay("date"), true},
+		{"numeric_decay on nonexistent property errors", numericDecay("doesNotExist"), true},
+	}
+
+	parser := NewParser(false, getClass, nil, false)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &pb.SearchRequest{
+				Collection: boostClass,
+				Boost:      &pb.Boost{Conditions: []*pb.Boost_Condition{tt.cond}},
+			}
+			_, err := parser.Search(req, &config.Config{QueryDefaults: config.QueryDefaults{Limit: 10}})
+			if tt.error {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
 			}
 		})
 	}

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -2840,14 +2840,17 @@ func TestGRPCSearchRequestBoostPropertyTypeValidation(t *testing.T) {
 		{"property_value on text errors", propertyValue("name"), true},
 		{"property_value on number array errors", propertyValue("floats"), true},
 		{"property_value on nonexistent property errors", propertyValue("doesNotExist"), true},
+		{"property_value on nested path errors", propertyValue("number.foo"), true},
 		{"time_decay on date is valid", timeDecay("date"), false},
 		{"time_decay on number errors", timeDecay("number"), true},
 		{"time_decay on text errors", timeDecay("name"), true},
 		{"time_decay on nonexistent property errors", timeDecay("doesNotExist"), true},
+		{"time_decay on nested path errors", timeDecay("date.foo"), true},
 		{"numeric_decay on number is valid", numericDecay("number"), false},
 		{"numeric_decay on int is valid", numericDecay("int"), false},
 		{"numeric_decay on date errors", numericDecay("date"), true},
 		{"numeric_decay on nonexistent property errors", numericDecay("doesNotExist"), true},
+		{"numeric_decay on nested path errors", numericDecay("number.foo"), true},
 	}
 
 	parser := NewParser(false, getClass, nil, false)

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -212,7 +212,8 @@ func distToScore(results []search.Result) {
 // precomputePropertyValueScores computes normalized [0,1] scores for each
 // property_value condition across all results. Min-max normalization is applied
 // after the modifier so that the highest value in the result set scores 1.0.
-// Returns a slice indexed by [conditionIdx][resultIdx].
+// Results missing the property score 0. Returns a slice indexed by
+// [conditionIdx][resultIdx].
 func precomputePropertyValueScores(results []search.Result, conditions []filters.BoostCondition) [][]float32 {
 	scores := make([][]float32, len(conditions))
 
@@ -241,6 +242,8 @@ func precomputePropertyValueScores(results []search.Result, conditions []filters
 		fv := cond.PropertyValue
 		propName := string(fv.Path.Property)
 		raw := make([]float64, len(results))
+		present := make([]bool, len(results))
+		minVal, maxVal := math.Inf(1), math.Inf(-1)
 
 		for j := range results {
 			if propsByIdx[j] == nil {
@@ -251,28 +254,22 @@ func precomputePropertyValueScores(results []search.Result, conditions []filters
 				continue
 			}
 			raw[j] = applyPropertyValueModifier(val, fv.Modifier)
+			present[j] = true
+			minVal = math.Min(minVal, raw[j])
+			maxVal = math.Max(maxVal, raw[j])
 		}
 
-		// Min-max normalize to [0,1].
-		minVal, maxVal := raw[0], raw[0]
-		for _, v := range raw[1:] {
-			if v < minVal {
-				minVal = v
-			}
-			if v > maxVal {
-				maxVal = v
-			}
-		}
-
+		// Normalize over present values only; missing properties score 0 so
+		// they can't outrank actual negative values.
 		scores[i] = make([]float32, len(results))
 		rangeVal := maxVal - minVal
-		if rangeVal > 0 {
-			for j := range raw {
+		for j := range raw {
+			switch {
+			case !present[j]:
+				// stays 0
+			case rangeVal > 0:
 				scores[i][j] = float32((raw[j] - minVal) / rangeVal)
-			}
-		} else {
-			// All same value — normalize to 1.0
-			for j := range scores[i] {
+			default:
 				scores[i][j] = 1.0
 			}
 		}

--- a/usecases/traverser/boost_scorer_test.go
+++ b/usecases/traverser/boost_scorer_test.go
@@ -1217,6 +1217,66 @@ func TestApplyBoostScoring_OffsetBeyondResults(t *testing.T) {
 	assert.Nil(t, got, "offset beyond result count should return nil")
 }
 
+// Reproduces https://github.com/weaviate/weaviate/issues/11592: a missing
+// numeric property must not be treated as raw 0, which would outrank objects
+// whose actual values are negative.
+func TestApplyBoostScoring_PropertyValueMissingPropertyWithNegativeValues(t *testing.T) {
+	results := []search.Result{
+		makeResult("11111111-1111-1111-1111-111111111111", 0.5, map[string]any{"rating": float64(-1.0)}),
+		makeResult("22222222-2222-2222-2222-222222222222", 0.5, map[string]any{"rating": float64(-2.0)}),
+		makeResult("33333333-3333-3333-3333-333333333333", 0.5, map[string]any{"title": "missing rating"}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{propertyValueCondition("rating", filters.PropertyValueModifierNone)},
+		Weight:     1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	require.Len(t, got, 3)
+	assert.Equal(t, strfmt.UUID("11111111-1111-1111-1111-111111111111"), got[0].ID,
+		"object with highest present rating (-1.0) must rank first")
+}
+
+// log1p clamps negatives to 0, collapsing all present values to the same raw
+// score (range 0). Present results must still rank above the missing one.
+func TestApplyBoostScoring_PropertyValueModifierNegativeAndMissing(t *testing.T) {
+	for _, modifier := range []filters.PropertyValueModifierType{
+		filters.PropertyValueModifierLog1p, filters.PropertyValueModifierSqrt,
+	} {
+		t.Run(string(modifier), func(t *testing.T) {
+			results := []search.Result{
+				makeResult("aaaaaaaa-0000-0000-0000-000000000001", 0.5, map[string]any{"rating": float64(-1.0)}),
+				makeResult("aaaaaaaa-0000-0000-0000-000000000002", 0.5, map[string]any{"rating": float64(-2.0)}),
+				makeResult("aaaaaaaa-0000-0000-0000-000000000003", 0.5, map[string]any{"title": "missing rating"}),
+			}
+			boost := &filters.Boost{
+				Conditions: []filters.BoostCondition{propertyValueCondition("rating", modifier)},
+				Weight:     1.0,
+			}
+			got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+			require.Len(t, got, 3)
+			assert.Equal(t, strfmt.UUID("aaaaaaaa-0000-0000-0000-000000000003"), got[2].ID,
+				"missing property must rank last")
+		})
+	}
+}
+
+func TestApplyBoostScoring_PropertyValueAllMissing(t *testing.T) {
+	results := []search.Result{
+		makeResult("low-primary", 0.2, map[string]any{"title": "x"}),
+		makeResult("high-primary", 0.9, map[string]any{"title": "y"}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{propertyValueCondition("rating", filters.PropertyValueModifierNone)},
+		Weight:     0.5,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	require.Len(t, got, 2)
+	// No result has the property: the condition is neutral and the primary
+	// score decides the order.
+	assert.Equal(t, strfmt.UUID("high-primary"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("low-primary"), got[1].ID)
+}
+
 func cloneResults(results []search.Result) []search.Result {
 	out := make([]search.Result, len(results))
 	copy(out, results)


### PR DESCRIPTION
### What's being changed:
- The boost scorer was handling missing properties incorrectly. Not now correctly downranks them.
- The property and decay boosts were missing property type validation
- Additional tests added for mixed boosts with missing properties

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
