### PR TITLE
fix(rest): return 422 when query limit+offset exceeds QUERY_MAXIMUM_RESULTS …

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -257,6 +257,9 @@ func (h *objectHandlers) getObjects(params objects.ObjectsListParams,
 		case errors.As(err, &uco.ErrEndpointGone{}):
 			return objects.NewObjectsListGone().
 				WithPayload(errPayloadFromSingleErr(principal, err))
+		case errors.As(err, &uco.ErrInvalidUserInput{}):
+			return objects.NewObjectsClassGetUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return objects.NewObjectsListInternalServerError().
 				WithPayload(errPayloadFromSingleErr(principal, err))

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -164,9 +164,10 @@ func (m *Manager) getObjectsFromRepo(ctx context.Context,
 	offset, limit *int64, sort, order *string, after *string,
 	additional additional.Properties, tenant string,
 ) ([]*models.Object, error) {
+
 	smartOffset, smartLimit, err := m.localOffsetLimit(offset, limit)
 	if err != nil {
-		return nil, NewErrInternal("list objects: %v", err)
+		return nil, NewErrInvalidUserInput("list objects: %v", err)
 	}
 	if after != nil {
 		return nil, NewErrInternal("list objects: after parameter not allowed, cursor must be specific to one class, set class query param")
@@ -231,7 +232,7 @@ func (m *Manager) localOffsetOrZero(paramOffset *int64) int {
 	return int(offset)
 }
 
-func (m *Manager) localLimitOrGlobalLimit(offset int64, paramMaxResults *int64) int {
+func (m *Manager) localLimitOrGlobalLimit(paramMaxResults *int64) int {
 	limit := int64(m.config.Config.QueryDefaults.Limit)
 	// Get the max results from params, if exists
 	if paramMaxResults != nil {
@@ -242,8 +243,17 @@ func (m *Manager) localLimitOrGlobalLimit(offset int64, paramMaxResults *int64) 
 }
 
 func (m *Manager) localOffsetLimit(paramOffset *int64, paramLimit *int64) (int, int, error) {
+
 	offset := m.localOffsetOrZero(paramOffset)
-	limit := m.localLimitOrGlobalLimit(int64(offset), paramLimit)
+	limit := m.localLimitOrGlobalLimit(paramLimit)
+
+	if offset < 0 {
+		return 0, 0, fmt.Errorf("offset must be >= 0")
+	}
+
+	if limit < 0 {
+		return 0, 0, fmt.Errorf("limit must be >= 0")
+	}
 
 	if int64(offset+limit) > m.config.Config.QueryMaximumResults {
 		return 0, 0, fmt.Errorf(

--- a/usecases/objects/get_test.go
+++ b/usecases/objects/get_test.go
@@ -276,7 +276,18 @@ func Test_GetAction(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "query maximum results exceeded")
 	})
-
+	t.Run("with negative limit", func(t *testing.T) {
+		reset()
+		_, err := manager.GetObjects(context.Background(), &models.Principal{}, ptInt64(10), ptInt64(-1), nil, nil, nil, additional.Properties{}, "")
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "limit must be >= 0")
+	})
+	t.Run("with negative offset", func(t *testing.T) {
+		reset()
+		_, err := manager.GetObjects(context.Background(), &models.Principal{}, ptInt64(-1), ptInt64(10), nil, nil, nil, additional.Properties{}, "")
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "offset must be >= 0")
+	})
 	t.Run("additional props", func(t *testing.T) {
 		t.Run("on get single requests", func(t *testing.T) {
 			t.Run("feature projection", func(t *testing.T) {

--- a/usecases/objects/get_test.go
+++ b/usecases/objects/get_test.go
@@ -276,17 +276,45 @@ func Test_GetAction(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "query maximum results exceeded")
 	})
-	t.Run("with negative limit", func(t *testing.T) {
-		reset()
-		_, err := manager.GetObjects(context.Background(), &models.Principal{}, ptInt64(10), ptInt64(-1), nil, nil, nil, additional.Properties{}, "")
-		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), "limit must be >= 0")
-	})
-	t.Run("with negative offset", func(t *testing.T) {
-		reset()
-		_, err := manager.GetObjects(context.Background(), &models.Principal{}, ptInt64(-1), ptInt64(10), nil, nil, nil, additional.Properties{}, "")
-		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), "offset must be >= 0")
+	t.Run("negative pagination values", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			offset   *int64
+			limit    *int64
+			expected string
+		}{
+			{
+				name:     "negative limit",
+				offset:   ptInt64(10),
+				limit:    ptInt64(-1),
+				expected: "limit must be >= 0",
+			},
+			{
+				name:     "negative offset",
+				offset:   ptInt64(-1),
+				limit:    ptInt64(10),
+				expected: "offset must be >= 0",
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				reset()
+
+				_, err := manager.GetObjects(
+					context.Background(),
+					&models.Principal{},
+					tc.offset,
+					tc.limit,
+					nil, nil, nil,
+					additional.Properties{},
+					"",
+				)
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expected)
+			})
+		}
 	})
 	t.Run("additional props", func(t *testing.T) {
 		t.Run("on get single requests", func(t *testing.T) {


### PR DESCRIPTION
…or when offset or limit have negative values

### What's being changed:
The REST list endpoint `(GET /v1/objects) `  now returns `422: Unpocessable Entity`  instead of `500: Internal Server Error` when the `limit + offset ` exceeds `QUERY_MAXIMUM_RESULTS` or when `limit < 0` or when `offset < 0`

Fixes [#11661](https://github.com/weaviate/weaviate/issues/11661).

### Code of Conduct
- [x] I have read and agree to the Weaviate's [Contributor Guide](https://weaviate.io/developers/contributor-guide) and [Code of Conduct](https://weaviate.io/service/code-of-conduct)
