### PR TITLE
perf(replication): share one zstd encoder in REST client instead of sync.Pool

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -24,7 +24,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -58,39 +57,24 @@ const (
 
 type replicationClient struct {
 	retryClient
-	zstdEncoderPool sync.Pool
+	// Shared instance: EncodeAll is concurrency-safe and internally multiplexes GOMAXPROCS sub-encoders.
+	zstdEncoder *zstd.Encoder
 }
 
 var _ replica.Client = (*replicationClient)(nil)
 
 func NewReplicationClient(httpClient *http.Client) (*replicationClient, error) {
-	// Verify encoder creation works at startup before returning the client.
 	enc, err := zstd.NewWriter(nil)
 	if err != nil {
 		return nil, fmt.Errorf("create zstd encoder: %w", err)
 	}
-	c := &replicationClient{
+	return &replicationClient{
 		retryClient: retryClient{
 			client:  httpClient,
 			retryer: newRetryer(),
 		},
-	}
-	// zstdEncoderPool amortizes *zstd.Encoder creation cost across calls.
-	// EncodeAll is safe for concurrent use on a single encoder, but allocating
-	// a fresh encoder on every RPC has measurable overhead; the pool reuses
-	// instances instead. New returns nil on failure; call sites guard with an
-	// ok+nil check and fall back to creating a fresh encoder.
-	c.zstdEncoderPool = sync.Pool{
-		New: func() any {
-			e, err := zstd.NewWriter(nil)
-			if err != nil {
-				return nil
-			}
-			return e
-		},
-	}
-	c.zstdEncoderPool.Put(enc)
-	return c, nil
+		zstdEncoder: enc,
+	}, nil
 }
 
 // FetchObject fetches one object it exits
@@ -308,15 +292,7 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 		return nil, fmt.Errorf("marshal hashtree level input: %w", err)
 	}
 
-	enc, ok := c.zstdEncoderPool.Get().(*zstd.Encoder)
-	if !ok || enc == nil {
-		enc, err = zstd.NewWriter(nil)
-		if err != nil {
-			return nil, fmt.Errorf("create zstd encoder: %w", err)
-		}
-	}
-	bodyBytes := enc.EncodeAll(body, make([]byte, 0, len(body)))
-	c.zstdEncoderPool.Put(enc)
+	bodyBytes := c.zstdEncoder.EncodeAll(body, make([]byte, 0, len(body)))
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
 	defer cancel()
@@ -384,15 +360,7 @@ func (c *replicationClient) OverwriteObjects(ctx context.Context,
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	enc, ok := c.zstdEncoderPool.Get().(*zstd.Encoder)
-	if !ok || enc == nil {
-		enc, err = zstd.NewWriter(nil)
-		if err != nil {
-			return nil, fmt.Errorf("create zstd encoder: %w", err)
-		}
-	}
-	bodyCompressed := enc.EncodeAll(body, make([]byte, 0, len(body)))
-	c.zstdEncoderPool.Put(enc)
+	bodyCompressed := c.zstdEncoder.EncodeAll(body, make([]byte, 0, len(body)))
 
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodPut, host, index, shard,

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -877,8 +877,6 @@ func TestReplicationOverwriteObjectsConcurrent(t *testing.T) {
 		{ID: UUID1.String(), UpdateTime: now.UnixMilli()},
 	}
 
-	// Each request handler decompresses the body independently to verify the
-	// pooled encoder produces correct output under concurrent use.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dec, err := zstd.NewReader(r.Body)
 		if err != nil {
@@ -895,8 +893,6 @@ func TestReplicationOverwriteObjectsConcurrent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// A single client is shared across all goroutines to exercise the encoder
-	// pool under concurrent use. Run with -race to detect data races.
 	c := newReplicationClient(t, server.Client())
 
 	const goroutines = 50


### PR DESCRIPTION
## Motivation

Allocation profiling (30-min `alloc_space` window on a v1.37 node) attributed **~41 GB / 8.6%** of allocation churn under `Shard.hashBeat` to `zstd.encoderOptions.encoder`. That symbol only runs from `zstd.NewWriter` initialization — never per `EncodeAll` — so the 41 GB is **thousands of encoder constructions**, not compression work.

Root cause is in the REST replication client ([`adapters/clients/replication.go`](https://github.com/weaviate/weaviate/blob/perf/async-rep-shared-zstd-encoder/adapters/clients/replication.go)): it pooled `*zstd.Encoder` in a `sync.Pool`. That is counterproductive because a `*zstd.Encoder` **already** multiplexes `GOMAXPROCS` internal sub-encoders behind a channel and `EncodeAll` is concurrency-safe. So:

- Each pooled entry is itself a `GOMAXPROCS`-wide Writer (a pool of pools).
- `sync.Pool` evicts across GC (victim cache = ~2 cycles). Hashbeat compression is **bursty** (a burst per beat, then 5–30 s idle); at the profile's ~268 MB/s alloc rate GC runs many times per idle gap, so pooled encoders are evicted between beats.
- Every cold burst then calls `NewWriter`, which **eagerly allocates `GOMAXPROCS` sub-encoders** (~1.26 MB window each) — the `GOMAXPROCS×` amplifier that produces the 41 GB.

This only affects the REST path (`REPLICATION_GRPC_ENABLED` unset → default; the gRPC path already uses a single shared encoder).

## Change

Replace the `sync.Pool` with a **single long-lived shared encoder** on the client — mirroring what the gRPC side (`shared.CompressOverwriteRaw`) already does. Both encode sites (`HashTreeLevel`, `OverwriteObjects`) collapse to a one-line `c.zstdEncoder.EncodeAll(...)`.

## Why this is not a bottleneck (incl. 25k tenants)

- **Concurrency unchanged.** One shared encoder serves `GOMAXPROCS` `EncodeAll` calls in true parallel and blocks the rest briefly on its internal channel — correct backpressure for CPU-bound compression. Concurrent hashbeats are already capped at `maxMaxWorkers = 100` by the scheduler.
- **Footprint is constant, not per-tenant.** The client is a node-wide singleton, so live encoder memory is a fixed `GOMAXPROCS × ~1.26 MB` (~20 MB @16 cores) regardless of tenant count. 25k tenants is exactly where the old pool churned worst (bursts of up to 100 workers each missing → allocating `GOMAXPROCS` sub-encoders).

## Risk / review areas

- Correctness hinges on `EncodeAll` being safe for concurrent use — it is (documented; already relied on by the gRPC path). Covered by the existing 50-goroutine shared-client test under `-race`.
- The startup encoder-creation check is preserved (constructor still fails if `NewWriter` errors).
- No wire-format change; compression output is identical.

## Testing

- `./adapters/clients/` unit + 50-goroutine shared-encoder concurrency test — pass under `-race`; lint clean.
- Acceptance `test/acceptance/replication/async_replication` (deletes, insertions, updates, multi-tenancy, base repair) — pass (416 s).
- Acceptance `.../async_replication/raw_propagation` — pass (82 s). Both run with `REPLICATION_GRPC_ENABLED` unset, i.e. the REST path this change touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)