### PR TITLE
Avoid pausing compaction in ApplyToObjectDigests

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -433,49 +433,29 @@ func (b *Bucket) resumeCompaction(ctx context.Context) error {
 	return b.disk.resumeCompaction(ctx)
 }
 
-// ApplyToObjectDigests iterates over all objects in the bucket, both in memtable
-// and on disk, and applies the given function to each object.
-// The afterInMemCallback is called after the in-memory memtable has been processed.
-// This allows the caller to perform actions that need to happen after the in-memory
-// objects have been processed.
-// The function f is called for each object, and if it returns an error, the
-// processing is stopped and the error is returned.
-// Note: this function pauses compaction while it is running, to ensure a consistent view of the data.
+// ApplyToObjectDigests applies f to every object in the bucket (memtable and disk),
+// stopping on the first error. afterInMemCallback fires once the in-memory scan is done.
+//
+// The on-disk cursor is created while the in-mem cursor holds the flush lock, so both
+// snapshots are taken at a single consistent point with no flush in between. Compaction
+// is not paused: the on-disk cursor pins its segments via reference counting.
 func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	afterInMemCallback func(), f func(uuidBytes []byte, updateTime int64) error,
 ) error {
-	err := b.pauseCompaction(ctx)
-	if err != nil {
-		afterInMemCallback()
-		return fmt.Errorf("pausing compaction: %w", err)
-	}
-	defer func() {
-		ec := errorcompounder.New()
-
-		if err != nil {
-			ec.AddWrapf(err, "during ApplyToObjectDigests")
-		}
-
-		err = b.resumeCompaction(ctx)
-		if err != nil {
-			ec.AddWrapf(err, "resuming compaction after ApplyToObjectDigests")
-		}
-
-		err = ec.ToError()
-	}()
-
-	// note: it's important to first create the on disk cursor so to avoid potential double scanning over flushing memtable
-	onDiskCursor := b.CursorOnDisk()
-	defer onDiskCursor.Close()
+	var onDiskCursor *CursorReplace
 
 	inmemProcessedDocIDs := make(map[uint64]struct{})
 
 	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
-	err = func() error {
+	err := func() error {
 		defer afterInMemCallback()
 
 		inMemCursor := b.CursorInMem()
 		defer inMemCursor.Close()
+
+		// created under the in-mem cursor's flush lock, so it is consistent with the
+		// memtable view: no flush can run between the two snapshots.
+		onDiskCursor = b.CursorOnDisk()
 
 		for k, v := inMemCursor.First(); k != nil; k, v = inMemCursor.Next() {
 			select {
@@ -496,6 +476,9 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 
 		return nil
 	}()
+	if onDiskCursor != nil {
+		defer onDiskCursor.Close()
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Avoid pausing compaction during async-replication hash tree initialization

### Motivation

`Bucket.ApplyToObjectDigests` is used by async replication to build a shard's hash tree by scanning every object digest (UUID + update time) in a bucket. The scan over the on-disk portion can take a long time on large shards. It paused compaction for the entire duration of the scan to guarantee a consistent view, which stalled compaction on the affected bucket for as long as initialization ran.

Pausing compaction was genuinely necessary back when cursors did not hold a stable view of the underlying segments — compaction could swap or drop a segment out from under an in-flight scan. That is no longer the case: on-disk cursors now take a consistent, pinned snapshot of their segments via atomic reference counting (`getConsistentViewOfSegments` `incRef`s each segment under the maintenance RLock, `decRef`s on close). With that in place, the compaction pause has become redundant overhead, and this PR removes it.

### Approach

The on-disk cursor pins its segments through reference counting, so compaction can merge or drop segments concurrently while the cursor keeps reading the pinned ones until it closes.

The only remaining requirement is that the on-disk and in-memory snapshots are taken at a single consistent point with no flush in between (otherwise an object flushed from memtable to disk could be missed or double-counted). The previous code created the on-disk cursor first; this version instead creates the on-disk cursor *inside* the in-mem cursor's critical section, while `CursorInMem` still holds the flush RLock — so no flush can interleave between the two snapshots. After that point, neither flush nor compaction needs to be held back.

Net effect: `pauseCompaction`/`resumeCompaction` (and the surrounding `errorcompounder` deferred-error dance) are gone; compaction runs freely during the long on-disk scan.

### Key areas for review

- `bucket.go:ApplyToObjectDigests` — confirm the on-disk cursor is created under the in-mem cursor's flush lock (inside the inner func, before iterating), and that it's closed exactly once. `onDiskCursor` is declared as a nil pointer outside the closure and the `defer Close()` is guarded by `if onDiskCursor != nil`.
- The consistency invariant rests on `CursorInMem` holding `flushLock.RLock` for the cursor's whole lifetime — the on-disk snapshot must be taken while that lock is held.

### Risks and mitigations

- **Missed/double-counted objects from a flush racing the two snapshots**: mitigated by creating the on-disk cursor while the in-mem cursor holds the flush RLock — flush cannot run between the two snapshots.
- **Cursor reading segments that compaction frees mid-scan**: mitigated by the per-segment refcount pinning that on-disk cursors now use; segments stay alive until the cursor closes. This is precisely the guarantee that makes the compaction pause unnecessary.
- **`afterInMemCallback` contract**: unchanged — it still fires exactly once when the in-memory scan completes, preserving the guarantee the sole caller (`shard_async_replication.go`) relies on to close `minimalHashtreeInitializationCh`.

### Testing

- `go build`, `go vet`, goroutine linter, `golangci-lint` (0 issues)
- `go test -race` full `lsmkv` unit suite; `TestReplaceCursorConsistentView` ×20 under `-race`
- Async-replication / hashtree-init tests in `adapters/repos/db`
- `go test -tags integrationTest -race` for `lsmkv`
