### PR TITLE
test(replication): stabilize TestReadRepairDeleteOnConflict against node-boot timing

### DIFF
--- a/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
@@ -105,19 +106,20 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 		common.StartNodeAt(ctx, t, compose, 2)
 	})
 
-	t.Run("run fetch to trigger read repair", func(t *testing.T) {
-		_, err := common.GetObjectCL(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
-	})
-
 	t.Run("require new object read repair was made", func(t *testing.T) {
-		resp, err := common.GetObjectCL(t, compose.GetWeaviateNode2().URI(),
-			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.Equal(t, repairObj.ID, resp.ID)
-		require.Equal(t, repairObj.Class, resp.Class)
-		require.EqualValues(t, repairObj.Properties, resp.Properties)
-		require.EqualValues(t, repairObj.Vector, resp.Vector)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 2 may still be loading right after restart
+			_, err := common.GetObjectCL(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+
+			resp, err := common.GetObjectCL(t, compose.GetWeaviateNode2().URI(),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.Equal(collect, repairObj.ID, resp.ID)
+			require.Equal(collect, repairObj.Class, resp.Class)
+			require.EqualValues(collect, repairObj.Properties, resp.Properties)
+			require.EqualValues(collect, repairObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("stop node 3", func(t *testing.T) {
@@ -137,26 +139,27 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 		common.StartNodeAt(ctx, t, compose, 3)
 	})
 
-	t.Run("run exists to trigger read repair", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
-		require.True(t, exists)
-	})
-
 	t.Run("require updated object read repair was made", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 3 may still be loading right after restart
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+			require.True(collect, exists)
 
-		resp, err := common.GetObjectCL(t, compose.GetWeaviateNode3().URI(),
-			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.Equal(t, replaceObj.ID, resp.ID)
-		require.Equal(t, replaceObj.Class, resp.Class)
-		require.EqualValues(t, replaceObj.Properties, resp.Properties)
-		require.EqualValues(t, replaceObj.Vector, resp.Vector)
+			exists, err = common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+
+			resp, err := common.GetObjectCL(t, compose.GetWeaviateNode3().URI(),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.Equal(collect, replaceObj.ID, resp.ID)
+			require.Equal(collect, replaceObj.Class, resp.Class)
+			require.EqualValues(collect, replaceObj.Properties, resp.Properties)
+			require.EqualValues(collect, replaceObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("stop node 2", func(t *testing.T) {
@@ -189,30 +192,39 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 	})
 
 	t.Run("deleted article should not be present in node3", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.False(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("run exists to trigger read repair with deleted object resolution", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
-		require.False(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger deletion read repair on every attempt; node 3 may still be loading right after restart
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("deleted article should not be present in node3", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.False(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("deleted article should not be present in node2", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.False(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 }


### PR DESCRIPTION
## Motivation

`TestReadRepairDeleteOnConflict` flakes intermittently. After a node is restarted, the test fired a **single** read-repair trigger (`GetObjectCL` / `ObjectExistsCL` at CL=All) and then **immediately** asserted the restarted node's local copy at CL=One. That races the node's shard load: the read-repair `Overwrite` to a still-loading shard returns a retryable "shard is not ready" error (the readiness gate added in #10199, already present on this branch), so a single immediate trigger can observe the follower still stale and fail.

This is a **test-only** stabilization. The product-side fix (the `OverwriteObjects` `StatusLoading` gate) is already on `stable/v1.36`; this PR only makes the test deterministic against node-boot timing.

> Context: this started as a fix for the same flake on `stable/v1.28` (which is *missing* the gate). On `stable/v1.36` the gate already exists, so only the test hardening is needed here.

## Approach

Wrap the post-restart per-node verifications in `assert.EventuallyWithT` (30s / 500ms). Each attempt **re-issues** the CL=All read that *triggers* read repair, then re-checks the follower at CL=One — so the assertion keeps re-triggering repair until the just-restarted node finishes loading and converges, instead of firing once and racing shard boot. This mirrors the established pattern in `crud_test.go` / `scale_test.go` in the same package.

Applied to all four post-restart checks (new-object repair on node 2, updated-object repair on node 3, and the two deletion-resolution checks), not just the one most-often-failing assertion.

## Key areas for review

- Each `Eventually` closure re-runs the repair-*triggering* read inside the loop (not just a follower re-check), so retries actually drive convergence.
- Helpers (`common.GetObjectCL` / `common.ObjectExistsCL`) return errors rather than calling `t.Fatal`, so they're safe to drive from inside `EventuallyWithT` and assert on `collect`.

## Risks

Minimal — test-only change, no production code touched. Worst case on a genuinely broken build is a 30s timeout per block instead of an instant failure.

## Testing

`go vet` clean. The `EventuallyWithT` pattern was validated end-to-end on the sibling `stable/v1.28` work (image built with the same change, `TestReadRepairDeleteOnConflict` green across 4 consecutive runs where it previously flaked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
