### PR TITLE
Fix BQ Manhattan flat search

### DIFF
--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -423,7 +423,12 @@ func (index *flat) searchTimeRescore(k int) int {
 
 func (index *flat) SearchByVector(ctx context.Context, vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error) {
 	switch index.compressionType {
-	case CompressionBQ, CompressionRQ1, CompressionRQ8:
+	case CompressionBQ:
+		if index.distancerProvider.Type() == "manhattan" {
+			return index.searchByVector(ctx, vector, k, allow)
+		}
+		return index.searchByVectorQuantized(ctx, vector, k, allow)
+	case CompressionRQ1, CompressionRQ8:
 		return index.searchByVectorQuantized(ctx, vector, k, allow)
 	default:
 		return index.searchByVector(ctx, vector, k, allow)

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -1239,6 +1239,62 @@ func Test_NoRace_QuantizedSearchFunctionality(t *testing.T) {
 	}
 }
 
+func Test_NoRace_BQManhattanSearchIsTranslationInvariant(t *testing.T) {
+	ctx := context.Background()
+	manhattan := distancer.NewManhattanProvider()
+
+	runCase := func(t *testing.T, vectors [][]float32, query []float32) ([]uint64, []float32) {
+		store, dirName := createTestStore(t)
+		index, err := New(Config{
+			ID:                "test-bq-manhattan-translation-" + uuid.New().String(),
+			RootPath:          dirName,
+			DistanceProvider:  manhattan,
+			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+		}, flatent.UserConfig{
+			BQ: flatent.CompressionUserConfig{
+				Enabled:      true,
+				Cache:        true,
+				RescoreLimit: 0,
+			},
+		}, store)
+		require.NoError(t, err)
+		defer index.Shutdown(context.Background())
+
+		for id, vec := range vectors {
+			require.NoError(t, index.Add(ctx, uint64(id+1), vec))
+		}
+
+		results, distances, err := index.SearchByVector(ctx, query, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Len(t, distances, 1)
+
+		return results, distances
+	}
+
+	baseVectors := [][]float32{
+		{-0.1, -0.1},
+		{1.0, 1.0},
+		{2.0, 2.0},
+		{3.0, 3.0},
+	}
+	baseQuery := []float32{0.0, 0.0}
+
+	translatedVectors := [][]float32{
+		{9.9, 9.9},
+		{11.0, 11.0},
+		{12.0, 12.0},
+		{13.0, 13.0},
+	}
+	translatedQuery := []float32{10.0, 10.0}
+
+	baseResults, baseDistances := runCase(t, baseVectors, baseQuery)
+	translatedResults, translatedDistances := runCase(t, translatedVectors, translatedQuery)
+
+	require.Equal(t, []uint64{1}, baseResults, "base nearest neighbor: distances=%v", baseDistances)
+	require.Equal(t, []uint64{1}, translatedResults, "translated nearest neighbor: distances=%v", translatedDistances)
+}
+
 func Test_NoRace_EdgeCases(t *testing.T) {
 	ctx := context.Background()
 	distancer := distancer.NewCosineDistanceProvider()


### PR DESCRIPTION
### What's being changed:

Fixes #11656.

Flat BQ search now falls back to the exact flat scan when the distance provider
is Manhattan. BQ sign-bit candidate preselection is not translation invariant for
Manhattan distance, so it can miss the true nearest neighbor before rescoring.

This also adds a regression test for the reported top-1 translation case with
BQ, cache enabled, and `rescoreLimit=0`.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: Not necessary; this is an internal flat vector search correctness fix.
- [x] Chaos pipeline run or not necessary. Link to pipeline: Not necessary; this is covered by local package tests.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary; the change favors exact flat search for BQ with Manhattan distance to preserve correctness.

Validation:

```bash
go test -count=1 ./adapters/repos/db/vector/flat -run Test_NoRace_BQManhattanSearchIsTranslationInvariant -v
```

```text
=== RUN   Test_NoRace_BQManhattanSearchIsTranslationInvariant
--- PASS: Test_NoRace_BQManhattanSearchIsTranslationInvariant (0.20s)
PASS
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/flat	0.265s
```

```bash
go test -count=1 ./adapters/repos/db/vector/flat -run 'Test_NoRace_(BQManhattanSearchIsTranslationInvariant|QuantizedSearchFunctionality)$' -v
```

```text
--- PASS: Test_NoRace_QuantizedSearchFunctionality (0.26s)
--- PASS: Test_NoRace_BQManhattanSearchIsTranslationInvariant (0.16s)
PASS
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/flat	0.479s
```
