### PR TITLE
Switch cycle manager to backoff on idle

### DIFF
--- a/adapters/repos/db/index_cyclecallbacks.go
+++ b/adapters/repos/db/index_cyclecallbacks.go
@@ -44,6 +44,11 @@ type indexCycleCallbacks struct {
 func (index *Index) initCycleCallbacks() {
 	routinesN := concurrency.TimesGOMAXPROCS(index.Config.CycleManagerRoutinesFactor)
 
+	// Single-tenant collections let the shared ticker back off when idle, keeping
+	// many quiet collections cheap. Multi-tenant pins the min interval and relies on
+	// per-shard backoff; a shared backoff could stall a newly-active tenant by up to max.
+	backoff := !index.partitioningEnabled
+
 	vectorTombstoneCleanupIntervalSeconds := hnsw.DefaultCleanupIntervalSeconds
 	switch cfg := index.GetVectorIndexConfig("").(type) {
 	case hnsw.UserConfig:
@@ -69,7 +74,7 @@ func (index *Index) initCycleCallbacks() {
 		compactionCallbacks = cyclemanager.NewCallbackGroup(id("compaction"), index.logger, routinesN)
 		compactionCycle = cyclemanager.NewManager(
 			cm("compaction"),
-			cyclemanager.CompactionCycleTicker(),
+			cyclemanager.CompactionCycleTicker(backoff),
 			compactionCallbacks.CycleCallback, index.logger)
 		compactionAuxCycle = cyclemanager.NewManagerNoop()
 	} else {
@@ -77,19 +82,19 @@ func (index *Index) initCycleCallbacks() {
 		compactionCallbacks = cyclemanager.NewCallbackGroup(id("compaction-non-objects"), index.logger, routinesNDiv2)
 		compactionCycle = cyclemanager.NewManager(
 			cm("compaction-non-objects"),
-			cyclemanager.CompactionCycleTicker(),
+			cyclemanager.CompactionCycleTicker(backoff),
 			compactionCallbacks.CycleCallback, index.logger)
 		compactionAuxCallbacks = cyclemanager.NewCallbackGroup(id("compaction-objects"), index.logger, routinesNDiv2)
 		compactionAuxCycle = cyclemanager.NewManager(
 			cm("compaction-objects"),
-			cyclemanager.CompactionCycleTicker(),
+			cyclemanager.CompactionCycleTicker(backoff),
 			compactionAuxCallbacks.CycleCallback, index.logger)
 	}
 
 	flushCallbacks := cyclemanager.NewCallbackGroup(id("flush"), index.logger, routinesN)
 	flushCycle := cyclemanager.NewManager(
 		cm("flush"),
-		cyclemanager.MemtableFlushCycleTicker(),
+		cyclemanager.MemtableFlushCycleTicker(backoff),
 		flushCallbacks.CycleCallback, index.logger)
 
 	vectorCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(id("vector", "commit_logger"), index.logger, routinesN)
@@ -111,7 +116,7 @@ func (index *Index) initCycleCallbacks() {
 	// introduced to address https://github.com/weaviate/weaviate/issues/2783
 	vectorCommitLoggerCycle := cyclemanager.NewManager(
 		cm("vector", "commit_logger"),
-		cyclemanager.HnswCommitLoggerCycleTicker(),
+		cyclemanager.HnswCommitLoggerCycleTicker(backoff),
 		vectorCommitLoggerCallbacks.CycleCallback, index.logger)
 
 	vectorTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(id("vector", "tombstone_cleanup"), index.logger, routinesN)
@@ -123,7 +128,7 @@ func (index *Index) initCycleCallbacks() {
 	geoPropsCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(id("geo_props", "commit_logger"), index.logger, routinesN)
 	geoPropsCommitLoggerCycle := cyclemanager.NewManager(
 		cm("geo_props", "commit_logger"),
-		cyclemanager.GeoCommitLoggerCycleTicker(),
+		cyclemanager.GeoCommitLoggerCycleTicker(backoff),
 		geoPropsCommitLoggerCallbacks.CycleCallback, index.logger)
 
 	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(id("geo_props", "tombstone_cleanup"), index.logger, routinesN)

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -42,7 +42,7 @@ func newTestBucketWithFlushCycle(t *testing.T, opts ...BucketOption) *Bucket {
 	dirName := t.TempDir()
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
-	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(false), flushCallbacks.CycleCallback, logger)
 	flushCycle.Start()
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)

--- a/adapters/repos/db/shard_cyclecallbacks.go
+++ b/adapters/repos/db/shard_cyclecallbacks.go
@@ -41,6 +41,16 @@ func (s *Shard) initCycleCallbacks() {
 		return strings.Join(elems, "/")
 	}
 
+	// Multi-tenant collections back off per shard; single-tenant collections
+	// back off at the collection (ticker) level instead. Only one of the two
+	// should be active, otherwise the two backoffs interfere.
+	withIntervals := func(intervals cyclemanager.CycleIntervals) cyclemanager.RegisterOption {
+		if !s.index.partitioningEnabled {
+			return nil
+		}
+		return cyclemanager.WithIntervals(intervals)
+	}
+
 	var compactionCallbacks cyclemanager.CycleCallbackGroup
 	var compactionCallbacksCtrl cyclemanager.CycleCallbackCtrl
 	var compactionAuxCallbacks cyclemanager.CycleCallbackGroup
@@ -51,33 +61,33 @@ func (s *Shard) initCycleCallbacks() {
 		compactionCallbacks = cyclemanager.NewCallbackGroup(compactionId, s.index.logger, 1)
 		compactionCallbacksCtrl = s.index.cycleCallbacks.compactionCallbacks.Register(
 			compactionId, compactionCallbacks.CycleCallback,
-			cyclemanager.WithIntervals(cyclemanager.CompactionCycleIntervals()))
+			withIntervals(cyclemanager.CompactionCycleIntervals()))
 		compactionAuxCallbacksCtrl = cyclemanager.NewCallbackCtrlNoop()
 	} else {
 		compactionId := id("compaction-non-objects")
 		compactionCallbacks = cyclemanager.NewCallbackGroup(compactionId, s.index.logger, 1)
 		compactionCallbacksCtrl = s.index.cycleCallbacks.compactionCallbacks.Register(
 			compactionId, compactionCallbacks.CycleCallback,
-			cyclemanager.WithIntervals(cyclemanager.CompactionCycleIntervals()))
+			withIntervals(cyclemanager.CompactionCycleIntervals()))
 
 		compactionAuxId := id("compaction-objects")
 		compactionAuxCallbacks = cyclemanager.NewCallbackGroup(compactionAuxId, s.index.logger, 1)
 		compactionAuxCallbacksCtrl = s.index.cycleCallbacks.compactionAuxCallbacks.Register(
 			compactionAuxId, compactionAuxCallbacks.CycleCallback,
-			cyclemanager.WithIntervals(cyclemanager.CompactionCycleIntervals()))
+			withIntervals(cyclemanager.CompactionCycleIntervals()))
 	}
 
 	flushId := id("flush")
 	flushCallbacks := cyclemanager.NewCallbackGroup(flushId, s.index.logger, 1)
 	flushCallbacksCtrl := s.index.cycleCallbacks.flushCallbacks.Register(
 		flushId, flushCallbacks.CycleCallback,
-		cyclemanager.WithIntervals(cyclemanager.MemtableFlushCycleIntervals()))
+		withIntervals(cyclemanager.MemtableFlushCycleIntervals()))
 
 	vectorCommitLoggerId := id("vector", "commit_logger")
 	vectorCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(vectorCommitLoggerId, s.index.logger, 1)
 	vectorCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.vectorCommitLoggerCallbacks.Register(
 		vectorCommitLoggerId, vectorCommitLoggerCallbacks.CycleCallback,
-		cyclemanager.WithIntervals(cyclemanager.HnswCommitLoggerCycleIntervals()))
+		withIntervals(cyclemanager.HnswCommitLoggerCycleIntervals()))
 
 	vectorTombstoneCleanupId := id("vector", "tombstone_cleanup")
 	vectorTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(vectorTombstoneCleanupId, s.index.logger, 1)
