### PR TITLE
Return proper error code from shard endpoints when index is not found

### DIFF
--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -248,6 +248,9 @@ func (s *schemaHandlers) getShardsStatus(params schema.SchemaObjectsShardsGetPar
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsShardsGetForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsShardsGetNotFound().
+				WithPayload(errPayloadFromSingleErr(err))
 		default:
 			return schema.NewSchemaObjectsShardsGetInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
@@ -272,6 +275,9 @@ func (s *schemaHandlers) updateShardStatus(params schema.SchemaObjectsShardsUpda
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsShardsUpdateForbidden().
+				WithPayload(errPayloadFromSingleErr(err))
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsShardsUpdateNotFound().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
 			return schema.NewSchemaObjectsShardsUpdateInternalServerError().

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -541,7 +541,8 @@ func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string
 
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
-		return nil, errors.Errorf("cannot get shards status for a non-existing index for %s", className)
+		// index not yet local (RAFT schema not applied on this node) or class does not exist
+		return nil, fmt.Errorf("cannot get shards status for a non-existing index for %s: %w", className, schemaUC.ErrNotFound)
 	}
 
 	return idx.getShardsStatus(ctx, tenant)
@@ -555,7 +556,8 @@ func (m *Migrator) UpdateShardStatus(ctx context.Context, className, shardName, 
 
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
-		return errors.Errorf("cannot update shard status to a non-existing index for %s", className)
+		// index not yet local (RAFT schema not applied on this node) or class does not exist
+		return fmt.Errorf("cannot update shard status to a non-existing index for %s: %w", className, schemaUC.ErrNotFound)
 	}
 
 	return idx.updateShardStatus(ctx, shardName, targetStatus)

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -340,6 +340,41 @@ func TestUpdateIndexShards(t *testing.T) {
 	}
 }
 
+// When the index is not local yet (RAFT schema not applied on this node) or
+// the class does not exist, the shard-status migrator methods must wrap
+// schemaUC.ErrNotFound so the REST handler maps them to 404 rather than 500.
+func TestShardsStatusNonExistingIndexWrapsNotFound(t *testing.T) {
+	logger := logrus.New()
+	migrator := NewMigrator(&DB{}, logger, "node1")
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "GetShardsStatus",
+			call: func() error {
+				_, err := migrator.GetShardsStatus(context.Background(), "DoesNotExist", "")
+				return err
+			},
+		},
+		{
+			name: "UpdateShardStatus",
+			call: func() error {
+				return migrator.UpdateShardStatus(context.Background(), "DoesNotExist", "shard1", models.TenantActivityStatusHOT, 0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			require.Error(t, err)
+			require.ErrorIs(t, err, schemaUC.ErrNotFound)
+		})
+	}
+}
+
 func TestListAndGetFilesWithIntegrityChecking(t *testing.T) {
 	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
 	mockSchemaGetter.On("NodeName").Return("node1")


### PR DESCRIPTION
### What's being changed:

Was changed from blanket 404 to blanket 500. Now we detect the specific 404 cases and return the correct code

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
