### PR TITLE
fix(hnsw): parallel-cursor prefill for unbounded uncompressed vector cache

### DIFF
--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -543,6 +543,10 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 			} else {
 				h.compressor.PrefillMultiCache(ctx, h.docIDVectors)
 			}
+		} else if h.useParallelPrefill() {
+			// Unbounded uncompressed cache: scan the objects bucket with a parallel
+			// cursor instead of looking up every vector by id (disk-seek bound).
+			err = h.prefillCacheParallel(ctx)
 		} else {
 			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(context.Background(), limit)
 		}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -34,7 +34,9 @@ import (
 //   - sync only: an overwriting Preload from a snapshot cursor races live writes;
 //     the serial path's load-if-absent Get does not.
 //   - unbounded cache only: a full scan ignores the size limit the serial path honors.
-//   - single-vector or muvera only: true multivector keys the cache per passage.
+//   - single-vector only: a multivector cache holds per-passage vectors, and a muvera
+//     cache holds encoded vectors from the dedicated _muvera_vectors bucket — neither
+//     lives in the objects bucket this scan reads, so both stay on the serial path.
 func (h *hnsw) useParallelPrefill() bool {
 	// No real objects bucket (tests wiring only a VectorForID thunk, or pre-attach):
 	// fall back to the serial prefiller.
@@ -69,7 +71,7 @@ func parallelPrefillEligible(in parallelPrefillInputs) bool {
 	if !in.waitForPrefill {
 		return false
 	}
-	if in.multivector && !in.muvera {
+	if in.multivector || in.muvera {
 		return false
 	}
 	return in.cacheMaxSize >= in.nodeCount

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -1,0 +1,267 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// disableParallelPrefillEnvVar is a kill switch that forces the serial,
+// by-id prefiller even when the parallel cursor path would otherwise be
+// eligible. It exists so an operator can fall back without a redeploy if the
+// parallel path ever misbehaves in production.
+const disableParallelPrefillEnvVar = "DISABLE_PARALLEL_VECTOR_CACHE_PREFILL"
+
+// useParallelPrefill reports whether the uncompressed vector cache can be
+// prefilled by scanning the objects bucket with a parallel cursor instead of the
+// serial, by-id vectorCachePrefiller. It is eligible only when:
+//
+//   - the prefill is synchronous (waitForCachePrefill). In async mode the prefill
+//     runs alongside live writes; the serial path's load-if-absent cache.Get is
+//     race-safe there, whereas an overwriting Preload from a snapshot cursor is not.
+//   - the cache is effectively unbounded, i.e. it can hold every vector. When the
+//     cache is smaller than the node count the serial prefiller is required because
+//     it honors the size limit (it stops at `limit`); a full bucket scan would not.
+//   - the index is single-vector or muvera. True multivector stores vectors per
+//     passage with a different cache keying and keeps the serial path (mirrors the
+//     compressed split in prefillCache).
+func (h *hnsw) useParallelPrefill() bool {
+	// The parallel path cursor-scans the objects bucket directly. Without it — e.g.
+	// indexes wired only through a VectorForID thunk (tests) or before the store is
+	// attached — fall back to the serial, thunk-based prefiller.
+	if h.store == nil || h.store.Bucket(helpers.ObjectsBucketLSM) == nil {
+		return false
+	}
+
+	h.RLock()
+	nodeCount := int64(len(h.nodes))
+	h.RUnlock()
+
+	return parallelPrefillEligible(parallelPrefillInputs{
+		waitForPrefill: h.waitForCachePrefill,
+		killSwitch:     os.Getenv(disableParallelPrefillEnvVar) == "true",
+		multivector:    h.multivector.Load(),
+		muvera:         h.muvera.Load(),
+		cacheMaxSize:   h.cache.CopyMaxSize(),
+		nodeCount:      nodeCount,
+	})
+}
+
+type parallelPrefillInputs struct {
+	waitForPrefill bool
+	killSwitch     bool
+	multivector    bool
+	muvera         bool
+	cacheMaxSize   int64
+	nodeCount      int64
+}
+
+// parallelPrefillEligible holds the decision logic for useParallelPrefill in a
+// pure form so it can be exercised directly in tests. See useParallelPrefill for
+// the rationale behind each condition.
+func parallelPrefillEligible(in parallelPrefillInputs) bool {
+	if !in.waitForPrefill {
+		return false
+	}
+	if in.killSwitch {
+		return false
+	}
+	if in.multivector && !in.muvera {
+		return false
+	}
+	return in.cacheMaxSize >= in.nodeCount
+}
+
+// prefillCacheParallel populates the (uncompressed) vector cache by scanning the
+// objects bucket with a parallel, per-segment cursor rather than looking up every
+// vector by id through the HNSW graph.
+//
+// The by-id prefiller (vectorCachePrefiller) issues one random read per vector.
+// The objects bucket is keyed by UUID, so a lookup by doc id is a random seek;
+// doing that serially for millions of vectors is latency-bound and can take hours
+// on network-attached storage, with the CPU idle. When the cache is unbounded the
+// index lookup is pure overhead: a cursor scan reads in storage order (sequential)
+// and parallelizes the decode across cores. This mirrors
+// compressionhelpers.(*quantizedVectorsCompressor).PrefillCache, which does the
+// same over the dedicated compressed-vector bucket.
+//
+// Unlike the compressed variant, it preloads into the cache as it scans instead of
+// first collecting every vector into a temporary slice: full float32 vectors are
+// large and a second full copy would roughly double peak memory during startup.
+// The cache is already grown to len(h.nodes) at restore, so a direct Preload is
+// in-bounds for every live doc id; the rare id beyond that grows the cache
+// defensively.
+func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
+	before := time.Now()
+
+	bucket := h.store.Bucket(helpers.ObjectsBucketLSM)
+	if bucket == nil {
+		return fmt.Errorf("prefill cache: objects bucket %q not found", helpers.ObjectsBucketLSM)
+	}
+	targetVector := h.getTargetVector()
+
+	h.RLock()
+	preGrown := uint64(len(h.nodes))
+	h.RUnlock()
+
+	var loaded atomic.Int64
+	onVector := func(id uint64, vec []float32) {
+		if id >= preGrown {
+			// The cache is grown to len(h.nodes) at restore, so every live doc id is
+			// already in-bounds. Grow only for the unexpected larger id (e.g. a write
+			// landed after we snapshotted the node count).
+			h.cache.Grow(id)
+		}
+		h.cache.Preload(id, vec)
+		loaded.Add(1)
+	}
+
+	if err := scanObjectVectorsParallel(ctx, bucket, targetVector, onVector, h.logger); err != nil {
+		return err
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"action":   "hnsw_vector_cache_prefill",
+		"count":    loaded.Load(),
+		"took":     time.Since(before),
+		"index_id": h.id,
+		"parallel": true,
+	}).Info("prefilled vector cache")
+	return nil
+}
+
+// scanObjectVectorsParallel splits the objects keyspace into ranges using quantile
+// seed keys and scans each range with its own cursor concurrently, invoking
+// onVector for every (docID, vector) pair. onVector must be safe for concurrent use.
+func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, targetVector string,
+	onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
+) error {
+	parallel := 2 * runtime.GOMAXPROCS(0)
+	if parallel < 1 {
+		parallel = 1
+	}
+
+	// One fewer seed than the desired parallelism: the first routine reads from the
+	// start to seeds[0], the last reads from the final seed to the end.
+	seeds := bucket.QuantileKeys(parallel - 1)
+
+	type keyRange struct{ start, end []byte } // nil start = from first; nil end = to the end
+	var ranges []keyRange
+	if len(seeds) == 0 {
+		// Empty or very small bucket: a single full scan.
+		ranges = []keyRange{{start: nil, end: nil}}
+	} else {
+		ranges = append(ranges, keyRange{start: nil, end: seeds[0]})
+		for i := 0; i < len(seeds)-1; i++ {
+			ranges = append(ranges, keyRange{start: seeds[i], end: seeds[i+1]})
+		}
+		ranges = append(ranges, keyRange{start: seeds[len(seeds)-1], end: nil})
+	}
+
+	var (
+		wg       sync.WaitGroup
+		firstErr atomic.Pointer[error]
+	)
+	for i := range ranges {
+		r := ranges[i]
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			if err := scanObjectVectorsRange(ctx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
+				e := err
+				firstErr.CompareAndSwap(nil, &e)
+			}
+		}, logger)
+	}
+	wg.Wait()
+
+	if e := firstErr.Load(); e != nil {
+		return *e
+	}
+	return nil
+}
+
+func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, end []byte,
+	targetVector string, onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	c := bucket.Cursor()
+	defer c.Close()
+
+	var k, v []byte
+	if start == nil {
+		k, v = c.First()
+	} else {
+		k, v = c.Seek(start)
+	}
+
+	const checkContextEveryN = 1024
+	n := 0
+	for ; k != nil; k, v = c.Next() {
+		if end != nil && bytes.Compare(k, end) >= 0 {
+			break
+		}
+		n++
+		if n%checkContextEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		if len(v) == 0 {
+			continue
+		}
+
+		id, err := storobj.DocIDFromBinary(v)
+		if err != nil {
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping object with undecodable doc id: %v", err)
+			continue
+		}
+
+		// nil buffer: VectorFromBinary returns a view into the supplied buffer when
+		// it is large enough, which would alias across iterations. A fresh allocation
+		// per vector keeps every cached slice independent.
+		vec, err := storobj.VectorFromBinary(v, nil, targetVector)
+		if err != nil {
+			var notFound storobj.ErrTargetVectorNotFound
+			if errors.As(err, &notFound) {
+				// object simply has no vector for this target vector; nothing to cache
+				continue
+			}
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping doc id %d with undecodable vector: %v", id, err)
+			continue
+		}
+		if len(vec) == 0 {
+			continue
+		}
+		onVector(id, vec)
+	}
+	return nil
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -131,7 +131,10 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, targetVector string,
 	onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
 ) error {
-	parallel := 2 * runtime.GOMAXPROCS(0)
+	// 2x oversubscription: while one cursor blocks on a disk read another keeps a
+	// core busy decoding — the IO-bound default used across the vector package.
+	const cursorsPerProc = 2
+	parallel := cursorsPerProc * runtime.GOMAXPROCS(0)
 	if parallel < 1 {
 		parallel = 1
 	}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -181,6 +181,12 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		ranges = append(ranges, keyRange{start: seeds[len(seeds)-1], end: nil})
 	}
 
