### PR TITLE
feat(drop-vector-index): reject introducing the "none" vector index type on collection update

### DIFF
--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -528,7 +528,17 @@ func UpdateClassInternal(h *Handler, ctx context.Context, className string, upda
 	initial := h.schemaReader.ReadOnlyClass(className)
 
 	if err := rejectVectorIndexTypeNone(initial, updated); err != nil {
-		return err
+		vclasses, qErr := h.schemaManager.QueryReadOnlyClasses(className)
+		if qErr != nil {
+			return err
+		}
+		consistent, ok := vclasses[className]
+		if !ok || consistent.Class == nil {
+			return err
+		}
+		if err := rejectVectorIndexTypeNone(consistent.Class, updated); err != nil {
+			return err
+		}
 	}
 
 	if err := h.validateVectorSettingsAgainst(updated, initial); err != nil {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -527,6 +527,10 @@ func UpdateClassInternal(h *Handler, ctx context.Context, className string, upda
 	// in validateVectorSettingsAgainst.
 	initial := h.schemaReader.ReadOnlyClass(className)
 
+	if err := rejectVectorIndexTypeNone(initial, updated); err != nil {
+		return err
+	}
+
 	if err := h.validateVectorSettingsAgainst(updated, initial); err != nil {
 		return err
 	}
@@ -1036,6 +1040,29 @@ func (h *Handler) validateCanAddClass(ctx context.Context, class *models.Class, 
 	}
 
 	return h.validateClassInvariants(ctx, class, originalName, classGetterWithAuth, relaxCrossRefValidation)
+}
+
+// rejectVectorIndexTypeNone rejects a client update that newly introduces the
+// dropped-index sentinel (VectorIndexType=="none"); an existing "none" may
+// persist. That marker is set only server-side by DeleteClassVectorIndex.
+func rejectVectorIndexTypeNone(prev, next *models.Class) error {
+	if next == nil {
+		return nil
+	}
+	for name, nextCfg := range next.VectorConfig {
+		if !modelsext.IsVectorIndexDropped(nextCfg) {
+			continue
+		}
+		if prev != nil {
+			if prevCfg, ok := prev.VectorConfig[name]; ok && modelsext.IsVectorIndexDropped(prevCfg) {
+				continue
+			}
+		}
+		return fmt.Errorf("vector %q: vectorIndexType %q is an internal sentinel for "+
+			"dropped indexes and cannot be set through a class update; use the drop "+
+			"vector index API instead", name, modelsext.VectorIndexTypeNone)
+	}
+	return nil
 }
 
 func (h *Handler) validateClassInvariants(

--- a/usecases/schema/class_drop_vector_test.go
+++ b/usecases/schema/class_drop_vector_test.go
@@ -15,10 +15,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/vectorindex"
+	"github.com/weaviate/weaviate/entities/versioned"
 )
 
 func TestDropVectorIndex_RejectVectorIndexTypeNone(t *testing.T) {
@@ -118,6 +120,9 @@ func TestDropVectorIndex_UpdateClassRejectsNoneIntroduction(t *testing.T) {
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("ReadOnlyClass", prev.Class).Return(prev)
+	// Leader-consistent view agrees the index is live, so the rejection stands.
+	fakeSchemaManager.On("QueryReadOnlyClasses", []string{prev.Class}).
+		Return(map[string]versioned.Class{prev.Class: {Class: prev}}, nil)
 
 	updated := &models.Class{
 		Class: "DropSentinelClass",
@@ -130,4 +135,52 @@ func TestDropVectorIndex_UpdateClassRejectsNoneIntroduction(t *testing.T) {
 	err := handler.UpdateClass(ctx, nil, updated.Class, updated)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "internal sentinel for dropped indexes")
+}
+
+func TestDropVectorIndex_UpdateClassAllowsExistingNoneOnStaleNode(t *testing.T) {
+	ctx := context.Background()
+	handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+
+	className := "DropSentinelClass"
+	// Stale local read: still shows foo as a live hnsw index.
+	stale := &models.Class{
+		Class: className,
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {
+				VectorIndexType: hnswT,
+				Vectorizer:      map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+			},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+	}
+	// Leader-consistent read: foo already dropped.
+	dropped := &models.Class{
+		Class: className,
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {
+				VectorIndexType: modelsext.VectorIndexTypeNone,
+				Vectorizer:      map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+			},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+	}
+	fakeSchemaManager.On("ReadOnlyClass", className).Return(stale)
+	fakeSchemaManager.On("QueryReadOnlyClasses", []string{className}).
+		Return(map[string]versioned.Class{className: {Class: dropped}}, nil)
+	fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
+
+	updated := &models.Class{
+		Class:       className,
+		Description: "updated after drop",
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {
+				VectorIndexType: modelsext.VectorIndexTypeNone,
+				Vectorizer:      map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+			},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+	}
+
+	err := handler.UpdateClass(ctx, nil, className, updated)
+	require.NoError(t, err)
 }

--- a/usecases/schema/class_drop_vector_test.go
+++ b/usecases/schema/class_drop_vector_test.go
@@ -1,0 +1,133 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
+	"github.com/weaviate/weaviate/entities/vectorindex"
+)
+
+func TestDropVectorIndex_RejectVectorIndexTypeNone(t *testing.T) {
+	none := vectorindex.VectorIndexTypeNone
+
+	classWith := func(cfg map[string]models.VectorConfig) *models.Class {
+		return &models.Class{Class: "C", VectorConfig: cfg}
+	}
+
+	tests := []struct {
+		name       string
+		prev       *models.Class
+		next       *models.Class
+		wantErr    bool
+		wantTarget string
+	}{
+		{
+			name:       "real -> none is rejected",
+			prev:       classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: hnswT}}),
+			next:       classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+			wantErr:    true,
+			wantTarget: "foo",
+		},
+		{
+			name:       "absent -> none is rejected",
+			prev:       classWith(map[string]models.VectorConfig{}),
+			next:       classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+			wantErr:    true,
+			wantTarget: "foo",
+		},
+		{
+			name:       "nil prev introducing none is rejected",
+			prev:       nil,
+			next:       classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+			wantErr:    true,
+			wantTarget: "foo",
+		},
+		{
+			name: "existing none persists across an unrelated update",
+			prev: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+			next: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+		},
+		{
+			name: "none -> real type is not blocked here (handled by the parser)",
+			prev: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: none}}),
+			next: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: hnswT}}),
+		},
+		{
+			name: "all real types pass",
+			prev: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: hnswT}}),
+			next: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: hnswT}, "bar": {VectorIndexType: hnswT}}),
+		},
+		{
+			name:       "one real one newly dropped reports the dropped one",
+			prev:       classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: hnswT}, "bar": {VectorIndexType: hnswT}}),
+			next:       classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: hnswT}, "bar": {VectorIndexType: none}}),
+			wantErr:    true,
+			wantTarget: "bar",
+		},
+		{
+			name: "nil next passes",
+			prev: classWith(map[string]models.VectorConfig{"foo": {VectorIndexType: hnswT}}),
+			next: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectVectorIndexTypeNone(tt.prev, tt.next)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.ErrorContains(t, err, "internal sentinel for dropped indexes")
+			require.ErrorContains(t, err, tt.wantTarget)
+		})
+	}
+}
+
+// TestDropVectorIndex_UpdateClassRejectsNoneIntroduction proves the C10 guard is
+// wired into the client update path: a client cannot turn a live index into the
+// "none" sentinel via UpdateClass (which would be a backdoor drop). The legit
+// drop flow bypasses this path entirely via DeleteClassVectorIndex.
+func TestDropVectorIndex_UpdateClassRejectsNoneIntroduction(t *testing.T) {
+	ctx := context.Background()
+	handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+
+	prev := &models.Class{
+		Class: "DropSentinelClass",
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {
+				VectorIndexType: hnswT,
+				Vectorizer:      map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+			},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+	}
+	fakeSchemaManager.On("ReadOnlyClass", prev.Class).Return(prev)
+
+	updated := &models.Class{
+		Class: "DropSentinelClass",
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {VectorIndexType: modelsext.VectorIndexTypeNone},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+	}
+
+	err := handler.UpdateClass(ctx, nil, updated.Class, updated)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "internal sentinel for dropped indexes")
+}


