### PR TITLE
Fix compact v2 in case of commit logger reset

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_concurrent_compaction_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_concurrent_compaction_test.go
@@ -1,0 +1,208 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"io"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/compact"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// TestCommitLog_ConcurrentSwitchAndCompaction runs a writer, a log switcher, and
+// a compactor against one commit logger at once. The compactor doesn't take the
+// logger's mutex, so it relies on never touching the live file while rotation
+// creates and deletes files around it. -race catches a data race; the reload at
+// the end catches data loss.
+func TestCommitLog_ConcurrentSwitchAndCompaction(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	rootPath := t.TempDir()
+	const name = "concurrent"
+
+	// A tiny threshold makes nearly every maintenance pass rotate.
+	l, err := NewCommitLogger(rootPath, name, logger,
+		cyclemanager.NewCallbackGroupNoop(),
+		WithFS(common.NewOSFS()),
+		WithCommitlogThreshold(256))
+	require.NoError(t, err)
+
+	const numNodes = 4000
+	levelFor := func(id uint64) int {
+		switch {
+		case id == 0:
+			return 2
+		case id%11 == 0:
+			return 1
+		default:
+			return 0
+		}
+	}
+	isTombstoned := func(id uint64) bool { return id != 0 && id%7 == 0 }
+
+	noAbort := cyclemanager.ShouldAbortCallback(func() bool { return false })
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	var writeErr error
+
+	// Single writer so the acknowledged state is deterministic. Every id is added
+	// once (ids are never reused in HNSW) and linked to the hub so none are bare.
+	wg.Add(1)
+	enterrors.GoWrapper(func() {
+		defer wg.Done()
+		defer close(done)
+
+		fail := func(err error) bool {
+			if err != nil {
+				writeErr = err
+				return true
+			}
+			return false
+		}
+
+		if fail(l.AddNode(&vertex{id: 0, level: 2})) {
+			return
+		}
+		if fail(l.SetEntryPointWithMaxLayer(0, 2)) {
+			return
+		}
+
+		for id := uint64(1); id <= numNodes; id++ {
+			lvl := levelFor(id)
+			if fail(l.AddNode(&vertex{id: id, level: lvl})) {
+				return
+			}
+			if fail(l.AddLinkAtLevel(id, 0, 0)) {
+				return
+			}
+			if lvl >= 1 {
+				if fail(l.AddLinkAtLevel(id, 1, 0)) {
+					return
+				}
+			}
+			if isTombstoned(id) {
+				if fail(l.AddTombstone(id)) {
+					return
+				}
+			}
+			if id%8 == 0 {
+				if fail(l.Flush()) {
+					return
+				}
+			}
+		}
+		fail(l.Flush())
+	}, logger)
+
+	wg.Add(1)
+	enterrors.GoWrapper(func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				l.startSwitchLogs(noAbort)
+			}
+		}
+	}, logger)
+
+	wg.Add(1)
+	enterrors.GoWrapper(func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				l.startCommitLogsMaintenance(noAbort)
+			}
+		}
+	}, logger)
+
+	wg.Wait()
+	require.NoError(t, writeErr)
+
+	for range 200 {
+		if !l.startCommitLogsMaintenance(noAbort) {
+			break
+		}
+	}
+	require.NoError(t, l.Shutdown(context.Background()))
+
+	loader := compact.NewLoader(compact.LoaderConfig{
+		Dir:    commitLogDirectory(rootPath, name),
+		Logger: logger,
+	})
+	res, err := loader.Load()
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.State)
+	g := res.State.Graph
+	require.NotNil(t, g)
+
+	nodeAt := func(id uint64) *struct {
+		present bool
+		level   int
+		links0  []uint64
+	} {
+		out := &struct {
+			present bool
+			level   int
+			links0  []uint64
+		}{}
+		if id >= uint64(len(g.Nodes)) {
+			return out
+		}
+		v := g.Nodes[id]
+		if v == nil {
+			return out
+		}
+		out.present = true
+		out.level = v.Level
+		if v.Connections != nil && v.Connections.Layers() > 0 {
+			out.links0 = v.Connections.GetLayer(0)
+		}
+		return out
+	}
+
+	containsHub := func(links []uint64) bool {
+		return slices.Contains(links, 0)
+	}
+
+	hub := nodeAt(0)
+	require.True(t, hub.present, "hub node 0 lost")
+	require.Equal(t, 2, hub.level, "hub node 0 level changed")
+	require.Equal(t, uint64(0), g.Entrypoint, "entrypoint changed")
+	require.Equal(t, uint16(2), g.Level, "graph max level changed")
+
+	for id := uint64(1); id <= numNodes; id++ {
+		n := nodeAt(id)
+		require.Truef(t, n.present, "node %d lost after concurrent rotation+compaction", id)
+		require.Equalf(t, levelFor(id), n.level, "node %d level mismatch", id)
+		require.Truef(t, containsHub(n.links0),
+			"node %d lost its level-0 link to the hub", id)
+		if isTombstoned(id) {
+			require.Containsf(t, g.Tombstones, id, "tombstone for node %d lost", id)
+		}
+	}
+}

