### PR TITLE
fix(bm25): record max-impact pair on memtable BlockEntry

### DIFF
--- a/adapters/repos/db/bm25_block_memtable_prune_test.go
+++ b/adapters/repos/db/bm25_block_memtable_prune_test.go
@@ -1,0 +1,230 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/searchparams"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestBM25FBlockMemtableImpactNotPruned exercises the full
+// shard.ObjectSearch -> bm25_searcher_block.go path (term creation, SetIdf,
+// per-segment DoBlockMaxWand, combineResults) for a memtable-resident term.
+//
+// A memtable term that leaves its synthesized BlockEntry max-impact pair at
+// zero gets a zero BlockMax-WAND upper bound, so its documents are silently
+// pruned once the per-segment result heap fills. The existing block harness
+// (TestBM25FCompareBlock) never triggered this because it searches with
+// limit=1000 over ~7 docs: the heap never fills, so the zero bound is harmless.
+//
+// To force pruning the filler term must occupy more than the per-segment
+// internal limit, which bm25_searcher_block.go bumps to max(limit*1.1,
+// limit+10) — so a low caller limit alone is not enough; the segment needs
+// >internalLimit matching docs. The rare doc is inserted last (highest docID,
+// scored last by WAND, after the heap is full) and matches only the rare term,
+// so its survival depends entirely on that term's WAND upper bound.
+func TestBM25FBlockMemtableImpactNotPruned(t *testing.T) {
+	config.DefaultUsingBlockMaxWAND = true
+	ctx := context.Background()
+	logger := logrus.New()
+	repo, schemaGetter := newBM25BlockTestRepo(t, logger)
+	defer repo.Shutdown(ctx)
+
+	const (
+		fillerTerm = "filler"
+		rareTerm   = "rare"
+		rareText   = "rare rare rare rare rare rare rare rare"
+		// internalLimit for callerLimit=1 is max(1.1, 11)=11, so the filler term
+		// needs more than that in a single segment to fill the WAND heap.
+		fillerCount = 20
+		callerLimit = 1
+		// no pruning happens here: internalLimit >> doc count, so this is the
+		// ground-truth ranking the limited search must reproduce.
+		oracleLimit = fillerCount + 10
+	)
+
+	cases := []struct {
+		name string
+		// flushAfterFiller flushes the first filler batch to disk, then leaves a
+		// fresh filler batch + the rare doc memtable-resident on top of it.
+		flushAfterFiller bool
+		// flushAll flushes everything so the term comes from a disk segment
+		// (which populates max-impact correctly) — a control that must stay green.
+		flushAll bool
+	}{
+		{name: "memtable_resident"},
+		{name: "memtable_over_flushed_segment", flushAfterFiller: true},
+		{name: "disk_resident", flushAll: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			className := "BM25Block_" + tc.name
+			shard := setupSingleTextClass(t, repo, schemaGetter, logger, className)
+
+			docID := 0
+			put := func(text string) uint64 {
+				putTextDoc(t, repo, className, docID, text)
+				id := uint64(docID)
+				docID++
+				return id
+			}
+
+			if tc.flushAfterFiller {
+				// first half on disk, second half + rare memtable-resident on top
+				for i := 0; i < fillerCount; i++ {
+					put(fillerTerm)
+				}
+				require.NoError(t, shard.Store().FlushMemtables(ctx))
+				for i := 0; i < fillerCount; i++ {
+					put(fillerTerm)
+				}
+			} else {
+				for i := 0; i < fillerCount; i++ {
+					put(fillerTerm)
+				}
+			}
+			rareID := put(rareText)
+
+			if tc.flushAll {
+				require.NoError(t, shard.Store().FlushMemtables(ctx))
+			}
+
+			search := func(limit int) ([]uint64, []float32) {
+				kwr := &searchparams.KeywordRanking{
+					Type:       "bm25",
+					Properties: []string{"text"},
+					Query:      fillerTerm + " " + rareTerm,
+				}
+				objs, scores, err := shard.ObjectSearch(ctx, limit, nil, kwr, nil, nil,
+					additional.Properties{}, []string{"text"})
+				require.NoError(t, err)
+				ids := make([]uint64, len(objs))
+				for i, o := range objs {
+					ids[i] = o.DocID
+				}
+				return ids, scores
+			}
+
+			oracleIDs, _ := search(oracleLimit)
+			require.NotEmpty(t, oracleIDs)
+			require.Equal(t, rareID, oracleIDs[0],
+				"sanity: the rare high-tf doc must top the ranking when nothing is pruned")
+
+			limitedIDs, _ := search(callerLimit)
+			require.NotEmpty(t, limitedIDs)
+			require.Equal(t, rareID, limitedIDs[0],
+				"rare memtable doc (id %d) was pruned by BlockMax-WAND once the heap filled; got %v",
+				rareID, limitedIDs)
+		})
+	}
+}
+
+func putTextDoc(t *testing.T, repo *DB, className string, idx int, text string) {
+	t.Helper()
+	id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", idx)).String())
+	obj := &models.Object{
+		Class:              className,
+		ID:                 id,
+		Properties:         map[string]interface{}{"text": text},
+		CreationTimeUnix:   1565612833955,
+		LastUpdateTimeUnix: 10000020,
+	}
+	require.NoError(t, repo.PutObject(context.Background(), obj, []float32{1, 3, 5, 0.4}, nil, nil, nil, 0))
+}
+
+func setupSingleTextClass(t *testing.T, repo *DB, schemaGetter *fakeSchemaGetter, logger logrus.FieldLogger, className string) ShardLike {
+	t.Helper()
+	vFalse, vTrue := false, true
+	class := &models.Class{
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: BM25FinvertedConfig(1.2, 0.75, "none"),
+		Class:               className,
+		Properties: []*models.Property{
+			{
+				Name:            "text",
+				DataType:        schema.DataTypeText.PropString(),
+				Tokenization:    models.PropertyTokenizationWord,
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vTrue,
+			},
+		},
+	}
+	schemaGetter.schema = schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+	migrator := NewMigrator(repo, logger, "node1")
+	migrator.AddClass(context.Background(), class)
+
+	idx := repo.GetIndex(schema.ClassName(className))
+	require.NotNil(t, idx)
+	var shard ShardLike
+	require.NoError(t, idx.ForEachShard(func(_ string, s ShardLike) error {
+		shard = s
+		return nil
+	}))
+	require.NotNil(t, shard)
+	return shard
+}
+
+func newBM25BlockTestRepo(t *testing.T, logger logrus.FieldLogger) (*DB, *fakeSchemaGetter) {
+	t.Helper()
+	shardState := singleShardState()
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+		shardState: shardState,
+	}
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardState.AllPhysicalShards(), nil).Maybe()
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+		class := &models.Class{Class: className}
+		return readFunc(class, shardState)
+	}).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	mockNodeSelector := cluster.NewMockNodeSelector(t)
+	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
+	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
+	repo, err := New(logger, "node1", Config{
+		MemtablesFlushDirtyAfter:  60,
+		RootPath:                  t.TempDir(),
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, nil, nil, memwatch.NewDummyMonitor(),
+		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader)
+	require.Nil(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.Nil(t, repo.WaitForStartup(context.TODO()))
+	return repo, schemaGetter
+}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2173,6 +2173,12 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 	}
 	term.propLengths = make(map[uint64]uint32)
 
