### PR TITLE
fix(hnsw): stop dropping nodes at snapshot block boundaries

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -918,11 +918,15 @@ func (l *hnswCommitLogger) writeStateTo(state *DeserializationResult, wr io.Writ
 		hasher.Reset()
 		hw = io.MultiWriter(&block, hasher)
 
-		// write next node index at the start of the new block
-		if i+1 < len(state.Nodes) {
-			if err := writeUint64(hw, uint64(i+1)); err != nil {
-				return err
-			}
+		// the current node did not fit the previous block, so it begins the new
+		// one: write its id as the block's start index, then the node entry
+		// itself. (Previously the start index was written as i+1 and the entry
+		// was never written, silently dropping one node per block boundary.)
+		if err := writeUint64(hw, uint64(i)); err != nil {
+			return err
+		}
+		if _, err := hw.Write(buf.Bytes()); err != nil {
+			return err
 		}
 	}
 

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -849,28 +849,29 @@ func (l *hnswCommitLogger) writeStateTo(state *DeserializationResult, wr io.Writ
 			_, tombstoneIsCleaned := state.TombstonesDeleted[n.id]
 
 			if hasATombstone && tombstoneIsCleaned {
-				// if the node has been deleted but its tombstone has been cleaned up
-				// we can write a nil node
+				// the node has been deleted and its tombstone already cleaned up:
+				// persist it as a nil slot so the on-disk slot index stays aligned
+				// with node ids. (Previously this `continue`d without appending the
+				// byte to the block, shifting every later node in the block.)
 				if err := writeByte(&buf, 0); err != nil {
 					return err
 				}
-				continue
-			}
-
-			if hasATombstone {
-				_ = writeByte(&buf, 1)
 			} else {
-				_ = writeByte(&buf, 2)
-			}
+				if hasATombstone {
+					_ = writeByte(&buf, 1)
+				} else {
+					_ = writeByte(&buf, 2)
+				}
 
-			_ = writeUint32(&buf, uint32(n.level))
+				_ = writeUint32(&buf, uint32(n.level))
 
-			connData := n.connections.Data()
-			_ = writeUint32(&buf, uint32(len(connData)))
+				connData := n.connections.Data()
+				_ = writeUint32(&buf, uint32(len(connData)))
 
-			_, err = buf.Write(connData)
-			if err != nil {
-				return errors.Wrapf(err, "write connections data for node %d", n.id)
+				_, err = buf.Write(connData)
+				if err != nil {
+					return errors.Wrapf(err, "write connections data for node %d", n.id)
+				}
 			}
 		} else {
 			// nil node

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -880,6 +880,14 @@ func (l *hnswCommitLogger) writeStateTo(state *DeserializationResult, wr io.Writ
 			}
 		}
 
+		// a single node entry must fit within an otherwise-empty block (which
+		// already carries an 8-byte start-index header); otherwise no valid
+		// fixed-size block can hold it. Fail loudly rather than emit a malformed
+		// (oversized) block or panic on negative padding.
+		if buf.Len()+8 > maxBlockSize {
+			return fmt.Errorf("node %d entry of %d bytes exceeds block capacity %d", i, buf.Len(), maxBlockSize-8)
+		}
+
 		// add node data to block if there's enough space, otherwise create a new block
 		if buf.Len()+block.Len() < maxBlockSize {
 			_, err := hw.Write(buf.Bytes())

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1460,6 +1460,31 @@ func TestSnapshotMultiBlockNodeLossRepro(t *testing.T) {
 		"(one per 4KB block boundary): %v", missing)
 }
 
+// TestSnapshotOversizedNodeReturnsError ensures a single node entry that cannot
+// fit in one block fails loudly instead of panicking (negative pad math) or
+// being silently dropped. Uses a tiny block size to make one node oversized.
+func TestSnapshotOversizedNodeReturnsError(t *testing.T) {
+	c, err := packedconn.NewWithMaxLayer(2)
+	require.Nil(t, err)
+	c.ReplaceLayer(0, connsSlice1)
+
+	state := &DeserializationResult{
+		Entrypoint: 0,
+		Level:      0,
+		Nodes:      []*vertex{{id: 0, level: 0, connections: c}},
+		Tombstones: make(map[uint64]struct{}),
+	}
+
+	dir := t.TempDir()
+	id := "test"
+	cl := createTestCommitLoggerForSnapshots(t, dir, id)
+	cl.snapshotBlockSize = 64 // force the single node to exceed one block
+
+	snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+	err = cl.writeSnapshot(state, snapshotPath)
+	require.Error(t, err, "a node larger than a block must be rejected, not dropped/panic")
+}
+
 // TestSnapshotCleanedTombstoneKeepsSlotAlignment covers the sibling drop: a node
 // that was deleted with its tombstone already cleaned up must be persisted as a
 // nil slot. The buggy code wrote a nil byte to the scratch buffer then

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1407,6 +1407,56 @@ func TestMetadataWriteAndRestore(t *testing.T) {
 	})
 }
 
