### PR TITLE
chore(generative-deepseek): add support for stop setting in module settings

### DIFF
--- a/modules/generative-deepseek/clients/deepseek.go
+++ b/modules/generative-deepseek/clients/deepseek.go
@@ -178,6 +178,11 @@ func (c *client) parseOptions(cfg moduletools.ClassConfig, options any) deepseek
 			p.MaxTokens = &val
 		}
 	}
+	if len(p.Stop) == 0 {
+		if stop := settings.Stop(); len(stop) > 0 {
+			p.Stop = stop
+		}
+	}
 	return p
 }
 

--- a/modules/generative-deepseek/config/class_settings.go
+++ b/modules/generative-deepseek/config/class_settings.go
@@ -26,6 +26,7 @@ const (
 	presencePenaltyProperty  = "presencePenalty"
 	topPProperty             = "topP"
 	baseURLProperty          = "baseURL"
+	stopProperty             = "stop"
 )
 
 var (
@@ -56,6 +57,7 @@ type ClassSettings interface {
 	PresencePenalty() float64
 	TopP() float64
 	BaseURL() string
+	Stop() []string
 	Validate(class *models.Class) error
 }
 
@@ -143,4 +145,8 @@ func (ic *classSettings) PresencePenalty() float64 {
 
 func (ic *classSettings) TopP() float64 {
 	return *ic.getFloatProperty(topPProperty, &DefaultDeepSeekTopP)
+}
+
+func (ic *classSettings) Stop() []string {
+	return ic.propertyValuesHelper.GetPropertyAsListOfStrings(ic.cfg, stopProperty, nil)
 }


### PR DESCRIPTION
### What's being changed:

This PR adds support for `stop` setting in `generative-deepseek` module settings.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
