### PR TITLE
Fix multi-role delete

### DIFF
--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -234,6 +234,7 @@ func (m *Manager) DeleteRoles(roles ...string) error {
 	m.restoreLock.RLock()
 	defer m.restoreLock.RUnlock()
 
+	changed := false
 	for _, roleName := range roles {
 		// remove role
 		roleRemoved, err := m.casbin.RemoveFilteredNamedPolicy("p", 0, conv.PrefixRoleName(roleName))
@@ -246,9 +247,14 @@ func (m *Manager) DeleteRoles(roles ...string) error {
 			return fmt.Errorf("RemoveFilteredGroupingPolicy: %w", err)
 		}
 
-		if !roleRemoved && !roleAssignmentsRemoved {
-			return nil // deletes are idempotent
+		// Deleting an already-absent role is a no-op; keep going so the rest of
+		// the batch is still removed.
+		if roleRemoved || roleAssignmentsRemoved {
+			changed = true
 		}
+	}
+	if !changed {
+		return nil
 	}
 	if err := m.casbin.SavePolicy(); err != nil {
 		return fmt.Errorf("SavePolicy: %w", err)

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -387,6 +387,90 @@ func TestRemovePermissions(t *testing.T) {
 	}
 }
 
+func TestDeleteRoles(t *testing.T) {
+	const (
+		roleA   = "role-a"
+		roleB   = "role-b"
+		absentA = "absent-a"
+		absentB = "absent-b"
+	)
+	perm := authorization.Policy{Resource: authorization.CollectionsMetadata("Foo")[0], Verb: authorization.READ, Domain: authorization.SchemaDomain}
+
+	tests := []struct {
+		name        string
+		create      []string
+		delete      []string
+		wantAbsent  []string
+		wantPresent []string
+	}{
+		{
+			// An absent role early in the batch must not abort it: roleA and
+			// roleB are still requested and must be deleted.
+			name:       "absent role first, rest present",
+			create:     []string{roleA, roleB},
+			delete:     []string{absentA, roleA, roleB},
+			wantAbsent: []string{roleA, roleB},
+		},
+		{
+			// A real delete followed by an absent role must still be persisted
+			// (SavePolicy/InvalidateCache must not be skipped).
+			name:       "present then absent persists durably",
+			create:     []string{roleA},
+			delete:     []string{roleA, absentA},
+			wantAbsent: []string{roleA},
+		},
+		{
+			name:        "all roles absent is a no-op",
+			create:      []string{roleA},
+			delete:      []string{absentA, absentB},
+			wantPresent: []string{roleA},
+		},
+		{
+			name:       "all present happy path",
+			create:     []string{roleA, roleB},
+			delete:     []string{roleA, roleB},
+			wantAbsent: []string{roleA, roleB},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			m, err := setupTestManager(t, logger)
+			require.NoError(t, err)
+
+			roles := make(map[string][]authorization.Policy, len(tt.create))
+			for _, name := range tt.create {
+				roles[name] = []authorization.Policy{perm}
+			}
+			require.NoError(t, m.CreateRolesPermissions(roles))
+
+			require.NoError(t, m.DeleteRoles(tt.delete...))
+
+			assertRoles := func(t *testing.T) {
+				got, err := m.GetRoles(append(append([]string{}, tt.wantAbsent...), tt.wantPresent...)...)
+				require.NoError(t, err)
+				for _, name := range tt.wantAbsent {
+					_, ok := got[name]
+					assert.False(t, ok, "role %q should be deleted", name)
+				}
+				for _, name := range tt.wantPresent {
+					_, ok := got[name]
+					assert.True(t, ok, "role %q should still be present", name)
+				}
+			}
+
+			// In-memory state.
+			assertRoles(t)
+
+			// Durable state: reload from the policy file. A skipped SavePolicy
+			// would let deleted roles reappear here.
+			require.NoError(t, m.casbin.LoadPolicy())
+			assertRoles(t)
+		})
+	}
+}
+
 func TestSnapshotAndRestoreUpgrade(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
### What's being changed:

`Manager.DeleteRoles` aborted the loop with `return nil` as soon as it hit an already-absent role, skipping the remaining roles **and** the trailing `SavePolicy()`/`InvalidateCache()`. Any role removed in-memory before the short-circuit was  never persisted or cache-invalidated → it would reappear after a restart and linger in a stale cache.

Note that this was not triggerable from the API, but any code change could expose this in the future

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
