### PR TITLE
Dont timeout shard halting in unrelated unittest

### DIFF
--- a/adapters/repos/db/shard_path_test.go
+++ b/adapters/repos/db/shard_path_test.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -30,7 +29,9 @@ func TestShardFileSanitize(t *testing.T) {
 	ctx := testCtx()
 	className := "TestClass"
 	shd, idx := testShard(t, ctx, className)
-	require.NoError(t, shd.HaltForTransfer(ctx, false, 100*time.Millisecond))
+	// 0 timeout disables inactivity auto-resume, so slow setup can't resume
+	// the shard before ListBackupFiles runs.
+	require.NoError(t, shd.HaltForTransfer(ctx, false, 0))
 	amount := 10
 
 	for range amount {


### PR DESCRIPTION
### What's being changed:

The test would sometimes fail on a slow CI runner because it would take longer than the 100ms timeout for halting the shard. The affected test tests something unrelated (path safety) so there is no need to have a timeout at all

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
