### PR TITLE
[DO NOT MERGE] QA perf: AFTER-A (query-path A-stack + hang fix) image build

### DIFF
--- a/adapters/repos/db/helpers/slow_queries_details.go
+++ b/adapters/repos/db/helpers/slow_queries_details.go
@@ -36,6 +36,9 @@ func InitSlowQueryDetails(ctx context.Context) context.Context {
 }
 
 func AnnotateSlowQueryLog(ctx context.Context, key string, value any) {
+	if ctx == nil {
+		return
+	}
 	val := ctx.Value("slow_query_details")
 	if val == nil {
 		return
@@ -57,6 +60,9 @@ func AnnotateSlowQueryLog(ctx context.Context, key string, value any) {
 }
 
 func AnnotateSlowQueryLogAppend[T any](ctx context.Context, key string, value T) {
+	if ctx == nil {
+		return
+	}
 	val := ctx.Value("slow_query_details")
 	if val == nil {
 		return

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -263,11 +263,23 @@ func (b *BM25Searcher) wandBlock(
 }
 
 func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int) ([]*storobj.Object, []float32) {
+	// Preallocate by the real upper bound (total result rows across
+	// properties/segments), not limit*len(allIds): for unlimited (limit==0)
+	// queries the caller inflates limit to the sum of all term counts, which
+	// would over-allocate these slices by orders of magnitude.
+	totalRows, totalTerms := 0, 0
+	for i := range allIds {
+		for j := range allIds[i] {
+			totalRows += len(allIds[i][j])
+		}
+		totalTerms += len(queryTerms[i])
+	}
+
 	// combine all results
-	combinedIds := make([]uint64, 0, limit*len(allIds))
-	combinedScores := make([]float32, 0, limit*len(allIds))
-	combinedExplanations := make([][]*terms.DocPointerWithScore, 0, limit*len(allIds))
-	combinedTerms := make([]string, 0, limit*len(allIds))
+	combinedIds := make([]uint64, 0, totalRows)
+	combinedScores := make([]float32, 0, totalRows)
+	combinedExplanations := make([][]*terms.DocPointerWithScore, 0, totalRows)
+	combinedTerms := make([]string, 0, totalTerms)
 
 	// combine all results
 	for i := range allIds {

--- a/adapters/repos/db/inverted/terms/terms_block.go
+++ b/adapters/repos/db/inverted/terms/terms_block.go
@@ -43,12 +43,19 @@ func (b *BlockEntry) Encode() []byte {
 }
 
 func DecodeBlockEntry(data []byte) *BlockEntry {
-	return &BlockEntry{
-		MaxId:               binary.LittleEndian.Uint64(data),
-		Offset:              binary.LittleEndian.Uint32(data[8:]),
-		MaxImpactTf:         binary.LittleEndian.Uint32(data[12:]),
-		MaxImpactPropLength: binary.LittleEndian.Uint32(data[16:]),
-	}
+	b := &BlockEntry{}
+	DecodeBlockEntryInto(data, b)
+	return b
+}
+
+// DecodeBlockEntryInto decodes a block entry into an existing value, letting
+// callers decode a whole []BlockEntry contiguously without a heap allocation per
+// block.
+func DecodeBlockEntryInto(data []byte, b *BlockEntry) {
+	b.MaxId = binary.LittleEndian.Uint64(data)
+	b.Offset = binary.LittleEndian.Uint32(data[8:])
+	b.MaxImpactTf = binary.LittleEndian.Uint32(data[12:])
+	b.MaxImpactPropLength = binary.LittleEndian.Uint32(data[16:])
 }
 
 type BlockDataDecoded struct {

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2169,8 +2169,8 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 	// active memtable
 	output[len(view.Disk)+1] = make([]*SegmentBlockMax, 0, len(query))
 
-	// memtable tombstones are invariant within a consistent view; read them once
-	// per query instead of cloning + OR-ing the same bitmaps for every term.
+	// Memtable tombstones are invariant within a consistent view: read once and
+	// OR into a single bitmap shared by every term.
 	memTombstones := sroar.NewBitmap()
 	var activeTombstones *sroar.Bitmap
 	if view.Active != nil {
@@ -2190,10 +2190,10 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		memTombstones.Or(flushingTombstones)
 	}
 
-	// per-(segment, term) index nodes prefetched together with the doc counts in
-	// a single index descent (hasKey, getDocCount and the term constructor each
-	// did their own before). diskSkip marks inverted segments where the key is
-	// definitively absent, so construction is not attempted at all.
+	// One index descent per (segment, term): diskNodes/diskNodeOk cache the node
+	// and doc count for reuse by both the count below and term construction.
+	// diskSkip marks inverted segments where the key is absent, so construction
+	// is skipped.
 	qn := len(query)
 	diskNodes := make([]segmentindex.Node, len(view.Disk)*qn)
 	diskNodeOk := make([]bool, len(view.Disk)*qn)
@@ -2203,8 +2203,6 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		key := []byte(queryTerm)
 		n := uint64(0)
 
-		// memtable terms are built only when the memtable actually holds the key
-		// (the common case is that it doesn't — or there is no memtable at all).
 		var active, flushing *SegmentBlockMax
 		if view.Active != nil {
 			if mapPairs, err := view.Active.getMap(key); err == nil {
@@ -2289,8 +2287,8 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 			if diskSkip[idx] {
 				continue
 			}
-			// non-inverted segments have no prefetched node; the constructor
-			// falls back to its own index lookup exactly as before.
+			// non-inverted segments have no prefetched node; nil makes the
+			// constructor do its own index lookup.
 			var node *segmentindex.Node
 			if diskNodeOk[idx] {
 				node = &diskNodes[idx]

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2169,70 +2169,100 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 	// active memtable
 	output[len(view.Disk)+1] = make([]*SegmentBlockMax, 0, len(query))
 
+	// memtable tombstones are invariant within a consistent view; read them once
+	// per query instead of cloning + OR-ing the same bitmaps for every term.
 	memTombstones := sroar.NewBitmap()
+	var activeTombstones *sroar.Bitmap
+	if view.Active != nil {
+		activeTombstones, err = view.Active.ReadOnlyTombstones()
+		if err != nil {
+			view.ReleaseView()
+			return nil, nil, func() {}, fmt.Errorf("active tombstones: %w", err)
+		}
+		memTombstones.Or(activeTombstones)
+	}
+	if view.Flushing != nil {
+		flushingTombstones, err := view.Flushing.ReadOnlyTombstones()
+		if err != nil {
+			view.ReleaseView()
+			return nil, nil, func() {}, fmt.Errorf("flushing tombstones: %w", err)
+		}
+		memTombstones.Or(flushingTombstones)
+	}
+
+	// per-(segment, term) index nodes prefetched together with the doc counts in
+	// a single index descent (hasKey, getDocCount and the term constructor each
+	// did their own before). diskSkip marks inverted segments where the key is
+	// definitively absent, so construction is not attempted at all.
+	qn := len(query)
+	diskNodes := make([]segmentindex.Node, len(view.Disk)*qn)
+	diskNodeOk := make([]bool, len(view.Disk)*qn)
+	diskSkip := make([]bool, len(view.Disk)*qn)
 
 	for i, queryTerm := range query {
 		key := []byte(queryTerm)
 		n := uint64(0)
 
-		active := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
-		flushing := NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config)
-
-		var activeTombstones *sroar.Bitmap
+		// memtable terms are built only when the memtable actually holds the key
+		// (the common case is that it doesn't — or there is no memtable at all).
+		var active, flushing *SegmentBlockMax
 		if view.Active != nil {
-			n2, _ := fillTerm(view.Active, key, active, filterDocIds)
-			if active.Count() > 0 {
-				output[len(view.Disk)+1] = append(output[len(view.Disk)+1], active)
-			}
-			n += n2
+			if mapPairs, err := view.Active.getMap(key); err == nil {
+				if active = NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config); active != nil {
+					n2, _ := addDataToTerm(mapPairs, filterDocIds, active)
+					if active.Count() > 0 {
+						output[len(view.Disk)+1] = append(output[len(view.Disk)+1], active)
+					}
+					n += n2
 
-			activeTombstones, err = view.Active.ReadOnlyTombstones()
-			if err != nil {
-				view.ReleaseView()
-				return nil, nil, func() {}, fmt.Errorf("active tombstones: %w", err)
-			}
-			memTombstones.Or(activeTombstones)
-
-			if !active.Exhausted() {
-				active.advanceOnTombstoneOrFilter()
+					if !active.Exhausted() {
+						active.advanceOnTombstoneOrFilter()
+					}
+				}
 			}
 		}
 
 		if view.Flushing != nil {
-			n2, _ := fillTerm(view.Flushing, key, flushing, filterDocIds)
-			if flushing.Count() > 0 {
-				output[len(view.Disk)] = append(output[len(view.Disk)], flushing)
-			}
-			n += n2
+			if mapPairs, err := view.Flushing.getMap(key); err == nil {
+				if flushing = NewSegmentBlockMaxDecoded(key, i, propertyBoost, filterDocIds, averagePropLength, config); flushing != nil {
+					n2, _ := addDataToTerm(mapPairs, filterDocIds, flushing)
+					if flushing.Count() > 0 {
+						output[len(view.Disk)] = append(output[len(view.Disk)], flushing)
+					}
+					n += n2
 
-			tombstones, err := view.Flushing.ReadOnlyTombstones()
-			if err != nil {
-				view.ReleaseView()
-				return nil, nil, func() {}, fmt.Errorf("flushing tombstones: %w", err)
+					if !flushing.Exhausted() {
+						flushing.tombstones = activeTombstones
+						flushing.advanceOnTombstoneOrFilter()
+					}
+				}
 			}
-			memTombstones.Or(tombstones)
-
-			if !flushing.Exhausted() {
-				flushing.tombstones = activeTombstones
-				flushing.advanceOnTombstoneOrFilter()
-			}
-
 		}
 
-		for _, segment := range view.Disk {
-			if segment.getStrategy() == segmentindex.StrategyInverted && segment.hasKey(key) {
-				n += segment.getDocCount(key)
+		for j, segment := range view.Disk {
+			if segment.getStrategy() != segmentindex.StrategyInverted {
+				continue
+			}
+			if node, docCount, ok := segment.getInvertedNodeAndDocCount(key); ok {
+				n += docCount
+				diskNodes[j*qn+i] = node
+				diskNodeOk[j*qn+i] = true
+			} else {
+				diskSkip[j*qn+i] = true
 			}
 		}
 
 		// we can only know the full n after we have checked all segments and all memtables
 		idfs[i] = math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateTextBoosts[i])
 
-		active.idf = idfs[i]
-		active.currentBlockImpact = float32(idfs[i])
-
-		flushing.idf = idfs[i]
-		flushing.currentBlockImpact = float32(idfs[i])
+		if active != nil {
+			active.idf = idfs[i]
+			active.currentBlockImpact = float32(idfs[i])
+		}
+		if flushing != nil {
+			flushing.idf = idfs[i]
+			flushing.currentBlockImpact = float32(idfs[i])
+		}
 
 		idfCounts[queryTerm] = n
 	}
@@ -2255,7 +2285,17 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		}
 
 		for i, key := range query {
-			term := segment.newSegmentBlockMax([]byte(key), i, idfs[i], propertyBoost, segTombstones, memTombstones, filterDocIds, averagePropLength, config)
+			idx := j*qn + i
+			if diskSkip[idx] {
+				continue
+			}
+			// non-inverted segments have no prefetched node; the constructor
+			// falls back to its own index lookup exactly as before.
+			var node *segmentindex.Node
+			if diskNodeOk[idx] {
+				node = &diskNodes[idx]
+			}
+			term := segment.newSegmentBlockMax(node, []byte(key), i, idfs[i], propertyBoost, segTombstones, memTombstones, filterDocIds, averagePropLength, config)
 			if term != nil {
 				output[j] = append(output[j], term)
 			}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2313,8 +2313,8 @@ func addDataToTerm(mem []MapPair, filterDocIds helpers.AllowList, term *SegmentB
 		return n, nil
 	}
 	term.exhausted = false
-	term.blockEntries = make([]*terms.BlockEntry, 1)
-	term.blockEntries[0] = &terms.BlockEntry{
+	term.blockEntries = make([]terms.BlockEntry, 1)
+	term.blockEntries[0] = terms.BlockEntry{
 		MaxId:  term.blockDataDecoded.DocIds[len(term.blockDataDecoded.DocIds)-1],
 		Offset: 0,
 	}

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -2463,7 +2463,7 @@ func validateMapPairListVsBlockMaxSearchFromSegments(ctx context.Context, segmen
 		duplicateTextBoosts[0] = 1
 		diskTerms := make([][]*SegmentBlockMax, 0, len(segments))
 		for _, segment := range segments {
-			bmws := segment.newSegmentBlockMax(mapKey, 0, 1, 1, nil, nil, nil, 3, bm25config)
+			bmws := segment.newSegmentBlockMax(nil, mapKey, 0, 1, 1, nil, nil, nil, 3, bm25config)
 			diskTerms = append(diskTerms, []*SegmentBlockMax{bmws})
 		}
 

--- a/adapters/repos/db/lsmkv/lazy_segment.go
+++ b/adapters/repos/db/lsmkv/lazy_segment.go
@@ -385,17 +385,22 @@ func (s *lazySegment) newInvertedCursorReusable() *segmentCursorInvertedReusable
 	return s.segment.newInvertedCursorReusable()
 }
 
-func (s *lazySegment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64,
+func (s *lazySegment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64,
 	propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList,
 	averagePropLength float64, config schema.BM25Config,
 ) *SegmentBlockMax {
 	s.mustLoad()
-	return s.segment.newSegmentBlockMax(key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+	return s.segment.newSegmentBlockMax(node, key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
 }
 
 func (s *lazySegment) getDocCount(key []byte) uint64 {
 	s.mustLoad()
 	return s.segment.getDocCount(key)
+}
+
+func (s *lazySegment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	s.mustLoad()
+	return s.segment.getInvertedNodeAndDocCount(key)
 }
 
 func (s *lazySegment) getCountNetAdditions() int {

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -136,11 +136,17 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			// so no explicit exhausted guard is needed here.
 			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
+				// a real shallow advance moves idPointer without re-sorting (and may
+				// even exhaust mid-array), so the slice may then hold inversions that
+				// only a full sortByID repairs — see the matched branch. blockEntryIdx
+				// changes on every actual move/exhaust but not on the early-return
+				// no-op (docCount==1 terms never initialize currentBlockMaxId, so the
+				// guard over-fires for them; the no-op must not defeat the fast path).
+				prevBlockIdx := t.blockEntryIdx
 				t.AdvanceAtLeastShallow(pivotID)
-				// a shallow advance moves idPointer without re-sorting (and may even
-				// exhaust mid-array), so the slice may now hold inversions that only
-				// a full sortByID repairs — see the matched branch.
-				needFullSort = true
+				if t.blockEntryIdx != prevBlockIdx {
+					needFullSort = true
+				}
 			}
 			upperBound += t.currentBlockImpact
 		}

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -111,11 +111,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		upperBound = float32(0)
-		for i := 0; i <= pivotPoint; i++ {
+		// reslice to [0,pivotPoint] (pivotPoint < len, guaranteed by the pivotID
+		// check above) so the compiler drops the per-iteration bounds check.
+		candidates := results[:pivotPoint+1]
+		for i := range candidates {
 			// exhausted terms carry currentBlockMaxId==MaxUint64 (so the shallow
 			// advance is skipped) and currentBlockImpact==0 (so the add is a no-op),
 			// so no explicit exhausted guard is needed here.
-			t := results[i]
+			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
 				t.AdvanceAtLeastShallow(pivotID)
 			}
@@ -123,14 +126,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
-			if additionalExplanations {
-				docInfos = make([]*terms.DocPointerWithScore, termCount)
-			}
-			if pivotID == results[firstNonExhausted].idPointer {
+			firstTerm := results[firstNonExhausted]
+			if pivotID == firstTerm.idPointer {
 				// a deferred tombstone hit: advance the aligned terms past the pivot
 				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
-				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
+				pivotTombstoned := deferTombstoneToScore && firstTerm.tombstoned(pivotID)
 				if !pivotTombstoned {
+					if additionalExplanations {
+						docInfos = make([]*terms.DocPointerWithScore, termCount)
+					}
 					score := 0.0
 					termsMatched := 0
 					for _, term := range results {
@@ -180,13 +184,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			maxWeight := results[nextList].idf
 			next := uint64(math.MaxUint64) // max uint
 
-			for i := 0; i <= pivotPoint; i++ {
-				if i < pivotPoint && results[i].idf > maxWeight {
+			candidates := results[:pivotPoint+1]
+			for i := range candidates {
+				t := candidates[i]
+				if i < pivotPoint && t.idf > maxWeight {
 					nextList = i
-					maxWeight = results[i].idf
+					maxWeight = t.idf
 				}
-				if results[i].currentBlockMaxId < next {
-					next = results[i].currentBlockMaxId
+				if t.currentBlockMaxId < next {
+					next = t.currentBlockMaxId
 				}
 			}
 
@@ -230,40 +236,41 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 		return topKHeap
 	}
 
+	ctxCheck := 0
 	for {
 		iterations++
 
-		if iterations%100000 == 0 && ctx != nil && ctx.Err() != nil {
-			segmentPath := ""
-			terms := ""
-			filterCardinality := -1
-			for _, r := range results {
-				if r == nil {
-					continue
-				}
-				if r.segment != nil {
-					segmentPath = r.segment.path
-					if r.filterDocIds != nil {
-						filterCardinality = r.filterDocIds.Len()
+		// periodic cancellation check; countdown instead of a 64-bit modulo on the
+		// hot loop (same change as DoBlockMaxWand), same every-100000 cadence.
+		ctxCheck++
+		if ctxCheck == 100000 {
+			ctxCheck = 0
+			if ctx != nil && ctx.Err() != nil {
+				segmentPath := ""
+				terms := ""
+				filterCardinality := -1
+				for _, r := range results {
+					if r == nil {
+						continue
 					}
+					if r.segment != nil {
+						segmentPath = r.segment.path
+						if r.filterDocIds != nil {
+							filterCardinality = r.filterDocIds.Len()
+						}
+					}
+					terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
 				}
-				terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
-			}
-			logger.WithFields(logrus.Fields{
-				"segment":           segmentPath,
-				"iterations":        iterations,
-				"pivotID":           pivotID,
-				"lenResults":        len(results),
-				"upperBound":        upperBound,
-				"terms":             terms,
-				"filterCardinality": filterCardinality,
-				"limit":             limit,
-			}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
-			return topKHeap
-		}
-
-		for i := 0; i < len(results); i++ {
-			if results[i].exhausted {
+				logger.WithFields(logrus.Fields{
+					"segment":           segmentPath,
+					"iterations":        iterations,
+					"pivotID":           pivotID,
+					"lenResults":        len(results),
+					"upperBound":        upperBound,
+					"terms":             terms,
+					"filterCardinality": filterCardinality,
+					"limit":             limit,
+				}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
 				return topKHeap
 			}
 		}
@@ -276,12 +283,17 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 
 		pivotID = results[0].idPointer
 
+		// AND is terminal the instant any term exhausts: no higher doc id can align
+		// across every term, so the heap is frozen and we return at the advance site
+		// rather than rescanning all terms at the top of each iteration. results[0]
+		// is covered just above; the others can only exhaust here or in the
+		// candidate-advance loop below.
+		upperBound = results[0].currentBlockImpact
 		for i := 1; i < len(results); i++ {
 			results[i].AdvanceAtLeastShallow(pivotID)
-		}
-
-		upperBound = float32(0)
-		for i := 0; i < len(results); i++ {
+			if results[i].exhausted {
+				return topKHeap
+			}
 			upperBound += results[i].currentBlockImpact
 		}
 
@@ -289,6 +301,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 			isCandidate := true
 			for i := 1; i < len(results); i++ {
 				results[i].AdvanceAtLeast(pivotID)
+				if results[i].exhausted {
+					return topKHeap
+				}
 				if results[i].idPointer != pivotID {
 					isCandidate = false
 					break

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -37,7 +37,12 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	var pivotPoint int
 	upperBound := float32(0)
 
-	done := ctx.Done()
+	// a nil ctx is tolerated (some callers pass none): a nil done channel never
+	// selects, so cancellation is simply disabled rather than panicking.
+	var done <-chan struct{}
+	if ctx != nil {
+		done = ctx.Done()
+	}
 	ctxCheck := 0
 	for {
 		iterations++

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -127,29 +127,34 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 				docInfos = make([]*terms.DocPointerWithScore, termCount)
 			}
 			if pivotID == results[firstNonExhausted].idPointer {
-				score := 0.0
-				termsMatched := 0
-				for _, term := range results {
-					if term.idPointer != pivotID {
-						break
-					}
-					termsMatched++
-					_, s, d := term.Score(averagePropLength, additionalExplanations)
-					score += s
+				// a deferred tombstone hit: advance the aligned terms past the pivot
+				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
+				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
+				if !pivotTombstoned {
+					score := 0.0
+					termsMatched := 0
+					for _, term := range results {
+						if term.idPointer != pivotID {
+							break
+						}
+						termsMatched++
+						_, s, d := term.Score(averagePropLength, additionalExplanations)
+						score += s
 
-					if additionalExplanations {
-						docInfos[term.QueryTermIndex()] = d
-					}
+						if additionalExplanations {
+							docInfos[term.QueryTermIndex()] = d
+						}
 
+					}
+					if topKHeap.ShouldEnqueue(float32(score), limit) && termsMatched >= minimumOrTokensMatch {
+						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+					}
 				}
 				for _, term := range results {
 					if !term.exhausted && term.idPointer != pivotID {
 						break
 					}
 					term.Advance()
-				}
-				if topKHeap.ShouldEnqueue(float32(score), limit) && termsMatched >= minimumOrTokensMatch {
-					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 				}
 
 				results.sortByID()
@@ -290,20 +295,28 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 				}
 			}
 			if isCandidate {
-				score := 0.0
-				if additionalExplanations {
-					docInfos = make([]*terms.DocPointerWithScore, termCount)
-				}
-				for _, term := range results {
-					_, s, d := term.Score(averagePropLength, additionalExplanations)
-					score += s
-					if additionalExplanations {
-						docInfos[term.QueryTermIndex()] = d
+				// deferred tombstone hit (see deferTombstoneToScore): advance past the
+				// candidate without scoring it.
+				if deferTombstoneToScore && results[0].tombstoned(pivotID) {
+					for _, term := range results {
+						term.Advance()
 					}
-					term.Advance()
-				}
-				if topKHeap.ShouldEnqueue(float32(score), limit) {
-					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+				} else {
+					score := 0.0
+					if additionalExplanations {
+						docInfos = make([]*terms.DocPointerWithScore, termCount)
+					}
+					for _, term := range results {
+						_, s, d := term.Score(averagePropLength, additionalExplanations)
+						score += s
+						if additionalExplanations {
+							docInfos[term.QueryTermIndex()] = d
+						}
+						term.Advance()
+					}
+					if topKHeap.ShouldEnqueue(float32(score), limit) {
+						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
+					}
 				}
 			} else {
 				pivotID += 1

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -111,11 +111,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		upperBound = float32(0)
-		for i := 0; i <= pivotPoint; i++ {
+		// reslice to [0,pivotPoint] (pivotPoint < len, guaranteed by the pivotID
+		// check above) so the compiler drops the per-iteration bounds check.
+		candidates := results[:pivotPoint+1]
+		for i := range candidates {
 			// exhausted terms carry currentBlockMaxId==MaxUint64 (so the shallow
 			// advance is skipped) and currentBlockImpact==0 (so the add is a no-op),
 			// so no explicit exhausted guard is needed here.
-			t := results[i]
+			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
 				t.AdvanceAtLeastShallow(pivotID)
 			}
@@ -123,10 +126,11 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
-			if pivotID == results[firstNonExhausted].idPointer {
+			firstTerm := results[firstNonExhausted]
+			if pivotID == firstTerm.idPointer {
 				// a deferred tombstone hit: advance the aligned terms past the pivot
 				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
-				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
+				pivotTombstoned := deferTombstoneToScore && firstTerm.tombstoned(pivotID)
 				if !pivotTombstoned {
 					if additionalExplanations {
 						docInfos = make([]*terms.DocPointerWithScore, termCount)
@@ -180,13 +184,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			maxWeight := results[nextList].idf
 			next := uint64(math.MaxUint64) // max uint
 
-			for i := 0; i <= pivotPoint; i++ {
-				if i < pivotPoint && results[i].idf > maxWeight {
+			candidates := results[:pivotPoint+1]
+			for i := range candidates {
+				t := candidates[i]
+				if i < pivotPoint && t.idf > maxWeight {
 					nextList = i
-					maxWeight = results[i].idf
+					maxWeight = t.idf
 				}
-				if results[i].currentBlockMaxId < next {
-					next = results[i].currentBlockMaxId
+				if t.currentBlockMaxId < next {
+					next = t.currentBlockMaxId
 				}
 			}
 
@@ -230,40 +236,41 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 		return topKHeap
 	}
 
+	ctxCheck := 0
 	for {
 		iterations++
 
-		if iterations%100000 == 0 && ctx != nil && ctx.Err() != nil {
-			segmentPath := ""
-			terms := ""
-			filterCardinality := -1
-			for _, r := range results {
-				if r == nil {
-					continue
-				}
-				if r.segment != nil {
-					segmentPath = r.segment.path
-					if r.filterDocIds != nil {
-						filterCardinality = r.filterDocIds.Len()
+		// periodic cancellation check; countdown instead of a 64-bit modulo on the
+		// hot loop (same change as DoBlockMaxWand), same every-100000 cadence.
+		ctxCheck++
+		if ctxCheck == 100000 {
+			ctxCheck = 0
+			if ctx != nil && ctx.Err() != nil {
+				segmentPath := ""
+				terms := ""
+				filterCardinality := -1
+				for _, r := range results {
+					if r == nil {
+						continue
 					}
+					if r.segment != nil {
+						segmentPath = r.segment.path
+						if r.filterDocIds != nil {
+							filterCardinality = r.filterDocIds.Len()
+						}
+					}
+					terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
 				}
-				terms += r.QueryTerm() + ":" + strconv.Itoa(int(r.IdPointer())) + ":" + strconv.Itoa(r.Count()) + ", "
-			}
-			logger.WithFields(logrus.Fields{
-				"segment":           segmentPath,
-				"iterations":        iterations,
-				"pivotID":           pivotID,
-				"lenResults":        len(results),
-				"upperBound":        upperBound,
-				"terms":             terms,
-				"filterCardinality": filterCardinality,
-				"limit":             limit,
-			}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
-			return topKHeap
-		}
-
-		for i := 0; i < len(results); i++ {
-			if results[i].exhausted {
+				logger.WithFields(logrus.Fields{
+					"segment":           segmentPath,
+					"iterations":        iterations,
+					"pivotID":           pivotID,
+					"lenResults":        len(results),
+					"upperBound":        upperBound,
+					"terms":             terms,
+					"filterCardinality": filterCardinality,
+					"limit":             limit,
+				}).Warnf("DoBlockMaxAnd: search timed out, returning partial results")
 				return topKHeap
 			}
 		}
@@ -276,12 +283,17 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 
 		pivotID = results[0].idPointer
 
+		// AND is terminal the instant any term exhausts: no higher doc id can align
+		// across every term, so the heap is frozen and we return at the advance site
+		// rather than rescanning all terms at the top of each iteration. results[0]
+		// is covered just above; the others can only exhaust here or in the
+		// candidate-advance loop below.
+		upperBound = results[0].currentBlockImpact
 		for i := 1; i < len(results); i++ {
 			results[i].AdvanceAtLeastShallow(pivotID)
-		}
-
-		upperBound = float32(0)
-		for i := 0; i < len(results); i++ {
+			if results[i].exhausted {
+				return topKHeap
+			}
 			upperBound += results[i].currentBlockImpact
 		}
 
@@ -289,6 +301,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 			isCandidate := true
 			for i := 1; i < len(results); i++ {
 				results[i].AdvanceAtLeast(pivotID)
+				if results[i].exhausted {
+					return topKHeap
+				}
 				if results[i].idPointer != pivotID {
 					isCandidate = false
 					break

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -123,14 +123,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
-			if additionalExplanations {
-				docInfos = make([]*terms.DocPointerWithScore, termCount)
-			}
 			if pivotID == results[firstNonExhausted].idPointer {
 				// a deferred tombstone hit: advance the aligned terms past the pivot
 				// (below) but skip scoring/enqueue. See deferTombstoneToScore.
 				pivotTombstoned := deferTombstoneToScore && results[firstNonExhausted].tombstoned(pivotID)
 				if !pivotTombstoned {
+					if additionalExplanations {
+						docInfos = make([]*terms.DocPointerWithScore, termCount)
+					}
 					score := 0.0
 					termsMatched := 0
 					for _, term := range results {

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -30,7 +30,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	var docInfos []*terms.DocPointerWithScore
 	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
 	worstDist := float64(-10000) // tf score can be negative
-	sort.Sort(results)
+	results.sortByID()
 	iterations := 0
 	var firstNonExhausted int
 	pivotID := uint64(0)
@@ -130,7 +130,6 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 					termsMatched++
 					_, s, d := term.Score(averagePropLength, additionalExplanations)
 					score += s
-					upperBound -= term.currentBlockImpact - float32(s)
 
 					if additionalExplanations {
 						docInfos[term.QueryTermIndex()] = d
@@ -147,7 +146,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 					topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 				}
 
-				sort.Sort(results)
+				results.sortByID()
 
 			} else {
 				nextList := pivotPoint
@@ -168,20 +167,18 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 
 			}
 		} else {
+			// single pass over [0, pivotPoint] computing both the heaviest term to
+			// advance (over [0, pivotPoint)) and the smallest block-max id (over
+			// [0, pivotPoint]) — formerly two separate scans.
 			nextList := pivotPoint
 			maxWeight := results[nextList].Idf()
+			next := uint64(math.MaxUint64) // max uint
 
-			for i := 0; i < pivotPoint; i++ {
-				if results[i].Idf() > maxWeight {
+			for i := 0; i <= pivotPoint; i++ {
+				if i < pivotPoint && results[i].Idf() > maxWeight {
 					nextList = i
 					maxWeight = results[i].Idf()
 				}
-			}
-
-			// max uint
-			next := uint64(math.MaxUint64)
-
-			for i := 0; i <= pivotPoint; i++ {
 				if results[i].currentBlockMaxId < next {
 					next = results[i].currentBlockMaxId
 				}
@@ -372,6 +369,24 @@ func (t Terms) Less(i, j int) bool {
 
 func (t Terms) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
+}
+
+// sortByID sorts the terms ascending by idPointer with a concrete insertion
+// sort. It replaces sort.Sort on the WAND hot path: the term list is small
+// (query-term count) and, after the first pass, nearly sorted — the regime where
+// insertion sort wins — and comparing idPointer directly avoids the
+// sort.Interface Less/Swap dispatch that showed up as ~5% self time.
+func (t Terms) sortByID() {
+	for i := 1; i < len(t); i++ {
+		cur := t[i]
+		id := cur.idPointer
+		j := i - 1
+		for j >= 0 && t[j].idPointer > id {
+			t[j+1] = t[j]
+			j--
+		}
+		t[j+1] = cur
+	}
 }
 
 type TermsBySize []*SegmentBlockMax

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -38,10 +38,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	upperBound := float32(0)
 
 	done := ctx.Done()
+	ctxCheck := 0
 	for {
 		iterations++
 
-		if iterations%100000 == 0 {
+		// periodic cancellation check; a countdown avoids a 64-bit modulo on the
+		// hottest loop in BMW (the modulo was ~1.5% of self time).
+		ctxCheck++
+		if ctxCheck == 100000 {
+			ctxCheck = 0
 			select {
 			case <-done:
 				segmentPath := ""
@@ -88,7 +93,7 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			if firstNonExhausted == -1 {
 				firstNonExhausted = pivotPoint
 			}
-			cumScore += float64(results[pivotPoint].Idf())
+			cumScore += results[pivotPoint].idf
 			if cumScore >= worstDist {
 				pivotID = results[pivotPoint].idPointer
 				for i := pivotPoint + 1; i < len(results); i++ {
@@ -107,13 +112,14 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 
 		upperBound = float32(0)
 		for i := 0; i <= pivotPoint; i++ {
-			if results[i].exhausted {
-				continue
+			// exhausted terms carry currentBlockMaxId==MaxUint64 (so the shallow
+			// advance is skipped) and currentBlockImpact==0 (so the add is a no-op),
+			// so no explicit exhausted guard is needed here.
+			t := results[i]
+			if t.currentBlockMaxId < pivotID {
+				t.AdvanceAtLeastShallow(pivotID)
 			}
-			if results[i].currentBlockMaxId < pivotID {
-				results[i].AdvanceAtLeastShallow(pivotID)
-			}
-			upperBound += results[i].currentBlockImpact
+			upperBound += t.currentBlockImpact
 		}
 
 		if topKHeap.ShouldEnqueue(upperBound, limit) {
@@ -155,15 +161,10 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 				}
 				results[nextList].AdvanceAtLeast(pivotID)
 
-				// sort partial
-				for i := nextList + 1; i < len(results); i++ {
-					if results[i].idPointer < results[i-1].idPointer {
-						// swap
-						results[i], results[i-1] = results[i-1], results[i]
-					} else {
-						break
-					}
-				}
+				// only results[nextList] moved (rightward), so a single re-insertion
+				// restores order — same permutation as the old swap bubble, one move
+				// per step instead of a two-write swap.
+				results.reinsertRight(nextList)
 
 			}
 		} else {
@@ -171,13 +172,13 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			// advance (over [0, pivotPoint)) and the smallest block-max id (over
 			// [0, pivotPoint]) — formerly two separate scans.
 			nextList := pivotPoint
-			maxWeight := results[nextList].Idf()
+			maxWeight := results[nextList].idf
 			next := uint64(math.MaxUint64) // max uint
 
 			for i := 0; i <= pivotPoint; i++ {
-				if i < pivotPoint && results[i].Idf() > maxWeight {
+				if i < pivotPoint && results[i].idf > maxWeight {
 					nextList = i
-					maxWeight = results[i].Idf()
+					maxWeight = results[i].idf
 				}
 				if results[i].currentBlockMaxId < next {
 					next = results[i].currentBlockMaxId
@@ -195,14 +196,13 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			}
 			results[nextList].AdvanceAtLeast(next)
 
-			for i := nextList + 1; i < len(results); i++ {
-				if results[i].idPointer < results[i-1].idPointer {
-					// swap
-					results[i], results[i-1] = results[i-1], results[i]
-				} else if results[i].exhausted && i < len(results)-1 {
-					results[i], results[i+1] = results[i+1], results[i]
-				}
-			}
+			// AdvanceAtLeast only ever increases results[nextList].idPointer (or
+			// exhausts it to MaxUint64), so the slice is sorted everywhere except
+			// that one element, which must move right. Re-insert it and stop the
+			// instant it settles — the old loop had no early break and rescanned the
+			// whole tail every iteration (its exhausted-swap branch only ever
+			// reordered MaxUint64 sentinels, which no reader observes).
+			results.reinsertRight(nextList)
 
 		}
 
@@ -369,6 +369,21 @@ func (t Terms) Less(i, j int) bool {
 
 func (t Terms) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
+}
+
+// reinsertRight restores ascending-by-idPointer order when exactly one element
+// (at index i) has had its idPointer increased and everything else is already
+// sorted. It shifts the element rightward to its slot and stops as soon as it
+// settles — O(displacement), with one move per step instead of a two-write swap.
+func (t Terms) reinsertRight(i int) {
+	cur := t[i]
+	id := cur.idPointer
+	j := i
+	for j+1 < len(t) && t[j+1].idPointer < id {
+		t[j] = t[j+1]
+		j++
+	}
+	t[j] = cur
 }
 
 // sortByID sorts the terms ascending by idPointer with a concrete insertion

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -248,13 +248,24 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			}
 			results[nextList].AdvanceAtLeast(next)
 
-			// AdvanceAtLeast only ever increases results[nextList].idPointer (or
-			// exhausts it to MaxUint64), so the slice is sorted everywhere except
-			// that one element, which must move right. Re-insert it and stop the
-			// instant it settles — the old loop had no early break and rescanned the
-			// whole tail every iteration (its exhausted-swap branch only ever
-			// reordered MaxUint64 sentinels, which no reader observes).
-			results.reinsertRight(nextList)
+			// Full-tail repair pass (no early break). Unlike the other branches,
+			// this one must fix more than the single advanced element: the
+			// upper-bound loop above calls AdvanceAtLeastShallow on every term in
+			// [0, pivotPoint] whose block trailed the pivot, and that mutates their
+			// idPointer to an approximate (previous-block-max) value — leaving the
+			// prefix unsorted and stranding exhausted terms mid-slice. A single
+			// re-insertion of results[nextList] does NOT repair that; the disorder
+			// then accumulates across iterations until the pivot scan can no longer
+			// advance and DoBlockMaxWand spins forever on a long (many-term) query.
+			// The per-iteration bubble pass keeps the slice converging toward sorted
+			// (and pushes exhausted MaxUint64 sentinels rightward) the way base did.
+			for i := nextList + 1; i < len(results); i++ {
+				if results[i].idPointer < results[i-1].idPointer {
+					results[i], results[i-1] = results[i-1], results[i]
+				} else if results[i].exhausted && i < len(results)-1 {
+					results[i], results[i+1] = results[i+1], results[i]
+				}
+			}
 
 		}
 

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -38,6 +38,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	pivotID := uint64(0)
 	var pivotPoint int
 	upperBound := float32(0)
+	// needFullSort tracks whether shallow advances have run since the last full
+	// sortByID. Shallow advances move idPointers (and can exhaust terms) in place,
+	// so the slice may hold inversions or mis-placed exhausted sentinels that only
+	// a full sort repairs. While false, the matched branch can restore order with
+	// a per-advanced-term re-insertion instead of re-sorting all terms — matched
+	// iterations themselves never shallow-advance (their live prefix is already
+	// aligned, so currentBlockMaxId >= pivotID), so matched-dense queries stay on
+	// the cheap path.
+	needFullSort := false
 
 	// a nil ctx is tolerated (some callers pass none): a nil done channel never
 	// selects, so cancellation is simply disabled rather than panicking.
@@ -128,6 +137,10 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			t := candidates[i]
 			if t.currentBlockMaxId < pivotID {
 				t.AdvanceAtLeastShallow(pivotID)
+				// a shallow advance moves idPointer without re-sorting (and may even
+				// exhaust mid-array), so the slice may now hold inversions that only
+				// a full sortByID repairs — see the matched branch.
+				needFullSort = true
 			}
 			upperBound += t.currentBlockImpact
 		}
@@ -161,14 +174,29 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 						topKHeap.InsertAndPop(pivotID, score, limit, &worstDist, docInfos)
 					}
 				}
+				advanced := 0
 				for _, term := range results {
 					if !term.exhausted && term.idPointer != pivotID {
 						break
 					}
 					term.Advance()
+					advanced++
 				}
 
-				results.sortByID()
+				if needFullSort {
+					results.sortByID()
+					needFullSort = false
+				} else {
+					// only the advanced prefix moved (each idPointer increased) and the
+					// suffix is inversion-free, so re-inserting the prefix right-to-left
+					// yields the exact permutation a full stable sortByID would: at each
+					// step the suffix is already sorted, and reinsertRight's strict `<`
+					// settles equal ids in original index order, matching insertion-sort
+					// stability.
+					for i := advanced - 1; i >= 0; i-- {
+						results.reinsertRight(i)
+					}
+				}
 
 			} else {
 				nextList := pivotPoint

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -28,7 +28,9 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 	termCount, minimumOrTokensMatch int, logger logrus.FieldLogger,
 ) (*priorityqueue.Queue[[]*terms.DocPointerWithScore], error) {
 	var docInfos []*terms.DocPointerWithScore
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	results.sortByID()
 	iterations := 0
@@ -225,7 +227,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 ) *priorityqueue.Queue[[]*terms.DocPointerWithScore] {
 	results := TermsBySize(resultsByTerm)
 	var docInfos []*terms.DocPointerWithScore
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	sort.Sort(results)
 	iterations := 0
@@ -355,7 +359,9 @@ func DoBlockMaxAnd(ctx context.Context, limit int, resultsByTerm Terms, averageP
 func DoWand(ctx context.Context, limit int, results *terms.Terms, averagePropLength float64, additionalExplanations bool,
 	minimumOrTokensMatch int, logger logrus.FieldLogger,
 ) *priorityqueue.Queue[[]*terms.DocPointerWithScore] {
-	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit)
+	// limit+1: InsertAndPop holds limit+1 items between insert and pop, so an
+	// exact-limit capacity forces one slice regrow per query.
+	topKHeap := priorityqueue.NewMinWithId[[]*terms.DocPointerWithScore](limit + 1)
 	worstDist := float64(-10000) // tf score can be negative
 	sort.Sort(results)
 	iterations := 0

--- a/adapters/repos/db/lsmkv/search_segment_longquery_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_longquery_test.go
@@ -1,0 +1,107 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// A long (many-term) BM25 query — e.g. a user pasting a multi-page document for
+// near-duplicate search — must not hang the WAND loop. Regression for a
+// DoBlockMaxWand non-termination: the upper-bound loop's AdvanceAtLeastShallow
+// mutates idPointer on the [0,pivotPoint] prefix, and when the prune branch
+// repaired only the single advanced element that disorder accumulated until the
+// pivot could no longer advance and the query spun forever.
+//
+// A done-channel + watchdog is used deliberately (not a query ctx deadline) so a
+// non-terminating loop fails the test instead of being masked as a timeout.
+// (Repro authored by QA Claude.)
+func TestBlockMaxWandLongQueryTerminates(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+	bucket.SetMemtableThreshold(1 << 30)
+
+	const nDocs, vocab, termsPerDoc = 50000, 30000, 40
+	rng := rand.New(rand.NewSource(1))
+	zipf := rand.NewZipf(rng, 1.07, 1.0, uint64(vocab-1))
+	key := func(id uint64) string { return "t" + strconv.FormatUint(id, 36) }
+	var plSum float64
+	for d := 0; d < nDocs; d++ {
+		pl := float32(20 + rng.Intn(500))
+		plSum += float64(pl)
+		seen := make(map[uint64]uint32, termsPerDoc)
+		for k := 0; k < termsPerDoc; k++ {
+			seen[zipf.Uint64()]++
+		}
+		for tid, tf := range seen {
+			require.NoError(t, bucket.MapSet([]byte(key(tid)),
+				NewMapPairFromDocIdAndTf(uint64(d), float32(tf), pl, false)))
+		}
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+	avgPropLen := plSum / float64(nDocs)
+
+	// 200 unique terms, Zipf-drawn with count boosts (mirrors a real paste:
+	// AnalyzeAndCountDuplicates dedups to unique terms + duplicateBoosts).
+	qz := rand.NewZipf(rand.New(rand.NewSource(99)), 1.07, 1.0, uint64(vocab-1))
+	counts := map[string]int{}
+	for len(counts) < 200 {
+		counts[key(qz.Uint64())]++
+	}
+	terms, boosts := make([]string, 0, 200), make([]int, 0, 200)
+	for tk, c := range counts {
+		terms, boosts = append(terms, tk), append(boosts, c)
+	}
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(nDocs), nil, terms, "", 1, boosts, schema.BM25Config{K1: 1.2, B: 0.75})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		for _, segTerms := range diskTerms {
+			if len(segTerms) == 0 {
+				continue
+			}
+			h, _ := DoBlockMaxWand(ctx, 10, segTerms, avgPropLen, false, len(terms), 1, logger)
+			for h != nil && h.Len() > 0 {
+				h.Pop()
+			}
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("DoBlockMaxWand did not terminate within 20s on a 200-term query (pivot not advancing)")
+	}
+}

--- a/adapters/repos/db/lsmkv/search_segment_nilctx_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_nilctx_test.go
@@ -1,0 +1,32 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// DoBlockMaxWand must tolerate a nil ctx (some callers pass none). Empty results
+// reach both ctx-use sites: the pre-loop ctx.Done() and the normal-return
+// AnnotateSlowQueryLog. Either one panics on a nil ctx without the guards.
+func TestDoBlockMaxWand_NilContext(t *testing.T) {
+	logger := logrus.New()
+
+	//nolint:staticcheck // SA1012: passing a nil ctx is the behaviour under test.
+	heap, err := DoBlockMaxWand(nil, 10, Terms{}, 1.0, false, 0, 1, logger)
+	require.NoError(t, err)
+	require.NotNil(t, heap)
+	require.Equal(t, 0, heap.Len())
+}

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -87,11 +87,12 @@ type Segment interface {
 	// map/bmw specific
 	hasKey(key []byte) bool
 	getDocCount(key []byte) uint64
+	getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool)
 	getPropertyLengths() (map[uint64]uint32, error)
 	isPropertyLengthsLoaded() bool
 	freePropertyLengths()
 	newInvertedCursorReusable() *segmentCursorInvertedReusable
-	newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
+	newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax
 
 	// replace specific
 	getCountNetAdditions() int

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -488,16 +488,23 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		return
 	}
 
-	for s.blockEntryIdx < len(s.blockEntries) && docId > s.blockEntries[s.blockEntryIdx].MaxId {
-		s.blockEntryIdx++
+	// scan with locals so the index stays in a register and the decoded/freqDecoded
+	// stores happen once after the loop instead of on every skipped block.
+	entries := s.blockEntries
+	idx := s.blockEntryIdx
+	for idx < len(entries) && docId > entries[idx].MaxId {
+		idx++
+	}
+	if idx != s.blockEntryIdx {
+		s.blockEntryIdx = idx
 		s.decoded = false
 		s.freqDecoded = false
 	}
 
-	// the loop only stops when blockEntryIdx hits the end or docId <= this
-	// block's MaxId, so the "last block, still past it" case the old condition
-	// also tested can never hold here — a bounds check is enough.
-	if s.blockEntryIdx >= len(s.blockEntries) {
+	// the loop only stops when idx hits the end or docId <= this block's MaxId,
+	// so the "last block, still past it" case the old condition also tested can
+	// never hold here — a bounds check is enough.
+	if idx >= len(entries) {
 		s.exhaust()
 		return
 	}
@@ -506,9 +513,15 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		s.decodeBlock()
 	}
 
-	for s.blockDataIdx < s.blockDataSize-1 && docId > s.blockDataDecoded.DocIds[s.blockDataIdx] {
-		s.blockDataIdx++
+	// read after decodeBlock: it rewrites the decoded buffer in place and updates
+	// blockDataSize.
+	docIDs := s.blockDataDecoded.DocIds
+	last := s.blockDataSize - 1
+	j := s.blockDataIdx
+	for j < last && docId > docIDs[j] {
+		j++
 	}
+	s.blockDataIdx = j
 
 	s.advanceOnTombstoneOrFilter()
 }
@@ -521,8 +534,9 @@ func (s *SegmentBlockMax) AdvanceAtLeastShallow(docId uint64) {
 		return
 	}
 
-	for s.blockEntryIdx < len(s.blockEntries) && docId > s.blockEntries[s.blockEntryIdx].MaxId {
-
+	// the in-loop bounds return below guarantees blockEntryIdx < len on every
+	// condition re-eval, so the index is always valid here — no length guard needed.
+	for docId > s.blockEntries[s.blockEntryIdx].MaxId {
 		s.blockEntryIdx++
 		s.blockDataIdx = 0
 		s.decoded = false

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -202,8 +202,17 @@ type SegmentBlockMax struct {
 	Metrics BlockMetrics
 }
 
-func (s *segment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
-	return NewSegmentBlockMax(s, key, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+// node may carry the term's index node prefetched by getInvertedNodeAndDocCount
+// (one descent for docCount + construction); nil means look it up here.
+func (s *segment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
+	if node == nil {
+		n, err := s.index.Get(key)
+		if err != nil {
+			return nil
+		}
+		node = &n
+	}
+	return newSegmentBlockMaxFromNode(s, *node, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
 }
 
 func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
@@ -211,7 +220,10 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	if err != nil {
 		return nil
 	}
+	return newSegmentBlockMaxFromNode(s, node, queryTermIndex, idf, propertyBoost, tombstones, memTombstones, filterDocIds, averagePropLength, config)
+}
 
+func newSegmentBlockMaxFromNode(s *segment, node segmentindex.Node, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	// if filter is empty after checking for tombstones,
 	// we can skip it and return nil for the segment
 	if filterDocIds != nil && filterDocIds.IsEmpty() {
@@ -255,8 +267,7 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 		sectionReader: sectionReader,
 	}
 
-	err = output.reset()
-	if err != nil {
+	if err := output.reset(); err != nil {
 		return nil
 	}
 	output.Metrics.BlockCountTotal += uint64(len(output.blockEntries))

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -145,6 +145,16 @@ type BlockMetrics struct {
 }
 
 type SegmentBlockMax struct {
+	// Hot scalars read on every WAND scan iteration — kept together at the top so
+	// they share a cache line (the gated-off Metrics block sits at the tail).
+	idPointer          uint64
+	idf                float64
+	currentBlockMaxId  uint64
+	currentBlockImpact float32
+	exhausted          bool
+	decoded            bool
+	freqDecoded        bool
+
 	segment               *segment
 	node                  segmentindex.Node
 	docCount              uint64
@@ -158,23 +168,15 @@ type SegmentBlockMax struct {
 	blockDataSize         int
 	blockDataStartOffset  uint64
 	blockDataEndOffset    uint64
-	idPointer             uint64
-	idf                   float64
-	exhausted             bool
-	decoded               bool
-	freqDecoded           bool
 	queryTermIndex        int
-	Metrics               BlockMetrics
 	averagePropLength     float64
 	b                     float64
 	k1                    float64
 	propertyBoost         float64
 
-	currentBlockImpact float32
-	currentBlockMaxId  uint64
-	tombstones         *sroar.Bitmap
-	memTombstones      *sroar.Bitmap
-	filterDocIds       helpers.AllowList
+	tombstones    *sroar.Bitmap
+	memTombstones *sroar.Bitmap
+	filterDocIds  helpers.AllowList
 
 	// stateless reusable-decode functions, resolved once from the segment's
 	// codecs (doc ids and term frequencies). Func values, not an encoder
@@ -186,6 +188,10 @@ type SegmentBlockMax struct {
 	blockDatasTest []*terms.BlockData
 
 	sectionReader *io.SectionReader
+
+	// cold: only written under collectBlockMetrics (off in production); kept last
+	// so it never separates the hot scalars above.
+	Metrics BlockMetrics
 }
 
 func (s *segment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
@@ -202,6 +208,17 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	// we can skip it and return nil for the segment
 	if filterDocIds != nil && filterDocIds.IsEmpty() {
 		return nil
+	}
+
+	// Normalize empty-but-non-nil tombstone bitmaps to nil so advanceOnTombstoneOrFilter
+	// short-circuits them instead of paying a sroar.Contains per advanced doc.
+	// memTombstones is built as a fresh sroar.NewBitmap() and is non-nil even with
+	// no in-memory deletes (the common case), which otherwise costs a probe per doc.
+	if tombstones != nil && tombstones.IsEmpty() {
+		tombstones = nil
+	}
+	if memTombstones != nil && memTombstones.IsEmpty() {
+		memTombstones = nil
 	}
 
 	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(s.invertedHeader.DataFields)

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -377,8 +377,8 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 }
 
 // tombstoned reports whether docID is deleted in this iterator's view. All terms
-// in a segment share its tombstone bitmaps, so any aligned term answers for the
-// pivot.
+// in a segment share the same tombstone bitmaps, so any one of them can report
+// tombstone status for a pivot they all align on.
 func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
 	return (s.tombstones != nil && s.tombstones.Contains(docID)) ||
 		(s.memTombstones != nil && s.memTombstones.Contains(docID))

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -26,7 +26,26 @@ import (
 
 var blockMaxBufferSize = 4096
 
-func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint64]uint32) ([]*terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
+// collectBlockMetrics gates the per-doc/per-block BlockMetrics bookkeeping in the
+// scoring hot path. No production code reads these counters; the profiling
+// harness sets this true to populate them. Default false keeps Score/decodeBlock
+// free of the counter writes.
+var collectBlockMetrics = false
+
+// decodeFuncsFromCodecs resolves the stateless doc-id and tf decode functions for
+// a segment's codecs once, so per-term iterators carry func values instead of
+// allocating decoder instances.
+func decodeFuncsFromCodecs(codecs []varenc.VarEncDataType) (docIds, tfs func(data []byte, values []uint64)) {
+	if len(codecs) > 0 {
+		docIds = varenc.GetDecodeFunc(codecs[0])
+	}
+	if len(codecs) > 1 {
+		tfs = varenc.GetDecodeFunc(codecs[1])
+	}
+	return docIds, tfs
+}
+
+func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint64]uint32) ([]terms.BlockEntry, uint64, *terms.BlockDataDecoded, error) {
 	var buf []byte
 	if s.readFromMemory {
 		buf = s.contents[node.Start : node.Start+uint64(8+12*terms.ENCODE_AS_FULL_BYTES)]
@@ -49,10 +68,10 @@ func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint6
 
 	if docCount <= uint64(terms.ENCODE_AS_FULL_BYTES) {
 		data := convertFixedLengthFromMemory(buf, int(docCount))
-		entries := make([]*terms.BlockEntry, 1)
+		entries := make([]terms.BlockEntry, 1)
 		propLength := propLengths[data.DocIds[0]]
 		tf := data.Tfs[0]
-		entries[0] = &terms.BlockEntry{
+		entries[0] = terms.BlockEntry{
 			Offset:              0,
 			MaxId:               data.DocIds[len(data.DocIds)-1],
 			MaxImpactTf:         uint32(tf),
@@ -64,7 +83,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint6
 
 	blockCount := (docCount + uint64(terms.BLOCK_SIZE-1)) / uint64(terms.BLOCK_SIZE)
 
-	entries := make([]*terms.BlockEntry, blockCount)
+	entries := make([]terms.BlockEntry, blockCount)
 	if s.readFromMemory {
 		buf = s.contents[node.Start+16 : node.Start+16+uint64(blockCount*20)]
 	} else {
@@ -82,7 +101,7 @@ func (s *segment) loadBlockEntries(node segmentindex.Node, propLengths map[uint6
 	}
 
 	for i := 0; i < int(blockCount); i++ {
-		entries[i] = terms.DecodeBlockEntry(buf[i*20 : (i+1)*20])
+		terms.DecodeBlockEntryInto(buf[i*20:(i+1)*20], &entries[i])
 	}
 
 	return entries, docCount, nil, nil
@@ -129,7 +148,7 @@ type SegmentBlockMax struct {
 	segment               *segment
 	node                  segmentindex.Node
 	docCount              uint64
-	blockEntries          []*terms.BlockEntry
+	blockEntries          []terms.BlockEntry
 	blockEntryIdx         int
 	blockDataBufferOffset uint64
 	blockDataBuffer       []byte
@@ -157,8 +176,11 @@ type SegmentBlockMax struct {
 	memTombstones      *sroar.Bitmap
 	filterDocIds       helpers.AllowList
 
-	// at position 0 we have the doc ids decoder, at position 1 is the tfs decoder
-	decoders []varenc.VarEncEncoder[uint64]
+	// stateless reusable-decode functions, resolved once from the segment's
+	// codecs (doc ids and term frequencies). Func values, not an encoder
+	// interface slice, so the query path allocates no per-term decoder buffers.
+	decodeDocIds func(data []byte, values []uint64)
+	decodeTfs    func(data []byte, values []uint64)
 
 	propLengths    map[uint64]uint32
 	blockDatasTest []*terms.BlockData
@@ -182,13 +204,7 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 		return nil
 	}
 
-	codecs := s.invertedHeader.DataFields
-	decoders := make([]varenc.VarEncEncoder[uint64], len(codecs))
-
-	for i, codec := range codecs {
-		decoders[i] = varenc.GetVarEncEncoder64(codec)
-		decoders[i].Init(terms.BLOCK_SIZE)
-	}
+	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(s.invertedHeader.DataFields)
 
 	var sectionReader *io.SectionReader
 
@@ -205,7 +221,8 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 
 		b:             config.B,
 		k1:            config.K1,
-		decoders:      decoders,
+		decodeDocIds:  decodeDocIds,
+		decodeTfs:     decodeTfs,
 		propertyBoost: float64(propertyBoost),
 		filterDocIds:  filterDocIds,
 		tombstones:    tombstones,
@@ -224,12 +241,8 @@ func NewSegmentBlockMax(s *segment, key []byte, queryTermIndex int, idf float64,
 	return output
 }
 
-func NewSegmentBlockMaxTest(docCount uint64, blockEntries []*terms.BlockEntry, blockDatas []*terms.BlockData, propLengths map[uint64]uint32, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config, codecs []varenc.VarEncDataType) *SegmentBlockMax {
-	decoders := make([]varenc.VarEncEncoder[uint64], len(codecs))
-
-	for i, codec := range codecs {
-		decoders[i] = varenc.GetVarEncEncoder64(codec)
-	}
+func NewSegmentBlockMaxTest(docCount uint64, blockEntries []terms.BlockEntry, blockDatas []*terms.BlockData, propLengths map[uint64]uint32, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config, codecs []varenc.VarEncDataType) *SegmentBlockMax {
+	decodeDocIds, decodeTfs := decodeFuncsFromCodecs(codecs)
 
 	// if filter is empty after checking for tombstones,
 	// we can skip it and return nil for the segment
@@ -245,7 +258,8 @@ func NewSegmentBlockMaxTest(docCount uint64, blockEntries []*terms.BlockEntry, b
 		averagePropLength: averagePropLength,
 		b:                 config.B,
 		k1:                config.K1,
-		decoders:          decoders,
+		decodeDocIds:      decodeDocIds,
+		decodeTfs:         decodeTfs,
 		propertyBoost:     float64(propertyBoost),
 		filterDocIds:      filterDocIds,
 		tombstones:        tombstones,
@@ -307,9 +321,16 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		return
 	}
 
-	for (s.filterDocIds != nil && !s.filterDocIds.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) ||
-		(s.tombstones != nil && s.tombstones.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) ||
-		(s.memTombstones != nil && s.memTombstones.Contains(s.blockDataDecoded.DocIds[s.blockDataIdx])) {
+	for {
+		// read the current doc id once instead of re-indexing the slice in each
+		// of the up-to-three membership checks below
+		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
+		passes := (s.filterDocIds == nil || s.filterDocIds.Contains(docID)) &&
+			(s.tombstones == nil || !s.tombstones.Contains(docID)) &&
+			(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		if passes {
+			break
+		}
 		s.blockDataIdx++
 		if s.blockDataIdx > s.blockDataSize-1 {
 			if s.blockEntryIdx >= len(s.blockEntries)-1 {
@@ -341,7 +362,12 @@ func (s *SegmentBlockMax) reset() error {
 	}
 
 	if s.blockDataDecoded == nil {
-		s.blockDataBuffer = make([]byte, blockMaxBufferSize)
+		// blockDataBuffer is only read in the non-mmap path of
+		// loadBlockDataReusable; when readFromMemory we decode straight from
+		// s.contents, so allocating it would be pure dead weight per term.
+		if !s.segment.readFromMemory {
+			s.blockDataBuffer = make([]byte, blockMaxBufferSize)
+		}
 		s.blockDataDecoded = &terms.BlockDataDecoded{
 			DocIds: make([]uint64, terms.BLOCK_SIZE),
 			Tfs:    make([]uint64, terms.BLOCK_SIZE),
@@ -383,8 +409,10 @@ func (s *SegmentBlockMax) decodeBlock() error {
 		s.blockDataSize = int(s.docCount)
 		s.freqDecoded = true
 		s.decoded = true
-		s.Metrics.BlockCountDecodedDocIds++
-		s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+		if collectBlockMetrics {
+			s.Metrics.BlockCountDecodedDocIds++
+			s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+		}
 		return nil
 	}
 	if s.segment != nil {
@@ -406,9 +434,11 @@ func (s *SegmentBlockMax) decodeBlock() error {
 	if s.blockEntryIdx == len(s.blockEntries)-1 {
 		s.blockDataSize = int(s.docCount) - terms.BLOCK_SIZE*s.blockEntryIdx
 	}
-	s.decoders[0].DecodeReusable(s.blockDataEncoded.DocIds, s.blockDataDecoded.DocIds[:s.blockDataSize])
-	s.Metrics.BlockCountDecodedDocIds++
-	s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+	s.decodeDocIds(s.blockDataEncoded.DocIds, s.blockDataDecoded.DocIds[:s.blockDataSize])
+	if collectBlockMetrics {
+		s.Metrics.BlockCountDecodedDocIds++
+		s.Metrics.DocCountDecodedDocIds += uint64(s.blockDataSize)
+	}
 	s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 	s.freqDecoded = false
 	s.decoded = true
@@ -428,7 +458,10 @@ func (s *SegmentBlockMax) AdvanceAtLeast(docId uint64) {
 		s.freqDecoded = false
 	}
 
-	if (s.blockEntryIdx == len(s.blockEntries)-1 && docId > s.blockEntries[s.blockEntryIdx].MaxId) || s.blockEntryIdx >= len(s.blockEntries) {
+	// the loop only stops when blockEntryIdx hits the end or docId <= this
+	// block's MaxId, so the "last block, still past it" case the old condition
+	// also tested can never hold here — a bounds check is enough.
+	if s.blockEntryIdx >= len(s.blockEntries) {
 		s.exhaust()
 		return
 	}
@@ -464,10 +497,9 @@ func (s *SegmentBlockMax) AdvanceAtLeastShallow(docId uint64) {
 		}
 	}
 
-	if (s.blockEntryIdx == len(s.blockEntries)-1 && docId > s.blockEntries[s.blockEntryIdx].MaxId) || s.blockEntryIdx >= len(s.blockEntries) {
-		s.exhaust()
-		return
-	}
+	// the loop exits only by reaching a block with docId <= MaxId (the >= len
+	// case returns inside the loop above), so no further exhaustion check is
+	// needed here.
 	s.idPointer = s.blockEntries[s.blockEntryIdx-1].MaxId
 	s.currentBlockMaxId = s.blockEntries[s.blockEntryIdx].MaxId
 	s.currentBlockImpact = s.computeCurrentBlockImpact()
@@ -505,18 +537,20 @@ func (s *SegmentBlockMax) Score(averagePropLength float64, additionalExplanation
 	var doc *terms.DocPointerWithScore
 
 	if !s.freqDecoded {
-		s.decoders[1].DecodeReusable(s.blockDataEncoded.Tfs, s.blockDataDecoded.Tfs[:s.blockDataSize])
+		s.decodeTfs(s.blockDataEncoded.Tfs, s.blockDataDecoded.Tfs[:s.blockDataSize])
 		s.freqDecoded = true
 	}
 
 	freq := float64(s.blockDataDecoded.Tfs[s.blockDataIdx])
 	propLength := s.propLengths[s.idPointer]
 	tf := freq / (freq + s.k1*((1-s.b)+s.b*(float64(propLength)/s.averagePropLength)))
-	s.Metrics.DocCountScored++
-	if s.blockEntryIdx != s.Metrics.LastAddedBlock {
-		s.Metrics.BlockCountDecodedFreqs++
-		s.Metrics.DocCountDecodedFreqs += uint64(s.blockDataSize)
-		s.Metrics.LastAddedBlock = s.blockEntryIdx
+	if collectBlockMetrics {
+		s.Metrics.DocCountScored++
+		if s.blockEntryIdx != s.Metrics.LastAddedBlock {
+			s.Metrics.BlockCountDecodedFreqs++
+			s.Metrics.DocCountDecodedFreqs += uint64(s.blockDataSize)
+			s.Metrics.LastAddedBlock = s.blockEntryIdx
+		}
 	}
 
 	if additionalExplanation {

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -202,8 +202,8 @@ type SegmentBlockMax struct {
 	Metrics BlockMetrics
 }
 
-// node may carry the term's index node prefetched by getInvertedNodeAndDocCount
-// (one descent for docCount + construction); nil means look it up here.
+// A non-nil node is the term's prefetched index node, reused as-is; nil means
+// look it up here.
 func (s *segment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	if node == nil {
 		n, err := s.index.Get(key)

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -32,6 +32,14 @@ var blockMaxBufferSize = 4096
 // free of the counter writes.
 var collectBlockMetrics = false
 
+// deferTombstoneToScore rejects tombstoned (deleted) docs in the DoBlockMax*
+// scoring branch rather than skipping them per advance. Filters stay at advance
+// time because they prune the WAND candidate space; a tombstone does not (the
+// deleted doc still occupies its posting slot and is still visited), so probing it
+// per advanced doc is pure overhead. Bit-identical either way — a doc dropped at
+// scoring affects neither other scores nor the heap threshold.
+var deferTombstoneToScore = true
+
 // decodeFuncsFromCodecs resolves the stateless doc-id and tf decode functions for
 // a segment's codecs once, so per-term iterators carry func values instead of
 // allocating decoder instances.
@@ -331,7 +339,8 @@ func NewSegmentBlockMaxDecoded(key []byte, queryTermIndex int, propertyBoost flo
 }
 
 func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
-	if (s.filterDocIds == nil && s.tombstones == nil && s.memTombstones == nil) || s.exhausted {
+	checkTomb := !deferTombstoneToScore && (s.tombstones != nil || s.memTombstones != nil)
+	if (s.filterDocIds == nil && !checkTomb) || s.exhausted {
 		if !s.exhausted {
 			s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 		}
@@ -342,9 +351,11 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		// read the current doc id once instead of re-indexing the slice in each
 		// of the up-to-three membership checks below
 		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
-		passes := (s.filterDocIds == nil || s.filterDocIds.Contains(docID)) &&
-			(s.tombstones == nil || !s.tombstones.Contains(docID)) &&
-			(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		passes := s.filterDocIds == nil || s.filterDocIds.Contains(docID)
+		if passes && checkTomb {
+			passes = (s.tombstones == nil || !s.tombstones.Contains(docID)) &&
+				(s.memTombstones == nil || !s.memTombstones.Contains(docID))
+		}
 		if passes {
 			break
 		}
@@ -363,6 +374,14 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 	if !s.exhausted {
 		s.idPointer = s.blockDataDecoded.DocIds[s.blockDataIdx]
 	}
+}
+
+// tombstoned reports whether docID is deleted in this iterator's view. All terms
+// in a segment share its tombstone bitmaps, so any aligned term answers for the
+// pivot.
+func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
+	return (s.tombstones != nil && s.tombstones.Contains(docID)) ||
+		(s.memTombstones != nil && s.memTombstones.Contains(docID))
 }
 
 func (s *SegmentBlockMax) reset() error {

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -385,6 +385,19 @@ func (s *fakeSegment) getDocCount(key []byte) uint64 {
 	return uint64(len(s.collectionStore[string(key)]))
 }
 
+func (s *fakeSegment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.strategy != segmentindex.StrategyInverted {
+		return segmentindex.Node{}, 0, false
+	}
+	pairs, ok := s.collectionStore[string(key)]
+	if !ok {
+		return segmentindex.Node{}, 0, false
+	}
+	// the fake's newSegmentBlockMax rebuilds terms from collectionStore and
+	// ignores the node, so a zero node with the right count is sufficient
+	return segmentindex.Node{Key: key}, uint64(len(pairs)), true
+}
+
 func (s *fakeSegment) getCountNetAdditions() int {
 	// NOTE: This oversimplified fake implementation ignores deletes and updates,
 	// it pretends every write is a unique insert.
@@ -433,7 +446,7 @@ func (s *fakeSegment) stripTmpExtensions(leftSegmentID, rightSegmentID string) e
 	return nil
 }
 
-func (s *fakeSegment) newSegmentBlockMax(key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
+func (s *fakeSegment) newSegmentBlockMax(node *segmentindex.Node, key []byte, queryTermIndex int, idf float64, propertyBoost float32, tombstones, memTombstones *sroar.Bitmap, filterDocIds helpers.AllowList, averagePropLength float64, config schema.BM25Config) *SegmentBlockMax {
 	// we're taking a bit of a creative route to make this work with a fake
 	// segment. We have existing functions to create a SegmentBlockMax from a
 	// memtable which are used with real memtables. So if we convert the fake

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
@@ -98,7 +99,7 @@ type fakeSegment struct {
 	roaringRangeAdditions map[uint64]*sroar.Bitmap
 	roaringRangeDeletions *sroar.Bitmap
 	collectionStore       map[string][]value
-	refs                  int
+	refs                  atomic.Int64
 	path                  string
 	getCounter            int
 
@@ -137,15 +138,15 @@ func (f *fakeSegment) setSize(size int64) {
 }
 
 func (f *fakeSegment) incRef() {
-	f.refs++
+	f.refs.Add(1)
 }
 
 func (f *fakeSegment) decRef() {
-	f.refs--
+	f.refs.Add(-1)
 }
 
 func (f *fakeSegment) getRefs() int {
-	return f.refs
+	return int(f.refs.Load())
 }
 
 func (f *fakeSegment) indexSize() int {

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -283,3 +283,25 @@ func (s *segment) getDocCount(key []byte) uint64 {
 
 	return binary.LittleEndian.Uint64(buffer)
 }
+
+// getInvertedNodeAndDocCount resolves a term's index node and posting doc count
+// with a single index descent, so the BMW setup path can reuse the node instead
+// of descending again in hasKey/getDocCount/the term constructor. Inverted
+// segments only; callers check the strategy.
+func (s *segment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.useBloomFilter && !s.bloomFilter.Test(key) {
+		return segmentindex.Node{}, 0, false
+	}
+
+	node, err := s.index.Get(key)
+	if err != nil {
+		return segmentindex.Node{}, 0, false
+	}
+
+	var buf [8]byte
+	if err = s.copyNode(buf[:], nodeOffset{node.Start, node.Start + 8}); err != nil {
+		return segmentindex.Node{}, 0, false
+	}
+
+	return node, binary.LittleEndian.Uint64(buf[:]), true
+}

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -284,10 +284,9 @@ func (s *segment) getDocCount(key []byte) uint64 {
 	return binary.LittleEndian.Uint64(buffer)
 }
 
-// getInvertedNodeAndDocCount resolves a term's index node and posting doc count
-// with a single index descent, so the BMW setup path can reuse the node instead
-// of descending again in hasKey/getDocCount/the term constructor. Inverted
-// segments only; callers check the strategy.
+// getInvertedNodeAndDocCount returns a term's index node and posting doc count
+// from a single index descent, letting the caller reuse the node for term
+// construction. Inverted segments only; the caller must check the strategy.
 func (s *segment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
 	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return segmentindex.Node{}, 0, false

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -286,8 +286,13 @@ func (s *segment) getDocCount(key []byte) uint64 {
 
 // getInvertedNodeAndDocCount returns a term's index node and posting doc count
 // from a single index descent, letting the caller reuse the node for term
-// construction. Inverted segments only; the caller must check the strategy.
+// construction. The doc count is read from the inverted posting layout, so it
+// returns false for any non-inverted strategy.
 func (s *segment) getInvertedNodeAndDocCount(key []byte) (segmentindex.Node, uint64, bool) {
+	if s.strategy != segmentindex.StrategyInverted {
+		return segmentindex.Node{}, 0, false
+	}
+
 	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return segmentindex.Node{}, 0, false
 	}

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -51,41 +51,36 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 		return Node{}, lsmkv.NotFound
 	}
 	var out Node
-	rw := byteops.NewReadWriter(t.data)
+	data := t.data
+	pos := uint64(0)
 
-	// jump to the buffer until the node with _key_ is found or return a NotFound error.
-	// This function avoids allocations by reusing the same buffer for all keys and avoids memory reads by only
-	// extracting the necessary pieces of information while skipping the rest
-	NodeKeyBuffer := make([]byte, len(key))
+	// jump through the buffer until the node with _key_ is found or return a
+	// NotFound error. Node keys are compared in place against the tree data, so
+	// the descent allocates nothing; only the matched node's key is materialized
+	// (callers may keep it beyond the underlying segment's lifetime).
 	for {
 		// detect if there is no node with the wanted key.
-		if rw.Position+4 > uint64(len(t.data)) || rw.Position+4 < 4 {
+		if pos+4 > uint64(len(data)) || pos+4 < 4 {
 			return out, lsmkv.NotFound
 		}
 
-		keyLen := rw.ReadUint32()
-		if int(keyLen) > len(NodeKeyBuffer) {
-			NodeKeyBuffer = make([]byte, int(keyLen))
-		} else if int(keyLen) < len(NodeKeyBuffer) {
-			NodeKeyBuffer = NodeKeyBuffer[:keyLen]
-		}
-		_, err := rw.CopyBytesFromBuffer(uint64(keyLen), NodeKeyBuffer)
-		if err != nil {
-			return out, fmt.Errorf("copy node key: %w", err)
+		keyLen := uint64(binary.LittleEndian.Uint32(data[pos:]))
+		pos += 4
+		if pos+keyLen > uint64(len(data)) {
+			return out, fmt.Errorf("copy node key: key at %d len %d out of range", pos, keyLen)
 		}
 
-		keyEqual := bytes.Compare(key, NodeKeyBuffer)
+		keyEqual := bytes.Compare(key, data[pos:pos+keyLen])
+		pos += keyLen
 		if keyEqual == 0 {
-			out.Key = NodeKeyBuffer
-			out.Start = rw.ReadUint64()
-			out.End = rw.ReadUint64()
+			out.Key = bytes.Clone(data[pos-keyLen : pos])
+			out.Start = binary.LittleEndian.Uint64(data[pos:])
+			out.End = binary.LittleEndian.Uint64(data[pos+8:])
 			return out, nil
 		} else if keyEqual < 0 {
-			rw.MoveBufferPositionForward(2 * 8) // jump over start+end position
-			rw.Position = rw.ReadUint64()       // left child
+			pos = binary.LittleEndian.Uint64(data[pos+16:]) // skip start+end, read left child
 		} else {
-			rw.MoveBufferPositionForward(3 * 8) // jump over start+end position and left child
-			rw.Position = rw.ReadUint64()       // right child
+			pos = binary.LittleEndian.Uint64(data[pos+24:]) // skip start+end+left, read right child
 		}
 	}
 }

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -52,40 +52,60 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 	}
 	var out Node
 	data := t.data
+	dataLen := uint64(len(data))
 	pos := uint64(0)
 
 	// jump through the buffer until the node with _key_ is found or return a
 	// NotFound error. Node keys are compared in place against the tree data, so
 	// the descent allocates nothing; only the matched node's key is materialized
 	// (callers may keep it beyond the underlying segment's lifetime).
+	//
+	// pos can be an arbitrary child offset read from possibly corrupt data, so
+	// every read is bounds-checked against dataLen-pos (never pos+n, which would
+	// wrap). Truncated or corrupt data yields NotFound or an error, never a panic.
 	for {
-		// detect if there is no node with the wanted key.
-		if pos+4 > uint64(len(data)) || pos+4 < 4 {
+		// node layout: [keyLen:4][key:keyLen][start:8][end:8][left:8][right:8].
+		if pos+4 > dataLen || pos+4 < 4 {
 			return out, lsmkv.NotFound
 		}
 
 		keyLen := uint64(binary.LittleEndian.Uint32(data[pos:]))
 		pos += 4
-		if pos+keyLen > uint64(len(data)) {
-			return out, fmt.Errorf("copy node key: key at %d len %d out of range", pos, keyLen)
+		if keyLen > dataLen-pos {
+			return out, fmt.Errorf("node key at %d len %d out of range", pos, keyLen)
 		}
 
 		keyEqual := bytes.Compare(key, data[pos:pos+keyLen])
 		pos += keyLen
+		avail := dataLen - pos
 		if keyEqual == 0 {
+			if avail < 16 { // start + end
+				return out, fmt.Errorf("node value at %d out of range", pos)
+			}
 			out.Key = bytes.Clone(data[pos-keyLen : pos])
 			out.Start = binary.LittleEndian.Uint64(data[pos:])
 			out.End = binary.LittleEndian.Uint64(data[pos+8:])
 			return out, nil
 		} else if keyEqual < 0 {
+			if avail < 24 { // start + end + left child
+				return out, fmt.Errorf("node left child at %d out of range", pos)
+			}
 			pos = binary.LittleEndian.Uint64(data[pos+16:]) // skip start+end, read left child
 		} else {
+			if avail < 32 { // start + end + left + right child
+				return out, fmt.Errorf("node right child at %d out of range", pos)
+			}
 			pos = binary.LittleEndian.Uint64(data[pos+24:]) // skip start+end+left, read right child
 		}
 	}
 }
 
 func (t *DiskTree) readNodeAt(offset int64) (dtNode, error) {
+	// offset is a child pointer that may be corrupt; bound it before slicing so a
+	// stray value yields an error instead of an out-of-range panic.
+	if offset < 0 || offset > int64(len(t.data)) {
+		return dtNode{}, fmt.Errorf("node offset %d out of range (buffer %d)", offset, len(t.data))
+	}
 	retNode, _, err := t.readNode(t.data[offset:])
 	return retNode, err
 }
@@ -101,6 +121,13 @@ func (t *DiskTree) readNode(in []byte) (dtNode, int, error) {
 	rw := byteops.NewReadWriter(in)
 
 	keyLen := uint64(rw.ReadUint32())
+	// the whole node is keyLen + TREE_KEY_STORE_OVERHEAD bytes; the len check
+	// above only covers a zero-length key. Reject a keyLen that would push the
+	// key or the fixed trailer past the buffer (corrupt/truncated index) so the
+	// reads below cannot panic. Compared against len(in)-overhead to avoid wrap.
+	if keyLen > uint64(len(in))-TREE_KEY_STORE_OVERHEAD {
+		return out, int(rw.Position), fmt.Errorf("node key len %d out of range (buffer %d)", keyLen, len(in))
+	}
 	copiedBytes, err := rw.CopyBytesFromBuffer(keyLen, nil)
 	if err != nil {
 		return out, int(rw.Position), fmt.Errorf("copy node key: %w", err)

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -1,0 +1,98 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package segmentindex
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A corrupt or truncated on-disk index must never crash the node: every read
+// path (Get, Seek/Next, AllKeys) has to return NotFound or an error instead of
+// panicking on an out-of-range slice.
+func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
+	tree := NewTree(4)
+	elements := []struct {
+		key        []byte
+		start, end uint64
+	}{
+		{[]byte("foobar"), 17, 18}, // inserted first -> BST root at offset 0
+		{[]byte("abc"), 4, 5},
+		{[]byte("zzz"), 34, 35},
+		{[]byte("aaa"), 1, 2},
+		{[]byte("zzzz"), 100, 102},
+	}
+	for _, e := range elements {
+		tree.Insert(e.key, e.start, e.end)
+	}
+	valid, err := tree.MarshalBinary()
+	require.NoError(t, err)
+	require.Greater(t, len(valid), TREE_KEY_STORE_OVERHEAD)
+
+	// queries span match, descend-left and descend-right branches plus misses.
+	queries := [][]byte{
+		[]byte("aaa"), []byte("abc"), []byte("foobar"), []byte("zzz"), []byte("zzzz"),
+		[]byte("a"), []byte("m"), []byte("zzzzz"), {},
+	}
+
+	t.Run("every truncation of the buffer", func(t *testing.T) {
+		for trunc := 0; trunc <= len(valid); trunc++ {
+			dTree := NewDiskTree(valid[:trunc])
+			require.NotPanics(t, func() {
+				_, _ = dTree.AllKeys()
+			}, "AllKeys panicked at truncation=%d", trunc)
+			for _, q := range queries {
+				require.NotPanics(t, func() {
+					_, _ = dTree.Get(q)
+				}, "Get panicked at truncation=%d query=%q", trunc, q)
+				require.NotPanics(t, func() {
+					_, _ = dTree.Seek(q)
+				}, "Seek panicked at truncation=%d query=%q", trunc, q)
+			}
+		}
+	})
+
+	t.Run("corrupt keyLen larger than the buffer returns an error", func(t *testing.T) {
+		corrupt := make([]byte, len(valid))
+		copy(corrupt, valid)
+		binary.LittleEndian.PutUint32(corrupt[0:4], 0xFFFFFFFF)
+		dTree := NewDiskTree(corrupt)
+
+		var getErr, allErr error
+		require.NotPanics(t, func() {
+			_, getErr = dTree.Get([]byte("foobar"))
+			_, allErr = dTree.AllKeys()
+			_, _ = dTree.Seek([]byte("foobar"))
+		})
+		require.Error(t, getErr)
+		require.Error(t, allErr)
+	})
+
+	t.Run("corrupt child pointers do not panic", func(t *testing.T) {
+		corrupt := make([]byte, len(valid))
+		copy(corrupt, valid)
+		// root node at offset 0: [keyLen:4][key][start:8][end:8][left:8][right:8].
+		keyLen := int(binary.LittleEndian.Uint32(corrupt[0:4]))
+		childBase := 4 + keyLen + 16                                             // past keyLen + key + start + end
+		binary.LittleEndian.PutUint64(corrupt[childBase:], 0xFFFFFFFFFFFFFFFF)   // left child
+		binary.LittleEndian.PutUint64(corrupt[childBase+8:], 0xFFFFFFFFFFFFFFF0) // right child
+		dTree := NewDiskTree(corrupt)
+
+		require.NotPanics(t, func() {
+			_, _ = dTree.Get([]byte("aaa"))   // descends left into the bad pointer
+			_, _ = dTree.Get([]byte("zzzzz")) // descends right into the bad pointer
+			_, _ = dTree.Seek([]byte("aaa"))
+		})
+	})
+}

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -43,7 +43,7 @@ func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
 	// queries span match, descend-left and descend-right branches plus misses.
 	queries := [][]byte{
 		[]byte("aaa"), []byte("abc"), []byte("foobar"), []byte("zzz"), []byte("zzzz"),
-		[]byte("a"), []byte("m"), []byte("zzzzz"), {},
+		[]byte("a"), []byte("m"), []byte("zzzzz"), []byte(""),
 	}
 
 	t.Run("every truncation of the buffer", func(t *testing.T) {

--- a/adapters/repos/db/lsmkv/varenc/simple.go
+++ b/adapters/repos/db/lsmkv/varenc/simple.go
@@ -84,6 +84,15 @@ func (e SimpleEncoder[T]) DecodeReusable(data []byte, values []T) {
 	}
 }
 
+// decodeSimpleUint64 is the stateless uint64 variant of DecodeReusable, used by
+// GetDecodeFunc so the read path needs no SimpleEncoder instance.
+func decodeSimpleUint64(data []byte, values []uint64) {
+	count := binary.LittleEndian.Uint64(data)
+	for i := 0; i < int(count); i++ {
+		values[i] = binary.LittleEndian.Uint64(data[8+i*8 : 8+(i+1)*8])
+	}
+}
+
 func (e *SimpleEncoder[T]) Encode(values []T) []byte {
 	e.EncodeReusable(values, e.buf)
 	return e.buf

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding.go
@@ -46,3 +46,21 @@ func GetVarEncEncoder64(t VarEncDataType) VarEncEncoder[uint64] {
 		return nil
 	}
 }
+
+// GetDecodeFunc returns a stateless reusable-decode function for the query read
+// path. Unlike GetVarEncEncoder64 it allocates no per-call buffers and needs no
+// encoder instance — DecodeReusable writes straight into the caller's slice — so
+// callers avoid one heap allocation per term and the interface dispatch. Returns
+// nil for codecs without a uint64 decoder (same contract as GetVarEncEncoder64).
+func GetDecodeFunc(t VarEncDataType) func(data []byte, values []uint64) {
+	switch t {
+	case VarIntUint64:
+		return func(data []byte, values []uint64) { decodeReusable(values, data, false) }
+	case DeltaVarIntUint64:
+		return func(data []byte, values []uint64) { decodeReusable(values, data, true) }
+	case SimpleUint64:
+		return decodeSimpleUint64
+	default:
+		return nil
+	}
+}

--- a/adapters/repos/db/priorityqueue/queue.go
+++ b/adapters/repos/db/priorityqueue/queue.go
@@ -66,7 +66,9 @@ func NewMax[T supportedValueType](capacity int) *Queue[T] {
 }
 
 func (q *Queue[T]) ShouldEnqueue(distance float32, limit int) bool {
-	return q.Len() < limit || q.Top().Dist < distance
+	// read items[0].Dist directly rather than via Top(), which returns the whole
+	// Item by value (a multi-word copy) on this hot path.
+	return len(q.items) < limit || q.items[0].Dist < distance
 }
 
 func (q *Queue[T]) InsertAndPop(id uint64, score float64, limit int, worstDist *float64, val T) {


### PR DESCRIPTION
**DO NOT MERGE.** Throwaway image-build PR for QA cloud perf measurement of the BM25 BlockMax-WAND series. No review needed; will be closed once measurements are captured.

**AFTER-A image** = full query-path A-stack (A1–A7: #11770/#11772/#11773/#11774/#11775/#11776/#11777) **with the long-query hang fix `407aa75cc6` applied**, on the baseline. Measures the **latency** win. (A and B measured as separate clean images — they make entangled refactors to `segment_blockmax.go`; orthogonal, so combined effect = union.)

🔬 QA Claude