### PR TITLE
fix: route multivector queue deletes through DeleteMulti

### DIFF
--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -217,6 +217,9 @@ func (iq *VectorIndexQueue) DequeueBatch() (*queue.Batch, error) {
 
 func (iq *VectorIndexQueue) Delete(ids ...uint64) error {
 	if !iq.asyncEnabled {
+		if iq.vectorIndex.Multivector() {
+			return iq.vectorIndex.(VectorIndexMulti).DeleteMulti(ids...)
+		}
 		return iq.vectorIndex.Delete(ids...)
 	}
 
@@ -427,8 +430,10 @@ func (t *Task[T]) Execute(ctx context.Context) error {
 		return t.idx.Add(ctx, t.id, any(t.vector).([]float32))
 	case vectorIndexQueueMultiInsertOp:
 		return t.idx.(VectorIndexMulti).AddMulti(ctx, t.id, any(t.vector).([][]float32))
-	case vectorIndexQueueDeleteOp, vectorIndexQueueMultiDeleteOp:
+	case vectorIndexQueueDeleteOp:
 		return t.idx.Delete(t.id)
+	case vectorIndexQueueMultiDeleteOp:
+		return t.idx.(VectorIndexMulti).DeleteMulti(t.id)
 	}
 
 	return errors.Errorf("unknown operation: %d", t.Op())
@@ -477,8 +482,10 @@ func (t *TaskGroup[T]) Execute(ctx context.Context) error {
 		return t.idx.AddBatch(ctx, t.ids, any(t.vectors).([][]float32))
 	case vectorIndexQueueMultiInsertOp:
 		return t.idx.(VectorIndexMulti).AddMultiBatch(ctx, t.ids, any(t.vectors).([][][]float32))
-	case vectorIndexQueueDeleteOp, vectorIndexQueueMultiDeleteOp:
+	case vectorIndexQueueDeleteOp:
 		return t.idx.Delete(t.ids...)
+	case vectorIndexQueueMultiDeleteOp:
+		return t.idx.(VectorIndexMulti).DeleteMulti(t.ids...)
 	}
 
 	return errors.Errorf("unknown operation: %d", t.Op())

--- a/adapters/repos/db/vector_index_queue_unit_test.go
+++ b/adapters/repos/db/vector_index_queue_unit_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/noop"
+)
+
+func TestVectorIndexQueueDeleteUsesDeleteMultiForSyncMultivectorIndex(t *testing.T) {
+	index := newRecordingMultiVectorIndex()
+	queue := &VectorIndexQueue{vectorIndex: index}
+
+	err := queue.Delete(10, 11)
+
+	require.NoError(t, err)
+	require.Empty(t, index.deleteCalls)
+	require.Equal(t, [][]uint64{{10, 11}}, index.deleteMultiCalls)
+}
+
+func TestVectorIndexQueueMultiDeleteTaskUsesDeleteMulti(t *testing.T) {
+	index := newRecordingMultiVectorIndex()
+	task := &Task[[][]float32]{
+		op:  vectorIndexQueueMultiDeleteOp,
+		id:  12,
+		idx: index,
+	}
+
+	err := task.Execute(context.Background())
+
+	require.NoError(t, err)
+	require.Empty(t, index.deleteCalls)
+	require.Equal(t, [][]uint64{{12}}, index.deleteMultiCalls)
+}
+
+func TestVectorIndexQueueMultiDeleteTaskGroupUsesDeleteMulti(t *testing.T) {
+	index := newRecordingMultiVectorIndex()
+	taskGroup := &TaskGroup[[][]float32]{
+		op:  vectorIndexQueueMultiDeleteOp,
+		ids: []uint64{13, 14},
+		idx: index,
+	}
+
+	err := taskGroup.Execute(context.Background())
+
+	require.NoError(t, err)
+	require.Empty(t, index.deleteCalls)
+	require.Equal(t, [][]uint64{{13, 14}}, index.deleteMultiCalls)
+}
+
+type recordingMultiVectorIndex struct {
+	*noop.Index
+
+	deleteCalls      [][]uint64
+	deleteMultiCalls [][]uint64
+}
+
+func newRecordingMultiVectorIndex() *recordingMultiVectorIndex {
+	return &recordingMultiVectorIndex{Index: noop.NewIndex()}
+}
+
+func (r *recordingMultiVectorIndex) Delete(ids ...uint64) error {
+	r.deleteCalls = append(r.deleteCalls, append([]uint64(nil), ids...))
+	return nil
+}
+
+func (r *recordingMultiVectorIndex) DeleteMulti(ids ...uint64) error {
+	r.deleteMultiCalls = append(r.deleteMultiCalls, append([]uint64(nil), ids...))
+	return nil
+}
+
+func (r *recordingMultiVectorIndex) Multivector() bool {
+	return true
+}

--- a/adapters/repos/db/vector_index_queue_unit_test.go
+++ b/adapters/repos/db/vector_index_queue_unit_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package db
 
 import (


### PR DESCRIPTION
## Summary
- route sync multivector queue deletes through DeleteMulti
- route async multivector delete tasks and task groups through DeleteMulti
- add focused queue tests covering sync, single-task, and grouped multivector deletes

## Tests
- go test ./adapters/repos/db -run 'TestVectorIndexQueue.*Delete'