### PR TITLE
feat(telemetry): stable cluster and node identity for correlatable telemetry

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -36,6 +36,7 @@ import (
 	openapierrors "github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/swag"
+	"github.com/google/uuid"
 	"github.com/pbnjay/memory"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -951,13 +952,24 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		setupDistributedTasksHandlers(api, appState.Authorizer, appState.ClusterService.Raft)
 	}
 
+	persistedNodeID, err := telemetry.ReadOrCreateNodeID(appState.ServerConfig.Config.Persistence.DataPath)
+	if err != nil {
+		appState.Logger.Warnf("persist node-id failed, using ephemeral id: %v", err)
+		persistedNodeID = uuid.NewString()
+	}
+
 	telemeter := telemetry.New(
 		appState.DB,
 		appState.SchemaManager,
 		appState.Logger,
-		getTelemetryURL(appState),
-		appState.ServerConfig.Config.TelemetryPushInterval,
-		telemetryEnabled(appState),
+		telemetry.Config{
+			ConsumerURL:          getTelemetryURL(appState),
+			PushInterval:         appState.ServerConfig.Config.TelemetryPushInterval,
+			Enabled:              telemetryEnabled(appState),
+			NodeID:               persistedNodeID,
+			AsyncIndexingEnabled: appState.ServerConfig.Config.AsyncIndexingEnabled,
+		},
+		appState.ClusterService.WaitForClusterID,
 	)
 
 	var grpcInstrument []grpc.ServerOption

