### PR TITLE
perf(bm25): round-6 query-setup path optimization

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2187,70 +2187,100 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 	// active memtable
 	output[len(view.Disk)+1] = make([]*SegmentBlockMax, 0, len(query))
 
+	// memtable tombstones are invariant within a consistent view; read them once
+	// per query instead of cloning + OR-ing the same bitmaps for every term.
 	memTombstones := sroar.NewBitmap()
+	var activeTombstones *sroar.Bitmap
+	if view.Active != nil {
+		activeTombstones, err = view.Active.ReadOnlyTombstones()
+		if err != nil {
+			view.ReleaseView()
+			return nil, nil, func() {}, fmt.Errorf("active tombstones: %w", err)
+		}
+		memTombstones.Or(activeTombstones)
+	}
+	if view.Flushing != nil {
+		flushingTombstones, err := view.Flushing.ReadOnlyTombstones()
+		if err != nil {
+			view.ReleaseView()
+			return nil, nil, func() {}, fmt.Errorf("flushing tombstones: %w", err)
+		}
+		memTombstones.Or(flushingTombstones)
+	}
+
+	// per-(segment, term) index nodes prefetched together with the doc counts in
+	// a single index descent (hasKey, getDocCount and the term constructor each
+	// did their own before). diskSkip marks inverted segments where the key is
+	// definitively absent, so construction is not attempted at all.
+	qn := len(query)
+	diskNodes := make([]segmentindex.Node, len(view.Disk)*qn)
+	diskNodeOk := make([]bool, len(view.Disk)*qn)
+	diskSkip := make([]bool, len(view.Disk)*qn)
 
 	for i, queryTerm := range query {
 		key := []byte(queryTerm)
 		n := uint64(0)
 
-		active := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
-		flushing := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
-
-		var activeTombstones *sroar.Bitmap
+		// memtable terms are built only when the memtable actually holds the key
+		// (the common case is that it doesn't — or there is no memtable at all).
+		var active, flushing *SegmentBlockMax
 		if view.Active != nil {
-			n2, _ := fillTerm(view.Active, key, active, filterDocIds)
-			if active.Count() > 0 {
-				output[len(view.Disk)+1] = append(output[len(view.Disk)+1], active)
-			}
-			n += n2
+			if mapPairs, err := view.Active.getMap(key); err == nil {
+				if active = NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config); active != nil {
+					n2, _ := addDataToTerm(mapPairs, filterDocIds, active)
+					if active.Count() > 0 {
+						output[len(view.Disk)+1] = append(output[len(view.Disk)+1], active)
+					}
+					n += n2
 
-			activeTombstones, err = view.Active.ReadOnlyTombstones()
-			if err != nil {
-				view.ReleaseView()
-				return nil, nil, func() {}, fmt.Errorf("active tombstones: %w", err)
-			}
-			memTombstones.Or(activeTombstones)
-
-			if !active.Exhausted() {
-				active.advanceOnTombstoneOrFilter()
+					if !active.Exhausted() {
+						active.advanceOnTombstoneOrFilter()
+					}
+				}
 			}
 		}
 
 		if view.Flushing != nil {
-			n2, _ := fillTerm(view.Flushing, key, flushing, filterDocIds)
-			if flushing.Count() > 0 {
-				output[len(view.Disk)] = append(output[len(view.Disk)], flushing)
-			}
-			n += n2
+			if mapPairs, err := view.Flushing.getMap(key); err == nil {
+				if flushing = NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config); flushing != nil {
+					n2, _ := addDataToTerm(mapPairs, filterDocIds, flushing)
+					if flushing.Count() > 0 {
+						output[len(view.Disk)] = append(output[len(view.Disk)], flushing)
+					}
+					n += n2
 
-			tombstones, err := view.Flushing.ReadOnlyTombstones()
-			if err != nil {
-				view.ReleaseView()
-				return nil, nil, func() {}, fmt.Errorf("flushing tombstones: %w", err)
+					if !flushing.Exhausted() {
+						flushing.tombstones = activeTombstones
+						flushing.advanceOnTombstoneOrFilter()
+					}
+				}
 			}
-			memTombstones.Or(tombstones)
-
-			if !flushing.Exhausted() {
-				flushing.tombstones = activeTombstones
-				flushing.advanceOnTombstoneOrFilter()
-			}
-
 		}
 
-		for _, segment := range view.Disk {
-			if segment.getStrategy() == segmentindex.StrategyInverted && segment.hasKey(key) {
-				n += segment.getDocCount(key)
+		for j, segment := range view.Disk {
+			if segment.getStrategy() != segmentindex.StrategyInverted {
+				continue
+			}
+			if node, docCount, ok := segment.getInvertedNodeAndDocCount(key); ok {
+				n += docCount
+				diskNodes[j*qn+i] = node
+				diskNodeOk[j*qn+i] = true
+			} else {
+				diskSkip[j*qn+i] = true
 			}
 		}
 
 		// we can only know the full n after we have checked all segments and all memtables
 		idfs[i] = math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateTextBoosts[i])
 
-		active.idf = idfs[i]
-		active.currentBlockImpact = float32(idfs[i])
-
-		flushing.idf = idfs[i]
-		flushing.currentBlockImpact = float32(idfs[i])
+		if active != nil {
+			active.idf = idfs[i]
+			active.currentBlockImpact = float32(idfs[i])
+		}
+		if flushing != nil {
+			flushing.idf = idfs[i]
+			flushing.currentBlockImpact = float32(idfs[i])
+		}
 
 		idfCounts[queryTerm] = n
 	}
@@ -2273,7 +2303,17 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		}
 
 		for i, key := range query {
-			term := segment.newSegmentBlockMax([]byte(key), i, idfs[i], propertyBoost, segTombstones, memTombstones, filterDocIds, averagePropLength, config)
+			idx := j*qn + i
+			if diskSkip[idx] {
+				continue
+			}
+			// non-inverted segments have no prefetched node; the constructor
+			// falls back to its own index lookup exactly as before.
+			var node *segmentindex.Node
+			if diskNodeOk[idx] {
+				node = &diskNodes[idx]
+			}
+			term := segment.newSegmentBlockMax(node, []byte(key), i, idfs[i], propertyBoost, segTombstones, memTombstones, filterDocIds, averagePropLength, config)
 			if term != nil {
 				output[j] = append(output[j], term)
 			}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2187,8 +2187,8 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 	// active memtable
 	output[len(view.Disk)+1] = make([]*SegmentBlockMax, 0, len(query))
 
-	// memtable tombstones are invariant within a consistent view; read them once
-	// per query instead of cloning + OR-ing the same bitmaps for every term.
+	// Memtable tombstones are invariant within a consistent view: read once and
+	// OR into a single bitmap shared by every term.
 	memTombstones := sroar.NewBitmap()
 	var activeTombstones *sroar.Bitmap
 	if view.Active != nil {
@@ -2208,10 +2208,10 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		memTombstones.Or(flushingTombstones)
 	}
 
-	// per-(segment, term) index nodes prefetched together with the doc counts in
-	// a single index descent (hasKey, getDocCount and the term constructor each
-	// did their own before). diskSkip marks inverted segments where the key is
-	// definitively absent, so construction is not attempted at all.
+	// One index descent per (segment, term): diskNodes/diskNodeOk cache the node
+	// and doc count for reuse by both the count below and term construction.
+	// diskSkip marks inverted segments where the key is absent, so construction
+	// is skipped.
 	qn := len(query)
 	diskNodes := make([]segmentindex.Node, len(view.Disk)*qn)
 	diskNodeOk := make([]bool, len(view.Disk)*qn)
@@ -2221,8 +2221,6 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		key := []byte(queryTerm)
 		n := uint64(0)
 
-		// memtable terms are built only when the memtable actually holds the key
-		// (the common case is that it doesn't — or there is no memtable at all).
 		var active, flushing *SegmentBlockMax
 		if view.Active != nil {
 			if mapPairs, err := view.Active.getMap(key); err == nil {
@@ -2307,8 +2305,8 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 			if diskSkip[idx] {
 				continue
 			}
-			// non-inverted segments have no prefetched node; the constructor
-			// falls back to its own index lookup exactly as before.
+			// non-inverted segments have no prefetched node; nil makes the
+			// constructor do its own index lookup.
 			var node *segmentindex.Node
 			if diskNodeOk[idx] {
 				node = &diskNodes[idx]

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -2463,7 +2463,7 @@ func validateMapPairListVsBlockMaxSearchFromSegments(ctx context.Context, segmen
 		duplicateTextBoosts[0] = 1
 		diskTerms := make([][]*SegmentBlockMax, 0, len(segments))
 		for _, segment := range segments {
-			bmws := segment.newSegmentBlockMax(mapKey, 0, 1, 1, nil, nil, nil, 3, bm25config)
+			bmws := segment.newSegmentBlockMax(nil, mapKey, 0, 1, 1, nil, nil, nil, 3, bm25config)
 			diskTerms = append(diskTerms, []*SegmentBlockMax{bmws})
 		}
 

--- a/adapters/repos/db/lsmkv/lazy_segment.go
+++ b/adapters/repos/db/lsmkv/lazy_segment.go
@@ -385,17 +385,22 @@ func (s *lazySegment) newInvertedCursorReusable() *segmentCursorInvertedReusable
 	return s.segment.newInvertedCursorReusable()
 }
 
-func (s *lazySegment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64,
+func (s *lazySegment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64,
 	propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList,
 	averagePropLength float64, config schema.BM25Config,
 ) *SegmentBlockMax {
 	s.mustLoad()
-	return s.segment.newSegmentBlockMax(key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+	return s.segment.newSegmentBlockMax(node, key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
 }
 
 func (s *lazySegment) getDocCount(key []byte) uint64 {
 	s.mustLoad()
 	return s.segment.getDocCount(key)
+}
+
+func (s *lazySegment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	s.mustLoad()
+	return s.segment.getInvertedNodeAndDocCount(key)
 }
 
 func (s *lazySegment) getCountNetAdditions() int {

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -28,7 +28,9 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	termCount, minimumOrTokensMatch int, logger logrus.FieldLogger,
 ) (*priorityqueue.Queue[[]*terms.DocPointerWithScore], error) {
 	var docInfos []*terms.DocPointerWithScore
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	results.sortByID()
 	iterations := 0
@@ -228,7 +230,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 ) *priorityqueue.Queue[[]*terms.DocPointerWithScore] {
 	results := TermsBySize(resultsByTerm)
 	var docInfos []*terms.DocPointerWithScore
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	sort.Sort(results)
 	iterations := 0
@@ -358,7 +362,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 func DoWand(ctx context.Context, limit int, results *terms.Terms, averagePropLength float64, additionalExplanations bool,
 	minimumOrTokensMatch int, logger logrus.FieldLogger,
 ) *priorityqueue.Queue[[]*terms.DocPointerWithScore] {
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	sort.Sort(results)
 	iterations := 0

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -87,11 +87,12 @@ type Segment interface {
 	// map/bmw specific
 	hasKey(key []byte) bool
 	getDocCount(key []byte) uint64
+	getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool)
 	getPropertyLengths() (map[uint64]uint32, error)
 	isPropertyLengthsLoaded() bool
 	freePropertyLengths()
 	newInvertedCursorReusable() *segmentCursorInvertedReusable
-	newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
+	newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
 
 	// replace specific
 	getCountNetAdditions() int

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -202,8 +202,17 @@ type SegmentBlockMax struct {
 	Metrics BlockMetrics
 }
 
-func (s *segment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
-	return NewSegmentBlockMax(s, key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+// node may carry the term's index node prefetched by getInvertedNodeAndDocCount
+// (one descent for docCount + construction); nil means look it up here.
+func (s *segment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
+	if node == nil {
+		n, err := s.index.Get(key)
+		if err != nil {
+			return nil
+		}
+		node = &n
+	}
+	return newSegmentBlockMaxFromNode(s, *node, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
 }
 
 func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
@@ -211,7 +220,10 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	if err != nil {
 		return nil
 	}
+	return newSegmentBlockMaxFromNode(s, node, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+}
 
+func newSegmentBlockMaxFromNode(s *segment, node segmentindex.Node, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	// if filter is empty after checking for tombstones,
 	// we can skip it and return nil for the segment
 	if filterDocIds != nil && filterDocIds.IsEmpty() {
@@ -255,8 +267,7 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 		sectionReader: sectionReader,
 	}
 
-	err = output.reset()
-	if err != nil {
+	if err := output.reset(); err != nil {
 		return nil
 	}
 	output.Metrics.BlockCountTotal += uint64(len(output.blockEntries))

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -202,8 +202,8 @@ type SegmentBlockMax struct {
 	Metrics BlockMetrics
 }
 
-// node may carry the term's index node prefetched by getInvertedNodeAndDocCount
-// (one descent for docCount + construction); nil means look it up here.
+// A non-nil node is the term's prefetched index node, reused as-is; nil means
+// look it up here.
 func (s *segment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	if node == nil {
 		n, err := s.index.Get(key)

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -385,6 +385,19 @@ func (s *fakeSegment) getDocCount(key []byte) uint64 {
 	return uint64(len(s.collectionStore[string(key)]))
 }
 
+func (s *fakeSegment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.strategy != segmentindex.StrategyInverted {
+		return segmentindex.Node{}, 0, false
+	}
+	pairs, ok := s.collectionStore[string(key)]
+	if !ok {
+		return segmentindex.Node{}, 0, false
+	}
+	// the fake's newSegmentBlockMax rebuilds terms from collectionStore and
+	// ignores the node, so a zero node with the right count is sufficient
+	return segmentindex.Node{Key: key}, uint64(len(pairs)), true
+}
+
 func (s *fakeSegment) getCountNetAdditions() int {
 	// NOTE: This oversimplified fake implementation ignores deletes and updates,
 	// it pretends every write is a unique insert.
@@ -433,7 +446,7 @@ func (s *fakeSegment) stripTmpExtensions(leftSegmentID, rightSegmentID string) e
 	return nil
 }
 
-func (s *fakeSegment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
+func (s *fakeSegment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	// we're taking a bit of a creative route to make this work with a fake
 	// segment. We have existing functions to create a SegmentBlockMax from a
 	// memtable which are used with real memtables. So if we convert the fake

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -283,3 +283,25 @@ func (s *segment) getDocCount(key []byte) uint64 {
 
 	return binary.LittleEndian.Uint64(buffer)
 }
+
+// getInvertedNodeAndDocCount resolves a term's index node and posting doc count
+// with a single index descent, so the BMW setup path can reuse the node instead
+// of descending again in hasKey/getDocCount/the term constructor. Inverted
+// segments only; callers check the strategy.
+func (s *segment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.useBloomFilter && !s.bloomFilter.Test(key) {
+		return segmentindex.Node{}, 0, false
+	}
+
+	node, err := s.index.Get(key)
+	if err != nil {
+		return segmentindex.Node{}, 0, false
+	}
+
+	var buf [8]byte
+	if err = s.copyNode(buf[:], nodeOffset{node.Start, node.Start + 8}); err != nil {
+		return segmentindex.Node{}, 0, false
+	}
+
+	return node, binary.LittleEndian.Uint64(buf[:]), true
+}

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -284,10 +284,9 @@ func (s *segment) getDocCount(key []byte) uint64 {
 	return binary.LittleEndian.Uint64(buffer)
 }
 
-// getInvertedNodeAndDocCount resolves a term's index node and posting doc count
-// with a single index descent, so the BMW setup path can reuse the node instead
-// of descending again in hasKey/getDocCount/the term constructor. Inverted
-// segments only; callers check the strategy.
+// getInvertedNodeAndDocCount returns a term's index node and posting doc count
+// from a single index descent, letting the caller reuse the node for term
+// construction. Inverted segments only; the caller must check the strategy.
 func (s *segment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
 	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return segmentindex.Node{}, 0, false

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -286,8 +286,13 @@ func (s *segment) getDocCount(key []byte) uint64 {
 
 // getInvertedNodeAndDocCount returns a term's index node and posting doc count
 // from a single index descent, letting the caller reuse the node for term
-// construction. Inverted segments only; the caller must check the strategy.
+// construction. The doc count is read from the inverted posting layout, so it
+// returns false for any non-inverted strategy.
 func (s *segment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.strategy != segmentindex.StrategyInverted {
+		return segmentindex.Node{}, 0, false
+	}
+
 	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return segmentindex.Node{}, 0, false
 	}

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -51,41 +51,36 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 		return Node{}, lsmkv.NotFound
 	}
 	var out Node
-	rw := byteops.NewReadWriter(t.data)
+	data := t.data
+	pos := uint64(0)
 
-	// jump to the buffer until the node with _key_ is found or return a NotFound error.
-	// This function avoids allocations by reusing the same buffer for all keys and avoids memory reads by only
-	// extracting the necessary pieces of information while skipping the rest
-	NodeKeyBuffer := make([]byte, len(key))
+	// jump through the buffer until the node with _key_ is found or return a
+	// NotFound error. Node keys are compared in place against the tree data, so
+	// the descent allocates nothing; only the matched node's key is materialized
+	// (callers may keep it beyond the underlying segment's lifetime).
 	for {
 		// detect if there is no node with the wanted key.
-		if rw.Position+4 > uint64(len(t.data)) || rw.Position+4 < 4 {
+		if pos+4 > uint64(len(data)) || pos+4 < 4 {
 			return out, lsmkv.NotFound
 		}
 
-		keyLen := rw.ReadUint32()
-		if int(keyLen) > len(NodeKeyBuffer) {
-			NodeKeyBuffer = make([]byte, int(keyLen))
-		} else if int(keyLen) < len(NodeKeyBuffer) {
-			NodeKeyBuffer = NodeKeyBuffer[:keyLen]
-		}
-		_, err := rw.CopyBytesFromBuffer(uint64(keyLen), NodeKeyBuffer)
-		if err != nil {
-			return out, fmt.Errorf("copy node key: %w", err)
+		keyLen := uint64(binary.LittleEndian.Uint32(data[pos:]))
+		pos += 4
+		if pos+keyLen > uint64(len(data)) {
+			return out, fmt.Errorf("copy node key: key at %d len %d out of range", pos, keyLen)
 		}
 
-		keyEqual := bytes.Compare(key, NodeKeyBuffer)
+		keyEqual := bytes.Compare(key, data[pos:pos+keyLen])
+		pos += keyLen
 		if keyEqual == 0 {
-			out.Key = NodeKeyBuffer
-			out.Start = rw.ReadUint64()
-			out.End = rw.ReadUint64()
+			out.Key = bytes.Clone(data[pos-keyLen : pos])
+			out.Start = binary.LittleEndian.Uint64(data[pos:])
+			out.End = binary.LittleEndian.Uint64(data[pos+8:])
 			return out, nil
 		} else if keyEqual < 0 {
-			rw.MoveBufferPositionForward(2 * 8) // jump over start+end position
-			rw.Position = rw.ReadUint64()       // left child
+			pos = binary.LittleEndian.Uint64(data[pos+16:]) // skip start+end, read left child
 		} else {
-			rw.MoveBufferPositionForward(3 * 8) // jump over start+end position and left child
-			rw.Position = rw.ReadUint64()       // right child
+			pos = binary.LittleEndian.Uint64(data[pos+24:]) // skip start+end+left, read right child
 		}
 	}
 }

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -52,40 +52,60 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 	}
 	var out Node
 	data := t.data
+	dataLen := uint64(len(data))
 	pos := uint64(0)
 
 	// jump through the buffer until the node with _key_ is found or return a
 	// NotFound error. Node keys are compared in place against the tree data, so
 	// the descent allocates nothing; only the matched node's key is materialized
 	// (callers may keep it beyond the underlying segment's lifetime).
+	//
+	// pos can be an arbitrary child offset read from possibly corrupt data, so
+	// every read is bounds-checked against dataLen-pos (never pos+n, which would
+	// wrap). Truncated or corrupt data yields NotFound or an error, never a panic.
 	for {
-		// detect if there is no node with the wanted key.
-		if pos+4 > uint64(len(data)) || pos+4 < 4 {
+		// node layout: [keyLen:4][key:keyLen][start:8][end:8][left:8][right:8].
+		if pos+4 > dataLen || pos+4 < 4 {
 			return out, lsmkv.NotFound
 		}
 
 		keyLen := uint64(binary.LittleEndian.Uint32(data[pos:]))
 		pos += 4
-		if pos+keyLen > uint64(len(data)) {
-			return out, fmt.Errorf("copy node key: key at %d len %d out of range", pos, keyLen)
+		if keyLen > dataLen-pos {
+			return out, fmt.Errorf("node key at %d len %d out of range", pos, keyLen)
 		}
 
 		keyEqual := bytes.Compare(key, data[pos:pos+keyLen])
 		pos += keyLen
+		avail := dataLen - pos
 		if keyEqual == 0 {
+			if avail < 16 { // start + end
+				return out, fmt.Errorf("node value at %d out of range", pos)
+			}
 			out.Key = bytes.Clone(data[pos-keyLen : pos])
 			out.Start = binary.LittleEndian.Uint64(data[pos:])
 			out.End = binary.LittleEndian.Uint64(data[pos+8:])
 			return out, nil
 		} else if keyEqual < 0 {
+			if avail < 24 { // start + end + left child
+				return out, fmt.Errorf("node left child at %d out of range", pos)
+			}
 			pos = binary.LittleEndian.Uint64(data[pos+16:]) // skip start+end, read left child
 		} else {
+			if avail < 32 { // start + end + left + right child
+				return out, fmt.Errorf("node right child at %d out of range", pos)
+			}
 			pos = binary.LittleEndian.Uint64(data[pos+24:]) // skip start+end+left, read right child
 		}
 	}
 }
 
 func (t *DiskTree) readNodeAt(offset int64) (dtNode, error) {
+	// offset is a child pointer that may be corrupt; bound it before slicing so a
+	// stray value yields an error instead of an out-of-range panic.
+	if offset < 0 || offset > int64(len(t.data)) {
+		return dtNode{}, fmt.Errorf("node offset %d out of range (buffer %d)", offset, len(t.data))
+	}
 	retNode, _, err := t.readNode(t.data[offset:])
 	return retNode, err
 }
@@ -101,6 +121,13 @@ func (t *DiskTree) readNode(in []byte) (dtNode, int, error) {
 	rw := byteops.NewReadWriter(in)
 
 	keyLen := uint64(rw.ReadUint32())
+	// the whole node is keyLen + TREE_KEY_STORE_OVERHEAD bytes; the len check
+	// above only covers a zero-length key. Reject a keyLen that would push the
+	// key or the fixed trailer past the buffer (corrupt/truncated index) so the
+	// reads below cannot panic. Compared against len(in)-overhead to avoid wrap.
+	if keyLen > uint64(len(in))-TREE_KEY_STORE_OVERHEAD {
+		return out, int(rw.Position), fmt.Errorf("node key len %d out of range (buffer %d)", keyLen, len(in))
+	}
 	copiedBytes, err := rw.CopyBytesFromBuffer(keyLen, nil)
 	if err != nil {
 		return out, int(rw.Position), fmt.Errorf("copy node key: %w", err)

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -1,0 +1,98 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package segmentindex
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A corrupt or truncated on-disk index must never crash the node: every read
+// path (Get, Seek/Next, AllKeys) has to return NotFound or an error instead of
+// panicking on an out-of-range slice.
+func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
+	tree := NewTree(4)
+	elements := []struct {
+		key        []byte
+		start, end uint64
+	}{
+		{[]byte("foobar"), 17, 18}, // inserted first -> BST root at offset 0
+		{[]byte("abc"), 4, 5},
+		{[]byte("zzz"), 34, 35},
+		{[]byte("aaa"), 1, 2},
+		{[]byte("zzzz"), 100, 102},
+	}
+	for _, e := range elements {
+		tree.Insert(e.key, e.start, e.end)
+	}
+	valid, err := tree.MarshalBinary()
+	require.NoError(t, err)
+	require.Greater(t, len(valid), TREE_KEY_STORE_OVERHEAD)
+
+	// queries span match, descend-left and descend-right branches plus misses.
+	queries := [][]byte{
+		[]byte("aaa"), []byte("abc"), []byte("foobar"), []byte("zzz"), []byte("zzzz"),
+		[]byte("a"), []byte("m"), []byte("zzzzz"), {},
+	}
+
+	t.Run("every truncation of the buffer", func(t *testing.T) {
+		for trunc := 0; trunc <= len(valid); trunc++ {
+			dTree := NewDiskTree(valid[:trunc])
+			require.NotPanics(t, func() {
+				_, _ = dTree.AllKeys()
+			}, "AllKeys panicked at truncation=%d", trunc)
+			for _, q := range queries {
+				require.NotPanics(t, func() {
+					_, _ = dTree.Get(q)
+				}, "Get panicked at truncation=%d query=%q", trunc, q)
+				require.NotPanics(t, func() {
+					_, _ = dTree.Seek(q)
+				}, "Seek panicked at truncation=%d query=%q", trunc, q)
+			}
+		}
+	})
+
+	t.Run("corrupt keyLen larger than the buffer returns an error", func(t *testing.T) {
+		corrupt := make([]byte, len(valid))
+		copy(corrupt, valid)
+		binary.LittleEndian.PutUint32(corrupt[0:4], 0xFFFFFFFF)
+		dTree := NewDiskTree(corrupt)
+
+		var getErr, allErr error
+		require.NotPanics(t, func() {
+			_, getErr = dTree.Get([]byte("foobar"))
+			_, allErr = dTree.AllKeys()
+			_, _ = dTree.Seek([]byte("foobar"))
+		})
+		require.Error(t, getErr)
+		require.Error(t, allErr)
+	})
+
+	t.Run("corrupt child pointers do not panic", func(t *testing.T) {
+		corrupt := make([]byte, len(valid))
+		copy(corrupt, valid)
+		// root node at offset 0: [keyLen:4][key][start:8][end:8][left:8][right:8].
+		keyLen := int(binary.LittleEndian.Uint32(corrupt[0:4]))
+		childBase := 4 + keyLen + 16                                             // past keyLen + key + start + end
+		binary.LittleEndian.PutUint64(corrupt[childBase:], 0xFFFFFFFFFFFFFFFF)   // left child
+		binary.LittleEndian.PutUint64(corrupt[childBase+8:], 0xFFFFFFFFFFFFFFF0) // right child
+		dTree := NewDiskTree(corrupt)
+
+		require.NotPanics(t, func() {
+			_, _ = dTree.Get([]byte("aaa"))   // descends left into the bad pointer
+			_, _ = dTree.Get([]byte("zzzzz")) // descends right into the bad pointer
+			_, _ = dTree.Seek([]byte("aaa"))
+		})
+	})
+}

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -43,7 +43,7 @@ func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
 	// queries span match, descend-left and descend-right branches plus misses.
 	queries := [][]byte{
 		[]byte("aaa"), []byte("abc"), []byte("foobar"), []byte("zzz"), []byte("zzzz"),
-		[]byte("a"), []byte("m"), []byte("zzzzz"), {},
+		[]byte("a"), []byte("m"), []byte("zzzzz"), []byte(""),
 	}
 
 	t.Run("every truncation of the buffer", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed
Optimizes query setup (dominates AND ~75%, weighs on OR ~26%): one index descent per (term,segment) via `getInvertedNodeAndDocCount`; zero-copy `DiskTree.Get` (compare node keys in place, clone only the match); hoist memtable tombstones out of the per-term loop; build memtable terms only when the key is present; size topK heaps at `limit+1`. Setup-bound loads: **~−46% AND latency, ~−84% allocations.**

_Part of the BM25 BlockMax-WAND series; **stacked** — based on its predecessor branch, so the diff shown is only this PR's change. Bit-identical to stable._