### PR TITLE
perf(async-replication): allocate propagation buffers per-hashBeat, not per-range

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1624,6 +1624,21 @@ type objectToPropagate struct {
 	remoteStaleUpdateTime int64
 }
 
+// propagationScratch holds buffers reused across all diff ranges of a hashBeat, allocating them per-beat not per-range.
+type propagationScratch struct {
+	filteredDigests    []types.RepairResponse
+	localDigestsByUUID map[uuid.UUID]int64
+	objectsToPropagate []objectToPropagate
+}
+
+func newPropagationScratch(diffBatchSize int) *propagationScratch {
+	return &propagationScratch{
+		filteredDigests:    make([]types.RepairResponse, 0, diffBatchSize),
+		localDigestsByUUID: make(map[uuid.UUID]int64, diffBatchSize),
+		objectsToPropagate: make([]objectToPropagate, 0, diffBatchSize),
+	}
+}
+
 // collectObjectsToPropagate scans the hashtree diff ranges and returns the local
 // objects that must be propagated. It owns a single reusable objects-bucket
 // cursor for the whole scan (released before propagation begins) so the cursor,
@@ -1650,6 +1665,8 @@ func (s *Shard) collectObjectsToPropagate(
 	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceReusable()
 	defer cursor.Close()
 
+	scratch := newPropagationScratch(config.diffBatchSize)
+
 	for len(localObjectsToPropagate) < config.propagationLimit {
 		initialLeaf, finalLeaf, rangeErr := rangeReader.Next()
 		if rangeErr != nil {
@@ -1663,6 +1680,7 @@ func (s *Shard) collectObjectsToPropagate(
 			ctx,
 			config,
 			cursor,
+			scratch,
 			targetNodeAddress,
 			targetNodeName,
 			initialLeaf,
@@ -1702,11 +1720,12 @@ func (s *Shard) collectObjectsToPropagate(
 // returned entry is queued; tombstone resolution is left to the post-Overwrite
 // resolveObjectConflict path.
 func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncReplicationConfig,
-	cursor *lsmkv.CursorReplace,
+	cursor *lsmkv.CursorReplace, scratch *propagationScratch,
 	targetNodeAddress, targetNodeName string, initialLeaf, finalLeaf uint64, limit int,
 	targetNodeOverrides additional.AsyncReplicationTargetNodeOverrides,
 ) (localObjectsCount int, objectsToPropagate []objectToPropagate, err error) {
-	objectsToPropagate = make([]objectToPropagate, 0, min(limit, config.diffBatchSize))
+	// Returned buffer must start empty; caller copies it out before the next range reuses it.
+	objectsToPropagate = scratch.objectsToPropagate[:0]
 
 	hashtreeHeight := config.hashtreeHeight
 
@@ -1721,9 +1740,9 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 	currLocalUUIDBytes := make([]byte, 16)
 	binary.BigEndian.PutUint64(currLocalUUIDBytes, initialLeaf<<(64-hashtreeHeight))
 
-	// Reused (reset) each iteration to avoid per-batch allocations.
-	filteredDigests := make([]types.RepairResponse, 0, config.diffBatchSize)
-	localDigestsByUUID := make(map[uuid.UUID]int64, config.diffBatchSize)
+	// From scratch: reset before use each batch (below), so per-beat not per-range.
+	filteredDigests := scratch.filteredDigests
+	localDigestsByUUID := scratch.localDigestsByUUID
 
 	for limit > 0 && bytes.Compare(currLocalUUIDBytes, finalUUIDBytes) < 1 {
 		if ctx.Err() != nil {

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -196,7 +196,8 @@ func (s *Shard) propagateWithinRangeForTest(t *testing.T, ctx context.Context,
 	t.Helper()
 	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceReusable()
 	defer cursor.Close()
-	return s.objectsToPropagateWithinRange(ctx, cfg, cursor, addr, node, initialLeaf, finalLeaf, limit, overrides)
+	scratch := newPropagationScratch(cfg.diffBatchSize)
+	return s.objectsToPropagateWithinRange(ctx, cfg, cursor, scratch, addr, node, initialLeaf, finalLeaf, limit, overrides)
 }
 
 // ─── objectsToPropagateWithinRange ───────────────────────────────────────────
@@ -386,6 +387,33 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 		assert.Contains(t, err.Error(), "simulated rpc unavailable",
 			"original error must be preserved via %w wrapping")
 		assert.Empty(t, objs, "no objects must be queued when CompareDigests fails")
+		_ = idx
+	})
+
+	// ScratchReusedAcrossRanges guards the per-beat buffer reuse: a second call on the same scratch must not leak the first's queued objects.
+	t.Run("ScratchReusedAcrossRanges", func(t *testing.T) {
+		sl, idx := testShard(t, ctx, class, withReplicationClient(t, &fixedDigestsClient{}))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidHigh, tsFarPast)))
+
+		s := concreteShard(t, sl)
+		require.NoError(t, s.store.FlushMemtables(ctx))
+		cfg := fullRangeConfig(100)
+
+		cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceReusable()
+		defer cursor.Close()
+		scratch := newPropagationScratch(cfg.diffBatchSize)
+
+		local1, objs1, err := s.objectsToPropagateWithinRange(ctx, cfg, cursor, scratch, "http://fake", "node2", 0, 1, 100, nil)
+		require.NoError(t, err)
+		require.Len(t, objs1, 2)
+		want := []strfmt.UUID{objs1[0].uuid, objs1[1].uuid}
+
+		local2, objs2, err := s.objectsToPropagateWithinRange(ctx, cfg, cursor, scratch, "http://fake", "node2", 0, 1, 100, nil)
+		require.NoError(t, err)
+		require.Len(t, objs2, 2, "reused scratch must not leak the prior range's queued objects")
+		assert.Equal(t, local1, local2)
+		assert.Equal(t, want, []strfmt.UUID{objs2[0].uuid, objs2[1].uuid})
 		_ = idx
 	})
 }


### PR DESCRIPTION
## Motivation

A 30-min `alloc_space` profile of a v1.37 node attributed **~25.8 GB / 5.34%** of allocation churn to `Shard.objectsToPropagateWithinRange`. The three profile leaf sizes matched the source exactly and are **per-call, fixed to `diffBatchSize`** — independent of how many objects are actually propagated:

| Allocation | element | cap=1000 |
|---|---|---|
| `filteredDigests` | `types.RepairResponse` | 56 kB |
| `localDigestsByUUID` | `map[uuid.UUID]int64` | 26.62 kB |
| `objectsToPropagate` | `objectToPropagate` | 32 kB |

≈ **114.6 kB per call**. The function runs **once per hashtree diff range** inside `collectObjectsToPropagate`, which runs **once per hashBeat**. On write-hot shards the `propagationDelay` filter makes each beat walk many ranges that propagate nothing, so this 114.6 kB tax scaled with *range probes*, not work done (~236k calls in the profiled window).

## Change

Hoist the three buffers into a `propagationScratch` allocated **once per hashBeat** in `collectObjectsToPropagate` and threaded into `objectsToPropagateWithinRange`, collapsing the allocation from per-range to per-beat — cutting this line item by roughly the number of ranges scanned per beat.

## No semantic change

- The returned buffer is reset to `[:0]` at entry, reproducing the empty state of the original per-call `make`; content returned is identical.
- `filteredDigests` / `localDigestsByUUID` keep their existing per-batch reset (`[:0]` / `clear`) before use, so a reused buffer never leaks into results.
- Sizing to `diffBatchSize` vs the original `min(limit, diffBatchSize)` is a capacity hint only; `append` grows as needed.

## No new race or deadlock

- The scratch is a **local of `collectObjectsToPropagate`** and never escapes.
- Neither function spawns goroutines; the whole beat runs on a single scheduler-worker goroutine, and per-shard hashBeat is serialized (`asyncRepWg`). Each beat builds its own scratch.
- `CompareDigests` (fed `filteredDigests`) marshals-and-sends synchronously and retains no reference — reuse after the call is already today's invariant (the code resets and reuses it across batches within a call).

## Why per-beat, not a retained per-shard pool

Retaining buffers per shard would hold ~25k × 114.6 kB ≈ **2.7 GB** resident under 25k tenants. Per-beat allocation keeps the buffers transient (GC'd after each beat), scales cleanly, and still removes the per-range multiplier.

## Testing

- `go test -tags integrationTest -race` on `TestObjectsToPropagateWithinRange` (incl. a new `ScratchReusedAcrossRanges` subtest asserting a second call on the same scratch does not leak the first range's queued objects) and `AsyncRep|Propagate|CollectObjects` — pass.
- `golangci-lint` (0 issues) and the goroutine-wrapper linter — clean.

Independent of #11960 (different file, no overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)