### PR TITLE
Fix potential deadlock in backup in big clusters

### DIFF
--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -754,7 +754,11 @@ func (c *coordinator) commitAll(ctx context.Context, req *StatusRequest, nodes m
 		node string
 		err  error
 	}
-	errChan := make(chan pair)
+	// Buffer one slot per node so a failing worker never blocks on the send.
+	// The consumer only runs after the submit loop finishes, so an unbuffered
+	// channel would let the first _MaxNumberConns failures hold every g.Go slot
+	// while blocked on the send, deadlocking the submit loop.
+	errChan := make(chan pair, len(nodes))
 	aCounter := int64(len(nodes))
 	g, ctx := enterrors.NewErrorGroupWithContextWrapper(c.log, ctx)
 	g.SetLimit(_MaxNumberConns)

--- a/usecases/backup/coordinator_test.go
+++ b/usecases/backup/coordinator_test.go
@@ -13,6 +13,8 @@ package backup
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -22,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/weaviate/weaviate/entities/backup"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -911,4 +914,56 @@ func TestCoordinatorCommitCancellation(t *testing.T) {
 		assert.Equal(t, backup.Cancelled, coordinator.Participants["N1"].Status)
 		assert.Contains(t, coordinator.Participants["N1"].Reason, context.Canceled.Error())
 	})
+}
+
+// TestCommitAllManyFailures verifies commitAll does not deadlock when the number
+// of participants exceeds the connection limit and they all fail. Each failing
+// worker sends on errChan, but the consumer only runs after every worker is
+// submitted; with an unbuffered channel the first _MaxNumberConns workers block
+// on the send, holding all the errgroup slots so the submit loop can never reach
+// the consumer.
+func TestCommitAllManyFailures(t *testing.T) {
+	t.Parallel()
+
+	const numNodes = _MaxNumberConns * 2
+	var (
+		backendName = "s3"
+		backupID    = "test-backup"
+		ctx         = context.Background()
+		any         = mock.Anything
+	)
+
+	nodes := make([]string, numNodes)
+	for i := range nodes {
+		nodes[i] = fmt.Sprintf("N%d", i)
+	}
+
+	fc := newFakeCoordinator(newFakeNodeResolver(nodes))
+	coordinator := fc.coordinator()
+
+	node2Addr := make(map[string]string, numNodes)
+	for _, n := range nodes {
+		coordinator.Participants[n] = participantStatus{
+			Status:   backup.Transferring,
+			LastTime: time.Now(),
+		}
+		node2Addr[n] = n
+	}
+
+	// Every commit fails, so every worker tries to send on errChan.
+	fc.client.On("Commit", any, any, any).Return(errors.New("commit failed"))
+
+	req := &StatusRequest{Method: OpRestore, ID: backupID, Backend: backendName}
+
+	done := make(chan int, 1)
+	enterrors.GoWrapper(func() {
+		done <- coordinator.commitAll(ctx, req, node2Addr)
+	}, coordinator.log)
+
+	select {
+	case nFailures := <-done:
+		assert.Equal(t, numNodes, nFailures)
+	case <-time.After(10 * time.Second):
+		t.Fatal("commitAll deadlocked with more failing participants than the connection limit")
+	}
 }


### PR DESCRIPTION
### What's being changed:

commitAll (coordinator.go:771-812) submits one g.Go per node with` g.SetLimit(_MaxNumberConns) (16)`, and workers send errors on an unbuffered errChan. The consumer `(for x :=  range errChan)` only starts after the submit loop finishes. If `#nodes > 16` and the first 16 commits all error, those workers block on` errChan <-` (no consumer yet) while the submit loop blocks in g.Go (limit full, no slot frees) → deadlock.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
