### PR TITLE
feat(drop-vector-index): gate Phase-2 cleanup enqueue on cluster min version

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -723,7 +723,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	// Created here (not in the DTM wiring) so it can be injected into the schema
 	// manager at construction, and so the edit-op liveness provider is installed
 	// before ClusterService.Open drives restore-time shard loads.
-	dropVectorEnqueuer := newDropVectorIndexEnqueuer(appState.ClusterService, appState.ClusterService.Raft, appState.Logger)
+	dropVectorEnqueuer := newDropVectorIndexEnqueuer(appState.ClusterService, appState.ClusterService.Raft, repo, appState.Logger)
 	editops.SetLivenessProvider(dropVectorEnqueuer.LiveOpIDs)
 
 	schemaManager, err := schema.NewManager(migrator,

--- a/adapters/handlers/rest/drop_vector_index_enqueuer.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer.go
@@ -14,7 +14,9 @@ package rest
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,10 +27,23 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
 	entschema "github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
+
+// dropVectorMinClusterVersion is the lowest server version that can run the
+// drop-vector Phase-2 cleanup (edit-ops machinery). No cleanup task is enqueued
+// until every node is at least this version (rolling-upgrade safety). Ships in 1.39.
+const dropVectorMinClusterVersion = "1.39.0"
+
+// dropVectorVersionRegex matches the leading "MAJOR.MINOR.PATCH" of a server
+// version. It is deliberately tolerant of pre-release/build suffixes (e.g.
+// "1.39.0-dev", "1.39.0-rc.1") which are treated as satisfying the minimum once
+// the MAJOR.MINOR.PATCH triple is >= the threshold — a dev/rc build of the
+// supporting release does understand the feature.
+var dropVectorVersionRegex = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)`)
 
 // dropVectorIndexEnqueuer implements schema.DropVectorIndexEnqueuer. It submits
 // the background cleanup distributed task and reports whether one is in flight,
@@ -37,7 +52,8 @@ import (
 type dropVectorIndexEnqueuer struct {
 	clusterService clusterDropTaskClient
 	schemaState    schemaStateQuerier
-	logger         logrus.FieldLogger // nil-safe: only used for skip warnings
+	versions       clusterVersionLister
+	logger         logrus.FieldLogger // nil-safe throughout
 }
 
 // clusterDropTaskClient is the slice of the cluster service the enqueuer uses.
@@ -58,8 +74,22 @@ type schemaStateQuerier interface {
 	QueryReadOnlyClasses(classes ...string) (map[string]versioned.Class, error)
 }
 
-func newDropVectorIndexEnqueuer(clusterService clusterDropTaskClient, schemaState schemaStateQuerier, logger logrus.FieldLogger) *dropVectorIndexEnqueuer {
-	return &dropVectorIndexEnqueuer{clusterService: clusterService, schemaState: schemaState, logger: logger}
+// clusterVersionLister reports per-node software versions; *db.DB satisfies it via
+// GetNodeStatus (each NodeStatus carries the build Version). "Minimal" verbosity
+// keeps the cross-node call cheap — only the Version field is read.
+type clusterVersionLister interface {
+	GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error)
+}
+
+func newDropVectorIndexEnqueuer(clusterService clusterDropTaskClient, schemaState schemaStateQuerier,
+	versions clusterVersionLister, logger logrus.FieldLogger,
+) *dropVectorIndexEnqueuer {
+	return &dropVectorIndexEnqueuer{
+		clusterService: clusterService,
+		schemaState:    schemaState,
+		versions:       versions,
+		logger:         logger,
+	}
 }
 
 // warnSkippedPayload surfaces an undecodable active-task payload instead of
@@ -104,12 +134,35 @@ func (e *dropVectorIndexEnqueuer) HasActiveDrop(ctx context.Context, collection,
 // one unit per (shard, replica) grouped by shard, so each replica node strips
 // its own objects bucket.
 func (e *dropVectorIndexEnqueuer) EnqueueDropVectorIndex(ctx context.Context, collection string, targets []string) error {
+	// Rolling-upgrade gate: an older node predates the edit-ops machinery and can't
+	// run a cleanup unit, so defer enqueueing until every node is upgraded. Skip
+	// (return nil), don't error: Phase 1 already set the marker and the
+	// reconciliation loop re-enqueues it once the cluster is fully upgraded, so the
+	// user's drop isn't failed by an in-flight upgrade.
+	upgraded, err := e.clusterFullyUpgraded(ctx)
+	if err != nil {
+		// Versions unreadable (e.g. a node unreachable mid-upgrade): defer, don't fail.
+		if e.logger != nil {
+			e.logger.WithField("collection", collection).WithField("targets", targets).
+				Warnf("drop-vector enqueue: cannot verify cluster version, deferring cleanup to reconciliation: %v", err)
+		}
+		return nil
+	}
+	if !upgraded {
+		if e.logger != nil {
+			e.logger.WithField("collection", collection).WithField("targets", targets).
+				WithField("min_version", dropVectorMinClusterVersion).
+				Info("drop-vector enqueue: cluster not fully upgraded, deferring Phase-2 cleanup to reconciliation")
+		}
+		return nil
+	}
+
 	// Re-validate against the leader-consistent class: the marker commit and this
 	// enqueue are not atomic, and reconciliation may run off a stale local schema
 	// snapshot. A target that is no longer marked dropped (class deleted and
 	// re-created, or already finalized elsewhere) must not get a cleanup task —
 	// that task would strip a live vector.
-	targets, err := e.stillDroppedTargets(collection, targets)
+	targets, err = e.stillDroppedTargets(collection, targets)
 	if err != nil {
 		return fmt.Errorf("drop-vector enqueue: verify targets for %q: %w", collection, err)
 	}
@@ -233,6 +286,73 @@ func (e *dropVectorIndexEnqueuer) LiveOpIDs(ctx context.Context) (map[string]str
 		live[p.OpID] = struct{}{}
 	}
 	return live, nil
+}
+
+// clusterFullyUpgraded reports whether every node is at or above
+// dropVectorMinClusterVersion. A nil version source (no lister wired) counts as
+// upgraded, so missing wiring never permanently blocks the feature.
+//
+// Determinism: runs at request/reconciliation time, not in a RAFT apply, so it may
+// read non-replicated, eventually-consistent per-node versions. The replicated
+// marker is written separately in Phase 1; this only decides enqueue-now vs defer.
+func (e *dropVectorIndexEnqueuer) clusterFullyUpgraded(ctx context.Context) (bool, error) {
+	if e.versions == nil {
+		return true, nil
+	}
+	statuses, err := e.versions.GetNodeStatus(ctx, "", "", verbosity.OutputMinimal)
+	if err != nil {
+		return false, fmt.Errorf("drop-vector enqueue: list node versions: %w", err)
+	}
+	if len(statuses) == 0 {
+		return false, fmt.Errorf("drop-vector enqueue: no node statuses returned")
+	}
+	for _, s := range statuses {
+		if s == nil {
+			return false, fmt.Errorf("drop-vector enqueue: nil node status")
+		}
+		ok, err := versionAtLeast(s.Version, dropVectorMinClusterVersion)
+		if err != nil {
+			return false, fmt.Errorf("drop-vector enqueue: node %q version %q: %w", s.Name, s.Version, err)
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// versionAtLeast reports whether the MAJOR.MINOR.PATCH prefix of have is >= the
+// MAJOR.MINOR.PATCH of want. Pre-release/build suffixes on have are ignored (see
+// dropVectorVersionRegex): a "1.39.0-dev" build of the supporting release is
+// considered to satisfy "1.39.0".
+func versionAtLeast(have, want string) (bool, error) {
+	hMaj, hMin, hPat, err := parseSemverPrefix(have)
+	if err != nil {
+		return false, err
+	}
+	wMaj, wMin, wPat, err := parseSemverPrefix(want)
+	if err != nil {
+		return false, fmt.Errorf("threshold %q: %w", want, err)
+	}
+	if hMaj != wMaj {
+		return hMaj > wMaj, nil
+	}
+	if hMin != wMin {
+		return hMin > wMin, nil
+	}
+	return hPat >= wPat, nil
+}
+
+func parseSemverPrefix(v string) (major, minor, patch int, err error) {
+	m := dropVectorVersionRegex.FindStringSubmatch(v)
+	if m == nil {
+		return 0, 0, 0, fmt.Errorf("unparseable version %q", v)
+	}
+	// Regex groups are \d+ so Atoi cannot fail.
+	major, _ = strconv.Atoi(m[1])
+	minor, _ = strconv.Atoi(m[2])
+	patch, _ = strconv.Atoi(m[3])
+	return major, minor, patch, nil
 }
 
 var _ schema.DropVectorIndexEnqueuer = (*dropVectorIndexEnqueuer)(nil)

--- a/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
@@ -14,6 +14,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -308,17 +309,44 @@ func TestEnqueueDropVectorIndex_NoShardsNonMultiTenant_Errors(t *testing.T) {
 	require.Error(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
 }
 
+// fakeVersionLister returns canned per-node statuses (just names + versions) and
+// an optional error, standing in for *db.DB.GetNodeStatus in the C8 gate tests.
+type fakeVersionLister struct {
+	versions map[string]string // node name -> version
+	err      error
+}
+
+func (f *fakeVersionLister) GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]*models.NodeStatus, 0, len(f.versions))
+	for name, v := range f.versions {
+		out = append(out, &models.NodeStatus{Name: name, Version: v})
+	}
+	return out, nil
+}
+
+// allUpgraded is a version lister where the single node is at the supporting
+// version, so the gate lets enqueues through.
+func allUpgraded() *fakeVersionLister {
+	return &fakeVersionLister{versions: map[string]string{"node1": "1.39.0"}}
+}
+
 // TestEnqueueDropVectorIndex_PayloadSurvivesClusterMarshal pins the encoding
 // contract: the enqueuer must hand AddDistributedTaskWithGroups the payload
 // struct, not pre-marshaled bytes (which the cluster layer would double-encode
 // into a JSON string, breaking CheckConflict and the provider — the bug the
 // drop endpoint hit in e2e).
 func TestEnqueueDropVectorIndex_PayloadSurvivesClusterMarshal(t *testing.T) {
+	logger, _ := test.NewNullLogger()
 	cluster := &fakeClusterDropClient{}
 	state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
 		"shard1": {BelongsToNodes: []string{"node1"}},
 	})}
-	enq := &dropVectorIndexEnqueuer{clusterService: cluster, schemaState: state}
+	enq := &dropVectorIndexEnqueuer{
+		clusterService: cluster, schemaState: state, versions: allUpgraded(), logger: logger,
+	}
 
 	require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
 
@@ -336,4 +364,152 @@ func TestEnqueueDropVectorIndex_PayloadSurvivesClusterMarshal(t *testing.T) {
 	require.NotEmpty(t, p.OpID)
 	require.Equal(t, "node1", p.UnitToNode["shard1__node1"])
 	require.Equal(t, "shard1", p.UnitToShard["shard1__node1"])
+}
+
+// TestEnqueueDropVectorIndex_ClusterVersionGate pins C8: a Phase-2 cleanup task
+// is only submitted when every node is at the supporting version. Mixed/old
+// versions or an unreadable version source defer the task (no submit, no error)
+// so the user's drop still succeeds and startup reconciliation retries later.
+func TestEnqueueDropVectorIndex_ClusterVersionGate(t *testing.T) {
+	tests := []struct {
+		name         string
+		versions     *fakeVersionLister
+		expectSubmit bool
+	}{
+		{
+			name:         "all nodes upgraded -> enqueue proceeds",
+			versions:     &fakeVersionLister{versions: map[string]string{"n1": "1.39.0", "n2": "1.40.2"}},
+			expectSubmit: true,
+		},
+		{
+			name:         "dev build of supporting release counts as upgraded",
+			versions:     &fakeVersionLister{versions: map[string]string{"n1": "1.39.0-dev", "n2": "1.39.0"}},
+			expectSubmit: true,
+		},
+		{
+			name:         "one old node -> gated (no task)",
+			versions:     &fakeVersionLister{versions: map[string]string{"n1": "1.39.0", "n2": "1.38.5"}},
+			expectSubmit: false,
+		},
+		{
+			name:         "all old nodes -> gated",
+			versions:     &fakeVersionLister{versions: map[string]string{"n1": "1.38.0", "n2": "1.38.5"}},
+			expectSubmit: false,
+		},
+		{
+			name:         "version source error -> gated, deferred",
+			versions:     &fakeVersionLister{err: errors.New("node unreachable")},
+			expectSubmit: false,
+		},
+		{
+			name:         "empty cluster status -> gated",
+			versions:     &fakeVersionLister{versions: map[string]string{}},
+			expectSubmit: false,
+		},
+		{
+			name:         "unparseable version -> gated, deferred",
+			versions:     &fakeVersionLister{versions: map[string]string{"n1": "weird"}},
+			expectSubmit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			cluster := &fakeClusterDropClient{}
+			state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+				"shard1": {BelongsToNodes: []string{"node1"}},
+			})}
+			enq := &dropVectorIndexEnqueuer{
+				clusterService: cluster, schemaState: state, versions: tt.versions, logger: logger,
+			}
+
+			err := enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"})
+			require.NoError(t, err, "gate never fails the drop; it defers")
+
+			if tt.expectSubmit {
+				require.NotEmpty(t, cluster.gotTaskID, "task should have been submitted")
+			} else {
+				require.Empty(t, cluster.gotTaskID, "task must not be submitted when gated")
+			}
+		})
+	}
+}
+
+// TestEnqueueDropVectorIndex_NilVersionLister verifies that a nil version source
+// (DTM wired without a lister) does not permanently block the feature: the gate
+// is best-effort and treats unknown version info as upgraded.
+func TestEnqueueDropVectorIndex_NilVersionLister(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	cluster := &fakeClusterDropClient{}
+	state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+		"shard1": {BelongsToNodes: []string{"node1"}},
+	})}
+	enq := &dropVectorIndexEnqueuer{
+		clusterService: cluster, schemaState: state, versions: nil, logger: logger,
+	}
+
+	require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
+	require.NotEmpty(t, cluster.gotTaskID, "nil version source must not block enqueue")
+}
+
+func TestVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		have, want string
+		expect     bool
+		expectErr  bool
+	}{
+		{have: "1.39.0", want: "1.39.0", expect: true},
+		{have: "1.39.1", want: "1.39.0", expect: true},
+		{have: "1.40.0", want: "1.39.0", expect: true},
+		{have: "2.0.0", want: "1.39.0", expect: true},
+		{have: "1.38.9", want: "1.39.0", expect: false},
+		{have: "1.39.0", want: "1.39.1", expect: false},
+		{have: "0.39.0", want: "1.39.0", expect: false},
+		{have: "1.39.0-dev", want: "1.39.0", expect: true},
+		{have: "1.39.0-rc.1", want: "1.39.0", expect: true},
+		{have: "v1.39.0", want: "1.39.0", expect: true},
+		{have: "1.38.0-dev", want: "1.39.0", expect: false},
+		{have: "", want: "1.39.0", expectErr: true},
+		{have: "garbage", want: "1.39.0", expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.have+"_vs_"+tt.want, func(t *testing.T) {
+			ok, err := versionAtLeast(tt.have, tt.want)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, ok)
+		})
+	}
+}
+
+// TestReconcile_RetriesAfterUpgrade simulates the defer-to-reconciliation
+// behavior: while the cluster is mixed-version the enqueue is gated (no task),
+// then once upgraded the same reconciliation pass enqueues it. Uses the real
+// enqueuer so the gate is exercised end to end.
+func TestReconcile_RetriesAfterUpgrade(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	classes := []*models.Class{
+		{Class: "A", VectorConfig: map[string]models.VectorConfig{"v1": dropped()}},
+	}
+	cluster := &fakeClusterDropClient{}
+	state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+		"shard1": {BelongsToNodes: []string{"node1"}},
+	})}
+	mixed := &fakeVersionLister{versions: map[string]string{"n1": "1.39.0", "n2": "1.38.0"}}
+	enq := &dropVectorIndexEnqueuer{
+		clusterService: cluster, schemaState: state, versions: mixed, logger: logger,
+	}
+
+	// First pass: cluster not fully upgraded -> gated, no task submitted.
+	reconcileDroppedVectorIndexes(context.Background(), classes, enq, logger)
+	require.Empty(t, cluster.gotTaskID, "gated while a node is on the old version")
+
+	// Cluster finishes upgrading; reconciliation runs again and enqueues.
+	mixed.versions["n2"] = "1.39.0"
+	reconcileDroppedVectorIndexes(context.Background(), classes, enq, logger)
+	require.NotEmpty(t, cluster.gotTaskID, "enqueued once the cluster is fully upgraded")
 }


### PR DESCRIPTION
### What's being changed

Gates the Phase-2 cleanup enqueue (`EnqueueDropVectorIndex`) on the cluster being **fully upgraded** to a minimum version. The edit-ops cleanup machinery and its RAFT-replicated task semantics only exist in newer nodes; enqueuing the drop task while older nodes are still in the cluster (e.g. mid rolling-upgrade) would hand work to nodes that can't process it correctly. If the cluster isn't yet fully upgraded, the enqueue is **deferred** (logged + `return nil`) so a later reconciliation pass picks it up once every node is on a supported version.

### How

- New `clusterVersionLister` interface (`GetNodeStatus`) — wired in `configure_api.go`.
- `clusterFullyUpgraded` / `versionAtLeast` / `parseSemverPrefix` helpers walk per-node versions and compare against `dropVectorMinClusterVersion`.
- Gate at the top of `EnqueueDropVectorIndex`: not-fully-upgraded ⇒ log and return nil (defer), don't enqueue.

### ⚠️ Needs confirmation

`dropVectorMinClusterVersion = "1.39.0"` is a **placeholder** — it must be set to the first release that ships the full drop-vector Phase-2 stack (S1–S18). Please confirm/adjust before merge.

### Risk / blast radius

Low. Pure pre-flight guard; the only effect is deferring enqueue on a mixed-version cluster, which is strictly safer than the prior unconditional enqueue. On a fully-upgraded cluster behavior is unchanged.

### Key review areas

- `parseSemverPrefix` tolerates suffixes (`-rc`, build metadata) by parsing the leading `major.minor.patch`.
- The gate returns nil (defer) rather than erroring — the drop is not lost, just postponed.
- Optional follow-up: hoist `GetNodeStatus` to once-per-reconciliation-pass instead of per-enqueue if call volume warrants.

### Stacking

Stacked on #11889 (S15+S16), independent of #11900 (S17). Base: `drop-vector-s15-s16`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
