### PR TITLE
Fix partial permission removal from role

### DIFF
--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -195,14 +195,20 @@ func (m *Manager) RemovePermissions(roleName string, permissions []*authorizatio
 	m.restoreLock.RLock()
 	defer m.restoreLock.RUnlock()
 
+	changed := false
 	for _, permission := range permissions {
 		ok, err := m.casbin.RemoveNamedPolicy("p", conv.PrefixRoleName(roleName), permission.Resource, permission.Verb, permission.Domain)
 		if err != nil {
 			return fmt.Errorf("RemoveNamedPolicy: %w", err)
 		}
-		if !ok {
-			return nil // deletes are idempotent
+		// Removing an already-absent permission is a no-op; keep going so the
+		// rest of the batch is still removed.
+		if ok {
+			changed = true
 		}
+	}
+	if !changed {
+		return nil
 	}
 	if err := m.casbin.SavePolicy(); err != nil {
 		return fmt.Errorf("SavePolicy: %w", err)

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -305,6 +305,88 @@ func TestRestoreInvalidatesEnforceCache(t *testing.T) {
 	assert.False(t, allowed, "enforce cache was not invalidated during Restore; stale cached result returned")
 }
 
+func TestRemovePermissions(t *testing.T) {
+	const role = "test-role"
+	p1 := &authorization.Policy{Resource: "collections/Foo", Verb: authorization.READ, Domain: authorization.SchemaDomain}
+	p2 := &authorization.Policy{Resource: "collections/Bar", Verb: authorization.READ, Domain: authorization.SchemaDomain}
+	absentA := &authorization.Policy{Resource: "collections/AbsentA", Verb: authorization.READ, Domain: authorization.SchemaDomain}
+	absentB := &authorization.Policy{Resource: "collections/AbsentB", Verb: authorization.READ, Domain: authorization.SchemaDomain}
+
+	tests := []struct {
+		name        string
+		initial     []*authorization.Policy
+		remove      []*authorization.Policy
+		wantPresent []*authorization.Policy
+		wantAbsent  []*authorization.Policy
+	}{
+		{
+			// First permission absent must not abort the batch: P1 and P2 are
+			// still requested and must be removed.
+			name:       "first permission absent, rest present",
+			initial:    []*authorization.Policy{p1, p2},
+			remove:     []*authorization.Policy{absentA, p1, p2},
+			wantAbsent: []*authorization.Policy{p1, p2},
+		},
+		{
+			// A real removal followed by an absent permission must still be
+			// persisted (SavePolicy must not be skipped).
+			name:       "present then absent persists durably",
+			initial:    []*authorization.Policy{p1},
+			remove:     []*authorization.Policy{p1, absentA},
+			wantAbsent: []*authorization.Policy{p1},
+		},
+		{
+			name:        "all permissions absent is a no-op",
+			initial:     []*authorization.Policy{p1},
+			remove:      []*authorization.Policy{absentA, absentB},
+			wantPresent: []*authorization.Policy{p1},
+		},
+		{
+			name:       "all present happy path",
+			initial:    []*authorization.Policy{p1, p2},
+			remove:     []*authorization.Policy{p1, p2},
+			wantAbsent: []*authorization.Policy{p1, p2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			m, err := setupTestManager(t, logger)
+			require.NoError(t, err)
+
+			initial := make([]authorization.Policy, len(tt.initial))
+			for i, p := range tt.initial {
+				initial[i] = *p
+			}
+			require.NoError(t, m.CreateRolesPermissions(map[string][]authorization.Policy{role: initial}))
+
+			require.NoError(t, m.RemovePermissions(role, tt.remove))
+
+			assertPermissions := func(t *testing.T) {
+				for _, p := range tt.wantAbsent {
+					has, err := m.HasPermission(role, p)
+					require.NoError(t, err)
+					assert.False(t, has, "permission %v should be removed", p)
+				}
+				for _, p := range tt.wantPresent {
+					has, err := m.HasPermission(role, p)
+					require.NoError(t, err)
+					assert.True(t, has, "permission %v should still be present", p)
+				}
+			}
+
+			// In-memory state.
+			assertPermissions(t)
+
+			// Durable state: reload from the policy file. A skipped SavePolicy
+			// would let removed permissions reappear here.
+			require.NoError(t, m.casbin.LoadPolicy())
+			assertPermissions(t)
+		})
+	}
+}
+
 func TestSnapshotAndRestoreUpgrade(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
### What's being changed:

When trying to remove multiple permissions from a role, the loop would abort on the first permission that the roles does not have and return. 

This has several problems:
- the order matters eg [not-present, present] and [present, not-present] have a different result
- the policy is changed in memory, but caches are not invalidated and the policy is not saved to disk. So the change might or might not be visible

Now non-present permissions are simply skipped and the rest removed

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
