### PR TITLE
perf(usage): replace per-shard jitter with bounded concurrent shard readers

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2145,7 +2145,7 @@ func postInitRuntimeOverrides(appState *state.State, cm *configRuntime.ConfigMan
 				registered.UsageS3Prefix = appState.ServerConfig.Config.Usage.S3Prefix
 				// common config
 				registered.UsageScrapeInterval = appState.ServerConfig.Config.Usage.ScrapeInterval
-				registered.UsageShardJitterInterval = appState.ServerConfig.Config.Usage.ShardJitterInterval
+				registered.UsageShardConcurrency = appState.ServerConfig.Config.Usage.ShardConcurrency
 				registered.UsagePolicyVersion = appState.ServerConfig.Config.Usage.PolicyVersion
 				registered.UsageVerifyPermissions = appState.ServerConfig.Config.Usage.VerifyPermissions
 			})

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -545,6 +545,14 @@ func setupDebugHandlers(appState *state.State) {
 
 	http.HandleFunc("/debug/usage", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		service := usage.NewService(appState.SchemaManager, appState.DB, appState.Modules, appState.Logger)
+		if param := r.URL.Query().Get("shardConcurrency"); param != "" {
+			shardConcurrency, err := strconv.Atoi(param)
+			if err != nil || shardConcurrency < 1 {
+				http.Error(w, "shardConcurrency must be a positive integer", http.StatusBadRequest)
+				return
+			}
+			service.SetShardConcurrency(shardConcurrency)
+		}
 
 		exactCountParam := r.URL.Query().Get("exactObjectCount")
 		exactObjectCount := exactCountParam == "true" // false by default

--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -486,7 +486,7 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	}))
 	newIndex.shards.LoadAndDelete(tenantNamePopulated)
 
-	usage, err := newIndex.usageForCollection(ctx, time.Nanosecond, true, class.VectorConfig)
+	usage, err := newIndex.usageForCollection(ctx, 4, true, class.VectorConfig)
 	require.NoError(t, err)
 
 	for _, shardUsage := range usage.Shards {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -18,6 +18,8 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -26,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/diskio"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -33,7 +36,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, jitterInterval time.Duration, exactObjectCount bool, vectorsConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
+func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, shardConcurrency int, exactObjectCount bool, vectorsConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
 	var (
 		index  *Index
 		exists bool
@@ -56,13 +59,17 @@ func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, jit
 		index.dropIndex.RUnlock()
 	}()
 
-	return index.usageForCollection(ctx, jitterInterval, exactObjectCount, vectorsConfig)
+	return index.usageForCollection(ctx, shardConcurrency, exactObjectCount, vectorsConfig)
 }
 