--- a/cluster/fsm/snapshot.go
+++ b/cluster/fsm/snapshot.go
@@ -35,6 +35,9 @@ type Snapshot struct {
 	ReplicationOps []byte `json:"replication_ops,omitempty"`
 	// DbUsers is the state of dynamic db users that will be used to restore the FSM
 	DbUsers []byte `json:"dbusers,omitempty"`
+
+	// ClusterID is the stable UUIDv7 committed once per cluster lifetime.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // Snapshotter is used to snapshot and restore any (FSM) state

--- a/cluster/proto/api/message.pb.go
+++ b/cluster/proto/api/message.pb.go
@@ -76,6 +76,8 @@ const (
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_CANCEL                                    ApplyRequest_Type = 301
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED                     ApplyRequest_Type = 302
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_CLEAN_UP                                  ApplyRequest_Type = 303
+	// Cluster identity - set once by the raft leader; replayed during recovery.
+	ApplyRequest_TYPE_CLUSTER_ID_SET ApplyRequest_Type = 400
 )
 
 // Enum value maps for ApplyRequest_Type.
@@ -131,6 +133,7 @@ var (
 		301: "TYPE_DISTRIBUTED_TASK_CANCEL",
 		302: "TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED",
 		303: "TYPE_DISTRIBUTED_TASK_CLEAN_UP",
+		400: "TYPE_CLUSTER_ID_SET",
 	}
 	ApplyRequest_Type_value = map[string]int32{
 		"TYPE_UNSPECIFIED":                                                0,
@@ -183,6 +186,7 @@ var (
 		"TYPE_DISTRIBUTED_TASK_CANCEL":                                    301,
 		"TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED":                     302,
 		"TYPE_DISTRIBUTED_TASK_CLEAN_UP":                                  303,
+		"TYPE_CLUSTER_ID_SET":                                             400,
 	}
 )
 
@@ -1742,6 +1746,52 @@ func (x *DeleteAliasRequest) GetAlias() string {
 	return ""
 }
 
+// SetClusterIDRequest carries the stable cluster identity committed once per
+// cluster lifetime via TYPE_CLUSTER_ID_SET. Field numbers are permanent.
+type SetClusterIDRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ClusterId     string                 `protobuf:"bytes,1,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetClusterIDRequest) Reset() {
+	*x = SetClusterIDRequest{}
+	mi := &file_api_message_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetClusterIDRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetClusterIDRequest) ProtoMessage() {}
+
+func (x *SetClusterIDRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_message_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetClusterIDRequest.ProtoReflect.Descriptor instead.
+func (*SetClusterIDRequest) Descriptor() ([]byte, []int) {
+	return file_api_message_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *SetClusterIDRequest) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
+}
+
 var File_api_message_proto protoreflect.FileDescriptor
 
 const file_api_message_proto_rawDesc = "" +
@@ -1760,13 +1810,13 @@ const file_api_message_proto_rawDesc = "" +
 	"\x11NotifyPeerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x14\n" +
-	"\x12NotifyPeerResponse\"\x97\x0f\n" +
+	"\x12NotifyPeerResponse\"\xb1\x0f\n" +
 	"\fApplyRequest\x12@\n" +
 	"\x04type\x18\x01 \x01(\x0e2,.weaviate.internal.cluster.ApplyRequest.TypeR\x04type\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x04R\aversion\x12\x1f\n" +
 	"\vsub_command\x18\x04 \x01(\fR\n" +
-	"subCommand\"\xf3\r\n" +
+	"subCommand\"\x8d\x0e\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eTYPE_ADD_CLASS\x10\x01\x12\x15\n" +
@@ -1818,7 +1868,8 @@ const file_api_message_proto_rawDesc = "" +
 	"\x19TYPE_DISTRIBUTED_TASK_ADD\x10\xac\x02\x12!\n" +
 	"\x1cTYPE_DISTRIBUTED_TASK_CANCEL\x10\xad\x02\x120\n" +
 	"+TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED\x10\xae\x02\x12#\n" +
-	"\x1eTYPE_DISTRIBUTED_TASK_CLEAN_UP\x10\xaf\x02\"\x04\bc\x10c\"A\n" +
+	"\x1eTYPE_DISTRIBUTED_TASK_CLEAN_UP\x10\xaf\x02\x12\x18\n" +
+	"\x13TYPE_CLUSTER_ID_SET\x10\x90\x03\"\x04\bc\x10c\"A\n" +
 	"\rApplyResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x04R\aversion\x12\x16\n" +
 	"\x06leader\x18\x02 \x01(\tR\x06leader\"\x91\b\n" +
@@ -1924,7 +1975,10 @@ const file_api_message_proto_rawDesc = "" +
 	"collection\x12\x14\n" +
 	"\x05alias\x18\x02 \x01(\tR\x05alias\"*\n" +
 	"\x12DeleteAliasRequest\x12\x14\n" +
-	"\x05alias\x18\x01 \x01(\tR\x05alias2\x8d\x04\n" +
+	"\x05alias\x18\x01 \x01(\tR\x05alias\"4\n" +
+	"\x13SetClusterIDRequest\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\x01 \x01(\tR\tclusterId2\x8d\x04\n" +
 	"\x0eClusterService\x12k\n" +
 	"\n" +
 	"RemovePeer\x12,.weaviate.internal.cluster.RemovePeerRequest\x1a-.weaviate.internal.cluster.RemovePeerResponse\"\x00\x12e\n" +
@@ -1948,7 +2002,7 @@ func file_api_message_proto_rawDescGZIP() []byte {
 }
 
 var file_api_message_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_api_message_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_api_message_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_api_message_proto_goTypes = []any{
 	(ApplyRequest_Type)(0),                             // 0: weaviate.internal.cluster.ApplyRequest.Type
 	(QueryRequest_Type)(0),                             // 1: weaviate.internal.cluster.QueryRequest.Type
@@ -1978,6 +2032,7 @@ var file_api_message_proto_goTypes = []any{
 	(*CreateAliasRequest)(nil),                         // 25: weaviate.internal.cluster.CreateAliasRequest
 	(*ReplaceAliasRequest)(nil),                        // 26: weaviate.internal.cluster.ReplaceAliasRequest
 	(*DeleteAliasRequest)(nil),                         // 27: weaviate.internal.cluster.DeleteAliasRequest
+	(*SetClusterIDRequest)(nil),                        // 28: weaviate.internal.cluster.SetClusterIDRequest
 }
 var file_api_message_proto_depIdxs = []int32{
 	0,  // 0: weaviate.internal.cluster.ApplyRequest.type:type_name -> weaviate.internal.cluster.ApplyRequest.Type
@@ -2017,7 +2072,7 @@ func file_api_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_message_proto_rawDesc), len(file_api_message_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -99,6 +99,9 @@ message ApplyRequest {
     TYPE_DISTRIBUTED_TASK_CANCEL = 301;
     TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED = 302;
     TYPE_DISTRIBUTED_TASK_CLEAN_UP = 303;
+
+    // Cluster identity - set once by the raft leader; replayed during recovery.
+    TYPE_CLUSTER_ID_SET = 400;
   }
   Type type = 1;
   string class = 2;
@@ -246,4 +249,10 @@ message ReplaceAliasRequest {
 
 message DeleteAliasRequest {
   string alias = 1;
+}
+
+// SetClusterIDRequest carries the stable cluster identity committed once per
+// cluster lifetime via TYPE_CLUSTER_ID_SET. Field numbers are permanent.
+message SetClusterIDRequest {
+  string cluster_id = 1;
 }

--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -86,3 +86,13 @@ func (s *Raft) ReplicationFsm() *replication.ShardReplicationFSM {
 func (s *Raft) IsLeader() bool {
 	return s.store.IsLeader()
 }
+
+// ClusterID returns the stable cluster identity UUIDv7, or "" if not yet committed.
+func (s *Raft) ClusterID() string {
+	return s.store.ClusterID()
+}
+
+// WaitForClusterID blocks until the cluster identity is committed or ctx expires.
+func (s *Raft) WaitForClusterID(ctx context.Context) (string, error) {
+	return s.store.WaitForClusterID(ctx)
+}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -266,7 +266,6 @@ type Store struct {
 	clusterIDSet chan struct{}
 
 	// bootstrapLoopCancel stops clusterIDBootstrapLoop on Store.Close().
-	// Initialized to a no-op in NewFSM(); replaced with a real cancel in Open().
 	bootstrapLoopCancel context.CancelFunc
 }
 
@@ -432,13 +431,8 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	f := func() { st.onLeaderFound(time.Hour * 24) }
 	enterrors.GoWrapper(f, st.log)
 
-	// clusterIDBootstrapLoop retries committing the cluster identity on every leader
-	// tick until committed. This closes the gap where a leader crash before commit
-	// would leave the cluster without an identity indefinitely. The loop exits once
-	// clusterIDSet is closed (id set on any node) or loopCtx is cancelled (Store.Close).
-	// loopCtx derives from Open's ctx, which must outlive Open (the current caller
-	// passes context.Background()). The loop is normally stopped by bootstrapLoopCancel
-	// in Close(); cancelling ctx is an additional shutdown signal, not a per-request one.
+	// loopCtx derives from Open's ctx (currently context.Background() at the call
+	// site); also cancelled via bootstrapLoopCancel in Close().
 	loopCtx, loopCancel := context.WithCancel(ctx)
 	st.bootstrapLoopCancel = loopCancel
 	enterrors.GoWrapper(func() { st.clusterIDBootstrapLoop(loopCtx) }, st.log)
@@ -551,12 +545,9 @@ func (st *Store) Close(ctx context.Context) error {
 		return nil
 	}
 
-	// Signal the cluster-id bootstrap loop to stop before tearing down raft. This
-	// only cancels the loop's context; it does not wait for the goroutine to
-	// return, so a tick already inside maybeCommitClusterID -> Execute may briefly
-	// race raft teardown. That is safe: Execute() on a shutting-down raft returns
-	// ErrRaftShutdown/ErrNotLeader, which maybeCommitClusterID logs rather than
-	// panicking on.
+	// Cancels the bootstrap loop without waiting for it to exit, so a tick may
+	// briefly race raft teardown. Safe: Execute() on a shutting-down raft returns
+	// an error, which maybeCommitClusterID logs rather than treating as fatal.
 	st.bootstrapLoopCancel()
 
 	// transfer leadership: it stops accepting client requests, ensures
@@ -983,14 +974,12 @@ func (st *Store) recoverSingleNode(force bool) error {
 	return nil
 }
 
-// setClusterIDFields records the cluster identity into the in-memory FSM state.
-// It is idempotent: once set the first value wins. The clusterIDSet channel is
-// closed exactly once, guarded by the set-once check below.
+// setClusterIDFields sets the cluster identity in memory. Idempotent: the
+// first value wins, and clusterIDSet is closed exactly once.
 func (st *Store) setClusterIDFields(clusterID string) {
 	st.clusterIDmu.Lock()
 	defer st.clusterIDmu.Unlock()
 	if st.clusterID != "" {
-		// already set; first value wins (set-once guarantee)
 		st.log.WithFields(logrus.Fields{
 			"existing_cluster_id":  st.clusterID,
 			"duplicate_cluster_id": clusterID,
@@ -1019,10 +1008,9 @@ func (st *Store) WaitForClusterID(ctx context.Context) (string, error) {
 	}
 }
 
-// maybeCommitClusterID generates a UUIDv7 cluster identity and commits it via raft
-// if one has not been set yet. It is safe to call concurrently and from any leader;
-// the set-once guard in applyClusterIDSet ensures exactly one value is stored.
-// Must only be called when this node is the raft leader.
+// maybeCommitClusterID commits a fresh UUIDv7 cluster identity via raft if one
+// isn't set yet. Safe to call concurrently from any leader (applyClusterIDSet's
+// set-once guard dedupes); caller must be the raft leader.
 func (st *Store) maybeCommitClusterID() {
 	if st.ClusterID() != "" {
 		return
@@ -1060,16 +1048,9 @@ func (st *Store) maybeCommitClusterID() {
 	}
 }
 
-// clusterIDBootstrapLoop runs until the cluster identity is committed (by this or any
-// node) or storeCtx is cancelled. It ticks every 2 s and calls maybeCommitClusterID
-// when this node is the leader. This closes the leadership-churn gap: if the initial
-// leader crashes before commit, the next leader retries on its next tick.
-//
-// Two exit conditions:
-//   - clusterIDSet closed: identity committed on this node (happy path, typically seconds).
-//   - storeCtx cancelled: Store.Close() called, e.g. on shutdown or if the cluster
-//     never achieves quorum. This prevents the loop from running indefinitely and
-//     calling Execute() on a shutdown raft instance.
+// clusterIDBootstrapLoop retries committing the cluster identity every 2s while
+// this node is leader, until clusterIDSet closes or storeCtx is cancelled
+// (Store.Close). Retrying handles a leader crash before the initial commit.
 func (st *Store) clusterIDBootstrapLoop(storeCtx context.Context) {
 	t := time.NewTicker(2 * time.Second)
 	defer t.Stop()

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -18,20 +18,24 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/raft"
 	raftbolt "github.com/hashicorp/raft-boltdb/v2"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
+	googleproto "google.golang.org/protobuf/proto"
 
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/cluster/dynusers"
 	"github.com/weaviate/weaviate/cluster/fsm"
 	"github.com/weaviate/weaviate/cluster/log"
+	api "github.com/weaviate/weaviate/cluster/proto/api"
 	rbacRaft "github.com/weaviate/weaviate/cluster/rbac"
 	"github.com/weaviate/weaviate/cluster/replication"
 	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
@@ -252,6 +256,18 @@ type Store struct {
 	authZController authorization.Controller
 
 	metrics *storeMetrics
+
+	// clusterID is the stable UUIDv7 committed once per cluster lifetime via raft.
+	// Protected by clusterIDmu.
+	clusterIDmu sync.RWMutex
+	clusterID   string
+	// clusterIDSet is closed once clusterID is set (either by apply or snapshot restore).
+	// Waiters block on a receive from it.
+	clusterIDSet chan struct{}
+
+	// bootstrapLoopCancel stops clusterIDBootstrapLoop on Store.Close().
+	// Initialized to a no-op in NewFSM(); replaced with a real cancel in Open().
+	bootstrapLoopCancel context.CancelFunc
 }
 
 // storeMetrics exposes RAFT store related prometheus metrics
@@ -312,10 +328,12 @@ func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fs
 	schemaManager.SetReplicationFSM(replicationManager.GetReplicationFSM())
 
 	return Store{
-		cfg:          cfg,
-		log:          cfg.Logger,
-		candidates:   make(map[string]string, cfg.BootstrapExpect),
-		applyTimeout: time.Second * 20,
+		cfg:                 cfg,
+		log:                 cfg.Logger,
+		candidates:          make(map[string]string, cfg.BootstrapExpect),
+		applyTimeout:        time.Second * 20,
+		clusterIDSet:        make(chan struct{}),
+		bootstrapLoopCancel: func() { /* no-op until Open() installs the real cancel */ },
 		raftResolver: resolver.NewRaft(resolver.RaftConfig{
 			ClusterStateReader: cfg.NodeSelector,
 			RaftPort:           cfg.RaftPort,
@@ -413,6 +431,17 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	// However, we believe that 1 day should be more than sufficient.
 	f := func() { st.onLeaderFound(time.Hour * 24) }
 	enterrors.GoWrapper(f, st.log)
+
+	// clusterIDBootstrapLoop retries committing the cluster identity on every leader
+	// tick until committed. This closes the gap where a leader crash before commit
+	// would leave the cluster without an identity indefinitely. The loop exits once
+	// clusterIDSet is closed (id set on any node) or loopCtx is cancelled (Store.Close).
+	// loopCtx derives from Open's ctx, which must outlive Open (the current caller
+	// passes context.Background()). The loop is normally stopped by bootstrapLoopCancel
+	// in Close(); cancelling ctx is an additional shutdown signal, not a per-request one.
+	loopCtx, loopCancel := context.WithCancel(ctx)
+	st.bootstrapLoopCancel = loopCancel
+	enterrors.GoWrapper(func() { st.clusterIDBootstrapLoop(loopCtx) }, st.log)
 	return nil
 }
 
@@ -521,6 +550,10 @@ func (st *Store) Close(ctx context.Context) error {
 	if !st.open.Load() {
 		return nil
 	}
+
+	// Stop the cluster-id bootstrap loop before tearing down raft so the loop
+	// cannot call Execute() on a shutdown raft instance.
+	st.bootstrapLoopCancel()
 
 	// transfer leadership: it stops accepting client requests, ensures
 	// the target server is up to date and initiates the transfer
@@ -944,4 +977,108 @@ func (st *Store) recoverSingleNode(force bool) error {
 	st.schemaManager.ReplaceStatesNodeName(string(newNode.ID))
 
 	return nil
+}
+
+// setClusterIDFields records the cluster identity into the in-memory FSM state.
+// It is idempotent: once set the first value wins. The clusterIDSet channel is
+// closed exactly once, guarded by the set-once check below.
+func (st *Store) setClusterIDFields(clusterID string) {
+	st.clusterIDmu.Lock()
+	defer st.clusterIDmu.Unlock()
+	if st.clusterID != "" {
+		// already set; first value wins (set-once guarantee)
+		st.log.WithFields(logrus.Fields{
+			"existing_cluster_id":  st.clusterID,
+			"duplicate_cluster_id": clusterID,
+		}).Debug("clamping duplicate cluster-id set (set-once; duplicate is a no-op)")
+		return
+	}
+	st.clusterID = clusterID
+	close(st.clusterIDSet)
+}
+
+// ClusterID returns the committed cluster identity, or "" if not yet set.
+func (st *Store) ClusterID() string {
+	st.clusterIDmu.RLock()
+	defer st.clusterIDmu.RUnlock()
+	return st.clusterID
+}
+
+// WaitForClusterID blocks until the cluster identity is committed or ctx expires.
+// Returns (clusterID, nil) on success; ("", ctx.Err()) on timeout.
+func (st *Store) WaitForClusterID(ctx context.Context) (string, error) {
+	select {
+	case <-st.clusterIDSet:
+		return st.ClusterID(), nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// maybeCommitClusterID generates a UUIDv7 cluster identity and commits it via raft
+// if one has not been set yet. It is safe to call concurrently and from any leader;
+// the set-once guard in applyClusterIDSet ensures exactly one value is stored.
+// Must only be called when this node is the raft leader.
+func (st *Store) maybeCommitClusterID() {
+	if st.ClusterID() != "" {
+		return
+	}
+
+	id, err := uuid.NewV7()
+	if err != nil {
+		// fall back to v4 if the monotonic-random source fails
+		id = uuid.New()
+	}
+	idStr := id.String()
+	if idStr == "" {
+		st.log.Warn("cluster-id generation produced empty UUID, skipping commit")
+		return
+	}
+
+	req := &api.SetClusterIDRequest{
+		ClusterId: idStr,
+	}
+	subCmd, err := googleproto.Marshal(req)
+	if err != nil {
+		st.log.WithFields(logrus.Fields{
+			"cluster_id": idStr,
+		}).Warnf("maybeCommitClusterID: marshal subcommand: %v", err)
+		return
+	}
+	applyReq := &api.ApplyRequest{
+		Type:       api.ApplyRequest_TYPE_CLUSTER_ID_SET,
+		SubCommand: subCmd,
+	}
+	if _, err := st.Execute(applyReq); err != nil {
+		st.log.WithFields(logrus.Fields{
+			"cluster_id": idStr,
+		}).Warnf("maybeCommitClusterID: execute: %v", err)
+	}
+}
+
+// clusterIDBootstrapLoop runs until the cluster identity is committed (by this or any
+// node) or storeCtx is cancelled. It ticks every 2 s and calls maybeCommitClusterID
+// when this node is the leader. This closes the leadership-churn gap: if the initial
+// leader crashes before commit, the next leader retries on its next tick.
+//
+// Two exit conditions:
+//   - clusterIDSet closed: identity committed on this node (happy path, typically seconds).
+//   - storeCtx cancelled: Store.Close() called, e.g. on shutdown or if the cluster
+//     never achieves quorum. This prevents the loop from running indefinitely and
+//     calling Execute() on a shutdown raft instance.
+func (st *Store) clusterIDBootstrapLoop(storeCtx context.Context) {
+	t := time.NewTicker(2 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-storeCtx.Done():
+			return
+		case <-st.clusterIDSet:
+			return
+		case <-t.C:
+			if st.IsLeader() {
+				st.maybeCommitClusterID()
+			}
+		}
+	}
 }

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -1034,7 +1034,7 @@ func (st *Store) maybeCommitClusterID() {
 	if err != nil {
 		st.log.WithFields(logrus.Fields{
 			"cluster_id": idStr,
-		}).Warnf("maybeCommitClusterID: marshal subcommand: %v", err)
+		}).Warnf("marshal cluster-id set subcommand: %v", err)
 		return
 	}
 	applyReq := &api.ApplyRequest{
@@ -1044,7 +1044,7 @@ func (st *Store) maybeCommitClusterID() {
 	if _, err := st.Execute(applyReq); err != nil {
 		st.log.WithFields(logrus.Fields{
 			"cluster_id": idStr,
-		}).Warnf("maybeCommitClusterID: execute: %v", err)
+		}).Warnf("commit cluster-id set command: %v", err)
 	}
 }
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -551,8 +551,12 @@ func (st *Store) Close(ctx context.Context) error {
 		return nil
 	}
 
-	// Stop the cluster-id bootstrap loop before tearing down raft so the loop
-	// cannot call Execute() on a shutdown raft instance.
+	// Signal the cluster-id bootstrap loop to stop before tearing down raft. This
+	// only cancels the loop's context; it does not wait for the goroutine to
+	// return, so a tick already inside maybeCommitClusterID -> Execute may briefly
+	// race raft teardown. That is safe: Execute() on a shutting-down raft returns
+	// ErrRaftShutdown/ErrNotLeader, which maybeCommitClusterID logs rather than
+	// panicking on.
 	st.bootstrapLoopCancel()
 
 	// transfer leadership: it stops accepting client requests, ensures

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -443,10 +443,10 @@ func (st *Store) numberOfNodesInTheCluster() int {
 func (st *Store) applyClusterIDSet(cmd *api.ApplyRequest) error {
 	req := &api.SetClusterIDRequest{}
 	if err := proto.Unmarshal(cmd.SubCommand, req); err != nil {
-		return fmt.Errorf("applyClusterIDSet: unmarshal: %w", err)
+		return fmt.Errorf("unmarshal cluster-id set command: %w", err)
 	}
 	if req.ClusterId == "" {
-		return fmt.Errorf("applyClusterIDSet: received empty cluster_id, refusing to store")
+		return fmt.Errorf("empty cluster_id in cluster-id set command")
 	}
 	st.setClusterIDFields(req.ClusterId)
 	return nil

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -410,9 +410,8 @@ func (st *Store) Apply(l *raft.Log) any {
 		}
 
 	default:
-		// A command type unknown to this (older) binary, e.g. one introduced in a later
-		// version. We log rather than panic so a forward-incompatible command degrades to
-		// a no-op instead of crash-looping the node; upgrade the binary to apply it.
+		// Unknown command from a newer binary version: log and no-op rather than
+		// panic, so a forward-incompatible command doesn't crash-loop the node.
 		const msg = "consider upgrading to newer version"
 		st.log.WithFields(logrus.Fields{
 			"type":  cmd.Type,

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -402,9 +402,17 @@ func (st *Store) Apply(l *raft.Log) any {
 			ret.Error = st.distributedTasksManager.CleanUpTask(&cmd)
 		}
 
+	// TYPE_CLUSTER_ID_SET is a set-once pure-metadata command; it is NOT gated on
+	// schemaOnly because it has no DB-side effect and must apply during cold-start replay.
+	case api.ApplyRequest_TYPE_CLUSTER_ID_SET:
+		f = func() {
+			ret.Error = st.applyClusterIDSet(&cmd)
+		}
+
 	default:
-		// This could occur when a new command has been introduced in a later app version
-		// At this point, we need to panic so that the app undergo an upgrade during restart
+		// A command type unknown to this (older) binary, e.g. one introduced in a later
+		// version. We log rather than panic so a forward-incompatible command degrades to
+		// a no-op instead of crash-looping the node; upgrade the binary to apply it.
 		const msg = "consider upgrading to newer version"
 		st.log.WithFields(logrus.Fields{
 			"type":  cmd.Type,
@@ -429,4 +437,18 @@ func (st *Store) Apply(l *raft.Log) any {
 
 func (st *Store) numberOfNodesInTheCluster() int {
 	return len(st.raft.GetConfiguration().Configuration().Servers)
+}
+
+// applyClusterIDSet decodes and applies a TYPE_CLUSTER_ID_SET log entry.
+// It is idempotent: the first value wins (set-once). A duplicate on replay is a logged no-op.
+func (st *Store) applyClusterIDSet(cmd *api.ApplyRequest) error {
+	req := &api.SetClusterIDRequest{}
+	if err := proto.Unmarshal(cmd.SubCommand, req); err != nil {
+		return fmt.Errorf("applyClusterIDSet: unmarshal: %w", err)
+	}
+	if req.ClusterId == "" {
+		return fmt.Errorf("applyClusterIDSet: received empty cluster_id, refusing to store")
+	}
+	st.setClusterIDFields(req.ClusterId)
+	return nil
 }

--- a/cluster/store_cluster_id_realraft_test.go
+++ b/cluster/store_cluster_id_realraft_test.go
@@ -25,28 +25,8 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster/mocks"
 )
 
-// TestClusterID_CommittedByRealRaftLeader exercises the real bootstrap path that
-// the in-memory unit tests in store_cluster_id_test.go deliberately fake. It
-// stands up a self-electing single-node raft leader and lets clusterIDBootstrapLoop
-// drive the whole chain end to end:
-//
-//	loop tick -> IsLeader() -> maybeCommitClusterID() -> uuid.NewV7() -> Execute()
-//	-> raft consensus -> FSM.Apply -> applyClusterIDSet -> setClusterIDFields
-//	-> close(clusterIDSet)
-//
-// This is the leadership retry path the reviewer flagged as uncovered: the
-// identity is committed through real raft (not poked in-memory), proving that a
-// leader with no clusterId set will commit exactly one, and that the loop wiring,
-// the proto command, and the apply handler all agree.
-//
-// A full 3-node leader-crash-before-commit reproduction (kill the leader inside
-// the 2s commit window and assert a second leader converges) needs a live
-// multi-node consensus harness that does not exist at this layer and is prone to
-// memberlist/election flakiness in CI; it is left to acceptance-level testing.
-// The two properties that path relies on are both covered deterministically:
-// (1) any leader with an unset id commits one via the real loop (this test), and
-// (2) a second commit is a no-op under the set-once guard (asserted below and in
-// TestClusterID_IdempotentOnReplay).
+// TestClusterID_CommittedByRealRaftLeader drives cluster-id commit through a
+// real single-node raft leader end to end (loop -> Execute -> Apply -> commit).
 func TestClusterID_CommittedByRealRaftLeader(t *testing.T) {
 	ctx := context.Background()
 	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
@@ -65,8 +45,7 @@ func TestClusterID_CommittedByRealRaftLeader(t *testing.T) {
 	require.True(t, tryNTimesWithWait(10, 200*time.Millisecond, srv.Ready),
 		"node did not become ready")
 
-	// The bootstrap loop ticks every 2s; the id is committed via real raft apply
-	// shortly after leadership. 15s is a generous ceiling for a loaded CI runner.
+	// generous ceiling for a loaded CI runner; loop ticks every 2s
 	require.True(t, tryNTimesWithWait(75, 200*time.Millisecond, func() bool {
 		return srv.store.ClusterID() != ""
 	}), "bootstrap loop did not commit a clusterId via real raft within timeout")
@@ -74,7 +53,6 @@ func TestClusterID_CommittedByRealRaftLeader(t *testing.T) {
 	id := srv.store.ClusterID()
 	require.NotEmpty(t, id)
 
-	// WaitForClusterID returns the committed identity without blocking.
 	waitCtx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	gotID, err := srv.store.WaitForClusterID(waitCtx)

--- a/cluster/store_cluster_id_realraft_test.go
+++ b/cluster/store_cluster_id_realraft_test.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/utils"
+	"github.com/weaviate/weaviate/usecases/cluster/mocks"
+)
+
+// TestClusterID_CommittedByRealRaftLeader exercises the real bootstrap path that
+// the in-memory unit tests in store_cluster_id_test.go deliberately fake. It
+// stands up a self-electing single-node raft leader and lets clusterIDBootstrapLoop
+// drive the whole chain end to end:
+//
+//	loop tick -> IsLeader() -> maybeCommitClusterID() -> uuid.NewV7() -> Execute()
+//	-> raft consensus -> FSM.Apply -> applyClusterIDSet -> setClusterIDFields
+//	-> close(clusterIDSet)
+//
+// This is the leadership retry path the reviewer flagged as uncovered: the
+// identity is committed through real raft (not poked in-memory), proving that a
+// leader with no clusterId set will commit exactly one, and that the loop wiring,
+// the proto command, and the apply handler all agree.
+//
+// A full 3-node leader-crash-before-commit reproduction (kill the leader inside
+// the 2s commit window and assert a second leader converges) needs a live
+// multi-node consensus harness that does not exist at this layer and is prone to
+// memberlist/election flakiness in CI; it is left to acceptance-level testing.
+// The two properties that path relies on are both covered deterministically:
+// (1) any leader with an unset id commits one via the real loop (this test), and
+// (2) a second commit is a no-op under the set-once guard (asserted below and in
+// TestClusterID_IdempotentOnReplay).
+func TestClusterID_CommittedByRealRaftLeader(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
+	m.indexer.On("Open", mock.Anything).Return(nil)
+	m.indexer.On("Close", mock.Anything).Return(nil)
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
+	defer srv.Close(ctx)
+	require.NoError(t, srv.Open(ctx, m.indexer))
+	require.NoError(t, srv.store.Notify(m.cfg.NodeID, addr))
+
+	require.True(t, tryNTimesWithWait(25, 200*time.Millisecond, srv.store.IsLeader),
+		"node did not become raft leader")
+	require.True(t, tryNTimesWithWait(10, 200*time.Millisecond, srv.Ready),
+		"node did not become ready")
+
+	// The bootstrap loop ticks every 2s; the id is committed via real raft apply
+	// shortly after leadership. 15s is a generous ceiling for a loaded CI runner.
+	require.True(t, tryNTimesWithWait(75, 200*time.Millisecond, func() bool {
+		return srv.store.ClusterID() != ""
+	}), "bootstrap loop did not commit a clusterId via real raft within timeout")
+
+	id := srv.store.ClusterID()
+	require.NotEmpty(t, id)
+
+	// WaitForClusterID returns the committed identity without blocking.
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	gotID, err := srv.store.WaitForClusterID(waitCtx)
+	require.NoError(t, err)
+	assert.Equal(t, id, gotID)
+
+	// Set-once under real raft: another leader commit attempt must not change it.
+	srv.store.maybeCommitClusterID()
+	assert.Equal(t, id, srv.store.ClusterID(),
+		"clusterId must be stable once committed (set-once)")
+}

--- a/cluster/store_cluster_id_test.go
+++ b/cluster/store_cluster_id_test.go
@@ -48,7 +48,6 @@ func buildClusterIDApplyRequest(t *testing.T, clusterID string) *api.ApplyReques
 	}
 }
 
-// T-CID-1: set-once apply. applyClusterIDSet with id A then id B leaves clusterId == A.
 func TestClusterID_SetOnce(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
@@ -58,7 +57,6 @@ func TestClusterID_SetOnce(t *testing.T) {
 	assert.Equal(t, "id-A", st.ClusterID(), "first set wins")
 }
 
-// T-CID-2: idempotent on log replay. Applying the same entry twice yields one value, no error.
 func TestClusterID_IdempotentOnReplay(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
@@ -69,8 +67,8 @@ func TestClusterID_IdempotentOnReplay(t *testing.T) {
 	assert.Equal(t, "replay-id", st.ClusterID())
 }
 
-// T-CID-4: survives snapshot Persist→Restore (via the FSM snapshot struct
-// directly, since Store.Persist needs a full raft sink).
+// Exercises the FSM snapshot struct directly, since Store.Persist needs a full
+// raft sink.
 func TestClusterID_SnapshotPersistRestore(t *testing.T) {
 	const testID = "snap-cluster-id"
 
@@ -92,7 +90,7 @@ func TestClusterID_SnapshotPersistRestore(t *testing.T) {
 	assert.Equal(t, testID, st.ClusterID())
 }
 
-// T-CID-5: restore-then-replay is idempotent (no double-cancel panic).
+// Guards the restore-then-replay path against a double-close panic.
 func TestClusterID_RestoreThenReplayIdempotent(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
@@ -104,7 +102,6 @@ func TestClusterID_RestoreThenReplayIdempotent(t *testing.T) {
 	assert.Equal(t, "original-id", st.ClusterID())
 }
 
-// T-CID-6: empty-UUID guard - applyClusterIDSet rejects empty cluster_id.
 func TestClusterID_EmptyUUIDGuard(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 	err := st.applyClusterIDSet(buildClusterIDApplyRequest(t, ""))
@@ -112,7 +109,7 @@ func TestClusterID_EmptyUUIDGuard(t *testing.T) {
 	assert.Empty(t, st.ClusterID(), "cluster id must remain unset")
 }
 
-// T-CID-7: WaitForClusterID returns immediately after clusterIDSet is closed.
+// WaitForClusterID returns immediately once clusterIDSet is closed.
 func TestClusterID_WaitReturnsOnCancel(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
@@ -126,7 +123,6 @@ func TestClusterID_WaitReturnsOnCancel(t *testing.T) {
 	assert.Equal(t, "wait-test-id", id)
 }
 
-// T-CID-7 (timeout arm): WaitForClusterID returns ctx.Err() when deadline expires.
 func TestClusterID_WaitTimesOut(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 	// Do NOT set cluster id, so context will expire.
@@ -139,7 +135,6 @@ func TestClusterID_WaitTimesOut(t *testing.T) {
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
-// T-COMPAT-1: old-snapshot decode - ClusterID=="" after unmarshal, no error.
 func TestClusterID_OldSnapshotDecode(t *testing.T) {
 	// A snapshot JSON that has no cluster_id or cluster_created_at fields.
 	oldSnap := `{"node_id":"n1","snapshot_id":"s1"}`
@@ -148,7 +143,6 @@ func TestClusterID_OldSnapshotDecode(t *testing.T) {
 	assert.Empty(t, snap.ClusterID, "old snapshot must decode without cluster_id")
 }
 
-// T-CID-8: bootstrap loop exits promptly once clusterId is committed on any node.
 func TestClusterIDBootstrapLoop_ExitsOnClusterIDSet(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
@@ -171,7 +165,6 @@ func TestClusterIDBootstrapLoop_ExitsOnClusterIDSet(t *testing.T) {
 	assert.Equal(t, "bootstrap-loop-exit-id", st.ClusterID())
 }
 
-// T-CID-9: bootstrap loop exits promptly when the store context is cancelled (Store.Close path).
 func TestClusterIDBootstrapLoop_ExitsOnStoreContextCancelled(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
@@ -192,7 +185,6 @@ func TestClusterIDBootstrapLoop_ExitsOnStoreContextCancelled(t *testing.T) {
 	}
 }
 
-// T-COMPAT-2: new-snapshot -> old-struct decode (unknown keys ignored).
 func TestClusterID_NewSnapshotToOldStructIgnored(t *testing.T) {
 	newSnap := `{"node_id":"n1","cluster_id":"xyz","cluster_created_at":12345}`
 	type oldSnapshot struct {

--- a/cluster/store_cluster_id_test.go
+++ b/cluster/store_cluster_id_test.go
@@ -1,0 +1,224 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	googleproto "google.golang.org/protobuf/proto"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/fsm"
+	api "github.com/weaviate/weaviate/cluster/proto/api"
+)
+
+// newStoreForClusterIDTests returns a Store with just enough initialized for cluster-id tests:
+// a logger and the clusterIDSet done-channel.
+func newStoreForClusterIDTests(t *testing.T) *Store {
+	t.Helper()
+	logger, _ := logrustest.NewNullLogger()
+	return &Store{
+		log:          logger,
+		clusterIDSet: make(chan struct{}),
+	}
+}
+
+// buildClusterIDApplyRequest constructs a TYPE_CLUSTER_ID_SET ApplyRequest.
+func buildClusterIDApplyRequest(t *testing.T, clusterID string) *api.ApplyRequest {
+	t.Helper()
+	req := &api.SetClusterIDRequest{
+		ClusterId: clusterID,
+	}
+	b, err := googleproto.Marshal(req)
+	require.NoError(t, err)
+	return &api.ApplyRequest{
+		Type:       api.ApplyRequest_TYPE_CLUSTER_ID_SET,
+		SubCommand: b,
+	}
+}
+
+// T-CID-1: set-once apply. applyClusterIDSet with id A then id B leaves clusterId == A.
+func TestClusterID_SetOnce(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+
+	require.NoError(t, st.applyClusterIDSet(buildClusterIDApplyRequest(t, "id-A")))
+	require.NoError(t, st.applyClusterIDSet(buildClusterIDApplyRequest(t, "id-B")))
+
+	assert.Equal(t, "id-A", st.ClusterID(), "first set wins")
+}
+
+// T-CID-2: idempotent on log replay. Applying the same entry twice yields one value, no error.
+func TestClusterID_IdempotentOnReplay(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+
+	req := buildClusterIDApplyRequest(t, "replay-id")
+	require.NoError(t, st.applyClusterIDSet(req))
+	require.NoError(t, st.applyClusterIDSet(req), "second apply must not error")
+
+	assert.Equal(t, "replay-id", st.ClusterID())
+}
+
+// T-CID-4: survives snapshot Persist→Restore.
+// We use the FSM snapshot struct directly since Store.Persist needs a full raft sink.
+func TestClusterID_SnapshotPersistRestore(t *testing.T) {
+	const testID = "snap-cluster-id"
+
+	// Persist: build a snapshot with the cluster id set.
+	snapWithID := fsm.Snapshot{
+		NodeID:    "node1",
+		ClusterID: testID,
+	}
+	b, err := json.Marshal(snapWithID)
+	require.NoError(t, err)
+
+	// Restore: unmarshal into a fresh Snapshot and call setClusterIDFields.
+	var restored fsm.Snapshot
+	require.NoError(t, json.Unmarshal(b, &restored))
+	assert.Equal(t, testID, restored.ClusterID)
+
+	// Apply to a fresh store (simulating the Restore path).
+	st := newStoreForClusterIDTests(t)
+	if restored.ClusterID != "" {
+		st.setClusterIDFields(restored.ClusterID)
+	}
+	assert.Equal(t, testID, st.ClusterID())
+}
+
+// T-CID-5: restore-then-replay is idempotent (no double-cancel panic).
+func TestClusterID_RestoreThenReplayIdempotent(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+
+	// Simulate snapshot restore
+	st.setClusterIDFields("original-id")
+
+	// Simulate replaying the same log entry (should be a no-op)
+	require.NoError(t, st.applyClusterIDSet(buildClusterIDApplyRequest(t, "original-id")))
+	require.NoError(t, st.applyClusterIDSet(buildClusterIDApplyRequest(t, "other-id")))
+
+	// First value still wins; no panic.
+	assert.Equal(t, "original-id", st.ClusterID())
+}
+
+// T-CID-6: empty-UUID guard - applyClusterIDSet rejects empty cluster_id.
+func TestClusterID_EmptyUUIDGuard(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+	err := st.applyClusterIDSet(buildClusterIDApplyRequest(t, ""))
+	assert.Error(t, err, "must reject empty cluster_id")
+	assert.Empty(t, st.ClusterID(), "cluster id must remain unset")
+}
+
+// T-CID-7: WaitForClusterID returns immediately after clusterIDSet is closed.
+func TestClusterID_WaitReturnsOnCancel(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+
+	// Set the cluster id, which closes clusterIDSet.
+	st.setClusterIDFields("wait-test-id")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	id, err := st.WaitForClusterID(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "wait-test-id", id)
+}
+
+// T-CID-7 (timeout arm): WaitForClusterID returns ctx.Err() when deadline expires.
+func TestClusterID_WaitTimesOut(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+	// Do NOT set cluster id, so context will expire.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := st.WaitForClusterID(ctx)
+	assert.Error(t, err, "must return error on timeout")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// T-COMPAT-1: old-snapshot decode - ClusterID=="" after unmarshal, no error.
+func TestClusterID_OldSnapshotDecode(t *testing.T) {
+	// A snapshot JSON that has no cluster_id or cluster_created_at fields.
+	oldSnap := `{"node_id":"n1","snapshot_id":"s1"}`
+	var snap fsm.Snapshot
+	require.NoError(t, json.Unmarshal([]byte(oldSnap), &snap))
+	assert.Empty(t, snap.ClusterID, "old snapshot must decode without cluster_id")
+}
+
+// T-CID-8: bootstrap loop exits promptly once clusterId is committed on any node.
+//
+// Drives the loop directly (no real raft instance) since setting up a multi-node
+// raft harness for a leadership-churn test is disproportionately expensive for a
+// unit suite. The IsLeader()+maybeCommitClusterID() retry path (a second leader
+// committing the clusterId after the first leader crashes pre-commit) is left to a
+// separate 3-node integration test.
+func TestClusterIDBootstrapLoop_ExitsOnClusterIDSet(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	defer loopCancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		st.clusterIDBootstrapLoop(loopCtx)
+	}()
+
+	// Simulate any node (including this one) committing the cluster id via raft apply.
+	st.setClusterIDFields("bootstrap-loop-exit-id")
+
+	select {
+	case <-done:
+		// loop exited as expected
+	case <-time.After(5 * time.Second):
+		t.Fatal("clusterIDBootstrapLoop did not exit within 5s after clusterId set")
+	}
+	assert.Equal(t, "bootstrap-loop-exit-id", st.ClusterID())
+}
+
+// T-CID-9: bootstrap loop exits promptly when the store context is cancelled (Store.Close path).
+func TestClusterIDBootstrapLoop_ExitsOnStoreContextCancelled(t *testing.T) {
+	st := newStoreForClusterIDTests(t)
+
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		st.clusterIDBootstrapLoop(loopCtx)
+	}()
+
+	loopCancel() // simulates Store.Close() calling st.bootstrapLoopCancel()
+
+	select {
+	case <-done:
+		// loop exited as expected
+	case <-time.After(5 * time.Second):
+		t.Fatal("clusterIDBootstrapLoop did not exit within 5s after context cancel")
+	}
+}
+
+// T-COMPAT-2: new-snapshot -> old-struct decode (unknown keys ignored).
+func TestClusterID_NewSnapshotToOldStructIgnored(t *testing.T) {
+	newSnap := `{"node_id":"n1","cluster_id":"xyz","cluster_created_at":12345}`
+	// Decode into a struct without the new fields (simulate old binary).
+	type oldSnapshot struct {
+		NodeID string `json:"node_id"`
+	}
+	var old oldSnapshot
+	require.NoError(t, json.Unmarshal([]byte(newSnap), &old))
+	assert.Equal(t, "n1", old.NodeID)
+}

--- a/cluster/store_cluster_id_test.go
+++ b/cluster/store_cluster_id_test.go
@@ -26,8 +26,6 @@ import (
 	api "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-// newStoreForClusterIDTests returns a Store with just enough initialized for cluster-id tests:
-// a logger and the clusterIDSet done-channel.
 func newStoreForClusterIDTests(t *testing.T) *Store {
 	t.Helper()
 	logger, _ := logrustest.NewNullLogger()
@@ -37,7 +35,6 @@ func newStoreForClusterIDTests(t *testing.T) *Store {
 	}
 }
 
-// buildClusterIDApplyRequest constructs a TYPE_CLUSTER_ID_SET ApplyRequest.
 func buildClusterIDApplyRequest(t *testing.T, clusterID string) *api.ApplyRequest {
 	t.Helper()
 	req := &api.SetClusterIDRequest{
@@ -72,12 +69,11 @@ func TestClusterID_IdempotentOnReplay(t *testing.T) {
 	assert.Equal(t, "replay-id", st.ClusterID())
 }
 
-// T-CID-4: survives snapshot Persist→Restore.
-// We use the FSM snapshot struct directly since Store.Persist needs a full raft sink.
+// T-CID-4: survives snapshot Persist→Restore (via the FSM snapshot struct
+// directly, since Store.Persist needs a full raft sink).
 func TestClusterID_SnapshotPersistRestore(t *testing.T) {
 	const testID = "snap-cluster-id"
 
-	// Persist: build a snapshot with the cluster id set.
 	snapWithID := fsm.Snapshot{
 		NodeID:    "node1",
 		ClusterID: testID,
@@ -85,12 +81,10 @@ func TestClusterID_SnapshotPersistRestore(t *testing.T) {
 	b, err := json.Marshal(snapWithID)
 	require.NoError(t, err)
 
-	// Restore: unmarshal into a fresh Snapshot and call setClusterIDFields.
 	var restored fsm.Snapshot
 	require.NoError(t, json.Unmarshal(b, &restored))
 	assert.Equal(t, testID, restored.ClusterID)
 
-	// Apply to a fresh store (simulating the Restore path).
 	st := newStoreForClusterIDTests(t)
 	if restored.ClusterID != "" {
 		st.setClusterIDFields(restored.ClusterID)
@@ -102,14 +96,11 @@ func TestClusterID_SnapshotPersistRestore(t *testing.T) {
 func TestClusterID_RestoreThenReplayIdempotent(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
-	// Simulate snapshot restore
 	st.setClusterIDFields("original-id")
 
-	// Simulate replaying the same log entry (should be a no-op)
 	require.NoError(t, st.applyClusterIDSet(buildClusterIDApplyRequest(t, "original-id")))
 	require.NoError(t, st.applyClusterIDSet(buildClusterIDApplyRequest(t, "other-id")))
 
-	// First value still wins; no panic.
 	assert.Equal(t, "original-id", st.ClusterID())
 }
 
@@ -125,7 +116,6 @@ func TestClusterID_EmptyUUIDGuard(t *testing.T) {
 func TestClusterID_WaitReturnsOnCancel(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
-	// Set the cluster id, which closes clusterIDSet.
 	st.setClusterIDFields("wait-test-id")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -159,12 +149,6 @@ func TestClusterID_OldSnapshotDecode(t *testing.T) {
 }
 
 // T-CID-8: bootstrap loop exits promptly once clusterId is committed on any node.
-//
-// Drives the loop directly (no real raft instance) since setting up a multi-node
-// raft harness for a leadership-churn test is disproportionately expensive for a
-// unit suite. The IsLeader()+maybeCommitClusterID() retry path (a second leader
-// committing the clusterId after the first leader crashes pre-commit) is left to a
-// separate 3-node integration test.
 func TestClusterIDBootstrapLoop_ExitsOnClusterIDSet(t *testing.T) {
 	st := newStoreForClusterIDTests(t)
 
@@ -177,12 +161,10 @@ func TestClusterIDBootstrapLoop_ExitsOnClusterIDSet(t *testing.T) {
 		st.clusterIDBootstrapLoop(loopCtx)
 	}()
 
-	// Simulate any node (including this one) committing the cluster id via raft apply.
 	st.setClusterIDFields("bootstrap-loop-exit-id")
 
 	select {
 	case <-done:
-		// loop exited as expected
 	case <-time.After(5 * time.Second):
 		t.Fatal("clusterIDBootstrapLoop did not exit within 5s after clusterId set")
 	}
@@ -205,7 +187,6 @@ func TestClusterIDBootstrapLoop_ExitsOnStoreContextCancelled(t *testing.T) {
 
 	select {
 	case <-done:
-		// loop exited as expected
 	case <-time.After(5 * time.Second):
 		t.Fatal("clusterIDBootstrapLoop did not exit within 5s after context cancel")
 	}
@@ -214,7 +195,6 @@ func TestClusterIDBootstrapLoop_ExitsOnStoreContextCancelled(t *testing.T) {
 // T-COMPAT-2: new-snapshot -> old-struct decode (unknown keys ignored).
 func TestClusterID_NewSnapshotToOldStructIgnored(t *testing.T) {
 	newSnap := `{"node_id":"n1","cluster_id":"xyz","cluster_created_at":12345}`
-	// Decode into a struct without the new fields (simulate old binary).
 	type oldSnapshot struct {
 		NodeID string `json:"node_id"`
 	}

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -58,6 +58,10 @@ func (s *Store) Persist(sink raft.SnapshotSink) (err error) {
 		return fmt.Errorf("replication snapshot: %w", err)
 	}
 
+	s.clusterIDmu.RLock()
+	snapClusterID := s.clusterID
+	s.clusterIDmu.RUnlock()
+
 	snap := fsm.Snapshot{
 		NodeID:           s.cfg.NodeID,
 		SnapshotID:       sink.ID(),
@@ -67,6 +71,7 @@ func (s *Store) Persist(sink raft.SnapshotSink) (err error) {
 		DbUsers:          dbUserSnapshot,
 		DistributedTasks: tasksSnapshot,
 		ReplicationOps:   replicationSnapshot,
+		ClusterID:        snapClusterID,
 	}
 	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
 		return fmt.Errorf("encode: %w", err)
@@ -166,6 +171,10 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 				st.log.WithError(err).Error("restoring db user from snapshot")
 				return fmt.Errorf("restore db user from snapshot: %w", err)
 			}
+		}
+
+		if snap.ClusterID != "" {
+			st.setClusterIDFields(snap.ClusterID)
 		}
 
 		if st.cfg.MetadataOnlyVoters {

--- a/usecases/telemetry/curated_fields_test.go
+++ b/usecases/telemetry/curated_fields_test.go
@@ -26,7 +26,6 @@ import (
 
 func ptrTo[T any](v T) *T { return &v }
 
-// T-FIELDS-1: curated extraction - mixed RF, MT, named-vector, hnsw/flat/dynamic.
 func TestCuratedFields_Extraction(t *testing.T) {
 	sg := &fakeNodesStatusGetter{}
 	sm := &fakeSchemaManager{}
@@ -87,7 +86,6 @@ func TestCuratedFields_Extraction(t *testing.T) {
 	assert.Equal(t, 1, payload.VectorIndexTypeCounts["dynamic"])
 }
 
-// T-FIELDS-2: usedModules fallback - nil ModuleConfig but Vectorizer set.
 func TestUsedModules_NilModuleConfigFallback(t *testing.T) {
 	sg := &fakeNodesStatusGetter{}
 	sm := &fakeSchemaManager{}
@@ -131,7 +129,6 @@ func TestUsedModules_NilModuleConfigFallback(t *testing.T) {
 	assert.NotContains(t, modules, "", "empty vectorizer must not appear")
 }
 
-// T-FIELDS-3: node count comes from schemaManager.Nodes().
 func TestCuratedFields_NodeCount(t *testing.T) {
 	sg := &fakeNodesStatusGetter{}
 	sm := &fakeSchemaManager{}
@@ -150,8 +147,8 @@ func TestCuratedFields_NodeCount(t *testing.T) {
 	assert.Equal(t, 2, *payload.NodeCount)
 }
 
-// T-FIELDS-5: pointer fields serialize a measured zero/false instead of being
-// dropped by omitempty; nil means unmeasured.
+// Pointer fields serialize a measured zero/false instead of being dropped by
+// omitempty; nil means unmeasured.
 func TestPayload_PointerSemantics_JSON(t *testing.T) {
 	t.Run("measured zero/false serialize", func(t *testing.T) {
 		p := Payload{
@@ -191,7 +188,6 @@ func TestPayload_PointerSemantics_JSON(t *testing.T) {
 	})
 }
 
-// T-FIELDS-4: VectorIndexType defaults to "hnsw" when empty string.
 func TestCuratedFields_DefaultVectorIndexType(t *testing.T) {
 	sg := &fakeNodesStatusGetter{}
 	sm := &fakeSchemaManager{}

--- a/usecases/telemetry/curated_fields_test.go
+++ b/usecases/telemetry/curated_fields_test.go
@@ -1,0 +1,228 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/verbosity"
+)
+
+func ptrTo[T any](v T) *T { return &v }
+
+// T-FIELDS-1: curated extraction - mixed RF, MT, named-vector, hnsw/flat/dynamic.
+func TestCuratedFields_Extraction(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := &fakeSchemaManager{}
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{NodeID: "node-abc", AsyncIndexingEnabled: true}, nil)
+
+	// 3 nodes
+	sm.On("Nodes").Return([]string{"n1", "n2", "n3"})
+	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
+		&models.NodeStatus{Stats: &models.NodeStats{ObjectCount: 0}},
+	)
+
+	classes := []*models.Class{
+		{
+			// single-vector, hnsw, RF=3, not MT
+			Class:              "A",
+			VectorIndexType:    "hnsw",
+			ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false},
+		},
+		{
+			// single-vector, flat, RF=1, MT enabled
+			Class:              "B",
+			VectorIndexType:    "flat",
+			ReplicationConfig:  &models.ReplicationConfig{Factor: 1},
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		},
+		{
+			// named-vector (dynamic + flat), no RF, MT enabled
+			Class:              "C",
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+			VectorConfig: map[string]models.VectorConfig{
+				"v1": {VectorIndexType: "dynamic"},
+				"v2": {VectorIndexType: "flat"},
+			},
+		},
+	}
+
+	sm.On("GetSchemaSkipAuth").Return(schema.Schema{
+		Objects: &models.Schema{Classes: classes},
+	})
+
+	payload, err := tel.buildPayload(context.Background(), PayloadType.Init)
+	require.NoError(t, err)
+
+	require.NotNil(t, payload.NodeCount)
+	assert.Equal(t, 3, *payload.NodeCount)
+	require.NotNil(t, payload.MaxReplicationFactor)
+	assert.Equal(t, 3, *payload.MaxReplicationFactor)
+	require.NotNil(t, payload.ReplicationEnabled)
+	assert.True(t, *payload.ReplicationEnabled, "RF>1 → replicationEnabled=true")
+	require.NotNil(t, payload.MTCollectionCount)
+	assert.Equal(t, 2, *payload.MTCollectionCount)
+	require.NotNil(t, payload.NamedVectorCollectionCount)
+	assert.Equal(t, 1, *payload.NamedVectorCollectionCount, "only class C has VectorConfig")
+	require.NotNil(t, payload.AsyncIndexingEnabled)
+	assert.True(t, *payload.AsyncIndexingEnabled)
+	require.NotNil(t, payload.VectorIndexTypeCounts)
+	// class A → hnsw, class B → flat, class C → dynamic(1)+flat(1)
+	assert.Equal(t, 1, payload.VectorIndexTypeCounts["hnsw"])
+	assert.Equal(t, 2, payload.VectorIndexTypeCounts["flat"])
+	assert.Equal(t, 1, payload.VectorIndexTypeCounts["dynamic"])
+}
+
+// T-FIELDS-2: usedModules fallback - nil ModuleConfig but Vectorizer set.
+func TestUsedModules_NilModuleConfigFallback(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := &fakeSchemaManager{}
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{}, nil)
+
+	classes := []*models.Class{
+		{
+			// nil ModuleConfig with a non-"none" Vectorizer → fallback adds the module
+			Class:        "WithVectorizer",
+			ModuleConfig: nil,
+			Vectorizer:   "text2vec-openai",
+		},
+		{
+			// "none" vectorizer should NOT appear
+			Class:        "BYOV",
+			ModuleConfig: nil,
+			Vectorizer:   "none",
+		},
+		{
+			// empty Vectorizer should NOT appear
+			Class:        "EmptyVectorizer",
+			ModuleConfig: nil,
+			Vectorizer:   "",
+		},
+		{
+			// properly configured class (non-nil ModuleConfig) - unchanged behavior
+			Class: "ProperlyConfigured",
+			ModuleConfig: map[string]interface{}{
+				"text2vec-cohere": map[string]interface{}{},
+			},
+			Vectorizer: "text2vec-cohere",
+		},
+	}
+
+	sm.On("GetSchemaSkipAuth").Return(schema.Schema{
+		Objects: &models.Schema{Classes: classes},
+	})
+
+	modules, err := tel.getUsedModules()
+	require.NoError(t, err)
+	assert.Contains(t, modules, "text2vec-openai", "fallback must add vectorizer when ModuleConfig is nil")
+	assert.Contains(t, modules, "text2vec-cohere", "properly-configured class unchanged")
+	assert.NotContains(t, modules, "none", "BYOV vectorizer 'none' must not appear")
+	assert.NotContains(t, modules, "", "empty vectorizer must not appear")
+}
+
+// T-FIELDS-3: node count comes from schemaManager.Nodes().
+func TestCuratedFields_NodeCount(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := &fakeSchemaManager{}
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{}, nil)
+
+	sm.On("Nodes").Return([]string{"a", "b"})
+	sm.On("GetSchemaSkipAuth").Return(schema.Schema{})
+	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
+		&models.NodeStatus{Stats: &models.NodeStats{}},
+	)
+
+	payload, err := tel.buildPayload(context.Background(), PayloadType.Init)
+	require.NoError(t, err)
+	require.NotNil(t, payload.NodeCount)
+	assert.Equal(t, 2, *payload.NodeCount)
+}
+
+// T-FIELDS-5: pointer fields serialize a measured zero/false rather than being
+// dropped by omitempty, and a nil field is omitted. This is the guard Marcin
+// asked for: with the old value-type fields, nodeCount:0 / replicationEnabled:false
+// were silently dropped and unknown was indistinguishable from known-zero.
+func TestPayload_PointerSemantics_JSON(t *testing.T) {
+	t.Run("measured zero/false serialize", func(t *testing.T) {
+		p := Payload{
+			NodeCount:                  ptrTo(0),
+			MaxReplicationFactor:       ptrTo(0),
+			ReplicationEnabled:         ptrTo(false),
+			MTCollectionCount:          ptrTo(0),
+			NamedVectorCollectionCount: ptrTo(0),
+			AsyncIndexingEnabled:       ptrTo(false),
+		}
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		s := string(b)
+
+		assert.Contains(t, s, `"nodeCount":0`)
+		assert.Contains(t, s, `"maxReplicationFactor":0`)
+		assert.Contains(t, s, `"replicationEnabled":false`)
+		assert.Contains(t, s, `"mtCollectionCount":0`)
+		assert.Contains(t, s, `"namedVectorCollectionCount":0`)
+		assert.Contains(t, s, `"asyncIndexingEnabled":false`)
+	})
+
+	t.Run("nil curated fields omitted; measured field present", func(t *testing.T) {
+		p := Payload{
+			ClusterID: "00000000-0000-7000-0000-000000000001",
+			NodeCount: ptrTo(3),
+			// remaining curated pointers nil: not measured.
+		}
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		s := string(b)
+
+		assert.Contains(t, s, `"clusterId":"00000000-0000-7000-0000-000000000001"`)
+		assert.Contains(t, s, `"nodeCount":3`)
+		assert.NotContains(t, s, "replicationEnabled")
+		assert.NotContains(t, s, "asyncIndexingEnabled")
+		assert.NotContains(t, s, "mtCollectionCount")
+	})
+}
+
+// T-FIELDS-4: VectorIndexType defaults to "hnsw" when empty string.
+func TestCuratedFields_DefaultVectorIndexType(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := &fakeSchemaManager{}
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{}, nil)
+
+	sm.On("GetSchemaSkipAuth").Return(schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{Class: "X", VectorIndexType: ""},
+			},
+		},
+	})
+	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
+		&models.NodeStatus{Stats: &models.NodeStats{}},
+	)
+
+	payload, err := tel.buildPayload(context.Background(), PayloadType.Init)
+	require.NoError(t, err)
+	require.NotNil(t, payload.VectorIndexTypeCounts)
+	assert.Equal(t, 1, payload.VectorIndexTypeCounts["hnsw"], "empty VectorIndexType defaults to hnsw")
+	assert.Equal(t, 0, payload.VectorIndexTypeCounts[""])
+}

--- a/usecases/telemetry/curated_fields_test.go
+++ b/usecases/telemetry/curated_fields_test.go
@@ -33,7 +33,6 @@ func TestCuratedFields_Extraction(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	tel := New(sg, sm, logger, Config{NodeID: "node-abc", AsyncIndexingEnabled: true}, nil)
 
-	// 3 nodes
 	sm.On("Nodes").Return([]string{"n1", "n2", "n3"})
 	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 		&models.NodeStatus{Stats: &models.NodeStats{ObjectCount: 0}},
@@ -41,21 +40,18 @@ func TestCuratedFields_Extraction(t *testing.T) {
 
 	classes := []*models.Class{
 		{
-			// single-vector, hnsw, RF=3, not MT
 			Class:              "A",
 			VectorIndexType:    "hnsw",
 			ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false},
 		},
 		{
-			// single-vector, flat, RF=1, MT enabled
 			Class:              "B",
 			VectorIndexType:    "flat",
 			ReplicationConfig:  &models.ReplicationConfig{Factor: 1},
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 		},
 		{
-			// named-vector (dynamic + flat), no RF, MT enabled
 			Class:              "C",
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 			VectorConfig: map[string]models.VectorConfig{
@@ -100,25 +96,21 @@ func TestUsedModules_NilModuleConfigFallback(t *testing.T) {
 
 	classes := []*models.Class{
 		{
-			// nil ModuleConfig with a non-"none" Vectorizer → fallback adds the module
 			Class:        "WithVectorizer",
 			ModuleConfig: nil,
 			Vectorizer:   "text2vec-openai",
 		},
 		{
-			// "none" vectorizer should NOT appear
 			Class:        "BYOV",
 			ModuleConfig: nil,
 			Vectorizer:   "none",
 		},
 		{
-			// empty Vectorizer should NOT appear
 			Class:        "EmptyVectorizer",
 			ModuleConfig: nil,
 			Vectorizer:   "",
 		},
 		{
-			// properly configured class (non-nil ModuleConfig) - unchanged behavior
 			Class: "ProperlyConfigured",
 			ModuleConfig: map[string]interface{}{
 				"text2vec-cohere": map[string]interface{}{},
@@ -158,10 +150,8 @@ func TestCuratedFields_NodeCount(t *testing.T) {
 	assert.Equal(t, 2, *payload.NodeCount)
 }
 
-// T-FIELDS-5: pointer fields serialize a measured zero/false rather than being
-// dropped by omitempty, and a nil field is omitted. This is the guard Marcin
-// asked for: with the old value-type fields, nodeCount:0 / replicationEnabled:false
-// were silently dropped and unknown was indistinguishable from known-zero.
+// T-FIELDS-5: pointer fields serialize a measured zero/false instead of being
+// dropped by omitempty; nil means unmeasured.
 func TestPayload_PointerSemantics_JSON(t *testing.T) {
 	t.Run("measured zero/false serialize", func(t *testing.T) {
 		p := Payload{
@@ -188,7 +178,6 @@ func TestPayload_PointerSemantics_JSON(t *testing.T) {
 		p := Payload{
 			ClusterID: "00000000-0000-7000-0000-000000000001",
 			NodeCount: ptrTo(3),
-			// remaining curated pointers nil: not measured.
 		}
 		b, err := json.Marshal(p)
 		require.NoError(t, err)

--- a/usecases/telemetry/fakes_for_test.go
+++ b/usecases/telemetry/fakes_for_test.go
@@ -47,6 +47,21 @@ func (f *fakeSchemaManager) GetSchemaSkipAuth() schema.Schema {
 	return schema.Schema{}
 }
 
+func (f *fakeSchemaManager) Nodes() []string {
+	if len(f.ExpectedCalls) > 0 {
+		for _, call := range f.ExpectedCalls {
+			if call.Method == "Nodes" {
+				args := f.Called()
+				if args.Get(0) != nil {
+					return args.Get(0).([]string)
+				}
+				return nil
+			}
+		}
+	}
+	return []string{"node1"}
+}
+
 type fakeCloudInfoProvider struct {
 	mock.Mock
 }

--- a/usecases/telemetry/node_id_test.go
+++ b/usecases/telemetry/node_id_test.go
@@ -29,18 +29,15 @@ func TestReadOrCreateNodeID_CreatesAndReads(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, id1)
 
-	// second call reads the same value
 	id2, err := ReadOrCreateNodeID(dir)
 	require.NoError(t, err)
 	assert.Equal(t, id1, id2, "second read must return the same UUID")
 
-	// file on disk contains the UUID
 	b, err := os.ReadFile(filepath.Join(dir, "node-id"))
 	require.NoError(t, err)
 	assert.Equal(t, id1, string(b))
 
-	// the tmp file must not linger: rename consumes it and the deferred cleanup
-	// removes it on any post-write failure path.
+	// tmp file must not linger after a successful write (rename consumes it)
 	_, statErr := os.Stat(filepath.Join(dir, "node-id.tmp"))
 	assert.True(t, os.IsNotExist(statErr), "node-id.tmp must not be left behind")
 }
@@ -65,9 +62,7 @@ func TestNodeIDSurvivesRestart(t *testing.T) {
 	assert.Equal(t, tel1.nodeID, tel2.nodeID, "nodeId must be identical across restarts")
 }
 
-// T-IDENT-3: machineId != nodeId, and the R2/R3 overwrite slip is absent.
-// Two New() calls with the same data dir: machineId differs (fresh per process)
-// while nodeId is identical. This is the key correctness guard.
+// T-IDENT-3: machineId (ephemeral) must never equal nodeId (persisted).
 func TestMachineIDDiffersFromNodeID(t *testing.T) {
 	dir := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -85,14 +80,11 @@ func TestMachineIDDiffersFromNodeID(t *testing.T) {
 	require.NoError(t, err)
 	tel2 := New(sg2, sm2, logger, Config{NodeID: nodeID2}, nil)
 
-	// nodeId is stable: both telemeters see the same persisted UUID
 	assert.Equal(t, tel1.nodeID, tel2.nodeID, "nodeId must be identical across New() calls")
 
-	// machineId is ephemeral: each New() call gets a fresh UUID
 	assert.NotEqual(t, string(tel1.machineID), string(tel2.machineID),
 		"machineId must differ across New() calls (counts restarts)")
 
-	// machineId must not equal nodeId for either instance
 	assert.NotEqual(t, string(tel1.machineID), tel1.nodeID,
 		"machineId must not overwrite nodeId (slip guard)")
 	assert.NotEqual(t, string(tel2.machineID), tel2.nodeID,
@@ -120,7 +112,6 @@ func TestReadOrCreateNodeID_UnwritableDirReturnsError(t *testing.T) {
 		t.Skip("requires non-root; root bypasses dir perms")
 	}
 	dir := t.TempDir()
-	// Make the directory read-only so writes fail.
 	require.NoError(t, os.Chmod(dir, 0o555))
 	defer os.Chmod(dir, 0o755) //nolint:errcheck
 
@@ -128,7 +119,7 @@ func TestReadOrCreateNodeID_UnwritableDirReturnsError(t *testing.T) {
 	assert.Error(t, err, "expected an error on unwritable dir")
 }
 
-// waitForClusterID timing test: returns immediately once context cancelled.
+// waitForClusterID stub: exercises the injected-waiter code path directly.
 func TestWaitForClusterIDFuncWithStub(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	sg := &fakeNodesStatusGetter{}
@@ -140,9 +131,7 @@ func TestWaitForClusterIDFuncWithStub(t *testing.T) {
 	}
 	tel := New(sg, sm, logger, Config{NodeID: "test-node-id"}, stub)
 
-	// Start sets clusterID from the stub waiter
-	// We call it directly to test the field assignment path (Start itself makes
-	// a network push which we don't want in unit tests).
+	// call the waiter directly; Start() would also push over the network
 	waitCtx := context.Background()
 	clusterID, err := tel.waitForClusterID(waitCtx)
 	require.NoError(t, err)

--- a/usecases/telemetry/node_id_test.go
+++ b/usecases/telemetry/node_id_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// T-IDENT-1: ReadOrCreateNodeID creates then reads stable.
 func TestReadOrCreateNodeID_CreatesAndReads(t *testing.T) {
 	dir := t.TempDir()
 	id1, err := ReadOrCreateNodeID(dir)
@@ -42,7 +41,6 @@ func TestReadOrCreateNodeID_CreatesAndReads(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "node-id.tmp must not be left behind")
 }
 
-// T-IDENT-2: nodeId survives simulated restart (two New() calls same dir).
 func TestNodeIDSurvivesRestart(t *testing.T) {
 	dir := t.TempDir()
 
@@ -62,7 +60,6 @@ func TestNodeIDSurvivesRestart(t *testing.T) {
 	assert.Equal(t, tel1.nodeID, tel2.nodeID, "nodeId must be identical across restarts")
 }
 
-// T-IDENT-3: machineId (ephemeral) must never equal nodeId (persisted).
 func TestMachineIDDiffersFromNodeID(t *testing.T) {
 	dir := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -91,7 +88,6 @@ func TestMachineIDDiffersFromNodeID(t *testing.T) {
 		"machineId must not overwrite nodeId (slip guard)")
 }
 
-// T-IDENT-4: nodeId resets on data-dir wipe.
 func TestNodeIDResetsOnDataDirWipe(t *testing.T) {
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
@@ -104,7 +100,6 @@ func TestNodeIDResetsOnDataDirWipe(t *testing.T) {
 	assert.NotEqual(t, id1, id2, "different data dirs must produce different nodeIds")
 }
 
-// T-IDENT-5: read-only / unwritable dir falls back.
 // Skipped when running as root because root bypasses dir permission bits,
 // causing the write to succeed and the assertion to fail in CI containers.
 func TestReadOrCreateNodeID_UnwritableDirReturnsError(t *testing.T) {

--- a/usecases/telemetry/node_id_test.go
+++ b/usecases/telemetry/node_id_test.go
@@ -38,6 +38,11 @@ func TestReadOrCreateNodeID_CreatesAndReads(t *testing.T) {
 	b, err := os.ReadFile(filepath.Join(dir, "node-id"))
 	require.NoError(t, err)
 	assert.Equal(t, id1, string(b))
+
+	// the tmp file must not linger: rename consumes it and the deferred cleanup
+	// removes it on any post-write failure path.
+	_, statErr := os.Stat(filepath.Join(dir, "node-id.tmp"))
+	assert.True(t, os.IsNotExist(statErr), "node-id.tmp must not be left behind")
 }
 
 // T-IDENT-2: nodeId survives simulated restart (two New() calls same dir).

--- a/usecases/telemetry/node_id_test.go
+++ b/usecases/telemetry/node_id_test.go
@@ -1,0 +1,145 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package telemetry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// T-IDENT-1: ReadOrCreateNodeID creates then reads stable.
+func TestReadOrCreateNodeID_CreatesAndReads(t *testing.T) {
+	dir := t.TempDir()
+	id1, err := ReadOrCreateNodeID(dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, id1)
+
+	// second call reads the same value
+	id2, err := ReadOrCreateNodeID(dir)
+	require.NoError(t, err)
+	assert.Equal(t, id1, id2, "second read must return the same UUID")
+
+	// file on disk contains the UUID
+	b, err := os.ReadFile(filepath.Join(dir, "node-id"))
+	require.NoError(t, err)
+	assert.Equal(t, id1, string(b))
+}
+
+// T-IDENT-2: nodeId survives simulated restart (two New() calls same dir).
+func TestNodeIDSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	sg1 := &fakeNodesStatusGetter{}
+	sm1 := &fakeSchemaManager{}
+	logger, _ := test.NewNullLogger()
+	nodeID1, err := ReadOrCreateNodeID(dir)
+	require.NoError(t, err)
+	tel1 := New(sg1, sm1, logger, Config{NodeID: nodeID1}, nil)
+
+	sg2 := &fakeNodesStatusGetter{}
+	sm2 := &fakeSchemaManager{}
+	nodeID2, err := ReadOrCreateNodeID(dir)
+	require.NoError(t, err)
+	tel2 := New(sg2, sm2, logger, Config{NodeID: nodeID2}, nil)
+
+	assert.Equal(t, tel1.nodeID, tel2.nodeID, "nodeId must be identical across restarts")
+}
+
+// T-IDENT-3: machineId != nodeId, and the R2/R3 overwrite slip is absent.
+// Two New() calls with the same data dir: machineId differs (fresh per process)
+// while nodeId is identical. This is the key correctness guard.
+func TestMachineIDDiffersFromNodeID(t *testing.T) {
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	nodeID, err := ReadOrCreateNodeID(dir)
+	require.NoError(t, err)
+
+	sg1 := &fakeNodesStatusGetter{}
+	sm1 := &fakeSchemaManager{}
+	tel1 := New(sg1, sm1, logger, Config{NodeID: nodeID}, nil)
+
+	sg2 := &fakeNodesStatusGetter{}
+	sm2 := &fakeSchemaManager{}
+	nodeID2, err := ReadOrCreateNodeID(dir)
+	require.NoError(t, err)
+	tel2 := New(sg2, sm2, logger, Config{NodeID: nodeID2}, nil)
+
+	// nodeId is stable: both telemeters see the same persisted UUID
+	assert.Equal(t, tel1.nodeID, tel2.nodeID, "nodeId must be identical across New() calls")
+
+	// machineId is ephemeral: each New() call gets a fresh UUID
+	assert.NotEqual(t, string(tel1.machineID), string(tel2.machineID),
+		"machineId must differ across New() calls (counts restarts)")
+
+	// machineId must not equal nodeId for either instance
+	assert.NotEqual(t, string(tel1.machineID), tel1.nodeID,
+		"machineId must not overwrite nodeId (slip guard)")
+	assert.NotEqual(t, string(tel2.machineID), tel2.nodeID,
+		"machineId must not overwrite nodeId (slip guard)")
+}
+
+// T-IDENT-4: nodeId resets on data-dir wipe.
+func TestNodeIDResetsOnDataDirWipe(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	id1, err := ReadOrCreateNodeID(dir1)
+	require.NoError(t, err)
+	id2, err := ReadOrCreateNodeID(dir2)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, id1, id2, "different data dirs must produce different nodeIds")
+}
+
+// T-IDENT-5: read-only / unwritable dir falls back.
+// Skipped when running as root because root bypasses dir permission bits,
+// causing the write to succeed and the assertion to fail in CI containers.
+func TestReadOrCreateNodeID_UnwritableDirReturnsError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("requires non-root; root bypasses dir perms")
+	}
+	dir := t.TempDir()
+	// Make the directory read-only so writes fail.
+	require.NoError(t, os.Chmod(dir, 0o555))
+	defer os.Chmod(dir, 0o755) //nolint:errcheck
+
+	_, err := ReadOrCreateNodeID(dir)
+	assert.Error(t, err, "expected an error on unwritable dir")
+}
+
+// waitForClusterID timing test: returns immediately once context cancelled.
+func TestWaitForClusterIDFuncWithStub(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	sg := &fakeNodesStatusGetter{}
+	sm := &fakeSchemaManager{}
+
+	const fixedID = "00000000-0000-7000-0000-000000000099"
+	stub := func(ctx context.Context) (string, error) {
+		return fixedID, nil
+	}
+	tel := New(sg, sm, logger, Config{NodeID: "test-node-id"}, stub)
+
+	// Start sets clusterID from the stub waiter
+	// We call it directly to test the field assignment path (Start itself makes
+	// a network push which we don't want in unit tests).
+	waitCtx := context.Background()
+	clusterID, err := tel.waitForClusterID(waitCtx)
+	require.NoError(t, err)
+	assert.Equal(t, fixedID, clusterID)
+}

--- a/usecases/telemetry/payload.go
+++ b/usecases/telemetry/payload.go
@@ -28,6 +28,7 @@ var PayloadType = struct {
 
 // Payload is the object transmitted for telemetry purposes
 type Payload struct {
+	// --- existing fields, UNCHANGED ---
 	MachineID        strfmt.UUID                     `json:"machineId"`
 	Type             string                          `json:"type"`
 	Version          string                          `json:"version"`
@@ -39,4 +40,31 @@ type Payload struct {
 	ClientUsage      map[ClientType]map[string]int64 `json:"clientUsage,omitempty"`
 	CloudProvider    *string                         `json:"cloudProvider,omitempty"`
 	UniqueID         *string                         `json:"uniqueID,omitempty"`
+
+	// --- NEW: stable identity ---
+	// NodeID is a persisted UUID tied to the data volume. Stable across restarts;
+	// resets only on data-volume wipe. NOT the hostname. Empty means unknown; it
+	// has no meaningful set-but-empty value, so a value type with omitempty is
+	// sufficient (no unknown-vs-known-empty ambiguity).
+	NodeID string `json:"nodeId,omitempty"`
+	// ClusterID is a UUIDv7 committed once per cluster lifetime via raft, including
+	// single-node deployments (the sole leader still commits it). Empty means the
+	// identity was not yet committed at push time (best-effort; times out after
+	// 30s in Start()); there is no known-empty clusterId, so string+omitempty is
+	// sufficient. Cluster inception time is derived downstream from the UUIDv7
+	// timestamp bits, so it is not sent as a separate field.
+	ClusterID string `json:"clusterId,omitempty"`
+
+	// --- NEW: curated signal ---
+	// These are pointers so a successfully-measured zero/false serializes (e.g.
+	// nodeCount:0, replicationEnabled:false) instead of being dropped by omitempty.
+	// A nil pointer means the value could not be determined; the schema-derived
+	// fields below are always measured, so they are always non-nil in practice.
+	NodeCount                  *int           `json:"nodeCount,omitempty"`
+	MaxReplicationFactor       *int           `json:"maxReplicationFactor,omitempty"`
+	ReplicationEnabled         *bool          `json:"replicationEnabled,omitempty"`
+	MTCollectionCount          *int           `json:"mtCollectionCount,omitempty"`
+	NamedVectorCollectionCount *int           `json:"namedVectorCollectionCount,omitempty"`
+	AsyncIndexingEnabled       *bool          `json:"asyncIndexingEnabled,omitempty"`
+	VectorIndexTypeCounts      map[string]int `json:"vectorIndexTypeCounts,omitempty"`
 }

--- a/usecases/telemetry/payload.go
+++ b/usecases/telemetry/payload.go
@@ -28,7 +28,6 @@ var PayloadType = struct {
 
 // Payload is the object transmitted for telemetry purposes
 type Payload struct {
-	// --- existing fields, UNCHANGED ---
 	MachineID        strfmt.UUID                     `json:"machineId"`
 	Type             string                          `json:"type"`
 	Version          string                          `json:"version"`
@@ -41,25 +40,17 @@ type Payload struct {
 	CloudProvider    *string                         `json:"cloudProvider,omitempty"`
 	UniqueID         *string                         `json:"uniqueID,omitempty"`
 
-	// --- NEW: stable identity ---
-	// NodeID is a persisted UUID tied to the data volume. Stable across restarts;
-	// resets only on data-volume wipe. NOT the hostname. Empty means unknown; it
-	// has no meaningful set-but-empty value, so a value type with omitempty is
-	// sufficient (no unknown-vs-known-empty ambiguity).
+	// NodeID is a persisted UUID tied to the data volume (NOT the hostname);
+	// stable across restarts, reset only on volume wipe. Empty means unknown.
 	NodeID string `json:"nodeId,omitempty"`
-	// ClusterID is a UUIDv7 committed once per cluster lifetime via raft, including
-	// single-node deployments (the sole leader still commits it). Empty means the
-	// identity was not yet committed at push time (best-effort; times out after
-	// 30s in Start()); there is no known-empty clusterId, so string+omitempty is
-	// sufficient. Cluster inception time is derived downstream from the UUIDv7
-	// timestamp bits, so it is not sent as a separate field.
+	// ClusterID is a UUIDv7 committed once per cluster lifetime via raft
+	// (including single-node deployments). Empty means not yet committed
+	// (best-effort; 30s timeout in Start()). Inception time is derived from the
+	// UUIDv7 timestamp downstream, so it isn't sent as a separate field.
 	ClusterID string `json:"clusterId,omitempty"`
 
-	// --- NEW: curated signal ---
-	// These are pointers so a successfully-measured zero/false serializes (e.g.
-	// nodeCount:0, replicationEnabled:false) instead of being dropped by omitempty.
-	// A nil pointer means the value could not be determined; the schema-derived
-	// fields below are always measured, so they are always non-nil in practice.
+	// Pointer fields so a measured zero/false (e.g. nodeCount:0) serializes
+	// instead of being dropped by omitempty; nil means unmeasured.
 	NodeCount                  *int           `json:"nodeCount,omitempty"`
 	MaxReplicationFactor       *int           `json:"maxReplicationFactor,omitempty"`
 	ReplicationEnabled         *bool          `json:"replicationEnabled,omitempty"`

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -59,9 +59,7 @@ type Telemeter struct {
 	nodesStatusGetter nodesStatusGetter
 	schemaManager     schemaManager
 	logger            logrus.FieldLogger
-	// shutdown is buffered(1) so Stop() never blocks while Start() waits on the
-	// clusterId wait. Consequence: Terminate may push before Init during a
-	// shutdown-during-startup race; ordering is not guaranteed.
+	// buffered(1) so Stop() never blocks; Terminate may precede Init at shutdown-during-startup.
 	shutdown        chan struct{}
 	consumer        string
 	pushInterval    time.Duration

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -50,7 +50,6 @@ type nodesStatusGetter interface {
 type schemaManager interface {
 	GetSchemaSkipAuth() schema.Schema
 	// Nodes returns a snapshot of the current cluster node names.
-	// concrete *schema.Handler already implements this.
 	Nodes() []string
 }
 
@@ -60,24 +59,21 @@ type Telemeter struct {
 	nodesStatusGetter nodesStatusGetter
 	schemaManager     schemaManager
 	logger            logrus.FieldLogger
-	// shutdown is buffered(1) so Stop() never blocks while Start() is still inside
-	// the clusterId wait. Consequence: on shutdown-during-startup Stop() can send
-	// and push Terminate before Start() pushes Init, so Terminate-before-Init
-	// ordering is not guaranteed.
+	// shutdown is buffered(1) so Stop() never blocks while Start() waits on the
+	// clusterId wait. Consequence: Terminate may push before Init during a
+	// shutdown-during-startup race; ordering is not guaranteed.
 	shutdown        chan struct{}
 	consumer        string
 	pushInterval    time.Duration
 	clientTracker   *ClientTracker
 	cloudInfoHelper *cloudInfoHelper
 
-	// nodeID is the persisted per-node UUID from the data-volume file. NOT the hostname.
-	// machineID stays uuid.NewString() per process (unchanged, counts restarts).
+	// nodeID is the persisted per-node UUID from the data-volume file (NOT the hostname).
 	nodeID               string
 	asyncIndexingEnabled bool
 
-	// mu guards clusterID and failedToStart: both are written by Start() (the
-	// clusterId wait can run for up to 30s) and read by Stop() during shutdown,
-	// so shutdown-during-startup would otherwise race them.
+	// mu guards clusterID and failedToStart, both written by Start() (which can
+	// run up to 30s) and read by Stop(); without it, shutdown-during-startup races them.
 	mu            sync.Mutex
 	failedToStart bool
 	// clusterID is populated in Start() before the Init push.
@@ -117,8 +113,8 @@ func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
 	}
 
 	tel := &Telemeter{
-		// machineID is a fresh UUID each process start - this is intentional and unchanged.
-		// It counts restarts. nodeID (below) is the stable per-node identity.
+		// machineID is a fresh UUID per process (counts restarts); distinct from
+		// the persisted nodeID.
 		machineID:            strfmt.UUID(uuid.NewString()),
 		nodesStatusGetter:    nodesStatusGetter,
 		schemaManager:        schemaManager,
@@ -136,16 +132,14 @@ func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
 }
 
 // ReadOrCreateNodeID reads the stable per-node UUID from dataPath/node-id.
-// If the file does not exist it generates a new UUID, writes it atomically
-// (tmp+rename mirroring adapters/repos/db/inverted/new_prop_length_tracker.go),
-// and returns it. On any I/O error it returns an error; the caller falls back
-// to an ephemeral UUID so a read-only data dir does not prevent startup.
+// If the file does not exist it generates and atomically persists (tmp+rename)
+// a new UUID. On I/O error it returns an error; the caller falls back to an
+// ephemeral UUID so a read-only data dir doesn't block startup.
 func ReadOrCreateNodeID(dataPath string) (string, error) {
 	// dataPath is trusted operator config (PERSISTENCE_DATA_PATH), not request
 	// input, and the filename is a constant; filepath.Join cleans the result.
 	nodePath := filepath.Join(dataPath, "node-id")
 
-	// happy path: file exists
 	if b, err := os.ReadFile(nodePath); err == nil {
 		id := strings.TrimSpace(string(b))
 		if id != "" {
@@ -155,7 +149,6 @@ func ReadOrCreateNodeID(dataPath string) (string, error) {
 		return "", fmt.Errorf("read node-id: %w", err)
 	}
 
-	// generate a fresh UUID and persist it atomically
 	id := uuid.NewString()
 	tmp := nodePath + ".tmp"
 	// 0o600: the node-id is private per-node state only the server process reads.
@@ -168,7 +161,7 @@ func ReadOrCreateNodeID(dataPath string) (string, error) {
 	if err := os.Rename(tmp, nodePath); err != nil {
 		return "", fmt.Errorf("rename node-id: %w", err)
 	}
-	// re-read to confirm (mirrors new_prop_length_tracker pattern)
+	// re-read to confirm the write landed
 	b, err := os.ReadFile(nodePath)
 	if err != nil {
 		return "", fmt.Errorf("re-read node-id after write: %w", err)
@@ -207,10 +200,9 @@ func (tel *Telemeter) getFailedToStart() bool {
 
 // Start begins telemetry for the node
 func (tel *Telemeter) Start(ctx context.Context) error {
-	// Wait up to 30 s for the raft leader to commit the cluster identity before the
-	// INIT push. On timeout we proceed without clusterId (best-effort; do not block
-	// startup). Single-node Docker typically resolves within ~1-2 s; restarts with a
-	// snapshot have the id restored immediately.
+	// Wait up to 30s for the raft leader to commit the cluster identity before the
+	// INIT push; on timeout, proceed without clusterId (best-effort, does not
+	// block startup).
 	if tel.waitForClusterID != nil {
 		waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
@@ -360,29 +352,24 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 
 	cloudProvider, uniqueID := tel.getCloudInfo()
 
-	// Curated signal fields - one pass over the schema. These are always measured,
-	// so they map to non-nil pointers and a measured 0/false serializes rather than
-	// being dropped by omitempty.
 	nodeCount, maxRF, mtCount, namedVecCount, vectorIndexTypeCounts := tel.getCuratedSchemaFields()
 	replicationEnabled := maxRF > 1
 	asyncIndexingEnabled := tel.asyncIndexingEnabled
 
 	return &Payload{
-		MachineID:        tel.machineID,
-		Type:             payloadType,
-		Version:          config.ServerVersion,
-		ObjectsCount:     objs,
-		OS:               runtime.GOOS,
-		Arch:             runtime.GOARCH,
-		UsedModules:      usedMods,
-		CollectionsCount: cols,
-		ClientUsage:      clientUsage,
-		CloudProvider:    cloudProvider,
-		UniqueID:         uniqueID,
-		// stable identity
-		NodeID:    tel.nodeID,
-		ClusterID: tel.getClusterID(),
-		// curated signal
+		MachineID:                  tel.machineID,
+		Type:                       payloadType,
+		Version:                    config.ServerVersion,
+		ObjectsCount:               objs,
+		OS:                         runtime.GOOS,
+		Arch:                       runtime.GOARCH,
+		UsedModules:                usedMods,
+		CollectionsCount:           cols,
+		ClientUsage:                clientUsage,
+		CloudProvider:              cloudProvider,
+		UniqueID:                   uniqueID,
+		NodeID:                     tel.nodeID,
+		ClusterID:                  tel.getClusterID(),
 		NodeCount:                  &nodeCount,
 		MaxReplicationFactor:       &maxRF,
 		ReplicationEnabled:         &replicationEnabled,
@@ -470,9 +457,8 @@ func (tel *Telemeter) getUsedModules() ([]string, error) {
 					usedModulesMap[tel.determineModule(name, cfg)] = struct{}{}
 				}
 			} else if class.Vectorizer != "" && class.Vectorizer != "none" {
-				// Fallback for classes whose ModuleConfig is nil but the class-level
-				// Vectorizer field is set (pre-v1.14 schemas and old-migration gap).
-				// "none" (BYOV) is intentionally excluded - it is not a module.
+				// Fallback for classes with nil ModuleConfig but a set class-level
+				// Vectorizer (pre-v1.14 schemas). "none" (BYOV) is excluded - not a module.
 				usedModulesMap[class.Vectorizer] = struct{}{}
 			}
 			for _, vectorConfig := range class.VectorConfig {

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -46,6 +48,9 @@ type nodesStatusGetter interface {
 
 type schemaManager interface {
 	GetSchemaSkipAuth() schema.Schema
+	// Nodes returns a snapshot of the current cluster node names.
+	// concrete *schema.Handler already implements this.
+	Nodes() []string
 }
 
 // Telemeter is responsible for managing the transmission of telemetry data
@@ -54,40 +59,108 @@ type Telemeter struct {
 	nodesStatusGetter nodesStatusGetter
 	schemaManager     schemaManager
 	logger            logrus.FieldLogger
-	shutdown          chan struct{}
+	shutdown          chan struct{} // buffered(1): Stop() must not block during Start()'s clusterId wait
 	failedToStart     bool
 	consumer          string
 	pushInterval      time.Duration
 	clientTracker     *ClientTracker
 	cloudInfoHelper   *cloudInfoHelper
+
+	// nodeID is the persisted per-node UUID from the data-volume file. NOT the hostname.
+	// machineID stays uuid.NewString() per process (unchanged, counts restarts).
+	nodeID string
+	// clusterID is populated in Start() before the Init push.
+	clusterID            string
+	asyncIndexingEnabled bool
+	// waitForClusterID blocks until the raft leader commits the cluster identity.
+	waitForClusterID func(ctx context.Context) (string, error)
+}
+
+// Config holds the scalar settings for a Telemeter.
+type Config struct {
+	// ConsumerURL is base64-encoded. If empty, DefaultTelemetryConsumerURL is used.
+	ConsumerURL string
+	// PushInterval defaults to DefaultTelemetryPushInterval if zero.
+	PushInterval time.Duration
+	// Enabled gates whether usage trackers spin up and payloads are pushed.
+	Enabled bool
+	// NodeID is the persisted per-node UUID from the data-volume file (NOT the hostname).
+	NodeID string
+	// AsyncIndexingEnabled is wired from server config.
+	AsyncIndexingEnabled bool
 }
 
 // New creates a new Telemeter instance.
-// consumerURL should be base64-encoded. If empty, uses DefaultTelemetryConsumerURL.
-// pushInterval defaults to DefaultTelemetryPushInterval if zero.
+// waitForClusterID blocks until the raft leader commits the cluster identity; may be nil
+// (only in tests) in which case clusterId is omitted from payloads.
 func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
-	logger logrus.FieldLogger, consumerURL string, pushInterval time.Duration,
-	telemetryEnabled bool,
+	logger logrus.FieldLogger, cfg Config,
+	waitForClusterID func(ctx context.Context) (string, error),
 ) *Telemeter {
+	consumerURL := cfg.ConsumerURL
 	if consumerURL == "" {
 		consumerURL = DefaultTelemetryConsumerURL
 	}
+	pushInterval := cfg.PushInterval
 	if pushInterval == 0 {
 		pushInterval = DefaultTelemetryPushInterval
 	}
 
 	tel := &Telemeter{
-		machineID:         strfmt.UUID(uuid.NewString()),
-		nodesStatusGetter: nodesStatusGetter,
-		schemaManager:     schemaManager,
-		logger:            logger,
-		shutdown:          make(chan struct{}),
-		consumer:          consumerURL,
-		pushInterval:      pushInterval,
-		clientTracker:     NewClientTracker(logger),
-		cloudInfoHelper:   newCloudInfoHelper(logger, telemetryEnabled),
+		// machineID is a fresh UUID each process start - this is intentional and unchanged.
+		// It counts restarts. nodeID (below) is the stable per-node identity.
+		machineID:            strfmt.UUID(uuid.NewString()),
+		nodesStatusGetter:    nodesStatusGetter,
+		schemaManager:        schemaManager,
+		logger:               logger,
+		shutdown:             make(chan struct{}, 1),
+		consumer:             consumerURL,
+		pushInterval:         pushInterval,
+		clientTracker:        NewClientTracker(logger),
+		cloudInfoHelper:      newCloudInfoHelper(logger, cfg.Enabled),
+		nodeID:               cfg.NodeID,
+		asyncIndexingEnabled: cfg.AsyncIndexingEnabled,
+		waitForClusterID:     waitForClusterID,
 	}
 	return tel
+}
+
+// ReadOrCreateNodeID reads the stable per-node UUID from dataPath/node-id.
+// If the file does not exist it generates a new UUID, writes it atomically
+// (tmp+rename mirroring adapters/repos/db/inverted/new_prop_length_tracker.go),
+// and returns it. On any I/O error it returns an error; the caller falls back
+// to an ephemeral UUID so a read-only data dir does not prevent startup.
+func ReadOrCreateNodeID(dataPath string) (string, error) {
+	// dataPath is trusted operator config (PERSISTENCE_DATA_PATH), not request
+	// input, and the filename is a constant; filepath.Join cleans the result.
+	nodePath := filepath.Join(dataPath, "node-id")
+
+	// happy path: file exists
+	if b, err := os.ReadFile(nodePath); err == nil {
+		id := strings.TrimSpace(string(b))
+		if id != "" {
+			return id, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("read node-id: %w", err)
+	}
+
+	// generate a fresh UUID and persist it atomically
+	id := uuid.NewString()
+	tmp := nodePath + ".tmp"
+	// 0o600: the node-id is private per-node state only the server process reads.
+	if err := os.WriteFile(tmp, []byte(id), 0o600); err != nil {
+		return "", fmt.Errorf("write node-id tmp: %w", err)
+	}
+	if err := os.Rename(tmp, nodePath); err != nil {
+		return "", fmt.Errorf("rename node-id: %w", err)
+	}
+	// re-read to confirm (mirrors new_prop_length_tracker pattern)
+	b, err := os.ReadFile(nodePath)
+	if err != nil {
+		return "", fmt.Errorf("re-read node-id after write: %w", err)
+	}
+	return strings.TrimSpace(string(b)), nil
 }
 
 // GetClientTracker returns the client tracker instance for use in middleware
@@ -97,6 +170,22 @@ func (tel *Telemeter) GetClientTracker() *ClientTracker {
 
 // Start begins telemetry for the node
 func (tel *Telemeter) Start(ctx context.Context) error {
+	// Wait up to 30 s for the raft leader to commit the cluster identity before the
+	// INIT push. On timeout we proceed without clusterId (best-effort; do not block
+	// startup). Single-node Docker typically resolves within ~1-2 s; restarts with a
+	// snapshot have the id restored immediately.
+	if tel.waitForClusterID != nil {
+		waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		clusterID, err := tel.waitForClusterID(waitCtx)
+		if err != nil {
+			tel.logger.WithField("action", "telemetry_cluster_id_wait").
+				Warnf("cluster identity not available within 30s, pushing INIT without clusterId: %v", err)
+		} else {
+			tel.clusterID = clusterID
+		}
+	}
+
 	payload, err := tel.push(ctx, PayloadType.Init)
 	if err != nil {
 		tel.failedToStart = true
@@ -234,6 +323,13 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 
 	cloudProvider, uniqueID := tel.getCloudInfo()
 
+	// Curated signal fields - one pass over the schema. These are always measured,
+	// so they map to non-nil pointers and a measured 0/false serializes rather than
+	// being dropped by omitempty.
+	nodeCount, maxRF, mtCount, namedVecCount, vectorIndexTypeCounts := tel.getCuratedSchemaFields()
+	replicationEnabled := maxRF > 1
+	asyncIndexingEnabled := tel.asyncIndexingEnabled
+
 	return &Payload{
 		MachineID:        tel.machineID,
 		Type:             payloadType,
@@ -246,7 +342,81 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 		ClientUsage:      clientUsage,
 		CloudProvider:    cloudProvider,
 		UniqueID:         uniqueID,
+		// stable identity
+		NodeID:    tel.nodeID,
+		ClusterID: tel.clusterID,
+		// curated signal
+		NodeCount:                  &nodeCount,
+		MaxReplicationFactor:       &maxRF,
+		ReplicationEnabled:         &replicationEnabled,
+		MTCollectionCount:          &mtCount,
+		NamedVectorCollectionCount: &namedVecCount,
+		AsyncIndexingEnabled:       &asyncIndexingEnabled,
+		VectorIndexTypeCounts:      vectorIndexTypeCounts,
 	}, nil
+}
+
+// getCuratedSchemaFields performs a single pass over the schema to extract the
+// curated signal fields. Returns (nodeCount, maxRF, mtCount, namedVecCount, vectorIndexTypeCounts).
+func (tel *Telemeter) getCuratedSchemaFields() (nodeCount, maxRF, mtCount, namedVecCount int, vectorIndexTypeCounts map[string]int) {
+	nodeCount = len(tel.schemaManager.Nodes())
+
+	sch := tel.schemaManager.GetSchemaSkipAuth()
+	if sch.Objects == nil {
+		return nodeCount, 0, 0, 0, nil
+	}
+
+	vectorIndexTypeCounts = make(map[string]int)
+
+	for _, class := range sch.Objects.Classes {
+		if class == nil {
+			continue
+		}
+		if rf := replicationFactor(class); rf > maxRF {
+			maxRF = rf
+		}
+		if class.MultiTenancyConfig != nil && class.MultiTenancyConfig.Enabled {
+			mtCount++
+		}
+		if countVectorIndexTypes(class, vectorIndexTypeCounts) {
+			namedVecCount++
+		}
+	}
+
+	if len(vectorIndexTypeCounts) == 0 {
+		vectorIndexTypeCounts = nil
+	}
+	return nodeCount, maxRF, mtCount, namedVecCount, vectorIndexTypeCounts
+}
+
+// replicationFactor returns the class replication factor, or 0 if unset.
+func replicationFactor(class *models.Class) int {
+	if class.ReplicationConfig == nil {
+		return 0
+	}
+	return int(class.ReplicationConfig.Factor)
+}
+
+// countVectorIndexTypes records the vector index type(s) for one class into counts
+// (defaulting "" to "hnsw") and reports whether the class uses named vectors.
+func countVectorIndexTypes(class *models.Class, counts map[string]int) (named bool) {
+	if len(class.VectorConfig) > 0 {
+		for _, vc := range class.VectorConfig {
+			counts[orHNSW(vc.VectorIndexType)]++
+		}
+		return true
+	}
+	// legacy single-vector: read from class-level VectorIndexType
+	counts[orHNSW(class.VectorIndexType)]++
+	return false
+}
+
+// orHNSW maps an empty vector index type to the "hnsw" default.
+func orHNSW(vectorIndexType string) string {
+	if vectorIndexType == "" {
+		return "hnsw"
+	}
+	return vectorIndexType
 }
 
 func (tel *Telemeter) getUsedModules() ([]string, error) {
@@ -255,10 +425,18 @@ func (tel *Telemeter) getUsedModules() ([]string, error) {
 
 	if sch.Objects != nil {
 		for _, class := range sch.Objects.Classes {
+			if class == nil {
+				continue
+			}
 			if modCfg, ok := class.ModuleConfig.(map[string]interface{}); ok {
 				for name, cfg := range modCfg {
 					usedModulesMap[tel.determineModule(name, cfg)] = struct{}{}
 				}
+			} else if class.Vectorizer != "" && class.Vectorizer != "none" {
+				// Fallback for classes whose ModuleConfig is nil but the class-level
+				// Vectorizer field is set (pre-v1.14 schemas and old-migration gap).
+				// "none" (BYOV) is intentionally excluded - it is not a module.
+				usedModulesMap[class.Vectorizer] = struct{}{}
 			}
 			for _, vectorConfig := range class.VectorConfig {
 				if modCfg, ok := vectorConfig.Vectorizer.(map[string]interface{}); ok {

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -59,19 +60,28 @@ type Telemeter struct {
 	nodesStatusGetter nodesStatusGetter
 	schemaManager     schemaManager
 	logger            logrus.FieldLogger
-	shutdown          chan struct{} // buffered(1): Stop() must not block during Start()'s clusterId wait
-	failedToStart     bool
-	consumer          string
-	pushInterval      time.Duration
-	clientTracker     *ClientTracker
-	cloudInfoHelper   *cloudInfoHelper
+	// shutdown is buffered(1) so Stop() never blocks while Start() is still inside
+	// the clusterId wait. Consequence: on shutdown-during-startup Stop() can send
+	// and push Terminate before Start() pushes Init, so Terminate-before-Init
+	// ordering is not guaranteed.
+	shutdown        chan struct{}
+	consumer        string
+	pushInterval    time.Duration
+	clientTracker   *ClientTracker
+	cloudInfoHelper *cloudInfoHelper
 
 	// nodeID is the persisted per-node UUID from the data-volume file. NOT the hostname.
 	// machineID stays uuid.NewString() per process (unchanged, counts restarts).
-	nodeID string
-	// clusterID is populated in Start() before the Init push.
-	clusterID            string
+	nodeID               string
 	asyncIndexingEnabled bool
+
+	// mu guards clusterID and failedToStart: both are written by Start() (the
+	// clusterId wait can run for up to 30s) and read by Stop() during shutdown,
+	// so shutdown-during-startup would otherwise race them.
+	mu            sync.Mutex
+	failedToStart bool
+	// clusterID is populated in Start() before the Init push.
+	clusterID string
 	// waitForClusterID blocks until the raft leader commits the cluster identity.
 	waitForClusterID func(ctx context.Context) (string, error)
 }
@@ -152,6 +162,9 @@ func ReadOrCreateNodeID(dataPath string) (string, error) {
 	if err := os.WriteFile(tmp, []byte(id), 0o600); err != nil {
 		return "", fmt.Errorf("write node-id tmp: %w", err)
 	}
+	// Clean up the tmp file on any failure after it is written (rename or re-read).
+	// On the happy path rename consumes tmp, so this is a no-op (ignored ENOENT).
+	defer func() { _ = os.Remove(tmp) }()
 	if err := os.Rename(tmp, nodePath); err != nil {
 		return "", fmt.Errorf("rename node-id: %w", err)
 	}
@@ -168,6 +181,30 @@ func (tel *Telemeter) GetClientTracker() *ClientTracker {
 	return tel.clientTracker
 }
 
+func (tel *Telemeter) setClusterID(id string) {
+	tel.mu.Lock()
+	defer tel.mu.Unlock()
+	tel.clusterID = id
+}
+
+func (tel *Telemeter) getClusterID() string {
+	tel.mu.Lock()
+	defer tel.mu.Unlock()
+	return tel.clusterID
+}
+
+func (tel *Telemeter) setFailedToStart(v bool) {
+	tel.mu.Lock()
+	defer tel.mu.Unlock()
+	tel.failedToStart = v
+}
+
+func (tel *Telemeter) getFailedToStart() bool {
+	tel.mu.Lock()
+	defer tel.mu.Unlock()
+	return tel.failedToStart
+}
+
 // Start begins telemetry for the node
 func (tel *Telemeter) Start(ctx context.Context) error {
 	// Wait up to 30 s for the raft leader to commit the cluster identity before the
@@ -182,13 +219,13 @@ func (tel *Telemeter) Start(ctx context.Context) error {
 			tel.logger.WithField("action", "telemetry_cluster_id_wait").
 				Warnf("cluster identity not available within 30s, pushing INIT without clusterId: %v", err)
 		} else {
-			tel.clusterID = clusterID
+			tel.setClusterID(clusterID)
 		}
 	}
 
 	payload, err := tel.push(ctx, PayloadType.Init)
 	if err != nil {
-		tel.failedToStart = true
+		tel.setFailedToStart(true)
 		return fmt.Errorf("push: %w", err)
 	}
 	f := func() {
@@ -234,7 +271,7 @@ func (tel *Telemeter) Stop(ctx context.Context) error {
 		}
 	}()
 
-	if tel.failedToStart {
+	if tel.getFailedToStart() {
 		return nil
 	}
 
@@ -344,7 +381,7 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 		UniqueID:         uniqueID,
 		// stable identity
 		NodeID:    tel.nodeID,
-		ClusterID: tel.clusterID,
+		ClusterID: tel.getClusterID(),
 		// curated signal
 		NodeCount:                  &nodeCount,
 		MaxReplicationFactor:       &maxRF,

--- a/usecases/telemetry/telemetry_shutdown_race_test.go
+++ b/usecases/telemetry/telemetry_shutdown_race_test.go
@@ -1,0 +1,87 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package telemetry
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+)
+
+// TestStop_DuringStartupClusterIDWait exercises Stop() while Start() is still
+// blocked inside the clusterId wait window. Start() then writes tel.clusterID
+// (and, on push failure, tel.failedToStart) while the concurrent Stop() reads
+// them via getFailedToStart and push(Terminate) -> buildPayload. Without the
+// mutex those accesses are unsynchronized and `go test -race` reports a data
+// race on tel.clusterID; with the mutex the accesses are ordered and the test
+// passes clean.
+//
+// The wait window is made deterministic with the entered/release channels: the
+// test only proceeds to Stop() once Start() has signaled it is inside the
+// waiter, and only releases the waiter once Stop() is running, so the write and
+// read genuinely overlap.
+func TestStop_DuringStartupClusterIDWait(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sg := &fakeNodesStatusGetter{}
+	sg.On("LocalNodeStatus", mock.Anything, "", "", verbosity.OutputVerbose).Return(
+		&models.NodeStatus{Stats: &models.NodeStats{ObjectCount: 1}})
+	sm := &fakeSchemaManager{}
+	logger, _ := test.NewNullLogger()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	waiter := func(ctx context.Context) (string, error) {
+		close(entered)
+		select {
+		case <-release:
+			return "00000000-0000-7000-0000-0000000000ab", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+
+	tel := New(sg, sm, logger, Config{}, waiter)
+	tel.consumer = base64.StdEncoding.EncodeToString([]byte(server.URL))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = tel.Start(context.Background())
+	}()
+
+	<-entered
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(release)
+	}()
+	require.NoError(t, tel.Stop(context.Background()))
+
+	wg.Wait()
+}

--- a/usecases/telemetry/telemetry_shutdown_race_test.go
+++ b/usecases/telemetry/telemetry_shutdown_race_test.go
@@ -27,18 +27,8 @@ import (
 	"github.com/weaviate/weaviate/entities/verbosity"
 )
 
-// TestStop_DuringStartupClusterIDWait exercises Stop() while Start() is still
-// blocked inside the clusterId wait window. Start() then writes tel.clusterID
-// (and, on push failure, tel.failedToStart) while the concurrent Stop() reads
-// them via getFailedToStart and push(Terminate) -> buildPayload. Without the
-// mutex those accesses are unsynchronized and `go test -race` reports a data
-// race on tel.clusterID; with the mutex the accesses are ordered and the test
-// passes clean.
-//
-// The wait window is made deterministic with the entered/release channels: the
-// test only proceeds to Stop() once Start() has signaled it is inside the
-// waiter, and only releases the waiter once Stop() is running, so the write and
-// read genuinely overlap.
+// TestStop_DuringStartupClusterIDWait races Stop() against Start()'s in-flight
+// clusterId wait to pin the tel.clusterID/failedToStart data race under -race.
 func TestStop_DuringStartupClusterIDWait(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.Copy(io.Discard, r.Body)

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -602,8 +602,13 @@ func newTestTelemeter(opts ...telemetryOpt,
 	sg := &fakeNodesStatusGetter{}
 	sm := &fakeSchemaManager{}
 	logger, _ := test.NewNullLogger()
-	// Pass empty url/duration to use defaults
-	tel := New(sg, sm, logger, "", 0, false)
+	// stubWaiter returns a fixed cluster identity immediately, exercising the
+	// wait path without actual raft. Tests that want no-wait can pass nil.
+	stubWaiter := func(ctx context.Context) (string, error) {
+		return "00000000-0000-7000-0000-000000000001", nil
+	}
+	// Empty Config uses defaults; nodeID "" means omitempty in payload.
+	tel := New(sg, sm, logger, Config{}, stubWaiter)
 	for _, opt := range opts {
 		opt(tel)
 	}

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -602,12 +602,10 @@ func newTestTelemeter(opts ...telemetryOpt,
 	sg := &fakeNodesStatusGetter{}
 	sm := &fakeSchemaManager{}
 	logger, _ := test.NewNullLogger()
-	// stubWaiter returns a fixed cluster identity immediately, exercising the
-	// wait path without actual raft. Tests that want no-wait can pass nil.
+	// stubWaiter exercises the wait path without real raft; pass nil for no-wait.
 	stubWaiter := func(ctx context.Context) (string, error) {
 		return "00000000-0000-7000-0000-000000000001", nil
 	}
-	// Empty Config uses defaults; nodeID "" means omitempty in payload.
 	tel := New(sg, sm, logger, Config{}, stubWaiter)
 	for _, opt := range opts {
 		opt(tel)


### PR DESCRIPTION
### Summary

Weaviate OSS telemetry cannot be correlated across restarts today: the payload is keyed on `machineId`, which is a fresh in-memory UUID regenerated on every process start, so a single cluster looks like a brand-new deployment on every restart (~94% of events carry a unique `machineId`). This adds two stable identities so downstream can de-churn and correlate a cluster over time:

- a **cluster identity** (`clusterId`, a UUIDv7) committed once per cluster lifetime through the raft FSM, shared by every node, surviving restarts and snapshots, including single-node deployments;
- a **node identity** (`nodeId`) persisted to the data volume, stable across restarts and independent of the per-process `machineId` (which is kept as an intentional restart counter).

It also adds a small curated set of high-value schema signal fields (`nodeCount`, replication factor / enabled, multi-tenant collection count, named-vector collection count, async-indexing flag, vector-index-type counts) and fixes the empty `usedModules` population.

This PR targets **`stable/v1.36`** and is the **canonical base** for this feature. The team forward-ports it up into the newer release lines (1.37, 1.38) and `main`. Basing on the oldest supported line first keeps the identity scheme identical everywhere it lands.

### Mechanism

`clusterId` lives in the replicated raft FSM so all nodes agree on one value:

- A new raft command `ApplyRequest_TYPE_CLUSTER_ID_SET = 400` (a clean gap; 1.36 command types top out at 303) carries `SetClusterIDRequest{cluster_id}`. `cluster/store_apply.go` applies it set-once (first value wins) and, crucially, it is **not** `schemaOnly`-gated: it is pure metadata with no DB side effect and must apply during cold-start log replay.
- `clusterIDBootstrapLoop` (`cluster/store.go`) ticks every 2s and, while this node is leader, commits a UUIDv7 if none is set yet. This closes the leader-crash-before-commit gap: if the first leader dies before the command commits, the next leader retries on its next tick. The loop is started in `Store.Open` and cancelled in `Store.Close` before raft teardown so it can never call `Execute()` on a shutdown raft instance.
- The id is carried in the JSON `fsm.Snapshot` as `cluster_id` (`omitempty`) and restored set-once. This is backward/forward compatible: an older binary decoding a new snapshot silently ignores the unknown key (no `DisallowUnknownFields` anywhere in the snapshot codec), and a new binary restoring an id-less snapshot re-mints. An older binary that meets a type-400 log entry hits the default apply arm and logs-and-continues (the stale "we need to panic" comment is corrected here) rather than crash-looping.
- Telemetry waits up to 30s in `Start()` for the leader to commit the id before the INIT push, then proceeds best-effort (omits `clusterId` on timeout). The `shutdown` channel is buffered(1) so `Stop()` cannot block during that wait.

`nodeId` is persisted to `<PERSISTENCE_DATA_PATH>/node-id` via a tmp+rename atomic write (mirroring the prop-length-tracker pattern), read once at startup. On any I/O error the server logs and falls back to an ephemeral UUID rather than failing to start.

### Fix

- Proto: `TYPE_CLUSTER_ID_SET` enum + `SetClusterIDRequest{cluster_id}` message; `message.pb.go` regenerated with `buf`.
- FSM: set-once `clusterID` state, `ClusterID()` / `WaitForClusterID()` on `*cluster.Store`, promoted onto `*cluster.Service` via the embedded `*Raft`.
- Snapshot persist/restore of `cluster_id`.
- Telemetry: new `nodeId` / `clusterId` payload fields, curated pointer fields (a pointer so a measured `0`/`false` serializes instead of being dropped by `omitempty`), `ReadOrCreateNodeID`, a `Config`-based `New()` signature, the 30s cluster-id wait, and a `usedModules` fallback for schemas whose `ModuleConfig` is nil but whose class-level `Vectorizer` is set ("none"/BYOV excluded).
- Wiring: `configure_api.go` reads/creates the node-id and passes `telemetry.Config` + `ClusterService.WaitForClusterID` into `telemetry.New`.

### Tests

- `cluster/store_cluster_id_test.go`: set-once apply, idempotent replay, snapshot persist/restore, empty-uuid guard, wait success + timeout, old-snapshot decode, new-snapshot-to-old-struct compat, bootstrap-loop exit on both id-set and context-cancel.
- `cluster/store_cluster_id_realraft_test.go`: a real self-electing single-node raft leader drives the whole `loop -> IsLeader -> maybeCommitClusterID -> Execute -> Apply -> setClusterIDFields` chain through real consensus, and asserts set-once holds under a second commit attempt.
- `usecases/telemetry/curated_fields_test.go` and `node_id_test.go`: curated extraction, usedModules fallback, node count, pointer JSON semantics, default vector index type, node-id create/read/restart-stability/reset/unwritable-dir.
- shutdown-during-startup race test: drives `Stop()` while `Start()` is parked in the clusterId wait window; trips the race detector without the clusterID/failedToStart mutex and passes clean with it.

### Out of scope

- **`clusterCreatedAt` payload field**: intentionally not emitted; cluster inception time is derived downstream from the UUIDv7 timestamp bits (compliance decision), so there is no timestamp field on the raft command, snapshot, or payload.
- **`clientIntegrationUsage` payload changes**: this field does not exist on 1.36; this change is ADD-only for the identity/curated feature and does not touch or introduce it.
- **Collector / BigQuery DDL**: the collector flattening and the additive `ALTER TABLE` land in `weaviate/weaviate-telemetry`, not here.
- **A 3-node leader-crash-before-commit acceptance test**: the load-bearing properties are covered deterministically by the real-raft single-node test plus the set-once idempotency tests; a live multi-node consensus harness is a separate acceptance-level follow-up.

### Verification

- [x] `go build ./...` clean
- [x] `golangci-lint run` clean on the touched packages (0 issues, new-from-rev vs `origin/stable/v1.36`); goroutine linter clean
- [x] unit tests green: `go test ./cluster/... ./usecases/telemetry/...`
- [x] `-race` clean on the cluster-identity and telemetry suites
- [x] empirical topology matrix on the equivalent mainline change: single-node mint + restart stability; 5-node (3 voters + 2 non-voters) converging on one id through leader kill, non-voter restart, and late join; 3-node rolling upgrade minting once, downgrade replaying the new command as a clean no-op, re-upgrade retaining the id
