### PR TITLE
fix(compact): truncate corrupt compacted segments to last valid record on load

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/crash_recovery_test.go
@@ -234,6 +234,18 @@ func TestCrashRecovery_TruncatedCompactedWALFilesRecover(t *testing.T) {
 				require.GreaterOrEqual(t, len(result.State.Graph.Nodes), 2)
 				require.NotNil(t, result.State.Graph.Nodes[0])
 				require.NotNil(t, result.State.Graph.Nodes[1])
+
+				// Recovery truncates the segment back to its last valid record,
+				// so the file is now clean: a second load reads it without any
+				// further recovery, and still sees the same surviving records.
+				// This is what keeps the next compaction from tripping on it.
+				result2, err := NewLoader(LoaderConfig{Dir: dir, Logger: crashTestLogger()}).Load()
+				require.NoError(t, err)
+				require.NotNil(t, result2)
+				assert.False(t, result2.RecoveredFromCrash, "second load should be clean after truncation")
+				require.GreaterOrEqual(t, len(result2.State.Graph.Nodes), 2)
+				require.NotNil(t, result2.State.Graph.Nodes[0])
+				require.NotNil(t, result2.State.Graph.Nodes[1])
 			})
 		}
 	}

--- a/adapters/repos/db/vector/hnsw/compact/loader.go
+++ b/adapters/repos/db/vector/hnsw/compact/loader.go
@@ -275,32 +275,15 @@ func (l *Loader) loadWALFile(f FileInfo, state *ent.DeserializationResult) (*ent
 		case FileTypeRaw:
 			// Raw/live WAL files may be interrupted mid-write by a crash,
 			// leaving a partial record at the tail. Keep the complete records
-			// and truncate the file to the last valid commit so the next write
-			// starts from a clean boundary. Only torn-tail errors are
+			// and truncate the file back to its last valid commit so the next
+			// write starts from a clean boundary. Only torn-tail errors are
 			// recoverable here; anything else is a genuine read failure.
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				l.config.Logger.WithFields(logrus.Fields{
 					"action": "hnsw_loader",
 					"file":   f.Path,
 				}).Warnf("WAL file truncated - recovering from crash: %v", err)
-
-				// Truncate raw files to remove partial entries.
-				// This prevents the partial entry from becoming corrupted on next write
-				// and ensures clean compaction later.
-				validBytes := walReader.BytesRead()
-				if truncErr := l.fs.Truncate(f.Path, validBytes); truncErr != nil {
-					l.config.Logger.
-						WithField("file", f.Path).
-						WithField("valid_bytes", validBytes).
-						Errorf("failed to truncate corrupt WAL file: %v", truncErr)
-				} else {
-					l.config.Logger.WithFields(logrus.Fields{
-						"action":      "hnsw_loader",
-						"file":        f.Path,
-						"valid_bytes": validBytes,
-					}).Info("truncated corrupt WAL file")
-				}
-
+				l.truncateToLastValidRecord(f.Path, walReader.LastValidOffset())
 				return result, true, nil // true = recovered from crash
 			}
 			return result, false, err
@@ -308,25 +291,26 @@ func (l *Loader) loadWALFile(f FileInfo, state *ent.DeserializationResult) (*ent
 		case FileTypeSorted, FileTypeCondensed:
 			// Compacted segments are immutable and written atomically via
 			// SafeFileWriter (temp file + fsync + rename), so the committed
-			// bytes are never torn by a crash. A read error here therefore
-			// means the on-disk file is corrupt from disk-level damage (a
-			// truncated or garbage-appended tail). Failing the whole index
-			// load over one bad segment would take the entire collection
-			// offline, so instead we drop the unreadable segment and recover
-			// from the snapshot plus the segments already applied. `result`
-			// keeps the records read before the corruption, and replay
-			// continues with the remaining files.
+			// bytes are never torn by a crash. A read error here means the
+			// on-disk file is corrupt from disk-level damage (a truncated or
+			// garbage-appended tail). Failing the whole index load over one bad
+			// segment would take the entire collection offline, so instead we
+			// truncate the file back to its last valid record: the records read
+			// before the corruption are kept (best-effort recall), and the file
+			// becomes valid again so the next compaction reads it without
+			// stalling. The damaged tail is unrecoverable regardless.
 			//
 			// This only relaxes the *load* path. Compaction still fails closed
 			// when it reads a corrupt merge input (see Compactor / the merge
-			// iterators), so a corrupt segment can never be silently merged
-			// away and have its still-valid sources deleted.
+			// iterators); repairing the file here just means a segment whose
+			// corruption is detected at load never reaches that merge as a torn
+			// input in the first place.
 			l.config.Logger.WithFields(logrus.Fields{
 				"action": "hnsw_loader",
 				"file":   f.Path,
 				"type":   f.Type.String(),
-			}).Warnf("corrupt compacted commit log segment - dropping it and recovering from snapshot: %v", err)
-
+			}).Warnf("corrupt compacted commit log segment - truncating to last valid record and recovering: %v", err)
+			l.truncateToLastValidRecord(f.Path, walReader.LastValidOffset())
 			return result, true, nil // true = recovered from crash
 
 		default:
