### PR TITLE
fix(backup): reliably restart the halt-for-transfer inactivity monitor

### DIFF
--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -141,24 +141,22 @@ func (s *Shard) mayInitInactivityMonitoring() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.haltForTransferCancel = cancel
 
-	s.haltForTransferInactivityTimer = time.NewTimer(s.haltForTransferInactivityTimeout)
+	timer := time.NewTimer(s.haltForTransferInactivityTimeout)
+	s.haltForTransferInactivityTimer = timer
 
 	enterrors.GoWrapper(func() {
-		// this goroutine will release maintenance cycles if no file activity
-		// is detected in the specified inactivity timeout
-		defer func() {
-			s.haltForTransferMux.Lock()
-			s.haltForTransferInactivityTimer.Stop()
-			s.haltForTransferCancel = nil
-			s.haltForTransferMux.Unlock()
-		}()
+		// releases maintenance cycles if no file activity is seen within the inactivity timeout.
+		// stops its own captured timer, not the shared field, so a successor monitor's timer survives.
+		defer timer.Stop()
 
 		select {
 		case <-ctx.Done():
 			return
-		case <-s.haltForTransferInactivityTimer.C:
+		case <-timer.C:
 			s.haltForTransferMux.Lock()
-			s.mayForceResumeMaintenanceCycles(context.Background(), true)
+			if err := s.mayForceResumeMaintenanceCycles(context.Background(), true); err != nil {
+				s.index.logger.Error(err)
+			}
 			s.haltForTransferMux.Unlock()
 			return
 		}
@@ -303,8 +301,10 @@ func (s *Shard) mayForceResumeMaintenanceCycles(ctx context.Context, forced bool
 	}
 
 	if s.haltForTransferCancel != nil {
-		// terminate background goroutine checking for inactivity timeout
+		// terminate the inactivity monitor and clear the sentinel synchronously under the mux,
+		// so a subsequent HaltForTransfer reliably starts a new monitor.
 		s.haltForTransferCancel()
+		s.haltForTransferCancel = nil
 	}
 
 	g := enterrors.NewErrorGroupWrapper(s.index.logger)


### PR DESCRIPTION
## Motivation

`TestShard_IllegalStateForTransfer` was flaky. Root cause: on a `halt -> resume -> halt` sequence, the second `HaltForTransfer` could fail to start a new inactivity auto-resume monitor, leaving the shard paused for maintenance indefinitely — the inactivity timer would never fire again to auto-resume compaction and vector/geo maintenance cycles.

## Approach

`mayInitInactivityMonitoring` uses `s.haltForTransferCancel` for two purposes at once: as the goroutine's cancel func *and* as the "is a monitor already running?" sentinel (the early `return` at the top of the function). The bug was that this sentinel was cleared **asynchronously**, inside the monitor goroutine's `defer`, rather than at the point where the monitor is actually torn down.

So when a resume cancelled the monitor and a new halt raced in before the cancelled goroutine's `defer` ran, the new halt observed a stale non-nil sentinel and skipped spawning a replacement monitor.

Two coupled fixes, both keeping the sentinel's lifetime tied to the mux that already guards it:

- Clear `haltForTransferCancel = nil` **synchronously** in `mayForceResumeMaintenanceCycles`, right after calling `cancel()`, under `haltForTransferMux`. This is the one place a monitor is deliberately torn down, so the sentinel is now accurate the instant a resume completes.
- Have each monitor goroutine `Stop()` its **own captured timer** (`defer timer.Stop()`) instead of the shared `s.haltForTransferInactivityTimer` field. Otherwise a departing goroutine could stop the *successor* monitor's timer, reintroducing the same "never auto-resumes" hang from the other direction.

The goroutine's `defer` no longer touches shared state at all, which is what makes the synchronous clear safe.

## Key areas for review

- `shard_backup.go:mayForceResumeMaintenanceCycles` — the synchronous `cancel()` + `nil` clear under `haltForTransferMux`. Confirm every teardown path routes through here (the early `haltForTransferCount == 0` and decrement-without-reaching-zero returns correctly leave the monitor running).
- `shard_backup.go:mayInitInactivityMonitoring` — captured-timer semantics. The goroutine no longer reads shared fields in its `defer`.

## Risks and mitigations

- **Double-clear / clearing a live monitor's sentinel**: not possible — the clear only runs after `cancel()` inside the same critical section that gates monitor creation; a new monitor cannot be spawned until the mux is released.
- **Stopping the wrong timer**: eliminated by capturing the timer in the closure; `mayResetInactivityTimer` still resets the shared field, which always points at the most recently installed monitor's timer.
- Behavior is unchanged on the common single halt/resume path; the fix only affects the previously-broken re-halt case.

Also logs the previously-ignored error from the timer-fired `mayForceResumeMaintenanceCycles` call.

## Testing

Fixes the flaky `TestShard_IllegalStateForTransfer`, which exercises exactly the halt -> resume -> halt transition. Verified locally with `-race -count 20` across `TestShard_IllegalStateForTransfer`, `TestShard_HaltingBeforeTransfer`, and `TestShard_ConcurrentTransfers` — all green. Goroutine linter and `golangci-lint` clean.