### PR TITLE
perf(bm25): []uint32 doc ids for the sparse property-length pairs layout

### DIFF
--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -29,15 +29,17 @@ type segmentInvertedData struct {
 	tombstones       *sroar.Bitmap
 	tombstonesLoaded bool
 
-	// Per-document property lengths in one of two representations (exactly one
-	// non-nil once loaded, both nil when the segment has none): a dense array
-	// indexed by docID-propLengthsDenseMin when the docID range is ≥1/3 occupied
-	// (4B×span ≤ 12B×count — smaller AND O(1) to read), else docID-sorted parallel
-	// arrays read via propLengthsView. Full-map consumers (compaction) reconstruct
-	// a transient map via getPropertyLengths.
+	// Per-document property lengths in one of two representations (the unused one
+	// stays nil; all nil when the segment has none): a dense array indexed by
+	// docID-propLengthsDenseMin when the docID range is ≥1/3 occupied (4B×span ≤
+	// 12B×count — smaller AND O(1) to read), else docID-sorted parallel arrays
+	// read via propLengthsView. The pairs ids are propLengthsPairIds32 (4B) when
+	// the segment's max docID fits uint32, else propLengthsPairIds (8B). Full-map
+	// consumers (compaction) reconstruct a transient map via getPropertyLengths.
 	propLengthsDense      []uint32
 	propLengthsDenseMin   uint64
 	propLengthsPairIds    []uint64
+	propLengthsPairIds32  []uint32
 	propLengthsPairLens   []uint32
 	propertyLengthsLoaded bool
 
@@ -46,6 +48,25 @@ type segmentInvertedData struct {
 	// avg/count are read unlocked by combinePropertyLengths; this flag stops the
 	// on-demand load from re-writing (racing) them after open.
 	propertyLengthsStatsLoaded bool
+}
+
+// propLengths is the loaded per-document property lengths in exactly one
+// representation (all-nil = none): dense (indexed by docID-denseMin) or
+// docID-sorted pairs whose ids are ids32 (max docID fits uint32) or ids64.
+type propLengths struct {
+	dense    []uint32
+	denseMin uint64
+	ids64    []uint64
+	ids32    []uint32
+	lens     []uint32
+}
+
+func (d *segmentInvertedData) propLengthsSnapshot() propLengths {
+	return propLengths{
+		dense: d.propLengthsDense, denseMin: d.propLengthsDenseMin,
+		ids64: d.propLengthsPairIds, ids32: d.propLengthsPairIds32,
+		lens: d.propLengthsPairLens,
+	}
 }
 
 func (s *segment) loadTombstones() (*sroar.Bitmap, error) {
@@ -106,7 +127,7 @@ func (s *segment) loadPropertyLengthsStats() error {
 	propertyLengthsSize := binary.LittleEndian.Uint64(buffer[16:24])
 
 	if math.IsNaN(s.invertedData.avgPropertyLengthsAvg) || math.IsInf(s.invertedData.avgPropertyLengthsAvg, 0) {
-		_, _, _, _, err := s.loadPropertyLengthsLocked()
+		_, err := s.loadPropertyLengthsLocked()
 		return err
 	}
 
@@ -120,27 +141,26 @@ func (s *segment) loadPropertyLengthsStats() error {
 func (s *segment) loadPropertyLengths() error {
 	s.invertedData.lockInvertedData.Lock()
 	defer s.invertedData.lockInvertedData.Unlock()
-	_, _, _, _, err := s.loadPropertyLengthsLocked()
+	_, err := s.loadPropertyLengthsLocked()
 	return err
 }
 
 // loadPropertyLengthsLocked requires the caller to hold lockInvertedData. It
 // returns the loaded arrays so callers needn't re-read the struct after
 // unlocking, where a freePropertyLengths could have niled them.
-func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uint32, error) {
+func (s *segment) loadPropertyLengthsLocked() (propLengths, error) {
 	if s.strategy != segmentindex.StrategyInverted {
-		return nil, 0, nil, nil, fmt.Errorf("property only supported for inverted strategy")
+		return propLengths{}, fmt.Errorf("property only supported for inverted strategy")
 	}
 
 	if s.invertedData.propertyLengthsLoaded {
-		return s.invertedData.propLengthsDense, s.invertedData.propLengthsDenseMin,
-			s.invertedData.propLengthsPairIds, s.invertedData.propLengthsPairLens, nil
+		return s.invertedData.propLengthsSnapshot(), nil
 	}
 
 	buffer := make([]byte, 8*3)
 
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.PropertyLengthsOffset, s.invertedHeader.PropertyLengthsOffset + 8*3}); err != nil {
-		return nil, 0, nil, nil, fmt.Errorf("copy node: %w", err)
+		return propLengths{}, fmt.Errorf("copy node: %w", err)
 	}
 
 	// don't re-write stats already set at open: readers access them unlocked
@@ -153,7 +173,7 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 
 	if propertyLengthsSize == 0 {
 		s.invertedData.propertyLengthsLoaded = true
-		return nil, 0, nil, nil, nil
+		return propLengths{}, nil
 	}
 
 	propertyLengthsStart := s.invertedHeader.PropertyLengthsOffset + 16 + 8
@@ -161,11 +181,11 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 
 	buffer = make([]byte, propertyLengthsSize)
 	if err := s.copyNode(buffer, nodeOffset{propertyLengthsStart, propertyLengthsEnd}); err != nil {
-		return nil, 0, nil, nil, fmt.Errorf("copy node: %w", err)
+		return propLengths{}, fmt.Errorf("copy node: %w", err)
 	}
 	ids, lens, err := gobenc.DecodePairs(buffer)
 	if err != nil {
-		return nil, 0, nil, nil, fmt.Errorf("decode property lengths: %w", err)
+		return propLengths{}, fmt.Errorf("decode property lengths: %w", err)
 	}
 
 	if math.IsNaN(s.invertedData.avgPropertyLengthsAvg) || math.IsInf(s.invertedData.avgPropertyLengthsAvg, 0) {
@@ -208,26 +228,41 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 			s.invertedData.propLengthsDense = dense
 			s.invertedData.propLengthsDenseMin = minID
 		} else {
-			sortPropLenPairs(ids, lens)
-			s.invertedData.propLengthsPairIds = ids
+			maxID := sortPropLenPairs(ids, lens)
+			// Narrow ids to uint32 (4B vs 8B) when the segment's max docID fits.
+			// Runtime per-segment gate, never an assumption: docIDs aren't reused
+			// on delete, so a churned shard's max can exceed uint32 with few live
+			// docs. maxID is the sort's full scan, not the dense gate's early-stop.
+			if maxID <= math.MaxUint32 {
+				ids32 := make([]uint32, len(ids))
+				for i, id := range ids {
+					ids32[i] = uint32(id)
+				}
+				s.invertedData.propLengthsPairIds32 = ids32
+			} else {
+				s.invertedData.propLengthsPairIds = ids
+			}
 			s.invertedData.propLengthsPairLens = lens
 		}
 	}
 
 	s.invertedData.propertyLengthsLoaded = true
-	return s.invertedData.propLengthsDense, s.invertedData.propLengthsDenseMin,
-		s.invertedData.propLengthsPairIds, s.invertedData.propLengthsPairLens, nil
+	return s.invertedData.propLengthsSnapshot(), nil
 }
 
 // sortPropLenPairs sorts both arrays in tandem by docID using an LSD radix sort
 // over only the bytes the largest docID needs (~4 passes for realistic ID
 // ranges). Entries arrive in gob map-iteration order (random), so a comparison
 // sort would pay ~n log n interface-dispatched swaps — radix is linear and
-// allocation-bounded to one scratch copy of each array.
-func sortPropLenPairs(ids []uint64, lens []uint32) {
+// allocation-bounded to one scratch copy of each array. Returns the full max
+// docID (free from the radix scan) so the caller can gate the uint32-ids layout.
+func sortPropLenPairs(ids []uint64, lens []uint32) uint64 {
 	n := len(ids)
 	if n < 2 {
-		return
+		if n == 1 {
+			return ids[0]
+		}
+		return 0
 	}
 	var maxID uint64
 	for _, id := range ids {
@@ -268,6 +303,7 @@ func sortPropLenPairs(ids []uint64, lens []uint32) {
 		copy(ids, srcIds)
 		copy(lens, srcLens)
 	}
+	return maxID
 }
 
 // ReadOnlyTombstones returns segment's tombstones
@@ -310,57 +346,75 @@ func (s *segment) MergeTombstones(other *sroar.Bitmap) (*sroar.Bitmap, error) {
 // lookups go through propLengthsView; the full map is for compaction-frequency
 // consumers only.
 func (s *segment) getPropertyLengths() (map[uint64]uint32, error) {
-	dense, minID, ids, lens, err := s.propLengthArrays()
+	pl, err := s.propLengthArrays()
 	if err != nil {
 		return nil, err
 	}
-	if dense != nil {
+	if pl.dense != nil {
 		// dense is only chosen when no stored length is 0, so a zero slot is
 		// always an absent docID and the reconstruction reproduces the key set
 		m := make(map[uint64]uint32)
-		for i, l := range dense {
+		for i, l := range pl.dense {
 			if l != 0 {
-				m[minID+uint64(i)] = l
+				m[pl.denseMin+uint64(i)] = l
 			}
 		}
 		return m, nil
 	}
-	if len(ids) == 0 {
+	if pl.ids32 != nil {
+		m := make(map[uint64]uint32, len(pl.ids32))
+		for i, id := range pl.ids32 {
+			m[uint64(id)] = pl.lens[i]
+		}
+		return m, nil
+	}
+	if len(pl.ids64) == 0 {
 		return nil, nil
 	}
-	m := make(map[uint64]uint32, len(ids))
-	for i, id := range ids {
-		m[id] = lens[i]
+	m := make(map[uint64]uint32, len(pl.ids64))
+	for i, id := range pl.ids64 {
+		m[id] = pl.lens[i]
 	}
 	return m, nil
 }
 
 // getPropertyLengthsPairs returns the property lengths as docID-sorted arrays
-// (no map): the loaded slices directly for pairs segments, or the dense array
-// walked into pairs (0 = absent skipped). Returned slices are read-only.
+// (no map): the loaded slices directly for uint64-pairs segments, the dense
+// array walked into pairs (0 = absent skipped), or uint32-pairs widened to
+// uint64. Returned slices are read-only (the uint64-pairs case aliases the
+// cached slice).
 func (s *segment) getPropertyLengthsPairs() ([]uint64, []uint32, error) {
-	dense, minID, ids, lens, err := s.propLengthArrays()
+	pl, err := s.propLengthArrays()
 	if err != nil {
 		return nil, nil, err
 	}
-	if dense != nil {
+	if pl.dense != nil {
 		n := 0
-		for _, l := range dense {
+		for _, l := range pl.dense {
 			if l != 0 {
 				n++
 			}
 		}
 		outIDs := make([]uint64, 0, n)
 		outLens := make([]uint32, 0, n)
-		for i, l := range dense {
+		for i, l := range pl.dense {
 			if l != 0 {
-				outIDs = append(outIDs, minID+uint64(i))
+				outIDs = append(outIDs, pl.denseMin+uint64(i))
 				outLens = append(outLens, l)
 			}
 		}
 		return outIDs, outLens, nil
 	}
-	return ids, lens, nil
+	if pl.ids32 != nil {
+		// widen for the merge/encode path; on-disk stays uint64, so the narrow
+		// ids are resident-memory only and don't reach the wire format.
+		ids := make([]uint64, len(pl.ids32))
+		for i, id := range pl.ids32 {
+			ids[i] = uint64(id)
+		}
+		return ids, pl.lens, nil
+	}
+	return pl.ids64, pl.lens, nil
 }
 
 // mergePropLenPairs merges two docID-sorted pair arrays into one, deduping
@@ -402,17 +456,16 @@ func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uin
 // paths capture the arrays under the lock. The returned slices alias the cached
 // arrays; a later freePropertyLengths nils the struct fields but not these
 // headers, so a reader's slices stay valid.
-func (s *segment) propLengthArrays() (dense []uint32, minID uint64, ids []uint64, lens []uint32, err error) {
+func (s *segment) propLengthArrays() (propLengths, error) {
 	if s.strategy != segmentindex.StrategyInverted {
-		return nil, 0, nil, nil, fmt.Errorf("property length only supported for inverted strategy")
+		return propLengths{}, fmt.Errorf("property length only supported for inverted strategy")
 	}
 
 	s.invertedData.lockInvertedData.RLock()
 	if s.invertedData.propertyLengthsLoaded {
-		dense, minID = s.invertedData.propLengthsDense, s.invertedData.propLengthsDenseMin
-		ids, lens = s.invertedData.propLengthsPairIds, s.invertedData.propLengthsPairLens
+		pl := s.invertedData.propLengthsSnapshot()
 		s.invertedData.lockInvertedData.RUnlock()
-		return dense, minID, ids, lens, nil
+		return pl, nil
 	}
 	s.invertedData.lockInvertedData.RUnlock()
 
@@ -423,14 +476,13 @@ func (s *segment) propLengthArrays() (dense []uint32, minID uint64, ids []uint64
 
 // propLengthsView is a no-IO per-docID lookup over a segment's property
 // lengths: a single indexed load for dense segments, a cursor over the sorted
-// pairs otherwise. A miss returns 0, matching the map semantics this replaced.
-// The cursor exploits ascending docID access (scoring and posting iteration
-// order): lookups gallop forward from the last hit, so monotone scans are
-// amortized O(1); a backward jump restarts the search from the front.
+// pairs (ids or ids32, whichever the segment loaded) otherwise. A miss returns
+// 0, matching the map semantics this replaced.
 type propLengthsView struct {
 	dense []uint32
 	min   uint64
 	ids   []uint64
+	ids32 []uint32
 	lens  []uint32
 	cur   int
 }
@@ -442,38 +494,53 @@ func (v *propLengthsView) get(docID uint64) uint32 {
 		}
 		return 0
 	}
+	if v.ids32 != nil {
+		// every stored id fits uint32, so a query past that range is a sure miss
+		if docID > math.MaxUint32 {
+			return 0
+		}
+		val, cur := propLenPairLookup(v.ids32, v.lens, v.cur, docID)
+		v.cur = cur
+		return val
+	}
+	val, cur := propLenPairLookup(v.ids, v.lens, v.cur, docID)
+	v.cur = cur
+	return val
+}
 
-	ids := v.ids
+// propLenPairLookup is the docID-sorted-pairs cursor, shared across id widths
+// via a type parameter the compiler specializes (no per-access width branch on
+// the hot path). It exploits ascending docID access (scoring and posting
+// iteration order): lookups gallop forward from cur, so monotone scans are
+// amortized O(1); a backward jump restarts from the front. Returns the value
+// (0 on miss) and the advanced cursor.
+func propLenPairLookup[T uint32 | uint64](ids []T, lens []uint32, cur int, docID uint64) (uint32, int) {
 	n := len(ids)
-	c := v.cur
+	c := cur
 
-	if c >= n || ids[c] > docID {
+	if c >= n || uint64(ids[c]) > docID {
 		// went backward relative to the cursor (or cursor exhausted): restart
 		c = 0
 	}
 	// short linear probe from the cursor covers the small gaps of
 	// frequent-term scans
 	for k := 0; k < 4 && c < n; k++ {
-		if ids[c] >= docID {
-			if ids[c] == docID {
-				v.cur = c + 1
-				return v.lens[c]
+		if uint64(ids[c]) >= docID {
+			if uint64(ids[c]) == docID {
+				return lens[c], c + 1
 			}
-			v.cur = c
-			return 0
+			return 0, c
 		}
 		c++
 	}
 	if c >= n {
-		v.cur = n
-		return 0
+		return 0, n
 	}
 
 	lo := c - 1 // ids[lo] < docID by the loop above
 	hi := n - 1
-	if ids[hi] < docID {
-		v.cur = n
-		return 0
+	if uint64(ids[hi]) < docID {
+		return 0, n
 	}
 	// invariant: ids[lo] < docID <= ids[hi].
 	// bounded gallop first: frequent-term scans advance by small-to-medium gaps
@@ -484,7 +551,7 @@ func (v *propLengthsView) get(docID uint64) uint32 {
 		if p >= hi {
 			break
 		}
-		if ids[p] < docID {
+		if uint64(ids[p]) < docID {
 			lo = p
 		} else {
 			hi = p
@@ -497,14 +564,14 @@ func (v *propLengthsView) get(docID uint64) uint32 {
 	// cache-missing probes there (measured +30% on rare-term queries). The
 	// budget bounds adversarial distributions; binary search finishes the rest.
 	for budget := 0; budget < 8 && hi-lo > 1; budget++ {
-		span := ids[hi] - ids[lo]
-		p := lo + 1 + int(float64(docID-ids[lo])/float64(span)*float64(hi-lo-1))
+		span := uint64(ids[hi]) - uint64(ids[lo])
+		p := lo + 1 + int(float64(docID-uint64(ids[lo]))/float64(span)*float64(hi-lo-1))
 		if p <= lo {
 			p = lo + 1
 		} else if p >= hi {
 			p = hi - 1
 		}
-		if ids[p] < docID {
+		if uint64(ids[p]) < docID {
 			lo = p
 		} else {
 			hi = p
@@ -512,26 +579,24 @@ func (v *propLengthsView) get(docID uint64) uint32 {
 	}
 	for hi-lo > 1 {
 		mid := int(uint(lo+hi) >> 1)
-		if ids[mid] < docID {
+		if uint64(ids[mid]) < docID {
 			lo = mid
 		} else {
 			hi = mid
 		}
 	}
-	if ids[hi] == docID {
-		v.cur = hi + 1
-		return v.lens[hi]
+	if uint64(ids[hi]) == docID {
+		return lens[hi], hi + 1
 	}
-	v.cur = hi
-	return 0
+	return 0, hi
 }
 
 func (s *segment) propLengthsView() (propLengthsView, error) {
-	dense, minID, ids, lens, err := s.propLengthArrays()
+	pl, err := s.propLengthArrays()
 	if err != nil {
 		return propLengthsView{}, err
 	}
-	return propLengthsView{dense: dense, min: minID, ids: ids, lens: lens}, nil
+	return propLengthsView{dense: pl.dense, min: pl.denseMin, ids: pl.ids64, ids32: pl.ids32, lens: pl.lens}, nil
 }
 
 func (s *segment) isPropertyLengthsLoaded() bool {
@@ -559,6 +624,7 @@ func (s *segment) freePropertyLengths() {
 	s.invertedData.propLengthsDense = nil
 	s.invertedData.propLengthsDenseMin = 0
 	s.invertedData.propLengthsPairIds = nil
+	s.invertedData.propLengthsPairIds32 = nil
 	s.invertedData.propLengthsPairLens = nil
 	s.invertedData.propertyLengthsLoaded = false
 }

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -200,54 +200,78 @@ func (s *segment) loadPropertyLengthsLocked() (propLengths, error) {
 		}
 	}
 
-	if len(ids) > 0 {
-		minID, maxID := ids[0], ids[0]
-		// min/max only feed the dense gate, so stop at the first zero length — a
-		// zero rules dense out anyway (see the gate below)
-		hasZeroLen := lens[0] == 0
-		for i := 1; i < len(ids) && !hasZeroLen; i++ {
-			if ids[i] < minID {
-				minID = ids[i]
-			}
-			if ids[i] > maxID {
-				maxID = ids[i]
-			}
-			if lens[i] == 0 {
-				hasZeroLen = true
-			}
-		}
-		span := maxID - minID + 1
-		// dense uses 0 as the "docID absent" sentinel (getPropertyLengths drops
-		// zero slots), so a stored 0 would be lost — keep pairs when one exists.
-		if !hasZeroLen && span != 0 && span/3 <= uint64(len(ids)) {
-			// dense path: direct-indexed fill, no sort needed (unlike the pairs branch)
-			dense := make([]uint32, span)
-			for i, id := range ids {
-				dense[id-minID] = lens[i]
-			}
-			s.invertedData.propLengthsDense = dense
-			s.invertedData.propLengthsDenseMin = minID
-		} else {
-			maxID := sortPropLenPairs(ids, lens)
-			// Narrow ids to uint32 (4B vs 8B) when the segment's max docID fits.
-			// Runtime per-segment gate, never an assumption: docIDs aren't reused
-			// on delete, so a churned shard's max can exceed uint32 with few live
-			// docs. maxID is the sort's full scan, not the dense gate's early-stop.
-			if maxID <= math.MaxUint32 {
-				ids32 := make([]uint32, len(ids))
-				for i, id := range ids {
-					ids32[i] = uint32(id)
-				}
-				s.invertedData.propLengthsPairIds32 = ids32
-			} else {
-				s.invertedData.propLengthsPairIds = ids
-			}
-			s.invertedData.propLengthsPairLens = lens
-		}
-	}
+	layout := selectPropLengthLayout(ids, lens)
+	s.invertedData.propLengthsDense = layout.dense
+	s.invertedData.propLengthsDenseMin = layout.denseMin
+	s.invertedData.propLengthsPairIds32 = layout.ids32
+	s.invertedData.propLengthsPairIds = layout.ids64
+	s.invertedData.propLengthsPairLens = layout.lens
 
 	s.invertedData.propertyLengthsLoaded = true
 	return s.invertedData.propLengthsSnapshot(), nil
+}
+
+// propLengthLayout is the resident-memory representation chosen for a segment's
+// property lengths: exactly one of dense, narrow-pairs (ids32) or wide-pairs
+// (ids64) is populated, with lens set for the two pairs layouts.
+type propLengthLayout struct {
+	dense    []uint32
+	denseMin uint64
+	ids32    []uint32
+	ids64    []uint64
+	lens     []uint32
+}
+
+// selectPropLengthLayout picks the resident layout for decoded (ids, lens) pairs.
+// Extracted from the load path so the gate is unit-testable: DecodePairs yields
+// entries in gob map-iteration order (random per process), so a segment-flush
+// test can't pin the scan order — only a direct call with a fixed slice can.
+//
+// The dense gate's min/max loop early-stops at the first zero-length doc; that
+// truncated max is sound ONLY for ruling dense out (a stored zero can't use the
+// dense sentinel layout). The uint32 gate must use sortPropLenPairs' full-scan
+// max — using the early-stopped max would misclassify a segment whose true max
+// exceeds uint32 as narrow and silently truncate the high docID.
+func selectPropLengthLayout(ids []uint64, lens []uint32) propLengthLayout {
+	if len(ids) == 0 {
+		return propLengthLayout{}
+	}
+	minID, maxID := ids[0], ids[0]
+	hasZeroLen := lens[0] == 0
+	for i := 1; i < len(ids) && !hasZeroLen; i++ {
+		if ids[i] < minID {
+			minID = ids[i]
+		}
+		if ids[i] > maxID {
+			maxID = ids[i]
+		}
+		if lens[i] == 0 {
+			hasZeroLen = true
+		}
+	}
+	span := maxID - minID + 1
+	// dense uses 0 as the "docID absent" sentinel (getPropertyLengths drops zero
+	// slots), so a stored 0 would be lost — keep pairs when one exists.
+	if !hasZeroLen && span != 0 && span/3 <= uint64(len(ids)) {
+		// direct-indexed fill, no sort needed (unlike the pairs branch)
+		dense := make([]uint32, span)
+		for i, id := range ids {
+			dense[id-minID] = lens[i]
+		}
+		return propLengthLayout{dense: dense, denseMin: minID}
+	}
+	// Narrow ids to uint32 (4B vs 8B) when the segment's max docID fits. Runtime
+	// per-segment gate, never an assumption: docIDs aren't reused on delete, so a
+	// churned shard's max can exceed uint32 with few live docs.
+	trueMax := sortPropLenPairs(ids, lens)
+	if trueMax <= math.MaxUint32 {
+		ids32 := make([]uint32, len(ids))
+		for i, id := range ids {
+			ids32[i] = uint32(id)
+		}
+		return propLengthLayout{ids32: ids32, lens: lens}
+	}
+	return propLengthLayout{ids64: ids, lens: lens}
 }
 
 // sortPropLenPairs sorts both arrays in tandem by docID using an LSD radix sort

--- a/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
@@ -105,6 +105,56 @@ func TestInvertedLazyPropertyLengths(t *testing.T) {
 	}
 }
 
+// TestInvertedFreePropertyLengthsClearsNarrowPairs pins that freePropertyLengths
+// clears the uint32 pairs layout, not just dense. TestInvertedLazyPropertyLengths
+// above uses contiguous docIDs (the dense path), so its post-free nil check on
+// propLengthsPairIds32 is vacuous — that field is never populated there. Strided
+// docIDs with a max under uint32 force the narrow-pairs layout, exercising the
+// field for real.
+func TestInvertedFreePropertyLengthsClearsNarrowPairs(t *testing.T) {
+	ctx := context.Background()
+	const size = 100
+	const stride = 1_000_000 // max docID 99_000_000 < MaxUint32; span/3 >> size -> pairs, not dense
+	key := []byte("my-key")
+
+	dirName := t.TempDir()
+	mk := func() *Bucket {
+		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			WithStrategy(StrategyInverted))
+		require.Nil(t, err)
+		b.SetMemtableThreshold(1e9)
+		return b
+	}
+
+	b := mk()
+	for i := 0; i < size; i++ {
+		docID := uint64(i) * stride
+		require.Nil(t, b.MapSet(key, NewMapPairFromDocIdAndTf(docID, float32(1), float32(1+i%5), false)))
+	}
+	require.Nil(t, b.FlushAndSwitch())
+
+	// reopen so the segment is loaded from disk via newSegment
+	require.Nil(t, b.Shutdown(ctx))
+	b = mk()
+	defer b.Shutdown(ctx)
+
+	require.GreaterOrEqual(t, len(b.disk.segments), 1)
+	seg := b.disk.segments[0]
+
+	_, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	inv := seg.getInvertedData()
+	require.NotNil(t, inv.propLengthsPairIds32, "strided max under uint32 must select the narrow pairs layout")
+	require.Nil(t, inv.propLengthsDense, "sparse span must not select dense")
+	require.Nil(t, inv.propLengthsPairIds, "max under uint32 must not use wide pairs")
+
+	seg.freePropertyLengths()
+	require.False(t, seg.isPropertyLengthsLoaded())
+	require.Nil(t, seg.getInvertedData().propLengthsPairIds32, "free must clear the uint32 pairs layout")
+	require.Nil(t, seg.getInvertedData().propLengthsPairLens, "free must clear the pairs lengths")
+}
+
 // TestInvertedCompactionFreesLazyPropertyLengths verifies that an inverted
 // compaction releases a property length map it loaded itself, while leaving a
 // map that was already loaded before the compaction untouched. The aborted

--- a/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_lazy_proplength_test.go
@@ -88,6 +88,7 @@ func TestInvertedLazyPropertyLengths(t *testing.T) {
 			require.False(t, seg.isPropertyLengthsLoaded())
 			require.Nil(t, seg.getInvertedData().propLengthsDense)
 			require.Nil(t, seg.getInvertedData().propLengthsPairIds)
+			require.Nil(t, seg.getInvertedData().propLengthsPairIds32)
 			avgAfter, countAfter := b.GetAveragePropertyLength()
 			require.Equal(t, avg, avgAfter)
 			require.Equal(t, count, countAfter)

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_gate_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_gate_test.go
@@ -1,0 +1,98 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSelectPropLengthLayout is the deterministic pin for the load-side layout
+// gate. It calls the gate directly with fixed slices, bypassing the gob-map
+// round-trip whose iteration order is random per process — the reason a
+// flush-based test cannot reliably reproduce the early-stop trap.
+func TestSelectPropLengthLayout(t *testing.T) {
+	const highID = uint64(1) << 33 // > MaxUint32
+
+	type kind int
+	const (
+		empty kind = iota
+		dense
+		narrow // uint32 pairs
+		wide   // uint64 pairs
+	)
+
+	cases := []struct {
+		name string
+		ids  []uint64
+		lens []uint32
+		want kind
+	}{
+		{"empty", nil, nil, empty},
+		{"contiguous_no_zero_is_dense", []uint64{0, 1, 2, 3, 4, 5}, []uint32{5, 4, 3, 2, 1, 6}, dense},
+		{"sparse_no_zero_small_max_is_narrow", []uint64{0, 500}, []uint32{1, 2}, narrow},
+		{"sparse_no_zero_high_max_is_wide", []uint64{0, highID}, []uint32{1, 2}, wide},
+		{"boundary_maxuint32_is_narrow", []uint64{0, 1, 2, math.MaxUint32}, []uint32{1, 1, 1, 1}, narrow},
+		{"boundary_maxuint32_plus_1_is_wide", []uint64{0, 1, 2, math.MaxUint32 + 1}, []uint32{1, 1, 1, 1}, wide},
+		{"zero_length_small_max_is_narrow", []uint64{3, 7, 50}, []uint32{0, 5, 9}, narrow},
+
+		// The two order-sensitive cases below both MUST resolve to wide. They pin
+		// the early-stop trap: the dense gate's min/max loop stops at the first
+		// zero-length doc, so its max excludes anything after it. The uint32 gate
+		// must instead use sortPropLenPairs' full-scan max.
+		//
+		// zero_before_high: the zero-length doc precedes highID in slice order, so
+		// the early-stopped max is 3 (<=uint32). A gate that trusted it would narrow
+		// and truncate highID — this subtest catches that regression on every run.
+		{"zero_before_high_stays_wide", []uint64{3, highID, 7, 50}, []uint32{0, 12, 5, 9}, wide},
+		// zero_after_high: highID is scanned before the early-stop, so even the
+		// buggy gate happens to see the true max here — this subtest proves the
+		// correct gate is order-independent, not that it catches the bug.
+		{"zero_after_high_stays_wide", []uint64{highID, 3, 7, 50}, []uint32{12, 0, 5, 9}, wide},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var trueMax uint64 // capture before selectPropLengthLayout sorts in place
+			for _, id := range tc.ids {
+				if id > trueMax {
+					trueMax = id
+				}
+			}
+			layout := selectPropLengthLayout(tc.ids, tc.lens)
+			switch tc.want {
+			case empty:
+				assert.Nil(t, layout.dense)
+				assert.Nil(t, layout.ids32)
+				assert.Nil(t, layout.ids64)
+				assert.Nil(t, layout.lens)
+			case dense:
+				assert.NotNil(t, layout.dense, "expected dense layout")
+				assert.Nil(t, layout.ids32, "dense: no narrow pairs")
+				assert.Nil(t, layout.ids64, "dense: no wide pairs")
+			case narrow:
+				assert.NotNil(t, layout.ids32, "expected uint32 pairs")
+				assert.Nil(t, layout.ids64, "narrow: no uint64 pairs")
+				assert.Nil(t, layout.dense, "narrow: not dense")
+				assert.NotNil(t, layout.lens, "pairs must carry lens")
+			case wide:
+				assert.NotNil(t, layout.ids64, "expected uint64 pairs — true max exceeds uint32")
+				assert.Nil(t, layout.ids32, "wide: must not narrow, the high docID would truncate")
+				assert.Nil(t, layout.dense, "wide: not dense")
+				assert.Greater(t, trueMax, uint64(math.MaxUint32), "wide precondition: true max exceeds uint32")
+				assert.Contains(t, layout.ids64, trueMax, "the >uint32 docID must survive intact")
+			}
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -31,9 +31,12 @@ import (
 // the exact stored map that compaction round-trips to disk.
 func TestSegmentPropertyLengthsRepresentations(t *testing.T) {
 	tests := []struct {
-		name      string
-		docIDs    func() []uint64
-		wantDense bool
+		name string
+		// docIDs returns the docIDs to store; wantNarrow is only meaningful when
+		// !wantDense (pairs), where max docID <= MaxUint32 selects uint32 ids.
+		docIDs     func() []uint64
+		wantDense  bool
+		wantNarrow bool
 	}{
 		{
 			// contiguous ids: span == count -> dense array
@@ -48,7 +51,8 @@ func TestSegmentPropertyLengthsRepresentations(t *testing.T) {
 			wantDense: true,
 		},
 		{
-			// stride 10: span ~10x count, far below 1/3 occupancy -> sorted pairs
+			// stride 10: span ~10x count, far below 1/3 occupancy -> sorted pairs;
+			// max docID 4990 fits uint32 -> narrow ids
 			name: "sparse_strided",
 			docIDs: func() []uint64 {
 				ids := make([]uint64, 500)
@@ -57,7 +61,17 @@ func TestSegmentPropertyLengthsRepresentations(t *testing.T) {
 				}
 				return ids
 			},
-			wantDense: false,
+			wantDense:  false,
+			wantNarrow: true,
+		},
+		{
+			// sparse with a max docID beyond uint32 -> pairs must keep uint64 ids
+			name: "sparse_wide_id",
+			docIDs: func() []uint64 {
+				return []uint64{0, 10, 20, 30, 1 << 33}
+			},
+			wantDense:  false,
+			wantNarrow: false,
 		},
 		{
 			// exactly at the gate: span == 3*count keeps dense
@@ -105,7 +119,21 @@ func TestSegmentPropertyLengthsRepresentations(t *testing.T) {
 			plView, err := seg.propLengthsView()
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantDense, plView.dense != nil, "representation choice")
-			assert.Equal(t, tc.wantDense, plView.ids == nil, "exactly one representation populated")
+			switch {
+			case tc.wantDense:
+				assert.Nil(t, plView.ids, "dense: no uint64 pairs")
+				assert.Nil(t, plView.ids32, "dense: no uint32 pairs")
+			case tc.wantNarrow:
+				assert.NotNil(t, plView.ids32, "max docID fits uint32: narrow ids")
+				assert.Nil(t, plView.ids, "narrow ids: no uint64 pairs")
+				require.Len(t, plView.ids32, len(docIDs))
+				// 4B ids32 + 4B lens = 8B/entry (vs 12B with uint64 ids)
+				assert.Equal(t, 8, (4*len(plView.ids32)+4*len(plView.lens))/len(plView.ids32),
+					"uint32-ids pairs entry is 8B")
+			default:
+				assert.NotNil(t, plView.ids, "max docID exceeds uint32: uint64 fallback")
+				assert.Nil(t, plView.ids32, "wide ids: no uint32 pairs")
+			}
 
 			// ascending scan (the production access pattern)
 			for _, docID := range docIDs {
@@ -179,7 +207,8 @@ func TestSegmentPropertyLengthsSpanOverflow(t *testing.T) {
 	plView, err := seg.propLengthsView()
 	require.NoError(t, err)
 	assert.Nil(t, plView.dense, "overflowing span must not select dense")
-	assert.NotNil(t, plView.ids, "must fall back to sorted pairs")
+	assert.NotNil(t, plView.ids, "must fall back to sorted pairs (uint64 ids: max docID > uint32)")
+	assert.Nil(t, plView.ids32, "MaxUint64 docID can't use uint32 ids")
 	assert.Equal(t, uint32(3), plView.get(0))
 	assert.Equal(t, uint32(7), plView.get(math.MaxUint64))
 
@@ -217,7 +246,7 @@ func TestSegmentPropertyLengthsZeroLengthForcesPairs(t *testing.T) {
 	plView, err := seg.propLengthsView()
 	require.NoError(t, err)
 	assert.Nil(t, plView.dense, "a stored 0-length must force the pairs layout")
-	assert.NotNil(t, plView.ids)
+	assert.NotNil(t, plView.ids32, "max docID 3 fits uint32: narrow ids")
 
 	got, err := seg.getPropertyLengths()
 	require.NoError(t, err)
@@ -332,7 +361,8 @@ func TestInvertedCompactionPropertyLengthsSparsePairs(t *testing.T) {
 	plView, err := seg.propLengthsView()
 	require.NoError(t, err)
 	assert.Nil(t, plView.dense, "sparse docIDs must keep the merged segment on the pairs layout")
-	assert.NotNil(t, plView.ids, "pairs layout expected")
+	assert.NotNil(t, plView.ids32, "max docID 20000 fits uint32: narrow ids after the merge round-trip")
+	assert.Nil(t, plView.ids, "narrow ids: no uint64 pairs")
 	for id, l := range want {
 		require.Equal(t, l, plView.get(id), "view docID %d", id)
 	}

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_qa270_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_qa270_test.go
@@ -54,7 +54,7 @@ func TestProplen270_BoundaryMaxUint32(t *testing.T) {
 		maxID      uint64
 		wantNarrow bool
 	}{
-		{"max_eq_maxuint32_is_narrow", math.MaxUint32, true},      // 2^32-1 fits uint32 (inclusive)
+		{"max_eq_maxuint32_is_narrow", math.MaxUint32, true},           // 2^32-1 fits uint32 (inclusive)
 		{"max_eq_maxuint32_plus_1_is_wide", math.MaxUint32 + 1, false}, // 2^32 must stay uint64
 	}
 	for _, tc := range cases {
@@ -97,7 +97,7 @@ func TestProplen270_BoundaryMaxUint32(t *testing.T) {
 func TestProplen270_ZeroLengthHighDocIDStaysWide(t *testing.T) {
 	const highID = uint64(1) << 33 // > MaxUint32
 	want := map[uint64]uint32{
-		3:      0,  // zero-length: forces pairs AND is where the dense gate early-stops
+		3:      0, // zero-length: forces pairs AND is where the dense gate early-stops
 		7:      5,
 		50:     9,
 		highID: 12, // true max, far beyond uint32

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_qa270_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_qa270_test.go
@@ -1,0 +1,124 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// flushPropLenSegmentQA flushes one inverted segment whose stored property
+// lengths are exactly `want` (docID -> length; a length of 0 is stored verbatim,
+// which forces the pairs layout) and returns the on-disk segment.
+func flushPropLenSegmentQA(t *testing.T, want map[uint64]uint32) (Segment, func()) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	key := []byte("term")
+	for docID, l := range want {
+		require.NoError(t, bucket.MapSet(key, NewMapPairFromDocIdAndTf(docID, 1, float32(l), false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+	view := bucket.GetConsistentView()
+	require.Len(t, view.Disk, 1)
+	return view.Disk[0], func() { view.ReleaseView(); bucket.Shutdown(ctx) }
+}
+
+// TestProplen270_BoundaryMaxUint32 pins the load-side uint32/uint64 gate at the
+// exact boundary. SC's table only covers well-under (4990) and well-over (1<<33);
+// the off-by-one at math.MaxUint32 is where a `<` vs `<=` slip would hide.
+func TestProplen270_BoundaryMaxUint32(t *testing.T) {
+	cases := []struct {
+		name       string
+		maxID      uint64
+		wantNarrow bool
+	}{
+		{"max_eq_maxuint32_is_narrow", math.MaxUint32, true},      // 2^32-1 fits uint32 (inclusive)
+		{"max_eq_maxuint32_plus_1_is_wide", math.MaxUint32 + 1, false}, // 2^32 must stay uint64
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// a few low ids + the boundary id -> huge span forces pairs (not dense)
+			want := map[uint64]uint32{0: 11, 1: 22, 2: 33, tc.maxID: 44}
+			seg, cleanup := flushPropLenSegmentQA(t, want)
+			defer cleanup()
+
+			plView, err := seg.propLengthsView()
+			require.NoError(t, err)
+			assert.Nil(t, plView.dense, "huge span must not select dense")
+			if tc.wantNarrow {
+				assert.NotNil(t, plView.ids32, "max docID == MaxUint32 must select uint32 ids")
+				assert.Nil(t, plView.ids, "narrow: no uint64 pairs")
+			} else {
+				assert.NotNil(t, plView.ids, "max docID == MaxUint32+1 must keep uint64 ids")
+				assert.Nil(t, plView.ids32, "wide: no uint32 pairs")
+			}
+			// exact lengths incl. the boundary id (a uint32 truncation of MaxUint32+1
+			// would alias to 0 and return a wrong length here)
+			for id, l := range want {
+				assert.Equal(t, l, plView.get(id), "view docID %d", id)
+			}
+			gotMap, err := seg.getPropertyLengths()
+			require.NoError(t, err)
+			assert.Equal(t, want, gotMap, "map reconstruction exact at the boundary")
+		})
+	}
+}
+
+// TestProplen270_ZeroLengthHighDocIDStaysWide is the regression test for the trap
+// the issue calls out: the dense-gate min/max loop early-stops at the first
+// zero-length doc, so its max is NOT the segment's true max. The uint32 gate must
+// use sortPropLenPairs' full-scan max instead. Here a stored 0-length forces the
+// pairs layout AND the true max is > MaxUint32 — the segment MUST keep uint64 ids
+// and must not truncate the high docID. If the gate ever regresses to the dense
+// gate's early-stopped max, this segment would be misclassified as uint32 and the
+// 1<<33 length would be silently lost.
+func TestProplen270_ZeroLengthHighDocIDStaysWide(t *testing.T) {
+	const highID = uint64(1) << 33 // > MaxUint32
+	want := map[uint64]uint32{
+		3:      0,  // zero-length: forces pairs AND is where the dense gate early-stops
+		7:      5,
+		50:     9,
+		highID: 12, // true max, far beyond uint32
+	}
+	seg, cleanup := flushPropLenSegmentQA(t, want)
+	defer cleanup()
+
+	plView, err := seg.propLengthsView()
+	require.NoError(t, err)
+	assert.Nil(t, plView.dense, "a stored 0-length must force pairs")
+	assert.NotNil(t, plView.ids, "true max > MaxUint32 must keep uint64 ids despite the early zero-length")
+	assert.Nil(t, plView.ids32, "must NOT narrow to uint32 — the high docID would be truncated")
+	assert.Equal(t, uint32(12), plView.get(highID), "high docID length must be exact, not truncated")
+	assert.Equal(t, uint32(0), plView.get(3), "stored zero-length resolves to 0")
+	assert.Equal(t, uint32(5), plView.get(7))
+
+	gotMap, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	// The pairs path of getPropertyLengths reconstructs every stored entry verbatim,
+	// including the explicit 0-length (only the dense path drops zeros — and dense is
+	// never chosen when a 0 exists, so the two paths stay consistent for real data).
+	// The point of this test: the >uint32 docID is present and exact (not truncated).
+	assert.Equal(t, want, gotMap, "map reconstruction includes every stored docID, exact, incl. the >uint32 one")
+}

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_qa270_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_qa270_test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// flushPropLenSegmentQA flushes one inverted segment whose stored property
-// lengths are exactly `want` (docID -> length; a length of 0 is stored verbatim,
-// which forces the pairs layout) and returns the on-disk segment.
+// flushPropLenSegmentQA flushes one inverted segment whose stored property lengths
+// are exactly `want` (docID -> length; a length of 0 is stored verbatim, which
+// forces the pairs layout). The on-disk pairs order is gob map-iteration order,
+// so this exercises the integrated flush→load→view path but cannot pin the
+// dense-gate scan order — the deterministic gate pin lives in the unit test for
+// selectPropLengthLayout.
 func flushPropLenSegmentQA(t *testing.T, want map[uint64]uint32) (Segment, func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -86,18 +89,16 @@ func TestProplen270_BoundaryMaxUint32(t *testing.T) {
 	}
 }
 
-// TestProplen270_ZeroLengthHighDocIDStaysWide is the regression test for the trap
-// the issue calls out: the dense-gate min/max loop early-stops at the first
-// zero-length doc, so its max is NOT the segment's true max. The uint32 gate must
-// use sortPropLenPairs' full-scan max instead. Here a stored 0-length forces the
-// pairs layout AND the true max is > MaxUint32 — the segment MUST keep uint64 ids
-// and must not truncate the high docID. If the gate ever regresses to the dense
-// gate's early-stopped max, this segment would be misclassified as uint32 and the
-// 1<<33 length would be silently lost.
+// TestProplen270_ZeroLengthHighDocIDStaysWide is the integrated-path check for the
+// trap the issue calls out: a stored zero-length forces the pairs layout, and the
+// segment's true max (highID) exceeds uint32, so the segment must keep uint64 ids
+// and must not truncate the high docID. This exercises the real flush→load→view→get
+// path; the flush order (and thus the dense-gate scan order) is gob-random, so the
+// deterministic regression pin lives in TestSelectPropLengthLayout_* instead.
 func TestProplen270_ZeroLengthHighDocIDStaysWide(t *testing.T) {
-	const highID = uint64(1) << 33 // > MaxUint32
+	const highID = uint64(1) << 33 // > MaxUint32, the true max
 	want := map[uint64]uint32{
-		3:      0, // zero-length: forces pairs AND is where the dense gate early-stops
+		3:      0, // zero-length: forces pairs
 		7:      5,
 		50:     9,
 		highID: 12, // true max, far beyond uint32

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_test.go
@@ -51,9 +51,14 @@ func TestSortPropLenPairs(t *testing.T) {
 				want[id] = lens[i]
 			}
 
-			sortPropLenPairs(ids, lens)
+			gotMax := sortPropLenPairs(ids, lens)
 
 			require.True(t, sort.SliceIsSorted(ids, func(i, j int) bool { return ids[i] < ids[j] }))
+			var wantMax uint64
+			if len(ids) > 0 {
+				wantMax = ids[len(ids)-1] // sorted ascending: max is last
+			}
+			assert.Equal(t, wantMax, gotMax, "returned max docID gates the uint32-ids layout")
 			for i, id := range ids {
 				assert.Equal(t, want[id], lens[i], "length must move together with id %d", id)
 			}
@@ -75,18 +80,27 @@ func TestSortPropLenPairs(t *testing.T) {
 			want[ids[i]] = lens[i]
 		}
 
-		sortPropLenPairs(ids, lens)
+		gotMax := sortPropLenPairs(ids, lens)
 
 		require.True(t, sort.SliceIsSorted(ids, func(i, j int) bool { return ids[i] < ids[j] }))
+		require.Equal(t, ids[n-1], gotMax, "returned max docID")
 		for i, id := range ids {
 			require.Equal(t, want[id], lens[i])
 		}
 	})
 }
 
+type plLayout int
+
+const (
+	plDense plLayout = iota
+	plPairs64
+	plPairs32 // ids stored as []uint32 (requires every id <= MaxUint32)
+)
+
 // buildView constructs a view over the given docID->length set in the requested
-// representation, mirroring loadPropertyLengths' two layouts.
-func buildView(t *testing.T, m map[uint64]uint32, dense bool) propLengthsView {
+// representation, mirroring loadPropertyLengths' layouts.
+func buildView(t *testing.T, m map[uint64]uint32, layout plLayout) propLengthsView {
 	t.Helper()
 	ids := make([]uint64, 0, len(m))
 	for id := range m {
@@ -94,7 +108,7 @@ func buildView(t *testing.T, m map[uint64]uint32, dense bool) propLengthsView {
 	}
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 
-	if dense {
+	if layout == plDense {
 		require.NotEmpty(t, m, "dense layout needs at least one entry")
 		minID, maxID := ids[0], ids[len(ids)-1]
 		arr := make([]uint32, maxID-minID+1)
@@ -107,6 +121,14 @@ func buildView(t *testing.T, m map[uint64]uint32, dense bool) propLengthsView {
 	lens := make([]uint32, len(ids))
 	for i, id := range ids {
 		lens[i] = m[id]
+	}
+	if layout == plPairs32 {
+		ids32 := make([]uint32, len(ids))
+		for i, id := range ids {
+			require.LessOrEqual(t, id, uint64(math.MaxUint32), "plPairs32 needs all ids <= MaxUint32")
+			ids32[i] = uint32(id)
+		}
+		return propLengthsView{ids32: ids32, lens: lens}
 	}
 	return propLengthsView{ids: ids, lens: lens}
 }
@@ -124,14 +146,14 @@ func TestPropLengthsViewGet(t *testing.T) {
 	}
 
 	for _, layout := range []struct {
-		name  string
-		dense bool
-	}{{"pairs", false}, {"dense", true}} {
+		name   string
+		layout plLayout
+	}{{"pairs", plPairs64}, {"pairs32", plPairs32}, {"dense", plDense}} {
 		t.Run(layout.name, func(t *testing.T) {
 			t.Parallel()
 
 			t.Run("ascending_scan_hits_everything", func(t *testing.T) {
-				v := buildView(t, sparse, layout.dense)
+				v := buildView(t, sparse, layout.layout)
 				ids := make([]uint64, 0, len(sparse))
 				for id := range sparse {
 					ids = append(ids, id)
@@ -143,7 +165,7 @@ func TestPropLengthsViewGet(t *testing.T) {
 			})
 
 			t.Run("ascending_scan_with_misses", func(t *testing.T) {
-				v := buildView(t, sparse, layout.dense)
+				v := buildView(t, sparse, layout.layout)
 				ids := make([]uint64, 0, len(sparse))
 				for id := range sparse {
 					ids = append(ids, id)
@@ -158,7 +180,7 @@ func TestPropLengthsViewGet(t *testing.T) {
 			})
 
 			t.Run("random_access_restarts_cursor", func(t *testing.T) {
-				v := buildView(t, sparse, layout.dense)
+				v := buildView(t, sparse, layout.layout)
 				ids := make([]uint64, 0, len(sparse))
 				for id := range sparse {
 					ids = append(ids, id) // map order = random jumps incl. backward
@@ -169,7 +191,7 @@ func TestPropLengthsViewGet(t *testing.T) {
 			})
 
 			t.Run("out_of_range", func(t *testing.T) {
-				v := buildView(t, sparse, layout.dense)
+				v := buildView(t, sparse, layout.layout)
 				assert.Equal(t, uint32(0), v.get(0))
 				assert.Equal(t, uint32(0), v.get(99))
 				assert.Equal(t, uint32(0), v.get(math.MaxUint64))
@@ -181,7 +203,7 @@ func TestPropLengthsViewGet(t *testing.T) {
 			})
 
 			t.Run("repeated_lookup_same_doc", func(t *testing.T) {
-				v := buildView(t, sparse, layout.dense)
+				v := buildView(t, sparse, layout.layout)
 				for id, l := range sparse {
 					require.Equal(t, l, v.get(id))
 					require.Equal(t, l, v.get(id))
@@ -209,10 +231,20 @@ func TestPropLengthsViewGet(t *testing.T) {
 		for k := range m {
 			m[k] = uint32(k%97 + 1)
 		}
-		v := buildView(t, m, false)
+		v := buildView(t, m, plPairs64)
 		for i := uint64(1000); i < 2000; i++ {
 			require.Equal(t, m[i], v.get(i))
 		}
+	})
+
+	t.Run("pairs32_query_above_uint32_range_misses", func(t *testing.T) {
+		t.Parallel()
+		m := map[uint64]uint32{1: 5, 1000: 7, math.MaxUint32: 9}
+		v := buildView(t, m, plPairs32)
+		require.Equal(t, uint32(9), v.get(math.MaxUint32))   // largest in-range id hits
+		require.Equal(t, uint32(0), v.get(math.MaxUint32+1)) // one past the range short-circuits
+		require.Equal(t, uint32(0), v.get(math.MaxUint64))   // far past, no panic/scan
+		require.Equal(t, uint32(5), v.get(1))                // in-range still resolves afterwards
 	})
 }
 


### PR DESCRIPTION
SuperClaude here.

Implements weaviate/0-weaviate-issues#270 — a follow-up to weaviate/weaviate#11753.

**What.** In the sparse property-length **pairs** layout, ids were `[]uint64` (8B). When a segment's max docID fits uint32 (the common case), they're now `[]uint32` (4B) — cutting the pairs entry from **12B → 8B**, a 1.5× reduction on the pairs path.

**Why it's safe.** The gate is a runtime per-segment decision (`maxID <= MaxUint32`), never an assumption — docIDs aren't reused on delete, so a churned shard can exceed uint32 with few live docs. `maxID` comes free from `sortPropLenPairs`' radix scan (now returned), not the dense gate's early-stop. On-disk pairs format (`EncodePairs`/`DecodePairs`) stays uint64, so this is **format-compatible**; the narrow width is resident-memory only (compaction/`getPropertyLengths` widen transiently).

**Hot path.** `propLengthsView.get` dispatches to a generic `propLenPairLookup[uint32|uint64]` the compiler specializes, so the cursor pays no per-access width branch and the ~80-line lookup isn't duplicated. A query docID `> MaxUint32` against a uint32-ids segment short-circuits to a miss.

**Memory win (measured).** Post-GC `HeapAlloc` over a real `propLengthsView`: 10M resident pairs drop 114.4 MB → 76.3 MB (38.1 MB / 33.3%), matching the 12→8B arithmetic to GC granularity with no per-view overhead (measured by QA Claude, weaviate/weaviate#11855 thread). That 33% is the **per-pairs-segment** win; whole-cluster realization scales by the share of resident proplen bytes in sparse/pairs segments — dense (sequentially-ingested) segments take the `dense []uint32` no-op path — so it's workload-dependent. #11753's benchmark put that share near ~47% of resident entries; illustrative, not a guarantee for every workload.

**Tests** (all green under `-race`): view-level differential across all access orders for the uint32 path, the `>MaxUint32` short-circuit, the load-time gate (narrow vs uint64 fallback), `sortPropLenPairs`' returned max, an 8B/entry measurement, and the free-clears-`ids32` path. BM25F block comparison suite stays bit-identical.

**Base.** Rebased directly onto `stable/v1.37` now that the proplen-memory series merged (weaviate/weaviate#11753, weaviate/weaviate#11754). Net diff is the issue-270 delta only: `segment_inverted.go` plus the proplen tests.

— SuperClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgqYrgFA9YappDWqdvhtr2