--- a/adapters/repos/db/vector/hnsw/compact/compact_diff_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/compact_diff_test.go
@@ -1,0 +1,489 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compact
+
+import (
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/vectorindex/compression"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw/packedconn"
+)
+
+// These tests use a differential oracle: the trusted baseline is loading raw WAL
+// files with NO compaction (the legacy path), compared against the new on-disk
+// compaction pipeline. For any input the two must produce identical graphs. The
+// generator only emits realistic, unambiguous sequences; the genuinely ambiguous
+// interactions have dedicated unit tests.
+
+func quietLogger() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetLevel(logrus.ErrorLevel)
+	return l
+}
+
+type walOp func(t *testing.T, w *WALWriter)
+
+type genState struct {
+	present    map[uint64]struct{}
+	tombstones map[uint64]struct{}
+	levels     map[uint64]int
+	// used records every ID added since the last reset. IDs are never reused in
+	// production (an update is delete + insert of a fresh ID).
+	used map[uint64]struct{}
+}
+
+func newGenState() *genState {
+	return &genState{
+		present:    map[uint64]struct{}{},
+		tombstones: map[uint64]struct{}{},
+		levels:     map[uint64]int{},
+		used:       map[uint64]struct{}{},
+	}
+}
+
+func (g *genState) presentIDs() []uint64 {
+	ids := make([]uint64, 0, len(g.present))
+	for id := range g.present {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func (g *genState) tombstoneIDs() []uint64 {
+	ids := make([]uint64, 0, len(g.tombstones))
+	for id := range g.tombstones {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func (g *genState) pickPresent(r *rand.Rand) (uint64, bool) {
+	ids := g.presentIDs()
+	if len(ids) == 0 {
+		return 0, false
+	}
+	return ids[r.Intn(len(ids))], true
+}
+
+func (g *genState) randTargets(r *rand.Rand, max int) []uint64 {
+	ids := g.presentIDs()
+	if len(ids) == 0 {
+		return nil
+	}
+	n := 1 + r.Intn(max)
+	targets := make([]uint64, 0, n)
+	for i := 0; i < n; i++ {
+		targets = append(targets, ids[r.Intn(len(ids))])
+	}
+	return targets
+}
+
+// genWALOps produces n realistic operations, updating g in lock-step. When
+// allowReset is false, ResetIndex is never emitted.
+func genWALOps(r *rand.Rand, g *genState, n int, maxID uint64, allowReset bool) []walOp {
+	ops := make([]walOp, 0, n)
+	for len(ops) < n {
+		switch r.Intn(22) {
+		case 0, 1, 2, 3, 4: // AddNode (weighted: graphs need nodes)
+			id := uint64(r.Intn(int(maxID)))
+			if _, ok := g.used[id]; ok {
+				continue
+			}
+			level := r.Intn(4)
+			g.present[id] = struct{}{}
+			g.used[id] = struct{}{}
+			g.levels[id] = level
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteAddNode(id, uint16(level)))
+			})
+		case 5:
+			id, ok := g.pickPresent(r)
+			if !ok {
+				continue
+			}
+			level := g.levels[id]
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteSetEntryPointMaxLevel(id, uint16(level)))
+			})
+		case 6, 7:
+			src, ok := g.pickPresent(r)
+			if !ok {
+				continue
+			}
+			tgt, _ := g.pickPresent(r)
+			level := r.Intn(g.levels[src] + 1)
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteAddLinkAtLevel(src, uint16(level), tgt))
+			})
+		case 8, 9:
+			src, ok := g.pickPresent(r)
+			if !ok {
+				continue
+			}
+			level := r.Intn(g.levels[src] + 1)
+			targets := g.randTargets(r, 5)
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteAddLinksAtLevel(src, uint16(level), targets))
+			})
+		case 10, 11:
+			src, ok := g.pickPresent(r)
+			if !ok {
+				continue
+			}
+			level := r.Intn(g.levels[src] + 1)
+			targets := g.randTargets(r, 6)
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteReplaceLinksAtLevel(src, uint16(level), targets))
+			})
+		case 12:
+			id, ok := g.pickPresent(r)
+			if !ok {
+				continue
+			}
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteClearLinks(id))
+			})
+		case 13:
+			id, ok := g.pickPresent(r)
+			if !ok {
+				continue
+			}
+			level := r.Intn(g.levels[id] + 1)
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteClearLinksAtLevel(id, uint16(level)))
+			})
+		case 14, 15:
+			id, ok := g.pickPresent(r)
+			if !ok {
+				continue
+			}
+			g.tombstones[id] = struct{}{}
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteAddTombstone(id))
+			})
+		case 16:
+			ids := g.tombstoneIDs()
+			if len(ids) == 0 {
+				continue
+			}
+			id := ids[r.Intn(len(ids))]
+			delete(g.tombstones, id)
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteRemoveTombstone(id))
+			})
+		case 17: // DeleteNode, never a tombstoned node (ambiguous for a differential)
+			candidates := make([]uint64, 0, len(g.present))
+			for _, id := range g.presentIDs() {
+				if _, ts := g.tombstones[id]; !ts {
+					candidates = append(candidates, id)
+				}
+			}
+			if len(candidates) == 0 {
+				continue
+			}
+			id := candidates[r.Intn(len(candidates))]
+			delete(g.present, id)
+			delete(g.levels, id)
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteDeleteNode(id))
+			})
+		case 18:
+			data := &compression.SQData{
+				A:          0.5 + float32(r.Intn(100))/100,
+				B:          float32(r.Intn(100)) / 100,
+				Dimensions: uint16(1 + r.Intn(256)),
+			}
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteAddSQ(data))
+			})
+		case 19, 20: // more AddNode so graphs stay non-trivial
+			id := uint64(r.Intn(int(maxID)))
+			if _, ok := g.used[id]; ok {
+				continue
+			}
+			level := r.Intn(4)
+			g.present[id] = struct{}{}
+			g.used[id] = struct{}{}
+			g.levels[id] = level
+			ops = append(ops, func(t *testing.T, w *WALWriter) {
+				require.NoError(t, w.WriteAddNode(id, uint16(level)))
+			})
+		case 21: // ResetIndex, then re-seed a level-2 entrypoint so it stays non-trivial
+			if !allowReset {
+				continue
+			}
+			g.present = map[uint64]struct{}{0: {}}
+			g.tombstones = map[uint64]struct{}{}
+			g.levels = map[uint64]int{0: 2}
+			g.used = map[uint64]struct{}{0: {}}
+			ops = append(ops,
+				func(t *testing.T, w *WALWriter) { require.NoError(t, w.WriteResetIndex()) },
+				func(t *testing.T, w *WALWriter) { require.NoError(t, w.WriteAddNode(0, 2)) },
+				func(t *testing.T, w *WALWriter) { require.NoError(t, w.WriteSetEntryPointMaxLevel(0, 2)) },
+			)
+		}
+	}
+	return ops
+}
+
+func generateLogs(r *rand.Rand, numLogs, opsPerLog int, maxID uint64) [][]walOp {
+	g := newGenState()
+	logs := make([][]walOp, numLogs)
+
+	g.present[0] = struct{}{}
+	g.levels[0] = 2
+	g.used[0] = struct{}{}
+	seed := []walOp{
+		func(t *testing.T, w *WALWriter) { require.NoError(t, w.WriteAddNode(0, 2)) },
+		func(t *testing.T, w *WALWriter) { require.NoError(t, w.WriteSetEntryPointMaxLevel(0, 2)) },
+	}
+
+	for i := 0; i < numLogs; i++ {
+		// No ResetIndex in the final log, else the loaded graph could be vacuous.
+		allowReset := i < numLogs-1
+		ops := genWALOps(r, g, opsPerLog, maxID, allowReset)
+		if i == 0 {
+			ops = append(seed, ops...)
+		}
+		logs[i] = ops
+	}
+	return logs
+}
+
+func writeLogsToDir(t *testing.T, dir string, logs [][]walOp) {
+	t.Helper()
+	ts := int64(1000)
+	for _, log := range logs {
+		path := filepath.Join(dir, fmt.Sprintf("%d", ts))
+		createTestWALFile(t, path, func(w *WALWriter) {
+			for _, op := range log {
+				op(t, w)
+			}
+		})
+		ts += 1000
+	}
+}
+
+func loadGraph(t *testing.T, dir string) *ent.DeserializationResult {
+	t.Helper()
+	loader := NewLoader(LoaderConfig{Dir: dir, Logger: quietLogger()})
+	res, err := loader.Load()
+	require.NoError(t, err)
+	require.NotNil(t, res, "load returned nil result for %s", dir)
+	require.NotNil(t, res.State, "load returned nil state for %s", dir)
+	return res.State
+}
+
+// effectivelyAbsent reports whether a node is nil or a level-0 node with no
+// connections — both the legacy condensor and v2 compaction drop these.
+func effectivelyAbsent(v *ent.Vertex) bool {
+	if v == nil {
+		return true
+	}
+	if v.Level != 0 {
+		return false
+	}
+	if v.Connections == nil {
+		return true
+	}
+	for layer := uint8(0); layer < v.Connections.Layers(); layer++ {
+		if len(v.Connections.GetLayer(layer)) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func nodeAt(res *ent.DeserializationResult, id int) *ent.Vertex {
+	if id < 0 || id >= len(res.Graph.Nodes) {
+		return nil
+	}
+	return res.Graph.Nodes[id]
+}
+
+func sameUint64Slice(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameKeySet(a, b map[uint64]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func assertConnsEqual(t *testing.T, id int, want, got *packedconn.Connections) {
+	t.Helper()
+	if want == nil && got == nil {
+		return
+	}
+	require.False(t, want == nil || got == nil,
+		"node %d: connections nil mismatch (want nil=%v, got nil=%v)", id, want == nil, got == nil)
+	require.Equal(t, want.Layers(), got.Layers(), "node %d: layer count", id)
+	for layer := uint8(0); layer < want.Layers(); layer++ {
+		wl := want.GetLayer(layer)
+		gl := got.GetLayer(layer)
+		require.True(t, sameUint64Slice(wl, gl),
+			"node %d layer %d: connections differ\n want=%v\n got =%v", id, layer, wl, gl)
+	}
+}
+
+// assertGraphEqual compares the observable graph (entrypoint, per-node level and
+// connections, tombstones, compression). Internal reconstruction bookkeeping is
+// not compared — it legitimately differs between raw and post-compaction loads.
+func assertGraphEqual(t *testing.T, want, got *ent.DeserializationResult) {
+	t.Helper()
+
+	require.Equal(t, want.Graph.EntrypointChanged, got.Graph.EntrypointChanged, "entrypointChanged")
+	if want.Graph.EntrypointChanged {
+		require.Equal(t, want.Graph.Entrypoint, got.Graph.Entrypoint, "entrypoint")
+		require.Equal(t, want.Graph.Level, got.Graph.Level, "level")
+	}
+
+	require.True(t, sameKeySet(want.Graph.Tombstones, got.Graph.Tombstones),
+		"tombstones differ\n want=%v\n got =%v", want.Graph.Tombstones, got.Graph.Tombstones)
+
+	maxLen := len(want.Graph.Nodes)
+	if len(got.Graph.Nodes) > maxLen {
+		maxLen = len(got.Graph.Nodes)
+	}
+	for id := 0; id < maxLen; id++ {
+		wn := nodeAt(want, id)
+		gn := nodeAt(got, id)
+		if effectivelyAbsent(wn) && effectivelyAbsent(gn) {
+			continue
+		}
+		require.False(t, wn == nil || gn == nil,
+			"node %d: presence mismatch (want nil=%v, got nil=%v)", id, wn == nil, gn == nil)
+		require.Equal(t, wn.Level, gn.Level, "node %d: level", id)
+		assertConnsEqual(t, id, wn.Connections, gn.Connections)
+	}
+
+	assertCompressionEqual(t, want, got)
+}
+
+func assertCompressionEqual(t *testing.T, want, got *ent.DeserializationResult) {
+	t.Helper()
+	require.Equal(t, want.HasCompression(), got.HasCompression(), "compressed flag")
+	if !want.HasCompression() {
+		return
+	}
+	require.Equal(t, want.Compression.SQData, got.Compression.SQData, "SQ data")
+	require.Equal(t, want.Compression.PQData, got.Compression.PQData, "PQ data")
+	require.Equal(t, want.Compression.RQData, got.Compression.RQData, "RQ data")
+	require.Equal(t, want.Compression.BRQData, got.Compression.BRQData, "BRQ data")
+}
+
+// TestCompact_Randomized_PreservesGraphAcrossCompaction asserts that for many
+// random commit streams and compaction schedules, the post-compaction load
+// equals the no-compaction load.
+func TestCompact_Randomized_PreservesGraphAcrossCompaction(t *testing.T) {
+	seeds := []int64{1, 2, 3, 7, 42, 101, 2024, 999983, 123456789}
+	thresholds := []float64{0.1, 0.5, 0.9}
+
+	for _, seed := range seeds {
+		seed := seed
+		t.Run(fmt.Sprintf("seed-%d", seed), func(t *testing.T) {
+			t.Parallel()
+			r := rand.New(rand.NewSource(seed))
+			logs := generateLogs(r, 6, 30, 40)
+
+			baseDir := t.TempDir()
+			writeLogsToDir(t, baseDir, logs)
+			baseline := loadGraph(t, baseDir)
+
+			require.GreaterOrEqual(t, countNonNilNodes(baseline.Graph.Nodes), 5,
+				"generated graph too small to be a meaningful test")
+
+			workDir := t.TempDir()
+			writeLogsToDir(t, workDir, logs)
+			compactor := NewCompactor(CompactorConfig{
+				Dir:               workDir,
+				MaxFilesPerMerge:  2 + r.Intn(4),
+				SnapshotThreshold: thresholds[r.Intn(len(thresholds))],
+				BufferSize:        DefaultBufferSize,
+			}, quietLogger())
+
+			cycles := 1 + r.Intn(8)
+			for i := 0; i < cycles; i++ {
+				_, err := compactor.RunCycle(nil)
+				require.NoError(t, err, "RunCycle %d", i)
+			}
+
+			compacted := loadGraph(t, workDir)
+			assertGraphEqual(t, baseline, compacted)
+		})
+	}
+}
+
+// TestCompact_ConvergesAndIdempotent pins that RunCycle reaches a fixed point
+// and that the graph equals the no-compaction baseline after every cycle.
+func TestCompact_ConvergesAndIdempotent(t *testing.T) {
+	r := rand.New(rand.NewSource(20260617))
+	logs := generateLogs(r, 8, 40, 50)
+
+	baseDir := t.TempDir()
+	writeLogsToDir(t, baseDir, logs)
+	baseline := loadGraph(t, baseDir)
+	require.GreaterOrEqual(t, countNonNilNodes(baseline.Graph.Nodes), 5)
+
+	workDir := t.TempDir()
+	writeLogsToDir(t, workDir, logs)
+	compactor := NewCompactor(DefaultCompactorConfig(workDir), quietLogger())
+
+	const maxCycles = 50
+	converged := false
+	cyclesRun := 0
+	for i := 0; i < maxCycles; i++ {
+		action, err := compactor.RunCycle(nil)
+		require.NoError(t, err)
+		cyclesRun++
+
+		assertGraphEqual(t, baseline, loadGraph(t, workDir))
+
+		if action == ActionNone {
+			converged = true
+			break
+		}
+	}
+	require.True(t, converged, "compaction did not converge within %d cycles", maxCycles)
+
+	// Idempotence: another cycle after convergence must be a no-op.
+	action, err := compactor.RunCycle(nil)
+	require.NoError(t, err)
+	require.Equal(t, ActionNone, action, "extra cycle after convergence should be a no-op")
+	assertGraphEqual(t, baseline, loadGraph(t, workDir))
+
+	t.Logf("converged after %d cycles", cyclesRun)
+}

--- a/adapters/repos/db/vector/hnsw/compact/compactor.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor.go
@@ -266,6 +266,9 @@ func (c *Compactor) convertToSorted(state *DirectoryState, shouldAbort func() bo
 				return errors.Wrap(err, "discard files before reset")
 			}
 		}
+		if err := c.removeConvertedSource(f); err != nil {
+			return errors.Wrap(err, "remove converted source file")
+		}
 	}
 
 	return nil
@@ -357,11 +360,6 @@ func (c *Compactor) convertFileToSorted(f FileInfo) (bool, error) {
 		return false, errors.Wrap(err, "commit sorted file")
 	}
 
-	// Delete original file after successful conversion
-	if err := c.fs.Remove(f.Path); err != nil && !os.IsNotExist(err) {
-		return false, errors.Wrap(err, "remove original file")
-	}
-
 	c.logger.WithFields(logrus.Fields{
 		"action":   "hnsw_compactor_convert",
 		"original": filepath.Base(f.Path),
@@ -369,6 +367,13 @@ func (c *Compactor) convertFileToSorted(f FileInfo) (bool, error) {
 	}).Debug("converted file to sorted format")
 
 	return inMemReader.HasReset(), nil
+}
+
+func (c *Compactor) removeConvertedSource(f FileInfo) error {
+	if err := c.fs.Remove(f.Path); err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "remove original file")
+	}
+	return nil
 }
 
 // decideAction determines what compaction action to take based on current state.

