### PR TITLE
Make replica-movement vector-config guard fail closed

### DIFF
--- a/cluster/schema/movement_guard.go
+++ b/cluster/schema/movement_guard.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/models"
@@ -47,6 +48,12 @@ func dangerousVectorConfigChange(old, u *models.Class) string {
 }
 
 // vecDelta reports a structural change between one vector's old and new parsed index config.
+//
+// Detection fails CLOSED: rather than enumerate the DANGEROUS fields (which silently lets any
+// future structural field through), we zero the known QUERY-TIME-SAFE fields on a copy of each
+// side and reflect.DeepEqual the remainder. Any field not classified safe survives zeroing, so a
+// change to it surfaces as a mismatch and blocks the move. An unknown concrete config type also
+// blocks. Test_vectorConfigClassificationComplete forces every leaf to be consciously classified.
 func vecDelta(name string, oldCfg, newCfg any) string {
 	if oldCfg == nil || newCfg == nil {
 		// add/remove is the caller's map check; nil here just means absent on one side
@@ -59,70 +66,84 @@ func vecDelta(name string, oldCfg, newCfg any) string {
 	o, ok1 := oldCfg.(schemaConfig.VectorIndexConfig)
 	n, ok2 := newCfg.(schemaConfig.VectorIndexConfig)
 	if !ok1 || !ok2 {
-		// unknown config type: don't risk a false block
-		return ""
+		return fmt.Sprintf("structural vector config change on %s", label)
 	}
+	// Explicit messages for the two most common structural changes; the generic DeepEqual below
+	// would also catch them (an index-type change yields different concrete types), but a precise
+	// reason is more useful to the operator.
 	if o.IndexType() != n.IndexType() {
 		return fmt.Sprintf("vector index type change on %s", label)
 	}
 	if o.DistanceName() != n.DistanceName() {
 		return fmt.Sprintf("distance change on %s", label)
 	}
-	if compressionEnabled(oldCfg) != compressionEnabled(newCfg) {
-		return fmt.Sprintf("compression toggled on %s", label)
+	no, normOk1 := normalizeVectorConfig(oldCfg)
+	nn, normOk2 := normalizeVectorConfig(newCfg)
+	if !normOk1 || !normOk2 {
+		return fmt.Sprintf("structural vector config change on %s", label) // unknown type ⇒ fail closed
 	}
-	if compressionParamsChanged(oldCfg, newCfg) {
-		return fmt.Sprintf("compression re-parametrized on %s", label)
+	if !reflect.DeepEqual(no, nn) {
+		return fmt.Sprintf("structural vector config change on %s", label)
 	}
 	return ""
 }
 
-// compressionEnabled reports whether any quantizer is enabled. Dynamic recurses: both its flat
-// phase (BQ) and post-upgrade HNSW phase write compressed vectors to disk.
-func compressionEnabled(cfg any) bool {
+// normalizeVectorConfig returns a deep copy of cfg with every QUERY-TIME-SAFE field zeroed, so
+// reflect.DeepEqual of two normalized copies differs iff a STRUCTURAL field changed. Config structs
+// are scalar-only, so a Go value copy is a deep copy. An unknown concrete type returns ok=false so
+// the caller fails closed (blocks the move).
+func normalizeVectorConfig(cfg any) (any, bool) {
 	switch c := cfg.(type) {
 	case hnswent.UserConfig:
-		return c.PQ.Enabled || c.BQ.Enabled || c.SQ.Enabled || c.RQ.Enabled
+		return normalizeHNSW(c), true
 	case flatent.UserConfig:
-		return c.PQ.Enabled || c.BQ.Enabled || c.SQ.Enabled || c.RQ.Enabled
+		return normalizeFlat(c), true
 	case dynamicent.UserConfig:
-		return compressionEnabled(c.HnswUC) || compressionEnabled(c.FlatUC)
+		c.HnswUC = normalizeHNSW(c.HnswUC)
+		c.FlatUC = normalizeFlat(c.FlatUC)
+		// threshold is frozen at index construction so a user changing it does nothing
+		c.Threshold = 0
+		return c, true
 	default:
-		return false
+		return nil, false
 	}
 }
 
-// compressionParamsChanged reports a quantizer-param change that forces a re-encode of on-disk
-// vectors. Query-only knobs (RescoreLimit, Cache) are excluded; toggles are caught by
-// compressionEnabled.
-func compressionParamsChanged(old, new any) bool {
-	switch o := old.(type) {
-	case hnswent.UserConfig:
-		n, ok := new.(hnswent.UserConfig)
-		if !ok {
-			return true
-		}
-		return o.PQ != n.PQ || // PQConfig is wholly structural
-			o.SQ.Enabled != n.SQ.Enabled || o.SQ.TrainingLimit != n.SQ.TrainingLimit ||
-			o.RQ.Enabled != n.RQ.Enabled || o.RQ.Bits != n.RQ.Bits ||
-			o.BQ.Enabled != n.BQ.Enabled
-	case flatent.UserConfig:
-		n, ok := new.(flatent.UserConfig)
-		if !ok {
-			return true
-		}
-		return o.PQ.Enabled != n.PQ.Enabled || o.BQ.Enabled != n.BQ.Enabled ||
-			o.SQ.Enabled != n.SQ.Enabled ||
-			o.RQ.Enabled != n.RQ.Enabled || o.RQ.Bits != n.RQ.Bits
-	case dynamicent.UserConfig:
-		n, ok := new.(dynamicent.UserConfig)
-		if !ok {
-			return true
-		}
-		return compressionParamsChanged(o.HnswUC, n.HnswUC) || compressionParamsChanged(o.FlatUC, n.FlatUC)
-	default:
-		return false
-	}
+// normalizeHNSW zeroes the query-time-safe leaves of an HNSW config on a value copy. The remaining
+// (structural) leaves — Distance and the quantizer enable/param fields — are preserved for the
+// DeepEqual in vecDelta. MaxConnections/EFConstruction/Skip/Multivector.*/Skip+TrackDefault-
+// Quantization are classified safe (deferred): see plan.md "Consciously-deferred known gap".
+func normalizeHNSW(c hnswent.UserConfig) hnswent.UserConfig {
+	c.Skip = false
+	c.CleanupIntervalSeconds = 0
+	c.MaxConnections = 0
+	c.EFConstruction = 0
+	c.EF = 0
+	c.DynamicEFMin = 0
+	c.DynamicEFMax = 0
+	c.DynamicEFFactor = 0
+	c.VectorCacheMaxObjects = 0
+	c.FlatSearchCutoff = 0
+	c.FilterStrategy = ""
+	c.SkipDefaultQuantization = false
+	c.TrackDefaultQuantization = false
+	c.SQ.RescoreLimit = 0
+	c.RQ.RescoreLimit = 0
+	c.Multivector = hnswent.MultivectorConfig{} // every Multivector leaf is safe (deferred)
+	return c
+}
+
+// normalizeFlat zeroes the query-time-safe leaves of a flat config on a value copy. Quantizer
+// Enabled/Bits and Distance stay; RescoreLimit/Cache and VectorCacheMaxObjects are query-time.
+func normalizeFlat(c flatent.UserConfig) flatent.UserConfig {
+	c.VectorCacheMaxObjects = 0
+	c.SkipDefaultQuantization = false
+	c.TrackDefaultQuantization = false
+	c.PQ.RescoreLimit, c.PQ.Cache = 0, false
+	c.BQ.RescoreLimit, c.BQ.Cache = 0, false
+	c.SQ.RescoreLimit, c.SQ.Cache = 0, false
+	c.RQ.RescoreLimit, c.RQ.Cache = 0, false
+	return c
 }
 
 func findProp(c *models.Class, name string) *models.Property {

--- a/cluster/schema/movement_guard.go
+++ b/cluster/schema/movement_guard.go
@@ -80,7 +80,13 @@ func vecDelta(name string, oldCfg, newCfg any) string {
 	no, normOk1 := normalizeVectorConfig(oldCfg)
 	nn, normOk2 := normalizeVectorConfig(newCfg)
 	if !normOk1 || !normOk2 {
-		return fmt.Sprintf("structural vector config change on %s", label) // unknown type ⇒ fail closed
+		// Unknown config type (e.g. the experimental hfresh index, whose fields we don't yet
+		// classify): we can't isolate its structural from its query-time fields, so fail closed on
+		// any real change — but a no-op update changes nothing on disk and must pass.
+		if reflect.DeepEqual(oldCfg, newCfg) {
+			return ""
+		}
+		return fmt.Sprintf("structural vector config change on %s", label)
 	}
 	if !reflect.DeepEqual(no, nn) {
 		return fmt.Sprintf("structural vector config change on %s", label)

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -468,38 +468,17 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 			name     string
 			old, new *models.Class
 		}{
-			// HNSW — quantizer toggles + every structural param, one field per row.
-			{"hnsw distance", legacy(hnswent.UserConfig{Distance: "cosine"}), legacy(hnswent.UserConfig{Distance: "l2-squared"})},
-			{"hnsw pq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}})},
-			{"hnsw pq disabled", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}), legacy(hnswent.UserConfig{})},
-			{"hnsw pq segments", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Segments: 8}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Segments: 16}})},
-			{"hnsw pq centroids", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Centroids: 128}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Centroids: 256}})},
-			{"hnsw pq trainingLimit", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, TrainingLimit: 1000}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, TrainingLimit: 2000}})},
-			{"hnsw pq bitCompression", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, BitCompression: true}})},
-			{"hnsw pq encoder type", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Type: "kmeans"}}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Type: "tile"}}})},
-			{"hnsw pq encoder distribution", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Distribution: "normal"}}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Distribution: "log-normal"}}})},
-			{"hnsw bq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{BQ: hnswent.BQConfig{Enabled: true}})},
-			{"hnsw sq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true}})},
-			{"hnsw sq trainingLimit", legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, TrainingLimit: 1000}}), legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, TrainingLimit: 2000}})},
-			{"hnsw rq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true}})},
-			{"hnsw rq bits", legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 8}}), legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 1}})},
-			// Flat — quantizer toggles + bits, one field per row.
-			{"flat distance", legacy(flatent.UserConfig{Distance: "cosine"}), legacy(flatent.UserConfig{Distance: "l2-squared"})},
-			{"flat pq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{Enabled: true}})},
-			{"flat bq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{Enabled: true}})},
-			{"flat sq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{Enabled: true}})},
-			{"flat rq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true}})},
-			{"flat rq bits", legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true, Bits: 8}}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true, Bits: 1}})},
-			// Dynamic — distance and recursion into both phases (Threshold is query-time-safe; see allowed cases).
-			{"dynamic distance", legacy(dynamicent.UserConfig{Distance: "cosine"}), legacy(dynamicent.UserConfig{Distance: "l2-squared"})},
-			{"dynamic hnsw rq bits", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 8}}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 1}}})},
-			{"dynamic flat rq enabled", legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{}}), legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true}}})},
-			{"dynamic compression toggled", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
-			// Index type, named vector add/remove, and a within-config change on a named vector.
+			// One representative per distinct guard path. Field-by-field structural coverage lives
+			// in Test_vectorConfigClassificationComplete, which proves normalize preserves exactly
+			// the structural leaves — and that is what decides block-vs-allow here.
+			{"hnsw quantizer toggled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}})},
+			{"hnsw distance change", legacy(hnswent.UserConfig{Distance: "cosine"}), legacy(hnswent.UserConfig{Distance: "l2-squared"})},
 			{"index type change", legacy(hnswent.UserConfig{}), legacy(flatent.UserConfig{})},
+			{"flat structural param", legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true, Bits: 8}}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true, Bits: 1}})},
+			{"dynamic phase quantizer toggled", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
 			{"named vector added", &models.Class{Class: className}, named(map[string]any{"v1": hnswent.UserConfig{}})},
 			{"named vector removed", named(map[string]any{"v1": hnswent.UserConfig{}}), &models.Class{Class: className}},
-			{"named vector pq enabled", named(map[string]any{"v1": hnswent.UserConfig{}}), named(map[string]any{"v1": hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
+			{"named vector structural change", named(map[string]any{"v1": hnswent.UserConfig{}}), named(map[string]any{"v1": hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -515,48 +494,14 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 			name     string
 			old, new *models.Class
 		}{
+			// One representative per distinct guard path; field-by-field safe coverage lives in
+			// Test_vectorConfigClassificationComplete. dynamic-threshold and a deferred-safe field
+			// are kept explicitly because both are deliberate, contestable classifications.
 			{"no vector change", legacy(hnswent.UserConfig{Distance: "cosine"}), legacy(hnswent.UserConfig{Distance: "cosine"})},
-			// HNSW query-time knobs.
-			{"hnsw ef", legacy(hnswent.UserConfig{EF: 10}), legacy(hnswent.UserConfig{EF: 20})},
-			{"hnsw cleanupIntervalSeconds", legacy(hnswent.UserConfig{CleanupIntervalSeconds: 60}), legacy(hnswent.UserConfig{CleanupIntervalSeconds: 120})},
-			{"hnsw dynamicEfMin", legacy(hnswent.UserConfig{DynamicEFMin: 100}), legacy(hnswent.UserConfig{DynamicEFMin: 200})},
-			{"hnsw dynamicEfMax", legacy(hnswent.UserConfig{DynamicEFMax: 500}), legacy(hnswent.UserConfig{DynamicEFMax: 600})},
-			{"hnsw dynamicEfFactor", legacy(hnswent.UserConfig{DynamicEFFactor: 8}), legacy(hnswent.UserConfig{DynamicEFFactor: 16})},
-			{"hnsw vectorCacheMaxObjects", legacy(hnswent.UserConfig{VectorCacheMaxObjects: 1}), legacy(hnswent.UserConfig{VectorCacheMaxObjects: 2})},
-			{"hnsw flatSearchCutoff", legacy(hnswent.UserConfig{FlatSearchCutoff: 40000}), legacy(hnswent.UserConfig{FlatSearchCutoff: 50000})},
-			{"hnsw filterStrategy", legacy(hnswent.UserConfig{FilterStrategy: "acorn"}), legacy(hnswent.UserConfig{FilterStrategy: "sweeping"})},
-			{"hnsw rq rescoreLimit", legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, RescoreLimit: 10}}), legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, RescoreLimit: 20}})},
-			{"hnsw sq rescoreLimit", legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, RescoreLimit: 10}}), legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, RescoreLimit: 20}})},
-			// HNSW deferred-safe (currently non-blocking; parity must be preserved).
-			{"hnsw maxConnections", legacy(hnswent.UserConfig{MaxConnections: 16}), legacy(hnswent.UserConfig{MaxConnections: 32})},
-			{"hnsw efConstruction", legacy(hnswent.UserConfig{EFConstruction: 128}), legacy(hnswent.UserConfig{EFConstruction: 256})},
-			{"hnsw skip", legacy(hnswent.UserConfig{Skip: false}), legacy(hnswent.UserConfig{Skip: true})},
-			{"hnsw skipDefaultQuantization", legacy(hnswent.UserConfig{SkipDefaultQuantization: false}), legacy(hnswent.UserConfig{SkipDefaultQuantization: true})},
-			{"hnsw trackDefaultQuantization", legacy(hnswent.UserConfig{TrackDefaultQuantization: false}), legacy(hnswent.UserConfig{TrackDefaultQuantization: true})},
-			{"hnsw multivector enabled", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Enabled: false}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Enabled: true}})},
-			{"hnsw multivector aggregation", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Aggregation: "maxSim"}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Aggregation: "other"}})},
-			{"hnsw muvera enabled", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Enabled: false}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Enabled: true}}})},
-			{"hnsw muvera ksim", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{KSim: 4}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{KSim: 8}}})},
-			{"hnsw muvera dprojections", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{DProjections: 16}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{DProjections: 32}}})},
-			{"hnsw muvera repetitions", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Repetitions: 10}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Repetitions: 20}}})},
-			// Flat query-time knobs.
-			{"flat vectorCacheMaxObjects", legacy(flatent.UserConfig{VectorCacheMaxObjects: 1}), legacy(flatent.UserConfig{VectorCacheMaxObjects: 2})},
-			{"flat pq rescoreLimit", legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{RescoreLimit: 20}})},
-			{"flat pq cache", legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{Cache: false}}), legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{Cache: true}})},
-			{"flat bq rescoreLimit", legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{RescoreLimit: 20}})},
-			{"flat bq cache", legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{Cache: false}}), legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{Cache: true}})},
-			{"flat sq rescoreLimit", legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{RescoreLimit: 20}})},
-			{"flat sq cache", legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{Cache: false}}), legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{Cache: true}})},
-			{"flat rq rescoreLimit", legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{RescoreLimit: 20}})},
-			{"flat rq cache", legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Cache: false}}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Cache: true}})},
-			// Dynamic — Threshold is query-time-safe (the flat→HNSW upgrade it gates is deferred during
-			// a move and the schema is replicated to both replicas, so no divergence), plus recursion
-			// into both phases' query-time knobs.
+			{"hnsw query-time knob", legacy(hnswent.UserConfig{EF: 10}), legacy(hnswent.UserConfig{EF: 20})},
+			{"hnsw deferred-safe field", legacy(hnswent.UserConfig{MaxConnections: 16}), legacy(hnswent.UserConfig{MaxConnections: 32})},
 			{"dynamic threshold", legacy(dynamicent.UserConfig{Threshold: 1000}), legacy(dynamicent.UserConfig{Threshold: 2000})},
