### PR TITLE
perf(lsmkv): lock-free atomic segment refcount

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -132,7 +133,7 @@ type segment struct {
 	invertedData   *segmentInvertedData
 
 	observeMetaWrite diskio.MeteredWriterCallback // used for precomputing meta (cna + bloom)
-	refCount         int
+	refCount         atomic.Int64
 
 	deleteMarkerSuffix string
 }
@@ -774,32 +775,21 @@ func (c *readObserverCache) GetOrCreate(key string, metrics *Metrics) BytesReadO
 	return observer
 }
 
-// WARNING: This method is NOT thread-safe on its own. The caller must ensure
-// that it is safe to read and manipulate the refs. In practice, this is done
-// using a SegmentGroup.segmentRefCounterLock which both protects against racy
-// access, as well as guarantees a consistent view across refs of ALL segments
-// in the group.
+// refCount is an atomic, so incRef/decRef/getRefs are individually thread-safe
+// and need no external lock. Acquiring a consistent view of refs across ALL
+// segments in a group is still serialized against compaction via the
+// SegmentGroup.maintenanceLock: incRef happens under its RLock, segment swaps
+// under its write lock, and segments awaiting drop only ever see refs decrease.
 func (s *segment) incRef() {
-	s.refCount++
+	s.refCount.Add(1)
 }
 
