### PR TITLE
Authorize dynamic users restored from a backup artefact

### DIFF
--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -55,10 +55,7 @@ type DistributedBackupDescriptor struct {
 	PreCompressionSizeBytes int64                      `json:"preCompressionSizeBytes"` // Size of this node's backup in bytes before compression
 	CompressionType         CompressionType            `json:"compressionType"`
 	BaseBackupID            string                     `json:"baseBackupId"`
-	// Users are the dynamic-user IDs included in this backup (resolved includeUsers).
-	// Authz-only on restore; user-material restore is driven by the per-node
-	// UserBackups blob. nil/absent for backups taken without includeUsers.
-	Users []string `json:"users,omitempty"`
+	Users                   []string                   `json:"users,omitempty"`
 }
 
 // Len returns how many nodes exist in d

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -55,6 +55,10 @@ type DistributedBackupDescriptor struct {
 	PreCompressionSizeBytes int64                      `json:"preCompressionSizeBytes"` // Size of this node's backup in bytes before compression
 	CompressionType         CompressionType            `json:"compressionType"`
 	BaseBackupID            string                     `json:"baseBackupId"`
+	// Users are the dynamic-user IDs included in this backup (resolved includeUsers).
+	// Authz-only on restore; user-material restore is driven by the per-node
+	// UserBackups blob. nil/absent for backups taken without includeUsers.
+	Users []string `json:"users,omitempty"`
 }
 
 // Len returns how many nodes exist in d
@@ -94,6 +98,19 @@ func (d *DistributedBackupDescriptor) Classes() []string {
 	for cls := range set {
 		lst[i] = cls
 		i++
+	}
+	return lst
+}
+
+// UserList returns the deduped dynamic-user IDs recorded in d (empty when none).
+func (d *DistributedBackupDescriptor) UserList() []string {
+	set := make(map[string]struct{}, len(d.Users))
+	for _, u := range d.Users {
+		set[u] = struct{}{}
+	}
+	lst := make([]string, 0, len(set))
+	for u := range set {
+		lst = append(lst, u)
 	}
 	return lst
 }

--- a/entities/backup/descriptor_test.go
+++ b/entities/backup/descriptor_test.go
@@ -12,9 +12,11 @@
 package backup
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -451,6 +453,85 @@ func TestTestDistributedBackupResetStatus(t *testing.T) {
 		Status: Started,
 	}
 	assert.Equal(t, want, desc)
