### PR TITLE
Add percentage eager shards loaded to raft waiting for database to restore log

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -641,6 +641,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		DrainSleep:                      appState.ServerConfig.Config.Raft.DrainSleep.Get(),
 		MaxTenantsPerCollection:         appState.ServerConfig.Config.UsageLimits.MaxTenantsPerCollection,
 		UsageLimitsErrorMessage:         appState.ServerConfig.Config.UsageLimits.ErrorMessage,
+		DBLoadProgress:                  repo.StartupLoadingProgress,
 	}
 	for _, name := range appState.ServerConfig.Config.Raft.Join[:rConfig.BootstrapExpect] {
 		if strings.Contains(name, rConfig.NodeID) {

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -194,8 +194,10 @@ func (db *DB) StartupLoadingProgress() *StartupProgressSnapshot {
 // caches it. It returns a stop function that halts the ticker and pins the
 // final value; callers should defer it. The goroutine also exits if ctx is done.
 func (db *DB) trackStartupProgress(ctx context.Context) func() {
+	classNames := db.startupClassNames()
+
 	// Publish immediately so a value is available before the first log tick.
-	db.updateStartupProgress()
+	db.updateStartupProgress(classNames)
 
 	done := make(chan struct{})
 	enterrors.GoWrapper(func() {
@@ -208,7 +210,7 @@ func (db *DB) trackStartupProgress(ctx context.Context) func() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				db.updateStartupProgress()
+				db.updateStartupProgress(classNames)
 			}
 		}
 	}, db.logger)
@@ -216,29 +218,40 @@ func (db *DB) trackStartupProgress(ctx context.Context) func() {
 	return func() {
 		close(done)
 		// Pin the final value now that loading has finished.
-		db.updateStartupProgress()
+		db.updateStartupProgress(classNames)
 	}
+}
+
+// startupClassNames snapshots the current class names for the startup progress scan
+func (db *DB) startupClassNames() []string {
+	s := db.schemaGetter.GetSchemaSkipAuth()
+	if s.Objects == nil {
+		return nil
+	}
+	names := make([]string, 0, len(s.Objects.Classes))
+	for _, class := range s.Objects.Classes {
+		names = append(names, class.Class)
+	}
+	return names
 }
 
 // updateStartupProgress recomputes progress once and publishes it to the cached
 // snapshot and the Prometheus gauges.
-func (db *DB) updateStartupProgress() {
-	loaded, total := db.scanStartupProgress()
+func (db *DB) updateStartupProgress(classNames []string) {
+	loaded, total := db.scanStartupProgress(classNames)
 	db.startupProgress.Store(&StartupProgressSnapshot{Loaded: loaded, Total: total})
 	db.promMetrics.SetStartupShardProgress(loaded, total)
 }
 
-// scanStartupProgress computes eager shard-loading progress from scratch.
+// scanStartupProgress computes eager shard-loading progress from scratch for the
+// given classes.
 //
 // total starts from every HOT local shard known to the schema (eager and lazy);
 // lazy shards are then discounted as they are encountered in the index maps,
 // leaving the eager total. Safe to call while the DB is still loading.
-func (db *DB) scanStartupProgress() (loaded, total int64) {
-	s := db.schemaGetter.GetSchemaSkipAuth()
-	if s.Objects != nil {
-		for _, class := range s.Objects.Classes {
-			total += db.localShardsToLoad(class.Class)
-		}
+func (db *DB) scanStartupProgress(classNames []string) (loaded, total int64) {
+	for _, className := range classNames {
+		total += db.localShardsToLoad(className)
 	}
 
 	db.indexLock.RLock()

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -47,7 +47,6 @@ import (
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
-	"github.com/weaviate/weaviate/usecases/multitenancy"
 	"github.com/weaviate/weaviate/usecases/replica"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -238,11 +237,7 @@ func (db *DB) scanStartupProgress() (loaded, total int64) {
 	s := db.schemaGetter.GetSchemaSkipAuth()
 	if s.Objects != nil {
 		for _, class := range s.Objects.Classes {
-			n, err := db.localShardsToLoad(class)
-			if err != nil {
-				continue
-			}
-			total += int64(n)
+			total += db.localShardsToLoad(class.Class)
 		}
 	}
 
@@ -267,18 +262,23 @@ func (db *DB) scanStartupProgress() (loaded, total int64) {
 	return loaded, total
 }
 
-// localShardsToLoad returns the number of HOT local shards for the given class
-// (active local tenants for multi-tenant classes, all local physical shards
-// otherwise), mirroring the filter used by the index loader.
-func (db *DB) localShardsToLoad(class *models.Class) (int, error) {
-	if multitenancy.IsMultiTenant(class.MultiTenancyConfig) {
-		return db.schemaReader.LocalActiveShardsCount(class.Class)
-	}
-	shards, err := db.schemaReader.LocalShards(class.Class)
-	if err != nil {
-		return 0, err
-	}
-	return len(shards), nil
+// localShardsToLoad returns the number of local shards that count toward eager
+// startup loading for the given class: local physical shards whose activity
+// status is HOT (empty status counts as HOT)
+func (db *DB) localShardsToLoad(className string) int64 {
+	var count int64
+	_ = db.schemaReader.Read(className, true, func(_ *models.Class, state *sharding.State) error {
+		if state == nil {
+			return nil
+		}
+		for name, physical := range state.Physical {
+			if state.IsLocalShard(name) && physical.ActivityStatus() == models.TenantActivityStatusHOT {
+				count++
+			}
+		}
+		return nil
+	})
+	return count
 }
 
 // IndexGetter interface defines the methods that the service uses from db.IndexGetter

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -69,6 +69,7 @@ type DB struct {
 	indexCheckpoints          *indexcheckpoint.Checkpoints
 	shutdown                  chan struct{}
 	startupComplete           atomic.Bool
+	startupProgress           atomic.Pointer[StartupProgressSnapshot]
 	resourceScanState         *resourceScanState
 	memMonitor                *memwatch.Monitor
 
@@ -159,6 +160,9 @@ func (db *DB) GetScheduler() *queue.Scheduler {
 }
 
 func (db *DB) WaitForStartup(ctx context.Context) error {
+	stop := db.trackStartupProgress(ctx)
+	defer stop()
+
 	err := db.init(ctx)
 	if err != nil {
 		return err
@@ -172,11 +176,65 @@ func (db *DB) WaitForStartup(ctx context.Context) error {
 
 func (db *DB) StartupComplete() bool { return db.startupComplete.Load() }
 
-// StartupLoadingProgress reports how many eagerly-loaded local shards have
-// finished loading (loaded) against how many are expected to load eagerly
-// (total), for the repeated "waiting for database to be restored" startup log.
-func (db *DB) StartupLoadingProgress() (loaded, total int64) {
-	// Start from every HOT local shard known to the schema (eager and lazy).
+const startupProgressUpdateInterval = 5 * time.Second
+
+// StartupProgressSnapshot is a consistent reading of eager shard-loading progress
+type StartupProgressSnapshot struct {
+	Loaded int64
+	Total  int64
+}
+
+// StartupLoadingProgress reports the most recently computed eager shard-loading
+// progress: how many eagerly-loaded local shards have finished loading (loaded)
+// against how many are expected to load eagerly (total).
+func (db *DB) StartupLoadingProgress() *StartupProgressSnapshot {
+	return db.startupProgress.Load()
+}
+
+// trackStartupProgress recomputes eager shard-loading progress on a ticker and
+// caches it. It returns a stop function that halts the ticker and pins the
+// final value; callers should defer it. The goroutine also exits if ctx is done.
+func (db *DB) trackStartupProgress(ctx context.Context) func() {
+	// Publish immediately so a value is available before the first log tick.
+	db.updateStartupProgress()
+
+	done := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		ticker := time.NewTicker(startupProgressUpdateInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				db.updateStartupProgress()
+			}
+		}
+	}, db.logger)
+
+	return func() {
+		close(done)
+		// Pin the final value now that loading has finished.
+		db.updateStartupProgress()
+	}
+}
+
+// updateStartupProgress recomputes progress once and publishes it to the cached
+// snapshot and the Prometheus gauges.
+func (db *DB) updateStartupProgress() {
+	loaded, total := db.scanStartupProgress()
+	db.startupProgress.Store(&StartupProgressSnapshot{Loaded: loaded, Total: total})
+	db.promMetrics.SetStartupShardProgress(loaded, total)
+}
+
+// scanStartupProgress computes eager shard-loading progress from scratch.
+//
+// total starts from every HOT local shard known to the schema (eager and lazy);
+// lazy shards are then discounted as they are encountered in the index maps,
+// leaving the eager total. Safe to call while the DB is still loading.
+func (db *DB) scanStartupProgress() (loaded, total int64) {
 	s := db.schemaGetter.GetSchemaSkipAuth()
 	if s.Objects != nil {
 		for _, class := range s.Objects.Classes {
@@ -189,7 +247,13 @@ func (db *DB) StartupLoadingProgress() (loaded, total int64) {
 	}
 
 	db.indexLock.RLock()
+	indices := make([]*Index, 0, len(db.indices))
 	for _, idx := range db.indices {
+		indices = append(indices, idx)
+	}
+	db.indexLock.RUnlock()
+
+	for _, idx := range indices {
 		_ = idx.ForEachShard(func(_ string, shard ShardLike) error {
 			if _, ok := shard.(*LazyLoadShard); ok {
 				total--
@@ -199,7 +263,6 @@ func (db *DB) StartupLoadingProgress() (loaded, total int64) {
 			return nil
 		})
 	}
-	db.indexLock.RUnlock()
 
 	return loaded, total
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/entities/backup"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -46,6 +47,7 @@ import (
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/multitenancy"
 	"github.com/weaviate/weaviate/usecases/replica"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -169,6 +171,52 @@ func (db *DB) WaitForStartup(ctx context.Context) error {
 }
 
 func (db *DB) StartupComplete() bool { return db.startupComplete.Load() }
+
+// StartupLoadingProgress reports how many eagerly-loaded local shards have
+// finished loading (loaded) against how many are expected to load eagerly
+// (total), for the repeated "waiting for database to be restored" startup log.
+func (db *DB) StartupLoadingProgress() (loaded, total int64) {
+	// Start from every HOT local shard known to the schema (eager and lazy).
+	s := db.schemaGetter.GetSchemaSkipAuth()
+	if s.Objects != nil {
+		for _, class := range s.Objects.Classes {
+			n, err := db.localShardsToLoad(class)
+			if err != nil {
+				continue
+			}
+			total += int64(n)
+		}
+	}
+
+	db.indexLock.RLock()
+	for _, idx := range db.indices {
+		_ = idx.ForEachShard(func(_ string, shard ShardLike) error {
+			if _, ok := shard.(*LazyLoadShard); ok {
+				total--
+				return nil
+			}
+			loaded++
+			return nil
+		})
+	}
+	db.indexLock.RUnlock()
+
+	return loaded, total
+}
+
+// localShardsToLoad returns the number of HOT local shards for the given class
+// (active local tenants for multi-tenant classes, all local physical shards
+// otherwise), mirroring the filter used by the index loader.
+func (db *DB) localShardsToLoad(class *models.Class) (int, error) {
+	if multitenancy.IsMultiTenant(class.MultiTenancyConfig) {
+		return db.schemaReader.LocalActiveShardsCount(class.Class)
+	}
+	shards, err := db.schemaReader.LocalShards(class.Class)
+	if err != nil {
+		return 0, err
+	}
+	return len(shards), nil
+}
 
 // IndexGetter interface defines the methods that the service uses from db.IndexGetter
 // This allows for better testability by using interfaces instead of concrete types

--- a/adapters/repos/db/repo_test.go
+++ b/adapters/repos/db/repo_test.go
@@ -12,9 +12,12 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -64,4 +67,98 @@ func TestGetIndex(t *testing.T) {
 	}()
 	idx = db.GetIndex(schema.ClassName("test3"))
 	require.NotNil(t, idx)
+}
+
+// TestDB_scanStartupProgress covers the subtle counting in scanStartupProgress
+// and localShardsToLoad: the schema-derived HOT-local-shard total, discounting
+// lazily-loaded shards, and counting eagerly-loaded shards.
+func TestDB_scanStartupProgress(t *testing.T) {
+	const localNode = "node1"
+
+	stateWith := func(physicals ...sharding.Physical) *sharding.State {
+		m := make(map[string]sharding.Physical, len(physicals))
+		for _, p := range physicals {
+			m[p.Name] = p
+		}
+		s := &sharding.State{Physical: m}
+		s.SetLocalName(localNode)
+		return s
+	}
+
+	// indexWith builds a db.indices entry holding the given shards. A background
+	// closingCtx keeps ForEachShard from short-circuiting.
+	indexWith := func(logger logrus.FieldLogger, className string, shards map[string]ShardLike) map[string]*Index {
+		idx := &Index{
+			Config:     IndexConfig{ClassName: schema.ClassName(className)},
+			logger:     logger,
+			closingCtx: context.Background(),
+		}
+		for name, shard := range shards {
+			idx.shards.Store(name, shard)
+		}
+		return map[string]*Index{idx.ID(): idx}
+	}
+
+	tests := []struct {
+		name       string
+		classes    []*models.Class
+		states     map[string]*sharding.State
+		indices    func(t *testing.T, logger logrus.FieldLogger) map[string]*Index
+		wantLoaded int64
+		wantTotal  int64
+	}{
+		{
+			name:    "eager class: a loaded shard counts toward loaded and total",
+			classes: []*models.Class{{Class: "Eager"}},
+			states: map[string]*sharding.State{
+				// non-multi-tenant shard: empty status normalises to HOT.
+				"Eager": stateWith(sharding.Physical{Name: "s1", BelongsToNodes: []string{localNode}}),
+			},
+			indices: func(t *testing.T, logger logrus.FieldLogger) map[string]*Index {
+				return indexWith(logger, "Eager", map[string]ShardLike{"s1": NewMockShardLike(t)})
+			},
+			wantLoaded: 1,
+			wantTotal:  1,
+		},
+		{
+			name:    "lazy class: the shard is discounted from total and not counted as loaded",
+			classes: []*models.Class{{Class: "Lazy"}},
+			states: map[string]*sharding.State{
+				"Lazy": stateWith(sharding.Physical{Name: "s1", BelongsToNodes: []string{localNode}}),
+			},
+			indices: func(t *testing.T, logger logrus.FieldLogger) map[string]*Index {
+				return indexWith(logger, "Lazy", map[string]ShardLike{"s1": &LazyLoadShard{}})
+			},
+			wantLoaded: 0,
+			wantTotal:  0,
+		},
+		{
+			name: "multi-tenant: only HOT local tenants count toward total",
+			classes: []*models.Class{
+				{Class: "MT", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true}},
+			},
+			states: map[string]*sharding.State{
+				"MT": stateWith(
+					sharding.Physical{Name: "hot", BelongsToNodes: []string{localNode}, Status: models.TenantActivityStatusHOT},
+					sharding.Physical{Name: "cold", BelongsToNodes: []string{localNode}, Status: models.TenantActivityStatusCOLD},
+					sharding.Physical{Name: "remote", BelongsToNodes: []string{"node2"}, Status: models.TenantActivityStatusHOT},
+				),
+			},
+			wantLoaded: 0,
+			wantTotal:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := testDB(t, t.TempDir(), tt.classes, tt.states)
+			if tt.indices != nil {
+				db.indices = tt.indices(t, db.logger)
+			}
+
+			loaded, total := db.scanStartupProgress(db.startupClassNames())
+			assert.Equal(t, tt.wantLoaded, loaded, "loaded")
+			assert.Equal(t, tt.wantTotal, total, "total")
+		})
+	}
 }

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -195,6 +195,10 @@ type Config struct {
 	// UsageLimitsErrorMessage (USAGE_LIMITS_ERROR_MESSAGE) is rendered into the
 	// tenant-cap rejection, matching the handler fast-path.
 	UsageLimitsErrorMessage *runtime.DynamicValue[string]
+
+	// DBLoadProgress reports local shard-loading progress (loaded,
+	// total) while the DB is being restored on startup.
+	DBLoadProgress func() (loaded, total int64)
 }
 
 // Store is the implementation of RAFT on this local node. It will handle the local schema and RAFT operations (startup,
@@ -616,10 +620,29 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 				return nil
 			}
 			if time.Since(lastLog) >= logInterval {
-				st.log.Info("waiting for database to be restored")
+				st.log.WithFields(st.dbLoadProgressFields()).Info("waiting for database to be restored")
 				lastLog = time.Now()
 			}
 		}
+	}
+}
+
+// dbLoadProgressFields returns log fields describing shard-loading progress, or
+// nil when no progress source is configured or there are no shards to load.
+func (st *Store) dbLoadProgressFields() logrus.Fields {
+	if st.cfg.DBLoadProgress == nil {
+		return nil
+	}
+
+	loaded, total := st.cfg.DBLoadProgress()
+	if total <= 0 {
+		return nil
+	}
+
+	return logrus.Fields{
+		"shards_loaded": loaded,
+		"shards_total":  total,
+		"progress":      fmt.Sprintf("%.0f%%", float64(loaded)/float64(total)*100),
 	}
 }
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/cluster/dynusers"
 	"github.com/weaviate/weaviate/cluster/fsm"
@@ -198,7 +199,7 @@ type Config struct {
 
 	// DBLoadProgress reports local shard-loading progress (loaded,
 	// total) while the DB is being restored on startup.
-	DBLoadProgress func() (loaded, total int64)
+	DBLoadProgress func() *db.StartupProgressSnapshot
 }
 
 // Store is the implementation of RAFT on this local node. It will handle the local schema and RAFT operations (startup,
@@ -634,15 +635,19 @@ func (st *Store) dbLoadProgressFields() logrus.Fields {
 		return nil
 	}
 
-	loaded, total := st.cfg.DBLoadProgress()
-	if total <= 0 {
+	snapshot := st.cfg.DBLoadProgress()
+	if snapshot == nil {
+		return nil
+	}
+
+	if snapshot.Total <= 0 {
 		return nil
 	}
 
 	return logrus.Fields{
-		"shards_loaded": loaded,
-		"shards_total":  total,
-		"progress":      fmt.Sprintf("%.0f%%", float64(loaded)/float64(total)*100),
+		"shards_loaded": snapshot.Loaded,
+		"shards_total":  snapshot.Total,
+		"progress":      fmt.Sprintf("%.0f%%", float64(snapshot.Loaded)/float64(snapshot.Total)*100),
 	}
 }
 

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -32,6 +32,7 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/weaviate/weaviate/adapters/repos/db"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -1385,7 +1386,7 @@ func TestStoreMetrics(t *testing.T) {
 func TestStoreDBLoadProgressFields(t *testing.T) {
 	tests := []struct {
 		name     string
-		progress func() (loaded, total int64)
+		progress func() *db.StartupProgressSnapshot
 		want     logrus.Fields
 	}{
 		{
@@ -1395,32 +1396,32 @@ func TestStoreDBLoadProgressFields(t *testing.T) {
 		},
 		{
 			name:     "no shards to load returns nil",
-			progress: func() (int64, int64) { return 0, 0 },
+			progress: func() *db.StartupProgressSnapshot { return &db.StartupProgressSnapshot{Loaded: 0, Total: 0} },
 			want:     nil,
 		},
 		{
 			name:     "negative total returns nil",
-			progress: func() (int64, int64) { return 0, -1 },
+			progress: func() *db.StartupProgressSnapshot { return &db.StartupProgressSnapshot{Loaded: 0, Total: -1} },
 			want:     nil,
 		},
 		{
 			name:     "nothing loaded yet",
-			progress: func() (int64, int64) { return 0, 10 },
+			progress: func() *db.StartupProgressSnapshot { return &db.StartupProgressSnapshot{Loaded: 0, Total: 10} },
 			want:     logrus.Fields{"shards_loaded": int64(0), "shards_total": int64(10), "progress": "0%"},
 		},
 		{
 			name:     "partial progress rounds to whole percent",
-			progress: func() (int64, int64) { return 1, 3 },
+			progress: func() *db.StartupProgressSnapshot { return &db.StartupProgressSnapshot{Loaded: 1, Total: 3} },
 			want:     logrus.Fields{"shards_loaded": int64(1), "shards_total": int64(3), "progress": "33%"},
 		},
 		{
 			name:     "partial progress",
-			progress: func() (int64, int64) { return 3, 10 },
+			progress: func() *db.StartupProgressSnapshot { return &db.StartupProgressSnapshot{Loaded: 3, Total: 10} },
 			want:     logrus.Fields{"shards_loaded": int64(3), "shards_total": int64(10), "progress": "30%"},
 		},
 		{
 			name:     "fully loaded",
-			progress: func() (int64, int64) { return 10, 10 },
+			progress: func() *db.StartupProgressSnapshot { return &db.StartupProgressSnapshot{Loaded: 10, Total: 10} },
 			want:     logrus.Fields{"shards_loaded": int64(10), "shards_total": int64(10), "progress": "100%"},
 		},
 	}

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -1382,6 +1382,56 @@ func TestStoreMetrics(t *testing.T) {
 	})
 }
 
+func TestStoreDBLoadProgressFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress func() (loaded, total int64)
+		want     logrus.Fields
+	}{
+		{
+			name:     "no progress source returns nil",
+			progress: nil,
+			want:     nil,
+		},
+		{
+			name:     "no shards to load returns nil",
+			progress: func() (int64, int64) { return 0, 0 },
+			want:     nil,
+		},
+		{
+			name:     "negative total returns nil",
+			progress: func() (int64, int64) { return 0, -1 },
+			want:     nil,
+		},
+		{
+			name:     "nothing loaded yet",
+			progress: func() (int64, int64) { return 0, 10 },
+			want:     logrus.Fields{"shards_loaded": int64(0), "shards_total": int64(10), "progress": "0%"},
+		},
+		{
+			name:     "partial progress rounds to whole percent",
+			progress: func() (int64, int64) { return 1, 3 },
+			want:     logrus.Fields{"shards_loaded": int64(1), "shards_total": int64(3), "progress": "33%"},
+		},
+		{
+			name:     "partial progress",
+			progress: func() (int64, int64) { return 3, 10 },
+			want:     logrus.Fields{"shards_loaded": int64(3), "shards_total": int64(10), "progress": "30%"},
+		},
+		{
+			name:     "fully loaded",
+			progress: func() (int64, int64) { return 10, 10 },
+			want:     logrus.Fields{"shards_loaded": int64(10), "shards_total": int64(10), "progress": "100%"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &Store{cfg: Config{DBLoadProgress: tt.progress}}
+			assert.Equal(t, tt.want, st.dbLoadProgressFields())
+		})
+	}
+}
+
 type MockStore struct {
 	indexer        *fakes.MockSchemaExecutor
 	parser         *fakes.MockParser

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -564,10 +564,6 @@ func TestService_Usage_NilVectorIndexConfig(t *testing.T) {
 			return fn(nil, shardingState)
 		},
 	)
-	// WaitForStartup samples eager shard-loading progress, which reads local
-	// shard counts from the schema; allow those calls (see createTestDb).
-	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{"shard1"}, nil).Maybe()
-	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
 
 	repo := createTestDb(t, mockSchema, shardingState, class, nodeName)
 	repo.Shutdown(ctx)

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -85,6 +85,8 @@ func TestService_Usage_SingleTenant(t *testing.T) {
 			return fn(nil, shardingState)
 		},
 	)
+	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{"shard1"}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
 
 	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
 	mockSchemaGetter.EXPECT().GetSchemaSkipAuth().Return(entschema.Schema{
@@ -211,6 +213,8 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 			return fn(nil, shardingState)
 		},
 	)
+	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{"shard1"}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
 	mockSchemaReader.EXPECT().LocalActiveShardsCount(className).Return(len(shardingState.Physical), nil)
 
 	repo := createTestDb(t, mockSchema, shardingState, class, nodeName)
@@ -560,6 +564,10 @@ func TestService_Usage_NilVectorIndexConfig(t *testing.T) {
 			return fn(nil, shardingState)
 		},
 	)
+	// WaitForStartup samples eager shard-loading progress, which reads local
+	// shard counts from the schema; allow those calls (see createTestDb).
+	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{"shard1"}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
 
 	repo := createTestDb(t, mockSchema, shardingState, class, nodeName)
 	repo.Shutdown(ctx)

--- a/usecases/classification/integrationtest/classifier_integration_test.go
+++ b/usecases/classification/integrationtest/classifier_integration_test.go
@@ -60,6 +60,8 @@ func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
 	}).Maybe()
 	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
 	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{"shard1"}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
 	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
@@ -212,6 +214,10 @@ func Test_Classifier_ZeroShot_SaveConsistency(t *testing.T) {
 		return readFunc(class, shardState)
 	}).Maybe()
 	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	// WaitForStartup samples eager shard-loading progress, which reads local
+	// shard counts from the schema; allow those calls.
+	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{"shard1"}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
 	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()

--- a/usecases/classification/integrationtest/classifier_integration_test.go
+++ b/usecases/classification/integrationtest/classifier_integration_test.go
@@ -214,10 +214,6 @@ func Test_Classifier_ZeroShot_SaveConsistency(t *testing.T) {
 		return readFunc(class, shardState)
 	}).Maybe()
 	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
