### PR TITLE
feat(drop-vector-index): introduce (*storobj.Object).RemoveTargetVector method

### DIFF
--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -773,6 +773,18 @@ func (ko *Object) IterateThroughVectorDimensions(f func(targetVector string, dim
 	return nil
 }
 
+func (ko *Object) RemoveTargetVector(targetVector string) bool {
+	if _, ok := ko.Vectors[targetVector]; ok {
+		delete(ko.Vectors, targetVector)
+		return true
+	}
+	if _, ok := ko.MultiVectors[targetVector]; ok {
+		delete(ko.MultiVectors, targetVector)
+		return true
+	}
+	return false
+}
+
 func SearchResults(in []*Object, additional additional.Properties, tenant string) search.Results {
 	out := make(search.Results, len(in))
 

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -1970,3 +1970,127 @@ func pickRandomIDsBetween(start, end uint64, count int) []uint64 {
 	}
 	return ids
 }
+
+func TestStorageObjectRemoveTargetVector(t *testing.T) {
+	tests := []struct {
+		name             string
+		vectors          map[string][]float32
+		multiVectors     map[string][][]float32
+		targetVector     string
+		wantChanged      bool
+		wantVectors      []string
+		wantMultiVectors []string
+	}{
+		{
+			name:             "removes a regular vector",
+			vectors:          map[string][]float32{"foo": {1, 2}, "bar": {3, 4}},
+			targetVector:     "foo",
+			wantChanged:      true,
+			wantVectors:      []string{"bar"},
+			wantMultiVectors: []string{},
+		},
+		{
+			name:             "removes a multi vector",
+			multiVectors:     map[string][][]float32{"mv": {{1, 2}}, "keep": {{3, 4}}},
+			targetVector:     "mv",
+			wantChanged:      true,
+			wantVectors:      []string{},
+			wantMultiVectors: []string{"keep"},
+		},
+		{
+			name:             "absent name is a no-op",
+			vectors:          map[string][]float32{"foo": {1}},
+			multiVectors:     map[string][][]float32{"mv": {{2}}},
+			targetVector:     "missing",
+			wantChanged:      false,
+			wantVectors:      []string{"foo"},
+			wantMultiVectors: []string{"mv"},
+		},
+		{
+			name:             "nil maps are a no-op",
+			targetVector:     "foo",
+			wantChanged:      false,
+			wantVectors:      []string{},
+			wantMultiVectors: []string{},
+		},
+	}
+
+	vectorKeys := func(m map[string][]float32) []string {
+		out := make([]string, 0, len(m))
+		for k := range m {
+			out = append(out, k)
+		}
+		return out
+	}
+	multiVectorKeys := func(m map[string][][]float32) []string {
+		out := make([]string, 0, len(m))
+		for k := range m {
+			out = append(out, k)
+		}
+		return out
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Object{Vectors: tt.vectors, MultiVectors: tt.multiVectors}
+
+			assert.Equal(t, tt.wantChanged, o.RemoveTargetVector(tt.targetVector))
+			assert.ElementsMatch(t, tt.wantVectors, vectorKeys(o.Vectors))
+			assert.ElementsMatch(t, tt.wantMultiVectors, multiVectorKeys(o.MultiVectors))
+
+			assert.False(t, o.RemoveTargetVector(tt.targetVector))
+		})
+	}
+}
+
+func TestStorageObjectRemoveTargetVectorRoundTrip(t *testing.T) {
+	before := FromObject(
+		&models.Object{
+			Class: "DropClass",
+			ID:    strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168247"),
+		},
+		nil,
+		map[string][]float32{"keep": {1, 2, 3}, "drop": {4, 5, 6}},
+		map[string][][]float32{"mvkeep": {{7, 8}}, "mvdrop": {{9, 10}}},
+	)
+	before.DocID = 1
+
+	asBinary, err := before.MarshalBinary()
+	require.NoError(t, err)
+
+	obj, err := FromBinaryDisk(asBinary, "DropClass")
+	require.NoError(t, err)
+
+	require.True(t, obj.RemoveTargetVector("drop"))
+	require.True(t, obj.RemoveTargetVector("mvdrop"))
+	require.False(t, obj.RemoveTargetVector("drop"))
+
+	stripped, err := obj.MarshalBinary()
+	require.NoError(t, err)
+
+	after, err := FromBinaryDisk(stripped, "DropClass")
+	require.NoError(t, err)
+
+	vectorKeys := func(m map[string][]float32) []string {
+		out := make([]string, 0, len(m))
+		for k := range m {
+			out = append(out, k)
+		}
+		return out
+	}
+	multiVectorKeys := func(m map[string][][]float32) []string {
+		out := make([]string, 0, len(m))
+		for k := range m {
+			out = append(out, k)
+		}
+		return out
+	}
+
+	assert.ElementsMatch(t, []string{"keep"}, vectorKeys(after.Vectors))
+	assert.ElementsMatch(t, []string{"mvkeep"}, multiVectorKeys(after.MultiVectors))
+	assert.ElementsMatch(t, after.Vectors["keep"], []float32{1, 2, 3})
+	assert.ElementsMatch(t, after.MultiVectors["mvkeep"], [][]float32{{7, 8}})
+
+	assert.False(t, after.RemoveTargetVector("drop"))
+	assert.False(t, after.RemoveTargetVector("mvdrop"))
+}


### PR DESCRIPTION
## Motivation

Part of the Drop Vector Index work (Phase 2, S4). When a named vector index is dropped, persisted objects still carry that vector's payload in their `Vectors` / `MultiVectors` maps. We need a primitive to strip a single named vector from an in-memory `storobj.Object` so the dropped vector can be removed during object rewrite/migration without touching the rest of the object. This PR adds only that primitive — no callers yet; it's the building block later phases wire in.

## Approach

`RemoveTargetVector(targetVector string) bool` deletes the entry from whichever of the two maps holds it (regular `Vectors` or `MultiVectors`) and reports whether anything changed. A named vector lives in exactly one of the two maps, so checking both and returning on the first hit is sufficient and unambiguous. Returning `bool` lets callers skip a re-marshal/rewrite when the object didn't actually carry the dropped vector — important for the migration path where most objects may already be clean.

Only `Vectors` and `MultiVectors` are persisted by `MarshalBinary` (the `models.Object.Vectors` API field is populated on read but not re-serialized), so stripping those two maps is sufficient to drop the vector from the on-disk payload.

## Key areas for review

- `entities/storobj/storage_object.go` — `RemoveTargetVector`. Verify the assumption that a target vector name is never present in both `Vectors` and `MultiVectors` simultaneously; the method removes from the first match only.

## Risks and mitigations

Minimal. The method mutates the object's vector maps in place but is a pure helper with no I/O, no locking, and (currently) no callers in production paths. The round-trip test confirms that after removal and re-marshal the dropped vector is gone from the on-disk encoding while the remaining vectors survive intact, so there's no risk of the deletion corrupting the binary format or leaking the dropped vector back on reload.

## Testing

- `TestStorageObjectRemoveTargetVector` — table-driven: removing a regular vector, removing a multi-vector, no-op on an absent name, no-op on nil maps. Each case also asserts the second call returns `false` (idempotency / change-reporting correctness).
- `TestStorageObjectRemoveTargetVectorRoundTrip` — marshals an object with two regular + two multi vectors, reloads via `FromBinaryDisk`, removes one of each, re-marshals, reloads again, and asserts only the kept vectors remain with correct values. Pins the end-to-end behavior through the binary encoding, which is where a regression would actually hurt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