-			{"dynamic hnsw ef", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{EF: 10}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{EF: 20}})},
-			{"dynamic flat vectorCacheMaxObjects", legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{VectorCacheMaxObjects: 1}}), legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{VectorCacheMaxObjects: 2}})},
-			// Named vector query-time change.
-			{"named vector ef", named(map[string]any{"v1": hnswent.UserConfig{EF: 10}}), named(map[string]any{"v1": hnswent.UserConfig{EF: 20}})},
+			{"named vector query-time knob", named(map[string]any{"v1": hnswent.UserConfig{EF: 10}}), named(map[string]any{"v1": hnswent.UserConfig{EF: 20}})},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -695,78 +640,66 @@ func Test_vectorConfigClassificationComplete(t *testing.T) {
 	})
 
 	t.Run("normalize zeroes exactly the safe leaves", func(t *testing.T) {
-		hnswNorm := normalizeHNSW(populatedHNSW())
-		flatNorm := normalizeFlat(populatedFlat())
-		// assertLeaves walks a normalized value and checks each leaf against the registry: safe ⇒
-		// must be zero (got normalized away); structural ⇒ must be preserved (sentinel non-zero).
+		// assertLeaves walks a normalized config and checks each leaf against the registry: safe ⇒
+		// zeroed by normalize, structural ⇒ preserved (the fillNonZero sentinel survives). Dynamic's
+		// HnswUC/FlatUC remap to the base hnsw/flat prefixes, matching the completeness walk above.
 		var assertLeaves func(prefix string, v reflect.Value)
 		assertLeaves = func(prefix string, v reflect.Value) {
 			typ := v.Type()
 			for i := 0; i < typ.NumField(); i++ {
-				f := typ.Field(i)
-				fv := v.Field(i)
-				path := prefix + "." + f.Name
-				if classificationNestedStructs[f.Type] {
-					assertLeaves(path, fv)
-					continue
-				}
-				isSafe := vectorConfigClassification[path]
-				if isSafe {
-					require.True(t, fv.IsZero(), "%s is safe and must be zeroed by normalize", path)
-				} else {
-					require.False(t, fv.IsZero(), "%s is structural and must be preserved by normalize", path)
+				f, fv := typ.Field(i), v.Field(i)
+				switch {
+				case classificationNestedStructs[f.Type]:
+					assertLeaves(prefix+"."+f.Name, fv)
+				case f.Name == "HnswUC":
+					assertLeaves("hnsw", fv)
+				case f.Name == "FlatUC":
+					assertLeaves("flat", fv)
+				case vectorConfigClassification[prefix+"."+f.Name]:
+					require.True(t, fv.IsZero(), "%s.%s is safe and must be zeroed by normalize", prefix, f.Name)
+				default:
+					require.False(t, fv.IsZero(), "%s.%s is structural and must be preserved by normalize", prefix, f.Name)
 				}
 			}
 		}
-		assertLeaves("hnsw", reflect.ValueOf(hnswNorm))
-		assertLeaves("flat", reflect.ValueOf(flatNorm))
+		for _, root := range []struct {
+			prefix string
+			typ    reflect.Type
+		}{
+			{"hnsw", hnswType},
+			{"flat", flatType},
+			{"dynamic", dynamicType},
+		} {
+			filled := reflect.New(root.typ).Elem()
+			fillNonZero(filled)
+			norm, ok := normalizeVectorConfig(filled.Interface())
+			require.True(t, ok, "normalizeVectorConfig(%s) returned ok=false", root.prefix)
+			assertLeaves(root.prefix, reflect.ValueOf(norm))
+		}
 	})
 }
 
