### PR TITLE
backport: feat: add location configuration to text2vec-google module (#8418)

### DIFF
--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -56,7 +56,7 @@ var (
 	semanticSimilarity taskType = "SEMANTIC_SIMILARITY"
 )
 
-func buildURL(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string {
+func buildURL(useGenerativeAI bool, apiEndpoint, projectID, modelID, location string) string {
 	if useGenerativeAI {
 		if isLegacyModel(modelID) {
 			// legacy PaLM API
@@ -64,14 +64,15 @@ func buildURL(useGenerativeAI bool, apiEndpoint, projectID, modelID string) stri
 		}
 		return fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:batchEmbedContents", modelID)
 	}
-	urlTemplate := "https://%s/v1/projects/%s/locations/us-central1/publishers/google/models/%s:predict"
-	return fmt.Sprintf(urlTemplate, apiEndpoint, projectID, modelID)
+	urlTemplate := "https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:predict"
+	return fmt.Sprintf(urlTemplate, apiEndpoint, projectID, location, modelID)
 }
 
 type settings struct {
 	ApiEndpoint string
 	ProjectID   string
 	Model       string
+	Location    string
 	Dimensions  *int64
 	TaskType    string
 }
@@ -82,7 +83,7 @@ type google struct {
 	useGoogleAuth bool
 	rpm           int
 	httpClient    *http.Client
-	urlBuilderFn  func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string
+	urlBuilderFn  func(useGenerativeAI bool, apiEndpoint, projectID, modelID, location string) string
 	logger        logrus.FieldLogger
 }
 
@@ -161,7 +162,7 @@ func (v *google) vectorize(ctx context.Context, input []string, taskType taskTyp
 	}
 
 	endpointURL := v.urlBuilderFn(useGenerativeAIEndpoint,
-		v.getApiEndpoint(config), v.getProjectID(config), v.getModel(config))
+		v.getApiEndpoint(config), v.getProjectID(config), v.getModel(config), v.getLocation(config))
 
 	req, err := http.NewRequestWithContext(ctx, "POST", endpointURL,
 		bytes.NewReader(body))
@@ -327,6 +328,10 @@ func (v *google) getModel(config settings) string {
 	return config.Model
 }
 
+func (v *google) getLocation(config settings) string {
+	return config.Location
+}
+
 func (v *google) isLegacy(config settings) bool {
 	return isLegacyModel(config.Model)
 }
@@ -337,6 +342,7 @@ func (v *google) getSettings(config moduletools.ClassConfig) settings {
 		ApiEndpoint: icheck.ApiEndpoint(),
 		ProjectID:   icheck.ProjectID(),
 		Model:       icheck.Model(),
+		Location:    icheck.Location(),
 		Dimensions:  icheck.Dimensions(),
 		TaskType:    icheck.TaskType(),
 	}

--- a/modules/text2vec-google/clients/google_test.go
+++ b/modules/text2vec-google/clients/google_test.go
@@ -29,6 +29,53 @@ import (
 	"github.com/weaviate/weaviate/usecases/modulecomponents/apikey"
 )
 
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		name            string
+		useGenerativeAI bool
+		apiEndpoint     string
+		projectID       string
+		modelID         string
+		location        string
+		expectedURL     string
+	}{
+		{
+			name:            "Vertex AI with location",
+			useGenerativeAI: false,
+			apiEndpoint:     "europe-west1-aiplatform.googleapis.com",
+			projectID:       "my-project",
+			modelID:         "gemini-embedding-001",
+			location:        "europe-west1",
+			expectedURL:     "https://europe-west1-aiplatform.googleapis.com/v1/projects/my-project/locations/europe-west1/publishers/google/models/gemini-embedding-001:predict",
+		},
+		{
+			name:            "Generative AI endpoint ignores location",
+			useGenerativeAI: true,
+			apiEndpoint:     "generativelanguage.googleapis.com",
+			projectID:       "",
+			modelID:         "gemini-embedding-001",
+			location:        "europe-west1",
+			expectedURL:     "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents",
+		},
+		{
+			name:            "Legacy PaLM model ignores location",
+			useGenerativeAI: true,
+			apiEndpoint:     "generativelanguage.googleapis.com",
+			projectID:       "",
+			modelID:         "embedding-gecko-001",
+			location:        "europe-west1",
+			expectedURL:     "https://generativelanguage.googleapis.com/v1beta3/models/embedding-gecko-001:batchEmbedText",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := buildURL(tt.useGenerativeAI, tt.apiEndpoint, tt.projectID, tt.modelID, tt.location)
+			assert.Equal(t, tt.expectedURL, url)
+		})
+	}
+}
+
 func TestClient(t *testing.T) {
 	t.Run("when all is fine", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
@@ -37,24 +84,22 @@ func TestClient(t *testing.T) {
 			apiKey:       "apiKey",
 			httpClient:   &http.Client{},
 			googleApiKey: apikey.NewGoogleApiKey(),
-			urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string {
+			urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID, location string) string {
 				assert.Equal(t, "endpoint", apiEndpoint)
 				assert.Equal(t, "project", projectID)
 				assert.Equal(t, "model", modelID)
+				assert.Equal(t, "us-central1", location)
 				return server.URL
 			},
 			logger: nullLogger(),
 		}
-		expected := &modulecomponents.VectorizationResult[[]float32]{
-			Text:       []string{"This is my text"},
-			Vector:     [][]float32{{0.1, 0.2, 0.3}},
-			Dimensions: 3,
-		}
+		expected := expectedTextVectorization("This is my text")
 		res, err := c.vectorize(context.Background(), []string{"This is my text"}, retrievalDocument, "",
 			settings{
 				ApiEndpoint: "endpoint",
 				ProjectID:   "project",
 				Model:       "model",
+				Location:    "us-central1",
 			})
 
 		assert.Nil(t, err)
@@ -68,10 +113,8 @@ func TestClient(t *testing.T) {
 			apiKey:       "apiKey",
 			httpClient:   &http.Client{},
 			googleApiKey: apikey.NewGoogleApiKey(),
-			urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string {
-				return server.URL
-			},
-			logger: nullLogger(),
+			urlBuilderFn: staticURLBuilder(server.URL),
+			logger:       nullLogger(),
 		}
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now())
 		defer cancel()
@@ -92,10 +135,8 @@ func TestClient(t *testing.T) {
 			apiKey:       "apiKey",
 			httpClient:   &http.Client{},
 			googleApiKey: apikey.NewGoogleApiKey(),
-			urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string {
-				return server.URL
-			},
-			logger: nullLogger(),
+			urlBuilderFn: staticURLBuilder(server.URL),
+			logger:       nullLogger(),
 		}
 		_, err := c.vectorize(context.Background(), []string{"This is my text"}, retrievalDocument, "", settings{})
 
@@ -110,19 +151,13 @@ func TestClient(t *testing.T) {
 			apiKey:       "",
 			httpClient:   &http.Client{},
 			googleApiKey: apikey.NewGoogleApiKey(),
-			urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string {
-				return server.URL
-			},
-			logger: nullLogger(),
+			urlBuilderFn: staticURLBuilder(server.URL),
+			logger:       nullLogger(),
 		}
 		ctxWithValue := context.WithValue(context.Background(),
 			"X-Palm-Api-Key", []string{"some-key"})
 
-		expected := &modulecomponents.VectorizationResult[[]float32]{
-			Text:       []string{"This is my text"},
-			Vector:     [][]float32{{0.1, 0.2, 0.3}},
-			Dimensions: 3,
-		}
+		expected := expectedTextVectorization("This is my text")
 		res, err := c.vectorize(ctxWithValue, []string{"This is my text"}, retrievalDocument, "", settings{})
 
 		require.Nil(t, err)
@@ -136,10 +171,8 @@ func TestClient(t *testing.T) {
 			apiKey:       "",
 			httpClient:   &http.Client{},
 			googleApiKey: apikey.NewGoogleApiKey(),
-			urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string {
-				return server.URL
-			},
-			logger: nullLogger(),
+			urlBuilderFn: staticURLBuilder(server.URL),
+			logger:       nullLogger(),
 		}
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now())
 		defer cancel()
