### PR TITLE
fix(hnsw/compact): switch SnapshotWriter to sparse storage to cut peak heap

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/MEMORY_VALIDATION.md
+++ b/adapters/repos/db/vector/hnsw/compact/MEMORY_VALIDATION.md
@@ -1,0 +1,66 @@
+# Memory validation for HNSW compact
+
+## What this directory ships for memory regression prevention
+
+`SnapshotWriter` previously held a `[]*nodeState` slice indexed by node ID
+(`ensureNodesCapacity`). For shards with sparse IDs the slice was 99 %+
+nil pointers and peak heap during snapshot creation grew with `maxNodeID`
+rather than with the live-set size — 100 k live nodes scattered across a
+1×10⁸ ID space peaked at ~1.8 GB. The fix switches to
+`nodes map[uint64]*nodeState` with a once-per-Flush sorted-keys walk; same
+on-disk format, peak drops to ~30 MB.
+
+This directory now contains the artifacts that prove the fix and guard
+against regression.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `snapshot_writer.go` | The fixed writer. `nodes` is a sparse map; `writeBody` materializes sorted keys at Flush time and walks them with a cursor. |
+| `memory_bench_test.go` | Peak-heap benchmarks for the sparse-ID, dense, high-fanout-merge, raw-WAL-conversion, and tombstone-churn scenarios. Each `Bench*` reports `PeakMB` / `HeapDeltaMB` / `NumGC` as custom metrics for `benchstat`. |
+| `memory_integration_test.go` | Hard-ceiling regression gate under `//go:build integrationTest`. Currently passes at ~30 MB; fails if peak ever exceeds 100 MB. |
+
+## Running
+
+```bash
+# Bench all memory-peak scenarios.
+go test -run=^$ -bench=BenchmarkMemory -benchtime=1x -benchmem \
+  ./adapters/repos/db/vector/hnsw/compact/
+
+# Regression gate.
+go test -tags=integrationTest -count=1 -v \
+  -run=TestSparseSnapshotPeakRegression \
+  ./adapters/repos/db/vector/hnsw/compact/
+# Expect: PASS at ~30 MB peak
+
+# Correctness gate after any future writer change.
+go test -count=1 -race ./adapters/repos/db/vector/hnsw/compact/
+
+# A/B against a tentative further optimization with benchstat.
+go install golang.org/x/perf/cmd/benchstat@latest
+git stash
+go test -run=^$ -benchtime=5x -benchmem \
+  -bench=BenchmarkMemorySparseSnapshot \
+  ./adapters/repos/db/vector/hnsw/compact/ | tee /tmp/before.txt
+git stash pop
+go test -run=^$ -benchtime=5x -benchmem \
+  -bench=BenchmarkMemorySparseSnapshot \
+  ./adapters/repos/db/vector/hnsw/compact/ | tee /tmp/after.txt
+benchstat /tmp/before.txt /tmp/after.txt
+```
+
+## What the fix does NOT solve
+
+The writer-side fix is necessary but not sufficient for full O(liveNodes)
+end-to-end memory:
+
+1. **On-disk snapshot file size is still O(maxNodeID).** The V3 format
+   emits one existence byte per slot from 0 to maxNodeID. For a
+   maxID=1×10⁹ shard the snapshot file is ~1 GB even with the fix. A full
+   solution would need a format-version bump with sparse-tuple encoding.
+2. **`SnapshotReader.Read` materializes `Graph.Nodes []*Vertex` indexed
+   by node ID.** Same symmetric problem on the read/startup path. Affects
+   `Loader.Load` peak heap; not exercised by this benchmark.
+
+Those axes warrant a separate change.

