### PR TITLE
Only list files once in commitlogger

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_log_combiner.go
+++ b/adapters/repos/db/vector/hnsw/commit_log_combiner.go
@@ -43,18 +43,14 @@ func NewCommitLogCombiner(rootPath, id string, threshold int64,
 	}
 }
 
-func (c *CommitLogCombiner) Do(partitions ...string) (bool, error) {
+// Do expects a current listing of the commit log directory, ordered from old
+// to new.
+func (c *CommitLogCombiner) Do(fileNames []string, partitions ...string) (bool, error) {
 	// ensure partitions are sorted
 	sort.Strings(partitions)
 
 	executed := false
 	for {
-		// fileNames will already be in order
-		fileNames, err := getCommitFileNames(c.rootPath, c.id, 0, c.fs)
-		if err != nil {
-			return executed, errors.Wrap(err, "obtain files names")
-		}
-
 		anyOk := false
 		for _, partFileNames := range c.partitonFileNames(fileNames, partitions) {
 			ok, err := c.combineFirstMatch(partFileNames)
@@ -67,6 +63,13 @@ func (c *CommitLogCombiner) Do(partitions ...string) (bool, error) {
 			break
 		}
 		executed = true
+
+		// combining renamed files, refresh the listing for the next round
+		var err error
+		fileNames, err = getCommitFileNames(c.rootPath, c.id, 0, c.fs)
+		if err != nil {
+			return executed, errors.Wrap(err, "obtain files names")
+		}
 	}
 	return executed, nil
 }

--- a/adapters/repos/db/vector/hnsw/commit_log_combiner_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_log_combiner_integration_test.go
@@ -56,7 +56,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 		})
 
 		t.Run("run combiner", func(t *testing.T) {
-			_, err := NewCommitLogCombiner(rootPath, id, threshold, logger, common.NewOSFS()).Do()
+			_, err := NewCommitLogCombiner(rootPath, id, threshold, logger, common.NewOSFS()).Do(listCommitFiles(t, rootPath, id, common.NewOSFS()))
 			require.Nil(t, err)
 		})
 
@@ -138,7 +138,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 			})
 
 			t.Run("combine", func(t *testing.T) {
-				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do()
+				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do(listCommitFiles(t, rootPath, id, common.NewOSFS()))
 				require.NoError(t, err)
 			})
 
@@ -163,7 +163,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 			})
 
 			t.Run("combine", func(t *testing.T) {
-				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do("1004", "1008")
+				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do(listCommitFiles(t, rootPath, id, common.NewOSFS()), "1004", "1008")
 				require.NoError(t, err)
 			})
 
@@ -188,7 +188,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 			})
 
 			t.Run("combine", func(t *testing.T) {
-				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do("1003", "1006")
+				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do(listCommitFiles(t, rootPath, id, common.NewOSFS()), "1003", "1006")
 				require.NoError(t, err)
 			})
 
@@ -214,7 +214,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 			})
 
 			t.Run("combine", func(t *testing.T) {
-				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do("1003")
+				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do(listCommitFiles(t, rootPath, id, common.NewOSFS()), "1003")
 				require.NoError(t, err)
 			})
 
@@ -242,7 +242,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 			})
 
 			t.Run("combine", func(t *testing.T) {
-				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do("1005")
+				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do(listCommitFiles(t, rootPath, id, common.NewOSFS()), "1005")
 				require.NoError(t, err)
 			})
 
@@ -268,7 +268,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 			})
 
 			t.Run("combine", func(t *testing.T) {
-				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do("1005")
+				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do(listCommitFiles(t, rootPath, id, common.NewOSFS()), "1005")
 				require.NoError(t, err)
 			})
 
