### PR TITLE
fix(compact): fail closed on truncated compact files

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
@@ -13,6 +13,7 @@ package compact
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -109,6 +110,93 @@ func TestCrashRecovery_TruncatedWALFile_MultipleGarbageBytes(t *testing.T) {
 	assert.Equal(t, uint64(5), result.State.Graph.Entrypoint)
 	require.True(t, len(result.State.Graph.Nodes) > 5)
 	require.NotNil(t, result.State.Graph.Nodes[5])
+}
+
+func TestCrashRecovery_TruncatedCompactedWALFilesFailClosed(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		path  func(string) string
+		write func(*testing.T, string)
+	}{
+		{
+			name: "sorted",
+			path: func(dir string) string {
+				return filepath.Join(dir, BuildMergedFilename(1000, 1000, FileTypeSorted))
+			},
+			write: func(t *testing.T, dir string) {
+				writeTestSortedFileWithData(t, dir, 1000, 1000, func(w *WALWriter) {
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(0, 0))
+					require.NoError(t, w.WriteAddNode(0, 0))
+					require.NoError(t, w.WriteAddNode(1, 0))
+				})
+			},
+		},
+		{
+			name: "condensed",
+			path: func(dir string) string {
+				return filepath.Join(dir, BuildMergedFilename(1000, 1000, FileTypeCondensed))
+			},
+			write: func(t *testing.T, dir string) {
+				createTestWALFile(t, filepath.Join(dir, BuildMergedFilename(1000, 1000, FileTypeCondensed)), func(w *WALWriter) {
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(0, 0))
+					require.NoError(t, w.WriteAddNode(0, 0))
+					require.NoError(t, w.WriteAddNode(1, 0))
+				})
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.write(t, dir)
+
+			f, err := os.OpenFile(tt.path(dir), os.O_WRONLY|os.O_APPEND, 0o666)
+			require.NoError(t, err)
+			_, err = f.Write([]byte{byte(AddNode), 0x01, 0x02, 0x03})
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+
+			loader := NewLoader(LoaderConfig{Dir: dir, Logger: crashTestLogger()})
+			result, err := loader.Load()
+			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestCrashRecovery_TruncatedSortedMergeFailsClosedAndKeepsSources(t *testing.T) {
+	dir := t.TempDir()
+	paths := make([]string, 0, 6)
+
+	for i := int64(0); i < 6; i++ {
+		ts := 1000 + i
+		writeTestSortedFileWithData(t, dir, ts, ts, func(w *WALWriter) {
+			require.NoError(t, w.WriteSetEntryPointMaxLevel(uint64(i), 0))
+			require.NoError(t, w.WriteAddNode(uint64(i), 0))
+		})
+		paths = append(paths, filepath.Join(dir, BuildMergedFilename(ts, ts, FileTypeSorted)))
+	}
+
+	f, err := os.OpenFile(paths[0], os.O_WRONLY|os.O_APPEND, 0o666)
+	require.NoError(t, err)
+	_, err = f.Write([]byte{byte(AddNode), 0x01, 0x02, 0x03})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	compactor := NewCompactor(DefaultCompactorConfig(dir), crashTestLogger())
+	action, err := compactor.RunCycle(nil)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.Equal(t, ActionNone, action)
+
+	for _, path := range paths[:5] {
+		_, statErr := os.Stat(path)
+		require.NoError(t, statErr, "source file %s should remain after failed merge", path)
+	}
+
+	mergedPath := filepath.Join(dir, BuildMergedFilename(1000, 1004, FileTypeSorted))
+	_, err = os.Stat(mergedPath)
+	assert.True(t, os.IsNotExist(err), "failed merge should not commit output")
+	_, err = os.Stat(mergedPath + tempFileSuffix)
+	assert.True(t, os.IsNotExist(err), "failed merge should clean up temp output")
 }
 
 // ---------------------------------------------------------------------------

--- a/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
@@ -112,6 +112,48 @@ func TestCrashRecovery_TruncatedWALFile_MultipleGarbageBytes(t *testing.T) {
 	require.NotNil(t, result.State.Graph.Nodes[5])
 }
 
+func TestCrashRecovery_CompleteCompactedWALFilesLoad(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		write func(*testing.T, string)
+	}{
+		{
+			name: "sorted",
+			write: func(t *testing.T, dir string) {
+				writeTestSortedFileWithData(t, dir, 1000, 1000, func(w *WALWriter) {
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(0, 0))
+					require.NoError(t, w.WriteAddNode(0, 0))
+					require.NoError(t, w.WriteAddNode(1, 0))
+				})
+			},
+		},
+		{
+			name: "condensed",
+			write: func(t *testing.T, dir string) {
+				createTestWALFile(t, filepath.Join(dir, BuildMergedFilename(1000, 1000, FileTypeCondensed)), func(w *WALWriter) {
+					require.NoError(t, w.WriteSetEntryPointMaxLevel(0, 0))
+					require.NoError(t, w.WriteAddNode(0, 0))
+					require.NoError(t, w.WriteAddNode(1, 0))
+				})
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.write(t, dir)
+
+			loader := NewLoader(LoaderConfig{Dir: dir, Logger: crashTestLogger()})
+			result, err := loader.Load()
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.RecoveredFromCrash)
+			require.GreaterOrEqual(t, len(result.State.Graph.Nodes), 2)
+			require.NotNil(t, result.State.Graph.Nodes[0])
+			require.NotNil(t, result.State.Graph.Nodes[1])
+		})
+	}
+}
+
 func TestCrashRecovery_TruncatedCompactedWALFilesFailClosed(t *testing.T) {
 	for _, tt := range []struct {
 		name  string

--- a/adapters/repos/db/vector/hnsw/compact/iterator.go
+++ b/adapters/repos/db/vector/hnsw/compact/iterator.go
@@ -130,7 +130,7 @@ func (it *Iterator) readGlobalCommits() error {
 		c, err := it.reader.ReadNextCommit()
 		if err != nil {
 			if isEOF(err) {
-				// File ended (possibly truncated mid-write)
+				// File ended cleanly.
 				return nil
 			}
 			return err

--- a/adapters/repos/db/vector/hnsw/compact/iterator.go
+++ b/adapters/repos/db/vector/hnsw/compact/iterator.go
@@ -18,10 +18,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// isEOF returns true if the error indicates end of data, either a clean EOF
-// or an unexpected EOF from a file truncated mid-write (e.g., crash during flush).
+// isEOF returns true only for a clean EOF. Iterator inputs are immutable
+// compacted files; an unexpected EOF means committed-file corruption and must
+// abort the merge instead of materializing a partial prefix.
 func isEOF(err error) bool {
-	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+	return errors.Is(err, io.EOF)
 }
 
 // NodeCommits represents all commits for a single node.

--- a/adapters/repos/db/vector/hnsw/compact/iterator_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/iterator_test.go
@@ -357,7 +357,7 @@ func TestIterator_RemoveTombstoneCommit(t *testing.T) {
 	assert.True(t, ok)
 }
 
-// truncatedCommitReader simulates a sorted file truncated mid-write:
+// truncatedCommitReader simulates a sorted file corrupted after commit:
 // it returns commits normally, then io.ErrUnexpectedEOF instead of io.EOF.
 type truncatedCommitReader struct {
 	commits []Commit
@@ -373,19 +373,16 @@ func (f *truncatedCommitReader) ReadNextCommit() (Commit, error) {
 	return commit, nil
 }
 
-func TestIterator_TruncatedFile_GlobalCommitsOnly(t *testing.T) {
+func TestIterator_TruncatedFile_GlobalCommitsOnlyReturnsError(t *testing.T) {
 	reader := &truncatedCommitReader{commits: []Commit{
 		&SetEntryPointMaxLevelCommit{Entrypoint: 1, Level: 1},
 	}}
 
-	it, err := NewIterator(reader, 0, logrus.New())
-	require.NoError(t, err)
-
-	assert.True(t, it.Exhausted())
-	assert.Equal(t, 1, len(it.GlobalCommits()))
+	_, err := NewIterator(reader, 0, logrus.New())
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
-func TestIterator_TruncatedFile_MidNode(t *testing.T) {
+func TestIterator_TruncatedFile_MidNodeReturnsError(t *testing.T) {
 	// Simulate: two complete nodes, then truncation where a third would start.
 	reader := &truncatedCommitReader{commits: []Commit{
 		&AddNodeCommit{ID: 1, Level: 0},
@@ -401,27 +398,17 @@ func TestIterator_TruncatedFile_MidNode(t *testing.T) {
 	assert.Equal(t, uint64(1), it.Current().NodeID)
 	assert.Equal(t, 2, len(it.Current().Commits))
 
-	// Node 2
-	hasNext, err := it.Next()
-	require.NoError(t, err)
-	assert.True(t, hasNext)
-	assert.Equal(t, uint64(2), it.Current().NodeID)
-
-	// Exhausted — truncation treated as EOF
-	hasNext, err = it.Next()
-	require.NoError(t, err)
-	assert.False(t, hasNext)
-	assert.True(t, it.Exhausted())
+	// Node 2 cannot be trusted because the immutable sorted stream ended
+	// unexpectedly while reading it.
+	_, err = it.Next()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
-func TestIterator_TruncatedFile_Empty(t *testing.T) {
+func TestIterator_TruncatedFile_EmptyReturnsError(t *testing.T) {
 	reader := &truncatedCommitReader{commits: []Commit{}}
 
-	it, err := NewIterator(reader, 0, logrus.New())
-	require.NoError(t, err)
-
-	assert.True(t, it.Exhausted())
-	assert.Nil(t, it.Current())
+	_, err := NewIterator(reader, 0, logrus.New())
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
 func TestIterator_ClearLinksCommit(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/compact/loader.go
+++ b/adapters/repos/db/vector/hnsw/compact/loader.go
@@ -267,9 +267,11 @@ func (l *Loader) loadWALFile(f FileInfo, state *ent.DeserializationResult) (*ent
 	// keepLinkReplaceInfo=false at startup since we're building final state
 	result, err := inMemReader.Do(state, false)
 	if err != nil {
-		// For EOF/UnexpectedEOF, log warning and continue with partial state
-		// This can happen if the file was truncated due to crash
-		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		// Raw/live WAL files may be interrupted mid-write by a crash. Immutable
+		// compacted files (.condensed/.sorted) are created through SafeFileWriter,
+		// so truncation there indicates committed-file corruption and must fail
+		// closed instead of preserving a partial prefix.
+		if f.Type == FileTypeRaw && (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) {
 			l.config.Logger.WithFields(logrus.Fields{
 				"action": "hnsw_loader",
 				"file":   f.Path,
@@ -278,20 +280,18 @@ func (l *Loader) loadWALFile(f FileInfo, state *ent.DeserializationResult) (*ent
 			// Truncate raw files to remove partial entries.
 			// This prevents the partial entry from becoming corrupted on next write
 			// and ensures clean compaction later.
-			if f.Type == FileTypeRaw {
-				validBytes := walReader.BytesRead()
-				if truncErr := l.fs.Truncate(f.Path, validBytes); truncErr != nil {
-					l.config.Logger.
-						WithField("file", f.Path).
-						WithField("valid_bytes", validBytes).
-						Errorf("failed to truncate corrupt WAL file: %v", truncErr)
-				} else {
-					l.config.Logger.WithFields(logrus.Fields{
-						"action":      "hnsw_loader",
-						"file":        f.Path,
-						"valid_bytes": validBytes,
-					}).Info("truncated corrupt WAL file")
-				}
+			validBytes := walReader.BytesRead()
+			if truncErr := l.fs.Truncate(f.Path, validBytes); truncErr != nil {
+				l.config.Logger.
+					WithField("file", f.Path).
+					WithField("valid_bytes", validBytes).
+					Errorf("failed to truncate corrupt WAL file: %v", truncErr)
+			} else {
+				l.config.Logger.WithFields(logrus.Fields{
+					"action":      "hnsw_loader",
+					"file":        f.Path,
+					"valid_bytes": validBytes,
+				}).Info("truncated corrupt WAL file")
 			}
 
 			return result, true, nil // true = recovered from crash

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
@@ -19,6 +19,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math"
+	"sort"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -37,6 +38,13 @@ const (
 	// snapshotConcurrency is the number of goroutines used for concurrent block reading.
 	snapshotConcurrency = 8
 )
+
+// snapshotBlockRange is the node ID range covered by one body block: start is
+// included, end is excluded.
+type snapshotBlockRange struct {
+	start uint64
+	end   uint64
+}
 
 // ReadSeekReaderAt combines io.Reader, io.Seeker, and io.ReaderAt interfaces.
 // This is needed for concurrent block reading using io.SectionReader.
@@ -623,7 +631,7 @@ func (r *SnapshotReader) readBodyConcurrent(reader ReadSeekReaderAt, res *ent.De
 
 	bodySize := int(endPos - currentPos)
 	if bodySize == 0 {
-		return nil
+		return fmt.Errorf("snapshot body missing for %d nodes", len(res.Graph.Nodes))
 	}
 
 	// Seek back to where we were (body start)
@@ -633,6 +641,7 @@ func (r *SnapshotReader) readBodyConcurrent(reader ReadSeekReaderAt, res *ent.De
 
 	// Setup concurrent block reading
 	var mu sync.Mutex
+	ranges := make([]snapshotBlockRange, 0, (bodySize+int(r.blockSize)-1)/int(r.blockSize))
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(r.logger, context.Background())
 	eg.SetLimit(snapshotConcurrency)
 
@@ -666,9 +675,13 @@ func (r *SnapshotReader) readBodyConcurrent(reader ReadSeekReaderAt, res *ent.De
 					}
 
 					// Parse block and update result with mutex protection
-					if err := r.readBlockConcurrent(buf[:n], res, &mu); err != nil {
+					blockRange, err := r.readBlockConcurrent(buf[:n], res, &mu)
+					if err != nil {
 						return errors.Wrapf(err, "parse block at offset %d", offset)
 					}
+					mu.Lock()
+					ranges = append(ranges, blockRange)
+					mu.Unlock()
 				}
 			}
 		})
@@ -686,14 +699,18 @@ LOOP:
 	close(ch)
 
 	// Wait for all workers to complete
-	return eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	return validateSnapshotBlockRanges(ranges, len(res.Graph.Nodes))
 }
 
 // readBlockConcurrent parses a single block and populates nodes in the result.
 // Uses mutex protection for concurrent access to the result.
-func (r *SnapshotReader) readBlockConcurrent(buf []byte, res *ent.DeserializationResult, mu *sync.Mutex) error {
+func (r *SnapshotReader) readBlockConcurrent(buf []byte, res *ent.DeserializationResult, mu *sync.Mutex) (snapshotBlockRange, error) {
 	if len(buf) < 8 {
-		return fmt.Errorf("block too small: %d bytes", len(buf))
+		return snapshotBlockRange{}, fmt.Errorf("block too small: %d bytes", len(buf))
 	}
 
 	// Verify checksum
@@ -701,11 +718,17 @@ func (r *SnapshotReader) readBlockConcurrent(buf []byte, res *ent.Deserializatio
 	hasher := crc32.NewIEEE()
 	_, _ = hasher.Write(buf[4:])
 	if hasher.Sum32() != blockChecksum {
-		return fmt.Errorf("block checksum mismatch")
+		return snapshotBlockRange{}, fmt.Errorf("block checksum mismatch")
 	}
 
 	// Read block length from end
 	blockLen := binary.LittleEndian.Uint32(buf[len(buf)-4:])
+	if blockLen < 8 {
+		return snapshotBlockRange{}, fmt.Errorf("block length too small: %d bytes", blockLen)
+	}
+	if blockLen > uint32(len(buf)-8) {
+		return snapshotBlockRange{}, fmt.Errorf("block length %d exceeds buffer payload %d", blockLen, len(buf)-8)
+	}
 	block := buf[4 : 4+blockLen]
 
 	// Use byteops.ReadWriter instead of bytes.Reader + binary.Read
@@ -756,6 +779,43 @@ func (r *SnapshotReader) readBlockConcurrent(buf []byte, res *ent.Deserializatio
 		}
 
 		currNodeID++
+	}
+
+	return snapshotBlockRange{start: startNodeID, end: currNodeID}, nil
+}
+
+// validateSnapshotBlockRanges catches missing snapshot body blocks. The format
+// has per-block checksums, but no whole-file checksum or block count, so a file
+// truncated at a block boundary can otherwise look valid.
+func validateSnapshotBlockRanges(ranges []snapshotBlockRange, nodeCount int) error {
+	if nodeCount == 0 {
+		return nil
+	}
+	if len(ranges) == 0 {
+		return fmt.Errorf("snapshot body missing for %d nodes", nodeCount)
+	}
+
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].start < ranges[j].start
+	})
+
+	expected := uint64(0)
+	for _, blockRange := range ranges {
+		if blockRange.end < blockRange.start {
+			return fmt.Errorf("snapshot block range [%d,%d) is invalid", blockRange.start, blockRange.end)
+		}
+		if blockRange.start != expected {
+			return fmt.Errorf("snapshot body has range gap or overlap: expected node %d, got range [%d,%d)",
+				expected, blockRange.start, blockRange.end)
+		}
+		expected = blockRange.end
+		if expected > uint64(nodeCount) {
+			return fmt.Errorf("snapshot body covers node %d beyond metadata node count %d", expected, nodeCount)
+		}
+	}
+
+	if expected != uint64(nodeCount) {
+		return fmt.Errorf("snapshot body ended at node %d, expected %d", expected, nodeCount)
 	}
 
 	return nil

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
@@ -123,53 +123,55 @@ func (r *SnapshotReader) Read(reader ReadSeekReaderAt) (*ent.DeserializationResu
 	res := ent.NewDeserializationResult(0)
 
 	// Read and verify metadata
-	if err := r.readMetadata(reader, res); err != nil {
+	nodeCount, err := r.readMetadata(reader, res)
+	if err != nil {
 		return nil, errors.Wrap(err, "read metadata")
 	}
 
 	// Read body with concurrent block reading
-	if err := r.readBodyConcurrent(reader, res); err != nil {
+	if err := r.readBodyConcurrent(reader, res, nodeCount); err != nil {
 		return nil, errors.Wrap(err, "read body")
 	}
 
 	return res, nil
 }
 
-// readMetadata reads the snapshot metadata header.
-func (r *SnapshotReader) readMetadata(reader io.Reader, res *ent.DeserializationResult) error {
+// readMetadata reads the snapshot metadata header and returns the snapshot's
+// own node count before any replay pre-sizing is applied.
+func (r *SnapshotReader) readMetadata(reader io.Reader, res *ent.DeserializationResult) (uint32, error) {
 	// Read version
 	var version uint8
 	if err := binary.Read(reader, binary.LittleEndian, &version); err != nil {
-		return errors.Wrap(err, "read version")
+		return 0, errors.Wrap(err, "read version")
 	}
 
 	switch version {
 	case snapshotVersionV1, snapshotVersionV2:
-		return fmt.Errorf("legacy snapshot version %d detected; upgrade not supported. "+
+		return 0, fmt.Errorf("legacy snapshot version %d detected; upgrade not supported. "+
 			"Please downgrade Weaviate and either: (1) delete the snapshot file and let it "+
 			"regenerate, or (2) run a compaction cycle to create a V3 snapshot before upgrading", version)
 	case snapshotVersionV3:
 		// V3 is supported, continue with reading
 	default:
-		return fmt.Errorf("unsupported snapshot version %d", version)
+		return 0, fmt.Errorf("unsupported snapshot version %d", version)
 	}
 
 	// Read checksum
 	var checksum uint32
 	if err := binary.Read(reader, binary.LittleEndian, &checksum); err != nil {
-		return errors.Wrap(err, "read checksum")
+		return 0, errors.Wrap(err, "read checksum")
 	}
 
 	// Read metadata size
 	var metadataSize uint32
 	if err := binary.Read(reader, binary.LittleEndian, &metadataSize); err != nil {
-		return errors.Wrap(err, "read metadata size")
+		return 0, errors.Wrap(err, "read metadata size")
 	}
 
 	// Read metadata
 	metadata := make([]byte, metadataSize)
 	if _, err := io.ReadFull(reader, metadata); err != nil {
-		return errors.Wrap(err, "read metadata")
+		return 0, errors.Wrap(err, "read metadata")
 	}
 
 	// Verify checksum
@@ -182,7 +184,7 @@ func (r *SnapshotReader) readMetadata(reader io.Reader, res *ent.Deserialization
 	_, _ = hasher.Write(metaSizeBuf[:])
 	_, _ = hasher.Write(metadata)
 	if hasher.Sum32() != checksum {
-		return fmt.Errorf("metadata checksum mismatch")
+		return 0, fmt.Errorf("metadata checksum mismatch")
 	}
 
 	// Parse metadata
@@ -191,47 +193,47 @@ func (r *SnapshotReader) readMetadata(reader io.Reader, res *ent.Deserialization
 	// Entrypoint
 	var entrypoint uint64
 	if err := binary.Read(metaReader, binary.LittleEndian, &entrypoint); err != nil {
-		return errors.Wrap(err, "read entrypoint")
+		return 0, errors.Wrap(err, "read entrypoint")
 	}
 	res.Graph.Entrypoint = entrypoint
 
 	// Level
 	var level uint16
 	if err := binary.Read(metaReader, binary.LittleEndian, &level); err != nil {
-		return errors.Wrap(err, "read level")
+		return 0, errors.Wrap(err, "read level")
 	}
 	res.Graph.Level = level
 
 	// isCompressed
 	var isCompressed uint8
 	if err := binary.Read(metaReader, binary.LittleEndian, &isCompressed); err != nil {
-		return errors.Wrap(err, "read isCompressed")
+		return 0, errors.Wrap(err, "read isCompressed")
 	}
 	res.SetCompressed(isCompressed != 0)
 
 	if res.Compressed() {
 		if err := r.readCompressionData(metaReader, res); err != nil {
-			return errors.Wrap(err, "read compression data")
+			return 0, errors.Wrap(err, "read compression data")
 		}
 	}
 
 	// isEncoded (Muvera)
 	var isEncoded uint8
 	if err := binary.Read(metaReader, binary.LittleEndian, &isEncoded); err != nil {
-		return errors.Wrap(err, "read isEncoded")
+		return 0, errors.Wrap(err, "read isEncoded")
 	}
 	res.SetMuveraEnabled(isEncoded != 0)
 
 	if res.MuveraEnabled() {
 		if err := r.readMuveraData(metaReader, res); err != nil {
-			return errors.Wrap(err, "read muvera data")
+			return 0, errors.Wrap(err, "read muvera data")
 		}
 	}
 
 	// Node count
 	var nodeCount uint32
 	if err := binary.Read(metaReader, binary.LittleEndian, &nodeCount); err != nil {
-		return errors.Wrap(err, "read node count")
+		return 0, errors.Wrap(err, "read node count")
 	}
 
 	size := uint64(nodeCount)
@@ -242,7 +244,7 @@ func (r *SnapshotReader) readMetadata(reader io.Reader, res *ent.Deserialization
 
 	res.Graph.EntrypointChanged = true
 
-	return nil
+	return nodeCount, nil
 }
 
 // readCompressionData reads compression data from the metadata.
@@ -613,8 +615,8 @@ func (r *SnapshotReader) readMuveraData(reader io.Reader, res *ent.Deserializati
 
 // readBodyConcurrent reads the snapshot body blocks concurrently using multiple goroutines.
 // This significantly improves startup performance for large indexes.
-func (r *SnapshotReader) readBodyConcurrent(reader ReadSeekReaderAt, res *ent.DeserializationResult) error {
-	if len(res.Graph.Nodes) == 0 {
+func (r *SnapshotReader) readBodyConcurrent(reader ReadSeekReaderAt, res *ent.DeserializationResult, nodeCount uint32) error {
+	if nodeCount == 0 {
 		return nil
 	}
 
@@ -631,7 +633,7 @@ func (r *SnapshotReader) readBodyConcurrent(reader ReadSeekReaderAt, res *ent.De
 
 	bodySize := int(endPos - currentPos)
 	if bodySize == 0 {
-		return fmt.Errorf("snapshot body missing for %d nodes", len(res.Graph.Nodes))
+		return fmt.Errorf("snapshot body missing for %d nodes", nodeCount)
 	}
 
 	// Seek back to where we were (body start)
@@ -703,7 +705,7 @@ LOOP:
 		return err
 	}
 
-	return validateSnapshotBlockRanges(ranges, len(res.Graph.Nodes))
+	return validateSnapshotBlockRanges(ranges, int(nodeCount))
 }
 
 // readBlockConcurrent parses a single block and populates nodes in the result.

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_writer.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_writer.go
@@ -224,13 +224,13 @@ func (s *SnapshotWriter) addNodeStreaming(nodeID uint64, level uint16, connectio
 
 // AddTombstone marks a standalone tombstone for a nil slot.
 //
-// This does NOT emit a tombstone to the body: the V3 format has only three
-// existence bytes (0=absent, 1=alive-with-tombstone, 2=alive-without-tombstone)
-// and no encoding for a "deleted-with-tombstone" slot, so tombstones on nil
-// slots are dropped on purpose (see the absent-slot handling in bodyStreamer
-// for why that is safe under the runtime's cleanup ordering). Its only visible
-// effect is on sizing: it extends the node count so the metadata covers nodeID.
-// Use AddNode with hasTombstone=true to persist a tombstone for an alive node.
+// This does NOT emit a tombstone entry to the body: the V3 format has only
+// three existence bytes (0=absent, 1=alive-with-tombstone,
+// 2=alive-without-tombstone) and no encoding for a "deleted-with-tombstone"
+// slot. Its visible effect is sizing: it extends the node count so the
+// metadata covers nodeID, and bodyStreamer.finish emits absent markers through
+// that reserved range. Use AddNode with hasTombstone=true to persist a
+// tombstone for an alive node.
 func (s *SnapshotWriter) AddTombstone(nodeID uint64) {
 	if s.firstErr != nil {
 		return

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_writer_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_writer_test.go
@@ -401,6 +401,27 @@ func TestSnapshotReader_TruncatedAtBlockBoundaryFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "snapshot body ended")
 }
 
+func TestSnapshotReader_TrailingStandaloneTombstoneLoads(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewSnapshotWriterWithBlockSize(&buf, 256)
+	sw.SetEntrypoint(0, 0)
+	sw.AddNode(0, 0, nil, false)
+	sw.AddTombstone(10)
+	require.NoError(t, sw.Flush())
+
+	sr := NewSnapshotReaderWithBlockSize(logrus.New(), 256)
+	result, err := sr.Read(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	require.Len(t, result.Graph.Nodes, 11)
+	require.NotNil(t, result.Graph.Nodes[0])
+	for id := 1; id <= 10; id++ {
+		assert.Nil(t, result.Graph.Nodes[id], "standalone tombstone slot %d should load as absent", id)
+		_, ok := result.Graph.Tombstones[uint64(id)]
+		assert.False(t, ok, "standalone tombstone slot %d should not persist a tombstone marker", id)
+	}
+}
+
 // verifySnapshotMetadata checks the snapshot header values
 func verifySnapshotMetadata(t *testing.T, data []byte, expectedEntrypoint uint64, expectedLevel uint16, expectedNodeCount uint32) {
 	t.Helper()

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_writer_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_writer_test.go
@@ -360,6 +360,47 @@ func TestSnapshotReader_ChecksumValidation(t *testing.T) {
 	assert.Contains(t, err.Error(), "checksum")
 }
 
+func TestSnapshotReader_TruncatedAfterMetadataFails(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewSnapshotWriterWithBlockSize(&buf, 256)
+	sw.SetEntrypoint(0, 0)
+	sw.AddNode(0, 0, [][]uint64{{1}}, false)
+	sw.AddNode(1, 0, [][]uint64{{0}}, false)
+	require.NoError(t, sw.Flush())
+
+	data := buf.Bytes()
+	metadataSize := binary.LittleEndian.Uint32(data[5:9])
+	bodyStart := 9 + int(metadataSize)
+	require.Greater(t, len(data), bodyStart)
+
+	sr := NewSnapshotReaderWithBlockSize(logrus.New(), 256)
+	_, err := sr.Read(bytes.NewReader(data[:bodyStart]))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snapshot body missing")
+}
+
+func TestSnapshotReader_TruncatedAtBlockBoundaryFails(t *testing.T) {
+	const blockSize int64 = 256
+
+	var buf bytes.Buffer
+	sw := NewSnapshotWriterWithBlockSize(&buf, blockSize)
+	sw.SetEntrypoint(0, 0)
+	for i := uint64(0); i < 80; i++ {
+		sw.AddNode(i, 0, nil, false)
+	}
+	require.NoError(t, sw.Flush())
+
+	data := buf.Bytes()
+	metadataSize := binary.LittleEndian.Uint32(data[5:9])
+	bodyStart := 9 + int(metadataSize)
+	require.Greater(t, len(data)-bodyStart, int(blockSize))
+
+	sr := NewSnapshotReaderWithBlockSize(logrus.New(), blockSize)
+	_, err := sr.Read(bytes.NewReader(data[:bodyStart+int(blockSize)]))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snapshot body ended")
+}
+
 // verifySnapshotMetadata checks the snapshot header values
 func verifySnapshotMetadata(t *testing.T, data []byte, expectedEntrypoint uint64, expectedLevel uint16, expectedNodeCount uint32) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- keep raw/live WAL truncation recovery, but fail closed for truncated .sorted and .condensed compacted files
- make sorted-file merge iterators treat unexpected EOF as corruption instead of clean EOF
- validate snapshot body block coverage so block-boundary truncation cannot look valid

## Tests
- go test ./adapters/repos/db/vector/hnsw/compact -count=1