### PR TITLE
perf(async-rep): reuse a single cursor across the hashbeat digest scan

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -93,6 +93,37 @@ func (b *Bucket) Cursor() *CursorReplace {
 	}
 }
 
+// CursorReplaceReusable behaves like Cursor but backs each disk segment with a
+// reusable cursor, avoiding per-node reader allocations on the pread path.
+// Prefer it for long sequential scans. Same locking/Close contract as Cursor.
+func (b *Bucket) CursorReplaceReusable() *CursorReplace {
+	MustBeExpectedStrategy(b.strategy, StrategyReplace)
+
+	cursorOpenedAt := time.Now()
+	b.metrics.IncBucketOpenedCursorsByStrategy(b.strategy)
+	b.metrics.IncBucketOpenCursorsByStrategy(b.strategy)
+
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+
+	innerCursors, unlockSegmentGroup := b.disk.newReusableCursors()
+
+	if b.flushing != nil {
+		innerCursors = append(innerCursors, b.flushing.newCursor())
+	}
+	innerCursors = append(innerCursors, b.active.newCursor())
+
+	return &CursorReplace{
+		innerCursors: innerCursors,
+		unlock: func() {
+			unlockSegmentGroup()
+
+			b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
+			b.metrics.ObserveBucketCursorDurationByStrategy(b.strategy, time.Since(cursorOpenedAt))
+		},
+	}
+}
+
 // CursorInMemWith returns a cursor which scan over the primary key of entries
 // not yet persisted on disk.
 // Segment creation and compaction will be blocked until the cursor is closed

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_reusable_bench_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_reusable_bench_test.go
@@ -1,0 +1,95 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// benchScanBucket builds a pread objects-bucket-like dataset: n entries with
+// 16-byte sortable keys spread across `segments` flushed disk segments. This
+// reproduces the shape the async-replication digest scan walks.
+func benchScanBucket(tb testing.TB, ctx context.Context, n, segments int) *Bucket {
+	tb.Helper()
+	dir := tb.TempDir()
+	b, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithPread(true), WithMinMMapSize(0))
+	require.NoError(tb, err)
+	b.SetMemtableThreshold(1 << 30)
+
+	val := make([]byte, 300)
+	for i := range val {
+		val[i] = byte(i)
+	}
+	perSeg := n / segments
+	for i := 0; i < n; i++ {
+		key := make([]byte, 16)
+		binary.BigEndian.PutUint64(key[8:], uint64(i))
+		require.NoError(tb, b.Put(key, val))
+		if perSeg > 0 && (i+1)%perSeg == 0 && i+1 < n {
+			require.NoError(tb, b.FlushAndSwitch())
+		}
+	}
+	require.NoError(tb, b.FlushAndSwitch())
+
+	for _, seg := range b.disk.segments {
+		if s, ok := seg.(*segment); ok {
+			require.False(tb, s.readFromMemory, "benchmark must exercise the pread path")
+		}
+	}
+	return b
+}
+
+func benchScanAll(c *CursorReplace) int {
+	defer c.Close()
+	n := 0
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		n += len(k) + len(v)
+	}
+	return n
+}
+
+// BenchmarkDigestScanOldCursor scans the bucket with the default per-node
+// allocating Cursor (the pre-change behaviour).
+func BenchmarkDigestScanOldCursor(b *testing.B) {
+	ctx := context.Background()
+	bucket := benchScanBucket(b, ctx, 20000, 4)
+	defer bucket.Shutdown(ctx)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchScanAll(bucket.Cursor())
+	}
+}
+
+// BenchmarkDigestScanReusableCursor scans the same bucket with the reusable
+// cursor introduced for the async-replication digest scan.
+func BenchmarkDigestScanReusableCursor(b *testing.B) {
+	ctx := context.Background()
+	bucket := benchScanBucket(b, ctx, 20000, 4)
+	defer bucket.Shutdown(ctx)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchScanAll(bucket.CursorReplaceReusable())
+	}
+}

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_reusable_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_reusable_test.go
@@ -1,0 +1,119 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestCursorReplaceReusable_MatchesCursor proves that CursorReplaceReusable
+// yields the exact same merged view (First/Next and Seek/Next) as the default
+// Cursor across multiple disk segments, a live memtable, overlaps and
+// tombstones, in both the mmap (readFromMemory) and pread code paths.
+func TestCursorReplaceReusable_MatchesCursor(t *testing.T) {
+	ctx := context.Background()
+
+	modes := []struct {
+		name        string
+		readFromMem bool
+		opts        []BucketOption
+	}{
+		{"mmap", true, nil},
+		{"pread", false, []BucketOption{WithPread(true), WithMinMMapSize(0)}},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			b := newReusableTestBucket(t, ctx, mode.opts...)
+			defer b.Shutdown(ctx)
+
+			for i := 0; i < 50; i++ {
+				require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%03d", i)),
+					[]byte(fmt.Sprintf("v1-%03d", i))))
+			}
+			require.NoError(t, b.FlushAndSwitch())
+
+			for i := 25; i < 75; i++ {
+				require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%03d", i)),
+					[]byte(fmt.Sprintf("v2-%03d", i))))
+			}
+			for i := 0; i < 50; i += 5 {
+				require.NoError(t, b.Delete([]byte(fmt.Sprintf("key-%03d", i))))
+			}
+			require.NoError(t, b.FlushAndSwitch())
+
+			for i := 60; i < 90; i++ {
+				require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%03d", i)),
+					[]byte(fmt.Sprintf("v3-%03d", i))))
+			}
+			for i := 31; i < 40; i += 3 {
+				require.NoError(t, b.Delete([]byte(fmt.Sprintf("key-%03d", i))))
+			}
+
+			for _, seg := range b.disk.segments {
+				if s, ok := seg.(*segment); ok {
+					require.Equal(t, mode.readFromMem, s.readFromMemory,
+						"segment readFromMemory must match the configured access mode")
+				}
+			}
+
+			want := drainCursor(b.Cursor())
+			got := drainCursor(b.CursorReplaceReusable())
+			require.Equal(t, want, got, "First/Next sequence mismatch")
+			require.NotEmpty(t, got)
+
+			for _, target := range []string{
+				"", "key-000", "key-001", "key-033", "key-050", "key-074", "key-089", "key-999",
+			} {
+				w := drainSeek(b.Cursor(), []byte(target))
+				g := drainSeek(b.CursorReplaceReusable(), []byte(target))
+				require.Equal(t, w, g, "Seek(%q)/Next sequence mismatch", target)
+			}
+		})
+	}
+}
+
+func drainCursor(c *CursorReplace) []string {
+	defer c.Close()
+	var out []string
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		out = append(out, string(k)+"="+string(v))
+	}
+	return out
+}
+
+func drainSeek(c *CursorReplace, target []byte) []string {
+	defer c.Close()
+	var out []string
+	for k, v := c.Seek(target); k != nil; k, v = c.Next() {
+		out = append(out, string(k)+"="+string(v))
+	}
+	return out
+}
+
+func newReusableTestBucket(t *testing.T, ctx context.Context, opts ...BucketOption) *Bucket {
+	t.Helper()
+	dir := t.TempDir()
+	o := append([]BucketOption{WithStrategy(StrategyReplace)}, opts...)
+	b, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), o...)
+	require.NoError(t, err)
+	b.SetMemtableThreshold(1e9)
+	return b
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -278,14 +278,16 @@ func (s *segmentCursorReplace) parse(in []byte) error {
 }
 
 // segmentCursorReplaceReusable is a sequential cursor for the replace strategy