+	// Derived context so the first range to error short-circuits its siblings
+	// (they observe the cancellation on their next ctx check) instead of scanning
+	// to completion.
+	scanCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var (
 		wg       sync.WaitGroup
 		firstErr atomic.Pointer[error]
@@ -190,9 +196,11 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		wg.Add(1)
 		enterrors.GoWrapper(func() {
 			defer wg.Done()
-			if err := scanObjectVectorsRange(ctx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
+			if err := scanObjectVectorsRange(scanCtx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
 				e := err
-				firstErr.CompareAndSwap(nil, &e)
+				if firstErr.CompareAndSwap(nil, &e) {
+					cancel()
+				}
 			}
 		}, logger)
 	}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -28,23 +28,16 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-// useParallelPrefill reports whether the uncompressed vector cache can be
-// prefilled by scanning the objects bucket with a parallel cursor instead of the
-// serial, by-id vectorCachePrefiller. It is eligible only when:
-//
-//   - the prefill is synchronous (waitForCachePrefill). In async mode the prefill
-//     runs alongside live writes; the serial path's load-if-absent cache.Get is
-//     race-safe there, whereas an overwriting Preload from a snapshot cursor is not.
-//   - the cache is effectively unbounded, i.e. it can hold every vector. When the
-//     cache is smaller than the node count the serial prefiller is required because
-//     it honors the size limit (it stops at `limit`); a full bucket scan would not.
-//   - the index is single-vector or muvera. True multivector stores vectors per
-//     passage with a different cache keying and keeps the serial path (mirrors the
-//     compressed split in prefillCache).
+// useParallelPrefill reports whether the uncompressed cache can be prefilled by a
+// parallel cursor scan of the objects bucket rather than the serial by-id
+// vectorCachePrefiller. Gated to cases where that scan is both safe and complete:
+//   - sync only: an overwriting Preload from a snapshot cursor races live writes;
+//     the serial path's load-if-absent Get does not.
+//   - unbounded cache only: a full scan ignores the size limit the serial path honors.
+//   - single-vector or muvera only: true multivector keys the cache per passage.
 func (h *hnsw) useParallelPrefill() bool {
-	// The parallel path cursor-scans the objects bucket directly. Without it — e.g.
-	// indexes wired only through a VectorForID thunk (tests) or before the store is
-	// attached — fall back to the serial, thunk-based prefiller.
+	// No real objects bucket (tests wiring only a VectorForID thunk, or pre-attach):
+	// fall back to the serial prefiller.
 	if h.store == nil || h.store.Bucket(helpers.ObjectsBucketLSM) == nil {
 		return false
 	}
@@ -70,9 +63,8 @@ type parallelPrefillInputs struct {
 	nodeCount      int64
 }
 
-// parallelPrefillEligible holds the decision logic for useParallelPrefill in a
-// pure form so it can be exercised directly in tests. See useParallelPrefill for
-// the rationale behind each condition.
+// parallelPrefillEligible is the pure decision core of useParallelPrefill, split out
+// for direct testing.
 func parallelPrefillEligible(in parallelPrefillInputs) bool {
 	if !in.waitForPrefill {
 		return false
@@ -83,25 +75,13 @@ func parallelPrefillEligible(in parallelPrefillInputs) bool {
 	return in.cacheMaxSize >= in.nodeCount
 }
 
-// prefillCacheParallel populates the (uncompressed) vector cache by scanning the
-// objects bucket with a parallel, per-segment cursor rather than looking up every
-// vector by id through the HNSW graph.
-//
-// The by-id prefiller (vectorCachePrefiller) issues one random read per vector.
-// The objects bucket is keyed by UUID, so a lookup by doc id is a random seek;
-// doing that serially for millions of vectors is latency-bound and can take hours
-// on network-attached storage, with the CPU idle. When the cache is unbounded the
-// index lookup is pure overhead: a cursor scan reads in storage order (sequential)
-// and parallelizes the decode across cores. This mirrors
-// compressionhelpers.(*quantizedVectorsCompressor).PrefillCache, which does the
-// same over the dedicated compressed-vector bucket.
-//
-// Unlike the compressed variant, it preloads into the cache as it scans instead of
-// first collecting every vector into a temporary slice: full float32 vectors are
-// large and a second full copy would roughly double peak memory during startup.
-// The cache is already grown to len(h.nodes) at restore, so a direct Preload is
-// in-bounds for every live doc id; the rare id beyond that grows the cache
-// defensively.
+// prefillCacheParallel populates the uncompressed vector cache via a parallel cursor
+// scan of the objects bucket. The by-id vectorCachePrefiller issues one random seek
+// per vector (the bucket is UUID-keyed), which is latency-bound and can take hours on
+// network storage with the CPU idle; a cursor reads in storage order and decodes
+// across cores. Mirrors the compressed PrefillCache, but preloads as it scans rather
+// than collecting into a slice first; a second copy of full float32 vectors would
+// roughly double startup memory.
 func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 	before := time.Now()
 
@@ -118,9 +98,8 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 	var loaded atomic.Int64
 	onVector := func(id uint64, vec []float32) {
 		if id >= preGrown {
-			// The cache is grown to len(h.nodes) at restore, so every live doc id is
-			// already in-bounds. Grow only for the unexpected larger id (e.g. a write
-			// landed after we snapshotted the node count).
+			// Cache is pre-grown to len(h.nodes) at restore, so live ids are in-bounds;
+			// grow only for an id from a write that landed after we snapshotted the count.
 			h.cache.Grow(id)
 		}
 		h.cache.Preload(id, vec)
@@ -141,9 +120,8 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 	return nil
 }
 
-// scanObjectVectorsParallel splits the objects keyspace into ranges using quantile
-// seed keys and scans each range with its own cursor concurrently, invoking
-// onVector for every (docID, vector) pair. onVector must be safe for concurrent use.
+// scanObjectVectorsParallel scans the objects bucket across GOMAXPROCS cursors over
+// disjoint key ranges. onVector must be safe for concurrent use.
 func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, targetVector string,
 	onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
 ) error {
@@ -152,15 +130,13 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		parallel = 1
 	}
 
-	// One fewer seed than the desired parallelism: the first routine reads from the
-	// start to seeds[0], the last reads from the final seed to the end.
+	// n-1 seeds yield n ranges: [first,seeds[0]), interiors, [seeds[last],end).
 	seeds := bucket.QuantileKeys(parallel - 1)
 
-	type keyRange struct{ start, end []byte } // nil start = from first; nil end = to the end
+	type keyRange struct{ start, end []byte } // nil = open-ended (first / end)
 	var ranges []keyRange
 	if len(seeds) == 0 {
-		// Empty or very small bucket: a single full scan.
-		ranges = []keyRange{{start: nil, end: nil}}
+		ranges = []keyRange{{start: nil, end: nil}} // no seeds: single full scan
 	} else {
 		ranges = append(ranges, keyRange{start: nil, end: seeds[0]})
 		for i := 0; i < len(seeds)-1; i++ {
@@ -169,9 +145,7 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		ranges = append(ranges, keyRange{start: seeds[len(seeds)-1], end: nil})
 	}
 
-	// Derived context so the first range to error short-circuits its siblings
-	// (they observe the cancellation on their next ctx check) instead of scanning
-	// to completion.
+	// Cancel siblings as soon as one range errors, instead of scanning to completion.
 	scanCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -240,14 +214,12 @@ func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, en
 			continue
 		}
 
-		// nil buffer: VectorFromBinary returns a view into the supplied buffer when
-		// it is large enough, which would alias across iterations. A fresh allocation
-		// per vector keeps every cached slice independent.
+		// nil buffer forces a fresh allocation; a reused buffer would be aliased by
+		// VectorFromBinary across iterations and corrupt previously cached vectors.
 		vec, err := storobj.VectorFromBinary(v, nil, targetVector)
 		if err != nil {
 			var notFound storobj.ErrTargetVectorNotFound
 			if errors.As(err, &notFound) {
-				// object simply has no vector for this target vector; nothing to cache
 				continue
 			}
 			logger.WithField("action", "hnsw_vector_cache_prefill").

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -28,12 +27,6 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
-
-// disableParallelPrefillEnvVar is a kill switch that forces the serial,
-// by-id prefiller even when the parallel cursor path would otherwise be
-// eligible. It exists so an operator can fall back without a redeploy if the
-// parallel path ever misbehaves in production.
-const disableParallelPrefillEnvVar = "DISABLE_PARALLEL_VECTOR_CACHE_PREFILL"
 
 // useParallelPrefill reports whether the uncompressed vector cache can be
 // prefilled by scanning the objects bucket with a parallel cursor instead of the
@@ -62,7 +55,6 @@ func (h *hnsw) useParallelPrefill() bool {
 
 	return parallelPrefillEligible(parallelPrefillInputs{
 		waitForPrefill: h.waitForCachePrefill,
-		killSwitch:     os.Getenv(disableParallelPrefillEnvVar) == "true",
 		multivector:    h.multivector.Load(),
 		muvera:         h.muvera.Load(),
 		cacheMaxSize:   h.cache.CopyMaxSize(),
@@ -72,7 +64,6 @@ func (h *hnsw) useParallelPrefill() bool {
 
 type parallelPrefillInputs struct {
 	waitForPrefill bool
-	killSwitch     bool
 	multivector    bool
 	muvera         bool
 	cacheMaxSize   int64
@@ -84,9 +75,6 @@ type parallelPrefillInputs struct {
 // the rationale behind each condition.
 func parallelPrefillEligible(in parallelPrefillInputs) bool {
 	if !in.waitForPrefill {
-		return false
-	}
-	if in.killSwitch {
 		return false
 	}
 	if in.multivector && !in.muvera {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -99,6 +99,10 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 
 	var loaded atomic.Int64
 	onVector := func(id uint64, vec []float32) {
+		// cosine-dot keeps normalized vectors in the cache; the serial path gets this
+		// from the cache's normalizeOnRead wrapper, which Preload bypasses. vec is a
+		// fresh per-vector allocation, so normalizing in place is safe.
+		h.normalizeVecInPlace(vec)
 		if id >= preGrown {
 			// Cache is pre-grown to len(h.nodes) at restore, so live ids are in-bounds;
 			// grow only for an id from a write that landed after we snapshotted the count.

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
@@ -15,7 +15,6 @@ package hnsw
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -66,30 +65,37 @@ func newPrefillRoutingIndex(t *testing.T, id string, uc ent.UserConfig, store *l
 // each index type to the right prefill path: only a plain single-vector index takes
 // the parallel objects-bucket scan; multivector and muvera stay on the serial path
 // because their caches are not sourced from the objects bucket.
-func TestUseParallelPrefillRoutingRealIndex(t *testing.T) {
-	base := func() ent.UserConfig {
-		return ent.UserConfig{VectorCacheMaxObjects: 1e12, MaxConnections: 8, EFConstruction: 64, EF: 64}
-	}
+// prefillRoutingUserConfig is the baseline single-vector config that satisfies the
+// parallel-prefill gate (unbounded cache); tests layer Multivector/Muvera on top to
+// flip the expected routing.
+func prefillRoutingUserConfig() ent.UserConfig {
+	return ent.UserConfig{VectorCacheMaxObjects: 1e12, MaxConnections: 8, EFConstruction: 64, EF: 64}
+}
 
+func muveraUserConfig() ent.UserConfig {
+	uc := prefillRoutingUserConfig()
+	uc.Multivector = ent.MultivectorConfig{
+		Enabled:      true,
+		MuveraConfig: ent.MuveraConfig{Enabled: true, KSim: 2, DProjections: 3, Repetitions: 5},
+	}
+	return uc
+}
+
+func TestUseParallelPrefillRoutingRealIndex(t *testing.T) {
 	t.Run("single-vector uncompressed is eligible", func(t *testing.T) {
-		idx := newPrefillRoutingIndex(t, "single", base(), storeWithObjectsBucket(t))
+		idx := newPrefillRoutingIndex(t, "single", prefillRoutingUserConfig(), storeWithObjectsBucket(t))
 		require.True(t, idx.useParallelPrefill())
 	})
 
 	t.Run("true multivector keeps serial path", func(t *testing.T) {
-		uc := base()
+		uc := prefillRoutingUserConfig()
 		uc.Multivector = ent.MultivectorConfig{Enabled: true}
 		idx := newPrefillRoutingIndex(t, "multivector", uc, storeWithObjectsBucket(t))
 		require.False(t, idx.useParallelPrefill())
 	})
 
 	t.Run("muvera keeps serial path", func(t *testing.T) {
-		uc := base()
-		uc.Multivector = ent.MultivectorConfig{
-			Enabled:      true,
-			MuveraConfig: ent.MuveraConfig{Enabled: true, KSim: 2, DProjections: 3, Repetitions: 5},
-		}
-		idx := newPrefillRoutingIndex(t, "muvera", uc, storeWithObjectsBucket(t))
+		idx := newPrefillRoutingIndex(t, "muvera", muveraUserConfig(), storeWithObjectsBucket(t))
 		require.False(t, idx.useParallelPrefill())
 	})
 }
@@ -105,32 +111,7 @@ func TestMuveraSerialPrefillPopulatesCacheRealIndex(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	store := storeWithObjectsBucket(t)
 
-	idx, err := New(Config{
-		RootPath:              t.TempDir(),
-		ID:                    "muvera-prefill",
-		MakeCommitLoggerThunk: MakeNoopCommitLogger,
-		DistanceProvider:      distancer.NewDotProductProvider(),
-		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
-			return []float32{0}, errors.New("can not use VectorForIDThunk with multivector")
-		},
-		MultiVectorForIDThunk: func(ctx context.Context, id uint64) ([][]float32, error) {
-			return multiVectors[id], nil
-		},
-		MakeBucketOptions:   lsmkv.MakeNoopBucketOptions,
-		AllocChecker:        memwatch.NewDummyMonitor(),
-		GetViewThunk:        func() common.BucketView { return &multivectorNoopBucketView{} },
-		WaitForCachePrefill: true,
-	}, ent.UserConfig{
-		VectorCacheMaxObjects: 1e12,
-		MaxConnections:        8,
-		EFConstruction:        64,
-		EF:                    64,
-		Multivector: ent.MultivectorConfig{
-			Enabled:      true,
-			MuveraConfig: ent.MuveraConfig{Enabled: true, KSim: 2, DProjections: 3, Repetitions: 5},
-		},
-	}, cyclemanager.NewCallbackGroupNoop(), store)
-	require.NoError(t, err)
+	idx := newPrefillRoutingIndex(t, "muvera-prefill", muveraUserConfig(), store)
 
 	for i, vec := range multiVectors {
 		require.NoError(t, idx.AddMulti(ctx, uint64(i), vec))

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
@@ -1,0 +1,162 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package hnsw
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// storeWithObjectsBucket gives the index a real objects bucket so useParallelPrefill
+// gets past its bucket-presence check and actually evaluates the eligibility gate —
+// otherwise every index would fall back to serial for the wrong reason.
+func storeWithObjectsBucket(t *testing.T) *lsmkv.Store {
+	store := testinghelpers.NewDummyStore(t)
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+	return store
+}
+
+func newPrefillRoutingIndex(t *testing.T, id string, uc ent.UserConfig, store *lsmkv.Store) *hnsw {
+	idx, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    id,
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewDotProductProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{0.1, 0.2, 0.3}, nil
+		},
+		MultiVectorForIDThunk: func(ctx context.Context, id uint64) ([][]float32, error) {
+			return multiVectors[id], nil
+		},
+		MakeBucketOptions:   lsmkv.MakeNoopBucketOptions,
+		AllocChecker:        memwatch.NewDummyMonitor(),
+		GetViewThunk:        func() common.BucketView { return &multivectorNoopBucketView{} },
+		WaitForCachePrefill: true,
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	return idx
+}
+
+// TestUseParallelPrefillRoutingRealIndex builds real indexes (objects bucket present,
+// sync prefill, unbounded cache) and confirms the config→atomic→gate wiring routes
+// each index type to the right prefill path: only a plain single-vector index takes
+// the parallel objects-bucket scan; multivector and muvera stay on the serial path
+// because their caches are not sourced from the objects bucket.
+func TestUseParallelPrefillRoutingRealIndex(t *testing.T) {
+	base := func() ent.UserConfig {
+		return ent.UserConfig{VectorCacheMaxObjects: 1e12, MaxConnections: 8, EFConstruction: 64, EF: 64}
+	}
+
+	t.Run("single-vector uncompressed is eligible", func(t *testing.T) {
+		idx := newPrefillRoutingIndex(t, "single", base(), storeWithObjectsBucket(t))
+		require.True(t, idx.useParallelPrefill())
+	})
+
+	t.Run("true multivector keeps serial path", func(t *testing.T) {
+		uc := base()
+		uc.Multivector = ent.MultivectorConfig{Enabled: true}
+		idx := newPrefillRoutingIndex(t, "multivector", uc, storeWithObjectsBucket(t))
+		require.False(t, idx.useParallelPrefill())
+	})
+
+	t.Run("muvera keeps serial path", func(t *testing.T) {
+		uc := base()
+		uc.Multivector = ent.MultivectorConfig{
+			Enabled:      true,
+			MuveraConfig: ent.MuveraConfig{Enabled: true, KSim: 2, DProjections: 3, Repetitions: 5},
+		}
+		idx := newPrefillRoutingIndex(t, "muvera", uc, storeWithObjectsBucket(t))
+		require.False(t, idx.useParallelPrefill())
+	})
+}
+
+// TestMuveraSerialPrefillPopulatesCacheRealIndex is the end-to-end guard for the bug
+// the parallel path introduced: a muvera index's float32 cache is loaded from the
+// dedicated _muvera_vectors bucket, not the objects bucket. After clearing the cache
+// (cold-restart shape), the serial prefiller muvera routes to must repopulate it
+// fully with the correct muvera-encoded vectors — the parallel path would have left
+// it empty while marking it prefilled.
+func TestMuveraSerialPrefillPopulatesCacheRealIndex(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	store := storeWithObjectsBucket(t)
+
+	idx, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "muvera-prefill",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewDotProductProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{0}, errors.New("can not use VectorForIDThunk with multivector")
+		},
+		MultiVectorForIDThunk: func(ctx context.Context, id uint64) ([][]float32, error) {
+			return multiVectors[id], nil
+		},
+		MakeBucketOptions:   lsmkv.MakeNoopBucketOptions,
+		AllocChecker:        memwatch.NewDummyMonitor(),
+		GetViewThunk:        func() common.BucketView { return &multivectorNoopBucketView{} },
+		WaitForCachePrefill: true,
+	}, ent.UserConfig{
+		VectorCacheMaxObjects: 1e12,
+		MaxConnections:        8,
+		EFConstruction:        64,
+		EF:                    64,
+		Multivector: ent.MultivectorConfig{
+			Enabled:      true,
+			MuveraConfig: ent.MuveraConfig{Enabled: true, KSim: 2, DProjections: 3, Repetitions: 5},
+		},
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+
+	for i, vec := range multiVectors {
+		require.NoError(t, idx.AddMulti(ctx, uint64(i), vec))
+	}
+
+	require.False(t, idx.useParallelPrefill(),
+		"muvera must route to the serial prefiller, not the objects-bucket scan")
+
+	expected := make(map[uint64][]float32, len(multiVectors))
+	for i := range multiVectors {
+		v, err := idx.muveraEncoder.GetMuveraVectorForID(uint64(i), idx.id+"_muvera_vectors")
+		require.NoError(t, err)
+		expected[uint64(i)] = v
+	}
+
+	// Cold-restart shape: drop the cache, then run the serial prefiller muvera is
+	// routed to and confirm full, correct repopulation.
+	idx.cache.Drop()
+	require.Equal(t, int64(0), idx.cache.CountVectors())
+
+	require.NoError(t, newVectorCachePrefiller(idx.cache, idx, logger).Prefill(ctx, int(idx.cache.CopyMaxSize())))
+
+	require.Equal(t, int64(len(multiVectors)), idx.cache.CountVectors())
+	for id, want := range expected {
+		got, err := idx.cache.Get(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -209,19 +209,18 @@ func TestParallelPrefillEligible(t *testing.T) {
 	}
 }
 
-// TestPrefillCacheParallelEndToEnd runs the full prefill against a real bucket and
-// cache. VectorForID errors, so any vector the prefill missed surfaces as a Get error.
-func TestPrefillCacheParallelEndToEnd(t *testing.T) {
-	const n = 500
-
+// prefillParallelIntoCache fills an objects bucket with vecs (a legacy vector per id),
+// then runs prefillCacheParallel against a real cache wired so any miss errors. h.nodes
+// is sized to preGrown (and the cache grown to match when preGrown>0); preGrown==0
+// forces the defensive in-scan Grow path. Returns the populated cache.
+func prefillParallelIntoCache(t *testing.T, vecs map[uint64][]float32, preGrown int,
+	dp distancer.Provider, normalizeOnRead bool,
+) cache.Cache[float32] {
+	t.Helper()
 	store := newTestObjectsStore(t)
 	bucket := store.Bucket(helpers.ObjectsBucketLSM)
-
-	exp := make(map[uint64][]float32, n)
-	for i := uint64(0); i < n; i++ {
-		vec := []float32{float32(i), float32(i) * 0.5, float32(i) + 7}
-		putTestObject(t, bucket, i, vec, nil)
-		exp[i] = vec
+	for id, v := range vecs {
+		putTestObject(t, bucket, id, v, nil)
 	}
 	require.NoError(t, bucket.FlushAndSwitch())
 
@@ -229,26 +228,42 @@ func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
 		return nil, fmt.Errorf("unexpected cache miss for id %d: prefill should have loaded it", id)
 	}
-	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
-	c.Grow(uint64(n)) // mimic the restore-time pre-grow
-
+	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, normalizeOnRead, 0, nil)
+	if preGrown > 0 {
+		c.Grow(uint64(preGrown)) // mimic the restore-time pre-grow
+	}
 	h := &hnsw{
 		store:             store,
 		cache:             c,
-		nodes:             make([]*vertex, n),
+		nodes:             make([]*vertex, preGrown),
 		id:                "main", // no "vectors_" prefix => legacy default target vector
 		logger:            logger,
-		distancerProvider: distancer.NewDotProductProvider(), // non-cosine: no normalization
+		distancerProvider: dp,
 	}
-
 	require.NoError(t, h.prefillCacheParallel(context.Background()))
-	require.Equal(t, int64(n), c.CountVectors())
+	return c
+}
 
-	for i := uint64(0); i < n; i++ {
-		got, err := h.cache.Get(context.Background(), i)
-		require.NoErrorf(t, err, "doc id %d should be a cache hit", i)
-		require.Equalf(t, exp[i], got, "vector mismatch for doc id %d", i)
+func requireCacheContains(t *testing.T, c cache.Cache[float32], want map[uint64][]float32) {
+	t.Helper()
+	require.Equal(t, int64(len(want)), c.CountVectors())
+	for id, w := range want {
+		got, err := c.Get(context.Background(), id)
+		require.NoErrorf(t, err, "doc id %d should be a cache hit", id)
+		require.Equalf(t, w, got, "vector mismatch for doc id %d", id)
 	}
+}
+
+// TestPrefillCacheParallelEndToEnd runs the full prefill against a real bucket and
+// cache. VectorForID errors, so any vector the prefill missed surfaces as a Get error.
+func TestPrefillCacheParallelEndToEnd(t *testing.T) {
+	const n = 500
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		exp[i] = []float32{float32(i), float32(i) * 0.5, float32(i) + 7}
+	}
+	c := prefillParallelIntoCache(t, exp, n, distancer.NewDotProductProvider(), false)
+	requireCacheContains(t, c, exp)
 }
 
 // TestPrefillCacheParallelGrowsBeyondPreGrown exercises the defensive Grow path: with
@@ -256,40 +271,12 @@ func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 // cache slice under load. Run with -race to catch a missing lock on the grow.
 func TestPrefillCacheParallelGrowsBeyondPreGrown(t *testing.T) {
 	const n = 2000
-
-	store := newTestObjectsStore(t)
-	bucket := store.Bucket(helpers.ObjectsBucketLSM)
 	exp := make(map[uint64][]float32, n)
 	for i := uint64(0); i < n; i++ {
-		vec := []float32{float32(i), float32(i) + 1}
-		putTestObject(t, bucket, i, vec, nil)
-		exp[i] = vec
+		exp[i] = []float32{float32(i), float32(i) + 1}
 	}
-	require.NoError(t, bucket.FlushAndSwitch())
-
-	logger, _ := test.NewNullLogger()
-	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
-		return nil, fmt.Errorf("unexpected cache miss for id %d", id)
-	}
-	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
-
-	// Not pre-grown: preGrown == 0, so every id takes the defensive Grow path.
-	h := &hnsw{
-		store:             store,
-		cache:             c,
-		nodes:             nil,
-		id:                "main",
-		logger:            logger,
-		distancerProvider: distancer.NewDotProductProvider(),
-	}
-
-	require.NoError(t, h.prefillCacheParallel(context.Background()))
-	require.Equal(t, int64(n), c.CountVectors())
-	for i := uint64(0); i < n; i++ {
-		got, err := h.cache.Get(context.Background(), i)
-		require.NoErrorf(t, err, "doc id %d", i)
-		require.Equalf(t, exp[i], got, "doc id %d", i)
-	}
+	c := prefillParallelIntoCache(t, exp, 0, distancer.NewDotProductProvider(), false)
+	requireCacheContains(t, c, exp)
 }
 
 // TestScanObjectVectorsParallelLatestWinsAcrossSegments verifies that when the same

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -1,0 +1,249 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+func newTestObjectsStore(t *testing.T) *lsmkv.Store {
+	t.Helper()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroup("objects", logger, 1),
+		cyclemanager.NewCallbackGroup("nonObjects", logger, 1),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+	return store
+}
+
+func newTestObjectsBucket(t *testing.T) *lsmkv.Bucket {
+	t.Helper()
+	return newTestObjectsStore(t).Bucket(helpers.ObjectsBucketLSM)
+}
+
+// putTestObject marshals a storobj.Object (with a legacy vector and/or named target
+// vectors) exactly as the write path does and stores it under its UUID, so the
+// parallel cursor sees real on-disk data.
+func putTestObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, legacyVec []float32, named map[string][]float32) {
+	t.Helper()
+	// deterministic, valid v4-shaped UUID derived from docID
+	id := strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012x", docID))
+	obj := storobj.New(docID)
+	obj.Object = models.Object{ID: id, Class: "Test"}
+	obj.Vector = legacyVec
+	if named != nil {
+		obj.Vectors = named
+	}
+	data, err := obj.MarshalBinary()
+	require.NoError(t, err)
+
+	// The scan reads docID + vector from the value, not the key, so the key only
+	// needs to be unique and sortable; a 16-byte big-endian docID mirrors the real
+	// objects bucket's fixed-width key without needing a real UUID encoder.
+	key := make([]byte, 16)
+	binary.BigEndian.PutUint64(key[8:], docID)
+	require.NoError(t, bucket.Put(key, data))
+}
+
+func collectScan(t *testing.T, bucket *lsmkv.Bucket, target string) map[uint64][]float32 {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	var mu sync.Mutex
+	got := map[uint64][]float32{}
+	err := scanObjectVectorsParallel(context.Background(), bucket, target,
+		func(id uint64, vec []float32) {
+			mu.Lock()
+			defer mu.Unlock()
+			_, exists := got[id]
+			require.Falsef(t, exists, "doc id %d emitted more than once", id)
+			got[id] = vec
+		}, logger)
+	require.NoError(t, err)
+	return got
+}
+
+func assertVectorsEqual(t *testing.T, exp, got map[uint64][]float32) {
+	t.Helper()
+	require.Equal(t, len(exp), len(got), "vector count mismatch")
+	for id, ev := range exp {
+		gv, ok := got[id]
+		require.Truef(t, ok, "missing doc id %d", id)
+		require.Equalf(t, ev, gv, "vector mismatch for doc id %d", id)
+	}
+}
+
+func TestScanObjectVectorsParallel(t *testing.T) {
+	t.Run("legacy single vector, memtable only", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 50; i++ {
+			vec := []float32{float32(i), float32(i) + 0.5, float32(i) * 2}
+			putTestObject(t, bucket, i, vec, nil)
+			exp[i] = vec
+		}
+		assertVectorsEqual(t, exp, collectScan(t, bucket, ""))
+	})
+
+	t.Run("legacy, flushed to segment (exercises parallel ranges)", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 3000; i++ {
+			vec := []float32{float32(i), float32(-int64(i))}
+			putTestObject(t, bucket, i, vec, nil)
+			exp[i] = vec
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+		assertVectorsEqual(t, exp, collectScan(t, bucket, ""))
+	})
+
+	t.Run("named target vector", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 60; i++ {
+			vec := []float32{float32(i) + 0.25, float32(i) - 0.25}
+			putTestObject(t, bucket, i, nil, map[string][]float32{"custom": vec})
+			exp[i] = vec
+		}
+		assertVectorsEqual(t, exp, collectScan(t, bucket, "custom"))
+	})
+
+	t.Run("objects without the target vector are skipped", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 40; i++ {
+			if i%2 == 0 {
+				vec := []float32{float32(i)}
+				putTestObject(t, bucket, i, nil, map[string][]float32{"custom": vec})
+				exp[i] = vec
+			} else {
+				putTestObject(t, bucket, i, nil, map[string][]float32{"other": {1, 2, 3}})
+			}
+		}
+		assertVectorsEqual(t, exp, collectScan(t, bucket, "custom"))
+	})
+
+	t.Run("empty bucket", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		assert.Empty(t, collectScan(t, bucket, ""))
+	})
+
+	t.Run("context cancelled before scan returns error", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		for i := uint64(0); i < 3000; i++ {
+			putTestObject(t, bucket, i, []float32{float32(i)}, nil)
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		logger, _ := test.NewNullLogger()
+		err := scanObjectVectorsParallel(ctx, bucket, "", func(uint64, []float32) {}, logger)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestParallelPrefillEligible(t *testing.T) {
+	base := parallelPrefillInputs{
+		waitForPrefill: true,
+		killSwitch:     false,
+		multivector:    false,
+		muvera:         false,
+		cacheMaxSize:   1e12,
+		nodeCount:      1000,
+	}
+
+	tests := []struct {
+		name string
+		mod  func(*parallelPrefillInputs)
+		want bool
+	}{
+		{"sync + unbounded + single-vector", func(*parallelPrefillInputs) {}, true},
+		{"async prefill keeps serial path", func(in *parallelPrefillInputs) { in.waitForPrefill = false }, false},
+		{"kill switch keeps serial path", func(in *parallelPrefillInputs) { in.killSwitch = true }, false},
+		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = false }, false},
+		{"muvera multivector is eligible", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, true},
+		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},
+		{"cache exactly fits nodes is eligible", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1000; in.nodeCount = 1000 }, true},
+		{"empty index (0 nodes) is eligible", func(in *parallelPrefillInputs) { in.nodeCount = 0 }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := base
+			tt.mod(&in)
+			assert.Equal(t, tt.want, parallelPrefillEligible(in))
+		})
+	}
+}
+
+// TestPrefillCacheParallelEndToEnd drives the whole parallel prefill against a real
+// objects bucket and a real cache, then verifies every vector is resident with the
+// correct value. The cache is constructed with a VectorForID that errors, so any
+// vector the prefill failed to load would surface as a cache-miss error on Get.
+func TestPrefillCacheParallelEndToEnd(t *testing.T) {
+	const n = 500
+
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i), float32(i) * 0.5, float32(i) + 7}
+		putTestObject(t, bucket, i, vec, nil)
+		exp[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	logger, _ := test.NewNullLogger()
+	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
+		return nil, fmt.Errorf("unexpected cache miss for id %d: prefill should have loaded it", id)
+	}
+	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(n)) // mimic the restore-time pre-grow
+
+	h := &hnsw{
+		store:  store,
+		cache:  c,
+		nodes:  make([]*vertex, n),
+		id:     "main", // no "vectors_" prefix => legacy default target vector
+		logger: logger,
+	}
+
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(n), c.CountVectors())
+
+	for i := uint64(0); i < n; i++ {
+		got, err := h.cache.Get(context.Background(), i)
+		require.NoErrorf(t, err, "doc id %d should be a cache hit", i)
+		require.Equalf(t, exp[i], got, "vector mismatch for doc id %d", i)
+	}
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -180,7 +180,6 @@ func TestScanObjectVectorsParallel(t *testing.T) {
 func TestParallelPrefillEligible(t *testing.T) {
 	base := parallelPrefillInputs{
 		waitForPrefill: true,
-		killSwitch:     false,
 		multivector:    false,
 		muvera:         false,
 		cacheMaxSize:   1e12,
@@ -194,7 +193,6 @@ func TestParallelPrefillEligible(t *testing.T) {
 	}{
 		{"sync + unbounded + single-vector", func(*parallelPrefillInputs) {}, true},
 		{"async prefill keeps serial path", func(in *parallelPrefillInputs) { in.waitForPrefill = false }, false},
-		{"kill switch keeps serial path", func(in *parallelPrefillInputs) { in.killSwitch = true }, false},
 		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = false }, false},
 		{"muvera multivector is eligible", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, true},
 		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -316,3 +316,37 @@ func TestScanObjectVectorsParallelSkipsDeleted(t *testing.T) {
 		3: {3},
 	}, collectScan(t, bucket, ""))
 }
+
+// TestScanObjectVectorsParallelNamedVectorIsolation puts objects carrying several
+// named vectors (plus a legacy vector) in one bucket and scans each target
+// separately. Each named index shares the objects bucket with its siblings, so a
+// scan for one target must yield only that target's vectors and skip objects that
+// lack it — never bleed a sibling's vector or a legacy vector into the wrong cache.
+func TestScanObjectVectorsParallelNamedVectorIsolation(t *testing.T) {
+	bucket := newTestObjectsBucket(t)
+
+	// Deliberately sparse: not every object has every target.
+	putTestObject(t, bucket, 0, []float32{0, 0}, map[string][]float32{"title": {1, 0}, "body": {2, 0}})
+	putTestObject(t, bucket, 1, nil, map[string][]float32{"title": {1, 1}})
+	putTestObject(t, bucket, 2, nil, map[string][]float32{"body": {2, 2}})
+	putTestObject(t, bucket, 3, []float32{3, 3}, nil)
+	putTestObject(t, bucket, 4, nil, map[string][]float32{"title": {1, 4}, "body": {2, 4}})
+
+	// legacy target: only objects with a legacy vector.
+	assertVectorsEqual(t, map[uint64][]float32{
+		0: {0, 0},
+		3: {3, 3},
+	}, collectScan(t, bucket, ""))
+
+	assertVectorsEqual(t, map[uint64][]float32{
+		0: {1, 0},
+		1: {1, 1},
+		4: {1, 4},
+	}, collectScan(t, bucket, "title"))
+
+	assertVectorsEqual(t, map[uint64][]float32{
+		0: {2, 0},
+		2: {2, 2},
+		4: {2, 4},
+	}, collectScan(t, bucket, "body"))
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -67,12 +67,17 @@ func putTestObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, legacyVec [
 	data, err := obj.MarshalBinary()
 	require.NoError(t, err)
 
-	// The scan reads docID + vector from the value, not the key, so the key only
-	// needs to be unique and sortable; a 16-byte big-endian docID mirrors the real
-	// objects bucket's fixed-width key without needing a real UUID encoder.
+	require.NoError(t, bucket.Put(keyForDocID(docID), data))
+}
+
+// keyForDocID builds the bucket key for a doc id. The scan reads docID + vector
+// from the value, not the key, so the key only needs to be unique and sortable; a
+// 16-byte big-endian docID mirrors the real objects bucket's fixed-width key
+// without needing a real UUID encoder.
+func keyForDocID(docID uint64) []byte {
 	key := make([]byte, 16)
 	binary.BigEndian.PutUint64(key[8:], docID)
-	require.NoError(t, bucket.Put(key, data))
+	return key
 }
 
 func collectScan(t *testing.T, bucket *lsmkv.Bucket, target string) map[uint64][]float32 {
@@ -246,4 +251,75 @@ func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 		require.NoErrorf(t, err, "doc id %d should be a cache hit", i)
 		require.Equalf(t, exp[i], got, "vector mismatch for doc id %d", i)
 	}
+}
+
+// TestPrefillCacheParallelGrowsBeyondPreGrown exercises the defensive Grow path:
+// with an empty node list (preGrown == 0) every doc id triggers cache.Grow from the
+// concurrent scan goroutines, swapping the cache slice under load. Run with -race to
+// catch a missing lock on the grow. (The end-to-end test pre-grows to n, so it does
+// not hit this path.)
+func TestPrefillCacheParallelGrowsBeyondPreGrown(t *testing.T) {
+	const n = 2000
+
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i), float32(i) + 1}
+		putTestObject(t, bucket, i, vec, nil)
+		exp[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	logger, _ := test.NewNullLogger()
+	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
+		return nil, fmt.Errorf("unexpected cache miss for id %d", id)
+	}
+	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
+
+	// Deliberately NOT pre-grown: nodes is empty => preGrown == 0 => every id takes
+	// the defensive Grow path.
+	h := &hnsw{store: store, cache: c, nodes: nil, id: "main", logger: logger}
+
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(n), c.CountVectors())
+	for i := uint64(0); i < n; i++ {
+		got, err := h.cache.Get(context.Background(), i)
+		require.NoErrorf(t, err, "doc id %d", i)
+		require.Equalf(t, exp[i], got, "doc id %d", i)
+	}
+}
+
+// TestScanObjectVectorsParallelLatestWinsAcrossSegments verifies that when the same
+// key is written in two segments, the cursor yields the latest value exactly once.
+func TestScanObjectVectorsParallelLatestWinsAcrossSegments(t *testing.T) {
+	bucket := newTestObjectsBucket(t)
+
+	putTestObject(t, bucket, 7, []float32{1, 1}, nil)
+	require.NoError(t, bucket.FlushAndSwitch())
+	putTestObject(t, bucket, 7, []float32{2, 2}, nil) // same key, newer segment
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	got := collectScan(t, bucket, "")
+	require.Len(t, got, 1)
+	require.Equal(t, []float32{2, 2}, got[7])
+}
+
+// TestScanObjectVectorsParallelSkipsDeleted verifies tombstoned objects are skipped,
+// matching the serial path (which never sees a deleted doc id).
+func TestScanObjectVectorsParallelSkipsDeleted(t *testing.T) {
+	bucket := newTestObjectsBucket(t)
+
+	putTestObject(t, bucket, 1, []float32{1}, nil)
+	putTestObject(t, bucket, 2, []float32{2}, nil)
+	putTestObject(t, bucket, 3, []float32{3}, nil)
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	require.NoError(t, bucket.Delete(keyForDocID(2)))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	assertVectorsEqual(t, map[uint64][]float32{
+		1: {1},
+		3: {3},
+	}, collectScan(t, bucket, ""))
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -232,11 +233,12 @@ func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 	c.Grow(uint64(n)) // mimic the restore-time pre-grow
 
 	h := &hnsw{
-		store:  store,
-		cache:  c,
-		nodes:  make([]*vertex, n),
-		id:     "main", // no "vectors_" prefix => legacy default target vector
-		logger: logger,
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, n),
+		id:                "main", // no "vectors_" prefix => legacy default target vector
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(), // non-cosine: no normalization
 	}
 
 	require.NoError(t, h.prefillCacheParallel(context.Background()))
@@ -272,7 +274,14 @@ func TestPrefillCacheParallelGrowsBeyondPreGrown(t *testing.T) {
 	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
 
 	// Not pre-grown: preGrown == 0, so every id takes the defensive Grow path.
-	h := &hnsw{store: store, cache: c, nodes: nil, id: "main", logger: logger}
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             nil,
+		id:                "main",
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+	}
 
 	require.NoError(t, h.prefillCacheParallel(context.Background()))
 	require.Equal(t, int64(n), c.CountVectors())
@@ -349,4 +358,49 @@ func TestScanObjectVectorsParallelNamedVectorIsolation(t *testing.T) {
 		2: {2, 2},
 		4: {2, 4},
 	}, collectScan(t, bucket, "body"))
+}
+
+// TestPrefillCacheParallelNormalizesForCosine guards the normalization invariant:
+// for a cosine-dot index the cache must hold normalized vectors (so the dot product
+// equals cosine similarity). The objects bucket stores raw vectors, and the serial
+// prefiller normalizes them via the cache's normalizeOnRead wrapper — the parallel
+// path must match, or cosine search silently returns wrong distances.
+func TestPrefillCacheParallelNormalizesForCosine(t *testing.T) {
+	const n = 50
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	raw := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i) + 1, float32(i) + 2, float32(i) + 3} // non-unit on purpose
+		putTestObject(t, bucket, i, vec, nil)
+		raw[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	logger, _ := test.NewNullLogger()
+	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
+		return nil, fmt.Errorf("unexpected cache miss for id %d", id)
+	}
+	// normalizeOnRead=true mirrors how index.New builds the cache for cosine-dot.
+	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, true, 0, nil)
+	c.Grow(uint64(n))
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, n),
+		id:                "main",
+		logger:            logger,
+		distancerProvider: distancer.NewCosineDistanceProvider(),
+	}
+
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(n), c.CountVectors())
+	for i := uint64(0); i < n; i++ {
+		got, err := c.Get(context.Background(), i)
+		require.NoError(t, err)
+		require.Equalf(t, distancer.Normalize(raw[i]), got,
+			"cosine-dot cache must hold normalized vectors for doc %d", i)
+	}
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -190,7 +190,11 @@ func TestParallelPrefillEligible(t *testing.T) {
 		{"sync + unbounded + single-vector", func(*parallelPrefillInputs) {}, true},
 		{"async prefill keeps serial path", func(in *parallelPrefillInputs) { in.waitForPrefill = false }, false},
 		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = false }, false},
