### PR TITLE
perf(bm25): tighten block-entry scanning in the WAND loop

### DIFF
--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -37,7 +37,8 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	var pivotPoint int
 	upperBound := float32(0)
 
-	// nil for a non-cancellable ctx; guard below then skips the select.
+	// a nil ctx is tolerated (some callers pass none): a nil done channel never
+	// selects, so cancellation is simply disabled rather than panicking.
 	var done <-chan struct{}
 	if ctx != nil {
 		done = ctx.Done()

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -116,10 +116,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		upperBound = float32(0)
-		for i := 0; i <= pivotPoint; i++ {
-			// No exhausted guard: shallow-advance no-ops and impact is 0 when
-			// exhausted; and currentBlockMaxId isn't an exhausted sentinel (can be 0).
-			t := results[i]
+		// reslice to [0,pivotPoint] (pivotPoint < len, guaranteed by the pivotID
+		// check above) so the compiler drops the per-iteration bounds check.
+		candidates := results[:pivotPoint+1]
+		for i := range candidates {
+			// exhausted terms carry currentBlockMaxId==MaxUint64 (so the shallow
+			// advance is skipped) and currentBlockImpact==0 (so the add is a no-op),
+			// so no explicit exhausted guard is needed here.
+			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
 				t.AdvanceAtLeastShallow(pivotID)
 			}
@@ -127,10 +131,11 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
-			if pivotID == results[firstNonExhausted].idPointer {
+			firstTerm := results[firstNonExhausted]
+			if pivotID == firstTerm.idPointer {
 				// a deferred tombstone hit: advance the aligned terms past the pivot
 				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
-				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
+				pivotTombstoned := deferTombstoneToScore && firstTerm.tombstoned(pivotID)
 				if !pivotTombstoned {
 					if additionalExplanations {
 						docInfos = make([]*terms.DocPointerWithScore, termCount)
@@ -179,13 +184,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			maxWeight := results[nextList].idf
 			next := uint64(math.MaxUint64) // max uint
 
-			for i := 0; i <= pivotPoint; i++ {
-				if i < pivotPoint && results[i].idf > maxWeight {
+			candidates := results[:pivotPoint+1]
+			for i := range candidates {
+				t := candidates[i]
+				if i < pivotPoint && t.idf > maxWeight {
 					nextList = i
-					maxWeight = results[i].idf
+					maxWeight = t.idf
 				}
-				if results[i].currentBlockMaxId < next {
-					next = results[i].currentBlockMaxId
+				if t.currentBlockMaxId < next {
+					next = t.currentBlockMaxId
 				}
 			}
 
@@ -231,40 +238,41 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 		return topKHeap
 	}
 
+	ctxCheck := 0
 	for {
 		iterations++
 
-		if iterations%100000 == 0 && ctx != nil && ctx.Err() != nil {
-			segmentPath := ""
-			terms := ""
-			filterCardinality := -1
-			for _, r := range results {
-				if r == nil {
-					continue
-				}
-				if r.segment != nil {
-					segmentPath = r.segment.path
-					if r.filterDocIds != nil {
-						filterCardinality = r.filterDocIds.Len()
+		// periodic cancellation check; countdown instead of a 64-bit modulo on the
+		// hot loop (same change as DoBlockMaxWand), same every-100000 cadence.
+		ctxCheck++
+		if ctxCheck == 100000 {
+			ctxCheck = 0
+			if ctx != nil && ctx.Err() != nil {
+				segmentPath := ""
+				terms := ""
+				filterCardinality := -1
+				for _, r := range results {
+					if r == nil {
+						continue
 					}
+					if r.segment != nil {
+						segmentPath = r.segment.path
+						if r.filterDocIds != nil {
+							filterCardinality = r.filterDocIds.Len()
+						}
+					}
+					terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
 				}
-				terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
-			}
-			logger.WithFields(logrus.Fields{
-				"segment":           segmentPath,
-				"iterations":        iterations,
-				"pivotID":           pivotID,
-				"lenResults":        len(results),
-				"upperBound":        upperBound,
-				"terms":             terms,
-				"filterCardinality": filterCardinality,
-				"limit":             limit,
-			}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
-			return topKHeap
-		}
-
-		for i := 0; i < len(results); i++ {
-			if results[i].exhausted {
+				logger.WithFields(logrus.Fields{
+					"segment":           segmentPath,
+					"iterations":        iterations,
+					"pivotID":           pivotID,
+					"lenResults":        len(results),
+					"upperBound":        upperBound,
+					"terms":             terms,
+					"filterCardinality": filterCardinality,
+					"limit":             limit,
+				}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
 				return topKHeap
 			}
 		}
@@ -277,12 +285,17 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 
 		pivotID = results[0].idPointer
 
+		// AND is terminal the instant any term exhausts: no higher doc id can align
+		// across every term, so the heap is frozen and we return at the advance site
+		// rather than rescanning all terms at the top of each iteration. results[0]
+		// is covered just above; the others can only exhaust here or in the
+		// candidate-advance loop below.
+		upperBound = results[0].currentBlockImpact
 		for i := 1; i < len(results); i++ {
 			results[i].AdvanceAtLeastShallow(pivotID)
-		}
-
-		upperBound = float32(0)
-		for i := 0; i < len(results); i++ {
+			if results[i].exhausted {
+				return topKHeap
+			}
 			upperBound += results[i].currentBlockImpact
 		}
 
@@ -290,6 +303,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 			isCandidate := true
 			for i := 1; i < len(results); i++ {
 				results[i].AdvanceAtLeast(pivotID)
+				if results[i].exhausted {
+					return topKHeap
+				}
 				if results[i].idPointer != pivotID {
 					isCandidate = false
 					break

--- a/adapters/repos/db/lsmkv/search_segment_nilctx_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_nilctx_test.go
@@ -41,6 +41,9 @@ func TestWandLoops_NonCancellableContext(t *testing.T) {
 				topKHeap, err := DoBlockMaxWand(c.ctx, 10, Terms{}, 1.0, false, 0, 0, logrus.New())
 				require.NoError(t, err)
 				require.NotNil(t, topKHeap)
+				// empty input → empty heap; guards against an accidental population
+				// path that would silently satisfy the NotPanics + NotNil checks above.
+				require.Equal(t, 0, topKHeap.Len())
 			})
 		})
 
@@ -48,6 +51,7 @@ func TestWandLoops_NonCancellableContext(t *testing.T) {
 			require.NotPanics(t, func() {
 				topKHeap := DoWand(c.ctx, 10, &terms.Terms{}, 1.0, false, 0, logrus.New())
 				require.NotNil(t, topKHeap)
+				require.Equal(t, 0, topKHeap.Len())
 			})
 		})
 	}

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -492,15 +492,23 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		return
 	}
 
-	for s.blockEntryIdx < len(s.blockEntries) && docId > s.blockEntries[s.blockEntryIdx].MaxId {
-		s.blockEntryIdx++
+	// scan with locals so the index stays in a register and the decoded/freqDecoded
+	// stores happen once after the loop instead of on every skipped block.
+	entries := s.blockEntries
+	idx := s.blockEntryIdx
+	for idx < len(entries) && docId > entries[idx].MaxId {
+		idx++
+	}
+	if idx != s.blockEntryIdx {
+		s.blockEntryIdx = idx
 		s.decoded = false
 		s.freqDecoded = false
 	}
 
-	// the loop stops only at blockEntryIdx == len or docId <= this block's
-	// MaxId, so a bounds check is enough to detect exhaustion here.
-	if s.blockEntryIdx >= len(s.blockEntries) {
+	// the loop only stops when idx hits the end or docId <= this block's MaxId,
+	// so the "last block, still past it" case the old condition also tested can
+	// never hold here — a bounds check is enough.
+	if idx >= len(entries) {
 		s.exhaust()
 		return
 	}
@@ -509,9 +517,15 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		s.decodeBlock()
 	}
 
-	for s.blockDataIdx < s.blockDataSize-1 && docId > s.blockDataDecoded.DocIds[s.blockDataIdx] {
-		s.blockDataIdx++
+	// read after decodeBlock: it rewrites the decoded buffer in place and updates
+	// blockDataSize.
+	docIDs := s.blockDataDecoded.DocIds
+	last := s.blockDataSize - 1
+	j := s.blockDataIdx
+	for j < last && docId > docIDs[j] {
+		j++
 	}
+	s.blockDataIdx = j
 
 	s.advanceOnTombstoneOrFilter()
 }
@@ -524,8 +538,9 @@ func (s *SegmentBlockMax) AdvanceAtLeastShallow(docId uint64) {
 		return
 	}
 
-	for s.blockEntryIdx < len(s.blockEntries) && docId > s.blockEntries[s.blockEntryIdx].MaxId {
-
+	// the in-loop bounds return below guarantees blockEntryIdx < len on every
+	// condition re-eval, so the index is always valid here — no length guard needed.
+	for docId > s.blockEntries[s.blockEntryIdx].MaxId {
 		s.blockEntryIdx++
 		s.blockDataIdx = 0
 		s.decoded = false


### PR DESCRIPTION
### What's being changed
Caches the matched-branch pivot term instead of re-indexing the results slice, enables bounds-check elimination via reslicing, and drops provably-dead conditions in the block-scan loops. Small but on the hottest path.

_Part of the BM25 BlockMax-WAND series; **stacked** — based on its predecessor branch, so the diff shown is only this PR's change. Bit-identical to stable._