-func (i *Index) usageForCollection(ctx context.Context, jitterInterval time.Duration, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
+func (i *Index) usageForCollection(ctx context.Context, shardConcurrency int, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
 	collectionUsage := &types.CollectionUsage{
 		Name:              i.Config.ClassName.String(),
 		ReplicationFactor: int(i.Config.ReplicationFactor),
+	}
+
+	if shardConcurrency < 1 {
+		shardConcurrency = 1
 	}
 
 	localShards := map[string]struct{}{}
@@ -86,134 +93,168 @@ func (i *Index) usageForCollection(ctx context.Context, jitterInterval time.Dura
 		return nil, fmt.Errorf("schemareader: %w", err)
 	}
 
-	i.logger.WithField("class", i.Config.ClassName.String()).Debugf("creating usage report with %d shards", len(localShards))
-	var uniqueShardCount int
+	i.logger.WithFields(
+		logrus.Fields{
+			"class":             i.Config.ClassName.String(),
+			"shard_concurrency": shardConcurrency,
+		}).Debugf("creating usage report with %d shards", len(localShards))
+
+	shardNames := make([]string, 0, len(localShards))
+	for shardName := range localShards {
+		shardNames = append(shardNames, shardName)
+	}
 
 	// There is an important distinction between the state of the shard in the schema (in schemaReader) and the local
 	// state, which corresponds to which shard is loaded in memory and both can be out of sync.
 	//
-	// After collection all local shards from the sharding state, we now need to iterate through these shards, lock them
-	// individually against changes in the _local_ state (i.e. loading/unloading) and then collect their usage based
-	// on this local state.
+	// After collecting all local shards from the sharding state, we process them with a bounded number of
+	// concurrent readers. Each shard locks itself against changes in the _local_ state (i.e. loading/unloading)
+	// inside usageForShard.
+	var (
+		mu        sync.Mutex
+		processed atomic.Int64
+	)
 	start := time.Now()
-	for shardName := range localShards {
-		if err := func() error {
-			// Add jitter between tenant processing to not overload the system if there are many shards
-			if len(collectionUsage.Shards) > 0 {
-				addJitter(jitterInterval)
+
+	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
+	eg.SetLimit(shardConcurrency)
+	for _, shardName := range shardNames {
+		eg.Go(func() error {
+			if err := egCtx.Err(); err != nil {
+				return err
 			}
 
-			i.shardCreateLocks.RLock(shardName)
-			defer i.shardCreateLocks.RUnlock(shardName)
-
-			uniqueShardCount++
-
-			shard := i.shards.Load(shardName)
-			var localStatus string
-			if shard != nil {
-				localStatus = models.TenantActivityStatusACTIVE
-			} else {
-				// this might also be offloaded, we need to check this later
-				localStatus = models.TenantActivityStatusINACTIVE
-			}
-
-			// case1: newly created empty tenant - status does not matter as there is no data yet. This also includes
-			// tenants that were deleted in the meantime, but as we record zero usage, it doesn't matter
-			exists, err := i.tenantDirExists(shardName)
+			shardUsage, err := i.usageForShard(egCtx, shardName, exactObjectCount, vectorConfig)
 			if err != nil {
-				return fmt.Errorf("tenant exists: %w", err)
-			}
-			if !exists {
-				collectionUsage.Shards = append(collectionUsage.Shards, emptyShardUsageWithNameAndActivity(shardName, localStatus))
-				return nil
+				return err
 			}
 
-			var err2 error
-			var shardUsage *types.ShardUsage
-			switch localStatus {
-			case models.TenantActivityStatusACTIVE, models.TenantActivityStatusHOT:
-				// active tenants can be either fully loaded or lazy loaded. Lazy shards should _not_ be loaded just for
-				// usage calculation and are treated like inactive shards
-				lazyShard, isLazy := shard.(*LazyLoadShard)
-				if isLazy {
-					// distinguish between loaded and unloaded lazy shards - make sure that the shard is not loaded
-					// while we calculate usage for the unloaded case by blocking loading
-					func() {
-						release := lazyShard.blockLoading()
-						defer release()
-
-						if lazyShard.loaded {
-							shardUsage, err2 = i.calculateLoadedShardUsage(ctx, lazyShard.shard, exactObjectCount)
-							if err2 != nil {
-								err2 = fmt.Errorf("loaded lazy shard %s: %w", shardName, err2)
-							}
-						} else {
-							shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, vectorConfig)
-							if err2 != nil {
-								err2 = fmt.Errorf("unloaded lazy shard %s: %w", shardName, err2)
-							}
-						}
-					}()
-				} else {
-					loadedShard, ok := shard.(*Shard)
-					if !ok {
-						return fmt.Errorf("expected loaded shard, got %T", shard)
-					}
-					shardUsage, err2 = i.calculateLoadedShardUsage(ctx, loadedShard, exactObjectCount)
-					if err2 != nil {
-						err2 = fmt.Errorf("non-lazy shard %s: %w", shardName, err2)
-					}
-				}
-			case models.TenantActivityStatusINACTIVE, models.TenantActivityStatusCOLD:
-				shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, vectorConfig)
-				if err2 != nil {
-					err2 = fmt.Errorf("inactive shard %s: %w", shardName, err2)
-				}
-			case models.TenantActivityStatusFROZEN, models.TenantActivityStatusOFFLOADING, models.TenantActivityStatusOFFLOADED, models.TenantActivityStatusONLOADING, models.TenantActivityStatusUNFREEZING, models.TenantActivityStatusFREEZING:
-				// skip for now and handle after we stabilized them
-			default:
-				// should not happen as we only collected local shards from the sharding state
-				return fmt.Errorf("shard %s has unknown local status %s", shardName, localStatus)
+			count := processed.Add(1)
+			if shardUsage != nil {
+				func() {
+					mu.Lock()
+					defer mu.Unlock()
+					collectionUsage.Shards = append(collectionUsage.Shards, shardUsage)
+				}()
 			}
-			if err2 != nil {
-				// Files vanished mid-deletion: record zero usage instead of failing
-				// the whole report (same as the tenantDirExists check above).
-				if errors.Is(err2, fs.ErrNotExist) {
-					i.logger.WithFields(logrus.Fields{
-						"class": i.Config.ClassName.String(),
-						"shard": shardName,
-					}).Warnf("shard files missing during usage calculation, likely deleted concurrently; recording empty usage: %v", err2)
-					collectionUsage.Shards = append(collectionUsage.Shards, emptyShardUsageWithNameAndActivity(shardName, localStatus))
-					return nil
-				}
-				return err2
-			}
-			collectionUsage.Shards = append(collectionUsage.Shards, shardUsage)
 
+			if count%1000 == 0 {
+				i.logger.WithFields(
+					logrus.Fields{
+						"class":             i.Config.ClassName.String(),
+						"shard_concurrency": shardConcurrency,
+						"processed_shards":  count,
+						"took":              time.Since(start).Seconds(),
+					}).Debugf("processed %d/%d shards for usage report", count, len(shardNames))
+			}
 			return nil
-		}(); err != nil {
-			return nil, err
-		}
-		if uniqueShardCount%1000 == 0 {
-			i.logger.WithFields(
-				logrus.Fields{
-					"class":            i.Config.ClassName.String(),
-					"processed_shards": uniqueShardCount,
-					"took":             time.Since(start).Seconds(),
-				}).Debugf("processed %d/%d shards for usage report", uniqueShardCount, len(localShards))
-		}
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
+	uniqueShardCount := int(processed.Load())
 	i.logger.WithFields(
 		logrus.Fields{
-			"class":            i.Config.ClassName.String(),
-			"processed_shards": uniqueShardCount,
-			"took":             time.Since(start).Seconds(),
-		}).Debugf("finished processing %d/%d shards for usage report", uniqueShardCount, len(localShards))
+			"class":             i.Config.ClassName.String(),
+			"shard_concurrency": shardConcurrency,
+			"processed_shards":  uniqueShardCount,
+			"took":              time.Since(start).Seconds(),
+		}).Debugf("finished processing %d/%d shards for usage report", uniqueShardCount, len(shardNames))
 
 	collectionUsage.UniqueShardCount = uniqueShardCount
 	sort.Sort(collectionUsage.Shards)
 	return collectionUsage, nil
+}
+
+// usageForShard computes usage for a single local shard. A nil *ShardUsage with a nil error means
+// the shard should be skipped (transitional states like FREEZING/OFFLOADING). Safe to call
+// concurrently for distinct shards.
+func (i *Index) usageForShard(ctx context.Context, shardName string, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.ShardUsage, error) {
+	i.shardCreateLocks.RLock(shardName)
+	defer i.shardCreateLocks.RUnlock(shardName)
+
+	shard := i.shards.Load(shardName)
+	var localStatus string
+	if shard != nil {
+		localStatus = models.TenantActivityStatusACTIVE
+	} else {
+		// this might also be offloaded, we need to check this later
+		localStatus = models.TenantActivityStatusINACTIVE
+	}
+
+	// case1: newly created empty tenant - status does not matter as there is no data yet. This also includes
+	// tenants that were deleted in the meantime, but as we record zero usage, it doesn't matter
+	exists, err := i.tenantDirExists(shardName)
+	if err != nil {
+		return nil, fmt.Errorf("tenant exists: %w", err)
+	}
+	if !exists {
+		return emptyShardUsageWithNameAndActivity(shardName, localStatus), nil
+	}
+
+	var err2 error
+	var shardUsage *types.ShardUsage
+	switch localStatus {
+	case models.TenantActivityStatusACTIVE, models.TenantActivityStatusHOT:
+		// active tenants can be either fully loaded or lazy loaded. Lazy shards should _not_ be loaded just for
+		// usage calculation and are treated like inactive shards
+		lazyShard, isLazy := shard.(*LazyLoadShard)
+		if isLazy {
+			// distinguish between loaded and unloaded lazy shards - make sure that the shard is not loaded
+			// while we calculate usage for the unloaded case by blocking loading
+			func() {
+				release := lazyShard.blockLoading()
+				defer release()
+
+				if lazyShard.loaded {
+					shardUsage, err2 = i.calculateLoadedShardUsage(ctx, lazyShard.shard, exactObjectCount)
+					if err2 != nil {
+						err2 = fmt.Errorf("loaded lazy shard %s: %w", shardName, err2)
+					}
+				} else {
+					shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, vectorConfig)
+					if err2 != nil {
+						err2 = fmt.Errorf("unloaded lazy shard %s: %w", shardName, err2)
+					}
+				}
+			}()
+		} else {
+			loadedShard, ok := shard.(*Shard)
+			if !ok {
+				return nil, fmt.Errorf("expected loaded shard, got %T", shard)
+			}
+			shardUsage, err2 = i.calculateLoadedShardUsage(ctx, loadedShard, exactObjectCount)
+			if err2 != nil {
+				err2 = fmt.Errorf("non-lazy shard %s: %w", shardName, err2)
+			}
+		}
+	case models.TenantActivityStatusINACTIVE, models.TenantActivityStatusCOLD:
+		shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, vectorConfig)
+		if err2 != nil {
+			err2 = fmt.Errorf("inactive shard %s: %w", shardName, err2)
+		}
+	case models.TenantActivityStatusFROZEN, models.TenantActivityStatusOFFLOADING, models.TenantActivityStatusOFFLOADED, models.TenantActivityStatusONLOADING, models.TenantActivityStatusUNFREEZING, models.TenantActivityStatusFREEZING:
+		// skip for now and handle after we stabilized them
+		return nil, nil
+	default:
+		// should not happen as we only collected local shards from the sharding state
+		return nil, fmt.Errorf("shard %s has unknown local status %s", shardName, localStatus)
+	}
+	if err2 != nil {
+		// Files vanished mid-deletion: record zero usage instead of failing
+		// the whole report (same as the tenantDirExists check above).
+		if errors.Is(err2, fs.ErrNotExist) {
+			i.logger.WithFields(logrus.Fields{
+				"class": i.Config.ClassName.String(),
+				"shard": shardName,
+			}).Warnf("shard files missing during usage calculation, likely deleted concurrently; recording empty usage: %v", err2)
+			return emptyShardUsageWithNameAndActivity(shardName, localStatus), nil
+		}
+		return nil, err2
+	}
+	return shardUsage, nil
 }
 
 func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exactCount bool) (*types.ShardUsage, error) {
@@ -410,15 +451,6 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 		return nil, fmt.Errorf("save usage to disk: %w", err)
 	}
 	return shardUsage, err
