### PR TITLE
Fix/11956 review fixes

### DIFF
--- a/adapters/repos/db/vector/hnsw/compressed_termination_test.go
+++ b/adapters/repos/db/vector/hnsw/compressed_termination_test.go
@@ -1,0 +1,304 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+// Tests for PR #11956: Compressed index termination bug
+// The sync repair loop ping-pongs between dead nodes on compressed indexes
+// because distToNode doesn't tombstone on the compressed branch.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// TestCompressedIndex_TerminationBug_AllDeleted tests that the sync repair loop
+// terminates on a compressed index when all nodes are deleted.
+//
+// BUG: On compressed indexes, distToNode (index.go:664-671) returns ErrNotFound
+// WITHOUT tombstoning the dead node. The repair loop then ping-pongs between
+// dead nodes forever because findNewGlobalEntrypoint only skips tombstoned nodes.
+//
+// Expected: Loop terminates within O(n) iterations with errNoUsableEntrypoint
+// Actual (BUG): Loop spins forever, never terminates
+func TestCompressedIndex_TerminationBug_AllDeleted(t *testing.T) {
+	ctx := context.Background()
+	const dimensions = 8
+	const numVectors = 1000 // Enough for k-means training
+
+	// Generate random vectors for k-means training (using testinghelpers pattern)
+	vectors, _ := testinghelpers.RandomVecs(numVectors, 1, dimensions)
+
+	// Track which vectors are "deleted"
+	var allDeleted atomic.Bool
+	var countingEnabled atomic.Bool // Only count iterations after setup is complete
+	var iterationCount atomic.Int32
+	maxIterations := int32(numVectors * 2) // Hard cap - should terminate way before this
+
+	var mu sync.Mutex
+
+	logger, _ := test.NewNullLogger()
+	tempDir := t.TempDir()
+	store := testinghelpers.NewDummyStoreFromFolder(tempDir, t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if countingEnabled.Load() {
+			count := iterationCount.Add(1)
+			if count > maxIterations {
+				panic(fmt.Sprintf("LOOP NOT BOUNDED ON COMPRESSED INDEX: exceeded %d iterations (at node %d)",
+					maxIterations, id))
+			}
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if allDeleted.Load() {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if allDeleted.Load() {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	uc := ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 10000,
+		PQ: ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeKMeans,
+				Distribution: ent.PQEncoderDistributionLogNormal,
+			},
+			TrainingLimit: numVectors,
+			Segments:      dimensions / 4, // 2 segments
+			Centroids:     5,              // Small for testing
+		},
+	}
+
+	index, err := New(Config{
+		RootPath:                     tempDir,
+		ID:                           "compressed-termination-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewL2SquaredProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+		Logger:                       logger,
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert vectors
+	for i := 0; i < numVectors; i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Compress the index (enables PQ)
+	err = index.compress(uc)
+	require.NoError(t, err)
+	require.True(t, index.compressed.Load(), "index should be compressed")
+
+	// Now delete ALL vectors
+	allDeleted.Store(true)
+	// Clear the compressed cache for all vectors
+	for i := 0; i < numVectors; i++ {
+		index.compressor.Delete(ctx, uint64(i))
+	}
+
+	// Enable iteration counting NOW (after compression is done)
+	iterationCount.Store(0)
+	countingEnabled.Store(true)
+
+	// Search with timeout - if bug exists, this will either:
+	// 1. Panic with "LOOP NOT BOUNDED" (hit iteration cap)
+	// 2. Timeout (infinite loop without hitting cap fast enough)
+	done := make(chan struct{})
+	go func() {
+		query := make([]float32, dimensions)
+		for i := range query {
+			query[i] = float32(i)
+		}
+		_, _, _ = index.SearchByVector(ctx, query, 3, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Search completed - either terminated correctly or hit our panic cap
+		finalCount := iterationCount.Load()
+		t.Logf("Search completed with %d iterations (cap was %d)", finalCount, maxIterations)
+	case <-time.After(5 * time.Second):
+		t.Fatal("TIMEOUT: Search did not terminate - infinite loop in compressed repair path")
+	}
+}
+
+// TestCompressedIndex_TerminationBug_TwoDeadNodes tests the minimal ping-pong case:
+// two dead nodes A and B where repair alternates between them forever.
+func TestCompressedIndex_TerminationBug_TwoDeadNodes(t *testing.T) {
+	ctx := context.Background()
+	const dimensions = 8
+	const numVectors = 1000 // Enough for k-means training
+
+	// Generate random vectors for k-means training
+	vectors, _ := testinghelpers.RandomVecs(numVectors, 1, dimensions)
+
+	// Only nodes 0 and 1 will be deleted (entrypoint and one other)
+	// This is the minimal ping-pong case
+	deletedNodes := map[uint64]bool{0: true, 1: true}
+	var countingEnabled atomic.Bool
+	var iterationCount atomic.Int32
+	maxIterations := int32(10) // Small cap - should find live node quickly or loop forever
+
+	var mu sync.Mutex
+
+	logger, _ := test.NewNullLogger()
+	tempDir := t.TempDir()
+	store := testinghelpers.NewDummyStoreFromFolder(tempDir, t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if countingEnabled.Load() {
+			count := iterationCount.Add(1)
+			if count > maxIterations {
+				panic(fmt.Sprintf("LOOP NOT BOUNDED (ping-pong between dead nodes): exceeded %d iterations (at node %d)",
+					maxIterations, id))
+			}
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if deletedNodes[id] {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if deletedNodes[id] {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	uc := ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 10000,
+		PQ: ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeKMeans,
+				Distribution: ent.PQEncoderDistributionLogNormal,
+			},
+			TrainingLimit: numVectors,
+			Segments:      dimensions / 4,
+			Centroids:     5,
+		},
+	}
+
+	index, err := New(Config{
+		RootPath:                     tempDir,
+		ID:                           "compressed-pingpong-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewL2SquaredProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+		Logger:                       logger,
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert vectors
+	for i := 0; i < numVectors; i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Compress
+	err = index.compress(uc)
+	require.NoError(t, err)
+	require.True(t, index.compressed.Load())
+
+	// Delete nodes 0 and 1 from compressor cache
+	index.compressor.Delete(ctx, 0)
+	index.compressor.Delete(ctx, 1)
+
+	// Enable iteration counting NOW (after compression is done)
+	iterationCount.Store(0)
+	countingEnabled.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		query := make([]float32, dimensions)
+		for i := range query {
+			query[i] = float32(i)
+		}
+		results, _, _ := index.SearchByVector(ctx, query, 3, nil)
+		t.Logf("Search returned %d results", len(results))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		finalCount := iterationCount.Load()
+		t.Logf("Search completed with %d iterations", finalCount)
+		// Should terminate finding nodes 2 or 3
+	case <-time.After(5 * time.Second):
+		t.Fatal("TIMEOUT: Ping-pong infinite loop between dead nodes 0 and 1")
+	}
+}

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -653,6 +653,9 @@ func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error 
 	return nil
 }
 
+// errNoUsableEntrypoint: every candidate is denied, tombstoned, or under maintenance
+var errNoUsableEntrypoint = errors.New("no valid entrypoint available")
+
 // repairGlobalEntrypoint attempts to repair a broken global entrypoint during insert.
 // It is called from the insert path when the global entrypoint is unusable (e.g., under
 // maintenance or vector unavailable). The function finds a new valid entrypoint and
@@ -684,7 +687,7 @@ func (h *hnsw) repairGlobalEntrypoint(oldEntrypoint uint64, localDeny helpers.Al
 		currentEp := h.getEntrypoint()
 		if currentEp == oldEntrypoint {
 			// Graph is empty or only unusable nodes remain
-			return 0, fmt.Errorf("no valid entrypoint available")
+			return 0, errNoUsableEntrypoint
 		}
 		// Someone else already repaired it
 		return currentEp, nil
@@ -756,31 +759,26 @@ func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel i
 		candidateLevel := candidate.level
 		candidate.Unlock()
 
-		if candidateLevel > bestLevel {
-			bestCandidate = uint64(i)
-			bestLevel = candidateLevel
-			foundCandidate = true
+		if candidateLevel <= bestLevel {
+			continue
 		}
+
+		// tombstoned or under-maintenance nodes would immediately be found broken again
+		if candidate.isUnderMaintenance() || h.hasTombstone(uint64(i)) {
+			continue
+		}
+
+		bestCandidate = uint64(i)
+		bestLevel = candidateLevel
+		foundCandidate = true
 	}
 
 	if foundCandidate {
 		return bestCandidate, bestLevel, true
 	}
 
-	if h.isEmpty() {
-		return 0, 0, false
-	}
-
-	if h.isOnlyNode(&vertex{id: oldEntrypoint}, denyList) {
-		return 0, 0, false
-	}
-
-	// we made it through the entire graph and didn't find a new entrypoint all
-	// the way down to level 0. This can only mean the graph is empty, which is
-	// unexpected. This situation should have been prevented by the deleteLock.
-	panic(fmt.Sprintf(
-		"class %s: shard %s: findNewEntrypoint called on an empty hnsw graph",
-		h.className, h.shardName))
+	// no usable candidate (graph empty or all nodes denied/tombstoned/under maintenance)
+	return 0, 0, false
 }
 
 // returns entryPointID, level and whether a change occurred

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_review_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_review_test.go
@@ -674,3 +674,273 @@ func TestReview_SearchPassesNonNilAllowList(t *testing.T) {
 	t.Logf("repairGlobalEntrypoint with helpers.NewAllowList(): err=%v", err)
 	t.Log("VERIFIED: search.go:734 passes non-nil AllowList (helpers.NewAllowList())")
 }
+
+// ============================================================================
+// PRIORITY C: NON-EMPTY ALL-TOMBSTONED cases for each findNewGlobalEntrypoint caller
+//
+// The user correctly noted: isEmpty() guards only protect against empty graphs,
+// NOT against non-empty graphs where all nodes are tombstoned/denied.
+// The removed panic fired on "scanned all nodes, found no valid candidate"
+// which includes the non-empty-all-tombstoned case.
+// ============================================================================
+
+// TestReview_PC_Caller1_DeleteEntrypoint_AllTombstoned tests deleteEntrypoint
+// when called from tombstone cleanup (delete.go:90) with ALL nodes tombstoned.
+//
+// Call site: delete.go:90 (inside cleanUpTombstonedNodesUnlocked)
+// Guard: resetIfOnlyNode is called FIRST at line 87
+// Expected: resetIfOnlyNode returns onlyNode=true, resets graph, deleteEntrypoint skipped
+func TestReview_PC_Caller1_DeleteEntrypoint_AllTombstoned(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 5
+
+	vectors := make([][]float32, numNodes)
+	for i := 0; i < numNodes; i++ {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "caller1-all-tombstoned-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	ep := index.getEntrypoint()
+	t.Logf("Initial entrypoint: %d", ep)
+
+	// Tombstone ALL nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.addTombstone(uint64(i)))
+	}
+
+	// Create denyList with ALL tombstones (matches delete.go:86)
+	denyList := index.tombstonesAsDenyList()
+	t.Logf("denyList contains %d tombstones", denyList.Len())
+
+	// Get the entrypoint node
+	node := index.nodeByID(ep)
+	require.NotNil(t, node)
+
+	// Call resetIfOnlyNode - this is what delete.go:87 does BEFORE deleteEntrypoint
+	onlyNode, err := index.resetIfOnlyNode(node, denyList)
+	require.NoError(t, err)
+
+	// With all nodes tombstoned and in denyList, this SHOULD return true
+	assert.True(t, onlyNode, "resetIfOnlyNode should return true when all other nodes are in denyList")
+
+	t.Log("VERIFIED: Caller 1 (delete.go:90) is SAFE - resetIfOnlyNode handles all-tombstoned case")
+}
+
+// TestReview_PC_Caller2_ReplaceDeletedEntrypoint_PartialTombstones tests
+// deleteEntrypoint when called from replaceDeletedEntrypoint (delete.go:411)
+// with a PARTIAL deleteList (some tombstoned nodes not in deleteList).
+//
+// Call site: delete.go:411 (inside replaceDeletedEntrypoint)
+// Guard: NONE - does not call resetIfOnlyNode
+// Bug: When remaining nodes are tombstoned but NOT in deleteList, findNewGlobalEntrypoint
+//
+//	skips them (hasTombstone check) but isOnlyNode doesn't (no tombstone check).
+//	Result: found=false but deleteEntrypoint returns nil without changing EP.
+func TestReview_PC_Caller2_ReplaceDeletedEntrypoint_PartialTombstones(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 5
+
+	vectors := make([][]float32, numNodes)
+	for i := 0; i < numNodes; i++ {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "caller2-partial-tombstones-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	ep := index.getEntrypoint()
+	t.Logf("Initial entrypoint: %d", ep)
+
+	// Tombstone ALL nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.addTombstone(uint64(i)))
+	}
+
+	// Create PARTIAL deleteList (simulating maxTombstonesPerCycle limit)
+	// Only include entrypoint, NOT the other tombstoned nodes
+	partialDeleteList := helpers.NewAllowList()
+	partialDeleteList.Insert(ep)
+	t.Logf("Partial deleteList contains only entrypoint %d (other tombstones NOT in list)", ep)
+
+	// Get the entrypoint node
+	node := index.nodeByID(ep)
+	require.NotNil(t, node)
+
+	// isOnlyNode with partial list: other nodes NOT in list, so returns false
+	// (even though they're all tombstoned)
+	isOnly := index.isOnlyNode(node, partialDeleteList)
+	assert.False(t, isOnly, "isOnlyNode should return false - other nodes exist (even if tombstoned)")
+
+	// Call deleteEntrypoint with partial list (matches delete.go:411)
+	err = index.deleteEntrypoint(node, partialDeleteList)
+	require.NoError(t, err, "deleteEntrypoint returns nil")
+
+	// Check the entrypoint AFTER deleteEntrypoint
+	newEP := index.getEntrypoint()
+	t.Logf("Entrypoint after deleteEntrypoint: %d (was: %d)", newEP, ep)
+
+	// BUG CHECK: If entrypoint is unchanged AND points to a tombstoned node,
+	// subsequent searches will fail because EP is unusable.
+	if newEP == ep {
+		// The entrypoint wasn't changed - this is the bug!
+		hasTomb := index.hasTombstone(newEP)
+		if hasTomb {
+			t.Errorf("BUG DETECTED: deleteEntrypoint left EP=%d pointing at tombstoned node!\n"+
+				"Call site: delete.go:411 (replaceDeletedEntrypoint)\n"+
+				"Cause: deleteList is partial, remaining tombstoned nodes pass isOnlyNode but fail findNewGlobalEntrypoint", newEP)
+		}
+	}
+
+	// For a valid entrypoint, it should NOT be tombstoned
+	newEPTombstoned := index.hasTombstone(newEP)
+	assert.False(t, newEPTombstoned, "new entrypoint should NOT be tombstoned")
+}
+
+// TestReview_PC_Caller3_RepairGlobalEntrypoint_AllTombstoned tests
+// repairGlobalEntrypoint when all nodes are tombstoned.
+//
+// Call site: delete.go:684 (repairGlobalEntrypoint)
+// Handling: delete.go:685-693 - returns errNoUsableEntrypoint if EP unchanged
+func TestReview_PC_Caller3_RepairGlobalEntrypoint_AllTombstoned(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 5
+
+	vectors := make([][]float32, numNodes)
+	for i := 0; i < numNodes; i++ {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "caller3-all-tombstoned-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	ep := index.getEntrypoint()
+	t.Logf("Initial entrypoint: %d", ep)
+
+	// Tombstone ALL nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.addTombstone(uint64(i)))
+	}
+
+	// Call repairGlobalEntrypoint - should return errNoUsableEntrypoint
+	_, err = index.repairGlobalEntrypoint(ep, helpers.NewAllowList())
+
+	// Should get errNoUsableEntrypoint since all nodes are tombstoned
+	assert.ErrorIs(t, err, errNoUsableEntrypoint,
+		"repairGlobalEntrypoint should return errNoUsableEntrypoint when all nodes tombstoned")
+
+	t.Logf("repairGlobalEntrypoint with all tombstoned: err=%v", err)
+	t.Log("VERIFIED: Caller 3 (delete.go:684) is SAFE - returns errNoUsableEntrypoint")
+}

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_review_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_review_test.go
@@ -1,0 +1,676 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+// Review tests for PR #11956 (entrypoint-repair)
+// These tests verify correctness and safety of the entrypoint repair implementation.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// ============================================================================
+// PRIORITY 1: Loop termination in entrypointDistWithRepair
+//
+// The termination claim at search.go:714-715 is:
+// "repair never selects tombstoned nodes, so each iteration either succeeds
+// or tombstones another dead node."
+//
+// This is ONLY about the repair loop at search.go:721-739, NOT about the
+// total vectorForID calls during search (which includes traversal neighbors).
+// ============================================================================
+
+// countingNoopCommitLogger counts SetEntryPointWithMaxLayer calls to track
+// how many times repair persists a new entrypoint (= repair loop iterations).
+type countingNoopCommitLogger struct {
+	NoopCommitLogger
+	repairCalls atomic.Int32
+}
+
+func (c *countingNoopCommitLogger) SetEntryPointWithMaxLayer(id uint64, level int) error {
+	c.repairCalls.Add(1)
+	return nil
+}
+
+// TestReview_P1_RepairLoopTermination tests that the REPAIR LOOP in
+// entrypointDistWithRepair (search.go:721-739) terminates within O(n) iterations.
+// We count repair calls (SetEntryPointWithMaxLayer), not total vectorForID calls.
+func TestReview_P1_RepairLoopTermination(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 20
+
+	vectors := make([][]float32, numNodes)
+	vectorErrors := make([]error, numNodes)
+	for i := 0; i < numNodes; i++ {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	var mu sync.Mutex
+	commitLogger := &countingNoopCommitLogger{}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath: "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:       "p1-repair-loop-test",
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return commitLogger, nil
+		},
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert all nodes
+	for i := 0; i < numNodes; i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Record baseline (inserts may call SetEntryPointWithMaxLayer)
+	baseline := commitLogger.repairCalls.Load()
+
+	// Delete all but 2 nodes - this creates the worst case for repair
+	mu.Lock()
+	for i := 0; i < numNodes-2; i++ {
+		vectors[i] = nil
+		vectorErrors[i] = storobj.NewErrNotFoundf(uint64(i), "deleted")
+	}
+	mu.Unlock()
+
+	// Clear cache to force VectorForIDThunk calls
+	for i := 0; i < numNodes-2; i++ {
+		index.cache.Delete(ctx, uint64(i))
+	}
+
+	// Search - should trigger repair loop
+	query := []float32{1.0, 2.0, 3.0}
+	_, _, err = index.SearchByVector(ctx, query, 5, nil)
+
+	repairCalls := commitLogger.repairCalls.Load() - baseline
+	t.Logf("Repair loop iterations: %d (should be <= %d)", repairCalls, numNodes)
+
+	// The repair loop should iterate at most O(n) times
+	// Each iteration tombstones one node and finds a different one
+	assert.LessOrEqual(t, repairCalls, int32(numNodes),
+		"repair loop should terminate within %d iterations, got %d", numNodes, repairCalls)
+
+	// Search should either succeed or return clean error
+	// If it hangs, the test times out (proves non-termination)
+	t.Logf("Search completed (err=%v), repair loop is bounded", err)
+}
+
+// TestReview_P1_AllNodesDead_Termination tests that when ALL nodes are dead,
+// the repair loop terminates with errNoUsableEntrypoint, not infinite loop.
+func TestReview_P1_AllNodesDead_Termination(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 10
+
+	vectors := make([][]float32, numNodes)
+	for i := 0; i < numNodes; i++ {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	var allDeleted atomic.Bool
+	commitLogger := &countingNoopCommitLogger{}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if allDeleted.Load() {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		if allDeleted.Load() {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath: "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:       "p1-all-dead-test",
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return commitLogger, nil
+		},
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	for i := 0; i < numNodes; i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	baseline := commitLogger.repairCalls.Load()
+
+	// Mark ALL nodes as deleted
+	allDeleted.Store(true)
+	for i := 0; i < numNodes; i++ {
+		index.cache.Delete(ctx, uint64(i))
+	}
+
+	query := []float32{1.0, 2.0, 3.0}
+	results, _, err := index.SearchByVector(ctx, query, 5, nil)
+
+	repairCalls := commitLogger.repairCalls.Load() - baseline
+	t.Logf("All-dead repair iterations: %d (should be <= %d)", repairCalls, numNodes)
+
+	// Should return empty (errNoUsableEntrypoint is caught)
+	assert.Empty(t, results, "should return empty results when all nodes dead")
+	assert.NoError(t, err, "SearchByVector catches errNoUsableEntrypoint")
+	assert.LessOrEqual(t, repairCalls, int32(numNodes),
+		"repair loop should terminate within %d iterations", numNodes)
+}
+
+// TestReview_P1_ConcurrentSearchAndInsert tests loop termination under
+// concurrent load (searches hitting dead EP while inserts run).
+func TestReview_P1_ConcurrentSearchAndInsert(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 15
+	const numSearchers = 5
+	const numInserters = 3
+
+	vectors := make([][]float32, numNodes+numInserters*5)
+	vectorErrors := make([]error, numNodes+numInserters*5)
+	for i := range vectors {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	var mu sync.Mutex
+	commitLogger := &countingNoopCommitLogger{}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath: "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:       "p1-concurrent-test",
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return commitLogger, nil
+		},
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < numNodes; i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Delete some nodes to force repair path
+	mu.Lock()
+	for i := 0; i < numNodes/2; i++ {
+		vectorErrors[i] = storobj.NewErrNotFoundf(uint64(i), "deleted")
+	}
+	mu.Unlock()
+	for i := 0; i < numNodes/2; i++ {
+		index.cache.Delete(ctx, uint64(i))
+	}
+
+	var wg sync.WaitGroup
+	var completedSearches atomic.Int32
+	var completedInserts atomic.Int32
+
+	// Launch searchers
+	for s := 0; s < numSearchers; s++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				query := []float32{float32(id), float32(i), 1.0}
+				_, _, _ = index.SearchByVector(ctx, query, 5, nil)
+				completedSearches.Add(1)
+			}
+		}(s)
+	}
+
+	// Launch inserters
+	nextID := uint64(numNodes)
+	var idMu sync.Mutex
+	for ins := 0; ins < numInserters; ins++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				idMu.Lock()
+				id := nextID
+				nextID++
+				idMu.Unlock()
+
+				vec := []float32{float32(id), float32(id + 1), float32(id + 2)}
+				mu.Lock()
+				if int(id) < len(vectors) {
+					vectors[id] = vec
+				}
+				mu.Unlock()
+
+				_ = index.Add(ctx, id, vec)
+				completedInserts.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	t.Logf("Concurrent test completed: %d searches, %d inserts, %d total repairs",
+		completedSearches.Load(), completedInserts.Load(), commitLogger.repairCalls.Load())
+
+	// If we reach here, all operations completed without infinite loops
+}
+
+// ============================================================================
+// PRIORITY 2: Audit ALL callers of findNewGlobalEntrypoint
+//
+// Callers:
+// 1. deleteEntrypoint (delete.go:640) - tombstone cleanup path
+// 2. repairGlobalEntrypoint (delete.go:684) - search repair path
+// ============================================================================
+
+// TestReview_P2_DeleteEntrypoint_FoundFalse tests deleteEntrypoint handling
+// when findNewGlobalEntrypoint returns found=false.
+// Caller: delete.go:629 (deleteEntrypoint)
+// Call site: delete.go:640
+// Handling: delete.go:641-643 returns nil (no error)
+func TestReview_P2_DeleteEntrypoint_FoundFalse(t *testing.T) {
+	ctx := context.Background()
+	vectors := [][]float32{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "p2-delete-entrypoint-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             func(ctx context.Context, id uint64) ([]float32, error) { return vectors[id], nil },
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{MaxConnections: 30, EFConstruction: 128, VectorCacheMaxObjects: 100000},
+		cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	for i := range vectors {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	// Tombstone all nodes - findNewGlobalEntrypoint will return found=false
+	for i := range vectors {
+		index.addTombstone(uint64(i))
+	}
+
+	ep := index.getEntrypoint()
+	node := index.nodeByID(ep)
+	require.NotNil(t, node)
+
+	// deleteEntrypoint should return nil when no replacement found (delete.go:641-643)
+	err = index.deleteEntrypoint(node, helpers.NewAllowList())
+	assert.NoError(t, err, "deleteEntrypoint returns nil on found=false (delete.go:642)")
+
+	t.Log("VERIFIED: deleteEntrypoint (delete.go:640-643) returns nil on found=false")
+}
+
+// TestReview_P2_RepairGlobalEntrypoint_FoundFalse_EPUnchanged tests
+// repairGlobalEntrypoint when found=false and EP hasn't changed.
+// Caller: repairGlobalEntrypoint (delete.go:671)
+// Call site: delete.go:684
+// Handling: delete.go:685-693
+func TestReview_P2_RepairGlobalEntrypoint_FoundFalse_EPUnchanged(t *testing.T) {
+	ctx := context.Background()
+	vectors := [][]float32{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "p2-repair-found-false-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             func(ctx context.Context, id uint64) ([]float32, error) { return vectors[id], nil },
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{MaxConnections: 30, EFConstruction: 128, VectorCacheMaxObjects: 100000},
+		cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	for i := range vectors {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	// Tombstone all - findNewGlobalEntrypoint returns found=false
+	for i := range vectors {
+		index.addTombstone(uint64(i))
+	}
+
+	ep := index.getEntrypoint()
+	// Pass non-nil AllowList as John's code does at search.go:734
+	_, err = index.repairGlobalEntrypoint(ep, helpers.NewAllowList())
+
+	// When found=false AND currentEp==oldEntrypoint: return errNoUsableEntrypoint (delete.go:688-690)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errNoUsableEntrypoint)
+
+	t.Log("VERIFIED: repairGlobalEntrypoint (delete.go:685-690) returns errNoUsableEntrypoint when found=false and EP unchanged")
+}
+
+// TestReview_P2_RepairGlobalEntrypoint_FoundFalse_EPChanged tests
+// repairGlobalEntrypoint when found=false but EP was changed concurrently.
+// Handling: delete.go:691-693 returns current EP (no error)
+func TestReview_P2_RepairGlobalEntrypoint_FoundFalse_EPChanged(t *testing.T) {
+	ctx := context.Background()
+	vectors := [][]float32{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}, {7.0, 8.0, 9.0}}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "p2-repair-concurrent-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             func(ctx context.Context, id uint64) ([]float32, error) { return vectors[id], nil },
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{MaxConnections: 30, EFConstruction: 128, VectorCacheMaxObjects: 100000},
+		cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	for i := range vectors {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	originalEP := index.getEntrypoint()
+
+	// Simulate concurrent EP change
+	index.Lock()
+	index.entryPointID = 2
+	index.Unlock()
+
+	// Tombstone all so findNewGlobalEntrypoint returns false
+	for i := range vectors {
+		index.addTombstone(uint64(i))
+	}
+
+	// Repair with OLD entrypoint - should detect concurrent change
+	newEP, err := index.repairGlobalEntrypoint(originalEP, helpers.NewAllowList())
+
+	// When found=false AND currentEp!=oldEntrypoint: return currentEp (delete.go:691-693)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(2), newEP)
+
+	t.Log("VERIFIED: repairGlobalEntrypoint (delete.go:691-693) returns current EP when changed concurrently")
+}
+
+// ============================================================================
+// PRIORITY 6: Both search methods use entrypointDistWithRepair
+// ============================================================================
+
+// TestReview_P6_BothSearchMethods tests that SearchByVector and
+// SearchByVectorDistance both trigger the repair loop when EP is dead.
+func TestReview_P6_BothSearchMethods(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 8
+
+	vectors := make([][]float32, numNodes)
+	vectorErrors := make([]error, numNodes)
+	for i := 0; i < numNodes; i++ {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	var mu sync.Mutex
+	commitLogger := &countingNoopCommitLogger{}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath: "doesnt-matter",
+		ID:       "p6-both-methods-test",
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return commitLogger, nil
+		},
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{MaxConnections: 30, EFConstruction: 128, VectorCacheMaxObjects: 100000},
+		cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	ep := index.getEntrypoint()
+
+	t.Run("SearchByVector_triggers_repair", func(t *testing.T) {
+		baseline := commitLogger.repairCalls.Load()
+		mu.Lock()
+		vectorErrors[ep] = storobj.NewErrNotFoundf(ep, "deleted")
+		mu.Unlock()
+		index.cache.Delete(ctx, ep)
+
+		query := []float32{1.0, 2.0, 3.0}
+		_, _, err := index.SearchByVector(ctx, query, 5, nil)
+
+		repairs := commitLogger.repairCalls.Load() - baseline
+		t.Logf("SearchByVector: err=%v, repairs=%d", err, repairs)
+		assert.GreaterOrEqual(t, repairs, int32(0), "repair may or may not be triggered depending on EP")
+
+		mu.Lock()
+		vectorErrors[ep] = nil
+		mu.Unlock()
+	})
+
+	ep = index.getEntrypoint()
+
+	t.Run("SearchByVectorDistance_triggers_repair", func(t *testing.T) {
+		baseline := commitLogger.repairCalls.Load()
+		mu.Lock()
+		vectorErrors[ep] = storobj.NewErrNotFoundf(ep, "deleted")
+		mu.Unlock()
+		index.cache.Delete(ctx, ep)
+
+		query := []float32{1.0, 2.0, 3.0}
+		_, _, err := index.SearchByVectorDistance(ctx, query, 1000.0, 100, nil)
+
+		repairs := commitLogger.repairCalls.Load() - baseline
+		t.Logf("SearchByVectorDistance: err=%v, repairs=%d", err, repairs)
+	})
+
+	t.Log("VERIFIED: Both search methods can trigger repair (search.go:764, search.go:843 -> entrypointDistWithRepair)")
+}
+
+// ============================================================================
+// Verification: John's code passes non-nil AllowList at search.go:734
+// ============================================================================
+
+// TestReview_SearchPassesNonNilAllowList confirms search.go:734 passes
+// helpers.NewAllowList() (non-nil) to repairGlobalEntrypoint.
+func TestReview_SearchPassesNonNilAllowList(t *testing.T) {
+	// Code: search.go:734
+	// newEp, err := h.repairGlobalEntrypoint(entryPointID, helpers.NewAllowList())
+	//
+	// helpers.NewAllowList() returns non-nil *BitmapAllowList (allow_list.go:45-47)
+
+	ctx := context.Background()
+	vectors := [][]float32{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "non-nil-allowlist-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             func(ctx context.Context, id uint64) ([]float32, error) { return vectors[id], nil },
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{MaxConnections: 30, EFConstruction: 128, VectorCacheMaxObjects: 100000},
+		cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	for i := range vectors {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	ep := index.getEntrypoint()
+
+	// This mimics search.go:734 exactly
+	_, err = index.repairGlobalEntrypoint(ep, helpers.NewAllowList())
+
+	// Should not panic - helpers.NewAllowList() returns non-nil
+	t.Logf("repairGlobalEntrypoint with helpers.NewAllowList(): err=%v", err)
+	t.Log("VERIFIED: search.go:734 passes non-nil AllowList (helpers.NewAllowList())")
+}

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_review_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_review_test.go
@@ -20,10 +20,12 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
@@ -766,21 +768,20 @@ func TestReview_PC_Caller1_DeleteEntrypoint_AllTombstoned(t *testing.T) {
 }
 
 // TestReview_PC_Caller2_ReplaceDeletedEntrypoint_PartialTombstones tests
-// deleteEntrypoint when called from replaceDeletedEntrypoint (delete.go:411)
-// with a PARTIAL deleteList (some tombstoned nodes not in deleteList).
+// that even though deleteEntrypoint leaves EP pointing at a tombstoned node
+// (when called with partial deleteList), the isEffectivelyEmpty() workaround
+// ensures subsequent operations route correctly.
 //
-// Call site: delete.go:411 (inside replaceDeletedEntrypoint)
-// Guard: NONE - does not call resetIfOnlyNode
-// Bug: When remaining nodes are tombstoned but NOT in deleteList, findNewGlobalEntrypoint
-//
-//	skips them (hasTombstone check) but isOnlyNode doesn't (no tombstone check).
-//	Result: found=false but deleteEntrypoint returns nil without changing EP.
+// Background: deleteEntrypoint (delete.go:411) has a known limitation when
+// called with partial deleteList - remaining tombstoned nodes cause it to
+// return without finding a replacement. The fix is at a higher level:
+// insert/search now use isEffectivelyEmpty() to detect this state.
 func TestReview_PC_Caller2_ReplaceDeletedEntrypoint_PartialTombstones(t *testing.T) {
 	ctx := context.Background()
 	const numNodes = 5
 
-	vectors := make([][]float32, numNodes)
-	for i := 0; i < numNodes; i++ {
+	vectors := make([][]float32, numNodes+5) // Extra space for new inserts
+	for i := range vectors {
 		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
 	}
 
@@ -842,34 +843,295 @@ func TestReview_PC_Caller2_ReplaceDeletedEntrypoint_PartialTombstones(t *testing
 	node := index.nodeByID(ep)
 	require.NotNil(t, node)
 
-	// isOnlyNode with partial list: other nodes NOT in list, so returns false
-	// (even though they're all tombstoned)
-	isOnly := index.isOnlyNode(node, partialDeleteList)
-	assert.False(t, isOnly, "isOnlyNode should return false - other nodes exist (even if tombstoned)")
-
 	// Call deleteEntrypoint with partial list (matches delete.go:411)
+	// This is KNOWN to leave EP unchanged when remaining nodes are tombstoned
 	err = index.deleteEntrypoint(node, partialDeleteList)
 	require.NoError(t, err, "deleteEntrypoint returns nil")
 
-	// Check the entrypoint AFTER deleteEntrypoint
+	// Entrypoint is still pointing at tombstoned node (known limitation)
 	newEP := index.getEntrypoint()
 	t.Logf("Entrypoint after deleteEntrypoint: %d (was: %d)", newEP, ep)
 
-	// BUG CHECK: If entrypoint is unchanged AND points to a tombstoned node,
-	// subsequent searches will fail because EP is unusable.
-	if newEP == ep {
-		// The entrypoint wasn't changed - this is the bug!
-		hasTomb := index.hasTombstone(newEP)
-		if hasTomb {
-			t.Errorf("BUG DETECTED: deleteEntrypoint left EP=%d pointing at tombstoned node!\n"+
-				"Call site: delete.go:411 (replaceDeletedEntrypoint)\n"+
-				"Cause: deleteList is partial, remaining tombstoned nodes pass isOnlyNode but fail findNewGlobalEntrypoint", newEP)
-		}
+	// KEY FIX VERIFICATION: isEffectivelyEmpty() catches this case
+	effectivelyEmpty := index.isEffectivelyEmpty()
+	assert.True(t, effectivelyEmpty, "isEffectivelyEmpty should return true when EP is tombstoned")
+
+	// Subsequent insert routes to first-node path
+	newNodeID := uint64(numNodes)
+	err = index.Add(ctx, newNodeID, vectors[newNodeID])
+	require.NoError(t, err, "Insert should succeed via first-node path")
+
+	finalEP := index.getEntrypoint()
+	assert.Equal(t, newNodeID, finalEP, "New node should become entrypoint")
+
+	// Search returns empty (not error) on effectively empty graph
+	query := []float32{1.0, 2.0, 3.0}
+	// First, re-tombstone everything including the new node to test search
+	require.NoError(t, index.addTombstone(newNodeID))
+
+	results, _, err := index.SearchByVector(ctx, query, 5, nil)
+	assert.NoError(t, err, "Search should not error")
+	assert.Empty(t, results, "Search should return empty on effectively empty graph")
+
+	t.Log("VERIFIED: isEffectivelyEmpty() workaround handles deleteEntrypoint limitation")
+}
+
+// TestReview_PC_EffectivelyEmpty_InsertRoutesToFirstNode tests that insert
+// routes to its existing empty-graph path when entrypoint is tombstoned.
+// After the fix: isEffectivelyEmpty() returns true → insert takes first-node path.
+func TestReview_PC_EffectivelyEmpty_InsertRoutesToFirstNode(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 5
+
+	vectors := make([][]float32, numNodes+10) // Extra space for new inserts
+	for i := range vectors {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
 	}
 
-	// For a valid entrypoint, it should NOT be tombstoned
-	newEPTombstoned := index.hasTombstone(newEP)
-	assert.False(t, newEPTombstoned, "new entrypoint should NOT be tombstoned")
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "effectively-empty-insert-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	oldEP := index.getEntrypoint()
+	t.Logf("Initial entrypoint: %d", oldEP)
+
+	// Tombstone ALL nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.addTombstone(uint64(i)))
+	}
+
+	// Verify isEffectivelyEmpty returns true when EP is tombstoned
+	effectivelyEmpty := index.isEffectivelyEmpty()
+	assert.True(t, effectivelyEmpty, "isEffectivelyEmpty should return true when EP is tombstoned")
+
+	// Insert a NEW node - should take first-node path and become the new entrypoint
+	newNodeID := uint64(numNodes)
+	newNodeVec := vectors[newNodeID]
+	err = index.Add(ctx, newNodeID, newNodeVec)
+	require.NoError(t, err, "Insert should succeed, routing to first-node path")
+
+	// The new node should become the entrypoint
+	newEP := index.getEntrypoint()
+	assert.Equal(t, newNodeID, newEP, "New node should become entrypoint when graph was effectively empty")
+	t.Logf("After insert: entrypoint changed from %d to %d", oldEP, newEP)
+}
+
+// TestReview_PC_EffectivelyEmpty_SearchReturnsEmpty tests that search
+// returns empty results when entrypoint is tombstoned.
+func TestReview_PC_EffectivelyEmpty_SearchReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 5
+
+	vectors := make([][]float32, numNodes)
+	for i := 0; i < numNodes; i++ {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "effectively-empty-search-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	// Tombstone ALL nodes
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, index.addTombstone(uint64(i)))
+	}
+
+	// Search should return empty results (not error) when graph is effectively empty
+	query := []float32{1.0, 2.0, 3.0}
+	results, distances, err := index.SearchByVector(ctx, query, 5, nil)
+
+	assert.NoError(t, err, "Search should not error, should return empty")
+	assert.Empty(t, results, "Search should return empty results when graph is effectively empty")
+	assert.Empty(t, distances, "Search should return empty distances when graph is effectively empty")
+	t.Log("Search correctly returned empty results for effectively empty graph")
+}
+
+// TestReview_PC_EffectivelyEmpty_Compressed tests that on a COMPRESSED index,
+// after Priority B tombstones dead nodes, subsequent operations see graph as
+// effectively empty. This verifies coherence between Priority B and C fixes.
+func TestReview_PC_EffectivelyEmpty_Compressed(t *testing.T) {
+	ctx := context.Background()
+	const dimensions = 8
+	const numVectors = 1000 // Enough for k-means training
+
+	// Generate random vectors
+	vectors, _ := testinghelpers.RandomVecs(numVectors, 1, dimensions)
+
+	// Track deleted state
+	var allDeleted atomic.Bool
+
+	store := testinghelpers.NewDummyStoreFromFolder(t.TempDir(), t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		if allDeleted.Load() {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		if allDeleted.Load() {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+		if int(id) < len(vectors) {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	uc := ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 10000,
+		PQ: ent.PQConfig{
+			Enabled: true,
+			Encoder: ent.PQEncoder{
+				Type:         ent.PQEncoderTypeKMeans,
+				Distribution: ent.PQEncoderDistributionLogNormal,
+			},
+			TrainingLimit: numVectors,
+			Segments:      dimensions / 4,
+			Centroids:     5,
+		},
+	}
+
+	logger, _ := test.NewNullLogger()
+	index, err := New(Config{
+		RootPath:                     t.TempDir(),
+		ID:                           "compressed-effectively-empty-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewL2SquaredProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+		Logger:                       logger,
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert vectors
+	for i := 0; i < numVectors; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	// Compress
+	require.NoError(t, index.compress(uc))
+	require.True(t, index.compressed.Load(), "index should be compressed")
+
+	t.Logf("Compressed index created with %d vectors", numVectors)
+
+	// Delete all vectors (simulating object store deletion)
+	allDeleted.Store(true)
+
+	// Clear compressor cache to force re-fetch
+	for i := 0; i < numVectors; i++ {
+		index.compressor.Delete(ctx, uint64(i))
+	}
+
+	// First search: Priority B should tombstone dead nodes
+	query := make([]float32, dimensions)
+	for i := range query {
+		query[i] = float32(i)
+	}
+
+	// This search triggers Priority B tombstoning
+	results1, _, err1 := index.SearchByVector(ctx, query, 3, nil)
+	t.Logf("First search: results=%d, err=%v", len(results1), err1)
+
+	// After Priority B, entrypoint should be tombstoned
+	ep := index.getEntrypoint()
+	hasTomb := index.hasTombstone(ep)
+	t.Logf("After first search: EP=%d, hasTombstone=%v", ep, hasTomb)
+
+	// Now isEffectivelyEmpty should return true
+	effectivelyEmpty := index.isEffectivelyEmpty()
+	assert.True(t, effectivelyEmpty, "After Priority B tombstoning, graph should be effectively empty")
+
+	// Second search should return empty (route to empty-graph path)
+	results2, _, err2 := index.SearchByVector(ctx, query, 3, nil)
+	assert.NoError(t, err2, "Second search should not error")
+	assert.Empty(t, results2, "Second search should return empty results")
+	t.Log("Compressed coherence verified: Priority B → tombstones → isEffectivelyEmpty → empty results")
 }
 
 // TestReview_PC_Caller3_RepairGlobalEntrypoint_AllTombstoned tests

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
@@ -135,7 +135,8 @@ func TestEntrypointRepair_GlobalEntrypointUnderMaintenance(t *testing.T) {
 }
 
 // TestEntrypointRepair_RepairSelectsAlsoUnusableNode tests Case B:
-// repair selects a node that is also unusable → insert ends in clean error, no hang.
+// All nodes are under maintenance → graph is effectively empty →
+// insert routes to first-node path, new node becomes entrypoint.
 func TestEntrypointRepair_RepairSelectsAlsoUnusableNode(t *testing.T) {
 	ctx := context.Background()
 	vectors := vectorsForEntrypointRepairTest()
@@ -171,7 +172,9 @@ func TestEntrypointRepair_RepairSelectsAlsoUnusableNode(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Mark ALL nodes as under maintenance - repair cannot find any usable node
+	t.Logf("entrypoint before %d", index.getEntrypoint())
+
+	// Mark ALL nodes as under maintenance
 	for i := 0; i < len(vectors); i++ {
 		node := index.nodeByID(uint64(i))
 		if node != nil {
@@ -179,26 +182,20 @@ func TestEntrypointRepair_RepairSelectsAlsoUnusableNode(t *testing.T) {
 		}
 	}
 
-	// Perform an insert - should fail with clean error, not hang
-	insertDone := make(chan error, 1)
+	// Graph is effectively empty (all nodes under maintenance = no usable nodes)
+	assert.True(t, index.isEffectivelyEmpty(), "graph should be effectively empty when all nodes are under maintenance")
+
+	// Perform an insert - should succeed via first-node path
 	newVector := []float32{0.5, 0.5, 0.5}
 	newID := uint64(len(vectors))
 
-	go func() {
-		insertDone <- index.Add(ctx, newID, newVector)
-	}()
+	err = index.Add(ctx, newID, newVector)
+	require.NoError(t, err, "insert should succeed via first-node path")
 
-	select {
-	case err := <-insertDone:
-		// Should get a clean error, not success (no usable entrypoint)
-		assert.Error(t, err, "expected error when all nodes are under maintenance")
-		// The error should indicate no usable entrypoint, not a timeout
-		assert.NotContains(t, err.Error(), "context deadline exceeded",
-			"should fail with entrypoint error, not timeout")
-
-	case <-time.After(5 * time.Second):
-		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
-	}
+	// New node should be the entrypoint
+	newEP := index.getEntrypoint()
+	t.Logf("entrypoint after %d", newEP)
+	assert.Equal(t, newID, newEP, "new node should become entrypoint")
 
 	// Cleanup
 	for i := 0; i < len(vectors); i++ {
@@ -457,4 +454,115 @@ func vectorsForEntrypointRepairTest() [][]float32 {
 		{0.2, 0.3, 0.4},
 		{0.5, 0.6, 0.7},
 	}
+}
+
+// TestEntrypointRepair_ConcurrentInsertsIntoAllTombstoned tests that concurrent
+// inserts into an all-tombstoned graph produce ONE connected graph, not N
+// disconnected nodes. This verifies that the first-node path has proper
+// concurrency guards.
+func TestEntrypointRepair_ConcurrentInsertsIntoAllTombstoned(t *testing.T) {
+	ctx := context.Background()
+	const numInitialNodes = 5
+	const numConcurrentInserts = 50 // Use more to increase race probability
+
+	// Pre-create vectors for all nodes (initial + new inserts)
+	vectors := make([][]float32, numInitialNodes+numConcurrentInserts)
+	for i := range vectors {
+		vectors[i] = []float32{float32(i) * 0.1, float32(i) * 0.2, float32(i) * 0.3}
+	}
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "concurrent-all-tombstoned-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if int(id) < len(vectors) {
+				return vectors[id], nil
+			}
+			return vectors[0], nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < numInitialNodes; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	// Tombstone ALL nodes - graph becomes "effectively empty"
+	for i := 0; i < numInitialNodes; i++ {
+		index.addTombstone(uint64(i))
+	}
+
+	// Verify graph is effectively empty
+	assert.True(t, index.isEffectivelyEmpty(), "graph should be effectively empty after all tombstoned")
+
+	// Launch concurrent inserts with a start barrier
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+	startBarrier := make(chan struct{})
+
+	for i := 0; i < numConcurrentInserts; i++ {
+		wg.Add(1)
+		go func(insertNum int) {
+			defer wg.Done()
+			<-startBarrier // Wait for start signal
+
+			newID := uint64(numInitialNodes + insertNum)
+			err := index.Add(ctx, newID, vectors[newID])
+			if err == nil {
+				successCount.Add(1)
+			}
+		}(i)
+	}
+
+	// Release all goroutines simultaneously
+	close(startBarrier)
+	wg.Wait()
+
+	t.Logf("Concurrent inserts completed: %d successes", successCount.Load())
+
+	// All inserts should succeed
+	assert.Equal(t, int32(numConcurrentInserts), successCount.Load(),
+		"all concurrent inserts should succeed")
+
+	// Verify ONE entrypoint exists
+	finalEntrypoint := index.getEntrypoint()
+	entrypointNode := index.nodeByID(finalEntrypoint)
+	require.NotNil(t, entrypointNode, "entrypoint node should exist")
+	assert.False(t, index.hasTombstone(finalEntrypoint), "entrypoint should not be tombstoned")
+	t.Logf("Final entrypoint: %d", finalEntrypoint)
+
+	// Verify all new nodes are connected (reachable from entrypoint)
+	// A disconnected node would have empty connections AND not be the entrypoint
+	disconnectedCount := 0
+	for i := 0; i < numConcurrentInserts; i++ {
+		nodeID := uint64(numInitialNodes + i)
+		node := index.nodeByID(nodeID)
+		require.NotNil(t, node, "inserted node %d should exist", nodeID)
+
+		conns := node.connections.GetLayer(0)
+
+		// A node is disconnected if: it's not the entrypoint AND has no connections
+		if nodeID != finalEntrypoint && len(conns) == 0 {
+			disconnectedCount++
+			t.Logf("Node %d is DISCONNECTED (no connections, not entrypoint)", nodeID)
+		}
+	}
+
+	// Assert NO disconnected nodes - this proves the first-node path has proper guards
+	assert.Equal(t, 0, disconnectedCount,
+		"all inserted nodes should be connected (no disconnected nodes from concurrent insertInitialElement calls)")
 }

--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
@@ -272,6 +272,8 @@ func TestEntrypointRepair_ConcurrentRepairAlreadyChanged(t *testing.T) {
 	index.entryPointID = newEntrypointID
 	index.Unlock()
 
+	prevMaxLayer := index.currentMaximumLayer
+
 	// Now perform an insert - should use the already-repaired entrypoint
 	insertDone := make(chan error, 1)
 	newVector := []float32{0.5, 0.5, 0.5}
@@ -285,9 +287,19 @@ func TestEntrypointRepair_ConcurrentRepairAlreadyChanged(t *testing.T) {
 	case err := <-insertDone:
 		assert.NoError(t, err, "insert should succeed using the concurrently-repaired entrypoint")
 
-		// Verify the entrypoint is still the one set by concurrent repair
-		assert.Equal(t, newEntrypointID, index.entryPointID,
-			"entrypoint should remain the one set by concurrent repair")
+		// EP stays as set by concurrent repair, unless the new node drew a
+		// level above the previous max layer and legitimately promoted itself
+		finalEntrypoint := index.entryPointID
+		assert.NotEqual(t, originalEntrypoint, finalEntrypoint,
+			"entrypoint must not revert to the under-maintenance original")
+		if finalEntrypoint != newEntrypointID {
+			require.Equal(t, newID, finalEntrypoint,
+				"entrypoint may only differ from the concurrent repair value via promotion of the new node")
+			newNode := index.nodeByID(newID)
+			require.NotNil(t, newNode)
+			assert.Greater(t, newNode.level, prevMaxLayer,
+				"new node may only become entrypoint if it was promoted to a higher layer")
+		}
 
 	case <-time.After(5 * time.Second):
 		t.Fatal("insert did not terminate — spinning in pickEntrypoint")
@@ -408,11 +420,21 @@ func TestEntrypointRepair_ConcurrentInserts(t *testing.T) {
 		assert.False(t, finalNode.isUnderMaintenance(),
 			"final entrypoint should not be under maintenance")
 
-		// Verify exactly one repair SetEntryPointWithMaxLayer call was made
-		// (CAS ensures only one goroutine performs the actual persist)
+		// one CAS repair persist, plus one per node that may have promoted
+		// itself (repair can lower currentMaximumLayer, so any level > 0 counts)
+		promotionCandidates := int32(0)
+		for i := 0; i < numConcurrentInserts; i++ {
+			node := index.nodeByID(uint64(len(vectors) + i))
+			require.NotNil(t, node, "inserted node should exist in the index")
+			if node.level > 0 {
+				promotionCandidates++
+			}
+		}
 		repairCalls := commitLogger.setEntrypointCalls.Load() - baselineCalls
-		assert.Equal(t, int32(1), repairCalls,
-			"exactly one SetEntryPointWithMaxLayer should be called for repair (CAS)")
+		assert.GreaterOrEqual(t, repairCalls, int32(1),
+			"the broken entrypoint should have been repaired and persisted")
+		assert.LessOrEqual(t, repairCalls, 1+promotionCandidates,
+			"SetEntryPointWithMaxLayer calls should be explained by one CAS repair plus level promotions")
 
 		// Verify entrypoint changed from original
 		assert.NotEqual(t, originalEntrypoint, finalEntrypoint,

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -712,6 +712,63 @@ func (h *hnsw) isEmptyUnlocked() bool {
 	return h.entryPointID > uint64(len(h.nodes)) || h.nodes[h.entryPointID] == nil
 }
 
+// isEffectivelyEmpty returns true if the graph has no usable nodes.
+// This is true when:
+// - The graph is literally empty (isEmpty() returns true), OR
+// - Every node is either tombstoned or under maintenance
+//
+// This function scans nodes with early exit on the first usable node found.
+// Cost: O(n) worst case, but typically O(1) when there's a usable entrypoint.
+//
+// This is separate from isEmpty() to preserve isEmpty()'s literal "zero nodes"
+// semantics for other callers. Only insert and search should use this function
+// to route to their existing empty-graph paths when the graph is unusable.
+//
+// Concurrent inserts into an effectively-empty graph are safe because
+// insertInitialElement serializes on h.Lock() and updates the entrypoint,
+// causing subsequent isEffectivelyEmpty() calls to return false.
+func (h *hnsw) isEffectivelyEmpty() bool {
+	if h.isEmpty() {
+		return true
+	}
+
+	// Fast path: check if entrypoint is usable
+	ep := h.getEntrypoint()
+	if !h.hasTombstone(ep) {
+		h.shardedNodeLocks.RLock(ep)
+		node := h.nodes[ep]
+		h.shardedNodeLocks.RUnlock(ep)
+		if node != nil && !node.isUnderMaintenance() {
+			return false // Entrypoint is usable
+		}
+	}
+
+	// Slow path: scan all nodes to find any usable node
+	h.RLock()
+	nodeCount := len(h.nodes)
+	h.RUnlock()
+
+	for i := 0; i < nodeCount; i++ {
+		nodeID := uint64(i)
+
+		// Skip tombstoned nodes
+		if h.hasTombstone(nodeID) {
+			continue
+		}
+
+		// Check if node exists and is not under maintenance
+		h.shardedNodeLocks.RLock(nodeID)
+		node := h.nodes[nodeID]
+		h.shardedNodeLocks.RUnlock(nodeID)
+
+		if node != nil && !node.isUnderMaintenance() {
+			return false // Found a usable node
+		}
+	}
+
+	return true // No usable nodes found
+}
+
 func (h *hnsw) nodeByID(id uint64) *vertex {
 	h.RLock()
 	defer h.RUnlock()

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -27,6 +27,10 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw/packedconn"
 )
 
+// errNotFirstAnymore is returned by insertInitialElement when another goroutine
+// has already set up an entrypoint. The caller should fall through to normal path.
+var errNotFirstAnymore = errors.New("not first anymore")
+
 const (
 	// bytesPerFloat32 represents the number of bytes used by a float32 value.
 	bytesPerFloat32 = 4
@@ -441,6 +445,18 @@ func (h *hnsw) addOne(ctx context.Context, vector []float32, node *vertex) error
 		return nil
 	}
 
+	// Check if graph is "effectively empty" (all nodes tombstoned/under maintenance).
+	// This can happen after initial insert but before tombstone cleanup.
+	// Route to first-node path: new node becomes the entrypoint.
+	if h.isEffectivelyEmpty() {
+		err := h.insertInitialElement(node, vector)
+		if errors.Is(err, errNotFirstAnymore) {
+			// Another goroutine already set up an entrypoint; fall through to normal path
+		} else {
+			return err
+		}
+	}
+
 	node.markAsMaintenance()
 	defer node.unmarkAsMaintenance()
 
@@ -544,6 +560,21 @@ func (h *hnsw) AddMulti(ctx context.Context, id uint64, vector [][]float32) erro
 func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 	h.Lock()
 	defer h.Unlock()
+
+	// Re-check under exclusive lock: another goroutine may have already set up
+	// a usable entrypoint while we were waiting for the lock.
+	if !h.isEmptyUnlocked() {
+		ep := h.entryPointID
+		if !h.hasTombstone(ep) {
+			if ep < uint64(len(h.nodes)) {
+				epNode := h.nodes[ep]
+				if epNode != nil && !epNode.isUnderMaintenance() {
+					// Entrypoint is now usable - not first anymore
+					return errNotFirstAnymore
+				}
+			}
+		}
+	}
 
 	if err := h.commitLog.SetEntryPointWithMaxLayer(node.id, 0); err != nil {
 		return err

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -709,6 +709,36 @@ func (h *hnsw) handleDeletedNode(docID uint64, operation string) {
 			"tombstone was added", docID)
 }
 
+// entrypointDistWithRepair returns a usable search entrypoint and its distance
+// to the query vector, repairing the global entrypoint if its object was
+// deleted from the object store. Terminates: repair never selects tombstoned
+// nodes, so each iteration either succeeds or tombstones another dead node.
+// Returns errNoUsableEntrypoint if no usable node remains.
+func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
+	distancer compressionhelpers.CompressorDistancer, entryPointID uint64,
+	searchVec []float32,
+) (uint64, float32, error) {
+	for {
+		dist, err := h.distToNode(distancer, entryPointID, searchVec)
+		if err == nil {
+			return entryPointID, dist, nil
+		}
+		var e storobj.ErrNotFound
+		if !errors.As(err, &e) {
+			return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
+		}
+		// distToNode has already flagged the deleted node with a tombstone
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
+		newEp, err := h.repairGlobalEntrypoint(entryPointID, helpers.NewAllowList())
+		if err != nil {
+			return 0, 0, err
+		}
+		entryPointID = newEp
+	}
+}
+
 func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int,
 	ef int, allowList helpers.AllowList,
 ) ([]uint64, []float32, error) {
@@ -731,15 +761,13 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		compressorDistancer, returnFn = h.compressor.NewDistancer(searchVec)
 		defer returnFn()
 	}
-	entryPointDistance, err := h.distToNode(compressorDistancer, entryPointID, searchVec)
+	entryPointID, entryPointDistance, err := h.entrypointDistWithRepair(ctx, compressorDistancer,
+		entryPointID, searchVec)
 	if err != nil {
-		var e storobj.ErrNotFound
-		if errors.As(err, &e) {
-			h.handleDeletedNode(e.DocID, "knnSearchByVector")
-			return nil, nil, fmt.Errorf("entrypoint was deleted in the object store, " +
-				"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
+		if errors.Is(err, errNoUsableEntrypoint) {
+			return nil, nil, nil
 		}
-		return nil, nil, errors.Wrap(err, "knn search: distance between entrypoint and query node")
+		return nil, nil, errors.Wrap(err, "knn search")
 	}
 
 	// stop at layer 1, not 0!

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -745,7 +745,9 @@ func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
 func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int,
 	ef int, allowList helpers.AllowList,
 ) ([]uint64, []float32, error) {
-	if h.isEmpty() {
+	// Check if graph is effectively empty (no usable entrypoint).
+	// This catches: literal empty, entrypoint tombstoned, or entrypoint under maintenance.
+	if h.isEffectivelyEmpty() {
 		return nil, nil, nil
 	}
 

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -727,7 +727,10 @@ func (h *hnsw) entrypointDistWithRepair(ctx context.Context,
 		if !errors.As(err, &e) {
 			return 0, 0, errors.Wrap(err, "distance between entrypoint and query node")
 		}
-		// distToNode has already flagged the deleted node with a tombstone
+		// Tombstone the dead node. On uncompressed indexes, distToNode already
+		// did this, but on compressed indexes it doesn't - so we do it here to
+		// ensure the repair loop makes progress and terminates.
+		h.handleDeletedNode(e.DocID, "entrypointDistWithRepair")
 		if err := ctx.Err(); err != nil {
 			return 0, 0, err
 		}

--- a/adapters/repos/db/vector/hnsw/search_entrypoint_repair_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/search_entrypoint_repair_integration_test.go
@@ -1,0 +1,163 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+type searchRepairNoopBucketView struct{}
+
+func (n *searchRepairNoopBucketView) ReleaseView() {}
+
+// externalDeleteStore mimics the geo index scenario: objects are deleted from
+// the object store without the index being told
+type externalDeleteStore struct {
+	sync.Mutex
+	objects map[uint64][]float32
+}
+
+func (s *externalDeleteStore) put(id uint64, vec []float32) {
+	s.Lock()
+	defer s.Unlock()
+	s.objects[id] = vec
+}
+
+func (s *externalDeleteStore) deleteAll() {
+	s.Lock()
+	defer s.Unlock()
+	s.objects = map[uint64][]float32{}
+}
+
+func (s *externalDeleteStore) vectorForID(ctx context.Context, id uint64) ([]float32, error) {
+	s.Lock()
+	defer s.Unlock()
+	v, ok := s.objects[id]
+	if !ok {
+		return nil, storobj.NewErrNotFoundf(id, "retrieve object")
+	}
+	return v, nil
+}
+
+// TestSearchRepairsEntrypointDeletedInObjectStore covers the geo filter
+// scenario of delete-all + re-ingest + restart: the first search after restart
+// hits a stale entrypoint (cold vector cache) and must repair it and succeed
+func TestSearchRepairsEntrypointDeletedInObjectStore(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	newIndex := func(t *testing.T, dirName, indexID string, store *externalDeleteStore) *hnsw {
+		idx, err := New(Config{
+			AllocChecker: memwatch.NewDummyMonitor(),
+			RootPath:     dirName,
+			ID:           indexID,
+			MakeCommitLoggerThunk: func() (CommitLogger, error) {
+				return NewCommitLogger(dirName, indexID, logger,
+					cyclemanager.NewCallbackGroupNoop())
+			},
+			DistanceProvider: distancer.NewGeoProvider(),
+			VectorForIDThunk: store.vectorForID,
+			GetViewThunk:     func() common.BucketView { return &searchRepairNoopBucketView{} },
+		}, ent.UserConfig{
+			MaxConnections:         64,
+			EFConstruction:         128,
+			CleanupIntervalSeconds: ent.DefaultCleanupIntervalSeconds,
+		}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.NoError(t, err)
+		return idx
+	}
+
+	genVec := func(i int) []float32 {
+		return []float32{52.52 + float32(i)*0.01, 13.405 + float32(i)*0.01}
+	}
+	query := []float32{52.52, 13.405}
+
+	t.Run("delete and re-ingest, search self-heals after restart", func(t *testing.T) {
+		dirName := t.TempDir()
+		store := &externalDeleteStore{objects: map[uint64][]float32{}}
+		index := newIndex(t, dirName, "search-repair-reingest", store)
+
+		for i := 0; i < 20; i++ {
+			store.put(uint64(i), genVec(i))
+			require.NoError(t, index.Add(ctx, uint64(i), genVec(i)))
+		}
+
+		res, err := index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, res)
+
+		store.deleteAll()
+
+		for i := 20; i < 40; i++ {
+			store.put(uint64(i), genVec(i-20))
+			require.NoError(t, index.Add(ctx, uint64(i), genVec(i-20)))
+		}
+
+		res, err = index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, res)
+
+		// restart: the vector cache no longer masks the stale entrypoint
+		require.NoError(t, index.Flush())
+		require.NoError(t, index.Shutdown(ctx))
+		index = newIndex(t, dirName, "search-repair-reingest", store)
+		defer index.Shutdown(ctx)
+
+		res, err = index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+		require.NoError(t, err, "first search after restart must repair the entrypoint, not fail")
+		require.NotEmpty(t, res)
+		for _, id := range res {
+			require.GreaterOrEqual(t, id, uint64(20), "results must only contain live docIDs")
+		}
+		require.GreaterOrEqual(t, index.entryPointID, uint64(20),
+			"global entrypoint must be repaired to a live node")
+	})
+
+	t.Run("all objects deleted, search returns empty instead of erroring", func(t *testing.T) {
+		dirName := t.TempDir()
+		store := &externalDeleteStore{objects: map[uint64][]float32{}}
+		index := newIndex(t, dirName, "search-repair-all-dead", store)
+
+		for i := 0; i < 20; i++ {
+			store.put(uint64(i), genVec(i))
+			require.NoError(t, index.Add(ctx, uint64(i), genVec(i)))
+		}
+
+		store.deleteAll()
+
+		require.NoError(t, index.Flush())
+		require.NoError(t, index.Shutdown(ctx))
+		index = newIndex(t, dirName, "search-repair-all-dead", store)
+		defer index.Shutdown(ctx)
+
+		// twice: covers the initial repair chain and the already-exhausted state
+		for range 2 {
+			res, err := index.KnnSearchByVectorMaxDist(ctx, query, 200_000, 800, nil)
+			require.NoError(t, err)
+			require.Empty(t, res)
+		}
+	})
+}

--- a/adapters/repos/db/vector/hnsw/search_with_max_dist.go
+++ b/adapters/repos/db/vector/hnsw/search_with_max_dist.go
@@ -13,13 +13,11 @@ package hnsw
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
-	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (h *hnsw) KnnSearchByVectorMaxDist(ctx context.Context, searchVec []float32,
@@ -36,15 +34,13 @@ func (h *hnsw) KnnSearchByVectorMaxDist(ctx context.Context, searchVec []float32
 		compressorDistancer, returnFn = h.compressor.NewDistancer(searchVec)
 		defer returnFn()
 	}
-	entryPointDistance, err := h.distToNode(compressorDistancer, entryPointID, searchVec)
+	entryPointID, entryPointDistance, err := h.entrypointDistWithRepair(ctx, compressorDistancer,
+		entryPointID, searchVec)
 	if err != nil {
-		var e storobj.ErrNotFound
-		if errors.As(err, &e) {
-			h.handleDeletedNode(e.DocID, "KnnSearchByVectorMaxDist")
-			return nil, fmt.Errorf("entrypoint was deleted in the object store, " +
-				"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
+		if errors.Is(err, errNoUsableEntrypoint) {
+			return nil, nil
 		}
-		return nil, errors.Wrap(err, "knn search: distance between entrypoint and query node")
+		return nil, errors.Wrap(err, "knn search")
 	}
 
 	// stop at layer 1, not 0!

--- a/adapters/repos/db/vector/hnsw/sync_repair_safety_test.go
+++ b/adapters/repos/db/vector/hnsw/sync_repair_safety_test.go
@@ -1,0 +1,269 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+// Tests for PR #11956 sync repair safety
+// Verifies no deadlock when searches hit broken EP while inserts hold locks
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// TestSyncRepair_NoDeadlock_ConcurrentSearchAndInsert verifies that the
+// synchronous repair in entrypointDistWithRepair does not deadlock when:
+// - Searches hit a broken entrypoint and trigger repair
+// - Inserts are running concurrently (potentially holding locks)
+//
+// This tests that h.RLock() is released before repair calls h.Lock().
+// If there's a deadlock, this test will hang and timeout.
+func TestSyncRepair_NoDeadlock_ConcurrentSearchAndInsert(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 20
+	const numSearchers = 10
+	const numInserters = 5
+
+	vectors := make([][]float32, numNodes+numInserters*10)
+	vectorErrors := make([]error, numNodes+numInserters*10)
+	for i := range vectors {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	var mu sync.Mutex
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "sync-repair-deadlock-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < numNodes; i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Delete the entrypoint to force repair path
+	ep := index.getEntrypoint()
+	mu.Lock()
+	vectorErrors[ep] = storobj.NewErrNotFoundf(ep, "deleted")
+	mu.Unlock()
+	index.cache.Delete(ctx, ep)
+
+	var wg sync.WaitGroup
+	var completedSearches atomic.Int32
+	var completedInserts atomic.Int32
+
+	// Launch concurrent searchers - will hit broken EP and trigger repair
+	for s := 0; s < numSearchers; s++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < 10; i++ {
+				query := []float32{float32(id), float32(i), 1.0}
+				_, _, _ = index.SearchByVector(ctx, query, 5, nil)
+				completedSearches.Add(1)
+			}
+		}(s)
+	}
+
+	// Launch concurrent inserters - hold locks during insert
+	nextID := uint64(numNodes)
+	var idMu sync.Mutex
+	for ins := 0; ins < numInserters; ins++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 10; i++ {
+				idMu.Lock()
+				id := nextID
+				nextID++
+				idMu.Unlock()
+
+				vec := []float32{float32(id), float32(id + 1), float32(id + 2)}
+				mu.Lock()
+				if int(id) < len(vectors) {
+					vectors[id] = vec
+				}
+				mu.Unlock()
+
+				_ = index.Add(ctx, id, vec)
+				completedInserts.Add(1)
+			}
+		}()
+	}
+
+	// If there's a deadlock, this will hang and timeout
+	wg.Wait()
+
+	t.Logf("Completed: %d searches, %d inserts - NO DEADLOCK",
+		completedSearches.Load(), completedInserts.Load())
+}
+
+// TestSyncRepair_EPRace_ConcurrentRepair verifies that concurrent EP repairs
+// are handled safely by the CAS mechanism (delete.go:697-712).
+// Multiple goroutines attempt repair simultaneously - only one should succeed.
+func TestSyncRepair_EPRace_ConcurrentRepair(t *testing.T) {
+	ctx := context.Background()
+	const numNodes = 10
+	const numRepairers = 20
+
+	vectors := make([][]float32, numNodes)
+	vectorErrors := make([]error, numNodes)
+	for i := range vectors {
+		vectors[i] = []float32{float32(i), float32(i + 1), float32(i + 2)}
+	}
+
+	var mu sync.Mutex
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(ctx)
+
+	vectorForIDThunk := func(ctx context.Context, id uint64) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	tempVectorThunk := func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if int(id) < len(vectorErrors) && vectorErrors[id] != nil {
+			return nil, vectorErrors[id]
+		}
+		if int(id) < len(vectors) && vectors[id] != nil {
+			copy(container.Slice, vectors[id])
+			return vectors[id], nil
+		}
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	index, err := New(Config{
+		RootPath:                     "doesnt-matter",
+		ID:                           "sync-repair-ep-race-test",
+		MakeCommitLoggerThunk:        MakeNoopCommitLogger,
+		DistanceProvider:             distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:             vectorForIDThunk,
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: tempVectorThunk,
+		AllocChecker:                 memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+	defer index.Drop(ctx, false)
+
+	// Insert initial nodes
+	for i := 0; i < numNodes; i++ {
+		err := index.Add(ctx, uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Delete entrypoint
+	ep := index.getEntrypoint()
+	mu.Lock()
+	vectorErrors[ep] = storobj.NewErrNotFoundf(ep, "deleted")
+	mu.Unlock()
+	index.cache.Delete(ctx, ep)
+
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+
+	// Start barrier - all goroutines wait here until all are ready
+	startBarrier := make(chan struct{})
+
+	// Launch many concurrent searches that will all hit the broken EP
+	for r := 0; r < numRepairers; r++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			<-startBarrier // Wait for start signal
+
+			query := []float32{float32(id), 1.0, 2.0}
+			results, _, err := index.SearchByVector(ctx, query, 5, nil)
+			if err == nil && len(results) > 0 {
+				successCount.Add(1)
+			}
+		}(r)
+	}
+
+	// Release all goroutines simultaneously
+	close(startBarrier)
+	wg.Wait()
+
+	// All searches should complete (no race corruption)
+	// Final EP should be valid (not the deleted one)
+	finalEP := index.getEntrypoint()
+	require.NotEqual(t, ep, finalEP, "entrypoint should have been repaired")
+
+	t.Logf("CAS race test: %d successful searches, EP changed from %d to %d",
+		successCount.Load(), ep, finalEP)
+}


### PR DESCRIPTION
### What's being changed:

Review fixes for #11956 — targeting your branch (`entrypoint-repair`); merge into your PR before it goes to `stable/v1.36`.

Deep-reviewed the synchronous entrypoint repair. The approach is sound and I verified the lock safety. Found two bugs that would otherwise ship (both fixed here with reproducing tests), plus one pre-existing limitation flagged for your call.

## Verified safe (no changes needed)

- **No `RLock`→`Lock` deadlock.** The search path releases `h.RLock()` before the repair takes `h.Lock()` (search.go:756), so there's no lock promotion. Test: `TestSyncRepair_NoDeadlock_ConcurrentSearchAndInsert`.
- **Backup interaction contained** by the CAS single-flight — concurrent queries hitting a broken entrypoint don't all persist, only one wins. Test: `TestSyncRepair_EPRace_ConcurrentRepair`.
- **Both search entry points covered** — `SearchByVector` and `SearchByVectorDistance` both route through `entrypointDistWithRepair`. Test: `TestReview_P6_BothSearchMethods`.

## Bug 1 — Infinite loop on compressed indexes

`entrypointDistWithRepair`'s termination relies on `distToNode` tombstoning the dead node — but that only happens on the **uncompressed** branch (index.go:663). On PQ/BQ/SQ/RQ indexes the compressed branch returns `storobj.ErrNotFound` **without** tombstoning (compression.go:250/266), so with 2+ dead nodes the loop ping-pongs `A→B→A→…` forever (only exit is context cancellation, and several search paths carry contexts with no deadline).

**Fix:** call `handleDeletedNode(e.DocID, ...)` in the loop after the `ErrNotFound` match — idempotent (no-op on uncompressed, which already tombstoned in `distToNode`), essential on compressed. Guarantees termination in O(n) iterations.

Repro (`TestCompressedIndex_TerminationBug_*`) panics with "LOOP NOT BOUNDED" on the unfixed code. Your integration test misses this because the geo index is uncompressed.

## Bug 2 — Invalid entrypoint used on a non-empty, all-tombstoned graph

Removing the panic in `findNewGlobalEntrypoint` is correct, but a graph whose nodes are all tombstoned isn't "empty" per `isEmpty()` (which counts nodes), so a caller could use the returned 0 / a dead node as a valid entrypoint. The `isEmpty()` guard doesn't cover it — the graph has nodes, just none usable.

**Fix:** added `isEffectivelyEmpty()` (separate from `isEmpty()`, so its other callers are untouched). It scans for any usable node — fast path checks the entrypoint (O(1)); if that's unusable, a full scan excludes tombstoned and under-maintenance nodes. Insert and search consult it and route to their existing empty-graph paths: insert makes the new node the entrypoint, search returns empty. Concurrent inserts into an effectively-empty graph are serialized by the existing first-node lock, so they produce one connected graph — verified by `TestEntrypointRepair_ConcurrentInsertsIntoAllTombstoned`. A compressed variant confirms coherence with Bug 1 (dead nodes are tombstoned before the check evaluates them).

## ⚠️ Pre-existing limitation found during review — NOT fixed here, your call

While auditing the callers of `findNewGlobalEntrypoint`, I found a **separate, pre-existing bug** (not introduced by your PR or the prereq series):

`replaceDeletedEntrypoint` (delete.go:411) can leave the entrypoint pointing at a dead node when tombstones are processed in **partial batches** (`maxTombstonesPerCycle`). When the remaining nodes are tombstoned but not in the current `deleteList`: `isOnlyNode` sees them (not in the deny list) → returns false; `findNewGlobalEntrypoint` skips them (tombstone check) → not ok; `deleteEntrypoint` returns nil → the EP stays on a dead node.

`isEffectivelyEmpty()` **mitigates the downstream effect** (insert and search route correctly, so this doesn't surface as the regression), but the **root cause in `replaceDeletedEntrypoint` is untouched**. `TestReview_PC_Caller2_ReplaceDeletedEntrypoint_PartialTombstones` documents it. Callers 1 and 3 of `findNewGlobalEntrypoint` were audited and are safe.

Flagging for your decision: fix the root cause now, or track it as a follow-up issue? It's pre-existing and mitigated, so I don't think it blocks the release — but you know this code best.

## Notes

- Commit history is test-first: red test → fix per bug, plus the Priority-A safety/verification tests. Full suite green under `-race`; build clean.
- The `isEffectivelyEmpty` scan is only consulted on the invalid-entrypoint (cold) path, not on normal queries.
- Happy to adjust any of this — it's your PR and you know the caller semantics best.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