+}
+
+func TestDistributedBackupDescriptor_UserList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "nil", in: nil, want: []string{}},
+		{name: "empty", in: []string{}, want: []string{}},
+		{name: "single", in: []string{"ns1:alice"}, want: []string{"ns1:alice"}},
+		{name: "many", in: []string{"ns1:alice", "ns1:bob"}, want: []string{"ns1:alice", "ns1:bob"}},
+		{name: "dedupes", in: []string{"ns1:alice", "ns1:alice", "ns1:bob"}, want: []string{"ns1:alice", "ns1:bob"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := DistributedBackupDescriptor{Users: tc.in}
+			got := d.UserList()
+			sort.Strings(got)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("json round-trip omits absent users", func(t *testing.T) {
+		// A pre-change artefact carries no "users" key; it must unmarshal to no users.
+		old := `{"id":"1","version":"1","serverVersion":"1"}`
+		var d DistributedBackupDescriptor
+		require.NoError(t, json.Unmarshal([]byte(old), &d))
+		assert.Empty(t, d.UserList())
+
+		// omitempty: a descriptor with no users marshals without the key, keeping the
+		// on-disk shape identical to a pre-change backup.
+		b, err := json.Marshal(DistributedBackupDescriptor{ID: "1"})
+		require.NoError(t, err)
+		assert.NotContains(t, string(b), `"users"`)
+	})
+
+	t.Run("json round-trip preserves users", func(t *testing.T) {
+		d := DistributedBackupDescriptor{ID: "1", Users: []string{"ns1:alice"}}
+		b, err := json.Marshal(d)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"users":["ns1:alice"]`)
+
+		var back DistributedBackupDescriptor
+		require.NoError(t, json.Unmarshal(b, &back))
+		assert.Equal(t, []string{"ns1:alice"}, back.UserList())
+	})
+
+	// Persistence fidelity: the Users field and the per-node UserBackups blob are
+	// persisted on different paths and only the field drives restore authz. Pin that
+	// Users survives both the in-place ResetStatus reset and a marshal→unmarshal cycle,
+	// so a future hand-written copy/reset that rebuilds the struct can't silently drop
+	// it and disable authz on a backup that included users.
+	t.Run("users survive ResetStatus and marshal cycle", func(t *testing.T) {
+		d := DistributedBackupDescriptor{
+			ID:            "1",
+			Version:       "1",
+			ServerVersion: "1",
+			Status:        Success,
+			Nodes:         map[string]*NodeDescriptor{"N1": {Status: Success}},
+			Users:         []string{"ns1:alice", "ns1:bob"},
+		}
+
+		d.ResetStatus()
+		got := d.UserList()
+		sort.Strings(got)
+		assert.Equal(t, []string{"ns1:alice", "ns1:bob"}, got)
+		assert.Equal(t, Started, d.Status, "ResetStatus must still reset status")
+
+		b, err := json.Marshal(&d)
+		require.NoError(t, err)
+		require.True(t, strings.Contains(string(b), `"users"`), "marshalled meta must carry users")
+
+		var back DistributedBackupDescriptor
+		require.NoError(t, json.Unmarshal(b, &back))
+		got = back.UserList()
+		sort.Strings(got)
+		assert.Equal(t, []string{"ns1:alice", "ns1:bob"}, got)
+	})
 }
 
 func TestShardDescriptorClear(t *testing.T) {

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -196,6 +196,7 @@ func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Reques
 		Leader:          leader,
 		CompressionType: compressionType,
 		BaseBackupID:    req.BaseBackupID,
+		Users:           req.Users,
 	}
 
 	for key := range c.Participants {

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -285,11 +285,6 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	return data, nil
 }
 
-// authorizeRestoreUsers authorizes the dynamic users a restore will materialize.
-// No-op when user restore is disabled, and — deliberately — also a no-op when the
-// artefact enumerates no users (a backup predating the Users field, or one taken
-// without includeUsers), so existing disaster-recovery restores keep working
-// unchanged. AuthZ is evoked only when the artefact explicitly records user IDs.
 func (s *Scheduler) authorizeRestoreUsers(
 	ctx context.Context, pr *models.Principal,
 	req *BackupRequest, meta *backup.DistributedBackupDescriptor,

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 var (
@@ -222,12 +223,6 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		}
 	}
 
-	if req.UserRestoreOption != models.RestoreConfigUsersOptionsNoRestore {
-		if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.BackupUsers(req.IncludeUsers...)...); err != nil {
-			return nil, err
-		}
-	}
-
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
 	if err != nil {
 		err = fmt.Errorf("no backup backend %q: %w, did you enable the right module?", req.Backend, err)
@@ -247,6 +242,10 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 			return nil, err
 		}
 		meta.Include(allowed)
+	}
+
+	if err := s.authorizeRestoreUsers(ctx, pr, req, meta); err != nil {
+		return nil, err
 	}
 
 	schema, err := s.fetchSchema(ctx, req.Backend, req.Bucket, req.Path, meta)
@@ -284,6 +283,35 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 
 	data.Status = &status
 	return data, nil
+}
+
+// authorizeRestoreUsers authorizes the dynamic users a restore will materialize.
+// No-op when user restore is disabled, and — deliberately — also a no-op when the
+// artefact enumerates no users (a backup predating the Users field, or one taken
+// without includeUsers), so existing disaster-recovery restores keep working
+// unchanged. AuthZ is evoked only when the artefact explicitly records user IDs.
+func (s *Scheduler) authorizeRestoreUsers(
+	ctx context.Context, pr *models.Principal,
+	req *BackupRequest, meta *backup.DistributedBackupDescriptor,
+) error {
+	if req.UserRestoreOption == models.RestoreConfigUsersOptionsNoRestore {
+		return nil
+	}
+	users := meta.UserList()
+	if len(users) == 0 {
+		// The artefact records no users (old artefact, or none included).
+		// Preserve pre-change restore behaviour: do not gate.
+		return nil
+	}
+	if req.ShouldStripNamespaces {
+		stripped := make([]string, len(users))
+		for i, u := range users {
+			stripped[i] = namespacing.StripNamespacePrefix(u)
+		}
+		users = stripped
+	}
+	return s.authorizer.Authorize(ctx, pr, authorization.CREATE,
+		authorization.BackupUsers(users...)...)
 }
 
 // filterBackupableClasses returns the subset of classes the caller may act on

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -1770,4 +1771,258 @@ func TestSchedulerCreateBackupIncludeUsers(t *testing.T) {
 		assert.Contains(t, err.Error(), "no dynamic users match")
 		assert.IsType(t, backup.ErrUnprocessable{}, err)
 	})
+}
+
+// denyUserAuthorizer denies one exact resource and defers everything else to the
+// embedded blanket fake, so Calls() still records the allowed authorizations.
+type denyUserAuthorizer struct {
+	*mocks.FakeAuthorizer
+	denyResource string
+}
+
+func (d *denyUserAuthorizer) Authorize(ctx context.Context, pr *models.Principal, verb string, resources ...string) error {
+	for _, r := range resources {
+		if r == d.denyResource {
+			return authzerrors.NewForbidden(pr, verb, resources...)
+		}
+	}
+	return d.FakeAuthorizer.Authorize(ctx, pr, verb, resources...)
+}
+
+// Scheduler.Backup must record the resolved dynamic-user IDs on the global
+// descriptor so the restore side can authorize them later. Ordinary backups (no
+// includeUsers) must record no users, keeping the on-disk shape unchanged.
+func TestSchedulerCreateBackupRecordsUsers(t *testing.T) {
+	t.Parallel()
+
+	var (
+		cls         = "Class-A"
+		node        = "Node-A"
+		backendName = "gcs"
+		backupID    = "1"
+		any         = mock.Anything
+		ctx         = context.Background()
+		path        = "dst/path"
+		cresp       = &CanCommitResponse{Method: OpCreate, ID: backupID, Timeout: 1}
+		sReq        = &StatusRequest{OpCreate, backupID, backendName, "", "", ""}
+		sresp       = &StatusResponse{Status: backup.Success, ID: backupID, Method: OpCreate}
+	)
+
+	setup := func(fs *fakeScheduler, req *BackupRequest) {
+		fs.selector.On("ListClasses", ctx).Return([]string{cls})
+		fs.selector.On("Backupable", ctx, req.Include).Return(nil)
+		fs.selector.On("Shards", ctx, cls).Return([]string{node}, nil)
+		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		fs.backend.On("Initialize", ctx, mock.Anything).Return(nil)
+		fs.client.On("CanCommit", any, node, any).Return(cresp, nil)
+		fs.client.On("Commit", any, node, sReq).Return(nil)
+		fs.client.On("Status", any, node, sReq).Return(sresp, nil)
+		fs.backend.On("PutObject", any, backupID, GlobalBackupFile, any).Return(nil).Twice()
+		fs.backend.On("GetObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(marshalMeta(backup.BackupDescriptor{Status: backup.Success}), nil)
+	}
+
+	t.Run("includeUsers are recorded on the global descriptor", func(t *testing.T) {
+		req := BackupRequest{
+			ID:           backupID,
+			Include:      []string{cls},
+			Backend:      backendName,
+			IncludeUsers: []string{"ns1:*"},
+		}
+		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+		fs.userLister.users = []string{"ns1:alice", "ns1:bob", "ns2:carol"}
+		setup(fs, &req)
+
+		resp, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
+		require.Nil(t, err)
+		assert.ElementsMatch(t, []string{"ns1:alice", "ns1:bob"}, resp.Users)
+		// ns2:carol must not leak in: only ns1:* was requested.
+		assert.ElementsMatch(t, []string{"ns1:alice", "ns1:bob"}, fs.backend.glMeta.UserList())
+	})
+
+	t.Run("ordinary backup records no users", func(t *testing.T) {
+		req := BackupRequest{
+			ID:      backupID,
+			Include: []string{cls},
+			Backend: backendName,
+		}
+		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+		setup(fs, &req)
+
+		resp, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
+		require.Nil(t, err)
+		assert.Empty(t, resp.Users)
+		assert.Nil(t, fs.backend.glMeta.Users)
+	})
+}
+
+// Scheduler.Restore must authorize each dynamic user recorded in the artefact with
+// a backup-create permission before any participant work, stripping the namespace
+// prefix when the restore strips it, and failing the whole restore if any user is
+// denied. Artefacts that enumerate no users, and restores with users disabled, must
+// not gate at all (preserving disaster-recovery and collection-only restores).
+func TestSchedulerRestoreAuthorizesUsers(t *testing.T) {
+	t.Parallel()
+
+	var (
+		cls         = "MyClass-A"
+		node        = "Node-A"
+		any         = mock.Anything
+		backendName = "gcs"
+		backupID    = "1"
+		timePt      = time.Now().UTC()
+		ctx         = context.Background()
+		path        = "bucket/backups/" + backupID
+		keyNode     = backupID + "/" + node
+		cResp       = &CanCommitResponse{Method: OpRestore, ID: backupID, Timeout: 1}
+		sReq        = &StatusRequest{OpRestore, backupID, backendName, "", "", ""}
+		sResp       = &StatusResponse{Status: backup.Success, ID: backupID, Method: OpRestore}
+	)
+
+	shardingStateBytes, _ := json.Marshal(&sharding.State{
+		IndexID:  cls,
+		Physical: map[string]sharding.Physical{"S1": {Name: "S1"}},
+	})
+	rawClassBytes, _ := json.Marshal(&models.Class{Class: cls})
+	nodeMeta := backup.BackupDescriptor{
+		ID:     backupID,
+		Status: backup.Success,
+		Classes: []backup.ClassDescriptor{{
+			Name:          cls,
+			Schema:        rawClassBytes,
+			ShardingState: shardingStateBytes,
+		}},
+	}
+	nodeMetaBytes, _ := json.Marshal(nodeMeta)
+
+	userBackupCall := func(fa *mocks.FakeAuthorizer) (mocks.AuthZReq, bool) {
+		for _, c := range fa.Calls() {
+			if len(c.Resources) > 0 && strings.HasPrefix(c.Resources[0], authorization.BackupsDomain+"/users/") {
+				return c, true
+			}
+		}
+		return mocks.AuthZReq{}, false
+	}
+
+	tests := []struct {
+		name         string
+		users        []string
+		option       string
+		strip        bool
+		denyResource string
+		// wantAuthz lists the user resources expected on the recorded authz call,
+		// empty when no user authz must be evoked.
+		wantAuthz    []string
+		wantDenied   bool
+		wantDispatch bool
+	}{
+		{
+			name:         "allowed users are authorized and restore proceeds",
+			users:        []string{"ns1:alice", "ns1:bob"},
+			option:       models.RestoreConfigUsersOptionsAll,
+			wantAuthz:    authorization.BackupUsers("ns1:alice", "ns1:bob"),
+			wantDispatch: true,
+		},
+		{
+			name:         "one denied user fails the whole restore before dispatch",
+			users:        []string{"ns1:alice", "ns1:bob"},
+			option:       models.RestoreConfigUsersOptionsAll,
+			denyResource: authorization.BackupsDomain + "/users/ns1:bob",
+			wantDenied:   true,
+		},
+		{
+			name:         "namespace is stripped before authorizing",
+			users:        []string{"ns1:alice"},
+			option:       models.RestoreConfigUsersOptionsAll,
+			strip:        true,
+			wantAuthz:    authorization.BackupUsers("alice"),
+			wantDispatch: true,
+		},
+		{
+			name:         "old/empty artefact is not gated and proceeds",
+			users:        nil,
+			option:       models.RestoreConfigUsersOptionsAll,
+			wantDispatch: true,
+		},
+		{
+			name:         "user restore disabled does not gate and proceeds",
+			users:        []string{"ns1:alice"},
+			option:       models.RestoreConfigUsersOptionsNoRestore,
+			wantDispatch: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := backup.DistributedBackupDescriptor{
+				ID:            backupID,
+				StartedAt:     timePt,
+				Version:       "1",
+				ServerVersion: "1",
+				Status:        backup.Success,
+				Nodes:         map[string]*backup.NodeDescriptor{node: {Classes: []string{cls}}},
+				Users:         tc.users,
+			}
+			metaBytes := marshalCoordinatorMeta(meta)
+
+			fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+			fa := mocks.NewMockAuthorizer()
+			fs.auth = &denyUserAuthorizer{FakeAuthorizer: fa, denyResource: tc.denyResource}
+
+			fs.backend.On("Initialize", ctx, mock.Anything).Return(nil)
+			fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(metaBytes, nil)
+			fs.backend.On("GetObject", ctx, backupID, GlobalRestoreFile).Return(metaBytes, nil)
+			fs.backend.On("GetObject", ctx, keyNode, BackupFile).Return(nodeMetaBytes, nil)
+			fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+			fs.backend.On("PutObject", mock.Anything, mock.Anything, GlobalRestoreFile, mock.AnythingOfType("[]uint8")).Return(nil)
+			fs.client.On("CanCommit", any, node, any).Return(cResp, nil)
+			fs.client.On("Commit", any, node, sReq).Return(nil)
+			fs.client.On("Status", any, node, sReq).Return(sResp, nil)
+
+			req := BackupRequest{
+				ID:                    backupID,
+				Include:               []string{cls},
+				Backend:               backendName,
+				UserRestoreOption:     tc.option,
+				ShouldStripNamespaces: tc.strip,
+			}
+			s := fs.scheduler()
+			resp, err := s.Restore(ctx, &models.Principal{}, &req, false)
+
+			if tc.wantDenied {
+				require.Error(t, err)
+				assert.Nil(t, resp)
+				assert.True(t, errors.As(err, &authzerrors.Forbidden{}), "expected forbidden, got %v", err)
+				// No participant work may have started for a denied user.
+				fs.client.AssertNotCalled(t, "CanCommit", any, node, any)
+				_, ok := userBackupCall(fa)
+				assert.False(t, ok, "denied user authz must not be recorded")
+				return
+			}
+
+			require.Nil(t, err)
+			require.NotNil(t, resp)
+			// Drain the async restore so AssertExpectations is stable.
+			for i := 0; i < 10; i++ {
+				time.Sleep(time.Millisecond * 60)
+				if i > 0 && s.restorer.lastOp.get().Status == "" {
+					break
+				}
+			}
+
+			call, ok := userBackupCall(fa)
+			if len(tc.wantAuthz) == 0 {
+				assert.False(t, ok, "no user authz expected; got %+v", call)
+			} else {
+				require.True(t, ok, "expected a user-backup authz call")
+				assert.Equal(t, authorization.CREATE, call.Verb)
+				assert.ElementsMatch(t, tc.wantAuthz, call.Resources)
+			}
+			if tc.wantDispatch {
+				fs.client.AssertCalled(t, "CanCommit", any, node, any)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed

- A backup now records the list of included dynamic-user IDs in its metadata, next to the list of collections it already records.
- On restore, Weaviate authorizes each recorded user before restoring, the same way it already authorizes each collection. If the caller lacks permission on any one of them, the whole restore is rejected before anything is applied.
- If the backup was taken with namespace-stripping enabled, the user IDs are stripped before the check so they match the users that are actually created on the destination.
- Restores of backups that record no users — including older backups taken before this change — are not gated. This deliberately preserves disaster-recovery restores: introducing this check must not change the outcome of restoring an existing backup or require new permissions for it.
- An earlier, ineffective check was removed. It looked at the restore *request's* user list, which is always empty on the restore path, so it never actually authorized the users being restored.

### Motivation and Context

- Backups can include dynamic database users (via `includeUsers`), and those carry credential material. Restoring them recreates that credential material, so the action must be authorized.
- The restore request carries no user list — the users live inside the backup artefact — so the only correct place to authorize them is against the list recorded in the backup. This change records that list at backup time and reads it back at restore time.
- Authorizing only when users are explicitly recorded keeps disaster-recovery and older-backup restores working exactly as before, with no new permission requirements.
- Restoring RBAC roles is a separate, more sensitive concern and is intentionally out of scope here; it is tracked separately.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