-}
-
-// addJitter adds a small random delay if jitter interval is set
-func addJitter(jitterInterval time.Duration) {
-	if jitterInterval <= 0 {
-		return // No jitter if interval is 0 or negative
-	}
-	jitter := time.Duration(time.Now().UnixNano() % int64(jitterInterval))
-	time.Sleep(jitter)
 }
 
 func emptyShardUsageWithNameAndActivity(shardName, activity string) *types.ShardUsage {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -97,19 +97,14 @@ func (i *Index) usageForCollection(ctx context.Context, shardConcurrency int, ex
 		logrus.Fields{
 			"class":             i.Config.ClassName.String(),
 			"shard_concurrency": shardConcurrency,
-		}).Debugf("creating usage report with %d shards", len(localShards))
+		}).Infof("creating usage report with %d shards", len(localShards))
 
 	shardNames := make([]string, 0, len(localShards))
 	for shardName := range localShards {
 		shardNames = append(shardNames, shardName)
 	}
 
-	// There is an important distinction between the state of the shard in the schema (in schemaReader) and the local
-	// state, which corresponds to which shard is loaded in memory and both can be out of sync.
-	//
-	// After collecting all local shards from the sharding state, we process them with a bounded number of
-	// concurrent readers. Each shard locks itself against changes in the _local_ state (i.e. loading/unloading)
-	// inside usageForShard.
+	// process the local shards with a bounded number of concurrent readers
 	var (
 		mu        sync.Mutex
 		processed atomic.Int64
@@ -161,16 +156,19 @@ func (i *Index) usageForCollection(ctx context.Context, shardConcurrency int, ex
 			"shard_concurrency": shardConcurrency,
 			"processed_shards":  uniqueShardCount,
 			"took":              time.Since(start).Seconds(),
-		}).Debugf("finished processing %d/%d shards for usage report", uniqueShardCount, len(shardNames))
+		}).Infof("finished processing %d/%d shards for usage report", uniqueShardCount, len(shardNames))
 
 	collectionUsage.UniqueShardCount = uniqueShardCount
 	sort.Sort(collectionUsage.Shards)
 	return collectionUsage, nil
 }
 
