### PR TITLE
feat: add support for dimensions setting in text2vec-aws module

### DIFF
--- a/modules/text2vec-aws/clients/aws.go
+++ b/modules/text2vec-aws/clients/aws.go
@@ -54,6 +54,7 @@ func (v *awsClient) vectorize(ctx context.Context, input []string,
 		Region:        config.Region,
 		Service:       aws.Service(config.Service),
 		Endpoint:      config.Endpoint,
+		Dimensions:    config.Dimensions,
 		OperationType: operationType,
 	})
 }

--- a/modules/text2vec-aws/ent/vectorization_config.go
+++ b/modules/text2vec-aws/ent/vectorization_config.go
@@ -18,4 +18,5 @@ type VectorizationConfig struct {
 	Endpoint      string
 	TargetModel   string
 	TargetVariant string
+	Dimensions    *int64
 }

--- a/modules/text2vec-aws/vectorizer/class_settings.go
+++ b/modules/text2vec-aws/vectorizer/class_settings.go
@@ -27,6 +27,7 @@ const (
 	endpointProperty      = "endpoint"
 	targetModelProperty   = "targetModel"
 	targetVariantProperty = "targetVariant"
+	dimensionsProperty    = "dimensions"
 )
 
 // Default values for service cannot be changed before we solve how old classes
@@ -132,6 +133,10 @@ func (ic *classSettings) TargetModel() string {
 
 func (ic *classSettings) TargetVariant() string {
 	return ic.getStringProperty(targetVariantProperty, "")
+}
+
+func (ic *classSettings) Dimensions() *int64 {
+	return ic.BaseClassSettings.GetPropertyAsInt64(dimensionsProperty, nil)
 }
 
 func isSagemaker(service string) bool {

--- a/modules/text2vec-aws/vectorizer/class_settings_test.go
+++ b/modules/text2vec-aws/vectorizer/class_settings_test.go
@@ -31,6 +31,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		wantEndpoint      string
 		wantTargetModel   string
 		wantTargetVariant string
+		wantDimensions    *int64
 		wantErr           error
 	}{
 		{
@@ -121,6 +122,22 @@ func Test_classSettings_Validate(t *testing.T) {
 				"region cannot be empty"),
 		},
 		{
+			name: "with dimensions - Titan Text v2",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"service":    "bedrock",
+					"region":     "us-east-1",
+					"model":      "amazon.titan-embed-text-v2:0",
+					"dimensions": 512,
+				},
+			},
+			wantService:    "bedrock",
+			wantRegion:     "us-east-1",
+			wantModel:      "amazon.titan-embed-text-v2:0",
+			wantDimensions: ptrInt64(512),
+			wantErr:        nil,
+		},
+		{
 			name: "wrong properties",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
@@ -145,7 +162,12 @@ func Test_classSettings_Validate(t *testing.T) {
 				assert.Equal(t, tt.wantEndpoint, ic.Endpoint())
 				assert.Equal(t, tt.wantTargetModel, ic.TargetModel())
 				assert.Equal(t, tt.wantTargetVariant, ic.TargetVariant())
+				assert.Equal(t, tt.wantDimensions, ic.Dimensions())
 			}
 		})
 	}
+}
+
+func ptrInt64(v int64) *int64 {
+	return &v
 }

--- a/modules/text2vec-aws/vectorizer/objects.go
+++ b/modules/text2vec-aws/vectorizer/objects.go
@@ -52,6 +52,7 @@ type ClassSettings interface {
 	Endpoint() string
 	TargetModel() string
 	TargetVariant() string
+	Dimensions() *int64
 }
 
 func (v *Vectorizer) Object(ctx context.Context, object *models.Object, cfg moduletools.ClassConfig,
@@ -76,6 +77,7 @@ func (v *Vectorizer) object(ctx context.Context, object *models.Object, cfg modu
 		Endpoint:      icheck.Endpoint(),
 		TargetModel:   icheck.TargetModel(),
 		TargetVariant: icheck.TargetVariant(),
+		Dimensions:    icheck.Dimensions(),
 	})
 	if err != nil {
 		return nil, err

--- a/modules/text2vec-aws/vectorizer/texts.go
+++ b/modules/text2vec-aws/vectorizer/texts.go
@@ -33,6 +33,7 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 			Endpoint:      settings.Endpoint(),
 			TargetModel:   settings.TargetModel(),
 			TargetVariant: settings.TargetVariant(),
+			Dimensions:    settings.Dimensions(),
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "remote client vectorize")