-// populatedHNSW returns an HNSW config with every leaf set to a non-zero sentinel, so a normalized
-// copy reveals exactly which leaves normalizeHNSW zeroes.
-func populatedHNSW() hnswent.UserConfig {
-	return hnswent.UserConfig{
-		Skip:                     true,
-		CleanupIntervalSeconds:   1,
-		MaxConnections:           1,
-		EFConstruction:           1,
-		EF:                       1,
-		DynamicEFMin:             1,
-		DynamicEFMax:             1,
-		DynamicEFFactor:          1,
-		VectorCacheMaxObjects:    1,
-		FlatSearchCutoff:         1,
-		Distance:                 "cosine",
-		FilterStrategy:           "acorn",
-		SkipDefaultQuantization:  true,
-		TrackDefaultQuantization: true,
-		PQ: hnswent.PQConfig{
-			Enabled: true, BitCompression: true, Segments: 1, Centroids: 1, TrainingLimit: 1,
-			Encoder: hnswent.PQEncoder{Type: "kmeans", Distribution: "log-normal"},
-		},
-		BQ: hnswent.BQConfig{Enabled: true},
-		SQ: hnswent.SQConfig{Enabled: true, TrainingLimit: 1, RescoreLimit: 1},
-		RQ: hnswent.RQConfig{Enabled: true, Bits: 1, RescoreLimit: 1},
-		Multivector: hnswent.MultivectorConfig{
-			Enabled: true, Aggregation: "maxSim",
-			MuveraConfig: hnswent.MuveraConfig{Enabled: true, KSim: 1, DProjections: 1, Repetitions: 1},
-		},
-	}
-}
-
-// populatedFlat returns a flat config with every leaf set to a non-zero sentinel.
-func populatedFlat() flatent.UserConfig {
-	cuc := flatent.CompressionUserConfig{Enabled: true, RescoreLimit: 1, Cache: true}
-	return flatent.UserConfig{
-		Distance:                 "cosine",
-		VectorCacheMaxObjects:    1,
-		SkipDefaultQuantization:  true,
-		TrackDefaultQuantization: true,
-		PQ:                       cuc,
-		BQ:                       cuc,
-		SQ:                       cuc,
-		RQ:                       flatent.RQUserConfig{Enabled: true, RescoreLimit: 1, Cache: true, Bits: 1},
+// fillNonZero sets every scalar leaf of the addressable struct value v to a non-zero sentinel,
+// recursing into nested structs. It lets the meta-test prove normalize zeroes exactly the safe
+// leaves without a hand-maintained fixture, and panics on an unhandled leaf kind so a new field
+// type cannot slip through unpopulated.
+func fillNonZero(v reflect.Value) {
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		switch f.Kind() {
+		case reflect.Struct:
+			fillNonZero(f)
+		case reflect.Bool:
+			f.SetBool(true)
+		case reflect.String:
+			f.SetString("x")
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			f.SetInt(1)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			f.SetUint(1)
+		default:
+			panic(fmt.Sprintf("fillNonZero: unhandled leaf kind %s (add a case)", f.Kind()))
+		}
 	}
 }
 

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -525,158 +525,87 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 	})
 }
 
