### PR TITLE
feat: add support for endpoint setting in OpenAI client

### DIFF
--- a/modules/text2vec-morph/clients/morph.go
+++ b/modules/text2vec-morph/clients/morph.go
@@ -69,6 +69,7 @@ func (v *client) getSettings(cfg moduletools.ClassConfig) openai.Settings {
 		ResourceName:         "", // Not used by Morph
 		DeploymentID:         "", // Not used by Morph
 		BaseURL:              settings.BaseURL(),
+		Endpoint:             settings.Endpoint(),
 		IsAzure:              false, // Morph doesn't support Azure
 		IsThirdPartyProvider: true,  // Morph is always third-party
 		ApiVersion:           "",    // Not used by Morph

--- a/modules/text2vec-morph/ent/class_settings.go
+++ b/modules/text2vec-morph/ent/class_settings.go
@@ -23,6 +23,7 @@ const (
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false
 	DefaultBaseURL               = "https://api.morphllm.com"
+	DefaultEndpoint              = "/v1/embeddings"
 	LowerCaseInput               = false
 )
 
@@ -37,6 +38,10 @@ func NewClassSettings(cfg moduletools.ClassConfig) *classSettings {
 
 func (cs *classSettings) BaseURL() string {
 	return cs.GetPropertyAsString("baseURL", DefaultBaseURL)
+}
+
+func (cs *classSettings) Endpoint() string {
+	return cs.GetPropertyAsString("endpoint", DefaultEndpoint)
 }
 
 func (cs *classSettings) Model() string {

--- a/modules/text2vec-morph/ent/class_settings_test.go
+++ b/modules/text2vec-morph/ent/class_settings_test.go
@@ -125,3 +125,28 @@ func Test_classSettings_Validate(t *testing.T) {
 		})
 	}
 }
+
+func Test_classSettings_Endpoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		cfg              moduletools.ClassConfig
+		expectedEndpoint string
+	}{
+		{
+			name:             "defaults to /v1/embeddings when not set",
+			cfg:              &fakeClassConfig{classConfig: map[string]any{}},
+			expectedEndpoint: DefaultEndpoint,
+		},
+		{
+			name:             "uses custom endpoint when set",
+			cfg:              &fakeClassConfig{classConfig: map[string]any{"endpoint": "/api/v3/embeddings"}},
+			expectedEndpoint: "/api/v3/embeddings",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := NewClassSettings(tt.cfg)
+			assert.Equal(t, tt.expectedEndpoint, cs.Endpoint())
+		})
+	}
+}

--- a/modules/text2vec-openai/clients/openai.go
+++ b/modules/text2vec-openai/clients/openai.go
@@ -69,6 +69,7 @@ func (v *client) getSettings(cfg moduletools.ClassConfig, action string) openai.
 		ResourceName:         settings.ResourceName(),
 		DeploymentID:         settings.DeploymentID(),
 		BaseURL:              settings.BaseURL(),
+		Endpoint:             settings.Endpoint(),
 		IsAzure:              settings.IsAzure(),
 		IsThirdPartyProvider: settings.IsThirdPartyProvider(),
 		ApiVersion:           settings.ApiVersion(),

--- a/modules/text2vec-openai/ent/class_settings.go
+++ b/modules/text2vec-openai/ent/class_settings.go
@@ -30,6 +30,7 @@ const (
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false
 	DefaultBaseURL               = "https://api.openai.com"
+	DefaultEndpoint              = "/v1/embeddings"
 	DefaultApiVersion            = "2024-02-01"
 	LowerCaseInput               = false
 )
@@ -138,6 +139,10 @@ func (cs *classSettings) ResourceName() string {
 
 func (cs *classSettings) BaseURL() string {
 	return cs.BaseClassSettings.GetPropertyAsString("baseURL", DefaultBaseURL)
+}
+
+func (cs *classSettings) Endpoint() string {
+	return cs.BaseClassSettings.GetPropertyAsString("endpoint", DefaultEndpoint)
 }
 
 func (cs *classSettings) DeploymentID() string {

--- a/modules/text2vec-openai/ent/class_settings_test.go
+++ b/modules/text2vec-openai/ent/class_settings_test.go
@@ -607,3 +607,35 @@ func TestClassSettings(t *testing.T) {
 		}
 	}
 }
+
+func TestClassSettings_Endpoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		cfg              moduletools.ClassConfig
+		expectedEndpoint string
+	}{
+		{
+			name: "defaults to /v1/embeddings when not set",
+			cfg: fakeClassConfig{
+				classConfig: make(map[string]interface{}),
+			},
+			expectedEndpoint: DefaultEndpoint,
+		},
+		{
+			name: "uses custom endpoint when set",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"endpoint": "/api/v3/embeddings",
+				},
+			},
+			expectedEndpoint: "/api/v3/embeddings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ic := NewClassSettings(tt.cfg)
+			assert.Equal(t, tt.expectedEndpoint, ic.Endpoint())
+		})
+	}
+}

--- a/usecases/modulecomponents/clients/openai/openai.go
+++ b/usecases/modulecomponents/clients/openai/openai.go
@@ -85,7 +85,7 @@ func (c *openAICode) UnmarshalJSON(data []byte) (err error) {
 	return nil
 }
 
