### PR TITLE
perf(hnsw): single-buffer WAL writes to cut per-record allocations

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/wal_writer.go
+++ b/adapters/repos/db/vector/hnsw/compact/wal_writer.go
@@ -16,9 +16,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/multivector"
-	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/vectorindex/compression"
 	"github.com/weaviate/weaviate/usecases/byteops"
 )
@@ -36,38 +34,42 @@ func NewWALWriter(w io.Writer) *WALWriter {
 
 // WriteAddNode writes an AddNode commit.
 func (w *WALWriter) WriteAddNode(id uint64, level uint16) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, AddNode))
-	ec.Add(writeUint64(w.w, id))
-	ec.Add(writeUint16(w.w, level))
-	return ec.ToError()
+	buf := make([]byte, 11)
+	buf[0] = byte(AddNode)
+	binary.LittleEndian.PutUint64(buf[1:9], id)
+	binary.LittleEndian.PutUint16(buf[9:11], level)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteDeleteNode writes a DeleteNode commit.
 func (w *WALWriter) WriteDeleteNode(id uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, DeleteNode))
-	ec.Add(writeUint64(w.w, id))
-	return ec.ToError()
+	buf := make([]byte, 9)
+	buf[0] = byte(DeleteNode)
+	binary.LittleEndian.PutUint64(buf[1:9], id)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteSetEntryPointMaxLevel writes a SetEntryPointMaxLevel commit.
 func (w *WALWriter) WriteSetEntryPointMaxLevel(entrypoint uint64, level uint16) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, SetEntryPointMaxLevel))
-	ec.Add(writeUint64(w.w, entrypoint))
-	ec.Add(writeUint16(w.w, level))
-	return ec.ToError()
+	buf := make([]byte, 11)
+	buf[0] = byte(SetEntryPointMaxLevel)
+	binary.LittleEndian.PutUint64(buf[1:9], entrypoint)
+	binary.LittleEndian.PutUint16(buf[9:11], level)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteAddLinkAtLevel writes an AddLinkAtLevel commit.
 func (w *WALWriter) WriteAddLinkAtLevel(source uint64, level uint16, target uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, AddLinkAtLevel))
-	ec.Add(writeUint64(w.w, source))
-	ec.Add(writeUint16(w.w, level))
-	ec.Add(writeUint64(w.w, target))
-	return ec.ToError()
+	buf := make([]byte, 19)
+	buf[0] = byte(AddLinkAtLevel)
+	binary.LittleEndian.PutUint64(buf[1:9], source)
+	binary.LittleEndian.PutUint16(buf[9:11], level)
+	binary.LittleEndian.PutUint64(buf[11:19], target)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteAddLinksAtLevel writes an AddLinksAtLevel commit.
@@ -88,52 +90,57 @@ func (w *WALWriter) WriteAddLinksAtLevel(source uint64, level uint16, targets []
 
 // WriteReplaceLinksAtLevel writes a ReplaceLinksAtLevel commit.
 func (w *WALWriter) WriteReplaceLinksAtLevel(source uint64, level uint16, targets []uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, ReplaceLinksAtLevel))
-	ec.Add(writeUint64(w.w, source))
-	ec.Add(writeUint16(w.w, level))
+	targetLength := min(len(targets), math.MaxUint16)
 
-	targetLength := len(targets)
-	if targetLength > math.MaxUint16 {
-		targetLength = math.MaxUint16
+	toWrite := make([]byte, 13+targetLength*8)
+	toWrite[0] = byte(ReplaceLinksAtLevel)
+	binary.LittleEndian.PutUint64(toWrite[1:9], source)
+	binary.LittleEndian.PutUint16(toWrite[9:11], level)
+	binary.LittleEndian.PutUint16(toWrite[11:13], uint16(targetLength))
+	for i, target := range targets[:targetLength] {
+		offsetStart := 13 + i*8
+		offsetEnd := offsetStart + 8
+		binary.LittleEndian.PutUint64(toWrite[offsetStart:offsetEnd], target)
 	}
-	ec.Add(writeUint16(w.w, uint16(targetLength)))
-	ec.Add(writeUint64Slice(w.w, targets[:targetLength]))
-
-	return ec.ToError()
+	_, err := w.w.Write(toWrite)
+	return err
 }
 
 // WriteClearLinks writes a ClearLinks commit.
 func (w *WALWriter) WriteClearLinks(id uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, ClearLinks))
-	ec.Add(writeUint64(w.w, id))
-	return ec.ToError()
+	buf := make([]byte, 9)
+	buf[0] = byte(ClearLinks)
+	binary.LittleEndian.PutUint64(buf[1:9], id)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteClearLinksAtLevel writes a ClearLinksAtLevel commit.
 func (w *WALWriter) WriteClearLinksAtLevel(id uint64, level uint16) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, ClearLinksAtLevel))
-	ec.Add(writeUint64(w.w, id))
-	ec.Add(writeUint16(w.w, level))
-	return ec.ToError()
+	buf := make([]byte, 11)
+	buf[0] = byte(ClearLinksAtLevel)
+	binary.LittleEndian.PutUint64(buf[1:9], id)
+	binary.LittleEndian.PutUint16(buf[9:11], level)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteAddTombstone writes an AddTombstone commit.
 func (w *WALWriter) WriteAddTombstone(id uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, AddTombstone))
