### PR TITLE
Add gate to disallow global non-operator users

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -119,6 +119,8 @@ func CreateGRPCServer(state *state.State, clientTracker *telemetry.ClientTracker
 	allowAnonymous := state.ServerConfig.Config.Authentication.AnonymousAccess.Enabled
 	authComposer := composer.New(
 		state.ServerConfig.Config.Authentication,
+		state.ServerConfig.Config.Namespaces.Enabled,
+		state.Logger,
 		state.APIKey,
 		state.OIDC,
 	)

--- a/adapters/handlers/mcp/server.go
+++ b/adapters/handlers/mcp/server.go
@@ -55,6 +55,8 @@ func NewMCPServer(state *state.State, objectsManager *objects.Manager, reg prome
 		state.ServerConfig.Config.Authentication.AnonymousAccess.Enabled,
 		composer.New(
 			state.ServerConfig.Config.Authentication,
+			state.ServerConfig.Config.Namespaces.Enabled,
+			state.Logger,
 			state.APIKey,
 			state.OIDC,
 		),

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1329,6 +1329,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	api.OidcAuth = composer.New(
 		appState.ServerConfig.Config.Authentication,
+		appState.ServerConfig.Config.Namespaces.Enabled, appState.Logger,
 		appState.APIKey, appState.OIDC)
 
 	api.Logger = func(msg string, args ...interface{}) {

--- a/usecases/auth/authentication/composer/token_validation.go
+++ b/usecases/auth/authentication/composer/token_validation.go
@@ -16,6 +16,7 @@ import (
 
 	openapi "github.com/go-openapi/errors"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/config"
 )
@@ -26,7 +27,27 @@ type TokenFunc func(token string, scopes []string) (*models.Principal, error)
 // function that validates the token either as OIDC or as an StaticAPIKey token
 // depending on which is configured. If both are configured, the scheme is
 // figured out at runtime.
-func New(config config.Authentication,
+//
+// On namespace-enabled clusters every authenticated principal must be either
+// namespace-confined or a global operator; the returned function rejects any
+// principal that is neither (see assertClassified).
+func New(config config.Authentication, namespacesEnabled bool, logger logrus.FieldLogger,
+	apikey authValidator, oidc authValidator,
+) TokenFunc {
+	inner := selectScheme(config, apikey, oidc)
+	return func(token string, scopes []string) (*models.Principal, error) {
+		principal, err := inner(token, scopes)
+		if err != nil {
+			return nil, err
+		}
+		if err := assertClassified(principal, namespacesEnabled, logger); err != nil {
+			return nil, err
+		}
+		return principal, nil
+	}
+}
+
+func selectScheme(config config.Authentication,
 	apikey authValidator, oidc authValidator,
 ) TokenFunc {
 	if config.AnyApiKeyAvailable() && config.OIDC.Enabled {
@@ -46,6 +67,22 @@ func New(config config.Authentication,
 			"but an 'Authorization' header was provided. Please configure an auth scheme "+
 			"or remove the header for anonymous access")
 	}
+}
+
+// assertClassified rejects an authenticated principal that carries no namespace
+// and no global-operator flag on a namespace-enabled cluster. Such a principal
+// would otherwise be treated as a least-privilege caller with cluster-wide
+// reach; fail immediately instead.
+func assertClassified(principal *models.Principal, namespacesEnabled bool, logger logrus.FieldLogger) error {
+	if !namespacesEnabled || principal == nil {
+		return nil
+	}
+	if principal.Namespace == "" && !principal.IsGlobalOperator {
+		logger.WithField("user", principal.Username).
+			Warn("rejecting authenticated principal with neither a namespace nor global-operator classification on namespace-enabled cluster")
+		return openapi.New(401, "unauthorized: principal is neither namespace-confined nor a global operator")
+	}
+	return nil
 }
 
 func pickAuthSchemeDynamically(

--- a/usecases/auth/authentication/composer/token_validation_test.go
+++ b/usecases/auth/authentication/composer/token_validation_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
@@ -23,13 +24,14 @@ import (
 
 func Test_TokenAuthComposer(t *testing.T) {
 	type test struct {
-		name         string
-		token        string
-		config       config.Authentication
-		oidc         TokenFunc
-		apiKey       TokenFunc
-		expectErr    bool
-		expectErrMsg string
+		name              string
+		token             string
+		config            config.Authentication
+		namespacesEnabled bool
+		oidc              TokenFunc
+		apiKey            TokenFunc
+		expectErr         bool
+		expectErrMsg      string
 	}
 
 	tests := []test{
@@ -214,12 +216,75 @@ func Test_TokenAuthComposer(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "john doe",
 		},
+		{
+			name: "namespaces enabled - rejects global non-operator principal",
+			config: config.Authentication{
+				APIKey: config.StaticAPIKey{Enabled: true},
+			},
+			namespacesEnabled: true,
+			token:             "does not matter",
+			apiKey: func(t string, s []string) (*models.Principal, error) {
+				return &models.Principal{Username: "drifted", Namespace: "", IsGlobalOperator: false}, nil
+			},
+			oidc: func(t string, s []string) (*models.Principal, error) {
+				panic("i should never be called")
+			},
+			expectErr:    true,
+			expectErrMsg: "neither namespace-confined nor a global operator",
+		},
+		{
+			name: "namespaces enabled - allows global operator principal",
+			config: config.Authentication{
+				APIKey: config.StaticAPIKey{Enabled: true},
+			},
+			namespacesEnabled: true,
+			token:             "does not matter",
+			apiKey: func(t string, s []string) (*models.Principal, error) {
+				return &models.Principal{Username: "root", Namespace: "", IsGlobalOperator: true}, nil
+			},
+			oidc: func(t string, s []string) (*models.Principal, error) {
+				panic("i should never be called")
+			},
+			expectErr: false,
+		},
+		{
+			name: "namespaces enabled - allows namespace-confined principal",
+			config: config.Authentication{
+				APIKey: config.StaticAPIKey{Enabled: true},
+			},
+			namespacesEnabled: true,
+			token:             "does not matter",
+			apiKey: func(t string, s []string) (*models.Principal, error) {
+				return &models.Principal{Username: "ns-user", Namespace: "ns1", IsGlobalOperator: false}, nil
+			},
+			oidc: func(t string, s []string) (*models.Principal, error) {
+				panic("i should never be called")
+			},
+			expectErr: false,
+		},
+		{
+			name: "namespaces disabled - allows global non-operator principal",
+			config: config.Authentication{
+				APIKey: config.StaticAPIKey{Enabled: true},
+			},
+			namespacesEnabled: false,
+			token:             "does not matter",
+			apiKey: func(t string, s []string) (*models.Principal, error) {
+				return &models.Principal{Username: "regular", Namespace: "", IsGlobalOperator: false}, nil
+			},
+			oidc: func(t string, s []string) (*models.Principal, error) {
+				panic("i should never be called")
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			v := New(
 				test.config,
+				test.namespacesEnabled,
+				logrus.New(),
 				fakeValidator{v: test.apiKey},
 				fakeValidator{v: test.oidc},
 			)

--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -44,13 +44,11 @@ func (m *Manager) auditFields(principal *models.Principal) logrus.Fields {
 		case principal.Namespace != "":
 			f["namespace"] = principal.Namespace
 		default:
-			// Defense-in-depth: every namespace enabled principal must be classified
-			// as namespace-bound or global upstream. If a producer drifts,
-			// default to global (no namespace claim is leaked) and warn so
-			// the gap surfaces.
+			// Producer drift: principal carries neither a namespace nor the
+			// operator flag. Label it unclassified rather than operator, and warn.
 			m.logger.WithField("user", principal.Username).
-				Warn("rbac: principal missing namespace and global classification on namespace enabled cluster; defaulting to global_operator")
-			f["global_operator"] = true
+				Warn("rbac: principal missing namespace and global-operator classification on namespace-enabled cluster")
+			f["unclassified"] = true
 		}
 	}
 	return f

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -878,15 +878,11 @@ func TestAudit_NamespaceFields_DenyPath(t *testing.T) {
 	require.False(t, hasGlobal)
 }
 
-// TestAudit_MalformedPrincipal_DefaultsToGlobalAndWarns covers the
-// defense-in-depth branch in auditFields: an namespace enabled cluster receiving
-// a principal with neither IsGlobalOperator nor Namespace set still emits
-// global_operator=true on the audit entry (audit invariant: exactly one
-// of the two top-level fields is present), and a Warn-level entry surfaces
-// to flag the producer-side drift. Upstream classification prevents this
-// in normal operation; this guards against future producers forgetting
-// to classify.
-func TestAudit_MalformedPrincipal_DefaultsToGlobalAndWarns(t *testing.T) {
+// TestAudit_MalformedPrincipal_MarksUnclassifiedAndWarns covers the
+// drift branch in auditFields: on a namespace enabled cluster a principal with
+// neither IsGlobalOperator nor Namespace set is labeled unclassified=true (not
+// global_operator) and a Warn-level entry surfaces the producer-side drift.
+func TestAudit_MalformedPrincipal_MarksUnclassifiedAndWarns(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	m, err := setupNSEnabledTestManager(t, logger)
 	require.NoError(t, err)
@@ -914,10 +910,12 @@ func TestAudit_MalformedPrincipal_DefaultsToGlobalAndWarns(t *testing.T) {
 		}
 	}
 	require.NotNil(t, warnEntry, "warn must surface for misclassified principal")
-	require.Contains(t, warnEntry.Message, "missing namespace and global classification")
+	require.Contains(t, warnEntry.Message, "missing namespace and global-operator classification")
 
 	require.NotNil(t, infoEntry, "audit info entry must still be emitted")
-	require.Equal(t, true, infoEntry.Data["global_operator"])
+	require.Equal(t, true, infoEntry.Data["unclassified"])
+	_, hasGlobal := infoEntry.Data["global_operator"]
+	require.False(t, hasGlobal, "unclassified principal must not be labeled global_operator")
 	_, hasNS := infoEntry.Data["namespace"]
 	require.False(t, hasNS)
 }


### PR DESCRIPTION
### What's being changed:

On namespaced clusters a principal can be one of two things:
- namespaced
- global operator

However the internal state allows a third state: no namespace + non-operator (can we have sum-types please?). This state is currently not reachable from any code-path but we want to make sure that it is not opened by accident in the future.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
