### PR TITLE
feat(multi2vec-twelvelabs): add TwelveLabs Marengo multimodal vectorizer module

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -110,6 +110,7 @@ import (
 	modmulti2vecgoogle "github.com/weaviate/weaviate/modules/multi2vec-google"
 	modmulti2vecjinaai "github.com/weaviate/weaviate/modules/multi2vec-jinaai"
 	modmulti2vecnvidia "github.com/weaviate/weaviate/modules/multi2vec-nvidia"
+	modmulti2vectwelvelabs "github.com/weaviate/weaviate/modules/multi2vec-twelvelabs"
 	modmulti2vecvoyageai "github.com/weaviate/weaviate/modules/multi2vec-voyageai"
 	modner "github.com/weaviate/weaviate/modules/ner-transformers"
 	modsloads3 "github.com/weaviate/weaviate/modules/offload-s3"
@@ -1736,6 +1737,7 @@ func registerModules(appState *state.State) error {
 		modtext2multivecjinaai.Name,
 		modnvidia.Name,
 		modmulti2vecnvidia.Name,
+		modmulti2vectwelvelabs.Name,
 		modmulti2multivecjinaai.Name,
 		modmulti2multivecweaviate.Name,
 		modmulti2vecaws.Name,
@@ -1989,6 +1991,14 @@ func registerModules(appState *state.State) error {
 		appState.Logger.
 			WithField("action", "startup").
 			WithField("module", modmulti2vecvoyageai.Name).
+			Debug("enabled module")
+	}
+
+	if _, ok := enabledModules[modmulti2vectwelvelabs.Name]; ok {
+		appState.Modules.Register(modmulti2vectwelvelabs.New())
+		appState.Logger.
+			WithField("action", "startup").
+			WithField("module", modmulti2vectwelvelabs.Name).
 			Debug("enabled module")
 	}
 

--- a/modules/multi2vec-twelvelabs/clients/meta.go
+++ b/modules/multi2vec-twelvelabs/clients/meta.go
@@ -1,0 +1,19 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+func (v *vectorizer) MetaInfo() (map[string]any, error) {
+	return map[string]any{
+		"name":              "TwelveLabs Multi Modal Module",
+		"documentationHref": "https://docs.twelvelabs.io/v1.3/api-reference/create-embeddings",
+	}, nil
+}

--- a/modules/multi2vec-twelvelabs/clients/twelvelabs.go
+++ b/modules/multi2vec-twelvelabs/clients/twelvelabs.go
@@ -1,0 +1,224 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/modules/multi2vec-twelvelabs/ent"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
+)
+
+type embedding struct {
+	Segments []segment `json:"segments"`
+}
+
+type segment struct {
+	Float []float32 `json:"float"`
+}
+
+// embedResponse mirrors the TwelveLabs Embed API response. Only one of the
+// *_embedding fields is populated per request depending on the input type.
+// See https://docs.twelvelabs.io/v1.3/api-reference/create-embeddings
+type embedResponse struct {
+	ModelName      string     `json:"model_name"`
+	TextEmbedding  *embedding `json:"text_embedding"`
+	ImageEmbedding *embedding `json:"image_embedding"`
+	Code           string     `json:"code"`
+	Message        string     `json:"message"`
+}
+
+type vectorizer struct {
+	apiKey     string
+	httpClient *http.Client
+	logger     logrus.FieldLogger
+}
+
+func New(apiKey string, timeout time.Duration, logger logrus.FieldLogger) *vectorizer {
+	return &vectorizer{
+		apiKey:     apiKey,
+		httpClient: modulecomponents.NewBaseHttpClient(timeout),
+		logger:     logger,
+	}
+}
+
+func (v *vectorizer) Vectorize(ctx context.Context,
+	texts, images []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
+	return v.vectorize(ctx, texts, images, cfg)
+}
+
+func (v *vectorizer) VectorizeQuery(ctx context.Context,
+	input []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
+	return v.vectorize(ctx, input, nil, cfg)
+}
+
+func (v *vectorizer) VectorizeImages(ctx context.Context,
+	images []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
+	return v.vectorize(ctx, nil, images, cfg)
+}
+
+// vectorize embeds texts and images with Marengo. The TwelveLabs Embed API
+// accepts a single input per request, so we issue one request per item.
+func (v *vectorizer) vectorize(ctx context.Context,
+	texts, images []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
+	settings := ent.NewClassSettings(cfg)
+	baseURL := settings.BaseURL()
+	model := settings.Model()
+
+	var textVectors, imageVectors [][]float32
+	for i := range texts {
+		vec, err := v.embedText(ctx, baseURL, model, texts[i])
+		if err != nil {
+			return nil, err
+		}
+		textVectors = append(textVectors, vec)
+	}
+	for i := range images {
+		vec, err := v.embedImage(ctx, baseURL, model, images[i])
+		if err != nil {
+			return nil, err
+		}
+		imageVectors = append(imageVectors, vec)
+	}
+
+	return &modulecomponents.VectorizationCLIPResult[[]float32]{
+		TextVectors:  textVectors,
+		ImageVectors: imageVectors,
+	}, nil
+}
+
+func (v *vectorizer) embedText(ctx context.Context, baseURL, model, text string) ([]float32, error) {
+	res, err := v.doEmbed(ctx, baseURL, model, func(w *multipart.Writer) error {
+		return w.WriteField("text", text)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return extractEmbedding(res.TextEmbedding)
+}
+
+func (v *vectorizer) embedImage(ctx context.Context, baseURL, model, image string) ([]float32, error) {
+	// Weaviate stores image properties as base64. The TwelveLabs Embed API
+	// accepts the raw bytes via the image_file multipart field.
+	img := image
+	if idx := strings.Index(img, ","); strings.HasPrefix(img, "data:") && idx != -1 {
+		img = img[idx+1:]
+	}
+	raw, err := base64.StdEncoding.DecodeString(img)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode base64 image")
+	}
+	res, err := v.doEmbed(ctx, baseURL, model, func(w *multipart.Writer) error {
+		part, err := w.CreateFormFile("image_file", "image")
+		if err != nil {
+			return err
+		}
+		_, err = part.Write(raw)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return extractEmbedding(res.ImageEmbedding)
+}
+
+func extractEmbedding(emb *embedding) ([]float32, error) {
+	if emb == nil || len(emb.Segments) == 0 || len(emb.Segments[0].Float) == 0 {
+		return nil, errors.New("empty embeddings response")
+	}
+	return emb.Segments[0].Float, nil
+}
+
+func (v *vectorizer) doEmbed(ctx context.Context, baseURL, model string,
+	writeInput func(*multipart.Writer) error,
+) (*embedResponse, error) {
+	apiKey, err := v.getApiKey(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "TwelveLabs API Key")
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if err := writer.WriteField("model_name", model); err != nil {
+		return nil, errors.Wrap(err, "write model_name field")
+	}
+	if err := writeInput(writer); err != nil {
+		return nil, errors.Wrap(err, "write input field")
+	}
+	if err := writer.Close(); err != nil {
+		return nil, errors.Wrap(err, "close multipart writer")
+	}
+
+	url := fmt.Sprintf("%s/embed", baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, errors.Wrap(err, "create POST request")
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	res, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "send POST request")
+	}
+	defer res.Body.Close()
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read response body")
+	}
+
+	var resBody embedResponse
+	if err := json.Unmarshal(bodyBytes, &resBody); err != nil {
+		return nil, errors.Wrapf(err, "unmarshal response body. got: %v", string(bodyBytes))
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New(v.getErrorMessage(res.StatusCode, resBody.Message))
+	}
+	return &resBody, nil
+}
+
+func (v *vectorizer) getErrorMessage(statusCode int, resBodyError string) string {
+	if resBodyError != "" {
+		return fmt.Sprintf("connection to TwelveLabs failed with status: %d error: %v", statusCode, resBodyError)
+	}
+	return fmt.Sprintf("connection to TwelveLabs failed with status: %d", statusCode)
+}
+
+func (v *vectorizer) getApiKey(ctx context.Context) (string, error) {
+	if apiKey := modulecomponents.GetValueFromContext(ctx, "X-Twelvelabs-Api-Key"); apiKey != "" {
+		return apiKey, nil
+	}
+	if v.apiKey != "" {
+		return v.apiKey, nil
+	}
+	return "", errors.New("no api key found " +
+		"neither in request header: X-TwelveLabs-Api-Key " +
+		"nor in environment variable under TWELVELABS_APIKEY")
+}

--- a/modules/multi2vec-twelvelabs/clients/twelvelabs_test.go
+++ b/modules/multi2vec-twelvelabs/clients/twelvelabs_test.go
@@ -1,0 +1,216 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
+)
+
+func TestClient(t *testing.T) {
+	t.Run("when embedding text and image", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t})
+		defer server.Close()
+		c := New("apiKey", 0, nullLogger())
+
+		expected := &modulecomponents.VectorizationCLIPResult[[]float32]{
+			TextVectors:  [][]float32{{0.1, 0.2, 0.3}},
+			ImageVectors: [][]float32{{0.4, 0.5, 0.6}},
+		}
+		res, err := c.Vectorize(context.Background(),
+			[]string{"This is my text"}, []string{base64.StdEncoding.EncodeToString([]byte("fake-image-bytes"))},
+			fakeClassConfig{classConfig: map[string]any{"baseURL": server.URL}},
+		)
+
+		require.Nil(t, err)
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("when the request sends correct multipart fields", func(t *testing.T) {
+		handler := &fakeHandler{t: t}
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		c := New("apiKey", 0, nullLogger())
+
+		_, err := c.VectorizeQuery(context.Background(), []string{"a query"},
+			fakeClassConfig{classConfig: map[string]any{"baseURL": server.URL}},
+		)
+
+		require.Nil(t, err)
+		assert.Equal(t, "marengo3.0", handler.gotModelName)
+		assert.Equal(t, "a query", handler.gotText)
+		assert.Equal(t, "apiKey", handler.gotAPIKey)
+	})
+
+	t.Run("when the context is expired", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t})
+		defer server.Close()
+		c := New("apiKey", 0, nullLogger())
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now())
+		defer cancel()
+
+		_, err := c.Vectorize(ctx, []string{"text"}, nil,
+			fakeClassConfig{classConfig: map[string]any{"baseURL": server.URL}},
+		)
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "context deadline exceeded")
+	})
+
+	t.Run("when the server returns an error", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t, serverError: "api_key_invalid"})
+		defer server.Close()
+		c := New("apiKey", 0, nullLogger())
+
+		_, err := c.Vectorize(context.Background(), []string{"text"}, nil,
+			fakeClassConfig{classConfig: map[string]any{"baseURL": server.URL}},
+		)
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "api_key_invalid")
+	})
+
+	t.Run("when the API key is passed via header", func(t *testing.T) {
+		handler := &fakeHandler{t: t}
+		server := httptest.NewServer(handler)
+		defer server.Close()
+		c := New("", 0, nullLogger())
+		ctx := context.WithValue(context.Background(),
+			"X-Twelvelabs-Api-Key", []string{"header-key"})
+
+		_, err := c.Vectorize(ctx, []string{"text"}, nil,
+			fakeClassConfig{classConfig: map[string]any{"baseURL": server.URL}},
+		)
+
+		require.Nil(t, err)
+		assert.Equal(t, "header-key", handler.gotAPIKey)
+	})
+
+	t.Run("when no API key is configured", func(t *testing.T) {
+		server := httptest.NewServer(&fakeHandler{t: t})
+		defer server.Close()
+		c := New("", 0, nullLogger())
+
+		_, err := c.Vectorize(context.Background(), []string{"text"}, nil,
+			fakeClassConfig{classConfig: map[string]any{"baseURL": server.URL}},
+		)
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "no api key found")
+	})
+}
+
+// TestClient_Live exercises the real Marengo Embed API and asserts a 512-dim
+// text embedding. It is skipped unless TWELVELABS_APIKEY is set.
+func TestClient_Live(t *testing.T) {
+	apiKey := os.Getenv("TWELVELABS_APIKEY")
+	if apiKey == "" {
+		t.Skip("set TWELVELABS_APIKEY to run the live TwelveLabs embedding test")
+	}
+
+	c := New(apiKey, 30*time.Second, nullLogger())
+	res, err := c.VectorizeQuery(context.Background(),
+		[]string{"a dog running on the beach"},
+		fakeClassConfig{classConfig: map[string]any{}},
+	)
+	require.Nil(t, err)
+	require.Len(t, res.TextVectors, 1)
+	assert.Len(t, res.TextVectors[0], 512)
+}
+
+type fakeHandler struct {
+	t            *testing.T
+	serverError  string
+	gotModelName string
+	gotText      string
+	gotImage     bool
+	gotAPIKey    string
+}
+
+func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	assert.Equal(f.t, http.MethodPost, r.Method)
+	f.gotAPIKey = r.Header.Get("x-api-key")
+
+	require.Nil(f.t, r.ParseMultipartForm(1<<20))
+	f.gotModelName = r.FormValue("model_name")
+	f.gotText = r.FormValue("text")
+	if file, _, err := r.FormFile("image_file"); err == nil {
+		f.gotImage = true
+		file.Close()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if f.serverError != "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(embedResponse{Code: "error", Message: f.serverError})
+		return
+	}
+
+	res := embedResponse{ModelName: "marengo3.0"}
+	if f.gotImage {
+		res.ImageEmbedding = &embedding{Segments: []segment{{Float: []float32{0.4, 0.5, 0.6}}}}
+	} else {
+		res.TextEmbedding = &embedding{Segments: []segment{{Float: []float32{0.1, 0.2, 0.3}}}}
+	}
+	json.NewEncoder(w).Encode(res)
+}
+
+func nullLogger() logrus.FieldLogger {
+	l, _ := test.NewNullLogger()
+	return l
+}
+
+type fakeClassConfig struct {
+	classConfig map[string]any
+}
+
+func (f fakeClassConfig) Class() map[string]any {
+	return f.classConfig
+}
+
+func (f fakeClassConfig) ClassByModuleName(moduleName string) map[string]any {
+	return f.classConfig
+}
+
+func (f fakeClassConfig) Property(propName string) map[string]any {
+	return f.classConfig
+}
+
+func (f fakeClassConfig) Tenant() string {
+	return ""
+}
+
+func (f fakeClassConfig) TargetVector() string {
+	return ""
+}
+
+func (f fakeClassConfig) PropertiesDataTypes() map[string]schema.DataType {
+	return nil
+}
+
+func (f fakeClassConfig) Config() *config.Config {
+	return nil
+}