@@ -92,7 +102,7 @@ func (s *Shard) initCycleCallbacks() {
 	geoPropsCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(geoPropsCommitLoggerId, s.index.logger, 1)
 	geoPropsCommitLoggerCallbacksCtrl := s.index.cycleCallbacks.geoPropsCommitLoggerCallbacks.Register(
 		geoPropsCommitLoggerId, geoPropsCommitLoggerCallbacks.CycleCallback,
-		cyclemanager.WithIntervals(cyclemanager.GeoCommitLoggerCycleIntervals()))
+		withIntervals(cyclemanager.GeoCommitLoggerCycleIntervals()))
 
 	geoPropsTombstoneCleanupId := id("geoProps", "tombstone_cleanup")
 	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(geoPropsTombstoneCleanupId, s.index.logger, 1)

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -45,7 +45,7 @@ func TestBackup_Integration(t *testing.T) {
 	parentCommitLoggerCallbacks := cyclemanager.NewCallbackGroup("parentCommitLogger", logger, 1)
 	parentCommitLoggerCycle := cyclemanager.NewManager(
 		"commit-logger",
-		cyclemanager.HnswCommitLoggerCycleTicker(),
+		cyclemanager.HnswCommitLoggerCycleTicker(false),
 		parentCommitLoggerCallbacks.CycleCallback, logger)
 	parentCommitLoggerCycle.Start()
 	defer parentCommitLoggerCycle.StopAndWait(ctx)

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -56,7 +56,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	parentCommitLoggerCallbacks := cyclemanager.NewCallbackGroup("parentCommitLogger", logger, 1)
 	parentCommitLoggerCycle := cyclemanager.NewManager(
 		"commit-logger",
-		cyclemanager.HnswCommitLoggerCycleTicker(),
+		cyclemanager.HnswCommitLoggerCycleTicker(false),
 		parentCommitLoggerCallbacks.CycleCallback, logger)
 	parentCommitLoggerCycle.Start()
 	defer parentCommitLoggerCycle.StopAndWait(ctx)

--- a/entities/cyclemanager/interval.go
+++ b/entities/cyclemanager/interval.go
@@ -26,10 +26,11 @@ func CompactionCycleIntervals() CycleIntervals {
 		compactionBase, compactionSteps)
 }
 
