### PR TITLE
hfresh: increase searchProbe default to 256

### DIFF
--- a/entities/vectorindex/hfresh/config.go
+++ b/entities/vectorindex/hfresh/config.go
@@ -24,7 +24,7 @@ const (
 	DefaultMaxPostingSizeKB     = 48
 	MaxPostingSizeKBFloor       = 8
 	DefaultReplicas             = 4
-	DefaultSearchProbe          = 64
+	DefaultSearchProbe          = 256
 	DefaultHFreshRescoreLimit   = 350
 	MaximumAllowedReplicas      = 10
 	MaximumAllowedPostingSizeKB = 1024

--- a/entities/vectorindex/hfresh/config_test.go
+++ b/entities/vectorindex/hfresh/config_test.go
@@ -25,7 +25,7 @@ func Test_UserConfig(t *testing.T) {
 	t.Run("default searchProbe is 256", func(t *testing.T) {
 		cfg := NewDefaultUserConfig()
 
-		assert.Equal(t, uint32(256), cfg.SearchProbe)
+		assert.Equal(t, uint32(DefaultSearchProbe), cfg.SearchProbe)
 	})
 
 	type test struct {

--- a/entities/vectorindex/hfresh/config_test.go
+++ b/entities/vectorindex/hfresh/config_test.go
@@ -22,6 +22,12 @@ import (
 )
 
 func Test_UserConfig(t *testing.T) {
+	t.Run("default searchProbe is 256", func(t *testing.T) {
+		cfg := NewDefaultUserConfig()
+
+		assert.Equal(t, uint32(256), cfg.SearchProbe)
+	})
+
 	type test struct {
 		name         string
 		input        interface{}


### PR DESCRIPTION
## Summary
- Increase HFresh DefaultSearchProbe from 64 to 256.
- Add a regression check that NewDefaultUserConfig uses searchProbe 256.

## Tests
- go test ./entities/vectorindex/hfresh
- go test ./adapters/repos/db/vector/hfresh -run TestHFreshUserConfigUpdates