@@ -174,6 +207,20 @@ func TestClient(t *testing.T) {
 	})
 }
 
+func staticURLBuilder(url string) func(bool, string, string, string, string) string {
+	return func(bool, string, string, string, string) string {
+		return url
+	}
+}
+
+func expectedTextVectorization(input string) *modulecomponents.VectorizationResult[[]float32] {
+	return &modulecomponents.VectorizationResult[[]float32]{
+		Text:       []string{input},
+		Vector:     [][]float32{{0.1, 0.2, 0.3}},
+		Dimensions: 3,
+	}
+}
+
 type fakeHandler struct {
 	t           *testing.T
 	serverError error
@@ -182,23 +229,33 @@ type fakeHandler struct {
 func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	assert.Equal(f.t, http.MethodPost, r.Method)
 
-	if f.serverError != nil {
-		embeddingResponse := &embeddingsResponse{
-			Error: &googleApiError{
-				Code:    http.StatusInternalServerError,
-				Status:  "error",
-				Message: f.serverError.Error(),
-			},
-		}
-
-		outBytes, err := json.Marshal(embeddingResponse)
-		require.Nil(f.t, err)
-
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write(outBytes)
+	if f.writeError(w) {
 		return
 	}
 
+	req := f.readRequest(r)
+	assert.Greater(f.t, len(req.Instances[0].Content), 0)
+	writeJSON(f.t, w, f.successResponse())
+}
+
+func (f *fakeHandler) writeError(w http.ResponseWriter) bool {
+	if f.serverError == nil {
+		return false
+	}
+
+	w.WriteHeader(http.StatusInternalServerError)
+	writeJSON(f.t, w, &embeddingsResponse{
+		Error: &googleApiError{
+			Code:    http.StatusInternalServerError,
+			Status:  "error",
+			Message: f.serverError.Error(),
+		},
+	})
+
+	return true
+}
+
+func (f *fakeHandler) readRequest(r *http.Request) embeddingsRequest {
 	bodyBytes, err := io.ReadAll(r.Body)
 	require.Nil(f.t, err)
 	defer r.Body.Close()
@@ -208,11 +265,11 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	require.NotNil(f.t, req)
 	require.Len(f.t, req.Instances, 1)
+	return req
+}
 
-	textInput := req.Instances[0].Content
-	assert.Greater(f.t, len(textInput), 0)
-
-	embeddingResponse := &embeddingsResponse{
+func (f *fakeHandler) successResponse() *embeddingsResponse {
+	return &embeddingsResponse{
 		Predictions: []prediction{
 			{
 				Embeddings: embeddings{
@@ -221,9 +278,11 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	}
+}
 
-	outBytes, err := json.Marshal(embeddingResponse)
-	require.Nil(f.t, err)
+func writeJSON(t *testing.T, w http.ResponseWriter, body interface{}) {
+	outBytes, err := json.Marshal(body)
+	require.Nil(t, err)
 
 	w.Write(outBytes)
 }

--- a/modules/text2vec-google/vectorizer/class_settings.go
+++ b/modules/text2vec-google/vectorizer/class_settings.go
@@ -27,6 +27,7 @@ const (
 	modelIDProperty     = "modelId"
 	modelProperty       = "model"
 	titleProperty       = "titleProperty"
+	locationProperty    = "location"
 	dimensionsProperty  = "dimensions"
 	taskTypeProperty    = "taskType"
 )
@@ -40,6 +41,7 @@ const (
 	DefaultModel                 = "gemini-embedding-001"
 	DefaultAIStudioEndpoint      = "generativelanguage.googleapis.com"
 	DefaulAIStudioModel          = "gemini-embedding-001"
+	DefaultLocation              = "us-central1"
 	DefaultTaskType              = "RETRIEVAL_QUERY"
 )
 
@@ -127,6 +129,10 @@ func (ic *classSettings) Model() string {
 
 func (ic *classSettings) TitleProperty() string {
 	return ic.getStringProperty(titleProperty, "")
+}
+
+func (ic *classSettings) Location() string {
+	return ic.getStringProperty(locationProperty, DefaultLocation)
 }
 
 func (ic *classSettings) Dimensions() *int64 {

--- a/modules/text2vec-google/vectorizer/class_settings_test.go
+++ b/modules/text2vec-google/vectorizer/class_settings_test.go
@@ -30,6 +30,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		wantProjectID   string
 		wantModelID     string
 		wantTitle       string
+		wantLocation    string
 		wantTaskType    string
 		wantDimensions  *int64
 		wantErr         error
@@ -44,7 +45,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "us-central1-aiplatform.googleapis.com",
 			wantProjectID:   "projectId",
 			wantModelID:     "gemini-embedding-001",
-			wantTaskType:    DefaultTaskType,
 			wantDimensions:  &DefaultDimensions,
 			wantErr:         nil,
 		},
@@ -63,6 +63,21 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantModelID:     "gemini-embedding-001",
 			wantTitle:       "title",
 			wantTaskType:    "CODE_RETRIEVAL_QUERY",
+			wantDimensions:  &DefaultDimensions,
+			wantErr:         nil,
+		},
+		{
+			name: "custom location",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"projectId": "projectId",
+					"location":  "europe-west1",
+				},
+			},
+			wantApiEndpoint: "us-central1-aiplatform.googleapis.com",
+			wantProjectID:   "projectId",
+			wantModelID:     "gemini-embedding-001",
+			wantLocation:    "europe-west1",
 			wantDimensions:  &DefaultDimensions,
 			wantErr:         nil,
 		},
@@ -95,7 +110,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "generativelanguage.googleapis.com",
 			wantProjectID:   "",
 			wantModelID:     "gemini-embedding-001",
-			wantTaskType:    DefaultTaskType,
 			wantDimensions:  &DefaultDimensions,
 			wantErr:         nil,
 		},
@@ -110,7 +124,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "generativelanguage.googleapis.com",
 			wantProjectID:   "",
 			wantModelID:     "embedding-gecko-001",
-			wantTaskType:    DefaultTaskType,
 			wantDimensions:  nil,
 			wantErr:         nil,
 		},
@@ -145,20 +158,32 @@ func Test_classSettings_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ic := NewClassSettings(tt.cfg)
 			if tt.wantErr != nil {
-				assert.EqualError(t, ic.Validate(&models.Class{Class: "Test", Properties: []*models.Property{
-					{
-						Name:     "test",
-						DataType: []string{schema.DataTypeText.String()},
-					},
-				}}), tt.wantErr.Error())
+				assert.EqualError(t, ic.Validate(classForSettingsValidation()), tt.wantErr.Error())
 			} else {
 				assert.Equal(t, tt.wantApiEndpoint, ic.ApiEndpoint())
 				assert.Equal(t, tt.wantProjectID, ic.ProjectID())
 				assert.Equal(t, tt.wantModelID, ic.Model())
 				assert.Equal(t, tt.wantTitle, ic.TitleProperty())
-				assert.Equal(t, tt.wantTaskType, ic.TaskType())
+				assert.Equal(t, wantOrDefault(tt.wantLocation, DefaultLocation), ic.Location())
+				assert.Equal(t, wantOrDefault(tt.wantTaskType, DefaultTaskType), ic.TaskType())
 				assert.Equal(t, tt.wantDimensions, ic.Dimensions())
 			}
 		})
 	}
