### PR TITLE
perf(bm25): round-7 matched-branch sort elision

### DIFF
--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -137,11 +137,17 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			// so no explicit exhausted guard is needed here.
 			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
+				// a real shallow advance moves idPointer without re-sorting (and may
+				// even exhaust mid-array), so the slice may then hold inversions that
+				// only a full sortByID repairs — see the matched branch. blockEntryIdx
+				// changes on every actual move/exhaust but not on the early-return
+				// no-op (docCount==1 terms never initialize currentBlockMaxId, so the
+				// guard over-fires for them; the no-op must not defeat the fast path).
+				prevBlockIdx := t.blockEntryIdx
 				t.AdvanceAtLeastShallow(pivotID)
-				// a shallow advance moves idPointer without re-sorting (and may even
-				// exhaust mid-array), so the slice may now hold inversions that only
-				// a full sortByID repairs — see the matched branch.
-				needFullSort = true
+				if t.blockEntryIdx != prevBlockIdx {
+					needFullSort = true
+				}
 			}
 			upperBound += t.currentBlockImpact
 		}

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -38,6 +38,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	pivotID := uint64(0)
 	var pivotPoint int
 	upperBound := float32(0)
+	// needFullSort tracks whether shallow advances have run since the last full
+	// sortByID. Shallow advances move idPointers (and can exhaust terms) in place,
+	// so the slice may hold inversions or mis-placed exhausted sentinels that only
+	// a full sort repairs. While false, the matched branch can restore order with
+	// a per-advanced-term re-insertion instead of re-sorting all terms — matched
+	// iterations themselves never shallow-advance (their live prefix is already
+	// aligned, so currentBlockMaxId >= pivotID), so matched-dense queries stay on
+	// the cheap path.
+	needFullSort := false
 
 	// a nil ctx is tolerated (some callers pass none): a nil done channel never
 	// selects, so cancellation is simply disabled rather than panicking.
@@ -129,6 +138,10 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
 				t.AdvanceAtLeastShallow(pivotID)
+				// a shallow advance moves idPointer without re-sorting (and may even
+				// exhaust mid-array), so the slice may now hold inversions that only
+				// a full sortByID repairs — see the matched branch.
+				needFullSort = true
 			}
 			upperBound += t.currentBlockImpact
 		}
@@ -162,14 +175,29 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 					}
 				}
+				advanced := 0
 				for _, term := range results {
 					if !term.exhausted && term.idPointer != pivotID {
 						break
 					}
 					term.Advance()
+					advanced++
 				}
 
-				results.sortByID()
+				if needFullSort {
+					results.sortByID()
+					needFullSort = false
+				} else {
+					// only the advanced prefix moved (each idPointer increased) and the
+					// suffix is inversion-free, so re-inserting the prefix right-to-left
+					// yields the exact permutation a full stable sortByID would: at each
+					// step the suffix is already sorted, and reinsertRight's strict `<`
+					// settles equal ids in original index order, matching insertion-sort
+					// stability.
+					for i := advanced - 1; i >= 0; i-- {
+						results.reinsertRight(i)
+					}
+				}
 
 			} else {
 				nextList := pivotPoint


### PR DESCRIPTION
### What's being changed
Elides the per-iteration full re-sort of the term list: a `needFullSort` flag is set only when `AdvanceAtLeastShallow` actually advances a block; otherwise the matched branch uses a cheap right-to-left re-insertion over the advanced prefix. Frequent-term queries re-sort only when the pivot moves: **large sample cluster −33%**. Includes a fix for a singleton-term (`docCount==1`) over-fire found in adversarial verification.

_Part of the BM25 BlockMax-WAND series; **stacked** — based on its predecessor branch, so the diff shown is only this PR's change. Bit-identical to stable._