-	ec.Add(writeUint64(w.w, id))
-	return ec.ToError()
+	buf := make([]byte, 9)
+	buf[0] = byte(AddTombstone)
+	binary.LittleEndian.PutUint64(buf[1:9], id)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteRemoveTombstone writes a RemoveTombstone commit.
 func (w *WALWriter) WriteRemoveTombstone(id uint64) error {
-	ec := errorcompounder.New()
-	ec.Add(writeCommitType(w.w, RemoveTombstone))
-	ec.Add(writeUint64(w.w, id))
-	return ec.ToError()
+	buf := make([]byte, 9)
+	buf[0] = byte(RemoveTombstone)
+	binary.LittleEndian.PutUint64(buf[1:9], id)
+	_, err := w.w.Write(buf)
+	return err
 }
 
 // WriteResetIndex writes a ResetIndex commit.
@@ -329,13 +336,4 @@ func writeBool(w io.Writer, v bool) error {
 	}
 	_, err := w.Write(b[:])
 	return err
-}
-
-func writeUint64Slice(w io.Writer, slice []uint64) error {
-	for _, v := range slice {
-		if err := writeUint64(w, v); err != nil {
-			return errors.Wrap(err, "write uint64 slice element")
-		}
-	}
-	return nil
 }

--- a/adapters/repos/db/vector/hnsw/compact/wal_writer_alloc_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/wal_writer_alloc_test.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compact
+
+import (
+	"io"
+	"testing"
+)
+
+// TestWALWriterAllocations guards against the regression described in
+// 0-weaviate-issues#271: the per-record WAL write path must serialize each
+// commit into a single buffer and emit exactly one Write, allocating at most
+// once per record.
+//
+// The original field-by-field implementation allocated once per field (every
+// writeUintXX helper passed a stack array as []byte to the io.Writer
+// interface, which escapes to the heap) plus once for errorcompounder.New(),
+// and ReplaceLinksAtLevel allocated once *per target*. That made tombstone
+// cleanup — which calls ReplaceLinksAtLevel once per reassigned neighbor per
+// layer — several times slower on hnsw-compact-v2 than on main. These bounds
+// match what commitlog.Logger (the main baseline) achieves.
+func TestWALWriterAllocations(t *testing.T) {
+	w := NewWALWriter(io.Discard)
+
+	// A full neighbourhood at layer 0 (M=64 → 128 connections) to prove the
+	// ReplaceLinksAtLevel cost no longer scales with the number of targets.
+	targets := make([]uint64, 128)
+	for i := range targets {
+		targets[i] = uint64(i)
+	}
+
+	tests := []struct {
+		name      string
+		fn        func() error
+		maxAllocs float64
+	}{
+		{"AddNode", func() error { return w.WriteAddNode(1, 3) }, 1},
+		{"DeleteNode", func() error { return w.WriteDeleteNode(1) }, 1},
+		{"SetEntryPointMaxLevel", func() error { return w.WriteSetEntryPointMaxLevel(1, 3) }, 1},
+		{"AddLinkAtLevel", func() error { return w.WriteAddLinkAtLevel(1, 2, 3) }, 1},
+		{"ReplaceLinksAtLevel", func() error { return w.WriteReplaceLinksAtLevel(1, 0, targets) }, 1},
+		{"ClearLinks", func() error { return w.WriteClearLinks(1) }, 1},
+		{"ClearLinksAtLevel", func() error { return w.WriteClearLinksAtLevel(1, 2) }, 1},
+		{"AddTombstone", func() error { return w.WriteAddTombstone(1) }, 1},
+		{"RemoveTombstone", func() error { return w.WriteRemoveTombstone(1) }, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allocs := testing.AllocsPerRun(200, func() {
+				if err := tt.fn(); err != nil {
+					t.Fatal(err)
+				}
+			})
+			if allocs > tt.maxAllocs {
+				t.Errorf("got %.1f allocs/op, want <= %.1f", allocs, tt.maxAllocs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Fixes the HNSW tombstone-cleanup slowdown on `hnsw-compact-v2` reported in [0-weaviate-issues#271](https://github.com/weaviate/0-weaviate-issues/issues/271).

**Root cause:** the new `compact.WALWriter` serialized each commit record field-by-field through `writeUintXX` helpers. Each helper passes a stack array as `[]byte` to the `io.Writer` interface, which escapes to the heap — so a record that should cost **1 allocation** cost **3–5**, plus an `errorcompounder.New()` per call. Worst of all, `WriteReplaceLinksAtLevel` wrote **one element at a time**, costing one allocation *per neighbor*. Tombstone cleanup calls `ReplaceLinksAtLevel` once per reassigned neighbor per layer, so the writer layer ran ~5–7× slower than on `main` (≈15% slower end-to-end cleanup on a laptop; absorbed by GC headroom on the perf machine).

**Fix:** serialize each record into a single buffer and emit one `Write`, matching the existing `WriteAddLinksAtLevel` in the same file and the `commitlog.Logger` baseline on `main`. Removed the now-unused `writeUint64Slice` helper and its imports.

**Result (allocations/record, before → after):**

| Method | before | after |
|---|---|---|
| RemoveTombstone / DeleteNode | 3 | 1 |
| AddLinkAtLevel | 5 | 1 |
| ReplaceLinksAtLevel (128 targets) | 133 | 1 |

The on-disk WAL format is byte-for-byte unchanged (round-trip and full `compact` suite pass under `-race`).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: _not necessary (internal write path, no format/API change)_
- [ ] Chaos pipeline run or not necessary. Link to pipeline: _not necessary_
- [x] All new code is covered by tests where it is reasonable. _Added `TestWALWriterAllocations`, which fails on the old writer and passes on the new one._
- [x] Performance tests have been run or not necessary. _Allocation regression test added; isolated writer cost restored to `main` levels (1 alloc/record)._
