### PR TITLE
test(replication): wait for shard readiness after restart in TestReadRepairDeleteOnConflict

### DIFF
--- a/test/acceptance/replication/common/crud_ops.go
+++ b/test/acceptance/replication/common/crud_ops.go
@@ -69,6 +69,16 @@ func StartNodeAt(ctx context.Context, t *testing.T, compose *docker.DockerCompos
 	<-time.After(1 * time.Second)
 }
 
+// WaitForNodeReadyForClass blocks until the node serves a CL=ALL read of probeID;
+// /ready can be up while the shard is still StatusLoading. probeID must exist on all replicas.
+func WaitForNodeReadyForClass(t *testing.T, hostURI, class string, probeID strfmt.UUID) {
+	t.Helper()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err := GetObjectCL(t, hostURI, class, probeID, types.ConsistencyLevelAll)
+		require.NoError(ct, err)
+	}, 120*time.Second, 500*time.Millisecond)
+}
+
 func GetClass(t *testing.T, host, class string) *models.Class {
 	t.Helper()
 	helper.SetupClient(host)

--- a/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_deleteonconflict_test.go
@@ -104,6 +104,7 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 
 	t.Run("restart node 2", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 2)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode2().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("require new object read repair was made", func(t *testing.T) {
@@ -137,6 +138,7 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 
 	t.Run("restart node 3", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 3)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode3().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("require updated object read repair was made", func(t *testing.T) {
@@ -173,6 +175,7 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 
 	t.Run("restart node 2", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 2)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode2().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("stop node3", func(t *testing.T) {
@@ -189,6 +192,7 @@ func (suite *ReplicationTestSuite) TestReadRepairDeleteOnConflict() {
 
 	t.Run("restart node 3", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 3)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode3().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("deleted article should not be present in node3", func(t *testing.T) {


### PR DESCRIPTION
## Motivation

`TestReadRepairDeleteOnConflict` is still flaky in CI even after #11748 (which wrapped the post-restart assertions in `EventuallyWithT`). The root cause is a **node-restart / shard-loading race**, not a read-repair convergence bug.

`StartNodeAt` only waits for the container's `/v1/.well-known/ready` endpoint (plus a 1s sleep), but a node can report ready while its shard is still in `StatusLoading`. A loading shard:
- **rejects replication ops** — `DigestObjects`/`Overwrite` used by read-repair return `ErrUnprocessable`, so read-repair can't run on the just-restarted node;
- **still serves stale single-node reads** — `ObjectByID` has no loading gate.

So an assertion made right after a restart can read stale data from the restarted node while read-repair is unable to fix it. On slower CI hosts this window can outlast the 30s `EventuallyWithT` budget, producing the intermittent `"a new paragraph"` vs `"this paragraph was replaced"` mismatch (and a sibling `500 "no object with id"` on the post-restart update).

## Change

- Add `WaitForNodeReadyForClass` (test helper): blocks until the node serves a **CL=ALL read** of a probe object, which is only possible once its shard has left `StatusLoading` and participates in replication.
- Call it after every `restart node N` in the test, using a never-deleted fixture object (`paragraphIDs[0]`) as the probe.

Test-only change; no production code touched.

## Verification

- Target test passed 8/8 locally with the change.
- `golangci-lint` (changed packages) and the goroutine linter: clean.

Note: the exact mismatch is rare and did not reproduce locally (fast local nodes barely have a loading window), but the change directly closes the established race window for every restart in the test.