### PR TITLE
chore(metric): remove deprecated old schema metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -333,13 +333,6 @@ This document is the single source of truth for Prometheus metrics exposed by We
 | `shards_loading` | Number of shards in process of loading | `Gauge` | `-` | - Low 
 | `shards_unloading` | Number of shards in process of unloading | `Gauge` | `-` | - Low 
 
-#### Schema Metrics
-| Name | Description | Type | Labels | High Cardinality |
-|---|---|---|---|---|
-| `schema_tx_opened_total` | Total number of opened schema transactions | `Counter` | `ownership` | - Low 
-| `schema_tx_closed_total` | Total number of closed schema transactions | `Counter` | `ownership, status` | - Low 
-| `schema_tx_duration_seconds` | Mean duration of a tx by status | `Summary` | `ownership, status` | - Low 
-
 #### Tombstone Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|

--- a/usecases/cluster/transactions_read.go
+++ b/usecases/cluster/transactions_read.go
@@ -13,12 +13,9 @@ package cluster
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 func (c *TxManager) CloseReadTransaction(ctx context.Context,
@@ -38,15 +35,6 @@ func (c *TxManager) CloseReadTransaction(ctx context.Context,
 	defer func() {
 		c.Lock()
 		c.currentTransaction = nil
-		monitoring.GetMetrics().SchemaTxClosed.With(prometheus.Labels{
-			"ownership": "coordinator",
-			"status":    "close_read",
-		}).Inc()
-		took := time.Since(c.currentTransactionBegin)
-		monitoring.GetMetrics().SchemaTxDuration.With(prometheus.Labels{
-			"ownership": "coordinator",
-			"status":    "close_read",
-		}).Observe(took.Seconds())
 		c.slowLog.Close("closed_read")
 		c.Unlock()
 	}()

--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -18,9 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
-	"github.com/weaviate/weaviate/usecases/monitoring"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -259,15 +257,6 @@ func (c *TxManager) resetTxExpiry(ttl time.Duration, id string) {
 			}
 
 			c.clearTransaction()
-			monitoring.GetMetrics().SchemaTxClosed.With(prometheus.Labels{
-				"ownership": "n/a",
-				"status":    "expire",
-			}).Inc()
-			took := time.Since(c.currentTransactionBegin)
-			monitoring.GetMetrics().SchemaTxDuration.With(prometheus.Labels{
-				"ownership": "n/a",
-				"status":    "expire",
-			}).Observe(took.Seconds())
 			c.slowLog.Close("expired")
 		}
 	}