### PR DESCRIPTION
### Motivation

The "none" `vectorIndexType` is an internal sentinel that marks a *dropped* named-vector index. It is only ever meant to be set server-side by the drop API (`DeleteClassVectorIndex`). The schema parser, however, explicitly skips the immutable-type check when the incoming config is `"none"` ([parser allows `real→"none"`](https://github.com/weaviate/weaviate/blob/e4885961ba43d3bb3af9cf3bb514258b989f583b/usecases/schema/parser.go)) — so a client could effectively drop a live index by issuing a plain class update (PATCH) that sets `vectorIndexType: "none"`, bypassing the proper drop flow and all the bookkeeping it does. This is contract **C10** of the Drop Vector Index RFC (step **S2**).

### Approach

Add a small directional guard, `rejectVectorIndexTypeNone(prev, next)`, called in `UpdateClassInternal` right after the current class is read and before `validateVectorSettingsAgainst`. The predicate is intentionally directional:

- **Newly introduced** `"none"` (real→none, absent→none, nil-prev→none) is rejected.
- An **already-existing** `"none"` is allowed to persist across unrelated updates, so normal PATCHes against a class that already has a dropped index don't break.
- `none→real` is *not* handled here — re-creation remains blocked by the existing parser rule until Phase 2; this guard only closes the introduction backdoor.

Why this seam: client updates flow `Handler.UpdateClass → UpdateClassInternal`. The legitimate drop (`DeleteClassVectorIndex → schemaManager.UpdateClass`) and the RAFT FSM apply both bypass `UpdateClassInternal`, so the guard never blocks the real drop path. The only other `UpdateClassInternal` caller (`shard_init_blockmax.go`) never introduces `"none"`, and the only legitimate `"none"`-setter is the drop API itself.

### Key areas for review

- `usecases/schema/class.go:rejectVectorIndexTypeNone` — the directional predicate. Verify the "existing none persists" branch is correct (prev has the same target with `"none"` ⇒ skip) and that a missing/nil prev still rejects introduction.
- `usecases/schema/class.go:UpdateClassInternal` — placement of the call (before `validateVectorSettingsAgainst`, after `ReadOnlyClass`). Confirm this is the single client-update chokepoint and that no other writer needs the same guard.

### Risks and mitigations

- **Blocking a legitimate drop**: mitigated by the seam analysis above — the drop API and FSM apply do not route through `UpdateClassInternal`, and the directional predicate lets an existing `"none"` survive subsequent updates.
- **Breaking unrelated updates on already-dropped classes**: covered by the "existing none persists across an unrelated update" case; only *new* introductions are rejected.

### Testing

`usecases/schema/class_drop_vector_test.go`:

- `TestDropVectorIndex_RejectVectorIndexTypeNone` — table-driven directional matrix: real→none, absent→none, nil-prev→none (all rejected); existing-none-persists, none→real, all-real, nil-next (all allowed); multi-target case asserts the *dropped* target is the one named in the error.
- `TestDropVectorIndex_UpdateClassRejectsNoneIntroduction` — end-to-end through `handler.UpdateClass`, proving the guard is actually wired into the client path and a live index cannot be turned into the sentinel via update.

Full `usecases/schema` suite passes; lint clean. The error maps to HTTP 422 on the REST update path.
