### PR TITLE
feat(drop-vector-index): reject writes carrying a dropped vector index

### DIFF
--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
@@ -160,11 +161,16 @@ func (ob *objectsBatcher) storeSingleBatchInLSM(ctx context.Context,
 	eg := enterrors.NewErrorGroupWrapper(ob.shard.Index().logger)
 	eg.SetLimit(_NUMCPU)
 
+	// Read the class once: it is invariant across the batch, and getClass()
+	// clones the class on every call. Passed into the per-item dropped-vector
+	// guard below.
+	class := ob.shard.Index().getClass()
+
 	for j, object := range batch {
 		object := object
 		index := j
 		f := func() error {
-			if err := ob.storeObjectOfBatchInLSM(ctx, index, object); err != nil {
+			if err := ob.storeObjectOfBatchInLSM(ctx, class, index, object); err != nil {
 				errLock.Lock()
 				errs[index] = err
 				errLock.Unlock()
@@ -180,7 +186,7 @@ func (ob *objectsBatcher) storeSingleBatchInLSM(ctx context.Context,
 }
 
 func (ob *objectsBatcher) storeObjectOfBatchInLSM(ctx context.Context,
-	objectIndex int, object *storobj.Object,
+	class *models.Class, objectIndex int, object *storobj.Object,
 ) error {
 	if _, ok := ob.duplicates[objectIndex]; ok {
 		return nil
@@ -188,7 +194,7 @@ func (ob *objectsBatcher) storeObjectOfBatchInLSM(ctx context.Context,
 
 	// Reject batch items carrying a dropped vector before persisting anything.
 	if len(object.Vectors) > 0 || len(object.MultiVectors) > 0 {
-		if err := rejectDroppedObjectVectors(ob.shard.Index().getClass(), object); err != nil {
+		if err := rejectDroppedObjectVectors(class, object); err != nil {
 			return err
 		}
 	}

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -185,6 +185,14 @@ func (ob *objectsBatcher) storeObjectOfBatchInLSM(ctx context.Context,
 	if _, ok := ob.duplicates[objectIndex]; ok {
 		return nil
 	}
+
+	// Reject batch items carrying a dropped vector before persisting anything.
+	if len(object.Vectors) > 0 || len(object.MultiVectors) > 0 {
+		if err := rejectDroppedObjectVectors(ob.shard.Index().getClass(), object); err != nil {
+			return err
+		}
+	}
+
 	uuidParsed, err := uuid.Parse(object.ID().String())
 	if err != nil {
 		return errors.Wrap(err, "invalid id")

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -161,9 +161,8 @@ func (ob *objectsBatcher) storeSingleBatchInLSM(ctx context.Context,
 	eg := enterrors.NewErrorGroupWrapper(ob.shard.Index().logger)
 	eg.SetLimit(_NUMCPU)
 
-	// Read the class once: it is invariant across the batch, and getClass()
-	// clones the class on every call. Passed into the per-item dropped-vector
-	// guard below.
+	// Read once and reuse: the class is invariant across the batch and
+	// getClass() clones on every call.
 	class := ob.shard.Index().getClass()
 
 	for j, object := range batch {

--- a/adapters/repos/db/shard_write_drop_vector.go
+++ b/adapters/repos/db/shard_write_drop_vector.go
@@ -1,0 +1,58 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// isDroppedVectorIndex reports whether the named vector's index has been
+// dropped (VectorConfig entry marked VectorIndexType=="none"). The legacy
+// vector (empty targetVector) is not managed through VectorConfig. A nil class
+// reports false, leaving the existing GetVectorIndexQueue !ok branch in charge.
+func isDroppedVectorIndex(class *models.Class, targetVector string) bool {
+	if class == nil || targetVector == "" {
+		return false
+	}
+	cfg, ok := class.VectorConfig[targetVector]
+	return ok && modelsext.IsVectorIndexDropped(cfg)
+}
+
+// errDroppedVectorIndex mirrors the error GetVectorIndexQueue !ok raises, so a
+// dropped vector is indistinguishable from a never-existed one to clients.
+func errDroppedVectorIndex(targetVector string) error {
+	return fmt.Errorf("vector index not found for %s", targetVector)
+}
+
+// rejectDroppedObjectVectors rejects an object carrying a dropped vector. Call
+// it before any storage mutation. It also catches the window where the marker
+// has applied but the queue teardown has not, during which GetVectorIndexQueue
+// still returns a live queue (the marker is applied before the queue is dropped
+// in cluster/schema/manager.go::apply). Callers gate on named vectors being
+// present so the schema read is skipped otherwise.
+func rejectDroppedObjectVectors(class *models.Class, object *storobj.Object) error {
+	for targetVector := range object.Vectors {
+		if isDroppedVectorIndex(class, targetVector) {
+			return errDroppedVectorIndex(targetVector)
+		}
+	}
+	for targetVector := range object.MultiVectors {
+		if isDroppedVectorIndex(class, targetVector) {
+			return errDroppedVectorIndex(targetVector)
+		}
+	}
+	return nil
+}

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -34,11 +34,10 @@ import (
 
 const dropVecClassName = "DropVectorWriteRejectClass"
 
-// setupDropVectorShard builds a shard with a named vector "foo" (hnsw) and a
-// "label" property. The returned *models.Class is the live schema object the
-// shard reads via getClass(); flipping class.VectorConfig["foo"] to
-// VectorIndexType="none" simulates the drop marker applying without the queue
-// teardown having happened yet.
+// setupDropVectorShard builds a shard with named vectors "foo" (hnsw) and "mv"
+// (multivector) plus a "label" property. The returned *models.Class is the live
+// schema object the shard reads via getClass(), so markDropped simulates the
+// drop marker applying before queue teardown has happened.
 func setupDropVectorShard(t *testing.T, ctx context.Context) (*Shard, *models.Class) {
 	t.Helper()
 	class := &models.Class{
@@ -165,10 +164,9 @@ func TestDropVectorIndex_MergeRejected(t *testing.T) {
 		require.NoError(t, shard.PutObject(ctx, obj))
 
 		markDropped(class, "foo")
-		// Tear the queue down for the real post-drop state: the stored object
-		// still carries the foo vector but GetVectorIndexQueue returns !ok. The
-		// merge omits vectors, so mergeProps copies foo forward; the re-index
-		// loop must skip it instead of erroring on the missing queue.
+		// Tear the queue down too, for the real post-drop state: the stored
+		// object still carries foo, but mergeProps copies it forward and the
+		// re-index loop must skip it rather than error on the missing queue.
 		require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
 
 		require.NoError(t, shard.MergeObject(ctx, objects.MergeDocument{
@@ -178,7 +176,6 @@ func TestDropVectorIndex_MergeRejected(t *testing.T) {
 			UpdateTime:      2_000,
 		}))
 
-		// The property update must have been persisted.
 		retrieved, err := shard.ObjectByID(ctx, obj.ID(), nil, additional.Properties{})
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -1,0 +1,193 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
+	"github.com/weaviate/weaviate/entities/schema"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+const dropVecClassName = "DropVectorWriteRejectClass"
+
+// setupDropVectorShard builds a shard with a named vector "foo" (hnsw) and a
+// "label" property. The returned *models.Class is the live schema object the
+// shard reads via getClass(); flipping class.VectorConfig["foo"] to
+// VectorIndexType="none" simulates the drop marker applying without the queue
+// teardown having happened yet.
+func setupDropVectorShard(t *testing.T, ctx context.Context) (*Shard, *models.Class) {
+	t.Helper()
+	class := &models.Class{
+		Class: dropVecClassName,
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			UsingBlockMaxWAND: config.DefaultUsingBlockMaxWAND,
+		},
+		Properties: []*models.Property{
+			{
+				Name:         "label",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWord,
+			},
+		},
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {VectorIndexType: hnsw.NewDefaultUserConfig().IndexType(), VectorIndexConfig: hnsw.NewDefaultUserConfig()},
+		},
+	}
+	vic := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
+	shardLike, _ := testShardWithSettings(t, ctx, class, vic, false, true, false, func(i *Index) {
+		i.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
+			"foo": hnsw.NewDefaultUserConfig(),
+		}
+	})
+
+	switch s := shardLike.(type) {
+	case *Shard:
+		return s, class
+	case *LazyLoadShard:
+		require.NoError(t, s.Load(ctx))
+		return s.shard, class
+	default:
+		t.Fatalf("unexpected shard type %T", shardLike)
+		return nil, nil
+	}
+}
+
+func dropVecObject(t *testing.T, label string, withFoo bool) *storobj.Object {
+	t.Helper()
+	obj := &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      dropVecClassName,
+			Properties: map[string]interface{}{"label": label},
+		},
+	}
+	if withFoo {
+		obj.Vectors = map[string][]float32{"foo": {1, 2, 3}}
+	}
+	return obj
+}
+
+func markFooDropped(class *models.Class) {
+	class.VectorConfig["foo"] = models.VectorConfig{VectorIndexType: modelsext.VectorIndexTypeNone}
+}
+
+// TestDropVectorIndex_PutRejected covers the put path (PutObject -> putOne),
+// including the window where the marker is visible but the queue is still live.
+func TestDropVectorIndex_PutRejected(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+
+	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "a", true)))
+
+	// Drop the marker but leave the queue alive (the race window).
+	markFooDropped(class)
+
+	err := shard.PutObject(ctx, dropVecObject(t, "b", true))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "vector index not found")
+	require.Contains(t, err.Error(), "foo")
+
+	// A write not carrying the dropped vector still succeeds.
+	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "c", false)))
+}
+
+// TestDropVectorIndex_MergeRejected pins both halves of the merge contract: a
+// client explicitly supplying the dropped vector is rejected, while a
+// property-only merge on an object that still carries the dropped vector
+// (carried over by mergeProps) succeeds — the carried-over vector is skipped,
+// not errored. The latter is a regression guard for the pre-existing bug where
+// such merges failed with "vector index not found" after a partial write.
+func TestDropVectorIndex_MergeRejected(t *testing.T) {
+	ctx := testCtx()
+
+	t.Run("client-supplied dropped vector is rejected", func(t *testing.T) {
+		shard, class := setupDropVectorShard(t, ctx)
+		obj := dropVecObject(t, "a", true)
+		require.NoError(t, shard.PutObject(ctx, obj))
+
+		markFooDropped(class)
+
+		err := shard.MergeObject(ctx, objects.MergeDocument{
+			ID:              obj.ID(),
+			Class:           dropVecClassName,
+			PrimitiveSchema: map[string]interface{}{"label": "b"},
+			Vectors:         models.Vectors{"foo": []float32{4, 5, 6}},
+			UpdateTime:      2_000,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "vector index not found")
+		require.Contains(t, err.Error(), "foo")
+	})
+
+	t.Run("property-only merge carrying a dropped vector succeeds", func(t *testing.T) {
+		shard, class := setupDropVectorShard(t, ctx)
+		obj := dropVecObject(t, "a", true)
+		require.NoError(t, shard.PutObject(ctx, obj))
+
+		markFooDropped(class)
+		// Tear the queue down for the real post-drop state: the stored object
+		// still carries the foo vector but GetVectorIndexQueue returns !ok. The
+		// merge omits vectors, so mergeProps copies foo forward; the re-index
+		// loop must skip it instead of erroring on the missing queue.
+		require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
+
+		require.NoError(t, shard.MergeObject(ctx, objects.MergeDocument{
+			ID:              obj.ID(),
+			Class:           dropVecClassName,
+			PrimitiveSchema: map[string]interface{}{"label": "b"},
+			UpdateTime:      2_000,
+		}))
+
+		// The property update must have been persisted.
+		retrieved, err := shard.ObjectByID(ctx, obj.ID(), nil, additional.Properties{})
+		require.NoError(t, err)
+		require.NotNil(t, retrieved)
+		require.Equal(t, "b", retrieved.Object.Properties.(map[string]interface{})["label"])
+	})
+}
+
+// TestDropVectorIndex_BatchRejected covers the batch path
+// (storeObjectOfBatchInLSM): only the item carrying the dropped vector fails.
+func TestDropVectorIndex_BatchRejected(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+
+	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "warmup", true)))
+
+	markFooDropped(class)
+
+	withFoo := dropVecObject(t, "withfoo", true)
+	withoutFoo := dropVecObject(t, "withoutfoo", false)
+
+	errs := shard.PutObjectBatch(ctx, []*storobj.Object{withFoo, withoutFoo})
+	require.Len(t, errs, 2)
+	require.Error(t, errs[0])
+	require.Contains(t, errs[0].Error(), "vector index not found")
+	require.Contains(t, errs[0].Error(), "foo")
+	require.NoError(t, errs[1])
+}

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -55,12 +55,14 @@ func setupDropVectorShard(t *testing.T, ctx context.Context) (*Shard, *models.Cl
 		},
 		VectorConfig: map[string]models.VectorConfig{
 			"foo": {VectorIndexType: hnsw.NewDefaultUserConfig().IndexType(), VectorIndexConfig: hnsw.NewDefaultUserConfig()},
+			"mv":  {VectorIndexType: hnsw.NewDefaultMultiVectorUserConfig().IndexType(), VectorIndexConfig: hnsw.NewDefaultMultiVectorUserConfig()},
 		},
 	}
 	vic := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
 	shardLike, _ := testShardWithSettings(t, ctx, class, vic, false, true, false, func(i *Index) {
 		i.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
 			"foo": hnsw.NewDefaultUserConfig(),
+			"mv":  hnsw.NewDefaultMultiVectorUserConfig(),
 		}
 	})
 
@@ -92,8 +94,21 @@ func dropVecObject(t *testing.T, label string, withFoo bool) *storobj.Object {
 	return obj
 }
 
-func markFooDropped(class *models.Class) {
-	class.VectorConfig["foo"] = models.VectorConfig{VectorIndexType: modelsext.VectorIndexTypeNone}
+func dropVecMultiObject(t *testing.T, label string) *storobj.Object {
+	t.Helper()
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      dropVecClassName,
+			Properties: map[string]interface{}{"label": label},
+		},
+		MultiVectors: map[string][][]float32{"mv": {{1, 2}, {3, 4}}},
+	}
+}
+
+func markDropped(class *models.Class, targetVector string) {
+	class.VectorConfig[targetVector] = models.VectorConfig{VectorIndexType: modelsext.VectorIndexTypeNone}
 }
 
 // TestDropVectorIndex_PutRejected covers the put path (PutObject -> putOne),
@@ -105,7 +120,7 @@ func TestDropVectorIndex_PutRejected(t *testing.T) {
 	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "a", true)))
 
 	// Drop the marker but leave the queue alive (the race window).
