### PR TITLE
fix: allow object writes after a named vector index is dropped

### DIFF
--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -513,7 +513,15 @@ func (p *Provider) getVector(object *models.Object, targetVector string) models.
 func (p *Provider) getVectorIndexConfig(class *models.Class, targetVector string) (hnsw.UserConfig, error) {
 	vectorIndexConfig := class.VectorIndexConfig
 	if targetVector != "" {
-		vectorIndexConfig = class.VectorConfig[targetVector].VectorIndexConfig
+		vectorConfig := class.VectorConfig[targetVector]
+		// A named vector whose index has been dropped keeps its vector data but
+		// has VectorIndexType "none" and a nil index config. It has no HNSW config
+		// to return, and writes must not be validated against the removed index,
+		// so report no config rather than failing the type check below.
+		if modelsext.IsVectorIndexDropped(vectorConfig) {
+			return hnsw.UserConfig{}, nil
+		}
+		vectorIndexConfig = vectorConfig.VectorIndexConfig
 	}
 	hnswConfig, okHnsw := vectorIndexConfig.(hnsw.UserConfig)
 	_, okFlat := vectorIndexConfig.(flat.UserConfig)

--- a/usecases/modules/vectorizer_test.go
+++ b/usecases/modules/vectorizer_test.go
@@ -218,6 +218,61 @@ func TestProvider_UpdateVector(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("with a dropped named vector index", func(t *testing.T) {
+		// Regression for #11917: dropping a named vector index leaves the vector
+		// in the schema with VectorIndexType "none" and a nil index config. A
+		// write must not be validated against the removed HNSW index.
+		className := "DropVectorBug"
+		dropped := models.VectorConfig{
+			Vectorizer:        map[string]interface{}{"none": map[string]interface{}{}},
+			VectorIndexType:   "none",
+			VectorIndexConfig: nil,
+		}
+		live := models.VectorConfig{
+			Vectorizer:        map[string]interface{}{"none": map[string]interface{}{}},
+			VectorIndexType:   "hnsw",
+			VectorIndexConfig: hnsw.UserConfig{},
+		}
+
+		tests := []struct {
+			name         string
+			vectorConfig map[string]models.VectorConfig
+			object       *models.Object
+		}{
+			{
+				name:         "write without the dropped vector succeeds",
+				vectorConfig: map[string]models.VectorConfig{"foo": dropped},
+				object:       &models.Object{Class: className},
+			},
+			{
+				name:         "write that still carries the dropped vector succeeds",
+				vectorConfig: map[string]models.VectorConfig{"foo": dropped},
+				object:       &models.Object{Class: className, Vectors: models.Vectors{"foo": []float32{0.1, 0.2}}},
+			},
+			{
+				name:         "write succeeds when a dropped index coexists with a live one",
+				vectorConfig: map[string]models.VectorConfig{"foo": dropped, "bar": live},
+				object:       &models.Object{Class: className},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := context.Background()
+				class := &models.Class{Class: className, VectorConfig: tt.vectorConfig}
+				sch := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+				logger, _ := test.NewNullLogger()
+
+				p := NewProvider(logger, config.Config{})
+				p.SetSchemaGetter(&fakeSchemaGetter{sch})
+
+				tt.object.ID = newUUID()
+				err := p.UpdateVector(ctx, tt.object, class, (&fakeObjectsRepo{}).Object, logger)
+				require.NoError(t, err)
+			})
+		}
+	})
+
 	t.Run("with ReferenceVectorizer", func(t *testing.T) {
 		ctx := context.Background()
 		modName := "some-vzr"


### PR DESCRIPTION
### What's being changed:

Fixes #11917.

Dropping a named vector index (the experimental `ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT` endpoint) keeps the vector in the class schema but sets its `VectorIndexType` to `none` and clears the index config. The write-time vectorize check in `getVectorIndexConfig` still asserted that every target vector had an HNSW config, so a later object write failed before storage with:

```
vectorize check for target vector foo: vector index config (<nil>) is not of type HNSW
```

This happened even when the object did not carry the dropped vector, so it should not have needed validation against the removed index.

`getVectorIndexConfig` now recognises a dropped index via the existing `modelsext.IsVectorIndexDropped` helper and returns no config instead of failing the type check. Writes that genuinely have an invalid (non-`none`) index config still error as before.

Added regression tests covering the reported journey and adjacent ones:
- a write that does not carry the dropped vector (the reported case),
- a write that still carries the dropped vector,
- a class that mixes a dropped index with a live HNSW index.

All three fail without the change and pass with it.

### Review checklist

- [ ] ~~Documentation has been updated, if necessary.~~ N/A — bug fix, no user-facing API change.
- [ ] ~~Chaos pipeline run or not necessary.~~ Not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] ~~Performance tests have been run or not necessary.~~ Not necessary.