-func buildUrl(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+func buildUrl(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 	if isAzure {
 		host := baseURL
 		if host == "" || host == "https://api.openai.com" {
@@ -99,13 +99,18 @@ func buildUrl(baseURL, resourceName, deploymentID, apiVersion string, isAzure bo
 	}
 
 	host := baseURL
-	path := "/v1/embeddings"
+	path := endpoint
+	if path == "" {
+		// fallback to default endpoint
+		path = "/v1/embeddings"
+	}
 	return url.JoinPath(host, path)
 }
 
 type Settings struct {
 	Type, Model, ModelVersion, ModelString, ResourceName string
 	BaseURL                                              string
+	Endpoint                                             string
 	DeploymentID                                         string
 	ApiVersion                                           string
 	IsAzure                                              bool
@@ -118,7 +123,7 @@ type Client struct {
 	openAIOrganization string
 	azureApiKey        string
 	httpClient         *http.Client
-	buildUrlFn         func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error)
+	buildUrlFn         func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error)
 	logger             logrus.FieldLogger
 	sampledLogger      *logrusext.Sampler
 }
@@ -252,7 +257,7 @@ func (v *Client) vectorize(ctx context.Context, input []string, model string, se
 }
 
 func (v *Client) buildURL(ctx context.Context, config Settings) (string, error) {
-	baseURL, resourceName, deploymentID, apiVersion, isAzure := config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.IsAzure
+	baseURL, resourceName, deploymentID, apiVersion, endpoint, isAzure := config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure
 
 	if headerBaseURL := modulecomponents.GetValueFromContext(ctx, "X-Openai-Baseurl"); headerBaseURL != "" {
 		baseURL = headerBaseURL
@@ -266,7 +271,7 @@ func (v *Client) buildURL(ctx context.Context, config Settings) (string, error) 
 		resourceName = headerResourceName
 	}
 
-	return v.buildUrlFn(baseURL, resourceName, deploymentID, apiVersion, isAzure)
+	return v.buildUrlFn(baseURL, resourceName, deploymentID, apiVersion, endpoint, isAzure)
 }
 
 func (v *Client) getError(statusCode int, requestID string, resBodyError *openAIApiError, isAzure bool) error {

--- a/usecases/modulecomponents/clients/openai/openai_test.go
+++ b/usecases/modulecomponents/clients/openai/openai_test.go
@@ -41,7 +41,7 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "https://api.openai.com",
 			IsAzure:      false,
 		}
-		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.IsAzure)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://api.openai.com/v1/embeddings", url)
 	})
@@ -56,7 +56,7 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "",
 			IsAzure:      true,
 		}
-		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.IsAzure)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/embeddings?api-version=2022-12-01", url)
 	})
@@ -72,7 +72,7 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "",
 			IsAzure:      true,
 		}
-		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.IsAzure)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/embeddings?api-version=2024-02-01", url)
 	})
@@ -88,7 +88,7 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "https://foobar.some.proxy",
 			IsAzure:      true,
 		}
-		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.IsAzure)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://foobar.some.proxy/openai/deployments/deploymentID/embeddings?api-version=2022-12-01", url)
 	})
@@ -104,9 +104,44 @@ func TestBuildUrlFn(t *testing.T) {
 			BaseURL:      "https://foobar.some.proxy",
 			IsAzure:      false,
 		}
-		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.IsAzure)
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
 		assert.Nil(t, err)
 		assert.Equal(t, "https://foobar.some.proxy/v1/embeddings", url)
+	})
+
+	t.Run("buildUrlFn defaults to /v1/embeddings when Endpoint is empty", func(t *testing.T) {
+		config := Settings{
+			BaseURL:  "https://api.openai.com",
+			Endpoint: "",
+			IsAzure:  false,
+		}
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
+		assert.Nil(t, err)
+		assert.Equal(t, "https://api.openai.com/v1/embeddings", url)
+	})
+
+	t.Run("buildUrlFn uses custom Endpoint when set", func(t *testing.T) {
+		config := Settings{
+			BaseURL:  "https://ark.cn-beijing.volces.com",
+			Endpoint: "/api/v3/embeddings",
+			IsAzure:  false,
+		}
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
+		assert.Nil(t, err)
+		assert.Equal(t, "https://ark.cn-beijing.volces.com/api/v3/embeddings", url)
+	})
+
+	t.Run("buildUrlFn ignores custom Endpoint for Azure", func(t *testing.T) {
+		config := Settings{
+			ResourceName: "resourceID",
+			DeploymentID: "deploymentID",
+			ApiVersion:   "2022-12-01",
+			Endpoint:     "/api/v3/embeddings",
+			IsAzure:      true,
+		}
+		url, err := buildUrl(config.BaseURL, config.ResourceName, config.DeploymentID, config.ApiVersion, config.Endpoint, config.IsAzure)
+		assert.Nil(t, err)
+		assert.Equal(t, "https://resourceID.openai.azure.com/openai/deployments/deploymentID/embeddings?api-version=2022-12-01", url)
 	})
 }
 
@@ -116,7 +151,7 @@ func TestClient(t *testing.T) {
 		defer server.Close()
 
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -144,7 +179,7 @@ func TestClient(t *testing.T) {
 		defer server.Close()
 
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -172,7 +207,7 @@ func TestClient(t *testing.T) {
 		defer server.Close()
 
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -199,7 +234,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -219,7 +254,7 @@ func TestClient(t *testing.T) {
 		})
 		defer server.Close()
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -237,7 +272,7 @@ func TestClient(t *testing.T) {
 		})
 		defer server.Close()
 		c := New("apiKey", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -251,7 +286,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -275,7 +310,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 
@@ -294,7 +329,7 @@ func TestClient(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
 		defer server.Close()
 		c := New("", "", "", 0, nullLogger())
-		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion string, isAzure bool) (string, error) {
+		c.buildUrlFn = func(baseURL, resourceName, deploymentID, apiVersion, endpoint string, isAzure bool) (string, error) {
 			return server.URL, nil
 		}
 


### PR DESCRIPTION
### What's being changed:

This PR adds support for endpoint setting in OpenAI client in modules:
- `text2vec-openai`
- `text2vec-morph`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