-	// WaitForStartup samples eager shard-loading progress, which reads local
-	// shard counts from the schema; allow those calls.
-	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{"shard1"}, nil).Maybe()
-	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
 	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -706,7 +706,7 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Help: "Disk I/O throuhput in bytes per second",
 		}, []string{"operation", "class_name", "shard_name"}),
 		StartupShardsLoaded: promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "startup_shards_loaded",
+			Name: "weaviate_startup_shards_loaded",
 			Help: "Number of eagerly-loaded local shards that have finished loading during startup",
 		}),
 		StartupShardsToLoad: promauto.NewGauge(prometheus.GaugeOpts{

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -121,6 +121,9 @@ type PrometheusMetrics struct {
 	StartupDurations *prometheus.SummaryVec
 	StartupDiskIO    *prometheus.SummaryVec
 
+	StartupShardsLoaded prometheus.Gauge
+	StartupShardsToLoad prometheus.Gauge
+
 	ShardsLoaded    prometheus.Gauge
 	ShardsUnloaded  prometheus.Gauge
 	ShardsLoading   prometheus.Gauge
@@ -702,6 +705,14 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "startup_diskio_throughput",
 			Help: "Disk I/O throuhput in bytes per second",
 		}, []string{"operation", "class_name", "shard_name"}),
+		StartupShardsLoaded: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "startup_shards_loaded",
+			Help: "Number of eagerly-loaded local shards that have finished loading during startup",
+		}),
+		StartupShardsToLoad: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "startup_shards_to_load",
+			Help: "Number of local shards expected to load eagerly during startup",
+		}),
 		QueryDimensions: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "query_dimensions_total",
 			Help: "The vector dimensions used by any read-query that involves vectors",

--- a/usecases/monitoring/shards.go
+++ b/usecases/monitoring/shards.go
@@ -96,3 +96,14 @@ func (pm *PrometheusMetrics) DeleteUnloadedShard() {
 
 	pm.ShardsUnloaded.Dec()
 }
+
+// SetStartupShardProgress publishes the latest eager shard-loading progress
+// (loaded so far / expected to load eagerly) computed during startup.
+func (pm *PrometheusMetrics) SetStartupShardProgress(loaded, total int64) {
+	if pm == nil {
+		return
+	}
+
+	pm.StartupShardsLoaded.Set(float64(loaded))
+	pm.StartupShardsToLoad.Set(float64(total))
+}


### PR DESCRIPTION
### What's being changed:

- Adds progress logging of eager shard loading during the RAFT waiting for database restore log
- Only tracks eager shards as they are loaded
- Lazy load shards do not count towards the total and are skipped when encountered

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
