### PR TITLE
fix(objects): reject negative offset and limit on REST objects list (gh-11660)

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -251,6 +251,9 @@ func (h *objectHandlers) getObjects(params objects.ObjectsListParams,
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return objects.NewObjectsListForbidden().
 				WithPayload(errPayloadFromSingleErr(principal, err))
+		case errors.As(err, &uco.ErrInvalidUserInput{}):
+			return objects.NewObjectsListUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrMultiTenancy{}):
 			return objects.NewObjectsListUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(principal, err))

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -166,10 +166,13 @@ func (m *Manager) getObjectsFromRepo(ctx context.Context,
 ) ([]*models.Object, error) {
 	smartOffset, smartLimit, err := m.localOffsetLimit(offset, limit)
 	if err != nil {
+		if errors.As(err, &ErrInvalidUserInput{}) {
+			return nil, err
+		}
 		return nil, NewErrInternal("list objects: %v", err)
 	}
 	if after != nil {
-		return nil, NewErrInternal("list objects: after parameter not allowed, cursor must be specific to one class, set class query param")
+		return nil, NewErrInvalidUserInput("after parameter not allowed, cursor must be specific to one class, set class query param")
 	}
 	res, err := m.vectorRepo.ObjectSearch(ctx, smartOffset, smartLimit,
 		nil, m.getSort(sort, order), additional, tenant)
@@ -242,13 +245,25 @@ func (m *Manager) localLimitOrGlobalLimit(offset int64, paramMaxResults *int64) 
 }
 
 func (m *Manager) localOffsetLimit(paramOffset *int64, paramLimit *int64) (int, int, error) {
+	if paramOffset != nil && *paramOffset < 0 {
+		return 0, 0, NewErrInvalidUserInput(
+			"offset must be non-negative, got %d", *paramOffset,
+		)
+	}
+	if paramLimit != nil && *paramLimit < 0 {
+		return 0, 0, NewErrInvalidUserInput(
+			"limit must be non-negative, got %d", *paramLimit,
+		)
+	}
+
 	offset := m.localOffsetOrZero(paramOffset)
 	limit := m.localLimitOrGlobalLimit(int64(offset), paramLimit)
 
 	if int64(offset+limit) > m.config.Config.QueryMaximumResults {
-		return 0, 0, fmt.Errorf(
-			"query maximum results exceeded: the total limit calculated from the provided offset '%d' and limit '%d' exceeds the configured value for QUERY_MAXIMUM_RESULTS '%d'. If you've supplied a negative offset or limit, this may be an underflow error",
-			offset, limit, m.config.Config.QueryMaximumResults)
+		return 0, 0, NewErrInvalidUserInput(
+			"query maximum results exceeded: the total limit calculated from the provided offset '%d' and limit '%d' exceeds the configured value for QUERY_MAXIMUM_RESULTS '%d'",
+			offset, limit, m.config.Config.QueryMaximumResults,
+		)
 	}
 
 	return offset, limit, nil

--- a/usecases/objects/get_pagination_test.go
+++ b/usecases/objects/get_pagination_test.go
@@ -1,0 +1,130 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package objects
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+func TestLocalOffsetLimit(t *testing.T) {
+	cfg := &config.WeaviateConfig{}
+	cfg.Config.QueryDefaults.Limit = 20
+	cfg.Config.QueryMaximumResults = 100
+	m := &Manager{config: cfg}
+
+	ptr := func(i int64) *int64 { return &i }
+
+	tests := []struct {
+		name       string
+		offset     *int64
+		limit      *int64
+		wantOffset int
+		wantLimit  int
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:       "nil offset and nil limit uses default limit",
+			offset:     nil,
+			limit:      nil,
+			wantOffset: 0,
+			wantLimit:  20,
+		},
+		{
+			name:       "valid offset and limit",
+			offset:     ptr(5),
+			limit:      ptr(10),
+			wantOffset: 5,
+			wantLimit:  10,
+		},
+		{
+			name:       "zero offset and limit",
+			offset:     ptr(0),
+			limit:      ptr(0),
+			wantOffset: 0,
+			wantLimit:  0,
+		},
+		{
+			name:       "nil offset with valid limit",
+			offset:     nil,
+			limit:      ptr(5),
+			wantOffset: 0,
+			wantLimit:  5,
+		},
+		{
+			name:       "negative offset is rejected",
+			offset:     ptr(-1),
+			limit:      ptr(10),
+			wantErr:    true,
+			wantErrMsg: "offset must be non-negative, got -1",
+		},
+		{
+			name:       "negative limit is rejected",
+			offset:     ptr(0),
+			limit:      ptr(-1),
+			wantErr:    true,
+			wantErrMsg: "limit must be non-negative, got -1",
+		},
+		{
+			name:       "negative offset and negative limit rejects offset first",
+			offset:     ptr(-5),
+			limit:      ptr(-10),
+			wantErr:    true,
+			wantErrMsg: "offset must be non-negative, got -5",
+		},
+		{
+			name:       "large negative limit is rejected",
+			offset:     nil,
+			limit:      ptr(-9999),
+			wantErr:    true,
+			wantErrMsg: "limit must be non-negative, got -9999",
+		},
+		{
+			name:       "offset plus limit exceeding maximum is rejected",
+			offset:     ptr(50),
+			limit:      ptr(60),
+			wantErr:    true,
+			wantErrMsg: "query maximum results exceeded",
+		},
+		{
+			name:       "offset at maximum boundary is allowed",
+			offset:     ptr(40),
+			limit:      ptr(60),
+			wantOffset: 40,
+			wantLimit:  60,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOffset, gotLimit, err := m.localOffsetLimit(tt.offset, tt.limit)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.As(err, &ErrInvalidUserInput{}),
+					"expected ErrInvalidUserInput, got %T: %v", err, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				assert.Equal(t, 0, gotOffset)
+				assert.Equal(t, 0, gotLimit)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOffset, gotOffset)
+			assert.Equal(t, tt.wantLimit, gotLimit)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Fixes #11660.

`GET /v1/objects?limit=-1` (and `?offset=-1`) previously returned HTTP 200 with an empty result instead of a validation error. `usecases/objects/Manager.localOffsetLimit` did not guard against negative pagination, and the existing "query maximum results exceeded" branch returned a plain `fmt.Errorf` that the handler mapped to HTTP 500 (this is also the cause of #11661).

`localOffsetLimit` now:

- rejects negative `offset` with `NewErrInvalidUserInput("offset must be non-negative, got %d")`
- rejects negative `limit` with `NewErrInvalidUserInput("limit must be non-negative, got %d")`
- returns the over-maximum case as `NewErrInvalidUserInput` so the handler returns HTTP 422 instead of 500

`getObjectsFromRepo` preserves the typed `ErrInvalidUserInput` returned by `localOffsetLimit` instead of rewrapping it as `NewErrInternal`. The `after`-without-class branch now returns `NewErrInvalidUserInput` for the same reason.

The REST `getObjects` handler maps `ErrInvalidUserInput` to `ObjectsListUnprocessableEntity` (422).

Both REST entry paths through `localOffsetLimit` benefit:

- `GET /v1/objects` (`getObjects` -> `getObjectsFromRepo`)
- `GET /v1/objects?class=X` (`query` -> `QueryParams.inputs` -- already mapped to `StatusBadRequest`/422 via `query.go:91`)

Added regression coverage in `usecases/objects/get_pagination_test.go`:

- `nil offset and nil limit uses default limit`
- `valid offset and limit`
- `zero offset and limit`
- `nil offset with valid limit`
- `negative offset is rejected`
- `negative limit is rejected`
- `negative offset and negative limit rejects offset first`
- `large negative limit is rejected`
- `offset plus limit exceeding maximum is rejected`
- `offset at maximum boundary is allowed`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: Not necessary; this is validation behavior for an invalid request.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: Not necessary; REST argument validation only.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. Not necessary; this adds three integer comparisons in the request setup path.

### Validation

- `go test -count=1 -race ./usecases/objects/...`
- `go test -count=1 ./adapters/handlers/rest/...`
- `golangci-lint run ./usecases/objects/... ./adapters/handlers/rest/...`
- `./tools/linter_go_routines.sh`
