### PR TITLE
hfresh: reduce task dedup memory

### DIFF
--- a/adapters/repos/db/vector/common/paged_bitset.go
+++ b/adapters/repos/db/vector/common/paged_bitset.go
@@ -137,18 +137,24 @@ func (b *PagedBitset) ensureReservedPage(pageID uint64) *pagedBitsetPage {
 			continue
 		}
 
-		b.mu.Lock()
-		cell := b.ensurePageCell(pageID)
-		page = cell.Load()
-		if page == nil {
-			page = &pagedBitsetPage{}
-			page.count.Store(1)
-			cell.Store(page)
-			b.live.Add(1)
-			b.mu.Unlock()
+		page, reserved := func() (*pagedBitsetPage, bool) {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+
+			cell := b.ensurePageCell(pageID)
+			page := cell.Load()
+			if page == nil {
+				var page pagedBitsetPage
+				page.count.Store(1)
+				cell.Store(&page)
+				b.live.Add(1)
+				return &page, true
+			}
+			return page, false
+		}()
+		if reserved || b.reserve(page) {
 			return page
 		}
-		b.mu.Unlock()
 	}
 }
 

--- a/adapters/repos/db/vector/common/paged_bitset.go
+++ b/adapters/repos/db/vector/common/paged_bitset.go
@@ -1,0 +1,214 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	pagedBitsetPageBits     = 16
+	pagedBitsetPageSize     = 1 << pagedBitsetPageBits
+	pagedBitsetPageMask     = pagedBitsetPageSize - 1
+	pagedBitsetWordBits     = 6
+	pagedBitsetWordSize     = 1 << pagedBitsetWordBits
+	pagedBitsetWordMask     = pagedBitsetWordSize - 1
+	pagedBitsetWordsPerPage = pagedBitsetPageSize / pagedBitsetWordSize
+
+	pagedBitsetCleanupBit = uint32(1 << 31)
+	pagedBitsetCountMask  = pagedBitsetCleanupBit - 1
+)
+
+// PagedBitset is a concurrent bitset optimized for dense, monotonic IDs.
+// Pages are allocated lazily and released when the last bit in a page is
+// deleted. Each page covers 64K IDs and costs 8KiB while live.
+type PagedBitset struct {
+	pages []atomic.Pointer[pagedBitsetPage]
+	live  atomic.Uint64
+
+	// mu protects page allocation. Reads, bit operations, and page deletion use
+	// atomics and do not take this lock.
+	mu sync.Mutex
+}
+
+type pagedBitsetPage struct {
+	count atomic.Uint32
+	words [pagedBitsetWordsPerPage]atomic.Uint64
+}
+
+// NewPagedBitset creates a PagedBitset that can address maxPages*64K IDs.
+func NewPagedBitset(maxPages uint64) *PagedBitset {
+	return &PagedBitset{
+		pages: make([]atomic.Pointer[pagedBitsetPage], maxPages),
+	}
+}
+
+// TryAdd sets id if it is not already present.
+// It returns true if id was added, and false if it was already present.
+func (b *PagedBitset) TryAdd(id uint64) bool {
+	pageID, wordID, mask := pagedBitsetLocation(id)
+	page := b.ensureReservedPage(pageID)
+
+	for {
+		old := page.words[wordID].Load()
+		if old&mask != 0 {
+			b.release(pageID, page, 1)
+			return false
+		}
+		if page.words[wordID].CompareAndSwap(old, old|mask) {
+			return true
+		}
+	}
+}
+
+// Delete clears id if present.
+// It returns true if id was present and cleared.
+func (b *PagedBitset) Delete(id uint64) bool {
+	pageID, wordID, mask := pagedBitsetLocation(id)
+	page := b.reserveExistingPage(pageID)
+	if page == nil {
+		return false
+	}
+
+	for {
+		old := page.words[wordID].Load()
+		if old&mask == 0 {
+			b.release(pageID, page, 1)
+			return false
+		}
+		if page.words[wordID].CompareAndSwap(old, old&^mask) {
+			if b.release(pageID, page, 2) == 0 {
+				b.cleanupPage(pageID, page)
+			}
+			return true
+		}
+	}
+}
+
+// Contains returns true if id is currently present.
+func (b *PagedBitset) Contains(id uint64) bool {
+	pageID, wordID, mask := pagedBitsetLocation(id)
+	page := b.reserveExistingPage(pageID)
+	if page == nil {
+		return false
+	}
+
+	exists := page.words[wordID].Load()&mask != 0
+	if b.release(pageID, page, 1) == 0 {
+		b.cleanupPage(pageID, page)
+	}
+	return exists
+}
+
+// LivePages returns the number of currently allocated bitset pages.
+func (b *PagedBitset) LivePages() uint64 {
+	return b.live.Load()
+}
+
+func (b *PagedBitset) ensureReservedPage(pageID uint64) *pagedBitsetPage {
+	for {
+		page := b.page(pageID)
+		if page != nil {
+			if b.reserve(page) {
+				return page
+			}
+			continue
+		}
+
+		b.mu.Lock()
+		page = b.page(pageID)
+		if page == nil {
+			page = &pagedBitsetPage{}
+			page.count.Store(1)
+			b.pageCell(pageID).Store(page)
+			b.live.Add(1)
+			b.mu.Unlock()
+			return page
+		}
+		b.mu.Unlock()
+	}
+}
+
+func (b *PagedBitset) reserveExistingPage(pageID uint64) *pagedBitsetPage {
+	for {
+		page := b.page(pageID)
+		if page == nil {
+			return nil
+		}
+		if b.reserve(page) {
+			return page
+		}
+	}
+}
+
+func (b *PagedBitset) reserve(page *pagedBitsetPage) bool {
+	for {
+		current := page.count.Load()
+		if current&pagedBitsetCleanupBit != 0 {
+			runtime.Gosched()
+			return false
+		}
+		if current&pagedBitsetCountMask == pagedBitsetCountMask {
+			panic("paged bitset page count overflow")
+		}
+		if page.count.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+func (b *PagedBitset) release(pageID uint64, page *pagedBitsetPage, n uint32) uint32 {
+	for {
+		current := page.count.Load()
+		if current&pagedBitsetCleanupBit != 0 || current&pagedBitsetCountMask < n {
+			panic("paged bitset page count underflow")
+		}
+		next := current - n
+		if page.count.CompareAndSwap(current, next) {
+			return next
+		}
+	}
+}
+
+func (b *PagedBitset) cleanupPage(pageID uint64, page *pagedBitsetPage) {
+	if !page.count.CompareAndSwap(0, pagedBitsetCleanupBit) {
+		return
+	}
+
+	if b.pageCell(pageID).CompareAndSwap(page, nil) {
+		b.live.Add(^uint64(0))
+		return
+	}
+
+	page.count.Store(0)
+}
+
+func (b *PagedBitset) page(pageID uint64) *pagedBitsetPage {
+	return b.pageCell(pageID).Load()
+}
+
+func (b *PagedBitset) pageCell(pageID uint64) *atomic.Pointer[pagedBitsetPage] {
+	if pageID >= uint64(len(b.pages)) {
+		panic("paged bitset capacity exceeded")
+	}
+	return &b.pages[pageID]
+}
+
+func pagedBitsetLocation(id uint64) (pageID uint64, wordID uint64, mask uint64) {
+	pageID = id >> pagedBitsetPageBits
+	localID := id & pagedBitsetPageMask
+	wordID = localID >> pagedBitsetWordBits
+	mask = uint64(1) << (localID & pagedBitsetWordMask)
+	return pageID, wordID, mask
+}

--- a/adapters/repos/db/vector/common/paged_bitset.go
+++ b/adapters/repos/db/vector/common/paged_bitset.go
@@ -18,6 +18,10 @@ import (
 )
 
 const (
+	pagedBitsetPagesPerGroup     = 128
+	pagedBitsetPagesPerGroupBits = 7
+	pagedBitsetPagesPerGroupMask = pagedBitsetPagesPerGroup - 1
+
 	pagedBitsetPageBits     = 16
 	pagedBitsetPageSize     = 1 << pagedBitsetPageBits
 	pagedBitsetPageMask     = pagedBitsetPageSize - 1
@@ -34,12 +38,17 @@ const (
 // Pages are allocated lazily and released when the last bit in a page is
 // deleted. Each page covers 64K IDs and costs 8KiB while live.
 type PagedBitset struct {
-	pages []atomic.Pointer[pagedBitsetPage]
-	live  atomic.Uint64
+	maxPages uint64
+	groups   []atomic.Pointer[pagedBitsetGroup]
+	live     atomic.Uint64
 
-	// mu protects page allocation. Reads, bit operations, and page deletion use
-	// atomics and do not take this lock.
+	// mu protects group and page allocation. Reads, bit operations, and page
+	// deletion use atomics and do not take this lock.
 	mu sync.Mutex
+}
+
+type pagedBitsetGroup struct {
+	pages [pagedBitsetPagesPerGroup]atomic.Pointer[pagedBitsetPage]
 }
 
 type pagedBitsetPage struct {
@@ -49,8 +58,10 @@ type pagedBitsetPage struct {
 
 // NewPagedBitset creates a PagedBitset that can address maxPages*64K IDs.
 func NewPagedBitset(maxPages uint64) *PagedBitset {
+	groupCount := (maxPages + pagedBitsetPagesPerGroup - 1) >> pagedBitsetPagesPerGroupBits
 	return &PagedBitset{
-		pages: make([]atomic.Pointer[pagedBitsetPage], maxPages),
+		maxPages: maxPages,
+		groups:   make([]atomic.Pointer[pagedBitsetGroup], groupCount),
 	}
 }
 
@@ -127,11 +138,12 @@ func (b *PagedBitset) ensureReservedPage(pageID uint64) *pagedBitsetPage {
 		}
 
 		b.mu.Lock()
-		page = b.page(pageID)
+		cell := b.ensurePageCell(pageID)
+		page = cell.Load()
 		if page == nil {
 			page = &pagedBitsetPage{}
 			page.count.Store(1)
-			b.pageCell(pageID).Store(page)
+			cell.Store(page)
 			b.live.Add(1)
 			b.mu.Unlock()
 			return page
@@ -186,7 +198,8 @@ func (b *PagedBitset) cleanupPage(pageID uint64, page *pagedBitsetPage) {
 		return
 	}
 
-	if b.pageCell(pageID).CompareAndSwap(page, nil) {
+	cell := b.pageCell(pageID)
+	if cell != nil && cell.CompareAndSwap(page, nil) {
 		b.live.Add(^uint64(0))
 		return
 	}
@@ -195,14 +208,40 @@ func (b *PagedBitset) cleanupPage(pageID uint64, page *pagedBitsetPage) {
 }
 
 func (b *PagedBitset) page(pageID uint64) *pagedBitsetPage {
-	return b.pageCell(pageID).Load()
+	cell := b.pageCell(pageID)
+	if cell == nil {
+		return nil
+	}
+	return cell.Load()
 }
 
 func (b *PagedBitset) pageCell(pageID uint64) *atomic.Pointer[pagedBitsetPage] {
-	if pageID >= uint64(len(b.pages)) {
+	if pageID >= b.maxPages {
 		panic("paged bitset capacity exceeded")
 	}
-	return &b.pages[pageID]
+
+	groupID := pageID >> pagedBitsetPagesPerGroupBits
+	group := b.groups[groupID].Load()
+	if group == nil {
+		return nil
+	}
+
+	return &group.pages[pageID&pagedBitsetPagesPerGroupMask]
+}
+
+func (b *PagedBitset) ensurePageCell(pageID uint64) *atomic.Pointer[pagedBitsetPage] {
+	if pageID >= b.maxPages {
+		panic("paged bitset capacity exceeded")
+	}
+
+	groupID := pageID >> pagedBitsetPagesPerGroupBits
+	group := b.groups[groupID].Load()
+	if group == nil {
+		group = &pagedBitsetGroup{}
+		b.groups[groupID].Store(group)
+	}
+
+	return &group.pages[pageID&pagedBitsetPagesPerGroupMask]
 }
 
 func pagedBitsetLocation(id uint64) (pageID uint64, wordID uint64, mask uint64) {

--- a/adapters/repos/db/vector/common/paged_bitset_test.go
+++ b/adapters/repos/db/vector/common/paged_bitset_test.go
@@ -86,6 +86,24 @@ func TestPagedBitsetReleasesOnlyEmptyPage(t *testing.T) {
 	}
 }
 
+func TestPagedBitsetSupportsHighIDs(t *testing.T) {
+	bs := NewPagedBitset(1 << 16)
+	id := uint64(1 << 30)
+
+	if !bs.TryAdd(id) {
+		t.Fatal("expected high ID add to return true")
+	}
+	if !bs.Contains(id) {
+		t.Fatal("expected high ID to be present")
+	}
+	if !bs.Delete(id) {
+		t.Fatal("expected high ID delete to return true")
+	}
+	if bs.LivePages() != 0 {
+		t.Fatalf("expected high ID page to be released, got %d live pages", bs.LivePages())
+	}
+}
+
 func TestPagedBitsetConcurrentDenseAddDelete(t *testing.T) {
 	bs := NewPagedBitset(64)
 

--- a/adapters/repos/db/vector/common/paged_bitset_test.go
+++ b/adapters/repos/db/vector/common/paged_bitset_test.go
@@ -1,0 +1,135 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestPagedBitset(t *testing.T) {
+	bs := NewPagedBitset(16)
+
+	if !bs.TryAdd(42) {
+		t.Fatal("expected first add to return true")
+	}
+	if !bs.Contains(42) {
+		t.Fatal("expected added ID to be present")
+	}
+	if bs.TryAdd(42) {
+		t.Fatal("expected duplicate add to return false")
+	}
+	if bs.LivePages() != 1 {
+		t.Fatalf("expected 1 live page, got %d", bs.LivePages())
+	}
+
+	if !bs.Delete(42) {
+		t.Fatal("expected delete to remove present ID")
+	}
+	if bs.Contains(42) {
+		t.Fatal("expected removed ID to be absent")
+	}
+	if bs.Delete(42) {
+		t.Fatal("expected delete on absent ID to return false")
+	}
+	if bs.LivePages() != 0 {
+		t.Fatalf("expected page to be released, got %d live pages", bs.LivePages())
+	}
+
+	if !bs.TryAdd(42) {
+		t.Fatal("expected re-add after page deletion to return true")
+	}
+	if !bs.Contains(42) {
+		t.Fatal("expected re-added ID to be present")
+	}
+}
+
+func TestPagedBitsetReleasesOnlyEmptyPage(t *testing.T) {
+	bs := NewPagedBitset(16)
+
+	firstPageID := uint64(1)
+	first := firstPageID << pagedBitsetPageBits
+	second := first + 1
+	otherPage := uint64(2) << pagedBitsetPageBits
+
+	if !bs.TryAdd(first) || !bs.TryAdd(second) || !bs.TryAdd(otherPage) {
+		t.Fatal("expected all first adds to return true")
+	}
+	if bs.LivePages() != 2 {
+		t.Fatalf("expected 2 live pages, got %d", bs.LivePages())
+	}
+
+	if !bs.Delete(first) {
+		t.Fatal("expected first ID to be removed")
+	}
+	if bs.LivePages() != 2 {
+		t.Fatalf("expected page to remain live, got %d live pages", bs.LivePages())
+	}
+
+	if !bs.Delete(second) {
+		t.Fatal("expected second ID to be removed")
+	}
+	if bs.LivePages() != 1 {
+		t.Fatalf("expected empty page to be released, got %d live pages", bs.LivePages())
+	}
+	if !bs.Contains(otherPage) {
+		t.Fatal("expected other page ID to remain present")
+	}
+}
+
+func TestPagedBitsetConcurrentDenseAddDelete(t *testing.T) {
+	bs := NewPagedBitset(64)
+
+	const prefill = 1_000_000
+	const inserts = 1_000_000
+	const deletes = 500_000
+	const workers = 16
+
+	for id := uint64(0); id < prefill; id++ {
+		if !bs.TryAdd(id) {
+			t.Fatalf("expected prefill add %d to return true", id)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(workers * 2)
+
+	for workerID := 0; workerID < workers; workerID++ {
+		workerID := workerID
+		go func() {
+			defer wg.Done()
+			for n := uint64(workerID); n < inserts; n += workers {
+				bs.TryAdd(prefill + n)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for id := uint64(workerID); id < deletes; id += workers {
+				bs.Delete(id)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	for id := uint64(0); id < deletes; id++ {
+		if bs.Contains(id) {
+			t.Fatalf("expected deleted ID %d to be absent", id)
+		}
+	}
+	for id := uint64(deletes); id < prefill+inserts; id++ {
+		if !bs.Contains(id) {
+			t.Fatalf("expected ID %d to be present", id)
+		}
+	}
+}

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -34,8 +34,6 @@ const (
 	DefaultRNGFactor = 10.0
 )
 
-const deduplicatorMaxPages = 16 * 1024 // 1 billion IDs with 64K IDs per page
-
 var (
 	ErrPostingNotFound = errors.New("posting not found")
 	ErrVectorNotFound  = errors.New("vector not found")
@@ -397,31 +395,4 @@ func (h *HFresh) CompressionStats() compressionhelpers.CompressionStats {
 
 func (h *HFresh) Preload(id uint64, vector []float32) {
 	// for now, nothing to do here
-}
-
-// deduplicator is a simple thread-safe structure to prevent duplicate values.
-type deduplicator struct {
-	bitset *common.PagedBitset
-}
-
-func newDeduplicator() *deduplicator {
-	return &deduplicator{
-		bitset: common.NewPagedBitset(deduplicatorMaxPages),
-	}
-}
-
-// tryAdd attempts to add an ID to the deduplicator.
-// Returns true if the ID was added, false if it already exists.
-func (d *deduplicator) tryAdd(id uint64) bool {
-	return d.bitset.TryAdd(id)
-}
-
-// done marks an ID as processed, removing it from the deduplicator.
-func (d *deduplicator) done(id uint64) {
-	d.bitset.Delete(id)
-}
-
-// contains checks if an ID is already in the deduplicator.
-func (d *deduplicator) contains(id uint64) bool {
-	return d.bitset.Contains(id)
 }

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
@@ -34,6 +33,8 @@ import (
 const (
 	DefaultRNGFactor = 10.0
 )
+
+const deduplicatorMaxPages = 16 * 1024 // 1 billion IDs with 64K IDs per page
 
 var (
 	ErrPostingNotFound = errors.New("posting not found")
@@ -400,29 +401,27 @@ func (h *HFresh) Preload(id uint64, vector []float32) {
 
 // deduplicator is a simple thread-safe structure to prevent duplicate values.
 type deduplicator struct {
-	m *xsync.Map[uint64, struct{}]
+	bitset *common.PagedBitset
 }
 
 func newDeduplicator() *deduplicator {
 	return &deduplicator{
-		m: xsync.NewMap[uint64, struct{}](),
+		bitset: common.NewPagedBitset(deduplicatorMaxPages),
 	}
 }
 
 // tryAdd attempts to add an ID to the deduplicator.
 // Returns true if the ID was added, false if it already exists.
 func (d *deduplicator) tryAdd(id uint64) bool {
-	_, loaded := d.m.LoadOrStore(id, struct{}{})
-	return !loaded
+	return d.bitset.TryAdd(id)
 }
 
 // done marks an ID as processed, removing it from the deduplicator.
 func (d *deduplicator) done(id uint64) {
-	d.m.Delete(id)
+	d.bitset.Delete(id)
 }
 
 // contains checks if an ID is already in the deduplicator.
 func (d *deduplicator) contains(id uint64) bool {
-	_, exists := d.m.Load(id)
-	return exists
+	return d.bitset.Contains(id)
 }

--- a/adapters/repos/db/vector/hfresh/reassign_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_test.go
@@ -69,7 +69,7 @@ func TestReassignVectorNotFound(t *testing.T) {
 }
 
 // Basic in-memory deduplicator functionality
-func TestReassignDeduplicatorBasic(t *testing.T) {
+func TestReassignTaskQueueDedupBasic(t *testing.T) {
 	tf := createHFreshIndex(t)
 
 	dedup := tf.Index.taskQueue.reassignList
@@ -85,7 +85,7 @@ func TestReassignDeduplicatorBasic(t *testing.T) {
 }
 
 // Done removes entry
-func TestReassignDeduplicatorDone(t *testing.T) {
+func TestReassignTaskQueueDedupDone(t *testing.T) {
 	tf := createHFreshIndex(t)
 
 	dedup := tf.Index.taskQueue.reassignList
@@ -99,7 +99,7 @@ func TestReassignDeduplicatorDone(t *testing.T) {
 	require.True(t, added, "should be able to add again after done")
 }
 
-func TestReassignDeduplicatorDoesNotPersistOnClose(t *testing.T) {
+func TestReassignTaskQueueDedupDoesNotPersistOnClose(t *testing.T) {
 	tf := createHFreshIndex(t)
 
 	err := tf.Index.taskQueue.EnqueueReassign(1, 300)

--- a/adapters/repos/db/vector/hfresh/reassign_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_test.go
@@ -29,7 +29,7 @@ func TestReassignDeletedVector(t *testing.T) {
 
 	_, err := tf.Index.VersionMap.MarkDeleted(t.Context(), vectorID)
 	require.NoError(t, err)
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(vectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(vectorID))
 
 	op := reassignOperation{
 		PostingID: 1,
@@ -42,7 +42,7 @@ func TestReassignDeletedVector(t *testing.T) {
 	deleted, err := tf.Index.VersionMap.IsDeleted(t.Context(), vectorID)
 	require.NoError(t, err)
 	require.True(t, deleted)
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(vectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(vectorID))
 }
 
 // Reassign a vector that doesn't exist
@@ -61,11 +61,11 @@ func TestReassignVectorNotFound(t *testing.T) {
 		VectorID:  9999,
 	}
 
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(op.VectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(op.VectorID))
 	err := tf.Index.doReassign(t.Context(), op)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to get vector by index ID")
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(op.VectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(op.VectorID))
 }
 
 // Basic in-memory deduplicator functionality
@@ -74,13 +74,13 @@ func TestReassignDeduplicatorBasic(t *testing.T) {
 
 	dedup := tf.Index.taskQueue.reassignList
 
-	added := dedup.tryAdd(100)
+	added := dedup.TryAdd(100)
 	require.True(t, added, "first add should succeed")
 
-	added = dedup.tryAdd(100)
+	added = dedup.TryAdd(100)
 	require.False(t, added, "duplicate add should fail")
 
-	added = dedup.tryAdd(100)
+	added = dedup.TryAdd(100)
 	require.False(t, added, "update should fail (already exists)")
 }
 
@@ -90,12 +90,12 @@ func TestReassignDeduplicatorDone(t *testing.T) {
 
 	dedup := tf.Index.taskQueue.reassignList
 
-	added := dedup.tryAdd(200)
+	added := dedup.TryAdd(200)
 	require.True(t, added)
 
-	dedup.done(200)
+	dedup.Delete(200)
 
-	added = dedup.tryAdd(200)
+	added = dedup.TryAdd(200)
 	require.True(t, added, "should be able to add again after done")
 }
 
@@ -123,7 +123,7 @@ func TestReassignEnqueuePushFailureClearsDedup(t *testing.T) {
 	err = tf.Index.taskQueue.EnqueueReassign(1, vectorID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to push reassign operation to queue")
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(vectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(vectorID))
 }
 
 // Reassign a vector whose version was concurrently changed should be skipped
@@ -153,10 +153,10 @@ func TestReassignConcurrentVersionChange(t *testing.T) {
 		VectorID:  vectorID,
 	}
 
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(vectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(vectorID))
 	err := tf.Index.doReassign(t.Context(), op)
 	require.NoError(t, err)
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(vectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(vectorID))
 }
 
 func TestReassignReenqueuesWhenSelectedPostingDisappears(t *testing.T) {
@@ -173,7 +173,7 @@ func TestReassignReenqueuesWhenSelectedPostingDisappears(t *testing.T) {
 	replicas := NewResultSet(1)
 	replicas.data = append(replicas.data, Result{ID: missingPostingID})
 
-	require.True(t, tf.Index.taskQueue.reassignList.tryAdd(vectorID))
+	require.True(t, tf.Index.taskQueue.reassignList.TryAdd(vectorID))
 
 	requeued, err := tf.Index.appendReassignReplicas(
 		t.Context(),
@@ -183,7 +183,7 @@ func TestReassignReenqueuesWhenSelectedPostingDisappears(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, requeued)
 	require.Equal(t, int64(1), tf.Index.taskQueue.reassignQueue.Size())
-	require.False(t, tf.Index.taskQueue.reassignList.tryAdd(vectorID))
+	require.False(t, tf.Index.taskQueue.reassignList.TryAdd(vectorID))
 }
 
 // Reassign properly manages task queue

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -39,7 +39,7 @@ const (
 	splitTaskQueueChunkSize    = 16 * 1024 // 16KB
 	reassignTaskQueueChunkSize = 16 * 1024 // 16KB
 	mergeTaskQueueChunkSize    = 16 * 1024 // 16KB
-	taskDeduplicatorMaxPages   = 16 * 1024 // 1 billion IDs with 64K IDs per page
+	taskDeduplicatorMaxPages   = 1 << 16   // Supports IDs < 1<<32 with 64K IDs per page
 )
 
 type TaskQueue struct {

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 )
 
 const (
@@ -38,6 +39,7 @@ const (
 	splitTaskQueueChunkSize    = 16 * 1024 // 16KB
 	reassignTaskQueueChunkSize = 16 * 1024 // 16KB
 	mergeTaskQueueChunkSize    = 16 * 1024 // 16KB
+	taskDeduplicatorMaxPages   = 16 * 1024 // 1 billion IDs with 64K IDs per page
 )
 
 type TaskQueue struct {
@@ -53,10 +55,10 @@ type TaskQueue struct {
 	scheduler *queue.Scheduler
 
 	index        *HFresh
-	analyzeList  *deduplicator // Prevents duplicate analyze operations
-	splitList    *deduplicator // Prevents duplicate split operations
-	mergeList    *deduplicator // Prevents duplicate merge operations
-	reassignList *deduplicator // Prevents duplicate reassign operations
+	analyzeList  *common.PagedBitset // Prevents duplicate analyze operations
+	splitList    *common.PagedBitset // Prevents duplicate split operations
+	mergeList    *common.PagedBitset // Prevents duplicate merge operations
+	reassignList *common.PagedBitset // Prevents duplicate reassign operations
 }
 
 func NewTaskQueue(index *HFresh, _ *lsmkv.Bucket) (*TaskQueue, error) {
@@ -65,10 +67,10 @@ func NewTaskQueue(index *HFresh, _ *lsmkv.Bucket) (*TaskQueue, error) {
 	tq := TaskQueue{
 		index:        index,
 		scheduler:    index.scheduler,
-		analyzeList:  newDeduplicator(),
-		splitList:    newDeduplicator(),
-		mergeList:    newDeduplicator(),
-		reassignList: newDeduplicator(),
+		analyzeList:  common.NewPagedBitset(taskDeduplicatorMaxPages),
+		splitList:    common.NewPagedBitset(taskDeduplicatorMaxPages),
+		mergeList:    common.NewPagedBitset(taskDeduplicatorMaxPages),
+		reassignList: common.NewPagedBitset(taskDeduplicatorMaxPages),
 	}
 
 	// create queue for analyze operations
@@ -215,28 +217,28 @@ func (tq *TaskQueue) Size() int64 {
 }
 
 func (tq *TaskQueue) AnalyzeDone(postingID uint64) {
-	tq.analyzeList.done(postingID)
+	tq.analyzeList.Delete(postingID)
 }
 
 func (tq *TaskQueue) SplitDone(postingID uint64) {
-	tq.splitList.done(postingID)
+	tq.splitList.Delete(postingID)
 }
 
 func (tq *TaskQueue) MergeDone(postingID uint64) {
-	tq.mergeList.done(postingID)
+	tq.mergeList.Delete(postingID)
 }
 
 func (tq *TaskQueue) ReassignDone(vectorID uint64) {
-	tq.reassignList.done(vectorID)
+	tq.reassignList.Delete(vectorID)
 }
 
 func (tq *TaskQueue) MergeContains(postingID uint64) bool {
-	return tq.mergeList.contains(postingID)
+	return tq.mergeList.Contains(postingID)
 }
 
 func (tq *TaskQueue) EnqueueAnalyze(postingID uint64) error {
 	// Check if the operation is already enqueued
-	if !tq.analyzeList.tryAdd(postingID) {
+	if !tq.analyzeList.TryAdd(postingID) {
 		return nil
 	}
 
@@ -250,7 +252,7 @@ func (tq *TaskQueue) EnqueueAnalyze(postingID uint64) error {
 
 func (tq *TaskQueue) EnqueueSplit(postingID uint64) error {
 	// Check if the operation is already enqueued
-	if !tq.splitList.tryAdd(postingID) {
+	if !tq.splitList.TryAdd(postingID) {
 		return nil
 	}
 
@@ -265,7 +267,7 @@ func (tq *TaskQueue) EnqueueSplit(postingID uint64) error {
 
 func (tq *TaskQueue) EnqueueMerge(postingID uint64) error {
 	// Check if the operation is already enqueued
-	if !tq.mergeList.tryAdd(postingID) {
+	if !tq.mergeList.TryAdd(postingID) {
 		return nil
 	}
 
@@ -280,12 +282,12 @@ func (tq *TaskQueue) EnqueueMerge(postingID uint64) error {
 
 func (tq *TaskQueue) EnqueueReassign(postingID uint64, vecID uint64) error {
 	// Check if the operation is already enqueued
-	if !tq.reassignList.tryAdd(vecID) {
+	if !tq.reassignList.TryAdd(vecID) {
 		return nil
 	}
 
 	if err := tq.reassignQueue.Push(encodeReassignTask(vecID, postingID)); err != nil {
-		tq.reassignList.done(vecID)
+		tq.reassignList.Delete(vecID)
 		return errors.Wrap(err, "failed to push reassign operation to queue")
 	}
 


### PR DESCRIPTION
### What's being changed:

This PR replaces HFresh task queue deduplication from `xsync.Map[uint64, struct{}]` to a new `common.PagedBitset`.

The new helper is a concurrent, lazily allocated bitset for dense monotonic IDs:

- allocates a tiny grouped top-level directory up front
- allocates 8 KiB bit pages only when IDs in that page are touched
- releases bit pages synchronously when the last bit in the page is deleted
- supports IDs `< 1<<32` for HFresh task dedup without forcing small indexes to reserve memory for the full range

HFresh now uses the bitset directly for `analyzeList`, `splitList`, `mergeList`, and `reassignList`.

Memory impact from local controlled benchmark, 1M IDs:

| implementation | heap after fill | heap after drain | fill time |
| --- | ---: | ---: | ---: |
| `xsync.Map[uint64, struct{}]` | 47.98 MiB | 0.038 MiB | 227.3 ms |
| `common.PagedBitset` | 0.150 MiB | 0.0058 MiB | 14.3 ms |

That is about 319x less heap at 1M pending IDs. At ~227M pending reassignment IDs, this implies the dedup structure moves from roughly multi-GB / ~10 GiB scale with `xsync.Map` to tens of MiB with the paged bitset (~27 MiB raw bit pages, plus small directory/group overhead).

Performance notes from the same local benchmark:

- Duplicate-heavy enqueue is faster:
  - all duplicates: `26.45 ns/op` -> `7.78 ns/op`
  - 90% duplicates: `40.41 ns/op` -> `6.89 ns/op`
- Mixed concurrent add/delete is slower:
  - add 1M + delete 500k: `76.52 ns/op` -> `219.8 ns/op`
  - add 1M + duplicate 1M + delete 500k: `71.33 ns/op` -> `150.0 ns/op`

The motivation for this change is the large HFresh import case where the reassign dedup map can hold hundreds of millions of dense vector IDs. In that workload, the memory reduction is the primary win.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary, internal helper / HFresh implementation detail.
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary, scoped in-memory structure change covered by package and race tests.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

Tests run:

```bash
rtk go test ./adapters/repos/db/vector/common
rtk go test ./adapters/repos/db/vector/hfresh
rtk go test -race ./adapters/repos/db/vector/common ./adapters/repos/db/vector/hfresh
```

Performance benchmark command shape:

```bash
rtk go test ./adapters/repos/db/vector/common -run '^$' -bench 'BenchmarkHFreshDedup...' -benchmem
```

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