+// TestSnapshotMultiBlockNodeLossRepro proves, directly against main's classic
+// writer/reader, that writeStateTo silently drops one node at every body-block
+// boundary (it labels the new block as starting at i+1 and never writes node i).
+// The existing "v3 - multi block" test masks this because it round-trips through
+// the same consistently-mislabeled reader and only asserts NotEqual. Here we
+// assert node-by-node survival, which fails at each block boundary.
+func TestSnapshotMultiBlockNodeLossRepro(t *testing.T) {
+	const size = 2000
+
+	c, err := packedconn.NewWithMaxLayer(2)
+	require.Nil(t, err)
+	c.ReplaceLayer(0, connsSlice1)
+
+	state := &DeserializationResult{
+		Entrypoint: 1,
+		Level:      6,
+		Compressed: false,
+		Nodes:      make([]*vertex, size),
+		Tombstones: make(map[uint64]struct{}),
+	}
+	// every slot is a live node — no nil slots, no tombstones — so the ONLY
+	// way a node can go missing on round-trip is the block-boundary bug.
+	for i := 0; i < size; i++ {
+		state.Nodes[i] = &vertex{
+			id:          uint64(i),
+			level:       i % 6,
+			connections: c,
+		}
+	}
+
+	dir := t.TempDir()
+	id := "test"
+	cl := createTestCommitLoggerForSnapshots(t, dir, id) // snapshotBlockSize = 4096
+
+	snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+	require.NoError(t, cl.writeSnapshot(state, snapshotPath))
+
+	restoredState, err := cl.readSnapshot(snapshotPath)
+	require.NoError(t, err)
+
+	var missing []int
+	for i := 0; i < size; i++ {
+		if restoredState.Nodes[i] == nil {
+			missing = append(missing, i)
+		}
+	}
+	require.Emptyf(t, missing, "nodes silently dropped on snapshot round-trip "+
+		"(one per 4KB block boundary): %v", missing)
+}
+
 var connsSlice1 = []uint64{
 	4477, 83, 6777, 13118, 12903, 12873, 14397, 15034, 15127, 15162, 15219, 15599, 17627,
 	18624, 18844, 19359, 22981, 23099, 36188, 37400, 39724, 39810, 47254, 58047, 59647, 61746,

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1403,7 +1403,10 @@ func TestMetadataWriteAndRestore(t *testing.T) {
 		restoredState, err := cl.readSnapshot(snapshotPath)
 		require.NoError(t, err)
 
-		require.NotEqual(t, state.Nodes, restoredState.Nodes)
+		// A multi-block snapshot must round-trip every slot faithfully. (This
+		// previously asserted NotEqual, which only held because the writer
+		// silently dropped a node at each block boundary.)
+		require.Equal(t, state.Nodes, restoredState.Nodes)
 	})
 }
 
@@ -1455,6 +1458,53 @@ func TestSnapshotMultiBlockNodeLossRepro(t *testing.T) {
 	}
 	require.Emptyf(t, missing, "nodes silently dropped on snapshot round-trip "+
 		"(one per 4KB block boundary): %v", missing)
