### PR TITLE
Search time entrypoint repair

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 
 	"github.com/sirupsen/logrus"
@@ -677,6 +678,12 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 	}
 	vec, err := s.multipleVectorForID(ctx, fetchID, relativeID)
 	if err != nil {
+		var e storobj.ErrNotFound
+		if errors.As(err, &e) && e.DocID != id {
+			// key not-found errors by the requested node id — callers ask this
+			// cache by node id and must not see the internal docID fetch
+			return nil, storobj.NewErrNotFoundf(id, "%v", err)
+		}
 		return nil, err
 	}
 

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -653,6 +653,9 @@ func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error 
 	return nil
 }
 
+// errNoUsableEntrypoint: every candidate is denied, tombstoned, or under maintenance
+var errNoUsableEntrypoint = errors.New("no valid entrypoint available")
+
 // repairGlobalEntrypoint attempts to repair a broken global entrypoint during insert.
 // It is called from the insert path when the global entrypoint is unusable (e.g., under
 // maintenance or vector unavailable). The function finds a new valid entrypoint and
@@ -684,7 +687,7 @@ func (h *hnsw) repairGlobalEntrypoint(oldEntrypoint uint64, localDeny helpers.Al
 		currentEp := h.getEntrypoint()
 		if currentEp == oldEntrypoint {
 			// Graph is empty or only unusable nodes remain
-			return 0, fmt.Errorf("no valid entrypoint available")
+			return 0, errNoUsableEntrypoint
 		}
 		// Someone else already repaired it
 		return currentEp, nil
@@ -756,31 +759,26 @@ func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel i
 		candidateLevel := candidate.level
 		candidate.Unlock()
 
-		if candidateLevel > bestLevel {
-			bestCandidate = uint64(i)
-			bestLevel = candidateLevel
-			foundCandidate = true
+		if candidateLevel <= bestLevel {
+			continue
 		}
+
+		// tombstoned or under-maintenance nodes would immediately be found broken again
+		if candidate.isUnderMaintenance() || h.hasTombstone(uint64(i)) {
+			continue
+		}
+
+		bestCandidate = uint64(i)
+		bestLevel = candidateLevel
+		foundCandidate = true
 	}
 
 	if foundCandidate {
 		return bestCandidate, bestLevel, true
 	}
 
-	if h.isEmpty() {
-		return 0, 0, false
-	}
-
-	if h.isOnlyNode(&vertex{id: oldEntrypoint}, denyList) {
-		return 0, 0, false
-	}
-
-	// we made it through the entire graph and didn't find a new entrypoint all
-	// the way down to level 0. This can only mean the graph is empty, which is
-	// unexpected. This situation should have been prevented by the deleteLock.
-	panic(fmt.Sprintf(
-		"class %s: shard %s: findNewEntrypoint called on an empty hnsw graph",
-		h.className, h.shardName))
+	// no usable candidate (graph empty or all nodes denied/tombstoned/under maintenance)
+	return 0, 0, false
 }
 
 // returns entryPointID, level and whether a change occurred

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -653,6 +653,62 @@ func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error 
 	return nil
 }
 
+// repairGlobalEntrypoint attempts to repair a broken global entrypoint during insert.
+// It is called from the insert path when the global entrypoint is unusable (e.g., under
+// maintenance or vector unavailable). The function finds a new valid entrypoint and
+// atomically updates it using CAS semantics.
+//
+// Parameters:
+//   - oldEntrypoint: the entrypoint that was found to be unusable
+//   - localDeny: nodes already tried and rejected during local fallback
+//
+// Returns the new entrypoint ID, or an error if no valid entrypoint can be found.
+// If another goroutine already repaired the entrypoint (CAS fails), returns the
+// current entrypoint value.
+func (h *hnsw) repairGlobalEntrypoint(oldEntrypoint uint64, localDeny helpers.AllowList) (uint64, error) {
+	// Build denyList: exclude oldEntrypoint + known-bad local nodes
+	denyList := localDeny.WrapOnWrite()
+	denyList.Insert(oldEntrypoint)
+
+	// Get the old entrypoint's level (best effort - may be nil if already deleted)
+	var targetLevel int
+	if node := h.nodeByID(oldEntrypoint); node != nil {
+		node.Lock()
+		targetLevel = node.level
+		node.Unlock()
+	}
+
+	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, targetLevel, oldEntrypoint)
+	if !ok {
+		// No change: either graph is empty, or entrypoint was already changed by concurrent op
+		currentEp := h.getEntrypoint()
+		if currentEp == oldEntrypoint {
+			// Graph is empty or only unusable nodes remain
+			return 0, fmt.Errorf("no valid entrypoint available")
+		}
+		// Someone else already repaired it
+		return currentEp, nil
+	}
+
+	// CAS: only update if entrypoint hasn't changed since we started
+	h.Lock()
+	if h.entryPointID == oldEntrypoint {
+		// CAS success: update in-memory first, then persist (matches deleteEntrypoint)
+		h.entryPointID = newEntrypoint
+		h.currentMaximumLayer = level
+		if err := h.commitLog.SetEntryPointWithMaxLayer(newEntrypoint, level); err != nil {
+			h.Unlock()
+			return 0, fmt.Errorf("persist entrypoint: %w", err)
+		}
+		h.Unlock()
+		return newEntrypoint, nil
+	}
+	// CAS failed: concurrent op already changed the entrypoint
+	currentEp := h.entryPointID
+	h.Unlock()
+	return currentEp, nil
+}
+
 // returns entryPointID, level and whether a change occurred
 func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel int,
 	oldEntrypoint uint64,

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -633,11 +633,10 @@ func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error 
 	}
 
 	node.Lock()
-	level := node.level
 	id := node.id
 	node.Unlock()
 
-	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, level, id)
+	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, id)
 	if !ok {
 		return nil
 	}
@@ -653,67 +652,36 @@ func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error 
 	return nil
 }
 
-// errNoUsableEntrypoint: every candidate is denied, tombstoned, or under maintenance
 var errNoUsableEntrypoint = errors.New("no valid entrypoint available")
 
