### PR TITLE
test(ci): split go-client-group-2 into group-2 (usage) and group-3

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -668,6 +668,8 @@ jobs:
             test: "--acceptance-go-client-only-fast-group-1"
           - name: "go-client-group-2"
             test: "--acceptance-go-client-only-fast-group-2"
+          - name: "go-client-group-3"
+            test: "--acceptance-go-client-only-fast-group-3"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Go

--- a/test/run.sh
+++ b/test/run.sh
@@ -571,7 +571,7 @@ function get_fast_go_client_packages() {
 function get_go_client_group() {
   case "$1" in
     1) echo "acceptance_tests_with_client/multi_tenancy_tests acceptance_tests_with_client/filters_tests" ;;
-    2) echo "acceptance_tests_with_client/compression acceptance_tests_with_client/usage" ;;
+    2) echo "acceptance_tests_with_client/usage" ;;
     *) echo "" ;;
   esac
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -16,6 +16,7 @@ function main() {
   run_acceptance_go_client=false
   run_acceptance_go_client_only_fast_group_1=false
   run_acceptance_go_client_only_fast_group_2=false
+  run_acceptance_go_client_only_fast_group_3=false
   run_acceptance_graphql_tests=false
   run_acceptance_replication_tests=false
   run_acceptance_replica_replication_fast_tests=false
@@ -60,9 +61,10 @@ function main() {
           --acceptance-distributed-tasks) run_all_tests=false; run_acceptance_distributed_tasks=true;;
           --acceptance-only-python|-aop) run_all_tests=false; run_acceptance_only_python=true;;
           --acceptance-go-client|-ag) run_all_tests=false; run_acceptance_go_client=true;;
-          --acceptance-go-client-only-fast|-agof) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_1=true; run_acceptance_go_client_only_fast_group_2=true;;
+          --acceptance-go-client-only-fast|-agof) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_1=true; run_acceptance_go_client_only_fast_group_2=true; run_acceptance_go_client_only_fast_group_3=true;;
           --acceptance-go-client-only-fast-group-1|-agof-g1) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_1=true;;
           --acceptance-go-client-only-fast-group-2|-agof-g2) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_2=true;;
+          --acceptance-go-client-only-fast-group-3|-agof-g3) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_3=true;;
           --acceptance-go-client-named-vectors-single-node|-agnvsn) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_named_vectors_single_node=true;;
           --acceptance-go-client-named-vectors-cluster|-agnvc) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_named_vectors_cluster=true;;
           --acceptance-only-graphql|-aog) run_all_tests=false; run_acceptance_graphql_tests=true ;;
@@ -152,7 +154,7 @@ function main() {
     echo_green "Integration tests successful"
   fi
 
-  if $run_acceptance_tests  || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $only_acceptance || $run_acceptance_objects
+  if $run_acceptance_tests  || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_only_fast_group_3 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $only_acceptance || $run_acceptance_objects
   then
     echo "Start docker container needed for acceptance and/or benchmark test"
     echo_green "Stop any running docker-compose containers..."
@@ -183,7 +185,7 @@ function main() {
       ./test/benchmark/run_performance_tracker.sh
     fi
 
-    if $run_acceptance_tests || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $run_all_tests || $only_acceptance || $run_acceptance_objects
+    if $run_acceptance_tests || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_only_fast_group_3 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $run_all_tests || $only_acceptance || $run_acceptance_objects
     then
       echo_green "Run acceptance tests..."
       run_acceptance_tests "$@"
@@ -366,6 +368,10 @@ function run_acceptance_tests() {
   if $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client || $run_acceptance_tests || $run_all_tests; then
   echo "running acceptance go client only fast group 2"
     run_acceptance_go_client_only_fast_group 2
+  fi
+  if $run_acceptance_go_client_only_fast_group_3 || $run_acceptance_go_client || $run_acceptance_tests || $run_all_tests; then
+  echo "running acceptance go client only fast group 3"
+    run_acceptance_go_client_only_fast_group 3
   fi
   if $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client || $run_acceptance_tests || $run_all_tests; then
   echo "running acceptance go client named vectors for single node"
@@ -560,28 +566,29 @@ function get_fast_go_client_packages() {
 }
 
 # get_go_client_group returns the package patterns for the specified group number.
-# Group 1 contains explicitly assigned packages for load balancing.
-# Group 2 will be handled as catch-all in the main function.
+# Groups 1 and 2 contain explicitly assigned packages for load balancing.
+# Group 3 will be handled as catch-all in the main function.
 function get_go_client_group() {
   case "$1" in
     1) echo "acceptance_tests_with_client/multi_tenancy_tests acceptance_tests_with_client/filters_tests" ;;
+    2) echo "acceptance_tests_with_client/compression acceptance_tests_with_client/usage" ;;
     *) echo "" ;;
   esac
 }
 