@@ -296,7 +296,8 @@ func Test_CommitlogCombiner(t *testing.T) {
 			})
 
 			t.Run("combine", func(t *testing.T) {
-				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do("1001", "1002",
+				_, err := NewCommitLogCombiner(rootPath, id, int64(threshold), logger, common.NewOSFS()).Do(
+					listCommitFiles(t, rootPath, id, common.NewOSFS()), "1001", "1002",
 					"1003", "1004", "1005", "1006", "1007", "1008", "1009", "1010")
 				require.NoError(t, err)
 			})
@@ -424,11 +425,11 @@ func TestCombinerCrashSafety(t *testing.T) {
 				cl, err := NewCommitLogger(rootPath, id, logger, cyclemanager.NewCallbackGroupNoop())
 				require.NoError(t, err)
 				cl.fs = fs
-				_, err = cl.combineLogs()
+				_, err = cl.combineLogs(listCommitFiles(t, rootPath, id, cl.fs))
 				require.Error(t, err)
 
 				// combine again, should work file
-				_, err = cl.combineLogs()
+				_, err = cl.combineLogs(listCommitFiles(t, rootPath, id, cl.fs))
 				require.NoError(t, err)
 
 				verifyFiles(t, rootPath, id)
@@ -456,11 +457,11 @@ func TestCombinerCrashSafety(t *testing.T) {
 		cl, err := NewCommitLogger(rootPath, id, logger, cyclemanager.NewCallbackGroupNoop())
 		require.NoError(t, err)
 		cl.fs = fs
-		_, err = cl.combineLogs()
+		_, err = cl.combineLogs(listCommitFiles(t, rootPath, id, cl.fs))
 		require.Error(t, err)
 
 		// combine again, should work
-		_, err = cl.combineLogs()
+		_, err = cl.combineLogs(listCommitFiles(t, rootPath, id, cl.fs))
 		require.NoError(t, err)
 
 		verifyFiles(t, rootPath, id)
@@ -486,14 +487,14 @@ func TestCombinerCrashSafety(t *testing.T) {
 		cl, err := NewCommitLogger(rootPath, id, logger, cyclemanager.NewCallbackGroupNoop())
 		cl.fs = fs
 		require.NoError(t, err)
-		_, err = cl.combineLogs()
+		_, err = cl.combineLogs(listCommitFiles(t, rootPath, id, cl.fs))
 		require.Error(t, err)
 
-		err = cl.fixCorruptedCommitLogs()
+		_, err = cl.fixCorruptedCommitLogs(listCommitFiles(t, rootPath, id, cl.fs))
 		require.NoError(t, err)
 
 		// combine again, should work
-		_, err = cl.combineLogs()
+		_, err = cl.combineLogs(listCommitFiles(t, rootPath, id, cl.fs))
 		require.NoError(t, err)
 
 		// verify files, we would expect
@@ -521,10 +522,17 @@ func TestCombinerCrashSafety(t *testing.T) {
 		cl, err := NewCommitLogger(rootPath, id, logger, cyclemanager.NewCallbackGroupNoop())
 		require.NoError(t, err)
 		cl.fs = fs
-		_, err = cl.combineLogs()
+		_, err = cl.combineLogs(listCommitFiles(t, rootPath, id, cl.fs))
 		require.NoError(t, err)
 		require.True(t, fsyncCalled, "fsync was not called")
 	})
+}
+
+func listCommitFiles(t *testing.T, rootPath, id string, fs common.FS) []string {
+	t.Helper()
+	fileNames, err := getCommitFileNames(rootPath, id, 0, fs)
+	require.NoError(t, err)
+	return fileNames
 }
 
 func getFileNames(t *testing.T, rootPath string) []string {
@@ -579,7 +587,7 @@ func TestCondensorCombiningCrashSafety(t *testing.T) {
 		fs.OnRemove = func(name string) error {
 			return errors.Errorf("fake temp error: cannot remove")
 		}
-		executed, err := NewCommitLogCombiner(rootPath, id, 1000, logger, fs).Do()
+		executed, err := NewCommitLogCombiner(rootPath, id, 1000, logger, fs).Do(listCommitFiles(t, rootPath, id, fs))
 		require.False(t, executed)
 		require.ErrorContains(t, err, "fake temp error: cannot remove")
 		fileNames = getFileNames(t, rootPath)

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -599,29 +599,54 @@ func (l *hnswCommitLogger) startSwitchLogs(shouldAbort cyclemanager.ShouldAbortC
 }
 
 func (l *hnswCommitLogger) startCommitLogsMaintenance(shouldAbort cyclemanager.ShouldAbortCallback) bool {
-	err := l.fixCorruptedCommitLogs()
-	if err != nil {
-		l.logger.WithError(err).
-			WithField("action", "hnsw_commit_log_fixing").
-			Error("hnsw commit log maintenance (fixing) failed")
-	}
+	executedCombine := false
+	executedCondense := false
 
-	executedCombine, err := l.combineLogs()
+	// one listing shared across phases, refreshed only after changes
+	fileNames, err := getCommitFileNames(l.rootPath, l.id, 0, l.fs)
 	if err != nil {
 		l.logger.WithError(err).
-			WithField("action", "hnsw_commit_log_combining").
+			WithField("action", "hnsw_commit_log_maintenance").
 			WithField("file", l.rootPath).
 			WithField("id", l.id).
-			Error("hnsw commit log maintenance (combining) failed")
-	}
+			Error("hnsw commit log maintenance (listing) failed")
+	} else {
+		fileNames, err = l.fixCorruptedCommitLogs(fileNames)
+		if err != nil {
+			l.logger.WithError(err).
+				WithField("action", "hnsw_commit_log_fixing").
+				Error("hnsw commit log maintenance (fixing) failed")
+		}
 
-	executedCondense, err := l.condenseLogs()
-	if err != nil {
-		l.logger.WithError(err).
-			WithField("action", "hnsw_commit_log_condensing").
-			WithField("file", l.rootPath).
-			WithField("id", l.id).
-			Error("hnsw commit log maintenance (condensing) failed")
+		executedCombine, err = l.combineLogs(fileNames)
+		if err != nil {
+			l.logger.WithError(err).
+				WithField("action", "hnsw_commit_log_combining").
+				WithField("file", l.rootPath).
+				WithField("id", l.id).
+				Error("hnsw commit log maintenance (combining) failed")
+		}
+
+		if executedCombine {
+			fileNames, err = getCommitFileNames(l.rootPath, l.id, 0, l.fs)
+			if err != nil {
+				l.logger.WithError(err).
+					WithField("action", "hnsw_commit_log_maintenance").
+					WithField("file", l.rootPath).
+					WithField("id", l.id).
+					Error("hnsw commit log maintenance (listing) failed")
+				fileNames = nil
+			}
+		}
+
+		executedCondense, err = l.condenseLogs(fileNames)
+		if err != nil {
+			l.logger.WithError(err).
+				WithField("action", "hnsw_commit_log_condensing").
+				WithField("file", l.rootPath).
+				WithField("id", l.id).
+				Error("hnsw commit log maintenance (condensing) failed")
+		}
 	}
 
 	executedSnapshot, err := l.createSnapshot(shouldAbort)
@@ -698,12 +723,8 @@ func (l *hnswCommitLogger) switchCommitLogs(force bool) (bool, error) {
 	return true, nil
 }
 
-func (l *hnswCommitLogger) condenseLogs() (bool, error) {
-	files, err := getCommitFileNames(l.rootPath, l.id, 0, l.fs)
-	if err != nil {
-		return false, err
-	}
-
+// condenseLogs expects a current listing of the commit log directory.
+func (l *hnswCommitLogger) condenseLogs(files []string) (bool, error) {
 	if len(files) <= 1 {
 		// if there are no files there is nothing to do
 		// if there is only a single file, it must still be in use, we can't do
@@ -749,13 +770,14 @@ func (l *hnswCommitLogger) condenseLogs() (bool, error) {
 	return false, nil
 }
 
-func (l *hnswCommitLogger) combineLogs() (bool, error) {
+// combineLogs expects a current listing of the commit log directory.
+func (l *hnswCommitLogger) combineLogs(fileNames []string) (bool, error) {
 	// maxSize is the desired final size, since we assume a lot of redundancy we
 	// can set the combining threshold higher than the final threshold under the
 	// assumption that the combined file will be considerably smaller than the
 	// sum of both input files
 	threshold := l.logCombiningThreshold()
-	return NewCommitLogCombiner(l.rootPath, l.id, threshold, l.logger, l.fs).Do(l.snapshotPartitions...)
+	return NewCommitLogCombiner(l.rootPath, l.id, threshold, l.logger, l.fs).Do(fileNames, l.snapshotPartitions...)
 }
 
 // TODO al:snapshot handle should abort
@@ -811,11 +833,7 @@ func (l *hnswCommitLogger) Flush() error {
 	return l.commitLogger.Flush()
 }
 
-func (l *hnswCommitLogger) fixCorruptedCommitLogs() error {
-	fileNames, err := getCommitFileNames(l.rootPath, l.id, 0, l.fs)
-	if err != nil {
-		return err
-	}
-	_, err = NewCorruptedCommitLogFixer().Do(fileNames)
-	return err
+// fixCorruptedCommitLogs deletes corrupt files and returns the remaining listing.
+func (l *hnswCommitLogger) fixCorruptedCommitLogs(fileNames []string) ([]string, error) {
+	return NewCorruptedCommitLogFixer().Do(fileNames)
 }

--- a/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer.go
+++ b/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer.go
@@ -13,9 +13,11 @@ package hnsw
 
 import (
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 )
 
 // CorruptCommitLogFixer helps identify potentially corrupt commit logs and
@@ -36,42 +38,32 @@ func NewCorruptedCommitLogFixer() *CorruptCommitLogFixer {
 // original file. We thus assume the file must be corrupted, and delete it, so
 // that the original will be used instead.
 func (fixer *CorruptCommitLogFixer) Do(fileNames []string) ([]string, error) {
-	out := make([]string, len(fileNames))
+	out := make([]string, 0, len(fileNames))
 
-	i := 0
+	// keep processing remaining files even if a delete fails, so the returned
+	// list always reflects every surviving (non-corrupt) file rather than
+	// being truncated at the first error
+	ec := errorcompounder.New()
 	for _, fileName := range fileNames {
 		if !strings.HasSuffix(fileName, ".condensed") {
 			// has no suffix, so it can never be considered corrupt
-			out[i] = fileName
-			i++
+			out = append(out, fileName)
 			continue
 		}
 
 		// this file has a suffix, check if one without the suffix exists as well
-		if !fixer.listContains(fileNames, strings.TrimSuffix(fileName, ".condensed")) {
+		if !slices.Contains(fileNames, strings.TrimSuffix(fileName, ".condensed")) {
 			// does not seem corrupt, proceed
-			out[i] = fileName
-			i++
+			out = append(out, fileName)
 			continue
 		}
 
-		// we have found a corrupt file, delete it and do not append it to the list
+		// we have found a corrupt file, delete it and do not append it to the
+		// list. The index must not read it even if the delete fails.
 		if err := os.Remove(fileName); err != nil {
-			return out[:i], errors.Wrapf(err, "delete corrupt commit log file %q", fileName)
+			ec.Add(errors.Wrapf(err, "delete corrupt commit log file %q", fileName))
 		}
 	}
 
-	return out[:i], nil
-}
-
-func (fixer *CorruptCommitLogFixer) listContains(haystack []string,
-	needle string,
-) bool {
-	for _, hay := range haystack {
-		if hay == needle {
-			return true
-		}
-	}
-
-	return false
+	return out, ec.ToError()
 }

--- a/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer.go
+++ b/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer.go
@@ -57,7 +57,7 @@ func (fixer *CorruptCommitLogFixer) Do(fileNames []string) ([]string, error) {
 
 		// we have found a corrupt file, delete it and do not append it to the list
 		if err := os.Remove(fileName); err != nil {
-			return out, errors.Wrapf(err, "delete corrupt commit log file %q", fileName)
+			return out[:i], errors.Wrapf(err, "delete corrupt commit log file %q", fileName)
 		}
 	}
 

--- a/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer_test.go
+++ b/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer_test.go
@@ -54,4 +54,26 @@ func TestCorruptCommitLogFixer_Do(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, []string{f}, files)
 	})
+
+	t.Run("keeps surviving files when a delete fails", func(t *testing.T) {
+		tmp := t.TempDir()
+		// commit5.log + commit5.log.condensed make the .condensed file corrupt,
+		// so the fixer will try to delete it. Making it a non-empty directory
+		// makes os.Remove fail, exercising the error path.
+		twin := filepath.Join(tmp, "commit5.log")
+		corrupt := filepath.Join(tmp, "commit5.log.condensed")
+		tail := filepath.Join(tmp, "commit6.log")
+		require.Nil(t, os.WriteFile(twin, []byte("twin"), 0o644))
+		require.Nil(t, os.MkdirAll(corrupt, 0o755))
+		require.Nil(t, os.WriteFile(filepath.Join(corrupt, "blocker"), []byte("x"), 0o644))
+		require.Nil(t, os.WriteFile(tail, []byte("tail"), 0o644))
+
+		fixer := NewCorruptedCommitLogFixer()
+		files, err := fixer.Do([]string{twin, corrupt, tail})
+		// the failed delete is reported...
+		require.Error(t, err)
+		// ...but the corrupt file is still excluded and the valid tail file
+		// after it survives instead of being truncated away
+		require.Equal(t, []string{twin, tail}, files)
+	})
 }


### PR DESCRIPTION
### What's being changed:

Changes the HNSW commit-log maintenance tick to list the files only once per tick to reduce the CPU load. With 1000 collections the idle load reduces by 20% due to this change

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
