### PR TITLE
hfresh: increase searchProbe default to 256

### DIFF
--- a/entities/vectorindex/hfresh/config.go
+++ b/entities/vectorindex/hfresh/config.go
@@ -24,7 +24,7 @@ const (
 	DefaultMaxPostingSizeKB     = 48
 	MaxPostingSizeKBFloor       = 8
 	DefaultReplicas             = 4
-	DefaultSearchProbe          = 64
+	DefaultSearchProbe          = 256
 	DefaultHFreshRescoreLimit   = 350
 	MaximumAllowedReplicas      = 10
 	MaximumAllowedPostingSizeKB = 1024

--- a/entities/vectorindex/hfresh/config_test.go
+++ b/entities/vectorindex/hfresh/config_test.go
@@ -25,7 +25,7 @@ func Test_UserConfig(t *testing.T) {
 	t.Run("default searchProbe is 256", func(t *testing.T) {
 		cfg := NewDefaultUserConfig()
 
-		assert.Equal(t, uint32(256), cfg.SearchProbe)
+		assert.Equal(t, uint32(DefaultSearchProbe), cfg.SearchProbe)
 	})
 
 	type test struct {

--- a/entities/vectorindex/hfresh/config_test.go
+++ b/entities/vectorindex/hfresh/config_test.go
@@ -22,6 +22,12 @@ import (
 )
 
 func Test_UserConfig(t *testing.T) {
+	t.Run("default searchProbe is 256", func(t *testing.T) {
+		cfg := NewDefaultUserConfig()
+
+		assert.Equal(t, uint32(256), cfg.SearchProbe)
+	})
+
 	type test struct {
 		name         string
 		input        interface{}


### PR DESCRIPTION
### What's being changed:

Backport of #11793 to `stable/v1.36`.

Increases the HFresh `searchProbe` default to 256. Both commits from the v1.37 PR were cherry-picked cleanly (no conflicts); the resulting files are identical to the v1.37 merge result.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary (backport, config default change)
- [x] All new code is covered by tests where it is reasonable. (`go test ./entities/vectorindex/hfresh/` — 25 passing)
- [x] Performance tests have been run or not necessary. Covered by original PR #11793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)