### PR TITLE
feat(drop-vector-index): fail the unit when cleanup quarantines a segment

### DIFF
--- a/adapters/repos/db/drop_vector_index_provider.go
+++ b/adapters/repos/db/drop_vector_index_provider.go
@@ -337,7 +337,7 @@ func (p *DropVectorIndexProvider) pollUntilEmpty(
 			// persistent errors fail the unit.
 			consecutiveErrors++
 			if consecutiveErrors >= maxConsecutivePollErrors {
-				return fmt.Errorf("read pending after %d consecutive errors: %w", consecutiveErrors, err)
+				return fmt.Errorf("read pending/quarantine set after %d consecutive errors: %w", consecutiveErrors, err)
 			}
 			p.unitLogger(task, nil, unitID).Warnf("drop-vector: pending read failed (%d/%d), retrying: %v",
 				consecutiveErrors, maxConsecutivePollErrors, err)

--- a/adapters/repos/db/drop_vector_index_provider.go
+++ b/adapters/repos/db/drop_vector_index_provider.go
@@ -43,6 +43,9 @@ const maxConsecutivePollErrors = 3
 type editOpBucket interface {
 	RegisterEditOp(opID string, desc lsmkv.OpDescriptor) error
 	EditOpPending(opID string) ([]string, error)
+	// EditOpQuarantined reports segments the cleanup driver gave up on; a
+	// non-empty result means the op cannot complete cleanly.
+	EditOpQuarantined(opID string) ([]string, error)
 	DeleteEditOp(opID string) error
 }
 
@@ -309,6 +312,8 @@ func (p *DropVectorIndexProvider) drainUnit(
 // pollUntilEmpty waits until the op has no pending segments on the bucket,
 // reporting progress each tick. The bucket's own compaction/cleanup transformer
 // does the actual rewriting; this only observes the pending set shrink to zero.
+// A segment quarantined by the cleanup driver fails the unit instead — empty
+// pending with a quarantine row is a permanently-incomplete rewrite, not success.
 func (p *DropVectorIndexProvider) pollUntilEmpty(
 	ctx context.Context, bucket editOpBucket, task *distributedtask.Task,
 	unitID, opID string,
@@ -320,6 +325,17 @@ func (p *DropVectorIndexProvider) pollUntilEmpty(
 	consecutiveErrors := 0
 	for {
 		pending, err := bucket.EditOpPending(opID)
+		if err == nil {
+			// A quarantined segment left the pending set UNSTRIPPED, so an empty
+			// pending set is not success — completing would let the task finalize
+			// with vectors still on disk. Fail the unit; the marker stays and the
+			// drop can be re-triggered. The read shares the blip tolerance below.
+			var quarantined []string
+			if quarantined, err = bucket.EditOpQuarantined(opID); err == nil && len(quarantined) > 0 {
+				return fmt.Errorf("cleanup quarantined %d segment(s) after exhausting the retry budget: %v",
+					len(quarantined), quarantined)
+			}
+		}
 		switch {
 		case err != nil:
 			// Tolerate a few consecutive blips (incl. the first read); only

--- a/adapters/repos/db/drop_vector_index_provider.go
+++ b/adapters/repos/db/drop_vector_index_provider.go
@@ -43,8 +43,6 @@ const maxConsecutivePollErrors = 3
 type editOpBucket interface {
 	RegisterEditOp(opID string, desc lsmkv.OpDescriptor) error
 	EditOpPending(opID string) ([]string, error)
-	// EditOpQuarantined reports segments the cleanup driver gave up on; a
-	// non-empty result means the op cannot complete cleanly.
 	EditOpQuarantined(opID string) ([]string, error)
 	DeleteEditOp(opID string) error
 }
@@ -312,8 +310,8 @@ func (p *DropVectorIndexProvider) drainUnit(
 // pollUntilEmpty waits until the op has no pending segments on the bucket,
 // reporting progress each tick. The bucket's own compaction/cleanup transformer
 // does the actual rewriting; this only observes the pending set shrink to zero.
-// A segment quarantined by the cleanup driver fails the unit instead — empty
-// pending with a quarantine row is a permanently-incomplete rewrite, not success.
+// A quarantined segment fails the unit instead: it left the pending set
+// unstripped, so empty pending with a quarantine row is not success.
 func (p *DropVectorIndexProvider) pollUntilEmpty(
 	ctx context.Context, bucket editOpBucket, task *distributedtask.Task,
 	unitID, opID string,
@@ -326,10 +324,7 @@ func (p *DropVectorIndexProvider) pollUntilEmpty(
 	for {
 		pending, err := bucket.EditOpPending(opID)
 		if err == nil {
-			// A quarantined segment left the pending set UNSTRIPPED, so an empty
-			// pending set is not success — completing would let the task finalize
-			// with vectors still on disk. Fail the unit; the marker stays and the
-			// drop can be re-triggered. The read shares the blip tolerance below.
+			// The quarantine read shares the blip tolerance below.
 			var quarantined []string
 			if quarantined, err = bucket.EditOpQuarantined(opID); err == nil && len(quarantined) > 0 {
 				return fmt.Errorf("cleanup quarantined %d segment(s) after exhausting the retry budget: %v",

--- a/adapters/repos/db/drop_vector_index_provider_test.go
+++ b/adapters/repos/db/drop_vector_index_provider_test.go
@@ -595,9 +595,7 @@ func TestProcessUnits_PartialArm_DrainsArmedFailsMissing(t *testing.T) {
 }
 
 // TestStartTask_QuarantinedSegment_UnitFailed pins the quarantine->FAILED
-// handoff: a quarantined segment left the pending set unstripped, so the unit
-// must fail rather than complete (else the task would falsely reach FINISHED
-// with vectors still on disk).
+// handoff: the unit must fail, not complete, when a segment is quarantined.
 func TestStartTask_QuarantinedSegment_UnitFailed(t *testing.T) {
 	bucket := &fakeEditOpBucket{
 		pendingSeq:  [][]string{{"s1"}}, // never drains on its own
@@ -619,7 +617,7 @@ func TestStartTask_QuarantinedSegment_UnitFailed(t *testing.T) {
 	require.Empty(t, rec.completed, "the unit must not complete when a segment is quarantined")
 }
 
-// --- OnGroupCompleted ---// --- OnGroupCompleted ---// --- OnGroupCompleted ---// --- OnGroupCompleted ---
+// --- OnGroupCompleted ---
 
 func TestOnGroupCompleted_PerTenantIndexFilesRemoved(t *testing.T) {
 	shards := &fakeShards{}

--- a/adapters/repos/db/drop_vector_index_provider_test.go
+++ b/adapters/repos/db/drop_vector_index_provider_test.go
@@ -35,17 +35,20 @@ type pendingStep struct {
 }
 
 type fakeEditOpBucket struct {
-	mu          sync.Mutex
-	registered  map[string]lsmkv.OpDescriptor
-	pendingSeq  [][]string    // successive EditOpPending responses; last repeats
-	script      []pendingStep // if set, takes precedence over pendingSeq (per-call val/err; last repeats)
-	callIdx     int
-	deleted     []string // opIDs passed to DeleteEditOp
-	deleteErr   error
-	quarantined []string                       // EditOpQuarantined response (nil = none)
-	pendingErr  error                          // when set, EditOpPending returns it
-	pendingFn   func(string) ([]string, error) // when set, overrides all other pending sources
-	polled      chan struct{}                  // if set, a non-blocking signal per EditOpPending call
+	mu             sync.Mutex
+	registered     map[string]lsmkv.OpDescriptor
+	pendingSeq     [][]string    // successive EditOpPending responses; last repeats
+	script         []pendingStep // if set, takes precedence over pendingSeq (per-call val/err; last repeats)
+	callIdx        int
+	deleted        []string // opIDs passed to DeleteEditOp
+	deleteErr      error
+	quarantined    []string   // EditOpQuarantined response (nil = none)
+	quarantinedSeq [][]string // successive responses; last repeats (precedence over quarantined)
+	quarantinedErr error      // when set, EditOpQuarantined returns it
+	quarantineIdx  int
+	pendingErr     error                          // when set, EditOpPending returns it
+	pendingFn      func(string) ([]string, error) // when set, overrides all other pending sources
+	polled         chan struct{}                  // if set, a non-blocking signal per EditOpPending call
 }
 
 func (f *fakeEditOpBucket) RegisterEditOp(opID string, desc lsmkv.OpDescriptor) error {
@@ -92,6 +95,17 @@ func (f *fakeEditOpBucket) EditOpPending(opID string) ([]string, error) {
 func (f *fakeEditOpBucket) EditOpQuarantined(opID string) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.quarantinedErr != nil {
+		return nil, f.quarantinedErr
+	}
+	if len(f.quarantinedSeq) > 0 {
+		i := f.quarantineIdx
+		if i >= len(f.quarantinedSeq) {
+			i = len(f.quarantinedSeq) - 1
+		}
+		f.quarantineIdx++
+		return f.quarantinedSeq[i], nil
+	}
 	return f.quarantined, nil
 }
 
@@ -615,6 +629,53 @@ func TestStartTask_QuarantinedSegment_UnitFailed(t *testing.T) {
 	require.Contains(t, rec.failed, "u1", "a quarantined segment must fail the unit")
 	require.Contains(t, rec.failed["u1"], "quarantined")
 	require.Empty(t, rec.completed, "the unit must not complete when a segment is quarantined")
+}
+
+// TestStartTask_QuarantineAppearsMidDrain_UnitFailed pins that the check runs
+// every tick, not only at start.
+func TestStartTask_QuarantineAppearsMidDrain_UnitFailed(t *testing.T) {
+	bucket := &fakeEditOpBucket{
+		pendingSeq:     [][]string{{"s1", "s2"}, {"s1"}},
+		quarantinedSeq: [][]string{{}, {"s1"}},
+	}
+	shards := &fakeShards{bucket: bucket}
+	rec := newFakeRecorder()
+	p := newTestDropProvider(shards, &fakeFinalizer{}, rec)
+
+	task := dropTask(distributedtask.TaskStatusStarted, map[string]*distributedtask.Unit{
+		"u1": {ID: "u1", Status: distributedtask.UnitStatusPending},
+	})
+	h, err := p.StartTask(task)
+	require.NoError(t, err)
+	waitDone(t, h)
+
+	require.Contains(t, rec.failed, "u1")
+	require.Contains(t, rec.failed["u1"], "quarantined")
+	require.Empty(t, rec.completed)
+}
+
+// TestStartTask_QuarantineReadErrorPersistent_UnitFailed pins that a
+// quarantine-read failure shares the poll's blip tolerance: persistent errors
+// fail the unit after maxConsecutivePollErrors.
+func TestStartTask_QuarantineReadErrorPersistent_UnitFailed(t *testing.T) {
+	bucket := &fakeEditOpBucket{
+		pendingSeq:     [][]string{{"s1"}},
+		quarantinedErr: errors.New("bolt read failed"),
+	}
+	shards := &fakeShards{bucket: bucket}
+	rec := newFakeRecorder()
+	p := newTestDropProvider(shards, &fakeFinalizer{}, rec)
+
+	task := dropTask(distributedtask.TaskStatusStarted, map[string]*distributedtask.Unit{
+		"u1": {ID: "u1", Status: distributedtask.UnitStatusPending},
+	})
+	h, err := p.StartTask(task)
+	require.NoError(t, err)
+	waitDone(t, h)
+
+	require.Contains(t, rec.failed, "u1")
+	require.Contains(t, rec.failed["u1"], "consecutive errors")
+	require.Empty(t, rec.completed)
 }
 
 // --- OnGroupCompleted ---

--- a/adapters/repos/db/drop_vector_index_provider_test.go
+++ b/adapters/repos/db/drop_vector_index_provider_test.go
@@ -35,16 +35,17 @@ type pendingStep struct {
 }
 
 type fakeEditOpBucket struct {
-	mu         sync.Mutex
-	registered map[string]lsmkv.OpDescriptor
-	pendingSeq [][]string    // successive EditOpPending responses; last repeats
-	script     []pendingStep // if set, takes precedence over pendingSeq (per-call val/err; last repeats)
-	callIdx    int
-	deleted    []string // opIDs passed to DeleteEditOp
-	deleteErr  error
-	pendingErr error                          // when set, EditOpPending returns it
-	pendingFn  func(string) ([]string, error) // when set, overrides all other pending sources
-	polled     chan struct{}                  // if set, a non-blocking signal per EditOpPending call
+	mu          sync.Mutex
+	registered  map[string]lsmkv.OpDescriptor
+	pendingSeq  [][]string    // successive EditOpPending responses; last repeats
+	script      []pendingStep // if set, takes precedence over pendingSeq (per-call val/err; last repeats)
+	callIdx     int
+	deleted     []string // opIDs passed to DeleteEditOp
+	deleteErr   error
+	quarantined []string                       // EditOpQuarantined response (nil = none)
+	pendingErr  error                          // when set, EditOpPending returns it
+	pendingFn   func(string) ([]string, error) // when set, overrides all other pending sources
+	polled      chan struct{}                  // if set, a non-blocking signal per EditOpPending call
 }
 
 func (f *fakeEditOpBucket) RegisterEditOp(opID string, desc lsmkv.OpDescriptor) error {
@@ -86,6 +87,12 @@ func (f *fakeEditOpBucket) EditOpPending(opID string) ([]string, error) {
 	}
 	f.callIdx++
 	return f.pendingSeq[i], nil
+}
+
+func (f *fakeEditOpBucket) EditOpQuarantined(opID string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.quarantined, nil
 }
 
 func (f *fakeEditOpBucket) DeleteEditOp(opID string) error {
@@ -587,7 +594,32 @@ func TestProcessUnits_PartialArm_DrainsArmedFailsMissing(t *testing.T) {
 	require.Contains(t, bucket2.registered, "op1")
 }
 
-// --- OnGroupCompleted ---// --- OnGroupCompleted ---// --- OnGroupCompleted ---
+// TestStartTask_QuarantinedSegment_UnitFailed pins the quarantine->FAILED
+// handoff: a quarantined segment left the pending set unstripped, so the unit
+// must fail rather than complete (else the task would falsely reach FINISHED
+// with vectors still on disk).
+func TestStartTask_QuarantinedSegment_UnitFailed(t *testing.T) {
+	bucket := &fakeEditOpBucket{
+		pendingSeq:  [][]string{{"s1"}}, // never drains on its own
+		quarantined: []string{"s1"},
+	}
+	shards := &fakeShards{bucket: bucket}
+	rec := newFakeRecorder()
+	p := newTestDropProvider(shards, &fakeFinalizer{}, rec)
+
+	task := dropTask(distributedtask.TaskStatusStarted, map[string]*distributedtask.Unit{
+		"u1": {ID: "u1", Status: distributedtask.UnitStatusPending},
+	})
+	h, err := p.StartTask(task)
+	require.NoError(t, err)
+	waitDone(t, h)
+
+	require.Contains(t, rec.failed, "u1", "a quarantined segment must fail the unit")
+	require.Contains(t, rec.failed["u1"], "quarantined")
+	require.Empty(t, rec.completed, "the unit must not complete when a segment is quarantined")
+}
+
+// --- OnGroupCompleted ---// --- OnGroupCompleted ---// --- OnGroupCompleted ---// --- OnGroupCompleted ---
 
 func TestOnGroupCompleted_PerTenantIndexFilesRemoved(t *testing.T) {
 	shards := &fakeShards{}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -453,17 +453,7 @@ func (b *Bucket) EditOpQuarantined(opID string) ([]string, error) {
 	if !b.HasEditOps() {
 		return nil, fmt.Errorf("edit ops not enabled for this bucket")
 	}
-	all, err := b.disk.editOps.Quarantined()
-	if err != nil {
-		return nil, err
-	}
-	var ids []string
-	for _, q := range all {
-		if q.OpID == opID {
-			ids = append(ids, q.SegmentID)
-		}
-	}
-	return ids, nil
+	return b.disk.editOps.QuarantinedFor(opID)
 }
 
 func (b *Bucket) GetStrategy() string {

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -446,10 +446,9 @@ func (b *Bucket) DeleteEditOp(opID string) error {
 	return b.disk.editOps.DeleteOp(opID)
 }
 
-// EditOpQuarantined returns the segment IDs the cleanup driver gave up on
-// (quarantined after exhausting its retry budget) for opID. A non-empty result
-// means the op can't complete cleanly — those segments still carry the dropped
-// data — so the caller must fail rather than treat empty pending as success.
+// EditOpQuarantined returns the segment IDs the cleanup driver quarantined
+// (retry budget exhausted) for opID; they still carry the dropped data, so the
+// caller must fail rather than treat empty pending as success.
 func (b *Bucket) EditOpQuarantined(opID string) ([]string, error) {
 	if !b.HasEditOps() {
 		return nil, fmt.Errorf("edit ops not enabled for this bucket")

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -446,6 +446,27 @@ func (b *Bucket) DeleteEditOp(opID string) error {
 	return b.disk.editOps.DeleteOp(opID)
 }
 
+// EditOpQuarantined returns the segment IDs the cleanup driver gave up on
+// (quarantined after exhausting its retry budget) for opID. A non-empty result
+// means the op can't complete cleanly — those segments still carry the dropped
+// data — so the caller must fail rather than treat empty pending as success.
+func (b *Bucket) EditOpQuarantined(opID string) ([]string, error) {
+	if !b.HasEditOps() {
+		return nil, fmt.Errorf("edit ops not enabled for this bucket")
+	}
+	all, err := b.disk.editOps.Quarantined()
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, q := range all {
+		if q.OpID == opID {
+			ids = append(ids, q.SegmentID)
+		}
+	}
+	return ids, nil
+}
+
 func (b *Bucket) GetStrategy() string {
 	return b.strategy
 }

--- a/adapters/repos/db/lsmkv/bucket_editops_test.go
+++ b/adapters/repos/db/lsmkv/bucket_editops_test.go
@@ -397,3 +397,40 @@ func TestBucket_ListFiles_ExcludesEditOpsSidecar(t *testing.T) {
 	}
 	require.NotEmpty(t, files, "segments must still be listed")
 }
+
+// TestBucket_EditOpQuarantined_ScopedByOp pins the per-op scoping: op B must not
+// see op A's quarantine verdicts (a re-triggered drop gets a fresh op ID and
+// must not fail on stale rows from a failed predecessor).
+func TestBucket_EditOpQuarantined_ScopedByOp(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	segs := segIDsOf(bucket)
+	require.Len(t, segs, 1)
+
+	require.NoError(t, editOps.RegisterOp("opA", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("opA", segs))
+	require.NoError(t, editOps.Quarantine("opA", segs[0]))
+
+	got, err := bucket.EditOpQuarantined("opA")
+	require.NoError(t, err)
+	require.Equal(t, []string{segs[0]}, got)
+
+	got, err = bucket.EditOpQuarantined("opB")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestBucket_EditOpQuarantined_RequiresEditOps(t *testing.T) {
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	bucket, err := NewBucketCreator().NewBucket(context.Background(), dir, dir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(context.Background())) })
+
+	_, err = bucket.EditOpQuarantined("op1")
+	require.ErrorContains(t, err, "edit ops not enabled")
+}

--- a/adapters/repos/db/lsmkv/segment_edit_ops.go
+++ b/adapters/repos/db/lsmkv/segment_edit_ops.go
@@ -665,6 +665,25 @@ func (s *SegmentEditOps) Quarantine(opID, segID string) error {
 	})
 }
 
+// QuarantinedFor returns opID's quarantined segment IDs (scoped sub-bucket
+// read, mirroring Pending).
+func (s *SegmentEditOps) QuarantinedFor(opID string) ([]string, error) {
+	var out []string
+	if err := s.withReadTx(func(tx *bolt.Tx) error {
+		sub := tx.Bucket(editOpsBucketQuarantine).Bucket([]byte(opID))
+		if sub == nil {
+			return nil
+		}
+		return sub.ForEach(func(segID, v []byte) error {
+			out = append(out, string(segID))
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Quarantined returns the quarantined segments across all operations.
 func (s *SegmentEditOps) Quarantined() ([]PendingSegment, error) {
 	var out []PendingSegment


### PR DESCRIPTION
### What's being changed

Phase-2 cleanup of a dropped vector index strips the named vector from stored objects via LSM **edit ops**. If a segment's rewrite exhausts its retry budget (`maxCleanupAttempts`), the cleaner **quarantines** that segment instead of applying the op. Before this change the drop task's `pollUntilEmpty` only waited for the pending op set to drain — a quarantined segment leaves the set empty-looking, so the task could report **FINISHED while data was never actually cleaned**. That false-success then satisfies the (now-merged) S15/S16 removal gate and lets the `VectorConfig` entry be removed, silently dropping the cleanup obligation.

This closes that honesty gap: a quarantined segment now fails the unit (task → `FAILED`) instead of completing it. The schema marker stays, so the drop can be re-triggered.

### How

- `lsmkv.Bucket.EditOpQuarantined(opID) ([]string, error)` — returns the quarantined segment IDs for a given op (filters `editOps.Quarantined()` by OpID).
- `drop_vector_index_provider.go` — the `editOpBucket` interface gains `EditOpQuarantined`; `pollUntilEmpty` checks the quarantine set on every successful pending read, *before* the empty-pending success return. A non-empty quarantine set fails the unit via `failUnit` (task → `FAILED`). A quarantine-read error is folded into the poll's existing transient-blip tolerance (`maxConsecutivePollErrors`) rather than failing immediately.

### Risk / blast radius

Low. New surface is read-only bookkeeping on the edit-ops sidecar; the only behavioral change is converting a previously-silent false-success into an explicit failure, which is the correct, safer outcome. A failed task is retriable, and quarantine rows are per-op, so a re-triggered drop (fresh op ID) is not affected by the old op's quarantine verdicts.

### Key review areas

- The quarantine check runs on every poll tick before the `len(pending)==0` success return — the first iteration covers the already-quarantined-at-start case.
- Regression test `TestStartTask_QuarantinedSegment_UnitFailed` is load-bearing — with the check disabled the unit completes falsely and the test fails.
- Quarantine durability across restarts/re-snapshots is pinned upstream (`TestSegmentEditOps_QuarantineSurvivesReSnapshot`, merged in #11876), so this verdict isn't erased by a reload.

### Stacking

Originally stacked on #11889 (S15+S16); that PR is merged, so this now bases directly on `main`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