-// usageForShard computes usage for a single local shard. A nil *ShardUsage with a nil error means
-// the shard should be skipped (transitional states like FREEZING/OFFLOADING). Safe to call
-// concurrently for distinct shards.
+// usageForShard computes usage for a single local shard. There is an important distinction between
+// the state of the shard in the schema (in schemaReader) and the local state, which corresponds to
+// which shard is loaded in memory — both can be out of sync, so the shard is locked against changes
+// in the _local_ state (i.e. loading/unloading) for the duration of the calculation. A nil
+// *ShardUsage with a nil error means the shard should be skipped (transitional states like
+// FREEZING/OFFLOADING). Safe to call concurrently for distinct shards.
 func (i *Index) usageForShard(ctx context.Context, shardName string, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.ShardUsage, error) {
 	i.shardCreateLocks.RLock(shardName)
 	defer i.shardCreateLocks.RUnlock(shardName)

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -106,7 +105,7 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 			require.DirExists(t, shardDir, "precondition: shard dir must exist")
 			require.NoError(t, os.RemoveAll(filepath.Join(shardDir, tt.removeRelPath)))
 
-			usage, err := index.usageForCollection(ctx, time.Nanosecond, true, nil)
+			usage, err := index.usageForCollection(ctx, 4, true, nil)
 			require.NoError(t, err, "one disappearing shard must not fail the whole report")
 			require.NotNil(t, usage)
 

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -881,7 +881,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	newIndex.shards.LoadAndDelete(tenantNamePopulated)
 
 	// Compare active and inactive metrics
-	collectionUsage, err := newIndex.usageForCollection(ctx, time.Nanosecond, true, class.VectorConfig)
+	collectionUsage, err := newIndex.usageForCollection(ctx, 4, true, class.VectorConfig)
 	require.NoError(t, err)
 	for _, tenant := range collectionUsage.Shards {
 		if tenant.Name == tenantNamePopulated {

--- a/cluster/usage/mock_service.go
+++ b/cluster/usage/mock_service.go
@@ -15,7 +15,6 @@ package usage
 
 import (
 	context "context"
-	time "time"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -35,35 +34,35 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
 }
 
-// SetJitterInterval provides a mock function with given fields: interval
-func (_m *MockService) SetJitterInterval(interval time.Duration) {
-	_m.Called(interval)
+// SetShardConcurrency provides a mock function with given fields: concurrency
+func (_m *MockService) SetShardConcurrency(concurrency int) {
+	_m.Called(concurrency)
 }
 
-// MockService_SetJitterInterval_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetJitterInterval'
-type MockService_SetJitterInterval_Call struct {
+// MockService_SetShardConcurrency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetShardConcurrency'
+type MockService_SetShardConcurrency_Call struct {
 	*mock.Call
 }
 
-// SetJitterInterval is a helper method to define mock.On call
-//   - interval time.Duration
-func (_e *MockService_Expecter) SetJitterInterval(interval interface{}) *MockService_SetJitterInterval_Call {
-	return &MockService_SetJitterInterval_Call{Call: _e.mock.On("SetJitterInterval", interval)}
+// SetShardConcurrency is a helper method to define mock.On call
+//   - concurrency int
+func (_e *MockService_Expecter) SetShardConcurrency(concurrency interface{}) *MockService_SetShardConcurrency_Call {
+	return &MockService_SetShardConcurrency_Call{Call: _e.mock.On("SetShardConcurrency", concurrency)}
 }
 
-func (_c *MockService_SetJitterInterval_Call) Run(run func(interval time.Duration)) *MockService_SetJitterInterval_Call {
+func (_c *MockService_SetShardConcurrency_Call) Run(run func(concurrency int)) *MockService_SetShardConcurrency_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(time.Duration))
+		run(args[0].(int))
 	})
 	return _c
 }
 
-func (_c *MockService_SetJitterInterval_Call) Return() *MockService_SetJitterInterval_Call {
+func (_c *MockService_SetShardConcurrency_Call) Return() *MockService_SetShardConcurrency_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockService_SetJitterInterval_Call) RunAndReturn(run func(time.Duration)) *MockService_SetJitterInterval_Call {
+func (_c *MockService_SetShardConcurrency_Call) RunAndReturn(run func(int)) *MockService_SetShardConcurrency_Call {
 	_c.Run(run)
 	return _c
 }
@@ -132,7 +131,8 @@ func (_c *MockService_Usage_Call) RunAndReturn(run func(context.Context, bool) (
 func NewMockService(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockService {
+},
+) *MockService {
 	mock := &MockService{}
 	mock.Mock.Test(t)
 

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -30,34 +31,42 @@ import (
 	"github.com/weaviate/weaviate/usecases/schema"
 )
 
+// DefaultShardConcurrency is the default number of shards processed concurrently while collecting usage.
+const DefaultShardConcurrency = 1
+
 type Service interface {
-	SetJitterInterval(interval time.Duration)
+	SetShardConcurrency(concurrency int)
 	Usage(ctx context.Context, exactObjectCount bool) (*types.Report, error)
 }
 
 type service struct {
-	schemaManager  schema.SchemaGetter
-	db             *db.DB
-	backups        backup.BackupBackendProvider
-	logger         logrus.FieldLogger
-	jitterInterval time.Duration
+	schemaManager    schema.SchemaGetter
+	db               *db.DB
+	backups          backup.BackupBackendProvider
+	logger           logrus.FieldLogger
+	shardConcurrency atomic.Int64
 }
 
 // db db.IndexGetter
 func NewService(schemaManager schema.SchemaGetter, db *db.DB, backups backup.BackupBackendProvider, logger logrus.FieldLogger) Service {
-	return &service{
-		schemaManager:  schemaManager,
-		db:             db,
-		backups:        backups,
-		logger:         logger,
-		jitterInterval: 0, // Default to no jitter
+	s := &service{
+		schemaManager: schemaManager,
+		db:            db,
+		backups:       backups,
+		logger:        logger,
 	}
+	s.shardConcurrency.Store(DefaultShardConcurrency)
+	return s
 }
 
-// SetJitterInterval sets the jitter interval for shard processing
-func (s *service) SetJitterInterval(interval time.Duration) {
-	s.jitterInterval = interval
-	s.logger.WithFields(logrus.Fields{"jitter_interval": interval.String()}).Info("shard jitter interval updated")
+// SetShardConcurrency sets the maximum number of shards processed concurrently during
+// collection. Values < 1 are clamped to 1.
+func (s *service) SetShardConcurrency(concurrency int) {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	s.shardConcurrency.Store(int64(concurrency))
+	s.logger.WithFields(logrus.Fields{"shard_concurrency": concurrency}).Info("usage shard concurrency updated")
 }
 
 // Usage service collects usage metrics for the node and shall return error in case of any error
@@ -81,7 +90,7 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 		if err != nil {
 			return nil, fmt.Errorf("collection %s: %w", collection.Class, err)
 		}
-		collectionUsage, err := s.db.UsageForIndex(ctx, entschema.ClassName(collection.Class), s.jitterInterval, exactObjectCount, vectorConfig)
+		collectionUsage, err := s.db.UsageForIndex(ctx, entschema.ClassName(collection.Class), int(s.shardConcurrency.Load()), exactObjectCount, vectorConfig)
 		// we lock the local index against being deleted while we collect usage, however we cannot lock the RAFT schema
 		// against being changed. If the class was deleted in the RAFT schema, we simply skip it here
 		// as it is no longer relevant for the current node usage

--- a/modules/usage-gcs/module_test.go
+++ b/modules/usage-gcs/module_test.go
@@ -238,7 +238,7 @@ func TestModule_SetUsageService(t *testing.T) {
 
 	// Test with valid service after initialization
 	usageService := clusterusage.NewMockService(t)
-	usageService.EXPECT().SetJitterInterval(mock.Anything).Return()
+	usageService.EXPECT().SetShardConcurrency(mock.Anything).Return()
 
 	assert.NotPanics(t, func() {
 		mod.SetUsageService(usageService)

--- a/modules/usage-s3/module_test.go
+++ b/modules/usage-s3/module_test.go
@@ -277,7 +277,7 @@ func TestModule_SetUsageService(t *testing.T) {
 
 	// Test with valid service after initialization
 	usageService := clusterusage.NewMockService(t)
-	usageService.EXPECT().SetJitterInterval(mock.Anything).Return()
+	usageService.EXPECT().SetShardConcurrency(mock.Anything).Return()
 
 	assert.NotPanics(t, func() {
 		m.SetUsageService(usageService)

--- a/test/acceptance_with_go_client/usage/get_debug_usage.go
+++ b/test/acceptance_with_go_client/usage/get_debug_usage.go
@@ -29,8 +29,11 @@ func getDebugUsage() (*usagetypes.Report, error) {
 }
 
 // Get the debug usage report from the endpoint
-func getDebugUsageWithPort(host string) (*usagetypes.Report, error) {
+func getDebugUsageWithPort(host string, shardConcurrency ...int) (*usagetypes.Report, error) {
 	url := fmt.Sprintf("http://%s/debug/usage?exactObjectCount=true", host)
+	if len(shardConcurrency) > 0 {
+		url += fmt.Sprintf("&shardConcurrency=%d", shardConcurrency[0])
+	}
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call endpoint: %w", err)

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -415,7 +415,8 @@ func TestRestart(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	usage, err := getDebugUsageWithPort(debug)
+	// collect with concurrent shard readers, compare with the default report after restart
+	usage, err := getDebugUsageWithPort(debug, 4)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 

--- a/tools/dev/config.runtime-overrides.yaml
+++ b/tools/dev/config.runtime-overrides.yaml
@@ -8,7 +8,6 @@ query_slow_log_threshold: 100ms
 inverted_sorter_disabled: false
 # for usage module if enabled make sure that usage-gcs or usage-s3 module is enabled
 # usage_scrape_interval: 1s
-# usage_shard_jitter_interval: 50ms
 
 # usage_gcs_bucket: weaviate-usage
 # usage_gcs_prefix: billing

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -45,7 +45,7 @@ type WeaviateRuntimeConfig struct {
 	UsageS3Bucket                     *runtime.DynamicValue[string]        `json:"usage_s3_bucket" yaml:"usage_s3_bucket"`
 	UsageS3Prefix                     *runtime.DynamicValue[string]        `json:"usage_s3_prefix" yaml:"usage_s3_prefix"`
 	UsageScrapeInterval               *runtime.DynamicValue[time.Duration] `json:"usage_scrape_interval" yaml:"usage_scrape_interval"`
-	UsageShardJitterInterval          *runtime.DynamicValue[time.Duration] `json:"usage_shard_jitter_interval" yaml:"usage_shard_jitter_interval"`
+	UsageShardConcurrency             *runtime.DynamicValue[int]           `json:"usage_shard_concurrency" yaml:"usage_shard_concurrency"`
 	UsagePolicyVersion                *runtime.DynamicValue[string]        `json:"usage_policy_version" yaml:"usage_policy_version"`
 	UsageVerifyPermissions            *runtime.DynamicValue[bool]          `json:"usage_verify_permissions" yaml:"usage_verify_permissions"`
 	OperationalMode                   *runtime.DynamicValue[string]        `json:"operational_mode" yaml:"operational_mode"`

--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -30,24 +30,23 @@ import (
 )
 
 const (
-	DefaultCollectionInterval = 1 * time.Hour
-	// DefaultShardJitterInterval short for shard-level operations and can be configurable later on
-	DefaultShardJitterInterval = 100 * time.Millisecond
+	DefaultCollectionInterval  = 1 * time.Hour
 	DefaultRuntimeLoadInterval = 2 * time.Minute
+	DefaultShardConcurrency    = clusterusage.DefaultShardConcurrency
 )
 
 // BaseModule contains the common logic for usage collection modules
 type BaseModule struct {
-	nodeID        string
-	policyVersion string
-	moduleName    string
-	config        *config.Config
-	storage       StorageBackend
-	interval      time.Duration
-	shardJitter   time.Duration
-	stopChan      chan struct{}
-	metrics       *Metrics
-	usageService  clusterusage.Service
+	nodeID           string
+	policyVersion    string
+	moduleName       string
+	config           *config.Config
+	storage          StorageBackend
+	interval         time.Duration
+	shardConcurrency int
+	stopChan         chan struct{}
+	metrics          *Metrics
+	usageService     clusterusage.Service
 	// support for resuming push after a restart
 	initialIntervalDefined bool
 	initialInterval        time.Duration
@@ -61,18 +60,18 @@ type BaseModule struct {
 // NewBaseModule creates a new base module instance
 func NewBaseModule(moduleName string, storage StorageBackend) *BaseModule {
 	return &BaseModule{
-		interval:    DefaultCollectionInterval,
-		shardJitter: DefaultShardJitterInterval,
-		stopChan:    make(chan struct{}),
-		storage:     storage,
-		moduleName:  moduleName,
+		interval:         DefaultCollectionInterval,
+		shardConcurrency: DefaultShardConcurrency,
+		stopChan:         make(chan struct{}),
+		storage:          storage,
+		moduleName:       moduleName,
 	}
 }
 
 func (b *BaseModule) SetUsageService(usageService any) {
 	if service, ok := usageService.(clusterusage.Service); ok {
 		b.usageService = service
-		service.SetJitterInterval(b.shardJitter)
+		service.SetShardConcurrency(b.shardConcurrency)
 	}
 }
 
@@ -110,11 +109,15 @@ func (b *BaseModule) InitializeCommon(ctx context.Context, config *config.Config
 		}
 	}
 
-	// Initialize shard jitter interval
-	if b.config.Usage.ShardJitterInterval != nil {
-		if jitterInterval := b.config.Usage.ShardJitterInterval.Get(); jitterInterval > 0 {
-			b.shardJitter = jitterInterval
+	// Initialize shard concurrency
+	if b.config.Usage.ShardConcurrency != nil {
+		if shardConcurrency := b.config.Usage.ShardConcurrency.Get(); shardConcurrency > 0 {
+			b.shardConcurrency = shardConcurrency
 		}
+	}
+	// push the parsed value in case the usage service was wired before Init
+	if b.usageService != nil {
+		b.usageService.SetShardConcurrency(b.shardConcurrency)
 	}
 
 	// Verify storage permissions (opt-in)
@@ -165,10 +168,9 @@ func (b *BaseModule) collectAndUploadPeriodically(ctx context.Context) {
 	}
 
 	b.logger.WithFields(logrus.Fields{
-		"base_interval":        b.interval.String(),
-		"load_interval":        loadInterval.String(),
-		"shard_jitter":         b.shardJitter.String(),
-		"default_shard_jitter": DefaultShardJitterInterval.String(),
+		"base_interval":     b.interval.String(),
+		"load_interval":     loadInterval.String(),
+		"shard_concurrency": b.shardConcurrency,
 	}).Debug("starting periodic collection with ticker")
 
 	// Create ticker with base interval
@@ -309,15 +311,16 @@ func (b *BaseModule) reloadConfig(ticker *time.Ticker) {
 		ticker.Reset(b.interval)
 	}
 
-	// Check for shard jitter interval updates
-	// Note: we allow 0 as a valid value for the shard jitter interval
-	if jitterInterval := b.config.Usage.ShardJitterInterval.Get(); jitterInterval >= 0 && b.shardJitter != jitterInterval {
-		b.logger.WithFields(logrus.Fields{
-			"old_jitter": b.shardJitter.String(),
-			"new_jitter": jitterInterval.String(),
-		}).Info("shard jitter interval updated")
-		b.shardJitter = jitterInterval
-		b.usageService.SetJitterInterval(b.shardJitter)
+	// Check for shard concurrency updates
+	if b.config.Usage.ShardConcurrency != nil {
+		if shardConcurrency := b.config.Usage.ShardConcurrency.Get(); shardConcurrency > 0 && b.shardConcurrency != shardConcurrency {
+			b.logger.WithFields(logrus.Fields{
+				"old_shard_concurrency": b.shardConcurrency,
+				"new_shard_concurrency": shardConcurrency,
+			}).Info("usage shard concurrency updated")
+			b.shardConcurrency = shardConcurrency
+			b.usageService.SetShardConcurrency(b.shardConcurrency)
+		}
 	}
 
 	// Build common storage config

--- a/usecases/modulecomponents/usage/base_module_test.go
+++ b/usecases/modulecomponents/usage/base_module_test.go
@@ -12,30 +12,94 @@
 package usage
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	clusterusage "github.com/weaviate/weaviate/cluster/usage"
+	"github.com/weaviate/weaviate/usecases/config"
+	configruntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
-func TestBaseModule_ShardJitterConfiguration(t *testing.T) {
-	// Test 1: Check that the default value is correct
-	assert.Equal(t, 100*time.Millisecond, DefaultShardJitterInterval, "jitter interval should be 100ms")
+// TestBaseModule_EnvShardConcurrencyReachesService verifies USAGE_SHARD_CONCURRENCY reaches
+// the usage service regardless of whether the service is wired before or after module Init.
+func TestBaseModule_EnvShardConcurrencyReachesService(t *testing.T) {
+	t.Setenv("USAGE_SHARD_CONCURRENCY", "3")
 
-	// Test 2: Test that the module initializes with default jitter
-	module := NewBaseModule("test-module", nil)
-	assert.Equal(t, DefaultShardJitterInterval, module.shardJitter, "module should use default jitter")
+	mockStorage := NewMockStorageBackend(t)
+	mockService := clusterusage.NewMockService(t)
+	mockService.EXPECT().SetShardConcurrency(DefaultShardConcurrency).Return().Once()
+	mockService.EXPECT().SetShardConcurrency(3).Return().Once()
 
-	// Test 3: Test configurable jitter
-	customJitter := 50 * time.Millisecond
-	module.shardJitter = customJitter
-	assert.Equal(t, customJitter, module.shardJitter, "module should use custom jitter")
+	module := NewBaseModule("test-module", mockStorage)
+	module.SetUsageService(mockService)
 
-	// Test 4: Test that zero jitter is handled gracefully
-	module.shardJitter = 0
-	assert.Equal(t, 0*time.Millisecond, module.shardJitter, "module should allow zero jitter")
+	cfg := &config.Config{}
+	cfg.Cluster.Hostname = "test-node"
+	cfg.Persistence.DataPath = t.TempDir()
+	require.NoError(t, ParseCommonUsageConfig(cfg))
 
-	// Test 5: Test that negative jitter is handled gracefully
-	module.shardJitter = -1 * time.Millisecond
-	assert.Equal(t, -1*time.Millisecond, module.shardJitter, "module should allow negative jitter")
+	require.NoError(t, module.InitializeCommon(context.Background(), cfg, logrus.New(),
+		NewMetrics(prometheus.NewRegistry(), "test-module")))
+	close(module.stopChan)
+
+	assert.Equal(t, 3, module.shardConcurrency)
+}
+
+// TestBaseModule_RuntimeOverridesShardConcurrencyReachesService exercises the full runtime
+// overrides chain: overrides file → ConfigManager → shared DynamicValue → module reloadConfig
+// → usage service.
+func TestBaseModule_RuntimeOverridesShardConcurrencyReachesService(t *testing.T) {
+	overridesPath := filepath.Join(t.TempDir(), "overrides.yaml")
+	require.NoError(t, os.WriteFile(overridesPath, []byte(""), 0o644))
+
+	cfg := &config.Config{}
+	cfg.Cluster.Hostname = "test-node"
+	cfg.Persistence.DataPath = t.TempDir()
+	cfg.RuntimeOverrides.LoadInterval = 10 * time.Millisecond
+	require.NoError(t, ParseCommonUsageConfig(cfg))
+
+	mockStorage := NewMockStorageBackend(t)
+	mockStorage.EXPECT().UpdateConfig(mock.Anything).Return(false, nil).Maybe()
+	mockService := clusterusage.NewMockService(t)
+	mockService.EXPECT().SetShardConcurrency(DefaultShardConcurrency).Return().Maybe()
+	pushed := make(chan int, 1)
+	mockService.EXPECT().SetShardConcurrency(5).Run(func(concurrency int) {
+		select {
+		case pushed <- concurrency:
+		default:
+		}
+	}).Return().Once()
+
+	module := NewBaseModule("test-module", mockStorage)
+	module.SetUsageService(mockService)
+	require.NoError(t, module.InitializeCommon(context.Background(), cfg, logrus.New(),
+		NewMetrics(prometheus.NewRegistry(), "test-module")))
+	defer close(module.stopChan)
+
+	// register the module's DynamicValue in a real config manager, like configure_api does
+	registered := &config.WeaviateRuntimeConfig{}
+	registered.UsageShardConcurrency = cfg.Usage.ShardConcurrency
+	cm, err := configruntime.NewConfigManager(overridesPath, config.ParseRuntimeConfig,
+		config.UpdateRuntimeConfig, registered, 10*time.Millisecond, logrus.New(), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(overridesPath, []byte("usage_shard_concurrency: 5\n"), 0o644))
+	require.NoError(t, cm.ReloadConfig())
+	require.Equal(t, 5, cfg.Usage.ShardConcurrency.Get())
+
+	select {
+	case concurrency := <-pushed:
+		assert.Equal(t, 5, concurrency)
+	case <-time.After(5 * time.Second):
+		t.Fatal("usage service did not receive the shard concurrency from runtime overrides")
+	}
 }

--- a/usecases/modulecomponents/usage/base_storage.go
+++ b/usecases/modulecomponents/usage/base_storage.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -171,18 +172,18 @@ func ParseCommonUsageConfig(config *config.Config) error {
 	}
 	config.Usage.PolicyVersion = runtime.NewDynamicValue(policyVersion)
 
-	// Parse shard jitter interval environment variable
-	shardJitterInterval := DefaultShardJitterInterval
-	if v := os.Getenv("USAGE_SHARD_JITTER_INTERVAL"); v != "" {
-		duration, err := time.ParseDuration(v)
+	// Parse shard concurrency environment variable
+	shardConcurrency := DefaultShardConcurrency
+	if v := os.Getenv("USAGE_SHARD_CONCURRENCY"); v != "" {
+		parsed, err := strconv.Atoi(v)
 		if err != nil {
-			return fmt.Errorf("invalid %s: %w", "USAGE_SHARD_JITTER_INTERVAL", err)
+			return fmt.Errorf("invalid %s: %w", "USAGE_SHARD_CONCURRENCY", err)
 		}
-		shardJitterInterval = duration
-	} else if config.Usage.ShardJitterInterval != nil {
-		shardJitterInterval = config.Usage.ShardJitterInterval.Get()
+		shardConcurrency = parsed
+	} else if config.Usage.ShardConcurrency != nil {
+		shardConcurrency = config.Usage.ShardConcurrency.Get()
 	}
-	config.Usage.ShardJitterInterval = runtime.NewDynamicValue(shardJitterInterval)
+	config.Usage.ShardConcurrency = runtime.NewDynamicValue(shardConcurrency)
 
 	// Parse verify permissions setting
 	verifyPermissions := false

--- a/usecases/modulecomponents/usage/common_test.go
+++ b/usecases/modulecomponents/usage/common_test.go
@@ -250,7 +250,7 @@ func TestCollectAndUploadPeriodically_ConfigChangesAndStop(t *testing.T) {
 
 	// Set up expectations
 	mockUsageService.EXPECT().Usage(mock.Anything, mock.Anything).Return(&types.Report{Node: "test-node"}, nil).Maybe()
-	mockUsageService.EXPECT().SetJitterInterval(mock.Anything).Return().Maybe()
+	mockUsageService.EXPECT().SetShardConcurrency(mock.Anything).Return().Maybe()
 	mockStorage.EXPECT().UploadUsageData(mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStorage.EXPECT().UpdateConfig(mock.Anything).Return(true, nil).Maybe()
 

--- a/usecases/modulecomponents/usage/types/types.go
+++ b/usecases/modulecomponents/usage/types/types.go
@@ -25,8 +25,8 @@ type UsageConfig struct {
 	S3Bucket *runtime.DynamicValue[string] `json:"usage_s3_bucket" yaml:"usage_s3_bucket"`
 	S3Prefix *runtime.DynamicValue[string] `json:"usage_s3_prefix" yaml:"usage_s3_prefix"`
 
-	ScrapeInterval      *runtime.DynamicValue[time.Duration] `json:"usage_scrape_interval" yaml:"usage_scrape_interval"`
-	ShardJitterInterval *runtime.DynamicValue[time.Duration] `json:"usage_shard_jitter_interval" yaml:"usage_shard_jitter_interval"`
-	PolicyVersion       *runtime.DynamicValue[string]        `json:"usage_policy_version" yaml:"usage_policy_version"`
-	VerifyPermissions   *runtime.DynamicValue[bool]          `json:"usage_verify_permissions" yaml:"usage_verify_permissions"`
+	ScrapeInterval    *runtime.DynamicValue[time.Duration] `json:"usage_scrape_interval" yaml:"usage_scrape_interval"`
+	ShardConcurrency  *runtime.DynamicValue[int]           `json:"usage_shard_concurrency" yaml:"usage_shard_concurrency"`
+	PolicyVersion     *runtime.DynamicValue[string]        `json:"usage_policy_version" yaml:"usage_policy_version"`
+	VerifyPermissions *runtime.DynamicValue[bool]          `json:"usage_verify_permissions" yaml:"usage_verify_permissions"`
 }


### PR DESCRIPTION
### What's being changed:

This PR replaces per-shard jitter with bounded concurrent shard readers

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
