### PR TITLE
Fix backup concurrency calculation

### DIFF
--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -57,7 +57,8 @@ const (
 	TempDirectory     = ".backup.tmp"
 )
 
-var _NUMCPU = runtime.NumCPU()
+// GOMAXPROCS honors the cgroup CPU limit; NumCPU would oversize pools in containers.
+var _NUMCPU = runtime.GOMAXPROCS(0)
 
 type objectStore struct {
 	backend modulecapabilities.BackupBackend

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -57,8 +57,12 @@ const (
 	TempDirectory     = ".backup.tmp"
 )
 
-// GOMAXPROCS honors the cgroup CPU limit; NumCPU would oversize pools in containers.
-var _NUMCPU = runtime.GOMAXPROCS(0)
+// numCPU sizes worker pools. GOMAXPROCS (not NumCPU) may reflect the cgroup CPU
+// limit, and is read at the call site so a GOMAXPROCS change during startup
+// (see limitResources) is honored rather than captured at package init.
+func numCPU() int {
+	return runtime.GOMAXPROCS(0)
+}
 
 type objectStore struct {
 	backend modulecapabilities.BackupBackend
@@ -780,7 +784,7 @@ func (fw *fileWriter) writeTempFiles(ctx context.Context, classTempDir, override
 	// no compression processed as before
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(fw.logger, ctx)
 	if !fw.compressed {
-		eg.SetLimit(2 * _NUMCPU)
+		eg.SetLimit(2 * numCPU())
 		for _, shard := range desc.Shards {
 			// Check for cancellation before processing each shard
 			if err := ctx.Err(); err != nil {
@@ -910,7 +914,7 @@ func routinePoolSize(percentage int) int {
 	} else if percentage > maxCPUPercentage {
 		percentage = maxCPUPercentage
 	}
-	if x := (_NUMCPU * percentage) / 100; x > 0 {
+	if x := (numCPU() * percentage) / 100; x > 0 {
 		return x
 	}
 	return 1

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -202,13 +202,13 @@ func TestZipConfig(t *testing.T) {
 		minPoolSize int
 		maxPoolSize int
 	}{
-		{0, 0, 1, _NUMCPU / 2},
-		{2 - 1, 50, _NUMCPU / 2, _NUMCPU},
-		{512 + 1, 50, _NUMCPU / 2, _NUMCPU},
-		{2, 0, 1, _NUMCPU / 2},
-		{1, 100, 1, _NUMCPU},
-		{100, 0, 1, _NUMCPU / 2}, // 100 MB
-		{513, 0, 1, _NUMCPU / 2},
+		{0, 0, 1, numCPU() / 2},
+		{2 - 1, 50, numCPU() / 2, numCPU()},
+		{512 + 1, 50, numCPU() / 2, numCPU()},
+		{2, 0, 1, numCPU() / 2},
+		{1, 100, 1, numCPU()},
+		{100, 0, 1, numCPU() / 2}, // 100 MB
+		{513, 0, 1, numCPU() / 2},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### What's being changed:

runtime.NumCPU returns the CPUs of the underlying server


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
