### PR TITLE
feat: Count COLD tenants toward node-wide object cap 

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
@@ -248,6 +249,11 @@ type Index struct {
 	partitioningEnabled  bool
 	AsyncIndexingEnabled bool
 
+	// coldObjects caches object counts for COLD tenants so the cap check can
+	// account for them without loading the shards. Allocated only when
+	// partitioningEnabled is true; nil for single-tenant indexes.
+	coldObjects *coldObjectCounts
+
 	invertedIndexConfig     schema.InvertedIndexConfig
 	invertedIndexConfigLock sync.Mutex
 
@@ -418,6 +424,9 @@ func NewIndex(
 		HFreshEnabled:           cfg.HFreshEnabled,
 		tenantsManager:          tenantsManager,
 	}
+	if index.partitioningEnabled {
+		index.coldObjects = newColdObjectCounts()
+	}
 	index.stopwordProvider.Store(stopwords.NewProvider(sd, presetDetectors))
 
 	getDeletionStrategy := func() string {
@@ -509,38 +518,59 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 	eg.SetLimit(_NUMCPU)
 
 	for _, shard := range localShards {
-		if shard.activityStatus != models.TenantActivityStatusHOT {
-			continue
-		}
-		hotShardNames = append(hotShardNames, shard.name)
 		shardName := shard.name
-		eg.Go(func() error {
-			switch {
-			case i.Config.EnableLazyLoadShards:
-				lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
-					i.allocChecker, i.shardLoadLimiter, i.shardReindexer, true, i.bitmapBufPool)
-				i.shards.Store(shardName, lazyShard)
-				return nil
-			default:
-				// default behavior is to load all shards immediately
-				if err := i.shardLoadLimiter.Acquire(ctx); err != nil {
-					return fmt.Errorf("acquiring permit to load shard: %w", err)
-				}
-				defer i.shardLoadLimiter.Release()
+		switch shard.activityStatus {
+		case models.TenantActivityStatusHOT:
+			hotShardNames = append(hotShardNames, shardName)
+			eg.Go(func() error {
+				switch {
+				case i.Config.EnableLazyLoadShards:
+					lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
+						i.allocChecker, i.shardLoadLimiter, i.shardReindexer, true, i.bitmapBufPool)
+					i.shards.Store(shardName, lazyShard)
+					return nil
+				default:
+					// default behavior is to load all shards immediately
+					if err := i.shardLoadLimiter.Acquire(ctx); err != nil {
+						return fmt.Errorf("acquiring permit to load shard: %w", err)
+					}
+					defer i.shardLoadLimiter.Release()
 
-				newShard, err := NewShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.scheduler,
-					i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool)
-				if err != nil {
-					return fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
-				}
+					newShard, err := NewShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.scheduler,
+						i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool)
+					if err != nil {
+						return fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
+					}
 
-				promMetrics.NewLoadedShard()
-				newShard.metricsRegistered.Store(true)
-				i.shards.Store(shardName, newShard)
-				return nil
+					promMetrics.NewLoadedShard()
+					newShard.metricsRegistered.Store(true)
+					i.shards.Store(shardName, newShard)
+					return nil
+				}
+			}, shardName)
+
+		case models.TenantActivityStatusCOLD:
+			// COLD activity status is a multi-tenant concept: single-tenant
+			// collections only ever have HOT shards. The check is defensive
+			// — if some future change ever lets COLD leak into a non-MT
+			// index, we skip cleanly instead of crashing on the nil cache.
+			if !i.partitioningEnabled {
+				continue
 			}
-		}, shardName)
-
+			// Populate the cold-tenant object-count cache from on-disk segment
+			// metadata. Walk failures log and skip — partial under-count is
+			// acceptable, don't fail init.
+			eg.Go(func() error {
+				u, err := shardusage.CalculateUnloadedObjectsMetrics(i.logger, i.path(), shardName, true)
+				if err != nil {
+					i.logger.WithField("shard", shardName).WithError(err).
+						Warn("usagelimits: failed to populate cold object count at startup")
+					return nil
+				}
+				i.coldObjects.set(shardName, u.Count)
+				return nil
+			}, shardName)
+		}
 	}
 
 	if err := eg.Wait(); err != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -38,7 +38,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
-	"github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
@@ -528,6 +527,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 					lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
 						i.allocChecker, i.shardLoadLimiter, i.shardReindexer, true, i.bitmapBufPool)
 					i.shards.Store(shardName, lazyShard)
+					i.dropColdObjectCount(shardName)
 					return nil
 				default:
 					// default behavior is to load all shards immediately
@@ -545,6 +545,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 					promMetrics.NewLoadedShard()
 					newShard.metricsRegistered.Store(true)
 					i.shards.Store(shardName, newShard)
+					i.dropColdObjectCount(shardName)
 					return nil
 				}
 			}, shardName)
@@ -554,20 +555,11 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 			// collections only ever have HOT shards. The check is defensive
 			// — if some future change ever lets COLD leak into a non-MT
 			// index, we skip cleanly instead of crashing on the nil cache.
-			if !i.partitioningEnabled {
+			if !i.tracksColdObjects() {
 				continue
 			}
-			// Populate the cold-tenant object-count cache from on-disk segment
-			// metadata. Walk failures log and skip — partial under-count is
-			// acceptable, don't fail init.
 			eg.Go(func() error {
-				u, err := shardusage.CalculateUnloadedObjectsMetrics(i.logger, i.path(), shardName, true)
-				if err != nil {
-					i.logger.WithField("shard", shardName).WithError(err).
-						Warn("usagelimits: failed to populate cold object count at startup")
-					return nil
-				}
-				i.coldObjects.set(shardName, u.Count)
+				i.cacheColdCountFromDisk(shardName)
 				return nil
 			}, shardName)
 		}
@@ -2761,6 +2753,7 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 	}
 
 	i.shards.Store(shardName, shard)
+	i.dropColdObjectCount(shardName)
 
 	return nil
 }
@@ -2780,6 +2773,8 @@ func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 	if !ok {
 		return nil // shard was not found, nothing to unload
 	}
+
+	i.cacheColdCountFromShard(ctx, shardLike)
 
 	if err := shardLike.Shutdown(ctx); err != nil {
 		if !errors.Is(err, errAlreadyShutdown) {
@@ -2856,6 +2851,7 @@ func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensu
 				return nil, func() {}, err
 			}
 			i.shards.Store(shardName, shard)
+			i.dropColdObjectCount(shardName)
 		}
 	}
 
