### PR TITLE
perf(bm25): faster varint decoding (reservoir + 64-bit reads)

### DIFF
--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -21,11 +21,15 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 		return // Error handling: insufficient input or output space
 	}
 
+	n := len(deltas)
+	if n == 0 {
+		return
+	}
+
 	// Read the first delta using BigEndian to handle byte order explicitly
 	deltas[0] = binary.BigEndian.Uint64(packed[0:8])
 
-	n := len(deltas)
-	if n <= 1 {
+	if n == 1 {
 		return
 	}
 
@@ -42,23 +46,26 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 	bits := packed[8:]
 	bitsLen := len(bits)
 
-	// High-aligned bit reservoir:
-	//   - `buf` holds the next bits to extract in its MSB; the very next bit
-	//     to read is at position 63.
-	//   - `bitsAvail` counts valid bits, which occupy positions 63..64-bitsAvail.
-	//   - Extract: value = buf >> (64 - bnu); buf <<= bnu; bitsAvail -= bnu.
-	//   - Refill: buf |= newBits << (64 - bitsAvail - chunkBits).
-	//
-	// The 6-bit header was consumed via `packed[8]>>2`; the low 2 bits of
-	// bits[0] are the start of the first delta and seed the reservoir.
-	buf := uint64(bits[0]&0x3) << 62
-	bitsAvail := 2
-	bytePos := 1
-
 	if bnu <= 32 {
+		// High-aligned bit reservoir:
+		//   - `buf` holds the next bits to extract in its MSB; the very next bit
+		//     to read is at position 63.
+		//   - `bitsAvail` counts valid bits, which occupy positions 63..64-bitsAvail.
+		//   - Extract: value = buf >> (64 - bnu); buf <<= bnu; bitsAvail -= bnu.
+		//   - Refill: buf |= newBits << (64 - bitsAvail - chunkBits).
+		//
+		// The 6-bit header was consumed via `packed[8]>>2`; the low 2 bits of
+		// bits[0] are the start of the first delta and seed the reservoir.
+		buf := uint64(bits[0]&0x3) << 62
+		bitsAvail := 2
+		bytePos := 1
+
 		// Refill 32 bits per chunk. We refill only when bitsAvail < bnu, so
 		// bitsAvail is at most 31 when we refill (bnu <= 32), keeping
 		// bitsAvail+32 <= 63 — safe to store in the reservoir.
+		//
+		// The delta and non-delta loops are split deliberately to keep the
+		// deltaDiff branch out of the per-value hot loop; do not merge them.
 		if deltaDiff {
 			prev := deltas[0]
 			i := 1
@@ -76,7 +83,7 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 				bitsAvail -= int(bnu)
 				deltas[i] = prev
 			}
-			decodeTailDelta(deltas, bits, bytePos, bitsLen, buf, bitsAvail, bnu, i, n, &prev)
+			decodeTailDelta(deltas, bits, bytePos, bitsLen, buf, bitsAvail, bnu, i, n, prev)
 		} else {
 			i := 1
 			for ; i < n; i++ {
@@ -97,8 +104,7 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 		return
 	}
 
-	// bnu > 32: per-iteration uint64 load. The reservoir state above is unused
-	// here; we recompute from bitPos.
+	// bnu > 32: per-iteration uint64 load, tracking the absolute bit position.
 	//
 	// Fast path: read 8 bytes at a time and extract bitsNeeded bits with a
 	// single shift+mask. Safe only when bnu <= 57 (so that bitOffset+bnu <= 64
@@ -106,6 +112,10 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 	bitPos := uint(6)
 	fastEnd := 1
 	if bnu <= 57 && bitsLen >= 8 {
+		// fastEnd is the first index whose 8-byte read might run past the end.
+		// That read needs bytePos+8 <= bitsLen, i.e. bitPos <= 8*bitsLen-57
+		// (= 8*(bitsLen-8)+7). bitPos starts at 6 and grows by bnu per value, so
+		// the safe delta-bit budget past the header is room = 8*bitsLen-63 (-57-6).
 		room := 8*bitsLen - 63
 		fastEnd = 2 + room/bitsNeeded
 		if fastEnd > n {
@@ -186,8 +196,8 @@ func decodeTail(deltas []uint64, bits []byte, bytePos, bitsLen int, buf uint64, 
 }
 
 // decodeTailDelta is the delta variant of decodeTail.
-func decodeTailDelta(deltas []uint64, bits []byte, bytePos, bitsLen int, buf uint64, bitsAvail int, bnu uint, i, n int, prev *uint64) {
-	p := *prev
+func decodeTailDelta(deltas []uint64, bits []byte, bytePos, bitsLen int, buf uint64, bitsAvail int, bnu uint, i, n int, prev uint64) {
+	p := prev
 	for ; i < n; i++ {
 		for bitsAvail < int(bnu) {
 			if bytePos >= bitsLen {

--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -17,12 +17,17 @@ import (
 )
 
 func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
-	if len(packed) < 8 {
+	if len(packed) < 9 {
 		return // Error handling: insufficient input or output space
 	}
 
 	// Read the first delta using BigEndian to handle byte order explicitly
 	deltas[0] = binary.BigEndian.Uint64(packed[0:8])
+
+	n := len(deltas)
+	if n <= 1 {
+		return
+	}
 
 	// Read bitsNeeded (6 bits starting from bit 2 of packed[8])
 	bitsNeeded := int((packed[8] >> 2) & 0x3F)
@@ -31,37 +36,168 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 		return
 	}
 
-	// Starting bit position after reading bitsNeeded
-	bitPos := 6
-	bytePos := 8 // Start from packed[8]
+	bnu := uint(bitsNeeded)
+	bitsMask := uint64(1)<<bnu - 1
 
-	// Initialize the bit buffer with the remaining bits in packed[8], if any
-	bitsLeft := 8 - bitPos
-	bitBuffer := uint64(packed[bytePos] & ((1 << bitsLeft) - 1))
+	bits := packed[8:]
+	bitsLen := len(bits)
 
-	bytePos++
+	// High-aligned bit reservoir:
+	//   - `buf` holds the next bits to extract in its MSB; the very next bit
+	//     to read is at position 63.
+	//   - `bitsAvail` counts valid bits, which occupy positions 63..64-bitsAvail.
+	//   - Extract: value = buf >> (64 - bnu); buf <<= bnu; bitsAvail -= bnu.
+	//   - Refill: buf |= newBits << (64 - bitsAvail - chunkBits).
+	//
+	// The 6-bit header was consumed via `packed[8]>>2`; the low 2 bits of
+	// bits[0] are the start of the first delta and seed the reservoir.
+	buf := uint64(bits[0]&0x3) << 62
+	bitsAvail := 2
+	bytePos := 1
 
-	// Precompute the mask for bitsNeeded bits
-	bitsMask := uint64((1 << bitsNeeded) - 1)
+	if bnu <= 32 {
+		// Refill 32 bits per chunk. We refill only when bitsAvail < bnu, so
+		// bitsAvail is at most 31 when we refill (bnu <= 32), keeping
+		// bitsAvail+32 <= 63 — safe to store in the reservoir.
+		if deltaDiff {
+			prev := deltas[0]
+			i := 1
+			for ; i < n; i++ {
+				if bitsAvail < int(bnu) {
+					if bytePos+4 > bitsLen {
+						break
+					}
+					buf |= uint64(binary.BigEndian.Uint32(bits[bytePos:])) << uint(32-bitsAvail)
+					bytePos += 4
+					bitsAvail += 32
+				}
+				prev += buf >> (64 - bnu)
+				buf <<= bnu
+				bitsAvail -= int(bnu)
+				deltas[i] = prev
+			}
+			decodeTailDelta(deltas, bits, bytePos, bitsLen, buf, bitsAvail, bnu, i, n, &prev)
+		} else {
+			i := 1
+			for ; i < n; i++ {
+				if bitsAvail < int(bnu) {
+					if bytePos+4 > bitsLen {
+						break
+					}
+					buf |= uint64(binary.BigEndian.Uint32(bits[bytePos:])) << uint(32-bitsAvail)
+					bytePos += 4
+					bitsAvail += 32
+				}
+				deltas[i] = buf >> (64 - bnu)
+				buf <<= bnu
+				bitsAvail -= int(bnu)
+			}
+			decodeTail(deltas, bits, bytePos, bitsLen, buf, bitsAvail, bnu, i, n)
+		}
+		return
+	}
 
-	// Read the deltas
-	for i := 1; i < len(deltas); i++ {
-		// Ensure we have enough bits in the buffer
+	// bnu > 32: per-iteration uint64 load. The reservoir state above is unused
+	// here; we recompute from bitPos.
+	//
+	// Fast path: read 8 bytes at a time and extract bitsNeeded bits with a
+	// single shift+mask. Safe only when bnu <= 57 (so that bitOffset+bnu <= 64
+	// for any bitOffset in [0,7]) and when we have 8 bytes available.
+	bitPos := uint(6)
+	fastEnd := 1
+	if bnu <= 57 && bitsLen >= 8 {
+		room := 8*bitsLen - 63
+		fastEnd = 2 + room/bitsNeeded
+		if fastEnd > n {
+			fastEnd = n
+		}
+	}
+
+	if deltaDiff {
+		prev := deltas[0]
+		for i := 1; i < fastEnd; i++ {
+			bytePos := bitPos >> 3
+			bitOffset := bitPos & 7
+			val := binary.BigEndian.Uint64(bits[bytePos:])
+			d := (val >> (64 - bitOffset - bnu)) & bitsMask
+			prev += d
+			deltas[i] = prev
+			bitPos += bnu
+		}
+	} else {
+		for i := 1; i < fastEnd; i++ {
+			bytePos := bitPos >> 3
+			bitOffset := bitPos & 7
+			val := binary.BigEndian.Uint64(bits[bytePos:])
+			deltas[i] = (val >> (64 - bitOffset - bnu)) & bitsMask
+			bitPos += bnu
+		}
+	}
+
+	if fastEnd >= n {
+		return
+	}
+
+	// Tail: byte-by-byte for the remaining values where a uint64 read would
+	// run past the end of the input.
+	bytePosT := int(bitPos >> 3)
+	bitOffset := int(bitPos & 7)
+	bitsLeft := 8 - bitOffset
+	bitBuffer := uint64(bits[bytePosT]) & (uint64(1)<<uint(bitsLeft) - 1)
+	bytePosT++
+
+	for i := fastEnd; i < n; i++ {
 		for bitsLeft < bitsNeeded {
-			if bytePos >= len(packed) {
-				// Handle insufficient data
+			if bytePosT >= bitsLen {
 				return
 			}
-			bitBuffer = (bitBuffer << 8) | uint64(packed[bytePos])
+			bitBuffer = (bitBuffer << 8) | uint64(bits[bytePosT])
 			bitsLeft += 8
-			bytePos++
+			bytePosT++
 		}
-		// Extract bitsNeeded bits from the buffer
 		bitsLeft -= bitsNeeded
-		deltas[i] = (bitBuffer >> bitsLeft) & bitsMask
+		deltas[i] = (bitBuffer >> uint(bitsLeft)) & bitsMask
 		if deltaDiff {
 			deltas[i] += deltas[i-1]
 		}
+	}
+}
+
+// decodeTail finishes the reservoir-style decode for the last few values, where
+// a 32-bit refill would run past the end of the input. Refills one byte at a
+// time. Called from the bnu <= 32 fast paths.
+func decodeTail(deltas []uint64, bits []byte, bytePos, bitsLen int, buf uint64, bitsAvail int, bnu uint, i, n int) {
+	for ; i < n; i++ {
+		for bitsAvail < int(bnu) {
+			if bytePos >= bitsLen {
+				return
+			}
+			buf |= uint64(bits[bytePos]) << uint(56-bitsAvail)
+			bytePos++
+			bitsAvail += 8
+		}
+		deltas[i] = buf >> (64 - bnu)
+		buf <<= bnu
+		bitsAvail -= int(bnu)
+	}
+}
+
+// decodeTailDelta is the delta variant of decodeTail.
+func decodeTailDelta(deltas []uint64, bits []byte, bytePos, bitsLen int, buf uint64, bitsAvail int, bnu uint, i, n int, prev *uint64) {
+	p := *prev
+	for ; i < n; i++ {
+		for bitsAvail < int(bnu) {
+			if bytePos >= bitsLen {
+				return
+			}
+			buf |= uint64(bits[bytePos]) << uint(56-bitsAvail)
+			bytePos++
+			bitsAvail += 8
+		}
+		p += buf >> (64 - bnu)
+		buf <<= bnu
+		bitsAvail -= int(bnu)
+		deltas[i] = p
 	}
 }
 

--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -141,6 +141,9 @@ func decodeReusable(deltas []uint64, packed []byte, deltaDiff bool) {
 	// Tail: byte-by-byte for the remaining values where a uint64 read would
 	// run past the end of the input.
 	bytePosT := int(bitPos >> 3)
+	if bytePosT >= bitsLen {
+		return
+	}
 	bitOffset := int(bitPos & 7)
 	bitsLeft := 8 - bitOffset
 	bitBuffer := uint64(bits[bytePosT]) & (uint64(1)<<uint(bitsLeft) - 1)

--- a/adapters/repos/db/lsmkv/varenc/varint_difftest_test.go
+++ b/adapters/repos/db/lsmkv/varenc/varint_difftest_test.go
@@ -1,0 +1,206 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package varenc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// decodeReusableLegacy is the pre-PR (stable/v1.37) varint decoder, preserved
+// verbatim as a reference oracle. The reservoir / 64-bit-read rewrite claims to
+// be "bit-identical to stable/v1.37"; the differential tests below pin that
+// claim by requiring byte-identical output from the new decoder for every
+// validly-encoded buffer. If the new decoder ever diverges, these fail.
+func decodeReusableLegacy(deltas []uint64, packed []byte, deltaDiff bool) {
+	if len(packed) < 8 {
+		return
+	}
+
+	deltas[0] = binary.BigEndian.Uint64(packed[0:8])
+
+	bitsNeeded := int((packed[8] >> 2) & 0x3F)
+	if bitsNeeded == 0 || bitsNeeded > 64 {
+		return
+	}
+
+	bitPos := 6
+	bytePos := 8
+
+	bitsLeft := 8 - bitPos
+	bitBuffer := uint64(packed[bytePos] & ((1 << bitsLeft) - 1))
+
+	bytePos++
+
+	bitsMask := uint64((1 << bitsNeeded) - 1)
+
+	for i := 1; i < len(deltas); i++ {
+		for bitsLeft < bitsNeeded {
+			if bytePos >= len(packed) {
+				return
+			}
+			bitBuffer = (bitBuffer << 8) | uint64(packed[bytePos])
+			bitsLeft += 8
+			bytePos++
+		}
+		bitsLeft -= bitsNeeded
+		deltas[i] = (bitBuffer >> bitsLeft) & bitsMask
+		if deltaDiff {
+			deltas[i] += deltas[i-1]
+		}
+	}
+}
+
+// diffSizes spans the reservoir/uint64 fast loops and their byte tails, plus the
+// 8/9-byte guard boundary and several non-block-aligned counts.
+var diffSizes = []int{1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 100, 127, 128, 129, 255, 256, 511, 512}
+
+// TestVarIntDecodeMatchesLegacyDecoder is the differential test backing the
+// PR's "bit-identical to stable/v1.37" claim: for both codecs, every supported
+// bit width, and a wide range of counts, the new decoder must produce exactly
+// the same values as the legacy decoder AND round-trip the original input.
+func TestVarIntDecodeMatchesLegacyDecoder(t *testing.T) {
+	rng := rand.New(rand.NewPCG(0x5eed, 0x1337))
+
+	for _, deltaDiff := range []bool{false, true} {
+		for bnu := 1; bnu <= maxSupportedBnu; bnu++ {
+			maxVal := uint64(1)<<uint(bnu) - 1
+			for _, n := range diffSizes {
+				// In delta mode the cumulative sum must stay within uint64.
+				if deltaDiff && maxVal != 0 && uint64(n) > ^uint64(0)/maxVal {
+					continue
+				}
+				for trial := 0; trial < 6; trial++ {
+					values := makeWidthValues(rng, n, bnu, maxVal, deltaDiff)
+
+					var packed []byte
+					if deltaDiff {
+						enc := &VarIntDeltaEncoder{}
+						enc.Init(n)
+						packed = enc.Encode(values)
+					} else {
+						enc := &VarIntEncoder{}
+						enc.Init(n)
+						packed = enc.Encode(values)
+					}
+
+					gotNew := make([]uint64, n)
+					gotOld := make([]uint64, n)
+					decodeReusable(gotNew, packed, deltaDiff)
+					decodeReusableLegacy(gotOld, packed, deltaDiff)
+
+					require.Equalf(t, gotOld, gotNew,
+						"new decoder diverged from legacy: deltaDiff=%v bnu=%d n=%d trial=%d packed=%x",
+						deltaDiff, bnu, n, trial, packed)
+					require.Equalf(t, values, gotNew,
+						"decode did not round-trip: deltaDiff=%v bnu=%d n=%d trial=%d packed=%x",
+						deltaDiff, bnu, n, trial, packed)
+				}
+			}
+		}
+	}
+}
+
+// makeWidthValues builds an n-element input whose deltas (or values, in
+// non-delta mode) are bounded by bnu bits, anchoring the last delta to maxVal so
+// the encoder records exactly bnu in the header.
+func makeWidthValues(rng *rand.Rand, n, bnu int, maxVal uint64, deltaDiff bool) []uint64 {
+	values := make([]uint64, n)
+	if deltaDiff {
+		values[0] = rng.Uint64N(1 << 30)
+		for i := 1; i < n; i++ {
+			var d uint64
+			if maxVal != 0 {
+				d = rng.Uint64N(maxVal + 1)
+			}
+			values[i] = values[i-1] + d
+		}
+		if n > 1 {
+			values[n-1] = values[n-2] + maxVal
+		}
+		return values
+	}
+	values[0] = rng.Uint64()
+	for i := 1; i < n; i++ {
+		if maxVal == 0 {
+			values[i] = 0
+		} else {
+			values[i] = rng.Uint64N(maxVal + 1)
+		}
+	}
+	if n > 1 {
+		values[n-1] = maxVal
+	}
+	return values
+}
+
+// TestVarIntDecodeShortBufferNoPanic pins the headline guard fix: the legacy
+// decoder read packed[8] after only checking len<8, so an exactly-8-byte buffer
+// panicked. The new len<9 guard must turn every sub-9-byte buffer into a safe
+// no-op for both codecs. (A valid encoding is always >= 9 bytes, so nothing
+// legitimate is rejected — see TestVarIntBitsNeededHeaderHasExpectedValue.)
+func TestVarIntDecodeShortBufferNoPanic(t *testing.T) {
+	out := make([]uint64, 4)
+	for l := 0; l <= 9; l++ {
+		buf := make([]byte, l)
+		require.NotPanicsf(t, func() { decodeReusable(out, buf, false) }, "len=%d non-delta", l)
+		require.NotPanicsf(t, func() { decodeReusable(out, buf, true) }, "len=%d delta", l)
+	}
+}
+
+// TestVarIntDecodeEmptyOutputNoPanic covers n==0: the deltas[0] write is guarded
+// by an n==0 check that precedes it, so an empty output slice is a no-op rather
+// than an index-out-of-range panic, even with a full-length packed buffer.
+func TestVarIntDecodeEmptyOutputNoPanic(t *testing.T) {
+	enc := &VarIntEncoder{}
+	enc.Init(4)
+	packed := enc.Encode([]uint64{10, 11, 12, 13})
+
+	require.NotPanics(t, func() { decodeReusable([]uint64{}, packed, false) })
+	require.NotPanics(t, func() { decodeReusable([]uint64{}, packed, true) })
+}
+
+// TestVarIntDecodeBnu59To63MatchesLegacy pins behavior in the unsupported width
+// range [59,63]. Both the new and legacy decoders lose high bits there because
+// the byte-refill tail overflows the 64-bit buffer (see the maxSupportedBnu
+// comment). This PR does not change that — it predates this code and never
+// occurs for BM25 doc-id/TF deltas — but the new decoder must stay byte-
+// identical to the legacy one across the full 6-bit header range. The NotEqual
+// assertion documents that the range is genuinely lossy today; if a future
+// change makes it round-trip, this test will flag that the format/decoder moved.
+func TestVarIntDecodeBnu59To63MatchesLegacy(t *testing.T) {
+	for bnu := 59; bnu <= 63; bnu++ {
+		t.Run(fmt.Sprintf("bnu=%d", bnu), func(t *testing.T) {
+			v := uint64(1)<<uint(bnu-1) | 1 // exactly bnu significant bits
+			require.Equal(t, bnu, bits.Len64(v))
+
+			values := []uint64{0, v}
+			enc := &VarIntEncoder{}
+			enc.Init(2)
+			packed := enc.Encode(values)
+			require.Equal(t, bnu, int((packed[8]>>2)&0x3F), "header should record bnu")
+
+			gotNew := make([]uint64, 2)
+			gotOld := make([]uint64, 2)
+			decodeReusable(gotNew, packed, false)
+			decodeReusableLegacy(gotOld, packed, false)
+
+			require.Equal(t, gotOld, gotNew, "new decoder must match legacy even in the lossy range")
+			require.NotEqual(t, v, gotNew[1], "bnu>=59 is known-lossy; a round-trip here means the format/decoder changed")
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/varenc/varint_difftest_test.go
+++ b/adapters/repos/db/lsmkv/varenc/varint_difftest_test.go
@@ -202,3 +202,98 @@ func TestVarIntDecodeBnu59To63MatchesLegacy(t *testing.T) {
 		})
 	}
 }
+
+// widthCases pick one bit width per decode strategy and tail boundary.
+var widthCases = []struct {
+	name string
+	bnu  int
+}{
+	{"reservoir_min", 1},
+	{"reservoir_mid", 16},
+	{"reservoir_max", 32},
+	{"uint64_first", 33},
+	{"uint64_max", 57},
+	{"tail_only", 58},
+}
+
+func encodeWidthValues(values []uint64, deltaDiff bool, n int) []byte {
+	if deltaDiff {
+		e := &VarIntDeltaEncoder{}
+		e.Init(n)
+		return e.Encode(values)
+	}
+	e := &VarIntEncoder{}
+	e.Init(n)
+	return e.Encode(values)
+}
+
+// TestVarIntDecodeTruncatedBodyMatchesLegacy pins the body-exhaustion guards: a
+// valid header with a short body must decode without panic and stay byte-
+// identical to the reference decoder for the surviving prefix.
+func TestVarIntDecodeTruncatedBodyMatchesLegacy(t *testing.T) {
+	rng := rand.New(rand.NewPCG(0xabcd, 0xef01))
+	const n = 40
+	for _, wc := range widthCases {
+		t.Run(wc.name, func(t *testing.T) {
+			for _, deltaDiff := range []bool{false, true} {
+				maxVal := uint64(1)<<uint(wc.bnu) - 1
+				if deltaDiff && maxVal != 0 && uint64(n) > ^uint64(0)/maxVal {
+					continue
+				}
+				values := makeWidthValues(rng, n, wc.bnu, maxVal, deltaDiff)
+				packed := encodeWidthValues(values, deltaDiff, n)
+				// Step by one byte to hit every truncation alignment.
+				for cut := len(packed); cut >= 9; cut-- {
+					trunc := packed[:cut]
+					gotNew := make([]uint64, n)
+					gotOld := make([]uint64, n)
+					require.NotPanicsf(t, func() { decodeReusable(gotNew, trunc, deltaDiff) },
+						"delta=%v cut=%d", deltaDiff, cut)
+					decodeReusableLegacy(gotOld, trunc, deltaDiff)
+					require.Equalf(t, gotOld, gotNew, "delta=%v cut=%d", deltaDiff, cut)
+				}
+			}
+		})
+	}
+}
+
+// TestVarIntDecodeOutputLengthMismatchMatchesLegacy pins the fastEnd clamp (output
+// shorter than the encoded count) and the exhaustion guards (output longer). Both
+// must match the reference decoder, with the overlapping prefix equal to the input.
+func TestVarIntDecodeOutputLengthMismatchMatchesLegacy(t *testing.T) {
+	rng := rand.New(rand.NewPCG(0x2233, 0x4455))
+	for _, wc := range widthCases {
+		t.Run(wc.name, func(t *testing.T) {
+			for _, deltaDiff := range []bool{false, true} {
+				maxVal := uint64(1)<<uint(wc.bnu) - 1
+				for _, m := range []int{2, 8, 64, 200} {
+					if deltaDiff && maxVal != 0 && uint64(m) > ^uint64(0)/maxVal {
+						continue
+					}
+					values := makeWidthValues(rng, m, wc.bnu, maxVal, deltaDiff)
+					packed := encodeWidthValues(values, deltaDiff, m)
+
+					// Output lengths around the encoded count; >= 4 keeps the
+					// bnu>32 fast path live so the fastEnd clamp is hit.
+					seen := map[int]bool{}
+					for _, outN := range []int{4, m - 1, m, m + 1, m + 50} {
+						if outN < 2 || seen[outN] {
+							continue
+						}
+						seen[outN] = true
+						gotNew := make([]uint64, outN)
+						gotOld := make([]uint64, outN)
+						require.NotPanicsf(t, func() { decodeReusable(gotNew, packed, deltaDiff) },
+							"delta=%v m=%d out=%d", deltaDiff, m, outN)
+						decodeReusableLegacy(gotOld, packed, deltaDiff)
+						require.Equalf(t, gotOld, gotNew, "delta=%v m=%d out=%d", deltaDiff, m, outN)
+
+						limit := min(outN, m)
+						require.Equalf(t, values[:limit], gotNew[:limit],
+							"delta=%v m=%d out=%d", deltaDiff, m, outN)
+					}
+				}
+			}
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/varenc/varint_difftest_test.go
+++ b/adapters/repos/db/lsmkv/varenc/varint_difftest_test.go
@@ -21,11 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// decodeReusableLegacy is the pre-PR (stable/v1.37) varint decoder, preserved
-// verbatim as a reference oracle. The reservoir / 64-bit-read rewrite claims to
-// be "bit-identical to stable/v1.37"; the differential tests below pin that
-// claim by requiring byte-identical output from the new decoder for every
-// validly-encoded buffer. If the new decoder ever diverges, these fail.
+// decodeReusableLegacy is a straightforward byte-by-byte varint decoder kept as
+// a reference oracle. The reservoir / 64-bit-read decoder must stay bit-identical
+// to it: the differential tests below require byte-identical output from both for
+// every validly-encoded buffer, and fail if the two ever diverge.
 func decodeReusableLegacy(deltas []uint64, packed []byte, deltaDiff bool) {
 	if len(packed) < 8 {
 		return
@@ -69,10 +68,10 @@ func decodeReusableLegacy(deltas []uint64, packed []byte, deltaDiff bool) {
 // 8/9-byte guard boundary and several non-block-aligned counts.
 var diffSizes = []int{1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 100, 127, 128, 129, 255, 256, 511, 512}
 
-// TestVarIntDecodeMatchesLegacyDecoder is the differential test backing the
-// PR's "bit-identical to stable/v1.37" claim: for both codecs, every supported
-// bit width, and a wide range of counts, the new decoder must produce exactly
-// the same values as the legacy decoder AND round-trip the original input.
+// TestVarIntDecodeMatchesLegacyDecoder is the differential test pinning decoder
+// bit-identity: for both codecs, every supported bit width, and a wide range of
+// counts, the reservoir decoder must produce exactly the same values as the
+// reference decoder AND round-trip the original input.
 func TestVarIntDecodeMatchesLegacyDecoder(t *testing.T) {
 	rng := rand.New(rand.NewPCG(0x5eed, 0x1337))
 
@@ -148,11 +147,11 @@ func makeWidthValues(rng *rand.Rand, n, bnu int, maxVal uint64, deltaDiff bool) 
 	return values
 }
 
-// TestVarIntDecodeShortBufferNoPanic pins the headline guard fix: the legacy
-// decoder read packed[8] after only checking len<8, so an exactly-8-byte buffer
-// panicked. The new len<9 guard must turn every sub-9-byte buffer into a safe
-// no-op for both codecs. (A valid encoding is always >= 9 bytes, so nothing
-// legitimate is rejected — see TestVarIntBitsNeededHeaderHasExpectedValue.)
+// TestVarIntDecodeShortBufferNoPanic pins the short-buffer guard: reading
+// packed[8] requires len >= 9, so the len<9 guard must turn every sub-9-byte
+// buffer into a safe no-op for both codecs. (A valid encoding is always >= 9
+// bytes, so nothing legitimate is rejected — see
+// TestVarIntBitsNeededHeaderHasExpectedValue.)
 func TestVarIntDecodeShortBufferNoPanic(t *testing.T) {
 	out := make([]uint64, 4)
 	for l := 0; l <= 9; l++ {
@@ -175,13 +174,12 @@ func TestVarIntDecodeEmptyOutputNoPanic(t *testing.T) {
 }
 
 // TestVarIntDecodeBnu59To63MatchesLegacy pins behavior in the unsupported width
-// range [59,63]. Both the new and legacy decoders lose high bits there because
-// the byte-refill tail overflows the 64-bit buffer (see the maxSupportedBnu
-// comment). This PR does not change that — it predates this code and never
-// occurs for BM25 doc-id/TF deltas — but the new decoder must stay byte-
-// identical to the legacy one across the full 6-bit header range. The NotEqual
-// assertion documents that the range is genuinely lossy today; if a future
-// change makes it round-trip, this test will flag that the format/decoder moved.
+// range [59,63]. Both decoders lose high bits there because the byte-refill tail
+// overflows the 64-bit buffer (see the maxSupportedBnu comment); this range never
+// occurs for BM25 doc-id/TF deltas. The reservoir decoder must stay byte-
+// identical to the reference one across the full 6-bit header range. The NotEqual
+// assertion documents that the range is genuinely lossy; if a future change makes
+// it round-trip, this test will flag that the format/decoder moved.
 func TestVarIntDecodeBnu59To63MatchesLegacy(t *testing.T) {
 	for bnu := 59; bnu <= 63; bnu++ {
 		t.Run(fmt.Sprintf("bnu=%d", bnu), func(t *testing.T) {

--- a/adapters/repos/db/lsmkv/varenc/varint_test.go
+++ b/adapters/repos/db/lsmkv/varenc/varint_test.go
@@ -1,0 +1,339 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package varenc
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The encoded format stores bitsNeeded in a 6-bit header field, so the largest
+// per-value bit width it can name is 63. The current decoder also loses bits
+// for bnu >= 59 because its byte-refill loop overflows the 64-bit buffer. The
+// tests below therefore cover bnu in [1, 58], which is the safely supported
+// range. Realistic delta/TF values are far below this ceiling.
+const maxSupportedBnu = 58
+
+// roundtripSizes covers small, boundary, and block-aligned sizes plus a few
+// large counts to exercise the fast and tail paths in decodeReusable.
+var roundtripSizes = []int{1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 200, 511, 512}
+
+func TestVarIntRoundtripFixedWidth(t *testing.T) {
+	// For each bit width in [1, maxSupportedBnu], generate values that exactly
+	// fit that width (including the boundary value 2^bnu - 1) and verify a
+	// full encode/decode roundtrip.
+	rng := rand.New(rand.NewPCG(0xdeadbeef, 0x12345678))
+
+	for bnu := 1; bnu <= maxSupportedBnu; bnu++ {
+		maxVal := uint64(1)<<uint(bnu) - 1
+		for _, n := range roundtripSizes {
+			t.Run(fmt.Sprintf("bnu=%d_n=%d", bnu, n), func(t *testing.T) {
+				values := make([]uint64, n)
+				values[0] = rng.Uint64() // first value is stored verbatim, can be anything
+				for i := 1; i < n; i++ {
+					if maxVal == 0 {
+						values[i] = 0
+					} else {
+						values[i] = rng.Uint64N(maxVal + 1)
+					}
+				}
+				// Force at least one boundary value so bitsNeeded is exactly bnu.
+				if n > 1 {
+					values[n-1] = maxVal
+				}
+
+				enc := &VarIntEncoder{}
+				enc.Init(n)
+				packed := enc.Encode(values)
+				decoded := enc.Decode(packed)
+				assert.Equal(t, values, decoded[:n])
+			})
+		}
+	}
+}
+
+func TestVarIntDeltaRoundtripFixedWidth(t *testing.T) {
+	// Same shape, but values are a non-decreasing cumulative sum so the deltas
+	// have a known bit width.
+	rng := rand.New(rand.NewPCG(0xc0ffee, 0xfeedface))
+
+	for bnu := 1; bnu <= maxSupportedBnu; bnu++ {
+		// Cap per-delta size by bnu and the count to keep the cumulative sum
+		// within uint64.
+		maxDelta := uint64(1)<<uint(bnu) - 1
+		for _, n := range roundtripSizes {
+			// Guard against overflow when n*maxDelta would wrap.
+			if maxDelta != 0 && uint64(n) > ^uint64(0)/maxDelta {
+				continue
+			}
+			t.Run(fmt.Sprintf("bnu=%d_n=%d", bnu, n), func(t *testing.T) {
+				values := make([]uint64, n)
+				values[0] = rng.Uint64N(1 << 30)
+				for i := 1; i < n; i++ {
+					var d uint64
+					if maxDelta == 0 {
+						d = 0
+					} else {
+						d = rng.Uint64N(maxDelta + 1)
+					}
+					values[i] = values[i-1] + d
+				}
+				if n > 1 {
+					// Force one boundary delta so bitsNeeded = bnu.
+					values[n-1] = values[n-2] + maxDelta
+				}
+
+				enc := &VarIntDeltaEncoder{}
+				enc.Init(n)
+				packed := enc.Encode(values)
+				decoded := enc.Decode(packed)
+				assert.Equal(t, values, decoded[:n])
+			})
+		}
+	}
+}
+
+func TestVarIntEdgeCases(t *testing.T) {
+	t.Run("single value", func(t *testing.T) {
+		// Only the first value, no deltas; should roundtrip unchanged.
+		for _, v := range []uint64{0, 1, 42, math.MaxUint32, math.MaxUint64} {
+			enc := &VarIntEncoder{}
+			enc.Init(1)
+			packed := enc.Encode([]uint64{v})
+			decoded := enc.Decode(packed)
+			assert.Equal(t, []uint64{v}, decoded[:1])
+		}
+	})
+
+	t.Run("all zero deltas", func(t *testing.T) {
+		// Non-delta encoder: all-zero values means bitsNeeded=1 (encoder enforces a
+		// minimum of 1 bit).
+		n := 128
+		values := make([]uint64, n)
+		// First value can be anything; the rest are zero.
+		values[0] = 1234
+
+		enc := &VarIntEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+
+	t.Run("delta encoder constant value", func(t *testing.T) {
+		// All values equal → all deltas zero → bitsNeeded=1.
+		n := 128
+		values := make([]uint64, n)
+		for i := range values {
+			values[i] = 42
+		}
+
+		enc := &VarIntDeltaEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+
+	t.Run("delta encoder strictly increasing by 1", func(t *testing.T) {
+		// The bnu=1 case in the fast reservoir path: maximum loads-per-refill.
+		n := 128
+		values := make([]uint64, n)
+		values[0] = 1000
+		for i := 1; i < n; i++ {
+			values[i] = values[i-1] + 1
+		}
+
+		enc := &VarIntDeltaEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+
+	t.Run("delta encoder max representable deltas", func(t *testing.T) {
+		// Deltas at the boundary of the supported bit width.
+		n := 64
+		maxDelta := uint64(1)<<maxSupportedBnu - 1
+		values := make([]uint64, n)
+		values[0] = 0
+		for i := 1; i < n; i++ {
+			values[i] = values[i-1] + maxDelta
+		}
+
+		enc := &VarIntDeltaEncoder{}
+		enc.Init(n)
+		packed := enc.Encode(values)
+		decoded := enc.Decode(packed)
+		assert.Equal(t, values, decoded[:n])
+	})
+}
+
+func TestVarIntFastAndTailPathCoverage(t *testing.T) {
+	// Force the decoder through both the reservoir fast path and the
+	// byte-by-byte tail by choosing block sizes such that the 32-bit refill
+	// runs out of room before processing every value.
+	//
+	// For bnu=8 and n=128, the encoded payload past the header is 127*8=1016
+	// bits = 127 bytes. Reservoir refills 4 bytes at a time, so the last few
+	// values are guaranteed to land in the tail. The roundtrip must still
+	// succeed.
+	for _, bnu := range []int{1, 2, 4, 8, 16, 24, 32} {
+		t.Run(fmt.Sprintf("reservoir_bnu=%d", bnu), func(t *testing.T) {
+			n := 128
+			maxVal := uint64(1)<<uint(bnu) - 1
+			rng := rand.New(rand.NewPCG(uint64(bnu), 0))
+			values := make([]uint64, n)
+			values[0] = rng.Uint64()
+			for i := 1; i < n; i++ {
+				values[i] = rng.Uint64N(maxVal + 1)
+			}
+			values[n-1] = maxVal // anchor bitsNeeded
+
+			enc := &VarIntEncoder{}
+			enc.Init(n)
+			packed := enc.Encode(values)
+			decoded := enc.Decode(packed)
+			require.Equal(t, values, decoded[:n])
+		})
+	}
+
+	// Same exercise for the uint64-load path (bnu in (32, 57]).
+	for _, bnu := range []int{33, 40, 48, 56} {
+		t.Run(fmt.Sprintf("uint64_load_bnu=%d", bnu), func(t *testing.T) {
+			n := 64
+			maxVal := uint64(1)<<uint(bnu) - 1
+			rng := rand.New(rand.NewPCG(uint64(bnu), 1))
+			values := make([]uint64, n)
+			values[0] = rng.Uint64()
+			for i := 1; i < n; i++ {
+				values[i] = rng.Uint64N(maxVal + 1)
+			}
+			values[n-1] = maxVal
+
+			enc := &VarIntEncoder{}
+			enc.Init(n)
+			packed := enc.Encode(values)
+			decoded := enc.Decode(packed)
+			require.Equal(t, values, decoded[:n])
+		})
+	}
+}
+
+func TestDecodeReusableReusesOutputBuffer(t *testing.T) {
+	// The Reusable variants are expected to write into a caller-provided slice
+	// without allocating. Verify two consecutive calls with different inputs
+	// produce the correct outputs in the same buffer.
+	enc := VarIntEncoder{}
+	enc1 := &VarIntEncoder{}
+	enc1.Init(32)
+
+	v1 := make([]uint64, 32)
+	v1[0] = 100
+	for i := 1; i < 32; i++ {
+		v1[i] = uint64(i * 3)
+	}
+	p1 := enc1.Encode(v1)
+
+	v2 := make([]uint64, 32)
+	v2[0] = 999_999
+	for i := 1; i < 32; i++ {
+		v2[i] = uint64(i)
+	}
+	p2 := enc1.Encode(v2)
+
+	out := make([]uint64, 32)
+	enc.DecodeReusable(p1, out)
+	assert.Equal(t, v1, out)
+	enc.DecodeReusable(p2, out)
+	assert.Equal(t, v2, out)
+}
+
+func TestVarIntBitsNeededHeaderHasExpectedValue(t *testing.T) {
+	// Confirm that the encoder writes the bitsNeeded value we expect for a
+	// known input, and that the decoder reads it back identically. This pins
+	// down the on-disk format so future format changes can't silently break
+	// readers in other segments.
+	for _, tc := range []struct {
+		name      string
+		values    []uint64
+		expectBnu int
+	}{
+		{"all_zero_deltas", []uint64{0, 0, 0, 0, 0, 0, 0, 0}, 1},
+		{"max_delta_3_bits", []uint64{0, 5, 7, 3, 0, 2}, 3},
+		{"max_delta_8_bits", []uint64{0, 255, 100, 200}, 8},
+		{"max_delta_16_bits", []uint64{0, 65535, 32000}, 16},
+		{"max_delta_32_bits", []uint64{0, math.MaxUint32, 1234}, 32},
+		{"max_delta_56_bits", []uint64{0, 1<<56 - 1, 0}, 56},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := &VarIntEncoder{}
+			enc.Init(len(tc.values))
+			packed := enc.Encode(tc.values)
+
+			// Header is the high 6 bits of packed[8].
+			require.GreaterOrEqual(t, len(packed), 9)
+			gotBnu := int((packed[8] >> 2) & 0x3F)
+			if tc.expectBnu == 0 {
+				// Encoder enforces a minimum of 1 bit even for all-zero deltas.
+				assert.Equal(t, 1, gotBnu)
+			} else {
+				assert.Equal(t, tc.expectBnu, gotBnu)
+			}
+
+			decoded := enc.Decode(packed)
+			assert.Equal(t, tc.values, decoded[:len(tc.values)])
+		})
+	}
+}
+
+// TestVarIntLargeBitWidthLimitation documents a known limitation in the
+// encoded format: bitsNeeded values above 58 are not safely supported.
+//   - The 6-bit header field can name at most 63 (so bnu=64 silently truncates
+//     to 0 and the decoder returns nothing).
+//   - For bnu in [59, 63] the decoder's byte-refill loop shifts a uint64 buffer
+//     left by 8 when it already holds >= 56 bits, losing the oldest 2 bits.
+//
+// In practice deltas requiring >= 59 bits never occur in the BM25 inverted
+// index use case (doc IDs and term frequencies fit comfortably below 2^40),
+// so this is documented rather than fixed. If a future caller starts feeding
+// values that need >= 59 bits, the format itself needs to change (wider
+// header, different refill strategy).
+func TestVarIntLargeBitWidthLimitation(t *testing.T) {
+	t.Run("bnu_64_truncated_to_zero", func(t *testing.T) {
+		// A delta requiring 64 bits would have bitsNeeded=64, which doesn't
+		// fit in the 6-bit header.
+		require.Equal(t, 64, bits.Len64(math.MaxUint64))
+
+		values := []uint64{0, math.MaxUint64}
+		enc := &VarIntEncoder{}
+		enc.Init(2)
+		packed := enc.Encode(values)
+
+		// The encoder wrote 64 in 6 bits, which is 0.
+		require.GreaterOrEqual(t, len(packed), 9)
+		gotBnu := int((packed[8] >> 2) & 0x3F)
+		assert.Equal(t, 0, gotBnu, "bnu=64 is truncated to 0 in the header")
+
+		// The decoder treats bnu=0 as invalid and returns without touching the
+		// remaining slots — only the first value comes through correctly.
+		decoded := enc.Decode(packed)
+		assert.Equal(t, uint64(0), decoded[0])
+		assert.Equal(t, uint64(0), decoded[1])
+	})
+}


### PR DESCRIPTION
### What's being changed
Speeds up varint decoding on the BlockMax-WAND block-read path: a reservoir-based decoder with 64-bit reads, plus an out-of-bounds guard in `decodeReusable`. Same decoded values; on-disk format unchanged.

| Benchmark | Original | uint64-load (intermediate) | Reservoir (this PR) | Δ |
|---|---|---|---|---|
| VarIntEncoder (bnu=8, spread) | 176 ns | 139 ns | 102 ns | −42 % |
| VarIntDeltaEncoder (bnu=1, sequential) | 132 ns | 138 ns | 80 ns | −39 % |
| DecoderMulti (mixed delta + TF) | 395 ns | 293 ns | 178 ns | −55 % |


_Part of the BM25 BlockMax-WAND performance series (see RFC/TDD). Bit-identical to `stable/v1.37` (same ranked top-K); on-disk format unchanged._