### PR TITLE
fix(traverser): goroutine leak in Explorer.Hybrid on search failure or cancellation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.35.0

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -197,6 +197,12 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		ctx = helpers.InitQueryProfileCollector(ctx)
 	}
 
+	// Return immediately if the request is already cancelled, before launching
+	// any leg. Avoids spinning up goroutines for work the client no longer wants.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	var err error
 	var results [][]*search.Result
 	var weights []float64
@@ -245,7 +251,12 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		resultsCount = 2
 	}
 
-	eg := enterrors.NewErrorGroupWrapper(e.logger)
+	// Coordinate the legs under an errgroup-derived cancellable context so that
+	// (A) a single leg's error cancels egCtx, which the sibling leg observes via
+	// its internal ctx.Err() checks and returns promptly instead of leaking, and
+	// (B) a client cancel (egCtx derives from ctx) tears down both legs' work.
+	// Only this call site changes; the shared NewErrorGroupWrapper is untouched.
+	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(e.logger, ctx)
 	eg.SetLimit(resultsCount)
 
 	results = make([][]*search.Result, resultsCount)
@@ -261,7 +272,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 			var res []*search.Result
 			var errorText string
 			if params.HybridSearch.NearTextParams != nil {
-				res, name, err = nearTextSubSearch(ctx, e, params, targetVectors)
+				res, name, err = nearTextSubSearch(egCtx, e, params, targetVectors)
 				errorText = "nearTextSubSearch"
 			} else if params.HybridSearch.NearVectorParams != nil {
 				searchVectors := make([]*searchparams.NearVector, len(targetVectors))
@@ -269,7 +280,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 					searchVectors[i] = params.HybridSearch.NearVectorParams
 					searchVectors[i].TargetVectors = []string{targetVector}
 				}
-				res, name, err = denseSearch(ctx, e, params, "nearVector", targetVectors, params.HybridSearch.NearVectorParams)
+				res, name, err = denseSearch(egCtx, e, params, "nearVector", targetVectors, params.HybridSearch.NearVectorParams)
 				errorText = "nearVectorSubSearch"
 			} else {
 				sch := e.schemaGetter.GetSchemaSkipAuth()
@@ -303,12 +314,12 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 							}
 							if isMultiVector {
 								searchVectors.TargetVectors[i] = targetVector
-								searchVector, err := e.modulesProvider.MultiVectorFromInput(ctx, params.ClassName, params.HybridSearch.Query, targetVector)
+								searchVector, err := e.modulesProvider.MultiVectorFromInput(egCtx, params.ClassName, params.HybridSearch.Query, targetVector)
 								searchVectors.Vectors[i] = searchVector
 								return err
 							}
 							searchVectors.TargetVectors[i] = targetVector
-							searchVector, err := e.modulesProvider.VectorFromInput(ctx, params.ClassName, params.HybridSearch.Query, targetVector)
+							searchVector, err := e.modulesProvider.VectorFromInput(egCtx, params.ClassName, params.HybridSearch.Query, targetVector)
 							searchVectors.Vectors[i] = searchVector
 							return err
 						})
@@ -318,7 +329,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 					}
 				}
 
-				res, name, err = denseSearch(ctx, e, params, "hybridVector", targetVectors, searchVectors)
+				res, name, err = denseSearch(egCtx, e, params, "hybridVector", targetVectors, searchVectors)
 				errorText = "hybrid"
 			}
 