--- a/adapters/repos/db/vector/hnsw/compact/compactor.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor.go
@@ -240,31 +240,95 @@ func (c *Compactor) resolveOverlaps(state *DirectoryState) error {
 // SafeFileWriter would otherwise leak a tmp file we can't cleanly orphan
 // from inside this function).
 func (c *Compactor) convertToSorted(state *DirectoryState, shouldAbort func() bool) error {
-	// Convert raw files (except live file)
+	// A ResetIndex wipes all prior state, but each file is converted in
+	// isolation, so without discarding older files the reset's effect stays
+	// confined to its own file and older files resurrect pre-reset data on load.
+	var resetBoundaryTS int64
+	foundReset := false
+
+	noteReset := func(f FileInfo, hasReset bool) {
+		if hasReset && f.StartTS > resetBoundaryTS {
+			resetBoundaryTS = f.StartTS
+			foundReset = true
+		}
+	}
+
 	for _, f := range state.RawFiles {
 		if isAborted(shouldAbort) {
 			return ErrCompactionAborted
 		}
-		if err := c.convertFileToSorted(f); err != nil {
+		hasReset, err := c.convertFileToSorted(f)
+		if err != nil {
 			return errors.Wrapf(err, "convert raw file %s", f.Path)
 		}
+		noteReset(f, hasReset)
 	}
 
-	// Convert condensed files
 	for _, f := range state.CondensedFiles {
 		if isAborted(shouldAbort) {
 			return ErrCompactionAborted
 		}
-		if err := c.convertFileToSorted(f); err != nil {
+		hasReset, err := c.convertFileToSorted(f)
+		if err != nil {
 			return errors.Wrapf(err, "convert condensed file %s", f.Path)
+		}
+		noteReset(f, hasReset)
+	}
+
+	if foundReset {
+		if err := c.discardFilesBeforeReset(resetBoundaryTS); err != nil {
+			return errors.Wrap(err, "discard files before reset")
 		}
 	}
 
 	return nil
 }
 
-// convertFileToSorted converts a single file (raw or condensed) to sorted format.
-func (c *Compactor) convertFileToSorted(f FileInfo) error {
+// discardFilesBeforeReset removes every commit-log file strictly older than
+// boundaryTS (the StartTS of the file carrying the ResetIndex). That file's own
+// output shares boundaryTS and is preserved; the live file is never removed.
+func (c *Compactor) discardFilesBeforeReset(boundaryTS int64) error {
+	discovery := NewFileDiscoveryWithFS(c.config.Dir, c.fs)
+	state, err := discovery.Scan()
+	if err != nil {
+		return errors.Wrap(err, "scan before discarding pre-reset files")
+	}
+
+	toRemove := make([]FileInfo, 0)
+	collect := func(files []FileInfo) {
+		for _, f := range files {
+			if f.StartTS < boundaryTS {
+				toRemove = append(toRemove, f)
+			}
+		}
+	}
+	collect(state.SortedFiles)
+	collect(state.RawFiles)
+	collect(state.CondensedFiles)
+	if state.Snapshot != nil && state.Snapshot.StartTS < boundaryTS {
+		toRemove = append(toRemove, *state.Snapshot)
+	}
+
+	for _, f := range toRemove {
+		if state.LiveFile != nil && f.Path == state.LiveFile.Path {
+			continue
+		}
+		if err := c.fs.Remove(f.Path); err != nil && !os.IsNotExist(err) {
+			return errors.Wrapf(err, "remove pre-reset file %s", f.Path)
+		}
+		c.logger.WithFields(logrus.Fields{
+			"action":      "hnsw_compactor_reset_discard",
+			"file":        filepath.Base(f.Path),
+			"boundary_ts": boundaryTS,
+		}).Info("discarded commit log file obsoleted by index reset")
+	}
+
+	return nil
+}
+
+// convertFileToSorted converts a single file to sorted format, returning
+// whether it contained a ResetIndex commit.
+func (c *Compactor) convertFileToSorted(f FileInfo) (bool, error) {
 	c.logger.WithFields(logrus.Fields{
 		"action": "hnsw_compactor_convert",
 		"file":   filepath.Base(f.Path),
@@ -274,7 +338,7 @@ func (c *Compactor) convertFileToSorted(f FileInfo) error {
 	// Open source file
 	srcFile, err := c.fs.Open(f.Path)
 	if err != nil {
-		return errors.Wrapf(err, "open source file")
+		return false, errors.Wrapf(err, "open source file")
 	}
 	defer srcFile.Close()
 
@@ -283,7 +347,7 @@ func (c *Compactor) convertFileToSorted(f FileInfo) error {
 	inMemReader := NewInMemoryReader(walReader, c.logger)
 	result, err := inMemReader.Do(nil, true) // keepLinkReplaceInformation = true
 	if err != nil {
-		return errors.Wrap(err, "read file into memory")
+		return false, errors.Wrap(err, "read file into memory")
 	}
 
 	// Build output filename
@@ -293,22 +357,22 @@ func (c *Compactor) convertFileToSorted(f FileInfo) error {
 	// Write using SortedWriter via SafeFileWriter
 	sfw, err := NewSafeFileWriterWithFS(outPath, c.config.BufferSize, c.fs)
 	if err != nil {
-		return errors.Wrap(err, "create safe file writer")
+		return false, errors.Wrap(err, "create safe file writer")
 	}
 	defer sfw.Abort() // cleanup on error
 
 	sortedWriter := NewSortedWriter(sfw.Writer(), c.logger)
 	if err := sortedWriter.WriteAll(result); err != nil {
-		return errors.Wrap(err, "write sorted file")
+		return false, errors.Wrap(err, "write sorted file")
 	}
 
 	if err := sfw.Commit(); err != nil {
-		return errors.Wrap(err, "commit sorted file")
+		return false, errors.Wrap(err, "commit sorted file")
 	}
 
 	// Delete original file after successful conversion
 	if err := c.fs.Remove(f.Path); err != nil && !os.IsNotExist(err) {
-		return errors.Wrap(err, "remove original file")
+		return false, errors.Wrap(err, "remove original file")
 	}
 
 	c.logger.WithFields(logrus.Fields{
@@ -317,7 +381,7 @@ func (c *Compactor) convertFileToSorted(f FileInfo) error {
 		"output":   outFilename,
 	}).Debug("converted file to sorted format")
 
-	return nil
+	return inMemReader.HasReset(), nil
 }
 
 // decideAction determines what compaction action to take based on current state.

--- a/adapters/repos/db/vector/hnsw/compact/compactor.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor.go
@@ -240,44 +240,31 @@ func (c *Compactor) resolveOverlaps(state *DirectoryState) error {
 // SafeFileWriter would otherwise leak a tmp file we can't cleanly orphan
 // from inside this function).
 func (c *Compactor) convertToSorted(state *DirectoryState, shouldAbort func() bool) error {
-	// A ResetIndex wipes all prior state, but each file is converted in
-	// isolation, so without discarding older files the reset's effect stays
-	// confined to its own file and older files resurrect pre-reset data on load.
-	var resetBoundaryTS int64
-	foundReset := false
-
-	noteReset := func(f FileInfo, hasReset bool) {
-		if hasReset && f.StartTS > resetBoundaryTS {
-			resetBoundaryTS = f.StartTS
-			foundReset = true
+	files := make([]FileInfo, 0, len(state.RawFiles)+len(state.CondensedFiles))
+	files = append(files, state.RawFiles...)
+	files = append(files, state.CondensedFiles...)
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].StartTS != files[j].StartTS {
+			return files[i].StartTS < files[j].StartTS
 		}
-	}
+		return files[i].Type < files[j].Type
+	})
 
-	for _, f := range state.RawFiles {
+	for _, f := range files {
 		if isAborted(shouldAbort) {
 			return ErrCompactionAborted
 		}
 		hasReset, err := c.convertFileToSorted(f)
 		if err != nil {
-			return errors.Wrapf(err, "convert raw file %s", f.Path)
+			return errors.Wrapf(err, "convert %s file %s", f.Type.String(), f.Path)
 		}
-		noteReset(f, hasReset)
-	}
-
-	for _, f := range state.CondensedFiles {
-		if isAborted(shouldAbort) {
-			return ErrCompactionAborted
-		}
-		hasReset, err := c.convertFileToSorted(f)
-		if err != nil {
-			return errors.Wrapf(err, "convert condensed file %s", f.Path)
-		}
-		noteReset(f, hasReset)
-	}
-
-	if foundReset {
-		if err := c.discardFilesBeforeReset(resetBoundaryTS); err != nil {
-			return errors.Wrap(err, "discard files before reset")
+		if hasReset {
+			// ResetIndex is consumed when this file is materialized into sorted
+			// output. Discard older files before any later abort can leave the
+			// directory without a durable reset marker.
+			if err := c.discardFilesBeforeReset(f.StartTS); err != nil {
+				return errors.Wrap(err, "discard files before reset")
+			}
 		}
 	}
 

--- a/adapters/repos/db/vector/hnsw/compact/compactor.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor.go
@@ -260,8 +260,8 @@ func (c *Compactor) convertToSorted(state *DirectoryState, shouldAbort func() bo
 		}
 		if hasReset {
 			// ResetIndex is consumed when this file is materialized into sorted
-			// output. Discard older files before any later abort can leave the
-			// directory without a durable reset marker.
+			// output. Discard older files before removing the source so crash
+			// recovery can still replay the reset if cleanup is interrupted.
 			if err := c.discardFilesBeforeReset(f.StartTS); err != nil {
 				return errors.Wrap(err, "discard files before reset")
 			}

--- a/adapters/repos/db/vector/hnsw/compact/compactor.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor.go
@@ -284,9 +284,9 @@ func (c *Compactor) convertToSorted(state *DirectoryState, shouldAbort func() bo
 	return nil
 }
 
-// discardFilesBeforeReset removes every commit-log file strictly older than
-// boundaryTS (the StartTS of the file carrying the ResetIndex). That file's own
-// output shares boundaryTS and is preserved; the live file is never removed.
+// discardFilesBeforeReset removes every commit-log file whose range starts
+// before boundaryTS (the StartTS of the file carrying the ResetIndex). That
+// file's own output shares boundaryTS and is preserved; the live file is never removed.
 func (c *Compactor) discardFilesBeforeReset(boundaryTS int64) error {
 	discovery := NewFileDiscoveryWithFS(c.config.Dir, c.fs)
 	state, err := discovery.Scan()

--- a/adapters/repos/db/vector/hnsw/compact/compactor_reset_acrossfiles_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor_reset_acrossfiles_test.go
@@ -1,0 +1,217 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compact
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the contract that, after compaction, a ResetIndex in a later
+// file makes everything older than it disappear — matching a no-compaction load.
+
+func compactToFixedPoint(t *testing.T, dir string) {
+	t.Helper()
+	c := NewCompactor(DefaultCompactorConfig(dir), quietLogger())
+	for i := 0; i < 50; i++ {
+		action, err := c.RunCycle(nil)
+		require.NoError(t, err, "RunCycle %d", i)
+		if action == ActionNone {
+			return
+		}
+	}
+	t.Fatal("compaction did not converge")
+}
+
+func TestCompact_ResetAcrossFiles_MatchesNoCompaction(t *testing.T) {
+	type file struct {
+		ts  int64
+		ops func(w *WALWriter)
+	}
+
+	tests := []struct {
+		name  string
+		files []file
+	}{
+		{
+			name: "reset clears tombstone from older file",
+			files: []file{
+				{1000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(1, 1))
+					require.NoError(t, w.WriteAddTombstone(1))
+				}},
+				{2000, func(w *WALWriter) {
+					require.NoError(t, w.WriteResetIndex())
+					require.NoError(t, w.WriteAddNode(2, 1))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(2, 1))
+				}},
+				{3000, func(w *WALWriter) { require.NoError(t, w.WriteAddNode(3, 0)) }},
+			},
+		},
+		{
+			name: "reset clears nodes and links from older files",
+			files: []file{
+				{1000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(10, 2))
+					require.NoError(t, w.WriteAddNode(11, 1))
+					require.NoError(t, w.WriteAddLinkAtLevel(10, 0, 11))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(10, 2))
+				}},
+				{2000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(12, 1))
+					require.NoError(t, w.WriteAddLinkAtLevel(12, 0, 10))
+				}},
+				{3000, func(w *WALWriter) {
+					require.NoError(t, w.WriteResetIndex())
+					require.NoError(t, w.WriteAddNode(20, 2))
+					require.NoError(t, w.WriteAddNode(21, 1))
+					require.NoError(t, w.WriteAddLinkAtLevel(20, 0, 21))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(20, 2))
+				}},
+				{4000, func(w *WALWriter) { require.NoError(t, w.WriteAddNode(22, 0)) }},
+			},
+		},
+		{
+			name: "reset in oldest non-live file",
+			files: []file{
+				{1000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(1, 1))
+					require.NoError(t, w.WriteResetIndex())
+					require.NoError(t, w.WriteAddNode(5, 1))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(5, 1))
+				}},
+				{2000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(6, 1))
+					require.NoError(t, w.WriteAddLinkAtLevel(6, 0, 5))
+				}},
+				{3000, func(w *WALWriter) { require.NoError(t, w.WriteAddNode(7, 0)) }},
+			},
+		},
+		{
+			name: "two resets in different files - last wins",
+			files: []file{
+				{1000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(1, 1))
+					require.NoError(t, w.WriteAddTombstone(1))
+				}},
+				{2000, func(w *WALWriter) {
+					require.NoError(t, w.WriteResetIndex())
+					require.NoError(t, w.WriteAddNode(2, 1))
+					require.NoError(t, w.WriteAddTombstone(2))
+				}},
+				{3000, func(w *WALWriter) {
+					require.NoError(t, w.WriteResetIndex())
+					require.NoError(t, w.WriteAddNode(3, 2))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(3, 2))
+				}},
+				{4000, func(w *WALWriter) { require.NoError(t, w.WriteAddNode(4, 0)) }},
+			},
+		},
+		{
+			name: "post-reset data in newer files survives",
+			files: []file{
+				{1000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(1, 1))
+					require.NoError(t, w.WriteAddTombstone(1))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(1, 1))
+				}},
+				{2000, func(w *WALWriter) {
+					require.NoError(t, w.WriteResetIndex())
+					require.NoError(t, w.WriteAddNode(2, 2))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(2, 2))
+				}},
+				{3000, func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(3, 1))
+					require.NoError(t, w.WriteAddLinkAtLevel(2, 0, 3))
+					require.NoError(t, w.WriteAddTombstone(3))
+				}},
+				{4000, func(w *WALWriter) { require.NoError(t, w.WriteAddNode(4, 0)) }},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseDir := t.TempDir()
+			workDir := t.TempDir()
+			for _, f := range tc.files {
+				name := fmt.Sprintf("%d", f.ts)
+				createTestWALFile(t, filepath.Join(baseDir, name), f.ops)
+				createTestWALFile(t, filepath.Join(workDir, name), f.ops)
+			}
+
+			baseline := loadGraph(t, baseDir)
+			compactToFixedPoint(t, workDir)
+			compacted := loadGraph(t, workDir)
+
+			assertGraphEqual(t, baseline, compacted)
+		})
+	}
+}
+
+// TestCompact_ResetDiscardsOlderSnapshot verifies a reset also obsoletes a
+// snapshot built from pre-reset data once the reset file is compacted.
+func TestCompact_ResetDiscardsOlderSnapshot(t *testing.T) {
+	baseDir := t.TempDir()
+	workDir := t.TempDir()
+
+	files := []struct {
+		ts  int64
+		ops func(w *WALWriter)
+	}{
+		{1000, func(w *WALWriter) {
+			require.NoError(t, w.WriteAddNode(1, 2))
+			require.NoError(t, w.WriteAddNode(2, 1))
+			require.NoError(t, w.WriteAddLinkAtLevel(1, 0, 2))
+			require.NoError(t, w.WriteAddTombstone(2))
+			require.NoError(t, w.WriteSetEntryPointMaxLevel(1, 2))
+		}},
+		{2000, func(w *WALWriter) {
+			require.NoError(t, w.WriteAddNode(3, 1))
+			require.NoError(t, w.WriteAddLinkAtLevel(1, 0, 3))
+		}},
+	}
+	for _, f := range files {
+		name := fmt.Sprintf("%d", f.ts)
+		createTestWALFile(t, filepath.Join(baseDir, name), f.ops)
+		createTestWALFile(t, filepath.Join(workDir, name), f.ops)
+	}
+
+	// Compact the first batch into a snapshot while file 2000 is still live.
+	compactToFixedPoint(t, workDir)
+	require.NotNil(t, NewLoader(LoaderConfig{Dir: workDir, Logger: quietLogger()}))
+
+	resetFile := func(w *WALWriter) {
+		require.NoError(t, w.WriteResetIndex())
+		require.NoError(t, w.WriteAddNode(9, 2))
+		require.NoError(t, w.WriteSetEntryPointMaxLevel(9, 2))
+	}
+	liveFile := func(w *WALWriter) { require.NoError(t, w.WriteAddNode(10, 0)) }
+	createTestWALFile(t, filepath.Join(baseDir, "3000"), resetFile)
+	createTestWALFile(t, filepath.Join(workDir, "3000"), resetFile)
+	createTestWALFile(t, filepath.Join(baseDir, "4000"), liveFile)
+	createTestWALFile(t, filepath.Join(workDir, "4000"), liveFile)
+
+	baseline := loadGraph(t, baseDir)
+	compactToFixedPoint(t, workDir)
+	compacted := loadGraph(t, workDir)
+
+	assertGraphEqual(t, baseline, compacted)
+
+	require.NotContains(t, compacted.Graph.Tombstones, uint64(2),
+		"pre-reset tombstone resurrected after compaction")
+	require.True(t, effectivelyAbsent(nodeAt(compacted, 1)),
+		"pre-reset node 1 resurrected after compaction")
+}

