### PR TITLE
feat(drop-vector-index): apply value transformer in segment cleaner

### DIFF
--- a/adapters/repos/db/lsmkv/segment_cleaner_replace.go
+++ b/adapters/repos/db/lsmkv/segment_cleaner_replace.go
@@ -31,11 +31,16 @@ type segmentCleanerReplace struct {
 	level                    uint16
 	secondaryIndexCount      uint16
 	enableChecksumValidation bool
+
+	// valueTransformer mirrors the compactor hook: when set, each non-tombstone
+	// value is rewritten before being written to the cleaned segment. nil means
+	// no active edit operation (values pass through untouched).
+	valueTransformer valueTransformer
 }
 
 func newSegmentCleanerReplace(w io.WriteSeeker, cursor innerCursorReplaceAllKeys,
 	keyExistsFn keyExistsOnUpperSegmentsFunc, level, secondaryIndexCount uint16,
-	enableChecksumValidation bool,
+	enableChecksumValidation bool, valueTransformer valueTransformer,
 ) *segmentCleanerReplace {
 	return &segmentCleanerReplace{
 		w:                        w,
@@ -46,6 +51,7 @@ func newSegmentCleanerReplace(w io.WriteSeeker, cursor innerCursorReplaceAllKeys
 		level:                    level,
 		secondaryIndexCount:      secondaryIndexCount,
 		enableChecksumValidation: enableChecksumValidation,
+		valueTransformer:         valueTransformer,
 	}
 }
 
@@ -128,6 +134,13 @@ func (p *segmentCleanerReplace) writeKeys(f *segmentindex.SegmentFile,
 		}
 		nodeCopy := node
 		nodeCopy.offset = offset
+		if p.valueTransformer != nil && !nodeCopy.tombstone && len(nodeCopy.value) > 0 {
+			transformed, terr := p.valueTransformer(nodeCopy.value)
+			if terr != nil {
+				return nil, fmt.Errorf("transform value: %w", terr)
+			}
+			nodeCopy.value = transformed
+		}
 		indexKey, err = nodeCopy.KeyIndexAndWriteTo(f.BodyWriter())
 		if err != nil {
 			break

--- a/adapters/repos/db/lsmkv/segment_cleaner_replace.go
+++ b/adapters/repos/db/lsmkv/segment_cleaner_replace.go
@@ -32,9 +32,9 @@ type segmentCleanerReplace struct {
 	secondaryIndexCount      uint16
 	enableChecksumValidation bool
 
-	// valueTransformer mirrors the compactor hook: when set, each non-tombstone
-	// value is rewritten before being written to the cleaned segment. nil means
-	// no active edit operation (values pass through untouched).
+	// valueTransformer, when set, rewrites each non-tombstone value before it is
+	// written to the cleaned segment (e.g. to strip a dropped vector). nil means
+	// no active edit operation, in which case values pass through untouched.
 	valueTransformer valueTransformer
 }
 

--- a/adapters/repos/db/lsmkv/segment_cleaner_replace_transform_test.go
+++ b/adapters/repos/db/lsmkv/segment_cleaner_replace_transform_test.go
@@ -1,0 +1,104 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func newReplaceBucketForCleanup(t *testing.T, transformer valueTransformer) *Bucket {
+	t.Helper()
+	ctx := context.Background()
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSegmentsCleanupInterval(time.Second))
+	require.NoError(t, err)
+	bucket.SetMemtableThreshold(1e9)
+	bucket.disk.valueTransformer = transformer
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+	return bucket
+}
+
+// TestSegmentCleanerReplaceValueTransformer verifies the cleaner mirrors the
+// compactor hook: a value that survives cleaning is rewritten through the
+// transformer, while a surviving tombstone bypasses it.
+func TestSegmentCleanerReplaceValueTransformer(t *testing.T) {
+	transformer := func(value []byte) ([]byte, error) {
+		if len(value) == 0 {
+			return nil, errors.New("transformer called with empty value")
+		}
+		return append([]byte("X:"), value...), nil
+	}
+
+	bucket := newReplaceBucketForCleanup(t, transformer)
+
+	// Segment 1 (oldest): a survivor, a tombstone, and a key shadowed by seg 2.
+	require.NoError(t, bucket.Put([]byte("keep"), []byte("v1")))
+	require.NoError(t, bucket.Delete([]byte("gone")))
+	require.NoError(t, bucket.Put([]byte("shadow"), []byte("old")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// Segment 2: shadows "shadow" so the cleaner has something to drop from seg 1.
+	require.NoError(t, bucket.Put([]byte("shadow"), []byte("new")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// Clean the oldest segment. Succeeds only if the tombstone never reached the
+	// transformer (it errors on empty input).
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+	require.NoError(t, err)
+	require.True(t, cleaned)
+
+	// The surviving live value was transformed exactly once.
+	keep, err := bucket.Get([]byte("keep"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("X:v1"), keep)
+
+	// The tombstone stayed a tombstone (not resurrected, not transformed).
+	gone, err := bucket.Get([]byte("gone"))
+	require.NoError(t, err)
+	require.Nil(t, gone)
+
+	// The shadowed key resolves to the newer, untouched segment.
+	shadow, err := bucket.Get([]byte("shadow"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), shadow)
+}
+
+// TestSegmentCleanerReplaceValueTransformerNil confirms cleaning is unaffected
+// when no transformer is set.
+func TestSegmentCleanerReplaceValueTransformerNil(t *testing.T) {
+	bucket := newReplaceBucketForCleanup(t, nil)
+
+	require.NoError(t, bucket.Put([]byte("keep"), []byte("v1")))
+	require.NoError(t, bucket.Put([]byte("shadow"), []byte("old")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("shadow"), []byte("new")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+	require.NoError(t, err)
+	require.True(t, cleaned)
+
+	keep, err := bucket.Get([]byte("keep"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), keep)
+}

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -507,7 +507,7 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 		case StrategyReplace:
 			c := newSegmentCleanerReplace(file, oldSegment.newCursor(),
 				c.sg.makeKeyExistsOnUpperSegments(segments, startIdx, lastIdx), oldSegment.getLevel(),
-				oldSegment.getSecondaryIndexCount(), c.sg.enableChecksumValidation)
+				oldSegment.getSecondaryIndexCount(), c.sg.enableChecksumValidation, c.sg.valueTransformer)
 			if err = c.do(shouldAbort); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
## Motivation

Phase 2 of Drop Vector Index physically strips a dropped vector out of stored objects by piggy-backing on maintenance work the LSM tree already does. S6 (#11812) added the transformer hook to the **compactor**. But compaction is not the only path that rewrites replace-strategy segments — the **segment cleaner** also rewrites a single segment in place to drop keys shadowed by newer segments. A dropped vector must be stripped on *both* paths, or a value would survive untransformed simply because it happened to be cleaned rather than compacted. S7 adds the matching hook to `segmentCleanerReplace`.

Stacked on #11812 (S6). Review/merge S6 first. As with S6, this lands inert: the hook is nil by default (pass-through), and the step that wires it to real drop-vector edit ops comes later.

## Approach

Same shape as the S6 compactor hook, deliberately so:
- `segmentCleanerReplace` gains an optional `valueTransformer`; the cleanup driver forwards `c.sg.valueTransformer` into the constructor on the `StrategyReplace` branch, mirroring how S6 forwards it during compaction.
- The transform runs in `writeKeys`, on `nodeCopy.value`, just before `KeyIndexAndWriteTo` — the single point every surviving value passes through during a clean, so no extra scan or buffer copy.
- Tombstones and empty values bypass the transformer (`!nodeCopy.tombstone && len(nodeCopy.value) > 0`), identical to the compactor guard.

The hook reuses the `valueTransformer` type and its pure/idempotent contract introduced in S6 — no new type, no new contract surface. (Both S6 and S7 currently read a static `sg.valueTransformer`; the next step builds it per-pass from active edit ops.)

## Key areas for review

- `segment_cleaner_replace.go:writeKeys` — the transform call site; verify the tombstone/empty guard and that the rewrite happens on `nodeCopy` before `KeyIndexAndWriteTo`, consistent with the existing offset handling.
- `segment_group_cleanup.go` — `c.sg.valueTransformer` forwarded only on the `StrategyReplace` branch.

## Risks and mitigations

- **Drift from the compactor path**: the two hooks must apply the same transform under the same guard, or a value gets stripped on one path and not the other. Mitigated by mirroring S6 exactly (same type, same guard expression, same call-site placement); the test asserts the cleaner produces the identical `X:`-prefixed result the S6 test expects from the compactor.
- **Transformer error corrupts a segment**: wrapped (`transform value: %w`) and propagated, aborting the clean before any segment is committed; cleanup retries later.
- **Tombstone resurrection / leaking into the transform**: guarded explicitly; the test's transformer errors on empty input, so a tombstone reaching it would fail the clean.
- **Behavior change for existing buckets**: none — nil everywhere until later wiring; the nil-path test confirms unchanged output.

## Testing

`segment_cleaner_replace_transform_test.go`, two cases driving a real `Bucket` and calling `cleanupOnce` directly:
- **Transformer set**: seg 1 holds a survivor (`keep`), a tombstone (`gone`), and a key (`shadow`) shadowed by seg 2; clean the oldest segment. Asserts `keep` is transformed exactly once (`v1`→`X:v1`), `gone` stays deleted (the transformer errors on empty input, so a tombstone reaching it would fail the clean), and `shadow` resolves to the newer untouched segment. Verified load-bearing: removing the hook makes this fail (`X:v1` vs raw `v1`).
- **Transformer nil (default)**: confirms clean output is unchanged when no hook is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