@@ -355,7 +366,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		eg.Go(func() error {
 			// If the user has given any weight to the keyword search, do a keyword search
 			params := keywordParams
-			sparseResults, name, err := sparseSearch(ctx, e, params)
+			sparseResults, name, err := sparseSearch(egCtx, e, params)
 			if err != nil {
 				e.logger.WithField("action", "hybrid").WithError(err).Error("sparseSearch failed")
 				return err
@@ -371,6 +382,14 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 	}
 
 	if err := eg.Wait(); err != nil {
+		// If the client cancelled, surface the canonical context error so callers
+		// can detect cancellation via errors.Is(err, context.Canceled). The leg
+		// that lost the errgroup race may wrap context.Canceled with a formatter
+		// that flattens the error chain (e.g. searchForTargets uses %v), so the
+		// raw eg.Wait() error is not guaranteed to satisfy errors.Is on cancel.
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
 		return nil, err
 	}
 

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -259,7 +259,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 	names = make([]string, resultsCount)
 	var belowCutoffSet map[strfmt.UUID]struct{}
 
-	if (params.HybridSearch.Alpha) > 0 {
+	if params.HybridSearch.Alpha > 0 {
 		eg.Go(func() error {
 			params := vectorParams
 			var err error

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -197,8 +197,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		ctx = helpers.InitQueryProfileCollector(ctx)
 	}
 
-	// Return immediately if the request is already cancelled, before launching
-	// any leg. Avoids spinning up goroutines for work the client no longer wants.
+	// Return immediately if ctx is cancelled before launching any leg.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -251,9 +250,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		resultsCount = 2
 	}
 
-	// Run the legs under an errgroup-derived cancellable ctx: a leg error (or a
-	// client cancel, since egCtx derives from ctx) cancels egCtx, so the sibling
-	// leg's ctx.Err() checks trip and it returns promptly instead of leaking.
+	// Run both legs under a cancellable context so a failing or cancelled leg stops the sibling instead of leaking.
 	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(e.logger, ctx)
 	eg.SetLimit(resultsCount)
 
@@ -380,11 +377,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 	}
 
 	if err := eg.Wait(); err != nil {
-		// If the client cancelled, surface the canonical context error so callers
-		// can detect cancellation via errors.Is(err, context.Canceled). The leg
-		// that lost the errgroup race may wrap context.Canceled with a formatter
-		// that flattens the error chain (e.g. searchForTargets uses %v), so the
-		// raw eg.Wait() error is not guaranteed to satisfy errors.Is on cancel.
+		// On client cancel, return the canonical context error: a losing leg may wrap it with %v and break errors.Is.
 		if cerr := ctx.Err(); cerr != nil {
 			return nil, cerr
 		}

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -251,11 +251,9 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		resultsCount = 2
 	}
 
-	// Coordinate the legs under an errgroup-derived cancellable context so that
-	// (A) a single leg's error cancels egCtx, which the sibling leg observes via
-	// its internal ctx.Err() checks and returns promptly instead of leaking, and
-	// (B) a client cancel (egCtx derives from ctx) tears down both legs' work.
-	// Only this call site changes; the shared NewErrorGroupWrapper is untouched.
+	// Run the legs under an errgroup-derived cancellable ctx: a leg error (or a
+	// client cancel, since egCtx derives from ctx) cancels egCtx, so the sibling
+	// leg's ctx.Err() checks trip and it returns promptly instead of leaking.
 	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(e.logger, ctx)
 	eg.SetLimit(resultsCount)
 

--- a/usecases/traverser/hybrid_goroutine_leak_test.go
+++ b/usecases/traverser/hybrid_goroutine_leak_test.go
@@ -35,54 +35,23 @@ import (
 	"github.com/weaviate/weaviate/usecases/modules"
 )
 
-// errSparseLegFailed is the deterministic error the BM25 leg returns in the
-// leak repro, standing in for any quick leg failure on a large shard.
 var errSparseLegFailed = errors.New("sparse leg failed fast")
-
-// errDenseLegFailed is a deterministic dense-leg failure used by the
-// both-legs-error case.
 var errDenseLegFailed = errors.New("dense leg failed fast")
 
-// leakFakeSearcher is a controllable objectsSearcher for the Hybrid
-// coordination-bug repro. It deliberately drives the two hybrid legs into the
-// failing shape described in the architect synthesis:
-//   - SparseObjectSearch returns an error quickly (the failing BM25 leg).
-//   - VectorSearch blocks, polling the ctx it was handed, and only returns once
-//     that ctx is cancelled (the sibling dense leg that should be torn down).
-//
-// It spawns NO goroutines of its own, so any goroutine goleak reports as leaked
-// is the Hybrid leg coordination goroutine, never test scaffolding.
+// leakFakeSearcher drives hybrid legs into the leak repro shape: SparseObjectSearch
+// fails quickly while VectorSearch blocks until ctx cancels.
 type leakFakeSearcher struct {
-	// sparseErr, when non-nil, is returned by SparseObjectSearch after sparseDelay.
 	sparseErr   error
 	sparseDelay time.Duration
 
-	// denseErr, when non-nil, is returned by VectorSearch after denseDelay
-	// (used by the both-legs-error case where the dense leg also fails fast).
 	denseErr   error
 	denseDelay time.Duration
 
-	// sparseErrIgnoreCtx, when true, makes SparseObjectSearch wait on
-	// releaseSparse (NOT on ctx) and then return sparseErr. This lets a test
-	// deterministically order a genuine non-cancel leg error against a client
-	// cancel: cancel the client ctx first, THEN release the sentinel leg, so
-	// eg.Wait() surfaces sparseErr while ctx.Err() is already non-nil.
 	sparseErrIgnoreCtx bool
 	releaseSparse      chan struct{}
 
-	// hardStop is closed by the test during cleanup to reap any goroutine that
-	// the bug leaks, so a RED test does not poison sibling tests in the same
-	// binary. goleak.VerifyNone runs (via defer) before t.Cleanup fires, so the
-	// leak is still observed while the goroutine is alive.
-	hardStop chan struct{}
-
-	// vectorSearchEntered is closed the first time VectorSearch is entered, so a
-	// test can wait until the dense leg is actually mid-flight before acting.
+	hardStop            chan struct{}
 	vectorSearchEntered chan struct{}
-
-	// sparseSearchEntered is closed the first time SparseObjectSearch is entered,
-	// so a test can assert the sparse leg launched (or, conversely, that it never
-	// launched in the early-guard case).
 	sparseSearchEntered chan struct{}
 }
 
@@ -95,10 +64,6 @@ func newLeakFakeSearcher() *leakFakeSearcher {
 	}
 }
 
-// VectorSearch is the dense leg. It blocks until either the ctx it was handed is
-// cancelled (the correct teardown signal) or hardStop is closed (test cleanup
-// safety net). On unmodified main, Hybrid hands this the original un-cancelled
-// ctx, so a sibling-leg failure never cancels it and this goroutine leaks.
 func (f *leakFakeSearcher) VectorSearch(ctx context.Context, params dto.GetParams,
 	targetVectors []string, searchVectors []models.Vector,
 ) ([]search.Result, error) {
@@ -131,17 +96,11 @@ func (f *leakFakeSearcher) VectorSearch(ctx context.Context, params dto.GetParam
 	}
 }
 
-// SparseObjectSearch is the BM25 leg. It returns an error quickly so that, in
-// the leak repro, the errgroup observes a failure while VectorSearch is still
-// mid-flight.
 func (f *leakFakeSearcher) SparseObjectSearch(ctx context.Context,
 	params dto.GetParams,
 ) ([]*storobj.Object, []float32, error) {
 	f.signalSparseEntered()
 	if f.sparseErrIgnoreCtx {
-		// Wait for the test to release us (deliberately NOT selecting on ctx), so
-		// the test can cancel the client ctx first and then make this leg return a
-		// genuine non-cancel error. This pins the cancel-normalization contract.
 		select {
 		case <-f.releaseSparse:
 		case <-f.hardStop:
@@ -161,9 +120,6 @@ func (f *leakFakeSearcher) SparseObjectSearch(ctx context.Context,
 	if f.sparseErr != nil {
 		return nil, nil, f.sparseErr
 	}
-	// No error configured: behave like the blocking dense leg (used by the
-	// cancellation test where BOTH legs must be in-flight when the client
-	// cancels).
 	ticker := time.NewTicker(2 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -183,7 +139,6 @@ func (f *leakFakeSearcher) SparseObjectSearch(ctx context.Context,
 func (f *leakFakeSearcher) signalEntered() {
 	select {
 	case <-f.vectorSearchEntered:
-		// already closed
 	default:
 		close(f.vectorSearchEntered)
 	}
@@ -192,14 +147,10 @@ func (f *leakFakeSearcher) signalEntered() {
 func (f *leakFakeSearcher) signalSparseEntered() {
 	select {
 	case <-f.sparseSearchEntered:
-		// already closed
 	default:
 		close(f.sparseSearchEntered)
 	}
 }
-
-// --- remaining objectsSearcher surface: unused by the hybrid leg paths under
-// test, present only to satisfy the interface. ---
 
 func (f *leakFakeSearcher) Search(ctx context.Context, params dto.GetParams) ([]search.Result, error) {
 	return nil, nil
@@ -237,18 +188,12 @@ func (f *leakFakeSearcher) ResolveReferences(ctx context.Context, objs search.Re
 	return objs, nil
 }
 
-// leakTestConfig sets QueryHybridMaximumResults so the hybrid leg sizing logic
-// has a non-zero bound without needing real data.
 var leakTestConfig = config.Config{
 	QueryDefaults:             config.QueryDefaults{Limit: 100},
 	QueryMaximumResults:       100,
 	QueryHybridMaximumResults: 100,
 }
 
-// newLeakExplorer wires an Explorer around the controllable fake searcher with a
-// single-class schema that has a legacy (default) vector index, so the dense leg
-// resolves to the default target vector "" and routes through VectorSearch with
-// no module/vectorizer dependency.
 func newLeakExplorer(t *testing.T, searcher objectsSearcher) *Explorer {
 	t.Helper()
 	log, _ := test.NewNullLogger()
@@ -262,16 +207,10 @@ func newLeakExplorer(t *testing.T, searcher objectsSearcher) *Explorer {
 	return e
 }
 
-// hybridLeakParams builds GetParams for a hybrid query with 0 < alpha < 1 so both
-// legs launch. NearVectorParams carries a pre-populated vector so the dense leg
-// needs no vectorizer; targetVectors resolves to the single default "" target.
 func hybridLeakParams() dto.GetParams {
 	return hybridLeakParamsAlpha(0.5)
 }
 
-// hybridLeakParamsAlpha is hybridLeakParams with a caller-chosen alpha so a test
-// can exercise single-leg shapes: alpha=1 runs only the dense leg, alpha=0 only
-// the sparse leg, 0<alpha<1 runs both concurrently.
 func hybridLeakParamsAlpha(alpha float64) dto.GetParams {
 	return dto.GetParams{
 		ClassName: "BestClass",
@@ -290,44 +229,19 @@ func hybridLeakParamsAlpha(alpha float64) dto.GetParams {
 	}
 }
 
-// TestHybridGoroutineLeak_SiblingLegFailure is the RED-first repro for the
-// goroutine leak in Explorer.Hybrid.
-//
-// Causal link: this test catches the leaked-goroutine bug because the sparse leg
-// returns errSparseLegFailed almost immediately while the dense leg (VectorSearch)
-// is blocked polling the ctx it was handed. On unmodified main, Hybrid runs the
-// legs under enterrors.NewErrorGroupWrapper (a bare errgroup with no derived,
-// cancellable context), so the first leg's error is surfaced by eg.Wait() and
-// Hybrid returns, but nothing ever cancels the ctx the dense leg holds. The dense
-// leg therefore never observes a cancel and its goroutine outlives Hybrid's
-// return -> goleak.VerifyNone reports it as leaked -> RED. After the fix (Child 2:
-// errgroup-derived cancellable ctx threaded into both legs), the sparse leg's
-// error cancels egCtx, the dense leg's ctx.Err() poll trips, it returns, and
-// goleak is clean -> GREEN.
-//
-// A plain return-value assertion would go red->green on the fix without proving
-// the leak is gone; goleak is what observes the goroutine that would be absent
-// only once the cancel actually propagates.
+// TestHybridGoroutineLeak_SiblingLegFailure pins that a failing leg cancels the sibling instead of leaking.
 func TestHybridGoroutineLeak_SiblingLegFailure(t *testing.T) {
-	// Baseline ignores goroutines already running when the test starts (logger
-	// flushers, test framework, etc.), so VerifyNone flags only NEW leaks.
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	searcher := newLeakFakeSearcher()
 	searcher.sparseErr = errSparseLegFailed
-	searcher.sparseDelay = 0 // fail immediately
+	searcher.sparseDelay = 0
 
-	// Safety net: reap any leaked dense-leg goroutine AFTER goleak has observed
-	// it. t.Cleanup runs after deferred VerifyNone, so RED is still seen first.
 	t.Cleanup(func() { close(searcher.hardStop) })
 
 	e := newLeakExplorer(t, searcher)
 	params := hybridLeakParams()
 
-	// Bound the call so a hung dense leg cannot wedge the test indefinitely; we
-	// assert the error came back, then goleak (deferred) inspects goroutines.
-	// This driver goroutine exits as soon as Hybrid returns (fast, once the
-	// sparse leg errors), so goleak's retry window does not flag it.
 	done := make(chan error, 1)
 	go func() {
 		_, err := e.Hybrid(context.Background(), params)
@@ -341,27 +255,14 @@ func TestHybridGoroutineLeak_SiblingLegFailure(t *testing.T) {
 		t.Fatal("Hybrid did not return within 5s after the sparse leg failed")
 	}
 
-	// Give the (buggy) dense-leg goroutine a moment to still be parked, so
-	// goleak observes the leak deterministically rather than racing the runtime.
 	time.Sleep(50 * time.Millisecond)
 }
 
-// TestHybridContextCancellation is the cancellation contract: when the client
-// cancels mid-flight, Hybrid returns context.Canceled promptly (<= 1s) and no
-// goroutine is leaked.
-//
-// Causal link: both legs block polling their ctx until cancelled. Cancelling the
-// client ctx ~10ms in must (a) return context.Canceled within the deadline and
-// (b) leave goleak clean. On main, the legs are handed the client's own
-// cancellable ctx, so their internal polls trip on client-cancel and this case
-// is the narrower one; the after-fix contract is that BOTH legs stop together and
-// nothing lingers.
+// TestHybridContextCancellation pins that client cancel returns context.Canceled promptly without leaking.
 func TestHybridContextCancellation(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	searcher := newLeakFakeSearcher()
-	// No sparseErr: both legs block until ctx cancel, so both are genuinely
-	// in-flight when the client cancels.
 	t.Cleanup(func() { close(searcher.hardStop) })
 
 	e := newLeakExplorer(t, searcher)
@@ -376,7 +277,6 @@ func TestHybridContextCancellation(t *testing.T) {
 		done <- err
 	}()
 
-	// Cancel ~10ms in, once both legs are mid-flight.
 	<-searcher.vectorSearchEntered
 	time.Sleep(10 * time.Millisecond)
 	cancel()
@@ -392,17 +292,8 @@ func TestHybridContextCancellation(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-// errLegMustNotRun is returned by failOnLegSearcher's legs so that, if a
-// regression ever launches a leg despite the early guard, Hybrid stops cleanly at
-// eg.Wait() (rather than proceeding into fusion with empty results); the t.Error
-// is what actually fails the test.
 var errLegMustNotRun = errors.New("leg must not run when ctx is already cancelled")
 
-// failOnLegSearcher fails the test if either hybrid leg is ever invoked. It is
-// used by the early-ctx.Err()-guard test to assert that an already-cancelled
-// request returns before any leg launches. The embedded objectsSearcher is nil;
-// only the two leg methods are reachable on the guarded path, and both are
-// overridden here.
 type failOnLegSearcher struct {
 	objectsSearcher
 	t *testing.T
@@ -422,14 +313,7 @@ func (f *failOnLegSearcher) SparseObjectSearch(ctx context.Context,
 	return nil, nil, errLegMustNotRun
 }
 
-// TestHybridEarlyCancelGuard pins the early ctx.Err() guard: a request whose ctx
-// is already cancelled before Hybrid is called must return the ctx error
-// immediately and launch NEITHER leg.
-//
-// Causal link: the fake fails the test if either leg searcher is invoked. The
-// guard added by this fix returns ctx.Err() before eg.Go, so neither method is
-// reached. A future edit moving the guard below leg-launch would invoke a leg and
-// trip f.t.Error here, turning this test RED.
+// TestHybridEarlyCancelGuard pins that an already-cancelled ctx returns immediately without launching legs.
 func TestHybridEarlyCancelGuard(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -437,26 +321,14 @@ func TestHybridEarlyCancelGuard(t *testing.T) {
 	params := hybridLeakParams()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already cancelled before the call
+	cancel()
 
 	_, err := e.Hybrid(ctx, params)
 	require.ErrorIs(t, err, context.Canceled,
 		"Hybrid must return the ctx error immediately when called with a cancelled ctx")
 }
 
-// TestHybridCancelNormalizationContract pins the deliberate cancel-normalization
-// trade-off (the Level C edge): when the client ctx is cancelled AND a leg
-// returns a genuine NON-cancel error, Hybrid returns context.Canceled, NOT the
-// leg's real error. This masking is intentional so upstream gRPC/REST handlers
-// can detect cancellation via errors.Is(err, context.Canceled). Pinning it means
-// a future refactor that "fixes" the masking to surface the real error will turn
-// this test RED instead of silently changing the contract.
-//
-// Determinism: the sparse leg ignores ctx and blocks on releaseSparse, so the
-// test orders the events exactly: wait until both legs are mid-flight, cancel the
-// client ctx, THEN release the sparse leg to return errSparseLegFailed. eg.Wait()
-// surfaces that genuine error while ctx.Err() is already non-nil, so the
-// normalization branch fires.
+// TestHybridCancelNormalizationContract pins that client-cancel + leg-error normalizes to context.Canceled.
 func TestHybridCancelNormalizationContract(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -477,8 +349,6 @@ func TestHybridCancelNormalizationContract(t *testing.T) {
 		done <- err
 	}()
 
-	// Ensure both legs are mid-flight, then cancel the client ctx and only AFTER
-	// that release the sparse leg so it returns a genuine non-cancel error.
 	<-searcher.vectorSearchEntered
 	<-searcher.sparseSearchEntered
 	cancel()
@@ -497,17 +367,7 @@ func TestHybridCancelNormalizationContract(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-// TestHybridSingleLegAndBothErrors covers the single-leg-under-cancel shapes and
-// the both-legs-error shape, all goleak-clean:
-//   - alpha=0: only the sparse leg runs; client cancel mid-flight returns promptly.
-//   - alpha=1: only the dense leg runs; client cancel mid-flight returns promptly.
-//   - both-error: both legs fail fast with genuine (non-cancel) errors; Hybrid
-//     returns a non-nil error, both legs return, nothing leaks.
-//
-// Causal link: the fix threads egCtx through the single-leg paths too. A
-// regression where only the 2-leg path received egCtx would pass the existing
-// 2-leg cancel test but leak (or hang) on alpha=0/alpha=1; these subtests would
-// then time out / flag goleak.
+// TestHybridSingleLegAndBothErrors pins single-leg cancel (alpha=0, alpha=1) and both-legs-error without leaks.
 func TestHybridSingleLegAndBothErrors(t *testing.T) {
 	t.Run("alpha=0 sparse-only under cancel", func(t *testing.T) {
 		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
@@ -581,9 +441,6 @@ func TestHybridSingleLegAndBothErrors(t *testing.T) {
 		params := hybridLeakParams() // alpha=0.5 -> both legs run
 
 		_, err := e.Hybrid(context.Background(), params)
-		// errgroup surfaces the first error; either genuine leg error is
-		// acceptable. The contract is: a non-nil, non-cancel error comes back
-		// and (via goleak) both legs returned without leaking.
 		require.Error(t, err, "both legs failing must surface a non-nil error")
 		require.NotErrorIs(t, err, context.Canceled,
 			"with no client cancel, the returned error must be a genuine leg error")

--- a/usecases/traverser/hybrid_goroutine_leak_test.go
+++ b/usecases/traverser/hybrid_goroutine_leak_test.go
@@ -1,0 +1,329 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package traverser
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/aggregation"
+	"github.com/weaviate/weaviate/entities/dto"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/modules"
+)
+
+// errSparseLegFailed is the deterministic error the BM25 leg returns in the
+// leak repro, standing in for any quick leg failure on a large shard.
+var errSparseLegFailed = errors.New("sparse leg failed fast")
+
+// leakFakeSearcher is a controllable objectsSearcher for the Hybrid
+// coordination-bug repro. It deliberately drives the two hybrid legs into the
+// failing shape described in the architect synthesis:
+//   - SparseObjectSearch returns an error quickly (the failing BM25 leg).
+//   - VectorSearch blocks, polling the ctx it was handed, and only returns once
+//     that ctx is cancelled (the sibling dense leg that should be torn down).
+//
+// It spawns NO goroutines of its own, so any goroutine goleak reports as leaked
+// is the Hybrid leg coordination goroutine, never test scaffolding.
+type leakFakeSearcher struct {
+	// sparseErr, when non-nil, is returned by SparseObjectSearch after sparseDelay.
+	sparseErr   error
+	sparseDelay time.Duration
+
+	// hardStop is closed by the test during cleanup to reap any goroutine that
+	// the bug leaks, so a RED test does not poison sibling tests in the same
+	// binary. goleak.VerifyNone runs (via defer) before t.Cleanup fires, so the
+	// leak is still observed while the goroutine is alive.
+	hardStop chan struct{}
+
+	// vectorSearchEntered is closed the first time VectorSearch is entered, so a
+	// test can wait until the dense leg is actually mid-flight before acting.
+	vectorSearchEntered chan struct{}
+}
+
+func newLeakFakeSearcher() *leakFakeSearcher {
+	return &leakFakeSearcher{
+		hardStop:            make(chan struct{}),
+		vectorSearchEntered: make(chan struct{}),
+	}
+}
+
+// VectorSearch is the dense leg. It blocks until either the ctx it was handed is
+// cancelled (the correct teardown signal) or hardStop is closed (test cleanup
+// safety net). On unmodified main, Hybrid hands this the original un-cancelled
+// ctx, so a sibling-leg failure never cancels it and this goroutine leaks.
+func (f *leakFakeSearcher) VectorSearch(ctx context.Context, params dto.GetParams,
+	targetVectors []string, searchVectors []models.Vector,
+) ([]search.Result, error) {
+	f.signalEntered()
+	ticker := time.NewTicker(2 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-f.hardStop:
+			return nil, errors.New("hard stopped by test cleanup")
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+		}
+	}
+}
+
+// SparseObjectSearch is the BM25 leg. It returns an error quickly so that, in
+// the leak repro, the errgroup observes a failure while VectorSearch is still
+// mid-flight.
+func (f *leakFakeSearcher) SparseObjectSearch(ctx context.Context,
+	params dto.GetParams,
+) ([]*storobj.Object, []float32, error) {
+	if f.sparseDelay > 0 {
+		select {
+		case <-time.After(f.sparseDelay):
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-f.hardStop:
+			return nil, nil, errors.New("hard stopped by test cleanup")
+		}
+	}
+	if f.sparseErr != nil {
+		return nil, nil, f.sparseErr
+	}
+	// No error configured: behave like the blocking dense leg (used by the
+	// cancellation test where BOTH legs must be in-flight when the client
+	// cancels).
+	ticker := time.NewTicker(2 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-f.hardStop:
+			return nil, nil, errors.New("hard stopped by test cleanup")
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
+			}
+		}
+	}
+}
+
+func (f *leakFakeSearcher) signalEntered() {
+	select {
+	case <-f.vectorSearchEntered:
+		// already closed
+	default:
+		close(f.vectorSearchEntered)
+	}
+}
+
+// --- remaining objectsSearcher surface: unused by the hybrid leg paths under
+// test, present only to satisfy the interface. ---
+
+func (f *leakFakeSearcher) Search(ctx context.Context, params dto.GetParams) ([]search.Result, error) {
+	return nil, nil
+}
+
+func (f *leakFakeSearcher) CrossClassVectorSearch(ctx context.Context, vector models.Vector,
+	targetVector string, offset, limit int, filters *filters.LocalFilter,
+) ([]search.Result, error) {
+	return nil, nil
+}
+
+func (f *leakFakeSearcher) Object(ctx context.Context, className string, id strfmt.UUID,
+	props search.SelectProperties, addl additional.Properties,
+	repl *additional.ReplicationProperties, tenant string,
+) (*search.Result, error) {
+	return nil, nil
+}
+
+func (f *leakFakeSearcher) ObjectsByID(ctx context.Context, id strfmt.UUID,
+	props search.SelectProperties, addl additional.Properties, tenant string,
+) (search.Results, error) {
+	return nil, nil
+}
+
+func (f *leakFakeSearcher) Aggregate(ctx context.Context, params aggregation.Params,
+	modules *modules.Provider,
+) (*aggregation.Result, error) {
+	return nil, nil
+}
+
+func (f *leakFakeSearcher) ResolveReferences(ctx context.Context, objs search.Results,
+	props search.SelectProperties, groupBy *searchparams.GroupBy,
+	addl additional.Properties, tenant string,
+) (search.Results, error) {
+	return objs, nil
+}
+
+// leakTestConfig sets QueryHybridMaximumResults so the hybrid leg sizing logic
+// has a non-zero bound without needing real data.
+var leakTestConfig = config.Config{
+	QueryDefaults:             config.QueryDefaults{Limit: 100},
+	QueryMaximumResults:       100,
+	QueryHybridMaximumResults: 100,
+}
+
+// newLeakExplorer wires an Explorer around the controllable fake searcher with a
+// single-class schema that has a legacy (default) vector index, so the dense leg
+// resolves to the default target vector "" and routes through VectorSearch with
+// no module/vectorizer dependency.
+func newLeakExplorer(t *testing.T, searcher objectsSearcher) *Explorer {
+	t.Helper()
+	log, _ := test.NewNullLogger()
+	metrics := &fakeMetrics{}
+	e := NewExplorer(searcher, log, getFakeModulesProvider(), metrics, leakTestConfig)
+	e.SetSchemaGetter(&fakeSchemaGetter{
+		schema: schema.Schema{Objects: &models.Schema{Classes: []*models.Class{
+			{Class: "BestClass"},
+		}}},
+	})
+	return e
+}
+
+// hybridLeakParams builds GetParams for a hybrid query with 0 < alpha < 1 so both
+// legs launch. NearVectorParams carries a pre-populated vector so the dense leg
+// needs no vectorizer; targetVectors resolves to the single default "" target.
+func hybridLeakParams() dto.GetParams {
+	return dto.GetParams{
+		ClassName: "BestClass",
+		Pagination: &filters.Pagination{
+			Limit:   10,
+			Offset:  0,
+			Autocut: -1,
+		},
+		HybridSearch: &searchparams.HybridSearch{
+			Query: "anything",
+			Alpha: 0.5, // 0 < alpha < 1 -> both legs run concurrently
+			NearVectorParams: &searchparams.NearVector{
+				Vectors: []models.Vector{[]float32{0.1, 0.2, 0.3}},
+			},
+		},
+	}
+}
+
+// TestHybridGoroutineLeak_SiblingLegFailure is the RED-first repro for the
+// goroutine leak in Explorer.Hybrid.
+//
+// Causal link: this test catches the leaked-goroutine bug because the sparse leg
+// returns errSparseLegFailed almost immediately while the dense leg (VectorSearch)
+// is blocked polling the ctx it was handed. On unmodified main, Hybrid runs the
+// legs under enterrors.NewErrorGroupWrapper (a bare errgroup with no derived,
+// cancellable context), so the first leg's error is surfaced by eg.Wait() and
+// Hybrid returns, but nothing ever cancels the ctx the dense leg holds. The dense
+// leg therefore never observes a cancel and its goroutine outlives Hybrid's
+// return -> goleak.VerifyNone reports it as leaked -> RED. After the fix (Child 2:
+// errgroup-derived cancellable ctx threaded into both legs), the sparse leg's
+// error cancels egCtx, the dense leg's ctx.Err() poll trips, it returns, and
+// goleak is clean -> GREEN.
+//
+// A plain return-value assertion would go red->green on the fix without proving
+// the leak is gone; goleak is what observes the goroutine that would be absent
+// only once the cancel actually propagates.
+func TestHybridGoroutineLeak_SiblingLegFailure(t *testing.T) {
+	// Baseline ignores goroutines already running when the test starts (logger
+	// flushers, test framework, etc.), so VerifyNone flags only NEW leaks.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	searcher := newLeakFakeSearcher()
+	searcher.sparseErr = errSparseLegFailed
+	searcher.sparseDelay = 0 // fail immediately
+
+	// Safety net: reap any leaked dense-leg goroutine AFTER goleak has observed
+	// it. t.Cleanup runs after deferred VerifyNone, so RED is still seen first.
+	t.Cleanup(func() { close(searcher.hardStop) })
+
+	e := newLeakExplorer(t, searcher)
+	params := hybridLeakParams()
+
+	// Bound the call so a hung dense leg cannot wedge the test indefinitely; we
+	// assert the error came back, then goleak (deferred) inspects goroutines.
+	// This driver goroutine exits as soon as Hybrid returns (fast, once the
+	// sparse leg errors), so goleak's retry window does not flag it.
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.Hybrid(context.Background(), params)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "Hybrid must surface the sparse leg failure")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Hybrid did not return within 5s after the sparse leg failed")
+	}
+
+	// Give the (buggy) dense-leg goroutine a moment to still be parked, so
+	// goleak observes the leak deterministically rather than racing the runtime.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestHybridContextCancellation is the cancellation contract: when the client
+// cancels mid-flight, Hybrid returns context.Canceled promptly (<= 1s) and no
+// goroutine is leaked.
+//
+// Causal link: both legs block polling their ctx until cancelled. Cancelling the
+// client ctx ~10ms in must (a) return context.Canceled within the deadline and
+// (b) leave goleak clean. On main, the legs are handed the client's own
+// cancellable ctx, so their internal polls trip on client-cancel and this case
+// is the narrower one; the after-fix contract is that BOTH legs stop together and
+// nothing lingers.
+func TestHybridContextCancellation(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	searcher := newLeakFakeSearcher()
+	// No sparseErr: both legs block until ctx cancel, so both are genuinely
+	// in-flight when the client cancels.
+	t.Cleanup(func() { close(searcher.hardStop) })
+
+	e := newLeakExplorer(t, searcher)
+	params := hybridLeakParams()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.Hybrid(ctx, params)
+		done <- err
+	}()
+
+	// Cancel ~10ms in, once both legs are mid-flight.
+	<-searcher.vectorSearchEntered
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled,
+			"Hybrid must return context.Canceled when the client ctx is cancelled")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Hybrid did not return within 1s of client cancellation")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}

--- a/usecases/traverser/hybrid_goroutine_leak_test.go
+++ b/usecases/traverser/hybrid_goroutine_leak_test.go
@@ -39,6 +39,10 @@ import (
 // leak repro, standing in for any quick leg failure on a large shard.
 var errSparseLegFailed = errors.New("sparse leg failed fast")
 
+// errDenseLegFailed is a deterministic dense-leg failure used by the
+// both-legs-error case.
+var errDenseLegFailed = errors.New("dense leg failed fast")
+
 // leakFakeSearcher is a controllable objectsSearcher for the Hybrid
 // coordination-bug repro. It deliberately drives the two hybrid legs into the
 // failing shape described in the architect synthesis:
@@ -53,6 +57,19 @@ type leakFakeSearcher struct {
 	sparseErr   error
 	sparseDelay time.Duration
 
+	// denseErr, when non-nil, is returned by VectorSearch after denseDelay
+	// (used by the both-legs-error case where the dense leg also fails fast).
+	denseErr   error
+	denseDelay time.Duration
+
+	// sparseErrIgnoreCtx, when true, makes SparseObjectSearch wait on
+	// releaseSparse (NOT on ctx) and then return sparseErr. This lets a test
+	// deterministically order a genuine non-cancel leg error against a client
+	// cancel: cancel the client ctx first, THEN release the sentinel leg, so
+	// eg.Wait() surfaces sparseErr while ctx.Err() is already non-nil.
+	sparseErrIgnoreCtx bool
+	releaseSparse      chan struct{}
+
 	// hardStop is closed by the test during cleanup to reap any goroutine that
 	// the bug leaks, so a RED test does not poison sibling tests in the same
 	// binary. goleak.VerifyNone runs (via defer) before t.Cleanup fires, so the
@@ -62,12 +79,19 @@ type leakFakeSearcher struct {
 	// vectorSearchEntered is closed the first time VectorSearch is entered, so a
 	// test can wait until the dense leg is actually mid-flight before acting.
 	vectorSearchEntered chan struct{}
+
+	// sparseSearchEntered is closed the first time SparseObjectSearch is entered,
+	// so a test can assert the sparse leg launched (or, conversely, that it never
+	// launched in the early-guard case).
+	sparseSearchEntered chan struct{}
 }
 
 func newLeakFakeSearcher() *leakFakeSearcher {
 	return &leakFakeSearcher{
 		hardStop:            make(chan struct{}),
 		vectorSearchEntered: make(chan struct{}),
+		sparseSearchEntered: make(chan struct{}),
+		releaseSparse:       make(chan struct{}),
 	}
 }
 
@@ -79,6 +103,18 @@ func (f *leakFakeSearcher) VectorSearch(ctx context.Context, params dto.GetParam
 	targetVectors []string, searchVectors []models.Vector,
 ) ([]search.Result, error) {
 	f.signalEntered()
+	if f.denseErr != nil {
+		if f.denseDelay > 0 {
+			select {
+			case <-time.After(f.denseDelay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-f.hardStop:
+				return nil, errors.New("hard stopped by test cleanup")
+			}
+		}
+		return nil, f.denseErr
+	}
 	ticker := time.NewTicker(2 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -101,6 +137,18 @@ func (f *leakFakeSearcher) VectorSearch(ctx context.Context, params dto.GetParam
 func (f *leakFakeSearcher) SparseObjectSearch(ctx context.Context,
 	params dto.GetParams,
 ) ([]*storobj.Object, []float32, error) {
+	f.signalSparseEntered()
+	if f.sparseErrIgnoreCtx {
+		// Wait for the test to release us (deliberately NOT selecting on ctx), so
+		// the test can cancel the client ctx first and then make this leg return a
+		// genuine non-cancel error. This pins the cancel-normalization contract.
+		select {
+		case <-f.releaseSparse:
+		case <-f.hardStop:
+			return nil, nil, errors.New("hard stopped by test cleanup")
+		}
+		return nil, nil, f.sparseErr
+	}
 	if f.sparseDelay > 0 {
 		select {
 		case <-time.After(f.sparseDelay):
@@ -138,6 +186,15 @@ func (f *leakFakeSearcher) signalEntered() {
 		// already closed
 	default:
 		close(f.vectorSearchEntered)
+	}
+}
+
+func (f *leakFakeSearcher) signalSparseEntered() {
+	select {
+	case <-f.sparseSearchEntered:
+		// already closed
+	default:
+		close(f.sparseSearchEntered)
 	}
 }
 
@@ -209,6 +266,13 @@ func newLeakExplorer(t *testing.T, searcher objectsSearcher) *Explorer {
 // legs launch. NearVectorParams carries a pre-populated vector so the dense leg
 // needs no vectorizer; targetVectors resolves to the single default "" target.
 func hybridLeakParams() dto.GetParams {
+	return hybridLeakParamsAlpha(0.5)
+}
+
+// hybridLeakParamsAlpha is hybridLeakParams with a caller-chosen alpha so a test
+// can exercise single-leg shapes: alpha=1 runs only the dense leg, alpha=0 only
+// the sparse leg, 0<alpha<1 runs both concurrently.
+func hybridLeakParamsAlpha(alpha float64) dto.GetParams {
 	return dto.GetParams{
 		ClassName: "BestClass",
 		Pagination: &filters.Pagination{
@@ -218,7 +282,7 @@ func hybridLeakParams() dto.GetParams {
 		},
 		HybridSearch: &searchparams.HybridSearch{
 			Query: "anything",
-			Alpha: 0.5, // 0 < alpha < 1 -> both legs run concurrently
+			Alpha: alpha,
 			NearVectorParams: &searchparams.NearVector{
 				Vectors: []models.Vector{[]float32{0.1, 0.2, 0.3}},
 			},
@@ -326,4 +390,203 @@ func TestHybridContextCancellation(t *testing.T) {
 	}
 
 	time.Sleep(50 * time.Millisecond)
+}
+
+// errLegMustNotRun is returned by failOnLegSearcher's legs so that, if a
+// regression ever launches a leg despite the early guard, Hybrid stops cleanly at
+// eg.Wait() (rather than proceeding into fusion with empty results); the t.Error
+// is what actually fails the test.
+var errLegMustNotRun = errors.New("leg must not run when ctx is already cancelled")
+
+// failOnLegSearcher fails the test if either hybrid leg is ever invoked. It is
+// used by the early-ctx.Err()-guard test to assert that an already-cancelled
+// request returns before any leg launches. The embedded objectsSearcher is nil;
+// only the two leg methods are reachable on the guarded path, and both are
+// overridden here.
+type failOnLegSearcher struct {
+	objectsSearcher
+	t *testing.T
+}
+
+func (f *failOnLegSearcher) VectorSearch(ctx context.Context, params dto.GetParams,
+	targetVectors []string, searchVectors []models.Vector,
+) ([]search.Result, error) {
+	f.t.Error("dense leg (VectorSearch) invoked despite already-cancelled ctx")
+	return nil, errLegMustNotRun
+}
+
+func (f *failOnLegSearcher) SparseObjectSearch(ctx context.Context,
+	params dto.GetParams,
+) ([]*storobj.Object, []float32, error) {
+	f.t.Error("sparse leg (SparseObjectSearch) invoked despite already-cancelled ctx")
+	return nil, nil, errLegMustNotRun
+}
+
+// TestHybridEarlyCancelGuard pins the early ctx.Err() guard: a request whose ctx
+// is already cancelled before Hybrid is called must return the ctx error
+// immediately and launch NEITHER leg.
+//
+// Causal link: the fake fails the test if either leg searcher is invoked. The
+// guard added by this fix returns ctx.Err() before eg.Go, so neither method is
+// reached. A future edit moving the guard below leg-launch would invoke a leg and
+// trip f.t.Error here, turning this test RED.
+func TestHybridEarlyCancelGuard(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	e := newLeakExplorer(t, &failOnLegSearcher{t: t})
+	params := hybridLeakParams()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the call
+
+	_, err := e.Hybrid(ctx, params)
+	require.ErrorIs(t, err, context.Canceled,
+		"Hybrid must return the ctx error immediately when called with a cancelled ctx")
+}
+
+// TestHybridCancelNormalizationContract pins the deliberate cancel-normalization
+// trade-off (the Level C edge): when the client ctx is cancelled AND a leg
+// returns a genuine NON-cancel error, Hybrid returns context.Canceled, NOT the
+// leg's real error. This masking is intentional so upstream gRPC/REST handlers
+// can detect cancellation via errors.Is(err, context.Canceled). Pinning it means
+// a future refactor that "fixes" the masking to surface the real error will turn
+// this test RED instead of silently changing the contract.
+//
+// Determinism: the sparse leg ignores ctx and blocks on releaseSparse, so the
+// test orders the events exactly: wait until both legs are mid-flight, cancel the
+// client ctx, THEN release the sparse leg to return errSparseLegFailed. eg.Wait()
+// surfaces that genuine error while ctx.Err() is already non-nil, so the
+// normalization branch fires.
+func TestHybridCancelNormalizationContract(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	searcher := newLeakFakeSearcher()
+	searcher.sparseErrIgnoreCtx = true
+	searcher.sparseErr = errSparseLegFailed
+	t.Cleanup(func() { close(searcher.hardStop) })
+
+	e := newLeakExplorer(t, searcher)
+	params := hybridLeakParams()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.Hybrid(ctx, params)
+		done <- err
+	}()
+
+	// Ensure both legs are mid-flight, then cancel the client ctx and only AFTER
+	// that release the sparse leg so it returns a genuine non-cancel error.
+	<-searcher.vectorSearchEntered
+	<-searcher.sparseSearchEntered
+	cancel()
+	close(searcher.releaseSparse)
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled,
+			"on client-cancel coinciding with a real leg error, Hybrid must normalize to context.Canceled")
+		require.NotErrorIs(t, err, errSparseLegFailed,
+			"the genuine leg error must be masked by the cancel-normalization contract")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Hybrid did not return within 1s")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestHybridSingleLegAndBothErrors covers the single-leg-under-cancel shapes and
+// the both-legs-error shape, all goleak-clean:
+//   - alpha=0: only the sparse leg runs; client cancel mid-flight returns promptly.
+//   - alpha=1: only the dense leg runs; client cancel mid-flight returns promptly.
+//   - both-error: both legs fail fast with genuine (non-cancel) errors; Hybrid
+//     returns a non-nil error, both legs return, nothing leaks.
+//
+// Causal link: the fix threads egCtx through the single-leg paths too. A
+// regression where only the 2-leg path received egCtx would pass the existing
+// 2-leg cancel test but leak (or hang) on alpha=0/alpha=1; these subtests would
+// then time out / flag goleak.
+func TestHybridSingleLegAndBothErrors(t *testing.T) {
+	t.Run("alpha=0 sparse-only under cancel", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		searcher := newLeakFakeSearcher()
+		t.Cleanup(func() { close(searcher.hardStop) })
+
+		e := newLeakExplorer(t, searcher)
+		params := hybridLeakParamsAlpha(0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := e.Hybrid(ctx, params)
+			done <- err
+		}()
+
+		<-searcher.sparseSearchEntered
+		cancel()
+
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(1 * time.Second):
+			t.Fatal("alpha=0: Hybrid did not return within 1s of cancel")
+		}
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	t.Run("alpha=1 dense-only under cancel", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		searcher := newLeakFakeSearcher()
+		t.Cleanup(func() { close(searcher.hardStop) })
+
+		e := newLeakExplorer(t, searcher)
+		params := hybridLeakParamsAlpha(1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := e.Hybrid(ctx, params)
+			done <- err
+		}()
+
+		<-searcher.vectorSearchEntered
+		cancel()
+
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(1 * time.Second):
+			t.Fatal("alpha=1: Hybrid did not return within 1s of cancel")
+		}
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	t.Run("both legs error", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		searcher := newLeakFakeSearcher()
+		searcher.sparseErr = errSparseLegFailed
+		searcher.denseErr = errDenseLegFailed
+		t.Cleanup(func() { close(searcher.hardStop) })
+
+		e := newLeakExplorer(t, searcher)
+		params := hybridLeakParams() // alpha=0.5 -> both legs run
+
+		_, err := e.Hybrid(context.Background(), params)
+		// errgroup surfaces the first error; either genuine leg error is
+		// acceptable. The contract is: a non-nil, non-cancel error comes back
+		// and (via goleak) both legs returned without leaking.
+		require.Error(t, err, "both legs failing must surface a non-nil error")
+		require.NotErrorIs(t, err, context.Canceled,
+			"with no client cancel, the returned error must be a genuine leg error")
+		time.Sleep(50 * time.Millisecond)
+	})
 }

--- a/usecases/traverser/hybrid_goroutine_leak_test.go
+++ b/usecases/traverser/hybrid_goroutine_leak_test.go
@@ -35,8 +35,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/modules"
 )
 
-var errSparseLegFailed = errors.New("sparse leg failed fast")
-var errDenseLegFailed = errors.New("dense leg failed fast")
+var (
+	errSparseLegFailed = errors.New("sparse leg failed fast")
+	errDenseLegFailed  = errors.New("dense leg failed fast")
+)
 
 // leakFakeSearcher drives hybrid legs into the leak repro shape: SparseObjectSearch
 // fails quickly while VectorSearch blocks until ctx cancels.


### PR DESCRIPTION
Hybrid search runs its keyword (BM25) and vector searches concurrently in an errgroup that has no cancellable context. If one of the two searches fails, the other is never told to stop and keeps running to completion. A cancelled or timed-out client request is also not passed down to the searches. Under load, these abandoned searches pile up as leaked goroutines.

### What changed

Run the two searches under a cancellable context (`NewErrorGroupWithContextWrapper`) and pass it to both the keyword and vector searches, including the multi-vector embedding step. Return early if the request is already cancelled, and surface cancellation as `context.Canceled` on the join so callers can detect it with `errors.Is`. The change is contained to `Explorer.Hybrid`; the shared `NewErrorGroupWrapper` is unchanged.

### Testing

New tests cover:
- One search failing now cancels the other instead of leaving it running
- A cancelled request stops both searches
- An already-cancelled request returns immediately without starting any search
- A cancelled request returns an error callers can detect with `errors.Is(err, context.Canceled)`
- Keyword-only and vector-only queries (alpha 0 and alpha 1)
- Both searches failing

All pass under `-race`.

### Compatibility

Read path only. Results for successful queries (recall and ranking) are unchanged.
