### PR TITLE
fix(compact): tolerate legacy snapshot block-boundary gaps on read

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
@@ -705,7 +705,19 @@ LOOP:
 		return err
 	}
 
-	return validateSnapshotBlockRanges(ranges, int(nodeCount))
+	missing, err := validateSnapshotBlockRanges(ranges, int(nodeCount))
+	if err != nil {
+		return err
+	}
+	if missing > 0 && r.logger != nil {
+		r.logger.WithFields(logrus.Fields{
+			"action":     "hnsw_snapshot_load",
+			"missing":    missing,
+			"node_count": nodeCount,
+		}).Warnf("snapshot is missing %d node(s) dropped by an older writer at block boundaries "+
+			"(weaviate/0-weaviate-issues#268); loading without them — they will be absent from the index", missing)
+	}
+	return nil
 }
 
 // readBlockConcurrent parses a single block and populates nodes in the result.
@@ -786,39 +798,57 @@ func (r *SnapshotReader) readBlockConcurrent(buf []byte, res *ent.Deserializatio
 	return snapshotBlockRange{start: startNodeID, end: currNodeID}, nil
 }
 
-// validateSnapshotBlockRanges catches missing snapshot body blocks. The format
-// has per-block checksums, but no whole-file checksum or block count, so a file
-// truncated at a block boundary can otherwise look valid.
-func validateSnapshotBlockRanges(ranges []snapshotBlockRange, nodeCount int) error {
+// validateSnapshotBlockRanges checks the body's block coverage against the
+// metadata node count and returns the number of nodes missing from interior
+// gaps.
+//
+// An interior gap (a block whose start is greater than the previous block's
+// end) is the signature of the legacy classic-writer block-boundary bug
+// (weaviate/0-weaviate-issues#268): it dropped one node at each block boundary.
+// Such gaps are tolerated — the missing slots load as nil — because the
+// fixed-offset reader cannot produce an interior gap from truncation: a
+// truncated tail ends the body short (caught below) and a mid-block cut fails
+// the per-block checksum. So an interior gap is unambiguously the old writer,
+// not corruption.
+//
+// Overlap, a trailing shortfall (truncation), and a node count beyond the
+// metadata still fail closed.
+func validateSnapshotBlockRanges(ranges []snapshotBlockRange, nodeCount int) (int, error) {
 	if nodeCount == 0 {
-		return nil
+		return 0, nil
 	}
 	if len(ranges) == 0 {
-		return fmt.Errorf("snapshot body missing for %d nodes", nodeCount)
+		return 0, fmt.Errorf("snapshot body missing for %d nodes", nodeCount)
 	}
 
 	sort.Slice(ranges, func(i, j int) bool {
 		return ranges[i].start < ranges[j].start
 	})
 
+	var missing int
 	expected := uint64(0)
 	for _, blockRange := range ranges {
 		if blockRange.end < blockRange.start {
-			return fmt.Errorf("snapshot block range [%d,%d) is invalid", blockRange.start, blockRange.end)
+			return 0, fmt.Errorf("snapshot block range [%d,%d) is invalid", blockRange.start, blockRange.end)
 		}
-		if blockRange.start != expected {
-			return fmt.Errorf("snapshot body has range gap or overlap: expected node %d, got range [%d,%d)",
+		if blockRange.start < expected {
+			return 0, fmt.Errorf("snapshot body has overlapping ranges: expected node %d, got range [%d,%d)",
 				expected, blockRange.start, blockRange.end)
+		}
+		if blockRange.start > expected {
+			// Interior gap: nodes [expected, start) were dropped by an old
+			// writer. Tolerate them — those slots load as nil.
+			missing += int(blockRange.start - expected)
 		}
 		expected = blockRange.end
 		if expected > uint64(nodeCount) {
-			return fmt.Errorf("snapshot body covers node %d beyond metadata node count %d", expected, nodeCount)
+			return 0, fmt.Errorf("snapshot body covers node %d beyond metadata node count %d", expected, nodeCount)
 		}
 	}
 
 	if expected != uint64(nodeCount) {
-		return fmt.Errorf("snapshot body ended at node %d, expected %d", expected, nodeCount)
+		return 0, fmt.Errorf("snapshot body ended at node %d, expected %d", expected, nodeCount)
 	}
 
-	return nil
+	return missing, nil
 }

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
@@ -705,19 +705,7 @@ LOOP:
 		return err
 	}
 
-	missing, err := validateSnapshotBlockRanges(ranges, int(nodeCount))
-	if err != nil {
-		return err
-	}
-	if missing > 0 && r.logger != nil {
-		r.logger.WithFields(logrus.Fields{
-			"action":     "hnsw_snapshot_load",
-			"missing":    missing,
-			"node_count": nodeCount,
-		}).Warnf("snapshot is missing %d node(s) dropped by an older writer at block boundaries "+
-			"(weaviate/0-weaviate-issues#268); loading without them — they will be absent from the index", missing)
-	}
-	return nil
+	return validateSnapshotBlockRanges(ranges, int(nodeCount), r.logger)
 }
 
 // readBlockConcurrent parses a single block and populates nodes in the result.
@@ -799,26 +787,26 @@ func (r *SnapshotReader) readBlockConcurrent(buf []byte, res *ent.Deserializatio
 }
 
 // validateSnapshotBlockRanges checks the body's block coverage against the
-// metadata node count and returns the number of nodes missing from interior
-// gaps.
+// metadata node count: it returns an error for genuine corruption and logs a
+// warning for tolerated interior gaps.
 //
 // An interior gap (a block whose start is greater than the previous block's
 // end) is the signature of the legacy classic-writer block-boundary bug
 // (weaviate/0-weaviate-issues#268): it dropped one node at each block boundary.
-// Such gaps are tolerated — the missing slots load as nil — because the
-// fixed-offset reader cannot produce an interior gap from truncation: a
-// truncated tail ends the body short (caught below) and a mid-block cut fails
-// the per-block checksum. So an interior gap is unambiguously the old writer,
-// not corruption.
+// Such gaps are tolerated — the missing slots load as nil and a warning is
+// logged — because the fixed-offset reader cannot produce an interior gap from
+// truncation: a truncated tail ends the body short (caught below) and a
+// mid-block cut fails the per-block checksum. So an interior gap is
+// unambiguously the old writer, not corruption.
 //
 // Overlap, a trailing shortfall (truncation), and a node count beyond the
 // metadata still fail closed.
-func validateSnapshotBlockRanges(ranges []snapshotBlockRange, nodeCount int) (int, error) {
+func validateSnapshotBlockRanges(ranges []snapshotBlockRange, nodeCount int, logger logrus.FieldLogger) error {
 	if nodeCount == 0 {
-		return 0, nil
+		return nil
 	}
 	if len(ranges) == 0 {
-		return 0, fmt.Errorf("snapshot body missing for %d nodes", nodeCount)
+		return fmt.Errorf("snapshot body missing for %d nodes", nodeCount)
 	}
 
 	sort.Slice(ranges, func(i, j int) bool {
@@ -829,10 +817,10 @@ func validateSnapshotBlockRanges(ranges []snapshotBlockRange, nodeCount int) (in
 	expected := uint64(0)
 	for _, blockRange := range ranges {
 		if blockRange.end < blockRange.start {
-			return 0, fmt.Errorf("snapshot block range [%d,%d) is invalid", blockRange.start, blockRange.end)
+			return fmt.Errorf("snapshot block range [%d,%d) is invalid", blockRange.start, blockRange.end)
 		}
 		if blockRange.start < expected {
-			return 0, fmt.Errorf("snapshot body has overlapping ranges: expected node %d, got range [%d,%d)",
+			return fmt.Errorf("snapshot body has overlapping ranges: expected node %d, got range [%d,%d)",
 				expected, blockRange.start, blockRange.end)
 		}
 		if blockRange.start > expected {
@@ -842,13 +830,22 @@ func validateSnapshotBlockRanges(ranges []snapshotBlockRange, nodeCount int) (in
 		}
 		expected = blockRange.end
 		if expected > uint64(nodeCount) {
-			return 0, fmt.Errorf("snapshot body covers node %d beyond metadata node count %d", expected, nodeCount)
+			return fmt.Errorf("snapshot body covers node %d beyond metadata node count %d", expected, nodeCount)
 		}
 	}
 
 	if expected != uint64(nodeCount) {
-		return 0, fmt.Errorf("snapshot body ended at node %d, expected %d", expected, nodeCount)
+		return fmt.Errorf("snapshot body ended at node %d, expected %d", expected, nodeCount)
 	}
 
-	return missing, nil
+	if missing > 0 && logger != nil {
+		logger.WithFields(logrus.Fields{
+			"action":     "hnsw_snapshot_load",
+			"missing":    missing,
+			"node_count": nodeCount,
+		}).Warnf("snapshot is missing %d node(s) dropped by an older writer at block boundaries "+
+			"(weaviate/0-weaviate-issues#268); loading without them — they will be absent from the index", missing)
+	}
+
+	return nil
 }

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_reader_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_reader_test.go
@@ -50,13 +50,22 @@ func TestValidateSnapshotBlockRanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			missing, err := validateSnapshotBlockRanges(tt.ranges, tt.nodeCount)
+			logger, hook := logtest.NewNullLogger()
+			err := validateSnapshotBlockRanges(tt.ranges, tt.nodeCount, logger)
 			if tt.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				require.Empty(t, hook.AllEntries(), "no warning expected on error")
+				return
 			}
-			require.Equal(t, tt.wantMissing, missing)
+			require.NoError(t, err)
+			if tt.wantMissing > 0 {
+				entries := hook.AllEntries()
+				require.Len(t, entries, 1)
+				require.Equal(t, logrus.WarnLevel, entries[0].Level)
+				require.Equal(t, tt.wantMissing, entries[0].Data["missing"])
+			} else {
+				require.Empty(t, hook.AllEntries(), "no warning when nothing is missing")
+			}
 		})
 	}
 }

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_reader_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_reader_test.go
@@ -1,0 +1,162 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compact
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSnapshotBlockRanges pins the tolerance policy: interior gaps
+// (the signature of the legacy classic-writer block-boundary bug, see
+// weaviate/0-weaviate-issues#268) are tolerated and reported as missing nodes,
+// while overlap, trailing shortfall (truncation), and beyond-count still fail
+// closed.
+func TestValidateSnapshotBlockRanges(t *testing.T) {
+	tests := []struct {
+		name        string
+		ranges      []snapshotBlockRange
+		nodeCount   int
+		wantMissing int
+		wantErr     bool
+	}{
+		{"zero nodes", nil, 0, 0, false},
+		{"missing body for nodes", nil, 10, 0, true},
+		{"clean contiguous", []snapshotBlockRange{{0, 5}, {5, 10}}, 10, 0, false},
+		{"interior gap tolerated", []snapshotBlockRange{{0, 5}, {6, 10}}, 10, 1, false},
+		{"multiple interior gaps tolerated", []snapshotBlockRange{{0, 5}, {6, 10}, {11, 15}}, 15, 2, false},
+		{"leading gap tolerated", []snapshotBlockRange{{2, 10}}, 10, 2, false},
+		{"overlap fails", []snapshotBlockRange{{0, 6}, {5, 10}}, 10, 0, true},
+		{"trailing shortfall fails", []snapshotBlockRange{{0, 5}}, 10, 0, true},
+		{"beyond node count fails", []snapshotBlockRange{{0, 12}}, 10, 0, true},
+		{"invalid range fails", []snapshotBlockRange{{5, 3}}, 10, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			missing, err := validateSnapshotBlockRanges(tt.ranges, tt.nodeCount)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantMissing, missing)
+		})
+	}
+}
+
+// TestSnapshotReader_ToleratesLegacyInteriorGap reads a snapshot whose body has
+// an interior gap (one node dropped at a block boundary, as the legacy classic
+// writer produced — weaviate/0-weaviate-issues#268). The reader must load it
+// without error, leave the dropped slot nil, keep its neighbours, and log a
+// warning. The compact writer cannot emit such a gap, so the body is crafted by
+// hand and paired with a real (writer-produced) metadata header.
+func TestSnapshotReader_ToleratesLegacyInteriorGap(t *testing.T) {
+	const (
+		blockSize = 128
+		nodeCount = 6
+		gapID     = 3
+	)
+
+	header := snapshotMetadataHeader(t, blockSize, nodeCount)
+	body := gappedSnapshotBody(t, blockSize, nodeCount, gapID)
+	full := append(append([]byte{}, header...), body...)
+
+	logger, hook := logtest.NewNullLogger()
+	result, err := NewSnapshotReaderWithBlockSize(logger, blockSize).Read(bytes.NewReader(full))
+	require.NoError(t, err)
+
+	require.Equal(t, nodeCount, len(result.Graph.Nodes))
+	require.Nil(t, result.Graph.Nodes[gapID], "dropped slot must load as nil")
+	for id := 0; id < nodeCount; id++ {
+		if id == gapID {
+			continue
+		}
+		require.NotNilf(t, result.Graph.Nodes[id], "node %d must survive", id)
+	}
+
+	var warned bool
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "missing") {
+			warned = true
+		}
+	}
+	require.True(t, warned, "expected a WARN about missing nodes")
+}
+
+// snapshotMetadataHeader returns the version+checksum+metadata prefix of a real
+// V3 snapshot with the given node count, so tests can pair valid metadata with a
+// hand-crafted body.
+func snapshotMetadataHeader(t *testing.T, blockSize, nodeCount int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	sw := NewSnapshotWriterWithBlockSize(&buf, int64(blockSize))
+	sw.SetEntrypoint(0, 0)
+	for i := 0; i < nodeCount; i++ {
+		sw.AddNode(uint64(i), 0, [][]uint64{{0}}, false)
+	}
+	require.NoError(t, sw.Flush())
+	b := buf.Bytes()
+	metaSize := binary.LittleEndian.Uint32(b[5:9])
+	return append([]byte{}, b[:9+int(metaSize)]...)
+}
+
+// gappedSnapshotBody builds a body of two fixed-size blocks that together cover
+// every slot except gapID: block one is [0,gapID), block two is [gapID+1,
+// nodeCount). Each present slot is a minimal live entry (existence 2, level 0,
+// no connections).
+func gappedSnapshotBody(t *testing.T, blockSize, nodeCount, gapID int) []byte {
+	t.Helper()
+	maxBlockSize := blockSize - 8
+
+	liveEntry := func() []byte {
+		var e [9]byte
+		e[0] = 2 // alive, no tombstone
+		// level (uint32) and connSize (uint32) both zero
+		return e[:]
+	}
+
+	buildBlock := func(startID uint64, count int) []byte {
+		var block bytes.Buffer
+		var u64 [8]byte
+		binary.LittleEndian.PutUint64(u64[:], startID)
+		block.Write(u64[:])
+		for i := 0; i < count; i++ {
+			block.Write(liveEntry())
+		}
+		blockLen := block.Len()
+		require.LessOrEqualf(t, blockLen, maxBlockSize, "block starting at %d does not fit", startID)
+		block.Write(make([]byte, maxBlockSize-blockLen))
+		var u32 [4]byte
+		binary.LittleEndian.PutUint32(u32[:], uint32(blockLen))
+		block.Write(u32[:])
+
+		cs := crc32.ChecksumIEEE(block.Bytes())
+		out := make([]byte, 0, blockSize)
+		binary.LittleEndian.PutUint32(u32[:], cs)
+		out = append(out, u32[:]...)
+		out = append(out, block.Bytes()...)
+		require.Equal(t, blockSize, len(out))
+		return out
+	}
+
+	b1 := buildBlock(0, gapID)                             // nodes [0, gapID)
+	b2 := buildBlock(uint64(gapID+1), nodeCount-(gapID+1)) // nodes [gapID+1, nodeCount)
+	return append(append([]byte{}, b1...), b2...)
+}


