### PR TITLE
Fix more error codes in REST handler

### DIFF
--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -48,7 +48,7 @@ func (s *aliasesHandlers) getAliases(params schema.AliasesGetParams,
 			return schema.NewAliasesGetForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewAliasesGetForbidden().
+			return schema.NewAliasesGetInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
@@ -75,7 +75,7 @@ func (s *aliasesHandlers) getAlias(params schema.AliasesGetAliasParams,
 			return schema.NewAliasesGetAliasForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewAliasesGetAliasForbidden().
+			return schema.NewAliasesGetAliasInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
@@ -141,7 +141,7 @@ func (s *aliasesHandlers) deleteAlias(params schema.AliasesDeleteParams, princip
 			return schema.NewAliasesDeleteForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewAliasesCreateUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewAliasesDeleteInternalServerError().WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
 

--- a/adapters/handlers/rest/handlers_backup.go
+++ b/adapters/handlers/rest/handlers_backup.go
@@ -268,16 +268,13 @@ func (s *backupHandlers) restoreBackupStatus(params backups.BackupsRestoreStatus
 		s.metricRequestsTotal.logError("", err)
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
-			return backups.NewBackupsRestoreForbidden().
+			return backups.NewBackupsRestoreStatusForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		case errors.As(err, &backup.ErrNotFound{}):
-			return backups.NewBackupsRestoreNotFound().
-				WithPayload(errPayloadFromSingleErr(err))
-		case errors.As(err, &backup.ErrUnprocessable{}):
-			return backups.NewBackupsRestoreUnprocessableEntity().
+			return backups.NewBackupsRestoreStatusNotFound().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return backups.NewBackupsRestoreInternalServerError().
+			return backups.NewBackupsRestoreStatusInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}

--- a/adapters/handlers/rest/handlers_distributed_tasks.go
+++ b/adapters/handlers/rest/handlers_distributed_tasks.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/distributed_tasks"
-	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/nodes"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -44,7 +43,7 @@ func (h *distributedTasksHandlers) getTasks(params distributed_tasks.Distributed
 		if errors.As(err, &autherrs.Forbidden{}) {
 			return distributed_tasks.NewDistributedTasksGetForbidden()
 		}
-		return nodes.NewNodesGetClassInternalServerError().
+		return distributed_tasks.NewDistributedTasksGetInternalServerError().
 			WithPayload(errPayloadFromSingleErr(err))
 	}
 

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -389,6 +389,8 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 		} else if errors.As(err, &authzerrors.Forbidden{}) {
 			return objects.NewObjectsClassPutForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
+		} else if errors.As(err, &uco.ErrNotFound{}) {
+			return objects.NewObjectsClassPutNotFound()
 		} else {
 			return objects.NewObjectsClassPutInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))


### PR DESCRIPTION
### What's being changed:

  | Endpoint | Handler | Before | After | Impact |
  |---|---|---|---|---|
  | `GET /schema/{class}/shards` | `getShardsStatus` | `500` | `404` | Index-not-local (RAFT propagation lag) / unknown class no longer reported as a server error |
  | `PUT /schema/{class}/shards/{shard}` | `updateShardStatus` | `500` | `404` | Same: non-existing index → 404, real failures still 500 |
  | `PUT /objects/{class}/{id}` | `updateObject` | `500` | `404` | Updating a missing object now returns Not Found (matches `deleteObject`/`patchObject`) |
  | `GET /aliases` | `getAliases` | `403` | `500` | Operational RAFT/query errors no longer mislabeled as Forbidden |
  | `GET /aliases/{name}` | `getAlias` | `403` | `500` | Same Forbidden-in-default bug |
  | `DELETE /aliases/{name}` | `deleteAlias` | `422` | `500` | Operational failures → 500, and correct operation's responder |
  | `GET /backups/{backend}/{id}/restore/status` | `restoreBackupStatus` | `422` | `500` | Correct responder family; `ErrUnprocessable` no longer emits an undeclared 422 |
  | `GET /tasks` | `getTasks` | `500` | `500` | Correct operation's responder (status unchanged) |

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
