### PR TITLE
Fix/hnsw repair global entrypoint

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -653,6 +653,62 @@ func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error 
 	return nil
 }
 
+// repairGlobalEntrypoint attempts to repair a broken global entrypoint during insert.
+// It is called from the insert path when the global entrypoint is unusable (e.g., under
+// maintenance or vector unavailable). The function finds a new valid entrypoint and
+// atomically updates it using CAS semantics.
+//
+// Parameters:
+//   - oldEntrypoint: the entrypoint that was found to be unusable
+//   - localDeny: nodes already tried and rejected during local fallback
+//
+// Returns the new entrypoint ID, or an error if no valid entrypoint can be found.
+// If another goroutine already repaired the entrypoint (CAS fails), returns the
+// current entrypoint value.
+func (h *hnsw) repairGlobalEntrypoint(oldEntrypoint uint64, localDeny helpers.AllowList) (uint64, error) {
+	// Build denyList: exclude oldEntrypoint + known-bad local nodes
+	denyList := localDeny.WrapOnWrite()
+	denyList.Insert(oldEntrypoint)
+
+	// Get the old entrypoint's level (best effort - may be nil if already deleted)
+	var targetLevel int
+	if node := h.nodeByID(oldEntrypoint); node != nil {
+		node.Lock()
+		targetLevel = node.level
+		node.Unlock()
+	}
+
+	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, targetLevel, oldEntrypoint)
+	if !ok {
+		// No change: either graph is empty, or entrypoint was already changed by concurrent op
+		currentEp := h.getEntrypoint()
+		if currentEp == oldEntrypoint {
+			// Graph is empty or only unusable nodes remain
+			return 0, fmt.Errorf("no valid entrypoint available")
+		}
+		// Someone else already repaired it
+		return currentEp, nil
+	}
+
+	// CAS: only update if entrypoint hasn't changed since we started
+	h.Lock()
+	if h.entryPointID == oldEntrypoint {
+		// CAS success: update in-memory first, then persist (matches deleteEntrypoint)
+		h.entryPointID = newEntrypoint
+		h.currentMaximumLayer = level
+		if err := h.commitLog.SetEntryPointWithMaxLayer(newEntrypoint, level); err != nil {
+			h.Unlock()
+			return 0, fmt.Errorf("persist entrypoint: %w", err)
+		}
+		h.Unlock()
+		return newEntrypoint, nil
+	}
+	// CAS failed: concurrent op already changed the entrypoint
+	currentEp := h.entryPointID
+	h.Unlock()
+	return currentEp, nil
+}
+
 // returns entryPointID, level and whether a change occurred
 func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel int,
 	oldEntrypoint uint64,

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
@@ -1,0 +1,438 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// countingCommitLogger wraps NoopCommitLogger and counts SetEntryPointWithMaxLayer calls
+type countingCommitLogger struct {
+	NoopCommitLogger
+	setEntrypointCalls atomic.Int32
+}
+
+func (c *countingCommitLogger) SetEntryPointWithMaxLayer(id uint64, level int) error {
+	c.setEntrypointCalls.Add(1)
+	return nil
+}
+
+func makeCountingCommitLogger(counter *countingCommitLogger) func() (CommitLogger, error) {
+	return func() (CommitLogger, error) {
+		return counter, nil
+	}
+}
+
+// TestEntrypointRepair_GlobalEntrypointUnderMaintenance tests the primary scenario:
+// when the global entrypoint is marked under maintenance, an insert should trigger
+// repair and succeed (not hang or timeout).
+func TestEntrypointRepair_GlobalEntrypointUnderMaintenance(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	// Build index with several nodes
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil // fallback for new inserts
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes to establish the index
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Get the current entrypoint
+	originalEntrypoint := index.entryPointID
+	require.True(t, originalEntrypoint < uint64(len(vectors)), "entrypoint should be one of the initial nodes")
+
+	// Mark the global entrypoint as under maintenance
+	entrypointNode := index.nodeByID(originalEntrypoint)
+	require.NotNil(t, entrypointNode, "entrypoint node should exist")
+	entrypointNode.markAsMaintenance()
+
+	// Perform an insert with a short timeout - should NOT hang
+	insertDone := make(chan error, 1)
+	newVector := []float32{0.5, 0.5, 0.5}
+	newID := uint64(len(vectors))
+
+	go func() {
+		insertDone <- index.Add(ctx, newID, newVector)
+	}()
+
+	select {
+	case err := <-insertDone:
+		// Insert terminated - check result
+		// On unfixed code, this may be an error or the test may hang
+		// On fixed code, this should succeed
+		if err != nil {
+			t.Fatalf("insert failed with error: %v (expected success after repair)", err)
+		}
+
+		// Verify the entrypoint was repaired to a valid node (not under maintenance)
+		newEntrypoint := index.entryPointID
+		if newEntrypoint == originalEntrypoint {
+			// Either repair happened and selected a different node, or repair didn't happen
+			// In either case, the original entrypoint is still under maintenance
+			newEntrypointNode := index.nodeByID(newEntrypoint)
+			if newEntrypointNode != nil && newEntrypointNode.isUnderMaintenance() {
+				t.Errorf("entrypoint is still under maintenance after insert - repair did not happen")
+			}
+		}
+
+		// Verify the new node was inserted
+		insertedNode := index.nodeByID(newID)
+		assert.NotNil(t, insertedNode, "inserted node should exist in the index")
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup: unmark maintenance so Drop can proceed cleanly
+	entrypointNode.unmarkAsMaintenance()
+}
+
+// TestEntrypointRepair_RepairSelectsAlsoUnusableNode tests Case B:
+// repair selects a node that is also unusable → insert ends in clean error, no hang.
+func TestEntrypointRepair_RepairSelectsAlsoUnusableNode(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-also-unusable-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Mark ALL nodes as under maintenance - repair cannot find any usable node
+	for i := 0; i < len(vectors); i++ {
+		node := index.nodeByID(uint64(i))
+		if node != nil {
+			node.markAsMaintenance()
+		}
+	}
+
+	// Perform an insert - should fail with clean error, not hang
+	insertDone := make(chan error, 1)
+	newVector := []float32{0.5, 0.5, 0.5}
+	newID := uint64(len(vectors))
+
+	go func() {
+		insertDone <- index.Add(ctx, newID, newVector)
+	}()
+
+	select {
+	case err := <-insertDone:
+		// Should get a clean error, not success (no usable entrypoint)
+		assert.Error(t, err, "expected error when all nodes are under maintenance")
+		// The error should indicate no usable entrypoint, not a timeout
+		assert.NotContains(t, err.Error(), "context deadline exceeded",
+			"should fail with entrypoint error, not timeout")
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup
+	for i := 0; i < len(vectors); i++ {
+		node := index.nodeByID(uint64(i))
+		if node != nil {
+			node.unmarkAsMaintenance()
+		}
+	}
+}
+
+// TestEntrypointRepair_ConcurrentRepairAlreadyChanged tests Case C:
+// concurrent repair already changed the entrypoint → the repaired value is used.
+func TestEntrypointRepair_ConcurrentRepairAlreadyChanged(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-concurrent-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	originalEntrypoint := index.entryPointID
+
+	// Mark the original entrypoint under maintenance
+	originalNode := index.nodeByID(originalEntrypoint)
+	require.NotNil(t, originalNode)
+	originalNode.markAsMaintenance()
+
+	// Simulate concurrent repair: manually change the entrypoint to a different valid node
+	// before the insert's repair runs
+	var newEntrypointID uint64
+	for i := uint64(0); i < uint64(len(vectors)); i++ {
+		if i != originalEntrypoint {
+			node := index.nodeByID(i)
+			if node != nil && !node.isUnderMaintenance() {
+				newEntrypointID = i
+				break
+			}
+		}
+	}
+	require.NotEqual(t, originalEntrypoint, newEntrypointID, "should find a different valid node")
+
+	// Manually set the entrypoint (simulating concurrent repair)
+	index.Lock()
+	index.entryPointID = newEntrypointID
+	index.Unlock()
+
+	// Now perform an insert - should use the already-repaired entrypoint
+	insertDone := make(chan error, 1)
+	newVector := []float32{0.5, 0.5, 0.5}
+	newID := uint64(len(vectors))
+
+	go func() {
+		insertDone <- index.Add(ctx, newID, newVector)
+	}()
+
+	select {
+	case err := <-insertDone:
+		assert.NoError(t, err, "insert should succeed using the concurrently-repaired entrypoint")
+
+		// Verify the entrypoint is still the one set by concurrent repair
+		assert.Equal(t, newEntrypointID, index.entryPointID,
+			"entrypoint should remain the one set by concurrent repair")
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup
+	originalNode.unmarkAsMaintenance()
+}
+
+// TestEntrypointRepair_ConcurrentInserts tests the concurrency scenario:
+// several inserts hit the bad entrypoint at once, only one repair should perform
+// the actual update (CAS semantics), and the entrypoint should end on a single
+// consistent valid value.
+func TestEntrypointRepair_ConcurrentInserts(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	// Use a counting commit logger to verify exactly one repair persists
+	commitLogger := &countingCommitLogger{}
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-concurrent-inserts-test",
+		MakeCommitLoggerThunk: makeCountingCommitLogger(commitLogger),
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors)+10 { // allow for new inserts
+				if int(id) < len(vectors) {
+					return vectors[id], nil
+				}
+				return []float32{0.5, 0.5, 0.5}, nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Record baseline SetEntryPointWithMaxLayer calls (from initial inserts that promoted entrypoint)
+	baselineCalls := commitLogger.setEntrypointCalls.Load()
+
+	originalEntrypoint := index.entryPointID
+
+	// Mark the entrypoint under maintenance
+	entrypointNode := index.nodeByID(originalEntrypoint)
+	require.NotNil(t, entrypointNode)
+	entrypointNode.markAsMaintenance()
+
+	// Launch multiple concurrent inserts with a start barrier to ensure overlap
+	const numConcurrentInserts = 10
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+	var errorCount atomic.Int32
+
+	// Start barrier: all goroutines wait here until all are ready
+	startBarrier := make(chan struct{})
+
+	for i := 0; i < numConcurrentInserts; i++ {
+		wg.Add(1)
+		go func(insertNum int) {
+			defer wg.Done()
+
+			// Wait for start signal
+			<-startBarrier
+
+			newID := uint64(len(vectors) + insertNum)
+			newVector := []float32{0.5 + float32(insertNum)*0.01, 0.5, 0.5}
+
+			err := index.Add(ctx, newID, newVector)
+			if err != nil {
+				errorCount.Add(1)
+			} else {
+				successCount.Add(1)
+			}
+		}(i)
+	}
+
+	// Release all goroutines simultaneously
+	close(startBarrier)
+
+	// Wait with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All inserts completed
+		t.Logf("Concurrent inserts completed: %d successes, %d errors",
+			successCount.Load(), errorCount.Load())
+
+		// All inserts should succeed (after repair)
+		assert.Equal(t, int32(numConcurrentInserts), successCount.Load(),
+			"all concurrent inserts should succeed after repair")
+
+		// The entrypoint should be consistent and valid (not under maintenance)
+		finalEntrypoint := index.entryPointID
+		finalNode := index.nodeByID(finalEntrypoint)
+		require.NotNil(t, finalNode, "final entrypoint node should exist")
+		assert.False(t, finalNode.isUnderMaintenance(),
+			"final entrypoint should not be under maintenance")
+
+		// Verify exactly one repair SetEntryPointWithMaxLayer call was made
+		// (CAS ensures only one goroutine performs the actual persist)
+		repairCalls := commitLogger.setEntrypointCalls.Load() - baselineCalls
+		assert.Equal(t, int32(1), repairCalls,
+			"exactly one SetEntryPointWithMaxLayer should be called for repair (CAS)")
+
+		// Verify entrypoint changed from original
+		assert.NotEqual(t, originalEntrypoint, finalEntrypoint,
+			"entrypoint should have been repaired to a different node")
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent inserts did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup
+	entrypointNode.unmarkAsMaintenance()
+}
+
+// vectorsForEntrypointRepairTest returns a small set of test vectors
+func vectorsForEntrypointRepairTest() [][]float32 {
+	return [][]float32{
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+		{0.7, 0.8, 0.9},
+		{0.2, 0.3, 0.4},
+		{0.5, 0.6, 0.7},
+	}
+}

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -447,34 +447,44 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 
 	candidate := n.entryPointID
 
-	// for our search we will need a copy of the current deny list, however, the
-	// cost of that copy can be significant. Let's first verify if the global
-	// entrypoint candidate is usable. If yes, we can return early and skip the
-	// copy.
-	success, err := n.tryEpCandidate(candidate)
+	// [1] Fast path: try the cached global entrypoint.
+	// ErrNotFound (deleted node) is treated as "not usable" and proceeds to repair,
+	// not returned as error - see tryEpCandidateIgnoreDeleted.
+	success, err := n.tryEpCandidateIgnoreDeleted(candidate)
 	if err != nil {
-		var e storobj.ErrNotFound
-		if !errors.As(err, &e) {
-			return err
-		}
-
-		// node was deleted in the meantime
-		// ignore the error and move to the logic below which will try more candidates
+		return err
 	}
-
 	if success {
-		// the global ep candidate is usable, let's skip the following logic (and
-		// therefore avoid the copy)
 		return nil
 	}
 
-	// The global candidate is not usable, we need to find a new one.
+	// [2] Global candidate failed → attempt global repair ONCE
 	localDeny := n.denyList.WrapOnWrite()
+	localDeny.Insert(candidate)
 
-	// make sure the loop cannot block forever. In most cases, results should be
-	// found within micro to milliseconds, this is just a last resort to handle
-	// the unknown somewhat gracefully, for example if there is a bug in the
-	// underlying object store and we cannot retrieve the vector in time, etc.
+	newEp, err := n.graph.repairGlobalEntrypoint(candidate, localDeny)
+	if err != nil {
+		return fmt.Errorf("global entrypoint repair: %w", err)
+	}
+
+	// [3] Try the repaired entrypoint (or concurrent repair's result).
+	// Note: newEp != candidate is always true when repair succeeds without error,
+	// because candidate (oldEntrypoint) is excluded via denyList. This guard is
+	// defensive documentation, not a reachable branch.
+	if newEp != candidate {
+		success, err = n.tryEpCandidateIgnoreDeleted(newEp)
+		if err != nil {
+			return err
+		}
+		if success {
+			return nil
+		}
+		localDeny.Insert(newEp)
+		candidate = newEp
+	}
+
+	// [4] Repaired entrypoint also failed → local fallback with no-progress backstop
+	// 60s timeout is last-resort safety net, not expected path
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	n.graph.logger.WithFields(logrus.Fields{
@@ -487,32 +497,43 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 			return err
 		}
 
-		success, err := n.tryEpCandidate(candidate)
-		if err != nil {
-			var e storobj.ErrNotFound
-			if !errors.As(err, &e) {
-				return err
-			}
-
-			// node was deleted in the meantime
-			// ignore the error and try the next candidate
-		}
-
-		if success {
-			return nil
-		}
-
-		// no success so far, we need to keep going and find a better candidate
-		// make sure we never visit this candidate again
-		localDeny.Insert(candidate)
-		// now find a new one
-
 		alternative, err := n.graph.findNewLocalEntrypoint(localDeny, candidate)
 		if err != nil {
 			return err
 		}
+
+		// No-progress detection: if we get the same candidate back or one already tried
+		if alternative == candidate || localDeny.Contains(alternative) {
+			return fmt.Errorf("no usable entrypoint: local fallback exhausted")
+		}
+
 		candidate = alternative
+
+		success, err = n.tryEpCandidateIgnoreDeleted(candidate)
+		if err != nil {
+			return err
+		}
+		if success {
+			return nil
+		}
+		localDeny.Insert(candidate)
 	}
+}
+
+// tryEpCandidateIgnoreDeleted wraps tryEpCandidate and handles the ErrNotFound case
+// consistently: deleted nodes are treated as "not usable" (returns false, nil),
+// while other errors are propagated.
+func (n *neighborFinderConnector) tryEpCandidateIgnoreDeleted(candidate uint64) (bool, error) {
+	success, err := n.tryEpCandidate(candidate)
+	if err != nil {
+		var e storobj.ErrNotFound
+		if errors.As(err, &e) {
+			// Node was deleted - treat as not usable, not as error
+			return false, nil
+		}
+		return false, err
+	}
+	return success, nil
 }
 
 func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error) {


### PR DESCRIPTION
### What's being changed:

When an insert finds the HNSW global entrypoint unusable, it now **repairs the entrypoint once** via the existing `findNewGlobalEntrypoint` machinery and continues, instead of spinning in the `pickEntrypoint` → `findNewLocalEntrypoint` fallback scan.

**The problem:** if the global entrypoint is rejected by `tryEpCandidate` (node nil, under maintenance, or no retrievable vector), `pickEntrypoint` falls into a local-entrypoint scan that can fail to terminate — `findNewLocalEntrypoint` returns `0` both as a valid node ID and as a "not found" sentinel, so the caller retries the same unusable candidate until a 60s context timeout. On a large index that scan is O(n) over millions of nodes. This is the insert-side CPU spike behind the stalled backups: the stuck insert never completes, the vector-queue drain (`PrepareForBackup` → `Pause` → `SharedGauge.Wait`) never reaches zero, and the next scheduled backup reports *"backup already in progress."*

**The fix:**
- New `repairGlobalEntrypoint(oldEntrypoint, localDeny)` in `delete.go`: builds a deny list that **excludes `oldEntrypoint`** (so `findNewGlobalEntrypoint` can't re-select the broken node — it does not exclude it on its own), finds a new valid entrypoint, and updates `entryPointID` / `currentMaximumLayer` under `h.Lock()` using a CAS check (`h.entryPointID == oldEntrypoint`). Persistence via `SetEntryPointWithMaxLayer` happens **only** in the CAS-success branch, in the same in-memory-then-persist order as `deleteEntrypoint`.
- Revised `pickEntrypoint` control flow: [1] try the global entrypoint; [2] if it fails, attempt global repair once; [3] try the repaired entrypoint; [4] only then fall back to a local scan, now bounded by a no-progress check (`alternative == candidate || localDeny.Contains(alternative)`) that returns a clean error instead of spinning. The 60s timeout remains only as an unreachable last-resort safety net.
- Error handling around `tryEpCandidate` (deleted-node `ErrNotFound` treated as "not usable", other errors propagated) is extracted into a single `tryEpCandidateIgnoreDeleted` helper so the three call sites can't diverge.

**Concurrency:** multiple inserts hitting the same broken entrypoint are handled by the CAS — only one goroutine performs the actual update and persist; the rest observe the repaired value. The repair runs under `deleteVsInsertLock.RLock()`, and lock-ordering analysis confirmed all paths acquire `deleteVsInsertLock` before `h`'s mutex (no ABBA deadlock); `SetEntryPointWithMaxLayer` is a non-blocking buffered write, so persisting inside `h.Lock()` is safe.

Commits are test-first: commit 1 adds tests that reproduce the scenarios (entrypoint under maintenance → repair; repair-selects-also-unusable → clean termination, no hang; concurrent inserts) and **FAIL** on the base branch; commit 2 applies the fix and they **PASS**.

Based on `stable/v1.36` (clean base, independent of the maintenance-flag PR).

### Review checklist
- [ ] Documentation has been updated, if necessary. Link to changed documentation: _not necessary — internal HNSW behavior, no user-facing or API change_
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable. _Repair, termination, and concurrency paths covered red→green; concurrency test asserts exactly one persist under a start barrier, green under `-race`._
- [ ] Performance tests have been run or not necessary.