+}
+
+func classForSettingsValidation() *models.Class {
+	return &models.Class{Class: "Test", Properties: []*models.Property{
+		{
+			Name:     "test",
+			DataType: []string{schema.DataTypeText.String()},
+		},
+	}}
+}
+
+func wantOrDefault(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
 }


### PR DESCRIPTION
### What's being changed:

* gh-8375 Add configurable location support to text2vec-google client

Fixes #8375

This change enables data residency compliance by making the Google Cloud location configurable instead of hardcoded to 'us-central1'.

Changes:
- Add Location field to VectorizationConfig struct
- Add location property to class settings with default 'us-central1'
- Update buildURL function to use dynamic location parameter
- Maintain backward compatibility (defaults to existing behavior)
- Follow same pattern as multi2vec-google for configuration

Users can now specify location in their schema:
{
  "moduleConfig": { "text2vec-google": { "location": "europe-west1", "projectId": "my-project" } } }

* gh-8375 Add comprehensive tests for location configuration

- Add TestBuildURL to verify URL construction with different locations
- Test location parameter passing in client tests
- Add location test cases in class settings validation
- Verify default location behavior (us-central1)
- Test custom locations (europe-west1, asia-southeast1)
- Ensure location is ignored for Generative AI endpoints

* gh-8375 Fix code duplication in tests

Removed duplicate test cases to reduce code duplication below 3% SonarCloud threshold while maintaining comprehensive test coverage.

* gh-8375 Reduce duplicated test scaffolding

* gh-8375 Refactor duplicated test helpers


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