-// that reuses internal buffers across iterations to minimise per-key allocations
-// during compaction. It is the replace-strategy analogue of
-// segmentCursorCollectionReusable.
+// that reuses internal buffers across iterations to minimise per-key
+// allocations. Used by compaction (compactorReplace) and, via
+// reusableInnerCursorReplace, by the bucket-level reusable merge cursor. It is
+// the replace-strategy analogue of segmentCursorCollectionReusable.
 //
-// Ownership contract: the *segmentReplaceNode returned by first()/next() is
-// valid only until the next call on the same cursor. Callers must not retain
-// the pointer across iterations. This is safe in compactorReplace because c1
-// and c2 are independent cursors with separate reusableNode fields.
+// Ownership contract: the *segmentReplaceNode returned by first()/next()/seek()
+// is valid only until the next call on the same cursor; callers must not retain
+// the pointer across iterations. Each consumer (compaction's c1/c2, the merge
+// cursor's per-segment adapter) owns its own cursor, so the aliased node is
+// never shared across cursors.
 type segmentCursorReplaceReusable struct {
 	segment      *segment
 	currOffset   uint64

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"bufio"
+	"errors"
 
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/usecases/byteops"
@@ -335,6 +336,17 @@ func (s *segmentCursorReplaceReusable) next() (*segmentReplaceNode, error) {
 	return s.parseInto()
 }
 
+// seek positions at the first node with key >= the given key; next() then
+// continues sequentially. Returns lsmkv.NotFound past the highest key.
+func (s *segmentCursorReplaceReusable) seek(key []byte) (*segmentReplaceNode, error) {
+	node, err := s.segment.index.Seek(key)
+	if err != nil {
+		return nil, err
+	}
+	s.currOffset = node.Start
+	return s.parseInto()
+}
+
 func (s *segmentCursorReplaceReusable) parseInto() (*segmentReplaceNode, error) {
 	if s.segment.readFromMemory {
 		buf := s.segment.contents[s.currOffset:]
@@ -357,4 +369,47 @@ func (s *segmentCursorReplaceReusable) parseInto() (*segmentReplaceNode, error) 
 		return &s.reusableNode, lsmkv.Deleted
 	}
 	return &s.reusableNode, nil
+}
+
+// reusableInnerCursorReplace adapts segmentCursorReplaceReusable to the
+// innerCursorReplace interface. Returned slices alias the reusable node and are
+// valid only until the next call; CursorReplace copies them out before advancing.
+type reusableInnerCursorReplace struct {
+	c *segmentCursorReplaceReusable
+}
+
+func nodeToKV(n *segmentReplaceNode, err error) ([]byte, []byte, error) {
+	if errors.Is(err, lsmkv.Deleted) {
+		// tombstone: key with nil value, so the merge can advance past it
+		return n.primaryKey, nil, err
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return n.primaryKey, n.value, nil
+}
+
+func (r *reusableInnerCursorReplace) first() ([]byte, []byte, error) {
+	return nodeToKV(r.c.first())
+}
+
+func (r *reusableInnerCursorReplace) next() ([]byte, []byte, error) {
+	return nodeToKV(r.c.next())
+}
+
+func (r *reusableInnerCursorReplace) seek(key []byte) ([]byte, []byte, error) {
+	return nodeToKV(r.c.seek(key))
+}
+
+// newReusableCursors mirrors newCursors but uses reusable per-segment cursors,
+// avoiding the per-node reader allocations of the default pread path.
+func (sg *SegmentGroup) newReusableCursors() ([]innerCursorReplace, func()) {
+	segments, release := sg.getConsistentViewOfSegments()
+
+	out := make([]innerCursorReplace, len(segments))
+	for i, segment := range segments {
+		out[i] = &reusableInnerCursorReplace{c: segment.newReplaceCursorReusable()}
+	}
+
+	return out, release
 }

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1493,57 +1493,22 @@ func (s *Shard) hashBeat(
 	hashtreeDiffTook := time.Since(hashtreeDiffStart)
 	s.metrics.ObserveAsyncReplicationHashtreeDiffDuration(hashtreeDiffTook)
 
-	rangeReader := shardDiffReader.RangeReader
-
 	objectDigestsDiffStart := time.Now()
-
-	localObjectDigestsCount := 0
-	objectsDiffCount := 0
-
-	localObjectsToPropagate := make([]strfmt.UUID, 0, config.propagationLimit)
-	localUpdateTimeByUUID := make(map[strfmt.UUID]int64, config.propagationLimit)
-	remoteStaleUpdateTimeByUUID := make(map[strfmt.UUID]int64, config.propagationLimit)
 
 	objectDigestsDiffCtx, cancel := context.WithTimeout(ctx, config.prePropagationTimeout)
 	defer cancel()
 
-	for len(localObjectsToPropagate) < config.propagationLimit {
-		initialLeaf, finalLeaf, err := rangeReader.Next()
-		if err != nil {
-			if errors.Is(err, hashtree.ErrNoMoreRanges) {
-				break
-			}
-			return nil, fmt.Errorf("reading collected differences: %w", err)
-		}
-
-		localObjsCountWithinRange, objsToPropagateWithinRange, err := s.objectsToPropagateWithinRange(
-			objectDigestsDiffCtx,
-			config,
-			shardDiffReader.TargetNodeAddress,
-			shardDiffReader.TargetNodeName,
-			initialLeaf,
-			finalLeaf,
-			config.propagationLimit-len(localObjectsToPropagate),
-			targetNodeOverridesSnapshot,
-		)
-		if err != nil {
-			if objectDigestsDiffCtx.Err() != nil {
-				// it may be the case that just pre propagation timeout was reached
-				// and some objects could be propagated
-				break
-			}
-
-			return nil, fmt.Errorf("collecting local objects to be propagated: %w", err)
-		}
-
-		localObjectDigestsCount += localObjsCountWithinRange
-		objectsDiffCount += len(objsToPropagateWithinRange)
-
-		for _, obj := range objsToPropagateWithinRange {
-			localObjectsToPropagate = append(localObjectsToPropagate, obj.uuid)
-			localUpdateTimeByUUID[obj.uuid] = obj.lastUpdateTime
-			remoteStaleUpdateTimeByUUID[obj.uuid] = obj.remoteStaleUpdateTime
-		}
+	localObjectsToPropagate, localUpdateTimeByUUID, remoteStaleUpdateTimeByUUID,
+		localObjectDigestsCount, objectsDiffCount, err := s.collectObjectsToPropagate(
+		objectDigestsDiffCtx,
+		config,
+		shardDiffReader.RangeReader,
+		shardDiffReader.TargetNodeAddress,
+		shardDiffReader.TargetNodeName,
+		targetNodeOverridesSnapshot,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	objectDigestsDiffTook := time.Since(objectDigestsDiffStart)
@@ -1634,14 +1599,6 @@ func (s *Shard) resolveObjectConflict(
 	return false, false, nil
 }
 
-func uuidFromBytes(uuidBytes []byte) (id strfmt.UUID, err error) {
-	uuidParsed, err := uuid.FromBytes(uuidBytes)
-	if err != nil {
-		return id, err
-	}
-	return strfmt.UUID(uuidParsed.String()), nil
-}
-
 func bytesFromUUID(id strfmt.UUID) (uuidBytes []byte, err error) {
 	uuidParsed, err := uuid.Parse(id.String())
 	if err != nil {
@@ -1667,15 +1624,85 @@ type objectToPropagate struct {
 	remoteStaleUpdateTime int64
 }
 
+// collectObjectsToPropagate scans the hashtree diff ranges and returns the local
+// objects that must be propagated. It owns a single reusable objects-bucket
+// cursor for the whole scan (released before propagation begins) so the cursor,
+// its memtable snapshot and segment reader chain are reused across all ranges
+// and batches instead of re-allocated per batch.
+func (s *Shard) collectObjectsToPropagate(
+	ctx context.Context,
+	config AsyncReplicationConfig,
+	rangeReader hashtree.AggregatedHashTreeRangeReader,
+	targetNodeAddress, targetNodeName string,
+	targetNodeOverrides additional.AsyncReplicationTargetNodeOverrides,
+) (
+	localObjectsToPropagate []strfmt.UUID,
+	localUpdateTimeByUUID map[strfmt.UUID]int64,
+	remoteStaleUpdateTimeByUUID map[strfmt.UUID]int64,
+	localObjectDigestsCount int,
+	objectsDiffCount int,
+	err error,
+) {
+	localObjectsToPropagate = make([]strfmt.UUID, 0, config.propagationLimit)
+	localUpdateTimeByUUID = make(map[strfmt.UUID]int64, config.propagationLimit)
+	remoteStaleUpdateTimeByUUID = make(map[strfmt.UUID]int64, config.propagationLimit)
+
+	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceReusable()
+	defer cursor.Close()
+
+	for len(localObjectsToPropagate) < config.propagationLimit {
+		initialLeaf, finalLeaf, rangeErr := rangeReader.Next()
+		if rangeErr != nil {
+			if errors.Is(rangeErr, hashtree.ErrNoMoreRanges) {
+				break
+			}
+			return nil, nil, nil, 0, 0, fmt.Errorf("reading collected differences: %w", rangeErr)
+		}
+
+		localObjsCountWithinRange, objsToPropagateWithinRange, rangeErr := s.objectsToPropagateWithinRange(
+			ctx,
+			config,
+			cursor,
+			targetNodeAddress,
+			targetNodeName,
+			initialLeaf,
+			finalLeaf,
+			config.propagationLimit-len(localObjectsToPropagate),
+			targetNodeOverrides,
+		)
+		if rangeErr != nil {
+			if ctx.Err() != nil {
+				// pre-propagation timeout may have been reached with some objects
+				// already collected; propagate those
+				break
+			}
+			return nil, nil, nil, 0, 0, fmt.Errorf("collecting local objects to be propagated: %w", rangeErr)
+		}
+
+		localObjectDigestsCount += localObjsCountWithinRange
+		objectsDiffCount += len(objsToPropagateWithinRange)
+
+		for _, obj := range objsToPropagateWithinRange {
+			localObjectsToPropagate = append(localObjectsToPropagate, obj.uuid)
+			localUpdateTimeByUUID[obj.uuid] = obj.lastUpdateTime
+			remoteStaleUpdateTimeByUUID[obj.uuid] = obj.remoteStaleUpdateTime
+		}
+	}
+
+	return localObjectsToPropagate, localUpdateTimeByUUID, remoteStaleUpdateTimeByUUID,
+		localObjectDigestsCount, objectsDiffCount, nil
+}
+
 // objectsToPropagateWithinRange returns the local objects in the given hashtree
 // leaf range that must be propagated to the target. Per batch it fetches local
-// digests (DigestObjectsInRange), drops the ones too recent to propagate (per
+// digests via the shared cursor, drops the ones too recent to propagate (per
 // maxUpdateTime), and asks the target via CompareDigests for the subset needing
 // action: objects missing on the target (UpdateTime==0, which also covers
 // target-side tombstones) and objects the source holds a newer version of. Every
 // returned entry is queued; tombstone resolution is left to the post-Overwrite
 // resolveObjectConflict path.
 func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncReplicationConfig,
+	cursor *lsmkv.CursorReplace,
 	targetNodeAddress, targetNodeName string, initialLeaf, finalLeaf uint64, limit int,
 	targetNodeOverrides additional.AsyncReplicationTargetNodeOverrides,
 ) (localObjectsCount int, objectsToPropagate []objectToPropagate, err error) {
@@ -1686,11 +1713,6 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 	finalUUIDBytes := make([]byte, 16)
 	binary.BigEndian.PutUint64(finalUUIDBytes, finalLeaf<<(64-hashtreeHeight)|((1<<(64-hashtreeHeight))-1))
 	copy(finalUUIDBytes[8:], []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
-
-	finalUUID, err := uuidFromBytes(finalUUIDBytes)
-	if err != nil {
-		return localObjectsCount, objectsToPropagate, err
-	}
 
 	// Computed once so every batch uses the same cut-off; a per-batch recompute
 	// would let objects near the boundary flip eligibility mid-scan.
@@ -1708,14 +1730,9 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 			return localObjectsCount, objectsToPropagate, ctx.Err()
 		}
 
-		currLocalUUID, err := uuidFromBytes(currLocalUUIDBytes)
-		if err != nil {
-			return localObjectsCount, objectsToPropagate, err
-		}
-
 		currBatchSize := min(limit, config.diffBatchSize)
 
-		allLocalDigests, err := s.index.DigestObjectsInRange(ctx, s.name, currLocalUUID, finalUUID, currBatchSize)
+		allLocalDigests, err := collectObjectDigests(ctx, cursor, currLocalUUIDBytes, finalUUIDBytes, currBatchSize)
 		if err != nil {
 			return localObjectsCount, objectsToPropagate, fmt.Errorf("fetching local object digests: %w", err)
 		}

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -30,7 +30,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	routerTypes "github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	entreplication "github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -187,6 +189,16 @@ func flushShard(t *testing.T, ctx context.Context, shard ShardLike) {
 	require.NoError(t, s.store.FlushMemtables(ctx))
 }
 
+func (s *Shard) propagateWithinRangeForTest(t *testing.T, ctx context.Context,
+	cfg AsyncReplicationConfig, addr, node string, initialLeaf, finalLeaf uint64,
+	limit int, overrides additional.AsyncReplicationTargetNodeOverrides,
+) (int, []objectToPropagate, error) {
+	t.Helper()
+	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceReusable()
+	defer cursor.Close()
+	return s.objectsToPropagateWithinRange(ctx, cfg, cursor, addr, node, initialLeaf, finalLeaf, limit, overrides)
+}
+
 // ─── objectsToPropagateWithinRange ───────────────────────────────────────────
 
 // TestObjectsToPropagateWithinRange covers the scanning and filtering logic
@@ -202,8 +214,8 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 		s := concreteShard(t, sl)
 		cfg := fullRangeConfig(100)
 
-		local, objs, err := s.objectsToPropagateWithinRange(
-			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		local, objs, err := s.propagateWithinRangeForTest(
+			t, ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, 0, local)
@@ -222,8 +234,8 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 		s := concreteShard(t, sl)
 		cfg := fullRangeConfig(100)
 
-		local, objs, err := s.objectsToPropagateWithinRange(
-			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		local, objs, err := s.propagateWithinRangeForTest(
+			t, ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, 2, local, "memtable objects must be visible to the merged bucket cursor")
@@ -247,8 +259,8 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 		require.NoError(t, s.store.FlushMemtables(ctx))
 		cfg := fullRangeConfig(100)
 
-		local, objs, err := s.objectsToPropagateWithinRange(
-			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		local, objs, err := s.propagateWithinRangeForTest(
+			t, ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, 2, local)
@@ -273,8 +285,8 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 		require.NoError(t, s.store.FlushMemtables(ctx))
 		cfg := fullRangeConfig(100)
 
-		_, objs, err := s.objectsToPropagateWithinRange(
-			ctx, cfg, "http://fake", "node2", 0, 1, limit, nil,
+		_, objs, err := s.propagateWithinRangeForTest(
+			t, ctx, cfg, "http://fake", "node2", 0, 1, limit, nil,
 		)
 		require.NoError(t, err)
 		assert.LessOrEqual(t, len(objs), limit,
@@ -307,8 +319,8 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 			propagationDelay: 30 * time.Second,
 		}
 
-		local, objs, err := s.objectsToPropagateWithinRange(
-			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		local, objs, err := s.propagateWithinRangeForTest(
+			t, ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, 0, local,
@@ -339,8 +351,8 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 			propagationDelay: 30 * time.Second,
 		}
 
-		local, objs, err := s.objectsToPropagateWithinRange(
-			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		local, objs, err := s.propagateWithinRangeForTest(
+			t, ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
 		)
 		require.NoError(t, err)
 		assert.Equal(t, 1, local,
@@ -365,8 +377,8 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 		require.NoError(t, s.store.FlushMemtables(ctx))
 		cfg := fullRangeConfig(100)
 
-		_, objs, err := s.objectsToPropagateWithinRange(
-			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		_, objs, err := s.propagateWithinRangeForTest(
+			t, ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "comparing digests with remote",

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -192,14 +192,21 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 		return nil, fmt.Errorf("invalid final UUID %q: %w", finalUUID, err)
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
-
-	cursor := bucket.Cursor()
+	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceReusable()
 	defer cursor.Close()
 
+	return collectObjectDigests(ctx, cursor, initialUUID16[:], finalUUID16[:], limit)
+}
+
+// collectObjectDigests seeks cursor to initialKey and returns up to limit
+// digests with key <= finalKey. The cursor is reused across calls by the
+// async-replication scan, so it must not be opened/closed here.
+func collectObjectDigests(ctx context.Context, cursor *lsmkv.CursorReplace,
+	initialKey, finalKey []byte, limit int) (objs []types.RepairResponse, err error,
+) {
 	n := 0
 
-	for k, v := cursor.Seek(initialUUID16[:]); n < limit && k != nil && bytes.Compare(k, finalUUID16[:]) < 1; k, v = cursor.Next() {
+	for k, v := cursor.Seek(initialKey); n < limit && k != nil && bytes.Compare(k, finalKey) < 1; k, v = cursor.Next() {
 		if ctx.Err() != nil {
 			return objs, ctx.Err()
 		}
@@ -214,12 +221,10 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 			return objs, fmt.Errorf("cannot parse object uuid: %w", err)
 		}
 
-		replicaObj := types.RepairResponse{
+		objs = append(objs, types.RepairResponse{
 			ID:         uuidParsed.String(),
 			UpdateTime: updateTime,
-		}
-
-		objs = append(objs, replicaObj)
+		})
 
 		n++
 	}


### PR DESCRIPTION
## Motivation

Async replication's hashbeat is the hottest read path on a replicated cluster: for every hashtree diff it scans the objects bucket to collect local digests, range by range and batch by batch. Today each batch goes through `Index.DigestObjectsInRange`, which opens a fresh `Bucket.Cursor()` per call. Every such cursor allocates a new per-segment reader chain, and on the pread path each node read allocates a new reader on top of that. On a busy node with many ranges/batches this churns a large number of short-lived allocations and re-snapshots the memtable on every batch, for no semantic benefit — the bucket view does not change within a single hashbeat scan.

This change makes the in-process hashbeat scan reuse a single cursor (and its segment reader chain + memtable snapshot) for the entire scan.

## Approach

Two layers:

1. **lsmkv: a reusable replace cursor.** `Bucket.CursorReplaceReusable()` (`adapters/repos/db/lsmkv/cursor_bucket_replace.go`) mirrors `Cursor()` but backs each disk segment with the already-existing `segmentCursorReplaceReusable` instead of the default per-node-allocating cursor. It keeps the same lock/Close contract as `Cursor()`. Supporting this, `cursor_segment_replace.go` gains a `seek` on the reusable segment cursor and a `reusableInnerCursorReplace` adapter implementing `innerCursorReplace`, plus `SegmentGroup.newReusableCursors` (the reusable twin of `newCursors`). The reusable node aliases internal buffers and is only valid until the next call — `CursorReplace` already copies keys/values out before advancing, so the merge stays correct.

2. **shard: reuse one cursor across the whole scan.** The per-range/per-batch loop in `hashBeat` is extracted into `Shard.collectObjectsToPropagate` (`shard_async_replication.go`), which opens **one** `CursorReplaceReusable` for the entire scan and threads it through `objectsToPropagateWithinRange` down to a new shared helper `collectObjectDigests` (`shard_read.go`). `ObjectDigestsInRange` (the RPC-facing read-repair path) is refactored to delegate to the same `collectObjectDigests` helper, so the digest-collection logic now has a single implementation. The scan also drops the per-batch `uuid.FromBytes`→string→`strfmt.UUID` round-trips: digest collection now seeks on raw `[]byte` UUID keys directly, so `uuidFromBytes` is removed.

## Behavioural change to be aware of

The source-side cursor is now held open for the **entire pre-propagation diff phase** (bounded by `prePropagationTimeout`, default 300s) — across all ranges and across the `CompareDigests` RPC round-trips — whereas previously each digest fetch opened and closed its own cursor before `CompareDigests`. The cursor holds only segment ref counts (no locks), so this is not a deadlock/contention risk, but it does pin the referenced source segments (deferring their physical drop by compaction) for longer. It is released before the propagation phase. This also yields a single consistent snapshot for the whole scan rather than a fresh per-batch snapshot.

## Concurrency notes

- The scan is single-flight per shard (`asyncReplicationScheduler` `inFlight`), and the RPC path opens its own cursor, so no cursor is ever shared across goroutines.
- The open cursor holds no locks, only ref counts; `Close()` takes only `segmentRefCounterLock`. The only ref-count waiter (`waitForReferenceCountToReachZero`, shutdown only) busy-polls without holding `maintenanceLock`, so `Close()` can always make progress — no lock cycle.

## Key areas for review

- `cursor_bucket_replace.go:CursorReplaceReusable` — verify it matches `Cursor()` exactly on lock acquisition (`flushLock.RLock`), the flushing/active memtable append order, and the unlock/metrics path.
- `cursor_segment_replace.go:nodeToKV` / `reusableInnerCursorReplace` — the aliasing contract. Confirm tombstones surface as `(primaryKey, nil, lsmkv.Deleted)` so the merge advances past them exactly like the non-reusable path.
- `shard_async_replication.go:collectObjectsToPropagate` — cursor lifetime: it must be closed before propagation, and the pre-propagation-timeout break must still return partially collected objects (preserved from the original loop).
- `shard_read.go:collectObjectDigests` — the shared helper. Note the range bound is `bytes.Compare(k, finalKey) < 1` (inclusive of `finalKey`), unchanged. Confirm `ObjectDigestsInRange` still opens/closes its own cursor while the async path owns the cursor externally.

## Testing

- `cursor_bucket_replace_reusable_test.go` (integration): reusable-vs-default cursor equivalence — byte-for-byte equality of merged First/Next and Seek/Next sequences across multiple overlapping disk segments, a live memtable, tombstones, and **both mmap (`readFromMemory`) and pread** paths.
- `shard_async_replication_test.go`: existing `TestObjectsToPropagateWithinRange` table tests now run through a `propagateWithinRangeForTest` helper that opens a `CursorReplaceReusable` and feeds it to `objectsToPropagateWithinRange`, exercising the empty-shard, memtable-only, flushed, limit, propagation-delay, and remote-error cases on the new shared-cursor path.

```
go test -tags integrationTest -race -count 1 -run 'TestCursorReplaceReusable_MatchesCursor' ./adapters/repos/db/lsmkv/
go test -tags integrationTest -count 1 -run 'TestObjectsToPropagateWithinRange' ./adapters/repos/db/
```

## Breaking changes

None. No API, on-disk format, or config changes. The reusable cursor is a new internal-only entry point; `Cursor()` and the `DigestObjectsInRange` RPC are unchanged.


---

## Allocation profile: before/after

Measured with `BenchmarkDigestScan{OldCursor,ReusableCursor}` (added in this PR) — a full replace-cursor scan over a 20k-object, 4-segment **pread** bucket (the shape the hashbeat digest scan walks). One binary, so `Cursor()` == pre-change behaviour and `CursorReplaceReusable()` == new.

| metric | old `Cursor()` | new `CursorReplaceReusable()` | reduction |
|---|---|---|---|
| allocs/op | 120,041 | 20,041 | **−83% (6.0×)** |
| B/op | 3,529,424 | 340,119 | **−90% (10.4×)** |
| total alloc_space | 553.85 MB | 106.79 MB | **5.2×** |
| ns/op | 12.8M | 9.7M | ~24% faster |

Old is ~6 allocs/object (a new reader stack per node), new is ~1.

### `alloc_space` top frames — OLD
```
206.51MB 37.29%  (*segment).newNodeReader        [472.52MB / 85.32% cum]
146.01MB 26.36%  io.NewSectionReader
   73MB 13.18%   diskio.NewMeteredReader
 46.50MB  8.40%  (*segment).bufferedReaderAt      [266.01MB / 48.03% cum]
 42.50MB  7.67%  ParseReplaceNodeIntoPread
```

### `alloc_space` top frames — NEW
```
 70.50MB 66.02%  ParseReplaceNodeIntoPread
  5.52MB  5.17%  bufio.NewReaderSize      (one buffered reader per cursor, reused across nodes)
   ... newNodeReader / NewSectionReader / NewMeteredReader: GONE
```

The `bufferedReaderAt → SectionReader + MeteredReader + nodeReader` per-node chain (266 MB / 48% of old allocations, and the dominant frames in the production hashbeat profile that motivated this PR) drops to **zero** on this path. The largest remaining allocator, `ParseReplaceNodeIntoPread` (the value/key copy into the reusable node), is the natural follow-up if we want to push further — already 1 alloc/object vs 6.

Note: this micro-benchmark isolates the **per-node reader** win. The second win — not reopening the cursor / re-snapshotting the memtable per batch across a cycle — is additional and only shows up in the full multi-batch `collectObjectsToPropagate` loop.

Reproduce:
```
go test -tags integrationTest -run '^$' -bench 'BenchmarkDigestScan' -benchmem ./adapters/repos/db/lsmkv/
```
