### PR TITLE
Fix/hnsw bound backup drain

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -419,6 +419,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		LazyLoadShardSizeThresholdGB:        appState.ServerConfig.Config.LazyLoadShardSizeThresholdGB,
 		ForceFullReplicasSearch:             appState.ServerConfig.Config.ForceFullReplicasSearch,
 		TransferInactivityTimeout:           appState.ServerConfig.Config.TransferInactivityTimeout,
+		QueueDrainTimeout:                   appState.ServerConfig.Config.QueueDrainTimeout,
 		ObjectsTTLBatchSize:                 appState.ServerConfig.Config.ObjectsTTLBatchSize,
 		ObjectsTTLPauseEveryNoBatches:       appState.ServerConfig.Config.ObjectsTTLPauseEveryNoBatches,
 		ObjectsTTLPauseDuration:             appState.ServerConfig.Config.ObjectsTTLPauseDuration,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -879,6 +879,7 @@ type IndexConfig struct {
 	EnableLazyLoadShards                bool
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
+	QueueDrainTimeout                   time.Duration
 	LSMEnableSegmentsChecksumValidation bool
 	TrackVectorDimensions               bool
 	TrackVectorDimensionsInterval       time.Duration

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -175,6 +175,7 @@ func (db *DB) init(ctx context.Context) error {
 				}(),
 				ForceFullReplicasSearch:                      db.config.ForceFullReplicasSearch,
 				TransferInactivityTimeout:                    db.config.TransferInactivityTimeout,
+				QueueDrainTimeout:                            db.config.QueueDrainTimeout,
 				LSMEnableSegmentsChecksumValidation:          db.config.LSMEnableSegmentsChecksumValidation,
 				ReplicationFactor:                            class.ReplicationConfig.Factor,
 				AsyncReplicationEnabled:                      class.ReplicationConfig.AsyncEnabled,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -199,6 +199,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			}(),
 			ForceFullReplicasSearch:                      m.db.config.ForceFullReplicasSearch,
 			TransferInactivityTimeout:                    m.db.config.TransferInactivityTimeout,
+			QueueDrainTimeout:                            m.db.config.QueueDrainTimeout,
 			LSMEnableSegmentsChecksumValidation:          m.db.config.LSMEnableSegmentsChecksumValidation,
 			ReplicationFactor:                            class.ReplicationConfig.Factor,
 			AsyncReplicationEnabled:                      class.ReplicationConfig.AsyncEnabled,

