### PR TITLE
[DO NOT MERGE] QA: v1.38 + HNSW parallel-prefill (slow-disk before/after image)

### DIFF
--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -542,6 +542,10 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 			} else {
 				h.compressor.PrefillMultiCache(ctx, h.docIDVectors)
 			}
+		} else if h.useParallelPrefill() {
+			// Unbounded uncompressed cache: scan the objects bucket with a parallel
+			// cursor instead of looking up every vector by id (disk-seek bound).
+			err = h.prefillCacheParallel(ctx)
 		} else {
 			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(context.Background(), limit)
 		}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -1,0 +1,267 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// disableParallelPrefillEnvVar is a kill switch that forces the serial,
+// by-id prefiller even when the parallel cursor path would otherwise be
+// eligible. It exists so an operator can fall back without a redeploy if the
+// parallel path ever misbehaves in production.
+const disableParallelPrefillEnvVar = "DISABLE_PARALLEL_VECTOR_CACHE_PREFILL"
+
+// useParallelPrefill reports whether the uncompressed vector cache can be
+// prefilled by scanning the objects bucket with a parallel cursor instead of the
+// serial, by-id vectorCachePrefiller. It is eligible only when:
+//
+//   - the prefill is synchronous (waitForCachePrefill). In async mode the prefill
+//     runs alongside live writes; the serial path's load-if-absent cache.Get is
+//     race-safe there, whereas an overwriting Preload from a snapshot cursor is not.
+//   - the cache is effectively unbounded, i.e. it can hold every vector. When the
+//     cache is smaller than the node count the serial prefiller is required because
+//     it honors the size limit (it stops at `limit`); a full bucket scan would not.
+//   - the index is single-vector or muvera. True multivector stores vectors per
+//     passage with a different cache keying and keeps the serial path (mirrors the
+//     compressed split in prefillCache).
+func (h *hnsw) useParallelPrefill() bool {
+	// The parallel path cursor-scans the objects bucket directly. Without it — e.g.
+	// indexes wired only through a VectorForID thunk (tests) or before the store is
+	// attached — fall back to the serial, thunk-based prefiller.
+	if h.store == nil || h.store.Bucket(helpers.ObjectsBucketLSM) == nil {
+		return false
+	}
+
+	h.RLock()
+	nodeCount := int64(len(h.nodes))
+	h.RUnlock()
+
+	return parallelPrefillEligible(parallelPrefillInputs{
+		waitForPrefill: h.waitForCachePrefill,
+		killSwitch:     os.Getenv(disableParallelPrefillEnvVar) == "true",
+		multivector:    h.multivector.Load(),
+		muvera:         h.muvera.Load(),
+		cacheMaxSize:   h.cache.CopyMaxSize(),
+		nodeCount:      nodeCount,
+	})
+}
+
+type parallelPrefillInputs struct {
+	waitForPrefill bool
+	killSwitch     bool
+	multivector    bool
+	muvera         bool
+	cacheMaxSize   int64
+	nodeCount      int64
+}
+
+// parallelPrefillEligible holds the decision logic for useParallelPrefill in a
+// pure form so it can be exercised directly in tests. See useParallelPrefill for
+// the rationale behind each condition.
+func parallelPrefillEligible(in parallelPrefillInputs) bool {
+	if !in.waitForPrefill {
+		return false
+	}
+	if in.killSwitch {
+		return false
+	}
+	if in.multivector && !in.muvera {
+		return false
+	}
+	return in.cacheMaxSize >= in.nodeCount
+}
+
+// prefillCacheParallel populates the (uncompressed) vector cache by scanning the
+// objects bucket with a parallel, per-segment cursor rather than looking up every
+// vector by id through the HNSW graph.
+//
+// The by-id prefiller (vectorCachePrefiller) issues one random read per vector.
+// The objects bucket is keyed by UUID, so a lookup by doc id is a random seek;
+// doing that serially for millions of vectors is latency-bound and can take hours
+// on network-attached storage, with the CPU idle. When the cache is unbounded the
+// index lookup is pure overhead: a cursor scan reads in storage order (sequential)
+// and parallelizes the decode across cores. This mirrors
+// compressionhelpers.(*quantizedVectorsCompressor).PrefillCache, which does the
+// same over the dedicated compressed-vector bucket.
+//
+// Unlike the compressed variant, it preloads into the cache as it scans instead of
+// first collecting every vector into a temporary slice: full float32 vectors are
+// large and a second full copy would roughly double peak memory during startup.
+// The cache is already grown to len(h.nodes) at restore, so a direct Preload is
+// in-bounds for every live doc id; the rare id beyond that grows the cache
+// defensively.
+func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
+	before := time.Now()
+
+	bucket := h.store.Bucket(helpers.ObjectsBucketLSM)
+	if bucket == nil {
+		return fmt.Errorf("prefill cache: objects bucket %q not found", helpers.ObjectsBucketLSM)
+	}
+	targetVector := h.getTargetVector()
+
+	h.RLock()
+	preGrown := uint64(len(h.nodes))
+	h.RUnlock()
+
+	var loaded atomic.Int64
+	onVector := func(id uint64, vec []float32) {
+		if id >= preGrown {
+			// The cache is grown to len(h.nodes) at restore, so every live doc id is
+			// already in-bounds. Grow only for the unexpected larger id (e.g. a write
+			// landed after we snapshotted the node count).
+			h.cache.Grow(id)
+		}
+		h.cache.Preload(id, vec)
+		loaded.Add(1)
+	}
+
+	if err := scanObjectVectorsParallel(ctx, bucket, targetVector, onVector, h.logger); err != nil {
+		return err
+	}
+
+	h.logger.WithFields(logrus.Fields{
+		"action":   "hnsw_vector_cache_prefill",
+		"count":    loaded.Load(),
+		"took":     time.Since(before),
+		"index_id": h.id,
+		"parallel": true,
+	}).Info("prefilled vector cache")
+	return nil
+}
+
+// scanObjectVectorsParallel splits the objects keyspace into ranges using quantile
+// seed keys and scans each range with its own cursor concurrently, invoking
+// onVector for every (docID, vector) pair. onVector must be safe for concurrent use.
+func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, targetVector string,
+	onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
+) error {
+	parallel := 2 * runtime.GOMAXPROCS(0)
+	if parallel < 1 {
+		parallel = 1
+	}
+
+	// One fewer seed than the desired parallelism: the first routine reads from the
+	// start to seeds[0], the last reads from the final seed to the end.
+	seeds := bucket.QuantileKeys(parallel - 1)
+
+	type keyRange struct{ start, end []byte } // nil start = from first; nil end = to the end
+	var ranges []keyRange
+	if len(seeds) == 0 {
+		// Empty or very small bucket: a single full scan.
+		ranges = []keyRange{{start: nil, end: nil}}
+	} else {
+		ranges = append(ranges, keyRange{start: nil, end: seeds[0]})
+		for i := 0; i < len(seeds)-1; i++ {
+			ranges = append(ranges, keyRange{start: seeds[i], end: seeds[i+1]})
+		}
+		ranges = append(ranges, keyRange{start: seeds[len(seeds)-1], end: nil})
+	}
+
+	var (
+		wg       sync.WaitGroup
+		firstErr atomic.Pointer[error]
+	)
+	for i := range ranges {
+		r := ranges[i]
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			if err := scanObjectVectorsRange(ctx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
+				e := err
+				firstErr.CompareAndSwap(nil, &e)
+			}
+		}, logger)
+	}
+	wg.Wait()
+
+	if e := firstErr.Load(); e != nil {
+		return *e
+	}
+	return nil
+}
+
+func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, end []byte,
+	targetVector string, onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	c := bucket.Cursor()
+	defer c.Close()
+
+	var k, v []byte
+	if start == nil {
+		k, v = c.First()
+	} else {
+		k, v = c.Seek(start)
+	}
+
+	const checkContextEveryN = 1024
+	n := 0
+	for ; k != nil; k, v = c.Next() {
+		if end != nil && bytes.Compare(k, end) >= 0 {
+			break
+		}
+		n++
+		if n%checkContextEveryN == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		if len(v) == 0 {
+			continue
+		}
+
+		id, err := storobj.DocIDFromBinary(v)
+		if err != nil {
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping object with undecodable doc id: %v", err)
+			continue
+		}
+
+		// nil buffer: VectorFromBinary returns a view into the supplied buffer when
+		// it is large enough, which would alias across iterations. A fresh allocation
+		// per vector keeps every cached slice independent.
+		vec, err := storobj.VectorFromBinary(v, nil, targetVector)
+		if err != nil {
+			var notFound storobj.ErrTargetVectorNotFound
+			if errors.As(err, &notFound) {
+				// object simply has no vector for this target vector; nothing to cache
+				continue
+			}
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping doc id %d with undecodable vector: %v", id, err)
+			continue
+		}
+		if len(vec) == 0 {
+			continue
+		}
+		onVector(id, vec)
+	}
+	return nil
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -181,6 +181,12 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		ranges = append(ranges, keyRange{start: seeds[len(seeds)-1], end: nil})
 	}
 
