### PR TITLE
hfresh: defer queue registration until restore completes

### DIFF
--- a/adapters/repos/db/queue/scheduler.go
+++ b/adapters/repos/db/queue/scheduler.go
@@ -306,6 +306,13 @@ func (s *Scheduler) updateQueueCountMetric() {
 	s.Metrics.QueueCount.Set(float64(len(s.queues.m)))
 }
 
+func (s *Scheduler) QueueCount() int {
+	s.queues.Lock()
+	defer s.queues.Unlock()
+
+	return len(s.queues.m)
+}
+
 func (s *Scheduler) Wait(ctx context.Context, id string) error {
 	if s.ctx == nil {
 		// scheduler not started

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -162,6 +162,8 @@ func New(cfg *Config, uc ent.UserConfig, store *lsmkv.Store) (*HFresh, error) {
 		return nil, errors.Wrapf(err, "unable to restore metadata from previous run")
 	}
 
+	h.taskQueue.Register()
+
 	return &h, nil
 }
 

--- a/adapters/repos/db/vector/hfresh/posting.go
+++ b/adapters/repos/db/vector/hfresh/posting.go
@@ -14,6 +14,7 @@ package hfresh
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"sync"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
@@ -142,5 +143,8 @@ func (d *Distancer) DistanceBetweenCompressedVectors(a, b []byte) (float32, erro
 }
 
 func (d *Distancer) DistanceBetweenVectors(a, b []float32) (float32, error) {
+	if d == nil || d.distancer == nil {
+		return 0, errors.New("hfresh distancer is not initialized")
+	}
 	return d.distancer.SingleDist(a, b)
 }

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -158,12 +158,14 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 		return nil, errors.Wrap(err, "failed to initialize hfresh merge queue")
 	}
 
-	index.scheduler.RegisterQueue(tq.analyzeQueue)
-	index.scheduler.RegisterQueue(tq.splitQueue)
-	index.scheduler.RegisterQueue(tq.reassignQueue)
-	index.scheduler.RegisterQueue(tq.mergeQueue)
-
 	return &tq, nil
+}
+
+func (tq *TaskQueue) Register() {
+	tq.scheduler.RegisterQueue(tq.analyzeQueue)
+	tq.scheduler.RegisterQueue(tq.splitQueue)
+	tq.scheduler.RegisterQueue(tq.reassignQueue)
+	tq.scheduler.RegisterQueue(tq.mergeQueue)
 }
 
 func (tq *TaskQueue) Close(ctx context.Context) error {

--- a/adapters/repos/db/vector/hfresh/task_queue_test.go
+++ b/adapters/repos/db/vector/hfresh/task_queue_test.go
@@ -1,0 +1,60 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hfresh
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+)
+
+func TestTaskQueueRegisterIsExplicit(t *testing.T) {
+	logger := logrus.New()
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger})
+	scheduler.Start()
+	t.Cleanup(func() {
+		require.NoError(t, scheduler.Close(t.Context()))
+	})
+
+	cfg := DefaultConfig()
+	cfg.ID = "hfresh"
+	cfg.ShardName = "shard"
+	cfg.RootPath = t.TempDir()
+	cfg.Logger = logger
+	cfg.Scheduler = scheduler
+
+	store := testinghelpers.NewDummyStore(t)
+	bucket, err := NewSharedBucket(store, cfg.ID, cfg.Store)
+	require.NoError(t, err)
+
+	index := &HFresh{
+		id:        cfg.ID,
+		logger:    logger,
+		config:    cfg,
+		scheduler: scheduler,
+	}
+	taskQueue, err := NewTaskQueue(index, bucket)
+	require.NoError(t, err)
+	index.taskQueue = *taskQueue
+	t.Cleanup(func() {
+		require.NoError(t, index.taskQueue.Close(t.Context()))
+	})
+
+	require.Equal(t, 0, scheduler.QueueCount())
+
+	index.taskQueue.Register()
+
+	require.Equal(t, 4, scheduler.QueueCount())
+}


### PR DESCRIPTION
### What's being changed:

Defers HFresh task queue registration until after metadata restore completes, so recovered disk queue tasks cannot run while quantizer/distancer state is still being restored. Also adds a defensive error when `DistanceBetweenVectors` is reached without initialized distance state, and covers the explicit queue registration behavior with a focused test.

Failing e2e test: [run-recovery-test async_indexing_test.py, 7-node cluster](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/27746639812/job/82104860900)

The failure mode was a panic from `ReassignTask -> doReassign -> RNGSelect -> Distancer.DistanceBetweenVectors` after pytest passed and the log panic scan ran.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary, internal bug fix.
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary for this code path; linked the failing e2e job above.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.