### PR TITLE
fix(bm25): initialize block impact for single-document terms

### DIFF
--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -383,6 +383,13 @@ func (s *SegmentBlockMax) decodeBlock() error {
 		s.blockDataSize = int(s.docCount)
 		s.freqDecoded = true
 		s.decoded = true
+		// The full-decode path below sets the block-max impact and id; this
+		// early-return branch must set them too. Leaving currentBlockImpact at 0
+		// understates the WAND upper bound and makes BlockMax-WAND prune away
+		// documents that match this term — which for a single-document term is
+		// exactly the rare, high-idf term whose matches matter most.
+		s.currentBlockImpact = s.computeCurrentBlockImpact()
+		s.currentBlockMaxId = s.blockEntries[s.blockEntryIdx].MaxId
 		s.Metrics.BlockCountDecodedDocIds++
 		s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
 		return nil

--- a/adapters/repos/db/lsmkv/segment_blockmax_singleton_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_singleton_test.go
@@ -1,0 +1,121 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// A single-document disk term takes decodeBlock's docCount<=ENCODE_AS_FULL_BYTES
+// early return, which used to skip initializing currentBlockImpact (the term's
+// WAND upper bound) and currentBlockMaxId, leaving them at 0. A 0 upper bound
+// makes BlockMax-WAND prune away documents that match the term — and a single-
+// document term is exactly a rare, high-idf term whose matches should rank high.
+//
+// TestSingletonTerm_BlockImpactInitialized checks the field directly;
+// TestSingletonTerm_NotPrunedFromTopK checks the user-visible consequence.
+func TestSingletonTerm_BlockImpactInitialized(t *testing.T) {
+	ctx := context.Background()
+	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
+	const N = 1_000_000
+
+	bucket := newInvertedBucket(t, ctx)
+	defer bucket.Shutdown(ctx)
+
+	require.NoError(t, bucket.MapSet([]byte("s"), NewMapPairFromDocIdAndTf(7, 5, 1, false))) // docCount==1
+	for d := uint64(1); d <= 50; d++ {
+		require.NoError(t, bucket.MapSet([]byte("m"), NewMapPairFromDocIdAndTf(d, 3, 1, false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, N, nil,
+		[]string{"s", "m"}, "", 1, []int{1, 1}, bm25)
+	require.NoError(t, err)
+
+	var singleton *SegmentBlockMax
+	for _, seg := range diskTerms {
+		for _, term := range seg {
+			if term.QueryTermIndex() == 0 {
+				singleton = term
+			}
+		}
+	}
+	require.NotNil(t, singleton)
+	require.EqualValues(t, 1, singleton.docCount)
+
+	// impact must equal the block's true max impact (idf * tf/(tf+k1) at propLen==1),
+	// not 0; block-max id must be the doc id, not 0.
+	require.NotZero(t, singleton.currentBlockImpact, "single-doc currentBlockImpact must be initialized")
+	require.InDelta(t, singleton.computeCurrentBlockImpact(), singleton.currentBlockImpact, 1e-6)
+	require.EqualValues(t, 7, singleton.currentBlockMaxId)
+}
+
+func TestSingletonTerm_NotPrunedFromTopK(t *testing.T) {
+	ctx := context.Background()
+	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
+	const N = 1_000_000
+	const avgPropLen = 1.0
+
+	bucket := newInvertedBucket(t, ctx)
+	defer bucket.Shutdown(ctx)
+
+	// "d": common term, docs 1..300 tf 1 (low idf). "s": rare term, doc 7 only,
+	// tf 5 (high idf). doc 7 matches both, so it is the unique true top-1.
+	for d := uint64(1); d <= 300; d++ {
+		require.NoError(t, bucket.MapSet([]byte("d"), NewMapPairFromDocIdAndTf(d, 1, 1, false)))
+	}
+	require.NoError(t, bucket.MapSet([]byte("s"), NewMapPairFromDocIdAndTf(7, 5, 1, false)))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, N, nil,
+		[]string{"d", "s"}, "", 1, []int{1, 1}, bm25)
+	require.NoError(t, err)
+
+	topID, topScore := uint64(0), float32(-1e30)
+	for _, segTerms := range diskTerms {
+		if len(segTerms) == 0 {
+			continue
+		}
+		heap, err := DoBlockMaxWand(ctx, 1, segTerms, avgPropLen, false, len(segTerms), 1, bucket.logger)
+		require.NoError(t, err)
+		for heap.Len() > 0 {
+			it := heap.Pop()
+			if it.Dist > topScore {
+				topScore, topID = it.Dist, it.ID
+			}
+		}
+	}
+	require.Equalf(t, uint64(7), topID,
+		"BlockMax-WAND must return doc 7 (matched by the rare term) as top-1, got doc %d @ %.4f", topID, topScore)
+}
+
+func newInvertedBucket(t *testing.T, ctx context.Context) *Bucket {
+	t.Helper()
+	dir := t.TempDir()
+	b, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	return b
+}


### PR DESCRIPTION
### What's being changed

A single-document disk term (`docCount <= ENCODE_AS_FULL_BYTES`, i.e. exactly one document in a segment) takes `decodeBlock`'s early-return branch. That branch set `idPointer`/`blockDataSize`/`decoded` but left **`currentBlockImpact` and `currentBlockMaxId` at 0**, whereas the full-decode path sets both.

`currentBlockImpact` is the term's WAND upper bound. Leaving it at 0 understates the bound, so BlockMax-WAND **prunes away documents that match the term**. A single-document term is exactly a rare, high-idf term, so the dropped documents are often the true top-K.

### Impact

A keyword/hybrid (BM25) query containing a rare term — one that appears in a single document of a segment — can silently miss the very documents that match that term, or rank them far too low.

Minimal reproduction (added as a regression test):

| | |
|---|---|
| term `d` | docs 1..300, tf 1 (common, low idf) |
| term `s` | doc 7 only, tf 5 (rare, high idf) |
| query | `d s`, limit 1 |

- True top-1: **doc 7 @ 14.50** (matched by both terms)
- Before fix: BMW returns **doc 1 @ 3.69** — doc 7 dropped entirely
- After fix: BMW returns **doc 7**

### The fix

Set `currentBlockImpact` (= `computeCurrentBlockImpact()`, the block's true max impact) and `currentBlockMaxId` in the early-return branch, mirroring the full-decode path.

This only affects **disk** terms. Memtable terms are pre-decoded (`decoded=true`), so `AdvanceAtLeast` never calls `decodeBlock` on them, and when they do advance past their single block they `exhaust()` before reaching this branch — so their existing `idf` upper bound is untouched.

### Tests

- `TestSingletonTerm_BlockImpactInitialized` — field-level: a single-doc disk term's `currentBlockImpact`/`currentBlockMaxId` are initialized (and equal the block's true max impact / doc id), not 0.
- `TestSingletonTerm_NotPrunedFromTopK` — end-to-end: a doc matched by a rare single-document term is returned as top-1 instead of being pruned.

Both fail on `stable/v1.37` without the change and pass with it. Pre-existing bug (not introduced by a recent change); `decodeBlock`'s single-document branch has skipped the impact since the BlockMax-WAND path was added.

### Verification
- Unit (`-race`) + integration BMW/inverted/tombstone/compaction suites pass.
- `golangci-lint`: 0 issues; goroutine linter clean.