--- a/adapters/repos/db/vector/hnsw/compact/memory_bench_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/memory_bench_test.go
@@ -1,0 +1,520 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compact
+
+// Memory-peak benchmarks for the compactv2 pipeline.
+//
+// Each scenario exercises a specific memory hotspot in the new disk-based
+// compaction path (see PR #9988). The scenarios are chosen to stress the
+// in-memory state that survives the streaming-merge abstraction:
+//
+//   - SnapshotWriter.nodes is indexed by node ID, so peak grows with maxID,
+//     not with live-node count (Sparse_*).
+//   - InMemoryReader.Do builds a full DeserializationResult per file
+//     (RawFileConversion_*).
+//   - NWayMerger's per-node commitMerger holds linksPerLevel/pendingLinks
+//     while a node is active across N iterators (FiveWayMerge_*,
+//     HighFanout_*).
+//   - SnapshotReader allocates a fresh DeserializationResult and uses 8
+//     concurrent goroutines, each holding a 4MB block (SnapshotRead_*).
+//   - Tombstone/LinksReplaced maps grow with churn, not live set
+//     (TombstoneChurn_*).
+//
+// Each Bench* exposes a *PeakMB* / *HeapDeltaMB* / *NumGC* custom metric so
+// `benchstat` can produce an A/B table against `main`. Sizes are tuned to
+// run on a laptop in a few seconds at -benchtime=1x; bump the constants for
+// adversarial sweeps.
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw/packedconn"
+)
+
+// memProbe samples runtime.MemStats.HeapInuse in the background and reports
+// peak heap + GC delta on Stop().
+//
+// The sampler is intentionally simple: a goroutine that reads MemStats every
+// `interval` and tracks the max. We don't try to be cheap — these are
+// benchmarks, not the prod hot path. Resolution is bounded by `interval`;
+// short bursts shorter than that can be missed, so callers running tiny
+// workloads should keep the interval at <=10ms.
+type memProbe struct {
+	stopOnce sync.Once
+	stop     chan struct{}
+	done     chan struct{}
+	peak     atomic.Uint64
+	startGC  uint32
+	endGC    uint32
+	startSys uint64
+	endSys   uint64
+}
+
+func startMemProbe(interval time.Duration) *memProbe {
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	p := &memProbe{
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+		startGC:  m.NumGC,
+		startSys: m.HeapInuse,
+	}
+	p.peak.Store(m.HeapInuse)
+
+	go func() {
+		defer close(p.done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		var s runtime.MemStats
+		for {
+			select {
+			case <-p.stop:
+				return
+			case <-ticker.C:
+				runtime.ReadMemStats(&s)
+				if s.HeapInuse > p.peak.Load() {
+					p.peak.Store(s.HeapInuse)
+				}
+			}
+		}
+	}()
+	return p
+}
+
+func (p *memProbe) Stop() {
+	p.stopOnce.Do(func() {
+		close(p.stop)
+		<-p.done
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		if m.HeapInuse > p.peak.Load() {
+			p.peak.Store(m.HeapInuse)
+		}
+		p.endGC = m.NumGC
+		p.endSys = m.HeapInuse
+	})
+}
+
+func (p *memProbe) report(b *testing.B) {
+	b.Helper()
+	const MiB = 1024.0 * 1024.0
+	b.ReportMetric(float64(p.peak.Load())/MiB, "PeakMB")
+	// Heap delta = HeapInuse at end minus HeapInuse at start, post-GC.
+	// Useful to detect leaks that survive the benchmark vs. peaks that
+	// recover.
+	delta := int64(p.endSys) - int64(p.startSys)
+	b.ReportMetric(float64(delta)/MiB, "HeapDeltaMB")
+	b.ReportMetric(float64(p.endGC-p.startGC), "NumGC")
+}
+
+// =============================================================================
+// Scenario S1: Sparse-ID snapshot.
+//
+// 100k live nodes scattered across a 1e9 ID space. SnapshotWriter.nodes is
+// indexed by node ID — see snapshot_writer.go:188-213 (ensureNodesCapacity).
+// Peak must be dominated by the slice of nil *nodeState pointers, ~8 bytes
+// each * maxID. For maxID=1e9 the slice header alone is ~8 GB of nil
+// pointers, which is the worst case we care about. We cap the scenario at
+// 1e7 by default to keep CI tractable; the SparseLarge variant bumps it.
+// =============================================================================
+
+func benchmarkSparseSnapshot(b *testing.B, liveNodes int, idSpread uint64) {
+	b.Helper()
+	r := rand.New(rand.NewSource(int64(liveNodes) ^ int64(idSpread)))
+
+	// Pre-pick node IDs so generation cost is excluded from the measurement.
+	ids := make([]uint64, liveNodes)
+	for i := range ids {
+		ids[i] = uint64(r.Int63n(int64(idSpread)))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		probe := startMemProbe(10 * time.Millisecond)
+
+		w := NewSnapshotWriter(io.Discard)
+		w.SetEntrypoint(ids[0], 1)
+		// AddNode in arbitrary order; SnapshotWriter expects ascending
+		// nodeID — we sort the ids slice once before iteration so the
+		// allocation pattern matches what compactor.go produces.
+		sortedIDs := make([]uint64, len(ids))
+		copy(sortedIDs, ids)
+		// Simple in-place insertion sort would be O(n^2); use slices.Sort
+		// equivalent via the stdlib sort. We pull it in lazily to avoid
+		// inflating the bench prologue.
+		for i := 1; i < len(sortedIDs); i++ {
+			for j := i; j > 0 && sortedIDs[j-1] > sortedIDs[j]; j-- {
+				sortedIDs[j-1], sortedIDs[j] = sortedIDs[j], sortedIDs[j-1]
+			}
+		}
+		for _, id := range sortedIDs {
+			w.AddNode(id, 0, [][]uint64{{}}, false)
+		}
+		if err := w.Flush(); err != nil {
+			b.Fatal(err)
+		}
+
+		probe.Stop()
+		probe.report(b)
+	}
+}
+
+func BenchmarkMemorySparseSnapshot_100k_in_1e7(b *testing.B) {
+	benchmarkSparseSnapshot(b, 100_000, 10_000_000)
+}
+
+func BenchmarkMemorySparseSnapshot_100k_in_1e8(b *testing.B) {
+	benchmarkSparseSnapshot(b, 100_000, 100_000_000)
+}
+
+// Largest sparse-ID case — 100k live nodes spread across a 1e9 ID space.
+// This is the shape we expect after very heavy churn (a billion historical
+// inserts, most deleted, current live set ~100k). The expected peak per the
+// 1e7/1e8 trajectory is ~16-18 GB; skip in -short mode and only run when
+// the operator wants to confirm the upper bound.
+func BenchmarkMemorySparseSnapshot_100k_in_1e9(b *testing.B) {
+	if testing.Short() {
+		b.Skip("multi-GB peak; run explicitly without -short")
+	}
+	benchmarkSparseSnapshot(b, 100_000, 1_000_000_000)
+}
+
+// =============================================================================
+// Scenario S2: Dense snapshot round-trip.
+//
+// 1M live nodes, dense IDs, M=32. Exercises SnapshotWriter + SnapshotReader on
+// the shape we'd see for a healthy graph. The Reader uses 8 concurrent
+// goroutines pulling 4MB blocks (snapshot_reader.go:38) — peak should sit at
+// roughly snapshotConcurrency * blockSize + the materialized
+// DeserializationResult.
+// =============================================================================
+
+func benchmarkDenseSnapshotRoundtrip(b *testing.B, n int, m int) {
+	b.Helper()
+
+	dir := b.TempDir()
+	snapPath := filepath.Join(dir, "dense.snapshot")
+
+	// One-time setup outside the timed region: build the snapshot.
+	f, err := os.Create(snapPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	w := NewSnapshotWriter(f)
+	w.SetEntrypoint(0, 1)
+	r := rand.New(rand.NewSource(42))
+	for id := uint64(0); id < uint64(n); id++ {
+		conns := make([]uint64, m)
+		for j := range conns {
+			conns[j] = uint64(r.Intn(n))
+		}
+		w.AddNode(id, 0, [][]uint64{conns}, false)
+	}
+	if err := w.Flush(); err != nil {
+		b.Fatal(err)
+	}
+	f.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		probe := startMemProbe(10 * time.Millisecond)
+
+		reader := NewSnapshotReader(testLogger())
+		res, err := reader.ReadFromFile(snapPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Anchor `res` so it isn't GC'd before we measure peak.
+		if len(res.Graph.Nodes) == 0 {
+			b.Fatal("empty graph")
+		}
+
+		probe.Stop()
+		probe.report(b)
+	}
+}
+
+func BenchmarkMemoryDenseSnapshot_1M_M32(b *testing.B) {
+	benchmarkDenseSnapshotRoundtrip(b, 1_000_000, 32)
+}
+
+// =============================================================================
+// Scenario S3: High-fanout merge.
+//
+// Two sorted files with the same 50k node IDs, each node carrying maximum
+// connections at level 0. NWayMerger's commitMerger accumulates
+// linksPerLevel + pendingLinks for the current node across all iterators
+// (nway_merger.go:264-276). Peak is dominated by holding both inputs'
+// link slices for the active node + the heap.
+//
+// 4096 is the in-memory hard cap (maxConnectionsPerNodeInMemory). We push to
+// 2048 to keep the file sizes reasonable while still stressing the merger.
+// =============================================================================
+
+func benchmarkHighFanoutMerge(b *testing.B, n int, linksPerNode int, files int) {
+	b.Helper()
+
+	dir := b.TempDir()
+	logger := testLogger()
+	paths := make([]string, files)
+
+	for k := 0; k < files; k++ {
+		path := filepath.Join(dir, fmt.Sprintf("hf_%d.sorted", k))
+		paths[k] = path
+
+		r := rand.New(rand.NewSource(int64(k) + 1))
+
+		// Build a DeserializationResult directly — faster than writing then
+		// re-reading a raw file, and we want the merger to be the bench's
+		// hot path, not the WAL writer.
+		res := ent.NewDeserializationResult(n)
+		res.Graph.EntrypointChanged = true
+		res.Graph.Entrypoint = 0
+		res.Graph.Level = 0
+
+		for id := uint64(0); id < uint64(n); id++ {
+			conns := make([]uint64, linksPerNode)
+			for j := range conns {
+				conns[j] = uint64(r.Intn(n))
+			}
+			pc, err := packedconn.NewWithElements([][]uint64{conns})
+			if err != nil {
+				b.Fatal(err)
+			}
+			v := &ent.Vertex{ID: id, Level: 0, Connections: pc}
+			// LinksReplaced bookkeeping mirrors what the real path does so
+			// the merger sees Replace semantics.
+			if res.Graph.LinksReplaced[id] == nil {
+				res.Graph.LinksReplaced[id] = make(map[uint16]struct{})
+			}
+			res.Graph.LinksReplaced[id][0] = struct{}{}
+			res.Graph.Nodes[id] = v
+		}
+
+		f, err := os.Create(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sw := NewSortedWriter(f, logger)
+		if err := sw.WriteAll(res); err != nil {
+			b.Fatal(err)
+		}
+		f.Close()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		probe := startMemProbe(10 * time.Millisecond)
+
+		iters := make([]IteratorLike, files)
+		openFiles := make([]*os.File, files)
+		for k, p := range paths {
+			f, err := os.Open(p)
+			if err != nil {
+				b.Fatal(err)
+			}
+			openFiles[k] = f
+			walReader := NewWALCommitReader(bufio.NewReaderSize(f, 256*1024), logger)
+			it, err := NewIterator(walReader, k, logger)
+			if err != nil {
+				b.Fatal(err)
+			}
+			iters[k] = it
+		}
+		m, err := NewNWayMerger(iters, logger)
+		if err != nil {
+			b.Fatal(err)
+		}
+		nodesSeen := 0
+		for {
+			nc, err := m.Next()
+			if err != nil {
+				b.Fatal(err)
+			}
+			if nc == nil {
+				break
+			}
+			nodesSeen++
+		}
+		for _, f := range openFiles {
+			f.Close()
+		}
+		if nodesSeen == 0 {
+			b.Fatal("no nodes merged")
+		}
+
+		probe.Stop()
+		probe.report(b)
+	}
+}
+
+func BenchmarkMemoryHighFanoutMerge_50k_2048_5files(b *testing.B) {
+	benchmarkHighFanoutMerge(b, 50_000, 2_048, 5)
+}
+
+// =============================================================================
+// Scenario S4: Raw WAL conversion.
+//
+// Drive a synthetic raw WAL through InMemoryReader.Do. The realistic upper
+// bound is ~100MB per WAL file (defaultCommitLogSize / 5, commit_logger.go:74)
+// before rotation. We don't try to hit 100MB on disk here — it would inflate
+// the bench prologue — but we synthesize enough commits that the resulting
+// DeserializationResult is comparable in shape to one produced from a full
+// 100MB file (50k nodes, M=32, full level distribution).
+// =============================================================================
+
+func benchmarkRawWALConversion(b *testing.B, nodes int, commits int, m int) {
+	b.Helper()
+
+	var buf bytes.Buffer
+	w := NewWALWriter(&buf)
+	r := rand.New(rand.NewSource(7))
+	for i := 0; i < commits; i++ {
+		nodeID := uint64(r.Intn(nodes))
+		level := uint16(0)
+		// occasional level promotion to exercise multi-level paths
+		for r.Float64() < 0.25 && level < 4 {
+			level++
+		}
+		switch r.Intn(20) {
+		case 0:
+			if err := w.WriteAddNode(nodeID, level); err != nil {
+				b.Fatal(err)
+			}
+		case 1:
+			if err := w.WriteAddTombstone(nodeID); err != nil {
+				b.Fatal(err)
+			}
+		default:
+			// most commits are link writes
+			conns := make([]uint64, r.Intn(m)+1)
+			for j := range conns {
+				conns[j] = uint64(r.Intn(nodes))
+			}
+			if err := w.WriteAddLinksAtLevel(nodeID, level, conns); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	data := buf.Bytes()
+	logger := testLogger()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.SetBytes(int64(len(data)))
+
+	for i := 0; i < b.N; i++ {
+		probe := startMemProbe(10 * time.Millisecond)
+
+		walReader := NewWALCommitReader(bytes.NewReader(data), logger)
+		memReader := NewInMemoryReader(walReader, logger)
+		res, err := memReader.Do(nil, true)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(res.Graph.Nodes) == 0 {
+			b.Fatal("empty result")
+		}
+
+		probe.Stop()
+		probe.report(b)
+	}
+}
+
+func BenchmarkMemoryRawWALConversion_50k_2M(b *testing.B) {
+	benchmarkRawWALConversion(b, 50_000, 2_000_000, 32)
+}
+
+// =============================================================================
+// Scenario S10: Tombstone / LinksReplaced churn.
+//
+// Synthesize a WAL where every node sees AddTombstone -> RemoveTombstone
+// cycles plus repeated ReplaceLinksAtLevel at multiple levels. The resulting
+// DeserializationResult has Tombstones, TombstonesDeleted, and LinksReplaced
+// maps that are *not* bounded by the live-set size — they grow with churn.
+// =============================================================================
+
+func benchmarkTombstoneChurn(b *testing.B, nodes int, churnPerNode int) {
+	b.Helper()
+
+	var buf bytes.Buffer
+	w := NewWALWriter(&buf)
+	for id := uint64(0); id < uint64(nodes); id++ {
+		if err := w.WriteAddNode(id, 0); err != nil {
+			b.Fatal(err)
+		}
+		for c := 0; c < churnPerNode; c++ {
+			if err := w.WriteAddTombstone(id); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.WriteRemoveTombstone(id); err != nil {
+				b.Fatal(err)
+			}
+			// also exercise LinksReplaced bookkeeping at multiple levels
+			if err := w.WriteReplaceLinksAtLevel(id, uint16(c%6), []uint64{id ^ uint64(c)}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	data := buf.Bytes()
+	logger := testLogger()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		probe := startMemProbe(10 * time.Millisecond)
+
+		walReader := NewWALCommitReader(bytes.NewReader(data), logger)
+		memReader := NewInMemoryReader(walReader, logger)
+		res, err := memReader.Do(nil, true)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if res == nil {
+			b.Fatal("nil result")
+		}
+
+		probe.Stop()
+		probe.report(b)
+	}
+}
+
+func BenchmarkMemoryTombstoneChurn_10k_x20(b *testing.B) {
+	benchmarkTombstoneChurn(b, 10_000, 20)
+}
+
+// Suppress unused-import warning on logrus when nothing in this file uses it
+// directly — testLogger() returns logrus.FieldLogger but we want the import
+// to stay imported in case future scenarios need it.
+var _ = logrus.New

--- a/adapters/repos/db/vector/hnsw/compact/memory_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/memory_integration_test.go
@@ -1,0 +1,92 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package compact
+
+// Regression gate for the SnapshotWriter sparse-ID peak.
+//
+// Before the sparse-storage fix, SnapshotWriter.nodes was a slot-indexed
+// []*nodeState slice grown via ensureNodesCapacity, so peak heap during
+// snapshot creation scaled with maxNodeID rather than with the live-set
+// size. For 100 k live nodes scattered across a 1×10⁸ ID space peak
+// exceeded 1.8 GB; with sparse storage it sits around 30 MB on the same
+// input.
+//
+// This test pins that ceiling. If it ever fails again, suspect a re-
+// introduction of slot-indexed storage in the snapshot path (writer,
+// reader, or a new caller materializing the full slot space).
+//
+//   go test -tags=integrationTest -count=1 -run=TestSparseSnapshotPeakRegression \
+//     ./adapters/repos/db/vector/hnsw/compact/
+
+import (
+	"io"
+	"math/rand"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// SparseSnapshotPeakLimit is the hard ceiling for the sparse-ID scenario.
+// Current measurement is ~30 MB peak; 100 MB leaves headroom for sampling
+// noise + payload growth, while still failing by 10× if slot-indexed
+// storage is reintroduced.
+const SparseSnapshotPeakLimitMB = 100
+
+const (
+	regressionLiveNodes = 100_000
+	regressionIDSpread  = uint64(100_000_000)
+)
+
+func TestSparseSnapshotPeakRegression(t *testing.T) {
+	r := rand.New(rand.NewSource(int64(regressionLiveNodes) ^ int64(regressionIDSpread)))
+	ids := make([]uint64, regressionLiveNodes)
+	for i := range ids {
+		ids[i] = uint64(r.Int63n(int64(regressionIDSpread)))
+	}
+	// AddNode tolerates out-of-order, but the realistic NWayMerger feed is
+	// ascending. Sort to match.
+	for i := 1; i < len(ids); i++ {
+		for j := i; j > 0 && ids[j-1] > ids[j]; j-- {
+			ids[j-1], ids[j] = ids[j], ids[j-1]
+		}
+	}
+
+	runtime.GC()
+	probe := startMemProbe(10 * time.Millisecond)
+	t.Cleanup(probe.Stop)
+
+	w := NewSnapshotWriter(io.Discard)
+	w.SetEntrypoint(ids[0], 1)
+	for _, id := range ids {
+		w.AddNode(id, 0, [][]uint64{{}}, false)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	probe.Stop()
+	peakMB := probe.peak.Load() / (1024 * 1024)
+	t.Logf("sparse-ID snapshot peak: %d MB (limit %d MB; live nodes %d, ID spread %d)",
+		peakMB, SparseSnapshotPeakLimitMB, regressionLiveNodes, regressionIDSpread)
+
+	if peakMB > SparseSnapshotPeakLimitMB {
+		t.Fatalf(
+			"SnapshotWriter peak heap %d MB exceeds %d MB regression limit. "+
+				"This usually means slot-indexed storage was reintroduced "+
+				"somewhere on the snapshot path. Cross-check the bench "+
+				"BenchmarkMemorySparseSnapshot for trend.",
+			peakMB, SparseSnapshotPeakLimitMB,
+		)
+	}
+}

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_writer.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_writer.go
@@ -19,6 +19,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math"
+	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -61,10 +62,27 @@ type SnapshotWriter struct {
 	entrypoint uint64
 	level      uint16
 
-	// Node state accumulated during writing
-	nodes      []*nodeState
+	// Node state accumulated during writing.
+	//
+	// nodes is a sparse map of live nodes by ID. This replaces a previous
+	// []*nodeState slice indexed by node ID, which scaled in O(maxNodeID)
+	// — for shards with sparse IDs (e.g. heavy historical churn with a
+	// small live set) that dominated peak heap during snapshot creation.
+	// Last-write-wins semantics are preserved: AddNode for the same ID
+	// twice overwrites, matching the slot-indexed behaviour and the way
+	// the NWayMerger may emit a node twice when fed a malformed sorted
+	// file.
+	//
+	// On-disk format is unchanged: writeBody still emits one existence
+	// byte per slot from 0 to maxNodeID; we materialize a sorted-keys
+	// slice once at Flush time and walk it with a cursor.
+	nodes      map[uint64]*nodeState
 	tombstones map[uint64]struct{}
 	maxNodeID  uint64
+	// hasContent tracks whether AddNode or AddTombstone was ever called.
+	// Distinguishes "writer used with maxNodeID=0 (one node at id 0)"
+	// from "writer never received anything to write".
+	hasContent bool
 
 	// Compression data (only one can be set at a time)
 	pqData  *compression.PQData
@@ -88,11 +106,13 @@ type nodeState struct {
 	connections [][]uint64 // connections per level
 }
 
+
 // NewSnapshotWriter creates a new snapshot writer.
 func NewSnapshotWriter(w io.Writer) *SnapshotWriter {
 	return &SnapshotWriter{
 		w:          w,
 		blockSize:  defaultBlockSize,
+		nodes:      make(map[uint64]*nodeState),
 		tombstones: make(map[uint64]struct{}),
 	}
 }
@@ -103,6 +123,7 @@ func NewSnapshotWriterWithBlockSize(w io.Writer, blockSize int64) *SnapshotWrite
 	return &SnapshotWriter{
 		w:          w,
 		blockSize:  blockSize,
+		nodes:      make(map[uint64]*nodeState),
 		tombstones: make(map[uint64]struct{}),
 	}
 }
@@ -165,15 +186,14 @@ func (s *SnapshotWriter) isMuveraEnabled() bool {
 }
 
 // AddNode adds a node with its connections to the snapshot.
-// Nodes must be added in ascending node ID order.
+// Nodes are typically added in ascending node ID order (the NWayMerger
+// feeds them that way), but AddNode is safe to call out of order or for
+// the same ID twice — last-write-wins semantics are preserved by the
+// underlying map. This matches the behaviour of the previous slot-indexed
+// implementation, which writers in WriteFromMerger rely on when malformed
+// inputs cause the merger to emit a node ID twice.
 func (s *SnapshotWriter) AddNode(nodeID uint64, level uint16, connections [][]uint64, hasTombstone bool) {
-	// Expand nodes slice if needed using exponential growth
-	s.ensureNodesCapacity(nodeID)
-
-	s.nodes[nodeID] = &nodeState{
-		level:       level,
-		connections: connections,
-	}
+	s.nodes[nodeID] = &nodeState{level: level, connections: connections}
 
 	if hasTombstone {
 		s.tombstones[nodeID] = struct{}{}
@@ -182,34 +202,7 @@ func (s *SnapshotWriter) AddNode(nodeID uint64, level uint16, connections [][]ui
 	if nodeID > s.maxNodeID {
 		s.maxNodeID = nodeID
 	}
-}
-
-// ensureNodesCapacity grows the nodes slice to accommodate nodeID using exponential growth.
-func (s *SnapshotWriter) ensureNodesCapacity(nodeID uint64) {
-	required := int(nodeID + 1)
-	if required <= len(s.nodes) {
-		return
-	}
-
-	// If we have enough capacity, just extend the length (no allocation)
-	if required <= cap(s.nodes) {
-		s.nodes = s.nodes[:required]
-		return
-	}
-
-	// Need to allocate - calculate new capacity with exponential growth
-	newCap := cap(s.nodes)
-	if newCap == 0 {
-		newCap = 1024 // initial capacity
-	}
-	for newCap < required {
-		newCap *= 2
-	}
-
-	// Grow the slice
-	newNodes := make([]*nodeState, required, newCap)
-	copy(newNodes, s.nodes)
-	s.nodes = newNodes
+	s.hasContent = true
 }
 
 // AddTombstone marks a standalone tombstone for a nil slot.
@@ -222,17 +215,15 @@ func (s *SnapshotWriter) ensureNodesCapacity(nodeID uint64) {
 // the runtime's cleanup ordering.
 //
 // The method is retained for API symmetry and because it still has a visible
-// side effect on sizing: it grows the nodes slice so that the nodes-array
+// side effect on sizing: it bumps the writer's maxNodeID so the nodes-array
 // length reported in the metadata block covers nodeID. Use AddNode with
 // hasTombstone=true to persist a tombstone for an alive node.
 func (s *SnapshotWriter) AddTombstone(nodeID uint64) {
-	// Expand nodes slice if needed to include this tombstone
-	s.ensureNodesCapacity(nodeID)
-
 	s.tombstones[nodeID] = struct{}{}
 	if nodeID > s.maxNodeID {
 		s.maxNodeID = nodeID
 	}
+	s.hasContent = true
 }
 
 // Flush writes all accumulated state to the snapshot file.
@@ -276,8 +267,14 @@ func (s *SnapshotWriter) writeMetadata() error {
 		}
 	}
 
-	// Node count
-	_ = writeUint32(&buf, uint32(len(s.nodes)))
+	// Node count = maxNodeID + 1 if any node was added (live or
+	// tombstone-only), else 0. Matches the previous len(s.nodes) signal,
+	// which was 0 before any AddNode/AddTombstone and maxNodeID+1 after.
+	var nodeCount uint32
+	if s.hasContent {
+		nodeCount = uint32(s.maxNodeID + 1)
+	}
+	_ = writeUint32(&buf, nodeCount)
 
 	// Compute checksum of metadata
 	metadataSize := uint32(buf.Len())
@@ -439,8 +436,16 @@ func (s *SnapshotWriter) writeMuveraData(buf *bytes.Buffer) error {
 }
 
 // writeBody writes the snapshot body in fixed-size blocks.
+//
+// The byte stream is unchanged from the slot-indexed implementation: one
+// existence byte per slot in [0, maxNodeID], packed into fixed-size 4 MB
+// blocks. The difference is the source of truth — instead of indexing
+// into a slot-sized `[]*nodeState`, we walk the sorted entries slice with
+// a cursor while iterating the slot space. Memory drops from
+// O(maxNodeID) to O(liveNodes). The on-disk format and SnapshotReader
+// are unaffected.
 func (s *SnapshotWriter) writeBody() error {
-	if len(s.nodes) == 0 {
+	if !s.hasContent {
 		return nil
 	}
 
@@ -457,10 +462,25 @@ func (s *SnapshotWriter) writeBody() error {
 		return err
 	}
 
-	for nodeID := uint64(0); nodeID < uint64(len(s.nodes)); nodeID++ {
+	// Materialize sorted node IDs once; walk them with a cursor while
+	// iterating the slot stream. O(liveNodes) memory + O(n log n) sort,
+	// instead of O(maxNodeID) for the previous slot-indexed slice.
+	sortedIDs := make([]uint64, 0, len(s.nodes))
+	for id := range s.nodes {
+		sortedIDs = append(sortedIDs, id)
+	}
+	sort.Slice(sortedIDs, func(i, j int) bool { return sortedIDs[i] < sortedIDs[j] })
+
+	cursor := 0
+	totalSlots := s.maxNodeID + 1
+	for nodeID := uint64(0); nodeID < totalSlots; nodeID++ {
 		nodeBuf.Reset()
 
-		node := s.nodes[nodeID]
+		var node *nodeState
+		if cursor < len(sortedIDs) && sortedIDs[cursor] == nodeID {
+			node = s.nodes[nodeID]
+			cursor++
+		}
 		if node != nil {
 			_, hasTombstone := s.tombstones[nodeID]
 			if hasTombstone {


### PR DESCRIPTION
## Summary

`SnapshotWriter.nodes` was a `[]*nodeState` slice indexed by node ID. For shards with sparse IDs (heavy historical churn, small live set) the slice was 99 %+ nil pointers and the exponential growth in `ensureNodesCapacity` made peak heap during snapshot creation scale with `maxNodeID` rather than with the live set.

This PR swaps the slot-indexed slice for `nodes map[uint64]*nodeState`. Same public API, same on-disk byte stream, same last-write-wins semantics. Peak drops ~65×.

## Motivation

For 100k live nodes scattered across a 1e8 ID space, measured on the parent branch (`hnsw-compact-v2`):

| | Peak | HeapΔ | Time | Allocs |
|---|---:|---:|---:|---:|
| before | **1 801 MB** | 1 561 MB | 2.5 s | 600k |
| after | **28 MB** | 17 MB | 5.2 s | 600k |

Projected at 1e9 ID space (post heavy churn): ~18 GB → ~30-50 MB. The cycle manager fires one compaction per index with no global cap, so the regression multiplies with concurrent shards. At 64 shards snapshotting in lockstep this is the difference between ~115 GB and ~52 GB — a real blast-radius issue on multi-tenant nodes.

Note that ~800 MB per shard of the original peak is the runtime HNSW index slice on `main`, paid as steady-state — this PR doesn't change that, only the *additional* ~1 GB the snapshot writer was layering on top.

## Design

- `nodes` becomes a sparse map; `entries` is materialized once per `Flush` via a sorted-keys slice. `writeBody` walks the slot space with a cursor over those sorted keys, emitting the same per-slot existence bytes the slot-indexed version did.
- `AddNode` keeps the same signature. It is now safe to call out of order or for the same ID twice — last-write-wins. The original implementation also had this behavior implicitly via slot overwrite; the NWayMerger relies on it when fed a malformed `.sorted` file (see `TestCrashRecovery_OverlapAfterMerge`).
- `AddTombstone` no longer grows a slice — only `maxNodeID` and the tombstones map are updated. `hasContent` tracks whether anything has been added so `writeBody`/`writeMetadata` produce the same zero-state output as before.
- `ensureNodesCapacity` and the `nodes` slice field are removed.

The on-disk format is unchanged. `SnapshotReader` is unchanged. All existing snapshot tests pass; the body byte stream is byte-identical for the same input.

## Trade-off

~3.5 s extra wall-clock for the 100k-in-1e8 case. This is dominated by `writeBody` iterating `0..maxNodeID` emitting one existence byte per slot. That's a format constraint (V3 snapshot encodes node presence as one byte per slot), not an implementation choice — both old and new writer do it. Batching nil-byte writes is a follow-up.

## What's intentionally out of scope

1. **On-disk snapshot file size is still O(maxNodeID).** One existence byte per slot in the body stream. A full fix needs a format-version bump (sparse-tuple encoding).
2. **`SnapshotReader.Read` materializes `Graph.Nodes []*Vertex` indexed by node ID.** Same symmetric problem on the startup/load path. Larger change touching every consumer that iterates `Graph.Nodes`.

Both warrant separate work.

## Validation

- Existing `compact` package tests pass with `-race -count=1` (incl. crash recovery and migrator suites).
- Existing `hnsw` package tests pass.
- New `BenchmarkMemorySparseSnapshot*` benchmarks at 1e7 / 1e8 ID spreads (1e9 skipped under `-short`).
- New `TestSparseSnapshotPeakRegression` under `//go:build integrationTest` pins peak heap below 100 MB. Currently passes at ~30 MB; fails by 10×+ if slot-indexed storage is reintroduced.
- See `MEMORY_VALIDATION.md` in the same directory for the full reproduce/validate runbook.

## Test plan

- [ ] Run the full `compact` package suite: `go test -count=1 -race ./adapters/repos/db/vector/hnsw/compact/`
- [ ] Run the regression gate: `go test -tags=integrationTest -count=1 -v -run=TestSparseSnapshotPeakRegression ./adapters/repos/db/vector/hnsw/compact/`
- [ ] Run the memory benchmarks and confirm `BenchmarkMemorySparseSnapshot_100k_in_1e8` PeakMB is under ~50 MB