### PR TITLE
Optimize cycle manager for large MT collections

### DIFF
--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -169,119 +169,105 @@ func (c *cycleCallbackGroup) cycleCallbackSequential(shouldAbort ShouldAbortCall
 }
 
 func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallback, routinesLimit int) bool {
+	// snapshot the due callbacks under a single lock, then dispatch without it,
+	// so the scan does not serialize Register/execution
+	dueIds := c.collectDueCallbacks()
 	// spawn no workers when nothing is due; callbacks becoming due right after
-	// this check are picked up on the next tick.
-	if c.countDueCallbacks() == 0 {
+	// the snapshot are picked up on the next tick
+	if len(dueIds) == 0 {
 		return false
 	}
 
 	anyExecuted := false
-	ch := make(chan uint32)
 	lock := new(sync.Mutex)
 	wg := new(sync.WaitGroup)
-	wg.Add(routinesLimit)
+	ch := make(chan uint32)
 
-	i := 0
-	for r := 0; r < routinesLimit; r++ {
-		f := func() {
-			defer wg.Done()
-			for callbackId := range ch {
-				if shouldAbort() {
-					// keep reading from channel until it is closed
-					continue
-				}
-
-				c.Lock()
-				meta, ok := c.callbacks[callbackId]
-				// callback missing or deactivated, proceed to the next one
-				if !ok || !meta.active {
-					c.Unlock()
-					continue
-				}
-				now := time.Now()
-				// not enough time passed since previous execution
-				if meta.intervals != nil && now.Sub(meta.started) < meta.intervals.Get() {
-					c.Unlock()
-					continue
-				}
-				// callback active, mark as running
-				runningCtx, cancel := context.WithCancel(context.Background())
-				meta.runningCtx = runningCtx
-				meta.started = now
-				c.Unlock()
-
-				func() {
-					// cancel called in recover, regardless of panic occurred or not
-					defer c.recover(meta.customId, cancel)
-					executed := meta.cycleCallback(func() bool {
-						if shouldAbort() {
-							return true
-						}
-
-						c.Lock()
-						defer c.Unlock()
-
-						return meta.shouldAbort
-					})
-
-					if executed {
-						lock.Lock()
-						anyExecuted = true
-						lock.Unlock()
-					}
-					if meta.intervals != nil {
-						if executed {
-							meta.intervals.Reset()
-						} else {
-							meta.intervals.Advance()
-						}
-					}
-				}()
+	worker := func() {
+		defer wg.Done()
+		for callbackId := range ch {
+			if shouldAbort() {
+				// keep reading from channel until it is closed
+				continue
 			}
+
+			c.Lock()
+			meta, ok := c.callbacks[callbackId]
+			// callback missing or deactivated, proceed to the next one
+			if !ok || !meta.active {
+				c.Unlock()
+				continue
+			}
+			now := time.Now()
+			// not enough time passed since previous execution
+			if meta.intervals != nil && now.Sub(meta.started) < meta.intervals.Get() {
+				c.Unlock()
+				continue
+			}
+			// callback active, mark as running
+			runningCtx, cancel := context.WithCancel(context.Background())
+			meta.runningCtx = runningCtx
+			meta.started = now
+			c.Unlock()
+
+			func() {
+				// cancel called in recover, regardless of panic occurred or not
+				defer c.recover(meta.customId, cancel)
+				executed := meta.cycleCallback(func() bool {
+					if shouldAbort() {
+						return true
+					}
+
+					c.Lock()
+					defer c.Unlock()
+
+					return meta.shouldAbort
+				})
+
+				if executed {
+					lock.Lock()
+					anyExecuted = true
+					lock.Unlock()
+				}
+				if meta.intervals != nil {
+					if executed {
+						meta.intervals.Reset()
+					} else {
+						meta.intervals.Advance()
+					}
+				}
+			}()
 		}
-		enterrors.GoWrapper(f, c.logger)
 	}
 
-	for {
+	wg.Add(routinesLimit)
+	for r := 0; r < routinesLimit; r++ {
+		enterrors.GoWrapper(worker, c.logger)
+	}
+
+	// dispatch only due ids, so workers re-lock per due id rather than per
+	// registered callback
+	for _, callbackId := range dueIds {
 		if shouldAbort() {
-			close(ch)
 			break
 		}
-
-		c.Lock()
-		// no more callbacks left, exit the loop
-		if i >= len(c.callbackIds) {
-			c.Unlock()
-			close(ch)
-			break
-		}
-
-		callbackId := c.callbackIds[i]
-		_, ok := c.callbacks[callbackId]
-		// callback deleted in the meantime, remove its id
-		// and proceed to the next one (no "i" increment required)
-		if !ok {
-			c.callbackIds = append(c.callbackIds[:i], c.callbackIds[i+1:]...)
-			c.Unlock()
-			continue
-		}
-		c.Unlock()
 		ch <- callbackId
-		i++
 	}
-
+	close(ch)
 	wg.Wait()
 	return anyExecuted
 }
 
-// countDueCallbacks prunes ids of deleted callbacks and counts callbacks that
-// are active and whose interval has elapsed, so an idle tick can skip spawning
-// workers entirely. Workers re-verify each callback under lock before executing.
-func (c *cycleCallbackGroup) countDueCallbacks() int {
+// collectDueCallbacks prunes ids of deleted callbacks and returns a snapshot of
+// the ids that are active and whose interval has elapsed. Workers re-verify each
+// under lock before executing, so ids deactivated or unregistered after the
+// snapshot are skipped. Callbacks registered after the snapshot run on the next
+// tick rather than the current one.
+func (c *cycleCallbackGroup) collectDueCallbacks() []uint32 {
 	c.Lock()
 	defer c.Unlock()
 
-	due := 0
+	var dueIds []uint32
 	now := time.Now()
 	i := 0
 	for _, callbackId := range c.callbackIds {
@@ -300,10 +286,10 @@ func (c *cycleCallbackGroup) countDueCallbacks() int {
 		if meta.intervals != nil && now.Sub(meta.started) < meta.intervals.Get() {
 			continue
 		}
-		due++
+		dueIds = append(dueIds, callbackId)
 	}
 	c.callbackIds = c.callbackIds[:i]
-	return due
+	return dueIds
 }
 
 func (c *cycleCallbackGroup) recover(callbackCustomId string, cancel context.CancelFunc) {

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -198,16 +198,10 @@ func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallba
 				c.Unlock()
 				continue
 			}
-			now := time.Now()
-			// not enough time passed since previous execution
-			if meta.intervals != nil && now.Sub(meta.started) < meta.intervals.Get() {
-				c.Unlock()
-				continue
-			}
 			// callback active, mark as running
 			runningCtx, cancel := context.WithCancel(context.Background())
 			meta.runningCtx = runningCtx
-			meta.started = now
+			meta.started = time.Now()
 			c.Unlock()
 
 			func() {
@@ -238,6 +232,11 @@ func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallba
 				}
 			}()
 		}
+	}
+
+	// no need for more workers than callbacks due
+	if routinesLimit > len(dueIds) {
+		routinesLimit = len(dueIds)
 	}
 
 	wg.Add(routinesLimit)

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -13,6 +13,8 @@ package cyclemanager
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -143,7 +145,7 @@ func TestCycleCallback_Parallel(t *testing.T) {
 		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
 	})
 
-	t.Run("register new while executing", func(t *testing.T) {
+	t.Run("register new while executing runs it on the next tick", func(t *testing.T) {
 		executedCounter1 := 0
 		callback1 := func(shouldAbort ShouldAbortCallback) bool {
 			time.Sleep(50 * time.Millisecond)
@@ -178,11 +180,10 @@ func TestCycleCallback_Parallel(t *testing.T) {
 		callbacks.Register("c2", callback2)
 		callbacks.Register("c3", callback3)
 
-		// register 4th callback while other are executed,
-		//
-		// while 1st and 2nd are being processed (50ms),
-		// 3rd is waiting for available routine (without 3rd callback loop would be finished)
-		// 4th is registered (25ms) to be called next along with 3rd
+		// register 4th callback while the others are executing:
+		// 1st and 2nd are processed first (50ms), 3rd waits for a free routine.
+		// The tick dispatches the callbacks due when it started (c1, c2, c3), so
+		// the 4th, registered afterwards, is not part of this tick.
 		go func() {
 			chStarted <- struct{}{}
 			start := time.Now()
@@ -199,8 +200,12 @@ func TestCycleCallback_Parallel(t *testing.T) {
 		assert.Equal(t, 1, executedCounter1)
 		assert.Equal(t, 1, executedCounter2)
 		assert.Equal(t, 1, executedCounter3)
-		assert.Equal(t, 1, executedCounter4)
+		assert.Equal(t, 0, executedCounter4)
 		assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+
+		// the next tick picks up the 4th callback
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, 1, executedCounter4)
 	})
 
 	t.Run("idle tick executes nothing", func(t *testing.T) {
@@ -1662,6 +1667,134 @@ func TestCycleCallback_Sequential_Unregister(t *testing.T) {
 		assert.LessOrEqual(t, counter, max)
 		assert.LessOrEqual(t, d, 200*time.Millisecond)
 	})
+}
+
+func TestCycleCallback_Parallel_DueDispatch(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	t.Run("only due callbacks execute among many not-due", func(t *testing.T) {
+		const total = 200
+		var executed int64
+
+		callbacks := NewCallbackGroup("id", logger, 4)
+		// long interval: due on the first tick (registration allows immediate
+		// execution), not due afterwards
+		for i := 0; i < total; i++ {
+			callbacks.Register(fmt.Sprintf("c%d", i),
+				func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&executed, 1)
+					return true
+				}, WithIntervals(NewFixedIntervals(time.Hour)))
+		}
+
+		// 1st tick: all due
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(total), atomic.LoadInt64(&executed))
+
+		// 2nd tick: none due, nothing runs
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(total), atomic.LoadInt64(&executed))
+	})
+
+	t.Run("concurrent register and unregister during cycles is race free", func(t *testing.T) {
+		callback := func(shouldAbort ShouldAbortCallback) bool { return true }
+
+		callbacks := NewCallbackGroup("id", logger, 4)
+		const stable = 8
+		for i := 0; i < stable; i++ {
+			callbacks.Register(fmt.Sprintf("stable%d", i), callback)
+		}
+
+		stop := make(chan struct{})
+		wg := new(sync.WaitGroup)
+		// churn: continuously register then unregister while cycles run
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				ctrl := callbacks.Register("churn", callback)
+				assert.NoError(t, ctrl.Unregister(context.Background()))
+			}
+		}()
+
+		for i := 0; i < 200; i++ {
+			callbacks.CycleCallback(shouldNotAbort)
+		}
+		close(stop)
+		wg.Wait()
+
+		// final tick prunes ids of the churned callbacks
+		callbacks.CycleCallback(shouldNotAbort)
+
+		group := callbacks.(*cycleCallbackGroup)
+		group.Lock()
+		defer group.Unlock()
+		assert.Len(t, group.callbacks, stable)
+		assert.Len(t, group.callbackIds, stable)
+	})
+}
+
+// BenchmarkCycleCallback_Parallel measures per-tick scheduling overhead of an
+// index-level group. The two regimes mirror the backoff decision in
+// index_cyclecallbacks.go: MT registers each shard entry with its own interval
+// (WithIntervals) and on a steady-state tick only a few shards are due; ST
+// registers entries with no interval (the ticker backs off instead), so every
+// entry is due whenever the group fires.
+func BenchmarkCycleCallback_Parallel(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+	noop := func(shouldAbort ShouldAbortCallback) bool { return true }
+
+	cases := []struct {
+		name        string
+		multiTenant bool
+		registered  int
+		due         int // only meaningful for MT; ST is always all-due
+	}{
+		{name: "MT/registered=5000/due=0", multiTenant: true, registered: 5000, due: 0},
+		{name: "MT/registered=5000/due=5", multiTenant: true, registered: 5000, due: 5},
+		{name: "MT/registered=5000/due=200", multiTenant: true, registered: 5000, due: 200},
+		{name: "MT/registered=5000/due=1000", multiTenant: true, registered: 5000, due: 1000},
+		{name: "MT/registered=5000/due=5000", multiTenant: true, registered: 5000, due: 5000},
+		{name: "MT/registered=1000/due=5", multiTenant: true, registered: 1000, due: 5},
+		{name: "MT/registered=10000/due=5", multiTenant: true, registered: 10000, due: 5},
+		{name: "ST/registered=1000", registered: 1000},
+		{name: "ST/registered=5000", registered: 5000},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			callbacks := NewCallbackGroup("id", logger, 4)
+			for i := 0; i < tc.registered; i++ {
+				switch {
+				case !tc.multiTenant:
+					// ST: no per-entry interval, so always due when the group fires
+					callbacks.Register(fmt.Sprintf("st%d", i), noop)
+				case i < tc.due:
+					// MT due entry: interval already elapsed, due on every tick
+					callbacks.Register(fmt.Sprintf("due%d", i), noop,
+						WithIntervals(NewFixedIntervals(time.Nanosecond)))
+				default:
+					// MT backed-off entry: long interval; priming below records
+					// started=now so it stays not-due for the rest of the benchmark
+					callbacks.Register(fmt.Sprintf("idle%d", i), noop,
+						WithIntervals(NewFixedIntervals(time.Hour)))
+				}
+			}
+			callbacks.CycleCallback(shouldNotAbort)
+
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				callbacks.CycleCallback(shouldNotAbort)
+			}
+		})
+	}
 }
 
 func TestCycleCallback_Sequential_Deactivate(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

For clusters with big MT collections (~25k tenants in total), the cyclemanager held a significant amount of CPU cycles for background tasks without anything happening.

This PR now:
- Take a snapshot of all due callbacks at the beginning of the tick to avoid two runs
- dispatches only due callbacks
- the lock is hold shorter to avoid lock contention:
  - workers lock once per due callback instead of once per registered callback
  - dispatch loop no longer takes the group lock at all  

### Benchmark

  | Scenario | Before (sec/op) | After (sec/op) | Δ (p=0.002, n=6) |
  |---|--:|--:|--:|
  | **MT** 5000, `due=0` (idle) | 41.17µ ± 2% | 44.17µ ± 1% | **+7.28%** |
  | **MT** 5000, `due=5` | 1510µ ± 21% | 51.38µ ± 2% | **−96.60%** |
  | **MT** 5000, `due=200` | 1532µ ± 1% | 123.5µ ± 1% | **−91.94%** |
  | **MT** 5000, `due=1000` | 1639µ ± 1% | 431.4µ ± 1% | **−73.68%** |
  | **MT** 5000, `due=5000` (all) | 2.075m ± 2% | 1.915m ± 2% | −7.70% |
  | **MT** 1000, `due=5` | 300.1µ ± 0% | 12.43µ ± 2% | **−95.86%** |
  | **MT** 10000, `due=5` | 3031µ ± 1% | 99.84µ ± 1% | **−96.71%** |
  | **ST** 1000 (all due) | 400.6µ ± 1% | 372.0µ ± 2% | −7.12% |
  | **ST** 5000 (all due) | 2.081m ± 1% | 1.916m ± 1% | −7.91% |
  | **geomean** | 855.6µ | 180.6µ | **−78.89%** |

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
