### PR TITLE
fix: persist advanced update time when object content is unchanged

### DIFF
--- a/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
@@ -15,6 +15,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -808,14 +809,21 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				require.NoError(t, err)
 			})
 
-			t.Run("verify same docID, same timestamps", func(t *testing.T) {
+			t.Run("verify same docID, advanced timestamps", func(t *testing.T) {
 				expectedNextDocID := uint64(1)
 				require.Equal(t, expectedNextDocID, shard.Counter().Get())
 
 				found := search(t, shard, filterId)
 				require.Len(t, found, 1)
-				require.Equal(t, origCreateTimeUnix, found[0].CreationTimeUnix())
-				require.Equal(t, origUpdateTimeUnix, found[0].LastUpdateTimeUnix())
+				require.Equal(t, updCreateTimeUnix, found[0].CreationTimeUnix())
+				require.Equal(t, updUpdateTimeUnix, found[0].LastUpdateTimeUnix())
+			})
+
+			t.Run("timestamp inverted index reflects advanced update time", func(t *testing.T) {
+				filterNew := filterEqual[string](fmt.Sprint(updUpdateTimeUnix), schema.DataTypeText, class.Class, "_lastUpdateTimeUnix")
+				require.Len(t, search(t, shard, filterNew), 1)
+				filterOld := filterEqual[string](fmt.Sprint(origUpdateTimeUnix), schema.DataTypeText, class.Class, "_lastUpdateTimeUnix")
+				require.Empty(t, search(t, shard, filterOld))
 			})
 
 			t.Run("verify search after put same as add", verifySearchAfterAdd(shard))
@@ -916,14 +924,14 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 				require.NoError(t, err)
 			})
 
-			t.Run("verify same docID, same timestamps", func(t *testing.T) {
+			t.Run("verify same docID, advanced update timestamp", func(t *testing.T) {
 				expectedNextDocID := uint64(1)
 				require.Equal(t, expectedNextDocID, shard.Counter().Get())
 
 				found := search(t, shard, filterId)
 				require.Len(t, found, 1)
 				require.Equal(t, origCreateTimeUnix, found[0].CreationTimeUnix())
-				require.Equal(t, origUpdateTimeUnix, found[0].LastUpdateTimeUnix())
+				require.Equal(t, updUpdateTimeUnix, found[0].LastUpdateTimeUnix())
 			})
 
 			t.Run("verify search after merge same as add", verifySearchAfterAdd(shard))
@@ -1194,14 +1202,14 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 					require.NoError(t, queue.Wait(t.Context()))
 				})
 