+	// Derived context so the first range to error short-circuits its siblings
+	// (they observe the cancellation on their next ctx check) instead of scanning
+	// to completion.
+	scanCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var (
 		wg       sync.WaitGroup
 		firstErr atomic.Pointer[error]
@@ -190,9 +196,11 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		wg.Add(1)
 		enterrors.GoWrapper(func() {
 			defer wg.Done()
-			if err := scanObjectVectorsRange(ctx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
+			if err := scanObjectVectorsRange(scanCtx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
 				e := err
-				firstErr.CompareAndSwap(nil, &e)
+				if firstErr.CompareAndSwap(nil, &e) {
+					cancel()
+				}
 			}
 		}, logger)
 	}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -28,12 +27,6 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
-
-// disableParallelPrefillEnvVar is a kill switch that forces the serial,
-// by-id prefiller even when the parallel cursor path would otherwise be
-// eligible. It exists so an operator can fall back without a redeploy if the
-// parallel path ever misbehaves in production.
-const disableParallelPrefillEnvVar = "DISABLE_PARALLEL_VECTOR_CACHE_PREFILL"
 
 // useParallelPrefill reports whether the uncompressed vector cache can be
 // prefilled by scanning the objects bucket with a parallel cursor instead of the
@@ -62,7 +55,6 @@ func (h *hnsw) useParallelPrefill() bool {
 
 	return parallelPrefillEligible(parallelPrefillInputs{
 		waitForPrefill: h.waitForCachePrefill,
-		killSwitch:     os.Getenv(disableParallelPrefillEnvVar) == "true",
 		multivector:    h.multivector.Load(),
 		muvera:         h.muvera.Load(),
 		cacheMaxSize:   h.cache.CopyMaxSize(),
@@ -72,7 +64,6 @@ func (h *hnsw) useParallelPrefill() bool {
 
 type parallelPrefillInputs struct {
 	waitForPrefill bool
-	killSwitch     bool
 	multivector    bool
 	muvera         bool
 	cacheMaxSize   int64
@@ -84,9 +75,6 @@ type parallelPrefillInputs struct {
 // the rationale behind each condition.
 func parallelPrefillEligible(in parallelPrefillInputs) bool {
 	if !in.waitForPrefill {
-		return false
-	}
-	if in.killSwitch {
 		return false
 	}
 	if in.multivector && !in.muvera {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -1,0 +1,249 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+func newTestObjectsStore(t *testing.T) *lsmkv.Store {
+	t.Helper()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroup("objects", logger, 1),
+		cyclemanager.NewCallbackGroup("nonObjects", logger, 1),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+	return store
+}
+
+func newTestObjectsBucket(t *testing.T) *lsmkv.Bucket {
+	t.Helper()
+	return newTestObjectsStore(t).Bucket(helpers.ObjectsBucketLSM)
+}
+
+// putTestObject marshals a storobj.Object (with a legacy vector and/or named target
+// vectors) exactly as the write path does and stores it under its UUID, so the
+// parallel cursor sees real on-disk data.
+func putTestObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, legacyVec []float32, named map[string][]float32) {
+	t.Helper()
+	// deterministic, valid v4-shaped UUID derived from docID
+	id := strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012x", docID))
+	obj := storobj.New(docID)
+	obj.Object = models.Object{ID: id, Class: "Test"}
+	obj.Vector = legacyVec
+	if named != nil {
+		obj.Vectors = named
+	}
+	data, err := obj.MarshalBinary()
+	require.NoError(t, err)
+
+	// The scan reads docID + vector from the value, not the key, so the key only
+	// needs to be unique and sortable; a 16-byte big-endian docID mirrors the real
+	// objects bucket's fixed-width key without needing a real UUID encoder.
+	key := make([]byte, 16)
+	binary.BigEndian.PutUint64(key[8:], docID)
+	require.NoError(t, bucket.Put(key, data))
+}
+
+func collectScan(t *testing.T, bucket *lsmkv.Bucket, target string) map[uint64][]float32 {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	var mu sync.Mutex
+	got := map[uint64][]float32{}
+	err := scanObjectVectorsParallel(context.Background(), bucket, target,
+		func(id uint64, vec []float32) {
+			mu.Lock()
+			defer mu.Unlock()
+			_, exists := got[id]
+			require.Falsef(t, exists, "doc id %d emitted more than once", id)
+			got[id] = vec
+		}, logger)
+	require.NoError(t, err)
+	return got
+}
+
+func assertVectorsEqual(t *testing.T, exp, got map[uint64][]float32) {
+	t.Helper()
+	require.Equal(t, len(exp), len(got), "vector count mismatch")
+	for id, ev := range exp {
+		gv, ok := got[id]
+		require.Truef(t, ok, "missing doc id %d", id)
+		require.Equalf(t, ev, gv, "vector mismatch for doc id %d", id)
+	}
+}
+
+func TestScanObjectVectorsParallel(t *testing.T) {
+	t.Run("legacy single vector, memtable only", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 50; i++ {
+			vec := []float32{float32(i), float32(i) + 0.5, float32(i) * 2}
+			putTestObject(t, bucket, i, vec, nil)
+			exp[i] = vec
+		}
+		assertVectorsEqual(t, exp, collectScan(t, bucket, ""))
+	})
+
+	t.Run("legacy, flushed to segment (exercises parallel ranges)", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 3000; i++ {
+			vec := []float32{float32(i), float32(-int64(i))}
+			putTestObject(t, bucket, i, vec, nil)
+			exp[i] = vec
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+		assertVectorsEqual(t, exp, collectScan(t, bucket, ""))
+	})
+
+	t.Run("named target vector", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 60; i++ {
+			vec := []float32{float32(i) + 0.25, float32(i) - 0.25}
+			putTestObject(t, bucket, i, nil, map[string][]float32{"custom": vec})
+			exp[i] = vec
+		}
+		assertVectorsEqual(t, exp, collectScan(t, bucket, "custom"))
+	})
+
+	t.Run("objects without the target vector are skipped", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		exp := map[uint64][]float32{}
+		for i := uint64(0); i < 40; i++ {
+			if i%2 == 0 {
+				vec := []float32{float32(i)}
+				putTestObject(t, bucket, i, nil, map[string][]float32{"custom": vec})
+				exp[i] = vec
+			} else {
+				putTestObject(t, bucket, i, nil, map[string][]float32{"other": {1, 2, 3}})
+			}
+		}
+		assertVectorsEqual(t, exp, collectScan(t, bucket, "custom"))
+	})
+
+	t.Run("empty bucket", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		assert.Empty(t, collectScan(t, bucket, ""))
+	})
+
+	t.Run("context cancelled before scan returns error", func(t *testing.T) {
+		bucket := newTestObjectsBucket(t)
+		for i := uint64(0); i < 3000; i++ {
+			putTestObject(t, bucket, i, []float32{float32(i)}, nil)
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		logger, _ := test.NewNullLogger()
+		err := scanObjectVectorsParallel(ctx, bucket, "", func(uint64, []float32) {}, logger)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestParallelPrefillEligible(t *testing.T) {
+	base := parallelPrefillInputs{
+		waitForPrefill: true,
+		killSwitch:     false,
+		multivector:    false,
+		muvera:         false,
+		cacheMaxSize:   1e12,
+		nodeCount:      1000,
+	}
+
+	tests := []struct {
+		name string
+		mod  func(*parallelPrefillInputs)
+		want bool
+	}{
+		{"sync + unbounded + single-vector", func(*parallelPrefillInputs) {}, true},
+		{"async prefill keeps serial path", func(in *parallelPrefillInputs) { in.waitForPrefill = false }, false},
+		{"kill switch keeps serial path", func(in *parallelPrefillInputs) { in.killSwitch = true }, false},
+		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = false }, false},
+		{"muvera multivector is eligible", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, true},
+		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},
+		{"cache exactly fits nodes is eligible", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1000; in.nodeCount = 1000 }, true},
+		{"empty index (0 nodes) is eligible", func(in *parallelPrefillInputs) { in.nodeCount = 0 }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := base
+			tt.mod(&in)
+			assert.Equal(t, tt.want, parallelPrefillEligible(in))
+		})
+	}
+}
+
+// TestPrefillCacheParallelEndToEnd drives the whole parallel prefill against a real
+// objects bucket and a real cache, then verifies every vector is resident with the
+// correct value. The cache is constructed with a VectorForID that errors, so any
+// vector the prefill failed to load would surface as a cache-miss error on Get.
+func TestPrefillCacheParallelEndToEnd(t *testing.T) {
+	const n = 500
+
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i), float32(i) * 0.5, float32(i) + 7}
+		putTestObject(t, bucket, i, vec, nil)
+		exp[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	logger, _ := test.NewNullLogger()
+	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
+		return nil, fmt.Errorf("unexpected cache miss for id %d: prefill should have loaded it", id)
+	}
+	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(n)) // mimic the restore-time pre-grow
+
+	h := &hnsw{
+		store:  store,
+		cache:  c,
+		nodes:  make([]*vertex, n),
+		id:     "main", // no "vectors_" prefix => legacy default target vector
+		logger: logger,
+	}
+
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(n), c.CountVectors())
+
+	for i := uint64(0); i < n; i++ {
+		got, err := h.cache.Get(context.Background(), i)
+		require.NoErrorf(t, err, "doc id %d should be a cache hit", i)
+		require.Equalf(t, exp[i], got, "vector mismatch for doc id %d", i)
+	}
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -180,7 +180,6 @@ func TestScanObjectVectorsParallel(t *testing.T) {
 func TestParallelPrefillEligible(t *testing.T) {
 	base := parallelPrefillInputs{
 		waitForPrefill: true,
-		killSwitch:     false,
 		multivector:    false,
 		muvera:         false,
 		cacheMaxSize:   1e12,
@@ -194,7 +193,6 @@ func TestParallelPrefillEligible(t *testing.T) {
 	}{
 		{"sync + unbounded + single-vector", func(*parallelPrefillInputs) {}, true},
 		{"async prefill keeps serial path", func(in *parallelPrefillInputs) { in.waitForPrefill = false }, false},
-		{"kill switch keeps serial path", func(in *parallelPrefillInputs) { in.killSwitch = true }, false},
 		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = false }, false},
 		{"muvera multivector is eligible", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, true},
 		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -67,12 +67,17 @@ func putTestObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, legacyVec [
 	data, err := obj.MarshalBinary()
 	require.NoError(t, err)
 
-	// The scan reads docID + vector from the value, not the key, so the key only
-	// needs to be unique and sortable; a 16-byte big-endian docID mirrors the real
-	// objects bucket's fixed-width key without needing a real UUID encoder.
+	require.NoError(t, bucket.Put(keyForDocID(docID), data))
+}
+
+// keyForDocID builds the bucket key for a doc id. The scan reads docID + vector
+// from the value, not the key, so the key only needs to be unique and sortable; a
+// 16-byte big-endian docID mirrors the real objects bucket's fixed-width key
+// without needing a real UUID encoder.
+func keyForDocID(docID uint64) []byte {
 	key := make([]byte, 16)
 	binary.BigEndian.PutUint64(key[8:], docID)
-	require.NoError(t, bucket.Put(key, data))
+	return key
 }
 
 func collectScan(t *testing.T, bucket *lsmkv.Bucket, target string) map[uint64][]float32 {
@@ -246,4 +251,75 @@ func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 		require.NoErrorf(t, err, "doc id %d should be a cache hit", i)
 		require.Equalf(t, exp[i], got, "vector mismatch for doc id %d", i)
 	}
+}
+
+// TestPrefillCacheParallelGrowsBeyondPreGrown exercises the defensive Grow path:
+// with an empty node list (preGrown == 0) every doc id triggers cache.Grow from the
+// concurrent scan goroutines, swapping the cache slice under load. Run with -race to
+// catch a missing lock on the grow. (The end-to-end test pre-grows to n, so it does
+// not hit this path.)
+func TestPrefillCacheParallelGrowsBeyondPreGrown(t *testing.T) {
+	const n = 2000
+
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i), float32(i) + 1}
+		putTestObject(t, bucket, i, vec, nil)
+		exp[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	logger, _ := test.NewNullLogger()
+	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
+		return nil, fmt.Errorf("unexpected cache miss for id %d", id)
+	}
+	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
+
+	// Deliberately NOT pre-grown: nodes is empty => preGrown == 0 => every id takes
+	// the defensive Grow path.
+	h := &hnsw{store: store, cache: c, nodes: nil, id: "main", logger: logger}
+
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(n), c.CountVectors())
+	for i := uint64(0); i < n; i++ {
+		got, err := h.cache.Get(context.Background(), i)
+		require.NoErrorf(t, err, "doc id %d", i)
+		require.Equalf(t, exp[i], got, "doc id %d", i)
+	}
+}
+
+// TestScanObjectVectorsParallelLatestWinsAcrossSegments verifies that when the same
+// key is written in two segments, the cursor yields the latest value exactly once.
+func TestScanObjectVectorsParallelLatestWinsAcrossSegments(t *testing.T) {
+	bucket := newTestObjectsBucket(t)
+
+	putTestObject(t, bucket, 7, []float32{1, 1}, nil)
+	require.NoError(t, bucket.FlushAndSwitch())
+	putTestObject(t, bucket, 7, []float32{2, 2}, nil) // same key, newer segment
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	got := collectScan(t, bucket, "")
+	require.Len(t, got, 1)
+	require.Equal(t, []float32{2, 2}, got[7])
+}
+
+// TestScanObjectVectorsParallelSkipsDeleted verifies tombstoned objects are skipped,
+// matching the serial path (which never sees a deleted doc id).
+func TestScanObjectVectorsParallelSkipsDeleted(t *testing.T) {
+	bucket := newTestObjectsBucket(t)
+
+	putTestObject(t, bucket, 1, []float32{1}, nil)
+	putTestObject(t, bucket, 2, []float32{2}, nil)
+	putTestObject(t, bucket, 3, []float32{3}, nil)
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	require.NoError(t, bucket.Delete(keyForDocID(2)))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	assertVectorsEqual(t, map[uint64][]float32{
+		1: {1},
+		3: {3},
+	}, collectScan(t, bucket, ""))
 }


### PR DESCRIPTION
**DO NOT MERGE.** Throwaway image-build PR for QA slow-disk before/after measurement of the HNSW parallel vector-cache prefill (weaviate/weaviate#11838), forward-ported to `stable/v1.38` so it is version-matched to the `bm25-tests` dev cluster (avoids a downgrade). Builds a v1.38 + parallel-prefill arm64 image. Will be closed after measurement.

Cherry-picks the 3 #11838 commits onto stable/v1.38 (clean, no conflicts); prefill tests green under `-race`. Doubles as a 1.38 forward-port check for the 36/37/38 SLA.

🔬 QA Claude