### PR TITLE
Fix wrong authz check for get groups for role

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -771,29 +771,29 @@ func (h *authZHandlers) getGroupsForRole(params authz.GetGroupsForRoleParams, pr
 		return authz.NewGetGroupsForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	users, err := h.controller.GetUsersOrGroupForRole(params.ID, authentication.AuthTypeOIDC, true)
+	groups, err := h.controller.GetUsersOrGroupForRole(params.ID, authentication.AuthTypeOIDC, true)
 	if err != nil {
 		return authz.NewGetGroupsForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsersOrGroupForRole: %w", err)))
 	}
 
-	filteredUsers := make([]string, 0, len(users))
-	for _, userName := range users {
-		if userName == principal.Username {
-			// own username
-			filteredUsers = append(filteredUsers, userName)
+	filteredGroups := make([]string, 0, len(groups))
+	for _, groupName := range groups {
+		if slices.Contains(principal.Groups, groupName) {
+			// own group
+			filteredGroups = append(filteredGroups, groupName)
 			continue
 		}
-		if err := h.authorizer.AuthorizeSilent(ctx, principal, authorization.READ, authorization.Users(userName)...); err == nil {
-			filteredUsers = append(filteredUsers, userName)
+		if err := h.authorizer.AuthorizeSilent(ctx, principal, authorization.READ, authorization.Groups(authentication.AuthTypeOIDC, groupName)...); err == nil {
+			filteredGroups = append(filteredGroups, groupName)
 		}
 	}
-	slices.Sort(filteredUsers)
+	slices.Sort(filteredGroups)
 
 	// only OIDC groups so far
 	oidc := models.GroupTypeOidc
 	var response []*authz.GetGroupsForRoleOKBodyItems0
-	for _, userId := range filteredUsers {
-		response = append(response, &authz.GetGroupsForRoleOKBodyItems0{GroupID: userId, GroupType: &oidc})
+	for _, groupID := range filteredGroups {
+		response = append(response, &authz.GetGroupsForRoleOKBodyItems0{GroupID: groupID, GroupType: &oidc})
 	}
 
 	h.logger.WithFields(logrus.Fields{

--- a/test/acceptance/authz/oidc_test.go
+++ b/test/acceptance/authz/oidc_test.go
@@ -290,6 +290,40 @@ func TestRbacWithOIDCGroups(t *testing.T) {
 			require.Equal(t, *rolesWithRoles[0].Name, createSchemaRoleName)
 			require.Len(t, rolesWithRoles[0].Permissions, 2)
 
+			// getGroupsForRole filters through the groups domain and exposes the
+			// caller's own groups. Root bypasses authorization, so exercise the
+			// non-root filter path with the OIDC custom user.
+			t.Run("getGroupsForRole visibility", func(t *testing.T) {
+				otherGroup := "other-oidc-group"
+				helper.AssignRoleToGroup(t, tokenAdmin, createSchemaRoleName, otherGroup)
+				defer helper.RevokeRoleFromGroup(t, tokenAdmin, createSchemaRoleName, otherGroup)
+
+				// root sees every group assigned to the role
+				adminGroups := helper.GetGroupsForRole(t, tokenAdmin, createSchemaRoleName)
+				require.ElementsMatch(t, []string{"custom-group", otherGroup}, adminGroups)
+
+				// roles + groups read, but nothing on the users domain
+				viewerRoleName := "groupAndRoleViewer"
+				allResources := "*"
+				viewerRole := &models.Role{
+					Name: &viewerRoleName,
+					Permissions: []*models.Permission{
+						{Action: &authorization.ReadRoles, Roles: &models.PermissionRoles{Role: &allResources}},
+						{Action: &authorization.ReadGroups, Groups: &models.PermissionGroups{Group: &allResources, GroupType: models.GroupTypeOidc}},
+					},
+				}
+				helper.DeleteRole(t, tokenAdmin, viewerRoleName)
+				helper.CreateRole(t, tokenAdmin, viewerRole)
+				defer helper.DeleteRole(t, tokenAdmin, viewerRoleName)
+				helper.AssignRoleToGroup(t, tokenAdmin, viewerRoleName, "custom-group")
+				defer helper.RevokeRoleFromGroup(t, tokenAdmin, viewerRoleName, "custom-group")
+
+				// custom-group via the own-group bypass, other-oidc-group via the
+				// groups-domain filter; neither would appear under the users domain
+				customGroups := helper.GetGroupsForRole(t, tokenCustom, createSchemaRoleName)
+				require.ElementsMatch(t, []string{"custom-group", otherGroup}, customGroups)
+			})
+
 			// delete class to test again after revocation
 			helper.DeleteClassWithAuthz(t, className, helper.CreateAuth(tokenAdmin))
 			helper.RevokeRoleFromGroup(t, tokenAdmin, createSchemaRoleName, "custom-group")


### PR DESCRIPTION
### What's being changed:

getRolesForGroups was checking user permissions. Now it checks correctly the group permissions

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