-// run cycle ticker with fixed minimal interval and let each shard
-// take care of its intervals
+// ticker backs off towards the max interval while cycles report no work
+// and resets to the min interval once work is done; each shard still
+// takes care of its own intervals underneath
 func CompactionCycleTicker() CycleTicker {
-	return NewFixedTicker(compactionMinInterval)
+	return newCycleTicker(CompactionCycleIntervals())
 }
 
 const (
@@ -45,10 +46,11 @@ func MemtableFlushCycleIntervals() CycleIntervals {
 		memtableFlushBase, memtableFlushSteps)
 }
 
-// run cycle ticker with fixed minimal interval and let each shard
-// take care of its intervals
+// ticker backs off towards the max interval while cycles report no work
+// and resets to the min interval once work is done; each shard still
+// takes care of its own intervals underneath
 func MemtableFlushCycleTicker() CycleTicker {
-	return NewFixedTicker(memtableFlushMinInterval)
+	return newCycleTicker(MemtableFlushCycleIntervals())
 }
 
 const (
@@ -64,10 +66,11 @@ func GeoCommitLoggerCycleIntervals() CycleIntervals {
 		geoCommitLoggerBase, geoCommitLoggerSteps)
 }
 
-// run cycle ticker with fixed minimal interval and let each shard
-// take care of its intervals
+// ticker backs off towards the max interval while cycles report no work
+// and resets to the min interval once work is done; each shard still
+// takes care of its own intervals underneath
 func GeoCommitLoggerCycleTicker() CycleTicker {
-	return NewFixedTicker(geoCommitLoggerMinInterval)
+	return newCycleTicker(GeoCommitLoggerCycleIntervals())
 }
 
 const (
@@ -83,8 +86,9 @@ func HnswCommitLoggerCycleIntervals() CycleIntervals {
 		hnswCommitLoggerBase, hnswCommitLoggerSteps)
 }
 
