### PR TITLE
Remove flaky assertion for dynamic index

### DIFF
--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -121,7 +121,6 @@ func TestDynamic(t *testing.T) {
 	recall2, latency2 := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
 	t.Logf("recall: %f, latency %f\n", recall2, latency2)
 	assert.True(t, recall2 > 0.9)
-	assert.True(t, latency1 > latency2)
 }
 
 func TestDynamicReturnsErrorIfNoAsync(t *testing.T) {
@@ -271,7 +270,6 @@ func TestDynamicWithTargetVectors(t *testing.T) {
 		recall2, latency2 := testinghelpers.RecallAndLatency(ctx, queries, k, v, truths)
 		t.Logf("recall: %f, latency %f\n", recall2, latency2)
 		assert.True(t, recall2 > 0.9)
-		assert.True(t, latency1 > latency2)
 	}
 }
 
@@ -866,7 +864,6 @@ func TestDynamicStoreMigrationBug(t *testing.T) {
 		recall2, latency2 := testinghelpers.RecallAndLatency(ctx, queries, k, v, truths)
 		fmt.Println(recall2, latency2)
 		assert.True(t, recall2 > 0.9)
-		assert.True(t, latency1 > latency2)
 	}
 
 	// check the content of the bolt db


### PR DESCRIPTION
### What's being changed:

- Removing flaky assertion for dynamic index
- Although the intent was good, these tests use 1000 20D vectors and mocks vector for id to be in memory and so depending on timing flat may be faster than HNSW.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