-	markFooDropped(class)
+	markDropped(class, "foo")
 
 	err := shard.PutObject(ctx, dropVecObject(t, "b", true))
 	require.Error(t, err)
@@ -130,7 +145,7 @@ func TestDropVectorIndex_MergeRejected(t *testing.T) {
 		obj := dropVecObject(t, "a", true)
 		require.NoError(t, shard.PutObject(ctx, obj))
 
-		markFooDropped(class)
+		markDropped(class, "foo")
 
 		err := shard.MergeObject(ctx, objects.MergeDocument{
 			ID:              obj.ID(),
@@ -149,7 +164,7 @@ func TestDropVectorIndex_MergeRejected(t *testing.T) {
 		obj := dropVecObject(t, "a", true)
 		require.NoError(t, shard.PutObject(ctx, obj))
 
-		markFooDropped(class)
+		markDropped(class, "foo")
 		// Tear the queue down for the real post-drop state: the stored object
 		// still carries the foo vector but GetVectorIndexQueue returns !ok. The
 		// merge omits vectors, so mergeProps copies foo forward; the re-index
@@ -169,6 +184,48 @@ func TestDropVectorIndex_MergeRejected(t *testing.T) {
 		require.NotNil(t, retrieved)
 		require.Equal(t, "b", retrieved.Object.Properties.(map[string]interface{})["label"])
 	})
+
+	t.Run("client-supplied dropped multivector is rejected", func(t *testing.T) {
+		shard, class := setupDropVectorShard(t, ctx)
+		obj := dropVecMultiObject(t, "a")
+		require.NoError(t, shard.PutObject(ctx, obj))
+
+		markDropped(class, "mv")
+
+		err := shard.MergeObject(ctx, objects.MergeDocument{
+			ID:              obj.ID(),
+			Class:           dropVecClassName,
+			PrimitiveSchema: map[string]interface{}{"label": "b"},
+			Vectors:         models.Vectors{"mv": [][]float32{{5, 6}, {7, 8}}},
+			UpdateTime:      2_000,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "vector index not found")
+		require.Contains(t, err.Error(), "mv")
+	})
+
+	t.Run("property-only merge carrying a dropped multivector succeeds", func(t *testing.T) {
+		shard, class := setupDropVectorShard(t, ctx)
+		obj := dropVecMultiObject(t, "a")
+		require.NoError(t, shard.PutObject(ctx, obj))
+
+		markDropped(class, "mv")
+		require.NoError(t, shard.DropVectorIndex(ctx, "mv"))
+
+		// mergeProps copies MultiVectors forward too; the re-index loop must skip
+		// the carried-over dropped multivector instead of erroring.
+		require.NoError(t, shard.MergeObject(ctx, objects.MergeDocument{
+			ID:              obj.ID(),
+			Class:           dropVecClassName,
+			PrimitiveSchema: map[string]interface{}{"label": "b"},
+			UpdateTime:      2_000,
+		}))
+
+		retrieved, err := shard.ObjectByID(ctx, obj.ID(), nil, additional.Properties{})
+		require.NoError(t, err)
+		require.NotNil(t, retrieved)
+		require.Equal(t, "b", retrieved.Object.Properties.(map[string]interface{})["label"])
+	})
 }
 
 // TestDropVectorIndex_BatchRejected covers the batch path
@@ -179,7 +236,7 @@ func TestDropVectorIndex_BatchRejected(t *testing.T) {
 
 	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "warmup", true)))
 
-	markFooDropped(class)
+	markDropped(class, "foo")
 
 	withFoo := dropVecObject(t, "withfoo", true)
 	withoutFoo := dropVecObject(t, "withoutfoo", false)

--- a/adapters/repos/db/shard_write_drop_vector_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_test.go
@@ -1,0 +1,129 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+func TestDropVectorIndex_IsDropped(t *testing.T) {
+	none := modelsext.VectorIndexTypeNone
+
+	classWith := func(cfg map[string]models.VectorConfig) *models.Class {
+		return &models.Class{Class: "TestClass", VectorConfig: cfg}
+	}
+
+	tests := []struct {
+		name         string
+		class        *models.Class
+		targetVector string
+		want         bool
+	}{
+		{name: "nil class", class: nil, targetVector: "foo", want: false},
+		{name: "legacy vector empty target is never dropped", class: classWith(map[string]models.VectorConfig{"": {VectorIndexType: none}}), targetVector: "", want: false},
+		{name: "target absent from config", class: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: "hnsw"}}), targetVector: "bar", want: false},
+		{name: "active hnsw", class: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: "hnsw"}}), targetVector: "foo", want: false},
+		{name: "active flat", class: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: "flat"}}), targetVector: "foo", want: false},
+		{name: "active dynamic", class: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: "dynamic"}}), targetVector: "foo", want: false},
+		{name: "dropped", class: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}), targetVector: "foo", want: true},
+		{name: "empty config map", class: classWith(map[string]models.VectorConfig{}), targetVector: "foo", want: false},
+		{name: "nil config map", class: &models.Class{Class: "TestClass"}, targetVector: "foo", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDroppedVectorIndex(tt.class, tt.targetVector))
+		})
+	}
+}
+
+func TestDropVectorIndex_RejectObjectVectors(t *testing.T) {
+	none := modelsext.VectorIndexTypeNone
+
+	classWith := func(cfg map[string]models.VectorConfig) *models.Class {
+		return &models.Class{Class: "TestClass", VectorConfig: cfg}
+	}
+
+	objWith := func(vectors map[string][]float32, multi map[string][][]float32) *storobj.Object {
+		return &storobj.Object{Object: models.Object{Class: "TestClass"}, Vectors: vectors, MultiVectors: multi}
+	}
+
+	tests := []struct {
+		name       string
+		class      *models.Class
+		object     *storobj.Object
+		wantErr    bool
+		wantTarget string
+	}{
+		{
+			name:   "no vectors",
+			class:  classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+			object: objWith(nil, nil),
+		},
+		{
+			name:   "active single vector",
+			class:  classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: "hnsw"}}),
+			object: objWith(map[string][]float32{"foo": {1, 2, 3}}, nil),
+		},
+		{
+			name:       "dropped single vector",
+			class:      classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+			object:     objWith(map[string][]float32{"foo": {1, 2, 3}}, nil),
+			wantErr:    true,
+			wantTarget: "foo",
+		},
+		{
+			name:       "dropped multi vector",
+			class:      classWith(map[string]models.VectorConfig{"bar": {VectorIndexType: none}}),
+			object:     objWith(nil, map[string][][]float32{"bar": {{1, 2}, {3, 4}}}),
+			wantErr:    true,
+			wantTarget: "bar",
+		},
+		{
+			name:  "mixed - one active one dropped",
+			class: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: "hnsw"}, "baz": {VectorIndexType: none}}),
+			// only the dropped one must trigger; assert the target appears in the error
+			object:     objWith(map[string][]float32{"foo": {1}, "baz": {2}}, nil),
+			wantErr:    true,
+			wantTarget: "baz",
+		},
+		{
+			name:   "all active across vectors and multivectors",
+			class:  classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: "hnsw"}, "bar": {VectorIndexType: "hnsw"}}),
+			object: objWith(map[string][]float32{"foo": {1}}, map[string][][]float32{"bar": {{1}}}),
+		},
+		{
+			name:   "nil class falls back to allow (existing !ok branch handles it)",
+			class:  nil,
+			object: objWith(map[string][]float32{"foo": {1}}, nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectDroppedObjectVectors(tt.class, tt.object)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "vector index not found")
+			assert.Contains(t, err.Error(), tt.wantTarget)
+		})
+	}
+}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -76,12 +76,11 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 }
 
 func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocument) error {
-	// Read once for both the reject below and the carried-over skip in the
-	// re-index loop. The guard lives here, not in MergeObject, because
-	// replication enters merge directly (shard_replication.go). This is a
-	// consistent snapshot: a drop applying after this read uses the pre-drop
-	// view for the rest of the call — the same inherent concurrent-schema-change
-	// window that predates this guard, not widened by it.
+	// Read once: reused by the reject below and the carried-over skip in the
+	// re-index loop. Lives here, not in MergeObject, because replication enters
+	// merge directly (shard_replication.go). The snapshot is intentionally
+	// consistent — a drop landing after this read isn't seen for the rest of the
+	// call (a pre-existing concurrent-schema-change window, not widened here).
 	class := s.index.getClass()
 
 	// Reject a merge that explicitly supplies a dropped vector.

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -78,7 +78,10 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocument) error {
 	// Read once for both the reject below and the carried-over skip in the
 	// re-index loop. The guard lives here, not in MergeObject, because
-	// replication enters merge directly (shard_replication.go).
+	// replication enters merge directly (shard_replication.go). This is a
+	// consistent snapshot: a drop applying after this read uses the pre-drop
+	// view for the rest of the call — the same inherent concurrent-schema-change
+	// window that predates this guard, not widened by it.
 	class := s.index.getClass()
 
 	// Reject a merge that explicitly supplies a dropped vector.
@@ -100,9 +103,6 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 	}
 
 	for targetVector, vector := range obj.Vectors {
-		// mergeProps copies prev vectors forward when the merge omits them, so
-		// a dropped vector can reach here; skip it rather than re-index into a
-		// queue that no longer exists.
 		if isDroppedVectorIndex(class, targetVector) {
 			continue
 		}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -76,6 +76,18 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 }
 
 func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocument) error {
+	// Read once for both the reject below and the carried-over skip in the
+	// re-index loop. The guard lives here, not in MergeObject, because
+	// replication enters merge directly (shard_replication.go).
+	class := s.index.getClass()
+
+	// Reject a merge that explicitly supplies a dropped vector.
+	for targetVector := range doc.Vectors {
+		if isDroppedVectorIndex(class, targetVector) {
+			return errDroppedVectorIndex(targetVector)
+		}
+	}
+
 	obj, status, err := s.mergeObjectInStorage(ctx, doc, idBytes)
 	if err != nil {
 		return err
@@ -88,11 +100,20 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 	}
 
 	for targetVector, vector := range obj.Vectors {
+		// mergeProps copies prev vectors forward when the merge omits them, so
+		// a dropped vector can reach here; skip it rather than re-index into a
+		// queue that no longer exists.
+		if isDroppedVectorIndex(class, targetVector) {
+			continue
+		}
 		if err = s.updateVectorIndex(ctx, vector, status, targetVector); err != nil {
 			return errors.Wrapf(err, "update vector index for target vector %s", targetVector)
 		}
 	}
 	for targetVector, vector := range obj.MultiVectors {
+		if isDroppedVectorIndex(class, targetVector) {
+			continue
+		}
 		if err = s.updateMultiVectorIndex(ctx, vector, status, targetVector); err != nil {
 			return errors.Wrapf(err, "update multi vector index for target vector %s", targetVector)
 		}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -46,6 +46,13 @@ func (s *Shard) PutObject(ctx context.Context, object *storobj.Object) error {
 }
 
 func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object) error {
+	// Reject writes carrying a dropped vector before persisting anything.
+	if len(object.Vectors) > 0 || len(object.MultiVectors) > 0 {
+		if err := rejectDroppedObjectVectors(s.index.getClass(), object); err != nil {
+			return err
+		}
+	}
+
 	status, err := s.putObjectLSM(ctx, object, uuid)
 	if err != nil {
 		return errors.Wrap(err, "store object in LSM store")


### PR DESCRIPTION
## Motivation

Part of the Drop Vector Index work (RFC step S1). Once a named vector's index is dropped (its `VectorConfig` entry is marked `VectorIndexType: "none"`), the per-shard index queue is torn down. Writes that still carry that vector must be rejected — otherwise they either crash on a missing queue or silently re-index into a queue that no longer exists.

The subtle part is timing: schema apply runs `updateSchema` (which flips the marker) *before* `updateStore` (which drops the queue) in `cluster/schema/manager.go::apply`. That leaves a window where `GetVectorIndexQueue` still returns a live queue even though the vector is logically dropped. Relying on the `!ok` branch alone is therefore racy.

## Approach

Gate on the live schema marker, not on queue presence. A new helper `rejectDroppedObjectVectors` checks each carried vector against the class's `VectorConfig` and rejects with the exact same `"vector index not found for <targetVector>"` error that a never-existed vector produces — so a dropped vector is indistinguishable from one that never existed, from the client's perspective.

The guard is placed at the lowest shared chokepoints (`putOne`, `merge`) rather than the public `PutObject`/`MergeObject`, because replication enters those internal methods directly (`shard_replication.go`). Batch goes through its own per-item path so it gets an explicit call in `storeObjectOfBatchInLSM`. The schema read is skipped entirely when an object carries no named vectors.

The legacy vector (empty `targetVector`) is deliberately out of scope here — it isn't managed through `VectorConfig`, so the existing `GetVectorIndexQueue !ok` branch stays in charge.

## Adjacent bug fixed

While adding the merge guard I hit a latent crash unrelated to client input: `mergeProps` carries previously-stored vectors forward when a merge omits them. So a property-only merge on an object that *still holds* a dropped vector (data persists until Phase 2 cleanup) reaches `merge()`'s re-index loop with that vector and fails on the missing queue — even though the client supplied nothing wrong. The re-index loop now skips carried-over dropped vectors (the data stays on disk, it's just not re-indexed) while still rejecting vectors the client explicitly supplies in the merge document. Covered by `TestDropVectorIndex_MergeRejected` and the integration tests.

## Key areas for review

- `shard_write_drop_vector.go` — the whole guard. Confirm the marker semantics (`IsVectorIndexDropped`) and that legacy/empty `targetVector` is correctly excluded.
- `shard_write_merge.go:merge` — two distinct behaviors sharing one `getClass()` read: hard reject for client-supplied dropped vectors, silent skip for carried-over ones. Verify the distinction is correct and that the guard lives in `merge` (not `MergeObject`) so replication is covered.
- `shard_write_put.go:putOne` / `shard_write_batch_objects.go:storeObjectOfBatchInLSM` — placement before any LSM mutation, and that replication paths funnel through here.

## Risks and mitigations

- **Race during the apply window**: this PR closes it — the guard reads the marker, which is set before the queue teardown, so no write slips through on a stale-but-live queue.
- **Rejecting legitimate writes**: only vectors whose `VectorConfig` entry is explicitly `"none"` are rejected; the schema read is skipped when no named vectors are present, so the common path is unaffected.
- **Data integrity on carried-over vectors**: the merge skip does not delete the carried vector data — it persists until Phase 2 cleanup and is merely not re-indexed, matching the intended drop lifecycle.

## Testing

- Unit: `TestDropVectorIndex_IsDropped` (marker detection, nil class, legacy vector), `TestDropVectorIndex_RejectObjectVectors` (single and multi-vector rejection).
- Integration: `TestDropVectorIndex_{Put,Merge,Batch}Rejected` — exercises the real shard write paths end-to-end, including the property-only-merge carry-over case.
