### PR TITLE
Deny operator only surface to namespaced users

### DIFF
--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/client/replication"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
 // s3Backend is the backend identifier for the backup-s3 module wired in
@@ -193,5 +194,120 @@ func TestNamespaces_RBACSurfaces(t *testing.T) {
 		require.NotNil(t, ok.Payload)
 		assert.Contains(t, ok.Payload.Classes, qualified,
 			"root's export must retain the qualified class through the backups filter")
+	})
+}
+
+// TestNamespaces_CustomRoleCannotReachOperatorDomains: even when an operator
+// delegates a global role granting backups/nodes/replicate to a namespaced user,
+// the user is denied those surfaces — own namespace and foreign alike — while
+// root reaches them, proving a real deny rather than a disabled endpoint.
+func TestNamespaces_CustomRoleCannotReachOperatorDomains(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, u1Key, _ := twoNamespaces(t)
+
+	const class = "Confined"
+	ownClass := ns1 + ":" + class     // u1's own namespace, qualified
+	foreignClass := ns2 + ":" + class // ns2's collection, named verbatim by u1
+	setupClassInNs1(t, ns1, class, u1Key)
+
+	// Root delegates a global role with three operator domains (on all
+	// collections) to the namespaced user u1.
+	const role = "opdomaindeny"
+	helper.CreateRole(t, adminKey, &models.Role{
+		Name: authorization.String(role),
+		Permissions: []*models.Permission{
+			helper.NewBackupPermission().
+				WithAction(authorization.ManageBackups).
+				WithCollection("*").
+				Permission(),
+			helper.NewNodesPermission().
+				WithAction(authorization.ReadNodes).
+				WithVerbosity("verbose").
+				WithCollection("*").
+				Permission(),
+			{
+				Action: authorization.String(authorization.CreateReplicate),
+				Replicate: &models.PermissionReplicate{
+					Collection: authorization.String("*"),
+					Shard:      authorization.String("*"),
+				},
+			},
+		},
+	})
+	t.Cleanup(func() { helper.DeleteRole(t, adminKey, role) })
+	helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
+	t.Cleanup(func() { helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1") })
+	helper.WaitForOwnRole(t, u1Key, role)
+
+	t.Run("backup create: namespaced role denied own and foreign, root allowed", func(t *testing.T) {
+		for _, tc := range []struct{ label, class string }{
+			{"own", ownClass},
+			{"foreign", foreignClass},
+		} {
+			_, err := helper.CreateBackupWithAuthz(
+				t, helper.DefaultBackupConfig(), tc.class, s3Backend, "cr-deny-"+tc.label,
+				helper.CreateAuth(u1Key))
+			require.Error(t, err)
+			var forbidden *backups.BackupsCreateForbidden
+			require.True(t, errors.As(err, &forbidden), "%s: expected BackupsCreateForbidden, got %T: %v", tc.label, err, err)
+		}
+
+		// Root backs up the same namespaced class and the backup reaches SUCCESS.
+		const backupID = "cr-root-backup"
+		ok, err := helper.CreateBackupWithAuthz(
+			t, helper.DefaultBackupConfig(), ownClass, s3Backend, backupID,
+			helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		require.NotNil(t, ok.Payload)
+		require.Contains(t, ok.Payload.Classes, ownClass)
+		helper.ExpectBackupEventuallyCreated(t, backupID, s3Backend, helper.CreateAuth(adminKey))
+	})
+
+	t.Run("nodes verbose: namespaced role denied own collection, root passes authz", func(t *testing.T) {
+		// Nodes rejects a foreign name before authz, so the reachable journey is
+		// the caller's own class by short name.
+		verbose := "verbose"
+		var forbidden *nodes.NodesGetClassForbidden
+
+		_, err := helper.Client(t).Nodes.NodesGetClass(
+			nodes.NewNodesGetClassParams().WithClassName(class).WithOutput(&verbose),
+			helper.CreateAuth(u1Key))
+		require.Error(t, err)
+		require.True(t, errors.As(err, &forbidden), "expected NodesGetClassForbidden, got %T: %v", err, err)
+
+		// Root names the qualified class and passes the auth gate.
+		_, err = helper.Client(t).Nodes.NodesGetClass(
+			nodes.NewNodesGetClassParams().WithClassName(ownClass).WithOutput(&verbose),
+			helper.CreateAuth(adminKey))
+		require.False(t, errors.As(err, &forbidden), "root must not be forbidden on nodes; got %v", err)
+	})
+
+	t.Run("replicate: namespaced role denied own and foreign, root passes authz", func(t *testing.T) {
+		// Synthetic node/shard names so the request fails after authz, not a real
+		// movement; only the authz verdict is asserted (REPLICA_MOVEMENT_ENABLED
+		// lets the handler reach authz).
+		shard, src, tgt := "shard-0", "node1", "node2"
+		var forbidden *replication.ReplicateForbidden
+
+		for _, tc := range []struct{ label, class string }{
+			{"own", ownClass},
+			{"foreign", foreignClass},
+		} {
+			coll := tc.class
+			req := &models.ReplicationReplicateReplicaRequest{
+				Collection: &coll, Shard: &shard, SourceNode: &src, TargetNode: &tgt,
+			}
+			_, err := helper.Client(t).Replication.Replicate(
+				replication.NewReplicateParams().WithBody(req), helper.CreateAuth(u1Key))
+			require.Error(t, err)
+			require.True(t, errors.As(err, &forbidden), "%s: expected ReplicateForbidden, got %T: %v", tc.label, err, err)
+		}
+
+		req := &models.ReplicationReplicateReplicaRequest{
+			Collection: &ownClass, Shard: &shard, SourceNode: &src, TargetNode: &tgt,
+		}
+		_, err := helper.Client(t).Replication.Replicate(
+			replication.NewReplicateParams().WithBody(req), helper.CreateAuth(adminKey))
+		require.False(t, errors.As(err, &forbidden), "root must not be forbidden on replicate; got %v", err)
 	})
 }

--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -210,8 +210,8 @@ func TestNamespaces_CustomRoleCannotReachOperatorDomains(t *testing.T) {
 	foreignClass := ns2 + ":" + class // ns2's collection, named verbatim by u1
 	setupClassInNs1(t, ns1, class, u1Key)
 
-	// Root delegates a global role with three operator domains (on all
-	// collections) to the namespaced user u1.
+	// Root delegates a global role spanning every operator domain (on all
+	// collections / namespaces) to the namespaced user u1.
 	const role = "opdomaindeny"
 	helper.CreateRole(t, adminKey, &models.Role{
 		Name: authorization.String(role),
@@ -232,6 +232,11 @@ func TestNamespaces_CustomRoleCannotReachOperatorDomains(t *testing.T) {
 					Shard:      authorization.String("*"),
 				},
 			},
+			{Action: authorization.String(authorization.ReadCluster)},
+			helper.NewNamespacesPermission().
+				WithAction(authorization.ManageNamespaces).
+				WithNamespace("*").
+				Permission(),
 		},
 	})
 	t.Cleanup(func() { helper.DeleteRole(t, adminKey, role) })
@@ -309,5 +314,33 @@ func TestNamespaces_CustomRoleCannotReachOperatorDomains(t *testing.T) {
 		_, err := helper.Client(t).Replication.Replicate(
 			replication.NewReplicateParams().WithBody(req), helper.CreateAuth(adminKey))
 		require.False(t, errors.As(err, &forbidden), "root must not be forbidden on replicate; got %v", err)
+	})
+
+	t.Run("cluster statistics: namespaced role denied despite read_cluster, root allowed", func(t *testing.T) {
+		// cluster is a single global surface (no own/foreign): the delegated
+		// read_cluster grant would match cluster/.* but the operator-only deny fires.
+		_, err := helper.Client(t).Cluster.ClusterGetStatistics(cluster.NewClusterGetStatisticsParams(), helper.CreateAuth(u1Key))
+		require.Error(t, err)
+		var forbidden *cluster.ClusterGetStatisticsForbidden
+		require.True(t, errors.As(err, &forbidden), "expected ClusterGetStatisticsForbidden, got %T: %v", err, err)
+
+		resp, err := helper.Client(t).Cluster.ClusterGetStatistics(cluster.NewClusterGetStatisticsParams(), helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+		assert.NotEmpty(t, resp.Payload.Statistics)
+	})
+
+	t.Run("create namespace: namespaced role denied despite manage_namespaces, root allowed", func(t *testing.T) {
+		// manage_namespaces was granted on all namespaces, yet the operator-only
+		// deny fires for the namespaced caller.
+		newNS := uniqueNS()
+		_, err := helper.Client(t).Namespaces.CreateNamespace(
+			clns.NewCreateNamespaceParams().WithNamespaceID(newNS), helper.CreateAuth(u1Key))
+		require.Error(t, err)
+		var forbidden *clns.CreateNamespaceForbidden
+		require.True(t, errors.As(err, &forbidden), "expected CreateNamespaceForbidden, got %T: %v", err, err)
+
+		helper.CreateNamespace(t, newNS, adminKey)
+		t.Cleanup(func() { helper.DeleteNamespace(t, newNS, adminKey) })
 	})
 }

--- a/test/acceptance/namespace/rbac_surfaces_test.go
+++ b/test/acceptance/namespace/rbac_surfaces_test.go
@@ -13,7 +13,9 @@ package namespace
 
 import (
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -120,8 +122,9 @@ func TestNamespaces_RBACSurfaces(t *testing.T) {
 		require.True(t, errors.As(err, &forbidden), "expected BackupsCreateForbidden, got %T: %v", err, err)
 
 		// Root backs up the same namespaced class by qualified name and the backup
-		// reaches SUCCESS — a real, completed operator action.
-		const backupID = "ns-root-backup"
+		// reaches SUCCESS — a real, completed operator action. The ID carries a
+		// unique suffix so reruns against the shared, persisted bucket don't collide.
+		backupID := fmt.Sprintf("ns-root-backup-%s-%d", ns1, time.Now().UnixNano())
 		okResp, err := helper.CreateBackupWithAuthz(
 			t, helper.DefaultBackupConfig(), qualified, s3Backend, backupID,
 			helper.CreateAuth(adminKey))
@@ -185,7 +188,7 @@ func TestNamespaces_RBACSurfaces(t *testing.T) {
 		// IsAsyncReplicationEnabled treats as async-not-required, so root clears
 		// every gate and the export actually starts — proof that root passed the
 		// backups-domain filter the namespaced admin did not.
-		rootID := "root-export-allowed"
+		rootID := fmt.Sprintf("root-export-allowed-%s-%d", ns1, time.Now().UnixNano())
 		ok, err := helper.Client(t).Export.ExportCreate(
 			export.NewExportCreateParams().WithBackend(s3Backend).WithBody(
 				&models.ExportCreateRequest{ID: &rootID, FileFormat: &fileFormat, Include: []string{qualified}}),
@@ -258,7 +261,9 @@ func TestNamespaces_CustomRoleCannotReachOperatorDomains(t *testing.T) {
 		}
 
 		// Root backs up the same namespaced class and the backup reaches SUCCESS.
-		const backupID = "cr-root-backup"
+		// The ID carries a unique suffix so reruns against the shared, persisted
+		// bucket don't collide.
+		backupID := fmt.Sprintf("cr-root-backup-%s-%d", ns1, time.Now().UnixNano())
 		ok, err := helper.CreateBackupWithAuthz(
 			t, helper.DefaultBackupConfig(), ownClass, s3Backend, backupID,
 			helper.CreateAuth(adminKey))

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -285,6 +285,11 @@ var (
 	dataCollectionsPrefix    = authorization.DataDomain + "/collections/"
 	aliasesCollectionsPrefix = authorization.AliasesDomain + "/collections/"
 	usersPrefix              = authorization.UsersDomain + "/"
+
+	// Operator-only domain prefixes; see operatorOnlyResource.
+	backupsPrefix   = authorization.BackupsDomain + "/"
+	nodesPrefix     = authorization.NodesDomain + "/"
+	replicatePrefix = authorization.ReplicateDomain + "/"
 )
 
 const (
@@ -398,6 +403,15 @@ func globalCallerNeedsNoWidening(reqObj string) bool {
 	return strings.IndexByte(reqObj, schema.NamespaceSeparator[0]) < 0
 }
 
+// operatorOnlyResource reports whether path addresses an operator-only domain
+// (backups, nodes, replicate). A namespaced caller is denied these regardless
+// of any role granting them.
+func operatorOnlyResource(path string) bool {
+	return strings.HasPrefix(path, backupsPrefix) ||
+		strings.HasPrefix(path, nodesPrefix) ||
+		strings.HasPrefix(path, replicatePrefix)
+}
+
 // weaviateKeyMatch runs the `/shards/#` vs `/shards/.*` carve-out then
 // KeyMatch5: a collection-level request must not match a per-tenant policy.
 func weaviateKeyMatch(reqObj, polObj string) bool {
@@ -417,7 +431,15 @@ func weaviateKeyMatch(reqObj, polObj string) bool {
 //     widen with anyNamespacePattern; qualified segments stay fixed.
 //   - ns == "" with an unqualified request, a users/<id> resource, or a
 //     non-namespaceable shape: no rewrite.
+//
+// Namespaced callers are denied the operator-only domains (backups, nodes,
+// replicate) outright.
 func namespaceAwareMatcher(reqObj, polObj, ns string) bool {
+	// Namespaced callers have no access to operator-only domains, whatever the policy.
+	if ns != "" && operatorOnlyResource(reqObj) {
+		return false
+	}
+
 	// Trivial passthrough (see globalCallerNeedsNoWidening). Only
 	// collection/data/aliases segments treat ':' as a namespace boundary.
 	if ns == "" && globalCallerNeedsNoWidening(reqObj) {

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -287,9 +287,11 @@ var (
 	usersPrefix              = authorization.UsersDomain + "/"
 
 	// Operator-only domain prefixes; see operatorOnlyResource.
-	backupsPrefix   = authorization.BackupsDomain + "/"
-	nodesPrefix     = authorization.NodesDomain + "/"
-	replicatePrefix = authorization.ReplicateDomain + "/"
+	backupsPrefix    = authorization.BackupsDomain + "/"
+	nodesPrefix      = authorization.NodesDomain + "/"
+	replicatePrefix  = authorization.ReplicateDomain + "/"
+	clusterPrefix    = authorization.ClusterDomain + "/"
+	namespacesPrefix = authorization.NamespacesDomain + "/"
 )
 
 const (
@@ -404,12 +406,16 @@ func globalCallerNeedsNoWidening(reqObj string) bool {
 }
 
 // operatorOnlyResource reports whether path addresses an operator-only domain
-// (backups, nodes, replicate). A namespaced caller is denied these regardless
-// of any role granting them.
+// (backups, nodes, replicate, cluster, namespaces). A namespaced caller is
+// denied these regardless of any role granting them. roles and groups are
+// excluded: their resources are namespace-bearing via qualified names, so a
+// blanket prefix-deny would be wrong for them.
 func operatorOnlyResource(path string) bool {
 	return strings.HasPrefix(path, backupsPrefix) ||
 		strings.HasPrefix(path, nodesPrefix) ||
-		strings.HasPrefix(path, replicatePrefix)
+		strings.HasPrefix(path, replicatePrefix) ||
+		strings.HasPrefix(path, clusterPrefix) ||
+		strings.HasPrefix(path, namespacesPrefix)
 }
 
 // weaviateKeyMatch runs the `/shards/#` vs `/shards/.*` carve-out then
@@ -433,7 +439,7 @@ func weaviateKeyMatch(reqObj, polObj string) bool {
 //     non-namespaceable shape: no rewrite.
 //
 // Namespaced callers are denied the operator-only domains (backups, nodes,
-// replicate) outright.
+// replicate, cluster, namespaces) outright.
 func namespaceAwareMatcher(reqObj, polObj, ns string) bool {
 	// Namespaced callers have no access to operator-only domains, whatever the policy.
 	if ns != "" && operatorOnlyResource(reqObj) {

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -483,6 +483,22 @@ func TestNamespaceAwareMatcherGate(t *testing.T) {
 		"NS-enabled: users/.* specializes to the caller's namespace")
 	assert.False(t, call(true, "users/customer2:bob", "users/.*", "customer1"),
 		"NS-enabled: cross-namespace user access denied")
+
+	// Operator-only domains are denied to namespaced callers (ns != "") even
+	// when a delegated role's wildcard policy would otherwise match, but stay
+	// reachable for the global caller (ns == "").
+	for _, dom := range []string{"backups", "nodes", "replicate", "cluster", "namespaces"} {
+		req := dom + "/anything"
+		assert.False(t, namespaceAwareMatcher(req, dom+"/.*", "customer1"),
+			"namespaced caller must be denied operator-only domain %q", dom)
+		assert.True(t, namespaceAwareMatcher(req, dom+"/.*", ""),
+			"global caller must reach operator-only domain %q", dom)
+	}
+
+	// roles/groups are namespace-bearing via qualified names, so the gate must
+	// not blanket-deny them for namespaced callers.
+	assert.True(t, call(true, "roles/customer1:editor", "roles/.*", "customer1"),
+		"namespaced caller keeps access to its own qualified role")
 }
 
 // TestRewriteSegment locks the contract of the per-segment rewriter directly,


### PR DESCRIPTION
### What's being changed:

Closes a hole in the RBAC matcher. The operator surfaces (backup/nodes/replication) are denied for namespaced users.
Note that it is on purpose this deep in the stack as the handler now contains handling for all the other surfaces. IF they are ever enabled for namespaced users, they need explicit handling there, too.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
