### PR TITLE
chore: add back `EventuallyWithT` to `TestAuthzReplicationReplicate` assertions

### DIFF
--- a/test/acceptance/authz/replication_replicate_test.go
+++ b/test/acceptance/authz/replication_replicate_test.go
@@ -112,10 +112,12 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, updateReplication)
 
 	t.Run("Cancel a replication of a shard with permissions", func(t *testing.T) {
-		_, err := helper.Client(t).Replication.
-			CancelReplication(replication.NewCancelReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		// Don't care about the error type here, as it can be either CancelReplicationNoContent or CancelReplicationConflict depending on the state of the replication.
-		require.IsNotType(t, replication.NewCancelReplicationForbidden(), err)
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			_, err := helper.Client(t).Replication.
+				CancelReplication(replication.NewCancelReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
+			// Don't care about the error type here, as it can be either CancelReplicationNoContent or CancelReplicationConflict depending on the state of the replication.
+			require.IsNotType(ct, replication.NewCancelReplicationForbidden(), err, "request should be permissioned but got different error type than expected: %s", err.Error())
+		}, 10*time.Second, 500*time.Millisecond, "op should be canceled but got error")
 	})
 
 	t.Run("Fail to read a replication of a shard without READ permissions", func(t *testing.T) {
@@ -146,10 +148,12 @@ func TestAuthzReplicationReplicate(t *testing.T) {
 	helper.AddPermissions(t, adminKey, testRoleName, deleteReplication)
 
 	t.Run("Delete a replication of a shard with permissions", func(t *testing.T) {
-		_, err := helper.Client(t).Replication.
-			DeleteReplication(replication.NewDeleteReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
-		// Don't care about the error type here, as it can be either DeleteReplicationNoContent or DeleteReplicationConflict depending on the state of the replication.
-		require.IsNotType(t, replication.NewDeleteReplicationForbidden(), err)
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			_, err := helper.Client(t).Replication.
+				DeleteReplication(replication.NewDeleteReplicationParams().WithID(replicationId), helper.CreateAuth(customKey))
+			// Don't care about the error type here, as it can be either DeleteReplicationNoContent or DeleteReplicationConflict depending on the state of the replication.
+			require.IsNotType(ct, replication.NewDeleteReplicationForbidden(), err, "request should be permissioned but got different error type than expected: %s", err.Error())
+		}, 10*time.Second, 500*time.Millisecond, "op should be deleted but got error")
 	})
 }
 


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