-// vectorConfigClassification maps every leaf field of the parsed vector-config structs (dotted
-// path, rooted at the index type) to whether it is QUERY-TIME-SAFE (true) or STRUCTURAL (false).
-// It is the single source of truth that Test_vectorConfigClassificationComplete cross-checks against
-// both the struct shape (every leaf must appear — fail-closed) and normalize* (safe ⇔ zeroed).
-var vectorConfigClassification = map[string]bool{
-	// hnsw.UserConfig
-	"hnsw.Skip":                                  true,
-	"hnsw.CleanupIntervalSeconds":                true,
-	"hnsw.MaxConnections":                        true,
-	"hnsw.EFConstruction":                        true,
-	"hnsw.EF":                                    true,
-	"hnsw.DynamicEFMin":                          true,
-	"hnsw.DynamicEFMax":                          true,
-	"hnsw.DynamicEFFactor":                       true,
-	"hnsw.VectorCacheMaxObjects":                 true,
-	"hnsw.FlatSearchCutoff":                      true,
-	"hnsw.Distance":                              false,
-	"hnsw.FilterStrategy":                        true,
-	"hnsw.SkipDefaultQuantization":               true,
-	"hnsw.TrackDefaultQuantization":              true,
-	"hnsw.PQ.Enabled":                            false,
-	"hnsw.PQ.BitCompression":                     false,
-	"hnsw.PQ.Segments":                           false,
-	"hnsw.PQ.Centroids":                          false,
-	"hnsw.PQ.TrainingLimit":                      false,
-	"hnsw.PQ.Encoder.Type":                       false,
-	"hnsw.PQ.Encoder.Distribution":               false,
-	"hnsw.BQ.Enabled":                            false,
-	"hnsw.SQ.Enabled":                            false,
-	"hnsw.SQ.TrainingLimit":                      false,
-	"hnsw.SQ.RescoreLimit":                       true,
-	"hnsw.RQ.Enabled":                            false,
-	"hnsw.RQ.Bits":                               false,
-	"hnsw.RQ.RescoreLimit":                       true,
-	"hnsw.Multivector.Enabled":                   true,
-	"hnsw.Multivector.Aggregation":               true,
-	"hnsw.Multivector.MuveraConfig.Enabled":      true,
-	"hnsw.Multivector.MuveraConfig.KSim":         true,
-	"hnsw.Multivector.MuveraConfig.DProjections": true,
-	"hnsw.Multivector.MuveraConfig.Repetitions":  true,
-	// flat.UserConfig
-	"flat.Distance":                 false,
-	"flat.VectorCacheMaxObjects":    true,
-	"flat.SkipDefaultQuantization":  true,
-	"flat.TrackDefaultQuantization": true,
-	"flat.PQ.Enabled":               false,
-	"flat.PQ.RescoreLimit":          true,
-	"flat.PQ.Cache":                 true,
-	"flat.BQ.Enabled":               false,
-	"flat.BQ.RescoreLimit":          true,
-	"flat.BQ.Cache":                 true,
-	"flat.SQ.Enabled":               false,
-	"flat.SQ.RescoreLimit":          true,
-	"flat.SQ.Cache":                 true,
-	"flat.RQ.Enabled":               false,
-	"flat.RQ.RescoreLimit":          true,
-	"flat.RQ.Cache":                 true,
-	"flat.RQ.Bits":                  false,
-	// dynamic.UserConfig (HnswUC/FlatUC recurse under the base hnsw/flat prefixes, not here)
-	"dynamic.Distance":  false,
-	"dynamic.Threshold": true,
-}
-
-// classificationNestedStructs are the config sub-structs the walk recurses into rather than
-// treating as opaque leaves. Dynamic's HnswUC/FlatUC are handled specially (base-prefix remap).
-var classificationNestedStructs = map[reflect.Type]bool{
-	reflect.TypeOf(hnswent.PQConfig{}):              true,
-	reflect.TypeOf(hnswent.PQEncoder{}):             true,
-	reflect.TypeOf(hnswent.BQConfig{}):              true,
-	reflect.TypeOf(hnswent.SQConfig{}):              true,
-	reflect.TypeOf(hnswent.RQConfig{}):              true,
-	reflect.TypeOf(hnswent.MultivectorConfig{}):     true,
-	reflect.TypeOf(hnswent.MuveraConfig{}):          true,
-	reflect.TypeOf(flatent.CompressionUserConfig{}): true,
-	reflect.TypeOf(flatent.RQUserConfig{}):          true,
-}
+// querySafeLeaves and structuralLeaves classify every leaf of the parsed vector-config structs by
+// dotted path (rooted at the index type; dynamic's HnswUC/FlatUC reuse the hnsw/flat paths). Every
+// leaf must appear in exactly one — that is the fail-closed guarantee: a newly-added field fails
+// Test_vectorConfigClassificationComplete until it is consciously placed here, so it cannot silently
+// slip past the move guard. normalize must zero exactly the safe leaves and preserve the structural.
+var (
+	querySafeLeaves = []string{
+		"hnsw.Skip", "hnsw.CleanupIntervalSeconds", "hnsw.MaxConnections", "hnsw.EFConstruction", "hnsw.EF",
+		"hnsw.DynamicEFMin", "hnsw.DynamicEFMax", "hnsw.DynamicEFFactor", "hnsw.VectorCacheMaxObjects", "hnsw.FlatSearchCutoff",
+		"hnsw.FilterStrategy", "hnsw.SkipDefaultQuantization", "hnsw.TrackDefaultQuantization", "hnsw.SQ.RescoreLimit", "hnsw.RQ.RescoreLimit",
+		"hnsw.Multivector.Enabled", "hnsw.Multivector.Aggregation", "hnsw.Multivector.MuveraConfig.Enabled",
+		"hnsw.Multivector.MuveraConfig.KSim", "hnsw.Multivector.MuveraConfig.DProjections", "hnsw.Multivector.MuveraConfig.Repetitions",
+		"flat.VectorCacheMaxObjects", "flat.SkipDefaultQuantization", "flat.TrackDefaultQuantization",
+		"flat.PQ.RescoreLimit", "flat.PQ.Cache", "flat.BQ.RescoreLimit", "flat.BQ.Cache",
+		"flat.SQ.RescoreLimit", "flat.SQ.Cache", "flat.RQ.RescoreLimit", "flat.RQ.Cache", "dynamic.Threshold",
+	}
+	structuralLeaves = []string{
+		"hnsw.Distance", "hnsw.PQ.Enabled", "hnsw.PQ.BitCompression", "hnsw.PQ.Segments", "hnsw.PQ.Centroids",
+		"hnsw.PQ.TrainingLimit", "hnsw.PQ.Encoder.Type", "hnsw.PQ.Encoder.Distribution", "hnsw.BQ.Enabled",
+		"hnsw.SQ.Enabled", "hnsw.SQ.TrainingLimit", "hnsw.RQ.Enabled", "hnsw.RQ.Bits",
+		"flat.Distance", "flat.PQ.Enabled", "flat.BQ.Enabled", "flat.SQ.Enabled", "flat.RQ.Enabled", "flat.RQ.Bits",
+		"dynamic.Distance",
+	}
+)
 
 // Test_vectorConfigClassificationComplete is the fail-closed guarantee: it forces every leaf of
