### PR TITLE
fix(compact): recover from corrupt compacted segments on load

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
@@ -154,8 +154,22 @@ func TestCrashRecovery_CompleteCompactedWALFilesLoad(t *testing.T) {
 	}
 }
 
-func TestCrashRecovery_TruncatedCompactedWALFilesFailClosed(t *testing.T) {
-	for _, tt := range []struct {
+// TestCrashRecovery_TruncatedCompactedWALFilesRecover verifies that a corrupt
+// .sorted/.condensed segment no longer fails the whole index load. Compacted
+// files are written atomically, so an unreadable tail means on-disk corruption
+// rather than a normal crash. Instead of erroring out (and taking the whole
+// collection offline), the loader drops the bad segment, keeps the records read
+// before the corruption, reports RecoveredFromCrash, and lets the caller
+// recover from the snapshot + clean segments.
+//
+// Both corruption shapes are covered: a torn record (ErrUnexpectedEOF) and
+// appended garbage that decodes to an unrecognized commit type — a non-EOF read
+// error (see weaviate/0-weaviate-issues#195).
+//
+// Note: this only relaxes the *load* path. Compaction still fails closed on a
+// corrupt merge input — see TestCrashRecovery_TruncatedSortedMergeFailsClosedAndKeepsSources.
+func TestCrashRecovery_TruncatedCompactedWALFilesRecover(t *testing.T) {
+	fileTypes := []struct {
 		name  string
 		path  func(string) string
 		write func(*testing.T, string)
@@ -186,22 +200,42 @@ func TestCrashRecovery_TruncatedCompactedWALFilesFailClosed(t *testing.T) {
 				})
 			},
 		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			tt.write(t, dir)
+	}
 
-			f, err := os.OpenFile(tt.path(dir), os.O_WRONLY|os.O_APPEND, 0o666)
-			require.NoError(t, err)
-			_, err = f.Write([]byte{byte(AddNode), 0x01, 0x02, 0x03})
-			require.NoError(t, err)
-			require.NoError(t, f.Close())
+	corruptions := []struct {
+		name string
+		tail []byte
+	}{
+		// Type byte followed by a partial body → io.ReadFull → ErrUnexpectedEOF.
+		{name: "torn record", tail: []byte{byte(AddNode), 0x01, 0x02, 0x03}},
+		// Bytes that decode to an unrecognized commit type → non-EOF read error.
+		{name: "appended garbage", tail: []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+	}
 
-			loader := NewLoader(LoaderConfig{Dir: dir, Logger: crashTestLogger()})
-			result, err := loader.Load()
-			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
-			assert.Nil(t, result)
-		})
+	for _, ft := range fileTypes {
+		for _, corrupt := range corruptions {
+			t.Run(ft.name+"/"+corrupt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				ft.write(t, dir)
+
+				f, err := os.OpenFile(ft.path(dir), os.O_WRONLY|os.O_APPEND, 0o666)
+				require.NoError(t, err)
+				_, err = f.Write(corrupt.tail)
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+
+				loader := NewLoader(LoaderConfig{Dir: dir, Logger: crashTestLogger()})
+				result, err := loader.Load()
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.True(t, result.RecoveredFromCrash, "corrupt compacted segment should trigger crash recovery")
+
+				// The complete records written before the corruption survive.
+				require.GreaterOrEqual(t, len(result.State.Graph.Nodes), 2)
+				require.NotNil(t, result.State.Graph.Nodes[0])
+				require.NotNil(t, result.State.Graph.Nodes[1])
+			})
+		}
 	}
 }
 

--- a/adapters/repos/db/vector/hnsw/compact/loader.go
+++ b/adapters/repos/db/vector/hnsw/compact/loader.go
@@ -68,9 +68,12 @@ type LoadResult struct {
 	// State is the accumulated HNSW graph state, or nil if directory was empty.
 	State *ent.DeserializationResult
 
-	// RecoveredFromCrash is true if a truncated/corrupt WAL file was detected
-	// and truncated during loading. When true, the caller should start a new
-	// commit log file instead of appending to the existing one.
+	// RecoveredFromCrash is true if a corrupt WAL file was detected during
+	// loading: a raw file with a torn tail (truncated back to its last valid
+	// commit) or a compacted .sorted/.condensed segment that could not be fully
+	// read and was dropped in favour of the snapshot + clean segments. When
+	// true, the caller should start a new commit log file instead of appending
+	// to the existing one.
 	RecoveredFromCrash bool
 }
 
