### PR TITLE
fix(flat): reject negative rescoreLimit on compression config (gh-11402)

### DIFF
--- a/entities/vectorindex/flat/config.go
+++ b/entities/vectorindex/flat/config.go
@@ -129,7 +129,7 @@ func ParseAndValidateConfig(input interface{}) (schemaConfig.VectorIndexConfig, 
 	return uc, nil
 }
 
-func parseCompressionMap(in interface{}, cuc *CompressionUserConfig) error {
+func parseCompressionMap(in interface{}, cuc *CompressionUserConfig, name string) error {
 	configMap, ok := in.(map[string]interface{})
 	if ok {
 		if err := vectorindexcommon.OptionalBoolFromMap(configMap, "enabled", func(v bool) {
@@ -149,6 +149,10 @@ func parseCompressionMap(in interface{}, cuc *CompressionUserConfig) error {
 		}); err != nil {
 			return err
 		}
+
+		if cuc.RescoreLimit < 0 {
+			return fmt.Errorf("%s.rescoreLimit must be non-negative, got %d", name, cuc.RescoreLimit)
+		}
 	}
 	return nil
 }
@@ -164,21 +168,21 @@ func parseCompression(in map[string]interface{}, uc *UserConfig) error {
 	}
 
 	if pqOk {
-		err := parseCompressionMap(pqConfigValue, &uc.PQ)
+		err := parseCompressionMap(pqConfigValue, &uc.PQ, "pq")
 		if err != nil {
 			return err
 		}
 	}
 
 	if bqOk {
-		err := parseCompressionMap(bqConfigValue, &uc.BQ)
+		err := parseCompressionMap(bqConfigValue, &uc.BQ, "bq")
 		if err != nil {
 			return err
 		}
 	}
 
 	if sqOk {
-		err := parseCompressionMap(sqConfigValue, &uc.SQ)
+		err := parseCompressionMap(sqConfigValue, &uc.SQ, "sq")
 		if err != nil {
 			return err
 		}
@@ -249,6 +253,10 @@ func parseRQConfig(in interface{}, rq *RQUserConfig) error {
 			rq.RescoreLimit = v
 		}); err != nil {
 			return err
+		}
+
+		if rq.RescoreLimit < 0 {
+			return fmt.Errorf("rq.rescoreLimit must be non-negative, got %d", rq.RescoreLimit)
 		}
 
 		if err := vectorindexcommon.OptionalIntFromMap(configMap, "bits", func(v int) {

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -341,6 +341,91 @@ func Test_FlatUserConfig(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "cannot enable multiple quantization methods at the same time",
 		},
+		{
+			name: "bq with negative rescoreLimit is rejected",
+			input: map[string]interface{}{
+				"distance": "cosine",
+				"bq": map[string]interface{}{
+					"enabled":      true,
+					"rescoreLimit": float64(-1),
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "bq.rescoreLimit must be non-negative, got -1",
+		},
+		{
+			name: "pq with negative rescoreLimit is rejected",
+			input: map[string]interface{}{
+				"distance": "cosine",
+				"pq": map[string]interface{}{
+					"enabled":      false,
+					"rescoreLimit": float64(-5),
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "pq.rescoreLimit must be non-negative, got -5",
+		},
+		{
+			name: "sq with negative rescoreLimit is rejected",
+			input: map[string]interface{}{
+				"distance": "cosine",
+				"sq": map[string]interface{}{
+					"enabled":      false,
+					"rescoreLimit": float64(-100),
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "sq.rescoreLimit must be non-negative, got -100",
+		},
+		{
+			name: "rq with negative rescoreLimit is rejected",
+			input: map[string]interface{}{
+				"distance": "cosine",
+				"rq": map[string]interface{}{
+					"enabled":      true,
+					"bits":         8,
+					"rescoreLimit": float64(-1),
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "rq.rescoreLimit must be non-negative, got -1",
+		},
+		{
+			name: "bq with zero rescoreLimit is allowed",
+			input: map[string]interface{}{
+				"vectorCacheMaxObjects": float64(100),
+				"distance":              "cosine",
+				"bq": map[string]interface{}{
+					"enabled":      true,
+					"rescoreLimit": float64(0),
+				},
+			},
+			expected: UserConfig{
+				VectorCacheMaxObjects: 100,
+				Distance:              common.DefaultDistanceMetric,
+				PQ: CompressionUserConfig{
+					Enabled:      DefaultCompressionEnabled,
+					RescoreLimit: DefaultCompressionRescore,
+					Cache:        DefaultVectorCache,
+				},
+				BQ: CompressionUserConfig{
+					Enabled:      true,
+					RescoreLimit: 0,
+					Cache:        DefaultVectorCache,
+				},
+				SQ: CompressionUserConfig{
+					Enabled:      DefaultCompressionEnabled,
+					RescoreLimit: DefaultCompressionRescore,
+					Cache:        DefaultVectorCache,
+				},
+				RQ: RQUserConfig{
+					Enabled:      DefaultCompressionEnabled,
+					RescoreLimit: DefaultCompressionRescore,
+					Cache:        DefaultVectorCache,
+					Bits:         DefaultRQBits,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -19,6 +19,27 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
 )
 
+func defaultExpectedUserConfig() UserConfig {
+	compression := CompressionUserConfig{
+		Enabled:      DefaultCompressionEnabled,
+		RescoreLimit: DefaultCompressionRescore,
+		Cache:        DefaultVectorCache,
+	}
+	return UserConfig{
+		VectorCacheMaxObjects: common.DefaultVectorCacheMaxObjects,
+		Distance:              common.DefaultDistanceMetric,
+		PQ:                    compression,
+		BQ:                    compression,
+		SQ:                    compression,
+		RQ: RQUserConfig{
+			Enabled:      DefaultCompressionEnabled,
+			RescoreLimit: DefaultCompressionRescore,
+			Cache:        DefaultVectorCache,
+			Bits:         DefaultRQBits,
+		},
+	}
+}
+
 func Test_FlatUserConfig(t *testing.T) {
 	type test struct {
 		name         string
@@ -400,31 +421,13 @@ func Test_FlatUserConfig(t *testing.T) {
 					"rescoreLimit": float64(0),
 				},
 			},
-			expected: UserConfig{
-				VectorCacheMaxObjects: 100,
-				Distance:              common.DefaultDistanceMetric,
-				PQ: CompressionUserConfig{
-					Enabled:      DefaultCompressionEnabled,
-					RescoreLimit: DefaultCompressionRescore,
-					Cache:        DefaultVectorCache,
-				},
-				BQ: CompressionUserConfig{
-					Enabled:      true,
-					RescoreLimit: 0,
-					Cache:        DefaultVectorCache,
-				},
-				SQ: CompressionUserConfig{
-					Enabled:      DefaultCompressionEnabled,
-					RescoreLimit: DefaultCompressionRescore,
-					Cache:        DefaultVectorCache,
-				},
-				RQ: RQUserConfig{
-					Enabled:      DefaultCompressionEnabled,
-					RescoreLimit: DefaultCompressionRescore,
-					Cache:        DefaultVectorCache,
-					Bits:         DefaultRQBits,
-				},
-			},
+			expected: func() UserConfig {
+				e := defaultExpectedUserConfig()
+				e.VectorCacheMaxObjects = 100
+				e.BQ.Enabled = true
+				e.BQ.RescoreLimit = 0
+				return e
+			}(),
 		},
 	}
 


### PR DESCRIPTION
### What's being changed:

Fixes #11402.

`flat.ParseAndValidateConfig` accepted `bq.rescoreLimit: -1` (and the equivalent on `pq`, `sq`, and `rq`) without error — the value was unmarshaled by `vectorindexcommon.OptionalIntFromMap` and stored verbatim on the compression config, where downstream search code silently fell back to default rescoring or behaved unpredictably.

`parseCompressionMap` (called for `pq`, `bq`, `sq`) and `parseRQConfig` (called for `rq`) now reject `rescoreLimit < 0` with a typed error:

```
<scope>.rescoreLimit must be non-negative, got <value>
```

Per the repo CLAUDE.md "no bug out of scope" rule the fix covers all four compression branches, not just the `bq` case in the report. Zero remains accepted — it is the documented "no rescoring" setting on the search hot paths in `adapters/repos/db/vector/hnsw/search.go` and `adapters/repos/db/vector/flat/index.go`.

Added regression coverage in `entities/vectorindex/flat/config_test.go`:

- `bq with negative rescoreLimit is rejected`
- `pq with negative rescoreLimit is rejected`
- `sq with negative rescoreLimit is rejected`
- `rq with negative rescoreLimit is rejected`
- `bq with zero rescoreLimit is allowed` (boundary, must remain accepted)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: Not necessary; this is validation behavior for an invalid request.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: Not necessary; flat index configuration parsing only.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. Not necessary; this adds a single integer comparison per compression branch during config parsing.

### Validation

- `go test -count=1 -race ./entities/vectorindex/flat/...`
- `go test -count=1 ./adapters/repos/db/vector/flat/...`
- `golangci-lint run ./entities/vectorindex/flat/...`
- `./tools/linter_go_routines.sh`