-// run cycle ticker with fixed minimal interval and let each shard
-// take care of its intervals
+// ticker backs off towards the max interval while cycles report no work
+// and resets to the min interval once work is done; each shard still
+// takes care of its own intervals underneath
 func HnswCommitLoggerCycleTicker() CycleTicker {
-	return NewFixedTicker(hnswCommitLoggerMinInterval)
+	return newCycleTicker(HnswCommitLoggerCycleIntervals())
 }

--- a/entities/cyclemanager/interval.go
+++ b/entities/cyclemanager/interval.go
@@ -26,10 +26,12 @@ func CompactionCycleIntervals() CycleIntervals {
 		compactionBase, compactionSteps)
 }
 
-// ticker backs off towards the max interval while cycles report no work
-// and resets to the min interval once work is done; each shard still
-// takes care of its own intervals underneath
-func CompactionCycleTicker() CycleTicker {
+// backoff true backs off towards the max interval while cycles report no work and
+// resets to min once work is done; false pins the fixed min interval.
+func CompactionCycleTicker(backoff bool) CycleTicker {
+	if !backoff {
+		return NewFixedTicker(compactionMinInterval)
+	}
 	return newCycleTicker(CompactionCycleIntervals())
 }
 
@@ -46,10 +48,12 @@ func MemtableFlushCycleIntervals() CycleIntervals {
 		memtableFlushBase, memtableFlushSteps)
 }
 
-// ticker backs off towards the max interval while cycles report no work
-// and resets to the min interval once work is done; each shard still
-// takes care of its own intervals underneath
-func MemtableFlushCycleTicker() CycleTicker {
+// backoff true backs off towards the max interval while cycles report no work and
+// resets to min once work is done; false pins the fixed min interval.
+func MemtableFlushCycleTicker(backoff bool) CycleTicker {
+	if !backoff {
+		return NewFixedTicker(memtableFlushMinInterval)
+	}
 	return newCycleTicker(MemtableFlushCycleIntervals())
 }
 
@@ -66,10 +70,12 @@ func GeoCommitLoggerCycleIntervals() CycleIntervals {
 		geoCommitLoggerBase, geoCommitLoggerSteps)
 }
 
-// ticker backs off towards the max interval while cycles report no work
-// and resets to the min interval once work is done; each shard still
-// takes care of its own intervals underneath
-func GeoCommitLoggerCycleTicker() CycleTicker {
+// backoff true backs off towards the max interval while cycles report no work and
+// resets to min once work is done; false pins the fixed min interval.
+func GeoCommitLoggerCycleTicker(backoff bool) CycleTicker {
+	if !backoff {
+		return NewFixedTicker(geoCommitLoggerMinInterval)
+	}
 	return newCycleTicker(GeoCommitLoggerCycleIntervals())
 }
 
@@ -86,9 +92,11 @@ func HnswCommitLoggerCycleIntervals() CycleIntervals {
 		hnswCommitLoggerBase, hnswCommitLoggerSteps)
 }
 