@@ -253,7 +256,8 @@ func (l *Loader) filterFilesAlreadyInSnapshot(files []FileInfo, snapshotEndTS in
 }
 
 // loadWALFile reads a single WAL file and applies it to the current state.
-// Returns the result, whether crash recovery occurred (truncation), and any error.
+// Returns the result, whether crash recovery occurred (a torn raw tail was
+// truncated, or a corrupt compacted segment was dropped), and any error.
 func (l *Loader) loadWALFile(f FileInfo, state *ent.DeserializationResult) (*ent.DeserializationResult, bool, error) {
 	file, err := l.fs.Open(f.Path)
 	if err != nil {
@@ -267,36 +271,67 @@ func (l *Loader) loadWALFile(f FileInfo, state *ent.DeserializationResult) (*ent
 	// keepLinkReplaceInfo=false at startup since we're building final state
 	result, err := inMemReader.Do(state, false)
 	if err != nil {
-		// Raw/live WAL files may be interrupted mid-write by a crash. Immutable
-		// compacted files (.condensed/.sorted) are created through SafeFileWriter,
-		// so truncation there indicates committed-file corruption and must fail
-		// closed instead of preserving a partial prefix.
-		if f.Type == FileTypeRaw && (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) {
+		switch f.Type {
+		case FileTypeRaw:
+			// Raw/live WAL files may be interrupted mid-write by a crash,
+			// leaving a partial record at the tail. Keep the complete records
+			// and truncate the file to the last valid commit so the next write
+			// starts from a clean boundary. Only torn-tail errors are
+			// recoverable here; anything else is a genuine read failure.
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				l.config.Logger.WithFields(logrus.Fields{
+					"action": "hnsw_loader",
+					"file":   f.Path,
+				}).Warnf("WAL file truncated - recovering from crash: %v", err)
+
+				// Truncate raw files to remove partial entries.
+				// This prevents the partial entry from becoming corrupted on next write
+				// and ensures clean compaction later.
+				validBytes := walReader.BytesRead()
+				if truncErr := l.fs.Truncate(f.Path, validBytes); truncErr != nil {
+					l.config.Logger.
+						WithField("file", f.Path).
+						WithField("valid_bytes", validBytes).
+						Errorf("failed to truncate corrupt WAL file: %v", truncErr)
+				} else {
+					l.config.Logger.WithFields(logrus.Fields{
+						"action":      "hnsw_loader",
+						"file":        f.Path,
+						"valid_bytes": validBytes,
+					}).Info("truncated corrupt WAL file")
+				}
+
+				return result, true, nil // true = recovered from crash
+			}
+			return result, false, err
+
+		case FileTypeSorted, FileTypeCondensed:
+			// Compacted segments are immutable and written atomically via
+			// SafeFileWriter (temp file + fsync + rename), so the committed
+			// bytes are never torn by a crash. A read error here therefore
+			// means the on-disk file is corrupt from disk-level damage (a
+			// truncated or garbage-appended tail). Failing the whole index
+			// load over one bad segment would take the entire collection
+			// offline, so instead we drop the unreadable segment and recover
+			// from the snapshot plus the segments already applied. `result`
+			// keeps the records read before the corruption, and replay
+			// continues with the remaining files.
+			//
+			// This only relaxes the *load* path. Compaction still fails closed
+			// when it reads a corrupt merge input (see Compactor / the merge
+			// iterators), so a corrupt segment can never be silently merged
+			// away and have its still-valid sources deleted.
 			l.config.Logger.WithFields(logrus.Fields{
 				"action": "hnsw_loader",
 				"file":   f.Path,
-			}).Warnf("WAL file truncated - recovering from crash: %v", err)
-
-			// Truncate raw files to remove partial entries.
-			// This prevents the partial entry from becoming corrupted on next write
-			// and ensures clean compaction later.
-			validBytes := walReader.BytesRead()
-			if truncErr := l.fs.Truncate(f.Path, validBytes); truncErr != nil {
-				l.config.Logger.
-					WithField("file", f.Path).
-					WithField("valid_bytes", validBytes).
-					Errorf("failed to truncate corrupt WAL file: %v", truncErr)
-			} else {
-				l.config.Logger.WithFields(logrus.Fields{
-					"action":      "hnsw_loader",
-					"file":        f.Path,
-					"valid_bytes": validBytes,
-				}).Info("truncated corrupt WAL file")
-			}
+				"type":   f.Type.String(),
+			}).Warnf("corrupt compacted commit log segment - dropping it and recovering from snapshot: %v", err)
 
 			return result, true, nil // true = recovered from crash
+
+		default:
+			return result, false, err
 		}
-		return result, false, err
 	}
 
 	l.config.Logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -96,11 +96,13 @@ func (h *hnsw) restoreFromDisk() error {
 		return nil
 	}
 
-	// A truncated/corrupt WAL was detected and truncated during load. Log
-	// for diagnostic visibility. The commit logger will start a fresh raw
-	// file regardless, so no further action is needed here.
+	// A corrupt WAL was detected during load: either a raw file's torn tail
+	// was truncated, or an unreadable compacted segment was dropped in favour
+	// of the snapshot + clean segments. Log for diagnostic visibility. The
+	// commit logger will start a fresh raw file regardless, so no further
+	// action is needed here.
 	if loadResult.RecoveredFromCrash {
-		h.logger.Info("recovered from crash - truncated corrupt WAL tail during restore")
+		h.logger.Info("recovered from crash during restore - corrupt WAL tail truncated or compacted segment dropped")
 	}
 
 	// Apply loaded state to index


### PR DESCRIPTION
### What's being changed:

PR #11802 made a truncated/corrupt `.sorted` or `.condensed` compacted segment **fail the entire index load** — one bad segment takes the whole collection offline ([0-weaviate-issues#269](https://github.com/weaviate/0-weaviate-issues/issues/269)). This restores **best-effort recovery on the load path**: when a compacted segment can't be fully read, the loader stops at the damage, keeps the records it read before that point (on top of the snapshot + earlier clean segments), flags `RecoveredFromCrash`, and brings the index up instead of failing.

This is the behaviour that worked before #11802 — the issue's last-known-good build `758f8ea`. The damaged tail is unrecoverable regardless: compacted files are written atomically (temp + fsync + rename) and their source WALs are deleted after commit, so a torn/garbage tail is disk-level corruption, not a normal crash. Keeping the clean prefix recovers the most data possible and keeps the collection online — TC-010 only requires the index to come back up with acceptable recall, which the partial state satisfies (generally better than discarding everything down to the snapshot would).

**Scope:** only the startup load path changes. Compaction still **fails closed** on a corrupt merge input (it would otherwise emit a lossy merge and delete the still-valid sources) — `TestCrashRecovery_TruncatedSortedMergeFailsClosedAndKeepsSources` is unchanged and still passing.

| File | Truncated / garbage tail on load |
| --- | --- |
| raw / live | keep records up to the last valid commit, truncate the file, recover (unchanged) |
| `.sorted` / `.condensed` | **keep records read before the damage, index stays up** (was: fail the whole load) |
| `.snapshot` | still fails closed (base state; loaded via `SnapshotReader`) |

Recovery triggers on **any** read error, not just EOF, so appended garbage that decodes to an unrecognized commit type also recovers instead of failing ([0-weaviate-issues#195](https://github.com/weaviate/0-weaviate-issues/issues/195)).

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary — internal load-path recovery behavior, no public API/doc change.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: recovery behavior is exercised by the e2e recovery suite (TC-010/012/013) in `weaviate-e2e-tests`; chaos run at reviewer's discretion.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)