### PR TITLE
fix: extend token fetch retry budget

### DIFF
--- a/usecases/modulecomponents/gcpcommon/auth_broker.go
+++ b/usecases/modulecomponents/gcpcommon/auth_broker.go
@@ -29,7 +29,7 @@ type AuthBrokerTokenSource struct {
 	client   *http.Client
 }
 
-const maxRetries = 3
+const maxRetries = 5
 
 var (
 	httpClientTimeout      = 5 * time.Second
@@ -65,8 +65,8 @@ func (b *AuthBrokerTokenSource) Token() (*oauth2.Token, error) {
 
 func (b *AuthBrokerTokenSource) fetchTokenWithRetry(ctx context.Context, identityToken string) (*oauth2.Token, error) {
 	backoff := gax.Backoff{
-		Initial:    200 * time.Millisecond,
-		Max:        2 * time.Second,
+		Initial:    500 * time.Millisecond,
+		Max:        3 * time.Second,
 		Multiplier: 2,
 	}
 


### PR DESCRIPTION
### What's being changed:

Increase the auth-broker token fetch retry budget from a worst-case ~600ms of backoff sleep across 3 attempts to ~6.5s across 5 attempts. This gives transient broker hiccups more room to recover before surfacing a failure to callers.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