-// ticker backs off towards the max interval while cycles report no work
-// and resets to the min interval once work is done; each shard still
-// takes care of its own intervals underneath
-func HnswCommitLoggerCycleTicker() CycleTicker {
+// backoff true backs off towards the max interval while cycles report no work and
+// resets to min once work is done; false pins the fixed min interval.
+func HnswCommitLoggerCycleTicker(backoff bool) CycleTicker {
+	if !backoff {
+		return NewFixedTicker(hnswCommitLoggerMinInterval)
+	}
 	return newCycleTicker(HnswCommitLoggerCycleIntervals())
 }

--- a/entities/cyclemanager/interval_test.go
+++ b/entities/cyclemanager/interval_test.go
@@ -1,0 +1,159 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cyclemanager
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CycleTickersBackOffWhenIdle(t *testing.T) {
+	type testCase struct {
+		name      string
+		newTicker func() CycleTicker
+		intervals func() CycleIntervals
+	}
+
+	testCases := []testCase{
+		{
+			name:      "compaction",
+			newTicker: CompactionCycleTicker,
+			intervals: CompactionCycleIntervals,
+		},
+		{
+			name:      "memtable flush",
+			newTicker: MemtableFlushCycleTicker,
+			intervals: MemtableFlushCycleIntervals,
+		},
+		{
+			name:      "geo commit logger",
+			newTicker: GeoCommitLoggerCycleTicker,
+			intervals: GeoCommitLoggerCycleIntervals,
+		},
+		{
+			name:      "hnsw commit logger",
+			newTicker: HnswCommitLoggerCycleTicker,
+			intervals: HnswCommitLoggerCycleIntervals,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := collectIntervals(tc.intervals())
+			require.Greater(t, len(expected), 1)
+			min := expected[0]
+			max := expected[len(expected)-1]
+
+			synctest.Test(t, func(t *testing.T) {
+				ticker := tc.newTicker()
+				ticker.Start()
+				defer ticker.Stop()
+
+				// each idle cycle advances the interval up to max
+				for _, want := range expected {
+					start := time.Now()
+					time.Sleep(want)
+					synctest.Wait()
+
+					tick := <-ticker.C()
+					assert.Equal(t, want, tick.Sub(start))
+
+					ticker.CycleExecuted(false)
+				}
+
+				// further idle cycles stay at max
+				start := time.Now()
+				time.Sleep(max)
+				synctest.Wait()
+
+				tick := <-ticker.C()
+				assert.Equal(t, max, tick.Sub(start))
+
+				// work resets to min
+				ticker.CycleExecuted(true)
+				start = time.Now()
+				time.Sleep(min)
+				synctest.Wait()
+
+				tick = <-ticker.C()
+				assert.Equal(t, min, tick.Sub(start))
+			})
+		})
+	}
+}
+
+func Test_CycleManagerBacksOffWhenIdle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var wakes int
+		busy := false
+
+		cycleCallback := func(shouldAbort ShouldAbortCallback) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			wakes++
+			return busy
+		}
+
+		cm := NewManager("test", MemtableFlushCycleTicker(), cycleCallback, logger)
+		cm.Start()
+
+		// idle: 100ms . 258ms .. 574ms .... 1.206s ........ 2.471s
+		// ................ 5s, then every 5s => 16 wakes in a minute
+		// (a fixed 100ms ticker would wake ~600 times)
+		time.Sleep(time.Minute)
+		synctest.Wait()
+
+		mu.Lock()
+		idleWakes := wakes
+		busy = true
+		mu.Unlock()
+
+		assert.Greater(t, idleWakes, 5)
+		assert.Less(t, idleWakes, 30)
+
+		// work: one tick at the current (max) interval picks the work up,
+		// then the ticker snaps back to the 100ms floor
+		time.Sleep(memtableFlushMaxInterval + time.Second)
+		synctest.Wait()
+
+		mu.Lock()
+		busyWakes := wakes - idleWakes
+		mu.Unlock()
+
+		assert.GreaterOrEqual(t, busyWakes, 8)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, cm.StopAndWait(ctx))
+	})
+}
+
+// collectIntervals advances given intervals until the value no longer
+// changes, returning the full min-to-max series
+func collectIntervals(intervals CycleIntervals) []time.Duration {
+	out := []time.Duration{intervals.Get()}
+	for {
+		intervals.Advance()
+		next := intervals.Get()
+		if next == out[len(out)-1] {
+			return out
+		}
+		out = append(out, next)
+	}
+}

