### PR TITLE
feat(backup-s3): tag S3 user-agent for attribution

### DIFF
--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/backup"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	"github.com/weaviate/weaviate/usecases/build"
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
@@ -65,6 +66,7 @@ func newClient(config *clientConfig, logger logrus.FieldLogger, dataPath string)
 	if err != nil {
 		return nil, errors.Wrap(err, "create client")
 	}
+	client.SetAppInfo(build.AppName, build.VersionOrDev())
 	return &s3Client{client, config, logger, dataPath, region}, nil
 }
 
@@ -191,11 +193,16 @@ func (s *s3Client) getClient(ctx context.Context) (*minio.Client, error) {
 	xAwsSecretKey := modulecomponents.GetValueFromContext(ctx, "X-AWS-SECRET-KEY")
 	xAwsSessionToken := modulecomponents.GetValueFromContext(ctx, "X-AWS-SESSION-TOKEN")
 	if xAwsAccessKey != "" && xAwsSecretKey != "" && xAwsSessionToken != "" {
-		return minio.New(s.config.Endpoint, &minio.Options{
+		client, err := minio.New(s.config.Endpoint, &minio.Options{
 			Creds:  credentials.NewStaticV4(xAwsAccessKey, xAwsSecretKey, xAwsSessionToken),
 			Region: s.region,
 			Secure: s.config.UseSSL,
 		})
+		if err != nil {
+			return nil, err
+		}
+		client.SetAppInfo(build.AppName, build.VersionOrDev())
+		return client, nil
 	}
 	return s.client, nil
 }

--- a/modules/usage-s3/storage.go
+++ b/modules/usage-s3/storage.go
@@ -20,11 +20,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go/middleware"
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/cluster/usage/types"
+	"github.com/weaviate/weaviate/usecases/build"
 	common "github.com/weaviate/weaviate/usecases/modulecomponents/usage"
 )
 
@@ -36,7 +39,11 @@ type S3Storage struct {
 
 // NewS3Storage creates a new S3 storage backend
 func NewS3Storage(ctx context.Context, logger logrus.FieldLogger, metrics *common.Metrics) (*S3Storage, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithAPIOptions([]func(*middleware.Stack) error{
+			awsmiddleware.AddUserAgentKeyValue(build.AppName, build.VersionOrDev()),
+		}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}

--- a/usecases/build/build.go
+++ b/usecases/build/build.go
@@ -49,6 +49,13 @@ const (
 	AppName = "weaviate"
 )
 
+func VersionOrDev() string {
+	if Version != "" {
+		return Version
+	}
+	return "dev"
+}
+
 func SetPrometheusBuildInfo() {
 	version.Version = Version
 	version.Revision = Revision

--- a/usecases/build/build_test.go
+++ b/usecases/build/build_test.go
@@ -1,0 +1,20 @@
+package build
+
+import "testing"
+
+func TestVersionOrDev(t *testing.T) {
+	previousVersion := Version
+	t.Cleanup(func() {
+		Version = previousVersion
+	})
+
+	Version = "1.2.3"
+	if got := VersionOrDev(); got != "1.2.3" {
+		t.Fatalf("expected build version, got %q", got)
+	}
+
+	Version = ""
+	if got := VersionOrDev(); got != "dev" {
+		t.Fatalf("expected dev fallback, got %q", got)
+	}
+}


### PR DESCRIPTION
### What's being changed:

Sets a `weaviate/<version>` product identifier on the S3 user-agent for the `backup-s3` and `usage-s3` modules, so requests carry a stable application tag. This works with Amazon S3 and any S3-compatible object store configured via `AWS_ENDPOINT` (for example Backblaze B2, Cloudflare R2, or MinIO). The change is minimal and additive: it does not alter credentials, endpoint resolution, request behavior, or existing configuration.

Details:
- `backup-s3/client.go`: calls `client.SetAppInfo(build.AppName, productVersion())` on both the shared minio client and the per-request client built from `X-AWS-*` context headers. A small `productVersion()` helper returns `build.Version`, falling back to `"dev"` for unstamped local builds.
- `usage-s3/storage.go`: adds an aws-sdk-go-v2 user-agent middleware (`AddUserAgentKeyValue(build.AppName, version)`) to the default config, with the same `"dev"` fallback.

Both modules reuse the existing `usecases/build` package for the app name and version, so the tag stays consistent with the rest of Weaviate and with the `weaviate_build_info` metric.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: not necessary. No public API, config surface, or user-facing behavior changes; this only adds a product tag to the outbound S3 user-agent.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: not necessary.
- [ ] All new code is covered by tests where it is reasonable. The only pure, unit-testable addition is the `productVersion()` fallback helper. The `SetAppInfo` / middleware wiring exercises minio and the AWS SDK against a live endpoint, which the existing module tests do not stand up. Happy to add a small table test for `productVersion()` (empty vs stamped `build.Version`) if you'd like it in this PR.
- [ ] Performance tests have been run or not necessary. Not necessary; setting the user-agent is a one-time client-init call and adds no per-request work.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
