### PR TITLE
 fix(usage-limits): tenant cap rejects ingest into existing tenants

### DIFF
--- a/test/acceptance/usage_limits/all_limits_test.go
+++ b/test/acceptance/usage_limits/all_limits_test.go
@@ -59,12 +59,12 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 
 	// One container, every limit set tight enough to hit, and a custom
 	// message template that exercises both placeholders. Collection cap
-	// is 4 to leave room for the MT collection used in the tenant
-	// sub-test (1 MT + 3 single-tenant = 4 = at cap; a 5th create
-	// rejects).
+	// is 5 to leave room for the two MT collections used in the tenant
+	// sub-tests (1 plain MT + 1 auto-tenant MT + 3 single-tenant = 5 = at
+	// cap; a 6th create rejects).
 	compose, terminate := startContainer(t, ctx, mergeEnv(aggressiveFlushEnv(), map[string]string{
 		"MAXIMUM_ALLOWED_OBJECTS_COUNT":          "10",
-		"MAXIMUM_ALLOWED_COLLECTIONS_COUNT":      "4",
+		"MAXIMUM_ALLOWED_COLLECTIONS_COUNT":      "5",
 		"MAXIMUM_ALLOWED_TENANTS_PER_COLLECTION": "2",
 		"MAXIMUM_ALLOWED_SHARDS_PER_COLLECTION":  "1",
 		"USAGE_LIMITS_ERROR_MESSAGE":             "hit limit of {value} {limit}, upgrade at https://x",
@@ -75,10 +75,11 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 	httpURI := "http://" + compose.GetWeaviate().URI()
 	grpcURI := compose.GetWeaviate().GrpcURI()
 
-	// Set up the MT collection up front so the tenant sub-test can run
-	// without consuming a "collection" slot mid-suite. It counts toward
-	// MAXIMUM_ALLOWED_COLLECTIONS_COUNT (4).
+	// Set up the two MT collections up front so the tenant sub-tests can
+	// run without consuming "collection" slots mid-suite. Together they
+	// count for 2 toward MAXIMUM_ALLOWED_COLLECTIONS_COUNT (5).
 	createMTCollection(t, ctx, httpURI, "MTcoll")
+	createAutoTenantMTCollection(t, ctx, httpURI, "MTautocoll")
 
 	t.Run("shard limit on class create", func(t *testing.T) {
 		body := []byte(`{
@@ -105,19 +106,41 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 	})
 
 	t.Run("collection limit hit after cap", func(t *testing.T) {
-		// MTcoll already counts as 1; create 3 more (4 total = cap),
-		// then the 5th must 429.
+		// MTcoll + MTautocoll already count as 2; create 3 more (5 total
+		// = cap), then the 6th must 429.
 		for _, name := range []string{"C1", "C2", "C3"} {
 			createCollection(t, ctx, httpURI, name)
 		}
 		body := []byte(`{"class":"C4","vectorizer":"none"}`)
-		assertLimitExceeded(t, ctx, httpURI+"/v1/schema", body, "collections", 4)
+		assertLimitExceeded(t, ctx, httpURI+"/v1/schema", body, "collections", 5)
 	})
 
 	t.Run("tenant limit per collection", func(t *testing.T) {
 		// Cap is 2 — first two tenants succeed, third rejected.
 		addTenants(t, ctx, httpURI, "MTcoll", []string{"T1", "T2"}, false, "")
 		addTenants(t, ctx, httpURI, "MTcoll", []string{"T3"}, true, "tenants")
+		// Cap rejection must not break ingestion into already-created tenants.
+		postOK(t, ctx, httpURI+"/v1/objects",
+			[]byte(`{"class":"MTcoll","tenant":"T1","properties":{"i":0}}`))
+	})
+
+	t.Run("auto-tenant on object ingest dedupes existing tenants against cap", func(t *testing.T) {
+		// With autoTenantCreation enabled, object ingest routes the tenant
+		// name through AddTenants. The cap must count only truly-new
+		// tenants — ingesting into an existing one stays under cap; a new
+		// name beyond cap rejects.
+		objectsURL := httpURI + "/v1/objects"
+
+		// Fill to cap=2 via implicit auto-tenant creation.
+		postOK(t, ctx, objectsURL, []byte(`{"class":"MTautocoll","tenant":"T1","properties":{"i":0}}`))
+		postOK(t, ctx, objectsURL, []byte(`{"class":"MTautocoll","tenant":"T2","properties":{"i":1}}`))
+
+		// Existing tenant — must succeed.
+		postOK(t, ctx, objectsURL, []byte(`{"class":"MTautocoll","tenant":"T1","properties":{"i":2}}`))
+
+		// New tenant beyond cap — must reject.
+		body := []byte(`{"class":"MTautocoll","tenant":"T3","properties":{"i":3}}`)
+		assertLimitExceeded(t, ctx, objectsURL, body, "tenants", 2)
 	})
 
 	t.Run("object limit single create — loops until limit fires", func(t *testing.T) {
@@ -329,6 +352,17 @@ func createMTCollection(t *testing.T, ctx context.Context, httpURI, name string)
 	t.Helper()
 	body := []byte(fmt.Sprintf(
 		`{"class":"%s","vectorizer":"none","multiTenancyConfig":{"enabled":true}}`,
+		name))
+	postOK(t, ctx, httpURI+"/v1/schema", body)
+}
+
+// createAutoTenantMTCollection creates an MT class with autoTenantCreation
+// enabled, so an object write referencing an unknown tenant implicitly
+// creates that tenant via usecases/objects/auto_schema.go autoTenants().
+func createAutoTenantMTCollection(t *testing.T, ctx context.Context, httpURI, name string) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(
+		`{"class":"%s","vectorizer":"none","multiTenancyConfig":{"enabled":true,"autoTenantCreation":true}}`,
 		name))
 	postOK(t, ctx, httpURI+"/v1/schema", body)
 }

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -62,6 +62,8 @@ func (h *Handler) AddTenants(ctx context.Context,
 	// in class.go — count current tenants, compare against the cap, return
 	// a typed *usagelimits.LimitExceededError on miss. Tenants are checked
 	// at create time only (not on subsequent MT config changes).
+	// Only truly-new tenants count toward the cap so re-asserting an existing
+	// name (e.g. auto-tenant creation on object ingest) doesn't trip it.
 	if dv := h.config.UsageLimits.MaxTenantsPerCollection; dv != nil {
 		cap := dv.Get()
 		if cap >= 0 {
@@ -69,9 +71,22 @@ func (h *Handler) AddTenants(ctx context.Context,
 			if err != nil {
 				return 0, fmt.Errorf("count tenants for limit check: %w", err)
 			}
+			// Skip the dedup pass when the upper-bound sum already fits.
 			if len(existing)+len(validated) > cap {
-				return 0, usagelimits.NewLimitExceededError(
-					h.errorMessageTemplate(), usagelimits.LimitTenants, int64(cap))
+				existingNames := make(map[string]struct{}, len(existing))
+				for _, t := range existing {
+					existingNames[t.Name] = struct{}{}
+				}
+				incoming := 0
+				for _, t := range validated {
+					if _, ok := existingNames[t.Name]; !ok {
+						incoming++
+					}
+				}
+				if len(existing)+incoming > cap {
+					return 0, usagelimits.NewLimitExceededError(
+						h.errorMessageTemplate(), usagelimits.LimitTenants, int64(cap))
+				}
 			}
 		}
 	}

--- a/usecases/schema/usage_limits_tenants_test.go
+++ b/usecases/schema/usage_limits_tenants_test.go
@@ -88,3 +88,79 @@ func TestAddTenants_WithUsageLimit(t *testing.T) {
 func namedTenant(i int) string {
 	return fmt.Sprintf("T_%d", i)
 }
+
+// TestAddTenants_WithUsageLimit_DedupesExistingNames asserts the per-collection
+// tenant cap counts only tenants from the request that are not already in the
+// collection, matching the RAFT-side check in cluster/schema/meta_class.go.
+func TestAddTenants_WithUsageLimit_DedupesExistingNames(t *testing.T) {
+	tests := []struct {
+		name           string
+		cap            int
+		existingNames  []string
+		requestedNames []string
+		expectExceed   bool
+	}{
+		{
+			name:           "at cap, only existing names re-asserted",
+			cap:            3,
+			existingNames:  []string{"T1", "T2", "T3"},
+			requestedNames: []string{"T3"},
+			expectExceed:   false,
+		},
+		{
+			name:           "at cap, existing + one new — new pushes over",
+			cap:            3,
+			existingNames:  []string{"T1", "T2", "T3"},
+			requestedNames: []string{"T3", "T4"},
+			expectExceed:   true,
+		},
+		{
+			name:           "below cap, existing + one new — exact fit",
+			cap:            3,
+			existingNames:  []string{"T1", "T2"},
+			requestedNames: []string{"T2", "T3"},
+			expectExceed:   false,
+		},
+		{
+			name:           "below cap, existing + two new — one over",
+			cap:            3,
+			existingNames:  []string{"T1", "T2"},
+			requestedNames: []string{"T2", "T3", "T4"},
+			expectExceed:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, fakeMgr := newTestHandler(t, &fakeDB{})
+			handler.config.UsageLimits.MaxTenantsPerCollection = runtime.NewDynamicValue(tt.cap)
+
+			existing := make([]*models.Tenant, len(tt.existingNames))
+			for i, name := range tt.existingNames {
+				existing[i] = &models.Tenant{Name: name}
+			}
+			fakeMgr.On("QueryTenants", "MTenabled", mock.Anything).
+				Return(existing, uint64(0), nil).Maybe()
+
+			if !tt.expectExceed {
+				fakeMgr.On("AddTenants", mock.Anything, mock.Anything).Return(nil)
+			}
+
+			requested := make([]*models.Tenant, len(tt.requestedNames))
+			for i, name := range tt.requestedNames {
+				requested[i] = &models.Tenant{Name: name}
+			}
+
+			_, err := handler.AddTenants(context.Background(), nil, "MTenabled", requested)
+			if tt.expectExceed {
+				require.Error(t, err)
+				le, ok := usagelimits.AsLimitExceeded(err)
+				require.True(t, ok, "expected *LimitExceededError, got %T: %v", err, err)
+				assert.Equal(t, usagelimits.LimitTenants, le.Limit)
+				assert.Equal(t, int64(tt.cap), le.Value)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary                                                                                                  
                                                                           
  With `MAXIMUM_ALLOWED_TENANTS_PER_COLLECTION` set on a multi-tenant collection with `autoTenantCreation: true`, object ingest into a tenant that already exists rejects with `limit=tenants` once the collection fills to the cap. Removing one tenant lets ingestion resume.                                                
                                                                                                              
  ## Cause                                                                                                    
                                                                                                            
  `Handler.AddTenants` (`usecases/schema/tenant.go`) compared `len(existing) + len(validated) > cap`, treating every name in the request as new — even names already present in the collection. On every object write, `AutoSchemaManager.autoTenants` calls `AddTenants` with the requested tenant name (existing or not), so at-cap ingest into an existing tenant trips the check.                                                                            
                                                                                                              
  The RAFT-side gate in `cluster/schema/meta_class.go` already counts correctly; only the handler fast-path was wrong.                                                          
                                                                                                              
  ## Fix                                                                                                      
                                                                                                            
  Mirror the RAFT-side logic: dedup the request against existing tenants and only count truly-new names toward the cap. Gated by a cheap `len(existing) + len(validated) > cap` short-circuit so the common case (well under cap) skips the map build.
                                                                                                              
  ## Tests                                                                 
                                                                                                              
  - Unit: `TestAddTenants_WithUsageLimit_DedupesExistingNames` — table-driven coverage of at-cap re-assert, exact-fit, and over-cap mixes.                                                                                                    
  - Acceptance: new sub-test in `TestAllLimits_SingleSharedContainer` exercises the actual object-ingest path (`POST /v1/objects` with `autoTenantCreation`) to prove the fix end-to-end.