-// every parsed vector-config struct to be consciously classified, and verifies normalize* zeroes
-// exactly the safe leaves. A newly-added field that nobody classifies makes this test fail, which
-// is the whole point — it cannot silently default to query-time-safe and slip past the move guard.
+// every parsed vector-config struct to be classified safe or structural, and verifies normalize
+// zeroes exactly the safe leaves. A newly-added field is unclassified until placed in
+// querySafeLeaves or structuralLeaves, so it cannot silently default to safe and slip past the guard.
 func Test_vectorConfigClassificationComplete(t *testing.T) {
-	hnswType := reflect.TypeOf(hnswent.UserConfig{})
-	flatType := reflect.TypeOf(flatent.UserConfig{})
-	dynamicType := reflect.TypeOf(dynamicent.UserConfig{})
+	toSet := func(xs []string) map[string]struct{} {
+		s := make(map[string]struct{}, len(xs))
+		for _, x := range xs {
+			s[x] = struct{}{}
+		}
+		return s
+	}
+	safe, structural := toSet(querySafeLeaves), toSet(structuralLeaves)
 
-	t.Run("every leaf is classified", func(t *testing.T) {
-		var missing []string
-		var walk func(prefix string, typ reflect.Type)
-		walk = func(prefix string, typ reflect.Type) {
-			for i := 0; i < typ.NumField(); i++ {
-				f := typ.Field(i)
-				switch {
-				case classificationNestedStructs[f.Type]:
-					walk(prefix+"."+f.Name, f.Type)
-				case f.Name == "HnswUC":
-					walk("hnsw", f.Type) // dynamic's HNSW phase reuses the base hnsw classification
-				case f.Name == "FlatUC":
-					walk("flat", f.Type)
-				default:
-					path := prefix + "." + f.Name
-					if _, ok := vectorConfigClassification[path]; !ok {
-						missing = append(missing, path)
-					}
+	// Walk a normalized, fully-populated config of each index type. Every leaf must be in exactly
+	// one bucket, and normalize must have zeroed it iff it is safe. Any field-typed struct is
+	// recursed into; dynamic's HnswUC/FlatUC reuse the hnsw/flat paths.
+	var walk func(prefix string, v reflect.Value)
+	walk = func(prefix string, v reflect.Value) {
+		for i := 0; i < v.NumField(); i++ {
+			f, fv := v.Type().Field(i), v.Field(i)
+			switch {
+			case f.Name == "HnswUC":
+				walk("hnsw", fv)
+			case f.Name == "FlatUC":
+				walk("flat", fv)
+			case f.Type.Kind() == reflect.Struct:
+				walk(prefix+"."+f.Name, fv)
+			default:
+				path := prefix + "." + f.Name
+				_, inSafe := safe[path]
+				_, inStructural := structural[path]
+				require.True(t, inSafe != inStructural,
+					"vector-config leaf %q must be classified in exactly one of querySafeLeaves / structuralLeaves", path)
+				if inSafe {
+					require.True(t, fv.IsZero(), "%s is query-time-safe and must be zeroed by normalize", path)
+				} else {
+					require.False(t, fv.IsZero(), "%s is structural and must be preserved by normalize", path)
 				}
 			}
 		}
-		walk("hnsw", hnswType)
-		walk("flat", flatType)
-		walk("dynamic", dynamicType)
-		require.Empty(t, missing,
-			"unclassified vector-config field(s) — classify in vectorConfigClassification AND normalize*: %v", missing)
-	})
-
-	t.Run("normalize zeroes exactly the safe leaves", func(t *testing.T) {
-		// assertLeaves walks a normalized config and checks each leaf against the registry: safe ⇒
-		// zeroed by normalize, structural ⇒ preserved (the fillNonZero sentinel survives). Dynamic's
-		// HnswUC/FlatUC remap to the base hnsw/flat prefixes, matching the completeness walk above.
-		var assertLeaves func(prefix string, v reflect.Value)
-		assertLeaves = func(prefix string, v reflect.Value) {
-			typ := v.Type()
-			for i := 0; i < typ.NumField(); i++ {
-				f, fv := typ.Field(i), v.Field(i)
-				switch {
-				case classificationNestedStructs[f.Type]:
-					assertLeaves(prefix+"."+f.Name, fv)
-				case f.Name == "HnswUC":
-					assertLeaves("hnsw", fv)
-				case f.Name == "FlatUC":
-					assertLeaves("flat", fv)
-				case vectorConfigClassification[prefix+"."+f.Name]:
-					require.True(t, fv.IsZero(), "%s.%s is safe and must be zeroed by normalize", prefix, f.Name)
-				default:
-					require.False(t, fv.IsZero(), "%s.%s is structural and must be preserved by normalize", prefix, f.Name)
-				}
-			}
-		}
-		for _, root := range []struct {
-			prefix string
-			typ    reflect.Type
-		}{
-			{"hnsw", hnswType},
-			{"flat", flatType},
-			{"dynamic", dynamicType},
-		} {
-			filled := reflect.New(root.typ).Elem()
-			fillNonZero(filled)
-			norm, ok := normalizeVectorConfig(filled.Interface())
-			require.True(t, ok, "normalizeVectorConfig(%s) returned ok=false", root.prefix)
-			assertLeaves(root.prefix, reflect.ValueOf(norm))
-		}
-	})
+	}
+	for _, root := range []struct {
+		prefix string
+		typ    reflect.Type
+	}{
+		{"hnsw", reflect.TypeOf(hnswent.UserConfig{})},
+		{"flat", reflect.TypeOf(flatent.UserConfig{})},
+		{"dynamic", reflect.TypeOf(dynamicent.UserConfig{})},
+	} {
+		filled := reflect.New(root.typ).Elem()
+		fillNonZero(filled)
+		norm, ok := normalizeVectorConfig(filled.Interface())
+		require.True(t, ok, "normalizeVectorConfig(%s) returned ok=false", root.prefix)
+		walk(root.prefix, reflect.ValueOf(norm))
+	}
 }
 
 // fillNonZero sets every scalar leaf of the addressable struct value v to a non-zero sentinel,

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	dynamicent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	hfreshent "github.com/weaviate/weaviate/entities/vectorindex/hfresh"
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -479,6 +480,9 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 			{"named vector added", &models.Class{Class: className}, named(map[string]any{"v1": hnswent.UserConfig{}})},
 			{"named vector removed", named(map[string]any{"v1": hnswent.UserConfig{}}), &models.Class{Class: className}},
 			{"named vector structural change", named(map[string]any{"v1": hnswent.UserConfig{}}), named(map[string]any{"v1": hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
+			// hfresh is an unclassified (experimental) index type: any real change fails closed.
+			{"hfresh field change", legacy(hfreshent.UserConfig{MaxPostingSizeKB: 48}), legacy(hfreshent.UserConfig{MaxPostingSizeKB: 64})},
+			{"hfresh distance change", legacy(hfreshent.UserConfig{Distance: "cosine"}), legacy(hfreshent.UserConfig{Distance: "l2-squared"})},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -498,6 +502,8 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 			// Test_vectorConfigClassificationComplete. dynamic-threshold and a deferred-safe field
 			// are kept explicitly because both are deliberate, contestable classifications.
 			{"no vector change", legacy(hnswent.UserConfig{Distance: "cosine"}), legacy(hnswent.UserConfig{Distance: "cosine"})},
+			// A no-op update on an unclassified (hfresh) config must pass — nothing changed on disk.
+			{"hfresh no-op", legacy(hfreshent.UserConfig{MaxPostingSizeKB: 48, Distance: "cosine"}), legacy(hfreshent.UserConfig{MaxPostingSizeKB: 48, Distance: "cosine"})},
 			{"hnsw query-time knob", legacy(hnswent.UserConfig{EF: 10}), legacy(hnswent.UserConfig{EF: 20})},
 			{"hnsw deferred-safe field", legacy(hnswent.UserConfig{MaxConnections: 16}), legacy(hnswent.UserConfig{MaxConnections: 32})},
 			{"dynamic threshold", legacy(dynamicent.UserConfig{Threshold: 1000}), legacy(dynamicent.UserConfig{Threshold: 2000})},

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -467,14 +468,38 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 			name     string
 			old, new *models.Class
 		}{
-			{"compression enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}})},
-			{"compression disabled", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}), legacy(hnswent.UserConfig{})},
-			{"pq re-parametrized", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Segments: 8}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Segments: 16}})},
-			{"distance change", legacy(hnswent.UserConfig{Distance: "cosine"}), legacy(hnswent.UserConfig{Distance: "l2-squared"})},
+			// HNSW — quantizer toggles + every structural param, one field per row.
+			{"hnsw distance", legacy(hnswent.UserConfig{Distance: "cosine"}), legacy(hnswent.UserConfig{Distance: "l2-squared"})},
+			{"hnsw pq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}})},
+			{"hnsw pq disabled", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}), legacy(hnswent.UserConfig{})},
+			{"hnsw pq segments", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Segments: 8}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Segments: 16}})},
+			{"hnsw pq centroids", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Centroids: 128}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Centroids: 256}})},
+			{"hnsw pq trainingLimit", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, TrainingLimit: 1000}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, TrainingLimit: 2000}})},
+			{"hnsw pq bitCompression", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, BitCompression: true}})},
+			{"hnsw pq encoder type", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Type: "kmeans"}}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Type: "tile"}}})},
+			{"hnsw pq encoder distribution", legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Distribution: "normal"}}}), legacy(hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true, Encoder: hnswent.PQEncoder{Distribution: "log-normal"}}})},
+			{"hnsw bq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{BQ: hnswent.BQConfig{Enabled: true}})},
+			{"hnsw sq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true}})},
+			{"hnsw sq trainingLimit", legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, TrainingLimit: 1000}}), legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, TrainingLimit: 2000}})},
+			{"hnsw rq enabled", legacy(hnswent.UserConfig{}), legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true}})},
+			{"hnsw rq bits", legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 8}}), legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 1}})},
+			// Flat — quantizer toggles + bits, one field per row.
+			{"flat distance", legacy(flatent.UserConfig{Distance: "cosine"}), legacy(flatent.UserConfig{Distance: "l2-squared"})},
+			{"flat pq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{Enabled: true}})},
+			{"flat bq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{Enabled: true}})},
+			{"flat sq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{Enabled: true}})},
+			{"flat rq enabled", legacy(flatent.UserConfig{}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true}})},
+			{"flat rq bits", legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true, Bits: 8}}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true, Bits: 1}})},
+			// Dynamic — distance and recursion into both phases (Threshold is query-time-safe; see allowed cases).
+			{"dynamic distance", legacy(dynamicent.UserConfig{Distance: "cosine"}), legacy(dynamicent.UserConfig{Distance: "l2-squared"})},
+			{"dynamic hnsw rq bits", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 8}}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, Bits: 1}}})},
+			{"dynamic flat rq enabled", legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{}}), legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true}}})},
+			{"dynamic compression toggled", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
+			// Index type, named vector add/remove, and a within-config change on a named vector.
 			{"index type change", legacy(hnswent.UserConfig{}), legacy(flatent.UserConfig{})},
 			{"named vector added", &models.Class{Class: className}, named(map[string]any{"v1": hnswent.UserConfig{}})},
 			{"named vector removed", named(map[string]any{"v1": hnswent.UserConfig{}}), &models.Class{Class: className}},
-			{"dynamic compression toggled", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
+			{"named vector pq enabled", named(map[string]any{"v1": hnswent.UserConfig{}}), named(map[string]any{"v1": hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}})},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -490,8 +515,48 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 			name     string
 			old, new *models.Class
 		}{
-			{"ef change", legacy(hnswent.UserConfig{EF: 10}), legacy(hnswent.UserConfig{EF: 20})},
 			{"no vector change", legacy(hnswent.UserConfig{Distance: "cosine"}), legacy(hnswent.UserConfig{Distance: "cosine"})},
+			// HNSW query-time knobs.
+			{"hnsw ef", legacy(hnswent.UserConfig{EF: 10}), legacy(hnswent.UserConfig{EF: 20})},
+			{"hnsw cleanupIntervalSeconds", legacy(hnswent.UserConfig{CleanupIntervalSeconds: 60}), legacy(hnswent.UserConfig{CleanupIntervalSeconds: 120})},
+			{"hnsw dynamicEfMin", legacy(hnswent.UserConfig{DynamicEFMin: 100}), legacy(hnswent.UserConfig{DynamicEFMin: 200})},
+			{"hnsw dynamicEfMax", legacy(hnswent.UserConfig{DynamicEFMax: 500}), legacy(hnswent.UserConfig{DynamicEFMax: 600})},
+			{"hnsw dynamicEfFactor", legacy(hnswent.UserConfig{DynamicEFFactor: 8}), legacy(hnswent.UserConfig{DynamicEFFactor: 16})},
+			{"hnsw vectorCacheMaxObjects", legacy(hnswent.UserConfig{VectorCacheMaxObjects: 1}), legacy(hnswent.UserConfig{VectorCacheMaxObjects: 2})},
+			{"hnsw flatSearchCutoff", legacy(hnswent.UserConfig{FlatSearchCutoff: 40000}), legacy(hnswent.UserConfig{FlatSearchCutoff: 50000})},
+			{"hnsw filterStrategy", legacy(hnswent.UserConfig{FilterStrategy: "acorn"}), legacy(hnswent.UserConfig{FilterStrategy: "sweeping"})},
+			{"hnsw rq rescoreLimit", legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, RescoreLimit: 10}}), legacy(hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true, RescoreLimit: 20}})},
+			{"hnsw sq rescoreLimit", legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, RescoreLimit: 10}}), legacy(hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true, RescoreLimit: 20}})},
+			// HNSW deferred-safe (currently non-blocking; parity must be preserved).
+			{"hnsw maxConnections", legacy(hnswent.UserConfig{MaxConnections: 16}), legacy(hnswent.UserConfig{MaxConnections: 32})},
+			{"hnsw efConstruction", legacy(hnswent.UserConfig{EFConstruction: 128}), legacy(hnswent.UserConfig{EFConstruction: 256})},
+			{"hnsw skip", legacy(hnswent.UserConfig{Skip: false}), legacy(hnswent.UserConfig{Skip: true})},
+			{"hnsw skipDefaultQuantization", legacy(hnswent.UserConfig{SkipDefaultQuantization: false}), legacy(hnswent.UserConfig{SkipDefaultQuantization: true})},
+			{"hnsw trackDefaultQuantization", legacy(hnswent.UserConfig{TrackDefaultQuantization: false}), legacy(hnswent.UserConfig{TrackDefaultQuantization: true})},
+			{"hnsw multivector enabled", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Enabled: false}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Enabled: true}})},
+			{"hnsw multivector aggregation", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Aggregation: "maxSim"}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{Aggregation: "other"}})},
+			{"hnsw muvera enabled", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Enabled: false}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Enabled: true}}})},
+			{"hnsw muvera ksim", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{KSim: 4}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{KSim: 8}}})},
+			{"hnsw muvera dprojections", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{DProjections: 16}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{DProjections: 32}}})},
+			{"hnsw muvera repetitions", legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Repetitions: 10}}}), legacy(hnswent.UserConfig{Multivector: hnswent.MultivectorConfig{MuveraConfig: hnswent.MuveraConfig{Repetitions: 20}}})},
+			// Flat query-time knobs.
+			{"flat vectorCacheMaxObjects", legacy(flatent.UserConfig{VectorCacheMaxObjects: 1}), legacy(flatent.UserConfig{VectorCacheMaxObjects: 2})},
+			{"flat pq rescoreLimit", legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{RescoreLimit: 20}})},
+			{"flat pq cache", legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{Cache: false}}), legacy(flatent.UserConfig{PQ: flatent.CompressionUserConfig{Cache: true}})},
+			{"flat bq rescoreLimit", legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{RescoreLimit: 20}})},
+			{"flat bq cache", legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{Cache: false}}), legacy(flatent.UserConfig{BQ: flatent.CompressionUserConfig{Cache: true}})},
+			{"flat sq rescoreLimit", legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{RescoreLimit: 20}})},
+			{"flat sq cache", legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{Cache: false}}), legacy(flatent.UserConfig{SQ: flatent.CompressionUserConfig{Cache: true}})},
+			{"flat rq rescoreLimit", legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{RescoreLimit: 10}}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{RescoreLimit: 20}})},
+			{"flat rq cache", legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Cache: false}}), legacy(flatent.UserConfig{RQ: flatent.RQUserConfig{Cache: true}})},
+			// Dynamic — Threshold is query-time-safe (the flat→HNSW upgrade it gates is deferred during
+			// a move and the schema is replicated to both replicas, so no divergence), plus recursion
+			// into both phases' query-time knobs.
+			{"dynamic threshold", legacy(dynamicent.UserConfig{Threshold: 1000}), legacy(dynamicent.UserConfig{Threshold: 2000})},
+			{"dynamic hnsw ef", legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{EF: 10}}), legacy(dynamicent.UserConfig{HnswUC: hnswent.UserConfig{EF: 20}})},
+			{"dynamic flat vectorCacheMaxObjects", legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{VectorCacheMaxObjects: 1}}), legacy(dynamicent.UserConfig{FlatUC: flatent.UserConfig{VectorCacheMaxObjects: 2}})},
+			// Named vector query-time change.
+			{"named vector ef", named(map[string]any{"v1": hnswent.UserConfig{EF: 10}}), named(map[string]any{"v1": hnswent.UserConfig{EF: 20}})},
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -513,6 +578,196 @@ func Test_UpdateClass_MovementRejection(t *testing.T) {
 		require.NotNil(t, cls)
 		require.Equal(t, hnswent.UserConfig{}, cls.VectorIndexConfig, "config must stay uncompressed after a rejected update")
 	})
