### PR TITLE
Optimize async replication to use efficient property unmarshalling

### DIFF
--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -121,6 +121,10 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 		return nil, fmt.Errorf("getting bucket class name: %w", err)
 	}
 
+	// Decode props via jsonparser (no reflection). Only schema properties are
+	// decoded; a stored property absent from the schema (i.e. deleted) is dropped.
+	propExtraction := storobj.AllPropertiesExtraction(s.index.getSchema.ReadOnlyClass(className))
+
 	for i, id := range ids {
 		bytes, err := bucket.Get(id)
 		if err != nil {
@@ -131,7 +135,7 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 			continue
 		}
 
-		obj, err := storobj.FromBinaryDisk(bytes, className)
+		obj, err := storobj.FromBinaryDiskWithProps(bytes, className, propExtraction)
 		if err != nil {
 			return nil, errors.Wrap(err, "unmarshal kind object")
 		}

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -124,8 +124,14 @@ func FromBinaryNetwork(data []byte) (*Object, error) {
 // FromBinaryNetwork for the on-disk-fallback path used by wire-receive callers
 // that have no canonical class to supply.
 func FromBinaryDisk(data []byte, className string) (*Object, error) {
+	return FromBinaryDiskWithProps(data, className, nil)
+}
+
+// FromBinaryDiskWithProps is FromBinaryDisk with a known property set; see
+// UnmarshalBinaryDiskWithProps for the contract.
+func FromBinaryDiskWithProps(data []byte, className string, properties *PropertyExtraction) (*Object, error) {
 	ko := &Object{}
-	if err := ko.UnmarshalBinaryDisk(data, className); err != nil {
+	if err := ko.UnmarshalBinaryDiskWithProps(data, className, properties); err != nil {
 		return nil, err
 	}
 
@@ -359,6 +365,20 @@ func NewPropExtraction() *PropertyExtraction {
 func (pe *PropertyExtraction) Add(props ...string) *PropertyExtraction {
 	for i := range props {
 		pe.PropertyPaths = append(pe.PropertyPaths, []string{props[i]})
+	}
+	return pe
+}
+
+// AllPropertiesExtraction lists every top-level property of the class for the
+// jsonparser-based decode path. Returns nil (json.Unmarshal fallback) when the
+// class is unknown or has no properties.
+func AllPropertiesExtraction(class *models.Class) *PropertyExtraction {
+	if class == nil || len(class.Properties) == 0 {
+		return nil
+	}
+	pe := NewPropExtraction()
+	for _, prop := range class.Properties {
+		pe.Add(prop.Name)
 	}
 	return pe
 }
@@ -1284,23 +1304,31 @@ func parseValues(dt jsonparser.ValueType, value []byte) (interface{}, error) {
 // Use UnmarshalBinaryDisk when reading from disk, as the on-disk class-name
 // may be empty.
 func (ko *Object) UnmarshalBinaryNetwork(data []byte) error {
-	return ko.unmarshalInternal(data, "")
+	return ko.unmarshalInternal(data, "", nil)
 }
 
 // UnmarshalBinaryDisk decodes onto ko and stamps the supplied className on
 // Object.Class, skipping the on-disk class-name bytes. className must be
 // non-empty.
 func (ko *Object) UnmarshalBinaryDisk(data []byte, className string) error {
+	return ko.UnmarshalBinaryDiskWithProps(data, className, nil)
+}
+
+// UnmarshalBinaryDiskWithProps is UnmarshalBinaryDisk with a known property
+// set: a non-nil properties decodes the property blob via UnmarshalProperties
+// (no reflection) instead of json.Unmarshal. Names not listed are dropped, so
+// callers must pass every property that can be present on disk.
+func (ko *Object) UnmarshalBinaryDiskWithProps(data []byte, className string, properties *PropertyExtraction) error {
 	if className == "" {
 		return errors.New("className is required for UnmarshalBinaryDisk; use UnmarshalBinaryNetwork to fall back to the on-disk value")
 	}
-	return ko.unmarshalInternal(data, className)
+	return ko.unmarshalInternal(data, className, properties)
 }
 
 // unmarshalInternal is the shared decoder behind UnmarshalBinaryDisk and
 // UnmarshalBinaryNetwork. A non-empty className stamps Object.Class; an empty
 // className falls back to the on-disk value.
-func (ko *Object) unmarshalInternal(data []byte, className string) error {
+func (ko *Object) unmarshalInternal(data []byte, className string, properties *PropertyExtraction) error {
 	version := data[0]
 	if version != 1 {
 		return errors.Errorf("unsupported binary marshaller version %d", version)

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -100,6 +100,125 @@ func TestStorageObjectMarshalling(t *testing.T) {
 	})
 }
 
+// TestFromBinaryDiskWithProps_EquivalentToJSONUnmarshal asserts the jsonparser
+// path with every property listed yields the same object as json.Unmarshal —
+// the equivalence the MultiObjectByID fast path relies on.
+func TestFromBinaryDiskWithProps_EquivalentToJSONUnmarshal(t *testing.T) {
+	const className = "MyFavoriteClass"
+
+	cases := []struct {
+		name  string
+		props map[string]interface{}
+	}{
+		{
+			name: "primitives",
+			props: map[string]interface{}{
+				"name":   "MyName",
+				"count":  float64(17),
+				"active": true,
+			},
+		},
+		{
+			name: "arrays",
+			props: map[string]interface{}{
+				"tags":    []interface{}{"a", "b", "c"},
+				"numbers": []interface{}{float64(1), float64(2), float64(3)},
+			},
+		},
+		{
+			name: "cross_ref_beacons",
+			props: map[string]interface{}{
+				"hasRef": []interface{}{
+					map[string]interface{}{"beacon": "weaviate://localhost/SomeClass/73f2eb5f-5abf-447a-81ca-74b1dd168247"},
+					map[string]interface{}{"beacon": "weaviate://localhost/SomeClass/a1b2c3d4-5abf-447a-81ca-74b1dd168247"},
+				},
+			},
+		},
+		{
+			name: "nested_object",
+			props: map[string]interface{}{
+				"address": map[string]interface{}{
+					"city": "Amsterdam",
+					"zip":  float64(1011),
+				},
+			},
+		},
+		{
+			name:  "empty",
+			props: map[string]interface{}{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := FromObject(
+				&models.Object{
+					Class:              className,
+					CreationTimeUnix:   123456,
+					LastUpdateTimeUnix: 56789,
+					ID:                 strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168247"),
+					Properties:         tc.props,
+				},
+				[]float32{1, 2, 0.7},
+				map[string][]float32{"vector1": {1, 2, 3}},
+				nil,
+			)
+			before.DocID = 7
+
+			asBinary, err := before.MarshalBinary()
+			require.NoError(t, err)
+
+			viaJSON, err := FromBinaryDisk(asBinary, className)
+			require.NoError(t, err)
+
+			pe := NewPropExtraction()
+			for name := range tc.props {
+				pe.Add(name)
+			}
+			viaJSONParser, err := FromBinaryDiskWithProps(asBinary, className, pe)
+			require.NoError(t, err)
+
+			assert.Equal(t, viaJSON, viaJSONParser)
+		})
+	}
+}
+
+func TestAllPropertiesExtraction(t *testing.T) {
+	cases := []struct {
+		name  string
+		class *models.Class
+		want  *PropertyExtraction
+	}{
+		{
+			name:  "nil class",
+			class: nil,
+			want:  nil,
+		},
+		{
+			name:  "no properties",
+			class: &models.Class{Class: "Empty"},
+			want:  nil,
+		},
+		{
+			name: "lists every property as a single-element path",
+			class: &models.Class{Class: "Doc", Properties: []*models.Property{
+				{Name: "name"},
+				{Name: "count"},
+				{Name: "hasRef"},
+			}},
+			want: &PropertyExtraction{PropertyPaths: [][]string{
+				{"name"}, {"count"}, {"hasRef"},
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, AllPropertiesExtraction(tc.class))
+		})
+	}
+}
+
 func TestStorageObjectMarshallingMultiVector(t *testing.T) {
 	before := FromObject(
 		&models.Object{


### PR DESCRIPTION
### What's being changed:

Async replication was using json.Unmarshal in each request to get the object which is very inefficient. This switches it to the faster branch that uses the allocation-free jsonparser library.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