### PR DESCRIPTION
### What's being changed:

Makes the compact-v2 snapshot reader tolerate snapshots corrupted by an old writer, so upgrading to compact-v2 no longer fails to load the index (weaviate/0-weaviate-issues#268).

**Background.** Weaviate releases before #11829 shipped a classic HNSW snapshot writer that silently dropped one node at each 4 MB snapshot block boundary, leaving an *interior coverage gap* (a block whose start index is greater than the previous block's end). The classic reader tolerated this silently. The compact-v2 reader added a strict block-coverage check (#11802) that rejects such a snapshot with `snapshot body has range gap or overlap`, so upgrading from an affected release to compact-v2 fails to load the index (observed on a multivector index whose ~60k nodes cross the boundary). The dropped nodes are unrecoverable — their source WALs were folded into the snapshot and deleted.

**Change.** `validateSnapshotBlockRanges` now tolerates interior gaps: it loads the nodes present, leaves the dropped slots nil, and `readBodyConcurrent` logs one WARN with the count. Overlap, trailing shortfall (truncation), node-count-beyond-metadata, and the per-block checksum still fail closed. This is safe because the fixed-offset reader cannot produce an interior gap from truncation (a truncated tail ends the body short; a mid-block cut fails the checksum), so an interior gap is the unambiguous signature of the old writer, not corruption. The next compaction rewrites a clean snapshot, so the warning self-clears.

**Relationship to #11829 (no cherry-pick).** #11829 fixes the *classic* writer (`commit_logger_snapshot.go`) on `stable/v1.37` (and eventually main). That file does not exist on compact-v2 — the classic writer was replaced by the compact `SnapshotWriter`, which already writes block boundaries correctly. The two changes are complementary: #11829 stops the classic line from producing corrupt snapshots; this lets compact-v2 read snapshots that pre-#11829 binaries already wrote corrupt.

**Known limitation.** If the old writer dropped the *very last* node(s), the body ends short and is indistinguishable from truncation, so it still fails closed.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary (internal storage read path; no API change)
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