+}
+
+// vectorConfigClassification maps every leaf field of the parsed vector-config structs (dotted
+// path, rooted at the index type) to whether it is QUERY-TIME-SAFE (true) or STRUCTURAL (false).
+// It is the single source of truth that Test_vectorConfigClassificationComplete cross-checks against
+// both the struct shape (every leaf must appear — fail-closed) and normalize* (safe ⇔ zeroed).
+var vectorConfigClassification = map[string]bool{
+	// hnsw.UserConfig
+	"hnsw.Skip":                                  true,
+	"hnsw.CleanupIntervalSeconds":                true,
+	"hnsw.MaxConnections":                        true,
+	"hnsw.EFConstruction":                        true,
+	"hnsw.EF":                                    true,
+	"hnsw.DynamicEFMin":                          true,
+	"hnsw.DynamicEFMax":                          true,
+	"hnsw.DynamicEFFactor":                       true,
+	"hnsw.VectorCacheMaxObjects":                 true,
+	"hnsw.FlatSearchCutoff":                      true,
+	"hnsw.Distance":                              false,
+	"hnsw.FilterStrategy":                        true,
+	"hnsw.SkipDefaultQuantization":               true,
+	"hnsw.TrackDefaultQuantization":              true,
+	"hnsw.PQ.Enabled":                            false,
+	"hnsw.PQ.BitCompression":                     false,
+	"hnsw.PQ.Segments":                           false,
+	"hnsw.PQ.Centroids":                          false,
+	"hnsw.PQ.TrainingLimit":                      false,
+	"hnsw.PQ.Encoder.Type":                       false,
+	"hnsw.PQ.Encoder.Distribution":               false,
+	"hnsw.BQ.Enabled":                            false,
+	"hnsw.SQ.Enabled":                            false,
+	"hnsw.SQ.TrainingLimit":                      false,
+	"hnsw.SQ.RescoreLimit":                       true,
+	"hnsw.RQ.Enabled":                            false,
+	"hnsw.RQ.Bits":                               false,
+	"hnsw.RQ.RescoreLimit":                       true,
+	"hnsw.Multivector.Enabled":                   true,
+	"hnsw.Multivector.Aggregation":               true,
+	"hnsw.Multivector.MuveraConfig.Enabled":      true,
+	"hnsw.Multivector.MuveraConfig.KSim":         true,
+	"hnsw.Multivector.MuveraConfig.DProjections": true,
+	"hnsw.Multivector.MuveraConfig.Repetitions":  true,
+	// flat.UserConfig
+	"flat.Distance":                 false,
+	"flat.VectorCacheMaxObjects":    true,
+	"flat.SkipDefaultQuantization":  true,
+	"flat.TrackDefaultQuantization": true,
+	"flat.PQ.Enabled":               false,
+	"flat.PQ.RescoreLimit":          true,
+	"flat.PQ.Cache":                 true,
+	"flat.BQ.Enabled":               false,
+	"flat.BQ.RescoreLimit":          true,
+	"flat.BQ.Cache":                 true,
+	"flat.SQ.Enabled":               false,
+	"flat.SQ.RescoreLimit":          true,
+	"flat.SQ.Cache":                 true,
+	"flat.RQ.Enabled":               false,
+	"flat.RQ.RescoreLimit":          true,
+	"flat.RQ.Cache":                 true,
+	"flat.RQ.Bits":                  false,
+	// dynamic.UserConfig (HnswUC/FlatUC recurse under the base hnsw/flat prefixes, not here)
+	"dynamic.Distance":  false,
+	"dynamic.Threshold": true,
+}
+
+// classificationNestedStructs are the config sub-structs the walk recurses into rather than
+// treating as opaque leaves. Dynamic's HnswUC/FlatUC are handled specially (base-prefix remap).
+var classificationNestedStructs = map[reflect.Type]bool{
+	reflect.TypeOf(hnswent.PQConfig{}):              true,
+	reflect.TypeOf(hnswent.PQEncoder{}):             true,
+	reflect.TypeOf(hnswent.BQConfig{}):              true,
+	reflect.TypeOf(hnswent.SQConfig{}):              true,
+	reflect.TypeOf(hnswent.RQConfig{}):              true,
+	reflect.TypeOf(hnswent.MultivectorConfig{}):     true,
+	reflect.TypeOf(hnswent.MuveraConfig{}):          true,
+	reflect.TypeOf(flatent.CompressionUserConfig{}): true,
+	reflect.TypeOf(flatent.RQUserConfig{}):          true,
+}
+
+// Test_vectorConfigClassificationComplete is the fail-closed guarantee: it forces every leaf of
+// every parsed vector-config struct to be consciously classified, and verifies normalize* zeroes
+// exactly the safe leaves. A newly-added field that nobody classifies makes this test fail, which
+// is the whole point — it cannot silently default to query-time-safe and slip past the move guard.
+func Test_vectorConfigClassificationComplete(t *testing.T) {
+	hnswType := reflect.TypeOf(hnswent.UserConfig{})
+	flatType := reflect.TypeOf(flatent.UserConfig{})
+	dynamicType := reflect.TypeOf(dynamicent.UserConfig{})
+
+	t.Run("every leaf is classified", func(t *testing.T) {
+		var missing []string
+		var walk func(prefix string, typ reflect.Type)
+		walk = func(prefix string, typ reflect.Type) {
+			for i := 0; i < typ.NumField(); i++ {
+				f := typ.Field(i)
+				switch {
+				case classificationNestedStructs[f.Type]:
+					walk(prefix+"."+f.Name, f.Type)
+				case f.Name == "HnswUC":
+					walk("hnsw", f.Type) // dynamic's HNSW phase reuses the base hnsw classification
+				case f.Name == "FlatUC":
+					walk("flat", f.Type)
+				default:
+					path := prefix + "." + f.Name
+					if _, ok := vectorConfigClassification[path]; !ok {
+						missing = append(missing, path)
+					}
+				}
+			}
+		}
+		walk("hnsw", hnswType)
+		walk("flat", flatType)
+		walk("dynamic", dynamicType)
+		require.Empty(t, missing,
+			"unclassified vector-config field(s) — classify in vectorConfigClassification AND normalize*: %v", missing)
+	})
+
+	t.Run("normalize zeroes exactly the safe leaves", func(t *testing.T) {
+		hnswNorm := normalizeHNSW(populatedHNSW())
+		flatNorm := normalizeFlat(populatedFlat())
+		// assertLeaves walks a normalized value and checks each leaf against the registry: safe ⇒
+		// must be zero (got normalized away); structural ⇒ must be preserved (sentinel non-zero).
+		var assertLeaves func(prefix string, v reflect.Value)
+		assertLeaves = func(prefix string, v reflect.Value) {
+			typ := v.Type()
+			for i := 0; i < typ.NumField(); i++ {
+				f := typ.Field(i)
+				fv := v.Field(i)
+				path := prefix + "." + f.Name
+				if classificationNestedStructs[f.Type] {
+					assertLeaves(path, fv)
+					continue
+				}
+				isSafe := vectorConfigClassification[path]
+				if isSafe {
+					require.True(t, fv.IsZero(), "%s is safe and must be zeroed by normalize", path)
+				} else {
+					require.False(t, fv.IsZero(), "%s is structural and must be preserved by normalize", path)
+				}
+			}
+		}
+		assertLeaves("hnsw", reflect.ValueOf(hnswNorm))
+		assertLeaves("flat", reflect.ValueOf(flatNorm))
+	})
+}
+
+// populatedHNSW returns an HNSW config with every leaf set to a non-zero sentinel, so a normalized
+// copy reveals exactly which leaves normalizeHNSW zeroes.
+func populatedHNSW() hnswent.UserConfig {
+	return hnswent.UserConfig{
+		Skip:                     true,
+		CleanupIntervalSeconds:   1,
+		MaxConnections:           1,
+		EFConstruction:           1,
+		EF:                       1,
+		DynamicEFMin:             1,
+		DynamicEFMax:             1,
+		DynamicEFFactor:          1,
+		VectorCacheMaxObjects:    1,
+		FlatSearchCutoff:         1,
+		Distance:                 "cosine",
+		FilterStrategy:           "acorn",
+		SkipDefaultQuantization:  true,
+		TrackDefaultQuantization: true,
+		PQ: hnswent.PQConfig{
+			Enabled: true, BitCompression: true, Segments: 1, Centroids: 1, TrainingLimit: 1,
+			Encoder: hnswent.PQEncoder{Type: "kmeans", Distribution: "log-normal"},
+		},
+		BQ: hnswent.BQConfig{Enabled: true},
+		SQ: hnswent.SQConfig{Enabled: true, TrainingLimit: 1, RescoreLimit: 1},
+		RQ: hnswent.RQConfig{Enabled: true, Bits: 1, RescoreLimit: 1},
+		Multivector: hnswent.MultivectorConfig{
+			Enabled: true, Aggregation: "maxSim",
+			MuveraConfig: hnswent.MuveraConfig{Enabled: true, KSim: 1, DProjections: 1, Repetitions: 1},
+		},
+	}
+}
+
+// populatedFlat returns a flat config with every leaf set to a non-zero sentinel.
+func populatedFlat() flatent.UserConfig {
+	cuc := flatent.CompressionUserConfig{Enabled: true, RescoreLimit: 1, Cache: true}
+	return flatent.UserConfig{
+		Distance:                 "cosine",
+		VectorCacheMaxObjects:    1,
+		SkipDefaultQuantization:  true,
+		TrackDefaultQuantization: true,
+		PQ:                       cuc,
+		BQ:                       cuc,
+		SQ:                       cuc,
+		RQ:                       flatent.RQUserConfig{Enabled: true, RescoreLimit: 1, Cache: true, Bits: 1},
+	}
 }
 
 // Test_UpdateProperty_MovementRejection verifies that disabling a property index is forbidden


### PR DESCRIPTION
During a shard move, the schema guard must reject structural vector-config changes that would make the source and target replicas diverge with no way to reconcile them. It previously detected those changes by listing the *dangerous* fields to check. This change inverts that logic: it lists the *safe* fields instead, so anything not explicitly marked safe is treated as dangerous and blocks the move.

### What's being changed

- The guard now compares two configs by ignoring a known set of query-time-only fields and checking whether anything else differs (`reflect.DeepEqual` on normalized copies), instead of hand-checking each dangerous field one by one.
- A new test walks every field of the vector-config types and fails if any field has not been classified as either safe or structural. This is the key safety net: adding a new field in the future forces a deliberate decision instead of letting it silently slip past the guard.
- An unrecognised index-config type is now treated as a structural change (blocked) rather than allowed.
- The existing rejection test gains thorough per-field coverage for the legacy and named-vector paths across all three index types (HNSW, flat, dynamic).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
