### PR TITLE
fix(backup): make halt-for-transfer inactivity monitor race-free

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -303,7 +303,6 @@ type Shard struct {
 	haltForTransferMux                sync.Mutex
 	haltForTransferInactivityTimeout  time.Duration
 	haltForTransferInactivityDeadline time.Time
-	haltForTransferGen                uint64
 	haltForTransferCount              int
 	haltForTransferCancel             func()
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -300,11 +300,12 @@ type Shard struct {
 	// Lock ordering when both are needed: asyncReplicationRWMux before asyncReplicationStatsMux.
 	asyncReplicationStatsMux sync.RWMutex
 
-	haltForTransferMux               sync.Mutex
-	haltForTransferInactivityTimeout time.Duration
-	haltForTransferInactivityTimer   *time.Timer
-	haltForTransferCount             int
-	haltForTransferCancel            func()
+	haltForTransferMux                sync.Mutex
+	haltForTransferInactivityTimeout  time.Duration
+	haltForTransferInactivityDeadline time.Time
+	haltForTransferGen                uint64
+	haltForTransferCount              int
+	haltForTransferCancel             func()
 
 	status              ShardStatus
 	statusLock          sync.RWMutex

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -304,7 +304,7 @@ type Shard struct {
 	haltForTransferInactivityTimeout  time.Duration
 	haltForTransferInactivityDeadline time.Time
 	haltForTransferCount              int
-	haltForTransferCancel             func()
+	haltForTransferCtxCancel          context.CancelFunc
 
 	status              ShardStatus
 	statusLock          sync.RWMutex

--- a/adapters/repos/db/shard_autoresume_maintenance_test.go
+++ b/adapters/repos/db/shard_autoresume_maintenance_test.go
@@ -14,6 +14,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -322,11 +323,10 @@ func TestShard_InactivityFireResumesWhenIdle(t *testing.T) {
 	defer timer.Stop()
 
 	s.haltForTransferMux.Lock()
-	gen := s.haltForTransferGen
 	s.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
 	s.haltForTransferMux.Unlock()
 
-	keepWatching := s.handleInactivityFire(gen, timer)
+	keepWatching := s.handleInactivityFire(context.Background(), timer)
 
 	s.haltForTransferMux.Lock()
 	countAfterFire := s.haltForTransferCount
@@ -447,13 +447,14 @@ func TestShard_StaleMonitorFireIsDropped(t *testing.T) {
 	timer := time.NewTimer(time.Hour)
 	defer timer.Stop()
 
+	staleCtx, cancelStale := context.WithCancel(context.Background())
+	cancelStale()
+
 	s.haltForTransferMux.Lock()
-	staleGen := s.haltForTransferGen
-	s.haltForTransferGen++
 	s.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
 	s.haltForTransferMux.Unlock()
 
-	keepWatching := s.handleInactivityFire(staleGen, timer)
+	keepWatching := s.handleInactivityFire(staleCtx, timer)
 
 	s.haltForTransferMux.Lock()
 	countAfterStaleFire := s.haltForTransferCount
@@ -487,11 +488,10 @@ func TestShard_FutureDeadlinePreventsResumeOnFire(t *testing.T) {
 	defer timer.Stop()
 
 	s.haltForTransferMux.Lock()
-	gen := s.haltForTransferGen
 	s.haltForTransferInactivityDeadline = time.Now().Add(time.Hour)
 	s.haltForTransferMux.Unlock()
 
-	keepWatching := s.handleInactivityFire(gen, timer)
+	keepWatching := s.handleInactivityFire(context.Background(), timer)
 
 	s.haltForTransferMux.Lock()
 	countAfterFire := s.haltForTransferCount

--- a/adapters/repos/db/shard_autoresume_maintenance_test.go
+++ b/adapters/repos/db/shard_autoresume_maintenance_test.go
@@ -330,7 +330,7 @@ func TestShard_InactivityFireResumesWhenIdle(t *testing.T) {
 
 	s.haltForTransferMux.Lock()
 	countAfterFire := s.haltForTransferCount
-	cancelAfterFire := s.haltForTransferCancel
+	cancelAfterFire := s.haltForTransferCtxCancel
 	s.haltForTransferMux.Unlock()
 
 	require.False(t, keepWatching)
@@ -359,9 +359,9 @@ func TestShard_ResumeClearsInactivityMonitorSentinel(t *testing.T) {
 	s := shd.(*Shard)
 
 	s.haltForTransferMux.Lock()
-	cancelBeforeResume := s.haltForTransferCancel
+	cancelBeforeResume := s.haltForTransferCtxCancel
 	resumeErr := s.mayForceResumeMaintenanceCycles(ctx, true)
-	cancelAfterResume := s.haltForTransferCancel
+	cancelAfterResume := s.haltForTransferCtxCancel
 	countAfterResume := s.haltForTransferCount
 	s.haltForTransferMux.Unlock()
 
@@ -395,7 +395,7 @@ func TestShard_DropClearsInactivityMonitorSentinel(t *testing.T) {
 	require.NoError(t, err)
 
 	s.haltForTransferMux.Lock()
-	cancelAfterDrop := s.haltForTransferCancel
+	cancelAfterDrop := s.haltForTransferCtxCancel
 	s.haltForTransferMux.Unlock()
 
 	require.Nil(t, cancelAfterDrop)
@@ -422,7 +422,7 @@ func TestShard_ShutdownClearsInactivityMonitorSentinel(t *testing.T) {
 	require.NoError(t, err)
 
 	s.haltForTransferMux.Lock()
-	cancelAfterShutdown := s.haltForTransferCancel
+	cancelAfterShutdown := s.haltForTransferCtxCancel
 	s.haltForTransferMux.Unlock()
 
 	require.Nil(t, cancelAfterShutdown)

--- a/adapters/repos/db/shard_autoresume_maintenance_test.go
+++ b/adapters/repos/db/shard_autoresume_maintenance_test.go
@@ -263,3 +263,276 @@ func TestShard_ConcurrentTransfers(t *testing.T) {
 	require.Nil(t, idx.drop())
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
 }
+
+func TestShard_ListBackupFilesExtendsInactivityDeadline(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	for range 10 {
+		require.NoError(t, shd.PutObject(ctx, testObject(className)))
+	}
+
+	s := shd.(*Shard)
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	s.haltForTransferMux.Lock()
+	s.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+	s.haltForTransferMux.Unlock()
+
+	_, err := s.ListBackupFiles(ctx, &backup.ShardDescriptor{})
+	require.NoError(t, err)
+
+	s.haltForTransferMux.Lock()
+	deadline := s.haltForTransferInactivityDeadline
+	s.haltForTransferMux.Unlock()
+
+	require.True(t, deadline.After(time.Now()))
+
+	require.NoError(t, s.resumeMaintenanceCycles(ctx))
+	require.Nil(t, idx.drop())
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func TestShard_InactivityFireResumesWhenIdle(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	s := shd.(*Shard)
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	s.haltForTransferMux.Lock()
+	gen := s.haltForTransferGen
+	s.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+	s.haltForTransferMux.Unlock()
+
+	keepWatching := s.handleInactivityFire(gen, timer)
+
+	s.haltForTransferMux.Lock()
+	countAfterFire := s.haltForTransferCount
+	cancelAfterFire := s.haltForTransferCancel
+	s.haltForTransferMux.Unlock()
+
+	require.False(t, keepWatching)
+	require.Zero(t, countAfterFire)
+	require.Nil(t, cancelAfterFire)
+
+	require.Nil(t, idx.drop())
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func TestShard_ResumeClearsInactivityMonitorSentinel(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	err := shd.HaltForTransfer(ctx, false, time.Hour)
+	require.NoError(t, err)
+
+	s := shd.(*Shard)
+
+	s.haltForTransferMux.Lock()
+	cancelBeforeResume := s.haltForTransferCancel
+	resumeErr := s.mayForceResumeMaintenanceCycles(ctx, true)
+	cancelAfterResume := s.haltForTransferCancel
+	countAfterResume := s.haltForTransferCount
+	s.haltForTransferMux.Unlock()
+
+	require.NotNil(t, cancelBeforeResume)
+	require.NoError(t, resumeErr)
+	require.Zero(t, countAfterResume)
+	require.Nil(t, cancelAfterResume)
+
+	require.Nil(t, idx.drop())
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func TestShard_DropClearsInactivityMonitorSentinel(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, _ := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	s := shd.(*Shard)
+
+	err := s.HaltForTransfer(ctx, false, time.Hour)
+	require.NoError(t, err)
+
+	err = s.drop(false)
+	require.NoError(t, err)
+
+	s.haltForTransferMux.Lock()
+	cancelAfterDrop := s.haltForTransferCancel
+	s.haltForTransferMux.Unlock()
+
+	require.Nil(t, cancelAfterDrop)
+}
+
+func TestShard_ShutdownClearsInactivityMonitorSentinel(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, _ := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	s := shd.(*Shard)
+
+	err := s.HaltForTransfer(ctx, false, time.Hour)
+	require.NoError(t, err)
+
+	err = s.Shutdown(ctx)
+	require.NoError(t, err)
+
+	s.haltForTransferMux.Lock()
+	cancelAfterShutdown := s.haltForTransferCancel
+	s.haltForTransferMux.Unlock()
+
+	require.Nil(t, cancelAfterShutdown)
+}
+
+func TestShard_StaleMonitorFireIsDropped(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	s := shd.(*Shard)
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	s.haltForTransferMux.Lock()
+	staleGen := s.haltForTransferGen
+	s.haltForTransferGen++
+	s.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+	s.haltForTransferMux.Unlock()
+
+	keepWatching := s.handleInactivityFire(staleGen, timer)
+
+	s.haltForTransferMux.Lock()
+	countAfterStaleFire := s.haltForTransferCount
+	s.haltForTransferMux.Unlock()
+
+	require.False(t, keepWatching)
+	require.Equal(t, 1, countAfterStaleFire)
+
+	require.NoError(t, s.resumeMaintenanceCycles(ctx))
+	require.Nil(t, idx.drop())
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func TestShard_FutureDeadlinePreventsResumeOnFire(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	s := shd.(*Shard)
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	s.haltForTransferMux.Lock()
+	gen := s.haltForTransferGen
+	s.haltForTransferInactivityDeadline = time.Now().Add(time.Hour)
+	s.haltForTransferMux.Unlock()
+
+	keepWatching := s.handleInactivityFire(gen, timer)
+
+	s.haltForTransferMux.Lock()
+	countAfterFire := s.haltForTransferCount
+	s.haltForTransferMux.Unlock()
+
+	require.True(t, keepWatching)
+	require.Equal(t, 1, countAfterFire)
+
+	require.NoError(t, s.resumeMaintenanceCycles(ctx))
+	require.Nil(t, idx.drop())
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+func TestShard_FullResumeResetsInactivityTimeout(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(shd.Index().Config.RootPath)
+
+	s := shd.(*Shard)
+
+	err := s.HaltForTransfer(ctx, false, 10*time.Millisecond)
+	require.NoError(t, err)
+
+	err = s.resumeMaintenanceCycles(ctx)
+	require.NoError(t, err)
+
+	s.haltForTransferMux.Lock()
+	timeoutAfterResume := s.haltForTransferInactivityTimeout
+	deadlineAfterResume := s.haltForTransferInactivityDeadline
+	s.haltForTransferMux.Unlock()
+
+	require.Zero(t, timeoutAfterResume)
+	require.True(t, deadlineAfterResume.IsZero())
+
+	require.Nil(t, idx.drop())
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -117,30 +117,21 @@ func (s *Shard) mayUpdateInactivityTimeout(inactivityTimeout time.Duration) {
 
 	s.haltForTransferInactivityTimeout = inactivityTimeout
 
-	s.mayResetInactivityTimer()
+	// restart any running monitor so the shorter timeout takes effect; the immediately-following
+	// mayInitInactivityMonitoring respawns it. cancelling only stops the goroutine, not maintenance.
+	if s.haltForTransferCancel != nil {
+		s.haltForTransferCancel()
+		s.haltForTransferCancel = nil
+	}
 }
 
-func (s *Shard) mayResetInactivityTimer() {
-	resetTimer(s.haltForTransferInactivityTimer, s.haltForTransferInactivityTimeout)
-}
-
-func resetTimer(t *time.Timer, d time.Duration) {
-	if t == nil {
+// mayResetInactivityDeadline records file activity by pushing the inactivity deadline forward.
+// The monitor re-arms against this deadline, so a reset can never race a fire into a spurious resume.
+func (s *Shard) mayResetInactivityDeadline() {
+	if s.haltForTransferInactivityTimeout <= 0 {
 		return
 	}
-
-	// if Stop returns false, the timer has either already fired or been stopped.
-	// in the "already fired" case, there may be a value in t.C that we need to drain.
-	if !t.Stop() {
-		select {
-		case <-t.C:
-			// drained a pending tick.
-		default:
-			// channel was already drained; nothing to do.
-		}
-	}
-
-	t.Reset(d)
+	s.haltForTransferInactivityDeadline = time.Now().Add(s.haltForTransferInactivityTimeout)
 }
 
 func (s *Shard) mayInitInactivityMonitoring() {
@@ -151,28 +142,50 @@ func (s *Shard) mayInitInactivityMonitoring() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.haltForTransferCancel = cancel
 
-	s.haltForTransferInactivityTimer = time.NewTimer(s.haltForTransferInactivityTimeout)
+	s.haltForTransferGen++
+	gen := s.haltForTransferGen
+	s.haltForTransferInactivityDeadline = time.Now().Add(s.haltForTransferInactivityTimeout)
+
+	timer := time.NewTimer(s.haltForTransferInactivityTimeout)
 
 	enterrors.GoWrapper(func() {
-		// this goroutine will release maintenance cycles if no file activity
-		// is detected in the specified inactivity timeout
-		defer func() {
-			s.haltForTransferMux.Lock()
-			s.haltForTransferInactivityTimer.Stop()
-			s.haltForTransferCancel = nil
-			s.haltForTransferMux.Unlock()
-		}()
+		// owns its timer; re-arms against the shared deadline on activity, and a generation guard
+		// drops a fire already superseded by a resume+re-halt. closes the reset-vs-fire/stale-fire races.
+		defer timer.Stop()
 
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.haltForTransferInactivityTimer.C:
-			s.haltForTransferMux.Lock()
-			s.mayForceResumeMaintenanceCycles(context.Background(), true)
-			s.haltForTransferMux.Unlock()
-			return
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				if !s.handleInactivityFire(gen, timer) {
+					return
+				}
+			}
 		}
 	}, s.index.logger)
+}
+
+// handleInactivityFire resolves an inactivity-timer fire. It returns true if the monitor should
+// keep watching (activity pushed the deadline forward, so the timer was re-armed) and false if it
+// should stop: either a resume+re-halt superseded this generation, or the shard was resumed.
+func (s *Shard) handleInactivityFire(gen uint64, timer *time.Timer) (keepWatching bool) {
+	s.haltForTransferMux.Lock()
+	defer s.haltForTransferMux.Unlock()
+
+	if gen != s.haltForTransferGen {
+		// a newer monitor superseded this one (resume + re-halt); stop.
+		return false
+	}
+	if remaining := time.Until(s.haltForTransferInactivityDeadline); remaining > 0 {
+		// activity pushed the deadline forward; re-arm and keep watching.
+		timer.Reset(remaining)
+		return true
+	}
+	if err := s.mayForceResumeMaintenanceCycles(context.Background(), true); err != nil {
+		s.index.logger.Error(err)
+	}
+	return false
 }
 
 // CreateBackupSnapshot halts compaction, lists backup files, hardlinks them into
@@ -251,7 +264,7 @@ func (s *Shard) ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor
 		return nil, fmt.Errorf("can not list files: illegal state: shard %q is not paused for transfer", s.name)
 	}
 
-	s.mayResetInactivityTimer()
+	s.mayResetInactivityDeadline()
 
 	if err := s.readBackupMetadata(ret); err != nil {
 		return nil, err
@@ -325,9 +338,15 @@ func (s *Shard) mayForceResumeMaintenanceCycles(ctx context.Context, forced bool
 	}
 
 	if s.haltForTransferCancel != nil {
-		// terminate background goroutine checking for inactivity timeout
+		// terminate the inactivity monitor and clear the sentinel synchronously under the mux,
+		// so a subsequent HaltForTransfer reliably starts a new monitor.
 		s.haltForTransferCancel()
+		s.haltForTransferCancel = nil
 	}
+
+	// fully resumed: reset so the next halt cycle uses its own timeout, not the shortest ever seen.
+	s.haltForTransferInactivityTimeout = 0
+	s.haltForTransferInactivityDeadline = time.Time{}
 
 	g := enterrors.NewErrorGroupWrapper(s.index.logger)
 
@@ -415,7 +434,7 @@ func (s *Shard) GetFileMetadata(ctx context.Context, relativeFilePath string) (f
 			relativeFilePath, s.name)
 	}
 
-	s.mayResetInactivityTimer()
+	s.mayResetInactivityDeadline()
 
 	finalPath, err := s.sanitizeFilePath(relativeFilePath)
 	if err != nil {
@@ -433,7 +452,7 @@ func (s *Shard) GetFile(ctx context.Context, relativeFilePath string) (io.ReadCl
 			relativeFilePath, s.name)
 	}
 
-	s.mayResetInactivityTimer()
+	s.mayResetInactivityDeadline()
 
 	finalPath, err := s.sanitizeFilePath(relativeFilePath)
 	if err != nil {

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -142,15 +142,12 @@ func (s *Shard) mayInitInactivityMonitoring() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.haltForTransferCancel = cancel
 
-	s.haltForTransferGen++
-	gen := s.haltForTransferGen
 	s.haltForTransferInactivityDeadline = time.Now().Add(s.haltForTransferInactivityTimeout)
 
 	timer := time.NewTimer(s.haltForTransferInactivityTimeout)
 
 	enterrors.GoWrapper(func() {
-		// owns its timer; re-arms against the shared deadline on activity, and a generation guard
-		// drops a fire already superseded by a resume+re-halt. closes the reset-vs-fire/stale-fire races.
+		// supersession and teardown cancel this ctx before any successor, so a stale fire is dropped.
 		defer timer.Stop()
 
 		for {
@@ -158,7 +155,7 @@ func (s *Shard) mayInitInactivityMonitoring() {
 			case <-ctx.Done():
 				return
 			case <-timer.C:
-				if !s.handleInactivityFire(gen, timer) {
+				if !s.handleInactivityFire(ctx, timer) {
 					return
 				}
 			}
@@ -166,15 +163,14 @@ func (s *Shard) mayInitInactivityMonitoring() {
 	}, s.index.logger)
 }
 
-// handleInactivityFire resolves an inactivity-timer fire. It returns true if the monitor should
-// keep watching (activity pushed the deadline forward, so the timer was re-armed) and false if it
-// should stop: either a resume+re-halt superseded this generation, or the shard was resumed.
-func (s *Shard) handleInactivityFire(gen uint64, timer *time.Timer) (keepWatching bool) {
+// handleInactivityFire resolves an inactivity-timer fire, returning true to keep watching
+// (activity re-armed the timer) or false to stop (ctx cancelled, or the shard was resumed).
+func (s *Shard) handleInactivityFire(ctx context.Context, timer *time.Timer) (keepWatching bool) {
 	s.haltForTransferMux.Lock()
 	defer s.haltForTransferMux.Unlock()
 
-	if gen != s.haltForTransferGen {
-		// a newer monitor superseded this one (resume + re-halt); stop.
+	if ctx.Err() != nil {
+		// superseded or torn down while this fire waited on the mux; stop without resuming.
 		return false
 	}
 	if remaining := time.Until(s.haltForTransferInactivityDeadline); remaining > 0 {

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -119,9 +119,15 @@ func (s *Shard) mayUpdateInactivityTimeout(inactivityTimeout time.Duration) {
 
 	// restart any running monitor so the shorter timeout takes effect; the immediately-following
 	// mayInitInactivityMonitoring respawns it. cancelling only stops the goroutine, not maintenance.
-	if s.haltForTransferCancel != nil {
-		s.haltForTransferCancel()
-		s.haltForTransferCancel = nil
+	s.mayStopInactivityMonitoring()
+}
+
+// mayStopInactivityMonitoring cancels the running inactivity monitor and clears the sentinel.
+// Caller must hold haltForTransferMux; must not lock here (callers hold it across a wider section).
+func (s *Shard) mayStopInactivityMonitoring() {
+	if s.haltForTransferCtxCancel != nil {
+		s.haltForTransferCtxCancel()
+		s.haltForTransferCtxCancel = nil
 	}
 }
 
@@ -135,12 +141,12 @@ func (s *Shard) mayResetInactivityDeadline() {
 }
 
 func (s *Shard) mayInitInactivityMonitoring() {
-	if s.haltForTransferCancel != nil {
+	if s.haltForTransferCtxCancel != nil {
 		return
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s.haltForTransferCancel = cancel
+	s.haltForTransferCtxCancel = cancel
 
 	s.haltForTransferInactivityDeadline = time.Now().Add(s.haltForTransferInactivityTimeout)
 
@@ -333,12 +339,9 @@ func (s *Shard) mayForceResumeMaintenanceCycles(ctx context.Context, forced bool
 		}
 	}
 
-	if s.haltForTransferCancel != nil {
-		// terminate the inactivity monitor and clear the sentinel synchronously under the mux,
-		// so a subsequent HaltForTransfer reliably starts a new monitor.
-		s.haltForTransferCancel()
-		s.haltForTransferCancel = nil
-	}
+	// terminate the inactivity monitor synchronously under the mux, so a subsequent
+	// HaltForTransfer reliably starts a new monitor.
+	s.mayStopInactivityMonitoring()
 
 	// fully resumed: reset so the next halt cycle uses its own timeout, not the shortest ever seen.
 	s.haltForTransferInactivityTimeout = 0

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -49,11 +49,8 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 	s.mayStopAsyncReplication()
 
 	s.haltForTransferMux.Lock()
-	if s.haltForTransferCancel != nil {
-		// also drops an already-fired monitor waiting on the mux, so it can't resume mid-teardown.
-		s.haltForTransferCancel()
-		s.haltForTransferCancel = nil
-	}
+	// also drops an already-fired monitor waiting on the mux, so it can't resume mid-teardown.
+	s.mayStopInactivityMonitoring()
 	s.haltForTransferMux.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 20*time.Second)

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -50,6 +50,7 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 
 	s.haltForTransferMux.Lock()
 	if s.haltForTransferCancel != nil {
+		// also drops an already-fired monitor waiting on the mux, so it can't resume mid-teardown.
 		s.haltForTransferCancel()
 		s.haltForTransferCancel = nil
 	}

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -51,6 +51,7 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 	s.haltForTransferMux.Lock()
 	if s.haltForTransferCancel != nil {
 		s.haltForTransferCancel()
+		s.haltForTransferCancel = nil
 	}
 	s.haltForTransferMux.Unlock()
 

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -94,11 +94,8 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	s.reindexer.Stop(s, fmt.Errorf("shard shutdown"))
 
 	s.haltForTransferMux.Lock()
-	if s.haltForTransferCancel != nil {
-		// also drops an already-fired monitor waiting on the mux, so it can't resume mid-teardown.
-		s.haltForTransferCancel()
-		s.haltForTransferCancel = nil
-	}
+	// also drops an already-fired monitor waiting on the mux, so it can't resume mid-teardown.
+	s.mayStopInactivityMonitoring()
 	s.haltForTransferMux.Unlock()
 
 	ec := errorcompounder.New()

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -95,6 +95,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 
 	s.haltForTransferMux.Lock()
 	if s.haltForTransferCancel != nil {
+		// also drops an already-fired monitor waiting on the mux, so it can't resume mid-teardown.
 		s.haltForTransferCancel()
 		s.haltForTransferCancel = nil
 	}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -96,6 +96,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	s.haltForTransferMux.Lock()
 	if s.haltForTransferCancel != nil {
 		s.haltForTransferCancel()
+		s.haltForTransferCancel = nil
 	}
 	s.haltForTransferMux.Unlock()
 


### PR DESCRIPTION
## Motivation

The shard's halt-for-transfer inactivity auto-resume monitor had coupled races around a shared timer and a sentinel that doubled as "is a monitor running?". The most visible one made `TestShard_IllegalStateForTransfer` flaky, but the underlying failure mode is a production hang: a shard can stay paused for maintenance (compaction + vector/geo cycles frozen) indefinitely, resume mid-backup, or resume *mid-teardown* while the shard is being dropped or shut down.

## The races

1. **Monitor never restarts.** `haltForTransferCtxCancel` doubled as the "is a monitor running?" sentinel but was cleared *asynchronously* in the goroutine's `defer`. A `halt -> resume -> halt` sequence could observe a stale non-nil sentinel and skip spawning a replacement monitor — the inactivity timer never fires again and the shard stays paused forever.
2. **Reset races fire.** `mayResetInactivityTimer` mutated the *shared* `time.Timer` the monitor goroutine was selecting on. A reset (file activity) racing a fire could resume maintenance despite fresh activity — and the concurrent `Stop`/drain/`Reset` on a shared timer is itself fragile.
3. **Stale fire resumes a newer halt.** A goroutine already past its `select` (timer branch taken, blocked on the mux) could force-resume a *newer* halt once it acquired the lock, after a resume+re-halt installed a fresh monitor.
4. **Stale fire resumes mid-teardown.** Same past-the-`select` goroutine, but racing `drop`/`Shutdown`: those cancel the monitor and return, then the fired goroutine acquires the mux and resumes compaction / vector cycles concurrently with the shard being torn down (activate-on-unregistered callbacks, `ResumeCompaction` on a closing store).

## Approach

Rework the monitor to **own its timer** and drive resume off a **deadline + its own context**, all under `haltForTransferMux`:

- **Synchronous sentinel clear** — `haltForTransferCtxCancel` (a `context.CancelFunc`) is nil'd under the mux at every teardown point via the shared `mayStopInactivityMonitoring` helper, so the "monitor running?" gate is always accurate and a re-halt reliably spawns a fresh monitor. Fixes race 1.
- **Per-goroutine timer + deadline** — activity records a `haltForTransferInactivityDeadline` instead of poking a shared timer. When the goroutine's own timer fires it checks the deadline: if activity pushed it forward it re-arms and keeps watching; otherwise it resumes. No shared-timer mutation. Fixes race 2.
- **Context guard** — each monitor owns a `context`. Every supersession (resume, re-halt with a shorter timeout) and teardown (`drop`, `Shutdown`) cancels that context before installing any successor, so a fire whose context is already cancelled is dropped in `handleInactivityFire`. A single signal that closes both race 3 and race 4.
- **Shorter-timeout restart** — lowering the timeout on an already-running monitor cancels and respawns it (via the immediately-following `mayInitInactivityMonitoring`) so the shorter timeout takes effect at once. Preserves prior semantics.

The goroutine no longer touches shared state in its `defer` (just `timer.Stop()` on its own timer), which is what makes the synchronous clear safe.

## Key areas for review

- `shard_backup.go:mayInitInactivityMonitoring` — the owned-timer loop and deadline re-arm.
- `shard_backup.go:handleInactivityFire` — the `ctx.Err()` guard that drops a superseded/torn-down fire.
- `shard_backup.go:mayStopInactivityMonitoring` — the shared cancel-and-clear helper (caller must hold `haltForTransferMux`, must not lock itself); every teardown routes through it, invalidating the monitor's context.
- `shard_backup.go:mayForceResumeMaintenanceCycles` / `shard_drop.go` / `shard_shutdown.go` — each calls `mayStopInactivityMonitoring()` under the mux, which is what invalidates an already-fired monitor waiting on the mux.
- `shard_backup.go:mayUpdateInactivityTimeout` — restart-on-shorten relies on being immediately followed by `mayInitInactivityMonitoring` (it always is, in `HaltForTransfer`'s defer).

## Risks

- The restart-on-shorten path assumes the `mayUpdateInactivityTimeout` -> `mayInitInactivityMonitoring` ordering in `HaltForTransfer`; that's the only caller.
- Behavior on the common single halt/resume path is unchanged.

## Testing

New/updated table of unit tests in `shard_autoresume_maintenance_test.go`:

- `TestShard_ListBackupFilesExtendsInactivityDeadline` — activity pushes the deadline forward.
- `TestShard_InactivityFireResumesWhenIdle` / `TestShard_FutureDeadlinePreventsResumeOnFire` — a fire resumes when idle, re-arms when activity moved the deadline ahead.
- `TestShard_StaleMonitorFireIsDropped` — a fire on a cancelled monitor context does not resume (covers the resume+re-halt and teardown races).
- `TestShard_ResumeClearsInactivityMonitorSentinel` / `TestShard_DropClearsInactivityMonitorSentinel` / `TestShard_ShutdownClearsInactivityMonitorSentinel` — resume/drop/shutdown clear the sentinel synchronously.
- `TestShard_FullResumeResetsInactivityTimeout` — a full resume resets timeout + deadline for the next cycle.

`TestShard_IllegalStateForTransfer`, `TestShard_HaltingBeforeTransfer`, `TestShard_ConcurrentTransfers` and the deadline/fire tests pass **`-race -count 30`**; the full `TestShard_` suite passes `-race`. Goroutine linter and `golangci-lint` clean.

