### PR TITLE
fix(backup): return 5xx for operational failures

### DIFF
--- a/adapters/handlers/rest/handlers_backup.go
+++ b/adapters/handlers/rest/handlers_backup.go
@@ -371,14 +371,13 @@ func (s *backupHandlers) list(params backups.BackupsListParams,
 		s.metricRequestsTotal.logError("", err)
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
-			return backups.NewBackupsRestoreForbidden().
+			return backups.NewBackupsListForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
-
 		case errors.As(err, &backup.ErrUnprocessable{}):
-			return backups.NewBackupsRestoreUnprocessableEntity().
+			return backups.NewBackupsListUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return backups.NewBackupsRestoreInternalServerError().
+			return backups.NewBackupsListInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -220,7 +220,7 @@ func (s *schemaHandlers) getSchema(params schema.SchemaDumpParams, principal *mo
 			return schema.NewSchemaDumpForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewSchemaDumpForbidden().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewSchemaDumpInternalServerError().WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
 
@@ -249,7 +249,7 @@ func (s *schemaHandlers) getShardsStatus(params schema.SchemaObjectsShardsGetPar
 			return schema.NewSchemaObjectsShardsGetForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewSchemaObjectsShardsGetNotFound().
+			return schema.NewSchemaObjectsShardsGetInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
@@ -265,15 +265,16 @@ func (s *schemaHandlers) updateShardStatus(params schema.SchemaObjectsShardsUpda
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
 	_, err := s.manager.UpdateShardStatus(
-		ctx, principal, params.ClassName, params.ShardName, params.Body.Status)
+		ctx, principal, params.ClassName, params.ShardName, params.Body.Status,
+	)
 	if err != nil {
 		s.metricRequestsTotal.logError("", err)
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
-			return schema.NewSchemaObjectsShardsGetForbidden().
+			return schema.NewSchemaObjectsShardsUpdateForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewSchemaObjectsShardsUpdateUnprocessableEntity().
+			return schema.NewSchemaObjectsShardsUpdateInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
@@ -289,7 +290,8 @@ func (s *schemaHandlers) createTenants(params schema.TenantsCreateParams,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
 	_, err := s.manager.AddTenants(
-		ctx, principal, params.ClassName, params.Body)
+		ctx, principal, params.ClassName, params.Body,
+	)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		if le, ok := usagelimits.AsLimitExceeded(err); ok {
@@ -315,7 +317,8 @@ func (s *schemaHandlers) updateTenants(params schema.TenantsUpdateParams,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
 	updatedTenants, err := s.manager.UpdateTenants(
-		ctx, principal, params.ClassName, params.Body)
+		ctx, principal, params.ClassName, params.Body,
+	)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {
@@ -337,7 +340,8 @@ func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
 	err := s.manager.DeleteTenants(
-		ctx, principal, params.ClassName, params.Tenants)
+		ctx, principal, params.ClassName, params.Tenants,
+	)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -172,11 +172,11 @@ func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Reques
 	}
 	// make sure there is no active backup
 	if prevID := c.lastOp.renew(req.ID, cstore.HomeDir(req.Bucket, req.Path), req.Bucket, req.Path); prevID != "" {
-		return fmt.Errorf("backup %s already in progress", prevID)
+		return backup.NewErrUnprocessable(fmt.Errorf("backup %s already in progress", prevID))
 	}
 	compressionType, err := CompressionTypeFromLevel(req.Level)
 	if err != nil {
-		return err
+		return backup.NewErrUnprocessable(err)
 	}
 
 	c.descriptor = &backup.DistributedBackupDescriptor{
@@ -257,7 +257,7 @@ func (c *coordinator) Restore(
 
 	// make sure there is no active backup
 	if prevID := c.lastOp.renew(desc.ID, store.HomeDir(req.Bucket, req.Path), req.Bucket, req.Path); prevID != "" {
-		return fmt.Errorf("restoration %s already in progress", prevID)
+		return backup.NewErrUnprocessable(fmt.Errorf("restoration %s already in progress", prevID))
 	}
 
 	for key := range c.Participants {
@@ -456,7 +456,10 @@ func (c *coordinator) OnStatus(ctx context.Context, store coordStore, req *Statu
 	meta, err := store.Meta(ctx, filename, store.bucket, store.path)
 	if err != nil {
 		path := st.Path
-		return nil, fmt.Errorf("coordinator cannot get status: %w: %q: %w store: %v", errMetaNotFound, path, err, st)
+		if errors.As(err, &backup.ErrNotFound{}) {
+			return nil, fmt.Errorf("coordinator cannot get status: %w: %q: %w store: %v", errMetaNotFound, path, err, st)
+		}
+		return nil, fmt.Errorf("coordinator cannot get status: %q: %w store: %v", path, err, st)
 	}
 
 	status := &Status{

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -73,12 +73,14 @@ func NewScheduler(
 			sourcer,
 			client,
 			schema,
-			logger, nodeResolver, backends),
+			logger, nodeResolver, backends,
+		),
 		restorer: newCoordinator(
 			sourcer,
 			client,
 			schema,
-			logger, nodeResolver, backends),
+			logger, nodeResolver, backends,
+		),
 	}
 	return m
 }
@@ -143,7 +145,7 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 	}
 
 	if err := store.Initialize(ctx, req.Bucket, req.Path); err != nil {
-		return nil, backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
+		return nil, fmt.Errorf("init uploader: %w", err)
 	}
 	breq := Request{
 		Method:       OpCreate,
@@ -156,7 +158,7 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		BaseBackupID: req.BaseBackupID,
 	}
 	if err := s.backupper.Backup(ctx, store, &breq); err != nil {
-		return nil, backup.NewErrUnprocessable(err)
+		return nil, err
 	} else {
 		st := s.backupper.lastOp.get()
 		status := string(st.Status)
@@ -199,7 +201,7 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 
 	schema, err := s.fetchSchema(ctx, req.Backend, req.Bucket, req.Path, meta)
 	if err != nil {
-		return nil, backup.NewErrUnprocessable(err)
+		return nil, err
 	}
 	status := string(backup.Started)
 	data := &models.BackupRestoreResponse{
@@ -226,7 +228,7 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	if err != nil {
 		status = string(backup.Failed)
 		data.Error = err.Error()
-		return nil, backup.NewErrUnprocessable(err)
+		return nil, err
 	}
 
 	data.Status = &status
@@ -248,7 +250,10 @@ func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principa
 	req := &StatusRequest{OpCreate, backupID, backend, store.bucket, store.path, ""}
 	st, err := s.backupper.OnStatus(ctx, store, req)
 	if err != nil {
-		return nil, backup.NewErrNotFound(err)
+		if errors.Is(err, errMetaNotFound) {
+			return nil, backup.NewErrNotFound(err)
+		}
+		return nil, err
 	}
 	return st, nil
 }
@@ -266,7 +271,10 @@ func (s *Scheduler) RestorationStatus(ctx context.Context, principal *models.Pri
 	req := &StatusRequest{OpRestore, backupID, backend, overrideBucket, overridePath, ""}
 	st, err := s.restorer.OnStatus(ctx, store, req)
 	if err != nil {
-		return nil, backup.NewErrNotFound(err)
+		if errors.Is(err, errMetaNotFound) {
+			return nil, backup.NewErrNotFound(err)
+		}
+		return nil, err
 	}
 	return st, nil
 }
@@ -289,7 +297,7 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 	}
 
 	if err := store.Initialize(ctx, overrideBucket, overridePath); err != nil {
-		return backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
+		return fmt.Errorf("init uploader: %w", err)
 	}
 
 	meta, _ := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath)
@@ -340,7 +348,7 @@ func (s *Scheduler) CancelRestore(ctx context.Context, principal *models.Princip
 	}
 
 	if err := store.Initialize(ctx, overrideBucket, overridePath); err != nil {
-		return backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
+		return fmt.Errorf("init uploader: %w", err)
 	}
 
 	meta, _ := store.Meta(ctx, GlobalRestoreFile, overrideBucket, overridePath)

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -220,7 +220,7 @@ func TestSchedulerBackupStatus(t *testing.T) {
 
 	t.Run("MetadataNotFound", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
 		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
 
 		_, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
@@ -229,6 +229,17 @@ func TestSchedulerBackupStatus(t *testing.T) {
 		if !errors.As(err, &nerr) {
 			t.Errorf("error want=%v got=%v", nerr, err)
 		}
+	})
+
+	t.Run("MetadataReadFails", func(t *testing.T) {
+		// A transient/operational read failure propagates raw so the handler
+		// default arm maps it to 500 instead of misclassifying as 404.
+		fs := newFakeScheduler(nil)
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, ErrAny)
+
+		_, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
+		assert.ErrorIs(t, err, ErrAny, "underlying backend error should propagate unwrapped")
 	})
 
 	t.Run("ReadFromMetadata", func(t *testing.T) {
@@ -241,7 +252,8 @@ func TestSchedulerBackupStatus(t *testing.T) {
 				Status: backup.Success,
 				// 2.5Gb
 				PreCompressionSizeBytes: 2684354560,
-			})
+			},
+		)
 		want := want
 		want.CompletedAt = completedAt
 		want.Status = backup.Success
@@ -316,13 +328,22 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 
 	t.Run("MetadataNotFound", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
 		_, err := fs.scheduler().RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.NotNil(t, err)
 		nerr := backup.ErrNotFound{}
 		if !errors.As(err, &nerr) {
 			t.Errorf("error want=%v got=%v", nerr, err)
 		}
+	})
+
+	t.Run("MetadataReadFails", func(t *testing.T) {
+		// A transient/operational read failure propagates raw so the handler
+		// default arm maps it to 500 instead of misclassifying as 404.
+		fs := newFakeScheduler(nil)
+		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, ErrAny)
+		_, err := fs.scheduler().RestorationStatus(ctx, nil, backendName, id, "", "")
+		assert.ErrorIs(t, err, ErrAny, "underlying backend error should propagate unwrapped")
 	})
 
 	t.Run("ReadFromMetadata", func(t *testing.T) {
@@ -427,7 +448,8 @@ func TestSchedulerCreateBackup(t *testing.T) {
 		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.NewErrNotFound(errors.New("not found")))
 		fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
 
-		fs.backend.On("Initialize", ctx, backupID).Return(errors.New("init meta failed"))
+		initErr := errors.New("init meta failed")
+		fs.backend.On("Initialize", ctx, backupID).Return(initErr)
 		meta, err := fs.scheduler().Backup(ctx, nil, &BackupRequest{
 			Backend: backendName,
 			ID:      backupID,
@@ -436,8 +458,8 @@ func TestSchedulerCreateBackup(t *testing.T) {
 
 		assert.Nil(t, meta)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "init")
-		assert.IsType(t, backup.ErrUnprocessable{}, err)
+		assert.ErrorIs(t, err, initErr, "underlying init error should propagate unwrapped")
+		assert.Contains(t, err.Error(), "init uploader")
 	})
 
 	t.Run("Success", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

This pr fixes status codes returned for backup rest api.  e.g. 

```
"Failed to launch cluster backup: failed fetching collections for backup: failed to list collections from cluster: list collections: HTTP 403: {\"error\":[{\"message\":\"could not read schema with strong consistency: failed to execute query: rpc error: code = Internal desc = server closed the stream without sending trailers\"}]}\n"
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