-		{"muvera multivector is eligible", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, true},
+		// muvera's float32 cache is sourced from the _muvera_vectors bucket, not the
+		// objects bucket the parallel scan reads, so it must stay on the serial path —
+		// regardless of whether the multivector flag happens to be set alongside it.
+		{"muvera keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, false},
+		{"muvera without multivector flag keeps serial path", func(in *parallelPrefillInputs) { in.multivector = false; in.muvera = true }, false},
 		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},
 		{"cache exactly fits nodes is eligible", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1000; in.nodeCount = 1000 }, true},
 		{"empty index (0 nodes) is eligible", func(in *parallelPrefillInputs) { in.nodeCount = 0 }, true},

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -51,12 +51,10 @@ func newTestObjectsBucket(t *testing.T) *lsmkv.Bucket {
 	return newTestObjectsStore(t).Bucket(helpers.ObjectsBucketLSM)
 }
 
-// putTestObject marshals a storobj.Object (with a legacy vector and/or named target
-// vectors) exactly as the write path does and stores it under its UUID, so the
-// parallel cursor sees real on-disk data.
+// putTestObject stores an object marshalled exactly as the write path does, so the
+// scan reads real on-disk data rather than a hand-rolled encoding.
 func putTestObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, legacyVec []float32, named map[string][]float32) {
 	t.Helper()
-	// deterministic, valid v4-shaped UUID derived from docID
 	id := strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012x", docID))
 	obj := storobj.New(docID)
 	obj.Object = models.Object{ID: id, Class: "Test"}
@@ -70,10 +68,8 @@ func putTestObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, legacyVec [
 	require.NoError(t, bucket.Put(keyForDocID(docID), data))
 }
 
-// keyForDocID builds the bucket key for a doc id. The scan reads docID + vector
-// from the value, not the key, so the key only needs to be unique and sortable; a
-// 16-byte big-endian docID mirrors the real objects bucket's fixed-width key
-// without needing a real UUID encoder.
+// keyForDocID builds a unique, sortable bucket key. The scan reads docID + vector from
+// the value, not the key, so a 16-byte big-endian docID stands in for the real UUID key.
 func keyForDocID(docID uint64) []byte {
 	key := make([]byte, 16)
 	binary.BigEndian.PutUint64(key[8:], docID)
@@ -208,10 +204,8 @@ func TestParallelPrefillEligible(t *testing.T) {
 	}
 }
 
-// TestPrefillCacheParallelEndToEnd drives the whole parallel prefill against a real
-// objects bucket and a real cache, then verifies every vector is resident with the
-// correct value. The cache is constructed with a VectorForID that errors, so any
-// vector the prefill failed to load would surface as a cache-miss error on Get.
+// TestPrefillCacheParallelEndToEnd runs the full prefill against a real bucket and
+// cache. VectorForID errors, so any vector the prefill missed surfaces as a Get error.
 func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 	const n = 500
 
@@ -251,11 +245,9 @@ func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 	}
 }
 