-				t.Run("verify same docID, same timestamps", func(t *testing.T) {
+				t.Run("verify same docID, advanced timestamps", func(t *testing.T) {
 					expectedNextDocID := uint64(1)
 					require.Equal(t, expectedNextDocID, shard.Counter().Get())
 
 					found := search(t, shard, filterId)
 					require.Len(t, found, 1)
-					require.Equal(t, origCreateTimeUnix, found[0].CreationTimeUnix())
-					require.Equal(t, origUpdateTimeUnix, found[0].LastUpdateTimeUnix())
+					require.Equal(t, updCreateTimeUnix, found[0].CreationTimeUnix())
+					require.Equal(t, updUpdateTimeUnix, found[0].LastUpdateTimeUnix())
 				})
 
 				t.Run("verify search after 2nd batch same as 1st", verifySearchAfterAdd(shard))

--- a/adapters/repos/db/shard_skipupsert_timestamp_test.go
+++ b/adapters/repos/db/shard_skipupsert_timestamp_test.go
@@ -1,0 +1,91 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	routerTypes "github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// Empty (but non-nil) properties reach the content-equality path so two versions
+// differ only by LastUpdateTimeUnix.
+func objWithEmptyPropsAndTime(class string, id strfmt.UUID, updateTime int64) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:                 id,
+			Class:              class,
+			Properties:         map[string]interface{}{},
+			LastUpdateTimeUnix: updateTime,
+		},
+	}
+}
+
+// TestPutIdenticalContentAdvancesUpdateTime reproduces the async-replication
+// perpetual-propagation loop: a write whose content is byte-identical to the
+// stored object but carries a newer update time must still advance the persisted
+// update time, otherwise the update-time-based digest comparison never converges
+// and the object is re-propagated on every hashbeat. This is what "multiple
+// update requests with the same content" produce across replicas that observe
+// the writes at different points.
+func TestPutIdenticalContentAdvancesUpdateTime(t *testing.T) {
+	ctx := context.Background()
+	const class = "SkipUpsertTimestampConvergence"
+
+	const (
+		tsMiddle int64 = 2_000
+		tsNewer  int64 = 3_000
+	)
+
+	tests := []struct {
+		name           string
+		firstTime      int64
+		secondTime     int64
+		wantStoredTime int64
+	}{
+		{name: "newer identical update advances and converges", firstTime: tsMiddle, secondTime: tsNewer, wantStoredTime: tsNewer},
+		{name: "equal identical update is a no-op", firstTime: tsMiddle, secondTime: tsMiddle, wantStoredTime: tsMiddle},
+		{name: "older identical update does not regress", firstTime: tsNewer, secondTime: tsMiddle, wantStoredTime: tsNewer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sl, _ := testShard(t, ctx, class)
+			s := concreteShard(t, sl)
+
+			require.NoError(t, sl.PutObject(ctx, objWithEmptyPropsAndTime(class, uuidLow, tt.firstTime)))
+			require.NoError(t, sl.PutObject(ctx, objWithEmptyPropsAndTime(class, uuidLow, tt.secondTime)))
+
+			obj, err := s.ObjectByID(ctx, uuidLow, nil, additional.Properties{})
+			require.NoError(t, err)
+			require.NotNil(t, obj)
+			assert.Equal(t, tt.wantStoredTime, obj.LastUpdateTimeUnix())
+
+			out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
+				{ID: string(uuidLow), UpdateTime: tt.wantStoredTime},
+			})
+			require.NoError(t, err)
+			assert.Empty(t, out, "replicas converged; no further propagation expected")
+		})
+	}
+}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -439,6 +439,14 @@ func (s *Shard) determineInsertStatus(prevObj, nextObj *storobj.Object) (objectI
 	// any update of geo property needs new docID for updating geo index.
 	if preserve, skip := compareObjsForInsertStatus(prevObj, nextObj); preserve || skip {
 		out.docID = prevObj.DocID
+		// Content unchanged, but if the update time advanced, take the docID-preserved
+		// path instead of skipping: it refreshes the object row, hashtree leaf and
+		// inverted index (incl. timestamp postings) while leaving the unchanged vector
+		// index alone. Skipping would persist a stale update time and break
+		// timestamp-based reconciliation (async replication, read-repair).
+		if skip && nextObj.LastUpdateTimeUnix() > prevObj.LastUpdateTimeUnix() {
+			preserve, skip = true, false
+		}
 		out.docIDPreserved = preserve
 		out.skipUpsert = skip
 		return out, nil


### PR DESCRIPTION
## Root cause

The object write path (`putObjectLSM` → `determineInsertStatus` → `compareObjsForInsertStatus`) decides whether a write is a no-op (`skipUpsert`) purely from **content** — properties, vectors and additional props. It never looks at the **update time**. When content matches the stored object, the whole write is dropped, including the timestamp.

So a re-PUT / update / merge that carries a newer update time but unchanged content leaves the persisted `LastUpdateTimeUnix` **stale**. This is a general write-path correctness issue, not specific to async replication — it affects update-time accuracy and any timestamp-based reconciliation.

It becomes a visible, persistent problem for reconciliation that compares replicas by update time:

- **Async replication** and **read-repair** flag an object when the source's update time is greater than the local one. Two replicas holding byte-identical content at different update times (e.g. repeated same-content updates, or update-then-revert, observed at different points / during lag) can never converge: the lagging replica keeps being flagged and re-propagated on every hashbeat, indefinitely. This showed up as a small, flat, non-draining propagation count over ~24h.

## Fix

In `determineInsertStatus`, when content is unchanged but the update time advanced, take the existing **docID-preserved** path instead of skipping:

- the object row, hashtree leaf and inverted index are refreshed — including the `_lastUpdateTimeUnix` / `_creationTimeUnix` timestamp postings when `IndexTimestamps` is enabled, so those stay consistent with the stored row;
- the unchanged **vector index** is left alone (no reindex);
- gated on **strictly newer** (`>`), so a write can never regress the stored time.

This keeps the persisted timestamp and its inverted-index postings consistent and lets timestamp-based reconciliation converge.

## Key review areas

- `determineInsertStatus` in `adapters/repos/db/shard_write_put.go` — the new content-unchanged/time-advanced branch.
- Comparator choice `>` (monotonic, never regress) vs `!=`.

## Behavior change

A re-PUT / update / merge of identical content carrying a newer `updateTime` now advances the stored `LastUpdateTimeUnix` (previously a complete no-op, issue #3949). The expensive vector reindex is still skipped, so the optimization intent is preserved.

## Tests

- **New** `TestPutIdenticalContentAdvancesUpdateTime` — table-driven: newer identical update advances the stored time and `CompareDigests` converges; equal is a no-op; older does not regress. Fails before the fix.
- **Updated** `TestShard_SkipVectorReindex` — the "replace/merge with same object, same vector" subtests now expect the advanced timestamps (docID preserved, vector not reindexed), plus a new assertion that the `_lastUpdateTimeUnix` inverted index reflects the advanced time (old time no longer matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)