### PR TITLE
fix(replication): gate OverwriteObjects on shard readiness during read repair

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -353,6 +353,10 @@ func (idx *Index) OverwriteObjects(ctx context.Context,
 	}
 	defer release()
 
+	if s.GetStatus() == storagestate.StatusLoading && idx.replicationEnabled() {
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shard))
+	}
+
 	var result []replica.RepairResponse
 
 	for i, u := range updates {

--- a/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
@@ -104,19 +105,20 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 		common.StartNodeAt(ctx, t, compose, 2)
 	})
 
-	t.Run("run fetch to trigger read repair", func(t *testing.T) {
-		_, err := common.GetObjectCL(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID, replica.All)
-		require.Nil(t, err)
-	})
-
 	t.Run("require new object read repair was made", func(t *testing.T) {
-		resp, err := common.GetObjectCL(t, compose.GetWeaviateNode2().URI(),
-			repairObj.Class, repairObj.ID, replica.One)
-		require.Nil(t, err)
-		require.Equal(t, repairObj.ID, resp.ID)
-		require.Equal(t, repairObj.Class, resp.Class)
-		require.EqualValues(t, repairObj.Properties, resp.Properties)
-		require.EqualValues(t, repairObj.Vector, resp.Vector)
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 2 may still be loading right after restart
+			_, err := common.GetObjectCL(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID, replica.All)
+			require.Nil(collect, err)
+
+			resp, err := common.GetObjectCL(t, compose.GetWeaviateNode2().URI(),
+				repairObj.Class, repairObj.ID, replica.One)
+			require.Nil(collect, err)
+			require.Equal(collect, repairObj.ID, resp.ID)
+			require.Equal(collect, repairObj.Class, resp.Class)
+			require.EqualValues(collect, repairObj.Properties, resp.Properties)
+			require.EqualValues(collect, repairObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("stop node 3", func(t *testing.T) {
@@ -136,26 +138,27 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 		common.StartNodeAt(ctx, t, compose, 3)
 	})
 
-	t.Run("run exists to trigger read repair", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, replica.All)
-		require.Nil(t, err)
-		require.True(t, exists)
-	})
-
 	t.Run("require updated object read repair was made", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, replica.One)
-		require.Nil(t, err)
-		require.True(t, exists)
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 3 may still be loading right after restart
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, replica.All)
+			require.Nil(collect, err)
+			require.True(collect, exists)
 
-		resp, err := common.GetObjectCL(t, compose.GetWeaviateNode3().URI(),
-			repairObj.Class, repairObj.ID, replica.One)
-		require.Nil(t, err)
-		require.Equal(t, replaceObj.ID, resp.ID)
-		require.Equal(t, replaceObj.Class, resp.Class)
-		require.EqualValues(t, replaceObj.Properties, resp.Properties)
-		require.EqualValues(t, replaceObj.Vector, resp.Vector)
+			exists, err = common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, replica.One)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+
+			resp, err := common.GetObjectCL(t, compose.GetWeaviateNode3().URI(),
+				repairObj.Class, repairObj.ID, replica.One)
+			require.Nil(collect, err)
+			require.Equal(collect, replaceObj.ID, resp.ID)
+			require.Equal(collect, replaceObj.Class, resp.Class)
+			require.EqualValues(collect, replaceObj.Properties, resp.Properties)
+			require.EqualValues(collect, replaceObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("stop node 2", func(t *testing.T) {
@@ -188,30 +191,39 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 	})
 
 	t.Run("deleted article should not be present in node3", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, replica.One)
-		require.Nil(t, err)
-		require.False(t, exists)
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, replica.One)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("run exists to trigger read repair with deleted object resolution", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, replica.All)
-		require.Nil(t, err)
-		require.False(t, exists)
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger deletion read repair on every attempt; node 3 may still be loading right after restart
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, replica.All)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("deleted article should not be present in node3", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, replica.One)
-		require.Nil(t, err)
-		require.False(t, exists)
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, replica.One)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("deleted article should not be present in node2", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, replica.One)
-		require.Nil(t, err)
-		require.False(t, exists)
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, replica.One)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 }


### PR DESCRIPTION
## Motivation

`TestReadRepairDeleteOnConflict` was failing intermittently. The root cause: `OverwriteObjects` — the synchronous read-repair write path — was missing the `StatusLoading` readiness check that its sibling read paths (`DigestObjects`, `FetchObject`, `Exists`) already have. When a repair `Overwrite` landed on a shard whose LSM store was still loading right after a node restart, the write was applied to a not-ready shard and effectively lost, leaving the replica permanently stale.

This is a backport of the readiness gate from #10199 (already on `main`) to `stable/v1.28`.

## Approach

Two independent fixes:

1. **Production gate** (`replication.go`): if the local shard is `StatusLoading` and replication is enabled, return a retryable `ErrUnprocessable` ("shard is not ready") instead of silently writing into a loading shard. The repair coordinator then retries against a ready replica, matching the existing behavior of the read paths. The condition (`s.GetStatus() == StatusLoading && idx.replicationEnabled()`) is copied verbatim from the `OverwriteObjects` gate on `main`, so the backport stays in lock-step with upstream.

2. **Test robustness**: post-restart verifications are now wrapped in `assert.EventuallyWithT` (30s / 500ms). Each attempt re-issues the CL=All read that *triggers* read repair, so the assertion keeps re-triggering repair until the just-restarted node finishes loading and converges — rather than firing a single repair that races shard boot.

## Key areas for review

- `adapters/repos/db/replication.go` — the gate. Worth confirming the `&& idx.replicationEnabled()` qualifier matches `main` (it does) and that returning `ErrUnprocessable` here is treated as retryable by the repair caller, not surfaced to the client as a hard failure.
- `read_repair_deleteonconflict_test.go` — verify the `Eventually` blocks re-run the repair-triggering read *inside* the closure (they do); a version that only re-checked the follower without re-triggering would loop uselessly.

## Risks and mitigations

- **Behavioral divergence from `main`**: low. The gate is the same form as `main`; the only difference from v1.28's sibling read paths is the added `replicationEnabled()` qualifier, which is intentional and matches upstream.
- **Repair starvation if a shard stays `StatusLoading`**: the gate returns a *retryable* error, so a shard stuck loading would defer repair rather than corrupt — same failure mode as the already-shipped read-path gates. No new risk introduced.

## Testing

`TestReadRepairDeleteOnConflict` (multi-node acceptance test with node restarts) exercises the exact scenario across new-object, updated-object, and deleted-object read-repair paths. Verified locally against an image built with this change: 4 consecutive green runs (1 single + 3× stability), where it previously failed intermittently.

No `weaviate-qa` chaos/e2e pipeline was triggered for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