+}
+
+// TestSnapshotCleanedTombstoneKeepsSlotAlignment covers the sibling drop: a node
+// that was deleted with its tombstone already cleaned up must be persisted as a
+// nil slot. The buggy code wrote a nil byte to the scratch buffer then
+// `continue`d, never appending it to the block, so every later node in the same
+// block was read back one id too low.
+func TestSnapshotCleanedTombstoneKeepsSlotAlignment(t *testing.T) {
+	const size = 10
+	const cleaned = 5
+
+	c, err := packedconn.NewWithMaxLayer(2)
+	require.Nil(t, err)
+	c.ReplaceLayer(0, connsSlice1)
+
+	state := &DeserializationResult{
+		Entrypoint:        0,
+		Level:             6,
+		Nodes:             make([]*vertex, size),
+		Tombstones:        make(map[uint64]struct{}),
+		TombstonesDeleted: make(map[uint64]struct{}),
+	}
+	for i := 0; i < size; i++ {
+		state.Nodes[i] = &vertex{id: uint64(i), level: i, connections: c}
+	}
+	// node `cleaned` was deleted and its tombstone already cleaned up
+	state.Tombstones[cleaned] = struct{}{}
+	state.TombstonesDeleted[cleaned] = struct{}{}
+
+	dir := t.TempDir()
+	id := "test"
+	cl := createTestCommitLoggerForSnapshots(t, dir, id)
+
+	snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+	require.NoError(t, cl.writeSnapshot(state, snapshotPath))
+
+	restored, err := cl.readSnapshot(snapshotPath)
+	require.NoError(t, err)
+
+	require.Nil(t, restored.Nodes[cleaned], "cleaned-tombstone node should be a nil slot")
+	for i := 0; i < size; i++ {
+		if i == cleaned {
+			continue
+		}
+		require.NotNilf(t, restored.Nodes[i], "node %d must survive", i)
+		require.Equalf(t, i, restored.Nodes[i].level, "node %d shifted id/level", i)
+	}
 }
 
 var connsSlice1 = []uint64{


### PR DESCRIPTION
### What's being changed:

Fixes the HNSW snapshot writer (`writeStateTo` in `commit_logger_snapshot.go`) silently dropping nodes when a snapshot body spans more than one 4 MB block.

**Bug.** When a node doesn't fit the current block, the writer flushes the block, writes the next block's start index as `i+1`, and advances the loop — **without ever writing node `i`**. So one node is lost at every block boundary and the new block's start index is off by one. A sibling case does the same for a node deleted with an already-cleaned tombstone: it `continue`s after writing the nil byte, dropping the slot and shifting every later node in that block down by one id.

It went unnoticed because the reader trusts each block's embedded start index, so it reads the mislabeled blocks back consistently and the lost node just becomes a nil slot — no error, only some recall loss on large indexes. It surfaces as a hard failure only under a stricter reader that validates block coverage: the compact-v2 upgrade path rejects such a snapshot with `snapshot body has range gap or overlap` (weaviate/0-weaviate-issues#268, hit on a multivector index whose ~60k nodes cross the boundary). Small, single-block snapshots are unaffected.

**Fix (3 commits):**
1. Start the new block at `i` and write node `i` into it (instead of labeling it `i+1` and dropping it).
2. Persist a cleaned-tombstone node as a nil slot — fall through to the block append instead of `continue` — preserving slot/id alignment.
3. Reject a single node entry larger than one block with a clear error instead of panicking on negative padding (such a node was previously dropped silently).

The on-disk format is unchanged (still V3) and correct output is read by all existing readers, so the change is backward- and forward-compatible. Note it stops *new* corruption; snapshots already written by older binaries remain affected until rewritten.

New tests cover multi-block node survival, cleaned-tombstone slot alignment, and the oversized-node guard. The existing `v3 - multi block` test's assertion (which had codified the buggy behavior) is corrected to assert a faithful round-trip.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary (internal storage format; no API change)
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
