### PR TITLE
feat(config): auto-force GraphQL/replication settings when NAMESPACES_ENABLED

### DIFF
--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -982,9 +982,6 @@ func FromEnv(config *Config) error {
 	config.DisableGraphQL = entcfg.Enabled(os.Getenv("DISABLE_GRAPHQL"))
 
 	config.Namespaces.Enabled = entcfg.Enabled(os.Getenv("NAMESPACES_ENABLED"))
-	if config.Namespaces.Enabled {
-		config.Persistence.LSMSkipWriteClassNameEnabled = true
-	}
 
 	if err := parser.ParseDynamicDurationWithValidation("NAMESPACE_CLEANUP_INTERVAL",
 		DefaultNamespaceCleanupInterval,
@@ -1408,7 +1405,36 @@ func FromEnv(config *Config) error {
 
 	config.DisableDimensionMetrics = configRuntime.NewDynamicValue(disableDimensionMetrics)
 
+	applyNamespaceForcedConfig(config, logrus.StandardLogger())
+
 	return nil
+}
+
+// applyNamespaceForcedConfig coerces the settings a namespace-enabled cluster
+// requires so operators don't have to set them by hand. NAMESPACES_ENABLED=true
+// forces DISABLE_GRAPHQL=true (the GraphQL schema can't model namespace-qualified
+// class names) and caps the replication factor at 1 (the only supported shape).
+// The same invariants are still enforced in Config.Validate() as a safety net.
+func applyNamespaceForcedConfig(config *Config, logger logrus.FieldLogger) {
+	if !config.Namespaces.Enabled {
+		return
+	}
+
+	config.Persistence.LSMSkipWriteClassNameEnabled = true
+
+	if !config.DisableGraphQL {
+		if _, set := os.LookupEnv("DISABLE_GRAPHQL"); set {
+			logger.Warn("NAMESPACES_ENABLED=true forces DISABLE_GRAPHQL=true; overriding configured DISABLE_GRAPHQL=false")
+		}
+		config.DisableGraphQL = true
+	}
+
+	if config.Replication.MaximumFactor != 1 {
+		if _, set := os.LookupEnv("REPLICATION_MAXIMUM_FACTOR"); set {
+			logger.Warnf("NAMESPACES_ENABLED=true forces REPLICATION_MAXIMUM_FACTOR=1; overriding configured REPLICATION_MAXIMUM_FACTOR=%d", config.Replication.MaximumFactor)
+		}
+		config.Replication.MaximumFactor = 1
+	}
 }
 
 func parseRAFTConfig(hostname string) (Raft, error) {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -14,9 +14,12 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -685,6 +688,178 @@ func TestEnvironmentDisableGraphQL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFromEnv_NamespacesForcedConfig verifies that NAMESPACES_ENABLED=true
+// coerces the deployment-shape settings (DISABLE_GRAPHQL=true,
+// REPLICATION_MAXIMUM_FACTOR=1, LSMSkipWriteClassNameEnabled=true), overriding
+// any conflicting operator-provided values.
+func TestFromEnv_NamespacesForcedConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		namespacesEnabled  bool
+		disableGraphQLEnv  string // "" means unset
+		maxFactorEnv       string // "" means unset
+		wantDisableGraphQL bool
+		wantMaxFactor      int
+		wantSkipClassName  bool
+	}{
+		{
+			name:               "namespaces disabled — no coercion",
+			namespacesEnabled:  false,
+			disableGraphQLEnv:  "false",
+			maxFactorEnv:       "3",
+			wantDisableGraphQL: false,
+			wantMaxFactor:      3,
+			wantSkipClassName:  false,
+		},
+		{
+			name:               "namespaces enabled, both unset — coerced silently",
+			namespacesEnabled:  true,
+			wantDisableGraphQL: true,
+			wantMaxFactor:      1,
+			wantSkipClassName:  true,
+		},
+		{
+			name:               "namespaces enabled, DISABLE_GRAPHQL=false — overridden",
+			namespacesEnabled:  true,
+			disableGraphQLEnv:  "false",
+			wantDisableGraphQL: true,
+			wantMaxFactor:      1,
+			wantSkipClassName:  true,
+		},
+		{
+			name:               "namespaces enabled, DISABLE_GRAPHQL=true — kept",
+			namespacesEnabled:  true,
+			disableGraphQLEnv:  "true",
+			wantDisableGraphQL: true,
+			wantMaxFactor:      1,
+			wantSkipClassName:  true,
+		},
+		{
+			name:               "namespaces enabled, REPLICATION_MAXIMUM_FACTOR=3 — overridden",
+			namespacesEnabled:  true,
+			maxFactorEnv:       "3",
+			wantDisableGraphQL: true,
+			wantMaxFactor:      1,
+			wantSkipClassName:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.namespacesEnabled {
+				t.Setenv("NAMESPACES_ENABLED", "true")
+			}
+			if tt.disableGraphQLEnv != "" {
+				t.Setenv("DISABLE_GRAPHQL", tt.disableGraphQLEnv)
+			}
+			if tt.maxFactorEnv != "" {
+				t.Setenv("REPLICATION_MAXIMUM_FACTOR", tt.maxFactorEnv)
+			}
+
+			conf := Config{}
+			require.NoError(t, FromEnv(&conf))
+
+			assert.Equal(t, tt.wantDisableGraphQL, conf.DisableGraphQL)
+			assert.Equal(t, tt.wantMaxFactor, conf.Replication.MaximumFactor)
+			assert.Equal(t, tt.wantSkipClassName, conf.Persistence.LSMSkipWriteClassNameEnabled)
+		})
+	}
+}
+
+// warnEntriesContaining returns the WARN-level log messages mentioning substr.
+func warnEntriesContaining(entries []*logrus.Entry, substr string) []string {
+	var msgs []string
+	for _, e := range entries {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, substr) {
+			msgs = append(msgs, e.Message)
+		}
+	}
+	return msgs
+}
+
+// TestApplyNamespaceForcedConfig pins the warn-vs-silent contract: an explicitly
+// configured conflicting value is overridden with a WARN; an unset value is
+// coerced silently; a disabled namespace is a no-op.
+func TestApplyNamespaceForcedConfig(t *testing.T) {
+	t.Run("namespaces disabled — no-op, no logs", func(t *testing.T) {
+		log, hook := logrustest.NewNullLogger()
+		c := &Config{DisableGraphQL: false}
+		c.Replication.MaximumFactor = 3
+
+		applyNamespaceForcedConfig(c, log)
+
+		assert.False(t, c.DisableGraphQL)
+		assert.Equal(t, 3, c.Replication.MaximumFactor)
+		assert.False(t, c.Persistence.LSMSkipWriteClassNameEnabled)
+		assert.Empty(t, hook.AllEntries())
+	})
+
+	t.Run("DISABLE_GRAPHQL=false explicitly set — overridden with warn", func(t *testing.T) {
+		t.Setenv("DISABLE_GRAPHQL", "false")
+		log, hook := logrustest.NewNullLogger()
+		c := &Config{DisableGraphQL: false}
+		c.Namespaces.Enabled = true
+
+		applyNamespaceForcedConfig(c, log)
+
+		assert.True(t, c.DisableGraphQL)
+		assert.NotEmpty(t, warnEntriesContaining(hook.AllEntries(), "DISABLE_GRAPHQL"),
+			"expected a warning about overriding DISABLE_GRAPHQL")
+	})
+
+	t.Run("DISABLE_GRAPHQL unset — coerced silently", func(t *testing.T) {
+		log, hook := logrustest.NewNullLogger()
+		c := &Config{DisableGraphQL: false}
+		c.Namespaces.Enabled = true
+
+		applyNamespaceForcedConfig(c, log)
+
+		assert.True(t, c.DisableGraphQL)
+		assert.Empty(t, warnEntriesContaining(hook.AllEntries(), "DISABLE_GRAPHQL"),
+			"unset DISABLE_GRAPHQL should be coerced without a warning")
+	})
+
+	t.Run("REPLICATION_MAXIMUM_FACTOR=3 explicitly set — overridden with warn", func(t *testing.T) {
+		t.Setenv("REPLICATION_MAXIMUM_FACTOR", "3")
+		log, hook := logrustest.NewNullLogger()
+		c := &Config{}
+		c.Namespaces.Enabled = true
+		c.Replication.MaximumFactor = 3
+
+		applyNamespaceForcedConfig(c, log)
+
+		assert.Equal(t, 1, c.Replication.MaximumFactor)
+		assert.NotEmpty(t, warnEntriesContaining(hook.AllEntries(), "REPLICATION_MAXIMUM_FACTOR"),
+			"expected a warning about overriding REPLICATION_MAXIMUM_FACTOR")
+	})
+
+	t.Run("REPLICATION_MAXIMUM_FACTOR unset — coerced silently", func(t *testing.T) {
+		log, hook := logrustest.NewNullLogger()
+		c := &Config{}
+		c.Namespaces.Enabled = true
+
+		applyNamespaceForcedConfig(c, log)
+
+		assert.Equal(t, 1, c.Replication.MaximumFactor)
+		assert.Empty(t, warnEntriesContaining(hook.AllEntries(), "REPLICATION_MAXIMUM_FACTOR"),
+			"unset REPLICATION_MAXIMUM_FACTOR should be coerced without a warning")
+	})
+
+	// MinimumFactor > 1 is fundamentally incompatible with namespaces (RF=1
+	// only). Coercion does not silently lower the floor — it leaves the bounds
+	// check to reject the config, so the misconfiguration surfaces loudly.
+	t.Run("MinimumFactor > 1 — coercion leaves bounds check to reject", func(t *testing.T) {
+		log, _ := logrustest.NewNullLogger()
+		c := &Config{}
+		c.Namespaces.Enabled = true
+		c.Replication.MinimumFactor = 3
+
+		applyNamespaceForcedConfig(c, log)
+
+		assert.Equal(t, 1, c.Replication.MaximumFactor)
+		require.Error(t, c.validateReplicationFactorBounds())
+	})
 }
 
 func TestEnvironmentCORS_Headers(t *testing.T) {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -694,6 +694,19 @@ func TestEnvironmentDisableGraphQL(t *testing.T) {
 // coerces the deployment-shape settings (DISABLE_GRAPHQL=true,
 // REPLICATION_MAXIMUM_FACTOR=1, LSMSkipWriteClassNameEnabled=true), overriding
 // any conflicting operator-provided values.
+
+// ensureUnset removes key from the environment for the duration of the test,
+// restoring any prior value on cleanup. The coercion logic keys off
+// os.LookupEnv, so a value leaking in from the dev/CI shell would otherwise
+// make these tests non-hermetic.
+func ensureUnset(t *testing.T, key string) {
+	t.Helper()
+	if v, ok := os.LookupEnv(key); ok {
+		require.NoError(t, os.Unsetenv(key))
+		t.Cleanup(func() { os.Setenv(key, v) })
+	}
+}
+
 func TestFromEnv_NamespacesForcedConfig(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -747,6 +760,12 @@ func TestFromEnv_NamespacesForcedConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Start from a clean slate so the result depends only on what this
+			// subtest sets, not on the surrounding shell.
+			ensureUnset(t, "NAMESPACES_ENABLED")
+			ensureUnset(t, "DISABLE_GRAPHQL")
+			ensureUnset(t, "REPLICATION_MAXIMUM_FACTOR")
+
 			if tt.namespacesEnabled {
 				t.Setenv("NAMESPACES_ENABLED", "true")
 			}
@@ -809,6 +828,7 @@ func TestApplyNamespaceForcedConfig(t *testing.T) {
 	})
 
 	t.Run("DISABLE_GRAPHQL unset — coerced silently", func(t *testing.T) {
+		ensureUnset(t, "DISABLE_GRAPHQL")
 		log, hook := logrustest.NewNullLogger()
 		c := &Config{DisableGraphQL: false}
 		c.Namespaces.Enabled = true
@@ -835,6 +855,7 @@ func TestApplyNamespaceForcedConfig(t *testing.T) {
 	})
 
 	t.Run("REPLICATION_MAXIMUM_FACTOR unset — coerced silently", func(t *testing.T) {
+		ensureUnset(t, "REPLICATION_MAXIMUM_FACTOR")
 		log, hook := logrustest.NewNullLogger()
 		c := &Config{}
 		c.Namespaces.Enabled = true


### PR DESCRIPTION
## Motivation

A namespace-enabled Weaviate cluster only runs in one supported shape: replication factor 1, GraphQL disabled (the GraphQL schema can't model namespace-qualified class names), and `LSMSkipWriteClassNameEnabled` on. Until now operators had to know and set each of these env vars by hand, and `Config.Validate()` rejects startup if any one is wrong — so `NAMESPACES_ENABLED=true` was a footgun where a single missing/stale env var failed startup with a validation error instead of just working.

This came out of weaviate-helm [#331](https://github.com/weaviate/weaviate-helm/pull/331): rather than have the chart inject `DISABLE_GRAPHQL`/`REPLICATION_MAXIMUM_FACTOR`, Weaviate should self-configure the settings it strictly requires when namespaces are enabled.

## Approach

A single `applyNamespaceForcedConfig` step at the end of `FromEnv` coerces the required settings when `NAMESPACES_ENABLED=true`:

- `DISABLE_GRAPHQL=true`
- `REPLICATION_MAXIMUM_FACTOR=1`
- `LSMSkipWriteClassNameEnabled=true` (this pre-existing inline side-effect is relocated into the helper so all namespace-forced settings live in one place)

It runs after both env vars are parsed, so the coercion is order-independent. Coercion is **not** a replacement for validation — the same invariants are still enforced in `Config.Validate()` as a defense-in-depth safety net.

**Warn-vs-silent contract:**
- An explicitly set conflicting value (`DISABLE_GRAPHQL=false`, `REPLICATION_MAXIMUM_FACTOR=3`) is overridden **with a WARN** — the operator asked for something incompatible and deserves to know it was changed.
- An unset value is coerced **silently**.
- Namespaces disabled is a complete no-op.

`os.LookupEnv` (not the parsed value) distinguishes "explicitly set" from "unset", which is what drives the warn decision.

One intentional non-action: when `REPLICATION_MINIMUM_FACTOR > 1`, coercion forces `MaximumFactor=1` but does **not** silently lower the floor — that would mask a genuinely contradictory config. Instead it lets `validateReplicationFactorBounds()` reject it loudly (pinned by a test).

This follows existing precedent: `NAMESPACES_ENABLED` already forced `LSMSkipWriteClassNameEnabled`, and `PROMETHEUS_MONITORING_ENABLED` forces several dependent settings.

## Key areas for review

- `usecases/config/environment.go` → `applyNamespaceForcedConfig` — the coercion and the `os.LookupEnv`-driven warn decision.
- Layering vs. `config_handler.go` (`validateReplicationFactorBounds` / `validateUsageLimitsReplicationLinkage`): coercion happens in `FromEnv`, validation runs later in `Validate()`. Confirm coercion can't make a contradictory config accidentally pass validation.

## Risks and mitigations

- **Operator surprise from silent override** — mitigated by a WARN whenever an explicitly configured value is overridden; only unset values coerce silently.
- **Coercion masking a real misconfiguration** — the `MinimumFactor > 1` case deliberately leaves rejection to the bounds check (regression test included).
- **Defense-in-depth not weakened** — the existing `Config.Validate()` checks are untouched and still run; RBAC remains a hard requirement (it can't be safely auto-enabled).

## Testing

Two suites, both passing (`go test ./usecases/config/`):

- `TestFromEnv_NamespacesForcedConfig` — end-to-end through `FromEnv`: namespaces-disabled (no coercion), enabled with both vars unset, with `DISABLE_GRAPHQL=false` (overridden), with `DISABLE_GRAPHQL=true` (kept), and with `REPLICATION_MAXIMUM_FACTOR=3` (overridden); asserts all three forced settings.
- `TestApplyNamespaceForcedConfig` — pins the warn-vs-silent contract via a logrus null-logger + hook: disabled no-op emits no logs, explicit conflicts override *with* a warn, unset values coerce *without* a warn, and `MinimumFactor > 1` is still rejected by `validateReplicationFactorBounds()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
