### PR TITLE
fix: prevent large vectors collapsing to zero during normalization

### DIFF
--- a/adapters/repos/db/vector/hnsw/distancer/normalize.go
+++ b/adapters/repos/db/vector/hnsw/distancer/normalize.go
@@ -24,6 +24,36 @@ func squaredNorm(v []float32) float32 {
 	return dotProductImplementation(v, v)
 }
 
+// scalable reports whether the float32 sum of squares can be turned into a
+// scaling factor. It is false for the zero vector, but also for vectors whose
+// components are valid float32 values yet square outside the float32 range:
+// 1e20*1e20 overflows to +Inf and 1e-25*1e-25 underflows to 0. Both cases
+// scale the vector to zeros, which reads as a valid vector downstream and
+// makes every cosine distance 1.
+func scalable(norm2 float32) bool {
+	return norm2 > 0 && !math.IsInf(float64(norm2), 1)
+}
+
+// normalizeFloat64 scales v to unit length into dst, accumulating the norm in
+// float64 so that squares beyond the float32 range still resolve. It reports
+// false and leaves dst untouched when v is the zero vector. It divides rather
+// than multiplying by the reciprocal because the reciprocal itself is not
+// always a finite float32. dst and v may be the same slice.
+func normalizeFloat64(dst, v []float32) bool {
+	var norm float64
+	for _, x := range v {
+		norm += float64(x) * float64(x)
+	}
+	if norm == 0 {
+		return false
+	}
+	norm = math.Sqrt(norm)
+	for i, x := range v {
+		dst[i] = float32(float64(x) / norm)
+	}
+	return true
+}
+
 // Normalize returns v scaled to unit length as a new slice. A zero vector
 // normalizes to the zero vector. The norm is applied as a multiplication by
 // the reciprocal, which is substantially faster than per-element division
