### PR TITLE
fix(runtime-config): add validation for default_vector_index runtime setting

### DIFF
--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -490,13 +490,18 @@ func NewRestrictionCompressionTypeListValidator() func([]string) error {
 // back from. The "none" sentinel is reserved for indexes dropped via
 // DeleteClassVectorIndex and must never appear as a class-creation default —
 // both env-time and runtime-override paths share this rule.
+//
+// The check is strict (exact match, no lowercase/trim) because
+// DynamicValue.SetValue stores the value verbatim and downstream parsers
+// (e.g. usecases/schema/parser.parseGivenVectorIndexConfig) compare
+// case-sensitively. Callers that need to accept mixed-case input — like the
+// env path — normalize before calling SetValue.
 func NewDefaultVectorIndexValidator() func(string) error {
 	return func(val string) error {
-		v := strings.ToLower(strings.TrimSpace(val))
-		if v == "" {
+		if val == "" {
 			return nil
 		}
-		if !slices.Contains(validRestrictionVectorIndexTypes, v) {
+		if !slices.Contains(validRestrictionVectorIndexTypes, val) {
 			return fmt.Errorf("invalid DEFAULT_VECTOR_INDEX %q, must be one of: %v",
 				val, validRestrictionVectorIndexTypes)
 		}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -485,6 +485,25 @@ func NewRestrictionCompressionTypeListValidator() func([]string) error {
 	return makeRestrictionListValidator(validRestrictionCompressionTypes, "ALLOWED_COMPRESSION_TYPES")
 }
 
+// NewDefaultVectorIndexValidator returns the per-value validator attached to
+// DefaultVectorIndexType. Empty means "unset", which the defaults path falls
+// back from. The "none" sentinel is reserved for indexes dropped via
+// DeleteClassVectorIndex and must never appear as a class-creation default —
+// both env-time and runtime-override paths share this rule.
+func NewDefaultVectorIndexValidator() func(string) error {
+	return func(val string) error {
+		v := strings.ToLower(strings.TrimSpace(val))
+		if v == "" {
+			return nil
+		}
+		if !slices.Contains(validRestrictionVectorIndexTypes, v) {
+			return fmt.Errorf("invalid DEFAULT_VECTOR_INDEX %q, must be one of: %v",
+				val, validRestrictionVectorIndexTypes)
+		}
+		return nil
+	}
+}
+
 // ValidateRestrictionsRuntime is the cross-field layer of validation
 // (per-value runs at SetValue time). On failure it logs and clears both
 // allow-lists — reverting to the prior value would need a snapshot

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -570,12 +570,13 @@ func FromEnv(config *Config) error {
 	if v := os.Getenv("DEFAULT_VECTOR_INDEX"); v != "" {
 		// Trim/lowercase for symmetry with ALLOWED_VECTOR_INDEX_TYPES.
 		defaultVectorIndexType = strings.ToLower(strings.TrimSpace(v))
-		validTypes := []string{"hnsw", "flat", "dynamic", "hfresh"}
-		if !slices.Contains(validTypes, defaultVectorIndexType) {
-			return fmt.Errorf("invalid DEFAULT_VECTOR_INDEX %q, must be one of: %v", defaultVectorIndexType, validTypes)
-		}
 	}
-	config.DefaultVectorIndexType = configRuntime.NewDynamicValue(defaultVectorIndexType)
+	defaultVectorIndexWithValidation, err := configRuntime.NewDynamicValueWithValidation(
+		defaultVectorIndexType, NewDefaultVectorIndexValidator())
+	if err != nil {
+		return err
+	}
+	config.DefaultVectorIndexType = defaultVectorIndexWithValidation
 
 	defaultShardingCount := 0
 	if err := parseNonNegativeInt(

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1722,6 +1722,8 @@ func TestEnvironmentDefaultVectorIndex(t *testing.T) {
 		{"uppercase FLAT", "FLAT", "flat", ""},
 		{"mixed case Hnsw", "Hnsw", "hnsw", ""},
 		{"invalid value", "invalid", "", `invalid DEFAULT_VECTOR_INDEX "invalid"`},
+		{"none sentinel rejected", "none", "", `invalid DEFAULT_VECTOR_INDEX "none"`},
+		{"noop sentinel rejected", "noop", "", `invalid DEFAULT_VECTOR_INDEX "noop"`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -706,6 +706,10 @@ func TestUpdateRuntimeConfig_DefaultVectorIndex(t *testing.T) {
 		{"invalid value rejected", "invalid", initial, `invalid DEFAULT_VECTOR_INDEX "invalid"`},
 		{"none sentinel rejected", "none", initial, `invalid DEFAULT_VECTOR_INDEX "none"`},
 		{"noop sentinel rejected", "noop", initial, `invalid DEFAULT_VECTOR_INDEX "noop"`},
+		// Strict validator: runtime YAML must already be lowercase + trimmed.
+		// SetValue stores verbatim and downstream parsers compare case-
+		// sensitively, so mixed case is rejected rather than silently stored.
+		{"uppercase HNSW rejected", "HNSW", initial, `invalid DEFAULT_VECTOR_INDEX "HNSW"`},
 	}
 
 	for _, tt := range tests {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -679,6 +679,72 @@ func TestExportDefaultPathRuntimeOverride(t *testing.T) {
 	}
 }
 
+// TestUpdateRuntimeConfig_DefaultVectorIndex mirrors
+// TestEnvironmentDefaultVectorIndex but exercises the runtime YAML override
+// path. The validator attached at construction time must apply the same
+// allow-list at SetValue time — accepted values replace the prior one,
+// rejected values (including the "none" sentinel reserved for dropped
+// indexes) leave it in place. UpdateRuntimeConfig logs SetValue errors
+// rather than surfacing them, so the only observable signal is the
+// post-update Get() value.
+func TestUpdateRuntimeConfig_DefaultVectorIndex(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+
+	const initial = "hnsw"
+	tests := []struct {
+		name        string
+		value       string // YAML scalar; "" means the field is omitted entirely
+		expected    string // Get() after UpdateRuntimeConfig
+		expectedErr string // substring of the direct SetValue error; "" means no error expected
+	}{
+		{"not set keeps initial", "", initial, ""},
+		{"hnsw", "hnsw", "hnsw", ""},
+		{"flat", "flat", "flat", ""},
+		{"dynamic", "dynamic", "dynamic", ""},
+		{"hfresh", "hfresh", "hfresh", ""},
+		{"invalid value rejected", "invalid", initial, `invalid DEFAULT_VECTOR_INDEX "invalid"`},
+		{"none sentinel rejected", "none", initial, `invalid DEFAULT_VECTOR_INDEX "none"`},
+		{"noop sentinel rejected", "noop", initial, `invalid DEFAULT_VECTOR_INDEX "noop"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mirror FromEnv: validator attached at construction time so
+			// runtime YAML overrides go through the same gate as env vars.
+			defaultVectorIndexWithValidation, err := runtime.NewDynamicValueWithValidation(
+				initial, NewDefaultVectorIndexValidator())
+			require.NoError(t, err)
+
+			// Direct SetValue: explicit assertion on the validator error
+			// (UpdateRuntimeConfig swallows SetValue errors into a log line,
+			// so a direct call is the only way to observe the error itself).
+			if tt.value != "" {
+				err := defaultVectorIndexWithValidation.SetValue(tt.value)
+				if tt.expectedErr != "" {
+					require.Error(t, err, "validator must reject %q", tt.value)
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			source := &WeaviateRuntimeConfig{
+				DefaultVectorIndexType: defaultVectorIndexWithValidation,
+			}
+			yaml := ""
+			if tt.value != "" {
+				yaml = "default_vector_index: " + tt.value
+			}
+			parsed, err := ParseRuntimeConfig([]byte(yaml))
+			require.NoError(t, err)
+			require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+
+			assert.Equal(t, tt.expected, source.DefaultVectorIndexType.Get())
+		})
+	}
+}
+
 // helpers
 // assertConfigKey asserts if the `yaml` key is standard `lower_snake_case` (e.g: not `UPPER_CASE`)
 func assertConfigKey(t *testing.T, key string) {


### PR DESCRIPTION
### What's being changed:

This PR adds validation for default_vector_index runtime setting.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
