### PR TITLE
Fix panic in `db.WaitForLocalInflightWrites`

### DIFF
--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -421,17 +421,22 @@ func (db *DB) GetIndex(className schema.ClassName) *Index {
 
 // WaitForLocalInflightWrites blocks until this node's in-flight coordinated
 // writes to the given shard have drained, or ctx is done.
+//
+// If the index is not found, or if the index has no replicator (i.e. this node is not a replica for the given shard), this method returns immediately without error.
 func (db *DB) WaitForLocalInflightWrites(ctx context.Context, class, shard string) error {
 	var index *Index
-	func() {
+	if ok := func() bool {
 		db.indexLock.RLock()
 		defer db.indexLock.RUnlock()
 		index = db.indices[indexID(schema.ClassName(class))]
 		if index == nil || index.replicator == nil {
-			return
+			return false
 		}
 		index.dropIndex.RLock()
-	}()
+		return true
+	}(); !ok {
+		return nil
+	}
 	defer index.dropIndex.RUnlock()
 	return index.replicator.WaitForDrain(ctx, shard)
 }


### PR DESCRIPTION
### What's being changed:

Ensure that function returns early if `index` or `index.replicator` is `nil` to avoid panic on `index.dropIndex.RUnlock`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
