### PR TITLE
fix: TestIndex_UsageForCollection_MissingShardFiles data race error

### DIFF
--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -251,7 +251,11 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
 	shard, release, err := index.GetShard(ctx, tenantName)
 	require.NoError(t, err)
 	require.NotNil(t, shard)
-	require.NoError(t, shard.Store().Bucket(helpers.ObjectsBucketLSM).FlushMemtable())
+	// FlushMemtables deactivates the background flush cycle before flushing, so
+	// it cannot race with the cycle's own FlushAndSwitch (which would nil out
+	// b.flushing under the other goroutine and panic). Poking a single bucket's
+	// FlushMemtable directly skips that guard.
+	require.NoError(t, shard.Store().FlushMemtables(ctx))
 	release()
 
 	vectorConfigs := index.GetVectorIndexConfigs()


### PR DESCRIPTION
### What's being changed:

Fixes a flaky panic in `TestIndex_UsageForCollection_MissingShardFiles`.

The test setup flushed a single bucket via `Bucket.FlushMemtable()` while the shard's background flush cycle was still running. Two concurrent `FlushAndSwitch` calls would race on `b.flushing` — one niling it out under the other — causing a nil-pointer panic (`SIGSEGV` at `bucket.go:1855`).

Switched the setup to `Store.FlushMemtables(ctx)`, the production-safe path that deactivates the flush cycle before flushing, so there is no concurrent flush to race with. Verified with 15× `-race` runs.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