-// repairGlobalEntrypoint attempts to repair a broken global entrypoint during insert.
-// It is called from the insert path when the global entrypoint is unusable (e.g., under
-// maintenance or vector unavailable). The function finds a new valid entrypoint and
-// atomically updates it using CAS semantics.
-//
-// Parameters:
-//   - oldEntrypoint: the entrypoint that was found to be unusable
-//   - localDeny: nodes already tried and rejected during local fallback
-//
-// Returns the new entrypoint ID, or an error if no valid entrypoint can be found.
-// If another goroutine already repaired the entrypoint (CAS fails), returns the
-// current entrypoint value.
-func (h *hnsw) repairGlobalEntrypoint(oldEntrypoint uint64, localDeny helpers.AllowList) (uint64, error) {
-	// Build denyList: exclude oldEntrypoint + known-bad local nodes
-	denyList := localDeny.WrapOnWrite()
-	denyList.Insert(oldEntrypoint)
-
-	// Get the old entrypoint's level (best effort - may be nil if already deleted)
-	var targetLevel int
-	if node := h.nodeByID(oldEntrypoint); node != nil {
-		node.Lock()
-		targetLevel = node.level
-		node.Unlock()
-	}
-
-	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, targetLevel, oldEntrypoint)
+// repairGlobalEntrypoint replaces an unusable global entrypoint with a usable
+// node, skipping nodes in denyList (which must already contain oldEntrypoint).
+// If a concurrent operation changed the entrypoint first, that entrypoint is
+// returned instead. Returns errNoUsableEntrypoint if no candidate remains.
+func (h *hnsw) repairGlobalEntrypoint(oldEntrypoint uint64, denyList helpers.AllowList) (uint64, error) {
+	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, oldEntrypoint)
 	if !ok {
-		// No change: either graph is empty, or entrypoint was already changed by concurrent op
-		currentEp := h.getEntrypoint()
-		if currentEp == oldEntrypoint {
-			// Graph is empty or only unusable nodes remain
-			return 0, errNoUsableEntrypoint
+		if currentEp := h.getEntrypoint(); currentEp != oldEntrypoint {
+			return currentEp, nil
 		}
-		// Someone else already repaired it
-		return currentEp, nil
+		return 0, errNoUsableEntrypoint
 	}
 
-	// CAS: only update if entrypoint hasn't changed since we started
 	h.Lock()
-	if h.entryPointID == oldEntrypoint {
-		// CAS success: update in-memory first, then persist (matches deleteEntrypoint)
-		h.entryPointID = newEntrypoint
-		h.currentMaximumLayer = level
-		if err := h.commitLog.SetEntryPointWithMaxLayer(newEntrypoint, level); err != nil {
-			h.Unlock()
-			return 0, fmt.Errorf("persist entrypoint: %w", err)
-		}
-		h.Unlock()
-		return newEntrypoint, nil
+	defer h.Unlock()
+	if h.entryPointID != oldEntrypoint {
+		return h.entryPointID, nil
 	}
-	// CAS failed: concurrent op already changed the entrypoint
-	currentEp := h.entryPointID
-	h.Unlock()
-	return currentEp, nil
+	h.entryPointID = newEntrypoint
+	h.currentMaximumLayer = level
+	if err := h.commitLog.SetEntryPointWithMaxLayer(newEntrypoint, level); err != nil {
+		return 0, fmt.Errorf("persist entrypoint: %w", err)
+	}
+	return newEntrypoint, nil
 }
 
 // returns entryPointID, level and whether a change occurred
-func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel int,
+func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList,
 	oldEntrypoint uint64,
 ) (uint64, int, bool) {
 	if h.getEntrypoint() != oldEntrypoint {
@@ -724,9 +692,9 @@ func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel i
 
 	h.metrics.TombstoneFindGlobalEntrypoint()
 
-	// First pass: find the node with the highest level that is not in the denyList.
-	// This handles cases where nodes may have higher levels than both targetLevel
-	// and currentMaximumLayer (e.g., due to corrupt commit log replay or
+	// Find the node with the highest level that is not in the denyList. This
+	// handles cases where nodes may have higher levels than
+	// currentMaximumLayer (e.g., due to corrupt commit log replay or
 	// deserialization bugs).
 	h.RLock()
 	maxNodes := len(h.nodes)
@@ -759,25 +727,20 @@ func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel i
 		candidateLevel := candidate.level
 		candidate.Unlock()
 
-		if candidateLevel <= bestLevel {
-			continue
+		// skip tombstoned and under-maintenance nodes: they would immediately
+		// be found broken again
+		if candidateLevel > bestLevel && !candidate.isUnderMaintenance() &&
+			!h.hasTombstone(uint64(i)) {
+			bestCandidate = uint64(i)
+			bestLevel = candidateLevel
+			foundCandidate = true
 		}
-
-		// tombstoned or under-maintenance nodes would immediately be found broken again
-		if candidate.isUnderMaintenance() || h.hasTombstone(uint64(i)) {
-			continue
-		}
-
-		bestCandidate = uint64(i)
-		bestLevel = candidateLevel
-		foundCandidate = true
 	}
 
 	if foundCandidate {
 		return bestCandidate, bestLevel, true
 	}
 
-	// no usable candidate (graph empty or all nodes denied/tombstoned/under maintenance)
 	return 0, 0, false
 }
 

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -147,12 +147,15 @@ func (h *hnsw) resetIfEmpty() (empty bool, err error) {
 
 		return h.isEmptyUnlocked()
 	}()
-	// It can happen that between calls of isEmptyUnlocked and resetUnlocked
-	// values of h.nodes will change (due to locks being RUnlocked and Locked again)
-	// This is acceptable in order to avoid long Locking of all striped locks
 	if empty {
 		h.shardedNodeLocks.LockAll()
 		defer h.shardedNodeLocks.UnlockAll()
+
+		// never wipe live nodes over a dangling entrypoint — the next search
+		// or insert repairs it reactively
+		if h.hasLiveNodesUnlocked() {
+			return false, nil
+		}
 
 		return true, h.resetUnlocked()
 	}

--- a/adapters/repos/db/vector/hnsw/dist_to_node_test.go
+++ b/adapters/repos/db/vector/hnsw/dist_to_node_test.go
@@ -1,0 +1,83 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// TestDistToNode_ReturnsErrorOnErrNotFound tests that distToNode propagates
+// storobj.ErrNotFound as an error rather than swallowing it and returning (0, nil).
+//
+// This is a prerequisite for the search-side entrypoint fix: callers already
+// have ErrNotFound handling code that never triggers because distToNode
+// currently returns (0, nil) on deleted nodes.
+//
+// Callers affected by this behavioral change (code-reading verified):
+//   - KnnSearchByVectorMaxDist: properly handles with handleDeletedNode (search_with_max_dist.go:41-46)
+//   - knnSearchByVector: properly handles with handleDeletedNode (search.go:736-741)
+//   - findBestEntrypointForNode: skips the level (continue) on ErrNotFound (index.go:581-589)
+//   - tryEpCandidate: returns false, fallback to other candidates (neighbor_connections.go:535-542)
+//   - processNode: returns MaxFloat32, deleted node deprioritized (neighbor_connections.go:107-115)
+//     NOTE: processNode is only invoked during tombstone cleanup (tombstoneCleanupNodes=true),
+//     not during normal insert/search. Normal insert uses searchLayerByVectorWithDistancer
+//     which calls distanceToFloatNode (already propagates errors).
+func TestDistToNode_ReturnsErrorOnErrNotFound(t *testing.T) {
+	const deletedNodeID = uint64(42)
+
+	// VectorForIDThunk that returns ErrNotFound for deletedNodeID
+	vectorForID := func(ctx context.Context, id uint64) ([]float32, error) {
+		if id == deletedNodeID {
+			return nil, storobj.NewErrNotFoundf(id, "node deleted from store")
+		}
+		return []float32{1.0, 2.0, 3.0}, nil
+	}
+
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "dist-to-node-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewL2SquaredProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		VectorForIDThunk:      vectorForID,
+		GetViewThunk:          func() common.BucketView { return &noopBucketView{} },
+	}, ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        64,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { index.Shutdown(context.Background()) })
+
+	// Call distToNode for the deleted node (uncompressed mode, distancer=nil)
+	searchVec := []float32{1.0, 2.0, 3.0}
+	_, err = index.distToNode(nil, deletedNodeID, searchVec)
+
+	// The bug: currently returns (0, nil), but should return an error
+	assert.Error(t, err, "distToNode should return error for deleted node, not (0, nil)")
+
+	// Verify it's specifically ErrNotFound
+	var notFoundErr storobj.ErrNotFound
+	assert.ErrorAs(t, err, &notFoundErr, "error should be storobj.ErrNotFound")
+	assert.Equal(t, deletedNodeID, notFoundErr.DocID)
+}

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_restart_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_restart_integration_test.go
@@ -1,0 +1,224 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+func (s *externalDeleteStore) deleteOne(id uint64) {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.objects, id)
+}
+
+// TestEntrypointRepair_DeletedEntrypoints covers entrypoint repair for
+// uncompressed and RQ-compressed (8 bit) indexes when the entrypoint's object
+// was deleted from the object store without the index being told:
+//  1. delete only the entrypoint, restart, query → repaired to a live node
+//  2. delete everything, restart, query → empty result, no error
+//  3. delete the entrypoint and evict it from the caches without a restart,
+//     query → repaired to a live node
+func TestEntrypointRepair_DeletedEntrypoints(t *testing.T) {
+	const (
+		numVectors = 100
+		dims       = 32
+		k          = 10
+	)
+
+	logger, _ := test.NewNullLogger()
+	vectors, queries := testinghelpers.RandomVecs(numVectors, 1, dims)
+	query := queries[0]
+
+	variants := []struct {
+		name       string
+		compressed bool
+	}{
+		{name: "uncompressed", compressed: false},
+		{name: "rq8", compressed: true},
+	}
+
+	newIndex := func(t *testing.T, dirName, indexID string,
+		store *externalDeleteStore, dummyStore *lsmkv.Store, compressed bool,
+	) *hnsw {
+		uc := ent.UserConfig{}
+		uc.SetDefaults()
+		if compressed {
+			uc.RQ = ent.RQConfig{Enabled: true, Bits: 8}
+		} else {
+			uc.RQ.Enabled = false
+			uc.SkipDefaultQuantization = true
+		}
+
+		idx, err := New(Config{
+			AllocChecker: memwatch.NewDummyMonitor(),
+			RootPath:     dirName,
+			ID:           indexID,
+			Logger:       logger,
+			MakeCommitLoggerThunk: func() (CommitLogger, error) {
+				return NewCommitLogger(dirName, indexID, logger,
+					cyclemanager.NewCallbackGroupNoop())
+			},
+			DistanceProvider:  distancer.NewL2SquaredProvider(),
+			VectorForIDThunk:  store.vectorForID,
+			GetViewThunk:      func() common.BucketView { return &searchRepairNoopBucketView{} },
+			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+		}, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+		require.NoError(t, err)
+		idx.PostStartup(context.Background())
+		return idx
+	}
+
+	populate := func(t *testing.T, ctx context.Context, idx *hnsw,
+		store *externalDeleteStore, compressed bool,
+	) {
+		for i := 0; i < numVectors; i++ {
+			store.put(uint64(i), vectors[i])
+			require.NoError(t, idx.Add(ctx, uint64(i), vectors[i]))
+		}
+		require.Equal(t, compressed, idx.Compressed())
+	}
+
+	// a hung repair loop should fail the test instead of blocking it forever
+	search := func(t *testing.T, idx *hnsw) ([]uint64, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		ids, _, err := idx.SearchByVector(ctx, query, k, nil)
+		require.NoError(t, ctx.Err(), "search did not terminate — repair loop is stuck")
+		return ids, err
+	}
+
+	// removes the id from everything except the index itself: the raw object
+	// store and, for compressed indexes, the compressed bucket and cache
+	deleteExternally := func(ctx context.Context, idx *hnsw,
+		store *externalDeleteStore, id uint64,
+	) {
+		store.deleteOne(id)
+		if idx.Compressed() {
+			idx.compressor.Delete(ctx, id)
+		}
+	}
+
+	for _, variant := range variants {
+		t.Run(variant.name, func(t *testing.T) {
+			t.Run("delete entrypoint, restart, query repairs entrypoint", func(t *testing.T) {
+				ctx := context.Background()
+				dirName := t.TempDir()
+				indexID := "entrypoint-repair-restart-" + variant.name
+				dummyStore := testinghelpers.NewDummyStore(t)
+				defer dummyStore.Shutdown(ctx)
+				store := &externalDeleteStore{objects: map[uint64][]float32{}}
+
+				idx := newIndex(t, dirName, indexID, store, dummyStore, variant.compressed)
+				populate(t, ctx, idx, store, variant.compressed)
+
+				oldEP := idx.entryPointID
+				deleteExternally(ctx, idx, store, oldEP)
+
+				require.NoError(t, idx.Flush())
+				require.NoError(t, idx.Shutdown(ctx))
+				idx = newIndex(t, dirName, indexID, store, dummyStore, variant.compressed)
+				defer idx.Shutdown(ctx)
+				require.Equal(t, variant.compressed, idx.Compressed())
+				require.Equal(t, oldEP, idx.entryPointID,
+					"restart should restore the stale entrypoint from the commit log")
+
+				ids, err := search(t, idx)
+				require.NoError(t, err, "first search after restart must repair the entrypoint")
+				require.NotEmpty(t, ids)
+				require.NotContains(t, ids, oldEP, "results must not contain the deleted node")
+
+				newEP := idx.entryPointID
+				require.NotEqual(t, oldEP, newEP, "a new entrypoint must have been selected")
+				_, err = store.vectorForID(ctx, newEP)
+				require.NoError(t, err, "new entrypoint must be a live node")
+				require.True(t, idx.hasTombstone(oldEP),
+					"deleted entrypoint must be flagged for cleanup")
+			})
+
+			t.Run("delete all vectors, restart, query returns empty without error", func(t *testing.T) {
+				ctx := context.Background()
+				dirName := t.TempDir()
+				indexID := "entrypoint-repair-all-dead-" + variant.name
+				dummyStore := testinghelpers.NewDummyStore(t)
+				defer dummyStore.Shutdown(ctx)
+				store := &externalDeleteStore{objects: map[uint64][]float32{}}
+
+				idx := newIndex(t, dirName, indexID, store, dummyStore, variant.compressed)
+				populate(t, ctx, idx, store, variant.compressed)
+
+				for i := 0; i < numVectors; i++ {
+					deleteExternally(ctx, idx, store, uint64(i))
+				}
+
+				require.NoError(t, idx.Flush())
+				require.NoError(t, idx.Shutdown(ctx))
+				idx = newIndex(t, dirName, indexID, store, dummyStore, variant.compressed)
+				defer idx.Shutdown(ctx)
+
+				// twice: covers the initial repair chain and the already-exhausted state
+				for i := 0; i < 2; i++ {
+					ids, err := search(t, idx)
+					require.NoError(t, err, "search %d over a fully deleted graph must not error", i)
+					require.Empty(t, ids)
+				}
+			})
+
+			t.Run("immediate entrypoint deletion without restart repairs entrypoint", func(t *testing.T) {
+				ctx := context.Background()
+				dirName := t.TempDir()
+				indexID := "entrypoint-repair-immediate-" + variant.name
+				dummyStore := testinghelpers.NewDummyStore(t)
+				defer dummyStore.Shutdown(ctx)
+				store := &externalDeleteStore{objects: map[uint64][]float32{}}
+
+				idx := newIndex(t, dirName, indexID, store, dummyStore, variant.compressed)
+				defer idx.Shutdown(ctx)
+				populate(t, ctx, idx, store, variant.compressed)
+
+				oldEP := idx.entryPointID
+				deleteExternally(ctx, idx, store, oldEP)
+				if !variant.compressed {
+					// the raw vector cache would otherwise mask the deletion
+					idx.cache.Delete(ctx, oldEP)
+				}
+
+				ids, err := search(t, idx)
+				require.NoError(t, err, "search must repair the entrypoint")
+				require.NotEmpty(t, ids)
+				require.NotContains(t, ids, oldEP, "results must not contain the deleted node")
+
+				newEP := idx.entryPointID
+				require.NotEqual(t, oldEP, newEP, "a new entrypoint must have been selected")
+				_, err = store.vectorForID(ctx, newEP)
+				require.NoError(t, err, "new entrypoint must be a live node")
+				require.True(t, idx.hasTombstone(oldEP),
+					"deleted entrypoint must be flagged for cleanup")
+			})
+		})
+	}
+}

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
@@ -1,0 +1,438 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// countingCommitLogger wraps NoopCommitLogger and counts SetEntryPointWithMaxLayer calls
+type countingCommitLogger struct {
+	NoopCommitLogger
+	setEntrypointCalls atomic.Int32
+}
+
+func (c *countingCommitLogger) SetEntryPointWithMaxLayer(id uint64, level int) error {
+	c.setEntrypointCalls.Add(1)
+	return nil
+}
+
+func makeCountingCommitLogger(counter *countingCommitLogger) func() (CommitLogger, error) {
+	return func() (CommitLogger, error) {
+		return counter, nil
+	}
+}
+
+// TestEntrypointRepair_GlobalEntrypointUnderMaintenance tests the primary scenario:
+// when the global entrypoint is marked under maintenance, an insert should trigger
+// repair and succeed (not hang or timeout).
+func TestEntrypointRepair_GlobalEntrypointUnderMaintenance(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	// Build index with several nodes
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil // fallback for new inserts
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes to establish the index
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Get the current entrypoint
+	originalEntrypoint := index.entryPointID
+	require.True(t, originalEntrypoint < uint64(len(vectors)), "entrypoint should be one of the initial nodes")
+
+	// Mark the global entrypoint as under maintenance
+	entrypointNode := index.nodeByID(originalEntrypoint)
+	require.NotNil(t, entrypointNode, "entrypoint node should exist")
+	entrypointNode.markAsMaintenance()
+
+	// Perform an insert with a short timeout - should NOT hang
+	insertDone := make(chan error, 1)
+	newVector := []float32{0.5, 0.5, 0.5}
+	newID := uint64(len(vectors))
+
+	go func() {
+		insertDone <- index.Add(ctx, newID, newVector)
+	}()
+
+	select {
+	case err := <-insertDone:
+		// Insert terminated - check result
+		// On unfixed code, this may be an error or the test may hang
+		// On fixed code, this should succeed
+		if err != nil {
+			t.Fatalf("insert failed with error: %v (expected success after repair)", err)
+		}
+
+		// Verify the entrypoint was repaired to a valid node (not under maintenance)
+		newEntrypoint := index.entryPointID
+		if newEntrypoint == originalEntrypoint {
+			// Either repair happened and selected a different node, or repair didn't happen
+			// In either case, the original entrypoint is still under maintenance
+			newEntrypointNode := index.nodeByID(newEntrypoint)
+			if newEntrypointNode != nil && newEntrypointNode.isUnderMaintenance() {
+				t.Errorf("entrypoint is still under maintenance after insert - repair did not happen")
+			}
+		}
+
+		// Verify the new node was inserted
+		insertedNode := index.nodeByID(newID)
+		assert.NotNil(t, insertedNode, "inserted node should exist in the index")
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup: unmark maintenance so Drop can proceed cleanly
+	entrypointNode.unmarkAsMaintenance()
+}
+
+// TestEntrypointRepair_RepairSelectsAlsoUnusableNode tests Case B:
+// repair selects a node that is also unusable → insert ends in clean error, no hang.
+func TestEntrypointRepair_RepairSelectsAlsoUnusableNode(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-also-unusable-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Mark ALL nodes as under maintenance - repair cannot find any usable node
+	for i := 0; i < len(vectors); i++ {
+		node := index.nodeByID(uint64(i))
+		if node != nil {
+			node.markAsMaintenance()
+		}
+	}
+
+	// Perform an insert - should fail with clean error, not hang
+	insertDone := make(chan error, 1)
+	newVector := []float32{0.5, 0.5, 0.5}
+	newID := uint64(len(vectors))
+
+	go func() {
+		insertDone <- index.Add(ctx, newID, newVector)
+	}()
+
+	select {
+	case err := <-insertDone:
+		// Should get a clean error, not success (no usable entrypoint)
+		assert.Error(t, err, "expected error when all nodes are under maintenance")
+		// The error should indicate no usable entrypoint, not a timeout
+		assert.NotContains(t, err.Error(), "context deadline exceeded",
+			"should fail with entrypoint error, not timeout")
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup
+	for i := 0; i < len(vectors); i++ {
+		node := index.nodeByID(uint64(i))
+		if node != nil {
+			node.unmarkAsMaintenance()
+		}
+	}
+}
+
+// TestEntrypointRepair_ConcurrentRepairAlreadyChanged tests Case C:
+// concurrent repair already changed the entrypoint → the repaired value is used.
+func TestEntrypointRepair_ConcurrentRepairAlreadyChanged(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-concurrent-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	originalEntrypoint := index.entryPointID
+
+	// Mark the original entrypoint under maintenance
+	originalNode := index.nodeByID(originalEntrypoint)
+	require.NotNil(t, originalNode)
+	originalNode.markAsMaintenance()
+
+	// Simulate concurrent repair: manually change the entrypoint to a different valid node
+	// before the insert's repair runs
+	var newEntrypointID uint64
+	for i := uint64(0); i < uint64(len(vectors)); i++ {
+		if i != originalEntrypoint {
+			node := index.nodeByID(i)
+			if node != nil && !node.isUnderMaintenance() {
+				newEntrypointID = i
+				break
+			}
+		}
+	}
+	require.NotEqual(t, originalEntrypoint, newEntrypointID, "should find a different valid node")
+
+	// Manually set the entrypoint (simulating concurrent repair)
+	index.Lock()
+	index.entryPointID = newEntrypointID
+	index.Unlock()
+
+	// Now perform an insert - should use the already-repaired entrypoint
+	insertDone := make(chan error, 1)
+	newVector := []float32{0.5, 0.5, 0.5}
+	newID := uint64(len(vectors))
+
+	go func() {
+		insertDone <- index.Add(ctx, newID, newVector)
+	}()
+
+	select {
+	case err := <-insertDone:
+		assert.NoError(t, err, "insert should succeed using the concurrently-repaired entrypoint")
+
+		// Verify the entrypoint is still the one set by concurrent repair
+		assert.Equal(t, newEntrypointID, index.entryPointID,
+			"entrypoint should remain the one set by concurrent repair")
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup
+	originalNode.unmarkAsMaintenance()
+}
+
+// TestEntrypointRepair_ConcurrentInserts tests the concurrency scenario:
+// several inserts hit the bad entrypoint at once, only one repair should perform
+// the actual update (CAS semantics), and the entrypoint should end on a single
+// consistent valid value.
+func TestEntrypointRepair_ConcurrentInserts(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	// Use a counting commit logger to verify exactly one repair persists
+	commitLogger := &countingCommitLogger{}
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-repair-concurrent-inserts-test",
+		MakeCommitLoggerThunk: makeCountingCommitLogger(commitLogger),
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors)+10 { // allow for new inserts
+				if int(id) < len(vectors) {
+					return vectors[id], nil
+				}
+				return []float32{0.5, 0.5, 0.5}, nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < len(vectors); i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Record baseline SetEntryPointWithMaxLayer calls (from initial inserts that promoted entrypoint)
+	baselineCalls := commitLogger.setEntrypointCalls.Load()
+
+	originalEntrypoint := index.entryPointID
+
+	// Mark the entrypoint under maintenance
+	entrypointNode := index.nodeByID(originalEntrypoint)
+	require.NotNil(t, entrypointNode)
+	entrypointNode.markAsMaintenance()
+
+	// Launch multiple concurrent inserts with a start barrier to ensure overlap
+	const numConcurrentInserts = 10
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+	var errorCount atomic.Int32
+
+	// Start barrier: all goroutines wait here until all are ready
+	startBarrier := make(chan struct{})
+
+	for i := 0; i < numConcurrentInserts; i++ {
+		wg.Add(1)
+		go func(insertNum int) {
+			defer wg.Done()
+
+			// Wait for start signal
+			<-startBarrier
+
+			newID := uint64(len(vectors) + insertNum)
+			newVector := []float32{0.5 + float32(insertNum)*0.01, 0.5, 0.5}
+
+			err := index.Add(ctx, newID, newVector)
+			if err != nil {
+				errorCount.Add(1)
+			} else {
+				successCount.Add(1)
+			}
+		}(i)
+	}
+
+	// Release all goroutines simultaneously
+	close(startBarrier)
+
+	// Wait with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All inserts completed
+		t.Logf("Concurrent inserts completed: %d successes, %d errors",
+			successCount.Load(), errorCount.Load())
+
+		// All inserts should succeed (after repair)
+		assert.Equal(t, int32(numConcurrentInserts), successCount.Load(),
+			"all concurrent inserts should succeed after repair")
+
+		// The entrypoint should be consistent and valid (not under maintenance)
+		finalEntrypoint := index.entryPointID
+		finalNode := index.nodeByID(finalEntrypoint)
+		require.NotNil(t, finalNode, "final entrypoint node should exist")
+		assert.False(t, finalNode.isUnderMaintenance(),
+			"final entrypoint should not be under maintenance")
+
+		// Verify exactly one repair SetEntryPointWithMaxLayer call was made
+		// (CAS ensures only one goroutine performs the actual persist)
+		repairCalls := commitLogger.setEntrypointCalls.Load() - baselineCalls
+		assert.Equal(t, int32(1), repairCalls,
+			"exactly one SetEntryPointWithMaxLayer should be called for repair (CAS)")
+
+		// Verify entrypoint changed from original
+		assert.NotEqual(t, originalEntrypoint, finalEntrypoint,
+			"entrypoint should have been repaired to a different node")
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("concurrent inserts did not terminate — spinning in pickEntrypoint")
+	}
+
+	// Cleanup
+	entrypointNode.unmarkAsMaintenance()
+}
+
+// vectorsForEntrypointRepairTest returns a small set of test vectors
+func vectorsForEntrypointRepairTest() [][]float32 {
+	return [][]float32{
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+		{0.7, 0.8, 0.9},
+		{0.2, 0.3, 0.4},
+		{0.5, 0.6, 0.7},
+	}
+}

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
@@ -272,6 +272,8 @@ func TestEntrypointRepair_ConcurrentRepairAlreadyChanged(t *testing.T) {
 	index.entryPointID = newEntrypointID
 	index.Unlock()
 
+	prevMaxLayer := index.currentMaximumLayer
+
 	// Now perform an insert - should use the already-repaired entrypoint
 	insertDone := make(chan error, 1)
 	newVector := []float32{0.5, 0.5, 0.5}
@@ -285,9 +287,19 @@ func TestEntrypointRepair_ConcurrentRepairAlreadyChanged(t *testing.T) {
 	case err := <-insertDone:
 		assert.NoError(t, err, "insert should succeed using the concurrently-repaired entrypoint")
 
-		// Verify the entrypoint is still the one set by concurrent repair
-		assert.Equal(t, newEntrypointID, index.entryPointID,
-			"entrypoint should remain the one set by concurrent repair")
+		// EP stays as set by concurrent repair, unless the new node drew a
+		// level above the previous max layer and legitimately promoted itself
+		finalEntrypoint := index.entryPointID
+		assert.NotEqual(t, originalEntrypoint, finalEntrypoint,
+			"entrypoint must not revert to the under-maintenance original")
+		if finalEntrypoint != newEntrypointID {
+			require.Equal(t, newID, finalEntrypoint,
+				"entrypoint may only differ from the concurrent repair value via promotion of the new node")
+			newNode := index.nodeByID(newID)
+			require.NotNil(t, newNode)
+			assert.Greater(t, newNode.level, prevMaxLayer,
+				"new node may only become entrypoint if it was promoted to a higher layer")
+		}
 
 	case <-time.After(5 * time.Second):
 		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
@@ -408,11 +420,21 @@ func TestEntrypointRepair_ConcurrentInserts(t *testing.T) {
 		assert.False(t, finalNode.isUnderMaintenance(),
 			"final entrypoint should not be under maintenance")
 
-		// Verify exactly one repair SetEntryPointWithMaxLayer call was made
-		// (CAS ensures only one goroutine performs the actual persist)
+		// one CAS repair persist, plus one per node that may have promoted
+		// itself (repair can lower currentMaximumLayer, so any level > 0 counts)
+		promotionCandidates := int32(0)
+		for i := 0; i < numConcurrentInserts; i++ {
+			node := index.nodeByID(uint64(len(vectors) + i))
+			require.NotNil(t, node, "inserted node should exist in the index")
+			if node.level > 0 {
+				promotionCandidates++
+			}
+		}
 		repairCalls := commitLogger.setEntrypointCalls.Load() - baselineCalls
-		assert.Equal(t, int32(1), repairCalls,
-			"exactly one SetEntryPointWithMaxLayer should be called for repair (CAS)")
+		assert.GreaterOrEqual(t, repairCalls, int32(1),
+			"the broken entrypoint should have been repaired and persisted")
+		assert.LessOrEqual(t, repairCalls, 1+promotionCandidates,
+			"SetEntryPointWithMaxLayer calls should be explained by one CAS repair plus level promotions")
 
 		// Verify entrypoint changed from original
 		assert.NotEqual(t, originalEntrypoint, finalEntrypoint,

--- a/adapters/repos/db/vector/hnsw/entrypoint_stranded_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_stranded_test.go
@@ -1,0 +1,123 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// TestDeleteEntrypoint_CandidatesUnderMaintenance deletes the entrypoint while
+// every other node is under maintenance, stranding the entrypoint on the
+// tombstoned node: cleanup must not wipe the live nodes and the next search
+// must repair the entrypoint.
+func TestDeleteEntrypoint_CandidatesUnderMaintenance(t *testing.T) {
+	ctx := context.Background()
+	vectors := vectorsForEntrypointRepairTest()
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "entrypoint-stranded-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	for i := 0; i < len(vectors); i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	oldEP := index.entryPointID
+
+	for i := 0; i < len(vectors); i++ {
+		if uint64(i) == oldEP {
+			continue
+		}
+		node := index.nodeByID(uint64(i))
+		require.NotNil(t, node)
+		node.markAsMaintenance()
+	}
+
+	require.NoError(t, index.Delete(oldEP))
+
+	// cleanup's reassignment unmarks maintenance, so re-mark on every
+	// shouldAbort invocation to keep simulating in-flight inserts
+	markAllLive := func() bool {
+		for i := 0; i < len(vectors); i++ {
+			if uint64(i) == oldEP {
+				continue
+			}
+			if node := index.nodeByID(uint64(i)); node != nil {
+				node.markAsMaintenance()
+			}
+		}
+		return false
+	}
+	_, err = index.cleanUpTombstonedNodes(markAllLive)
+	require.NoError(t, err)
+
+	for i := 0; i < len(vectors); i++ {
+		if uint64(i) == oldEP {
+			continue
+		}
+		if node := index.nodeByID(uint64(i)); node != nil {
+			node.unmarkAsMaintenance()
+		}
+	}
+
+	liveNodes := 0
+	for i := 0; i < len(vectors); i++ {
+		if uint64(i) == oldEP {
+			continue
+		}
+		if index.nodeByID(uint64(i)) != nil {
+			liveNodes++
+		}
+	}
+	assert.Equal(t, len(vectors)-1, liveNodes,
+		"tombstone cleanup must not remove live nodes")
+
+	ids, _, err := index.SearchByVector(ctx, vectors[1], 3, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, ids, "search must still find the live nodes")
+	assert.NotContains(t, ids, oldEP, "results must not contain the deleted node")
+
+	newEP := index.getEntrypoint()
+	assert.NotEqual(t, oldEP, newEP, "search must have repaired the entrypoint")
+	assert.NotNil(t, index.nodeByID(newEP), "repaired entrypoint must be a live node")
+}

--- a/adapters/repos/db/vector/hnsw/flat_search.go
+++ b/adapters/repos/db/vector/hnsw/flat_search.go
@@ -164,12 +164,7 @@ func (h *hnsw) flatMultiSearch(ctx context.Context, queryVector [][]float32, lim
 				dist, err := h.computeScore(queryVector, candidate)
 
 				if errors.As(err, &e) {
-					h.RLock()
-					vecIDs := h.docIDVectors[candidate]
-					h.RUnlock()
-					for _, vecID := range vecIDs {
-						h.handleDeletedNode(vecID, "flatSearch")
-					}
+					h.handleDeletedDocID(candidate, "flatSearch")
 					continue
 				}
 				if err != nil {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -679,7 +679,7 @@ func (h *hnsw) distToNode(distancer compressionhelpers.CompressorDistancer, node
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
 			h.handleDeletedNode(e.DocID, "distBetweenNodeAndVec")
-			return 0, nil
+			return 0, err
 		}
 		// not a typed error, we can recover from, return with err
 		return 0, errors.Wrapf(err,

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -664,6 +664,10 @@ func (h *hnsw) distToNode(distancer compressionhelpers.CompressorDistancer, node
 	if h.compressed.Load() {
 		dist, err := distancer.DistanceToNode(node)
 		if err != nil {
+			var e storobj.ErrNotFound
+			if errors.As(err, &e) {
+				h.handleDeletedNode(e.DocID, "distToNode")
+			}
 			return 0, err
 		}
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -706,14 +706,37 @@ func (h *hnsw) distToNode(distancer compressionhelpers.CompressorDistancer, node
 func (h *hnsw) isEmpty() bool {
 	h.RLock()
 	defer h.RUnlock()
-	h.shardedNodeLocks.RLock(h.entryPointID)
-	defer h.shardedNodeLocks.RUnlock(h.entryPointID)
 
-	return h.isEmptyUnlocked()
+	empty := func() bool {
+		h.shardedNodeLocks.RLock(h.entryPointID)
+		defer h.shardedNodeLocks.RUnlock(h.entryPointID)
+
+		return h.isEmptyUnlocked()
+	}()
+	if !empty {
+		return false
+	}
+
+	// a nil entrypoint slot is not proof of emptiness: cleanup can remove a
+	// stranded entrypoint while live nodes remain
+	h.shardedNodeLocks.RLockAll()
+	defer h.shardedNodeLocks.RUnlockAll()
+
+	return !h.hasLiveNodesUnlocked()
 }
 
 func (h *hnsw) isEmptyUnlocked() bool {
 	return h.entryPointID > uint64(len(h.nodes)) || h.nodes[h.entryPointID] == nil
+}
+
+// callers must hold h.RLock and all sharded node locks
+func (h *hnsw) hasLiveNodesUnlocked() bool {
+	for _, node := range h.nodes {
+		if node != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *hnsw) nodeByID(id uint64) *vertex {

--- a/adapters/repos/db/vector/hnsw/multivector_entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/multivector_entrypoint_repair_test.go
@@ -1,0 +1,245 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+type mvDeletableStore struct {
+	sync.Mutex
+	docs map[uint64][][]float32
+}
+
+func (s *mvDeletableStore) put(docID uint64, vecs [][]float32) {
+	s.Lock()
+	defer s.Unlock()
+	s.docs[docID] = vecs
+}
+
+func (s *mvDeletableStore) deleteDoc(docID uint64) {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.docs, docID)
+}
+
+func (s *mvDeletableStore) multiVectorForID(ctx context.Context, docID uint64) ([][]float32, error) {
+	s.Lock()
+	defer s.Unlock()
+	if vecs, ok := s.docs[docID]; ok {
+		return vecs, nil
+	}
+	return nil, storobj.NewErrNotFoundf(docID, "doc deleted from store")
+}
+
+// TestMultivectorEntrypointRepair covers entrypoint repair for multivector
+// (non-muvera) indexes, where HNSW node ids are vec ids but the store errors
+// by docID. docIDs are chosen so each equals a vec id of a different doc:
+// insert order assigns vec ids 0-2 to docID 3, 3-5 to docID 6, 6-8 to docID 0,
+// so tombstoning an ErrNotFound docID always hits a live vector.
+func TestMultivectorEntrypointRepair(t *testing.T) {
+	ctx := context.Background()
+
+	docIDs := []uint64{3, 6, 0}
+	docVecs := [][][]float32{
+		{{0.1, 0.2, 0.3, 0.4}, {0.2, 0.3, 0.4, 0.5}, {0.3, 0.4, 0.5, 0.6}},
+		{{0.9, 0.1, 0.2, 0.3}, {0.8, 0.2, 0.3, 0.4}, {0.7, 0.3, 0.4, 0.5}},
+		{{0.1, 0.9, 0.8, 0.2}, {0.2, 0.8, 0.7, 0.3}, {0.3, 0.7, 0.6, 0.4}},
+	}
+	query := [][]float32{{0.5, 0.5, 0.5, 0.5}, {0.4, 0.6, 0.4, 0.6}}
+
+	newIndex := func(t *testing.T, store *mvDeletableStore) *hnsw {
+		idx, err := New(Config{
+			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+			ID:                    "multivector-entrypoint-repair",
+			MakeCommitLoggerThunk: MakeNoopCommitLogger,
+			DistanceProvider:      distancer.NewDotProductProvider(),
+			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				return nil, errors.New("multivector index must not use VectorForIDThunk")
+			},
+			MultiVectorForIDThunk: store.multiVectorForID,
+			MakeBucketOptions:     lsmkv.MakeNoopBucketOptions,
+			GetViewThunk:          func() common.BucketView { return &noopBucketView{} },
+			AllocChecker:          memwatch.NewDummyMonitor(),
+		}, ent.UserConfig{
+			VectorCacheMaxObjects: 100000,
+			MaxConnections:        8,
+			EFConstruction:        64,
+			EF:                    64,
+			Multivector:           ent.MultivectorConfig{Enabled: true},
+		}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.NoError(t, err)
+
+		for i, docID := range docIDs {
+			store.put(docID, docVecs[i])
+			require.NoError(t, idx.AddMulti(ctx, docID, docVecs[i]))
+		}
+		return idx
+	}
+
+	// removes the doc from the store and evicts its vectors from the cache,
+	// mimicking a deletion the index was never told about. Delete also wipes
+	// the vec→doc mapping, so restore it as a restart would
+	deleteDocExternally := func(idx *hnsw, store *mvDeletableStore, docID uint64) {
+		store.deleteDoc(docID)
+		for rel, vecID := range idx.docIDVectors[docID] {
+			idx.cache.Delete(ctx, vecID)
+			idx.cache.SetKeys(vecID, docID, uint64(rel))
+		}
+	}
+
+	t.Run("entrypoint doc deleted externally", func(t *testing.T) {
+		store := &mvDeletableStore{docs: map[uint64][][]float32{}}
+		idx := newIndex(t, store)
+		defer idx.Drop(ctx, false)
+
+		epVec := idx.entryPointID
+		epDoc, _ := idx.cache.GetKeys(epVec)
+		deadVecs := append([]uint64{}, idx.docIDVectors[epDoc]...)
+		deleteDocExternally(idx, store, epDoc)
+
+		searchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		ids, _, err := idx.SearchByMultiVector(searchCtx, query, 10, nil)
+		require.NoError(t, searchCtx.Err(), "search did not terminate — repair loop is stuck")
+		require.NoError(t, err)
+
+		wantDocs := make([]uint64, 0, len(docIDs)-1)
+		for _, docID := range docIDs {
+			if docID != epDoc {
+				wantDocs = append(wantDocs, docID)
+			}
+		}
+		assert.ElementsMatch(t, wantDocs, ids, "search must return the live docs")
+
+		// epDoc doubles as a live vec id of another doc by construction
+		assert.False(t, idx.hasTombstone(epDoc),
+			"tombstoned a live vector id (docID/vec id confusion)")
+		for _, vecID := range deadVecs {
+			assert.True(t, idx.hasTombstone(vecID),
+				"all vectors of the dead doc must be tombstoned, missing %d", vecID)
+		}
+		assert.NotContains(t, deadVecs, idx.getEntrypoint(),
+			"entrypoint must be repaired to a live vector")
+	})
+
+	t.Run("dead vec tombstones the whole doc", func(t *testing.T) {
+		store := &mvDeletableStore{docs: map[uint64][][]float32{}}
+		idx := newIndex(t, store)
+		defer idx.Drop(ctx, false)
+
+		deadDoc := docIDs[1]
+		deadVecs := append([]uint64{}, idx.docIDVectors[deadDoc]...)
+		deleteDocExternally(idx, store, deadDoc)
+
+		idx.handleDeletedDocOfNode(deadVecs[0], "test")
+
+		for _, vecID := range deadVecs {
+			assert.True(t, idx.hasTombstone(vecID),
+				"sibling vec %d must be tombstoned", vecID)
+		}
+		for _, docID := range docIDs {
+			if docID == deadDoc {
+				continue
+			}
+			for _, vecID := range idx.docIDVectors[docID] {
+				assert.False(t, idx.hasTombstone(vecID),
+					"live vec %d must not be tombstoned", vecID)
+			}
+		}
+	})
+
+	t.Run("live doc never loses siblings to expansion", func(t *testing.T) {
+		store := &mvDeletableStore{docs: map[uint64][][]float32{}}
+		idx := newIndex(t, store)
+		defer idx.Drop(ctx, false)
+
+		// the doc is still live in the store (e.g. a phantom vec slot):
+		// expansion must probe siblings and leave the live ones alone
+		liveDoc := docIDs[2]
+		probed := idx.docIDVectors[liveDoc][0]
+		idx.handleDeletedDocOfNode(probed, "test")
+
+		assert.True(t, idx.hasTombstone(probed))
+		for _, vecID := range idx.docIDVectors[liveDoc][1:] {
+			assert.False(t, idx.hasTombstone(vecID),
+				"live sibling %d must not be tombstoned", vecID)
+		}
+	})
+
+	t.Run("cache miss errors are keyed by the requested vec id", func(t *testing.T) {
+		store := &mvDeletableStore{docs: map[uint64][][]float32{}}
+		idx := newIndex(t, store)
+		defer idx.Drop(ctx, false)
+
+		deadDoc := docIDs[1]
+		deadVec := idx.docIDVectors[deadDoc][0]
+		deleteDocExternally(idx, store, deadDoc)
+
+		_, err := idx.cache.Get(ctx, deadVec)
+		var e storobj.ErrNotFound
+		require.ErrorAs(t, err, &e)
+		assert.Equal(t, deadVec, e.DocID,
+			"error must carry the requested vec id, not the internal docID")
+	})
+
+	t.Run("stale vec to doc mapping only tombstones the probed vec", func(t *testing.T) {
+		store := &mvDeletableStore{docs: map[uint64][][]float32{}}
+		idx := newIndex(t, store)
+		defer idx.Drop(ctx, false)
+
+		probed := idx.docIDVectors[docIDs[0]][0]
+		// corrupt the mapping: point the probed vec at another doc
+		idx.cache.SetKeys(probed, docIDs[1], 0)
+
+		idx.handleDeletedDocOfNode(probed, "test")
+
+		assert.True(t, idx.hasTombstone(probed))
+		for _, vecID := range idx.docIDVectors[docIDs[1]] {
+			assert.False(t, idx.hasTombstone(vecID),
+				"vec %d of the wrongly mapped doc must not be tombstoned", vecID)
+		}
+	})
+
+	t.Run("all docs deleted externally", func(t *testing.T) {
+		store := &mvDeletableStore{docs: map[uint64][][]float32{}}
+		idx := newIndex(t, store)
+		defer idx.Drop(ctx, false)
+
+		for _, docID := range docIDs {
+			deleteDocExternally(idx, store, docID)
+		}
+
+		searchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		ids, _, err := idx.SearchByMultiVector(searchCtx, query, 10, nil)
+		require.NoError(t, searchCtx.Err(), "search did not terminate — repair loop is stuck")
+		require.NoError(t, err)
+		require.Empty(t, ids)
+	})
+}

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -447,10 +447,7 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 
 	candidate := n.entryPointID
 
-	// [1] Fast path: try the cached global entrypoint.
-	// ErrNotFound (deleted node) is treated as "not usable" and proceeds to repair,
-	// not returned as error - see tryEpCandidateIgnoreDeleted.
-	success, err := n.tryEpCandidateIgnoreDeleted(candidate)
+	success, err := n.tryEpCandidate(candidate)
 	if err != nil {
 		return err
 	}
@@ -458,33 +455,17 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 		return nil
 	}
 
-	// [2] Global candidate failed → attempt global repair ONCE
+	// the global candidate is unusable: repair the global entrypoint, then keep
+	// trying candidates locally, denying every node already found unusable
 	localDeny := n.denyList.WrapOnWrite()
 	localDeny.Insert(candidate)
 
-	newEp, err := n.graph.repairGlobalEntrypoint(candidate, localDeny)
+	candidate, err = n.graph.repairGlobalEntrypoint(candidate, localDeny)
 	if err != nil {
 		return fmt.Errorf("global entrypoint repair: %w", err)
 	}
 
-	// [3] Try the repaired entrypoint (or concurrent repair's result).
-	// Note: newEp != candidate is always true when repair succeeds without error,
-	// because candidate (oldEntrypoint) is excluded via denyList. This guard is
-	// defensive documentation, not a reachable branch.
-	if newEp != candidate {
-		success, err = n.tryEpCandidateIgnoreDeleted(newEp)
-		if err != nil {
-			return err
-		}
-		if success {
-			return nil
-		}
-		localDeny.Insert(newEp)
-		candidate = newEp
-	}
-
-	// [4] Repaired entrypoint also failed → local fallback with no-progress backstop
-	// 60s timeout is last-resort safety net, not expected path
+	// the 60s timeout is a last-resort safety net, not an expected path
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	n.graph.logger.WithFields(logrus.Fields{
@@ -497,19 +478,7 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 			return err
 		}
 
-		alternative, err := n.graph.findNewLocalEntrypoint(localDeny, candidate)
-		if err != nil {
-			return err
-		}
-
-		// No-progress detection: if we get the same candidate back or one already tried
-		if alternative == candidate || localDeny.Contains(alternative) {
-			return fmt.Errorf("no usable entrypoint: local fallback exhausted")
-		}
-
-		candidate = alternative
-
-		success, err = n.tryEpCandidateIgnoreDeleted(candidate)
+		success, err := n.tryEpCandidate(candidate)
 		if err != nil {
 			return err
 		}
@@ -517,23 +486,16 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 			return nil
 		}
 		localDeny.Insert(candidate)
-	}
-}
 
-// tryEpCandidateIgnoreDeleted wraps tryEpCandidate and handles the ErrNotFound case
-// consistently: deleted nodes are treated as "not usable" (returns false, nil),
-// while other errors are propagated.
-func (n *neighborFinderConnector) tryEpCandidateIgnoreDeleted(candidate uint64) (bool, error) {
-	success, err := n.tryEpCandidate(candidate)
-	if err != nil {
-		var e storobj.ErrNotFound
-		if errors.As(err, &e) {
-			// Node was deleted - treat as not usable, not as error
-			return false, nil
+		alternative, err := n.graph.findNewLocalEntrypoint(localDeny, candidate)
+		if err != nil {
+			return err
 		}
-		return false, err
+		if localDeny.Contains(alternative) {
+			return fmt.Errorf("no usable entrypoint: local fallback exhausted")
+		}
+		candidate = alternative
 	}
-	return success, nil
 }
 
 func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error) {

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -447,34 +447,44 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 
 	candidate := n.entryPointID
 
-	// for our search we will need a copy of the current deny list, however, the
-	// cost of that copy can be significant. Let's first verify if the global
-	// entrypoint candidate is usable. If yes, we can return early and skip the
-	// copy.
-	success, err := n.tryEpCandidate(candidate)
+	// [1] Fast path: try the cached global entrypoint.
+	// ErrNotFound (deleted node) is treated as "not usable" and proceeds to repair,
+	// not returned as error - see tryEpCandidateIgnoreDeleted.
+	success, err := n.tryEpCandidateIgnoreDeleted(candidate)
 	if err != nil {
-		var e storobj.ErrNotFound
-		if !errors.As(err, &e) {
-			return err
-		}
-
-		// node was deleted in the meantime
-		// ignore the error and move to the logic below which will try more candidates
+		return err
 	}
-
 	if success {
-		// the global ep candidate is usable, let's skip the following logic (and
-		// therefore avoid the copy)
 		return nil
 	}
 
-	// The global candidate is not usable, we need to find a new one.
+	// [2] Global candidate failed → attempt global repair ONCE
 	localDeny := n.denyList.WrapOnWrite()
+	localDeny.Insert(candidate)
 
-	// make sure the loop cannot block forever. In most cases, results should be
-	// found within micro to milliseconds, this is just a last resort to handle
-	// the unknown somewhat gracefully, for example if there is a bug in the
-	// underlying object store and we cannot retrieve the vector in time, etc.
+	newEp, err := n.graph.repairGlobalEntrypoint(candidate, localDeny)
+	if err != nil {
+		return fmt.Errorf("global entrypoint repair: %w", err)
+	}
+
+	// [3] Try the repaired entrypoint (or concurrent repair's result).
+	// Note: newEp != candidate is always true when repair succeeds without error,
+	// because candidate (oldEntrypoint) is excluded via denyList. This guard is
+	// defensive documentation, not a reachable branch.
+	if newEp != candidate {
+		success, err = n.tryEpCandidateIgnoreDeleted(newEp)
+		if err != nil {
+			return err
+		}
+		if success {
+			return nil
+		}
+		localDeny.Insert(newEp)
+		candidate = newEp
+	}
+
+	// [4] Repaired entrypoint also failed → local fallback with no-progress backstop
+	// 60s timeout is last-resort safety net, not expected path
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	n.graph.logger.WithFields(logrus.Fields{
@@ -487,32 +497,43 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 			return err
 		}
 
-		success, err := n.tryEpCandidate(candidate)
-		if err != nil {
-			var e storobj.ErrNotFound
-			if !errors.As(err, &e) {
-				return err
-			}
-
-			// node was deleted in the meantime
-			// ignore the error and try the next candidate
-		}
-
-		if success {
-			return nil
-		}
-
-		// no success so far, we need to keep going and find a better candidate
-		// make sure we never visit this candidate again
-		localDeny.Insert(candidate)
-		// now find a new one
-
 		alternative, err := n.graph.findNewLocalEntrypoint(localDeny, candidate)
 		if err != nil {
 			return err
 		}
+
+		// No-progress detection: if we get the same candidate back or one already tried
+		if alternative == candidate || localDeny.Contains(alternative) {
+			return fmt.Errorf("no usable entrypoint: local fallback exhausted")
+		}
+
 		candidate = alternative
+
+		success, err = n.tryEpCandidateIgnoreDeleted(candidate)
+		if err != nil {
+			return err
+		}
+		if success {
+			return nil
+		}
+		localDeny.Insert(candidate)
 	}
+}
+
+// tryEpCandidateIgnoreDeleted wraps tryEpCandidate and handles the ErrNotFound case
+// consistently: deleted nodes are treated as "not usable" (returns false, nil),
+// while other errors are propagated.
+func (n *neighborFinderConnector) tryEpCandidateIgnoreDeleted(candidate uint64) (bool, error) {
+	success, err := n.tryEpCandidate(candidate)
+	if err != nil {
+		var e storobj.ErrNotFound
+		if errors.As(err, &e) {
+			// Node was deleted - treat as not usable, not as error
+			return false, nil
+		}
+		return false, err
+	}
+	return success, nil
 }
 
 func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error) {

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -709,6 +709,36 @@ func (h *hnsw) handleDeletedNode(docID uint64, operation string) {
 			"tombstone was added", docID)
 }
 
+// entrypointDistWithRepair returns a usable search entrypoint and its distance
+// to the query vector, repairing the global entrypoint if its object was
+// deleted from the object store. Terminates: repair never selects tombstoned
+// nodes, so each iteration either succeeds or tombstones another dead node.
+// Returns errNoUsableEntrypoint if no usable node remains.
+func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
+	distancer compressionhelpers.CompressorDistancer, entryPointID uint64,
+	searchVec []float32,
+) (uint64, float32, error) {
+	for {
+		dist, err := h.distToNode(distancer, entryPointID, searchVec)
+		if err == nil {
+			return entryPointID, dist, nil
+		}
+		var e storobj.ErrNotFound
+		if !errors.As(err, &e) {
+			return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
+		}
+		// distToNode has already flagged the deleted node with a tombstone
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
+		newEp, err := h.repairGlobalEntrypoint(entryPointID, helpers.NewAllowList())
+		if err != nil {
+			return 0, 0, err
+		}
+		entryPointID = newEp
+	}
+}
+
 func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int,
 	ef int, allowList helpers.AllowList,
 ) ([]uint64, []float32, error) {
@@ -731,15 +761,13 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		compressorDistancer, returnFn = h.compressor.NewDistancer(searchVec)
 		defer returnFn()
 	}
-	entryPointDistance, err := h.distToNode(compressorDistancer, entryPointID, searchVec)
+	entryPointID, entryPointDistance, err := h.entrypointDistWithRepair(ctx, compressorDistancer,
+		entryPointID, searchVec)
 	if err != nil {
-		var e storobj.ErrNotFound
-		if errors.As(err, &e) {
-			h.handleDeletedNode(e.DocID, "knnSearchByVector")
-			return nil, nil, fmt.Errorf("entrypoint was deleted in the object store, " +
-				"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
+		if errors.Is(err, errNoUsableEntrypoint) {
+			return nil, nil, nil
 		}
-		return nil, nil, errors.Wrap(err, "knn search: distance between entrypoint and query node")
+		return nil, nil, errors.Wrap(err, "knn search")
 	}
 
 	// stop at layer 1, not 0!

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -727,7 +727,10 @@ func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
 		if !errors.As(err, &e) {
 			return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
 		}
-		// distToNode has already flagged the deleted node with a tombstone
+		// tombstone the dead node so repair never selects it again; the
+		// uncompressed distToNode path already did this, the compressed one
+		// does not, and without it repair could cycle between dead nodes
+		h.handleDeletedNode(e.DocID, "entrypointDistWithRepair")
 		if err := ctx.Err(); err != nil {
 			return 0, 0, err
 		}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -711,9 +711,10 @@ func (h *hnsw) handleDeletedNode(docID uint64, operation string) {
 
 // entrypointDistWithRepair returns a usable search entrypoint and its distance
 // to the query vector, repairing the global entrypoint if its object was
-// deleted from the object store. Terminates: repair never selects tombstoned
-// nodes, so each iteration either succeeds or tombstones another dead node.
-// Returns errNoUsableEntrypoint if no usable node remains.
+// deleted from the object store. Terminates: distToNode tombstones dead nodes
+// and repair never selects tombstoned nodes, so each iteration either succeeds
+// or rules out another dead node. Returns errNoUsableEntrypoint if no usable
+// node remains.
 func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
 	distancer compressionhelpers.CompressorDistancer, entryPointID uint64,
 	searchVec []float32,
@@ -727,14 +728,10 @@ func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
 		if !errors.As(err, &e) {
 			return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
 		}
-		// tombstone the dead node so repair never selects it again; the
-		// uncompressed distToNode path already did this, the compressed one
-		// does not, and without it repair could cycle between dead nodes
-		h.handleDeletedNode(e.DocID, "entrypointDistWithRepair")
 		if err := ctx.Err(); err != nil {
 			return 0, 0, err
 		}
-		newEp, err := h.repairGlobalEntrypoint(entryPointID, helpers.NewAllowList())
+		newEp, err := h.repairGlobalEntrypoint(entryPointID, helpers.NewAllowList(entryPointID))
 		if err != nil {
 			return 0, 0, err
 		}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -664,7 +665,7 @@ func (h *hnsw) distanceFromBytesToFloatNodeWithView(ctx context.Context, concret
 	if err != nil {
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
-			h.handleDeletedNode(e.DocID, "distanceFromBytesToFloatNodeWithView")
+			h.handleDeletedNode(nodeID, "distanceFromBytesToFloatNodeWithView")
 			return 0, err
 		}
 		// not a typed error, we can recover from, return with err
@@ -709,6 +710,63 @@ func (h *hnsw) handleDeletedNode(docID uint64, operation string) {
 			"tombstone was added", docID)
 }
 
+// handleDeletedDocID tombstones the nodes behind a store-reported docID: for
+// non-muvera multivector indexes docIDs are a different id space than node
+// ids and map to one or more vec ids
+func (h *hnsw) handleDeletedDocID(docID uint64, operation string) {
+	if !h.multivector.Load() || h.muvera.Load() {
+		h.handleDeletedNode(docID, operation)
+		return
+	}
+	h.RLock()
+	vecIDs := append([]uint64{}, h.docIDVectors[docID]...)
+	h.RUnlock()
+	for _, vecID := range vecIDs {
+		h.handleDeletedNode(vecID, operation)
+	}
+}
+
+// handleDeletedDocOfNode tombstones a dead node and, for non-muvera
+// multivector indexes, its doc's sibling vec ids — the store fetches whole
+// docs, so a dead vec usually means the entire doc is gone. Each sibling is
+// probed first and only tombstoned if it is really gone: a live doc can carry
+// a phantom vec slot (e.g. after snapshot corruption), and the mapping is only
+// trusted if the sibling list contains the probed node. Must not be called
+// while holding sharded node locks.
+func (h *hnsw) handleDeletedDocOfNode(nodeID uint64, operation string) {
+	h.handleDeletedNode(nodeID, operation)
+	if !h.multivector.Load() || h.muvera.Load() {
+		return
+	}
+	var docID uint64
+	if h.compressed.Load() {
+		docID, _ = h.compressor.GetKeys(nodeID)
+	} else {
+		docID, _ = h.cache.GetKeys(nodeID)
+	}
+	h.RLock()
+	siblings := append([]uint64{}, h.docIDVectors[docID]...)
+	h.RUnlock()
+	if !slices.Contains(siblings, nodeID) {
+		return
+	}
+	for _, sibling := range siblings {
+		if sibling == nodeID || h.hasTombstone(sibling) {
+			continue
+		}
+		var err error
+		if h.compressed.Load() {
+			_, err = h.compressor.NewDistancerFromID(sibling)
+		} else {
+			_, err = h.vectorForID(context.Background(), sibling)
+		}
+		var e storobj.ErrNotFound
+		if errors.As(err, &e) {
+			h.handleDeletedNode(sibling, operation)
+		}
+	}
+}
+
 // entrypointDistWithRepair returns a usable search entrypoint and its distance
 // to the query vector, repairing dead (nil or deleted-in-store) entrypoints.
 // Terminates: each iteration either succeeds or rules out another dead node.
@@ -727,6 +785,7 @@ func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
 			if !errors.As(err, &e) {
 				return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
 			}
+			h.handleDeletedDocOfNode(entryPointID, "entrypointDistWithRepair")
 		}
 		if err := ctx.Err(); err != nil {
 			return 0, 0, err

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -710,23 +710,23 @@ func (h *hnsw) handleDeletedNode(docID uint64, operation string) {
 }
 
 // entrypointDistWithRepair returns a usable search entrypoint and its distance
-// to the query vector, repairing the global entrypoint if its object was
-// deleted from the object store. Terminates: distToNode tombstones dead nodes
-// and repair never selects tombstoned nodes, so each iteration either succeeds
-// or rules out another dead node. Returns errNoUsableEntrypoint if no usable
-// node remains.
+// to the query vector, repairing dead (nil or deleted-in-store) entrypoints.
+// Terminates: each iteration either succeeds or rules out another dead node.
+// Returns errNoUsableEntrypoint if no usable node remains.
 func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
 	distancer compressionhelpers.CompressorDistancer, entryPointID uint64,
 	searchVec []float32,
 ) (uint64, float32, error) {
 	for {
-		dist, err := h.distToNode(distancer, entryPointID, searchVec)
-		if err == nil {
-			return entryPointID, dist, nil
-		}
-		var e storobj.ErrNotFound
-		if !errors.As(err, &e) {
-			return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
+		if h.nodeByID(entryPointID) != nil {
+			dist, err := h.distToNode(distancer, entryPointID, searchVec)
+			if err == nil {
+				return entryPointID, dist, nil
+			}
+			var e storobj.ErrNotFound
+			if !errors.As(err, &e) {
+				return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
+			}
 		}
 		if err := ctx.Err(); err != nil {
 			return 0, 0, err

--- a/adapters/repos/db/vector/hnsw/search_entrypoint_repair_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/search_entrypoint_repair_integration_test.go
@@ -1,0 +1,163 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+type searchRepairNoopBucketView struct{}
+
+func (n *searchRepairNoopBucketView) ReleaseView() {}
+
+// externalDeleteStore mimics the geo index scenario: objects are deleted from
+// the object store without the index being told
+type externalDeleteStore struct {
+	sync.Mutex
+	objects map[uint64][]float32
+}
+
+func (s *externalDeleteStore) put(id uint64, vec []float32) {
+	s.Lock()
+	defer s.Unlock()
+	s.objects[id] = vec
+}
+
+func (s *externalDeleteStore) deleteAll() {
+	s.Lock()
+	defer s.Unlock()
+	s.objects = map[uint64][]float32{}
+}
+
+func (s *externalDeleteStore) vectorForID(ctx context.Context, id uint64) ([]float32, error) {
+	s.Lock()
+	defer s.Unlock()
+	v, ok := s.objects[id]
+	if !ok {
+		return nil, storobj.NewErrNotFoundf(id, "retrieve object")
+	}
+	return v, nil
+}
+
+// TestSearchRepairsEntrypointDeletedInObjectStore covers the geo filter
+// scenario of delete-all + re-ingest + restart: the first search after restart
+// hits a stale entrypoint (cold vector cache) and must repair it and succeed
+func TestSearchRepairsEntrypointDeletedInObjectStore(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	newIndex := func(t *testing.T, dirName, indexID string, store *externalDeleteStore) *hnsw {
+		idx, err := New(Config{
+			AllocChecker: memwatch.NewDummyMonitor(),
+			RootPath:     dirName,
+			ID:           indexID,
+			MakeCommitLoggerThunk: func() (CommitLogger, error) {
+				return NewCommitLogger(dirName, indexID, logger,
+					cyclemanager.NewCallbackGroupNoop())
+			},
+			DistanceProvider: distancer.NewGeoProvider(),
+			VectorForIDThunk: store.vectorForID,
+			GetViewThunk:     func() common.BucketView { return &searchRepairNoopBucketView{} },
+		}, ent.UserConfig{
+			MaxConnections:         64,
+			EFConstruction:         128,
+			CleanupIntervalSeconds: ent.DefaultCleanupIntervalSeconds,
+		}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.NoError(t, err)
+		return idx
+	}
+
+	genVec := func(i int) []float32 {
+		return []float32{52.52 + float32(i)*0.01, 13.405 + float32(i)*0.01}
+	}
+	query := []float32{52.52, 13.405}
+
+	t.Run("delete and re-ingest, search self-heals after restart", func(t *testing.T) {
+		dirName := t.TempDir()
+		store := &externalDeleteStore{objects: map[uint64][]float32{}}
+		index := newIndex(t, dirName, "search-repair-reingest", store)
+
+		for i := 0; i < 20; i++ {
+			store.put(uint64(i), genVec(i))
+			require.NoError(t, index.Add(ctx, uint64(i), genVec(i)))
+		}
+
+		res, err := index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, res)
+
+		store.deleteAll()
+
+		for i := 20; i < 40; i++ {
+			store.put(uint64(i), genVec(i-20))
+			require.NoError(t, index.Add(ctx, uint64(i), genVec(i-20)))
+		}
+
+		res, err = index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, res)
+
+		// restart: the vector cache no longer masks the stale entrypoint
+		require.NoError(t, index.Flush())
+		require.NoError(t, index.Shutdown(ctx))
+		index = newIndex(t, dirName, "search-repair-reingest", store)
+		defer index.Shutdown(ctx)
+
+		res, err = index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+		require.NoError(t, err, "first search after restart must repair the entrypoint, not fail")
+		require.NotEmpty(t, res)
+		for _, id := range res {
+			require.GreaterOrEqual(t, id, uint64(20), "results must only contain live docIDs")
+		}
+		require.GreaterOrEqual(t, index.entryPointID, uint64(20),
+			"global entrypoint must be repaired to a live node")
+	})
+
+	t.Run("all objects deleted, search returns empty instead of erroring", func(t *testing.T) {
+		dirName := t.TempDir()
+		store := &externalDeleteStore{objects: map[uint64][]float32{}}
+		index := newIndex(t, dirName, "search-repair-all-dead", store)
+
+		for i := 0; i < 20; i++ {
+			store.put(uint64(i), genVec(i))
+			require.NoError(t, index.Add(ctx, uint64(i), genVec(i)))
+		}
+
+		store.deleteAll()
+
+		require.NoError(t, index.Flush())
+		require.NoError(t, index.Shutdown(ctx))
+		index = newIndex(t, dirName, "search-repair-all-dead", store)
+		defer index.Shutdown(ctx)
+
+		// twice: covers the initial repair chain and the already-exhausted state
+		for range 2 {
+			res, err := index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+			require.NoError(t, err)
+			require.Empty(t, res)
+		}
+	})
+}

--- a/adapters/repos/db/vector/hnsw/search_with_max_dist.go
+++ b/adapters/repos/db/vector/hnsw/search_with_max_dist.go
@@ -23,7 +23,11 @@ import (
 func (h *hnsw) KnnSearchByVectorMaxDist(ctx context.Context, searchVec []float32,
 	dist float32, ef int, allowList helpers.AllowList,
 ) ([]uint64, error) {
+	h.RLock()
 	entryPointID := h.entryPointID
+	maxLayer := h.currentMaximumLayer
+	h.RUnlock()
+
 	var compressorDistancer compressionhelpers.CompressorDistancer
 	if h.compressed.Load() {
 		var returnFn compressionhelpers.ReturnDistancerFn
@@ -40,7 +44,7 @@ func (h *hnsw) KnnSearchByVectorMaxDist(ctx context.Context, searchVec []float32
 	}
 
 	// stop at layer 1, not 0!
-	for level := h.currentMaximumLayer; level >= 1; level-- {
+	for level := maxLayer; level >= 1; level-- {
 		eps := priorityqueue.NewMin[any](1)
 		eps.Insert(entryPointID, entryPointDistance)
 		// ignore allowList on layers > 0

--- a/adapters/repos/db/vector/hnsw/search_with_max_dist.go
+++ b/adapters/repos/db/vector/hnsw/search_with_max_dist.go
@@ -13,13 +13,11 @@ package hnsw
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
-	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (h *hnsw) KnnSearchByVectorMaxDist(ctx context.Context, searchVec []float32,
@@ -32,15 +30,13 @@ func (h *hnsw) KnnSearchByVectorMaxDist(ctx context.Context, searchVec []float32
 		compressorDistancer, returnFn = h.compressor.NewDistancer(searchVec)
 		defer returnFn()
 	}
-	entryPointDistance, err := h.distToNode(compressorDistancer, entryPointID, searchVec)
+	entryPointID, entryPointDistance, err := h.entrypointDistWithRepair(ctx, compressorDistancer,
+		entryPointID, searchVec)
 	if err != nil {
-		var e storobj.ErrNotFound
-		if errors.As(err, &e) {
-			h.handleDeletedNode(e.DocID, "KnnSearchByVectorMaxDist")
-			return nil, fmt.Errorf("entrypoint was deleted in the object store, " +
-				"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
+		if errors.Is(err, errNoUsableEntrypoint) {
+			return nil, nil
 		}
-		return nil, errors.Wrap(err, "knn search: distance between entrypoint and query node")
+		return nil, errors.Wrap(err, "knn search")
 	}
 
 	// stop at layer 1, not 0!

--- a/adapters/repos/db/vector/hnsw/search_with_max_dist_race_test.go
+++ b/adapters/repos/db/vector/hnsw/search_with_max_dist_race_test.go
@@ -1,0 +1,103 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// TestKnnSearchByVectorMaxDist_RacesInsertPromotion detects a data race where
+// KnnSearchByVectorMaxDist reads h.entryPointID and h.currentMaximumLayer
+// without RLock, while insert.go writes them under h.Lock() during promotion.
+//
+// Run with: go test -race -run TestKnnSearchByVectorMaxDist_RacesInsertPromotion
+func TestKnnSearchByVectorMaxDist_RacesInsertPromotion(t *testing.T) {
+	const (
+		numInserts  = 500
+		numSearches = 500
+		dims        = 32
+	)
+
+	// Pre-generate random vectors for inserts
+	rng := rand.New(rand.NewSource(42))
+	vectors := make([][]float32, numInserts)
+	for i := range vectors {
+		vectors[i] = make([]float32, dims)
+		for j := range vectors[i] {
+			vectors[i][j] = rng.Float32()
+		}
+	}
+
+	// Vector lookup function
+	vectorForID := func(ctx context.Context, id uint64) ([]float32, error) {
+		if int(id) < len(vectors) {
+			return vectors[id], nil
+		}
+		return make([]float32, dims), nil
+	}
+
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "race-test-max-dist",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewL2SquaredProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		VectorForIDThunk:      vectorForID,
+		GetViewThunk:          func() common.BucketView { return &noopBucketView{} },
+	}, ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { index.Shutdown(context.Background()) })
+
+	// Seed one element so searches have something to find
+	require.NoError(t, index.Add(context.Background(), 0, vectors[0]))
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+
+	// Writer goroutine: inserts that can promote entrypoint
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 1; i < numInserts; i++ {
+			_ = index.Add(ctx, uint64(i), vectors[i])
+		}
+	}()
+
+	// Reader goroutine: concurrent KnnSearchByVectorMaxDist calls
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		searchVec := make([]float32, dims)
+		for i := 0; i < numSearches; i++ {
+			// Use large maxDist to ensure search proceeds
+			_, _ = index.KnnSearchByVectorMaxDist(ctx, searchVec, 100.0, 10, nil)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/visited"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/compression"
 )
 
@@ -449,6 +450,13 @@ func (h *hnsw) multiVectorForNodeID(ctx context.Context, nodeID uint64) ([]float
 	docID, relativeID := h.compressor.GetKeys(nodeID)
 	vecs, err := h.MultiVectorForIDThunk(ctx, docID)
 	if err != nil {
+		var e storobj.ErrNotFound
+		if errors.As(err, &e) {
+			// key not-found errors by the requested node id, not the internal
+			// docID fetch
+			return nil, storobj.NewErrNotFoundf(nodeID,
+				"multi-vector recovery (docID %d): %v", docID, err)
+		}
 		return nil, errors.Wrapf(err, "multi-vector recovery for nodeID %d (docID %d)", nodeID, docID)
 	}
 	if int(relativeID) >= len(vecs) {


### PR DESCRIPTION
### What's being changed:

This change ensures HNSW will fix missing entrypoints immediately on discovery eliminating "entrypoint not found" errors during search and indexing. `repairGlobalEntrypoint` calls the same function `findNewGlobalEntrypoint` that has been used to repair the entrypoint during the tombstone cleanup however this now runs when needed.

It also includes some minor multi-vector fixes on which id to replace on encountering a deleted id.

### Review checklist

- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/29306506134/job/87000946516
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

