### PR TITLE
feat(drop-vector-index): introduce segment edit ops bolt facility

### DIFF
--- a/adapters/repos/db/lsmkv/segment_edit_ops.go
+++ b/adapters/repos/db/lsmkv/segment_edit_ops.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"time"
 
 	bolt "go.etcd.io/bbolt"
 )
@@ -81,7 +82,11 @@ type PendingSegment struct {
 // OpenSegmentEditOps opens (creating if necessary) the edit-ops store for the
 // segment group rooted at dir.
 func OpenSegmentEditOps(dir string) (*SegmentEditOps, error) {
-	db, err := bolt.Open(filepath.Join(dir, segmentEditOpsFileName), 0o600, nil)
+	// One handle per segment group is the invariant. A non-zero Timeout turns a
+	// would-be-forever hang on an accidental second open into a fast, debuggable
+	// error; it never affects the single-open path (the file lock is uncontended).
+	db, err := bolt.Open(filepath.Join(dir, segmentEditOpsFileName), 0o600,
+		&bolt.Options{Timeout: 5 * time.Second})
 	if err != nil {
 		return nil, fmt.Errorf("open segment edit ops db: %w", err)
 	}
@@ -148,11 +153,20 @@ func (s *SegmentEditOps) LoadOps() ([]ActiveOp, error) {
 	return ops, nil
 }
 
-// SnapshotSegments records segIDs as pending for opID. It is idempotent: a
-// segment already pending (possibly with accrued retries) is left untouched, so
-// re-running a snapshot after a crash neither duplicates nor resets progress.
+// SnapshotSegments records segIDs as pending for opID, which must already be
+// registered. It is idempotent for segments that are still pending: an existing
+// pending row (with its accrued retries) is left untouched, so re-running a
+// snapshot after a crash neither duplicates rows nor resets progress.
+//
+// Progress is encoded as absence from the pending set, so callers must pass the
+// segments currently on disk: re-snapshotting an ID that has already been
+// completed (and whose segment was merged/cleaned away) re-queues it. Reconcile
+// is the safety net — it drops pending rows for segments no longer on disk.
 func (s *SegmentEditOps) SnapshotSegments(opID string, segIDs []string) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
+		if tx.Bucket(editOpsBucketOperations).Get([]byte(opID)) == nil {
+			return fmt.Errorf("snapshot segments: operation %q is not registered", opID)
+		}
 		sub, err := tx.Bucket(editOpsBucketPending).CreateBucketIfNotExists([]byte(opID))
 		if err != nil {
 			return err
@@ -233,7 +247,12 @@ func (s *SegmentEditOps) BumpAttempt(opID, segID string, opErr error) error {
 		if sub == nil {
 			return nil
 		}
-		ps, err := decodePending(opID, segID, sub.Get([]byte(segID)))
+		raw := sub.Get([]byte(segID))
+		if raw == nil {
+			// Already done or quarantined; do not resurrect a completed segment.
+			return nil
+		}
+		ps, err := decodePending(opID, segID, raw)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/lsmkv/segment_edit_ops.go
+++ b/adapters/repos/db/lsmkv/segment_edit_ops.go
@@ -1,0 +1,400 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// SegmentEditOps is a bolt-backed sidecar that records in-place segment edit
+// operations and tracks, per operation, which segments still need to be
+// rewritten. Drop-vector-index is its first user: an operation names the target
+// vectors to strip, and every segment present at registration time is recorded
+// as "pending" until compaction or the cleanup driver has rewritten it.
+//
+// The store is deliberately decoupled from SegmentGroup: callers pass in the
+// set of segment IDs (derived from segment file paths via segmentID) so the
+// store can be unit-tested in isolation and reused for future edit ops.
+//
+// On-disk layout (one bolt file per segment group, alongside the segments):
+//
+//	operations/<opID>            -> OpDescriptor (JSON)
+//	pending_segments/<opID>/<segID> -> pendingMeta (JSON)
+//	quarantined/<opID>/<segID>      -> pendingMeta (JSON)
+//
+// pending_segments and quarantined use a nested sub-bucket per operation so the
+// op and segment IDs never need an in-key separator.
+type SegmentEditOps struct {
+	db *bolt.DB
+}
+
+const segmentEditOpsFileName = "segment_edit_ops.db.bolt"
+
+var (
+	editOpsBucketOperations = []byte("operations")
+	editOpsBucketPending    = []byte("pending_segments")
+	editOpsBucketQuarantine = []byte("quarantined")
+)
+
+// OpDescriptor describes a single edit operation. It is opaque to the rewrite
+// machinery beyond Type, which selects the transformer to apply.
+type OpDescriptor struct {
+	// Type discriminates the operation; "remove_target_vectors" today.
+	Type string `json:"type"`
+	// Targets are the operands, e.g. the named vectors to strip.
+	Targets []string `json:"targets"`
+	// CreatedAt is a monotonic timestamp (caller-supplied) that orders
+	// transformer application when multiple ops are active.
+	CreatedAt int64 `json:"createdAt"`
+}
+
+// ActiveOp pairs an operation's ID with its descriptor.
+type ActiveOp struct {
+	ID         string
+	Descriptor OpDescriptor
+}
+
+// PendingSegment is one segment still awaiting rewrite for an operation, with
+// its retry bookkeeping.
+type PendingSegment struct {
+	OpID          string `json:"-"`
+	SegmentID     string `json:"-"`
+	Attempts      int    `json:"attempts"`
+	LastError     string `json:"lastError,omitempty"`
+	LastAttemptAt int64  `json:"lastAttemptAt,omitempty"`
+}
+
+// OpenSegmentEditOps opens (creating if necessary) the edit-ops store for the
+// segment group rooted at dir.
+func OpenSegmentEditOps(dir string) (*SegmentEditOps, error) {
+	db, err := bolt.Open(filepath.Join(dir, segmentEditOpsFileName), 0o600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open segment edit ops db: %w", err)
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		for _, name := range [][]byte{editOpsBucketOperations, editOpsBucketPending, editOpsBucketQuarantine} {
+			if _, err := tx.CreateBucketIfNotExists(name); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("init segment edit ops buckets: %w", err)
+	}
+
+	return &SegmentEditOps{db: db}, nil
+}
+
+func (s *SegmentEditOps) Close() error {
+	return s.db.Close()
+}
+
+// RegisterOp persists an operation descriptor. It is idempotent: re-registering
+// an existing op keeps the original descriptor (notably its CreatedAt) so a
+// retry does not reorder transformer application.
+func (s *SegmentEditOps) RegisterOp(opID string, op OpDescriptor) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(editOpsBucketOperations)
+		if b.Get([]byte(opID)) != nil {
+			return nil
+		}
+		enc, err := json.Marshal(op)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(opID), enc)
+	})
+}
+
+// LoadOps returns all active operations sorted by CreatedAt (ties broken by ID)
+// so transformers are applied in a deterministic order.
+func (s *SegmentEditOps) LoadOps() ([]ActiveOp, error) {
+	var ops []ActiveOp
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(editOpsBucketOperations).ForEach(func(k, v []byte) error {
+			var desc OpDescriptor
+			if err := json.Unmarshal(v, &desc); err != nil {
+				return fmt.Errorf("decode op %q: %w", k, err)
+			}
+			ops = append(ops, ActiveOp{ID: string(k), Descriptor: desc})
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(ops, func(i, j int) bool {
+		if ops[i].Descriptor.CreatedAt != ops[j].Descriptor.CreatedAt {
+			return ops[i].Descriptor.CreatedAt < ops[j].Descriptor.CreatedAt
+		}
+		return ops[i].ID < ops[j].ID
+	})
+	return ops, nil
+}
+
+// SnapshotSegments records segIDs as pending for opID. It is idempotent: a
+// segment already pending (possibly with accrued retries) is left untouched, so
+// re-running a snapshot after a crash neither duplicates nor resets progress.
+func (s *SegmentEditOps) SnapshotSegments(opID string, segIDs []string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		sub, err := tx.Bucket(editOpsBucketPending).CreateBucketIfNotExists([]byte(opID))
+		if err != nil {
+			return err
+		}
+		for _, segID := range segIDs {
+			if sub.Get([]byte(segID)) != nil {
+				continue
+			}
+			enc, err := json.Marshal(PendingSegment{})
+			if err != nil {
+				return err
+			}
+			if err := sub.Put([]byte(segID), enc); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// Pending returns the segment IDs still awaiting rewrite for opID.
+func (s *SegmentEditOps) Pending(opID string) ([]string, error) {
+	var segIDs []string
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		sub := tx.Bucket(editOpsBucketPending).Bucket([]byte(opID))
+		if sub == nil {
+			return nil
+		}
+		return sub.ForEach(func(k, _ []byte) error {
+			segIDs = append(segIDs, string(k))
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return segIDs, nil
+}
+
+// AllPending returns every pending segment across all operations, the feed for
+// the cleanup driver.
+func (s *SegmentEditOps) AllPending() ([]PendingSegment, error) {
+	var out []PendingSegment
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(editOpsBucketPending).ForEachBucket(func(opID []byte) error {
+			return tx.Bucket(editOpsBucketPending).Bucket(opID).ForEach(func(segID, v []byte) error {
+				ps, err := decodePending(string(opID), string(segID), v)
+				if err != nil {
+					return err
+				}
+				out = append(out, ps)
+				return nil
+			})
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MarkSegmentDone removes a segment from the pending set for opID, signalling
+// the rewrite for that (op, segment) pair is complete.
+func (s *SegmentEditOps) MarkSegmentDone(opID, segID string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		sub := tx.Bucket(editOpsBucketPending).Bucket([]byte(opID))
+		if sub == nil {
+			return nil
+		}
+		return sub.Delete([]byte(segID))
+	})
+}
+
+// BumpAttempt records a failed rewrite attempt for a pending segment. The
+// quarantine threshold decision lives in the cleanup driver; this only persists
+// the count and last error.
+func (s *SegmentEditOps) BumpAttempt(opID, segID string, opErr error) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		sub := tx.Bucket(editOpsBucketPending).Bucket([]byte(opID))
+		if sub == nil {
+			return nil
+		}
+		ps, err := decodePending(opID, segID, sub.Get([]byte(segID)))
+		if err != nil {
+			return err
+		}
+		ps.Attempts++
+		if opErr != nil {
+			ps.LastError = opErr.Error()
+		}
+		enc, err := json.Marshal(ps)
+		if err != nil {
+			return err
+		}
+		return sub.Put([]byte(segID), enc)
+	})
+}
+
+// Quarantine moves a segment from pending to quarantined for opID, preserving
+// its retry metadata. A quarantined segment fails the operation.
+func (s *SegmentEditOps) Quarantine(opID, segID string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		pendingSub := tx.Bucket(editOpsBucketPending).Bucket([]byte(opID))
+		var raw []byte
+		if pendingSub != nil {
+			raw = pendingSub.Get([]byte(segID))
+		}
+		if raw == nil {
+			// Nothing pending to quarantine; keep idempotent.
+			return nil
+		}
+		quarantineSub, err := tx.Bucket(editOpsBucketQuarantine).CreateBucketIfNotExists([]byte(opID))
+		if err != nil {
+			return err
+		}
+		if err := quarantineSub.Put([]byte(segID), raw); err != nil {
+			return err
+		}
+		return pendingSub.Delete([]byte(segID))
+	})
+}
+
+// Quarantined returns the quarantined segments across all operations.
+func (s *SegmentEditOps) Quarantined() ([]PendingSegment, error) {
+	var out []PendingSegment
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(editOpsBucketQuarantine).ForEachBucket(func(opID []byte) error {
+			return tx.Bucket(editOpsBucketQuarantine).Bucket(opID).ForEach(func(segID, v []byte) error {
+				ps, err := decodePending(string(opID), string(segID), v)
+				if err != nil {
+					return err
+				}
+				out = append(out, ps)
+				return nil
+			})
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeleteOp removes an operation and all of its pending and quarantined rows.
+// Called once the operation has fully completed (its DTM task is FINISHED).
+func (s *SegmentEditOps) DeleteOp(opID string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		if err := tx.Bucket(editOpsBucketOperations).Delete([]byte(opID)); err != nil {
+			return err
+		}
+		if err := deleteSubBucket(tx.Bucket(editOpsBucketPending), opID); err != nil {
+			return err
+		}
+		return deleteSubBucket(tx.Bucket(editOpsBucketQuarantine), opID)
+	})
+}
+
+// Reconcile repairs the store against ground truth at open time (C1):
+//
+//   - pending/quarantined rows for segments that no longer exist on disk are
+//     dropped. This covers a crash after a segment was renamed/merged away but
+//     before its row could be cleared.
+//   - operations whose ID is not in liveOpIDs are dropped entirely (descriptor
+//     plus rows), e.g. after a backup restore where the DTM task is gone.
+//
+// existingSegmentIDs and liveOpIDs are membership sets. A nil liveOpIDs skips
+// the orphaned-op sweep (used when the live set is unknown).
+func (s *SegmentEditOps) Reconcile(existingSegmentIDs, liveOpIDs map[string]struct{}) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		ops := tx.Bucket(editOpsBucketOperations)
+
+		// Drop orphaned operations first; the segment sweep then skips them.
+		if liveOpIDs != nil {
+			var orphans []string
+			if err := ops.ForEach(func(k, _ []byte) error {
+				if _, ok := liveOpIDs[string(k)]; !ok {
+					orphans = append(orphans, string(k))
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+			for _, opID := range orphans {
+				if err := ops.Delete([]byte(opID)); err != nil {
+					return err
+				}
+				if err := deleteSubBucket(tx.Bucket(editOpsBucketPending), opID); err != nil {
+					return err
+				}
+				if err := deleteSubBucket(tx.Bucket(editOpsBucketQuarantine), opID); err != nil {
+					return err
+				}
+			}
+		}
+
+		for _, top := range [][]byte{editOpsBucketPending, editOpsBucketQuarantine} {
+			if err := pruneMissingSegments(tx.Bucket(top), existingSegmentIDs); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// pruneMissingSegments deletes, across every operation sub-bucket, the segment
+// rows whose ID is absent from existingSegmentIDs.
+func pruneMissingSegments(parent *bolt.Bucket, existingSegmentIDs map[string]struct{}) error {
+	type rowKey struct{ opID, segID string }
+	var stale []rowKey
+	if err := parent.ForEachBucket(func(opID []byte) error {
+		return parent.Bucket(opID).ForEach(func(segID, _ []byte) error {
+			if _, ok := existingSegmentIDs[string(segID)]; !ok {
+				stale = append(stale, rowKey{opID: string(opID), segID: string(segID)})
+			}
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+	for _, r := range stale {
+		if sub := parent.Bucket([]byte(r.opID)); sub != nil {
+			if err := sub.Delete([]byte(r.segID)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func deleteSubBucket(parent *bolt.Bucket, opID string) error {
+	if parent.Bucket([]byte(opID)) == nil {
+		return nil
+	}
+	return parent.DeleteBucket([]byte(opID))
+}
+
+func decodePending(opID, segID string, raw []byte) (PendingSegment, error) {
+	ps := PendingSegment{OpID: opID, SegmentID: segID}
+	if len(raw) == 0 {
+		return ps, nil
+	}
+	if err := json.Unmarshal(raw, &ps); err != nil {
+		return ps, fmt.Errorf("decode pending segment %s/%s: %w", opID, segID, err)
+	}
+	ps.OpID = opID
+	ps.SegmentID = segID
+	return ps, nil
+}

--- a/adapters/repos/db/lsmkv/segment_edit_ops_test.go
+++ b/adapters/repos/db/lsmkv/segment_edit_ops_test.go
@@ -259,3 +259,30 @@ func TestSegmentEditOps_PersistsAcrossReopen(t *testing.T) {
 		}
 	}
 }
+
+func TestSegmentEditOps_BumpAttemptDoesNotResurrectDoneSegment(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1", "seg2"}))
+	require.NoError(t, s.MarkSegmentDone("op1", "seg1"))
+
+	// A late/duplicate error for an already-completed segment must not revive it.
+	require.NoError(t, s.BumpAttempt("op1", "seg1", errors.New("late error")))
+
+	p, err := s.Pending("op1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"seg2"}, p)
+}
+
+func TestSegmentEditOps_SnapshotSegmentsRequiresRegisteredOp(t *testing.T) {
+	s := newTestEditOps(t)
+
+	err := s.SnapshotSegments("unregistered", []string{"seg1"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not registered")
+
+	// No orphan pending rows were created.
+	p, err := s.Pending("unregistered")
+	require.NoError(t, err)
+	assert.Empty(t, p)
+}

--- a/adapters/repos/db/lsmkv/segment_edit_ops_test.go
+++ b/adapters/repos/db/lsmkv/segment_edit_ops_test.go
@@ -1,0 +1,261 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEditOps(t *testing.T) *SegmentEditOps {
+	t.Helper()
+	s, err := OpenSegmentEditOps(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
+}
+
+func set(ids ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		m[id] = struct{}{}
+	}
+	return m
+}
+
+func removeOp(targets ...string) OpDescriptor {
+	return OpDescriptor{Type: "remove_target_vectors", Targets: targets, CreatedAt: 100}
+}
+
+func TestSegmentEditOps_RegisterOpIdempotent(t *testing.T) {
+	s := newTestEditOps(t)
+
+	require.NoError(t, s.RegisterOp("op1", OpDescriptor{Type: "remove_target_vectors", Targets: []string{"foo"}, CreatedAt: 100}))
+	// Re-register with a different descriptor: the original must be kept.
+	require.NoError(t, s.RegisterOp("op1", OpDescriptor{Type: "remove_target_vectors", Targets: []string{"bar"}, CreatedAt: 999}))
+
+	ops, err := s.LoadOps()
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, "op1", ops[0].ID)
+	assert.Equal(t, []string{"foo"}, ops[0].Descriptor.Targets)
+	assert.EqualValues(t, 100, ops[0].Descriptor.CreatedAt)
+}
+
+func TestSegmentEditOps_LoadOpsSortedByCreatedAt(t *testing.T) {
+	s := newTestEditOps(t)
+
+	require.NoError(t, s.RegisterOp("b", OpDescriptor{Type: "t", CreatedAt: 200}))
+	require.NoError(t, s.RegisterOp("a", OpDescriptor{Type: "t", CreatedAt: 100}))
+	require.NoError(t, s.RegisterOp("c", OpDescriptor{Type: "t", CreatedAt: 100}))
+
+	ops, err := s.LoadOps()
+	require.NoError(t, err)
+	require.Len(t, ops, 3)
+	// Sorted by CreatedAt, ties broken by ID: (a,100), (c,100), (b,200).
+	assert.Equal(t, []string{"a", "c", "b"}, []string{ops[0].ID, ops[1].ID, ops[2].ID})
+}
+
+func TestSegmentEditOps_SnapshotSegmentsIdempotent(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1", "seg2"}))
+	require.NoError(t, s.BumpAttempt("op1", "seg1", errors.New("boom")))
+	// Re-snapshotting must not duplicate or reset accrued retry state.
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1", "seg2", "seg3"}))
+
+	pending, err := s.AllPending()
+	require.NoError(t, err)
+	require.Len(t, pending, 3)
+	byID := map[string]PendingSegment{}
+	for _, p := range pending {
+		byID[p.SegmentID] = p
+	}
+	assert.Equal(t, 1, byID["seg1"].Attempts)
+	assert.Equal(t, "boom", byID["seg1"].LastError)
+	assert.Equal(t, 0, byID["seg2"].Attempts)
+	assert.Equal(t, 0, byID["seg3"].Attempts)
+}
+
+func TestSegmentEditOps_PendingScopedPerOp(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+	require.NoError(t, s.RegisterOp("op2", removeOp("bar")))
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1", "seg2"}))
+	require.NoError(t, s.SnapshotSegments("op2", []string{"seg3"}))
+
+	p1, err := s.Pending("op1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"seg1", "seg2"}, p1)
+
+	p2, err := s.Pending("op2")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"seg3"}, p2)
+
+	// Unknown op returns nothing, not an error.
+	pNone, err := s.Pending("missing")
+	require.NoError(t, err)
+	assert.Empty(t, pNone)
+}
+
+func TestSegmentEditOps_MarkSegmentDone(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1", "seg2"}))
+
+	require.NoError(t, s.MarkSegmentDone("op1", "seg1"))
+
+	p, err := s.Pending("op1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"seg2"}, p)
+
+	// Idempotent: marking an already-done (or unknown) segment is a no-op.
+	require.NoError(t, s.MarkSegmentDone("op1", "seg1"))
+	require.NoError(t, s.MarkSegmentDone("missing", "seg1"))
+}
+
+func TestSegmentEditOps_BumpAttemptThenQuarantine(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1"}))
+
+	for range 3 {
+		require.NoError(t, s.BumpAttempt("op1", "seg1", errors.New("disk full")))
+	}
+
+	pending, err := s.AllPending()
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, 3, pending[0].Attempts)
+	assert.Equal(t, "disk full", pending[0].LastError)
+
+	require.NoError(t, s.Quarantine("op1", "seg1"))
+
+	// Moved out of pending, into quarantined, retry metadata preserved.
+	p, err := s.Pending("op1")
+	require.NoError(t, err)
+	assert.Empty(t, p)
+
+	q, err := s.Quarantined()
+	require.NoError(t, err)
+	require.Len(t, q, 1)
+	assert.Equal(t, "seg1", q[0].SegmentID)
+	assert.Equal(t, 3, q[0].Attempts)
+}
+
+func TestSegmentEditOps_DeleteOp(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+	require.NoError(t, s.RegisterOp("op2", removeOp("bar")))
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1"}))
+	require.NoError(t, s.SnapshotSegments("op2", []string{"seg2"}))
+	require.NoError(t, s.Quarantine("op1", "seg1")) // op1 has a quarantined row too... but it was the only pending
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1"}))
+
+	require.NoError(t, s.DeleteOp("op1"))
+
+	ops, err := s.LoadOps()
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, "op2", ops[0].ID)
+
+	p, err := s.Pending("op1")
+	require.NoError(t, err)
+	assert.Empty(t, p)
+	q, err := s.Quarantined()
+	require.NoError(t, err)
+	for _, qs := range q {
+		assert.NotEqual(t, "op1", qs.OpID)
+	}
+
+	// op2 untouched.
+	p2, err := s.Pending("op2")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"seg2"}, p2)
+}
+
+func TestSegmentEditOps_ReconcileDeletesStaleSegmentRows(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1", "seg2", "seg3"}))
+	require.NoError(t, s.Quarantine("op1", "seg3"))
+
+	// seg2 (pending) and seg3 (quarantined) no longer exist on disk.
+	require.NoError(t, s.Reconcile(set("seg1"), nil))
+
+	p, err := s.Pending("op1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"seg1"}, p)
+
+	q, err := s.Quarantined()
+	require.NoError(t, err)
+	assert.Empty(t, q)
+
+	// The operation itself survives (liveOpIDs nil = skip orphan sweep).
+	ops, err := s.LoadOps()
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+}
+
+func TestSegmentEditOps_ReconcileDeletesOrphanedOps(t *testing.T) {
+	s := newTestEditOps(t)
+	require.NoError(t, s.RegisterOp("live", removeOp("foo")))
+	require.NoError(t, s.RegisterOp("orphan", removeOp("bar")))
+	require.NoError(t, s.SnapshotSegments("live", []string{"seg1"}))
+	require.NoError(t, s.SnapshotSegments("orphan", []string{"seg1"}))
+
+	require.NoError(t, s.Reconcile(set("seg1"), set("live")))
+
+	ops, err := s.LoadOps()
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+	assert.Equal(t, "live", ops[0].ID)
+
+	// orphan's rows are gone; live's remain.
+	all, err := s.AllPending()
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, "live", all[0].OpID)
+}
+
+func TestSegmentEditOps_PersistsAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := OpenSegmentEditOps(dir)
+	require.NoError(t, err)
+	require.NoError(t, s.RegisterOp("op1", removeOp("foo")))
+	require.NoError(t, s.SnapshotSegments("op1", []string{"seg1", "seg2"}))
+	require.NoError(t, s.BumpAttempt("op1", "seg1", errors.New("boom")))
+	require.NoError(t, s.Close())
+
+	reopened, err := OpenSegmentEditOps(dir)
+	require.NoError(t, err)
+	defer reopened.Close()
+
+	ops, err := reopened.LoadOps()
+	require.NoError(t, err)
+	require.Len(t, ops, 1)
+
+	all, err := reopened.AllPending()
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	for _, p := range all {
+		if p.SegmentID == "seg1" {
+			assert.Equal(t, 1, p.Attempts)
+			assert.Equal(t, "boom", p.LastError)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Drop-vector-index removes named vectors from a collection in place. Stripping a vector from on-disk LSM segments is a long-running, crash-prone rewrite: a segment group may hold many segments, each must be rewritten without the target vector, and the node can restart, crash, or be restored from backup at any point. We need durable bookkeeping of *which* segments still owe a rewrite for *which* drop operation, so the work can resume idempotently after any interruption and so a permanently-failing segment can be quarantined instead of wedging the whole operation.

This is S5 (Phase 2) of the Drop Vector Index RFC. It is the persistence layer only — no rewrite/compaction integration yet. Those land in later stacked PRs.

Stacked on #11810 (S4); review/merge that first. The diff here is only the two new files.

## Approach

A self-contained bolt sidecar (`segment_edit_ops.db.bolt`), one per segment group, sitting alongside the segments. It is deliberately decoupled from `SegmentGroup`: callers pass in plain segment-ID sets (derived from segment file paths), so the store has no dependency on live segment state and is unit-testable in isolation. The descriptor (\`OpDescriptor\`) is generic over operation \`Type\` — \`remove_target_vectors\` is the only type today, but the facility is intended to be reused for future in-place edit ops.

On-disk layout (documented inline at the top of the file): an \`operations\` bucket of op descriptors, plus \`pending_segments\` and \`quarantined\` parents that nest one sub-bucket per op keyed by segment ID. Nested sub-buckets avoid needing an in-key \`op|seg\` separator.

The core design constraint is **idempotency under crash-and-retry**. Every mutating call is safe to re-run:
- \`RegisterOp\` keeps the original descriptor (notably \`CreatedAt\`) on re-registration, so a retry never reorders transformer application.
- \`SnapshotSegments\` skips segments already pending, so re-snapshotting after a crash neither duplicates rows nor resets accrued retry counts.
- \`MarkSegmentDone\` / \`Quarantine\` are no-ops when the row is already gone.
- \`LoadOps\` returns ops sorted by \`CreatedAt\` (ID as tiebreaker) for deterministic transformer ordering when multiple drops are active.

\`Reconcile\` repairs the store against ground truth at open time (RFC C1): it drops pending/quarantined rows for segments no longer on disk (crash after a merge/rename but before the row was cleared) and, when given the live op-ID set, drops operations that no longer exist (e.g. after a backup restore where the DTM task is gone). A nil \`liveOpIDs\` skips the orphan sweep for callers that don't know the live set.

## Key areas for review

- \`segment_edit_ops.go:Reconcile\` / \`pruneMissingSegments\` — the crash-recovery contract. Verify the orphan-op sweep runs before the segment sweep, and that deleting rows mid-iteration (collect-then-delete) is correct against bolt's cursor semantics.
- \`segment_edit_ops.go:Quarantine\` — moves a row pending → quarantined preserving retry metadata; check it stays idempotent when nothing is pending.
- \`segment_edit_ops.go:RegisterOp\` / \`SnapshotSegments\` — the two idempotency invariants that protect retry/ordering state; these are the ones a buggy caller could silently corrupt.
- On-disk layout comment (lines 33-40) — confirm the nested-bucket scheme matches the accessors.

## Risks and mitigations

- **Corruption of in-flight progress on retry**: mitigated by the idempotency rules above, each pinned by a dedicated test (re-register keeps original descriptor; re-snapshot preserves attempt counts).
- **Orphaned rows wedging future work after crash/restore**: \`Reconcile\` prunes against on-disk segments and the live op set at open time.
- **Bolt file lifecycle**: one file per segment group opened with \`CreateBucketIfNotExists\`; \`OpenSegmentEditOps\` closes the db if bucket init fails, avoiding a leaked handle.

No production call sites yet (this PR only adds the facility + tests), so blast radius is limited to the new package code.

## Testing

Table-/scenario-driven unit tests in \`segment_edit_ops_test.go\` covering: register idempotency, \`LoadOps\` ordering (CreatedAt + ID tiebreak), snapshot idempotency with preserved retry state, per-op pending scoping, mark-done idempotency, bump-attempt → quarantine with metadata preservation, \`DeleteOp\` isolation (one op deleted, sibling untouched), \`Reconcile\` for both stale-segment and orphaned-op cases, and full persistence across a close/reopen cycle.

\`\`\`
go test -race -run TestSegmentEditOps ./adapters/repos/db/lsmkv/
\`\`\`