-# get_other_go_client_packages returns fast go client packages not included in group 1.
-# These packages form group 2 and include any newly added tests automatically.
-# Returns normalized package paths, one per line.
+# get_other_go_client_packages returns fast go client packages not included in
+# groups 1 and 2. These packages form group 3 and include any newly added tests
+# automatically. Returns normalized package paths, one per line.
 function get_other_go_client_packages() {
-  local -a GROUP1=()
-  read -ra GROUP1 <<< "$(get_go_client_group 1)"
+  local -a ASSIGNED=()
+  read -ra ASSIGNED <<< "$(get_go_client_group 1) $(get_go_client_group 2)"
 
-  # All fast go client test packages, excluding those in group 1
+  # All fast go client test packages, excluding those in groups 1 and 2
   local -a other_fast_packages=()
   while IFS= read -r pkg; do
     [[ -n $pkg ]] && other_fast_packages+=("$pkg")
   done < <(
-    get_fast_go_client_packages | grep -F -x -v -f <(printf '%s\n' "${GROUP1[@]}")
+    get_fast_go_client_packages | grep -F -x -v -f <(printf '%s\n' "${ASSIGNED[@]}")
   )
 
   printf '%s\n' "${other_fast_packages[@]}"
@@ -621,34 +628,39 @@ function run_go_client_group() {
 
 # run_acceptance_go_client_only_fast_group runs a specific group of go client tests.
 # Parameters:
-#   $1: GROUP - group number to run (1-2)
-# Group 1 contains explicitly assigned packages for load balancing.
-# Group 2 automatically contains all other fast go client packages.
+#   $1: GROUP - group number to run (1-3)
+# Groups 1 and 2 contain explicitly assigned packages for load balancing.
+# Group 3 automatically contains all other fast go client packages.
 function run_acceptance_go_client_only_fast_group() {
   build_weaviate_test_image
   local GROUP="$1"
 
-  local -a GROUP1=()
-  read -ra GROUP1 <<< "$(get_go_client_group 1)"
-
   case "$GROUP" in
     1)
-      echo_green "acceptance-go-client-only-fast — group 1/2"
+      echo_green "acceptance-go-client-only-fast — group 1/3"
+      local -a GROUP1=()
+      read -ra GROUP1 <<< "$(get_go_client_group 1)"
       run_go_client_group "1" "${GROUP1[@]}"
       ;;
     2)
-      echo_green "acceptance-go-client-only-fast — group 2/2 (others from fast set)"
+      echo_green "acceptance-go-client-only-fast — group 2/3"
+      local -a GROUP2=()
+      read -ra GROUP2 <<< "$(get_go_client_group 2)"
+      run_go_client_group "2" "${GROUP2[@]}"
+      ;;
+    3)
+      echo_green "acceptance-go-client-only-fast — group 3/3 (others from fast set)"
 
       local -a other_fast_packages=()
       while IFS= read -r pkg; do
         [[ -n $pkg ]] && other_fast_packages+=("$pkg")
       done < <(get_other_go_client_packages)
 
-      [[ ${#other_fast_packages[@]} -eq 0 ]] && { echo "Nothing to run for group 2."; return 0; }
+      [[ ${#other_fast_packages[@]} -eq 0 ]] && { echo "Nothing to run for group 3."; return 0; }
 
-      run_go_client_group "2" "${other_fast_packages[@]}"
+      run_go_client_group "3" "${other_fast_packages[@]}"
       ;;
-    *) echo_red "Invalid group: $GROUP (must be 1 or 2)"; return 1 ;;
+    *) echo_red "Invalid group: $GROUP (must be 1, 2 or 3)"; return 1 ;;
   esac
 }
 


### PR DESCRIPTION
### What's being changed:

This PR splits go-client-group-2 into group-2 (compression/usage) and group-3

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
