### PR TITLE
chore: add detailed error logging to `TestReplicationTestSuite`

### DIFF
--- a/test/acceptance/replication/replica_replication/fast/endpoints_test.go
+++ b/test/acceptance/replication/replica_replication/fast/endpoints_test.go
@@ -13,6 +13,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -134,6 +135,10 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateEndpoints() {
 
 	t.Run("create replication operation", func(t *testing.T) {
 		created, err := helper.Client(t).Replication.Replicate(replication.NewReplicateParams().WithBody(getRequest(t, paragraphClass.Class)), nil)
+		var unprocessableErr *replication.ReplicateUnprocessableEntity
+		if errors.As(err, &unprocessableErr) {
+			t.Logf("replication operation could not be created: %s", unprocessableErr.Payload.Error[0].Message)
+		}
 		require.NoError(t, err, "failed to create replication operation %+v", err)
 		require.NotNil(t, created)
 		require.NotNil(t, created.Payload)
@@ -255,6 +260,10 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateEndpoints() {
 
 	t.Run("create one op and immediately delete all replication ops", func(t *testing.T) {
 		created, err := helper.Client(t).Replication.Replicate(replication.NewReplicateParams().WithBody(getRequest(t, paragraphClass.Class)), nil)
+		var unprocessableErr *replication.ReplicateUnprocessableEntity
+		if errors.As(err, &unprocessableErr) {
+			t.Logf("replication operation could not be created: %s", unprocessableErr.Payload.Error[0].Message)
+		}
 		require.NoError(t, err, "failed to create replication operation %+v", err)
 		require.NotNil(t, created)
 		require.NotNil(t, created.Payload)


### PR DESCRIPTION
### What's being changed:

Add clearer log to tests of `Replication.Replicate` in case of 422 flakes

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