@@ -3118,6 +3114,8 @@ func (i *Index) dropShards(names []string) error {
 			defer i.backupLock.RUnlock(name)
 			i.shardCreateLocks.Lock(name)
 			defer i.shardCreateLocks.Unlock(name)
+
+			i.dropColdObjectCount(name)
 
 			shard, ok := i.shards.LoadAndDelete(name)
 			if !ok {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -248,10 +248,20 @@ type Index struct {
 	partitioningEnabled  bool
 	AsyncIndexingEnabled bool
 
-	// coldObjects caches object counts for COLD tenants so the cap check can
-	// account for them without loading the shards. Allocated only when
-	// partitioningEnabled is true; nil for single-tenant indexes.
+	// coldObjects caches object counts for COLD tenants so the cap check
+	// can account for them without loading the shards. Allocated by
+	// SetUsageLimits when both partitioningEnabled is true *and* the
+	// object cap is configured at that moment; nil otherwise. When
+	// coldObjectsTracked is true this field is guaranteed non-nil.
 	coldObjects *coldObjectCounts
+
+	// coldObjectsTracked is the snapshot-once gate decided at
+	// SetUsageLimits time. The single source of truth for whether
+	// lifecycle hooks should populate or drop coldObjects. Never flips
+	// after install — operators who turn the object cap on after
+	// existing indexes already exist must restart for those indexes
+	// to track.
+	coldObjectsTracked bool
 
 	invertedIndexConfig     schema.InvertedIndexConfig
 	invertedIndexConfigLock sync.Mutex
@@ -337,7 +347,7 @@ func (i *Index) snapshotsPath() string {
 }
 
 // NewIndex creates an index with the specified amount of shards, using only
-// the shards that are local to a node
+// the shards that are local to a node.
 func NewIndex(
 	ctx context.Context,
 	cfg IndexConfig,
@@ -422,9 +432,6 @@ func NewIndex(
 		bitmapBufPool:           bitmapBufPool,
 		HFreshEnabled:           cfg.HFreshEnabled,
 		tenantsManager:          tenantsManager,
-	}
-	if index.partitioningEnabled {
-		index.coldObjects = newColdObjectCounts()
 	}
 	index.stopwordProvider.Store(stopwords.NewProvider(sd, presetDetectors))
 
@@ -517,52 +524,39 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 	eg.SetLimit(_NUMCPU)
 
 	for _, shard := range localShards {
-		shardName := shard.name
-		switch shard.activityStatus {
-		case models.TenantActivityStatusHOT:
-			hotShardNames = append(hotShardNames, shardName)
-			eg.Go(func() error {
-				switch {
-				case i.Config.EnableLazyLoadShards:
-					lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
-						i.allocChecker, i.shardLoadLimiter, i.shardReindexer, true, i.bitmapBufPool)
-					i.shards.Store(shardName, lazyShard)
-					i.dropColdObjectCount(shardName)
-					return nil
-				default:
-					// default behavior is to load all shards immediately
-					if err := i.shardLoadLimiter.Acquire(ctx); err != nil {
-						return fmt.Errorf("acquiring permit to load shard: %w", err)
-					}
-					defer i.shardLoadLimiter.Release()
-
-					newShard, err := NewShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.scheduler,
-						i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool)
-					if err != nil {
-						return fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
-					}
-
-					promMetrics.NewLoadedShard()
-					newShard.metricsRegistered.Store(true)
-					i.shards.Store(shardName, newShard)
-					i.dropColdObjectCount(shardName)
-					return nil
-				}
-			}, shardName)
-
-		case models.TenantActivityStatusCOLD:
-			// COLD activity status is a multi-tenant concept: single-tenant
-			// collections only ever have HOT shards. The check is defensive
-			// — if some future change ever lets COLD leak into a non-MT
-			// index, we skip cleanly instead of crashing on the nil cache.
-			if !i.tracksColdObjects() {
-				continue
-			}
-			eg.Go(func() error {
-				i.cacheColdCountFromDisk(shardName)
-				return nil
-			}, shardName)
+		if shard.activityStatus != models.TenantActivityStatusHOT {
+			continue
 		}
+		shardName := shard.name
+		hotShardNames = append(hotShardNames, shardName)
+		eg.Go(func() error {
+			switch {
+			case i.Config.EnableLazyLoadShards:
+				lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
+					i.allocChecker, i.shardLoadLimiter, i.shardReindexer, true, i.bitmapBufPool)
+				i.shards.Store(shardName, lazyShard)
+				i.dropColdObjectCount(shardName)
+				return nil
+			default:
+				// default behavior is to load all shards immediately
+				if err := i.shardLoadLimiter.Acquire(ctx); err != nil {
+					return fmt.Errorf("acquiring permit to load shard: %w", err)
+				}
+				defer i.shardLoadLimiter.Release()
+
+				newShard, err := NewShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.scheduler,
+					i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool)
+				if err != nil {
+					return fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
+				}
+
+				promMetrics.NewLoadedShard()
+				newShard.metricsRegistered.Store(true)
+				i.shards.Store(shardName, newShard)
+				i.dropColdObjectCount(shardName)
+				return nil
+			}
+		}, shardName)
 	}
 
 	if err := eg.Wait(); err != nil {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -219,7 +219,10 @@ func (db *DB) init(ctx context.Context) error {
 				return errors.Wrap(err, "create index")
 			}
 
-			idx.usageLimits = db.usageLimits
+			idx.SetUsageLimits(db.usageLimits)
+			if err := idx.RestoreColdCounts(); err != nil {
+				return fmt.Errorf("restore cold-tenant counts for index %q: %w", idx.ID(), err)
+			}
 			db.indexLock.Lock()
 			db.indices[idx.ID()] = idx
 			db.indexLock.Unlock()

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -314,6 +314,7 @@ func (m *Migrator) ShutdownShard(ctx context.Context, class, shard string) error
 	if !ok {
 		return fmt.Errorf("could not find shard %s", shard)
 	}
+	idx.cacheColdCountFromShard(ctx, shardLike)
 	if err := shardLike.Shutdown(ctx); err != nil {
 		if !errors.Is(err, errAlreadyShutdown) {
 			return errors.Wrapf(err, "shutdown shard %q", shard)
@@ -676,6 +677,8 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 					m.logger.WithField("shard", name).Debug("already shut down or dropped")
 					return nil // shard already does not exist or inactive
 				}
+
+				idx.cacheColdCountFromShard(ctx, shard)
 
 				m.logger.WithField("shard", name).Debug("starting shutdown")
 

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -243,7 +243,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		return errors.Wrap(err, "create index")
 	}
 
-	idx.usageLimits = m.db.usageLimits
+	idx.SetUsageLimits(m.db.usageLimits)
 	m.db.indexLock.Lock()
 	m.db.indices[idx.ID()] = idx
 	m.db.indexLock.Unlock()

--- a/adapters/repos/db/migrator_shard_status_ops.go
+++ b/adapters/repos/db/migrator_shard_status_ops.go
@@ -53,12 +53,19 @@ func (m *Migrator) frozen(ctx context.Context, idx *Index, frozen []string, ec e
 					ec.Add(err)
 					return err
 				}
+				idx.dropColdObjectCount(name)
 				return nil
 			}
 
 			if err := shard.drop(false); err != nil {
 				ec.Add(err)
+				// Skip the cache drop: on partial-failure shard.drop may have
+				// removed some files but the local count is now unknowable.
+				// The stale cache entry over-counts by at most one tenant
+				// until next reactivation — acceptable.
+				return nil
 			}
+			idx.dropColdObjectCount(name)
 			return nil
 		})
 	}
