### PR TITLE
Fix goroutine leak in listing all s3 backups

### DIFF
--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -125,18 +125,29 @@ func (s *s3Client) AllBackups(ctx context.Context,
 
 	// Construct the exact backup_config.json key for each backup ID prefix.
 	var keys []string
+	var listErr error
 	for info := range objectsInfo {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			listErr = err
+			break
 		}
 		if info.Err != nil {
-			return nil, fmt.Errorf("list objects: %w", info.Err)
+			listErr = fmt.Errorf("list objects: %w", info.Err)
+			break
 		}
 		// Non-recursive listing returns common prefixes (directories) as keys ending with "/".
 		// For each backup ID directory, the config file is at <prefix>backup_config.json.
 		if len(info.Key) > 0 && info.Key[len(info.Key)-1] == '/' {
 			keys = append(keys, info.Key+ubak.GlobalBackupFile)
 		}
+	}
+	if listErr != nil {
+		// Drain the channel as required by the ListObjects godoc ("caller
+		// must drain the channel entirely"); otherwise minio's producer
+		// goroutine blocks forever on an unguarded error-send.
+		for range objectsInfo {
+		}
+		return nil, listErr
 	}
 
 	return ubak.FetchBackupDescriptors(ctx, s.logger, keys, func(ctx context.Context, key string) ([]byte, error) {

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -12,9 +12,20 @@
 package modstgs3
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeObjectName(t *testing.T) {
@@ -130,4 +141,75 @@ func TestHomeDir(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+const (
+	listPage1 = `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>bucket</Name><Prefix>backups/</Prefix><Delimiter>/</Delimiter><CommonPrefixes><Prefix>backups/b0/</Prefix></CommonPrefixes><IsTruncated>true</IsTruncated><NextContinuationToken>t1</NextContinuationToken></ListBucketResult>`
+	listPage2 = `<?xml version="1.0" encoding="UTF-8"?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>bucket</Name><Prefix>backups/</Prefix><Delimiter>/</Delimiter><CommonPrefixes><Prefix>backups/b1/</Prefix></CommonPrefixes><CommonPrefixes><Prefix>backups/b2/</Prefix></CommonPrefixes><CommonPrefixes><Prefix>backups/b3/</Prefix></CommonPrefixes><IsTruncated>false</IsTruncated></ListBucketResult>`
+)
+
+// cancelOnSecondPageTransport fakes S3 ListObjectsV2: serving page 2 cancels
+// the listing context, so minio yields the page-2 items with ctx already
+// cancelled — the interleaving that leaks without the channel drain.
+type cancelOnSecondPageTransport struct {
+	mu     sync.Mutex
+	page   int
+	cancel context.CancelFunc
+}
+
+func (f *cancelOnSecondPageTransport) reset(cancel context.CancelFunc) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.page = 0
+	f.cancel = cancel
+}
+
+func (f *cancelOnSecondPageTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.page++
+	body := listPage1
+	if f.page > 1 {
+		body = listPage2
+		f.cancel()
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/xml"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    r,
+	}, nil
+}
+
+// AllBackups must drain the ListObjects channel on early return, otherwise
+// minio's producer goroutine blocks forever on an unguarded error-send.
+// The leaking interleaving is racy (~25% per run), hence the repetition.
+func TestAllBackupsNoGoroutineLeakOnCancel(t *testing.T) {
+	transport := &cancelOnSecondPageTransport{}
+	minioClient, err := minio.New("s3.example.invalid", &minio.Options{
+		Creds:     credentials.NewStaticV4("key", "secret", ""),
+		Region:    "us-east-1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+
+	s3c := &s3Client{
+		client: minioClient,
+		config: &clientConfig{Bucket: "bucket", BackupPath: "backups"},
+		logger: logrus.New(),
+	}
+
+	for i := 0; i < 50; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		transport.reset(cancel)
+		_, err := s3c.AllBackups(ctx)
+		require.Error(t, err)
+		cancel()
+	}
+
+	require.Eventually(t, func() bool {
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		return !strings.Contains(string(buf[:n]), "minio-go")
+	}, 3*time.Second, 50*time.Millisecond, "minio ListObjects producer goroutine leaked")
 }

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -208,8 +208,19 @@ func TestAllBackupsNoGoroutineLeakOnCancel(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		buf := make([]byte, 1<<20)
-		n := runtime.Stack(buf, true)
-		return !strings.Contains(string(buf[:n]), "minio-go")
+		return !strings.Contains(fullStackDump(), "minio-go")
 	}, 3*time.Second, 50*time.Millisecond, "minio ListObjects producer goroutine leaked")
+}
+
+// fullStackDump returns the full goroutine dump. runtime.Stack truncates
+// silently when the buffer is too small (n == len(buf)), so grow until it fits.
+func fullStackDump() string {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return string(buf[:n])
+		}
+		buf = make([]byte, 2*len(buf))
+	}
 }


### PR DESCRIPTION
### What's being changed:

Fixes a goroutine leak when an error occurred during backup listings: The minio channel needs to be drained in this case

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
