### PR TITLE
fix: handle text[] in Boost filter Equal (#11814)

### DIFF
--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -353,6 +353,31 @@ func matchesValueClause(clause *filters.Clause, props map[string]any) bool {
 }
 
 func compareValues(op filters.Operator, propVal, filterVal any) bool {
+	// When the property value is a slice (e.g. text[], number[], boolean[]),
+	// compare each element individually.  For Equal the condition matches if
+	// any element matches; for NotEqual it matches only when no element
+	// equals the filter value; for ordered comparisons it matches if any
+	// element satisfies the relation.
+	if elems, ok := asSlice(propVal); ok {
+		switch op {
+		case filters.OperatorNotEqual:
+			// Array does not contain the filter value.
+			for _, elem := range elems {
+				if compareValues(filters.OperatorEqual, elem, filterVal) {
+					return false
+				}
+			}
+			return true
+		default:
+			for _, elem := range elems {
+				if compareValues(op, elem, filterVal) {
+					return true
+				}
+			}
+			return false
+		}
+	}
+
 	// Try boolean comparison.
 	if boolVal, ok := asBool(propVal); ok {
 		if filterBool, ok := asBool(filterVal); ok {
@@ -438,6 +463,48 @@ func asFloat64(v any) (float64, bool) {
 		return float64(n), true
 	default:
 		return 0, false
+	}
+}
+
+// asSlice normalises a property value into a flat []any so that array-typed
+// properties (text[], number[], boolean[], int[]) can be element-wise
+// compared.  Returns (nil, false) for non-slice values.
+func asSlice(v any) ([]any, bool) {
+	switch s := v.(type) {
+	case []any:
+		return s, true
+	case []string:
+		out := make([]any, len(s))
+		for i, str := range s {
+			out[i] = str
+		}
+		return out, true
+	case []float64:
+		out := make([]any, len(s))
+		for i, n := range s {
+			out[i] = n
+		}
+		return out, true
+	case []int:
+		out := make([]any, len(s))
+		for i, n := range s {
+			out[i] = n
+		}
+		return out, true
+	case []int64:
+		out := make([]any, len(s))
+		for i, n := range s {
+			out[i] = n
+		}
+		return out, true
+	case []bool:
+		out := make([]any, len(s))
+		for i, b := range s {
+			out[i] = b
+		}
+		return out, true
+	default:
+		return nil, false
 	}
 }
 

--- a/usecases/traverser/boost_scorer_test.go
+++ b/usecases/traverser/boost_scorer_test.go
@@ -473,7 +473,7 @@ func TestCompareValues_Boolean(t *testing.T) {
 
 // --- compareValues with array-typed properties (text[], number[], boolean[]) ---
 
-func TestCompareValues_ArrayString(t *testing.T) {
+func TestBoostCompareValues_ArrayString(t *testing.T) {
 	tests := []struct {
 		name     string
 		op       filters.Operator
@@ -499,7 +499,7 @@ func TestCompareValues_ArrayString(t *testing.T) {
 	}
 }
 
-func TestCompareValues_ArrayFloat64(t *testing.T) {
+func TestBoostCompareValues_ArrayFloat64(t *testing.T) {
 	tests := []struct {
 		name     string
 		op       filters.Operator
@@ -525,7 +525,36 @@ func TestCompareValues_ArrayFloat64(t *testing.T) {
 	}
 }
 
-func TestCompareValues_ArrayBool(t *testing.T) {
+func TestBoostCompareValues_ArrayInt(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       filters.Operator
+		propVal  any
+		filterV  any
+		expected bool
+	}{
+		{"equal int match", filters.OperatorEqual, []int{10, 20}, float64(10), true},
+		{"equal int no match", filters.OperatorEqual, []int{10, 20}, float64(30), false},
+		{"not equal int no match", filters.OperatorNotEqual, []int{10, 20}, float64(30), true},
+		{"not equal int match", filters.OperatorNotEqual, []int{10, 20}, float64(10), false},
+		{"greater than int match", filters.OperatorGreaterThan, []int{5, 20}, float64(10), true},
+		{"greater than int no match", filters.OperatorGreaterThan, []int{5, 8}, float64(10), false},
+		{"less than int match", filters.OperatorLessThan, []int{5, 20}, float64(10), true},
+		{"less than int no match", filters.OperatorLessThan, []int{15, 20}, float64(10), false},
+		{"equal int64 match", filters.OperatorEqual, []int64{10, 20}, float64(20), true},
+		{"greater or equal int64", filters.OperatorGreaterThanEqual, []int64{10, 20}, float64(20), true},
+		{"less or equal int64", filters.OperatorLessThanEqual, []int64{10, 20}, float64(10), true},
+		{"empty int slice equal", filters.OperatorEqual, []int{}, float64(10), false},
+		{"empty int slice not equal", filters.OperatorNotEqual, []int{}, float64(10), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, compareValues(tt.op, tt.propVal, tt.filterV))
+		})
+	}
+}
+
+func TestBoostCompareValues_ArrayBool(t *testing.T) {
 	// []bool array with Equal
 	assert.True(t, compareValues(filters.OperatorEqual, []bool{false, true}, true))
 	assert.False(t, compareValues(filters.OperatorEqual, []bool{false, false}, true))
@@ -534,15 +563,22 @@ func TestCompareValues_ArrayBool(t *testing.T) {
 	assert.False(t, compareValues(filters.OperatorNotEqual, []bool{false, true}, true))
 }
 
-func TestCompareValues_AnySlice(t *testing.T) {
+func TestBoostCompareValues_AnySlice(t *testing.T) {
 	// []any containing mixed types
 	assert.True(t, compareValues(filters.OperatorEqual, []any{"a", "b"}, "b"))
 	assert.False(t, compareValues(filters.OperatorEqual, []any{"a", "b"}, "c"))
 	assert.True(t, compareValues(filters.OperatorNotEqual, []any{"a", "b"}, "c"))
 	assert.False(t, compareValues(filters.OperatorNotEqual, []any{"a", "b"}, "a"))
+	assert.True(t, compareValues(filters.OperatorEqual, []any{"a", int(10), nil, true}, float64(10)))
+	assert.True(t, compareValues(filters.OperatorEqual, []any{"a", int(10), nil, true}, true))
+	assert.False(t, compareValues(filters.OperatorEqual, []any{"a", int(10), nil, true}, nil))
+	assert.True(t, compareValues(filters.OperatorNotEqual, []any{"a", int(10), nil, true}, nil))
+	assert.False(t, compareValues(filters.OperatorGreaterThan, []any{"a", nil, true}, float64(10)))
+	assert.False(t, compareValues(filters.OperatorEqual, nil, nil))
+	assert.False(t, compareValues(filters.OperatorNotEqual, nil, "a"))
 }
 
-func TestCompareValues_NonSliceUnchanged(t *testing.T) {
+func TestBoostCompareValues_NonSliceUnchanged(t *testing.T) {
 	// Scalar values should still work as before (not affected by asSlice logic)
 	assert.True(t, compareValues(filters.OperatorEqual, "red", "red"))
 	assert.False(t, compareValues(filters.OperatorEqual, "red", "blue"))
@@ -947,7 +983,7 @@ func TestAsBool(t *testing.T) {
 
 // --- asSlice ---
 
-func TestAsSlice(t *testing.T) {
+func TestBoostAsSlice(t *testing.T) {
 	t.Run("[]string", func(t *testing.T) {
 		out, ok := asSlice([]string{"a", "b"})
 		assert.True(t, ok)
@@ -1001,6 +1037,13 @@ func TestAsSlice(t *testing.T) {
 
 	t.Run("empty slice", func(t *testing.T) {
 		out, ok := asSlice([]string{})
+		assert.True(t, ok)
+		assert.Empty(t, out)
+	})
+
+	t.Run("typed nil slice", func(t *testing.T) {
+		var in []int
+		out, ok := asSlice(in)
 		assert.True(t, ok)
 		assert.Empty(t, out)
 	})

--- a/usecases/traverser/boost_scorer_test.go
+++ b/usecases/traverser/boost_scorer_test.go
@@ -471,6 +471,84 @@ func TestCompareValues_Boolean(t *testing.T) {
 	assert.True(t, compareValues(filters.OperatorNotEqual, true, false))
 }
 
+// --- compareValues with array-typed properties (text[], number[], boolean[]) ---
+
+func TestCompareValues_ArrayString(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       filters.Operator
+		propVal  any
+		filterV  any
+		expected bool
+	}{
+		// Equal: match if any element matches
+		{"equal match first", filters.OperatorEqual, []string{"red", "green"}, "red", true},
+		{"equal match last", filters.OperatorEqual, []string{"red", "green"}, "green", true},
+		{"equal no match", filters.OperatorEqual, []string{"red", "green"}, "blue", false},
+		// NotEqual: true only when no element equals the filter
+		{"not equal no match", filters.OperatorNotEqual, []string{"red", "green"}, "blue", true},
+		{"not equal match", filters.OperatorNotEqual, []string{"red", "green"}, "red", false},
+		// Empty slice
+		{"empty slice equal", filters.OperatorEqual, []string{}, "red", false},
+		{"empty slice not equal", filters.OperatorNotEqual, []string{}, "red", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, compareValues(tt.op, tt.propVal, tt.filterV))
+		})
+	}
+}
+
+func TestCompareValues_ArrayFloat64(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       filters.Operator
+		propVal  any
+		filterV  any
+		expected bool
+	}{
+		{"equal match", filters.OperatorEqual, []float64{10, 20}, float64(10), true},
+		{"equal no match", filters.OperatorEqual, []float64{10, 20}, float64(30), false},
+		{"not equal", filters.OperatorNotEqual, []float64{10, 20}, float64(30), true},
+		{"not equal match", filters.OperatorNotEqual, []float64{10, 20}, float64(10), false},
+		{"greater than match", filters.OperatorGreaterThan, []float64{5, 20}, float64(10), true},
+		{"greater than no match", filters.OperatorGreaterThan, []float64{5, 8}, float64(10), false},
+		{"less than match", filters.OperatorLessThan, []float64{5, 20}, float64(10), true},
+		{"less than no match", filters.OperatorLessThan, []float64{15, 20}, float64(10), false},
+		{"greater or equal", filters.OperatorGreaterThanEqual, []float64{10, 20}, float64(10), true},
+		{"less or equal", filters.OperatorLessThanEqual, []float64{10, 20}, float64(10), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, compareValues(tt.op, tt.propVal, tt.filterV))
+		})
+	}
+}
+
+func TestCompareValues_ArrayBool(t *testing.T) {
+	// []bool array with Equal
+	assert.True(t, compareValues(filters.OperatorEqual, []bool{false, true}, true))
+	assert.False(t, compareValues(filters.OperatorEqual, []bool{false, false}, true))
+	// []bool array with NotEqual
+	assert.True(t, compareValues(filters.OperatorNotEqual, []bool{false, false}, true))
+	assert.False(t, compareValues(filters.OperatorNotEqual, []bool{false, true}, true))
+}
+
+func TestCompareValues_AnySlice(t *testing.T) {
+	// []any containing mixed types
+	assert.True(t, compareValues(filters.OperatorEqual, []any{"a", "b"}, "b"))
+	assert.False(t, compareValues(filters.OperatorEqual, []any{"a", "b"}, "c"))
+	assert.True(t, compareValues(filters.OperatorNotEqual, []any{"a", "b"}, "c"))
+	assert.False(t, compareValues(filters.OperatorNotEqual, []any{"a", "b"}, "a"))
+}
+
+func TestCompareValues_NonSliceUnchanged(t *testing.T) {
+	// Scalar values should still work as before (not affected by asSlice logic)
+	assert.True(t, compareValues(filters.OperatorEqual, "red", "red"))
+	assert.False(t, compareValues(filters.OperatorEqual, "red", "blue"))
+	assert.True(t, compareValues(filters.OperatorEqual, float64(42), float64(42)))
+}
+
 // --- Decay function tests ---
 
 func TestComputeDecayFunction_Exp(t *testing.T) {
@@ -865,6 +943,67 @@ func TestAsBool(t *testing.T) {
 
 	_, ok = asBool("string")
 	assert.False(t, ok)
+}
+
+// --- asSlice ---
+
+func TestAsSlice(t *testing.T) {
+	t.Run("[]string", func(t *testing.T) {
+		out, ok := asSlice([]string{"a", "b"})
+		assert.True(t, ok)
+		assert.Equal(t, []any{"a", "b"}, out)
+	})
+
+	t.Run("[]float64", func(t *testing.T) {
+		out, ok := asSlice([]float64{1, 2})
+		assert.True(t, ok)
+		assert.Equal(t, []any{float64(1), float64(2)}, out)
+	})
+
+	t.Run("[]bool", func(t *testing.T) {
+		out, ok := asSlice([]bool{true, false})
+		assert.True(t, ok)
+		assert.Equal(t, []any{true, false}, out)
+	})
+
+	t.Run("[]any", func(t *testing.T) {
+		in := []any{"x", 42}
+		out, ok := asSlice(in)
+		assert.True(t, ok)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("[]int", func(t *testing.T) {
+		out, ok := asSlice([]int{1, 2})
+		assert.True(t, ok)
+		assert.Equal(t, []any{1, 2}, out)
+	})
+
+	t.Run("[]int64", func(t *testing.T) {
+		out, ok := asSlice([]int64{1, 2})
+		assert.True(t, ok)
+		assert.Equal(t, []any{int64(1), int64(2)}, out)
+	})
+
+	t.Run("non-slice returns false", func(t *testing.T) {
+		_, ok := asSlice("not a slice")
+		assert.False(t, ok)
+
+		_, ok = asSlice(float64(42))
+		assert.False(t, ok)
+
+		_, ok = asSlice(true)
+		assert.False(t, ok)
+
+		_, ok = asSlice(nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		out, ok := asSlice([]string{})
+		assert.True(t, ok)
+		assert.Empty(t, out)
+	})
 }
 
 // --- parseOriginAsTime ---
@@ -1275,6 +1414,62 @@ func TestApplyBoostScoring_PropertyValueAllMissing(t *testing.T) {
 	// score decides the order.
 	assert.Equal(t, strfmt.UUID("high-primary"), got[0].ID)
 	assert.Equal(t, strfmt.UUID("low-primary"), got[1].ID)
+}
+
+// Integration: applyBoostScoring with array-typed properties (text[], number[]).
+// Reproduces https://github.com/weaviate/weaviate/issues/11814.
+func TestApplyBoostScoring_TextArrayFilter(t *testing.T) {
+	results := []search.Result{
+		makeResult("no-tag", 1.0, map[string]any{"tags": []string{"sports", "news"}}),
+		makeResult("has-tag", 0.5, map[string]any{"tags": []string{"tech", "science"}}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("tags", filters.OperatorEqual, "tech", schema.DataTypeText),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// has-tag contains "tech" → boost=1.0; no-tag does not → boost=0.0
+	require.Len(t, got, 2)
+	assert.Equal(t, strfmt.UUID("has-tag"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("no-tag"), got[1].ID)
+}
+
+func TestApplyBoostScoring_NumberArrayFilter(t *testing.T) {
+	results := []search.Result{
+		makeResult("match", 0.5, map[string]any{"scores": []float64{100, 200, 300}}),
+		makeResult("no-match", 1.0, map[string]any{"scores": []float64{10, 20, 30}}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("scores", filters.OperatorEqual, float64(200), schema.DataTypeNumber),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	require.Len(t, got, 2)
+	assert.Equal(t, strfmt.UUID("match"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("no-match"), got[1].ID)
+}
+
+func TestApplyBoostScoring_TextArrayNotEqual(t *testing.T) {
+	results := []search.Result{
+		makeResult("has-banned", 1.0, map[string]any{"tags": []string{"spam", "news"}}),
+		makeResult("clean", 0.5, map[string]any{"tags": []string{"sports", "tech"}}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("tags", filters.OperatorNotEqual, "spam", schema.DataTypeText),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// clean: no element == "spam" → NotEqual=true → boost=1.0
+	// has-banned: contains "spam" → NotEqual=false → boost=0.0
+	require.Len(t, got, 2)
+	assert.Equal(t, strfmt.UUID("clean"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("has-banned"), got[1].ID)
 }
 
 func cloneResults(results []search.Result) []search.Result {


### PR DESCRIPTION
Fixes #11814

## Problem

Boost filter conditions using `OperatorEqual` (or any other comparison operator) never match objects whose property is an array type (`text[]`, `number[]`, `boolean[]`, `int[]`). The `compareValues()` function in `boost_scorer.go` only handles scalar types (`bool`, `float64`, `string`) via type assertions. When the property value is a slice, all assertions fail and the function returns `false` unconditionally.

## Fix

Added an `asSlice()` helper that normalises typed slices (`[]string`, `[]float64`, `[]int`, `[]int64`, `[]bool`, `[]any`) into `[]any`, and handle slices at the top of `compareValues()` by iterating over elements:

- **Equal**: match if any element equals the filter value
- **NotEqual**: match if no element equals the filter value (array does not contain the value)
- **Ordered operators** (GreaterThan, LessThan, etc.): match if any element satisfies the relation