+	// SetIdf later recomputes currentBlockImpact from MaxImpactTf/PropLength. If
+	// those fields are left at zero, the recomputed impact — the WAND upper bound
+	// — is zero too, so record the posting list's max-impact pair here.
+	maxImpact := float64(0)
+	var maxImpactTf, maxImpactPropLength uint32
+
 	for _, v := range mem {
 		if v.Tombstone {
 			continue
@@ -2194,6 +2200,13 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		term.blockDataDecoded.Tfs = append(term.blockDataDecoded.Tfs, uint64(d.Frequency))
 		term.propLengths[d.Id] = uint32(d.PropLength)
 
+		tf := float64(d.Frequency)
+		pl := float64(d.PropLength)
+		if impact := tf / (tf + term.k1*(1-term.b+term.b*(pl/term.averagePropLength))); impact > maxImpact {
+			maxImpact = impact
+			maxImpactTf = uint32(d.Frequency)
+			maxImpactPropLength = uint32(d.PropLength)
+		}
 	}
 	if len(term.blockDataDecoded.DocIds) == 0 {
 		return n, nil
@@ -2201,8 +2214,10 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 	term.exhausted = false
 	term.blockEntries = make([]*terms.BlockEntry, 1)
 	term.blockEntries[0] = &terms.BlockEntry{
-		MaxId:  term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],
-		Offset: 0,
+		MaxId:               term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],
+		Offset:              0,
+		MaxImpactTf:         maxImpactTf,
+		MaxImpactPropLength: maxImpactPropLength,
 	}
 
 	term.currentBlockMaxId = term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1]