--- a/modules/multi2vec-twelvelabs/config.go
+++ b/modules/multi2vec-twelvelabs/config.go
@@ -1,0 +1,45 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modtwelvelabs
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/modules/multi2vec-twelvelabs/ent"
+)
+
+func (m *Module) ClassConfigDefaults() map[string]any {
+	return map[string]any{
+		"vectorizeClassName": ent.DefaultVectorizeClassName,
+		"baseURL":            ent.DefaultBaseURL,
+		"model":              ent.DefaultTwelveLabsModel,
+	}
+}
+
+func (m *Module) PropertyConfigDefaults(
+	dt *schema.DataType,
+) map[string]any {
+	return map[string]any{}
+}
+
+func (m *Module) ValidateClass(ctx context.Context,
+	class *models.Class, cfg moduletools.ClassConfig,
+) error {
+	icheck := ent.NewClassSettings(cfg)
+	return icheck.Validate()
+}
+
+var _ = modulecapabilities.ClassConfigurator(New())

--- a/modules/multi2vec-twelvelabs/ent/class_settings.go
+++ b/modules/multi2vec-twelvelabs/ent/class_settings.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package ent
+
+import (
+	"github.com/weaviate/weaviate/entities/moduletools"
+	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
+)
+
+const (
+	baseURLProperty = "baseURL"
+	modelProperty   = "model"
+)
+
+const (
+	DefaultBaseURL               = "https://api.twelvelabs.io/v1.3"
+	DefaultTwelveLabsModel       = "marengo3.0"
+	DefaultVectorizeClassName    = false
+	DefaultPropertyIndexed       = true
+	DefaultVectorizePropertyName = false
+)
+
+var fields = []string{basesettings.TextFieldsProperty, basesettings.ImageFieldsProperty}
+
+type classSettings struct {
+	base *basesettings.BaseClassMultiModalSettings
+	cfg  moduletools.ClassConfig
+}
+
+func NewClassSettings(cfg moduletools.ClassConfig) *classSettings {
+	return &classSettings{
+		cfg:  cfg,
+		base: basesettings.NewBaseClassMultiModalSettingsWithAltNames(cfg, false, "multi2vec-twelvelabs", nil, nil),
+	}
+}
+
+// TwelveLabs settings
+func (cs *classSettings) Model() string {
+	return cs.base.GetPropertyAsString(modelProperty, DefaultTwelveLabsModel)
+}
+
+func (cs *classSettings) BaseURL() string {
+	return cs.base.GetPropertyAsString(baseURLProperty, DefaultBaseURL)
+}
+
+// Multi-modal field settings
+func (ic *classSettings) ImageField(property string) bool {
+	return ic.base.ImageField(property)
+}
+
+func (ic *classSettings) ImageFieldsWeights() ([]float32, error) {
+	return ic.base.ImageFieldsWeights()
+}
+
+func (ic *classSettings) TextField(property string) bool {
+	return ic.base.TextField(property)
+}
+
+func (ic *classSettings) TextFieldsWeights() ([]float32, error) {
+	return ic.base.TextFieldsWeights()
+}
+
+func (ic *classSettings) Properties() ([]string, error) {
+	return ic.base.VectorizableProperties(fields)
+}
+
+func (ic *classSettings) Validate() error {
+	if err := ic.base.ValidateMultiModal(fields); err != nil {
+		return err
+	}
+	if err := ic.base.ValidateBaseURL(ic.BaseURL()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/modules/multi2vec-twelvelabs/ent/class_settings_test.go
+++ b/modules/multi2vec-twelvelabs/ent/class_settings_test.go
@@ -1,0 +1,217 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package ent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+func Test_classSettings_Validate(t *testing.T) {
+	type fields struct {
+		cfg moduletools.ClassConfig
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "should not pass with empty config",
+			wantErr: true,
+		},
+		{
+			name: "should not pass with nil config",
+			fields: fields{
+				cfg: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "should not pass with empty imageFields",
+			fields: fields{
+				cfg: newConfigBuilder().addSetting("imageFields", []any{}).build(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "should not pass with empty string in imageFields",
+			fields: fields{
+				cfg: newConfigBuilder().addSetting("imageFields", []any{""}).build(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "should pass with proper value in imageFields",
+			fields: fields{
+				cfg: newConfigBuilder().addSetting("imageFields", []any{"field"}).build(),
+			},
+		},
+		{
+			name: "should pass with proper value in imageFields and textFields",
+			fields: fields{
+				cfg: newConfigBuilder().
+					addSetting("imageFields", []any{"imageField"}).
+					addSetting("textFields", []any{"textField"}).
+					build(),
+			},
+		},
+		{
+			name: "should pass with proper value in 2 imageFields and 2 textFields and weights",
+			fields: fields{
+				cfg: newConfigBuilder().
+					addSetting("textFields", []any{"textField1", "textField2"}).
+					addSetting("imageFields", []any{"imageField1", "imageField2"}).
+					addWeights([]any{1, 2}, []any{1, 2}).
+					build(),
+			},
+		},
+		{
+			name: "should not pass with mismatched weights and fields",
+			fields: fields{
+				cfg: newConfigBuilder().
+					addSetting("textFields", []any{"textField1", "textField2"}).
+					addSetting("imageFields", []any{"imageField1"}).
+					addWeights([]any{1}, []any{1}).
+					build(),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ic := NewClassSettings(tt.fields.cfg)
+			if err := ic.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("classSettings.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_classSettings_Defaults(t *testing.T) {
+	ic := NewClassSettings(newConfigBuilder().addSetting("imageFields", []any{"field"}).build())
+	assert.Equal(t, DefaultTwelveLabsModel, ic.Model())
+	assert.Equal(t, DefaultBaseURL, ic.BaseURL())
+}
+
+func Test_classSettings_ValidateBaseURL(t *testing.T) {
+	t.Setenv("MODULES_VALIDATE_BASE_URL", "true")
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr bool
+	}{
+		{
+			name:    "valid HTTPS URL",
+			baseURL: "https://api.twelvelabs.io/v1.3",
+			wantErr: false,
+		},
+		{
+			name:    "HTTP URL is rejected",
+			baseURL: "http://api.example.com",
+			wantErr: true,
+		},
+		{
+			name:    "loopback address is rejected",
+			baseURL: "https://127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "default URL is valid",
+			baseURL: DefaultBaseURL,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ic := NewClassSettings(newConfigBuilder().
+				addSetting("imageFields", []any{"field"}).
+				addSetting("baseURL", tt.baseURL).
+				build())
+			err := ic.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+type builder struct {
+	fakeClassConfig *fakeClassConfig
+}
+
+func newConfigBuilder() *builder {
+	return &builder{
+		fakeClassConfig: &fakeClassConfig{config: map[string]any{}},
+	}
+}
+
+func (b *builder) addSetting(name string, value any) *builder {
+	b.fakeClassConfig.config[name] = value
+	return b
+}
+
+func (b *builder) addWeights(textWeights, imageWeights []any) *builder {
+	if textWeights != nil || imageWeights != nil {
+		weightSettings := map[string]any{}
+		if textWeights != nil {
+			weightSettings["textFields"] = textWeights
+		}
+		if imageWeights != nil {
+			weightSettings["imageFields"] = imageWeights
+		}
+		b.fakeClassConfig.config["weights"] = weightSettings
+	}
+	return b
+}
+
+func (b *builder) build() *fakeClassConfig {
+	return b.fakeClassConfig
+}
+
+type fakeClassConfig struct {
+	config map[string]any
+}
+
+func (c fakeClassConfig) Class() map[string]any {
+	return c.config
+}
+
+func (c fakeClassConfig) ClassByModuleName(moduleName string) map[string]any {
+	return c.config
+}
+
+func (c fakeClassConfig) Property(propName string) map[string]any {
+	return c.config
+}
+
+func (f fakeClassConfig) Tenant() string {
+	return ""
+}
+
+func (f fakeClassConfig) TargetVector() string {
+	return ""
+}
+
+func (f fakeClassConfig) PropertiesDataTypes() map[string]schema.DataType {
+	return nil
+}
+
+func (f fakeClassConfig) Config() *config.Config {
+	return nil
+}

--- a/modules/multi2vec-twelvelabs/module.go
+++ b/modules/multi2vec-twelvelabs/module.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modtwelvelabs
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/modules/multi2vec-twelvelabs/clients"
+	"github.com/weaviate/weaviate/modules/multi2vec-twelvelabs/ent"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/vectorizer/batchclip"
+)
+
+const Name = "multi2vec-twelvelabs"
+
+func New() *Module {
+	return &Module{}
+}
+
+type Module struct {
+	vectorizer               batchclip.Vectorizer[[]float32]
+	batchSimple              *batch.BatchSimple[[]float32]
+	nearImageGraphqlProvider modulecapabilities.GraphQLArguments
+	nearImageSearcher        modulecapabilities.Searcher[[]float32]
+	nearTextGraphqlProvider  modulecapabilities.GraphQLArguments
+	nearTextSearcher         modulecapabilities.Searcher[[]float32]
+	nearTextTransformer      modulecapabilities.TextTransform
+	metaClient               metaClient
+	logger                   logrus.FieldLogger
+}
+
+type metaClient interface {
+	MetaInfo() (map[string]any, error)
+}
+
+func (m *Module) Name() string {
+	return Name
+}
+
+func (m *Module) Type() modulecapabilities.ModuleType {
+	return modulecapabilities.Multi2Vec
+}
+
+func (m *Module) Init(ctx context.Context,
+	params moduletools.ModuleInitParams,
+) error {
+	m.logger = params.GetLogger()
+	if err := m.initVectorizer(ctx, params.GetConfig().ModuleHttpClientTimeout, params.GetLogger()); err != nil {
+		return errors.Wrap(err, "init vectorizer")
+	}
+
+	if err := m.initNearImage(); err != nil {
+		return errors.Wrap(err, "init near image")
+	}
+
+	return nil
+}
+
+func (m *Module) InitExtension(modules []modulecapabilities.Module) error {
+	for _, module := range modules {
+		if module.Name() == m.Name() {
+			continue
+		}
+		if arg, ok := module.(modulecapabilities.TextTransformers); ok {
+			if arg != nil && arg.TextTransformers() != nil {
+				m.nearTextTransformer = arg.TextTransformers()["nearText"]
+			}
+		}
+	}
+
+	if err := m.initNearText(); err != nil {
+		return errors.Wrap(err, "init near text")
+	}
+
+	return nil
+}
+
+func (m *Module) initVectorizer(ctx context.Context, timeout time.Duration,
+	logger logrus.FieldLogger,
+) error {
+	apiKey := os.Getenv("TWELVELABS_APIKEY")
+	client := clients.New(apiKey, timeout, logger)
+
+	m.vectorizer = batchclip.New(Name, client)
+	m.batchSimple = batch.NewBatchSimple[[]float32](logger, 0)
+	m.metaClient = client
+
+	return nil
+}
+
+func (m *Module) VectorizeObject(ctx context.Context,
+	obj *models.Object, cfg moduletools.ClassConfig,
+) ([]float32, models.AdditionalProperties, error) {
+	return m.vectorizer.Object(ctx, obj, cfg)
+}
+
+func (m *Module) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
+	return m.batchSimple.VectorizeBatchObjects(ctx, objs, skipObject, cfg, m.vectorizer.Objects, 10)
+}
+
+func (m *Module) VectorizableProperties(cfg moduletools.ClassConfig) (bool, []string, error) {
+	ichek := ent.NewClassSettings(cfg)
+	mediaProps, err := ichek.Properties()
+	return false, mediaProps, err
+}
+
+func (m *Module) MetaInfo() (map[string]any, error) {
+	return m.metaClient.MetaInfo()
+}
+
+func (m *Module) VectorizeInput(ctx context.Context,
+	input string, cfg moduletools.ClassConfig,
+) ([]float32, error) {
+	return m.vectorizer.Texts(ctx, []string{input}, cfg)
+}
+
+// verify we implement the modules.Module interface
+var (
+	_ = modulecapabilities.Module(New())
+	_ = modulecapabilities.Vectorizer[[]float32](New())
+	_ = modulecapabilities.InputVectorizer[[]float32](New())
+)

--- a/modules/multi2vec-twelvelabs/nearArguments.go
+++ b/modules/multi2vec-twelvelabs/nearArguments.go
@@ -1,0 +1,51 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modtwelvelabs
+
+import (
+	"maps"
+
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/arguments/nearImage"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/arguments/nearText"
+)
+
+func (m *Module) initNearImage() error {
+	m.nearImageSearcher = nearImage.NewSearcher(m.vectorizer)
+	m.nearImageGraphqlProvider = nearImage.New()
+	return nil
+}
+
+func (m *Module) initNearText() error {
+	m.nearTextSearcher = nearText.NewSearcher(m.vectorizer)
+	m.nearTextGraphqlProvider = nearText.New(m.nearTextTransformer)
+	return nil
+}
+
+func (m *Module) Arguments() map[string]modulecapabilities.GraphQLArgument {
+	arguments := map[string]modulecapabilities.GraphQLArgument{}
+	maps.Copy(arguments, m.nearTextGraphqlProvider.Arguments())
+	maps.Copy(arguments, m.nearImageGraphqlProvider.Arguments())
+	return arguments
+}
+
+func (m *Module) VectorSearches() map[string]modulecapabilities.VectorForParams[[]float32] {
+	vectorSearches := map[string]modulecapabilities.VectorForParams[[]float32]{}
+	maps.Copy(vectorSearches, m.nearTextSearcher.VectorSearches())
+	maps.Copy(vectorSearches, m.nearImageSearcher.VectorSearches())
+	return vectorSearches
+}
+
+var (
+	_ = modulecapabilities.GraphQLArguments(New())
+	_ = modulecapabilities.Searcher[[]float32](New())
+)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

### What's being changed:

This PR adds a new opt-in `multi2vec-twelvelabs` vectorizer module that embeds text and image properties with TwelveLabs' [Marengo](https://docs.twelvelabs.io/v1.3/docs/concepts/models/marengo) multimodal model via the Embed API (`POST /v1.3/embed`). It produces 512-dim vectors that can be used for `nearText` and `nearImage` search, slotting TwelveLabs into the existing multimodal-embedder ecosystem alongside `multi2vec-cohere`, `multi2vec-voyageai`, etc.

Why it helps Weaviate: Marengo is a strong video/multimodal embedding model. This gives Weaviate users another best-in-class option for multimodal semantic search, and lays the groundwork for native video embeddings (see note below).

**Implementation** mirrors the existing `multi2vec-cohere` / `multi2vec-voyageai` modules so it stays consistent with the codebase:
- Reuses the shared `batchclip` vectorizer, the multi-modal `BaseClassMultiModalSettings`, and `modulecomponents.NewBaseHttpClient`.
- Registered in `configure_api.go` exactly like the sibling modules.
- API key via `TWELVELABS_APIKEY` env var or the `X-TwelveLabs-Api-Key` request header. `baseURL` and `model` (default `marengo3.0`) are configurable per-class.

**Opt-in / non-breaking:** the module is disabled by default and is only registered when explicitly enabled via `ENABLE_MODULES`. It changes no existing behaviour or defaults.

**Scope note:** Marengo's *video* embeddings use the asynchronous task endpoint, which doesn't fit Weaviate's synchronous `Vectorize` contract cleanly, so this first PR covers text + image (synchronous). Video can follow as a separate change if there's interest.

### How it was tested:
- No-network unit tests for the client (multipart request wiring, `model_name`/`text`/`image_file` fields, API-key resolution via header and env, server-error handling) and for the class settings / base-URL validation — all passing.
- An `TWELVELABS_APIKEY`-gated live test that calls the real Marengo Embed API and asserts a 512-dim text embedding — passing against production.
- `go build`, `go vet`, and `gofmt -l` are clean on the new packages.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: _docs live in weaviate-io; happy to open a follow-up_
- [x] Chaos pipeline run or not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

> Note: I'll sign the Weaviate CLA when the bot prompts. This is my (TwelveLabs') contribution.