--- a/adapters/repos/db/vector/hnsw/compact/compactor_reset_acrossfiles_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor_reset_acrossfiles_test.go
@@ -13,6 +13,7 @@ package compact
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -260,4 +261,75 @@ func TestCompact_ResetAbortAfterConversionDiscardsPreResetFiles(t *testing.T) {
 	assertGraphEqual(t, baseline, aborted)
 	require.True(t, effectivelyAbsent(nodeAt(aborted, 1)),
 		"pre-reset node 1 resurrected after aborting reset conversion")
+}
+
+func TestCompact_ResetDiscardFailureKeepsResetSourceForCrashRecovery(t *testing.T) {
+	tests := []struct {
+		name      string
+		resetFile string
+	}{
+		{
+			name:      "raw reset source",
+			resetFile: "2000",
+		},
+		{
+			name:      "condensed reset source",
+			resetFile: "2000.condensed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writeScenario := func(dir string) {
+				createTestWALFile(t, filepath.Join(dir, "1000"), func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(1, 1))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(1, 1))
+				})
+				createTestWALFile(t, filepath.Join(dir, tc.resetFile), func(w *WALWriter) {
+					require.NoError(t, w.WriteResetIndex())
+					require.NoError(t, w.WriteAddNode(2, 1))
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(2, 1))
+				})
+				createTestWALFile(t, filepath.Join(dir, "3000"), func(w *WALWriter) {
+					require.NoError(t, w.WriteAddNode(3, 1))
+				})
+				createTestWALFile(t, filepath.Join(dir, "4000"), func(w *WALWriter) {})
+			}
+
+			baseDir := t.TempDir()
+			workDir := t.TempDir()
+			writeScenario(baseDir)
+			writeScenario(workDir)
+
+			baseline := loadGraph(t, baseDir)
+			require.True(t, effectivelyAbsent(nodeAt(baseline, 1)),
+				"baseline reset should remove pre-reset node 1")
+
+			fs := common.NewTestFS()
+			fs.OnRemove = func(name string) error {
+				if filepath.Base(name) == "1000.sorted" {
+					return os.ErrPermission
+				}
+				return os.Remove(name)
+			}
+
+			config := DefaultCompactorConfig(workDir)
+			config.FS = fs
+			compactor := NewCompactor(config, quietLogger())
+
+			_, err := compactor.RunCycle(nil)
+			require.Error(t, err, "discard failure should abort this compaction cycle")
+
+			_, err = os.Stat(filepath.Join(workDir, tc.resetFile))
+			require.NoError(t, err, "reset source must survive until pre-reset discard succeeds")
+
+			recovered := loadGraph(t, workDir)
+			assertGraphEqual(t, baseline, recovered)
+			require.True(t, effectivelyAbsent(nodeAt(recovered, 1)),
+				"pre-reset node 1 resurrected after failed reset discard recovery")
+
+			_, err = os.Stat(filepath.Join(workDir, "2000.sorted"))
+			require.True(t, os.IsNotExist(err), "loader should remove duplicate sorted reset output")
+		})
+	}
 }

