### PR TITLE
[tracing] add injectable, per-area request tracing

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -109,7 +109,10 @@ func CreateGRPCServer(state *state.State, clientTracker *telemetry.ClientTracker
 	interceptors = append(interceptors, makeOperationalModeInterceptor(state))
 	interceptors = append(interceptors, makeMaintenanceModeUnaryInterceptor(state.Cluster.MaintenanceModeEnabledForLocalhost))
 
-	// Add OpenTelemetry tracing interceptors
+	// Add OpenTelemetry tracing interceptors. The unary interceptor opens the
+	// inbound server span that becomes the parent of any usecases/tracing spans
+	// emitted on the search path (client search is gRPC-unary). The HTTP
+	// middleware and the gRPC stream interceptor are not yet wired (deferred).
 	interceptors = append(interceptors, monitoring.GRPCTracingInterceptor())
 
 	if len(interceptors) > 0 {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -1116,6 +1116,7 @@ func extractAdditionalPropsFromMetadata(class *models.Class, prop *pb.MetadataRe
 		IsConsistent:       prop.IsConsistent,
 		Vectors:            prop.Vectors,
 		QueryProfile:       prop.QueryProfile,
+		TraceSpans:         prop.TraceSpans,
 	}
 
 	// certainty is not compatible with

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -243,8 +243,8 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	// Initialize OpenTelemetry tracing
 	if err := opentelemetry.Init(appState.Logger); err != nil {
 		appState.Logger.
-			WithField("action", "startup").WithError(err).
-			Error("failed to initialize OpenTelemetry")
+			WithField("action", "startup").
+			Errorf("failed to initialize OpenTelemetry: %v", err)
 	}
 
 	if appState.ServerConfig.Config.Monitoring.Enabled {
@@ -2610,6 +2610,9 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.MCPEnabled = appState.ServerConfig.Config.MCP.Enabled
 		registered.MCPWriteAccessEnabled = appState.ServerConfig.Config.MCP.WriteAccessEnabled
 		registered.DebugEndpointsEnabled = appState.ServerConfig.Config.Profiling.DebugEndpointsEnabled
+		registered.TraceVectorSearch = appState.ServerConfig.Config.TraceVectorSearch
+		registered.TraceBM25Search = appState.ServerConfig.Config.TraceBM25Search
+		registered.TraceHybridSearch = appState.ServerConfig.Config.TraceHybridSearch
 
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
 			registered.OIDCIssuer = appState.ServerConfig.Config.Authentication.OIDC.Issuer

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -44,6 +44,10 @@ type Properties struct {
 	// QueryProfile enables per-shard query profiling data collection and return.
 	QueryProfile bool `json:"queryProfile"`
 
+	// TraceSpans forces OTel span emission for this request only, independent of
+	// the runtime tracing toggles.
+	TraceSpans bool `json:"traceSpans"`
+
 	// The User is not interested in returning props, we can skip any costly
 	// operation that isn't required.
 	NoProps bool `json:"noProps"`

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -530,7 +530,10 @@ type MetadataRequest struct {
 	Vectors            []string               `protobuf:"bytes,10,rep,name=vectors,proto3" json:"vectors,omitempty"`
 	// query_profile enables per-shard query profiling. When true, the response includes
 	// timing breakdowns for each shard and search type.
-	QueryProfile  bool `protobuf:"varint,11,opt,name=query_profile,json=queryProfile,proto3" json:"query_profile,omitempty"`
+	QueryProfile bool `protobuf:"varint,11,opt,name=query_profile,json=queryProfile,proto3" json:"query_profile,omitempty"`
+	// trace_spans forces OTel span emission for this request only, independent of
+	// the runtime tracing toggles.
+	TraceSpans    bool `protobuf:"varint,12,opt,name=trace_spans,json=traceSpans,proto3" json:"trace_spans,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -638,6 +641,13 @@ func (x *MetadataRequest) GetVectors() []string {
 func (x *MetadataRequest) GetQueryProfile() bool {
 	if x != nil {
 		return x.QueryProfile
+	}
+	return false
+}
+
+func (x *MetadataRequest) GetTraceSpans() bool {
+	if x != nil {
+		return x.TraceSpans
 	}
 	return false
 }
@@ -2176,7 +2186,7 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\x11objects_per_group\x18\x03 \x01(\x05R\x0fobjectsPerGroup\":\n" +
 	"\x06SortBy\x12\x1c\n" +
 	"\tascending\x18\x01 \x01(\bR\tascending\x12\x12\n" +
-	"\x04path\x18\x02 \x03(\tR\x04path\"\xf7\x02\n" +
+	"\x04path\x18\x02 \x03(\tR\x04path\"\x98\x03\n" +
 	"\x0fMetadataRequest\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\bR\x04uuid\x12\x16\n" +
 	"\x06vector\x18\x02 \x01(\bR\x06vector\x12,\n" +
@@ -2189,7 +2199,9 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\ris_consistent\x18\t \x01(\bR\fisConsistent\x12\x18\n" +
 	"\avectors\x18\n" +
 	" \x03(\tR\avectors\x12#\n" +
-	"\rquery_profile\x18\v \x01(\bR\fqueryProfile\"\x9f\x02\n" +
+	"\rquery_profile\x18\v \x01(\bR\fqueryProfile\x12\x1f\n" +
+	"\vtrace_spans\x18\f \x01(\bR\n" +
+	"traceSpans\"\x9f\x02\n" +
 	"\x11PropertiesRequest\x12,\n" +
 	"\x12non_ref_properties\x18\x01 \x03(\tR\x10nonRefProperties\x12H\n" +
 	"\x0eref_properties\x18\x02 \x03(\v2!.weaviate.v1.RefPropertiesRequestR\rrefProperties\x12Q\n" +

--- a/grpc/proto/v1/search_get.proto
+++ b/grpc/proto/v1/search_get.proto
@@ -88,6 +88,9 @@ message MetadataRequest {
   // query_profile enables per-shard query profiling. When true, the response includes
   // timing breakdowns for each shard and search type.
   bool query_profile = 11;
+  // trace_spans forces OTel span emission for this request only, independent of
+  // the runtime tracing toggles.
+  bool trace_spans = 12;
 }
 
 message PropertiesRequest {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -335,6 +335,12 @@ type Config struct {
 
 	// Disable vector dimension tracking that are used for billing. These metrics are being deprecated in favor of more accurate metrics
 	DisableDimensionMetrics *runtime.DynamicValue[bool] `json:"disable_dimension_metrics" yaml:"disable_dimension_metrics"`
+
+	// Tracing per-area toggles. Each enables OTel span emission for one query
+	// area, hot-reloadable via runtime config and seeded from a TRACE_* env var.
+	TraceVectorSearch *runtime.DynamicValue[bool] `json:"trace_vector_search" yaml:"trace_vector_search"`
+	TraceBM25Search   *runtime.DynamicValue[bool] `json:"trace_bm25_search" yaml:"trace_bm25_search"`
+	TraceHybridSearch *runtime.DynamicValue[bool] `json:"trace_hybrid_search" yaml:"trace_hybrid_search"`
 }
 
 type MapToBlockamaxConfig struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1409,6 +1409,11 @@ func FromEnv(config *Config) error {
 
 	config.DisableDimensionMetrics = configRuntime.NewDynamicValue(disableDimensionMetrics)
 
+	// Tracing per-area toggles: env default, then hot-reloadable via runtime config.
+	config.TraceVectorSearch = configRuntime.NewDynamicValue(entcfg.Enabled(os.Getenv("TRACE_VECTOR_SEARCH")))
+	config.TraceBM25Search = configRuntime.NewDynamicValue(entcfg.Enabled(os.Getenv("TRACE_BM25_SEARCH")))
+	config.TraceHybridSearch = configRuntime.NewDynamicValue(entcfg.Enabled(os.Getenv("TRACE_HYBRID_SEARCH")))
+
 	return nil
 }
 

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -108,6 +108,12 @@ type WeaviateRuntimeConfig struct {
 	// MCP Server settings
 	MCPEnabled            *runtime.DynamicValue[bool] `json:"mcp_server_enabled" yaml:"mcp_server_enabled"`
 	MCPWriteAccessEnabled *runtime.DynamicValue[bool] `json:"mcp_server_write_access_enabled" yaml:"mcp_server_write_access_enabled"`
+
+	// Tracing per-area toggles. Each flips OTel span emission for one query area
+	// live, with no restart. Read at Traverser.GetClass to seed the request flags.
+	TraceVectorSearch *runtime.DynamicValue[bool] `json:"trace_vector_search" yaml:"trace_vector_search"`
+	TraceBM25Search   *runtime.DynamicValue[bool] `json:"trace_bm25_search" yaml:"trace_bm25_search"`
+	TraceHybridSearch *runtime.DynamicValue[bool] `json:"trace_hybrid_search" yaml:"trace_hybrid_search"`
 }
 
 // ParseRuntimeConfig decode WeaviateRuntimeConfig from raw bytes of YAML.
@@ -276,7 +282,7 @@ func updateRuntimeConfig(log logrus.FieldLogger, source, parsed reflect.Value, h
 		})
 
 		if r.err != nil {
-			logger.WithError(r.err).Errorf("runtime overrides: config '%v' change failed", r.field)
+			logger.Errorf("runtime overrides: config '%v' change failed: %v", r.field, r.err)
 			continue
 		}
 		logger.WithField("new_value", r.newV).Infof("runtime overrides: config '%v' changed from '%v' to '%v'", r.field, r.oldV, r.newV)

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -178,6 +178,8 @@ maximum_allowed_collections_count: 13`)
 			TenantActivityReadLogLevel:     runtime.NewDynamicValue("INFO"),
 			TenantActivityWriteLogLevel:    runtime.NewDynamicValue("INFO"),
 			RevectorizeCheckDisabled:       runtime.NewDynamicValue(true),
+			// Tracing toggle defaults off; the live flip is exercised below.
+			TraceVectorSearch: runtime.NewDynamicValue(false),
 		}
 
 		assert.Equal(t, 10, source.MaximumAllowedCollectionsCount.Get())
@@ -186,6 +188,7 @@ maximum_allowed_collections_count: 13`)
 		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
 		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
 		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+		assert.Equal(t, false, source.TraceVectorSearch.Get())
 
 		// Empty Parsing
 		buf := []byte("")
@@ -198,6 +201,7 @@ maximum_allowed_collections_count: 13`)
 		assert.Nil(t, parsed.TenantActivityReadLogLevel)
 		assert.Nil(t, parsed.TenantActivityWriteLogLevel)
 		assert.Nil(t, parsed.RevectorizeCheckDisabled)
+		assert.Nil(t, parsed.TraceVectorSearch)
 
 		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
 		assert.Equal(t, 10, source.MaximumAllowedCollectionsCount.Get())
@@ -206,10 +210,12 @@ maximum_allowed_collections_count: 13`)
 		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
 		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
 		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+		assert.Equal(t, false, source.TraceVectorSearch.Get())
 
 		// Non-empty parsing
 		buf = []byte(`autoschema_enabled: false
-maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
+maximum_allowed_collections_count: 13
+trace_vector_search: true`) // leaving out `asyncRep` config
 		parsed, err = ParseRuntimeConfig(buf)
 		require.NoError(t, err)
 
@@ -220,6 +226,7 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
 		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
 		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+		assert.Equal(t, true, source.TraceVectorSearch.Get()) // flipped on live, no restart
 
 		// Empty parsing again. Should go back to default values
 		buf = []byte("")
@@ -233,6 +240,7 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
 		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
 		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+		assert.Equal(t, false, source.TraceVectorSearch.Get()) // reset to default on removal
 	})
 
 	t.Run("Reset() of non-exist config values in parsed yaml shouldn't panic", func(t *testing.T) {

--- a/usecases/telemetry/opentelemetry/config.go
+++ b/usecases/telemetry/opentelemetry/config.go
@@ -30,6 +30,13 @@ type Config struct {
 	SamplingRate       float64
 	BatchTimeout       time.Duration
 	MaxExportBatchSize int
+	// Headers are sent with every OTLP export request, e.g. the auth token a
+	// managed backend like dash0 requires (Authorization=Bearer …).
+	Headers map[string]string
+	// Insecure disables transport TLS for the OTLP exporter. It defaults to true
+	// to preserve the historical localhost-collector behaviour; set it false for
+	// TLS-only backends.
+	Insecure bool
 }
 
 // DefaultConfig returns the default OpenTelemetry configuration
@@ -43,6 +50,7 @@ func DefaultConfig() *Config {
 		SamplingRate:       0.01, // 1% sampling by default
 		BatchTimeout:       5 * time.Second,
 		MaxExportBatchSize: 512,
+		Insecure:           true,
 	}
 }
 
@@ -107,7 +115,35 @@ func FromEnvironment() *Config {
 		}
 	}
 
+	// Exporter transport: TLS + headers for managed OTLP backends (e.g. dash0).
+	if insecure := os.Getenv("EXPERIMENTAL_OTEL_EXPORTER_INSECURE"); insecure != "" {
+		cfg.Insecure = config.Enabled(insecure)
+	}
+
+	if headers := parseHeaders(os.Getenv("EXPERIMENTAL_OTEL_EXPORTER_HEADERS")); len(headers) > 0 {
+		cfg.Headers = headers
+	}
+
 	return cfg
+}
+
+// parseHeaders parses "k=v,k=v" OTLP export headers, e.g.
+// "Authorization=Bearer abc,Dash0-Dataset=prod". Entries without "=" or with an
+// empty key are skipped; only the first "=" splits, so values may contain "=".
+func parseHeaders(raw string) map[string]string {
+	if raw == "" {
+		return nil
+	}
+	headers := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		k, v, ok := strings.Cut(pair, "=")
+		k = strings.TrimSpace(k)
+		if !ok || k == "" {
+			continue
+		}
+		headers[k] = strings.TrimSpace(v)
+	}
+	return headers
 }
 
 // IsValid checks if the configuration is valid

--- a/usecases/telemetry/opentelemetry/provider.go
+++ b/usecases/telemetry/opentelemetry/provider.go
@@ -13,6 +13,7 @@ package opentelemetry
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc/credentials"
 )
 
 // Provider manages the OpenTelemetry tracing provider
@@ -116,21 +118,36 @@ func createExporter(cfg *Config) (sdktrace.SpanExporter, error) {
 
 // createHTTPExporter creates an HTTP OTLP exporter
 func createHTTPExporter(cfg *Config) (sdktrace.SpanExporter, error) {
-	client := otlptracehttp.NewClient(
+	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(cfg.ExporterEndpoint),
-		otlptracehttp.WithInsecure(), // TODO: make configurable
-	)
+	}
+	if cfg.Insecure {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	} else {
+		opts = append(opts, otlptracehttp.WithTLSClientConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+	}
+	if len(cfg.Headers) > 0 {
+		opts = append(opts, otlptracehttp.WithHeaders(cfg.Headers))
+	}
 
-	return otlptrace.New(context.Background(), client)
+	return otlptrace.New(context.Background(), otlptracehttp.NewClient(opts...))
 }
 
 // createGRPCExporter creates a gRPC OTLP exporter
 func createGRPCExporter(cfg *Config) (sdktrace.SpanExporter, error) {
-	client := otlptracegrpc.NewClient(
+	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.ExporterEndpoint),
-		otlptracegrpc.WithInsecure(), // TODO: make configurable
-	)
-	return otlptrace.New(context.Background(), client)
+	}
+	if cfg.Insecure {
+		opts = append(opts, otlptracegrpc.WithInsecure())
+	} else {
+		// Unset RootCAs falls back to the host's system CA pool.
+		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})))
+	}
+	if len(cfg.Headers) > 0 {
+		opts = append(opts, otlptracegrpc.WithHeaders(cfg.Headers))
+	}
+	return otlptrace.New(context.Background(), otlptracegrpc.NewClient(opts...))
 }
 
 // Tracer returns the OpenTelemetry tracer

--- a/usecases/telemetry/opentelemetry/test_helpers.go
+++ b/usecases/telemetry/opentelemetry/test_helpers.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package opentelemetry
+
+import (
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SetTestProvider replaces the global provider for testing purposes.
+// It returns a cleanup function that restores the previous provider.
+// This must not be used concurrently — callers should not use t.Parallel().
+func SetTestProvider(p *Provider) func() {
+	prev := globalProvider.Load()
+	globalProvider.Store(p)
+	return func() {
+		globalProvider.Store(prev)
+	}
+}
+
+// NewTestProvider constructs a Provider from an existing SDK TracerProvider.
+// Use this with tracetest.InMemoryExporter to capture spans in tests without
+// requiring a real OTLP exporter.
+func NewTestProvider(tp *sdktrace.TracerProvider, serviceName string) *Provider {
+	return &Provider{
+		config: &Config{
+			Enabled:     true,
+			ServiceName: serviceName,
+		},
+		provider: tp,
+		tracer:   tp.Tracer(serviceName),
+	}
+}

--- a/usecases/telemetry/opentelemetry/tracer.go
+++ b/usecases/telemetry/opentelemetry/tracer.go
@@ -13,15 +13,17 @@ package opentelemetry
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
-// Global provider instance
-// TODO: find a way to avoid global state of the provider
-var globalProvider *Provider
+// globalProvider holds the process-wide provider. It is an atomic pointer so the
+// lockless hot-path reads in GetTracer/IsEnabled never race with Init (startup)
+// or SetTestProvider (tests).
+var globalProvider atomic.Pointer[Provider]
 
 // Init initializes the global OpenTelemetry provider
 func Init(logger logrus.FieldLogger) error {
@@ -32,7 +34,7 @@ func Init(logger logrus.FieldLogger) error {
 		return err
 	}
 
-	globalProvider = provider
+	globalProvider.Store(provider)
 
 	if provider.IsEnabled() {
 		logger.WithFields(logrus.Fields{
@@ -51,22 +53,25 @@ func Init(logger logrus.FieldLogger) error {
 
 // Shutdown gracefully shuts down the global provider
 func Shutdown(ctx context.Context) error {
-	if globalProvider == nil {
+	p := globalProvider.Load()
+	if p == nil {
 		return nil
 	}
 
-	return globalProvider.Shutdown(ctx)
+	return p.Shutdown(ctx)
 }
 
 // GetTracer returns the global tracer
 func GetTracer() trace.Tracer {
-	if globalProvider == nil {
+	p := globalProvider.Load()
+	if p == nil {
 		return noop.NewTracerProvider().Tracer("noop")
 	}
-	return globalProvider.Tracer()
+	return p.Tracer()
 }
 
 // IsEnabled returns whether OpenTelemetry is enabled globally
 func IsEnabled() bool {
-	return globalProvider != nil && globalProvider.IsEnabled()
+	p := globalProvider.Load()
+	return p != nil && p.IsEnabled()
 }

--- a/usecases/telemetry/opentelemetry/tracer_race_test.go
+++ b/usecases/telemetry/opentelemetry/tracer_race_test.go
@@ -1,0 +1,63 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package opentelemetry
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// TestGlobalProvider_ConcurrentAccess pins the globalProvider data race: it must
+// be safe to Init the provider concurrently with hot-path readers. Before the
+// atomic.Pointer conversion this failed under `go test -race`; with it, the
+// lockless Load/Store reads are clean.
+func TestGlobalProvider_ConcurrentAccess(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	t.Cleanup(func() { globalProvider.Store(nil) })
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	const readers = 8
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 200; j++ {
+				_ = IsEnabled()
+				_ = GetTracer()
+			}
+		}, logger)
+	}
+
+	wg.Add(1)
+	enterrors.GoWrapper(func() {
+		defer wg.Done()
+		<-start
+		for j := 0; j < 50; j++ {
+			// OTEL is disabled by default in tests, so this builds and stores a
+			// no-op provider repeatedly — exactly the startup write to race against.
+			_ = Init(logger)
+		}
+	}, logger)
+
+	close(start)
+	wg.Wait()
+
+	_ = Shutdown(context.Background())
+}

--- a/usecases/tracing/context.go
+++ b/usecases/tracing/context.go
@@ -1,0 +1,82 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tracing
+
+import "context"
+
+// Area identifies a traceable codepath. It is a string so the same value can
+// double as the runtime-config key, the env-var stem, and a span attribute.
+// Adding an area touches only this const block and the single place that builds
+// Flags — never the call sites.
+type Area string
+
+const (
+	AreaVector Area = "vector"
+	AreaBM25   Area = "bm25"
+	AreaHybrid Area = "hybrid"
+)
+
+// Flags controls which areas create spans for a single request. It is built
+// once at the request edge (Traverser.GetClass) and read-only below.
+//
+// Flags carries a map by reference, so copying the struct shares the map. This
+// is safe because the map is never mutated after WithFlags injects it.
+type Flags struct {
+	areas    map[Area]bool
+	forceAll bool
+}
+
+// NewFlags builds a Flags from a per-area enabled map. A nil map is allowed and
+// yields a Flags that enables nothing (unless WithForceAll is applied).
+func NewFlags(areas map[Area]bool) Flags {
+	return Flags{areas: areas}
+}
+
+// WithForceAll returns a copy of f with every area forced on. Used by the
+// per-request toggle, which ORs over the runtime per-area toggles.
+func WithForceAll(f Flags) Flags {
+	f.forceAll = true
+	return f
+}
+
+// IsEnabled reports whether the given area should emit spans. forceAll wins over
+// the per-area map; an unknown or zero Area returns false.
+func (f Flags) IsEnabled(a Area) bool {
+	return f.forceAll || f.areas[a]
+}
+
+// anyEnabled reports whether any area is enabled or forceAll is set. Used to
+// gate the root span without coupling it to one specific area.
+func (f Flags) anyEnabled() bool {
+	if f.forceAll {
+		return true
+	}
+	for _, on := range f.areas {
+		if on {
+			return true
+		}
+	}
+	return false
+}
+
+type flagsKey struct{}
+
+// WithFlags injects tracing flags into the context. Call this once at the
+// request entry point (e.g. Traverser.GetClass); every StartSpan below reads it.
+func WithFlags(ctx context.Context, f Flags) context.Context {
+	return context.WithValue(ctx, flagsKey{}, f)
+}
+
+func flagsFromContext(ctx context.Context) (Flags, bool) {
+	f, ok := ctx.Value(flagsKey{}).(Flags)
+	return f, ok
+}

--- a/usecases/tracing/span.go
+++ b/usecases/tracing/span.go
@@ -1,0 +1,85 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tracing
+
+import (
+	"context"
+	"crypto/rand"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/weaviate/weaviate/usecases/telemetry/opentelemetry"
+)
+
+// noopSpan is a single shared no-op span returned on the disabled path. Reusing
+// it (rather than NeverSample, which allocates) keeps StartSpan allocation-free
+// when an area is off.
+var noopSpan trace.Span
+
+func init() {
+	_, noopSpan = noop.NewTracerProvider().Tracer("").Start(context.Background(), "")
+}
+
+// StartSpan creates an OTel span only when the area is enabled in the
+// context-carried Flags and the global provider is active; otherwise it returns
+// the original context and a shared no-op span (zero allocation beyond a map
+// lookup). Callers always defer span.End().
+func StartSpan(ctx context.Context, area Area, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	f, ok := flagsFromContext(ctx)
+	if !ok || !f.IsEnabled(area) || !opentelemetry.IsEnabled() {
+		return ctx, noopSpan
+	}
+	return opentelemetry.GetTracer().Start(ctx, name, opts...)
+}
+
+// StartRootSpan creates the request-level root span when any area is enabled or
+// the per-request force-all flag is set. It is gated on "any area" rather than a
+// single area so a pure-bm25 query still produces a coherent root.
+//
+// When force-all is active (the per-request toggle) it seeds a fresh, sampled
+// remote parent so the forced trace records even under low/zero global sampling:
+// the production sampler is ParentBased, which honours a sampled parent, so the
+// whole forced subtree is captured regardless of the configured ratio. The fresh
+// random trace ID detaches the forced trace from the upstream gRPC trace — the
+// intended tradeoff for "trace this one request regardless of sampling".
+//
+// (trace.WithNewRoot alone is insufficient here: a new root is still subject to
+// the ParentBased root sampler — TraceIDRatioBased — and would be dropped at low
+// rates. Seeding a sampled parent is what actually forces recording.)
+func StartRootSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	f, ok := flagsFromContext(ctx)
+	if !ok || !f.anyEnabled() || !opentelemetry.IsEnabled() {
+		return ctx, noopSpan
+	}
+	if f.forceAll {
+		ctx = trace.ContextWithSpanContext(ctx, forcedSampledParent())
+	}
+	return opentelemetry.GetTracer().Start(ctx, name, opts...)
+}
+
+// forcedSampledParent builds a synthetic, sampled, remote SpanContext with a
+// fresh random trace/span ID. Used as the parent of a force-all root so a
+// ParentBased sampler records the request despite a low global ratio.
+func forcedSampledParent() trace.SpanContext {
+	var tid trace.TraceID
+	var sid trace.SpanID
+	// crypto/rand.Read never returns a short read or error for these sizes.
+	_, _ = rand.Read(tid[:])
+	_, _ = rand.Read(sid[:])
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+}

--- a/usecases/tracing/span_test.go
+++ b/usecases/tracing/span_test.go
@@ -1,0 +1,205 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/weaviate/weaviate/usecases/telemetry/opentelemetry"
+)
+
+// recordingProvider installs a test provider backed by an in-memory exporter
+// that records spans synchronously and always samples. It returns the exporter
+// and registers cleanup. Pass a non-nil sampler to override AlwaysSample.
+func recordingProvider(t *testing.T, sampler sdktrace.Sampler) *tracetest.InMemoryExporter {
+	t.Helper()
+	if sampler == nil {
+		sampler = sdktrace.AlwaysSample()
+	}
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
+		sdktrace.WithSampler(sampler),
+	)
+	cleanup := opentelemetry.SetTestProvider(opentelemetry.NewTestProvider(tp, "test"))
+	t.Cleanup(func() {
+		cleanup()
+		_ = tp.Shutdown(context.Background())
+	})
+	return exporter
+}
+
+func recordedNames(exporter *tracetest.InMemoryExporter) []string {
+	spans := exporter.GetSpans()
+	names := make([]string, len(spans))
+	for i, s := range spans {
+		names[i] = s.Name
+	}
+	return names
+}
+
+// TestStartSpan_TargetedGating is the DoD-4 proof: an area can be traced without
+// the others. Each row enables a subset and asserts exactly that subset records.
+func TestStartSpan_TargetedGating(t *testing.T) {
+	tests := []struct {
+		name  string
+		areas map[Area]bool
+		want  []string // span names expected, in start order
+	}{
+		{
+			name:  "hybrid+vector on, bm25 off",
+			areas: map[Area]bool{AreaHybrid: true, AreaBM25: false, AreaVector: true},
+			want:  []string{"hybrid", "vector"},
+		},
+		{
+			name:  "hybrid+bm25 on, vector off",
+			areas: map[Area]bool{AreaHybrid: true, AreaBM25: true, AreaVector: false},
+			want:  []string{"hybrid", "bm25"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := recordingProvider(t, nil)
+			ctx := WithFlags(context.Background(), NewFlags(tt.areas))
+
+			for _, area := range []Area{AreaHybrid, AreaBM25, AreaVector} {
+				_, span := StartSpan(ctx, area, string(area))
+				span.End()
+			}
+
+			assert.ElementsMatch(t, tt.want, recordedNames(exporter))
+		})
+	}
+}
+
+func TestStartSpan_NoopZeroAlloc(t *testing.T) {
+	// no flags in the context, and an explicitly disabled area: both must hit
+	// the shared no-op path without allocating.
+	disabled := WithFlags(context.Background(), NewFlags(map[Area]bool{AreaVector: false}))
+
+	for _, tt := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"no flags in context", context.Background()},
+		{"area disabled", disabled},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			outCtx, span := StartSpan(tt.ctx, AreaVector, "x")
+			assert.Equal(t, tt.ctx, outCtx, "context must be unchanged on the no-op path")
+			assert.Equal(t, noopSpan, span, "must return the shared no-op span, not a fresh allocation")
+			assert.False(t, span.IsRecording())
+
+			allocs := testing.AllocsPerRun(100, func() {
+				_, s := StartSpan(tt.ctx, AreaVector, "x")
+				s.End()
+			})
+			assert.Zero(t, allocs, "disabled StartSpan must not allocate")
+		})
+	}
+}
+
+func TestStartSpan_ProviderDisabled(t *testing.T) {
+	// Flags enabled, but no provider installed → IsEnabled() is false.
+	require.False(t, opentelemetry.IsEnabled())
+	ctx := WithFlags(context.Background(), NewFlags(map[Area]bool{AreaVector: true}))
+
+	_, span := StartSpan(ctx, AreaVector, "x")
+	assert.Equal(t, noopSpan, span)
+	assert.False(t, span.IsRecording())
+}
+
+func TestStartSpan_ForceAll(t *testing.T) {
+	exporter := recordingProvider(t, nil)
+	// every per-area flag is false; only forceAll is set.
+	ctx := WithFlags(context.Background(), WithForceAll(NewFlags(map[Area]bool{
+		AreaVector: false, AreaBM25: false, AreaHybrid: false,
+	})))
+
+	for _, area := range []Area{AreaHybrid, AreaBM25, AreaVector} {
+		_, span := StartSpan(ctx, area, string(area))
+		span.End()
+	}
+
+	assert.ElementsMatch(t, []string{"hybrid", "bm25", "vector"}, recordedNames(exporter))
+}
+
+// TestStartRootSpan_ForcedRootUnderZeroRate pins the sampling-bypass contract: a
+// per-request-forced trace must record even when the global sampler would drop
+// it. The sampler here is the production shape — ParentBased(TraceIDRatioBased)
+// at a 0 ratio, i.e. "sample nothing by ratio" — yet the forced root and its
+// children record because force-all seeds a sampled parent that ParentBased
+// honours. (A bare NeverSample is intentionally not used: it is not ParentBased,
+// so it would not represent how Weaviate's provider is configured.)
+func TestStartRootSpan_ForcedRootUnderZeroRate(t *testing.T) {
+	exporter := recordingProvider(t, sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0)))
+	ctx := WithFlags(context.Background(), WithForceAll(NewFlags(nil)))
+
+	// rootCtx descends from the flagged ctx, so the force-all Flags are still
+	// present for the child span.
+	rootCtx, root := StartRootSpan(ctx, "root")
+	require.True(t, root.IsRecording(), "forced root must record despite a 0 sampling ratio")
+
+	// a child started under the forced root must also record (ParentBased follows
+	// the sampled parent), proving the whole forced subtree is captured.
+	_, child := StartSpan(rootCtx, AreaVector, "child")
+	require.True(t, child.IsRecording(), "child of a forced root must record")
+	child.End()
+	root.End()
+
+	assert.ElementsMatch(t, []string{"root", "child"}, recordedNames(exporter))
+}
+
+func TestStartRootSpan_AnyAreaGate(t *testing.T) {
+	exporter := recordingProvider(t, nil)
+
+	// no area enabled, not forced → no root.
+	noneCtx := WithFlags(context.Background(), NewFlags(map[Area]bool{AreaBM25: false}))
+	_, span := StartRootSpan(noneCtx, "root-none")
+	assert.Equal(t, noopSpan, span)
+	span.End()
+	assert.Empty(t, recordedNames(exporter))
+
+	// a single area enabled → root records.
+	someCtx := WithFlags(context.Background(), NewFlags(map[Area]bool{AreaBM25: true}))
+	_, span = StartRootSpan(someCtx, "root-some")
+	span.End()
+	assert.Equal(t, []string{"root-some"}, recordedNames(exporter))
+}
+
+func TestFlags_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		f    Flags
+		area Area
+		want bool
+	}{
+		{"area on", NewFlags(map[Area]bool{AreaVector: true}), AreaVector, true},
+		{"area off", NewFlags(map[Area]bool{AreaVector: false}), AreaVector, false},
+		{"unknown area", NewFlags(map[Area]bool{AreaVector: true}), Area("nope"), false},
+		{"zero value", Flags{}, AreaVector, false},
+		{"force-all wins over disabled area", WithForceAll(NewFlags(map[Area]bool{AreaVector: false})), AreaVector, true},
+		{"force-all over nil map", WithForceAll(NewFlags(nil)), AreaHybrid, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.f.IsEnabled(tt.area))
+		})
+	}
+}

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -26,6 +26,9 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/autocut"
 	"github.com/weaviate/weaviate/entities/dto"
@@ -40,6 +43,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/floatcomp"
 	uc "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/tracing"
 	"github.com/weaviate/weaviate/usecases/traverser/grouper"
 )
 
@@ -216,6 +220,10 @@ func (e *Explorer) applyBoostIfNeeded(res []search.Result, boost *filters.Boost,
 }
 
 func (e *Explorer) getClassKeywordBased(ctx context.Context, params dto.GetParams) ([]search.Result, error) {
+	ctx, span := tracing.StartSpan(ctx, tracing.AreaBM25, "weaviate.explorer.bm25",
+		trace.WithAttributes(attribute.String("weaviate.collection", params.ClassName)))
+	defer span.End()
+
 	if params.NearVector != nil || params.NearObject != nil || len(params.ModuleParams) > 0 {
 		return nil, errors.Errorf("conflict: both near<Media> and keyword-based (bm25) arguments present, choose one")
 	}
@@ -262,6 +270,10 @@ func (e *Explorer) getClassKeywordBased(ctx context.Context, params dto.GetParam
 func (e *Explorer) getClassVectorSearch(ctx context.Context,
 	params dto.GetParams,
 ) ([]search.Result, models.Vector, error) {
+	ctx, span := tracing.StartSpan(ctx, tracing.AreaVector, "weaviate.explorer.vectorSearch",
+		trace.WithAttributes(attribute.String("weaviate.collection", params.ClassName)))
+	defer span.End()
+
 	targetVectors, err := e.targetFromParams(ctx, params)
 	if err != nil {
 		return nil, nil, errors.Errorf("explorer: get class: vectorize params: %v", err)

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
@@ -30,11 +32,16 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	nearText2 "github.com/weaviate/weaviate/usecases/modulecomponents/arguments/nearText"
+	"github.com/weaviate/weaviate/usecases/tracing"
 	"github.com/weaviate/weaviate/usecases/traverser/hybrid"
 )
 
 // Do a bm25 search.  The results will be used in the hybrid algorithm
 func sparseSearch(ctx context.Context, e *Explorer, params dto.GetParams) ([]*search.Result, string, error) {
+	ctx, span := tracing.StartSpan(ctx, tracing.AreaBM25, "weaviate.explorer.hybrid.sparseSearch",
+		trace.WithAttributes(attribute.String("weaviate.collection", params.ClassName)))
+	defer span.End()
+
 	params.KeywordRanking = &searchparams.KeywordRanking{
 		Query:      params.HybridSearch.Query,
 		Type:       "bm25",
@@ -85,6 +92,10 @@ func sparseSearch(ctx context.Context, e *Explorer, params dto.GetParams) ([]*se
 
 // Do a nearvector search.  The results will be used in the hybrid algorithm
 func denseSearch(ctx context.Context, e *Explorer, params dto.GetParams, searchname string, targetVectors []string, searchVector *searchparams.NearVector) ([]*search.Result, string, error) {
+	ctx, span := tracing.StartSpan(ctx, tracing.AreaVector, "weaviate.explorer.hybrid.denseSearch",
+		trace.WithAttributes(attribute.String("weaviate.collection", params.ClassName)))
+	defer span.End()
+
 	params.Pagination.Offset = 0
 	if params.Pagination.Limit < int(e.config.QueryHybridMaximumResults) {
 		params.Pagination.Limit = int(e.config.QueryHybridMaximumResults)
@@ -196,6 +207,10 @@ func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, t
 
 // Hybrid search.  This is the main entry point to the hybrid search algorithm
 func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.Result, error) {
+	ctx, span := tracing.StartSpan(ctx, tracing.AreaHybrid, "weaviate.explorer.Hybrid",
+		trace.WithAttributes(attribute.String("weaviate.collection", params.ClassName)))
+	defer span.End()
+
 	if params.AdditionalProperties.QueryProfile {
 		ctx = helpers.InitQueryProfileCollector(ctx)
 	}

--- a/usecases/traverser/traverser_get.go
+++ b/usecases/traverser/traverser_get.go
@@ -17,18 +17,28 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/entities/filters"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/weaviate/weaviate/entities/dto"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/tracing"
 )
 
 func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 	params dto.GetParams,
 ) ([]interface{}, error) {
+	// Seed trace flags here — the only layer with config access; everything below reads them off ctx.
+	ctx = tracing.WithFlags(ctx, buildTraceFlags(t.config.Config, params.AdditionalProperties.TraceSpans))
+	ctx, span := tracing.StartRootSpan(ctx, "weaviate.traverser.GetClass",
+		trace.WithAttributes(attribute.String("weaviate.collection", params.ClassName)))
+	defer span.End()
+
 	before := time.Now()
 
 	ok := t.ratelimiter.TryInc()
@@ -65,6 +75,22 @@ func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 	}
 
 	return t.explorer.GetClass(ctx, params)
+}
+
+// buildTraceFlags maps the live per-area runtime toggles into request trace
+// flags. traceSpans is the per-request override: when set it forces every area
+// on for this request, ORed over the runtime toggles (so a request can be traced
+// even while all runtime toggles are off). DynamicValue.Get is nil-safe.
+func buildTraceFlags(cfg config.Config, traceSpans bool) tracing.Flags {
+	flags := tracing.NewFlags(map[tracing.Area]bool{
+		tracing.AreaVector: cfg.TraceVectorSearch.Get(),
+		tracing.AreaBM25:   cfg.TraceBM25Search.Get(),
+		tracing.AreaHybrid: cfg.TraceHybridSearch.Get(),
+	})
+	if traceSpans {
+		flags = tracing.WithForceAll(flags)
+	}
+	return flags
 }
 
 // probeForRefDepthLimit checks to ensure reference nesting depth doesn't exceed the limit

--- a/usecases/traverser/traverser_trace_flags_test.go
+++ b/usecases/traverser/traverser_trace_flags_test.go
@@ -1,0 +1,76 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package traverser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/usecases/config"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/tracing"
+)
+
+func traceCfg(vector, bm25, hybrid bool) config.Config {
+	return config.Config{
+		TraceVectorSearch: configRuntime.NewDynamicValue(vector),
+		TraceBM25Search:   configRuntime.NewDynamicValue(bm25),
+		TraceHybridSearch: configRuntime.NewDynamicValue(hybrid),
+	}
+}
+
+// TestBuildTraceFlags is the DoD-3 OR-semantics proof: the per-request toggle
+// (traceSpans) forces every area on, ORing over the runtime toggles — so a
+// request can be traced even while all runtime toggles are off.
+func TestBuildTraceFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        config.Config
+		traceSpans bool
+		want       map[tracing.Area]bool
+	}{
+		{
+			name:       "per-request forces all areas over disabled runtime toggles",
+			cfg:        traceCfg(false, false, false),
+			traceSpans: true,
+			want:       map[tracing.Area]bool{tracing.AreaVector: true, tracing.AreaBM25: true, tracing.AreaHybrid: true},
+		},
+		{
+			name:       "no per-request, runtime toggles passed through",
+			cfg:        traceCfg(true, false, true),
+			traceSpans: false,
+			want:       map[tracing.Area]bool{tracing.AreaVector: true, tracing.AreaBM25: false, tracing.AreaHybrid: true},
+		},
+		{
+			name:       "no per-request, all runtime off",
+			cfg:        traceCfg(false, false, false),
+			traceSpans: false,
+			want:       map[tracing.Area]bool{tracing.AreaVector: false, tracing.AreaBM25: false, tracing.AreaHybrid: false},
+		},
+		{
+			name:       "per-request ORs over partially-enabled runtime toggles",
+			cfg:        traceCfg(true, false, false),
+			traceSpans: true,
+			want:       map[tracing.Area]bool{tracing.AreaVector: true, tracing.AreaBM25: true, tracing.AreaHybrid: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := buildTraceFlags(tt.cfg, tt.traceSpans)
+			for area, want := range tt.want {
+				assert.Equalf(t, want, flags.IsEnabled(area), "area %q", area)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a lightweight, opt-in tracing layer to Weaviate so we can watch how individual searches behave on real clusters, and see which part of a query (vector, keyword/BM25, or hybrid) is spending the time, without adding any cost when tracing is switched off.

### What's being changed

- A single tracing helper that any part of the codebase can call to record a timed step (a "span") of a search. When tracing is off it does nothing and allocates no memory, so there is no overhead on the hot query path.
- Tracing can be enabled per area of search. For example, you can trace hybrid queries while leaving plain keyword queries untraced.
- Two ways to switch it on: a runtime-config setting that takes effect live, with no restart; and a per-request flag on the gRPC search API that traces just that one request.
- Search traces are exported to an external observability backend (dash0) over the standard OpenTelemetry protocol. Settings for the endpoint, authentication headers, and TLS are now configurable.
- Fixes a pre-existing data race in the tracing provider setup, and corrects two logging calls to match the project's conventions.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