-// TestPrefillCacheParallelGrowsBeyondPreGrown exercises the defensive Grow path:
-// with an empty node list (preGrown == 0) every doc id triggers cache.Grow from the
-// concurrent scan goroutines, swapping the cache slice under load. Run with -race to
-// catch a missing lock on the grow. (The end-to-end test pre-grows to n, so it does
-// not hit this path.)
+// TestPrefillCacheParallelGrowsBeyondPreGrown exercises the defensive Grow path: with
+// preGrown == 0 every id triggers cache.Grow from concurrent scanners, swapping the
+// cache slice under load. Run with -race to catch a missing lock on the grow.
 func TestPrefillCacheParallelGrowsBeyondPreGrown(t *testing.T) {
 	const n = 2000
 
@@ -275,8 +267,7 @@ func TestPrefillCacheParallelGrowsBeyondPreGrown(t *testing.T) {
 	}
 	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
 
-	// Deliberately NOT pre-grown: nodes is empty => preGrown == 0 => every id takes
-	// the defensive Grow path.
+	// Not pre-grown: preGrown == 0, so every id takes the defensive Grow path.
 	h := &hnsw{store: store, cache: c, nodes: nil, id: "main", logger: logger}
 
 	require.NoError(t, h.prefillCacheParallel(context.Background()))


### PR DESCRIPTION
SuperClaude here.

## Motivation

On startup, prefilling a large **uncompressed** HNSW shard's vector cache can take hours because it looks up every vector by id through the HNSW graph (`vectorCachePrefiller`), issuing one random seek per vector into the UUID-sorted objects bucket. Being serial and queue-depth-1, it is latency-bound and leaves the CPU idle. This is the root cause behind weaviate/weaviate#11837 and implements the long-standing idea in weaviate/weaviate#2825 for the uncompressed path.

## Approach

When the cache is effectively unbounded (it will hold every vector anyway), the by-id lookup is pure overhead. This adds a parallel, per-segment cursor scan of the objects bucket (`scanObjectVectorsParallel`) that reads in storage order and decodes across cores — the same shape as `compressionhelpers`' `PrefillCache`, which already does this for the dedicated compressed-vector bucket.

Design points / review areas:

- **Preload during scan, not collect-then-load.** The compressed path collects all `(id, vec)` then `Grow`s + `Preload`s once. For full float32 vectors that second copy roughly doubles peak memory during startup, so this preloads directly as it scans. The cache is already grown to `len(h.nodes)` at restore, so every live doc id is in-bounds; the rare larger id grows defensively. `Preload`/`Grow` are sharded-lock / `LockAll` safe under the concurrent scan.
- **Gating (`useParallelPrefill`).** Eligible only when: synchronous prefill (`waitForCachePrefill`), unbounded cache (`CopyMaxSize() >= node count`), single-vector index, and a real objects bucket is attached. Async prefill keeps the serial load-if-absent path — its `cache.Get` is race-safe against concurrent writes, whereas a snapshot cursor + overwriting `Preload` is not. Multivector and muvera keep the serial path: a multivector cache holds per-passage vectors and a muvera cache is sourced from the dedicated `_muvera_vectors` bucket, neither of which lives in the objects bucket this scan reads. Bounded caches keep serial. No objects bucket → serial fallback (covers test/edge wiring).
- **Compressed path untouched** — new file only; zero changes to `parallel_iterator.go` / `compression.go`.

## Tests

- `scanObjectVectorsParallel` against a real objects bucket: legacy + named target vectors, flushed multi-segment (exercises the parallel quantile ranges and asserts every doc id is emitted exactly once), objects missing the target skipped, empty bucket, ctx cancellation.
- `parallelPrefillEligible`: exhaustive over every gate condition, including that multivector and muvera both stay on the serial path.
- End-to-end `prefillCacheParallel` against a real cache: verifies every vector is resident with the correct value and `CountVectors()` is exact. The cache's `VectorForID` is wired to error, so any vector the prefill missed surfaces as a failing `Get`.
- Full `hnsw` package suite green; `-race` clean; goroutine linter, gofumpt, and golangci-lint clean.

## Risk / backport

Targeting `stable/v1.36` for the 3-version SLA (36/37/38). The behavior change is confined to the sync + unbounded + single-vector prefill path (the slow case); all other paths and the compressed path are unchanged, with serial fallback as the safety net. Read amplification (reading the full object per vector) is unchanged and tracked as a separate follow-up in weaviate/weaviate#11837.

Refs weaviate/weaviate#11837, weaviate/weaviate#2825

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— SuperClaude
