### PR TITLE
Namespaces: Match colon-containing user/group ids literally for global callers

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -174,7 +174,7 @@ func (h *authZHandlers) createRole(params authz.CreateRoleParams, principal *mod
 		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("you cannot create role with the same name as built-in role %s", *params.Body.Name)))
 	}
 
-	if err := h.validateNoQualifiedNamespaceInPolicies(policies[*params.Body.Name]); err != nil {
+	if err := h.validateNoQualifiedNamespaceInPolicies(principal, policies[*params.Body.Name]); err != nil {
 		return authz.NewCreateRoleUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
@@ -225,7 +225,7 @@ func (h *authZHandlers) addPermissions(params authz.AddPermissionsParams, princi
 		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid permissions %w", err)))
 	}
 
-	if err := h.validateNoQualifiedNamespaceInPolicies(policies[params.ID]); err != nil {
+	if err := h.validateNoQualifiedNamespaceInPolicies(principal, policies[params.ID]); err != nil {
 		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
@@ -1234,18 +1234,28 @@ func (h *authZHandlers) validateUserIDForNamespaces(userID string) error {
 	return nil
 }
 
-// validateNoQualifiedNamespaceInPolicies rejects role-definition policies
-// whose resource paths contain the namespace separator. On namespace-enabled
-// clusters role definitions must remain namespace-relative templates; the
-// matcher specializes them at enforce time. No-op when namespaces are disabled.
-func (h *authZHandlers) validateNoQualifiedNamespaceInPolicies(policies []authorization.Policy) error {
+// validateNoQualifiedNamespaceInPolicies rejects role-definition policies that
+// carry an explicit namespace qualification. On namespace-enabled clusters role
+// definitions must stay namespace-relative templates; the matcher specializes
+// them at enforce time. No-op when namespaces are disabled.
+//
+// A ':' in a users/<id> or groups/<...> id is part of the opaque id (e.g. an
+// OIDC username), not a qualifier, so a global caller may use it. Namespaced
+// callers must still submit short, unqualified forms — symmetric with the
+// class-name rule that forbids them typing any "<namespace>:" prefix.
+func (h *authZHandlers) validateNoQualifiedNamespaceInPolicies(principal *models.Principal, policies []authorization.Policy) error {
 	if !h.namespacesEnabled {
 		return nil
 	}
+	global := principal == nil || principal.Namespace == ""
 	for _, p := range policies {
-		if conv.ContainsNamespaceSeparator(p.Resource) {
-			return fmt.Errorf("role permissions must not contain namespace-qualified resource paths; got %q", p.Resource)
+		if !conv.ContainsNamespaceSeparator(p.Resource) {
+			continue
 		}
+		if global && conv.IsOpaqueIDResource(p.Resource) {
+			continue
+		}
+		return fmt.Errorf("role permissions must not contain namespace-qualified resource paths; got %q", p.Resource)
 	}
 	return nil
 }

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -1242,7 +1242,9 @@ func (h *authZHandlers) validateUserIDForNamespaces(userID string) error {
 // A ':' in a users/<id> or groups/<...> id is part of the opaque id (e.g. an
 // OIDC username), not a qualifier, so a global caller may use it. Namespaced
 // callers must still submit short, unqualified forms — symmetric with the
-// class-name rule that forbids them typing any "<namespace>:" prefix.
+// class-name rule that forbids them typing any "<namespace>:" prefix. So a
+// namespaced caller cannot express a colon-bearing group id; acceptable while
+// group grants are global-only. Revisit if namespaced callers gain them.
 func (h *authZHandlers) validateNoQualifiedNamespaceInPolicies(principal *models.Principal, policies []authorization.Policy) error {
 	if !h.namespacesEnabled {
 		return nil

--- a/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
@@ -382,54 +382,92 @@ func TestAddPermissionsInternalServerError(t *testing.T) {
 }
 
 func TestValidateNoQualifiedNamespaceInPolicies(t *testing.T) {
+	global := &models.Principal{Username: "root"}
+	namespaced := &models.Principal{Username: "alice", Namespace: "customer1"}
+
 	tests := []struct {
 		name              string
 		namespacesEnabled bool
+		principal         *models.Principal
 		policies          []authorization.Policy
 		wantErr           bool
 	}{
 		{
 			name:              "namespaces disabled: qualified resource accepted",
 			namespacesEnabled: false,
+			principal:         namespaced,
 			policies:          []authorization.Policy{{Resource: "schema/collections/customer1:Movies/shards/#"}},
 		},
 		{
-			name:              "namespaces enabled: ns-relative resource accepted",
+			name:              "ns-relative resource accepted",
 			namespacesEnabled: true,
+			principal:         global,
 			policies:          []authorization.Policy{{Resource: "schema/collections/Movies/shards/#"}},
 		},
 		{
-			name:              "namespaces enabled: qualified collection segment rejected",
+			name:              "qualified collection segment rejected (global)",
 			namespacesEnabled: true,
+			principal:         global,
 			policies:          []authorization.Policy{{Resource: "schema/collections/customer1:Movies/shards/#"}},
 			wantErr:           true,
 		},
 		{
-			name:              "namespaces enabled: qualified alias segment rejected",
+			name:              "qualified alias segment rejected",
 			namespacesEnabled: true,
+			principal:         global,
 			policies:          []authorization.Policy{{Resource: "aliases/collections/Movies/aliases/customer1:Films"}},
 			wantErr:           true,
 		},
 		{
-			name:              "namespaces enabled: rejection scans every policy",
+			name:              "rejection scans every policy",
 			namespacesEnabled: true,
+			principal:         global,
 			policies: []authorization.Policy{
 				{Resource: "schema/collections/Movies/shards/#"},
 				{Resource: "data/collections/customer1:Movies/shards/.*/objects/.*"},
 			},
 			wantErr: true,
 		},
+		// users/<id> and groups/<...> ids may contain ':' — opaque, not a
+		// qualifier. Allowed for a global caller, rejected for a namespaced one
+		// (must submit the short form).
+		{
+			name:              "global: colon-bearing user id accepted",
+			namespacesEnabled: true,
+			principal:         global,
+			policies:          []authorization.Policy{{Resource: "users/urn:foo"}},
+		},
+		{
+			name:              "global: colon-bearing group name accepted",
+			namespacesEnabled: true,
+			principal:         global,
+			policies:          []authorization.Policy{{Resource: "groups/oidc/team:eng"}},
+		},
+		{
+			name:              "namespaced: colon-bearing user id rejected",
+			namespacesEnabled: true,
+			principal:         namespaced,
+			policies:          []authorization.Policy{{Resource: "users/customer2:bob"}},
+			wantErr:           true,
+		},
+		{
+			name:              "global: qualified user collection shape still rejected",
+			namespacesEnabled: true,
+			principal:         global,
+			policies:          []authorization.Policy{{Resource: "schema/collections/customer1:Movies/shards/#"}},
+			wantErr:           true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &authZHandlers{namespacesEnabled: tt.namespacesEnabled}
-			err := h.validateNoQualifiedNamespaceInPolicies(tt.policies)
+			err := h.validateNoQualifiedNamespaceInPolicies(tt.principal, tt.policies)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "namespace-qualified")
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/test/acceptance/namespace/colon_user_authz_test.go
+++ b/test/acceptance/namespace/colon_user_authz_test.go
@@ -1,0 +1,68 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/authz"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+)
+
+// TestGlobalCallerColonUserIDAuthz is the e2e guard for the colon-in-user-id
+// matcher fix. A global static-key caller (ns=="") with a narrow grant over
+// "gtarget" must not have it leak to a different user "x:gtarget" — expect 403
+// (deny), not 404 (authorized-through to a missing user).
+func TestGlobalCallerColonUserIDAuthz(t *testing.T) {
+	t.Parallel()
+
+	// gCaller (global, ns=="") gets a custom role granting read over one user:
+	// users/gtarget. Unqualified, so it passes the no-qualified-namespace validator.
+	readUsers := authorization.ReadUsers
+	target := gTarget
+	const roleName = "colon-authz-reader"
+	helper.CreateRoleAndAssign(t, adminKey, gCaller, roleName, &models.Permission{
+		Action: &readUsers,
+		Users:  &models.PermissionUsers{Users: &target},
+	})
+
+	// Positive control: the grant authorizes the exact target. Polling also
+	// settles RAFT-apply lag, so the deny below is the matcher, not lag.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := helper.Client(t).Authz.GetRolesForUser(
+			authz.NewGetRolesForUserParams().
+				WithID(gTarget).
+				WithUserType(string(models.UserTypeInputDb)),
+			helper.CreateAuth(gCallerKey),
+		)
+		assert.NoError(c, err, "grant over users/%s must authorize the caller", gTarget)
+	}, 15*time.Second, 100*time.Millisecond, "role binding for %q never became authorizing", roleName)
+
+	// The fix: the same grant must NOT reach a different colon-bearing user.
+	_, err := helper.Client(t).Authz.GetRolesForUser(
+		authz.NewGetRolesForUserParams().
+			WithID("x:"+gTarget).
+			WithUserType(string(models.UserTypeInputDb)),
+		helper.CreateAuth(gCallerKey),
+	)
+	require.Error(t, err)
+	var forbidden *authz.GetRolesForUserForbidden
+	require.True(t, errors.As(err, &forbidden),
+		"global caller's grant over users/%s must not widen to users/x:%s; got %T", gTarget, gTarget, err)
+}

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -57,6 +57,14 @@ func retryOnAliasLag(t *testing.T, op func() error) {
 // createNamespacedUser and granted the built-in admin role by this root.
 const adminUser, adminKey = "admin-user", "admin-key"
 
+// Two extra static API-key users for TestGlobalCallerColonUserIDAuthz. Static
+// keys are global operators (ns==""), the journey the matcher fix targets. The
+// test grants gCaller a narrow role at runtime; gTarget just needs to exist.
+const (
+	gCaller, gCallerKey = "gcaller", "gcaller-key"
+	gTarget, gTargetKey = "gtarget", "gtarget-key"
+)
+
 var sharedCompose *docker.DockerCompose
 
 func TestMain(m *testing.M) {
@@ -72,6 +80,8 @@ func TestMain(m *testing.M) {
 		WithApiKey().
 		WithRBAC().
 		WithUserApiKey(adminUser, adminKey).
+		WithUserApiKey(gCaller, gCallerKey).
+		WithUserApiKey(gTarget, gTargetKey).
 		WithRbacRoots(adminUser).
 		WithDbUsers().
 		WithNamespaces().

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -218,10 +218,9 @@ func CasbinNamespaces(name string) string {
 }
 
 // ContainsNamespaceSeparator reports whether a casbin resource path contains
-// the namespace separator. The separator never appears in any other valid
-// resource path segment (collection, shard, tenant, role, and user names all
-// forbid it), so a plain byte scan unambiguously detects namespace
-// qualification regardless of the path shape.
+// the namespace separator. A hit means qualification only for the collection
+// shapes (schema/data/aliases); for users/<id> and groups/<...>, whose ids may
+// contain ':' (e.g. OIDC usernames), callers must shape-check first.
 func ContainsNamespaceSeparator(resource string) bool {
 	return strings.IndexByte(resource, schema.NamespaceSeparator[0]) >= 0
 }

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -225,6 +225,14 @@ func ContainsNamespaceSeparator(resource string) bool {
 	return strings.IndexByte(resource, schema.NamespaceSeparator[0]) >= 0
 }
 
+// IsOpaqueIDResource reports whether resource addresses a users/<id> or
+// groups/<type>/<name> shape, whose id may legitimately contain ':' (e.g. an
+// OIDC username) as part of the id rather than a namespace qualifier.
+func IsOpaqueIDResource(resource string) bool {
+	return strings.HasPrefix(resource, authorization.UsersDomain+"/") ||
+		strings.HasPrefix(resource, authorization.GroupsDomain+"/")
+}
+
 func extractFromExtAction(inputAction string) (string, string, error) {
 	splits := strings.Split(inputAction, "_")
 	if len(splits) < 2 {

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -1241,3 +1241,28 @@ func TestGetUserAndPrefix(t *testing.T) {
 		})
 	}
 }
+
+// TestUserKeyRoundTripColonBearingID: a global user id containing ':' survives
+// the casbin-key encode/decode round trip verbatim — only the auth-type prefix
+// is split off the first ':', no namespace re-attribution.
+func TestUserKeyRoundTripColonBearingID(t *testing.T) {
+	ids := []string{
+		"alice",
+		"urn:foo",
+		"urn:keycloak:alice",
+		"customer1:alice",
+		":leading",
+		"trailing:",
+	}
+	for _, authType := range []authentication.AuthType{authentication.AuthTypeOIDC, authentication.AuthTypeDb} {
+		for _, id := range ids {
+			t.Run(string(authType)+"/"+id, func(t *testing.T) {
+				key := UserNameWithTypeFromId(id, authType)
+				user, prefix, err := GetUserAndPrefix(key)
+				require.NoError(t, err)
+				require.Equal(t, string(authType), prefix)
+				require.Equal(t, id, user, "id must round-trip verbatim, no namespace re-attribution")
+			})
+		}
+	}
+}

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -1266,3 +1266,23 @@ func TestUserKeyRoundTripColonBearingID(t *testing.T) {
 		}
 	}
 }
+
+func TestIsOpaqueIDResource(t *testing.T) {
+	tests := []struct {
+		resource string
+		want     bool
+	}{
+		{"users/alice", true},
+		{"users/urn:foo", true},
+		{"groups/oidc/team:eng", true},
+		{"schema/collections/Movies/shards/#", false},
+		{"data/collections/Movies/shards/T/objects/*", false},
+		{"roles/editor", false},
+		{"cluster/*", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.resource, func(t *testing.T) {
+			require.Equal(t, tt.want, IsOpaqueIDResource(tt.resource))
+		})
+	}
+}

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -330,6 +330,9 @@ func findNamespaceSegments(path string) (start, end int, hasAlias bool) {
 	if _, ok := strings.CutPrefix(path, usersPrefix); ok {
 		return len(usersPrefix), len(path), false
 	}
+	// groups/ is intentionally not registered: a colon-bearing group id is
+	// matched literally. Don't add it without also short-circuiting groups/
+	// in globalCallerNeedsNoWidening, or such ids would wrongly widen.
 	return 0, 0, false
 }
 

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -384,6 +384,17 @@ func rewritePolicy(policy string, colStart, colEnd int, hasAlias bool, prefix st
 	return b.String(), true
 }
 
+// globalCallerNeedsNoWidening reports whether a global caller's (ns == "")
+// request matches the policy literally rather than widening: true when it has
+// no ':', or is a users/<id> resource (a user id may contain ':', which is
+// part of the id, not a namespace prefix).
+func globalCallerNeedsNoWidening(reqObj string) bool {
+	if strings.HasPrefix(reqObj, usersPrefix) {
+		return true
+	}
+	return strings.IndexByte(reqObj, schema.NamespaceSeparator[0]) < 0
+}
+
 // weaviateKeyMatch runs the `/shards/#` vs `/shards/.*` carve-out then
 // KeyMatch5: a collection-level request must not match a per-tenant policy.
 func weaviateKeyMatch(reqObj, polObj string) bool {
@@ -401,18 +412,12 @@ func weaviateKeyMatch(reqObj, polObj string) bool {
 //     already-qualified segments must start with `<ns>:` exactly.
 //   - ns == "" with a qualified request segment: unqualified policy segments
 //     widen with anyNamespacePattern; qualified segments stay fixed.
-//   - ns == "" with an unqualified request segment, or a non-namespaceable
-//     path shape: no rewrite.
+//   - ns == "" with an unqualified request, a users/<id> resource, or a
+//     non-namespaceable shape: no rewrite.
 func namespaceAwareMatcher(reqObj, polObj, ns string) bool {
-	// Trivial passthrough: no rewrite is needed when the caller carries no
-	// namespace and the request resource is unqualified. This is the only
-	// path on namespace-disabled clusters (validation forbids `:` in any resource
-	// path) and also covers operator calls against unqualified resources
-	// on namespace-enabled clusters. The namespace separator never appears
-	// in any other part of a valid resource path
-	// (class/shard/tenant/role names all forbid `:`), so a single byte
-	// scan classifies the request.
-	if ns == "" && strings.IndexByte(reqObj, schema.NamespaceSeparator[0]) < 0 {
+	// Trivial passthrough (see globalCallerNeedsNoWidening). Only
+	// collection/data/aliases segments treat ':' as a namespace boundary.
+	if ns == "" && globalCallerNeedsNoWidening(reqObj) {
 		return weaviateKeyMatch(reqObj, polObj)
 	}
 

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -372,6 +372,87 @@ func TestNamespaceAwareMatcher(t *testing.T) {
 	}
 }
 
+// TestNamespaceAwareMatcher_ColonBearingGlobalUser: a global caller (ns == "")
+// may carry a user id containing ':'. The matcher must match users/<id>
+// literally — else such ids are falsely denied a wildcard grant, or falsely
+// matched against a grant to a different user.
+func TestNamespaceAwareMatcher_ColonBearingGlobalUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		reqObj   string
+		polObj   string
+		ns       string
+		expected bool
+	}{
+		{
+			"baseline: no colon, wildcard grant → allow",
+			"users/alice", "users/.*", "", true,
+		},
+		{
+			"colon in id must not break a wildcard grant → allow",
+			"users/urn:foo", "users/.*", "", true,
+		},
+		{
+			"leading colon must not break a wildcard grant → allow",
+			"users/:foo", "users/.*", "", true,
+		},
+		{
+			"trailing colon must not break a wildcard grant → allow",
+			"users/foo:", "users/.*", "", true,
+		},
+		{
+			"multi-colon id must not break a wildcard grant → allow",
+			"users/a:b:c", "users/.*", "", true,
+		},
+		{
+			"literal /* wildcard normalizes and still matches colon id → allow",
+			"users/customer1:alice", "users/*", "", true,
+		},
+		{
+			"root's bare * grant still matches colon id → allow",
+			"users/customer1:alice", "*", "", true,
+		},
+		{
+			"narrower grant to user 'a' must NOT widen to id 'x:a' → deny",
+			"users/x:a", "users/a", "", false,
+		},
+		{
+			"narrower grant to user 'alice' must NOT widen to id 'customer1:alice' → deny",
+			"users/customer1:alice", "users/alice", "", false,
+		},
+		{
+			"exact-match grant to a colon id → allow",
+			"users/customer1:alice", "users/customer1:alice", "", true,
+		},
+		{
+			"namespaced caller still specializes a relative user grant → allow",
+			"users/customer1:alice", "users/alice", "customer1", true,
+		},
+		{
+			"namespaced caller is denied a cross-namespace user → deny",
+			"users/customer2:alice", "users/alice", "customer1", false,
+		},
+		{
+			"colon in a group name is opaque too: exact grant → allow",
+			"groups/oidc/team:eng", "groups/oidc/team:eng", "", true,
+		},
+		{
+			"colon in a group name must not widen to a different group → deny",
+			"groups/oidc/team:eng", "groups/oidc/team:other", "", false,
+		},
+		{
+			"regression guard: collection widening for a global caller still works → allow",
+			"schema/collections/customer1:Movies/shards/#", conv.CasbinSchema("Movies*", "#"), "", true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testNamespaceAwareMatcher(t, tt.reqObj, tt.polObj, tt.ns, tt.expected)
+		})
+	}
+}
+
 // TestNamespaceAwareMatcherGate locks the namespacesEnabled gate: on
 // namespace-disabled clusters the matcher must not parse ':' as a namespace
 // prefix, because an OIDC username may legitimately contain ':' there
@@ -392,10 +473,10 @@ func TestNamespaceAwareMatcherGate(t *testing.T) {
 	assert.True(t, call(false, "schema/collections/Movies/shards/#", conv.CasbinSchema("Movies", "#"), ""),
 		"NS-disabled: collection matching unchanged")
 
-	// The gate is load-bearing: the raw namespace-aware core would wrongly match
-	// "x:a" against a grant to "a" via any-ns widening.
-	assert.True(t, namespaceAwareMatcher("users/x:a", "users/a", ""),
-		"documents the bug the gate prevents")
+	// NS-enabled global caller (ns == "") matches user ids literally: a grant to
+	// "a" must not widen to OIDC user "x:a".
+	assert.False(t, namespaceAwareMatcher("users/x:a", "users/a", ""),
+		"NS-enabled global caller: grant to user 'a' must not match OIDC user 'x:a'")
 
 	// NS-enabled: the gate delegates to the namespace-aware core.
 	assert.True(t, call(true, "users/customer1:bob", "users/.*", "customer1"),


### PR DESCRIPTION
### What's being changed:

Namespaces use : as a separator. A resource like schema/collections/acme:Products/... means "collection Products in namespace acme". The matcher splits on : to figure out the namespace.

However in static key (and in the future OIDC names), the ":" can be part of the name which results in bugs:

  For a global caller (ns == "") on a namespace-enabled cluster:

  1. False deny. A wildcard grant fails to match a colon user.
  grant:   users/*
  request: users/customer1:alice   →  DENIED   (should be allowed)
  The matcher reads customer1 as a namespace, rewrites the request, and users/* no longer matches.

  2. False allow (privilege leak). A grant scoped to one user leaks to a different user.
  grant:   users/a
  request: users/x:a               →  ALLOWED  (should be denied)
  The matcher strips x: as a phantom namespace prefix, leaving a, which matches users/a. User x:a gets access meant only for user a.

  3. Role creation blocked. The role-create validator rejected any colon-bearing resource, so a global admin couldn't even write a legitimate policy like users/customer1:alice.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