--- a/adapters/repos/db/lsmkv/bucket_blockmax_memtable_test.go
+++ b/adapters/repos/db/lsmkv/bucket_blockmax_memtable_test.go
@@ -1,0 +1,82 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// SetIdf() recomputes currentBlockImpact from a term's BlockEntry max-impact
+// pair. A memtable term that leaves those fields at zero gets a zero WAND bound,
+// so its unflushed matches are silently pruned once the result heap fills.
+func TestBlockMaxWandMemtableTermNotPruned(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+
+	const rareDocID = uint64(99) // highest id => processed last, after the heap fills
+	commonDocs := []uint64{10, 11, 12, 13, 14}
+	for _, id := range commonDocs {
+		require.NoError(t, bucket.MapSet([]byte("common"), NewMapPairFromDocIdAndTf(id, 1, 1, false)))
+	}
+	require.NoError(t, bucket.MapSet([]byte("rare"), NewMapPairFromDocIdAndTf(rareDocID, 8, 1, false)))
+
+	// deliberately NOT flushed: the terms stay memtable-resident.
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+
+	config := schema.BM25Config{K1: 1.2, B: 0.75}
+	corpusN := len(commonDocs) + 1 // distinct documents
+	limit := len(commonDocs)       // forces the heap to fill before the rare doc
+
+	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(corpusN), nil,
+		[]string{"common", "rare"}, "", 1, []int{1, 1}, config)
+	require.NoError(t, err)
+
+	got := make(map[uint64]float32)
+	for _, segTerms := range diskTerms {
+		if len(segTerms) == 0 {
+			continue
+		}
+		// mirror bm25_searcher_block.go, which calls SetIdf on every term.
+		for _, term := range segTerms {
+			require.Greater(t, term.CurrentBlockImpact(), float32(0),
+				"memtable term should have a positive block impact before SetIdf")
+			term.SetIdf(term.Idf())
+			require.Greater(t, term.CurrentBlockImpact(), float32(0),
+				"SetIdf must not zero a memtable term's block impact")
+		}
+		heap, err := DoBlockMaxWand(ctx, limit, segTerms, 1.0, false, len(segTerms), 1, logger)
+		require.NoError(t, err)
+		for heap.Len() > 0 {
+			item := heap.Pop()
+			got[item.ID] = item.Dist
+		}
+	}
+
+	_, found := got[rareDocID]
+	require.True(t, found,
+		"memtable rare term's document was pruned from the top-%d; got result ids %v", limit, got)
+}


### PR DESCRIPTION
### What's being changed:

A memtable-resident term synthesizes a single BlockEntry in addDataToTerm but left MaxImpactTf/MaxImpactPropLength at zero. createDiskTermFromCV seeds currentBlockImpact = idf for these terms, but the search path then calls SetIdf() on every term (bm25_searcher_block.go), which recomputes currentBlockImpact via computeCurrentBlockImpact() from those very fields. With both at zero the recomputed impact is zero, so the BlockMax-WAND upper bound omits the term, and its documents are silently pruned once the result heap fills — dropping recently inserted, not-yet-flushed matches from limited BM25/BM25F results.

Compute the block's max-impact (tf, propLength) pair over the posting list and store it on the synthesized BlockEntry, mirroring how flushed segments populate these fields in createBlocks (segment_serialization_inverted.go).

Regression test (TestBlockMaxWandMemtableTermNotPruned): memtable-resident rare + common terms, SetIdf applied as in production, limited multi-term WAND query; asserts the rare doc's impact survives SetIdf and the doc is not pruned. Red without the fix, green with it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
