### PR TITLE
Fix node handler return types

### DIFF
--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -44,7 +44,7 @@ func (n *nodesHandlers) getNodesStatus(params nodes.NodesGetParams, principal *m
 
 	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, "", "", output)
 	if err != nil {
-		return n.handleGetNodesError(err)
+		return n.handleNodesGetError(err)
 	}
 
 	status := &models.NodesStatusResponse{
@@ -68,7 +68,7 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 
 	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, params.ClassName, shardName, output)
 	if err != nil {
-		return n.handleGetNodesError(err)
+		return n.handleNodesGetClassError(err)
 	}
 
 	status := &models.NodesStatusResponse{
@@ -82,7 +82,7 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 func (n *nodesHandlers) getNodesStatistics(params cluster.ClusterGetStatisticsParams, principal *models.Principal) middleware.Responder {
 	nodeStatistics, err := n.manager.GetNodeStatistics(params.HTTPRequest.Context(), principal)
 	if err != nil {
-		return n.handleGetNodesError(err)
+		return n.handleNodesStatisticsError(err)
 	}
 
 	synchronized := map[string]struct{}{}
@@ -105,22 +105,57 @@ func (n *nodesHandlers) getNodesStatistics(params cluster.ClusterGetStatisticsPa
 	return cluster.NewClusterGetStatisticsOK().WithPayload(statistics)
 }
 
-func (n *nodesHandlers) handleGetNodesError(err error) middleware.Responder {
+func (n *nodesHandlers) handleNodesGetError(err error) middleware.Responder {
 	n.metricRequestsTotal.logError("", err)
-	if errors.As(err, &enterrors.ErrNotFound{}) {
+	switch {
+	case errors.As(err, &enterrors.ErrNotFound{}):
+		return nodes.NewNodesGetNotFound().
+			WithPayload(errPayloadFromSingleErr(err))
+	case errors.As(err, &autherrs.Forbidden{}):
+		return nodes.NewNodesGetForbidden().
+			WithPayload(errPayloadFromSingleErr(err))
+	case errors.As(err, &enterrors.ErrUnprocessable{}):
+		return nodes.NewNodesGetUnprocessableEntity().
+			WithPayload(errPayloadFromSingleErr(err))
+	default:
+		return nodes.NewNodesGetInternalServerError().
+			WithPayload(errPayloadFromSingleErr(err))
+	}
+}
+
+func (n *nodesHandlers) handleNodesGetClassError(err error) middleware.Responder {
+	n.metricRequestsTotal.logError("", err)
+	switch {
+	case errors.As(err, &enterrors.ErrNotFound{}):
 		return nodes.NewNodesGetClassNotFound().
 			WithPayload(errPayloadFromSingleErr(err))
-	}
-	if errors.As(err, &autherrs.Forbidden{}) {
+	case errors.As(err, &autherrs.Forbidden{}):
 		return nodes.NewNodesGetClassForbidden().
 			WithPayload(errPayloadFromSingleErr(err))
-	}
-	if errors.As(err, &enterrors.ErrUnprocessable{}) {
+	case errors.As(err, &enterrors.ErrUnprocessable{}):
 		return nodes.NewNodesGetClassUnprocessableEntity().
 			WithPayload(errPayloadFromSingleErr(err))
+	default:
+		return nodes.NewNodesGetClassInternalServerError().
+			WithPayload(errPayloadFromSingleErr(err))
 	}
-	return nodes.NewNodesGetClassInternalServerError().
-		WithPayload(errPayloadFromSingleErr(err))
+}
+
+// handleNodesStatisticsError has no NotFound arm: the statistics path cannot
+// return ErrNotFound and /cluster/statistics declares no 404.
+func (n *nodesHandlers) handleNodesStatisticsError(err error) middleware.Responder {
+	n.metricRequestsTotal.logError("", err)
+	switch {
+	case errors.As(err, &autherrs.Forbidden{}):
+		return cluster.NewClusterGetStatisticsForbidden().
+			WithPayload(errPayloadFromSingleErr(err))
+	case errors.As(err, &enterrors.ErrUnprocessable{}):
+		return cluster.NewClusterGetStatisticsUnprocessableEntity().
+			WithPayload(errPayloadFromSingleErr(err))
+	default:
+		return cluster.NewClusterGetStatisticsInternalServerError().
+			WithPayload(errPayloadFromSingleErr(err))
+	}
 }
 
 func setupNodesHandlers(api *operations.WeaviateAPI,


### PR DESCRIPTION
### What's being changed:

All node handlers were using `nodes.NewNodesGetClass` return types. Now everyone is using the correct type for their response. All error codes itself were correct before by accident, so the response itself will not change

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