--- a/adapters/repos/db/queue/prepare_for_backup_test.go
+++ b/adapters/repos/db/queue/prepare_for_backup_test.go
@@ -74,12 +74,7 @@ func TestPrepareForBackup_DrainTimeout(t *testing.T) {
 	drainTimeout := 100 * time.Millisecond
 	startTime := time.Now()
 
-	// Use context with timeout to simulate drainTimeout parameter
-	// (In the fix, the signature will change to PrepareForBackup(ctx, drainTimeout))
-	drainCtx, cancel := context.WithTimeout(t.Context(), drainTimeout)
-	defer cancel()
-
-	err := q.PrepareForBackup(drainCtx)
+	err := q.PrepareForBackup(t.Context(), drainTimeout)
 	elapsed := time.Since(startTime)
 
 	// Assert: completes within bounded time (well under blocking task duration)
@@ -135,10 +130,7 @@ func TestPrepareForBackup_NormalDrain(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call PrepareForBackup with generous timeout
-	drainCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-
-	err = q.PrepareForBackup(drainCtx)
+	err = q.PrepareForBackup(t.Context(), 5*time.Second)
 
 	// Assert: succeeds
 	require.NoError(t, err, "PrepareForBackup should succeed with fast-completing tasks")
@@ -155,10 +147,7 @@ func TestPrepareForBackup_NormalDrain(t *testing.T) {
 // TestPrepareForBackup_ZeroTimeoutMeansUnbounded verifies that with
 // drainTimeout == 0 (no timeout), PrepareForBackup does NOT abort instantly.
 // A quickly-completing drain should still succeed.
-//
-// NOTE: This test uses context.Background() to simulate drainTimeout == 0.
-// In the fix, the signature will change to PrepareForBackup(ctx, drainTimeout)
-// where drainTimeout == 0 means unbounded wait.
+// drainTimeout == 0 means unbounded wait (honors only parent ctx deadline).
 func TestPrepareForBackup_ZeroTimeoutMeansUnbounded(t *testing.T) {
 	s := makeScheduler(t, 1)
 	s.Start()
@@ -182,11 +171,10 @@ func TestPrepareForBackup_ZeroTimeoutMeansUnbounded(t *testing.T) {
 	err := q.Wait(t.Context())
 	require.NoError(t, err)
 
-	// Call PrepareForBackup with NO timeout (context.Background)
-	// This simulates drainTimeout == 0 which means unbounded wait.
+	// Call PrepareForBackup with drainTimeout == 0 (unbounded wait).
 	// The key assertion is that this does NOT abort instantly (as would happen
 	// if we incorrectly wrapped with context.WithTimeout(ctx, 0)).
-	err = q.PrepareForBackup(context.Background())
+	err = q.PrepareForBackup(t.Context(), 0)
 
 	// Assert: succeeds (does NOT abort instantly)
 	require.NoError(t, err,

--- a/adapters/repos/db/queue/prepare_for_backup_test.go
+++ b/adapters/repos/db/queue/prepare_for_backup_test.go
@@ -1,0 +1,198 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package queue
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrepareForBackup_DrainTimeout verifies that when a task blocks and the
+// drain times out, PrepareForBackup returns an error containing "drain" and
+// the queue ID, completes within a bounded time, leaves the queue NOT paused
+// (Resume ran), and does NOT enable maintenance mode (snapshot must not proceed
+// with in-flight tasks).
+func TestPrepareForBackup_DrainTimeout(t *testing.T) {
+	s := makeScheduler(t, 1)
+	s.Start()
+	defer s.Close(t.Context())
+
+	// Create a blocking task that never completes
+	blockCh := make(chan struct{})
+	started := make(chan struct{})
+	var taskStarted atomic.Bool
+
+	decoder := &mockTaskDecoder{
+		execFn: func(ctx context.Context, task *mockTask) error {
+			if !taskStarted.Swap(true) {
+				close(started)
+			}
+			// Block until test cleanup or context cancelled
+			select {
+			case <-blockCh:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+
+	q := makeQueueSize(t, s, decoder, 50)
+	defer func() {
+		close(blockCh) // unblock task for cleanup
+		q.Close(t.Context())
+	}()
+
+	// Push a task that will block
+	pushMany(t, q, 1, 100)
+
+	// Trigger scheduling and wait for the task to start executing
+	s.Schedule(t.Context())
+	select {
+	case <-started:
+		// Task is now blocking
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for blocking task to start")
+	}
+
+	// Call PrepareForBackup with a short timeout
+	drainTimeout := 100 * time.Millisecond
+	startTime := time.Now()
+
+	// Use context with timeout to simulate drainTimeout parameter
+	// (In the fix, the signature will change to PrepareForBackup(ctx, drainTimeout))
+	drainCtx, cancel := context.WithTimeout(t.Context(), drainTimeout)
+	defer cancel()
+
+	err := q.PrepareForBackup(drainCtx)
+	elapsed := time.Since(startTime)
+
+	// Assert: completes within bounded time (well under blocking task duration)
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"PrepareForBackup should complete within bounded time, not wait for blocking task")
+
+	// Assert: returns an error containing relevant information
+	// NOTE: Current code has a bug where error is discarded. This assertion
+	// catches the bug: it should fail until the fix is applied.
+	if assert.Error(t, err, "PrepareForBackup should return error when drain times out") {
+		assert.True(t, strings.Contains(err.Error(), "drain") ||
+			strings.Contains(err.Error(), "timeout") ||
+			strings.Contains(err.Error(), "deadline"),
+			"error should mention drain/timeout/deadline, got: %v", err)
+	}
+
+	// Assert: queue is NOT left paused (Resume ran via defer)
+	assert.False(t, s.IsQueuePaused(q.id),
+		"queue should not be left paused after PrepareForBackup error")
+
+	// Assert: maintenance mode was NOT enabled
+	// This is the key assertion that catches the discarded-error bug:
+	// current code enables maintenance mode despite the timeout error.
+	assert.False(t, q.maintenanceMode.Load(),
+		"maintenance mode should NOT be enabled when drain fails - would create inconsistent snapshot")
+}
+
+// TestPrepareForBackup_NormalDrain verifies that with fast-completing tasks,
+// PrepareForBackup succeeds, enables maintenance mode, and resumes the queue.
+func TestPrepareForBackup_NormalDrain(t *testing.T) {
+	s := makeScheduler(t, 1)
+	s.Start()
+	defer s.Close(t.Context())
+
+	// Create fast-completing tasks
+	decoder := &mockTaskDecoder{
+		execFn: func(ctx context.Context, task *mockTask) error {
+			return nil // complete immediately
+		},
+	}
+
+	q := makeQueueSize(t, s, decoder, 50)
+	defer q.Close(t.Context())
+
+	// Push some tasks
+	pushMany(t, q, 1, 100, 200, 300)
+
+	// Trigger scheduling
+	s.Schedule(t.Context())
+
+	// Wait for tasks to complete
+	err := q.Wait(t.Context())
+	require.NoError(t, err)
+
+	// Call PrepareForBackup with generous timeout
+	drainCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	err = q.PrepareForBackup(drainCtx)
+
+	// Assert: succeeds
+	require.NoError(t, err, "PrepareForBackup should succeed with fast-completing tasks")
+
+	// Assert: maintenance mode is enabled
+	assert.True(t, q.maintenanceMode.Load(),
+		"maintenance mode should be enabled after successful PrepareForBackup")
+
+	// Assert: queue is NOT left paused (Resume ran via defer)
+	assert.False(t, s.IsQueuePaused(q.id),
+		"queue should not be left paused after PrepareForBackup")
+}
+
+// TestPrepareForBackup_ZeroTimeoutMeansUnbounded verifies that with
+// drainTimeout == 0 (no timeout), PrepareForBackup does NOT abort instantly.
+// A quickly-completing drain should still succeed.
+//
+// NOTE: This test uses context.Background() to simulate drainTimeout == 0.
+// In the fix, the signature will change to PrepareForBackup(ctx, drainTimeout)
+// where drainTimeout == 0 means unbounded wait.
+func TestPrepareForBackup_ZeroTimeoutMeansUnbounded(t *testing.T) {
+	s := makeScheduler(t, 1)
+	s.Start()
+	defer s.Close(t.Context())
+
+	// Create fast-completing tasks
+	decoder := &mockTaskDecoder{
+		execFn: func(ctx context.Context, task *mockTask) error {
+			return nil // complete immediately
+		},
+	}
+
+	q := makeQueueSize(t, s, decoder, 50)
+	defer q.Close(t.Context())
+
+	// Push some tasks
+	pushMany(t, q, 1, 100, 200, 300)
+
+	// Trigger scheduling and wait for completion
+	s.Schedule(t.Context())
+	err := q.Wait(t.Context())
+	require.NoError(t, err)
+
+	// Call PrepareForBackup with NO timeout (context.Background)
+	// This simulates drainTimeout == 0 which means unbounded wait.
+	// The key assertion is that this does NOT abort instantly (as would happen
+	// if we incorrectly wrapped with context.WithTimeout(ctx, 0)).
+	err = q.PrepareForBackup(context.Background())
+
+	// Assert: succeeds (does NOT abort instantly)
+	require.NoError(t, err,
+		"PrepareForBackup with zero timeout should NOT abort instantly; quick drain should succeed")
+
+	// Assert: maintenance mode is enabled
+	assert.True(t, q.maintenanceMode.Load(),
+		"maintenance mode should be enabled after successful PrepareForBackup")
+}

--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -478,15 +478,37 @@ func (q *DiskQueue) Wait(ctx context.Context) error {
 	return q.scheduler.Wait(ctx, q.id)
 }
 
-// PrepareForBackup pauses the queue and flushes all tasks to disk to prepare for backup.
-// It also enables maintenance mode, which prevents processed chunk files from being deleted until the backup is complete.
-func (q *DiskQueue) PrepareForBackup(ctx context.Context) error {
-	q.Pause(ctx)
+// PrepareForBackup pauses the queue and waits for in-flight tasks to drain,
+// then flushes all tasks to disk to prepare for backup.
+// It also enables maintenance mode, which prevents processed chunk files from
+// being deleted until the backup is complete.
+//
+// drainTimeout bounds how long to wait for in-flight tasks to complete.
+// If drainTimeout == 0, the wait is unbounded (honors only parent ctx deadline).
+// If the drain times out, an error is returned and maintenance mode is NOT
+// enabled, preventing inconsistent backup snapshots.
+func (q *DiskQueue) PrepareForBackup(ctx context.Context, drainTimeout time.Duration) error {
+	// Pause scheduling immediately (don't wait in Pause, we'll wait explicitly below)
+	q.scheduler.PauseQueue(q.id)
 	defer q.Resume()
-	q.Wait(ctx)
 
-	err := q.Flush()
-	if err != nil {
+	// Apply drain timeout if specified; drainTimeout == 0 means unbounded
+	drainCtx := ctx
+	if drainTimeout > 0 {
+		var cancel context.CancelFunc
+		drainCtx, cancel = context.WithTimeout(ctx, drainTimeout)
+		defer cancel()
+	}
+
+	// Wait for in-flight tasks to complete - capture and propagate the error
+	if err := q.Wait(drainCtx); err != nil {
+		return fmt.Errorf("queue %q drain did not complete within %v "+
+			"(configurable via QUEUE_DRAIN_TIMEOUT); "+
+			"retry expected, investigate stuck tasks if repeated: %w",
+			q.id, drainTimeout, err)
+	}
+
+	if err := q.Flush(); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -310,6 +310,7 @@ type Config struct {
 	LazyLoadShardSizeThresholdGB        float64
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
+	QueueDrainTimeout                   time.Duration
 	LSMEnableSegmentsChecksumValidation bool
 	Replication                         replication.GlobalConfig
 	MaximumConcurrentShardLoads         int

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -77,7 +77,7 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 	}
 	// get the queues ready for backup (e.g. enable maintenance mode, switch to new chunks)
 	_ = s.ForEachVectorQueue(func(targetVector string, q *VectorIndexQueue) error {
-		if err = q.PrepareForBackup(ctx); err != nil {
+		if err = q.PrepareForBackup(ctx, s.index.Config.QueueDrainTimeout); err != nil {
 			return fmt.Errorf("prepare for backup of vector %q: %w", targetVector, err)
 		}
 		return nil

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -159,6 +159,7 @@ type Config struct {
 	LazyLoadShardSizeThresholdGB        float64                `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
 	ForceFullReplicasSearch             bool                   `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	TransferInactivityTimeout           time.Duration          `json:"transfer_inactivity_timeout" yaml:"transfer_inactivity_timeout"`
+	QueueDrainTimeout                   time.Duration          `json:"queue_drain_timeout" yaml:"queue_drain_timeout"`
 	RecountPropertiesAtStartup          bool                   `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
 	ReindexSetToRoaringsetAtStartup     bool                   `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
 	ReindexerGoroutinesFactor           float64                `json:"reindexer_goroutines_factor" yaml:"reindexer_goroutines_factor"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -58,6 +58,7 @@ const (
 	DefaultMaxShardingCount = 512
 
 	DefaultTransferInactivityTimeout = 5 * time.Minute
+	DefaultQueueDrainTimeout         = 60 * time.Second
 
 	DefaultTrackVectorDimensionsInterval = 5 * time.Minute
 )
@@ -175,6 +176,16 @@ func FromEnv(config *Config) error {
 		config.TransferInactivityTimeout = timeout
 	} else {
 		config.TransferInactivityTimeout = DefaultTransferInactivityTimeout
+	}
+
+	if v := os.Getenv("QUEUE_DRAIN_TIMEOUT"); v != "" {
+		timeout, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("parse QUEUE_DRAIN_TIMEOUT as duration: %w", err)
+		}
+		config.QueueDrainTimeout = timeout
+	} else {
+		config.QueueDrainTimeout = DefaultQueueDrainTimeout
 	}
 
 	// Recount all property lengths at startup to support accurate BM25 scoring

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1555,3 +1555,37 @@ func TestEnvironmentAsyncIndexing(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentQueueDrainTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		expected    time.Duration
+		expectError bool
+	}{
+		{"valid duration 30s", "30s", 30 * time.Second, false},
+		{"valid duration 2m", "2m", 2 * time.Minute, false},
+		{"valid duration 500ms", "500ms", 500 * time.Millisecond, false},
+		{"default when not set", "", DefaultQueueDrainTimeout, false},
+		{"invalid format", "not-a-duration", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.value != "" {
+				t.Setenv("QUEUE_DRAIN_TIMEOUT", tt.value)
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "QUEUE_DRAIN_TIMEOUT")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, conf.QueueDrainTimeout,
+					"QueueDrainTimeout should be %v when env is %q", tt.expected, tt.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Bounds the backup drain so a stuck in-flight task can no longer hang backups indefinitely. Previously `DiskQueue.PrepareForBackup` waited unbounded for the vector queue to drain (`Pause` → `Wait` → `SharedGauge.Wait`); a single stuck insert kept the in-flight gauge above zero, the wait never returned (observed blocked ~43 min in production), the backup never completed, and the next scheduled run reported *"backup already in progress."*

This change is a **two-part fix** — both parts are required:

1. **Propagate the drain error (the core correctness fix).** `PrepareForBackup` previously *discarded* the return value of `q.Wait(ctx)`. That means even with a timeout, the function would fall through to `Flush()` + `EnableMaintenanceMode()` with tasks still in flight — producing an **inconsistent backup snapshot**. The error is now captured and returned, aborting the backup so no snapshot is taken.
2. **Bound the wait with a configurable timeout.** New `QueueDrainTimeout` (env `QUEUE_DRAIN_TIMEOUT`, default 60s, operator-tunable). `PrepareForBackup(ctx, drainTimeout)` wraps the drain wait; on timeout it returns a clear, actionable error and takes no snapshot.

**Decided behavior on timeout:** abort with a clear error, do NOT proceed with a possibly-inconsistent snapshot. The scheduler retries on its next cycle; no special retry/backoff logic here. Rationale: a backup that fails cleanly and retries is strictly better than one that appears to succeed but restores a corrupt index — and we lose nothing, since a hung backup wasn't completing anyway. `drainTimeout == 0` means unbounded (matches the existing `inactivityTimeout` convention), so the timeout can be disabled without instantly aborting.

**Error message** names the queue, states the bound is configurable, and hints at the cause: `queue %q drain did not complete within %v (configurable via QUEUE_DRAIN_TIMEOUT); retry expected, investigate stuck tasks if repeated`.

**Abort-safety:** `defer q.Resume()` runs on the timeout/error path, so the queue is never left permanently paused; in-flight tasks continue to completion and a subsequent backup starts clean. (The previous redundant double-wait — `Pause(ctx)` already waited, then `Wait(ctx)` waited again — is collapsed into a single bounded wait; `PauseQueue`/`Resume` symmetry verified.)

**Config wiring:** `QueueDrainTimeout` threads from env parsing through `Config` → `db.Config` → `IndexConfig` → the `PrepareForBackup` call site (9 hops). Reviewers should check those struct assignments specifically: a dropped assignment compiles fine but silently leaves the value at zero (= unbounded = original bug). The env→Config parse is covered by a test; the inter-struct hops are verified by reading + the build.

Commits are test-first: commit 1 reproduces the bug (drain times out → `PrepareForBackup` returns nil AND enables maintenance mode despite the stuck task) and **FAILS**; commit 2 applies the two-part fix and it **PASSES**.

Based on `stable/v1.36` (clean base, independent of PR #1 and PR #2).

> **Note:** This PR stops backups from *hanging*, but on its own it turns the hang into a backup that fails every cycle on affected clusters. Backups only *succeed* again once the companion fix that lets the stuck insert terminate (global-entrypoint repair PR) is also merged. These should be evaluated together.

### Review checklist
- [ ] Documentation has been updated, if necessary. Link to changed documentation: _new env var `QUEUE_DRAIN_TIMEOUT` — may warrant a one-line entry in configuration docs; flagging for decision_
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable. _Drain-timeout, normal-drain, zero-means-unbounded, and env-parsing paths covered red→green; queue package green under `-race`._
- [ ] Performance tests have been run or not necessary.