### PR TITLE
perf(bm25): defer tombstone checks from advance-time to scoring

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_inverted_delete_test.go
+++ b/adapters/repos/db/lsmkv/bucket_inverted_delete_test.go
@@ -389,3 +389,71 @@ func runTombstoneInvertedCompactionTest(t *testing.T, size int) {
 		})
 	}
 }
+
+// TestBlockMaxWand_DeferTombstone_FlagEquivalence guards against divergence
+// between the deferred (scoring-time) and legacy (advance-time) tombstone
+// paths in BMW — see PR #11774.
+func TestBlockMaxWand_DeferTombstone_FlagEquivalence(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+	key := []byte("key1")
+	tombstonedDocID := uint64(42)
+
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.Nil(t, err)
+	b.SetMemtableThreshold(1e9)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	// varying tf so per-doc scores differ — top-K ordering becomes meaningful
+	for id := uint64(10); id <= 50; id++ {
+		require.NoError(t, b.MapSet(key,
+			NewMapPairFromDocIdAndTf(id, float32(id), 1, false)))
+	}
+	require.NoError(t, b.FlushAndSwitch())
+
+	// cross-segment tombstone for doc 42
+	tomb := NewMapPairFromDocIdAndTf(tombstonedDocID, 1, 1, true)
+	require.NoError(t, b.MapSet(key, tomb))
+	require.NoError(t, b.MapDeleteKey(key, tomb.Key))
+	require.NoError(t, b.FlushAndSwitch())
+
+	runQuery := func(deferToScore bool) map[uint64]float32 {
+		deferTombstoneToScore = deferToScore
+
+		view := b.GetConsistentView()
+		defer view.release()
+
+		N := 1000
+		diskTerms, _, _, err := b.createDiskTermFromCV(ctx, view, float64(N), nil,
+			[]string{string(key)}, "", 1, []int{1},
+			schema.BM25Config{K1: 1.2, B: 0.75})
+		require.NoError(t, err)
+
+		out := make(map[uint64]float32)
+		for _, dt := range diskTerms {
+			h, err := DoBlockMaxWand(ctx, N, dt, 1.0, true, 1, 1, b.logger)
+			require.NoError(t, err)
+			for h.Len() > 0 {
+				it := h.Pop()
+				out[it.ID] = it.Dist
+			}
+		}
+		return out
+	}
+
+	orig := deferTombstoneToScore
+	t.Cleanup(func() { deferTombstoneToScore = orig })
+
+	deferred := runQuery(true)
+	legacy := runQuery(false)
+
+	// 41 docs written, 1 tombstoned — the Len guard catches "BMW returned nothing"
+	const expectedHits = 40
+	require.Len(t, deferred, expectedHits)
+	require.Len(t, legacy, expectedHits)
+	require.Equal(t, legacy, deferred)
+	require.NotContains(t, deferred, tombstonedDocID)
+	require.NotContains(t, legacy, tombstonedDocID)
+}

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -131,29 +131,34 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 				docInfos = make([]*terms.DocPointerWithScore, termCount)
 			}
 			if pivotID == results[firstNonExhausted].idPointer {
-				score := 0.0
-				termsMatched := 0
-				for _, term := range results {
-					if term.idPointer != pivotID {
-						break
-					}
-					termsMatched++
-					_, s, d := term.Score(averagePropLength, additionalExplanations)
-					score += s
+				// a deferred tombstone hit: advance the aligned terms past the pivot
+				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
+				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
+				if !pivotTombstoned {
+					score := 0.0
+					termsMatched := 0
+					for _, term := range results {
+						if term.idPointer != pivotID {
+							break
+						}
+						termsMatched++
+						_, s, d := term.Score(averagePropLength, additionalExplanations)
+						score += s
 
-					if additionalExplanations {
-						docInfos[term.QueryTermIndex()] = d
-					}
+						if additionalExplanations {
+							docInfos[term.QueryTermIndex()] = d
+						}
 
+					}
+					if topKHeap.ShouldEnqueue(float32(score), limit) && termsMatched >= minimumOrTokensMatch {
+						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+					}
 				}
 				for _, term := range results {
 					if !term.exhausted && term.idPointer != pivotID {
 						break
 					}
 					term.Advance()
-				}
-				if topKHeap.ShouldEnqueue(float32(score), limit) && termsMatched >= minimumOrTokensMatch {
-					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 				}
 
 				results.sortByID()
@@ -291,20 +296,28 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 				}
 			}
 			if isCandidate {
-				score := 0.0
-				if additionalExplanations {
-					docInfos = make([]*terms.DocPointerWithScore, termCount)
-				}
-				for _, term := range results {
-					_, s, d := term.Score(averagePropLength, additionalExplanations)
-					score += s
-					if additionalExplanations {
-						docInfos[term.QueryTermIndex()] = d
+				// deferred tombstone hit (see deferTombstoneToScore): advance past the
+				// candidate without scoring it.
+				if deferTombstoneToScore && results[0].tombstoned(pivotID) {
+					for _, term := range results {
+						term.Advance()
 					}
-					term.Advance()
-				}
-				if topKHeap.ShouldEnqueue(float32(score), limit) {
-					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+				} else {
+					score := 0.0
+					if additionalExplanations {
+						docInfos = make([]*terms.DocPointerWithScore, termCount)
+					}
+					for _, term := range results {
+						_, s, d := term.Score(averagePropLength, additionalExplanations)
+						score += s
+						if additionalExplanations {
+							docInfos[term.QueryTermIndex()] = d
+						}
+						term.Advance()
+					}
+					if topKHeap.ShouldEnqueue(float32(score), limit) {
+						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+					}
 				}
 			} else {
 				pivotID += 1

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -127,14 +127,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
-			if additionalExplanations {
-				docInfos = make([]*terms.DocPointerWithScore, termCount)
-			}
 			if pivotID == results[firstNonExhausted].idPointer {
 				// a deferred tombstone hit: advance the aligned terms past the pivot
 				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
 				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
 				if !pivotTombstoned {
+					if additionalExplanations {
+						docInfos = make([]*terms.DocPointerWithScore, termCount)
+					}
 					score := 0.0
 					termsMatched := 0
 					for _, term := range results {

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -353,8 +353,7 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
 		passes := s.filterDocIds == nil || s.filterDocIds.Contains(docID)
 		if passes && checkTomb {
-			passes = (s.tombstones == nil || !s.tombstones.Contains(docID)) &&
-				(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+			passes = !s.tombstoned(docID)
 		}
 		if passes {
 			break

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -377,8 +377,8 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 }
 
 // tombstoned reports whether docID is deleted in this iterator's view. All terms
-// in a segment share its tombstone bitmaps, so any aligned term answers for the
-// pivot.
+// in a segment share the same tombstone bitmaps, so any one of them can report
+// tombstone status for a pivot they all align on.
 func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
 	return (s.tombstones != nil && s.tombstones.Contains(docID)) ||
 		(s.memTombstones != nil && s.memTombstones.Contains(docID))

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -32,6 +32,14 @@ var blockMaxBufferSize = 4096
 // free of the counter writes.
 var collectBlockMetrics = false
 
+// deferTombstoneToScore rejects tombstoned (deleted) docs in the DoBlockMax*
+// scoring branch rather than skipping them per advance. Filters stay at advance
+// time because they prune the WAND candidate space; a tombstone does not (the
+// deleted doc still occupies its posting slot and is still visited), so probing it
+// per advanced doc is pure overhead. Bit-identical either way — a doc dropped at
+// scoring affects neither other scores nor the heap threshold.
+var deferTombstoneToScore = true
+
 // decodeFuncsFromCodecs resolves the stateless doc-id and tf decode functions for
 // a segment's codecs once, so per-term iterators carry func values instead of
 // allocating decoder instances.
@@ -331,7 +339,8 @@ func NewSegmentBlockMaxDecoded(key []byte, queryTermIndex int, propertyBoost flo
 }
 
 func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
-	if (s.filterDocIds == nil && s.tombstones == nil && s.memTombstones == nil) || s.exhausted {
+	checkTomb := !deferTombstoneToScore && (s.tombstones != nil || s.memTombstones != nil)
+	if (s.filterDocIds == nil && !checkTomb) || s.exhausted {
 		if !s.exhausted {
 			s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 		}
@@ -342,9 +351,11 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		// read the current doc id once instead of re-indexing the slice in each
 		// of the up-to-three membership checks below
 		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
-		passes := (s.filterDocIds == nil || s.filterDocIds.Contains(docID)) &&
-			(s.tombstones == nil || !s.tombstones.Contains(docID)) &&
-			(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		passes := s.filterDocIds == nil || s.filterDocIds.Contains(docID)
+		if passes && checkTomb {
+			passes = (s.tombstones == nil || !s.tombstones.Contains(docID)) &&
+				(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		}
 		if passes {
 			break
 		}
@@ -363,6 +374,14 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 	if !s.exhausted {
 		s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 	}
+}
+
+// tombstoned reports whether docID is deleted in this iterator's view. All terms
+// in a segment share its tombstone bitmaps, so any aligned term answers for the
+// pivot.
+func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
+	return (s.tombstones != nil && s.tombstones.Contains(docID)) ||
+		(s.memTombstones != nil && s.memTombstones.Contains(docID))
 }
 
 func (s *SegmentBlockMax) reset() error {


### PR DESCRIPTION
### What's being changed
Tombstones don't prune the WAND candidate space, so probing them at advance time only forces extra advances. Moves the check into the scoring branch (tombstoned pivot advanced past, never scored/enqueued), gated by `deferTombstoneToScore` (default true); filters stay at advance. **Neutral with no tombstones, ~−26% at 2% tombstone density.**

_Part of the BM25 BlockMax-WAND series; **stacked** — based on its predecessor branch, so the diff shown is only this PR's change. Bit-identical to stable._