--- a/entities/cyclemanager/interval_test.go
+++ b/entities/cyclemanager/interval_test.go
@@ -32,22 +32,22 @@ func Test_CycleTickersBackOffWhenIdle(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:      "compaction",
-			newTicker: CompactionCycleTicker,
+			newTicker: func() CycleTicker { return CompactionCycleTicker(true) },
 			intervals: CompactionCycleIntervals,
 		},
 		{
 			name:      "memtable flush",
-			newTicker: MemtableFlushCycleTicker,
+			newTicker: func() CycleTicker { return MemtableFlushCycleTicker(true) },
 			intervals: MemtableFlushCycleIntervals,
 		},
 		{
 			name:      "geo commit logger",
-			newTicker: GeoCommitLoggerCycleTicker,
+			newTicker: func() CycleTicker { return GeoCommitLoggerCycleTicker(true) },
 			intervals: GeoCommitLoggerCycleIntervals,
 		},
 		{
 			name:      "hnsw commit logger",
-			newTicker: HnswCommitLoggerCycleTicker,
+			newTicker: func() CycleTicker { return HnswCommitLoggerCycleTicker(true) },
 			intervals: HnswCommitLoggerCycleIntervals,
 		},
 	}
@@ -110,7 +110,7 @@ func Test_CycleManagerBacksOffWhenIdle(t *testing.T) {
 			return busy
 		}
 
-		cm := NewManager("test", MemtableFlushCycleTicker(), cycleCallback, logger)
+		cm := NewManager("test", MemtableFlushCycleTicker(true), cycleCallback, logger)
 		cm.Start()
 
 		// idle: 100ms . 258ms .. 574ms .... 1.206s ........ 2.471s

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -47,9 +47,9 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", logger, 1)
 	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", logger, 1)
-	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(false), flushCallbacks.CycleCallback, logger)
 	flushCycle.Start()
-	compactionCycle := cyclemanager.NewManager("compaction", cyclemanager.CompactionCycleTicker(), compactionCallbacks.CycleCallback, logger)
+	compactionCycle := cyclemanager.NewManager("compaction", cyclemanager.CompactionCycleTicker(false), compactionCallbacks.CycleCallback, logger)
 	compactionCycle.Start()
 
 	bucket, err := c.NewBucket(ctx, filepath.Join(dir, "my-bucket"), "", logger, nil,

--- a/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
@@ -58,9 +58,9 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", logger, 1)
 	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", logger, 1)
-	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(false), flushCallbacks.CycleCallback, logger)
 	flushCycle.Start()
-	compactionCycle := cyclemanager.NewManager("compaction", cyclemanager.CompactionCycleTicker(), compactionCallbacks.CycleCallback, logger)
+	compactionCycle := cyclemanager.NewManager("compaction", cyclemanager.CompactionCycleTicker(false), compactionCallbacks.CycleCallback, logger)
 	compactionCycle.Start()
 
 	logger.Info("loading bucket")


### PR DESCRIPTION
### What's being changed:

This switches the cyclemanager to use a backoff timer if the collection is idle. As soon as some work is done, it switches back to the default numbers. Note that everything already exists, it was just wired up.

- after: Showing nodes accounting for 6.71s, 87.71% of 7.65s total
- before: Showing nodes accounting for 35.93s, 76.37% of 47.05s total

=> 6 times reduction in idle CPU

Overview of behaviour:

  | Cycle | Floor (= old fixed behavior) | Max after full idle ramp | Worst-case added latency |
  |---|---|---|---|
  | Memtable flush | 100ms | 5s | ~4.9s |
  | HNSW commit logger | 500ms | 10s | ~9.5s |
  | Compaction | 3s | 60s | ~57s |
  | Geo commit logger | 10s | 60s | ~50s |

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
