### PR TITLE
chore: fix flakiness of `TestAuthzReplicationReplicate`

### DIFF
--- a/test/acceptance/authz/replication_replicate_test.go
+++ b/test/acceptance/authz/replication_replicate_test.go
@@ -112,11 +112,10 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, updateReplication)
 
 	t.Run("Cancel a replication of a shard with permissions", func(t *testing.T) {
-		resp, err := helper.Client(t).Replication.
+		_, err := helper.Client(t).Replication.
 			CancelReplication(replication.NewCancelReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		require.Nil(t, err)
 		// Don't care about the response type here, as it can be either CancelReplicationNoContent or CancelReplicationConflict depending on the state of the replication.
-		require.IsNotType(t, replication.NewCancelReplicationForbidden(), resp)
+		require.IsNotType(t, replication.NewCancelReplicationForbidden(), err)
 	})
 
 	t.Run("Fail to read a replication of a shard without READ permissions", func(t *testing.T) {
@@ -147,11 +146,10 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, deleteReplication)
 
 	t.Run("Delete a replication of a shard with permissions", func(t *testing.T) {
-		resp, err := helper.Client(t).Replication.
+		_, err := helper.Client(t).Replication.
 			DeleteReplication(replication.NewDeleteReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		require.Nil(t, err)
 		// Don't care about the response type here, as it can be either DeleteReplicationNoContent or DeleteReplicationConflict depending on the state of the replication.
-		require.IsNotType(t, replication.NewDeleteReplicationForbidden(), resp)
+		require.IsNotType(t, replication.NewDeleteReplicationForbidden(), err)
 	})
 }
 

--- a/test/acceptance/authz/replication_replicate_test.go
+++ b/test/acceptance/authz/replication_replicate_test.go
@@ -114,7 +114,7 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	t.Run("Cancel a replication of a shard with permissions", func(t *testing.T) {
 		_, err := helper.Client(t).Replication.
 			CancelReplication(replication.NewCancelReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		// Don't care about the response type here, as it can be either CancelReplicationNoContent or CancelReplicationConflict depending on the state of the replication.
+		// Don't care about the error type here, as it can be either CancelReplicationNoContent or CancelReplicationConflict depending on the state of the replication.
 		require.IsNotType(t, replication.NewCancelReplicationForbidden(), err)
 	})
 
@@ -148,7 +148,7 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	t.Run("Delete a replication of a shard with permissions", func(t *testing.T) {
 		_, err := helper.Client(t).Replication.
 			DeleteReplication(replication.NewDeleteReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		// Don't care about the response type here, as it can be either DeleteReplicationNoContent or DeleteReplicationConflict depending on the state of the replication.
+		// Don't care about the error type here, as it can be either DeleteReplicationNoContent or DeleteReplicationConflict depending on the state of the replication.
 		require.IsNotType(t, replication.NewDeleteReplicationForbidden(), err)
 	})
 }

--- a/test/acceptance/authz/replication_replicate_test.go
+++ b/test/acceptance/authz/replication_replicate_test.go
@@ -112,9 +112,8 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, updateReplication)
 
 	t.Run("Cancel a replication of a shard with permissions", func(t *testing.T) {
-		resp, err := helper.Client(t).Replication.
+		resp, _ := helper.Client(t).Replication.
 			CancelReplication(replication.NewCancelReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		require.Nil(t, err)
 		// Don't care about the response type here, as it can be either CancelReplicationNoContent or CancelReplicationConflict depending on the state of the replication.
 		require.IsNotType(t, replication.NewCancelReplicationForbidden(), resp)
 	})
@@ -147,9 +146,8 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, deleteReplication)
 
 	t.Run("Delete a replication of a shard with permissions", func(t *testing.T) {
-		resp, err := helper.Client(t).Replication.
+		resp, _ := helper.Client(t).Replication.
 			DeleteReplication(replication.NewDeleteReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		require.Nil(t, err)
 		// Don't care about the response type here, as it can be either DeleteReplicationNoContent or DeleteReplicationConflict depending on the state of the replication.
 		require.IsNotType(t, replication.NewDeleteReplicationForbidden(), resp)
 	})

--- a/test/acceptance/authz/replication_replicate_test.go
+++ b/test/acceptance/authz/replication_replicate_test.go
@@ -112,12 +112,11 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, updateReplication)
 
 	t.Run("Cancel a replication of a shard with permissions", func(t *testing.T) {
-		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			resp, err := helper.Client(t).Replication.
-				CancelReplication(replication.NewCancelReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-			require.Nil(ct, err)
-			require.IsType(ct, replication.NewCancelReplicationNoContent(), resp)
-		}, 10*time.Second, 500*time.Millisecond, "op should be cancelled but got error")
+		resp, err := helper.Client(t).Replication.
+			CancelReplication(replication.NewCancelReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		// Don't care about the response type here, as it can be either CancelReplicationNoContent or CancelReplicationConflict depending on the state of the replication.
+		require.IsNotType(t, replication.NewCancelReplicationForbidden(), resp)
 	})
 
 	t.Run("Fail to read a replication of a shard without READ permissions", func(t *testing.T) {
@@ -148,12 +147,11 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, deleteReplication)
 
 	t.Run("Delete a replication of a shard with permissions", func(t *testing.T) {
-		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			resp, err := helper.Client(t).Replication.
-				DeleteReplication(replication.NewDeleteReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-			require.Nil(ct, err)
-			require.IsType(ct, replication.NewDeleteReplicationNoContent(), resp)
-		}, 10*time.Second, 500*time.Millisecond, "op should be deleted but got error")
+		resp, err := helper.Client(t).Replication.
+			DeleteReplication(replication.NewDeleteReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		// Don't care about the response type here, as it can be either DeleteReplicationNoContent or DeleteReplicationConflict depending on the state of the replication.
+		require.IsNotType(t, replication.NewDeleteReplicationForbidden(), resp)
 	})
 }
 


### PR DESCRIPTION
### What's being changed:

Don't assert success on permissioned cancel/delete calls in case of races with uncancellable field

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
