### PR TITLE
perf: direct-array compaction serialization via EncodePairs

### DIFF
--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -17,7 +17,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"maps"
 	"math"
 
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -57,8 +56,10 @@ type compactorInverted struct {
 	tombstonesToWrite *sroar.Bitmap
 	tombstonesToClean *sroar.Bitmap
 
-	propertyLengthsToWrite map[uint64]uint32
-	propertyLengthsToClean map[uint64]uint32
+	// merged property lengths of c1+c2 as docID-sorted parallel arrays, read by
+	// block re-encoding (via a cursor) and serialized directly — never a map.
+	propLengthIds  []uint64
+	propLengthLens []uint32
 
 	invertedHeader *segmentindex.HeaderInverted
 
@@ -132,23 +133,19 @@ func (c *compactorInverted) do(ctx context.Context) error {
 		return errors.Wrap(err, "get tombstones")
 	}
 
-	propertyLengthsToWrite, err := c.c1.segment.getPropertyLengths()
+	ids1, lens1, err := c.c1.segment.getPropertyLengthsPairs()
 	if err != nil {
 		return errors.Wrap(err, "get property lengths")
 	}
 
-	propertyLengthsToClean, err := c.c2.segment.getPropertyLengths()
+	ids2, lens2, err := c.c2.segment.getPropertyLengthsPairs()
 	if err != nil {
 		return errors.Wrap(err, "get property lengths")
 	}
 
-	c.propertyLengthsToWrite = make(map[uint64]uint32, len(propertyLengthsToWrite))
-	c.propertyLengthsToClean = make(map[uint64]uint32, len(propertyLengthsToClean))
+	c.propLengthIds, c.propLengthLens = mergePropLenPairs(ids1, lens1, ids2, lens2)
 
-	maps.Copy(c.propertyLengthsToWrite, propertyLengthsToWrite)
-	maps.Copy(c.propertyLengthsToClean, propertyLengthsToClean)
-
-	tombstones := c.computeTombstonesAndPropLengths()
+	tombstones := c.computeTombstones()
 
 	keysOffset := segmentindex.HeaderSize + segmentindex.SegmentInvertedDefaultHeaderSize + len(c.c1.segment.invertedHeader.DataFields)
 
@@ -164,7 +161,7 @@ func (c *compactorInverted) do(ctx context.Context) error {
 	}
 
 	propertyLengthsOffset := c.offset
-	_, err = c.writePropertyLengths(c.propertyLengthsToWrite)
+	_, err = c.writePropertyLengths()
 	if err != nil {
 		return errors.Wrap(err, "write property lengths")
 	}
@@ -271,8 +268,8 @@ func (c *compactorInverted) combinePropertyLengths() (uint64, float64) {
 	return count, average
 }
 
-func (c *compactorInverted) writePropertyLengths(propLengths map[uint64]uint32) (int, error) {
-	encoded, err := gobenc.Encode(propLengths)
+func (c *compactorInverted) writePropertyLengths() (int, error) {
+	encoded, err := gobenc.EncodePairs(c.propLengthIds, c.propLengthLens)
 	if err != nil {
 		return 0, err
 	}
@@ -340,7 +337,7 @@ func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.Key, 
 				continue
 			}
 
-			ki, err := c.writeIndividualNode(c.offset, key2, mergedPairs, c.propertyLengthsToWrite)
+			ki, err := c.writeIndividualNode(c.offset, key2, mergedPairs)
 			if err != nil {
 				return nil, errors.Wrap(err, "write individual node (equal keys)")
 			}
@@ -357,7 +354,7 @@ func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.Key, 
 		if (key1 != nil && bytes.Compare(key1, key2) == -1) || key2 == nil {
 			// key 1 is smaller
 			if values, skip := c.cleanupValues(value1); !skip {
-				ki, err := c.writeIndividualNode(c.offset, key1, values, c.propertyLengthsToWrite)
+				ki, err := c.writeIndividualNode(c.offset, key1, values)
 				if err != nil {
 					return nil, errors.Wrap(err, "write individual node (key1 smaller)")
 				}
@@ -368,7 +365,7 @@ func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.Key, 
 			key1, value1, _ = c.c1.next()
 		} else {
 			// key 2 is smaller
-			ki, err := c.writeIndividualNode(c.offset, key2, value2, c.propertyLengthsToWrite)
+			ki, err := c.writeIndividualNode(c.offset, key2, value2)
 			if err != nil {
 				return nil, errors.Wrap(err, "write individual node (key2 smaller)")
 			}
@@ -384,7 +381,7 @@ func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.Key, 
 }
 
 func (c *compactorInverted) writeIndividualNode(offset int, key []byte,
-	values []MapPair, propertyLengths map[uint64]uint32,
+	values []MapPair,
 ) (segmentindex.Key, error) {
 	// NOTE: There are no guarantees in the cursor logic that any memory is valid
 	// for more than a single iteration. Every time you call next() to advance
@@ -399,11 +396,14 @@ func (c *compactorInverted) writeIndividualNode(offset int, key []byte,
 	keyCopy := make([]byte, len(key))
 	copy(keyCopy, key)
 
+	// fresh cursor per term: its docIDs ascend, so lookups stay amortized O(1)
+	view := propLengthsView{ids: c.propLengthIds, lens: c.propLengthLens}
+
 	return segmentInvertedNode{
 		values:      values,
 		primaryKey:  keyCopy,
 		offset:      offset,
-		propLengths: propertyLengths,
+		propLengths: &view,
 	}.KeyIndexAndWriteTo(c.segmentFile.BodyWriter(), c.docIdEncoder, c.tfEncoder, c.k1, c.b, c.avgPropLen)
 }
 
@@ -440,9 +440,7 @@ func (c *compactorInverted) cleanupValues(values []MapPair) (vals []MapPair, ski
 	return values[:last], false
 }
 
-func (c *compactorInverted) computeTombstonesAndPropLengths() *sroar.Bitmap {
-	maps.Copy(c.propertyLengthsToWrite, c.propertyLengthsToClean)
-
+func (c *compactorInverted) computeTombstones() *sroar.Bitmap {
 	if c.cleanupTombstones { // no tombstones to write
 		return sroar.NewBitmap()
 	}

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -335,6 +335,34 @@ func (s *segment) getPropertyLengths() (map[uint64]uint32, error) {
 	return m, nil
 }
 
+// getPropertyLengthsPairs returns the property lengths as docID-sorted arrays
+// (no map): the loaded slices directly for pairs segments, or the dense array
+// walked into pairs (0 = absent skipped). Returned slices are read-only.
+func (s *segment) getPropertyLengthsPairs() ([]uint64, []uint32, error) {
+	dense, minID, ids, lens, err := s.propLengthArrays()
+	if err != nil {
+		return nil, nil, err
+	}
+	if dense != nil {
+		n := 0
+		for _, l := range dense {
+			if l != 0 {
+				n++
+			}
+		}
+		outIDs := make([]uint64, 0, n)
+		outLens := make([]uint32, 0, n)
+		for i, l := range dense {
+			if l != 0 {
+				outIDs = append(outIDs, minID+uint64(i))
+				outLens = append(outLens, l)
+			}
+		}
+		return outIDs, outLens, nil
+	}
+	return ids, lens, nil
+}
+
 // mergePropLenPairs merges two docID-sorted pair arrays into one, deduping
 // docIDs. On a tie the second array wins (c2 is the newer segment) — the
 // precedence the compactor's prior map overwrite relied on.

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -223,3 +223,58 @@ func TestSegmentPropertyLengthsZeroLengthForcesPairs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, want, got, "the 0-length key must survive reconstruction")
 }
+
+// TestInvertedCompactionPropertyLengths drives a real two-segment compaction and
+// verifies the merged segment's property lengths are correct end to end — the
+// array-merge serialization path (no map reconstruction) round-trips every
+// docID, and a docID present in both segments resolves to the newer segment's
+// value (c2 wins), matching the compactor's documented precedence.
+func TestInvertedCompactionPropertyLengths(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9) // never auto-flush mid-segment
+
+	// segment 1 (older, c1): docs 1,2,5 under term "alpha"
+	for docID, pl := range map[uint64]float32{1: 10, 2: 20, 5: 50} {
+		require.NoError(t, bucket.MapSet([]byte("alpha"), NewMapPairFromDocIdAndTf(docID, 1, pl, false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// segment 2 (newer, c2): docs 3,7 under "beta" plus docID 5 again with a
+	// different length — the duplicate the merge must resolve in c2's favor
+	for docID, pl := range map[uint64]float32{3: 30, 5: 999, 7: 70} {
+		require.NoError(t, bucket.MapSet([]byte("beta"), NewMapPairFromDocIdAndTf(docID, 1, pl, false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// compact until no longer eligible
+	for {
+		compacted, err := bucket.disk.compactOnce(ctx)
+		require.NoError(t, err)
+		if !compacted {
+			break
+		}
+	}
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1, "expected a single segment after compaction")
+	seg := view.Disk[0]
+
+	want := map[uint64]uint32{1: 10, 2: 20, 3: 30, 5: 999, 7: 70}
+
+	got, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "merged property lengths (duplicate docID 5 = newer segment's 999)")
+
+	plView, err := seg.propLengthsView()
+	require.NoError(t, err)
+	for id, l := range want {
+		require.Equal(t, l, plView.get(id), "view docID %d", id)
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -278,3 +278,62 @@ func TestInvertedCompactionPropertyLengths(t *testing.T) {
 		require.Equal(t, l, plView.get(id), "view docID %d", id)
 	}
 }
+
+// TestInvertedCompactionPropertyLengthsSparsePairs is the sparse-docID sibling of
+// TestInvertedCompactionPropertyLengths. The docID ranges are too sparse for the
+// dense layout (span/3 > count), so both source segments and the merged segment
+// store property lengths as sorted pairs — exercising the pairs branch of
+// getPropertyLengthsPairs and the pairs cursor on read-back, the representation
+// the dense case never reaches, while still pinning c2-wins precedence on the
+// docID (10000) present in both segments.
+func TestInvertedCompactionPropertyLengthsSparsePairs(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9) // never auto-flush mid-segment
+
+	// segment 1 (older, c1): span 9001 over 3 docs, far past the 1/3-occupancy
+	// dense cutoff, so this segment stores pairs
+	for docID, pl := range map[uint64]float32{1000: 10, 1001: 11, 10000: 100} {
+		require.NoError(t, bucket.MapSet([]byte("alpha"), NewMapPairFromDocIdAndTf(docID, 1, pl, false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// segment 2 (newer, c2): docID 10000 again with a different length — the
+	// cross-segment duplicate the merge must resolve in c2's favor
+	for docID, pl := range map[uint64]float32{5000: 50, 10000: 999, 20000: 200} {
+		require.NoError(t, bucket.MapSet([]byte("beta"), NewMapPairFromDocIdAndTf(docID, 1, pl, false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	for {
+		compacted, err := bucket.disk.compactOnce(ctx)
+		require.NoError(t, err)
+		if !compacted {
+			break
+		}
+	}
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1, "expected a single segment after compaction")
+	seg := view.Disk[0]
+
+	want := map[uint64]uint32{1000: 10, 1001: 11, 5000: 50, 10000: 999, 20000: 200}
+
+	got, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "merged property lengths (duplicate docID 10000 = newer segment's 999)")
+
+	plView, err := seg.propLengthsView()
+	require.NoError(t, err)
+	assert.Nil(t, plView.dense, "sparse docIDs must keep the merged segment on the pairs layout")
+	assert.NotNil(t, plView.ids, "pairs layout expected")
+	for id, l := range want {
+		require.Equal(t, l, plView.get(id), "view docID %d", id)
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -366,9 +366,9 @@ type segmentInvertedNode struct {
 	values     []MapPair
 	primaryKey []byte
 	offset     int
-	// propLengths is the compaction-time cursor over the merged segments'
-	// property lengths; nil for the flush path (which carries lengths inline in
-	// the postings' value bytes).
+	// propLengths is the lookup over the merged segments' property lengths used
+	// by block encoding. Required (non-nil): this node is built only during
+	// compaction; the flush path encodes via createAndEncodeBlocksWithLengths.
 	propLengths *propLengthsView
 }
 

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -76,7 +76,11 @@ func encodeBlockParam(nodes []MapPair, deltaEnc, tfEnc varenc.VarEncEncoder[uint
 	return packed
 }
 
-func createBlocks(nodes []MapPair, propLengths map[uint64]uint32, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]*terms.BlockEntry, []*terms.BlockData, *sroar.Bitmap, map[uint64]uint32) {
+// createBlocks builds the block-max metadata and encoded block data for a
+// term's postings. Property lengths come from, in order: lookup (compaction
+// cursor, no map), a non-empty propLengths map, or the value bytes — backfilled
+// into propLengths for the flush path.
+func createBlocks(nodes []MapPair, propLengths map[uint64]uint32, lookup *propLengthsView, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]*terms.BlockEntry, []*terms.BlockData, *sroar.Bitmap, map[uint64]uint32) {
 	tombstones, values := extractTombstones(nodes)
 	externalPropLengths := len(propLengths) != 0
 
@@ -101,9 +105,12 @@ func createBlocks(nodes []MapPair, propLengths map[uint64]uint32, deltaEnc, tfEn
 			tf := float64(math.Float32frombits(binary.LittleEndian.Uint32(values[j].Value[0:4])))
 			pl := float64(math.Float32frombits(binary.LittleEndian.Uint32(values[j].Value[4:8])))
 			docId := binary.BigEndian.Uint64(values[j].Key)
-			if externalPropLengths {
+			switch {
+			case lookup != nil:
+				pl = float64(lookup.get(docId))
+			case externalPropLengths:
 				pl = float64(propLengths[docId])
-			} else {
+			default:
 				propLengths[docId] = uint32(pl)
 			}
 
@@ -176,21 +183,24 @@ func createAndEncodeSingleValue(mapPairs []MapPair, propLengths map[uint64]uint3
 	return buffer[:offset], tombstones
 }
 
-func createAndEncodeBlocksTest(nodes []MapPair, propLengths map[uint64]uint32, encodeSingleSeparate int, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]byte, *sroar.Bitmap) {
+func createAndEncodeBlocksTest(nodes []MapPair, propLengths map[uint64]uint32, lookup *propLengthsView, encodeSingleSeparate int, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]byte, *sroar.Bitmap) {
 	if len(nodes) <= encodeSingleSeparate {
+		// single-value postings store tf inline and never consult propLengths
 		return createAndEncodeSingleValue(nodes, propLengths)
 	}
-	blockEntries, blockDatas, tombstones, _ := createBlocks(nodes, propLengths, deltaEnc, tfEnc, k1, b, avgPropLen)
+	blockEntries, blockDatas, tombstones, _ := createBlocks(nodes, propLengths, lookup, deltaEnc, tfEnc, k1, b, avgPropLen)
 	return encodeBlocks(blockEntries, blockDatas, uint64(len(nodes))), tombstones
 }
 
 func createAndEncodeBlocksWithLengths(nodes []MapPair, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]byte, *sroar.Bitmap) {
 	propLengths := make(map[uint64]uint32)
-	return createAndEncodeBlocksTest(nodes, propLengths, terms.ENCODE_AS_FULL_BYTES, deltaEnc, tfEnc, k1, b, avgPropLen)
+	return createAndEncodeBlocksTest(nodes, propLengths, nil, terms.ENCODE_AS_FULL_BYTES, deltaEnc, tfEnc, k1, b, avgPropLen)
 }
 
-func createAndEncodeBlocks(nodes []MapPair, propLengths map[uint64]uint32, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]byte, *sroar.Bitmap) {
-	return createAndEncodeBlocksTest(nodes, propLengths, terms.ENCODE_AS_FULL_BYTES, deltaEnc, tfEnc, k1, b, avgPropLen)
+// createAndEncodeBlocks is the compaction entry point: property lengths come
+// from the merged-segment cursor (lookup), not a map.
+func createAndEncodeBlocks(nodes []MapPair, lookup *propLengthsView, deltaEnc, tfEnc varenc.VarEncEncoder[uint64], k1, b, avgPropLen float64) ([]byte, *sroar.Bitmap) {
+	return createAndEncodeBlocksTest(nodes, nil, lookup, terms.ENCODE_AS_FULL_BYTES, deltaEnc, tfEnc, k1, b, avgPropLen)
 }
 
 func decodeBlocks(data []byte) ([]*terms.BlockEntry, []*terms.BlockData, int) {
@@ -353,10 +363,13 @@ func convertFixedLengthFromMemory(data []byte, blockSize int) *terms.BlockDataDe
 
 // a single node of strategy "inverted"
 type segmentInvertedNode struct {
-	values      []MapPair
-	primaryKey  []byte
-	offset      int
-	propLengths map[uint64]uint32
+	values     []MapPair
+	primaryKey []byte
+	offset     int
+	// propLengths is the compaction-time cursor over the merged segments'
+	// property lengths; nil for the flush path (which carries lengths inline in
+	// the postings' value bytes).
+	propLengths *propLengthsView
 }
 
 var invPayloadLen = 16


### PR DESCRIPTION
### What's being changed

Optimizes inverted-segment compaction to work directly on the sorted property-length arrays: 
- it two-pointer-merges the two segments' `(docID, length)` runs (`mergePropLenPairs`, newer segment wins on overlap) and serializes via `gobenc.EncodePairs` — eliminating the per-compaction transient-map reconstruction. 
- The serialized property-length block is **decode-equivalent** to the previous `gob.Encode(map)` path — it reads back to the same `map[uint64]uint32` — and is now written in deterministic docID order instead of gob's randomized map-iteration order (`TestEncodePairsMatchesEncode` asserts decode-equivalence for multi-entry maps, and byte-equality only for the ≤1-entry case). Pure optimization on the dense/sorted-pairs property-length representation; no on-disk format or behavior change.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

