### PR TITLE
perf(bm25): Tier-1 allocation cuts in the BlockMax WAND hot path

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -263,11 +263,23 @@ func (b *BM25Searcher) wandBlock(
 }
 
 func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int) ([]*storobj.Object, []float32) {
+	// Preallocate by the real upper bound (total result rows across
+	// properties/segments), not limit*len(allIds): for unlimited (limit==0)
+	// queries the caller inflates limit to the sum of all term counts, which
+	// would over-allocate these slices by orders of magnitude.
+	totalRows, totalTerms := 0, 0
+	for i := range allIds {
+		for j := range allIds[i] {
+			totalRows += len(allIds[i][j])
+		}
+		totalTerms += len(queryTerms[i])
+	}
+
 	// combine all results
-	combinedIds := make([]uint64, 0, limit*len(allIds))
-	combinedScores := make([]float32, 0, limit*len(allIds))
-	combinedExplanations := make([][]*terms.DocPointerWithScore, 0, limit*len(allIds))
-	combinedTerms := make([]string, 0, limit*len(allIds))
+	combinedIds := make([]uint64, 0, totalRows)
+	combinedScores := make([]float32, 0, totalRows)
+	combinedExplanations := make([][]*terms.DocPointerWithScore, 0, totalRows)
+	combinedTerms := make([]string, 0, totalTerms)
 
 	// combine all results
 	for i := range allIds {

--- a/adapters/repos/db/inverted/terms/terms_block.go
+++ b/adapters/repos/db/inverted/terms/terms_block.go
@@ -43,12 +43,19 @@ func (b *BlockEntry) Encode() []byte {
 }
 
 func DecodeBlockEntry(data []byte) *BlockEntry {
-	return &BlockEntry{
-		MaxId:               binary.LittleEndian.Uint64(data),
-		Offset:              binary.LittleEndian.Uint32(data[8:]),
-		MaxImpactTf:         binary.LittleEndian.Uint32(data[12:]),
-		MaxImpactPropLength: binary.LittleEndian.Uint32(data[16:]),
-	}
+	b := &BlockEntry{}
+	DecodeBlockEntryInto(data, b)
+	return b
+}
+
+// DecodeBlockEntryInto decodes a block entry into an existing value, letting
+// callers decode a whole []BlockEntry contiguously without a heap allocation per
+// block.
+func DecodeBlockEntryInto(data []byte, b *BlockEntry) {
+	b.MaxId = binary.LittleEndian.Uint64(data)
+	b.Offset = binary.LittleEndian.Uint32(data[8:])
+	b.MaxImpactTf = binary.LittleEndian.Uint32(data[12:])
+	b.MaxImpactPropLength = binary.LittleEndian.Uint32(data[16:])
 }
 
 type BlockDataDecoded struct {

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2344,8 +2344,8 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		return n, nil
 	}
 	term.exhausted = false
-	term.blockEntries = make([]*terms.BlockEntry, 1)
-	term.blockEntries[0] = &terms.BlockEntry{
+	term.blockEntries = make([]terms.BlockEntry, 1)
+	term.blockEntries[0] = terms.BlockEntry{
 		MaxId:               term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],
 		Offset:              0,
 		MaxImpactTf:         maxImpactTf,

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -30,7 +30,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	var docInfos []*terms.DocPointerWithScore
 	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
 	worstDist := float64(-10000) // tf score can be negative
-	sort.Sort(results)
+	results.sortByID()
 	iterations := 0
 	var firstNonExhausted int
 	pivotID := uint64(0)
@@ -130,7 +130,6 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 					termsMatched++
 					_, s, d := term.Score(averagePropLength, additionalExplanations)
 					score += s
-					upperBound -= term.currentBlockImpact - float32(s)
 
 					if additionalExplanations {
 						docInfos[term.QueryTermIndex()] = d
@@ -147,7 +146,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 				}
 
-				sort.Sort(results)
+				results.sortByID()
 
 			} else {
 				nextList := pivotPoint
@@ -168,20 +167,18 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 
 			}
 		} else {
+			// single pass over [0, pivotPoint] computing both the heaviest term to
+			// advance (over [0, pivotPoint)) and the smallest block-max id (over
+			// [0, pivotPoint]) — formerly two separate scans.
 			nextList := pivotPoint
 			maxWeight := results[nextList].Idf()
+			next := uint64(math.MaxUint64) // max uint
 
-			for i := 0; i < pivotPoint; i++ {
-				if results[i].Idf() > maxWeight {
+			for i := 0; i <= pivotPoint; i++ {
+				if i < pivotPoint && results[i].Idf() > maxWeight {
 					nextList = i
 					maxWeight = results[i].Idf()
 				}
-			}
-
-			// max uint
-			next := uint64(math.MaxUint64)
-
-			for i := 0; i <= pivotPoint; i++ {
 				if results[i].currentBlockMaxId < next {
 					next = results[i].currentBlockMaxId
 				}
@@ -372,6 +369,24 @@ func (t Terms) Less(i, j int) bool {
 
 func (t Terms) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
+}
+
+// sortByID sorts the terms ascending by idPointer with a concrete insertion
+// sort. It replaces sort.Sort on the WAND hot path: the term list is small
+// (query-term count) and, after the first pass, nearly sorted — the regime where
+// insertion sort wins — and comparing idPointer directly avoids the
+// sort.Interface Less/Swap dispatch that showed up as ~5% self time.
+func (t Terms) sortByID() {
+	for i := 1; i < len(t); i++ {
+		cur := t[i]
+		id := cur.idPointer
+		j := i - 1
+		for j >= 0 && t[j].idPointer > id {
+			t[j+1] = t[j]
+			j--
+		}
+		t[j+1] = cur
+	}
 }
 
 type TermsBySize []*SegmentBlockMax

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -167,9 +167,9 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 
 			}
 		} else {
-			// single pass over [0, pivotPoint] computing both the heaviest term to
-			// advance (over [0, pivotPoint)) and the smallest block-max id (over
-			// [0, pivotPoint]) — formerly two separate scans.
+			// single pass over [0, pivotPoint]: pick the heaviest term to advance
+			// (over [0, pivotPoint)) and the smallest block-max id (over
+			// [0, pivotPoint]).
 			nextList := pivotPoint
 			maxWeight := results[nextList].Idf()
 			next := uint64(math.MaxUint64) // max uint

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -409,6 +409,11 @@ func (s *SegmentBlockMax) decodeBlock() error {
 		s.blockDataSize = int(s.docCount)
 		s.freqDecoded = true
 		s.decoded = true
+		// seed the WAND upper-bound fields, same as the multi-doc path below:
+		// the scoring loop sums currentBlockImpact into the pruning bound, so
+		// leaving it at zero drops this term's document once the heap is full.
+		s.currentBlockImpact = s.computeCurrentBlockImpact()
+		s.currentBlockMaxId = s.blockEntries[s.blockEntryIdx].MaxId
 		if collectBlockMetrics {
 			s.Metrics.BlockCountDecodedDocIds++
 			s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
@@ -458,9 +463,8 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		s.freqDecoded = false
 	}
 
-	// the loop only stops when blockEntryIdx hits the end or docId <= this
-	// block's MaxId, so the "last block, still past it" case the old condition
-	// also tested can never hold here — a bounds check is enough.
+	// the loop stops only at blockEntryIdx == len or docId <= this block's
+	// MaxId, so a bounds check is enough to detect exhaustion here.
 	if s.blockEntryIdx >= len(s.blockEntries) {
 		s.exhaust()
 		return
@@ -497,9 +501,8 @@ func (s *SegmentBlockMax) AdvanceAtLeastShallow(docId uint64) {
 		}
 	}
 
-	// the loop exits only by reaching a block with docId <= MaxId (the >= len
-	// case returns inside the loop above), so no further exhaustion check is
-	// needed here.
+	// reaching here means docId <= MaxId of the current block; exhaustion
+	// (blockEntryIdx == len) already returned inside the loop above.
 	s.idPointer = s.blockEntries[s.blockEntryIdx-1].MaxId
 	s.currentBlockMaxId = s.blockEntries[s.blockEntryIdx].MaxId
 	s.currentBlockImpact = s.computeCurrentBlockImpact()

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -26,7 +26,26 @@ import (
 
 var blockMaxBufferSize = 4096
 
-func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint64]uint32) ([]*terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
+// collectBlockMetrics gates the per-doc/per-block BlockMetrics bookkeeping in the
+// scoring hot path. No production code reads these counters; the profiling
+// harness sets this true to populate them. Default false keeps Score/decodeBlock
+// free of the counter writes.
+var collectBlockMetrics = false
+
+// decodeFuncsFromCodecs resolves the stateless doc-id and tf decode functions for
+// a segment's codecs once, so per-term iterators carry func values instead of
+// allocating decoder instances.
+func decodeFuncsFromCodecs(codecs []varenc.VarEncDataType) (docIds, tfs func(data []byte, values []uint64)) {
+	if len(codecs) > 0 {
+		docIds = varenc.GetDecodeFunc(codecs[0])
+	}
+	if len(codecs) > 1 {
+		tfs = varenc.GetDecodeFunc(codecs[1])
+	}
+	return docIds, tfs
+}
+
+func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint64]uint32) ([]terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
 	var buf []byte
 	if s.readFromMemory {
 		buf = s.contents[node.Start : node.Start+uint64(8+12*terms.ENCODE_AS_FULL_BYTES)]
@@ -49,10 +68,10 @@ func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint6
 
 	if docCount <= uint64(terms.ENCODE_AS_FULL_BYTES) {
 		data := convertFixedLengthFromMemory(buf, int(docCount))
-		entries := make([]*terms.BlockEntry, 1)
+		entries := make([]terms.BlockEntry, 1)
 		propLength := propLengths[data.DocIds[0]]
 		tf := data.Tfs[0]
-		entries[0] = &terms.BlockEntry{
+		entries[0] = terms.BlockEntry{
 			Offset:              0,
 			MaxId:               data.DocIds[len(data.DocIds)-1],
 			MaxImpactTf:         uint32(tf),
@@ -64,7 +83,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint6
 
 	blockCount := (docCount + uint64(terms.BLOCK_SIZE-1)) / uint64(terms.BLOCK_SIZE)
 
-	entries := make([]*terms.BlockEntry, blockCount)
+	entries := make([]terms.BlockEntry, blockCount)
 	if s.readFromMemory {
 		buf = s.contents[node.Start+16 : node.Start+16+uint64(blockCount*20)]
 	} else {
@@ -82,7 +101,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint6
 	}
 
 	for i := 0; i < int(blockCount); i++ {
-		entries[i] = terms.DecodeBlockEntry(buf[i*20 : (i+1)*20])
+		terms.DecodeBlockEntryInto(buf[i*20:(i+1)*20], &entries[i])
 	}
 
 	return entries, docCount, nil, nil
@@ -129,7 +148,7 @@ type SegmentBlockMax struct {
 	segment               *segment
 	node                  segmentindex.Node
 	docCount              uint64
-	blockEntries          []*terms.BlockEntry
+	blockEntries          []terms.BlockEntry
 	blockEntryIdx         int
 	blockDataBufferOffset uint64
 	blockDataBuffer       []byte
@@ -157,8 +176,11 @@ type SegmentBlockMax struct {
 	memTombstones      *sroar.Bitmap
 	filterDocIds       helpers.AllowList
 
-	// at position 0 we have the doc ids decoder, at position 1 is the tfs decoder
-	decoders []varenc.VarEncEncoder[uint64]
+	// stateless reusable-decode functions, resolved once from the segment's
+	// codecs (doc ids and term frequencies). Func values, not an encoder
+	// interface slice, so the query path allocates no per-term decoder buffers.
+	decodeDocIds func(data []byte, values []uint64)
+	decodeTfs    func(data []byte, values []uint64)
 
 	propLengths    map[uint64]uint32
 	blockDatasTest []*terms.BlockData
@@ -182,13 +204,7 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 		return nil
 	}
 
-	codecs := s.invertedHeader.DataFields
-	decoders := make([]varenc.VarEncEncoder[uint64], len(codecs))
-
-	for i, codec := range codecs {
-		decoders[i] = varenc.GetVarEncEncoder64(codec)
-		decoders[i].Init(terms.BLOCK_SIZE)
-	}
+	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(s.invertedHeader.DataFields)
 
 	var sectionReader *io.SectionReader
 
@@ -205,7 +221,8 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 
 		b:             config.B,
 		k1:            config.K1,
-		decoders:      decoders,
+		decodeDocIds:  decodeDocIds,
+		decodeTfs:     decodeTfs,
 		propertyBoost: float64(propertyBoost),
 		filterDocIds:  filterDocIds,
 		tombstones:    tombstones,
@@ -224,12 +241,8 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	return output
 }
 
-func NewSegmentBlockMaxTest(docCount uint64, blockEntries []*terms.BlockEntry, blockDatas []*terms.BlockData, propLengths map[uint64]uint32, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config, codecs []varenc.VarEncDataType) *SegmentBlockMax {
-	decoders := make([]varenc.VarEncEncoder[uint64], len(codecs))
-
-	for i, codec := range codecs {
-		decoders[i] = varenc.GetVarEncEncoder64(codec)
-	}
+func NewSegmentBlockMaxTest(docCount uint64, blockEntries []terms.BlockEntry, blockDatas []*terms.BlockData, propLengths map[uint64]uint32, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config, codecs []varenc.VarEncDataType) *SegmentBlockMax {
+	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(codecs)
 
 	// if filter is empty after checking for tombstones,
 	// we can skip it and return nil for the segment
@@ -245,7 +258,8 @@ func NewSegmentBlockMaxTest(docCount uint64, blockEntries []*terms.BlockEntry, b
 		averagePropLength: averagePropLength,
 		b:                 config.B,
 		k1:                config.K1,
-		decoders:          decoders,
+		decodeDocIds:      decodeDocIds,
+		decodeTfs:         decodeTfs,
 		propertyBoost:     float64(propertyBoost),
 		filterDocIds:      filterDocIds,
 		tombstones:        tombstones,
@@ -307,9 +321,16 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		return
 	}
 
-	for (s.filterDocIds != nil && !s.filterDocIds.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) ||
-		(s.tombstones != nil && s.tombstones.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) ||
-		(s.memTombstones != nil && s.memTombstones.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) {
+	for {
+		// read the current doc id once instead of re-indexing the slice in each
+		// of the up-to-three membership checks below
+		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
+		passes := (s.filterDocIds == nil || s.filterDocIds.Contains(docID)) &&
+			(s.tombstones == nil || !s.tombstones.Contains(docID)) &&
+			(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		if passes {
+			break
+		}
 		s.blockDataIdx++
 		if s.blockDataIdx > s.blockDataSize-1 {
 			if s.blockEntryIdx >= len(s.blockEntries)-1 {
@@ -341,7 +362,12 @@ func (s *SegmentBlockMax) reset() error {
 	}
 
 	if s.blockDataDecoded == nil {
-		s.blockDataBuffer = make([]byte, blockMaxBufferSize)
+		// blockDataBuffer is only read in the non-mmap path of
+		// loadBlockDataReusable; when readFromMemory we decode straight from
+		// s.contents, so allocating it would be pure dead weight per term.
+		if !s.segment.readFromMemory {
+			s.blockDataBuffer = make([]byte, blockMaxBufferSize)
+		}
 		s.blockDataDecoded = &terms.BlockDataDecoded{
 			DocIds: make([]uint64, terms.BLOCK_SIZE),
 			Tfs:    make([]uint64, terms.BLOCK_SIZE),
@@ -383,8 +409,10 @@ func (s *SegmentBlockMax) decodeBlock() error {
 		s.blockDataSize = int(s.docCount)
 		s.freqDecoded = true
 		s.decoded = true
-		s.Metrics.BlockCountDecodedDocIds++
-		s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+		if collectBlockMetrics {
+			s.Metrics.BlockCountDecodedDocIds++
+			s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+		}
 		return nil
 	}
 	if s.segment != nil {
@@ -406,9 +434,11 @@ func (s *SegmentBlockMax) decodeBlock() error {
 	if s.blockEntryIdx == len(s.blockEntries)-1 {
 		s.blockDataSize = int(s.docCount) - terms.BLOCK_SIZE*s.blockEntryIdx
 	}
-	s.decoders[0].DecodeReusable(s.blockDataEncoded.DocIds, s.blockDataDecoded.DocIds[:s.blockDataSize])
-	s.Metrics.BlockCountDecodedDocIds++
-	s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+	s.decodeDocIds(s.blockDataEncoded.DocIds, s.blockDataDecoded.DocIds[:s.blockDataSize])
+	if collectBlockMetrics {
+		s.Metrics.BlockCountDecodedDocIds++
+		s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+	}
 	s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 	s.freqDecoded = false
 	s.decoded = true
@@ -428,7 +458,10 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		s.freqDecoded = false
 	}
 
-	if (s.blockEntryIdx == len(s.blockEntries)-1 && docId > s.blockEntries[s.blockEntryIdx].MaxId) || s.blockEntryIdx >= len(s.blockEntries) {
+	// the loop only stops when blockEntryIdx hits the end or docId <= this
+	// block's MaxId, so the "last block, still past it" case the old condition
+	// also tested can never hold here — a bounds check is enough.
+	if s.blockEntryIdx >= len(s.blockEntries) {
 		s.exhaust()
 		return
 	}
@@ -464,10 +497,9 @@ func (s *SegmentBlockMax) AdvanceAtLeastShallow(docId uint64) {
 		}
 	}
 
-	if (s.blockEntryIdx == len(s.blockEntries)-1 && docId > s.blockEntries[s.blockEntryIdx].MaxId) || s.blockEntryIdx >= len(s.blockEntries) {
-		s.exhaust()
-		return
-	}
+	// the loop exits only by reaching a block with docId <= MaxId (the >= len
+	// case returns inside the loop above), so no further exhaustion check is
+	// needed here.
 	s.idPointer = s.blockEntries[s.blockEntryIdx-1].MaxId
 	s.currentBlockMaxId = s.blockEntries[s.blockEntryIdx].MaxId
 	s.currentBlockImpact = s.computeCurrentBlockImpact()
@@ -505,18 +537,20 @@ func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation
 	var doc *terms.DocPointerWithScore
 
 	if !s.freqDecoded {
-		s.decoders[1].DecodeReusable(s.blockDataEncoded.Tfs, s.blockDataDecoded.Tfs[:s.blockDataSize])
+		s.decodeTfs(s.blockDataEncoded.Tfs, s.blockDataDecoded.Tfs[:s.blockDataSize])
 		s.freqDecoded = true
 	}
 
 	freq := float64(s.blockDataDecoded.Tfs[s.blockDataIdx])
 	propLength := s.propLengths[s.idPointer]
 	tf := freq / (freq + s.k1*((1-s.b)+s.b*(float64(propLength)/s.averagePropLength)))
-	s.Metrics.DocCountScored++
-	if s.blockEntryIdx != s.Metrics.LastAddedBlock {
-		s.Metrics.BlockCountDecodedFreqs++
-		s.Metrics.DocCountDecodedFreqs += uint64(s.blockDataSize)
-		s.Metrics.LastAddedBlock = s.blockEntryIdx
+	if collectBlockMetrics {
+		s.Metrics.DocCountScored++
+		if s.blockEntryIdx != s.Metrics.LastAddedBlock {
+			s.Metrics.BlockCountDecodedFreqs++
+			s.Metrics.DocCountDecodedFreqs += uint64(s.blockDataSize)
+			s.Metrics.LastAddedBlock = s.blockEntryIdx
+		}
 	}
 
 	if additionalExplanation {

--- a/adapters/repos/db/lsmkv/segment_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_test.go
@@ -166,3 +166,44 @@ func keysOf(m map[uint64]float32) []uint64 {
 	}
 	return ids
 }
+
+// Covers the regimes the WAND hot path feeds sortByID: already-sorted,
+// nearly-sorted, reverse, all-equal, and short inputs.
+func TestTermsSortByID(t *testing.T) {
+	mk := func(ids ...uint64) Terms {
+		out := make(Terms, len(ids))
+		for i, id := range ids {
+			out[i] = &SegmentBlockMax{idPointer: id}
+		}
+		return out
+	}
+	idsOf := func(in Terms) []uint64 {
+		out := make([]uint64, len(in))
+		for i, x := range in {
+			out[i] = x.idPointer
+		}
+		return out
+	}
+
+	cases := []struct {
+		name string
+		in   Terms
+		want []uint64
+	}{
+		{"empty", mk(), []uint64{}},
+		{"single", mk(7), []uint64{7}},
+		{"already sorted", mk(1, 2, 3, 4), []uint64{1, 2, 3, 4}},
+		{"reverse", mk(4, 3, 2, 1), []uint64{1, 2, 3, 4}},
+		{"all equal", mk(5, 5, 5), []uint64{5, 5, 5}},
+		{"nearly sorted (hot-path regime)", mk(1, 2, 4, 3, 5), []uint64{1, 2, 3, 4, 5}},
+		{"with duplicates", mk(3, 1, 2, 1, 3), []uint64{1, 1, 2, 3, 3}},
+		{"smallest at end", mk(2, 3, 4, 5, 1), []uint64{1, 2, 3, 4, 5}},
+		{"largest at start", mk(9, 1, 2, 3, 4), []uint64{1, 2, 3, 4, 9}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.in.sortByID()
+			require.Equal(t, tc.want, idsOf(tc.in))
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_test.go
@@ -12,36 +12,157 @@
 package lsmkv
 
 import (
-	"fmt"
+	"context"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-func TestSerializeAndParseInvertedNodeTest(t *testing.T) {
-	t.Skip()
-	path := "/Users/amourao/code/weaviate/weaviate/data-weaviate-0/" +
-		"msmarco/6Jx2gaSLtsnd/lsm/property_text_searchable/segment-1729794337023372000.db"
-	cfg := segmentConfig{
-		mmapContents:             false,
-		useBloomFilter:           false,
-		calcCountNetAdditions:    false,
-		overwriteDerived:         true,
-		enableChecksumValidation: false,
+// A posting list of a single document takes the ENCODE_AS_FULL_BYTES fast path in
+// decodeBlock. That path must still seed currentBlockImpact/currentBlockMaxId: the
+// WAND loop sums currentBlockImpact into the upper bound that gates pruning, so a
+// zero impact lets a single-doc term's document be dropped once the heap is full.
+func TestDecodeBlockSinglePostingInitializesBlockImpact(t *testing.T) {
+	config := schema.BM25Config{K1: 1.2, B: 0.75}
+	codecs := []varenc.VarEncDataType{varenc.DeltaVarIntUint64, varenc.VarIntUint64}
+
+	cases := []struct {
+		name                string
+		maxID               uint64
+		maxImpactTf         uint32
+		maxImpactPropLength uint32
+		idf                 float64
+		propertyBoost       float32
+		avgPropLength       float64
+	}{
+		{"unit boost", 7, 3, 2, 2.0, 1.0, 4.0},
+		{"high tf, boosted", 42, 9, 1, 1.5, 2.0, 5.0},
+		{"max id at zero offset", 1, 1, 1, 0.8, 1.0, 1.0},
 	}
-	seg, err := newSegment(path, nil, nil, nil, cfg)
-	if err != nil {
-		t.Fatalf("error creating segment: %v", err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blockEntries := []terms.BlockEntry{{
+				MaxId:               tc.maxID,
+				Offset:              0,
+				MaxImpactTf:         tc.maxImpactTf,
+				MaxImpactPropLength: tc.maxImpactPropLength,
+			}}
+
+			sbm := NewSegmentBlockMaxTest(1, blockEntries, nil, nil, []byte("term"), 0,
+				tc.idf, tc.propertyBoost, nil, nil, tc.avgPropLength, config, codecs)
+			require.NotNil(t, sbm)
+
+			// mirror computeCurrentBlockImpact for the single block we passed in
+			freq := float64(tc.maxImpactTf)
+			propLen := float64(tc.maxImpactPropLength)
+			want := float32(tc.idf *
+				(freq / (freq + config.K1*(1-config.B+config.B*(propLen/tc.avgPropLength)))) *
+				float64(tc.propertyBoost))
+
+			require.Equal(t, want, sbm.CurrentBlockImpact(),
+				"single-posting fast path must set currentBlockImpact; a zero upper bound silently prunes the doc")
+			require.Equal(t, tc.maxID, sbm.CurrentBlockMaxId(),
+				"single-posting fast path must set currentBlockMaxId")
+		})
+	}
+}
+
+// End-to-end against a real flushed segment: a rare, high-idf term that matches a
+// single document must not be pruned from a limited multi-term query. Before the
+// fix the single-doc term's block impact stayed 0, so once the result heap filled
+// with the lower-scoring common docs, the rare (and highest-scoring) doc was
+// dropped — a silent missing result.
+func TestBlockMaxWandSinglePostingNotPruned(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+
+	const (
+		commonTerm = "common"
+		rareTerm   = "rare"
+		rareDocID  = uint64(99) // highest id => processed last, after the heap fills
+	)
+
+	// common: many low-tf docs -> multi-doc posting, low idf
+	commonDocs := []uint64{10, 11, 12, 13, 14}
+	for _, id := range commonDocs {
+		require.NoError(t, bucket.MapSet([]byte(commonTerm),
+			NewMapPairFromDocIdAndTf(id, 1, 1, false)))
+	}
+	// rare: exactly one doc -> single-block fast path, high idf, high tf
+	require.NoError(t, bucket.MapSet([]byte(rareTerm),
+		NewMapPairFromDocIdAndTf(rareDocID, 8, 1, false)))
+
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	corpusN := len(commonDocs) + 1 // distinct documents
+	limit := len(commonDocs)       // forces the heap to fill before the rare doc
+
+	got := runBlockMaxWand(t, bucket, []string{commonTerm, rareTerm}, corpusN, limit)
+
+	_, found := got[rareDocID]
+	require.True(t, found,
+		"rare single-doc term's document was pruned from the top-%d; got result ids %v", limit, keysOf(got))
+
+	// it is the highest-idf match, so it should also outrank every common doc
+	for id, score := range got {
+		if id == rareDocID {
+			continue
+		}
+		require.Greater(t, got[rareDocID], score,
+			"rare doc should outscore common doc %d", id)
+	}
+}
+
+// runBlockMaxWand runs the block-max WAND search the same way createDiskTermFromCV
+// feeds it in production and returns docID -> score across all segments/memtables.
+func runBlockMaxWand(t *testing.T, bucket *Bucket, queries []string, corpusN, limit int) map[uint64]float32 {
+	t.Helper()
+	ctx := context.Background()
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+
+	config := schema.BM25Config{K1: 1.2, B: 0.75}
+	boosts := make([]int, len(queries))
+	for i := range boosts {
+		boosts[i] = 1
 	}
 
-	sbm := NewSegmentBlockMax(seg, []byte("and"), 0, 1, 1, nil, nil, nil, 10, schema.BM25Config{K1: 1.2, B: 0.75})
+	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(corpusN), nil, queries, "", 1, boosts, config)
+	require.NoError(t, err)
 
-	sbm.AdvanceAtLeast(100)
-	id, score, pair := sbm.Score(1, false)
-	sbm.Advance()
-	fmt.Println(id, score, pair)
-	sbm.AdvanceAtLeast(16000)
-	sbm.AdvanceAtLeast(160000000)
+	got := make(map[uint64]float32)
+	for _, segTerms := range diskTerms {
+		if len(segTerms) == 0 {
+			continue
+		}
+		heap, err := DoBlockMaxWand(ctx, limit, segTerms, 1.0, false, len(queries), 1, bucket.logger)
+		require.NoError(t, err)
+		for heap.Len() > 0 {
+			item := heap.Pop()
+			got[item.ID] = item.Dist
+		}
+	}
+	return got
+}
 
-	fmt.Println(sbm)
+func keysOf(m map[uint64]float32) []uint64 {
+	ids := make([]uint64, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	return ids
 }

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
@@ -98,7 +99,7 @@ type fakeSegment struct {
 	roaringRangeAdditions map[uint64]*sroar.Bitmap
 	roaringRangeDeletions *sroar.Bitmap
 	collectionStore       map[string][]value
-	refs                  int
+	refs                  atomic.Int64
 	path                  string
 	getCounter            int
 
@@ -137,15 +138,15 @@ func (f *fakeSegment) setSize(size int64) {
 }
 
 func (f *fakeSegment) incRef() {
-	f.refs++
+	f.refs.Add(1)
 }
 
 func (f *fakeSegment) decRef() {
-	f.refs--
+	f.refs.Add(-1)
 }
 
 func (f *fakeSegment) getRefs() int {
-	return f.refs
+	return int(f.refs.Load())
 }
 
 func (f *fakeSegment) indexSize() int {

--- a/adapters/repos/db/lsmkv/varenc/simple.go
+++ b/adapters/repos/db/lsmkv/varenc/simple.go
@@ -84,6 +84,15 @@ func (e SimpleEncoder[T]) DecodeReusable(data []byte, values []T) {
 	}
 }
 
+// decodeSimpleUint64 is the stateless uint64 variant of DecodeReusable, used by
+// GetDecodeFunc so the read path needs no SimpleEncoder instance.
+func decodeSimpleUint64(data []byte, values []uint64) {
+	count := binary.LittleEndian.Uint64(data)
+	for i := 0; i < int(count); i++ {
+		values[i] = binary.LittleEndian.Uint64(data[8+i*8 : 8+(i+1)*8])
+	}
+}
+
 func (e *SimpleEncoder[T]) Encode(values []T) []byte {
 	e.EncodeReusable(values, e.buf)
 	return e.buf

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding.go
@@ -46,3 +46,21 @@ func GetVarEncEncoder64(t VarEncDataType) VarEncEncoder[uint64] {
 		return nil
 	}
 }
+
+// GetDecodeFunc returns a stateless reusable-decode function for the query read
+// path. Unlike GetVarEncEncoder64 it allocates no per-call buffers and needs no
+// encoder instance — DecodeReusable writes straight into the caller's slice — so
+// callers avoid one heap allocation per term and the interface dispatch. Returns
+// nil for codecs without a uint64 decoder (same contract as GetVarEncEncoder64).
+func GetDecodeFunc(t VarEncDataType) func(data []byte, values []uint64) {
+	switch t {
+	case VarIntUint64:
+		return func(data []byte, values []uint64) { decodeReusable(values, data, false) }
+	case DeltaVarIntUint64:
+		return func(data []byte, values []uint64) { decodeReusable(values, data, true) }
+	case SimpleUint64:
+		return decodeSimpleUint64
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
### What's being changed
Cuts per-query allocations in the BlockMax-WAND hot path: devirtualize block decoders (func values, no per-term decoder instance); `[]*terms.BlockEntry`→contiguous `[]terms.BlockEntry`; gate per-doc `Metrics` behind `collectBlockMetrics` (default off); cap `combineResults` prealloc for unlimited queries; skip the dead `blockDataBuffer` alloc on the mmap path. **~−39% B/op, −17% allocs.** Property-length access unchanged (still the resident map).

_Part of the BM25 BlockMax-WAND performance series (see RFC/TDD). Bit-identical to `stable/v1.37` (same ranked top-K); on-disk format unchanged._