--- a/test/modules/text2vec-aws/text2vec_aws_test.go
+++ b/test/modules/text2vec-aws/text2vec_aws_test.go
@@ -14,6 +14,8 @@ package tests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/companies"
 )
@@ -22,9 +24,13 @@ func testText2VecAWS(rest, grpc, region string) func(t *testing.T) {
 	return func(t *testing.T) {
 		helper.SetupClient(rest)
 		className := "VectorizerTest"
+		ptrInt := func(i int) *int { return &i }
 		tests := []struct {
 			name  string
 			model string
+			// dimensions, when set, configures the output vector size. Only Titan Text
+			// Embeddings V2 supports it (accepted values: 256, 512, 1024).
+			dimensions *int
 		}{
 			{
 				name:  "amazon.titan-embed-text-v1",
@@ -33,6 +39,11 @@ func testText2VecAWS(rest, grpc, region string) func(t *testing.T) {
 			{
 				name:  "amazon.titan-embed-text-v2:0",
 				model: "amazon.titan-embed-text-v2:0",
+			},
+			{
+				name:       "amazon.titan-embed-text-v2:0 with dimensions",
+				model:      "amazon.titan-embed-text-v2:0",
+				dimensions: ptrInt(512),
 			},
 			{
 				name:  "cohere.embed-english-v3",
@@ -63,12 +74,38 @@ func testText2VecAWS(rest, grpc, region string) func(t *testing.T) {
 						"model":              tt.model,
 					},
 				}
+				if tt.dimensions != nil {
+					descriptionVectorizer["text2vec-aws"].(map[string]any)["dimensions"] = *tt.dimensions
+					emptyVectorizer["text2vec-aws"].(map[string]any)["dimensions"] = *tt.dimensions
+				}
 				t.Run("search", func(t *testing.T) {
 					companies.TestSuite(t, rest, grpc, className, descriptionVectorizer)
 				})
 				t.Run("empty values", func(t *testing.T) {
 					companies.TestSuiteWithEmptyValues(t, rest, grpc, className, descriptionVectorizer, emptyVectorizer)
 				})
+				if tt.dimensions != nil {
+					t.Run("dimensions", func(t *testing.T) {
+						class := companies.BaseClass(className)
+						class.VectorConfig = map[string]models.VectorConfig{
+							"description": {
+								Vectorizer:      descriptionVectorizer,
+								VectorIndexType: "hnsw",
+							},
+						}
+						helper.CreateClass(t, class)
+						defer helper.DeleteClass(t, class.Class)
+
+						companies.InsertObjects(t, rest, class.Class)
+
+						obj, err := helper.GetObject(t, class.Class, companies.SpaceX, "vector")
+						require.NoError(t, err)
+						require.NotNil(t, obj)
+						vector, ok := obj.Vectors["description"].([]float32)
+						require.True(t, ok)
+						require.Len(t, vector, *tt.dimensions)
+					})
+				}
 			})
 		}
 	}

--- a/usecases/modulecomponents/clients/aws/aws.go
+++ b/usecases/modulecomponents/clients/aws/aws.go
@@ -32,6 +32,7 @@ import (
 type bedrockEmbeddingsRequest struct {
 	InputText       *string                         `json:"inputText,omitempty"`
 	InputImage      *string                         `json:"inputImage,omitempty"`
+	Dimensions      *int64                          `json:"dimensions,omitempty"`
 	EmbeddingConfig *bedrockEmbeddingsRequestConfig `json:"embeddingConfig,omitempty"`
 }
 
@@ -352,15 +353,22 @@ func (c *Client) invokeCohereModel(ctx context.Context,
 }
 
 func (c *Client) createAmazonTitanBody(text, image string, settings Settings) bedrockEmbeddingsRequest {
-	var embeddingConfig *bedrockEmbeddingsRequestConfig
+	req := bedrockEmbeddingsRequest{
+		InputText:  c.ptrString(text),
+		InputImage: c.ptrString(image),
+	}
 	if settings.Dimensions != nil {
-		embeddingConfig = &bedrockEmbeddingsRequestConfig{OutputEmbeddingLength: settings.Dimensions}
+		// The two Titan embedding families expose the output size through different fields:
+		// Titan Multimodal Embeddings G1 (amazon.titan-embed-image-v1) uses the nested
+		// embeddingConfig.outputEmbeddingLength, while Titan Text Embeddings V2
+		// (amazon.titan-embed-text-v2) expects a top-level dimensions field.
+		if strings.Contains(settings.Model, "titan-embed-image") {
+			req.EmbeddingConfig = &bedrockEmbeddingsRequestConfig{OutputEmbeddingLength: settings.Dimensions}
+		} else {
+			req.Dimensions = settings.Dimensions
+		}
 	}
-	return bedrockEmbeddingsRequest{
-		InputText:       c.ptrString(text),
-		InputImage:      c.ptrString(image),
-		EmbeddingConfig: embeddingConfig,
-	}
+	return req
 }
 
 func (c *Client) createAmazonNovaBody(text, image string, settings Settings) bedrockAmazonNovaEmbeddingsRequest {

--- a/usecases/modulecomponents/clients/aws/aws.go
+++ b/usecases/modulecomponents/clients/aws/aws.go
@@ -358,14 +358,14 @@ func (c *Client) createAmazonTitanBody(text, image string, settings Settings) be
 		InputImage: c.ptrString(image),
 	}
 	if settings.Dimensions != nil {
-		// The two Titan embedding families expose the output size through different fields:
-		// Titan Multimodal Embeddings G1 (amazon.titan-embed-image-v1) uses the nested
-		// embeddingConfig.outputEmbeddingLength, while Titan Text Embeddings V2
-		// (amazon.titan-embed-text-v2) expects a top-level dimensions field.
-		if strings.Contains(settings.Model, "titan-embed-image") {
-			req.EmbeddingConfig = &bedrockEmbeddingsRequestConfig{OutputEmbeddingLength: settings.Dimensions}
-		} else {
+		// Only Titan Text Embeddings V2 (amazon.titan-embed-text-v2) expects a
+		// top-level dimensions field. The other Titan embedding models (e.g. Titan
+		// Multimodal Embeddings G1 / amazon.titan-embed-image-v1) use the nested
+		// embeddingConfig.outputEmbeddingLength field.
+		if strings.Contains(settings.Model, "titan-embed-text-v2") {
 			req.Dimensions = settings.Dimensions
+		} else {
+			req.EmbeddingConfig = &bedrockEmbeddingsRequestConfig{OutputEmbeddingLength: settings.Dimensions}
 		}
 	}
 	return req

--- a/usecases/modulecomponents/clients/aws/aws_test.go
+++ b/usecases/modulecomponents/clients/aws/aws_test.go
@@ -87,6 +87,12 @@ func TestCreateAmazonTitanBody(t *testing.T) {
 			model:      "amazon.titan-embed-text-v1",
 			dimensions: nil,
 		},
+		{
+			name:              "titan text v1 with dimensions uses embeddingConfig",
+			model:             "amazon.titan-embed-text-v1",
+			dimensions:        &dims,
+			wantEmbeddingConf: &dims,
+		},
 	}
 
 	for _, tt := range tests {

--- a/usecases/modulecomponents/clients/aws/aws_test.go
+++ b/usecases/modulecomponents/clients/aws/aws_test.go
@@ -59,6 +59,53 @@ func TestCreateRequestBody(t *testing.T) {
 	assert.Equal(t, "search_query", req.InputType)
 }
 
+func TestCreateAmazonTitanBody(t *testing.T) {
+	c := New("123", "", "", 1*time.Second, nullLogger())
+	dims := int64(512)
+
+	tests := []struct {
+		name              string
+		model             string
+		dimensions        *int64
+		wantDimensions    *int64
+		wantEmbeddingConf *int64
+	}{
+		{
+			name:           "titan text v2 with dimensions uses top-level field",
+			model:          "amazon.titan-embed-text-v2:0",
+			dimensions:     &dims,
+			wantDimensions: &dims,
+		},
+		{
+			name:              "titan multimodal with dimensions uses embeddingConfig",
+			model:             "amazon.titan-embed-image-v1",
+			dimensions:        &dims,
+			wantEmbeddingConf: &dims,
+		},
+		{
+			name:       "titan text v1 without dimensions sets neither",
+			model:      "amazon.titan-embed-text-v1",
+			dimensions: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := c.createAmazonTitanBody("Hello, world!", "", Settings{
+				Model:      tt.model,
+				Dimensions: tt.dimensions,
+			})
+			assert.Equal(t, tt.wantDimensions, req.Dimensions)
+			if tt.wantEmbeddingConf == nil {
+				assert.Nil(t, req.EmbeddingConfig)
+			} else {
+				require.NotNil(t, req.EmbeddingConfig)
+				assert.Equal(t, tt.wantEmbeddingConf, req.EmbeddingConfig.OutputEmbeddingLength)
+			}
+		})
+	}
+}
+
 func nullLogger() logrus.FieldLogger {
 	l, _ := test.NewNullLogger()
 	return l


### PR DESCRIPTION
### What's being changed:

This PR adds support for dimensions setting in text2vec-aws module.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