@@ -358,10 +347,6 @@ func (c *TxManager) beginTransaction(ctx context.Context, trType TransactionType
 	c.slowLog.Start(tx.ID, true, !tolerateNodeFailures)
 	c.Unlock()
 
-	monitoring.GetMetrics().SchemaTxOpened.With(prometheus.Labels{
-		"ownership": "coordinator",
-	}).Inc()
-
 	c.resetTxExpiry(ttl, tx.ID)
 
 	if err := c.remote.BroadcastTransaction(ctx, tx); err != nil {
@@ -387,15 +372,6 @@ func (c *TxManager) beginTransaction(ctx context.Context, trType TransactionType
 
 		c.Lock()
 		c.clearTransaction()
-		monitoring.GetMetrics().SchemaTxClosed.With(prometheus.Labels{
-			"ownership": "coordinator",
-			"status":    "abort",
-		}).Inc()
-		took := time.Since(c.currentTransactionBegin)
-		monitoring.GetMetrics().SchemaTxDuration.With(prometheus.Labels{
-			"ownership": "coordinator",
-			"status":    "abort",
-		}).Observe(took.Seconds())
 		c.slowLog.Close("abort_on_open")
 		c.Unlock()
 
@@ -435,15 +411,6 @@ func (c *TxManager) CommitWriteTransaction(ctx context.Context,
 	defer func() {
 		c.Lock()
 		c.clearTransaction()
-		monitoring.GetMetrics().SchemaTxClosed.With(prometheus.Labels{
-			"ownership": "coordinator",
-			"status":    "commit",
-		}).Inc()
-		took := time.Since(c.currentTransactionBegin)
-		monitoring.GetMetrics().SchemaTxDuration.With(prometheus.Labels{
-			"ownership": "coordinator",
-			"status":    "commit",
-		}).Observe(took.Seconds())
 		c.slowLog.Close("committed")
 		c.Unlock()
 	}()
@@ -498,10 +465,6 @@ func (c *TxManager) IncomingBeginTransaction(ctx context.Context,
 		return nil, err
 	}
 
-	monitoring.GetMetrics().SchemaTxOpened.With(prometheus.Labels{
-		"ownership": "participant",
-	}).Inc()
-
 	var ttl time.Duration
 	if tx.Deadline.UnixMilli() != 0 {
 		ttl = time.Until(tx.Deadline)
@@ -525,15 +488,6 @@ func (c *TxManager) IncomingAbortTransaction(ctx context.Context,
 	}
 
 	c.currentTransaction = nil
-	monitoring.GetMetrics().SchemaTxClosed.With(prometheus.Labels{
-		"ownership": "participant",
-		"status":    "abort",
-	}).Inc()
-	took := time.Since(c.currentTransactionBegin)
-	monitoring.GetMetrics().SchemaTxDuration.With(prometheus.Labels{
-		"ownership": "participant",
-		"status":    "abort",
-	}).Observe(took.Seconds())
 	c.slowLog.Close("abort_request_received")
 
 	if err := c.persistence.DeleteTx(ctx, tx.ID); err != nil {
@@ -615,15 +569,6 @@ func (c *TxManager) incomingTxCommitCleanup(
 	defer c.Unlock()
 	c.currentTransaction = nil
 
-	monitoring.GetMetrics().SchemaTxClosed.With(prometheus.Labels{
-		"ownership": "participant",
-		"status":    "commit",
-	}).Inc()
-	took := time.Since(c.currentTransactionBegin)
-	monitoring.GetMetrics().SchemaTxDuration.With(prometheus.Labels{
-		"ownership": "participant",
-		"status":    "commit",
-	}).Observe(took.Seconds())
 	c.slowLog.Close("committed")
 
 	if err := c.persistence.DeleteTx(ctx, tx.ID); err != nil {

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -146,13 +146,6 @@ type PrometheusMetrics struct {
 	// helps cut down on noise when monitoring
 	LSMCriticalBucketsOnly bool
 
-	// Deprecated metrics, keeping around because the classification features
-	// seems to sill use the old logic. However, those metrics are not actually
-	// used for the schema anymore, but only for the classification features.
-	SchemaTxOpened   *prometheus.CounterVec
-	SchemaTxClosed   *prometheus.CounterVec
-	SchemaTxDuration *prometheus.SummaryVec
-
 	// Vectorization
 	T2VBatches            *prometheus.GaugeVec
 	T2VBatchQueueDuration *prometheus.HistogramVec
@@ -776,20 +769,6 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "shard_halt_for_transfer_force_resume_total",
 			Help: "Halt-for-transfer inactivity watchdog firings. Non-zero indicates a transfer was force-resumed mid-stream.",
 		}, []string{}),
-
-		// Schema TX-metrics. Can be removed when RAFT is ready
-		SchemaTxOpened: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "schema_tx_opened_total",
-			Help: "Total number of opened schema transactions",
-		}, []string{"ownership"}),
-		SchemaTxClosed: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "schema_tx_closed_total",
-			Help: "Total number of closed schema transactions. A close must be either successful or failed",
-		}, []string{"ownership", "status"}),
-		SchemaTxDuration: promauto.NewSummaryVec(prometheus.SummaryOpts{
-			Name: "schema_tx_duration_seconds",
-			Help: "Mean duration of a tx by status",
-		}, []string{"ownership", "status"}),
 
 		// RAFT-based schema metrics
 		SchemaWrites: promauto.NewSummaryVec(prometheus.SummaryOpts{


### PR DESCRIPTION
### What's being changed:
this metric was intended before RAFT and not used, this PR remove the metric completely to avoid any confusion and clean up metrics  

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
