### PR TITLE
fix: repair broken main build in dynamic package after #9988 merge

### DIFF
--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -1125,7 +1125,7 @@ func TestDynamicStaleCommitLogCleanedOnRestart(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("upgrade callback not called after shutdown")
 	}
-	require.False(t, dyn1.upgraded.Load(), "upgrade must not have committed")
+	require.False(t, dyn1.status.IsUpgraded(), "upgrade must not have committed")
 
 	// Simulate stale WAL left by the aborted upgrade: if the shutdown was fast
 	// enough that hnsw.New() never ran, plant the directory+file manually.
@@ -1158,10 +1158,10 @@ func TestDynamicStaleCommitLogCleanedOnRestart(t *testing.T) {
 	wg.Add(1)
 	require.NoError(t, dyn2.Upgrade(func() { wg.Done() }))
 	wg.Wait()
-	// upgraded.Load() is the canonical "flat→HNSW swap committed" flag;
+	// status.IsUpgraded() is the canonical "flat→HNSW swap committed" flag;
 	// dynamic.Upgraded() also requires HNSW to be compressed, which is not
-	// configured in this test, so we check the atomic directly.
-	require.True(t, dyn2.upgraded.Load(), "upgrade must have committed to HNSW")
+	// configured in this test, so we check the status directly.
+	require.True(t, dyn2.status.IsUpgraded(), "upgrade must have committed to HNSW")
 
 	// Searches must return correct results — no "vector lengths don't match" panic.
 	recall, _ := testinghelpers.RecallAndLatency(ctx, queries, k, dyn2, truths)

--- a/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
@@ -76,8 +76,8 @@ func TestRestoreUpgradedLegacyDynamic(t *testing.T) {
 			TargetVector:     "", // legacy / default vector — the bug's trigger
 			Logger:           logger,
 			DistanceProvider: dp,
-			MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
-				return hnsw.NewCommitLogger(root, indexID, logger, noopCallback)
+			MakeCommitLoggerThunk: func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
+				return hnsw.NewCommitLogger(root, indexID, logger, noopCallback, opts...)
 			},
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 				vec := vectors[int(id)]


### PR DESCRIPTION
## Summary

`origin/main` (commit `a286dccc39`) does not build. PR #9988 (`hnsw-compact-v2`) was merged on top of a stale base and collided with two prior changes on `main`:

1. **PR #11503** (`bcc71db8c3`) renamed the `dynamic.upgraded atomic.Bool` field to a typed `dynamic.status` (an `atomic.Pointer[string]` with `IsUpgraded()` / `Upgrading()` / `Upgraded()` / `Reset()` methods).
2. **PR #9988** changed `hnsw.MakeCommitLogger` from `func() (CommitLogger, error)` to a variadic `func(opts ...CommitlogOption) (CommitLogger, error)`.

The merge succeeded textually but left the `dynamic` package failing to compile:

```
adapters/repos/db/vector/dynamic/index_test.go:1128:24: dyn1.upgraded undefined
adapters/repos/db/vector/dynamic/index_test.go:1164:23: dyn2.upgraded undefined
adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go:79:27:
  cannot use func() (hnsw.CommitLogger, error) {…} as hnsw.MakeCommitLogger
```

Note: `restore_legacy_integration_test.go` has a misleading `_integration_test.go` suffix but no `//go:build integrationTest` tag, so it compiles on every unit-test run.

## Fixes

- `index_test.go` lines 1128, 1164: `dyn.upgraded.Load()` → `dyn.status.IsUpgraded()` (canonical post-#11503 accessor); comment at L1161-1163 updated to match.
- `restore_legacy_integration_test.go` line 79: `MakeCommitLoggerThunk` updated to the variadic signature, matching the pattern already in `restore_integration_test.go:79` and `index_test.go:546`.

## Verification

```
$ go vet ./adapters/repos/db/vector/dynamic/...
$ go vet -tags integrationTest ./adapters/repos/db/vector/dynamic/...
$ go test -count 1 -run TestDynamicStaleCommitLogCleanedOnRestart ./adapters/repos/db/vector/dynamic/
ok      github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic   0.645s
```

All three commands clean on this branch; all three fail on `origin/main`.

## Process note

This PR fixes the symptom. A separate tracking issue covers the process question — how a CI-red merge commit landed on `main` despite the unit-tests job failing — so the team can decide on the required-status-check policy.

## Test plan

- [x] `go vet ./adapters/repos/db/vector/dynamic/...` passes
- [x] `go vet -tags integrationTest ./adapters/repos/db/vector/dynamic/...` passes
- [x] `TestDynamicStaleCommitLogCleanedOnRestart` passes
- [ ] CI green on the merge commit (no longer the stale PR head)