### PR TITLE
feat(drop-vector-index): introduce compactor transformer hook

### DIFF
--- a/adapters/repos/db/lsmkv/compactor_replace.go
+++ b/adapters/repos/db/lsmkv/compactor_replace.go
@@ -269,7 +269,8 @@ func (c *compactorReplace) writeIndividualNode(f *segmentindex.SegmentFile,
 	offset int, key, value []byte, secondaryKeys [][]byte, tombstone bool,
 ) (segmentindex.Key, error) {
 	// Rewrite live values through the active edit transformer before they hit
-	// the merged segment. Tombstones carry no payload, so they are skipped.
+	// the merged segment. Tombstones and empty payloads carry nothing to
+	// transform, so they are skipped.
 	if c.valueTransformer != nil && !tombstone && len(value) > 0 {
 		transformed, err := c.valueTransformer(value)
 		if err != nil {

--- a/adapters/repos/db/lsmkv/compactor_replace.go
+++ b/adapters/repos/db/lsmkv/compactor_replace.go
@@ -61,12 +61,22 @@ type compactorReplace struct {
 	// that writeDirectly does not need a second O(N) scan over the keys.
 	primaryIndexSize int64
 	secIndexSizes    []int64
+
+	// valueTransformer, when set, rewrites each non-tombstone value before it is
+	// written to the merged segment (e.g. to strip a dropped vector). nil means
+	// no active edit operation, in which case values pass through untouched.
+	valueTransformer valueTransformer
 }
+
+// valueTransformer rewrites a stored value in place during a segment rewrite.
+// It must be a pure, idempotent function of the value bytes.
+type valueTransformer func(value []byte) ([]byte, error)
 
 func newCompactorReplace(w io.WriteSeeker,
 	c1, c2 *segmentCursorReplaceReusable, level, secondaryIndexCount uint16,
 	cleanupTombstones bool,
 	enableChecksumValidation bool, maxNewFileSize int64, allocChecker memwatch.AllocChecker,
+	valueTransformer valueTransformer,
 ) *compactorReplace {
 	observeWrite := monitoring.GetMetrics().FileIOWrites.With(prometheus.Labels{
 		"operation": "compaction",
@@ -96,6 +106,7 @@ func newCompactorReplace(w io.WriteSeeker,
 		allocChecker:             allocChecker,
 		maxNewFileSize:           maxNewFileSize,
 		secIndexSizes:            secIndexSizes,
+		valueTransformer:         valueTransformer,
 	}
 }
 
@@ -257,6 +268,16 @@ func (c *compactorReplace) accumulateIndexSizes(ki segmentindex.Key) {
 func (c *compactorReplace) writeIndividualNode(f *segmentindex.SegmentFile,
 	offset int, key, value []byte, secondaryKeys [][]byte, tombstone bool,
 ) (segmentindex.Key, error) {
+	// Rewrite live values through the active edit transformer before they hit
+	// the merged segment. Tombstones carry no payload, so they are skipped.
+	if c.valueTransformer != nil && !tombstone && len(value) > 0 {
+		transformed, err := c.valueTransformer(value)
+		if err != nil {
+			return segmentindex.Key{}, fmt.Errorf("transform value: %w", err)
+		}
+		value = transformed
+	}
+
 	// Copy key bytes into stable arena memory. The reusable cursor reuses its
 	// internal buffers on every next() call, so ki.Key / ki.SecondaryKeys stored
 	// in the kis slice would otherwise be corrupted on the next iteration.

--- a/adapters/repos/db/lsmkv/compactor_replace_transform_test.go
+++ b/adapters/repos/db/lsmkv/compactor_replace_transform_test.go
@@ -105,3 +105,34 @@ func TestCompactorReplaceValueTransformerNil(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, bytes.Equal([]byte("v1"), v1))
 }
+
+// TestCompactorReplaceValueTransformerError confirms a failing transformer
+// aborts the compaction without data loss: the original segments stay in place
+// (no half-written merged segment is swapped in) and their values are readable
+// and untransformed.
+func TestCompactorReplaceValueTransformerError(t *testing.T) {
+	transformer := func(value []byte) ([]byte, error) {
+		return nil, errors.New("boom")
+	}
+	bucket := newReplaceBucketForCompaction(t, transformer)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.Len(t, bucket.disk.segments, 2)
+
+	compacted, err := bucket.disk.compactOnce(context.Background())
+	require.Error(t, err)
+	require.False(t, compacted)
+
+	// Both original segments survive; nothing was swapped in.
+	require.Len(t, bucket.disk.segments, 2)
+
+	v1, err := bucket.Get([]byte("k1"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), v1)
+	v2, err := bucket.Get([]byte("k2"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v2"), v2)
+}

--- a/adapters/repos/db/lsmkv/compactor_replace_transform_test.go
+++ b/adapters/repos/db/lsmkv/compactor_replace_transform_test.go
@@ -1,0 +1,107 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func newReplaceBucketForCompaction(t *testing.T, transformer valueTransformer) *Bucket {
+	t.Helper()
+	ctx := context.Background()
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithForceCompaction(true))
+	require.NoError(t, err)
+	bucket.SetMemtableThreshold(1e9)
+	bucket.disk.valueTransformer = transformer
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+	return bucket
+}
+
+func compactAll(t *testing.T, bucket *Bucket) {
+	t.Helper()
+	compacted, err := bucket.disk.compactOnce(context.Background())
+	for ; err == nil && compacted; compacted, err = bucket.disk.compactOnce(context.Background()) {
+	}
+	require.NoError(t, err)
+}
+
+// TestCompactorReplaceValueTransformer verifies the compaction transformer hook:
+// live values are rewritten through the transformer, while tombstones (no
+// payload) bypass it.
+func TestCompactorReplaceValueTransformer(t *testing.T) {
+	// Prefixes every value it sees; errors if ever handed an empty payload so a
+	// tombstone leaking into the transformer would fail the compaction.
+	transformer := func(value []byte) ([]byte, error) {
+		if len(value) == 0 {
+			return nil, errors.New("transformer called with empty value")
+		}
+		return append([]byte("X:"), value...), nil
+	}
+
+	bucket := newReplaceBucketForCompaction(t, transformer)
+
+	// Segment 1.
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.Put([]byte("doomed"), []byte("v-doomed")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// Segment 2: a fresh key plus a tombstone for the key from segment 1.
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.Delete([]byte("doomed")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	compactAll(t, bucket)
+
+	// Live values were transformed exactly once.
+	v1, err := bucket.Get([]byte("k1"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("X:v1"), v1)
+
+	v2, err := bucket.Get([]byte("k2"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("X:v2"), v2)
+
+	// The tombstoned key stays deleted; the transformer never saw it (otherwise
+	// compaction would have failed on the empty payload).
+	deleted, err := bucket.Get([]byte("doomed"))
+	require.NoError(t, err)
+	require.Nil(t, deleted)
+}
+
+// TestCompactorReplaceValueTransformerNil confirms compaction is unaffected when
+// no transformer is set (the default).
+func TestCompactorReplaceValueTransformerNil(t *testing.T) {
+	bucket := newReplaceBucketForCompaction(t, nil)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	compactAll(t, bucket)
+
+	v1, err := bucket.Get([]byte("k1"))
+	require.NoError(t, err)
+	require.True(t, bytes.Equal([]byte("v1"), v1))
+}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -97,6 +97,12 @@ type SegmentGroup struct {
 	lastCleanupCall    time.Time
 	lastCompactionCall time.Time
 
+	// valueTransformer, when set, rewrites each non-tombstone value during
+	// replace-strategy compaction (e.g. to strip a dropped vector). Wiring it
+	// from active edit operations lands in a later step; for now it is nil
+	// unless set directly.
+	valueTransformer valueTransformer
+
 	roaringSetRangeSegmentInMemory *roaringsetrange.SegmentInMemory
 	bitmapBufPool                  roaringset.BitmapBufPool
 	bm25config                     *schema.BM25Config

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -381,7 +381,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 	case segmentindex.StrategyReplace:
 		c := newCompactorReplace(f, left.newReplaceCursorReusable(), right.newReplaceCursorReusable(),
 			level, secondaryIndices, cleanupTombstones,
-			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
+			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker, sg.valueTransformer)
 
 		aborted, err := runCompactor(c.do)
 		if err != nil {


### PR DESCRIPTION
## Motivation

Phase 2 of Drop Vector Index needs a way to physically strip a dropped vector out of stored objects without a separate rewrite pass — the natural place to do that work is during the compaction the LSM tree already performs. This step (S6) adds the seam: a per-`SegmentGroup` hook that lets an active edit operation rewrite each live value as replace-strategy segments are merged. Wiring this hook to real drop-vector edit operations comes in a later step; here it lands inert (nil by default, pass-through behavior unchanged).

Stacked on #11811 (S5: segment edit ops bolt facility). Review/merge S5 first.

## Approach

`compactorReplace` gains an optional `valueTransformer func([]byte) ([]byte, error)`. When set, `writeIndividualNode` runs each live value through it just before the value is written to the merged segment. The transform is deliberately scoped to the one place every surviving value already passes through during a replace compaction, so no extra scan or buffer copy is introduced.

Key decisions:
- **Tombstones bypass the transformer.** They carry no payload, so transforming them is meaningless and a transformer that assumes a non-empty value would otherwise choke. The guard is `!tombstone && len(value) > 0`.
- **The hook lives on `SegmentGroup`, not threaded through every call site.** `compactOnce` reads `sg.valueTransformer` and forwards it into the compactor — mirroring the existing `shouldSkipKey` pattern. This keeps the activation point single and lets the later wiring step set/clear it from the edit-ops facility without touching the compactor signature again. (For now it's a static field; the next step builds it per-pass from active edit ops.)
- **Contract: pure and idempotent.** Documented on the `valueTransformer` type. Compaction can run repeatedly over the same logical data, so a non-idempotent transform would corrupt values — the test deliberately checks each value is transformed exactly once across a multi-segment merge.

## Key areas for review

- `compactor_replace.go:writeIndividualNode` — the transform call site; verify the tombstone/empty-value guard and that the rewrite happens before key bytes are copied into arena memory (i.e. it doesn't interfere with the existing buffer-stability handling).
- `compactor_replace.go` (type + constructor) — the `valueTransformer` "pure, idempotent" contract comment.
- `segment_group_compaction.go` — `sg.valueTransformer` is forwarded only on the `StrategyReplace` branch (correct — this is a replace-only hook).

## Risks and mitigations

- **Transformer error aborts compaction**: a transform error is wrapped (`transform value: %w`) and propagated, aborting the merge rather than silently writing bad data. Compaction retries later; no partial segment is committed.
- **Tombstone leaking into the transform path**: guarded explicitly; the test's transformer errors on an empty value precisely so a leak would fail the test.
- **Behavior change for existing buckets**: none. The field is nil everywhere until the later wiring step sets it; the nil-path test confirms compaction output is unchanged.

## Testing

`compactor_replace_transform_test.go`, two cases over a real `Bucket` with forced compaction:
- **Transformer set**: two segments (live keys `k1`, `k2` plus a `doomed` key tombstoned in the second segment), then compact-to-completion. Asserts both live values are transformed exactly once (`v1`→`X:v1`, `v2`→`X:v2`) and that the tombstoned key stays deleted — the transformer errors on empty input, so a tombstone reaching it would have failed the compaction. Verified load-bearing: removing the hook makes this case fail (`X:v1` vs raw `v1`).
- **Transformer nil (default)**: confirms compaction output is unchanged when no hook is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