--- a/adapters/repos/db/vector/hnsw/compact/compactor_reset_acrossfiles_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor_reset_acrossfiles_test.go
@@ -14,9 +14,12 @@ package compact
 import (
 	"fmt"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 )
 
 // These tests pin the contract that, after compaction, a ResetIndex in a later
@@ -214,4 +217,47 @@ func TestCompact_ResetDiscardsOlderSnapshot(t *testing.T) {
 		"pre-reset tombstone resurrected after compaction")
 	require.True(t, effectivelyAbsent(nodeAt(compacted, 1)),
 		"pre-reset node 1 resurrected after compaction")
+}
+
+func TestCompact_ResetAbortAfterConversionDiscardsPreResetFiles(t *testing.T) {
+	writeScenario := func(dir string) {
+		createTestWALFile(t, filepath.Join(dir, "1000"), func(w *WALWriter) {
+			require.NoError(t, w.WriteAddNode(1, 1))
+			require.NoError(t, w.WriteSetEntryPointMaxLevel(1, 1))
+		})
+		createTestWALFile(t, filepath.Join(dir, "2000"), func(w *WALWriter) {
+			require.NoError(t, w.WriteResetIndex())
+			require.NoError(t, w.WriteAddNode(2, 1))
+			require.NoError(t, w.WriteSetEntryPointMaxLevel(2, 1))
+		})
+		createTestWALFile(t, filepath.Join(dir, "3000"), func(w *WALWriter) {
+			require.NoError(t, w.WriteAddNode(3, 1))
+		})
+		createTestWALFile(t, filepath.Join(dir, "4000"), func(w *WALWriter) {})
+	}
+
+	baseDir := t.TempDir()
+	workDir := t.TempDir()
+	writeScenario(baseDir)
+	writeScenario(workDir)
+
+	baseline := loadGraph(t, baseDir)
+	require.True(t, effectivelyAbsent(nodeAt(baseline, 1)),
+		"baseline reset should remove pre-reset node 1")
+
+	var opens atomic.Int32
+	config := DefaultCompactorConfig(workDir)
+	config.FS = &countingOpenFS{FS: common.NewOSFS(), suffix: "", count: &opens}
+	compactor := NewCompactor(config, quietLogger())
+
+	_, err := compactor.RunCycle(func() bool {
+		return opens.Load() >= 2
+	})
+	require.True(t, errors.Is(err, ErrCompactionAborted),
+		"RunCycle should abort after the reset file is converted; got %v", err)
+
+	aborted := loadGraph(t, workDir)
+	assertGraphEqual(t, baseline, aborted)
+	require.True(t, effectivelyAbsent(nodeAt(aborted, 1)),
+		"pre-reset node 1 resurrected after aborting reset conversion")
 }