-// WARNING: This method is NOT thread-safe on its own. The caller must ensure
-// that it is safe to read and manipulate the refs. In practice, this is done
-// using a SegmentGroup.segmentRefCounterLock which both protects against racy
-// access, as well as guarantees a consistent view across refs of ALL segments
-// in the group.
 func (s *segment) decRef() {
-	if s.refCount <= 0 {
+	if s.refCount.Add(-1) < 0 {
 		panic("refCount already zero")
 	}
-	s.refCount--
 }
 
-// WARNING: This method is NOT thread-safe on its own. The caller must ensure
-// that it is safe to read and manipulate the refs. In practice, this is done
-// using a SegmentGroup.segmentRefCounterLock which both protects against racy
-// access, as well as guarantees a consistent view across refs of ALL segments
-// in the group.
 func (s *segment) getRefs() int {
-	return s.refCount
+	return int(s.refCount.Load())
 }

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -786,6 +786,7 @@ func (s *segment) incRef() {
 
 func (s *segment) decRef() {
 	if s.refCount.Add(-1) < 0 {
+		s.refCount.Add(1) // restore: a recovered panic must not pin the counter negative
 		panic("refCount already zero")
 	}
 }

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -41,8 +41,7 @@ import (
 )
 
 type SegmentGroup struct {
-	segments              []Segment
-	segmentRefCounterLock sync.Mutex
+	segments []Segment
 
 	// Holds compacted / cleaned up segments meant to be closed and removed from disk
 	// after their's refs counter drops to 0.
@@ -599,19 +598,18 @@ func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, relea
 	segments = make([]Segment, len(sg.segments))
 	copy(segments, sg.segments)
 
-	sg.segmentRefCounterLock.Lock()
+	// incRef under the RLock so the refs are taken before any compaction (which
+	// holds the write lock) can swap these segments out. refCount is atomic, so no
+	// separate refcount lock is needed.
 	for _, seg := range segments {
 		seg.incRef()
 	}
-	sg.segmentRefCounterLock.Unlock()
 	sg.maintenanceLock.RUnlock()
 
 	return segments, func() {
-		sg.segmentRefCounterLock.Lock()
 		for _, seg := range segments {
 			seg.decRef()
 		}
-		sg.segmentRefCounterLock.Unlock()
 	}
 }
 

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -566,8 +566,8 @@ func (sg *SegmentGroup) waitForReferenceCountToReachZero(segments ...Segment) {
 	var lastWarn time.Time
 	t := time.NewTicker(tickerInterval)
 	for {
-		sg.segmentRefCounterLock.Lock()
-
+		// these segments are already swapped out of the active set, so their refs
+		// only decrease; an atomic read per segment is sufficient.
 		allZero := true
 		var pos, count int
 		for i, seg := range segments {
@@ -578,8 +578,6 @@ func (sg *SegmentGroup) waitForReferenceCountToReachZero(segments ...Segment) {
 				break
 			}
 		}
-
-		sg.segmentRefCounterLock.Unlock()
 
 		if allZero {
 			return
@@ -637,33 +635,30 @@ func (sg *SegmentGroup) dropSegmentsAwaiting() (dropped int, err error) {
 	var maxWaitingSegment Segment
 	var maxWaitingRefs int
 
+	// segmentsAwaitingDrop is only touched by the (serial) compaction/cleanup
+	// cycle, and getRefs is an atomic read, so no lock is needed here.
 	toDrop := []Segment{}
-	func() {
-		sg.segmentRefCounterLock.Lock()
-		defer sg.segmentRefCounterLock.Unlock()
+	i := 0
+	for _, st := range sg.segmentsAwaitingDrop {
+		if refs := st.seg.getRefs(); refs == 0 {
+			toDrop = append(toDrop, st.seg)
+		} else {
+			sg.segmentsAwaitingDrop[i] = st
+			i++
 
-		i := 0
-		for _, st := range sg.segmentsAwaitingDrop {
-			if refs := st.seg.getRefs(); refs == 0 {
-				toDrop = append(toDrop, st.seg)
-			} else {
-				sg.segmentsAwaitingDrop[i] = st
-				i++
-
-				if !skipWarning {
-					if d := now.Sub(st.time); d >= warnThreshold {
-						waitingCount++
-						if d > maxWaitingDuration {
-							maxWaitingDuration = d
-							maxWaitingSegment = st.seg
-							maxWaitingRefs = refs
-						}
+			if !skipWarning {
+				if d := now.Sub(st.time); d >= warnThreshold {
+					waitingCount++
+					if d > maxWaitingDuration {
+						maxWaitingDuration = d
+						maxWaitingSegment = st.seg
+						maxWaitingRefs = refs
 					}
 				}
 			}
 		}
-		sg.segmentsAwaitingDrop = sg.segmentsAwaitingDrop[:i]
-	}()
+	}
+	sg.segmentsAwaitingDrop = sg.segmentsAwaitingDrop[:i]
 
 	if !skipWarning && maxWaitingDuration > 0 {
 		sg.segmentsAwaitingLastWarn = now

--- a/adapters/repos/db/lsmkv/segment_refcount_test.go
+++ b/adapters/repos/db/lsmkv/segment_refcount_test.go
@@ -60,6 +60,7 @@ func TestSegmentDecRefBelowZeroPanics(t *testing.T) {
 	t.Parallel()
 	s := &segment{}
 	require.Panics(t, func() { s.decRef() })
+	require.Equal(t, 0, s.getRefs()) // restored to 0, not pinned negative
 }
 
 // TestSegmentGroupConsistentViewConcurrent hammers the now lock-free

--- a/adapters/repos/db/lsmkv/segment_refcount_test.go
+++ b/adapters/repos/db/lsmkv/segment_refcount_test.go
@@ -1,0 +1,96 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSegmentRefCountAtomic verifies the lock-free atomic refcount: concurrent
+// incRef/decRef neither lose updates nor race. Run with -race to catch the
+// latter; the count assertions catch the former (a plain int would under-count).
+func TestSegmentRefCountAtomic(t *testing.T) {
+	t.Parallel()
+
+	s := &segment{}
+	const goroutines = 64
+	const perGoroutine = 20000
+
+	// wave 1: everyone incRefs — total must be exact (no lost increments)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				s.incRef()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, goroutines*perGoroutine, s.getRefs())
+
+	// wave 2: everyone decRefs — must land back exactly at zero
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				s.decRef()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 0, s.getRefs())
+}
+
+func TestSegmentDecRefBelowZeroPanics(t *testing.T) {
+	t.Parallel()
+	s := &segment{}
+	require.Panics(t, func() { s.decRef() })
+}
+
+// TestSegmentGroupConsistentViewConcurrent hammers the now lock-free
+// getConsistentViewOfSegments + release from many goroutines. -race proves the
+// refcount access is data-race-free without segmentRefCounterLock; the final
+// assertion proves every acquire is balanced by its release (refs return to 0).
+func TestSegmentGroupConsistentViewConcurrent(t *testing.T) {
+	t.Parallel()
+
+	segs := make([]Segment, 0, 4)
+	for i := 0; i < 4; i++ {
+		segs = append(segs, newFakeReplaceSegment(map[string][]byte{"k": []byte("v")}))
+	}
+	sg := &SegmentGroup{strategy: StrategyReplace, segments: segs}
+
+	const readers = 32
+	const iters = 10000
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_, release := sg.getConsistentViewOfSegments()
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, s := range sg.segments {
+		require.Equalf(t, 0, s.getRefs(), "segment %d should have no outstanding refs", i)
+	}
+}


### PR DESCRIPTION
### What's being changed
Makes segment reference counting lock-free: `segment.refCount` becomes an `atomic.Int64` and `SegmentGroup.segmentRefCounterLock` is removed. Cross-segment consistency is still serialized against compaction via the existing `maintenanceLock`. Reduces contention under concurrent queries; new `segment_refcount_test.go` covers the concurrent path.

_Independent; merge this before the Tier-1/setup PRs (all touch `segment.go`)._