@@ -343,6 +327,27 @@ func (l *Loader) loadWALFile(f FileInfo, state *ent.DeserializationResult) (*ent
 	}).Debug("loaded WAL file")
 
 	return result, false, nil
+}
+
+// truncateToLastValidRecord truncates a corrupt WAL file back to the end of its
+// last fully decoded commit (walReader.LastValidOffset), removing a torn or
+// garbage-appended tail. After this the file is a valid, shorter WAL again, so a
+// later load or compaction no longer trips on the same corruption. A truncation
+// failure is logged but not fatal: the in-memory state has already been
+// recovered from the valid prefix.
+func (l *Loader) truncateToLastValidRecord(path string, validBytes int64) {
+	if err := l.fs.Truncate(path, validBytes); err != nil {
+		l.config.Logger.
+			WithField("file", path).
+			WithField("valid_bytes", validBytes).
+			Errorf("failed to truncate corrupt WAL file: %v", err)
+		return
+	}
+	l.config.Logger.WithFields(logrus.Fields{
+		"action":      "hnsw_loader",
+		"file":        path,
+		"valid_bytes": validBytes,
+	}).Info("truncated corrupt WAL file to last valid record")
 }
 
 // maxNodeIDInWALs scans the given WAL files for the highest node ID they

--- a/adapters/repos/db/vector/hnsw/compact/wal_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/wal_reader.go
@@ -195,6 +195,12 @@ type WALCommitReader struct {
 	countingR *countingReader // tracks bytes read from underlying reader
 	logger    logrus.FieldLogger
 
+	// lastValidOffset is the byte offset at the end of the last fully decoded
+	// commit. Unlike BytesRead, it never includes the partially-consumed bytes
+	// of a failed read, so it is the correct point to truncate a corrupt file
+	// back to its last valid record.
+	lastValidOffset int64
+
 	reusableBuf     []byte
 	reusableUint64s []uint64
 }
@@ -217,11 +223,30 @@ func (w *WALCommitReader) BytesRead() int64 {
 	return w.countingR.count - int64(w.r.Buffered())
 }
 
+// LastValidOffset returns the byte offset at the end of the last commit that
+// was decoded successfully. Use this (not BytesRead) to truncate a file back to
+// its last valid record after a read error: BytesRead includes the type byte
+// and any partial body consumed by the failed read, so truncating to it would
+// leave a stray fragment that re-triggers the error on the next read.
+func (w *WALCommitReader) LastValidOffset() int64 {
+	return w.lastValidOffset
+}
+
 // ReadNextCommit returns the next commit in the WAL.
 //   - (Commit, nil) on success
 //   - (nil, io.EOF) when no more commits are available
 //   - (nil, err) on other errors
+//
+// On success it advances LastValidOffset to the end of the returned commit.
 func (w *WALCommitReader) ReadNextCommit() (Commit, error) {
+	c, err := w.decodeNextCommit()
+	if err == nil {
+		w.lastValidOffset = w.BytesRead()
+	}
+	return c, err
+}
+
+func (w *WALCommitReader) decodeNextCommit() (Commit, error) {
 	ct, err := readCommitType(w.r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What's being changed:

Follow-up to #11848. That PR recovered from a corrupt `.sorted`/`.condensed` segment on load but **left the bad file on disk** — so the next compaction read it as a merge input, failed closed, and stalled compaction indefinitely while WAL files accumulated (raised in review). This **truncates the segment back to its last valid record on load** instead: the file becomes a valid, shorter WAL again, so compaction reads it without tripping. The collection stays online *and* compaction keeps making progress, with no quarantine file and no new on-disk format.

Truncation uses a new `WALCommitReader.LastValidOffset` — the byte offset at the end of the last fully decoded commit — rather than `BytesRead()`, which includes the type byte and partial body consumed by the *failed* read. Truncating to `BytesRead()` would leave a stray fragment that re-triggers the error (and would keep stalling compaction), so the clean offset is what makes the repair actually stick.

This also fixes a latent bug in the existing **raw-file** truncation, which used `BytesRead()` and so cut a few bytes into the bad record — silently re-recovering on every restart (its "subsequent loads are clean" doc comment wasn't true). Raw now cuts clean too.

**Scope:** only the load path. The compaction merge path is untouched and still fails closed on a corrupt merge input (#11802); this just repairs a segment whose corruption is detected at load, before that merge ever sees it.

| Path | Behavior |
| --- | --- |
| raw / live | truncate to last **valid record** (was: to `BytesRead`, a few bytes into the bad record) |
| `.sorted` / `.condensed` | **truncate to last valid record** so compaction no longer stalls (was: dropped in-memory, left corrupt on disk) |
| merge / compaction | unchanged — still fails closed on a corrupt input |

The recovery test now asserts a **second load is clean** (`RecoveredFromCrash == false`) across sorted/condensed × torn-record/appended-garbage, proving the file is genuinely repaired rather than re-recovered each restart.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary — internal load-path recovery behavior, no public API/doc change.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: recovery behavior is exercised by the e2e recovery suite (TC-010/012/013) in `weaviate-e2e-tests`; chaos run at reviewer's discretion.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)