### PR TITLE
perf: dense/sorted-pairs property-length representation

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1185,9 +1185,9 @@ func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsi
 
 		segmentStrategy := segmentsDisk[i].getStrategy()
 
-		propLengths := make(map[uint64]uint32)
+		var propLengths propLengthsView
 		if segmentStrategy == segmentindex.StrategyInverted && !c.skipPropertyLengths {
-			propLengths, err = segmentsDisk[i].getPropertyLengths()
+			propLengths, err = segmentsDisk[i].propLengthsView()
 			if err != nil {
 				return nil, err
 			}
@@ -1210,7 +1210,7 @@ func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsi
 					}
 				}
 				// put the property length in the value from the "external" property lengths
-				binary.LittleEndian.PutUint32(segmentDecoded[j].Value[4:], math.Float32bits(float32(propLengths[docId])))
+				binary.LittleEndian.PutUint32(segmentDecoded[j].Value[4:], math.Float32bits(float32(propLengths.get(docId))))
 
 			} else {
 				if err := segmentDecoded[j].FromBytes(v.value, false); err != nil {
@@ -2075,9 +2075,9 @@ func (b *Bucket) docPointerWithScoreListFromConsistentView(ctx context.Context, 
 
 		segmentStrategy := segmentsDisk[i].getStrategy()
 
-		propLengths := make(map[uint64]uint32)
+		var propLengths propLengthsView
 		if segmentStrategy == segmentindex.StrategyInverted {
-			propLengths, err = segmentsDisk[i].getPropertyLengths()
+			propLengths, err = segmentsDisk[i].propLengthsView()
 			if err != nil {
 				return nil, err
 			}
@@ -2087,7 +2087,7 @@ func (b *Bucket) docPointerWithScoreListFromConsistentView(ctx context.Context, 
 		for j, v := range plist {
 			if segmentStrategy == segmentindex.StrategyInverted {
 				docId := binary.BigEndian.Uint64(v.value[:8])
-				propLen := propLengths[docId]
+				propLen := propLengths.get(docId)
 				if err := segmentDecoded[j].FromBytesInverted(v.value, propBoost, float32(propLen)); err != nil {
 					return nil, err
 				}

--- a/adapters/repos/db/lsmkv/gobenc/gobenc.go
+++ b/adapters/repos/db/lsmkv/gobenc/gobenc.go
@@ -227,6 +227,13 @@ func decodePairsFast(data []byte) ([]uint64, []uint32, error) {
 	}
 	pos += n
 
+	// the count varint is bounded only against len(data), so it can run past
+	// msgEnd; without this, uint64(msgEnd-pos) underflows and the guard below
+	// admits a huge count that make([]uint64, count) panics on.
+	if pos > msgEnd {
+		return nil, nil, fmt.Errorf("map count truncated: read to offset %d past message end %d", pos, msgEnd)
+	}
+
 	// Each entry is at least 2 bytes (1 byte key + 1 byte value).
 	if count > uint64(msgEnd-pos)/2 {
 		return nil, nil, fmt.Errorf("count %d too large for remaining %d bytes", count, msgEnd-pos)
@@ -303,6 +310,11 @@ func decodeFast(data []byte) (map[uint64]uint32, error) {
 		return nil, fmt.Errorf("read map count: %w", err)
 	}
 	pos += n
+
+	// see decodePairsFast: bound pos so uint64(msgEnd-pos) can't underflow
+	if pos > msgEnd {
+		return nil, fmt.Errorf("map count truncated: read to offset %d past message end %d", pos, msgEnd)
+	}
 
 	// Each entry is at least 2 bytes (1 byte key + 1 byte value).
 	if count > uint64(msgEnd-pos)/2 {

--- a/adapters/repos/db/lsmkv/gobenc/gobenc.go
+++ b/adapters/repos/db/lsmkv/gobenc/gobenc.go
@@ -114,6 +114,38 @@ func Encode(m map[uint64]uint32) ([]byte, error) {
 	return buf, nil
 }
 
+// EncodePairs serializes parallel docID/length arrays into Encode's wire format
+// (a gob map[uint64]uint32) without materializing a map. The caller owns
+// uniqueness — a repeated key decodes to whichever value was written last.
+func EncodePairs(ids []uint64, lens []uint32) ([]byte, error) {
+	if len(ids) != len(lens) {
+		return nil, fmt.Errorf("gobenc: ids/lens length mismatch (%d vs %d)", len(ids), len(lens))
+	}
+
+	bodySize := len(dataPrefix) + gobUintSize(uint64(len(ids)))
+	for i, k := range ids {
+		bodySize += gobUintSize(k) + gobUintSize(uint64(lens[i]))
+	}
+
+	totalSize := len(gobMapPreamble) + gobUintSize(uint64(bodySize)) + bodySize
+	buf := make([]byte, 0, totalSize)
+
+	buf = append(buf, gobMapPreamble...)
+	buf = appendGobUint(buf, uint64(bodySize))
+	buf = append(buf, dataPrefix...)
+	buf = appendGobUint(buf, uint64(len(ids)))
+	for i, k := range ids {
+		buf = appendGobUint(buf, k)
+		buf = appendGobUint(buf, uint64(lens[i]))
+	}
+
+	if len(buf) != totalSize {
+		return nil, fmt.Errorf("gobenc: size bookkeeping bug: predicted %d bytes, wrote %d", totalSize, len(buf))
+	}
+
+	return buf, nil
+}
+
 // Decode deserializes gob-encoded bytes back into a map[uint64]uint32.
 // It first attempts a fast manual decode. If the preamble doesn't match
 // (e.g. data written by a different gob encoder configuration), it falls
@@ -131,6 +163,104 @@ func Decode(data []byte) (map[uint64]uint32, error) {
 		return nil, fmt.Errorf("gobenc: fast decode failed (%w), gob fallback also failed: %w", err, gobErr)
 	}
 	return m, nil
+}
+
+// DecodePairs deserializes gob-encoded map[uint64]uint32 bytes into two
+// parallel slices, pre-allocated at the exact entry count from the stream —
+// the map is never materialized. Entries are returned in stream order (gob
+// writes map iteration order, i.e. effectively random); callers sort.
+func DecodePairs(data []byte) ([]uint64, []uint32, error) {
+	ids, lens, err := decodePairsFast(data)
+	if err == nil {
+		return ids, lens, nil
+	}
+
+	// Fallback to stdlib gob for unexpected formats
+	dec := gob.NewDecoder(bytes.NewReader(data))
+	m := map[uint64]uint32{}
+	if gobErr := dec.Decode(&m); gobErr != nil {
+		return nil, nil, fmt.Errorf("gobenc: fast decode failed (%w), gob fallback also failed: %w", err, gobErr)
+	}
+	ids = make([]uint64, 0, len(m))
+	lens = make([]uint32, 0, len(m))
+	for k, v := range m {
+		ids = append(ids, k)
+		lens = append(lens, v)
+	}
+	return ids, lens, nil
+}
+
+func decodePairsFast(data []byte) ([]uint64, []uint32, error) {
+	preambleLen, typeID, err := parseGobMapPreamble(data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pos := preambleLen
+
+	msgLen, n, err := readGobUint(data, pos)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read message length: %w", err)
+	}
+	pos += n
+
+	if msgLen > uint64(len(data)-pos) {
+		return nil, nil, fmt.Errorf("message length %d exceeds data (%d bytes remaining)", msgLen, len(data)-pos)
+	}
+	msgEnd := pos + int(msgLen)
+
+	prefixID, n, err := readGobInt(data, pos)
+	if err != nil || pos+n >= msgEnd {
+		return nil, nil, fmt.Errorf("data prefix truncated")
+	}
+	if prefixID != typeID {
+		return nil, nil, fmt.Errorf("data prefix mismatch")
+	}
+	pos += n
+	if data[pos] != 0x00 {
+		return nil, nil, fmt.Errorf("data prefix mismatch")
+	}
+	pos++
+
+	count, n, err := readGobUint(data, pos)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read map count: %w", err)
+	}
+	pos += n
+
+	// Each entry is at least 2 bytes (1 byte key + 1 byte value).
+	if count > uint64(msgEnd-pos)/2 {
+		return nil, nil, fmt.Errorf("count %d too large for remaining %d bytes", count, msgEnd-pos)
+	}
+
+	ids := make([]uint64, count)
+	lens := make([]uint32, count)
+
+	for i := range count {
+		key, n, err := readGobUint(data, pos)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read key %d: %w", i, err)
+		}
+		pos += n
+
+		val, n, err := readGobUint(data, pos)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read value %d: %w", i, err)
+		}
+		pos += n
+
+		if val > math.MaxUint32 {
+			return nil, nil, fmt.Errorf("value %d at index %d overflows uint32", val, i)
+		}
+		ids[i] = key
+		lens[i] = uint32(val)
+	}
+
+	if pos != msgEnd {
+		return nil, nil, fmt.Errorf("trailing bytes: decoded to offset %d, expected %d", pos, msgEnd)
+	}
+
+	return ids, lens, nil
 }
 
 func decodeFast(data []byte) (map[uint64]uint32, error) {

--- a/adapters/repos/db/lsmkv/gobenc/gobenc.go
+++ b/adapters/repos/db/lsmkv/gobenc/gobenc.go
@@ -165,10 +165,9 @@ func Decode(data []byte) (map[uint64]uint32, error) {
 	return m, nil
 }
 
-// DecodePairs deserializes gob-encoded map[uint64]uint32 bytes into two
-// parallel slices, pre-allocated at the exact entry count from the stream —
-// the map is never materialized. Entries are returned in stream order (gob
-// writes map iteration order, i.e. effectively random); callers sort.
+// DecodePairs deserializes gob-encoded map[uint64]uint32 bytes into two parallel
+// slices in unspecified order (gob stores map-iteration order; the fallback
+// re-ranges a map), so callers needing order must sort.
 func DecodePairs(data []byte) ([]uint64, []uint32, error) {
 	ids, lens, err := decodePairsFast(data)
 	if err == nil {

--- a/adapters/repos/db/lsmkv/gobenc/gobenc_test.go
+++ b/adapters/repos/db/lsmkv/gobenc/gobenc_test.go
@@ -584,6 +584,46 @@ func TestDecodeErrors(t *testing.T) {
 	}
 }
 
+// malformedCountPastMsgEnd builds a stream whose count varint sits past the
+// declared message end — the input that panicked decodePairsFast before the
+// pos>msgEnd guard.
+func malformedCountPastMsgEnd() []byte {
+	buf := append([]byte{}, gobMapPreamble...)
+	buf = appendGobUint(buf, uint64(len(dataPrefix))) // msgEnd lands right at the count byte
+	buf = append(buf, dataPrefix...)
+	buf = appendGobUint(buf, uint64(1)<<62) // count past msgEnd
+	buf = append(buf, 0x01, 0x02)
+	return buf
+}
+
+// TestDecodePairsMalformedCountNoPanic pins the fix for the makeslice panic: a
+// count that decodes past msgEnd must return an error, never panic, on every
+// entry point (fast path, public DecodePairs incl. its gob fallback, and the
+// parallel map decoder).
+func TestDecodePairsMalformedCountNoPanic(t *testing.T) {
+	t.Parallel()
+	buf := malformedCountPastMsgEnd()
+
+	_, _, err := decodePairsFast(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "map count truncated")
+
+	_, err = decodeFast(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "map count truncated")
+
+	// public APIs must not panic; the fast path fails and the gob fallback,
+	// fed the same bytes, also fails, so both return a (combined) error.
+	require.NotPanics(t, func() {
+		_, _, perr := DecodePairs(buf)
+		require.Error(t, perr)
+	})
+	require.NotPanics(t, func() {
+		_, derr := Decode(buf)
+		require.Error(t, derr)
+	})
+}
+
 func BenchmarkEncode(b *testing.B) {
 	m := makeMap(1000)
 	for b.Loop() {

--- a/adapters/repos/db/lsmkv/gobenc/gobenc_test.go
+++ b/adapters/repos/db/lsmkv/gobenc/gobenc_test.go
@@ -15,6 +15,8 @@ import (
 	"bytes"
 	"encoding/gob"
 	"math"
+	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -625,4 +627,169 @@ func makeMap(n int) map[uint64]uint32 {
 		m[uint64(i)*7+3] = uint32(i*13 + 5)
 	}
 	return m
+}
+
+func pairsToMap(t *testing.T, ids []uint64, lens []uint32) map[uint64]uint32 {
+	t.Helper()
+	require.Equal(t, len(ids), len(lens))
+	m := make(map[uint64]uint32, len(ids))
+	for i, id := range ids {
+		_, dup := m[id]
+		require.False(t, dup, "duplicate id %d in decoded pairs", id)
+		m[id] = lens[i]
+	}
+	return m
+}
+
+func TestDecodePairsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[uint64]uint32
+	}{
+		{"empty", map[uint64]uint32{}},
+		{"single", map[uint64]uint32{1: 2}},
+		{"zero_key_value", map[uint64]uint32{0: 0}},
+		{"small_values", map[uint64]uint32{1: 2, 3: 4, 5: 6}},
+		{"large_keys", map[uint64]uint32{
+			1<<32 - 1: 100,
+			1<<48 - 1: 200,
+			1<<56 - 1: 300,
+		}},
+		{"max_values", map[uint64]uint32{math.MaxUint64: math.MaxUint32}},
+		{"boundary_127", map[uint64]uint32{127: 127}},
+		{"boundary_128", map[uint64]uint32{128: 128}},
+		{"thousand_entries", makeMap(1000)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := Encode(tc.m)
+			require.NoError(t, err)
+			ids, lens, err := DecodePairs(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, tc.m, pairsToMap(t, ids, lens))
+			assert.Equal(t, len(tc.m), len(ids))
+		})
+	}
+}
+
+// DecodePairs must fall back to stdlib gob for streams the fast path rejects,
+// exactly like Decode does.
+func TestDecodePairsGobFallback(t *testing.T) {
+	t.Parallel()
+
+	m := makeMap(257)
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(m))
+
+	ids, lens, err := DecodePairs(buf.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, m, pairsToMap(t, ids, lens))
+}
+
+func TestDecodePairsMatchesDecode(t *testing.T) {
+	t.Parallel()
+
+	rnd := rand.New(rand.NewSource(42))
+	m := make(map[uint64]uint32, 10000)
+	for i := 0; i < 10000; i++ {
+		m[rnd.Uint64()>>rnd.Intn(40)] = uint32(rnd.Intn(1 << 20))
+	}
+
+	encoded, err := Encode(m)
+	require.NoError(t, err)
+
+	viaMap, err := Decode(encoded)
+	require.NoError(t, err)
+	ids, lens, err := DecodePairs(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, viaMap, pairsToMap(t, ids, lens))
+}
+
+func TestEncodePairsMatchesEncode(t *testing.T) {
+	t.Parallel()
+
+	maps := []map[uint64]uint32{
+		{},
+		{1: 2},
+		{0: 0},
+		{1: 2, 3: 4, 5: 6},
+		{1<<32 - 1: 100, 1<<48 - 1: 200, 1<<56 - 1: 300},
+		{math.MaxUint64: math.MaxUint32},
+		makeMap(1000),
+	}
+	for _, m := range maps {
+		// build sorted pairs from the map (EncodePairs callers pass sorted arrays)
+		ids := make([]uint64, 0, len(m))
+		for k := range m {
+			ids = append(ids, k)
+		}
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		lens := make([]uint32, len(ids))
+		for i, id := range ids {
+			lens[i] = m[id]
+		}
+
+		// EncodePairs output must decode to the same map as the input
+		encoded, err := EncodePairs(ids, lens)
+		require.NoError(t, err)
+		decoded, err := Decode(encoded)
+		require.NoError(t, err)
+		assert.Equal(t, m, decoded)
+
+		// and entry-for-entry identical to Encode of the same single-key maps:
+		// the byte stream differs only by entry order, so compare via decode of
+		// each, plus a same-order equality when the map has <=1 entry
+		if len(m) <= 1 {
+			viaMap, err := Encode(m)
+			require.NoError(t, err)
+			assert.Equal(t, viaMap, encoded)
+		}
+	}
+}
+
+func TestEncodePairsLengthMismatch(t *testing.T) {
+	t.Parallel()
+	_, err := EncodePairs([]uint64{1, 2}, []uint32{1})
+	require.Error(t, err)
+}
+
+// TestCrossCompatEncodePairsToGob is the downgrade guarantee: EncodePairs output
+// must decode under stdlib encoding/gob, so an older binary can read property
+// lengths written from the arrays by this version. TestEncodePairsMatchesEncode
+// only checks multi-entry output against the custom decoder, not stdlib gob.
+func TestCrossCompatEncodePairsToGob(t *testing.T) {
+	t.Parallel()
+
+	maps := []map[uint64]uint32{
+		{},
+		{42: 100},
+		{1: 2, 100: 200, 1000: 2000},
+		{1<<32 - 1: 100, 1<<48 - 1: 200, 1<<56 - 1: 300},
+		{math.MaxUint64: math.MaxUint32, 0: 0},
+		makeMap(1000),
+	}
+	for _, m := range maps {
+		ids := make([]uint64, 0, len(m))
+		for k := range m {
+			ids = append(ids, k)
+		}
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		lens := make([]uint32, len(ids))
+		for i, id := range ids {
+			lens[i] = m[id]
+		}
+
+		encoded, err := EncodePairs(ids, lens)
+		require.NoError(t, err)
+
+		// decode with the stdlib decoder, exactly as an older binary would
+		result := map[uint64]uint32{}
+		require.NoError(t, gob.NewDecoder(bytes.NewReader(encoded)).Decode(&result))
+		assert.Equal(t, m, result)
+	}
 }

--- a/adapters/repos/db/lsmkv/lazy_segment.go
+++ b/adapters/repos/db/lsmkv/lazy_segment.go
@@ -365,7 +365,7 @@ func (s *lazySegment) getPropertyLengths() (map[uint64]uint32, error) {
 }
 
 func (s *lazySegment) isPropertyLengthsLoaded() bool {
-	// an unloaded segment cannot have a cached map, and checking must not load it
+	// an unloaded segment cannot have cached arrays, and checking must not load it
 	if !s.isLoaded() {
 		return false
 	}
@@ -378,6 +378,13 @@ func (s *lazySegment) freePropertyLengths() {
 		return
 	}
 	s.segment.freePropertyLengths()
+}
+
+func (s *lazySegment) propLengthsView() (propLengthsView, error) {
+	if err := s.load(); err != nil {
+		return propLengthsView{}, fmt.Errorf("lazySegment::propLengthsView: %w", err)
+	}
+	return s.segment.propLengthsView()
 }
 
 func (s *lazySegment) newInvertedCursorReusable() *segmentCursorInvertedReusable {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -92,6 +92,7 @@ type Segment interface {
 	getPropertyLengths() (map[uint64]uint32, error)
 	isPropertyLengthsLoaded() bool
 	freePropertyLengths()
+	propLengthsView() (propLengthsView, error)
 	newInvertedCursorReusable() *segmentCursorInvertedReusable
 	newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
 
@@ -418,7 +419,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 				return nil, fmt.Errorf("load property length stats: %w", err)
 			}
 		} else {
-			if _, err := seg.loadPropertyLengths(); err != nil {
+			if err := seg.loadPropertyLengths(); err != nil {
 				return nil, fmt.Errorf("load property lengths: %w", err)
 			}
 		}

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -53,7 +53,7 @@ func decodeFuncsFromCodecs(codecs []varenc.VarEncDataType) (docIds, tfs func(dat
 	return docIds, tfs
 }
 
-func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint64]uint32) ([]terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
+func (s *segment) loadBlockEntries(node segmentindex.Node, plView *propLengthsView) ([]terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
 	var buf []byte
 	if s.readFromMemory {
 		buf = s.contents[node.Start : node.Start+uint64(8+12*terms.ENCODE_AS_FULL_BYTES)]
@@ -77,7 +77,9 @@ func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint6
 	if docCount <= uint64(terms.ENCODE_AS_FULL_BYTES) {
 		data := convertFixedLengthFromMemory(buf, int(docCount))
 		entries := make([]terms.BlockEntry, 1)
-		propLength := propLengths[data.DocIds[0]]
+		// reuse the snapshot reset already took under lock (propLengthsView), so
+		// this never reads the segment's arrays unlocked
+		propLength := plView.get(data.DocIds[0])
 		tf := data.Tfs[0]
 		entries[0] = terms.BlockEntry{
 			Offset:              0,
@@ -192,6 +194,10 @@ type SegmentBlockMax struct {
 	decodeDocIds func(data []byte, values []uint64)
 	decodeTfs    func(data []byte, values []uint64)
 
+	// disk terms read property lengths through the cursor view over the
+	// segment's sorted pairs; the map remains only for memtable-decoded terms
+	// (addDataToTerm) and the in-memory test constructor.
+	plView         propLengthsView
 	propLengths    map[uint64]uint32
 	blockDatasTest []*terms.BlockData
 
@@ -397,12 +403,14 @@ func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
 func (s *SegmentBlockMax) reset() error {
 	var err error
 
-	s.propLengths, err = s.segment.getPropertyLengths()
+	// the view is a no-IO cursor over the segment's sorted pairs —
+	// getPropertyLengths would reconstruct the whole map per query.
+	s.plView, err = s.segment.propLengthsView()
 	if err != nil {
 		return err
 	}
 
-	s.blockEntries, s.docCount, s.blockDataDecoded, err = s.segment.loadBlockEntries(s.node, s.propLengths)
+	s.blockEntries, s.docCount, s.blockDataDecoded, err = s.segment.loadBlockEntries(s.node, &s.plView)
 	if err != nil {
 		return err
 	}
@@ -593,6 +601,17 @@ func (s *SegmentBlockMax) QueryTerm() string {
 	return string(s.node.Key)
 }
 
+// propLengthOf returns the property length for a docID: the segment view for
+// disk terms (dense indexed load, or the pairs cursor — scoring visits docIDs
+// in ascending order, so the cursor is amortized O(1)), the map for
+// memtable-decoded terms. A docID without an entry yields 0 in all paths.
+func (s *SegmentBlockMax) propLengthOf(docID uint64) uint32 {
+	if s.plView.dense != nil || s.plView.ids != nil {
+		return s.plView.get(docID)
+	}
+	return s.propLengths[docID]
+}
+
 func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation bool) (uint64, float64, *terms.DocPointerWithScore) {
 	if s.exhausted {
 		return 0, 0, nil
@@ -606,7 +625,7 @@ func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation
 	}
 
 	freq := float64(s.blockDataDecoded.Tfs[s.blockDataIdx])
-	propLength := s.propLengths[s.idPointer]
+	propLength := s.propLengthOf(s.idPointer)
 	tf := freq / (freq + s.k1*((1-s.b)+s.b*(float64(propLength)/s.averagePropLength)))
 	if collectBlockMetrics {
 		s.Metrics.DocCountScored++

--- a/adapters/repos/db/lsmkv/segment_blockmax_impact_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_impact_test.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+)
+
+// TestComputeCurrentBlockImpact_UsesBlockEntry_NotResidentMap pins that the WAND
+// block-max upper bound derives from BlockEntry.MaxImpactPropLength (the on-disk
+// precomputed value), never from a per-document property-length lookup. If it
+// ever read the resident structure instead, the block-max bound would diverge
+// from the on-disk metadata and WAND pruning could skip blocks it must score.
+// The resident in-mem map deliberately holds a different value for the same doc.
+func TestComputeCurrentBlockImpact_UsesBlockEntry_NotResidentMap(t *testing.T) {
+	const (
+		k1            = 1.2
+		b             = 0.75
+		idf           = 2.5
+		propertyBoost = 1.0
+		avgPropLen    = 42.0
+
+		blockMaxImpactTf      = uint32(5)
+		blockMaxImpactPropLen = uint32(30)
+		// different value for the same doc: if computeCurrentBlockImpact reads the
+		// resident map instead of the BlockEntry, the assertions catch it.
+		residentPropLenForSameDoc = uint32(999)
+	)
+
+	impact := func(idf, propLen float64) float32 {
+		freq := float64(blockMaxImpactTf)
+		return float32(idf * (freq / (freq + k1*(1-b+b*(propLen/avgPropLen)))) * propertyBoost)
+	}
+	expected := impact(idf, float64(blockMaxImpactPropLen))
+	wrong := impact(idf, float64(residentPropLenForSameDoc))
+	require.NotEqual(t, expected, wrong, "test setup: pick constants that make the two impacts differ")
+
+	s := &SegmentBlockMax{
+		blockEntries: []terms.BlockEntry{{
+			MaxId:               10,
+			Offset:              0,
+			MaxImpactTf:         blockMaxImpactTf,
+			MaxImpactPropLength: blockMaxImpactPropLen,
+		}},
+		propLengths:       map[uint64]uint32{10: residentPropLenForSameDoc},
+		k1:                k1,
+		b:                 b,
+		idf:               idf,
+		propertyBoost:     propertyBoost,
+		averagePropLength: avgPropLen,
+	}
+
+	got := s.computeCurrentBlockImpact()
+	require.Equalf(t, expected, got,
+		"block impact must use BlockEntry.MaxImpactPropLength=%d, not resident %d",
+		blockMaxImpactPropLen, residentPropLenForSameDoc)
+	require.NotEqual(t, wrong, got, "block impact must not derive from the resident map")
+
+	// SetIdf recomputes; it must still use the BlockEntry value, not the map.
+	newIdf := idf * 1.5
+	s.SetIdf(newIdf)
+	require.Equal(t, impact(newIdf, float64(blockMaxImpactPropLen)), s.currentBlockImpact)
+
+	require.Falsef(t, math.IsNaN(float64(got)) || math.IsInf(float64(got), 0),
+		"block impact must be finite; got %v", got)
+}

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -409,7 +409,26 @@ func (s *fakeSegment) getCountNetAdditions() int {
 }
 
 func (s *fakeSegment) getPropertyLengths() (map[uint64]uint32, error) {
-	panic("not implemented")
+	// reconstruct from the same getInvertedData arrays propLengthsView reads, so
+	// the map and the view agree (mirrors segment.getPropertyLengths)
+	d := s.getInvertedData()
+	if d.propLengthsDense != nil {
+		m := make(map[uint64]uint32)
+		for i, l := range d.propLengthsDense {
+			if l != 0 {
+				m[d.propLengthsDenseMin+uint64(i)] = l
+			}
+		}
+		return m, nil
+	}
+	if len(d.propLengthsPairIds) == 0 {
+		return nil, nil
+	}
+	m := make(map[uint64]uint32, len(d.propLengthsPairIds))
+	for i, id := range d.propLengthsPairIds {
+		m[id] = d.propLengthsPairLens[i]
+	}
+	return m, nil
 }
 
 func (s *fakeSegment) isPropertyLengthsLoaded() bool { return false }
@@ -417,7 +436,16 @@ func (s *fakeSegment) isPropertyLengthsLoaded() bool { return false }
 func (s *fakeSegment) freePropertyLengths() {}
 
 func (s *fakeSegment) propLengthsView() (propLengthsView, error) {
-	panic("not implemented")
+	// mirror segment.propLengthsView over the fake's getInvertedData arrays so
+	// inverted read paths (Bucket.MapList / DocPointerWithScoreList) get real
+	// lengths instead of a panic
+	d := s.getInvertedData()
+	return propLengthsView{
+		dense: d.propLengthsDense,
+		min:   d.propLengthsDenseMin,
+		ids:   d.propLengthsPairIds,
+		lens:  d.propLengthsPairLens,
+	}, nil
 }
 
 func (s *fakeSegment) newInvertedCursorReusable() *segmentCursorInvertedReusable {

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -221,13 +221,11 @@ func (f *fakeSegment) getCollectionBytes(key []byte) ([][]byte, error) {
 func (f *fakeSegment) getInvertedData() *segmentInvertedData {
 	return &segmentInvertedData{
 		tombstones: sroar.NewBitmap(),
-		propertyLengths: map[uint64]uint32{
-			// NOTE: we are returning hardcoded fake data here which is good enough
-			// for the purpose of this test. This could be extended to return real
-			// data if necessary in the future.
-			0: 3,
-			1: 3,
-		},
+		// NOTE: we are returning hardcoded fake data here which is good enough
+		// for the purpose of this test. This could be extended to return real
+		// data if necessary in the future.
+		propLengthIds:           []uint64{0, 1},
+		propLengthLens:          []uint32{3, 3},
 		propertyLengthsLoaded:   true,
 		tombstonesLoaded:        true,
 		avgPropertyLengthsAvg:   3.0,
@@ -417,6 +415,10 @@ func (s *fakeSegment) getPropertyLengths() (map[uint64]uint32, error) {
 func (s *fakeSegment) isPropertyLengthsLoaded() bool { return false }
 
 func (s *fakeSegment) freePropertyLengths() {}
+
+func (s *fakeSegment) propLengthsView() (propLengthsView, error) {
+	panic("not implemented")
+}
 
 func (s *fakeSegment) newInvertedCursorReusable() *segmentCursorInvertedReusable {
 	panic("not implemented")

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -224,8 +224,8 @@ func (f *fakeSegment) getInvertedData() *segmentInvertedData {
 		// NOTE: we are returning hardcoded fake data here which is good enough
 		// for the purpose of this test. This could be extended to return real
 		// data if necessary in the future.
-		propLengthIds:           []uint64{0, 1},
-		propLengthLens:          []uint32{3, 3},
+		propLengthsPairIds:      []uint64{0, 1},
+		propLengthsPairLens:     []uint32{3, 3},
 		propertyLengthsLoaded:   true,
 		tombstonesLoaded:        true,
 		avgPropertyLengthsAvg:   3.0,

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -182,16 +182,24 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 
 	if len(ids) > 0 {
 		minID, maxID := ids[0], ids[0]
-		for _, id := range ids[1:] {
-			if id < minID {
-				minID = id
+		// min/max only feed the dense gate, so stop at the first zero length — a
+		// zero rules dense out anyway (see the gate below)
+		hasZeroLen := lens[0] == 0
+		for i := 1; i < len(ids) && !hasZeroLen; i++ {
+			if ids[i] < minID {
+				minID = ids[i]
 			}
-			if id > maxID {
-				maxID = id
+			if ids[i] > maxID {
+				maxID = ids[i]
+			}
+			if lens[i] == 0 {
+				hasZeroLen = true
 			}
 		}
 		span := maxID - minID + 1
-		if span != 0 && span/3 <= uint64(len(ids)) {
+		// dense uses 0 as the "docID absent" sentinel (getPropertyLengths drops
+		// zero slots), so a stored 0 would be lost — keep pairs when one exists.
+		if !hasZeroLen && span != 0 && span/3 <= uint64(len(ids)) {
 			// dense path: direct-indexed fill, no sort needed (unlike the pairs branch)
 			dense := make([]uint32, span)
 			for i, id := range ids {
@@ -307,8 +315,8 @@ func (s *segment) getPropertyLengths() (map[uint64]uint32, error) {
 		return nil, err
 	}
 	if dense != nil {
-		// stored lengths are always >= 1, so zero slots are exactly the absent
-		// docIDs and the reconstruction reproduces the stored key set
+		// dense is only chosen when no stored length is 0, so a zero slot is
+		// always an absent docID and the reconstruction reproduces the key set
 		m := make(map[uint64]uint32)
 		for i, l := range dense {
 			if l != 0 {

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -29,7 +29,16 @@ type segmentInvertedData struct {
 	tombstones       *sroar.Bitmap
 	tombstonesLoaded bool
 
-	propertyLengths       map[uint64]uint32
+	// Property lengths replace the old ~33B/entry map with one of two
+	// representations (exactly one non-nil once loaded, both nil when the segment
+	// has none): a dense array indexed by docID-propLengthsMin when the docID
+	// range is ≥1/3 occupied (4B×span ≤ 12B×count — smaller AND O(1) to read),
+	// else docID-sorted parallel arrays read via propLengthsView. Full-map
+	// consumers (compaction) reconstruct a transient map via getPropertyLengths.
+	propLengthsDense      []uint32
+	propLengthsMin        uint64
+	propLengthIds         []uint64
+	propLengthLens        []uint32
 	propertyLengthsLoaded bool
 
 	avgPropertyLengthsAvg   float64
@@ -73,9 +82,9 @@ func (s *segment) loadTombstones() (*sroar.Bitmap, error) {
 	return bitmap, nil
 }
 
-// loadPropertyLengthsStats loads only the avg/count header, leaving the
-// per-document map for on-demand loading. A NaN/Inf stored average can only be
-// recomputed from the full map, so that case falls back to a full load.
+// loadPropertyLengthsStats loads only the avg/count header, deferring the
+// per-document arrays to first use. A NaN/Inf stored average can only be
+// recomputed from the full data, so that case falls back to a full load.
 func (s *segment) loadPropertyLengthsStats() error {
 	s.invertedData.lockInvertedData.Lock()
 	defer s.invertedData.lockInvertedData.Unlock()
@@ -97,9 +106,7 @@ func (s *segment) loadPropertyLengthsStats() error {
 	propertyLengthsSize := binary.LittleEndian.Uint64(buffer[16:24])
 
 	if math.IsNaN(s.invertedData.avgPropertyLengthsAvg) || math.IsInf(s.invertedData.avgPropertyLengthsAvg, 0) {
-		// a NaN/Inf average can only be recomputed from the full map
-		_, err := s.loadPropertyLengthsLocked()
-		return err
+		return s.loadPropertyLengthsLocked()
 	}
 
 	s.invertedData.propertyLengthsStatsLoaded = true
@@ -109,26 +116,26 @@ func (s *segment) loadPropertyLengthsStats() error {
 	return nil
 }
 
-func (s *segment) loadPropertyLengths() (map[uint64]uint32, error) {
+func (s *segment) loadPropertyLengths() error {
 	s.invertedData.lockInvertedData.Lock()
 	defer s.invertedData.lockInvertedData.Unlock()
 	return s.loadPropertyLengthsLocked()
 }
 
 // loadPropertyLengthsLocked requires the caller to hold lockInvertedData.
-func (s *segment) loadPropertyLengthsLocked() (map[uint64]uint32, error) {
+func (s *segment) loadPropertyLengthsLocked() error {
 	if s.strategy != segmentindex.StrategyInverted {
-		return nil, fmt.Errorf("property only supported for inverted strategy")
+		return fmt.Errorf("property only supported for inverted strategy")
 	}
 
 	if s.invertedData.propertyLengthsLoaded {
-		return s.invertedData.propertyLengths, nil
+		return nil
 	}
 
 	buffer := make([]byte, 8*3)
 
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.PropertyLengthsOffset, s.invertedHeader.PropertyLengthsOffset + 8*3}); err != nil {
-		return nil, fmt.Errorf("copy node: %w", err)
+		return fmt.Errorf("copy node: %w", err)
 	}
 
 	// don't re-write stats already set at open: readers access them unlocked
@@ -141,38 +148,112 @@ func (s *segment) loadPropertyLengthsLocked() (map[uint64]uint32, error) {
 
 	if propertyLengthsSize == 0 {
 		s.invertedData.propertyLengthsLoaded = true
-		return s.invertedData.propertyLengths, nil
+		return nil
 	}
 
 	propertyLengthsStart := s.invertedHeader.PropertyLengthsOffset + 16 + 8
 	propertyLengthsEnd := propertyLengthsStart + propertyLengthsSize
 
 	buffer = make([]byte, propertyLengthsSize)
-
 	if err := s.copyNode(buffer, nodeOffset{propertyLengthsStart, propertyLengthsEnd}); err != nil {
-		return nil, fmt.Errorf("copy node: %w", err)
+		return fmt.Errorf("copy node: %w", err)
 	}
-	propLengths, err := gobenc.Decode(buffer)
+	ids, lens, err := gobenc.DecodePairs(buffer)
 	if err != nil {
-		return s.invertedData.propertyLengths, fmt.Errorf("decode property lengths: %w", err)
+		return fmt.Errorf("decode property lengths: %w", err)
 	}
 
 	if math.IsNaN(s.invertedData.avgPropertyLengthsAvg) || math.IsInf(s.invertedData.avgPropertyLengthsAvg, 0) {
-		// recompute property lengths average
 		var totalLength uint64
-		for _, length := range propLengths {
+		for _, length := range lens {
 			totalLength += uint64(length)
 		}
-		if s.invertedData.avgPropertyLengthsCount > 0 && len(propLengths) > 0 {
-			s.invertedData.avgPropertyLengthsAvg = float64(totalLength) / float64(len(propLengths))
+		if s.invertedData.avgPropertyLengthsCount > 0 && len(lens) > 0 {
+			s.invertedData.avgPropertyLengthsAvg = float64(totalLength) / float64(len(lens))
 		} else {
 			s.invertedData.avgPropertyLengthsAvg = 0
 		}
 	}
 
+	if len(ids) > 0 {
+		minID, maxID := ids[0], ids[0]
+		for _, id := range ids[1:] {
+			if id < minID {
+				minID = id
+			}
+			if id > maxID {
+				maxID = id
+			}
+		}
+		span := maxID - minID + 1
+		if span/3 <= uint64(len(ids)) {
+			// dense path: direct-indexed fill, no sort needed (unlike the pairs branch)
+			dense := make([]uint32, span)
+			for i, id := range ids {
+				dense[id-minID] = lens[i]
+			}
+			s.invertedData.propLengthsDense = dense
+			s.invertedData.propLengthsMin = minID
+		} else {
+			sortPropLenPairs(ids, lens)
+			s.invertedData.propLengthIds = ids
+			s.invertedData.propLengthLens = lens
+		}
+	}
+
 	s.invertedData.propertyLengthsLoaded = true
-	s.invertedData.propertyLengths = propLengths
-	return s.invertedData.propertyLengths, nil
+	return nil
+}
+
+// sortPropLenPairs sorts both arrays in tandem by docID using an LSD radix sort
+// over only the bytes the largest docID needs (~4 passes for realistic ID
+// ranges). Entries arrive in gob map-iteration order (random), so a comparison
+// sort would pay ~n log n interface-dispatched swaps — radix is linear and
+// allocation-bounded to one scratch copy of each array.
+func sortPropLenPairs(ids []uint64, lens []uint32) {
+	n := len(ids)
+	if n < 2 {
+		return
+	}
+	var maxID uint64
+	for _, id := range ids {
+		if id > maxID {
+			maxID = id
+		}
+	}
+
+	srcIds, srcLens := ids, lens
+	dstIds := make([]uint64, n)
+	dstLens := make([]uint32, n)
+
+	var counts [256]int
+	for shift := uint(0); maxID>>shift > 0; shift += 8 {
+		for i := range counts {
+			counts[i] = 0
+		}
+		for _, id := range srcIds {
+			counts[byte(id>>shift)]++
+		}
+		sum := 0
+		for i, c := range counts {
+			counts[i] = sum
+			sum += c
+		}
+		for i, id := range srcIds {
+			j := counts[byte(id>>shift)]
+			counts[byte(id>>shift)]++
+			dstIds[j] = id
+			dstLens[j] = srcLens[i]
+		}
+		srcIds, dstIds = dstIds, srcIds
+		srcLens, dstLens = dstLens, srcLens
+	}
+
+	// after an odd number of passes the sorted data sits in the scratch arrays
+	if &srcIds[0] != &ids[0] {
+		copy(ids, srcIds)
+		copy(lens, srcLens)
+	}
 }
 
 // ReadOnlyTombstones returns segment's tombstones
@@ -211,21 +292,210 @@ func (s *segment) MergeTombstones(other *sroar.Bitmap) (*sroar.Bitmap, error) {
 	return s.invertedData.tombstones, nil
 }
 
+// getPropertyLengths reconstructs the full docID->propLength map. Per-query
+// lookups go through propLengthsView; the full map is for compaction-frequency
+// consumers only.
 func (s *segment) getPropertyLengths() (map[uint64]uint32, error) {
+	dense, minID, ids, lens, err := s.propLengthArrays()
+	if err != nil {
+		return nil, err
+	}
+	if dense != nil {
+		// stored lengths are always >= 1, so zero slots are exactly the absent
+		// docIDs and the reconstruction reproduces the stored key set
+		m := make(map[uint64]uint32)
+		for i, l := range dense {
+			if l != 0 {
+				m[minID+uint64(i)] = l
+			}
+		}
+		return m, nil
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	m := make(map[uint64]uint32, len(ids))
+	for i, id := range ids {
+		m[id] = lens[i]
+	}
+	return m, nil
+}
+
+// mergePropLenPairs merges two docID-sorted pair arrays into one, deduping
+// docIDs. On a tie the second array wins (c2 is the newer segment) — the
+// precedence the compactor's prior map overwrite relied on.
+func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uint32) ([]uint64, []uint32) {
+	outIDs := make([]uint64, 0, len(ids1)+len(ids2))
+	outLens := make([]uint32, 0, len(ids1)+len(ids2))
+	i, j := 0, 0
+	for i < len(ids1) && j < len(ids2) {
+		switch {
+		case ids1[i] < ids2[j]:
+			outIDs = append(outIDs, ids1[i])
+			outLens = append(outLens, lens1[i])
+			i++
+		case ids1[i] > ids2[j]:
+			outIDs = append(outIDs, ids2[j])
+			outLens = append(outLens, lens2[j])
+			j++
+		default: // equal docID: second (newer) wins
+			outIDs = append(outIDs, ids2[j])
+			outLens = append(outLens, lens2[j])
+			i++
+			j++
+		}
+	}
+	for ; i < len(ids1); i++ {
+		outIDs = append(outIDs, ids1[i])
+		outLens = append(outLens, lens1[i])
+	}
+	for ; j < len(ids2); j++ {
+		outIDs = append(outIDs, ids2[j])
+		outLens = append(outLens, lens2[j])
+	}
+	return outIDs, outLens
+}
+
+// propLengthArrays ensures the per-document arrays are loaded and returns them.
+// The loaded check and the array read share one critical section: a concurrent
+// freePropertyLengths can flip loaded back to false and nil the arrays, so a
+// dropped lock between them could hand a live reader empty data. The returned
+// slices alias the cached arrays (immutable while referenced).
+func (s *segment) propLengthArrays() (dense []uint32, minID uint64, ids []uint64, lens []uint32, err error) {
 	if s.strategy != segmentindex.StrategyInverted {
-		return nil, fmt.Errorf("property length only supported for inverted strategy")
+		return nil, 0, nil, nil, fmt.Errorf("property length only supported for inverted strategy")
 	}
 
-	// check the flag and read the map under one RLock: a freePropertyLengths
-	// between the two would hand a live reader a nil map
 	s.invertedData.lockInvertedData.RLock()
 	if s.invertedData.propertyLengthsLoaded {
-		defer s.invertedData.lockInvertedData.RUnlock()
-		return s.invertedData.propertyLengths, nil
+		dense, minID = s.invertedData.propLengthsDense, s.invertedData.propLengthsMin
+		ids, lens = s.invertedData.propLengthIds, s.invertedData.propLengthLens
+		s.invertedData.lockInvertedData.RUnlock()
+		return dense, minID, ids, lens, nil
 	}
 	s.invertedData.lockInvertedData.RUnlock()
 
-	return s.loadPropertyLengths()
+	if err := s.loadPropertyLengths(); err != nil {
+		return nil, 0, nil, nil, err
+	}
+
+	s.invertedData.lockInvertedData.RLock()
+	defer s.invertedData.lockInvertedData.RUnlock()
+	return s.invertedData.propLengthsDense, s.invertedData.propLengthsMin,
+		s.invertedData.propLengthIds, s.invertedData.propLengthLens, nil
+}
+
+// propLengthsView is a no-IO per-docID lookup over a segment's property
+// lengths: a single indexed load for dense segments, a cursor over the sorted
+// pairs otherwise. A miss returns 0, matching the map semantics this replaced.
+// The cursor exploits ascending docID access (scoring and posting iteration
+// order): lookups gallop forward from the last hit, so monotone scans are
+// amortized O(1); a backward jump restarts the search from the front.
+type propLengthsView struct {
+	dense []uint32
+	min   uint64
+	ids   []uint64
+	lens  []uint32
+	cur   int
+}
+
+func (v *propLengthsView) get(docID uint64) uint32 {
+	if v.dense != nil {
+		if idx := docID - v.min; idx < uint64(len(v.dense)) {
+			return v.dense[idx]
+		}
+		return 0
+	}
+
+	ids := v.ids
+	n := len(ids)
+	c := v.cur
+
+	if c >= n || ids[c] > docID {
+		// went backward relative to the cursor (or cursor exhausted): restart
+		c = 0
+	}
+	// short linear probe from the cursor covers the small gaps of
+	// frequent-term scans
+	for k := 0; k < 4 && c < n; k++ {
+		if ids[c] >= docID {
+			if ids[c] == docID {
+				v.cur = c + 1
+				return v.lens[c]
+			}
+			v.cur = c
+			return 0
+		}
+		c++
+	}
+	if c >= n {
+		v.cur = n
+		return 0
+	}
+
+	lo := c - 1 // ids[lo] < docID by the loop above
+	hi := n - 1
+	if ids[hi] < docID {
+		v.cur = n
+		return 0
+	}
+	// invariant: ids[lo] < docID <= ids[hi].
+	// bounded gallop first: frequent-term scans advance by small-to-medium gaps
+	// where a couple of near-cursor probes settle the window (measured faster
+	// than going straight to interpolation there)
+	for step := 4; step <= 64; step *= 4 {
+		p := lo + step
+		if p >= hi {
+			break
+		}
+		if ids[p] < docID {
+			lo = p
+		} else {
+			hi = p
+			break
+		}
+	}
+	// interpolation for the rest: the pairs are a near-uniformly thinned docID
+	// sequence, so the predicted position lands within a few entries of the
+	// target no matter how large the jump — a pure gallop paid ~log(gap)
+	// cache-missing probes there (measured +30% on rare-term queries). The
+	// budget bounds adversarial distributions; binary search finishes the rest.
+	for budget := 0; budget < 8 && hi-lo > 1; budget++ {
+		span := ids[hi] - ids[lo]
+		p := lo + 1 + int(float64(docID-ids[lo])/float64(span)*float64(hi-lo-1))
+		if p <= lo {
+			p = lo + 1
+		} else if p >= hi {
+			p = hi - 1
+		}
+		if ids[p] < docID {
+			lo = p
+		} else {
+			hi = p
+		}
+	}
+	for hi-lo > 1 {
+		mid := int(uint(lo+hi) >> 1)
+		if ids[mid] < docID {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	if ids[hi] == docID {
+		v.cur = hi + 1
+		return v.lens[hi]
+	}
+	v.cur = hi
+	return 0
+}
+
+func (s *segment) propLengthsView() (propLengthsView, error) {
+	dense, minID, ids, lens, err := s.propLengthArrays()
+	if err != nil {
+		return propLengthsView{}, err
+	}
+	return propLengthsView{dense: dense, min: minID, ids: ids, lens: lens}, nil
 }
 
 func (s *segment) isPropertyLengthsLoaded() bool {
@@ -239,8 +509,9 @@ func (s *segment) isPropertyLengthsLoaded() bool {
 	return s.invertedData.propertyLengthsLoaded
 }
 
-// freePropertyLengths releases the cached per-document map; the avg/count stats
-// are deliberately kept, as callers still read them after the map is freed.
+// freePropertyLengths releases the cached per-document arrays so they reload on
+// next use; the avg/count stats are kept (callers read them unlocked) and the
+// stats-loaded flag stays set so a reload skips re-reading the header.
 func (s *segment) freePropertyLengths() {
 	if s.strategy != segmentindex.StrategyInverted {
 		return
@@ -249,7 +520,10 @@ func (s *segment) freePropertyLengths() {
 	s.invertedData.lockInvertedData.Lock()
 	defer s.invertedData.lockInvertedData.Unlock()
 
-	s.invertedData.propertyLengths = nil
+	s.invertedData.propLengthsDense = nil
+	s.invertedData.propLengthsMin = 0
+	s.invertedData.propLengthIds = nil
+	s.invertedData.propLengthLens = nil
 	s.invertedData.propertyLengthsLoaded = false
 }
 

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -29,16 +29,16 @@ type segmentInvertedData struct {
 	tombstones       *sroar.Bitmap
 	tombstonesLoaded bool
 
-	// Property lengths replace the old ~33B/entry map with one of two
-	// representations (exactly one non-nil once loaded, both nil when the segment
-	// has none): a dense array indexed by docID-propLengthsMin when the docID
-	// range is ≥1/3 occupied (4B×span ≤ 12B×count — smaller AND O(1) to read),
-	// else docID-sorted parallel arrays read via propLengthsView. Full-map
-	// consumers (compaction) reconstruct a transient map via getPropertyLengths.
+	// Per-document property lengths in one of two representations (exactly one
+	// non-nil once loaded, both nil when the segment has none): a dense array
+	// indexed by docID-propLengthsDenseMin when the docID range is ≥1/3 occupied
+	// (4B×span ≤ 12B×count — smaller AND O(1) to read), else docID-sorted parallel
+	// arrays read via propLengthsView. Full-map consumers (compaction) reconstruct
+	// a transient map via getPropertyLengths.
 	propLengthsDense      []uint32
-	propLengthsMin        uint64
-	propLengthIds         []uint64
-	propLengthLens        []uint32
+	propLengthsDenseMin   uint64
+	propLengthsPairIds    []uint64
+	propLengthsPairLens   []uint32
 	propertyLengthsLoaded bool
 
 	avgPropertyLengthsAvg   float64
@@ -133,8 +133,8 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 	}
 
 	if s.invertedData.propertyLengthsLoaded {
-		return s.invertedData.propLengthsDense, s.invertedData.propLengthsMin,
-			s.invertedData.propLengthIds, s.invertedData.propLengthLens, nil
+		return s.invertedData.propLengthsDense, s.invertedData.propLengthsDenseMin,
+			s.invertedData.propLengthsPairIds, s.invertedData.propLengthsPairLens, nil
 	}
 
 	buffer := make([]byte, 8*3)
@@ -206,17 +206,17 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 				dense[id-minID] = lens[i]
 			}
 			s.invertedData.propLengthsDense = dense
-			s.invertedData.propLengthsMin = minID
+			s.invertedData.propLengthsDenseMin = minID
 		} else {
 			sortPropLenPairs(ids, lens)
-			s.invertedData.propLengthIds = ids
-			s.invertedData.propLengthLens = lens
+			s.invertedData.propLengthsPairIds = ids
+			s.invertedData.propLengthsPairLens = lens
 		}
 	}
 
 	s.invertedData.propertyLengthsLoaded = true
-	return s.invertedData.propLengthsDense, s.invertedData.propLengthsMin,
-		s.invertedData.propLengthIds, s.invertedData.propLengthLens, nil
+	return s.invertedData.propLengthsDense, s.invertedData.propLengthsDenseMin,
+		s.invertedData.propLengthsPairIds, s.invertedData.propLengthsPairLens, nil
 }
 
 // sortPropLenPairs sorts both arrays in tandem by docID using an LSD radix sort
@@ -381,8 +381,8 @@ func (s *segment) propLengthArrays() (dense []uint32, minID uint64, ids []uint64
 
 	s.invertedData.lockInvertedData.RLock()
 	if s.invertedData.propertyLengthsLoaded {
-		dense, minID = s.invertedData.propLengthsDense, s.invertedData.propLengthsMin
-		ids, lens = s.invertedData.propLengthIds, s.invertedData.propLengthLens
+		dense, minID = s.invertedData.propLengthsDense, s.invertedData.propLengthsDenseMin
+		ids, lens = s.invertedData.propLengthsPairIds, s.invertedData.propLengthsPairLens
 		s.invertedData.lockInvertedData.RUnlock()
 		return dense, minID, ids, lens, nil
 	}
@@ -529,9 +529,9 @@ func (s *segment) freePropertyLengths() {
 	defer s.invertedData.lockInvertedData.Unlock()
 
 	s.invertedData.propLengthsDense = nil
-	s.invertedData.propLengthsMin = 0
-	s.invertedData.propLengthIds = nil
-	s.invertedData.propLengthLens = nil
+	s.invertedData.propLengthsDenseMin = 0
+	s.invertedData.propLengthsPairIds = nil
+	s.invertedData.propLengthsPairLens = nil
 	s.invertedData.propertyLengthsLoaded = false
 }
 

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -106,7 +106,8 @@ func (s *segment) loadPropertyLengthsStats() error {
 	propertyLengthsSize := binary.LittleEndian.Uint64(buffer[16:24])
 
 	if math.IsNaN(s.invertedData.avgPropertyLengthsAvg) || math.IsInf(s.invertedData.avgPropertyLengthsAvg, 0) {
-		return s.loadPropertyLengthsLocked()
+		_, _, _, _, err := s.loadPropertyLengthsLocked()
+		return err
 	}
 
 	s.invertedData.propertyLengthsStatsLoaded = true
@@ -119,23 +120,28 @@ func (s *segment) loadPropertyLengthsStats() error {
 func (s *segment) loadPropertyLengths() error {
 	s.invertedData.lockInvertedData.Lock()
 	defer s.invertedData.lockInvertedData.Unlock()
-	return s.loadPropertyLengthsLocked()
+	_, _, _, _, err := s.loadPropertyLengthsLocked()
+	return err
 }
 
-// loadPropertyLengthsLocked requires the caller to hold lockInvertedData.
-func (s *segment) loadPropertyLengthsLocked() error {
+// loadPropertyLengthsLocked requires the caller to hold lockInvertedData. It
+// returns the arrays it loaded (or the already-cached ones) so callers can use
+// them without re-reading the struct after dropping the lock — a re-read could
+// race a freePropertyLengths and observe niled arrays.
+func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uint32, error) {
 	if s.strategy != segmentindex.StrategyInverted {
-		return fmt.Errorf("property only supported for inverted strategy")
+		return nil, 0, nil, nil, fmt.Errorf("property only supported for inverted strategy")
 	}
 
 	if s.invertedData.propertyLengthsLoaded {
-		return nil
+		return s.invertedData.propLengthsDense, s.invertedData.propLengthsMin,
+			s.invertedData.propLengthIds, s.invertedData.propLengthLens, nil
 	}
 
 	buffer := make([]byte, 8*3)
 
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.PropertyLengthsOffset, s.invertedHeader.PropertyLengthsOffset + 8*3}); err != nil {
-		return fmt.Errorf("copy node: %w", err)
+		return nil, 0, nil, nil, fmt.Errorf("copy node: %w", err)
 	}
 
 	// don't re-write stats already set at open: readers access them unlocked
@@ -148,7 +154,7 @@ func (s *segment) loadPropertyLengthsLocked() error {
 
 	if propertyLengthsSize == 0 {
 		s.invertedData.propertyLengthsLoaded = true
-		return nil
+		return nil, 0, nil, nil, nil
 	}
 
 	propertyLengthsStart := s.invertedHeader.PropertyLengthsOffset + 16 + 8
@@ -156,11 +162,11 @@ func (s *segment) loadPropertyLengthsLocked() error {
 
 	buffer = make([]byte, propertyLengthsSize)
 	if err := s.copyNode(buffer, nodeOffset{propertyLengthsStart, propertyLengthsEnd}); err != nil {
-		return fmt.Errorf("copy node: %w", err)
+		return nil, 0, nil, nil, fmt.Errorf("copy node: %w", err)
 	}
 	ids, lens, err := gobenc.DecodePairs(buffer)
 	if err != nil {
-		return fmt.Errorf("decode property lengths: %w", err)
+		return nil, 0, nil, nil, fmt.Errorf("decode property lengths: %w", err)
 	}
 
 	if math.IsNaN(s.invertedData.avgPropertyLengthsAvg) || math.IsInf(s.invertedData.avgPropertyLengthsAvg, 0) {
@@ -202,7 +208,8 @@ func (s *segment) loadPropertyLengthsLocked() error {
 	}
 
 	s.invertedData.propertyLengthsLoaded = true
-	return nil
+	return s.invertedData.propLengthsDense, s.invertedData.propLengthsMin,
+		s.invertedData.propLengthIds, s.invertedData.propLengthLens, nil
 }
 
 // sortPropLenPairs sorts both arrays in tandem by docID using an LSD radix sort
@@ -357,10 +364,12 @@ func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uin
 }
 
 // propLengthArrays ensures the per-document arrays are loaded and returns them.
-// The loaded check and the array read share one critical section: a concurrent
-// freePropertyLengths can flip loaded back to false and nil the arrays, so a
-// dropped lock between them could hand a live reader empty data. The returned
-// slices alias the cached arrays (immutable while referenced).
+// Both paths capture the arrays while holding the lock — the fast path reads the
+// cached arrays under a single RLock, the slow path returns what the load set
+// under its write lock. Re-reading the struct after dropping the lock could race
+// a freePropertyLengths and hand a live reader niled arrays (an empty view) with
+// no error. The returned slices alias the cached arrays; a later free nils the
+// struct fields but not these headers (the backing array stays referenced).
 func (s *segment) propLengthArrays() (dense []uint32, minID uint64, ids []uint64, lens []uint32, err error) {
 	if s.strategy != segmentindex.StrategyInverted {
 		return nil, 0, nil, nil, fmt.Errorf("property length only supported for inverted strategy")
@@ -375,14 +384,9 @@ func (s *segment) propLengthArrays() (dense []uint32, minID uint64, ids []uint64
 	}
 	s.invertedData.lockInvertedData.RUnlock()
 
-	if err := s.loadPropertyLengths(); err != nil {
-		return nil, 0, nil, nil, err
-	}
-
-	s.invertedData.lockInvertedData.RLock()
-	defer s.invertedData.lockInvertedData.RUnlock()
-	return s.invertedData.propLengthsDense, s.invertedData.propLengthsMin,
-		s.invertedData.propLengthIds, s.invertedData.propLengthLens, nil
+	s.invertedData.lockInvertedData.Lock()
+	defer s.invertedData.lockInvertedData.Unlock()
+	return s.loadPropertyLengthsLocked()
 }
 
 // propLengthsView is a no-IO per-docID lookup over a segment's property

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -125,9 +125,8 @@ func (s *segment) loadPropertyLengths() error {
 }
 
 // loadPropertyLengthsLocked requires the caller to hold lockInvertedData. It
-// returns the arrays it loaded (or the already-cached ones) so callers can use
-// them without re-reading the struct after dropping the lock — a re-read could
-// race a freePropertyLengths and observe niled arrays.
+// returns the loaded arrays so callers needn't re-read the struct after
+// unlocking, where a freePropertyLengths could have niled them.
 func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uint32, error) {
 	if s.strategy != segmentindex.StrategyInverted {
 		return nil, 0, nil, nil, fmt.Errorf("property only supported for inverted strategy")
@@ -192,7 +191,7 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 			}
 		}
 		span := maxID - minID + 1
-		if span/3 <= uint64(len(ids)) {
+		if span != 0 && span/3 <= uint64(len(ids)) {
 			// dense path: direct-indexed fill, no sort needed (unlike the pairs branch)
 			dense := make([]uint32, span)
 			for i, id := range ids {
@@ -363,13 +362,10 @@ func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uin
 	return outIDs, outLens
 }
 
-// propLengthArrays ensures the per-document arrays are loaded and returns them.
-// Both paths capture the arrays while holding the lock — the fast path reads the
-// cached arrays under a single RLock, the slow path returns what the load set
-// under its write lock. Re-reading the struct after dropping the lock could race
-// a freePropertyLengths and hand a live reader niled arrays (an empty view) with
-// no error. The returned slices alias the cached arrays; a later free nils the
-// struct fields but not these headers (the backing array stays referenced).
+// propLengthArrays loads (if needed) and returns the per-document arrays. Both
+// paths capture the arrays under the lock. The returned slices alias the cached
+// arrays; a later freePropertyLengths nils the struct fields but not these
+// headers, so a reader's slices stay valid.
 func (s *segment) propLengthArrays() (dense []uint32, minID uint64, ids []uint64, lens []uint32, err error) {
 	if s.strategy != segmentindex.StrategyInverted {
 		return nil, 0, nil, nil, fmt.Errorf("property length only supported for inverted strategy")

--- a/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
@@ -17,6 +17,7 @@ package lsmkv
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -223,6 +224,93 @@ func TestInvertedLazyPropertyLengthsStatsNoRace(t *testing.T) {
 
 	wg.Wait()
 	require.NoError(t, loadErr)
+}
+
+// TestInvertedPropertyLengthsViewNoEmptyUnderFree pins that a reader taking the
+// load-on-demand slow path never observes an empty property-length view because
+// a concurrent freePropertyLengths niled the cached arrays mid-load. The slow
+// path returns the arrays captured under the load's own lock; re-reading the
+// struct after dropping that lock (the regressed behavior) could hand back a
+// zero-value view with no error, silently scoring every doc with propLength 0.
+// The freer and the readers run in separate goroutines so the free can land in
+// a reader's load window; every stored length is >= 1, so a 0 means "lost".
+func TestInvertedPropertyLengthsViewNoEmptyUnderFree(t *testing.T) {
+	ctx := context.Background()
+	const size = 500
+	key := []byte("my-key")
+	lazy := configRuntime.NewDynamicValue(true)
+
+	dirName := t.TempDir()
+	mk := func() *Bucket {
+		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			WithStrategy(StrategyInverted), WithLazyPropertyLengths(lazy))
+		require.Nil(t, err)
+		b.SetMemtableThreshold(1e9)
+		return b
+	}
+
+	want := make([]uint32, size)
+	b := mk()
+	for i := 0; i < size; i++ {
+		propLen := float32(1 + i%50)
+		want[i] = uint32(propLen)
+		require.Nil(t, b.MapSet(key, NewMapPairFromDocIdAndTf(uint64(i), float32(1), propLen, false)))
+	}
+	require.Nil(t, b.FlushAndSwitch())
+	require.Nil(t, b.Shutdown(ctx))
+
+	b = mk()
+	defer b.Shutdown(ctx)
+	require.GreaterOrEqual(t, len(b.disk.segments), 1)
+	seg := b.disk.segments[0]
+
+	// hammer free so readers keep falling into the load-on-demand slow path
+	var freerWg sync.WaitGroup
+	stop := make(chan struct{})
+	freerWg.Add(1)
+	enterrors.GoWrapper(func() {
+		defer freerWg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				seg.freePropertyLengths()
+			}
+		}
+	}, nullLogger())
+
+	// each reader builds its own view (own cursor) and scans ascending; under the
+	// fix every present docID must resolve to its stored length, never 0
+	var mismatches atomic.Int64
+	var readersWg sync.WaitGroup
+	const readers = 16
+	for r := 0; r < readers; r++ {
+		readersWg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer readersWg.Done()
+			for iter := 0; iter < 3000; iter++ {
+				view, err := seg.propLengthsView()
+				if err != nil {
+					mismatches.Add(1)
+					continue
+				}
+				for id := uint64(0); id < size; id++ {
+					if view.get(id) != want[id] {
+						mismatches.Add(1)
+					}
+				}
+			}
+		}, nullLogger())
+	}
+
+	readersWg.Wait()
+	close(stop)
+	freerWg.Wait()
+
+	require.Zero(t, mismatches.Load(),
+		"property-length view returned wrong/zero lengths under concurrent free")
 }
 
 // TestInvertedLazyPropertyLengthsBlockMaxQuery runs a BM25 query in lazy mode

--- a/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
@@ -226,14 +226,11 @@ func TestInvertedLazyPropertyLengthsStatsNoRace(t *testing.T) {
 	require.NoError(t, loadErr)
 }
 
-// TestInvertedPropertyLengthsViewNoEmptyUnderFree pins that a reader taking the
-// load-on-demand slow path never observes an empty property-length view because
-// a concurrent freePropertyLengths niled the cached arrays mid-load. The slow
-// path returns the arrays captured under the load's own lock; re-reading the
-// struct after dropping that lock (the regressed behavior) could hand back a
-// zero-value view with no error, silently scoring every doc with propLength 0.
-// The freer and the readers run in separate goroutines so the free can land in
-// a reader's load window; every stored length is >= 1, so a 0 means "lost".
+// TestInvertedPropertyLengthsViewNoEmptyUnderFree pins that the load-on-demand
+// slow path never hands a reader an empty view because a concurrent
+// freePropertyLengths niled the arrays mid-load (which would silently score
+// every doc with propLength 0). Freer and readers race in separate goroutines;
+// every stored length is >= 1, so any 0 a reader sees means the view was lost.
 func TestInvertedPropertyLengthsViewNoEmptyUnderFree(t *testing.T) {
 	ctx := context.Background()
 	const size = 500
@@ -281,8 +278,7 @@ func TestInvertedPropertyLengthsViewNoEmptyUnderFree(t *testing.T) {
 		}
 	}, nullLogger())
 
-	// each reader builds its own view (own cursor) and scans ascending; under the
-	// fix every present docID must resolve to its stored length, never 0
+	// each reader builds its own view (own cursor) and scans ascending
 	var mismatches atomic.Int64
 	var readersWg sync.WaitGroup
 	const readers = 16

--- a/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
@@ -87,7 +87,7 @@ func TestInvertedLazyPropertyLengths(t *testing.T) {
 			seg.freePropertyLengths()
 			require.False(t, seg.isPropertyLengthsLoaded())
 			require.Nil(t, seg.getInvertedData().propLengthsDense)
-			require.Nil(t, seg.getInvertedData().propLengthIds)
+			require.Nil(t, seg.getInvertedData().propLengthsPairIds)
 			avgAfter, countAfter := b.GetAveragePropertyLength()
 			require.Equal(t, avg, avgAfter)
 			require.Equal(t, count, countAfter)

--- a/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
@@ -82,10 +82,11 @@ func TestInvertedLazyPropertyLengths(t *testing.T) {
 			require.Len(t, pl, size)
 			require.True(t, seg.isPropertyLengthsLoaded())
 
-			// freeing releases the map but keeps the stats
+			// freeing releases the per-document arrays but keeps the stats
 			seg.freePropertyLengths()
 			require.False(t, seg.isPropertyLengthsLoaded())
-			require.Nil(t, seg.getInvertedData().propertyLengths)
+			require.Nil(t, seg.getInvertedData().propLengthsDense)
+			require.Nil(t, seg.getInvertedData().propLengthIds)
 			avgAfter, countAfter := b.GetAveragePropertyLength()
 			require.Equal(t, avg, avgAfter)
 			require.Equal(t, count, countAfter)

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -1,0 +1,151 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestSegmentPropertyLengthsRepresentations flushes real inverted segments with
+// dense and sparse docID patterns and verifies that the on-load representation
+// choice (dense array vs sorted pairs) is invisible to all consumers: the
+// per-docID view matches what was written, and getPropertyLengths reconstructs
+// the exact stored map that compaction round-trips to disk.
+func TestSegmentPropertyLengthsRepresentations(t *testing.T) {
+	tests := []struct {
+		name      string
+		docIDs    func() []uint64
+		wantDense bool
+	}{
+		{
+			// contiguous ids: span == count -> dense array
+			name: "dense_sequential",
+			docIDs: func() []uint64 {
+				ids := make([]uint64, 500)
+				for i := range ids {
+					ids[i] = uint64(i)
+				}
+				return ids
+			},
+			wantDense: true,
+		},
+		{
+			// stride 10: span ~10x count, far below 1/3 occupancy -> sorted pairs
+			name: "sparse_strided",
+			docIDs: func() []uint64 {
+				ids := make([]uint64, 500)
+				for i := range ids {
+					ids[i] = uint64(i) * 10
+				}
+				return ids
+			},
+			wantDense: false,
+		},
+		{
+			// exactly at the gate: span == 3*count keeps dense
+			name: "boundary_one_third",
+			docIDs: func() []uint64 {
+				ids := make([]uint64, 500)
+				for i := range ids {
+					ids[i] = uint64(i) * 3
+				}
+				return ids
+			},
+			wantDense: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(StrategyInverted))
+			require.NoError(t, err)
+			defer bucket.Shutdown(ctx)
+
+			key := []byte("term")
+			docIDs := tc.docIDs()
+			want := make(map[uint64]uint32, len(docIDs))
+			for i, docID := range docIDs {
+				propLen := float32(i%50 + 1)
+				want[docID] = uint32(propLen)
+				require.NoError(t, bucket.MapSet(key, NewMapPairFromDocIdAndTf(docID, 1, propLen, false)))
+			}
+			require.NoError(t, bucket.FlushAndSwitch())
+
+			view := bucket.GetConsistentView()
+			defer view.ReleaseView()
+			require.Len(t, view.Disk, 1)
+			seg := view.Disk[0]
+
+			got, err := seg.getPropertyLengths()
+			require.NoError(t, err)
+			assert.Equal(t, want, got, "getPropertyLengths must reconstruct the exact stored map")
+
+			plView, err := seg.propLengthsView()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantDense, plView.dense != nil, "representation choice")
+			assert.Equal(t, tc.wantDense, plView.ids == nil, "exactly one representation populated")
+
+			// ascending scan (the production access pattern)
+			for _, docID := range docIDs {
+				require.Equal(t, want[docID], plView.get(docID), "docID %d", docID)
+			}
+			// absent ids inside and outside the range
+			fresh, err := seg.propLengthsView()
+			require.NoError(t, err)
+			assert.Equal(t, uint32(0), fresh.get(docIDs[len(docIDs)-1]+1))
+			if !tc.wantDense {
+				assert.Equal(t, uint32(0), fresh.get(docIDs[0]+1), "strided gap must miss")
+			}
+		})
+	}
+}
+
+// TestSegmentPropertyLengthsEmpty covers a segment whose postings carry no
+// property lengths section payload.
+func TestSegmentPropertyLengthsEmpty(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+
+	// a single tombstoned doc: the posting flushes but contributes no length
+	pair := NewMapPairFromDocIdAndTf(7, 1, 1, true)
+	require.NoError(t, bucket.MapSet([]byte("term"), pair))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1)
+
+	got, err := view.Disk[0].getPropertyLengths()
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	plView, err := view.Disk[0].propLengthsView()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), plView.get(7))
+}

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -187,3 +187,39 @@ func TestSegmentPropertyLengthsSpanOverflow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
+
+// TestSegmentPropertyLengthsZeroLengthForcesPairs pins that a stored length of 0
+// keeps the segment on the pairs layout. Dense treats a 0 slot as "docID absent"
+// and getPropertyLengths drops it, so a dense layout would lose the key on the
+// compaction round-trip; pairs preserves it.
+func TestSegmentPropertyLengthsZeroLengthForcesPairs(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+
+	// contiguous docIDs (span==count) would select dense were it not for the 0
+	key := []byte("term")
+	want := map[uint64]uint32{0: 0, 1: 5, 2: 5, 3: 5}
+	for id := uint64(0); id < 4; id++ {
+		require.NoError(t, bucket.MapSet(key, NewMapPairFromDocIdAndTf(id, 1, float32(want[id]), false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1)
+	seg := view.Disk[0]
+
+	plView, err := seg.propLengthsView()
+	require.NoError(t, err)
+	assert.Nil(t, plView.dense, "a stored 0-length must force the pairs layout")
+	assert.NotNil(t, plView.ids)
+
+	got, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "the 0-length key must survive reconstruction")
+}

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -16,6 +16,7 @@ package lsmkv
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,4 +149,41 @@ func TestSegmentPropertyLengthsEmpty(t *testing.T) {
 	plView, err := view.Disk[0].propLengthsView()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(0), plView.get(7))
+}
+
+// TestSegmentPropertyLengthsSpanOverflow pins that a docID range whose span
+// (maxID-minID+1) overflows uint64 to 0 falls back to sorted pairs instead of a
+// zero-length dense array the fill would panic on. Unreachable with sequential
+// docIDs, but a corrupt/legacy segment must not crash the loader.
+func TestSegmentPropertyLengthsSpanOverflow(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+
+	key := []byte("term")
+	want := map[uint64]uint32{0: 3, math.MaxUint64: 7}
+	require.NoError(t, bucket.MapSet(key, NewMapPairFromDocIdAndTf(0, 1, 3, false)))
+	require.NoError(t, bucket.MapSet(key, NewMapPairFromDocIdAndTf(math.MaxUint64, 1, 7, false)))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1)
+	seg := view.Disk[0]
+
+	// must not panic; a dense array for this span would need 2^64 entries
+	plView, err := seg.propLengthsView()
+	require.NoError(t, err)
+	assert.Nil(t, plView.dense, "overflowing span must not select dense")
+	assert.NotNil(t, plView.ids, "must fall back to sorted pairs")
+	assert.Equal(t, uint32(3), plView.get(0))
+	assert.Equal(t, uint32(7), plView.get(math.MaxUint64))
+
+	got, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
 }

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_test.go
@@ -1,0 +1,303 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortPropLenPairs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ids  []uint64
+	}{
+		{"empty", nil},
+		{"single", []uint64{42}},
+		{"two_sorted", []uint64{1, 2}},
+		{"two_reversed", []uint64{2, 1}},
+		{"already_sorted", []uint64{1, 2, 3, 4, 5, 6, 7, 8}},
+		{"reverse_sorted", []uint64{8, 7, 6, 5, 4, 3, 2, 1}},
+		{"single_radix_pass", []uint64{200, 3, 100, 7}},
+		{"multi_radix_pass", []uint64{1 << 40, 1, 1 << 24, 1 << 8, 1 << 16, 0}},
+		{"max_uint64", []uint64{math.MaxUint64, 0, math.MaxUint64 - 1, 1}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ids := append([]uint64(nil), tc.ids...)
+			lens := make([]uint32, len(ids))
+			want := make(map[uint64]uint32, len(ids))
+			for i, id := range ids {
+				lens[i] = uint32(i + 1)
+				want[id] = lens[i]
+			}
+
+			sortPropLenPairs(ids, lens)
+
+			require.True(t, sort.SliceIsSorted(ids, func(i, j int) bool { return ids[i] < ids[j] }))
+			for i, id := range ids {
+				assert.Equal(t, want[id], lens[i], "length must move together with id %d", id)
+			}
+		})
+	}
+
+	t.Run("random_large", func(t *testing.T) {
+		t.Parallel()
+
+		rnd := rand.New(rand.NewSource(7))
+		const n = 200_000
+		ids := make([]uint64, n)
+		lens := make([]uint32, n)
+		want := make(map[uint64]uint32, n)
+		for i := range ids {
+			// unique ids: random high bits + index low bits
+			ids[i] = rnd.Uint64()<<20 | uint64(i)
+			lens[i] = rnd.Uint32()
+			want[ids[i]] = lens[i]
+		}
+
+		sortPropLenPairs(ids, lens)
+
+		require.True(t, sort.SliceIsSorted(ids, func(i, j int) bool { return ids[i] < ids[j] }))
+		for i, id := range ids {
+			require.Equal(t, want[id], lens[i])
+		}
+	})
+}
+
+// buildView constructs a view over the given docID->length set in the requested
+// representation, mirroring loadPropertyLengths' two layouts.
+func buildView(t *testing.T, m map[uint64]uint32, dense bool) propLengthsView {
+	t.Helper()
+	ids := make([]uint64, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	if dense {
+		require.NotEmpty(t, m, "dense layout needs at least one entry")
+		minID, maxID := ids[0], ids[len(ids)-1]
+		arr := make([]uint32, maxID-minID+1)
+		for id, l := range m {
+			arr[id-minID] = l
+		}
+		return propLengthsView{dense: arr, min: minID}
+	}
+
+	lens := make([]uint32, len(ids))
+	for i, id := range ids {
+		lens[i] = m[id]
+	}
+	return propLengthsView{ids: ids, lens: lens}
+}
+
+func TestPropLengthsViewGet(t *testing.T) {
+	t.Parallel()
+
+	// every stored length is >= 1, mirroring production data: 0 means absent
+	sparse := map[uint64]uint32{}
+	rnd := rand.New(rand.NewSource(11))
+	next := uint64(100)
+	for i := 0; i < 5000; i++ {
+		next += uint64(rnd.Intn(1000) + 1)
+		sparse[next] = uint32(rnd.Intn(200) + 1)
+	}
+
+	for _, layout := range []struct {
+		name  string
+		dense bool
+	}{{"pairs", false}, {"dense", true}} {
+		t.Run(layout.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("ascending_scan_hits_everything", func(t *testing.T) {
+				v := buildView(t, sparse, layout.dense)
+				ids := make([]uint64, 0, len(sparse))
+				for id := range sparse {
+					ids = append(ids, id)
+				}
+				sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+				for _, id := range ids {
+					require.Equal(t, sparse[id], v.get(id), "docID %d", id)
+				}
+			})
+
+			t.Run("ascending_scan_with_misses", func(t *testing.T) {
+				v := buildView(t, sparse, layout.dense)
+				ids := make([]uint64, 0, len(sparse))
+				for id := range sparse {
+					ids = append(ids, id)
+				}
+				sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+				for _, id := range ids {
+					if _, present := sparse[id-1]; !present {
+						require.Equal(t, uint32(0), v.get(id-1), "absent docID %d", id-1)
+					}
+					require.Equal(t, sparse[id], v.get(id), "docID %d", id)
+				}
+			})
+
+			t.Run("random_access_restarts_cursor", func(t *testing.T) {
+				v := buildView(t, sparse, layout.dense)
+				ids := make([]uint64, 0, len(sparse))
+				for id := range sparse {
+					ids = append(ids, id) // map order = random jumps incl. backward
+				}
+				for _, id := range ids {
+					require.Equal(t, sparse[id], v.get(id), "docID %d", id)
+				}
+			})
+
+			t.Run("out_of_range", func(t *testing.T) {
+				v := buildView(t, sparse, layout.dense)
+				assert.Equal(t, uint32(0), v.get(0))
+				assert.Equal(t, uint32(0), v.get(99))
+				assert.Equal(t, uint32(0), v.get(math.MaxUint64))
+				// cursor exhausted by the MaxUint64 probe; earlier ids must still work
+				for id, l := range sparse {
+					assert.Equal(t, l, v.get(id))
+					break
+				}
+			})
+
+			t.Run("repeated_lookup_same_doc", func(t *testing.T) {
+				v := buildView(t, sparse, layout.dense)
+				for id, l := range sparse {
+					require.Equal(t, l, v.get(id))
+					require.Equal(t, l, v.get(id))
+					require.Equal(t, l, v.get(id))
+					break
+				}
+			})
+		})
+	}
+
+	t.Run("empty_view", func(t *testing.T) {
+		t.Parallel()
+		var v propLengthsView
+		assert.Equal(t, uint32(0), v.get(0))
+		assert.Equal(t, uint32(0), v.get(42))
+	})
+
+	t.Run("pairs_adjacent_ids_use_linear_fast_path", func(t *testing.T) {
+		t.Parallel()
+		m := map[uint64]uint32{}
+		for i := uint64(1000); i < 2000; i++ {
+			m[i] = uint32(i % 97 * 2)
+		}
+		// lengths of 0 don't occur in production; rebuild with >=1
+		for k := range m {
+			m[k] = uint32(k%97 + 1)
+		}
+		v := buildView(t, m, false)
+		for i := uint64(1000); i < 2000; i++ {
+			require.Equal(t, m[i], v.get(i))
+		}
+	})
+}
+
+func TestMergePropLenPairs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ids1, ids2 []uint64
+		lens1      []uint32
+		lens2      []uint32
+		wantIDs    []uint64
+		wantLens   []uint32
+	}{
+		{"both_empty", nil, nil, nil, nil, nil, nil},
+		{
+			"left_empty",
+			nil,
+			[]uint64{2, 5},
+			nil,
+			[]uint32{20, 50},
+			[]uint64{2, 5},
+			[]uint32{20, 50},
+		},
+		{
+			"right_empty",
+			[]uint64{1, 3},
+			nil,
+			[]uint32{10, 30},
+			nil,
+			[]uint64{1, 3},
+			[]uint32{10, 30},
+		},
+		{
+			"disjoint_interleaved",
+			[]uint64{1, 4, 6},
+			[]uint64{2, 3, 7},
+			[]uint32{10, 40, 60},
+			[]uint32{20, 30, 70},
+			[]uint64{1, 2, 3, 4, 6, 7},
+			[]uint32{10, 20, 30, 40, 60, 70},
+		},
+		{
+			// duplicate docIDs: c2 (second/newer) wins, matching the compactor's
+			// prior maps.Copy(toWrite<-toClean) precedence
+			"duplicates_c2_wins",
+			[]uint64{1, 5, 9},
+			[]uint64{5, 9, 12},
+			[]uint32{10, 50, 90},
+			[]uint32{555, 999, 120},
+			[]uint64{1, 5, 9, 12},
+			[]uint32{10, 555, 999, 120},
+		},
+		{
+			"all_duplicates",
+			[]uint64{1, 2},
+			[]uint64{1, 2},
+			[]uint32{10, 20},
+			[]uint32{11, 22},
+			[]uint64{1, 2},
+			[]uint32{11, 22},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ids, lens := mergePropLenPairs(tc.ids1, tc.lens1, tc.ids2, tc.lens2)
+			assert.Equal(t, tc.wantIDs, nilIfEmpty(ids))
+			assert.Equal(t, tc.wantLens, nilIfEmptyU32(lens))
+			require.True(t, sort.SliceIsSorted(ids, func(i, j int) bool { return ids[i] < ids[j] }))
+		})
+	}
+}
+
+func nilIfEmpty(s []uint64) []uint64 {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}
+
+func nilIfEmptyU32(s []uint32) []uint32 {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}

--- a/adapters/repos/db/shard_bucket_options.go
+++ b/adapters/repos/db/shard_bucket_options.go
@@ -39,7 +39,6 @@ func (s *Shard) makeDefaultBucketOptions(strategy string, customOptions ...lsmkv
 			s.index.Config.MemtablesMaxActiveSeconds,
 		),
 		lsmkv.WithLazySegmentLoading(s.lazySegmentLoadingEnabled),
-		lsmkv.WithLazyPropertyLengths(s.index.Config.LazyPropertyLengthsEnabled),
 	}
 
 	switch strategy {

--- a/adapters/repos/db/shard_bucket_options.go
+++ b/adapters/repos/db/shard_bucket_options.go
@@ -39,6 +39,7 @@ func (s *Shard) makeDefaultBucketOptions(strategy string, customOptions ...lsmkv
 			s.index.Config.MemtablesMaxActiveSeconds,
 		),
 		lsmkv.WithLazySegmentLoading(s.lazySegmentLoadingEnabled),
+		lsmkv.WithLazyPropertyLengths(s.index.Config.LazyPropertyLengthsEnabled),
 	}
 
 	switch strategy {


### PR DESCRIPTION
### What's being changed
Replaces the resident `map[uint64]uint32` of per-document BM25 property lengths with a compact in-memory representation:

- a **dense `[]uint32`** when the docID range is ≥1/3 occupied (4 B/slot, O(1) read), or
- **docID-sorted parallel paris arrays** read through a cursor (`propLengthsView`) that's amortized O(1) on the ascending-docID scan order of scoring.

This cuts the property-length live heap ~4–12× (≈8.5 GB → ≈1.8 GB on the large sample workload) with equal-or-faster reads. The **on-disk format is unchanged** (still the gob `map[uint64]uint32`); only the in-memory shape changes. Read paths (BM25 scoring, the bucket consistent-view consumers) go through the cursor; compaction is untouched and still reconstructs a transient map (fixed in follow up PR). Adds `gobenc.DecodePairs`/`EncodePairs` (byte-identical wire format).

**On-disk format is unchanged** — fully backward/forward compatible, so this is safe to roll out and roll back.


**Heap savings:**

- Dense case will trigger mostly on compacted segments or bulk inserted data with few deletes and updates
- Pairs apply on other cases where docIds are more sparse on the segments (frequent deletes and updates)

| On-disk segment l(level) | Live entries | Representation | Old map heap | New array heap | Reduction |
|---|---|---|---|---|---|
| l18  | 130.4 M | dense (4 B × maxDocId-minDocId) | 5.83 GB | 0.50 GB | 11.7× |
| l16 | 38.3 M | pairs (12 B × n) | 1.71 GB | 0.43 GB | 4.0× |
| l15 | 34.9 M | pairs | 1.56 GB | 0.39 GB | 4.0× |
| l12 | 25.7 M | pairs | 1.15 GB | 0.29 GB | 4.0× |
| l13 | 15.0 M | pairs | 0.67 GB | 0.17 GB | 4.0× |
| l5 (tiny) | 0.08 M | pairs | 0.004 GB | 0.001 GB | 4.0× |
| **Total** | **244.5 M** | — | **~10.9 GB** | **~1.77 GB** | **~6.2×** |

**Read latency.** 

The dominant scoring path — frequent terms scanned in ascending docID order - gets **faster**, since the dense path is an O(1) indexed load and the pairs cursor is amortized O(1) on monotone scans:

- Dense segments: **~2 ns/read (~45–50× faster** than the map's cold ~90–100 ns).
- Sorted-pairs segments: **3–5 ns/read on ascending scans (18–28× faster)**.

**The one regression is bounded and confined.** On the *sorted-pairs* path only, rare-term lookups (a few scattered, cold docIDs) are **~1.3–2.5× slower than the map** (tens-to-low-hundreds of ns, on a handful of docs per query — sub-millisecond total). The dense path is immune (still ~2 ns regardless of access pattern), and high-occupancy/bulk-loaded data never hits this case. Net effect on query latency is positive because frequent terms dominate the BMW scoring work.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