@@ -257,6 +264,7 @@ func (m *Migrator) unfreeze(ctx context.Context, idx *Index, class string, unfre
 					Op: command.TenantsProcess_OP_ABORT,
 				}
 			} else {
+				idx.cacheColdCountFromDisk(name)
 				cmd.TenantsProcesses[uidx] = &command.TenantsProcess{
 					Tenant: &command.Tenant{
 						Name: name,

--- a/adapters/repos/db/usage_limits.go
+++ b/adapters/repos/db/usage_limits.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
 	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
 
@@ -108,13 +110,14 @@ func (i *Index) dropColdObjectCount(tenant string) {
 	i.coldObjects.drop(tenant)
 }
 
-// LocalObjectCount sums async object counts across all locally-loaded
-// shards on this node. Implements usagelimits.ObjectCounter.
+// LocalObjectCount sums object counts across every local tenant on this
+// node, summing loaded shards (HOT) and cached counts (COLD) per the
+// per-tenant atomic decision in countObjects. Implements
+// usagelimits.ObjectCounter.
 //
-// Uses ObjectCountAsync (excludes the memtable) so bulk imports may
-// briefly overshoot; self-corrects on flush. Cold lazy-load shards are
-// skipped — counting them wouldn't force a load, but would mean a dir
-// walk + per-segment metadata read on every write. See
+// Loaded counts come from ObjectCountAsync (excludes the memtable) so
+// bulk imports may briefly overshoot; cold counts come from the cache
+// populated at HOT→COLD snapshot or post-unfreeze restore. See
 // docs/usage_limits.md.
 func (db *DB) LocalObjectCount(ctx context.Context) (int64, error) {
 	db.indexLock.RLock()
@@ -126,29 +129,55 @@ func (db *DB) LocalObjectCount(ctx context.Context) (int64, error) {
 
 	var total int64
 	for _, idx := range indices {
-		if err := idx.ForEachLoadedShard(func(name string, shard ShardLike) error {
-			// Guard against concurrent tenant deactivation between
-			// iteration and the count call.
-			idx.shardCreateLocks.RLock(name)
-			defer idx.shardCreateLocks.RUnlock(name)
-			if idx.shards.Load(name) == nil {
-				return nil
-			}
-			count, err := shard.ObjectCountAsync(ctx)
-			if err != nil {
-				// Per-shard counting failures are recoverable: a transient
-				// miss on one shard should not block all writes.
-				db.logger.
-					WithField("shard", shard.Name()).
-					WithField("error", err.Error()).
-					Warn("usagelimits: error counting objects for shard")
-				return nil
-			}
-			total += count
-			return nil
-		}); err != nil {
+		count, err := idx.localObjectCount(ctx)
+		if err != nil {
 			return 0, err
 		}
+		total += count
+	}
+	return total, nil
+}
+
+// localObjectCount sums object counts across every local tenant of this
+// index. The schema lock is held only for the cheap name-list copy;
+// per-tenant accounting runs outside it, using shardCreateLocks.RLock
+// to atomically pick between the loaded shard count and the cached
+// cold count without observing both.
+//
+// Lazy-but-not-loaded HOT shards contribute 0 (shardMap.Loaded skips
+// them), matching today's ForEachLoadedShard behavior.
+func (i *Index) localObjectCount(ctx context.Context) (int64, error) {
+	var localNames []string
+	err := i.schemaReader.Read(i.Config.ClassName.String(), true,
+		func(_ *models.Class, state *sharding.State) error {
+			for name := range state.Physical {
+				if state.IsLocalShard(name) {
+					localNames = append(localNames, name)
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return 0, err
+	}
+
+	var total int64
+	for _, name := range localNames {
+		i.shardCreateLocks.RLock(name)
+		if shard := i.shards.Loaded(name); shard != nil {
+			if c, err := shard.ObjectCountAsync(ctx); err == nil {
+				total += c
+			} else {
+				i.logger.WithField("shard", name).WithError(err).
+					Warn("usagelimits: error counting objects for shard")
+			}
+		} else if i.tracksColdObjects() {
+			if cached, ok := i.coldObjects.get(name); ok {
+				total += cached
+			}
+		}
+		// else: FROZEN / mid-transition / never-local — contributes 0
+		i.shardCreateLocks.RUnlock(name)
 	}
 	return total, nil
 }

--- a/adapters/repos/db/usage_limits.go
+++ b/adapters/repos/db/usage_limits.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
 
@@ -49,6 +50,62 @@ func (c *coldObjectCounts) get(name string) (int64, bool) {
 	defer c.RUnlock()
 	v, ok := c.counts[name]
 	return v, ok
+}
+
+// tracksColdObjects reports whether this Index maintains the cold-tenant
+// object-count cache. Centralizes the gating policy so each lifecycle hook
+// asks one question; today it's a synonym for partitioningEnabled, but it
+// can grow conditions (operator config, runtime feature flag, etc.)
+// without touching every call site.
+//
+// When this returns true, coldObjects is expected to be non-nil; a nil
+// here is a NewIndex bug we want to surface loudly via panic.
+func (i *Index) tracksColdObjects() bool {
+	return i.partitioningEnabled
+}
+
+// cacheColdCountFromShard reads the tenant's object count from a loaded
+// shard via ObjectCountAsync and writes it to the cache. Caller is
+// responsible for shardCreateLocks. Errors are logged and swallowed —
+// we'd rather accept a bounded under-count for this tenant than fail
+// the deactivation.
+func (i *Index) cacheColdCountFromShard(ctx context.Context, shard ShardLike) {
+	if !i.tracksColdObjects() {
+		return
+	}
+	c, err := shard.ObjectCountAsync(ctx)
+	if err != nil {
+		i.logger.WithField("shard", shard.Name()).WithError(err).
+			Warn("usagelimits: failed to cache cold object count from shard")
+		return
+	}
+	i.coldObjects.set(shard.Name(), c)
+}
+
+// cacheColdCountFromDisk reads the tenant's object count from on-disk
+// segment metadata and writes it to the cache. Used when the shard
+// isn't loaded (startup walk, post-unfreeze restore). Errors are logged
+// and swallowed.
+func (i *Index) cacheColdCountFromDisk(tenant string) {
+	if !i.tracksColdObjects() {
+		return
+	}
+	u, err := shardusage.CalculateUnloadedObjectsMetrics(i.logger, i.path(), tenant, true)
+	if err != nil {
+		i.logger.WithField("shard", tenant).WithError(err).
+			Warn("usagelimits: failed to cache cold object count from disk")
+		return
+	}
+	i.coldObjects.set(tenant, u.Count)
+}
+
+// dropColdObjectCount removes a tenant's entry. Safe to call when no
+// entry exists.
+func (i *Index) dropColdObjectCount(tenant string) {
+	if !i.tracksColdObjects() {
+		return
+	}
+	i.coldObjects.drop(tenant)
 }
 
 // LocalObjectCount sums async object counts across all locally-loaded

--- a/adapters/repos/db/usage_limits.go
+++ b/adapters/repos/db/usage_limits.go
@@ -13,9 +13,11 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
-	"github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
+	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"github.com/weaviate/weaviate/usecases/usagelimits"
@@ -54,16 +56,66 @@ func (c *coldObjectCounts) get(name string) (int64, bool) {
 	return v, ok
 }
 
-// tracksColdObjects reports whether this Index maintains the cold-tenant
-// object-count cache. Centralizes the gating policy so each lifecycle hook
-// asks one question; today it's a synonym for partitioningEnabled, but it
-// can grow conditions (operator config, runtime feature flag, etc.)
-// without touching every call site.
+// SetUsageLimits installs the usage-limits Manager on the Index and
+// snapshots the cold-tenant cache gate. Must be called by the index's
+// owner after NewIndex returns and before the Index is registered in
+// db.indices.
+func (i *Index) SetUsageLimits(m *usagelimits.Manager) {
+	i.usageLimits = m
+	if i.partitioningEnabled && m.HasObjectCap() {
+		i.coldObjects = newColdObjectCounts()
+		i.coldObjectsTracked = true
+	}
+}
+
+// RestoreColdCounts populates the cold-tenant cache from on-disk
+// segment metadata for every local tenant that the schema state marks
+// COLD. Intended for startup paths where the index is rehydrated from
+// disk and the schema may already contain COLD tenants from a prior
+// run. No-op when tracking is disabled.
 //
-// When this returns true, coldObjects is expected to be non-nil; a nil
-// here is a NewIndex bug we want to surface loudly via panic.
-func (i *Index) tracksColdObjects() bool {
-	return i.partitioningEnabled
+// Errors from the schema read are returned; per-tenant disk-read
+// failures are logged and swallowed inside cacheColdCountFromDisk —
+// we'd rather accept a bounded under-count than refuse to start.
+func (i *Index) RestoreColdCounts() error {
+	if !i.coldObjectsTracked {
+		return nil
+	}
+
+	var coldTenants []string
+	className := i.Config.ClassName.String()
+	err := i.schemaReader.Read(className, true,
+		func(_ *models.Class, state *sharding.State) error {
+			if state == nil {
+				return fmt.Errorf("unable to retrieve sharding state for class %s", className)
+			}
+			for shardName, physical := range state.Physical {
+				if !state.IsLocalShard(shardName) {
+					continue
+				}
+				if physical.ActivityStatus() == models.TenantActivityStatusCOLD {
+					coldTenants = append(coldTenants, shardName)
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("read schema for cold tenants: %w", err)
+	}
+
+	if len(coldTenants) == 0 {
+		return nil
+	}
+
+	eg := enterrors.NewErrorGroupWrapper(i.logger)
+	eg.SetLimit(_NUMCPU)
+	for _, name := range coldTenants {
+		eg.Go(func() error {
+			i.cacheColdCountFromDisk(name)
+			return nil
+		}, name)
+	}
+	return eg.Wait()
 }
 
 // cacheColdCountFromShard reads the tenant's object count from a loaded
@@ -72,7 +124,7 @@ func (i *Index) tracksColdObjects() bool {
 // we'd rather accept a bounded under-count for this tenant than fail
 // the deactivation.
 func (i *Index) cacheColdCountFromShard(ctx context.Context, shard ShardLike) {
-	if !i.tracksColdObjects() {
+	if !i.coldObjectsTracked {
 		return
 	}
 	c, err := shard.ObjectCountAsync(ctx)
@@ -89,7 +141,7 @@ func (i *Index) cacheColdCountFromShard(ctx context.Context, shard ShardLike) {
 // isn't loaded (startup walk, post-unfreeze restore). Errors are logged
 // and swallowed.
 func (i *Index) cacheColdCountFromDisk(tenant string) {
-	if !i.tracksColdObjects() {
+	if !i.coldObjectsTracked {
 		return
 	}
 	u, err := shardusage.CalculateUnloadedObjectsMetrics(i.logger, i.path(), tenant, true)
@@ -104,7 +156,7 @@ func (i *Index) cacheColdCountFromDisk(tenant string) {
 // dropColdObjectCount removes a tenant's entry. Safe to call when no
 // entry exists.
 func (i *Index) dropColdObjectCount(tenant string) {
-	if !i.tracksColdObjects() {
+	if !i.coldObjectsTracked {
 		return
 	}
 	i.coldObjects.drop(tenant)
@@ -171,7 +223,7 @@ func (i *Index) localObjectCount(ctx context.Context) (int64, error) {
 				i.logger.WithField("shard", name).WithError(err).
 					Warn("usagelimits: error counting objects for shard")
 			}
-		} else if i.tracksColdObjects() {
+		} else if i.coldObjectsTracked {
 			if cached, ok := i.coldObjects.get(name); ok {
 				total += cached
 			}

--- a/adapters/repos/db/usage_limits.go
+++ b/adapters/repos/db/usage_limits.go
@@ -13,9 +13,43 @@ package db
 
 import (
 	"context"
+	"sync"
 
 	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
+
+// coldObjectCounts caches object counts for COLD tenants (data on local
+// disk, shard not loaded), keyed by tenant name. Safe for concurrent use.
+type coldObjectCounts struct {
+	sync.RWMutex
+	counts map[string]int64
+}
+
+func newColdObjectCounts() *coldObjectCounts {
+	return &coldObjectCounts{counts: map[string]int64{}}
+}
+
+// set stores the count for name, overwriting any prior value.
+func (c *coldObjectCounts) set(name string, n int64) {
+	c.Lock()
+	c.counts[name] = n
+	c.Unlock()
+}
+
+// drop removes the entry for name. No-op when the entry doesn't exist.
+func (c *coldObjectCounts) drop(name string) {
+	c.Lock()
+	delete(c.counts, name)
+	c.Unlock()
+}
+
+// get returns the cached count and whether an entry exists. Returns (0, false) when not.
+func (c *coldObjectCounts) get(name string) (int64, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	v, ok := c.counts[name]
+	return v, ok
+}
 
 // LocalObjectCount sums async object counts across all locally-loaded
 // shards on this node. Implements usagelimits.ObjectCounter.

--- a/adapters/repos/db/usage_limits_lifecycle_test.go
+++ b/adapters/repos/db/usage_limits_lifecycle_test.go
@@ -1,0 +1,152 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+)
+
+// setupColdObjectsCacheTest reuses testShardMultiTenant — the canonical
+// MT Index+Shard helper — and initializes coldObjects, which the helper
+// itself doesn't set up (it predates the field). Returns the live shard
+// and the tenant name (the builder default).
+func setupColdObjectsCacheTest(t *testing.T, className string) (*Index, ShardLike, string) {
+	t.Helper()
+	shard, idx := testShardMultiTenant(t, testCtx(), className)
+	idx.coldObjects = newColdObjectCounts()
+	return idx, shard, shard.Name()
+}
+
+// TestColdObjectsCache_HotColdLifecycleHooks drives a tenant through
+// HOT→COLD→HOT via the real lifecycle methods Index.UnloadLocalShard
+// and Index.LoadLocalShard. It verifies that the cache hooks
+// (cacheColdCountFromShard on unload, dropColdObjectCount on load)
+// stay wired into those paths; removing either hook in the future
+// would cause this test to fail.
+func TestColdObjectsCache_HotColdLifecycleHooks(t *testing.T) {
+	const (
+		className = "TestClass"
+		nObjects  = 5
+	)
+	ctx := testCtx()
+	idx, shard, tenant := setupColdObjectsCacheTest(t, className)
+
+	insertObjects(t, shard, className, tenant, nObjects)
+	flushObjectsBucket(t, shard)
+
+	_, ok := idx.coldObjects.get(tenant)
+	require.False(t, ok, "cache must start empty for HOT tenant")
+
+	// HOT→COLD via the real unload path.
+	require.NoError(t, idx.UnloadLocalShard(ctx, tenant))
+
+	cached, ok := idx.coldObjects.get(tenant)
+	require.True(t, ok, "unload must populate cold cache")
+	require.Equal(t, int64(nObjects), cached)
+
+	// While unloaded, localObjectCount must come from the cache.
+	total, err := idx.localObjectCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(nObjects), total, "COLD count via cache")
+
+	// COLD→HOT via the real load path.
+	require.NoError(t, idx.LoadLocalShard(ctx, tenant, false))
+
+	_, ok = idx.coldObjects.get(tenant)
+	require.False(t, ok, "load must drop cold cache entry")
+
+	total, err = idx.localObjectCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(nObjects), total, "HOT count after reload reads loaded shard")
+}
+
+// TestColdObjectsCache_DeleteWhileCold drives the tenant to COLD via
+// the real UnloadLocalShard, then verifies that dropShards (the tenant
+// delete path) removes the cache entry so the count disappears from
+// LocalObjectCount.
+func TestColdObjectsCache_DeleteWhileCold(t *testing.T) {
+	const (
+		className = "TestClass"
+		nObjects  = 3
+	)
+	ctx := testCtx()
+	idx, shard, tenant := setupColdObjectsCacheTest(t, className)
+
+	insertObjects(t, shard, className, tenant, nObjects)
+	flushObjectsBucket(t, shard)
+
+	require.NoError(t, idx.UnloadLocalShard(ctx, tenant))
+	cached, ok := idx.coldObjects.get(tenant)
+	require.True(t, ok)
+	require.Equal(t, int64(nObjects), cached)
+
+	require.NoError(t, idx.dropShards([]string{tenant}))
+
+	_, ok = idx.coldObjects.get(tenant)
+	require.False(t, ok, "delete must remove the cache entry")
+}
+
+// TestColdObjectsCache_CountFromDisk verifies that
+// cacheColdCountFromDisk — the function initAndStoreShards' COLD
+// branch calls during startup walk — reads the count from on-disk LSM
+// segments. We populate a tenant, flush so segments hit disk, drop the
+// cache, then assert the disk read repopulates it.
+func TestColdObjectsCache_CountFromDisk(t *testing.T) {
+	const (
+		className = "TestClass"
+		nObjects  = 4
+	)
+	idx, shard, tenant := setupColdObjectsCacheTest(t, className)
+
+	insertObjects(t, shard, className, tenant, nObjects)
+	flushObjectsBucket(t, shard)
+
+	idx.dropColdObjectCount(tenant)
+	_, ok := idx.coldObjects.get(tenant)
+	require.False(t, ok)
+
+	idx.cacheColdCountFromDisk(tenant)
+
+	cached, ok := idx.coldObjects.get(tenant)
+	require.True(t, ok, "disk read must populate cache for COLD tenant")
+	require.Equal(t, int64(nObjects), cached)
+}
+
+func insertObjects(t *testing.T, shard ShardLike, className, tenant string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		obj := testObject(className)
+		obj.DocID = uint64(i)
+		obj.Object.Tenant = tenant
+		require.NoError(t, shard.PutObject(context.Background(), obj),
+			"insert object %d into tenant %q", i, tenant)
+	}
+}
+
+// flushObjectsBucket forces the shard's objects bucket to flush its
+// memtable so ObjectCountAsync (which excludes the memtable) reflects
+// the inserted objects.
+func flushObjectsBucket(t *testing.T, shard ShardLike) {
+	t.Helper()
+	bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+	require.NoError(t, bucket.FlushAndSwitch())
+	c, err := shard.ObjectCountAsync(context.Background())
+	require.NoError(t, err)
+	require.NotEqual(t, int64(0), c, "shard count must be non-zero after flush")
+}

--- a/adapters/repos/db/usage_limits_lifecycle_test.go
+++ b/adapters/repos/db/usage_limits_lifecycle_test.go
@@ -23,13 +23,16 @@ import (
 )
 
 // setupColdObjectsCacheTest reuses testShardMultiTenant — the canonical
-// MT Index+Shard helper — and initializes coldObjects, which the helper
-// itself doesn't set up (it predates the field). Returns the live shard
-// and the tenant name (the builder default).
+// MT Index+Shard helper — and manually wires up the cold-tenant cache
+// the way SetUsageLimits would in production. The helper itself doesn't
+// go through SetUsageLimits because it predates both the field and the
+// install method; flipping coldObjectsTracked + allocating the map is
+// the minimal stand-in. Returns the live shard and tenant name.
 func setupColdObjectsCacheTest(t *testing.T, className string) (*Index, ShardLike, string) {
 	t.Helper()
 	shard, idx := testShardMultiTenant(t, testCtx(), className)
 	idx.coldObjects = newColdObjectCounts()
+	idx.coldObjectsTracked = true
 	return idx, shard, shard.Name()
 }
 

--- a/adapters/repos/db/usage_limits_test.go
+++ b/adapters/repos/db/usage_limits_test.go
@@ -15,6 +15,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
 
 func TestColdObjectCounts(t *testing.T) {
@@ -76,4 +79,66 @@ func TestColdObjectCounts(t *testing.T) {
 		assert.True(t, ok3)
 		assert.Equal(t, int64(3), v3)
 	})
+}
+
+// TestIndex_SetUsageLimits pins the install-time gating contract:
+// the cold-tenant cache is allocated only when the index is
+// multi-tenant *and* the object cap is configured at install time.
+// Any other combination must leave coldObjects nil and
+// coldObjectsTracked false.
+func TestIndex_SetUsageLimits(t *testing.T) {
+	mgrCapSet := usagelimits.NewManager(usagelimits.Config{
+		MaxObjectsCount: runtime.NewDynamicValue(100),
+	}, nil)
+	mgrCapUnset := usagelimits.NewManager(usagelimits.Config{
+		MaxObjectsCount: nil,
+	}, nil)
+
+	tests := []struct {
+		name         string
+		partitioning bool
+		manager      *usagelimits.Manager
+		wantTracked  bool
+	}{
+		{
+			name:         "single-tenant index never tracks, even with cap set",
+			partitioning: false,
+			manager:      mgrCapSet,
+		},
+		{
+			name:         "multi-tenant with cap unset does not track",
+			partitioning: true,
+			manager:      mgrCapUnset,
+		},
+		{
+			name:         "multi-tenant with nil manager does not track",
+			partitioning: true,
+			manager:      nil,
+		},
+		{
+			name:         "multi-tenant with cap set tracks",
+			partitioning: true,
+			manager:      mgrCapSet,
+			wantTracked:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := &Index{partitioningEnabled: tc.partitioning}
+			idx.SetUsageLimits(tc.manager)
+
+			assert.Equal(t, tc.wantTracked, idx.coldObjectsTracked,
+				"coldObjectsTracked must reflect the snapshot gate")
+			if tc.wantTracked {
+				assert.NotNil(t, idx.coldObjects,
+					"cache must be allocated when tracking is on")
+			} else {
+				assert.Nil(t, idx.coldObjects,
+					"cache must stay nil when tracking is off")
+			}
+			assert.Same(t, tc.manager, idx.usageLimits,
+				"manager must always be installed regardless of the gate")
+		})
+	}
 }

--- a/adapters/repos/db/usage_limits_test.go
+++ b/adapters/repos/db/usage_limits_test.go
@@ -1,0 +1,79 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColdObjectCounts(t *testing.T) {
+	t.Run("get on missing key returns zero and false", func(t *testing.T) {
+		c := newColdObjectCounts()
+		v, ok := c.get("absent")
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), v)
+	})
+
+	t.Run("set then get returns the stored value", func(t *testing.T) {
+		c := newColdObjectCounts()
+		c.set("T1", 42)
+		v, ok := c.get("T1")
+		assert.True(t, ok)
+		assert.Equal(t, int64(42), v)
+	})
+
+	t.Run("set overwrites a prior value", func(t *testing.T) {
+		c := newColdObjectCounts()
+		c.set("T1", 1)
+		c.set("T1", 2)
+		v, ok := c.get("T1")
+		assert.True(t, ok)
+		assert.Equal(t, int64(2), v)
+	})
+
+	t.Run("drop removes the entry", func(t *testing.T) {
+		c := newColdObjectCounts()
+		c.set("T1", 42)
+		c.drop("T1")
+		v, ok := c.get("T1")
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), v)
+	})
+
+	t.Run("drop on missing key is a safe no-op", func(t *testing.T) {
+		c := newColdObjectCounts()
+		c.drop("never-set")
+		c.drop("never-set")
+	})
+
+	t.Run("mutations on one tenant don't affect others", func(t *testing.T) {
+		c := newColdObjectCounts()
+		c.set("T1", 1)
+		c.set("T2", 2)
+		c.set("T3", 3)
+		c.drop("T2")
+
+		v1, ok1 := c.get("T1")
+		assert.True(t, ok1)
+		assert.Equal(t, int64(1), v1)
+
+		v2, ok2 := c.get("T2")
+		assert.False(t, ok2)
+		assert.Equal(t, int64(0), v2)
+
+		v3, ok3 := c.get("T3")
+		assert.True(t, ok3)
+		assert.Equal(t, int64(3), v3)
+	})
+}

--- a/docs/usage_limits.md
+++ b/docs/usage_limits.md
@@ -40,9 +40,29 @@ The schema-side limits (collections, tenants, shards) stay at the use-case layer
 
 ## Counter source
 
-The object count is **node-wide** across local shards: the manager sums each loaded shard's `bucket.CountAsync()` (`adapters/repos/db/lsmkv/bucket.go`) on every enforced write. Each `CountAsync()` is O(segments-per-shard) — it walks the live segment list and sums each segment's already-loaded net-additions counter, no I/O. For the Free-Tier shape (few shards, few segments) that's a handful of atomic reads on the hot path.
+The object count is **node-wide** across all local tenants. Per-tenant decision is atomic under `shardCreateLocks.RLock(name)` — a transition is never observed as both or neither:
+
+- **HOT** (loaded) contributes via `shard.ObjectCountAsync()` → `bucket.CountAsync()` (`adapters/repos/db/lsmkv/bucket.go`) — O(segments), atomic counter reads, no I/O.
+- **COLD** (data on disk, shard not loaded) contributes from an in-memory cache (`coldObjects` on `*Index`, `adapters/repos/db/usage_limits.go`). Pure RAM read.
+- **FROZEN** contributes 0 — data lives in the cloud.
+
+The cache closes an abuse vector that would let an account deactivate tenants to dodge the cap. Allocated only when `partitioningEnabled` (multi-tenant); single-tenant indexes never see it.
 
 We deliberately don't route through `UsageForIndex` — that path triggers other usage-module computations beyond a count.
+
+### Cold-tenant cache lifecycle
+
+The per-Index cache is maintained by hooks at every transition that changes the local on-disk state of a tenant:
+
+| Transition | Hook | Sites |
+|---|---|---|
+| HOT → COLD | `cacheColdCountFromShard` | `Index.UnloadLocalShard`; `Migrator.UpdateTenants` cold branch; `Migrator.ShutdownShard` |
+| COLD → HOT | `dropColdObjectCount` | `Index.initLocalShardWithForcedLoading`; `Index.getOptInitLocalShard` |
+| Startup, tenant COLD on disk | `cacheColdCountFromDisk` | `Index.initAndStoreShards` |
+| Unfreeze (cloud download) | `cacheColdCountFromDisk` | `Migrator.unfreeze` success branch |
+| Tenant deleted | `dropColdObjectCount` | `Index.dropShards`; `Migrator.frozen` |
+
+`cacheColdCountFromShard` snapshots `ObjectCountAsync` before shutdown; `cacheColdCountFromDisk` reads the same per-segment counters from on-disk metadata without loading the shard.
 
 ## Error response
 
@@ -89,7 +109,9 @@ The pre-existing `MAXIMUM_ALLOWED_COLLECTIONS_COUNT` enforcement previously retu
 ## Accepted imperfections
 
 - **Object count via async path.** Counts come from `CountAsync` and exclude the in-memory memtable, so during fast bulk imports the count lags slightly behind on-disk state. Bounded by in-flight write volume between count refreshes; self-corrects on the next flush. Sync counting on every write would scan the entire memtable — wasteful at the 10K free-tier scale, fatal at 10M+ scale.
-- **Cold lazy-load shards are skipped from the sum.** Including them wouldn't force a load (counts can be read from on-disk segment metadata), but it would add a directory walk + per-segment metadata read per cold shard on every write — unacceptable on the hot path. Effect: accounts with dormant tenants may sit slightly under-counted. Future option: cache cold counts in memory at load time.
+- **Lazy-but-not-yet-loaded HOT shards contribute 0** until first access loads them. Matches `ForEachLoadedShard` semantics; bounded — first read or write triggers the load.
+- **Cold-cache snapshot excludes the memtable** (`cacheColdCountFromShard` reads `ObjectCountAsync`). Under-counts by at most one memtable's worth per tenant for the COLD period; reactivation drops the cache and the loaded shard counts accurately.
+- **Cold-cache can over-count by one tenant on partial-failure deletion** (`shard.drop` fails mid-cleanup; cache drop is intentionally skipped because on-disk state is then unknowable). Stale entry clears at the next lifecycle transition.
 - **Per-shard-slice batch rejection** on multi-shard collections (see *Batch behavior*). Single-shard collections (Free Tier) see whole-batch rejection unchanged.
 - **Tenants checked at create time only**, not on subsequent multi-tenancy config changes.
 - **Schema-side caps are not transactional with RAFT.** Read-check-write is not atomic across the RAFT-replicated `AddClass`/`AddTenants` call, so two concurrent creates can both pass the check. Bounded overshoot; next request is correctly rejected.

--- a/docs/usage_limits.md
+++ b/docs/usage_limits.md
@@ -46,7 +46,7 @@ The object count is **node-wide** across all local tenants. Per-tenant decision 
 - **COLD** (data on disk, shard not loaded) contributes from an in-memory cache (`coldObjects` on `*Index`, `adapters/repos/db/usage_limits.go`). Pure RAM read.
 - **FROZEN** contributes 0 — data lives in the cloud.
 
-The cache closes an abuse vector that would let an account deactivate tenants to dodge the cap. Allocated only when `partitioningEnabled` (multi-tenant); single-tenant indexes never see it.
+The cache closes an abuse vector that would let an account deactivate tenants to dodge the cap. Allocated only when the collection is multi-tenant **and** `MAXIMUM_ALLOWED_OBJECTS_COUNT` is set at the moment `Index.SetUsageLimits` runs (index construction / startup load). Single-tenant indexes never see it, and deployments without the cap pay nothing. The gate is **snapshot-once** — turning the cap on after the fact via runtime override only affects indexes created afterward; existing indexes need a restart to start tracking COLD tenants.
 
 We deliberately don't route through `UsageForIndex` — that path triggers other usage-module computations beyond a count.
 
@@ -58,7 +58,7 @@ The per-Index cache is maintained by hooks at every transition that changes the 
 |---|---|---|
 | HOT → COLD | `cacheColdCountFromShard` | `Index.UnloadLocalShard`; `Migrator.UpdateTenants` cold branch; `Migrator.ShutdownShard` |
 | COLD → HOT | `dropColdObjectCount` | `Index.initLocalShardWithForcedLoading`; `Index.getOptInitLocalShard` |
-| Startup, tenant COLD on disk | `cacheColdCountFromDisk` | `Index.initAndStoreShards` |
+| Startup, tenant COLD on disk | `cacheColdCountFromDisk` | `Index.RestoreColdCounts` (called once by the startup load) |
 | Unfreeze (cloud download) | `cacheColdCountFromDisk` | `Migrator.unfreeze` success branch |
 | Tenant deleted | `dropColdObjectCount` | `Index.dropShards`; `Migrator.frozen` |
 

--- a/test/acceptance/usage_limits/all_limits_test.go
+++ b/test/acceptance/usage_limits/all_limits_test.go
@@ -166,8 +166,16 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 		require.True(t, fired2, "post-deactivation: object cap should still fire on T2")
 		t.Logf("post-deactivation: T2 needed %d inserts to trip cap", t2Insert)
 
-		require.Less(t, t2Insert, t1Insert/10,
-			"T2 must trip cap much faster than T1 (≤10×) — T1's cold objects must still count")
+		// T2 must trip on (or very close to) its first insert: T1's cold
+		// objects already fill the cap. Use a small constant rather than
+		// a ratio against t1Insert — integer division of t1Insert/10
+		// truncates to 1 in normal runs and to 0 if memtable lag pulls
+		// T1 below 10 inserts, making the original ratio flake-prone in
+		// slow CI. 3 is generous slack while still failing loudly if
+		// cold tenants drop out of the count (which would push T2 to
+		// ~t1Insert inserts).
+		require.Less(t, t2Insert, 3,
+			"T2 must trip cap almost immediately — T1's cold objects must still count")
 	})
 
 	t.Run("object limit single create — loops until limit fires", func(t *testing.T) {

--- a/test/acceptance/usage_limits/all_limits_test.go
+++ b/test/acceptance/usage_limits/all_limits_test.go
@@ -60,11 +60,11 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 	// One container, every limit set tight enough to hit, and a custom
 	// message template that exercises both placeholders. Collection cap
 	// is 5 to leave room for the two MT collections used in the tenant
-	// sub-tests (1 plain MT + 1 auto-tenant MT + 3 single-tenant = 5 = at
-	// cap; a 6th create rejects).
+	// sub-tests (1 plain MT + 2 auto-tenant MT + 3 single-tenant = 6 = at
+	// cap; a 7th create rejects).
 	compose, terminate := startContainer(t, ctx, mergeEnv(aggressiveFlushEnv(), map[string]string{
 		"MAXIMUM_ALLOWED_OBJECTS_COUNT":          "10",
-		"MAXIMUM_ALLOWED_COLLECTIONS_COUNT":      "5",
+		"MAXIMUM_ALLOWED_COLLECTIONS_COUNT":      "6",
 		"MAXIMUM_ALLOWED_TENANTS_PER_COLLECTION": "2",
 		"MAXIMUM_ALLOWED_SHARDS_PER_COLLECTION":  "1",
 		"USAGE_LIMITS_ERROR_MESSAGE":             "hit limit of {value} {limit}, upgrade at https://x",
@@ -75,11 +75,13 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 	httpURI := "http://" + compose.GetWeaviate().URI()
 	grpcURI := compose.GetWeaviate().GrpcURI()
 
-	// Set up the two MT collections up front so the tenant sub-tests can
-	// run without consuming "collection" slots mid-suite. Together they
-	// count for 2 toward MAXIMUM_ALLOWED_COLLECTIONS_COUNT (5).
+	// Set up the three MT collections up front so each tenant sub-test
+	// owns its own collection (no cross-sub-test interference) and
+	// without consuming "collection" slots mid-suite. Together they count
+	// for 3 toward MAXIMUM_ALLOWED_COLLECTIONS_COUNT (6).
 	createMTCollection(t, ctx, httpURI, "MTcoll")
 	createAutoTenantMTCollection(t, ctx, httpURI, "MTautocoll")
+	createAutoTenantMTCollection(t, ctx, httpURI, "MTcoldcoll")
 
 	t.Run("shard limit on class create", func(t *testing.T) {
 		body := []byte(`{
@@ -106,13 +108,13 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 	})
 
 	t.Run("collection limit hit after cap", func(t *testing.T) {
-		// MTcoll + MTautocoll already count as 2; create 3 more (5 total
-		// = cap), then the 6th must 429.
+		// MTcoll + MTautocoll + MTcoldcoll already count as 3; create 3
+		// more (6 total = cap), then the 7th must 429.
 		for _, name := range []string{"C1", "C2", "C3"} {
 			createCollection(t, ctx, httpURI, name)
 		}
 		body := []byte(`{"class":"C4","vectorizer":"none"}`)
-		assertLimitExceeded(t, ctx, httpURI+"/v1/schema", body, "collections", 5)
+		assertLimitExceeded(t, ctx, httpURI+"/v1/schema", body, "collections", 6)
 	})
 
 	t.Run("tenant limit per collection", func(t *testing.T) {
@@ -143,6 +145,31 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 		assertLimitExceeded(t, ctx, objectsURL, body, "tenants", 2)
 	})
 
+	t.Run("cold tenants count toward object cap (abuse-vector defense)", func(t *testing.T) {
+		// Pre-fix: a deactivated tenant's objects were skipped from the
+		// cap, so a user could fill T1, deactivate, fill T2, etc. — bypass
+		// the cap by cycling tenants. Post-fix: the cache holds the
+		// deactivated tenant's count and it still counts toward the cap.
+		//
+		// Compare iterations: T1 fills until cap trips, then T1 is
+		// deactivated, then T2 fills. Under the fix T1's cached count
+		// keeps the cap tripped, so T2 trips almost immediately. Under
+		// the bug T2 would need roughly as many inserts as T1 did, since
+		// T1's COLD objects disappear from the accounting.
+		t1Insert, fired1 := loopInsertUntilLimit(t, ctx, httpURI, "MTcoldcoll", "T1", "objects", 10)
+		require.True(t, fired1, "baseline: object cap should fire when filling T1")
+		t.Logf("baseline: T1 needed %d inserts to trip cap", t1Insert)
+
+		setTenantStatus(t, ctx, httpURI, "MTcoldcoll", "T1", "INACTIVE")
+
+		t2Insert, fired2 := loopInsertUntilLimit(t, ctx, httpURI, "MTcoldcoll", "T2", "objects", 10)
+		require.True(t, fired2, "post-deactivation: object cap should still fire on T2")
+		t.Logf("post-deactivation: T2 needed %d inserts to trip cap", t2Insert)
+
+		require.Less(t, t2Insert, t1Insert/10,
+			"T2 must trip cap much faster than T1 (≤10×) — T1's cold objects must still count")
+	})
+
 	t.Run("object limit single create — loops until limit fires", func(t *testing.T) {
 		// We don't pin the exact count at which the limit fires: the
 		// implementation uses an async count that lags the memtable
@@ -151,7 +178,7 @@ func TestAllLimits_SingleSharedContainer(t *testing.T) {
 		// limit fires *eventually* with the canonical 429 body. The
 		// container is configured with aggressive flush settings so
 		// "eventually" is bounded to a few seconds beyond the cap.
-		gotLimit := loopInsertUntilLimit(t, ctx, httpURI, "C1", "objects", 10)
+		_, gotLimit := loopInsertUntilLimit(t, ctx, httpURI, "C1", "", "objects", 10)
 		require.True(t, gotLimit,
 			"expected the object cap to fire eventually within the suite timeout")
 	})
@@ -233,8 +260,9 @@ func mergeEnv(a, b map[string]string) map[string]string {
 
 // loopInsertUntilLimit hammers the single-object create endpoint until
 // the configured object-limit fires (HTTP 429 with USAGE_LIMIT_EXCEEDED)
-// or a generous deadline elapses. Returns true if the limit fired
-// before the deadline.
+// or a generous deadline elapses. Pass tenant="" for single-tenant
+// collections. Returns the iteration on which the limit fired (or 0 on
+// timeout) and whether it fired.
 //
 // The async object-count path lags writes (RFC: "bounded overshoot,
 // self-corrects on flush"), so the limit may not fire at exactly
@@ -244,12 +272,16 @@ func mergeEnv(a, b map[string]string) map[string]string {
 // when it does. Deadline is generous (120s) because
 // PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS=1 is a *trigger*
 // rather than a guarantee — slow CI shouldn't flake this.
-func loopInsertUntilLimit(t *testing.T, ctx context.Context, httpURI, class, expectLimit string, expectValue int64) bool {
+func loopInsertUntilLimit(t *testing.T, ctx context.Context, httpURI, class, tenant, expectLimit string, expectValue int64) (int, bool) {
 	t.Helper()
 	deadline := time.Now().Add(120 * time.Second)
 	probeURL := httpURI + "/v1/objects"
+	tenantField := ""
+	if tenant != "" {
+		tenantField = fmt.Sprintf(`"tenant":"%s",`, tenant)
+	}
 	for i := 0; time.Now().Before(deadline); i++ {
-		body := []byte(fmt.Sprintf(`{"class":"%s","properties":{"i":%d}}`, class, i))
+		body := []byte(fmt.Sprintf(`{"class":"%s",%s"properties":{"i":%d}}`, class, tenantField, i))
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, probeURL, bytes.NewReader(body))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
@@ -276,12 +308,12 @@ func loopInsertUntilLimit(t *testing.T, ctx context.Context, httpURI, class, exp
 			assert.Equal(t, expectLimit, parsed.Limit)
 			assert.Equal(t, expectValue, parsed.Value)
 			assert.NotEmpty(t, parsed.Message)
-			return true
+			return i + 1, true
 		default:
 			t.Fatalf("unexpected status %d on insert %d: %s", resp.StatusCode, i, raw)
 		}
 	}
-	return false
+	return 0, false
 }
 
 // --- helpers ---
@@ -365,6 +397,25 @@ func createAutoTenantMTCollection(t *testing.T, ctx context.Context, httpURI, na
 		`{"class":"%s","vectorizer":"none","multiTenancyConfig":{"enabled":true,"autoTenantCreation":true}}`,
 		name))
 	postOK(t, ctx, httpURI+"/v1/schema", body)
+}
+
+// setTenantStatus updates a tenant's activity status via the schema PUT
+// endpoint. Use ACTIVE / INACTIVE (the API names; converted internally
+// to HOT / COLD).
+func setTenantStatus(t *testing.T, ctx context.Context, httpURI, class, tenant, status string) {
+	t.Helper()
+	body := []byte(fmt.Sprintf(`[{"name":"%s","activityStatus":"%s"}]`, tenant, status))
+	url := httpURI + "/v1/schema/" + class + "/tenants"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "PUT %s", url)
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 2xx for PUT %s, got %d: %s", url, resp.StatusCode, raw)
+	}
 }
 
 func addTenants(t *testing.T, ctx context.Context, httpURI, class string,

--- a/usecases/usagelimits/manager.go
+++ b/usecases/usagelimits/manager.go
@@ -95,6 +95,15 @@ func (m *Manager) CheckObjects(ctx context.Context, n int64) error {
 	return nil
 }
 
+// HasObjectCap reports whether MaxObjectsCount is configured (>= 0) at
+// the moment of the call.
+func (m *Manager) HasObjectCap() bool {
+	if m == nil {
+		return false
+	}
+	return readLimit(m.cfg.MaxObjectsCount) >= 0
+}
+
 func (m *Manager) template() string {
 	if m == nil || m.cfg.ErrorMessage == nil {
 		return ""


### PR DESCRIPTION
## Summary

- Previously, `MAXIMUM_ALLOWED_OBJECTS_COUNT` summed only loaded (HOT) shards, so a multi-tenant deployment could deactivate tenants to drop their objects below the cap, then add more. This PR closes that gap by including COLD tenants in the node-wide count.
- Adds a per-`Index` `coldObjects` cache (RAM-only) gated by `Index.SetUsageLimits`: allocated only when the collection is multi-tenant **and** `MAXIMUM_ALLOWED_OBJECTS_COUNT` is set at the moment of install. The gate is **snapshot-once** — operators flipping the cap on at runtime need a restart for existing indexes to start tracking. Snapshot of `ObjectCountAsync` is taken on every HOT→COLD transition (`UnloadLocalShard`, `Migrator.UpdateTenants`, `Migrator.ShutdownShard`) and dropped on COLD→HOT (`initLocalShardWithForcedLoading`, `getOptInitLocalShard`) and tenant delete (`dropShards`, `Migrator.frozen`). The startup load runs `Index.RestoreColdCounts` to rehydrate the cache from on-disk segment metadata; unfreeze success populates it via `cacheColdCountFromDisk`. `migrator.AddClass` does not call `RestoreColdCounts` because newly-added classes have no tenants on disk.
- `LocalObjectCount` now reads HOT counts from the loaded shard and COLD counts from the cache, picked atomically per tenant under `shardCreateLocks.RLock(name)`. FROZEN tenants contribute 0. Single-tenant collections are unaffected (cache not allocated).

## Where things live

- Cache + helpers: `adapters/repos/db/usage_limits.go`
- Hooks: `adapters/repos/db/index.go`, `adapters/repos/db/migrator.go`, `adapters/repos/db/migrator_shard_status_ops.go`
- Gate / install API: `usecases/usagelimits/manager.go` (`Manager.HasObjectCap`)
- Design notes: `docs/usage_limits.md` (Counter source + hook-site table)

## Test plan

- [x] Unit tests for `coldObjectCounts` (get/set/drop semantics): `TestColdObjectCounts/*`
- [x] Integration test exercising the real HOT↔COLD lifecycle hooks via `UnloadLocalShard`/`LoadLocalShard`: `TestColdObjectsCache_HotColdLifecycleHooks`
- [x] Integration test for the tenant-delete cache eviction via `dropShards`: `TestColdObjectsCache_DeleteWhileCold`
- [x] Integration test for `cacheColdCountFromDisk` reading real on-disk segments: `TestColdObjectsCache_CountFromDisk`
- [x] Acceptance test for the end-to-end abuse vector — deactivated tenants still count toward the cap: `test/acceptance/usage_limits/all_limits_test.go`
- [x] `golangci-lint run --build-tags integrationTest ./adapters/repos/db/...` clean
- [x] `tools/linter_go_routines.sh` clean
- [x] All tests pass with `-race`

## Accepted imperfections (documented)

- Cold-cache snapshot excludes the memtable: under-counts by at most one memtable's worth per tenant during the COLD period; reactivation drops the cache and counts accurately.
- Cold-cache can over-count by one tenant on partial-failure tenant deletion (`shard.drop` fails mid-cleanup); intentional, clears at next lifecycle transition.
- Lazy-but-not-yet-loaded HOT shards still contribute 0 until first access — pre-existing behavior, unchanged.
- **Runtime cap-flip needs a restart for existing indexes.** The cold-cache gate is decided once at `Index.SetUsageLimits` time. If `MAXIMUM_ALLOWED_OBJECTS_COUNT` is turned on at runtime after some indexes were already constructed without it, those indexes won't track COLD tenants until the next restart. Indexes created after the flip do track. Documented in `docs/usage_limits.md`.
