### PR TITLE
Reduce goroutines spawned by cyclemanager

### DIFF
--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -169,10 +169,10 @@ func (c *cycleCallbackGroup) cycleCallbackSequential(shouldAbort ShouldAbortCall
 }
 
 func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallback, routinesLimit int) bool {
-	// spawn no workers on idle ticks and no more workers than due callbacks
-	// on busy ones. Callbacks registered while a busy tick is running are
-	// still picked up by the dispatch loop below; on an idle tick they wait
-	// for the next one.
+	// spawn no workers on idle ticks and no more than due callbacks on busy
+	// ones. Callbacks registered or becoming due after this count wait for the
+	// next tick; holding spare workers to catch them would bring back the churn
+	// this avoids.
 	due := c.countDueCallbacks()
 	if due == 0 {
 		return false

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -169,16 +169,10 @@ func (c *cycleCallbackGroup) cycleCallbackSequential(shouldAbort ShouldAbortCall
 }
 
 func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallback, routinesLimit int) bool {
-	// spawn no workers on idle ticks and no more than due callbacks on busy
-	// ones. Callbacks registered or becoming due after this count wait for the
-	// next tick; holding spare workers to catch them would bring back the churn
-	// this avoids.
-	due := c.countDueCallbacks()
-	if due == 0 {
+	// spawn no workers when nothing is due; callbacks becoming due right after
+	// this check are picked up on the next tick.
+	if c.countDueCallbacks() == 0 {
 		return false
-	}
-	if routinesLimit > due {
-		routinesLimit = due
 	}
 
 	anyExecuted := false
@@ -281,8 +275,8 @@ func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallba
 }
 
 // countDueCallbacks prunes ids of deleted callbacks and counts callbacks that
-// are active and whose interval has elapsed. The count is only a sizing hint:
-// workers re-verify each callback under lock before executing it.
+// are active and whose interval has elapsed, so an idle tick can skip spawning
+// workers entirely. Workers re-verify each callback under lock before executing.
 func (c *cycleCallbackGroup) countDueCallbacks() int {
 	c.Lock()
 	defer c.Unlock()

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -169,6 +169,18 @@ func (c *cycleCallbackGroup) cycleCallbackSequential(shouldAbort ShouldAbortCall
 }
 
 func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallback, routinesLimit int) bool {
+	// spawn no workers on idle ticks and no more workers than due callbacks
+	// on busy ones. Callbacks registered while a busy tick is running are
+	// still picked up by the dispatch loop below; on an idle tick they wait
+	// for the next one.
+	due := c.countDueCallbacks()
+	if due == 0 {
+		return false
+	}
+	if routinesLimit > due {
+		routinesLimit = due
+	}
+
 	anyExecuted := false
 	ch := make(chan uint32)
 	lock := new(sync.Mutex)
@@ -266,6 +278,38 @@ func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallba
 
 	wg.Wait()
 	return anyExecuted
+}
+
+// countDueCallbacks prunes ids of deleted callbacks and counts callbacks that
+// are active and whose interval has elapsed. The count is only a sizing hint:
+// workers re-verify each callback under lock before executing it.
+func (c *cycleCallbackGroup) countDueCallbacks() int {
+	c.Lock()
+	defer c.Unlock()
+
+	due := 0
+	now := time.Now()
+	i := 0
+	for _, callbackId := range c.callbackIds {
+		meta, ok := c.callbacks[callbackId]
+		// callback deleted in the meantime, drop its id
+		if !ok {
+			continue
+		}
+		c.callbackIds[i] = callbackId
+		i++
+		// callback deactivated
+		if !meta.active {
+			continue
+		}
+		// not enough time passed since previous execution
+		if meta.intervals != nil && now.Sub(meta.started) < meta.intervals.Get() {
+			continue
+		}
+		due++
+	}
+	c.callbackIds = c.callbackIds[:i]
+	return due
 }
 
 func (c *cycleCallbackGroup) recover(callbackCustomId string, cancel context.CancelFunc) {

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -13,6 +13,8 @@ package cyclemanager
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -201,6 +203,100 @@ func TestCycleCallback_Parallel(t *testing.T) {
 		assert.Equal(t, 1, executedCounter3)
 		assert.Equal(t, 1, executedCounter4)
 		assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+	})
+
+	t.Run("idle tick executes nothing", func(t *testing.T) {
+		executedCounter1 := 0
+		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+			executedCounter1++
+			return true
+		}
+		executedCounter2 := 0
+		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+			executedCounter2++
+			return true
+		}
+
+		callbacks := NewCallbackGroup("id", logger, 2)
+		callbacks.Register("c1", callback1, WithIntervals(NewFixedIntervals(time.Hour)))
+		callbacks.Register("c2", callback2, WithIntervals(NewFixedIntervals(time.Hour)))
+
+		// 1st tick: both callbacks due (registration allows immediate execution)
+		executed := callbacks.CycleCallback(shouldNotAbort)
+		assert.True(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+
+		// 2nd tick: intervals not elapsed, nothing due
+		executed = callbacks.CycleCallback(shouldNotAbort)
+		assert.False(t, executed)
+		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 1, executedCounter2)
+	})
+
+	t.Run("workers capped at number of due callbacks", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			due      int
+			inactive int
+		}{
+			{name: "1 due of 3", due: 1, inactive: 2},
+			{name: "3 due of 4", due: 3, inactive: 1},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				baseline := runtime.NumGoroutine()
+
+				started := uint32(0)
+				chRelease := make(chan struct{})
+				blocking := func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddUint32(&started, 1)
+					<-chRelease
+					return true
+				}
+				inactive := func(shouldAbort ShouldAbortCallback) bool { return true }
+
+				callbacks := NewCallbackGroup("id", logger, 32)
+				for i := range tt.due {
+					callbacks.Register(fmt.Sprintf("due-%d", i), blocking)
+				}
+				for i := range tt.inactive {
+					callbacks.Register(fmt.Sprintf("inactive-%d", i), inactive, AsInactive())
+				}
+
+				chFinished := make(chan bool)
+				go func() {
+					chFinished <- callbacks.CycleCallback(shouldNotAbort)
+				}()
+
+				// all due callbacks block in parallel: the pool is capped at
+				// the due count, not routinesLimit=32
+				assert.Eventually(t, func() bool {
+					return atomic.LoadUint32(&started) == uint32(tt.due)
+				}, time.Second, 5*time.Millisecond)
+				assert.Less(t, runtime.NumGoroutine(), baseline+8)
+
+				close(chRelease)
+				assert.True(t, <-chFinished)
+			})
+		}
+	})
+
+	t.Run("idle tick prunes ids of unregistered callbacks", func(t *testing.T) {
+		callback := func(shouldAbort ShouldAbortCallback) bool { return true }
+
+		callbacks := NewCallbackGroup("id", logger, 2)
+		ctrl1 := callbacks.Register("c1", callback)
+		ctrl2 := callbacks.Register("c2", callback)
+
+		require.NoError(t, ctrl1.Unregister(context.Background()))
+		require.NoError(t, ctrl2.Unregister(context.Background()))
+
+		executed := callbacks.CycleCallback(shouldNotAbort)
+
+		assert.False(t, executed)
+		assert.Empty(t, callbacks.(*cycleCallbackGroup).callbackIds)
 	})
 
 	t.Run("run with intervals", func(T *testing.T) {

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -275,7 +275,9 @@ func TestCycleCallback_Parallel(t *testing.T) {
 				assert.Eventually(t, func() bool {
 					return atomic.LoadUint32(&started) == uint32(tt.due)
 				}, time.Second, 5*time.Millisecond)
-				assert.Less(t, runtime.NumGoroutine(), baseline+8)
+				// real count is due+1 (<=4); the regression spawns
+				// routinesLimit+1=33. 12 clears the ceiling with noise margin.
+				assert.Less(t, runtime.NumGoroutine(), baseline+12)
 
 				close(chRelease)
 				assert.True(t, <-chFinished)

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -13,8 +13,6 @@ package cyclemanager
 
 import (
 	"context"
-	"fmt"
-	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -232,57 +230,6 @@ func TestCycleCallback_Parallel(t *testing.T) {
 		assert.False(t, executed)
 		assert.Equal(t, 1, executedCounter1)
 		assert.Equal(t, 1, executedCounter2)
-	})
-
-	t.Run("workers capped at number of due callbacks", func(t *testing.T) {
-		tests := []struct {
-			name     string
-			due      int
-			inactive int
-		}{
-			{name: "1 due of 3", due: 1, inactive: 2},
-			{name: "3 due of 4", due: 3, inactive: 1},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				baseline := runtime.NumGoroutine()
-
-				started := uint32(0)
-				chRelease := make(chan struct{})
-				blocking := func(shouldAbort ShouldAbortCallback) bool {
-					atomic.AddUint32(&started, 1)
-					<-chRelease
-					return true
-				}
-				inactive := func(shouldAbort ShouldAbortCallback) bool { return true }
-
-				callbacks := NewCallbackGroup("id", logger, 32)
-				for i := range tt.due {
-					callbacks.Register(fmt.Sprintf("due-%d", i), blocking)
-				}
-				for i := range tt.inactive {
-					callbacks.Register(fmt.Sprintf("inactive-%d", i), inactive, AsInactive())
-				}
-
-				chFinished := make(chan bool)
-				go func() {
-					chFinished <- callbacks.CycleCallback(shouldNotAbort)
-				}()
-
-				// all due callbacks block in parallel: the pool is capped at
-				// the due count, not routinesLimit=32
-				assert.Eventually(t, func() bool {
-					return atomic.LoadUint32(&started) == uint32(tt.due)
-				}, time.Second, 5*time.Millisecond)
-				// real count is due+1 (<=4); the regression spawns
-				// routinesLimit+1=33. 12 clears the ceiling with noise margin.
-				assert.Less(t, runtime.NumGoroutine(), baseline+12)
-
-				close(chRelease)
-				assert.True(t, <-chFinished)
-			})
-		}
 	})
 
 	t.Run("idle tick prunes ids of unregistered callbacks", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Dont spawn workers if cyclemanger does not need to do any work


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