--- a/adapters/repos/db/vector/hnsw/compact/in_memory_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/in_memory_reader.go
@@ -67,6 +67,8 @@ func NewInMemoryReader(reader *WALCommitReader, logger logrus.FieldLogger) *InMe
 // If initialState is provided, commits are applied on top of it.
 // keepLinkReplaceInformation controls whether LinksReplaced tracking is maintained.
 func (r *InMemoryReader) Do(initialState *ent.DeserializationResult, keepLinkReplaceInformation bool) (*ent.DeserializationResult, error) {
+	r.hasReset = false
+
 	out := initialState
 	commitTypeMetrics := make(map[HnswCommitType]int)
 

--- a/adapters/repos/db/vector/hnsw/compact/in_memory_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/in_memory_reader.go
@@ -45,8 +45,14 @@ const (
 // is compatible with the v2 WALCommitReader instead of parsing a raw file like
 // the old condensor did.
 type InMemoryReader struct {
-	logger logrus.FieldLogger
-	reader *WALCommitReader
+	logger   logrus.FieldLogger
+	reader   *WALCommitReader
+	hasReset bool
+}
+
+// HasReset reports whether a ResetIndexCommit was applied during the last Do call.
+func (r *InMemoryReader) HasReset() bool {
+	return r.hasReset
 }
 
 // NewInMemoryReader creates a new reader that deserializes commits into memory.
@@ -126,6 +132,7 @@ func (r *InMemoryReader) Do(initialState *ent.DeserializationResult, keepLinkRep
 		case *DeleteNodeCommit:
 			err = r.readDeleteNode(commit, out)
 		case *ResetIndexCommit:
+			r.hasReset = true
 			out.Graph.Entrypoint = 0
 			out.Graph.Level = 0
 			out.Graph.Nodes = make([]*ent.Vertex, cache.InitialSize)

--- a/adapters/repos/db/vector/hnsw/compact/in_memory_reader_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/in_memory_reader_test.go
@@ -107,6 +107,26 @@ func TestInMemoryReader_GarbageTargets(t *testing.T) {
 	})
 }
 
+func TestInMemoryReader_HasResetReflectsLastDoCall(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWALWriter(&buf)
+	require.NoError(t, w.WriteResetIndex())
+	require.NoError(t, w.WriteAddNode(1, 1))
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+	reader := NewWALCommitReader(&buf, logger)
+	memReader := NewInMemoryReader(reader, logger)
+
+	_, err := memReader.Do(nil, false)
+	require.NoError(t, err)
+	require.True(t, memReader.HasReset(), "first Do should report the reset it applied")
+
+	_, err = memReader.Do(nil, false)
+	require.NoError(t, err)
+	require.False(t, memReader.HasReset(), "second Do should clear the previous reset state")
+}
+
 func TestFilterValidTargets(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.FatalLevel)

--- a/adapters/repos/db/vector/hnsw/compact/safe_file_writer.go
+++ b/adapters/repos/db/vector/hnsw/compact/safe_file_writer.go
@@ -154,15 +154,16 @@ func (s *SafeFileWriter) Abort() error {
 	return nil
 }
 
-// CleanupCorruptCondensedFiles removes .condensed files when a raw file with the
-// same timestamp exists.
+// CleanupCorruptCondensedFiles removes converted files when their source file
+// with the same timestamp still exists.
 //
 // This indicates an interrupted condensing operation - a successful condense would
 // have deleted the original raw file. The .condensed file is likely corrupt, so we
 // delete it and use the raw file instead.
 //
-// The same logic applies to .sorted files - if both exist with the same timestamp,
-// the sort was interrupted and the .sorted file should be removed.
+// The same logic applies to .sorted files - if a raw or .condensed source with
+// the same timestamp still exists, the sort was interrupted and the .sorted file
+// should be removed.
 func CleanupCorruptCondensedFiles(dir string) error {
 	return CleanupCorruptCondensedFilesWithFS(dir, common.NewOSFS())
 }
@@ -178,16 +179,19 @@ func CleanupCorruptCondensedFilesWithFS(dir string, fs common.FS) error {
 		return errors.Wrapf(err, "read directory %s", dir)
 	}
 
-	// Build set of raw file timestamps
+	// Build set of source file timestamps
 	rawTimestamps := make(map[string]struct{})
+	condensedTimestamps := make(map[string]struct{})
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
-		// Raw files have no suffix (just a timestamp)
-		if !hasKnownSuffix(name) {
+		switch {
+		case !hasKnownSuffix(name):
 			rawTimestamps[name] = struct{}{}
+		case len(name) > len(suffixCondensed) && name[len(name)-len(suffixCondensed):] == suffixCondensed:
+			condensedTimestamps[name[:len(name)-len(suffixCondensed)]] = struct{}{}
 		}
 	}
 
@@ -199,17 +203,22 @@ func CleanupCorruptCondensedFilesWithFS(dir string, fs common.FS) error {
 		name := entry.Name()
 
 		var baseName string
+		shouldRemove := false
 		switch {
 		case len(name) > len(suffixCondensed) && name[len(name)-len(suffixCondensed):] == suffixCondensed:
 			baseName = name[:len(name)-len(suffixCondensed)]
+			_, shouldRemove = rawTimestamps[baseName]
 		case len(name) > len(suffixSorted) && name[len(name)-len(suffixSorted):] == suffixSorted:
 			baseName = name[:len(name)-len(suffixSorted)]
+			_, shouldRemove = rawTimestamps[baseName]
+			if !shouldRemove {
+				_, shouldRemove = condensedTimestamps[baseName]
+			}
 		default:
 			continue
 		}
 
-		// If a raw file with the same timestamp exists, the processed file is corrupt
-		if _, exists := rawTimestamps[baseName]; exists {
+		if shouldRemove {
 			corruptPath := filepath.Join(dir, name)
 			if err := fs.Remove(corruptPath); err != nil && !os.IsNotExist(err) {
 				return errors.Wrapf(err, "remove corrupt file %s", corruptPath)

--- a/adapters/repos/db/vector/hnsw/compact/safe_file_writer_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/safe_file_writer_test.go
@@ -262,6 +262,12 @@ func TestCleanupCorruptCondensedFiles(t *testing.T) {
 	err = os.WriteFile(validCondensed, []byte("valid condensed"), 0o666)
 	require.NoError(t, err)
 
+	// Create a .sorted file with the same timestamp as a .condensed source
+	// (simulates interrupted condensed-to-sorted conversion).
+	sortedFromCondensed := filepath.Join(dir, "9999999999.sorted")
+	err = os.WriteFile(sortedFromCondensed, []byte("corrupt sorted"), 0o666)
+	require.NoError(t, err)
+
 	// Run cleanup
 	err = CleanupCorruptCondensedFiles(dir)
 	require.NoError(t, err)
@@ -279,6 +285,10 @@ func TestCleanupCorruptCondensedFiles(t *testing.T) {
 	// Valid .condensed should still exist
 	_, err = os.Stat(validCondensed)
 	require.NoError(t, err, "valid .condensed should still exist")
+
+	// Duplicate .sorted from an unfinished condensed-to-sorted conversion should be removed
+	_, err = os.Stat(sortedFromCondensed)
+	assert.True(t, os.IsNotExist(err), "corrupt .sorted should be removed when .condensed source exists")
 }
 
 func TestCleanupCorruptCondensedFiles_NonExistentDir(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

- Fix compact v2 in case where `Reset()` is called (this occurs when all vectors are deleted from an index)
- Previously this could leave nodes in older commit logs
- This PR also adds additional tests including a property test for randomized preserve graph across compaction, a convergence test, and a concurrent switch commit logs and compaction test.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