@@ -31,7 +61,8 @@ func squaredNorm(v []float32) float32 {
 func Normalize(v []float32) []float32 {
 	out := make([]float32, len(v))
 	norm2 := squaredNorm(v)
-	if norm2 == 0 {
+	if !scalable(norm2) {
+		normalizeFloat64(out, v)
 		return out
 	}
 	f32.Scale(out, v, float32(1/math.Sqrt(float64(norm2))))
@@ -43,7 +74,8 @@ func Normalize(v []float32) []float32 {
 // A zero vector is left unchanged.
 func NormalizeInPlace(v []float32) {
 	norm2 := squaredNorm(v)
-	if norm2 == 0 {
+	if !scalable(norm2) {
+		normalizeFloat64(v, v)
 		return
 	}
 	f32.Scale(v, v, float32(1/math.Sqrt(float64(norm2))))
@@ -59,8 +91,10 @@ func NormalizeInto(dst, v []float32) []float32 {
 	}
 	dst = dst[:len(v)]
 	norm2 := squaredNorm(v)
-	if norm2 == 0 {
-		clear(dst)
+	if !scalable(norm2) {
+		if !normalizeFloat64(dst, v) {
+			clear(dst)
+		}
 		return dst
 	}
 	f32.Scale(dst, v, float32(1/math.Sqrt(float64(norm2))))

--- a/adapters/repos/db/vector/hnsw/distancer/normalize_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/normalize_test.go
@@ -40,6 +40,31 @@ func TestNormalize(t *testing.T) {
 		result := Normalize(v)
 		assert.Equal(t, []float32{0, 0, 0}, result)
 	})
+
+	t.Run("large components do not collapse to zero", func(t *testing.T) {
+		// 1e20*1e20 is 1e40, past the float32 max, so the sum of squares
+		// overflows to +Inf and the vector used to scale to all zeros.
+		v := []float32{1e20, 1e20, 1e20, 1e20}
+		assertUnitLength(t, Normalize(v))
+	})
+
+	t.Run("tiny components do not collapse to zero", func(t *testing.T) {
+		// The mirror case: 1e-25*1e-25 underflows to 0 in float32, so the sum
+		// of squares reads as a zero vector.
+		v := []float32{1e-25, 1e-25, 1e-25, 1e-25}
+		assertUnitLength(t, Normalize(v))
+	})
+}
+
+// assertUnitLength checks the magnitude in float64 so that the check itself
+// does not overflow on the inputs it is meant to cover.
+func assertUnitLength(t *testing.T, v []float32) {
+	t.Helper()
+	var mag float64
+	for _, x := range v {
+		mag += float64(x) * float64(x)
+	}
+	assert.InDelta(t, 1.0, math.Sqrt(mag), 0.0001)
 }
 
 func TestNormalizeInPlace(t *testing.T) {
@@ -98,6 +123,12 @@ func TestNormalizeInPlace(t *testing.T) {
 		NormalizeInPlace(v)
 		assert.Equal(t, []float32{}, v)
 	})
+
+	t.Run("large components do not collapse to zero", func(t *testing.T) {
+		v := []float32{1e20, -1e20, 1e20, -1e20}
+		NormalizeInPlace(v)
+		assertUnitLength(t, v)
+	})
 }
 
 // TestNormalizeMatchesScalarReference checks the SIMD-backed implementation
@@ -147,6 +178,13 @@ func TestNormalizeInto(t *testing.T) {
 		buf := []float32{1, 2, 3}
 		got := NormalizeInto(buf, []float32{0, 0, 0})
 		assert.Equal(t, []float32{0, 0, 0}, got)
+	})
+
+	t.Run("large components do not collapse to zero", func(t *testing.T) {
+		v := []float32{1e20, 1e20, 1e20, 1e20}
+		got := NormalizeInto([]float32{99}, v)
+		assertUnitLength(t, got)
+		assert.Equal(t, []float32{1e20, 1e20, 1e20, 1e20}, v, "input must be preserved")
 	})
 }
 


### PR DESCRIPTION
### What's being changed:

Fixes #11671.

`Normalize`, `NormalizeInPlace` and `NormalizeInto` in `adapters/repos/db/vector/hnsw/distancer/normalize.go` get the sum of squares from `squaredNorm`, which returns a `float32`:

```go
func squaredNorm(v []float32) float32 {
	if len(v) == 0 {
		return 0
	}
	return dotProductImplementation(v, v)
}
```

For a large but valid `float32` component the square exceeds the `float32` range (`1e20 * 1e20 = 1e40`, past the `~3.4e38` max), so the result is `+Inf`. Widening to `float64` afterwards is too late, the overflow already happened, and `1/math.Sqrt(+Inf)` is `0`, so scaling collapses the whole vector to zeros.

The same thing happens from the other end: `1e-25 * 1e-25` rounds to `0` in `float32`, so a small vector reads as the zero vector and takes the early return.

For cosine distance (where vectors are normalized before the dot product), a zero vector makes the similarity `0` against every stored object, so each one reports a distance of `1` and search results lose all ranking. A single query vector with large magnitude components (e.g. `[1e20, ...]`) is enough to trigger it, as shown in the issue.

### The fix

Keep the SIMD path exactly as is for the normal case. When the `float32` sum of squares comes back `0` or `+Inf`, redo the norm in `float64`, which covers the whole `float32` range squared. That path divides instead of multiplying by the reciprocal, because for very small vectors the reciprocal is not a finite `float32` even when the result is.

The extra check is one comparison per call on the hot path. `BenchmarkNormalize` on a 1536-dim vector is unchanged (alloc ~490ns, into ~283ns, same as `main` within noise).

### Test

Regression tests in `normalize_test.go` cover all three entry points: normalizing `[1e20, 1e20, 1e20, 1e20]` must produce a unit vector, plus the underflow mirror case `[1e-25, ...]` for `Normalize`. All four fail on `main` (magnitude 0) and pass with this change. The full `distancer` package suite stays green under `-race`.

Rebased onto current `main`. The SIMD rewrite in #12324 replaced the loop this originally patched, but the overflow survived it, so the fix is now written against the new implementation.

### Review checklist

- [ ] ~~Documentation has been updated, if necessary.~~ N/A bug fix, no API change.
- [ ] ~~Chaos pipeline run or not necessary.~~ Not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. `BenchmarkNormalize` is unchanged.
