### PR TITLE
perf(async-replication): batched hashtree-root pre-filter for many-tenant clusters

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -328,6 +328,45 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 	return result, err
 }
 
+func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	body, err := json.Marshal(replica.CompareHashTreeRootsReq{Roots: roots})
+	if err != nil {
+		return nil, fmt.Errorf("marshal compare hashtree roots request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
+	defer cancel()
+
+	req, err := newHttpReplicaIndexRequest(ctx, http.MethodPost, host, index,
+		"_compareHashTreeRoots", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create http request: %w", err)
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		// Older peers don't expose this route; fall back to the per-shard path.
+		return nil, replica.ErrCompareHashTreeRootsUnsupported
+	}
+	if code := res.StatusCode; !successCode(code) {
+		errBody, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("status code: %v, error: %s", code, errBody)
+	}
+
+	var resp replica.CompareHashTreeRootsResp
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("decode compare hashtree roots response: %w", err)
+	}
+	return resp.DivergingShards, nil
+}
+
 func (c *replicationClient) CountObjects(ctx context.Context, host string, index string, shard string) (int, error) {
 	var resp int
 	req, err := newHttpReplicaRequest(
@@ -597,6 +636,17 @@ func newHttpReplicaRequest(ctx context.Context, method, host, index, shard, requ
 	}
 	u.RawQuery = urlValues.Encode()
 
+	return http.NewRequestWithContext(ctx, method, u.String(), body)
+}
+
+// newHttpReplicaIndexRequest builds an index-level (shard-less) replica request,
+// e.g. the batched CompareHashTreeRoots pre-filter.
+func newHttpReplicaIndexRequest(ctx context.Context, method, host, index, suffix string, body io.Reader) (*http.Request, error) {
+	u := url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   fmt.Sprintf("/replicas/indices/%s/objects/%s", index, suffix),
+	}
 	return http.NewRequestWithContext(ctx, method, u.String(), body)
 }
 

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -639,8 +639,7 @@ func newHttpReplicaRequest(ctx context.Context, method, host, index, shard, requ
 	return http.NewRequestWithContext(ctx, method, u.String(), body)
 }
 
-// newHttpReplicaIndexRequest builds an index-level (shard-less) replica request,
-// e.g. the batched CompareHashTreeRoots pre-filter.
+// newHttpReplicaIndexRequest builds an index-level (shard-less) replica request.
 func newHttpReplicaIndexRequest(ctx context.Context, method, host, index, suffix string, body io.Reader) (*http.Request, error) {
 	u := url.URL{
 		Scheme: "http",

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -416,9 +416,9 @@ func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, 
 	shards := make([]*protocol.ShardRootDigest, 0, len(roots))
 	for shard, root := range roots {
 		shards = append(shards, &protocol.ShardRootDigest{
-			Shard:      shard,
-			RootHashHi: root[0],
-			RootHashLo: root[1],
+			Shard:        shard,
+			RootHashHigh: root[0],
+			RootHashLow:  root[1],
 		})
 	}
 

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
 	clusterapi "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared"
@@ -401,6 +403,38 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 		return nil, fmt.Errorf("gRPC CompareDigests: %w", err)
 	}
 	return protoToRepairResponses(resp.GetDigests()), nil
+}
+
+func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	client, err := c.getClient(host)
+	if err != nil {
+		return nil, err
+	}
+
+	shards := make([]*protocol.ShardRootDigest, 0, len(roots))
+	for shard, root := range roots {
+		shards = append(shards, &protocol.ShardRootDigest{
+			Shard:  shard,
+			RootH1: root[0],
+			RootH2: root[1],
+		})
+	}
+
+	resp, err := client.CompareHashTreeRoots(ctx, &protocol.CompareHashTreeRootsRequest{
+		Index:  index,
+		Shards: shards,
+	})
+	if err != nil {
+		// Older peers don't serve this RPC; surface a sentinel so the caller
+		// falls back to the per-shard path instead of failing the cycle.
+		if status.Code(err) == codes.Unimplemented {
+			return nil, replica.ErrCompareHashTreeRootsUnsupported
+		}
+		return nil, fmt.Errorf("gRPC CompareHashTreeRoots: %w", err)
+	}
+	return resp.GetDivergingShards(), nil
 }
 
 func (c *grpcReplicationClient) OverwriteObjects(ctx context.Context, host, index, shard string,

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -416,15 +416,15 @@ func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, 
 	shards := make([]*protocol.ShardRootDigest, 0, len(roots))
 	for shard, root := range roots {
 		shards = append(shards, &protocol.ShardRootDigest{
-			Shard:  shard,
-			RootH1: root[0],
-			RootH2: root[1],
+			Shard:      shard,
+			RootHashHi: root[0],
+			RootHashLo: root[1],
 		})
 	}
 
 	resp, err := client.CompareHashTreeRoots(ctx, &protocol.CompareHashTreeRootsRequest{
-		Index:  index,
-		Shards: shards,
+		Index:            index,
+		ShardRootDigests: shards,
 	})
 	if err != nil {
 		// Older peers don't serve this RPC; sentinel lets the caller fall back.

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -427,8 +427,7 @@ func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, 
 		Shards: shards,
 	})
 	if err != nil {
-		// Older peers don't serve this RPC; surface a sentinel so the caller
-		// falls back to the per-shard path instead of failing the cycle.
+		// Older peers don't serve this RPC; sentinel lets the caller fall back.
 		if status.Code(err) == codes.Unimplemented {
 			return nil, replica.ErrCompareHashTreeRootsUnsupported
 		}

--- a/adapters/clients/replication_mixed.go
+++ b/adapters/clients/replication_mixed.go
@@ -201,6 +201,15 @@ func (s *switchReplicationClient) CompareDigests(ctx context.Context, host, inde
 	return s.restClient.CompareDigests(ctx, host, index, shard, digests)
 }
 
+func (s *switchReplicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	if s.useGRPC() {
+		return s.grpcClient.CompareHashTreeRoots(ctx, host, index, roots)
+	}
+	return s.restClient.CompareHashTreeRoots(ctx, host, index, roots)
+}
+
 func (s *switchReplicationClient) CountObjects(ctx context.Context, host string, index string, shard string) (int, error) {
 	if s.useGRPC() {
 		return s.grpcClient.CountObjects(ctx, host, index, shard)

--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -118,6 +118,10 @@ func (f *fakeReplicator) CompareDigests(ctx context.Context, className, shardNam
 	return nil, nil
 }
 
+func (f *fakeReplicator) CompareHashTreeRoots(ctx context.Context, className string, roots map[string]hashtree.Digest) ([]string, error) {
+	return nil, nil
+}
+
 func (f *fakeReplicator) Done() {
 	close(f.commitBlock)
 }

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
@@ -2045,6 +2045,166 @@ func (x *HashTreeLevelResponse) GetDigestsData() []byte {
 	return nil
 }
 
+// CompareHashTreeRoots pre-filters shards by comparing hashtree roots in bulk.
+// The source sends its local root per shard; the target replies only with the
+// shards whose roots differ (or that it lacks / has not fully initialised), so
+// the source can skip the per-shard descent for the rest.
+type ShardRootDigest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Shard         string                 `protobuf:"bytes,1,opt,name=shard,proto3" json:"shard,omitempty"`
+	RootH1        uint64                 `protobuf:"fixed64,2,opt,name=root_h1,json=rootH1,proto3" json:"root_h1,omitempty"` // Digest[0]
+	RootH2        uint64                 `protobuf:"fixed64,3,opt,name=root_h2,json=rootH2,proto3" json:"root_h2,omitempty"` // Digest[1]
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShardRootDigest) Reset() {
+	*x = ShardRootDigest{}
+	mi := &file_protocol_replication_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShardRootDigest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShardRootDigest) ProtoMessage() {}
+
+func (x *ShardRootDigest) ProtoReflect() protoreflect.Message {
+	mi := &file_protocol_replication_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShardRootDigest.ProtoReflect.Descriptor instead.
+func (*ShardRootDigest) Descriptor() ([]byte, []int) {
+	return file_protocol_replication_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ShardRootDigest) GetShard() string {
+	if x != nil {
+		return x.Shard
+	}
+	return ""
+}
+
+func (x *ShardRootDigest) GetRootH1() uint64 {
+	if x != nil {
+		return x.RootH1
+	}
+	return 0
+}
+
+func (x *ShardRootDigest) GetRootH2() uint64 {
+	if x != nil {
+		return x.RootH2
+	}
+	return 0
+}
+
+type CompareHashTreeRootsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Index         string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	Shards        []*ShardRootDigest     `protobuf:"bytes,2,rep,name=shards,proto3" json:"shards,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CompareHashTreeRootsRequest) Reset() {
+	*x = CompareHashTreeRootsRequest{}
+	mi := &file_protocol_replication_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CompareHashTreeRootsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CompareHashTreeRootsRequest) ProtoMessage() {}
+
+func (x *CompareHashTreeRootsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_protocol_replication_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CompareHashTreeRootsRequest.ProtoReflect.Descriptor instead.
+func (*CompareHashTreeRootsRequest) Descriptor() ([]byte, []int) {
+	return file_protocol_replication_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *CompareHashTreeRootsRequest) GetIndex() string {
+	if x != nil {
+		return x.Index
+	}
+	return ""
+}
+
+func (x *CompareHashTreeRootsRequest) GetShards() []*ShardRootDigest {
+	if x != nil {
+		return x.Shards
+	}
+	return nil
+}
+
+type CompareHashTreeRootsResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	DivergingShards []string               `protobuf:"bytes,1,rep,name=diverging_shards,json=divergingShards,proto3" json:"diverging_shards,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *CompareHashTreeRootsResponse) Reset() {
+	*x = CompareHashTreeRootsResponse{}
+	mi := &file_protocol_replication_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CompareHashTreeRootsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CompareHashTreeRootsResponse) ProtoMessage() {}
+
+func (x *CompareHashTreeRootsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_protocol_replication_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CompareHashTreeRootsResponse.ProtoReflect.Descriptor instead.
+func (*CompareHashTreeRootsResponse) Descriptor() ([]byte, []int) {
+	return file_protocol_replication_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *CompareHashTreeRootsResponse) GetDivergingShards() []string {
+	if x != nil {
+		return x.DivergingShards
+	}
+	return nil
+}
+
 // CountObjects fetches hash tree level digests.
 type CountObjectsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2056,7 +2216,7 @@ type CountObjectsRequest struct {
 
 func (x *CountObjectsRequest) Reset() {
 	*x = CountObjectsRequest{}
-	mi := &file_protocol_replication_proto_msgTypes[35]
+	mi := &file_protocol_replication_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2068,7 +2228,7 @@ func (x *CountObjectsRequest) String() string {
 func (*CountObjectsRequest) ProtoMessage() {}
 
 func (x *CountObjectsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[35]
+	mi := &file_protocol_replication_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2081,7 +2241,7 @@ func (x *CountObjectsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountObjectsRequest.ProtoReflect.Descriptor instead.
 func (*CountObjectsRequest) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{35}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CountObjectsRequest) GetIndex() string {
@@ -2108,7 +2268,7 @@ type CountObjectsResponse struct {
 
 func (x *CountObjectsResponse) Reset() {
 	*x = CountObjectsResponse{}
-	mi := &file_protocol_replication_proto_msgTypes[36]
+	mi := &file_protocol_replication_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2120,7 +2280,7 @@ func (x *CountObjectsResponse) String() string {
 func (*CountObjectsResponse) ProtoMessage() {}
 
 func (x *CountObjectsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[36]
+	mi := &file_protocol_replication_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2133,7 +2293,7 @@ func (x *CountObjectsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountObjectsResponse.ProtoReflect.Descriptor instead.
 func (*CountObjectsResponse) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{36}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CountObjectsResponse) GetCount() int32 {
@@ -2289,12 +2449,21 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\x05level\x18\x03 \x01(\x05R\x05level\x12\"\n" +
 	"\fdiscriminant\x18\x04 \x01(\fR\fdiscriminant\":\n" +
 	"\x15HashTreeLevelResponse\x12!\n" +
-	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\"A\n" +
+	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\"Y\n" +
+	"\x0fShardRootDigest\x12\x14\n" +
+	"\x05shard\x18\x01 \x01(\tR\x05shard\x12\x17\n" +
+	"\aroot_h1\x18\x02 \x01(\x06R\x06rootH1\x12\x17\n" +
+	"\aroot_h2\x18\x03 \x01(\x06R\x06rootH2\"h\n" +
+	"\x1bCompareHashTreeRootsRequest\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\tR\x05index\x123\n" +
+	"\x06shards\x18\x02 \x03(\v2\x1b.clusterapi.ShardRootDigestR\x06shards\"I\n" +
+	"\x1cCompareHashTreeRootsResponse\x12)\n" +
+	"\x10diverging_shards\x18\x01 \x03(\tR\x0fdivergingShards\"A\n" +
 	"\x13CountObjectsRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\",\n" +
 	"\x14CountObjectsResponse\x12\x14\n" +
-	"\x05count\x18\x01 \x01(\x05R\x05count2\x88\v\n" +
+	"\x05count\x18\x01 \x01(\x05R\x05count2\xf3\v\n" +
 	"\x12ReplicationService\x12H\n" +
 	"\tPutObject\x12\x1c.clusterapi.PutObjectRequest\x1a\x1d.clusterapi.PutObjectResponse\x12K\n" +
 	"\n" +
@@ -2312,7 +2481,8 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\x0eCompareDigests\x12!.clusterapi.CompareDigestsRequest\x1a\".clusterapi.CompareDigestsResponse\x12]\n" +
 	"\x10OverwriteObjects\x12#.clusterapi.OverwriteObjectsRequest\x1a$.clusterapi.OverwriteObjectsResponse\x12H\n" +
 	"\tFindUUIDs\x12\x1c.clusterapi.FindUUIDsRequest\x1a\x1d.clusterapi.FindUUIDsResponse\x12T\n" +
-	"\rHashTreeLevel\x12 .clusterapi.HashTreeLevelRequest\x1a!.clusterapi.HashTreeLevelResponse\x12Q\n" +
+	"\rHashTreeLevel\x12 .clusterapi.HashTreeLevelRequest\x1a!.clusterapi.HashTreeLevelResponse\x12i\n" +
+	"\x14CompareHashTreeRoots\x12'.clusterapi.CompareHashTreeRootsRequest\x1a(.clusterapi.CompareHashTreeRootsResponse\x12Q\n" +
 	"\fCountObjects\x12\x1f.clusterapi.CountObjectsRequest\x1a .clusterapi.CountObjectsResponseB\x9d\x01\n" +
 	"\x0ecom.clusterapiB\x10ReplicationProtoP\x01Z1github.com/weaviate/weaviate/cloud/proto/protocol\xa2\x02\x03CXX\xaa\x02\n" +
 	"Clusterapi\xca\x02\n" +
@@ -2331,7 +2501,7 @@ func file_protocol_replication_proto_rawDescGZIP() []byte {
 	return file_protocol_replication_proto_rawDescData
 }
 
-var file_protocol_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_protocol_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_protocol_replication_proto_goTypes = []any{
 	(*ReplicaError)(nil),                 // 0: clusterapi.ReplicaError
 	(*SimpleReplicaResponse)(nil),        // 1: clusterapi.SimpleReplicaResponse
@@ -2368,8 +2538,11 @@ var file_protocol_replication_proto_goTypes = []any{
 	(*FindUUIDsResponse)(nil),            // 32: clusterapi.FindUUIDsResponse
 	(*HashTreeLevelRequest)(nil),         // 33: clusterapi.HashTreeLevelRequest
 	(*HashTreeLevelResponse)(nil),        // 34: clusterapi.HashTreeLevelResponse
-	(*CountObjectsRequest)(nil),          // 35: clusterapi.CountObjectsRequest
-	(*CountObjectsResponse)(nil),         // 36: clusterapi.CountObjectsResponse
+	(*ShardRootDigest)(nil),              // 35: clusterapi.ShardRootDigest
+	(*CompareHashTreeRootsRequest)(nil),  // 36: clusterapi.CompareHashTreeRootsRequest
+	(*CompareHashTreeRootsResponse)(nil), // 37: clusterapi.CompareHashTreeRootsResponse
+	(*CountObjectsRequest)(nil),          // 38: clusterapi.CountObjectsRequest
+	(*CountObjectsResponse)(nil),         // 39: clusterapi.CountObjectsResponse
 }
 var file_protocol_replication_proto_depIdxs = []int32{
 	0,  // 0: clusterapi.SimpleReplicaResponse.errors:type_name -> clusterapi.ReplicaError
@@ -2385,45 +2558,48 @@ var file_protocol_replication_proto_depIdxs = []int32{
 	2,  // 10: clusterapi.CompareDigestsRequest.digests:type_name -> clusterapi.RepairResponse
 	2,  // 11: clusterapi.CompareDigestsResponse.digests:type_name -> clusterapi.RepairResponse
 	2,  // 12: clusterapi.OverwriteObjectsResponse.results:type_name -> clusterapi.RepairResponse
-	3,  // 13: clusterapi.ReplicationService.PutObject:input_type -> clusterapi.PutObjectRequest
-	5,  // 14: clusterapi.ReplicationService.PutObjects:input_type -> clusterapi.PutObjectsRequest
-	7,  // 15: clusterapi.ReplicationService.MergeObject:input_type -> clusterapi.MergeObjectRequest
-	9,  // 16: clusterapi.ReplicationService.DeleteObject:input_type -> clusterapi.DeleteObjectRequest
-	11, // 17: clusterapi.ReplicationService.DeleteObjects:input_type -> clusterapi.DeleteObjectsRequest
-	13, // 18: clusterapi.ReplicationService.AddReferences:input_type -> clusterapi.AddReferencesRequest
-	15, // 19: clusterapi.ReplicationService.Commit:input_type -> clusterapi.CommitRequest
-	17, // 20: clusterapi.ReplicationService.Abort:input_type -> clusterapi.AbortRequest
-	19, // 21: clusterapi.ReplicationService.FetchObject:input_type -> clusterapi.FetchObjectRequest
-	21, // 22: clusterapi.ReplicationService.FetchObjects:input_type -> clusterapi.FetchObjectsRequest
-	23, // 23: clusterapi.ReplicationService.DigestObjects:input_type -> clusterapi.DigestObjectsRequest
-	25, // 24: clusterapi.ReplicationService.DigestObjectsInRange:input_type -> clusterapi.DigestObjectsInRangeRequest
-	27, // 25: clusterapi.ReplicationService.CompareDigests:input_type -> clusterapi.CompareDigestsRequest
-	29, // 26: clusterapi.ReplicationService.OverwriteObjects:input_type -> clusterapi.OverwriteObjectsRequest
-	31, // 27: clusterapi.ReplicationService.FindUUIDs:input_type -> clusterapi.FindUUIDsRequest
-	33, // 28: clusterapi.ReplicationService.HashTreeLevel:input_type -> clusterapi.HashTreeLevelRequest
-	35, // 29: clusterapi.ReplicationService.CountObjects:input_type -> clusterapi.CountObjectsRequest
-	4,  // 30: clusterapi.ReplicationService.PutObject:output_type -> clusterapi.PutObjectResponse
-	6,  // 31: clusterapi.ReplicationService.PutObjects:output_type -> clusterapi.PutObjectsResponse
-	8,  // 32: clusterapi.ReplicationService.MergeObject:output_type -> clusterapi.MergeObjectResponse
-	10, // 33: clusterapi.ReplicationService.DeleteObject:output_type -> clusterapi.DeleteObjectResponse
-	12, // 34: clusterapi.ReplicationService.DeleteObjects:output_type -> clusterapi.DeleteObjectsResponse
-	14, // 35: clusterapi.ReplicationService.AddReferences:output_type -> clusterapi.AddReferencesResponse
-	16, // 36: clusterapi.ReplicationService.Commit:output_type -> clusterapi.CommitResponse
-	18, // 37: clusterapi.ReplicationService.Abort:output_type -> clusterapi.AbortResponse
-	20, // 38: clusterapi.ReplicationService.FetchObject:output_type -> clusterapi.FetchObjectResponse
-	22, // 39: clusterapi.ReplicationService.FetchObjects:output_type -> clusterapi.FetchObjectsResponse
-	24, // 40: clusterapi.ReplicationService.DigestObjects:output_type -> clusterapi.DigestObjectsResponse
-	26, // 41: clusterapi.ReplicationService.DigestObjectsInRange:output_type -> clusterapi.DigestObjectsInRangeResponse
-	28, // 42: clusterapi.ReplicationService.CompareDigests:output_type -> clusterapi.CompareDigestsResponse
-	30, // 43: clusterapi.ReplicationService.OverwriteObjects:output_type -> clusterapi.OverwriteObjectsResponse
-	32, // 44: clusterapi.ReplicationService.FindUUIDs:output_type -> clusterapi.FindUUIDsResponse
-	34, // 45: clusterapi.ReplicationService.HashTreeLevel:output_type -> clusterapi.HashTreeLevelResponse
-	36, // 46: clusterapi.ReplicationService.CountObjects:output_type -> clusterapi.CountObjectsResponse
-	30, // [30:47] is the sub-list for method output_type
-	13, // [13:30] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	35, // 13: clusterapi.CompareHashTreeRootsRequest.shards:type_name -> clusterapi.ShardRootDigest
+	3,  // 14: clusterapi.ReplicationService.PutObject:input_type -> clusterapi.PutObjectRequest
+	5,  // 15: clusterapi.ReplicationService.PutObjects:input_type -> clusterapi.PutObjectsRequest
+	7,  // 16: clusterapi.ReplicationService.MergeObject:input_type -> clusterapi.MergeObjectRequest
+	9,  // 17: clusterapi.ReplicationService.DeleteObject:input_type -> clusterapi.DeleteObjectRequest
+	11, // 18: clusterapi.ReplicationService.DeleteObjects:input_type -> clusterapi.DeleteObjectsRequest
+	13, // 19: clusterapi.ReplicationService.AddReferences:input_type -> clusterapi.AddReferencesRequest
+	15, // 20: clusterapi.ReplicationService.Commit:input_type -> clusterapi.CommitRequest
+	17, // 21: clusterapi.ReplicationService.Abort:input_type -> clusterapi.AbortRequest
+	19, // 22: clusterapi.ReplicationService.FetchObject:input_type -> clusterapi.FetchObjectRequest
+	21, // 23: clusterapi.ReplicationService.FetchObjects:input_type -> clusterapi.FetchObjectsRequest
+	23, // 24: clusterapi.ReplicationService.DigestObjects:input_type -> clusterapi.DigestObjectsRequest
+	25, // 25: clusterapi.ReplicationService.DigestObjectsInRange:input_type -> clusterapi.DigestObjectsInRangeRequest
+	27, // 26: clusterapi.ReplicationService.CompareDigests:input_type -> clusterapi.CompareDigestsRequest
+	29, // 27: clusterapi.ReplicationService.OverwriteObjects:input_type -> clusterapi.OverwriteObjectsRequest
+	31, // 28: clusterapi.ReplicationService.FindUUIDs:input_type -> clusterapi.FindUUIDsRequest
+	33, // 29: clusterapi.ReplicationService.HashTreeLevel:input_type -> clusterapi.HashTreeLevelRequest
+	36, // 30: clusterapi.ReplicationService.CompareHashTreeRoots:input_type -> clusterapi.CompareHashTreeRootsRequest
+	38, // 31: clusterapi.ReplicationService.CountObjects:input_type -> clusterapi.CountObjectsRequest
+	4,  // 32: clusterapi.ReplicationService.PutObject:output_type -> clusterapi.PutObjectResponse
+	6,  // 33: clusterapi.ReplicationService.PutObjects:output_type -> clusterapi.PutObjectsResponse
+	8,  // 34: clusterapi.ReplicationService.MergeObject:output_type -> clusterapi.MergeObjectResponse
+	10, // 35: clusterapi.ReplicationService.DeleteObject:output_type -> clusterapi.DeleteObjectResponse
+	12, // 36: clusterapi.ReplicationService.DeleteObjects:output_type -> clusterapi.DeleteObjectsResponse
+	14, // 37: clusterapi.ReplicationService.AddReferences:output_type -> clusterapi.AddReferencesResponse
+	16, // 38: clusterapi.ReplicationService.Commit:output_type -> clusterapi.CommitResponse
+	18, // 39: clusterapi.ReplicationService.Abort:output_type -> clusterapi.AbortResponse
+	20, // 40: clusterapi.ReplicationService.FetchObject:output_type -> clusterapi.FetchObjectResponse
+	22, // 41: clusterapi.ReplicationService.FetchObjects:output_type -> clusterapi.FetchObjectsResponse
+	24, // 42: clusterapi.ReplicationService.DigestObjects:output_type -> clusterapi.DigestObjectsResponse
+	26, // 43: clusterapi.ReplicationService.DigestObjectsInRange:output_type -> clusterapi.DigestObjectsInRangeResponse
+	28, // 44: clusterapi.ReplicationService.CompareDigests:output_type -> clusterapi.CompareDigestsResponse
+	30, // 45: clusterapi.ReplicationService.OverwriteObjects:output_type -> clusterapi.OverwriteObjectsResponse
+	32, // 46: clusterapi.ReplicationService.FindUUIDs:output_type -> clusterapi.FindUUIDsResponse
+	34, // 47: clusterapi.ReplicationService.HashTreeLevel:output_type -> clusterapi.HashTreeLevelResponse
+	37, // 48: clusterapi.ReplicationService.CompareHashTreeRoots:output_type -> clusterapi.CompareHashTreeRootsResponse
+	39, // 49: clusterapi.ReplicationService.CountObjects:output_type -> clusterapi.CountObjectsResponse
+	32, // [32:50] is the sub-list for method output_type
+	14, // [14:32] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_protocol_replication_proto_init() }
@@ -2437,7 +2613,7 @@ func file_protocol_replication_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_protocol_replication_proto_rawDesc), len(file_protocol_replication_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   37,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
@@ -2050,10 +2050,11 @@ func (x *HashTreeLevelResponse) GetDigestsData() []byte {
 // shards whose roots differ (or that it lacks / has not fully initialised), so
 // the source can skip the per-shard descent for the rest.
 type ShardRootDigest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Shard         string                 `protobuf:"bytes,1,opt,name=shard,proto3" json:"shard,omitempty"`
-	RootH1        uint64                 `protobuf:"fixed64,2,opt,name=root_h1,json=rootH1,proto3" json:"root_h1,omitempty"` // Digest[0]
-	RootH2        uint64                 `protobuf:"fixed64,3,opt,name=root_h2,json=rootH2,proto3" json:"root_h2,omitempty"` // Digest[1]
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Shard string                 `protobuf:"bytes,1,opt,name=shard,proto3" json:"shard,omitempty"`
+	// The 128-bit hashtree root digest, split into two 64-bit words.
+	RootHashHi    uint64 `protobuf:"fixed64,2,opt,name=root_hash_hi,json=rootHashHi,proto3" json:"root_hash_hi,omitempty"` // Digest[0] (high 64 bits)
+	RootHashLo    uint64 `protobuf:"fixed64,3,opt,name=root_hash_lo,json=rootHashLo,proto3" json:"root_hash_lo,omitempty"` // Digest[1] (low 64 bits)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2095,26 +2096,26 @@ func (x *ShardRootDigest) GetShard() string {
 	return ""
 }
 
-func (x *ShardRootDigest) GetRootH1() uint64 {
+func (x *ShardRootDigest) GetRootHashHi() uint64 {
 	if x != nil {
-		return x.RootH1
+		return x.RootHashHi
 	}
 	return 0
 }
 
-func (x *ShardRootDigest) GetRootH2() uint64 {
+func (x *ShardRootDigest) GetRootHashLo() uint64 {
 	if x != nil {
-		return x.RootH2
+		return x.RootHashLo
 	}
 	return 0
 }
 
 type CompareHashTreeRootsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Index         string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
-	Shards        []*ShardRootDigest     `protobuf:"bytes,2,rep,name=shards,proto3" json:"shards,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Index            string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	ShardRootDigests []*ShardRootDigest     `protobuf:"bytes,2,rep,name=shard_root_digests,json=shardRootDigests,proto3" json:"shard_root_digests,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *CompareHashTreeRootsRequest) Reset() {
@@ -2154,9 +2155,9 @@ func (x *CompareHashTreeRootsRequest) GetIndex() string {
 	return ""
 }
 
-func (x *CompareHashTreeRootsRequest) GetShards() []*ShardRootDigest {
+func (x *CompareHashTreeRootsRequest) GetShardRootDigests() []*ShardRootDigest {
 	if x != nil {
-		return x.Shards
+		return x.ShardRootDigests
 	}
 	return nil
 }
@@ -2449,14 +2450,16 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\x05level\x18\x03 \x01(\x05R\x05level\x12\"\n" +
 	"\fdiscriminant\x18\x04 \x01(\fR\fdiscriminant\":\n" +
 	"\x15HashTreeLevelResponse\x12!\n" +
-	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\"Y\n" +
+	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\"k\n" +
 	"\x0fShardRootDigest\x12\x14\n" +
-	"\x05shard\x18\x01 \x01(\tR\x05shard\x12\x17\n" +
-	"\aroot_h1\x18\x02 \x01(\x06R\x06rootH1\x12\x17\n" +
-	"\aroot_h2\x18\x03 \x01(\x06R\x06rootH2\"h\n" +
+	"\x05shard\x18\x01 \x01(\tR\x05shard\x12 \n" +
+	"\froot_hash_hi\x18\x02 \x01(\x06R\n" +
+	"rootHashHi\x12 \n" +
+	"\froot_hash_lo\x18\x03 \x01(\x06R\n" +
+	"rootHashLo\"~\n" +
 	"\x1bCompareHashTreeRootsRequest\x12\x14\n" +
-	"\x05index\x18\x01 \x01(\tR\x05index\x123\n" +
-	"\x06shards\x18\x02 \x03(\v2\x1b.clusterapi.ShardRootDigestR\x06shards\"I\n" +
+	"\x05index\x18\x01 \x01(\tR\x05index\x12I\n" +
+	"\x12shard_root_digests\x18\x02 \x03(\v2\x1b.clusterapi.ShardRootDigestR\x10shardRootDigests\"I\n" +
 	"\x1cCompareHashTreeRootsResponse\x12)\n" +
 	"\x10diverging_shards\x18\x01 \x03(\tR\x0fdivergingShards\"A\n" +
 	"\x13CountObjectsRequest\x12\x14\n" +
@@ -2558,7 +2561,7 @@ var file_protocol_replication_proto_depIdxs = []int32{
 	2,  // 10: clusterapi.CompareDigestsRequest.digests:type_name -> clusterapi.RepairResponse
 	2,  // 11: clusterapi.CompareDigestsResponse.digests:type_name -> clusterapi.RepairResponse
 	2,  // 12: clusterapi.OverwriteObjectsResponse.results:type_name -> clusterapi.RepairResponse
-	35, // 13: clusterapi.CompareHashTreeRootsRequest.shards:type_name -> clusterapi.ShardRootDigest
+	35, // 13: clusterapi.CompareHashTreeRootsRequest.shard_root_digests:type_name -> clusterapi.ShardRootDigest
 	3,  // 14: clusterapi.ReplicationService.PutObject:input_type -> clusterapi.PutObjectRequest
 	5,  // 15: clusterapi.ReplicationService.PutObjects:input_type -> clusterapi.PutObjectsRequest
 	7,  // 16: clusterapi.ReplicationService.MergeObject:input_type -> clusterapi.MergeObjectRequest

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
@@ -2045,16 +2045,14 @@ func (x *HashTreeLevelResponse) GetDigestsData() []byte {
 	return nil
 }
 
-// CompareHashTreeRoots pre-filters shards by comparing hashtree roots in bulk.
-// The source sends its local root per shard; the target replies only with the
-// shards whose roots differ (or that it lacks / has not fully initialised), so
-// the source can skip the per-shard descent for the rest.
+// CompareHashTreeRoots pre-filters shards by bulk-comparing hashtree roots: the
+// target returns only shards whose roots differ, letting the source skip the rest.
 type ShardRootDigest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Shard string                 `protobuf:"bytes,1,opt,name=shard,proto3" json:"shard,omitempty"`
 	// The 128-bit hashtree root digest, split into two 64-bit words.
-	RootHashHi    uint64 `protobuf:"fixed64,2,opt,name=root_hash_hi,json=rootHashHi,proto3" json:"root_hash_hi,omitempty"` // Digest[0] (high 64 bits)
-	RootHashLo    uint64 `protobuf:"fixed64,3,opt,name=root_hash_lo,json=rootHashLo,proto3" json:"root_hash_lo,omitempty"` // Digest[1] (low 64 bits)
+	RootHashHigh  uint64 `protobuf:"fixed64,2,opt,name=root_hash_high,json=rootHashHigh,proto3" json:"root_hash_high,omitempty"` // Digest[0] (high 64 bits)
+	RootHashLow   uint64 `protobuf:"fixed64,3,opt,name=root_hash_low,json=rootHashLow,proto3" json:"root_hash_low,omitempty"`    // Digest[1] (low 64 bits)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2096,16 +2094,16 @@ func (x *ShardRootDigest) GetShard() string {
 	return ""
 }
 
-func (x *ShardRootDigest) GetRootHashHi() uint64 {
+func (x *ShardRootDigest) GetRootHashHigh() uint64 {
 	if x != nil {
-		return x.RootHashHi
+		return x.RootHashHigh
 	}
 	return 0
 }
 
-func (x *ShardRootDigest) GetRootHashLo() uint64 {
+func (x *ShardRootDigest) GetRootHashLow() uint64 {
 	if x != nil {
-		return x.RootHashLo
+		return x.RootHashLow
 	}
 	return 0
 }
@@ -2450,13 +2448,11 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\x05level\x18\x03 \x01(\x05R\x05level\x12\"\n" +
 	"\fdiscriminant\x18\x04 \x01(\fR\fdiscriminant\":\n" +
 	"\x15HashTreeLevelResponse\x12!\n" +
-	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\"k\n" +
+	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\"q\n" +
 	"\x0fShardRootDigest\x12\x14\n" +
-	"\x05shard\x18\x01 \x01(\tR\x05shard\x12 \n" +
-	"\froot_hash_hi\x18\x02 \x01(\x06R\n" +
-	"rootHashHi\x12 \n" +
-	"\froot_hash_lo\x18\x03 \x01(\x06R\n" +
-	"rootHashLo\"~\n" +
+	"\x05shard\x18\x01 \x01(\tR\x05shard\x12$\n" +
+	"\x0eroot_hash_high\x18\x02 \x01(\x06R\frootHashHigh\x12\"\n" +
+	"\rroot_hash_low\x18\x03 \x01(\x06R\vrootHashLow\"~\n" +
 	"\x1bCompareHashTreeRootsRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12I\n" +
 	"\x12shard_root_digests\x18\x02 \x03(\v2\x1b.clusterapi.ShardRootDigestR\x10shardRootDigests\"I\n" +

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication_grpc.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication_grpc.pb.go
@@ -35,6 +35,7 @@ const (
 	ReplicationService_OverwriteObjects_FullMethodName     = "/clusterapi.ReplicationService/OverwriteObjects"
 	ReplicationService_FindUUIDs_FullMethodName            = "/clusterapi.ReplicationService/FindUUIDs"
 	ReplicationService_HashTreeLevel_FullMethodName        = "/clusterapi.ReplicationService/HashTreeLevel"
+	ReplicationService_CompareHashTreeRoots_FullMethodName = "/clusterapi.ReplicationService/CompareHashTreeRoots"
 	ReplicationService_CountObjects_FullMethodName         = "/clusterapi.ReplicationService/CountObjects"
 )
 
@@ -63,6 +64,7 @@ type ReplicationServiceClient interface {
 	OverwriteObjects(ctx context.Context, in *OverwriteObjectsRequest, opts ...grpc.CallOption) (*OverwriteObjectsResponse, error)
 	FindUUIDs(ctx context.Context, in *FindUUIDsRequest, opts ...grpc.CallOption) (*FindUUIDsResponse, error)
 	HashTreeLevel(ctx context.Context, in *HashTreeLevelRequest, opts ...grpc.CallOption) (*HashTreeLevelResponse, error)
+	CompareHashTreeRoots(ctx context.Context, in *CompareHashTreeRootsRequest, opts ...grpc.CallOption) (*CompareHashTreeRootsResponse, error)
 	CountObjects(ctx context.Context, in *CountObjectsRequest, opts ...grpc.CallOption) (*CountObjectsResponse, error)
 }
 
@@ -234,6 +236,16 @@ func (c *replicationServiceClient) HashTreeLevel(ctx context.Context, in *HashTr
 	return out, nil
 }
 
+func (c *replicationServiceClient) CompareHashTreeRoots(ctx context.Context, in *CompareHashTreeRootsRequest, opts ...grpc.CallOption) (*CompareHashTreeRootsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CompareHashTreeRootsResponse)
+	err := c.cc.Invoke(ctx, ReplicationService_CompareHashTreeRoots_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *replicationServiceClient) CountObjects(ctx context.Context, in *CountObjectsRequest, opts ...grpc.CallOption) (*CountObjectsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CountObjectsResponse)
@@ -269,6 +281,7 @@ type ReplicationServiceServer interface {
 	OverwriteObjects(context.Context, *OverwriteObjectsRequest) (*OverwriteObjectsResponse, error)
 	FindUUIDs(context.Context, *FindUUIDsRequest) (*FindUUIDsResponse, error)
 	HashTreeLevel(context.Context, *HashTreeLevelRequest) (*HashTreeLevelResponse, error)
+	CompareHashTreeRoots(context.Context, *CompareHashTreeRootsRequest) (*CompareHashTreeRootsResponse, error)
 	CountObjects(context.Context, *CountObjectsRequest) (*CountObjectsResponse, error)
 }
 
@@ -326,6 +339,9 @@ func (UnimplementedReplicationServiceServer) FindUUIDs(context.Context, *FindUUI
 }
 func (UnimplementedReplicationServiceServer) HashTreeLevel(context.Context, *HashTreeLevelRequest) (*HashTreeLevelResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method HashTreeLevel not implemented")
+}
+func (UnimplementedReplicationServiceServer) CompareHashTreeRoots(context.Context, *CompareHashTreeRootsRequest) (*CompareHashTreeRootsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CompareHashTreeRoots not implemented")
 }
 func (UnimplementedReplicationServiceServer) CountObjects(context.Context, *CountObjectsRequest) (*CountObjectsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CountObjects not implemented")
@@ -638,6 +654,24 @@ func _ReplicationService_HashTreeLevel_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ReplicationService_CompareHashTreeRoots_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CompareHashTreeRootsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReplicationServiceServer).CompareHashTreeRoots(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReplicationService_CompareHashTreeRoots_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReplicationServiceServer).CompareHashTreeRoots(ctx, req.(*CompareHashTreeRootsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ReplicationService_CountObjects_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CountObjectsRequest)
 	if err := dec(in); err != nil {
@@ -726,6 +760,10 @@ var ReplicationService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "HashTreeLevel",
 			Handler:    _ReplicationService_HashTreeLevel_Handler,
+		},
+		{
+			MethodName: "CompareHashTreeRoots",
+			Handler:    _ReplicationService_CompareHashTreeRoots_Handler,
 		},
 		{
 			MethodName: "CountObjects",

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
@@ -264,8 +264,8 @@ message HashTreeLevelResponse {
 message ShardRootDigest {
   string shard = 1;
   // The 128-bit hashtree root digest, split into two 64-bit words.
-  fixed64 root_hash_hi = 2; // Digest[0] (high 64 bits)
-  fixed64 root_hash_lo = 3; // Digest[1] (low 64 bits)
+  fixed64 root_hash_high = 2; // Digest[0] (high 64 bits)
+  fixed64 root_hash_low = 3; // Digest[1] (low 64 bits)
 }
 
 message CompareHashTreeRootsRequest {

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
@@ -24,6 +24,7 @@ service ReplicationService {
   rpc OverwriteObjects (OverwriteObjectsRequest) returns (OverwriteObjectsResponse);
   rpc FindUUIDs (FindUUIDsRequest) returns (FindUUIDsResponse);
   rpc HashTreeLevel (HashTreeLevelRequest) returns (HashTreeLevelResponse);
+  rpc CompareHashTreeRoots (CompareHashTreeRootsRequest) returns (CompareHashTreeRootsResponse);
   rpc CountObjects (CountObjectsRequest) returns (CountObjectsResponse);
 }
 
@@ -256,6 +257,25 @@ message HashTreeLevelRequest {
 // HashTreeLevelResponse carries digests as opaque binary (JSON-encoded []hashtree.Digest).
 message HashTreeLevelResponse {
   bytes digests_data = 1; // JSON-encoded []hashtree.Digest
+}
+
+// CompareHashTreeRoots pre-filters shards by comparing hashtree roots in bulk.
+// The source sends its local root per shard; the target replies only with the
+// shards whose roots differ (or that it lacks / has not fully initialised), so
+// the source can skip the per-shard descent for the rest.
+message ShardRootDigest {
+  string shard = 1;
+  fixed64 root_h1 = 2; // Digest[0]
+  fixed64 root_h2 = 3; // Digest[1]
+}
+
+message CompareHashTreeRootsRequest {
+  string index = 1;
+  repeated ShardRootDigest shards = 2;
+}
+
+message CompareHashTreeRootsResponse {
+  repeated string diverging_shards = 1;
 }
 
 // CountObjects fetches hash tree level digests.

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
@@ -259,19 +259,18 @@ message HashTreeLevelResponse {
   bytes digests_data = 1; // JSON-encoded []hashtree.Digest
 }
 
-// CompareHashTreeRoots pre-filters shards by comparing hashtree roots in bulk.
-// The source sends its local root per shard; the target replies only with the
-// shards whose roots differ (or that it lacks / has not fully initialised), so
-// the source can skip the per-shard descent for the rest.
+// CompareHashTreeRoots pre-filters shards by bulk-comparing hashtree roots: the
+// target returns only shards whose roots differ, letting the source skip the rest.
 message ShardRootDigest {
   string shard = 1;
-  fixed64 root_h1 = 2; // Digest[0]
-  fixed64 root_h2 = 3; // Digest[1]
+  // The 128-bit hashtree root digest, split into two 64-bit words.
+  fixed64 root_hash_hi = 2; // Digest[0] (high 64 bits)
+  fixed64 root_hash_lo = 3; // Digest[1] (low 64 bits)
 }
 
 message CompareHashTreeRootsRequest {
   string index = 1;
-  repeated ShardRootDigest shards = 2;
+  repeated ShardRootDigest shard_root_digests = 2;
 }
 
 message CompareHashTreeRootsResponse {

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -274,10 +274,10 @@ func (s *ReplicationService) HashTreeLevel(ctx context.Context, req *pb.HashTree
 }
 
 func (s *ReplicationService) CompareHashTreeRoots(ctx context.Context, req *pb.CompareHashTreeRootsRequest) (*pb.CompareHashTreeRootsResponse, error) {
-	shards := req.GetShards()
+	shards := req.GetShardRootDigests()
 	roots := make(map[string]hashtree.Digest, len(shards))
 	for _, sr := range shards {
-		roots[sr.GetShard()] = hashtree.Digest{sr.GetRootH1(), sr.GetRootH2()}
+		roots[sr.GetShard()] = hashtree.Digest{sr.GetRootHashHi(), sr.GetRootHashLo()}
 	}
 
 	diverging, err := s.server.CompareHashTreeRoots(ctx, req.GetIndex(), roots)

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -273,6 +273,21 @@ func (s *ReplicationService) HashTreeLevel(ctx context.Context, req *pb.HashTree
 	return &pb.HashTreeLevelResponse{DigestsData: data}, nil
 }
 
+func (s *ReplicationService) CompareHashTreeRoots(ctx context.Context, req *pb.CompareHashTreeRootsRequest) (*pb.CompareHashTreeRootsResponse, error) {
+	shards := req.GetShards()
+	roots := make(map[string]hashtree.Digest, len(shards))
+	for _, sr := range shards {
+		roots[sr.GetShard()] = hashtree.Digest{sr.GetRootH1(), sr.GetRootH2()}
+	}
+
+	diverging, err := s.server.CompareHashTreeRoots(ctx, req.GetIndex(), roots)
+	if err != nil {
+		return nil, replicationErrorToGRPC(err)
+	}
+
+	return &pb.CompareHashTreeRootsResponse{DivergingShards: diverging}, nil
+}
+
 func (s *ReplicationService) CountObjects(ctx context.Context, req *pb.CountObjectsRequest) (*pb.CountObjectsResponse, error) {
 	count, err := s.server.CountObjects(ctx, req.GetIndex(), req.GetShard())
 	if err != nil {

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -277,7 +277,7 @@ func (s *ReplicationService) CompareHashTreeRoots(ctx context.Context, req *pb.C
 	shards := req.GetShardRootDigests()
 	roots := make(map[string]hashtree.Digest, len(shards))
 	for _, sr := range shards {
-		roots[sr.GetShard()] = hashtree.Digest{sr.GetRootHashHi(), sr.GetRootHashLo()}
+		roots[sr.GetShard()] = hashtree.Digest{sr.GetRootHashHigh(), sr.GetRootHashLow()}
 	}
 
 	diverging, err := s.server.CompareHashTreeRoots(ctx, req.GetIndex(), roots)

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -97,8 +97,8 @@ func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
 		resp, err := svc.CompareHashTreeRoots(context.Background(), &pb.CompareHashTreeRootsRequest{
 			Index: index,
 			ShardRootDigests: []*pb.ShardRootDigest{
-				{Shard: "shard-a", RootHashHi: 1, RootHashLo: 2},
-				{Shard: "shard-b", RootHashHi: 3, RootHashLo: 4},
+				{Shard: "shard-a", RootHashHigh: 1, RootHashLow: 2},
+				{Shard: "shard-b", RootHashHigh: 3, RootHashLow: 4},
 			},
 		})
 		require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
 
 		_, err := svc.CompareHashTreeRoots(context.Background(), &pb.CompareHashTreeRootsRequest{
 			Index:            index,
-			ShardRootDigests: []*pb.ShardRootDigest{{Shard: "shard-a", RootHashHi: 1, RootHashLo: 2}},
+			ShardRootDigests: []*pb.ShardRootDigest{{Shard: "shard-a", RootHashHigh: 1, RootHashLow: 2}},
 		})
 		require.Error(t, err)
 		st, ok := status.FromError(err)

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -12,15 +12,20 @@
 package grpc
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	pb "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -72,5 +77,49 @@ func TestLocalIndexNotReady(t *testing.T) {
 			},
 		}
 		assert.True(t, shared.LocalIndexNotReady(resp))
+	})
+}
+
+func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
+	const index = "MyClass"
+
+	t.Run("converts proto to map and returns diverging shards", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		mockReplicator.EXPECT().
+			CompareHashTreeRoots(mock.Anything, index, map[string]hashtree.Digest{
+				"shard-a": {1, 2},
+				"shard-b": {3, 4},
+			}).
+			Return([]string{"shard-b"}, nil)
+
+		resp, err := svc.CompareHashTreeRoots(context.Background(), &pb.CompareHashTreeRootsRequest{
+			Index: index,
+			Shards: []*pb.ShardRootDigest{
+				{Shard: "shard-a", RootH1: 1, RootH2: 2},
+				{Shard: "shard-b", RootH1: 3, RootH2: 4},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"shard-b"}, resp.GetDivergingShards())
+	})
+
+	t.Run("propagates replicator error as gRPC error", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		mockReplicator.EXPECT().
+			CompareHashTreeRoots(mock.Anything, index, mock.Anything).
+			Return(nil, errors.New("boom"))
+
+		_, err := svc.CompareHashTreeRoots(context.Background(), &pb.CompareHashTreeRootsRequest{
+			Index:  index,
+			Shards: []*pb.ShardRootDigest{{Shard: "shard-a", RootH1: 1, RootH2: 2}},
+		})
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
 	})
 }

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -96,9 +96,9 @@ func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
 
 		resp, err := svc.CompareHashTreeRoots(context.Background(), &pb.CompareHashTreeRootsRequest{
 			Index: index,
-			Shards: []*pb.ShardRootDigest{
-				{Shard: "shard-a", RootH1: 1, RootH2: 2},
-				{Shard: "shard-b", RootH1: 3, RootH2: 4},
+			ShardRootDigests: []*pb.ShardRootDigest{
+				{Shard: "shard-a", RootHashHi: 1, RootHashLo: 2},
+				{Shard: "shard-b", RootHashHi: 3, RootHashLo: 4},
 			},
 		})
 		require.NoError(t, err)
@@ -114,8 +114,8 @@ func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
 			Return(nil, errors.New("boom"))
 
 		_, err := svc.CompareHashTreeRoots(context.Background(), &pb.CompareHashTreeRootsRequest{
-			Index:  index,
-			Shards: []*pb.ShardRootDigest{{Shard: "shard-a", RootH1: 1, RootH2: 2}},
+			Index:            index,
+			ShardRootDigests: []*pb.ShardRootDigest{{Shard: "shard-a", RootHashHi: 1, RootHashLo: 2}},
 		})
 		require.Error(t, err)
 		st, ok := status.FromError(err)

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -83,6 +83,8 @@ var (
 		`\/shards\/(` + sh + `)\/objects\/hashtree\/level\/(` + l + `)`)
 	regexCompareDigests = regexp.MustCompile(`\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/objects/compareDigests`)
+	regexCompareHashTreeRoots = regexp.MustCompile(`\/indices\/(` + cl + `)` +
+		`\/objects/_compareHashTreeRoots`)
 	regxObjects = regexp.MustCompile(`\/replicas\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/objects`)
 	regxReferences = regexp.MustCompile(`\/replicas\/indices\/(` + cl + `)` +
@@ -168,6 +170,14 @@ func (i *replicatedIndices) handleRequest(w http.ResponseWriter, r *http.Request
 	case regexCompareDigests.MatchString(path):
 		if r.Method == http.MethodPost {
 			i.postCompareDigests().ServeHTTP(w, r)
+			return
+		}
+
+		http.Error(w, "405 Method not Allowed", http.StatusMethodNotAllowed)
+		return
+	case regexCompareHashTreeRoots.MatchString(path):
+		if r.Method == http.MethodPost {
+			i.postCompareHashTreeRoots().ServeHTTP(w, r)
 			return
 		}
 
@@ -495,6 +505,38 @@ func (i *replicatedIndices) getHashTreeLevel() http.Handler {
 		}
 
 		writeHashTreeLevelResponse(w, r, results)
+	})
+}
+
+func (i *replicatedIndices) postCompareHashTreeRoots() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		args := regexCompareHashTreeRoots.FindStringSubmatch(r.URL.Path)
+		if len(args) != 2 {
+			http.Error(w, "invalid URI", http.StatusBadRequest)
+			return
+		}
+		index := args[1]
+
+		defer r.Body.Close()
+
+		var req replica.CompareHashTreeRootsReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "unmarshal compare hashtree roots request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		diverging, err := i.replicator.CompareHashTreeRoots(r.Context(), index, req.Roots)
+		if err != nil {
+			http.Error(w, "compare hashtree roots: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		resBytes, err := json.Marshal(replica.CompareHashTreeRootsResp{DivergingShards: diverging})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(resBytes) //nolint:errcheck
 	})
 }
 

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -489,6 +489,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 			AsyncReplicationPropagationConcurrency:    appState.ServerConfig.Config.Replication.AsyncReplicationPropagationConcurrency,
 			AsyncReplicationPropagationBatchSize:      appState.ServerConfig.Config.Replication.AsyncReplicationPropagationBatchSize,
 			AsyncReplicationPropagationDelay:          appState.ServerConfig.Config.Replication.AsyncReplicationPropagationDelay,
+			AsyncReplicationRootPrefilterBatchSize:    appState.ServerConfig.Config.Replication.AsyncReplicationRootPrefilterBatchSize,
 		},
 		MaximumConcurrentShardLoads:                  appState.ServerConfig.Config.MaximumConcurrentShardLoads,
 		MaximumConcurrentBucketLoads:                 appState.ServerConfig.Config.MaximumConcurrentBucketLoads,
@@ -2221,6 +2222,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.AsyncReplicationPropagationConcurrency = appState.ServerConfig.Config.Replication.AsyncReplicationPropagationConcurrency
 		registered.AsyncReplicationPropagationBatchSize = appState.ServerConfig.Config.Replication.AsyncReplicationPropagationBatchSize
 		registered.AsyncReplicationPropagationDelay = appState.ServerConfig.Config.Replication.AsyncReplicationPropagationDelay
+		registered.AsyncReplicationRootPrefilterBatchSize = appState.ServerConfig.Config.Replication.AsyncReplicationRootPrefilterBatchSize
 		registered.ReplicationGRPCEnabled = appState.ServerConfig.Config.Replication.ReplicationGRPCEnabled
 		registered.AutoschemaEnabled = appState.ServerConfig.Config.AutoSchema.Enabled
 		registered.ReplicaMovementMinimumAsyncWait = appState.ServerConfig.Config.ReplicaMovementMinimumAsyncWait

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -38,12 +38,8 @@ const (
 	defaultAsyncReplicationHashtreeInitConcurrency = 100
 	maxMaxWorkers                                  = 100
 
-	// Root pre-filter batch defaults/cap. usecases/config is the single source of
-	// truth (also the env-parse default); these are local aliases so the scheduler
-	// reads without repeating the literals. fallback is used only when the runtime
-	// DynamicValue is nil (e.g. zero-valued config in tests). 1 disables the
-	// batched root compare (per-shard path); values <= 0 fall back to the default;
-	// the cap bounds per-batch work / RPC message size regardless of override.
+	// Root pre-filter batch defaults/cap; aliases of the usecases/config source of
+	// truth. 1 disables the batched compare; <= 0 falls back to the default.
 	fallbackRootPrefilterBatchSize = config.DefaultAsyncReplicationRootPrefilterBatchSize
 	maxRootPrefilterBatchSize      = config.MaxAsyncReplicationRootPrefilterBatchSize
 
@@ -80,10 +76,8 @@ type asyncSchedulerEntry struct {
 	nextRunAt time.Time
 	inFlight  bool // true while a worker is executing runHashbeatCycle
 	heapIdx   int  // maintained by the heap for O(log n) Fix/Remove
-	// descendDirect marks an entry the batched pre-filter already classified as
-	// diverging: dispatchDueLocked ships it as a standalone singleton for descent
-	// (bypassing coalescing and the pre-filter) so mass-divergence descents spread
-	// across the pool instead of serializing in one worker. Guarded by sched.mu.
+	// descendDirect: pre-filter classified this as diverging; dispatch ships it as a
+	// standalone singleton so descents spread across the pool. Guarded by sched.mu.
 	descendDirect bool
 	// seq is a monotonically-increasing counter assigned every time the entry
 	// is pushed onto the heap. Entries with the same nextRunAt are served in
@@ -132,9 +126,8 @@ type asyncSchedulerResult struct {
 	entry      *asyncSchedulerEntry
 	propagated bool
 	err        error
-	// deferDescent is set by deferDescent: the batched pre-filter classified this
-	// entry as diverging, so onResultLocked re-enqueues it immediately with
-	// descendDirect set rather than scheduling the next cycle at frequency.
+	// deferDescent: entry diverges; onResultLocked re-enqueues it immediately with
+	// descendDirect instead of scheduling the next cycle.
 	deferDescent bool
 	// cfg is the effective config snapshot used for this cycle, pre-read in
 	// the worker. onResultLocked uses it to avoid acquiring
@@ -178,13 +171,11 @@ type asyncReplicationSchedulerMetrics struct {
 	queueDepth prometheus.Gauge
 	// workerPoolSize is the current target worker pool size.
 	workerPoolSize prometheus.Gauge
-	// rootPrefilterSkips counts shard cycles short-circuited as in-sync by the
-	// batched root pre-filter (the "root RPC storm eliminated" headline).
+	// rootPrefilterSkips counts shard cycles short-circuited as in-sync by the pre-filter.
 	rootPrefilterSkips prometheus.Counter
 	// rootPrefilterBatchSize observes the number of shards per pre-filter batch.
 	rootPrefilterBatchSize prometheus.Histogram
-	// rootCompareRPC counts batched root-compare RPCs by outcome
-	// (ok|error|unsupported).
+	// rootCompareRPC counts batched root-compare RPCs by outcome (ok|error|unsupported).
 	rootCompareRPC *prometheus.CounterVec
 }
 
@@ -395,12 +386,8 @@ type AsyncReplicationScheduler struct {
 	// limit 10k concurrent scans would thrash disk and spike RSS.
 	hashtreeInitSem *semaphore.Weighted
 
-	// workCh feeds batches to the worker pool. Buffered (maxMaxWorkers) so
-	// dispatchDueLocked sends in O(1) under sched.mu; a full buffer triggers
-	// "all workers busy" backpressure via the default branch. Each item is a
-	// pooled batch of same-index entries (usually 1); a worker root-prefilters
-	// the batch then descends only the diverging shards, then returns it to
-	// batchPool. The pointer indirection lets the worker recycle the exact slice.
+	// workCh feeds pooled batches of same-index entries (usually 1) to the pool.
+	// Buffered (maxMaxWorkers) so sends are O(1) under mu; a full buffer = backpressure.
 	workCh chan *[]*asyncSchedulerEntry
 
 	// resultCh receives results from workers. Buffer absorbs normal-operation
@@ -418,20 +405,15 @@ type AsyncReplicationScheduler struct {
 	// for 30 s so the dispatcher wakes up promptly once the flag is cleared.
 	asyncReplicationDisabled *configRuntime.DynamicValue[bool]
 
-	// rootPrefilterBatchSize is a single cluster-wide value driving how many
-	// same-index (same-collection) shards are batched into one hashtree-root
-	// pre-filter RPC. 1 disables the pre-filter (per-shard path). Read per
-	// dispatch; invalid values (<= 0) warn once and fall back to the default,
-	// over-cap values are clamped.
+	// rootPrefilterBatchSize: cluster-wide count of same-index shards batched into one
+	// pre-filter RPC. 1 disables it; <= 0 warns and defaults; over-cap is clamped.
 	rootPrefilterBatchSize *configRuntime.DynamicValue[int]
 	warnedBatchSizeInvalid atomic.Bool
 	warnedBatchSizeClamp   atomic.Bool
 
-	// batchPool recycles the []*asyncSchedulerEntry slices sent on workCh; the
-	// dispatcher acquires, the worker releases after emitting all results.
+	// batchPool recycles the []*asyncSchedulerEntry slices sent on workCh.
 	batchPool sync.Pool
-	// dispatchBuckets groups due entries by index during one dispatch pass.
-	// Dispatcher-owned (only touched under mu by the dispatcher goroutine).
+	// dispatchBuckets groups due entries by index during one dispatch pass; dispatcher-owned.
 	dispatchBuckets map[*Index][]*asyncSchedulerEntry
 
 	metrics asyncReplicationSchedulerMetrics
@@ -841,10 +823,8 @@ func (sched *AsyncReplicationScheduler) timeUntilNextLocked() time.Duration {
 	return d
 }
 
-// effectiveBatchSize returns the root pre-filter batch size, applying the
-// runtime override with warn-and-default on invalid values and a one-shot warn
-// when clamped to the hard cap. A value of 1 disables the pre-filter (per-shard
-// path); values <= 0 are invalid and fall back to the default. Called under mu.
+// effectiveBatchSize returns the root pre-filter batch size: 1 disables it, <= 0
+// warns and defaults, over-cap warns once and clamps. Called under mu.
 func (sched *AsyncReplicationScheduler) effectiveBatchSize() int {
 	def := fallbackRootPrefilterBatchSize
 
@@ -879,9 +859,8 @@ func (sched *AsyncReplicationScheduler) rollbackReservedLocked(entry *asyncSched
 	heap.Push(&sched.h, entry)
 }
 
-// trySendBatchLocked copies entries into a pooled batch and non-blockingly sends
-// it to the worker pool. Returns false (releasing the pooled slice) if the
-// channel is full; the caller then rolls the entries back. mu must be held.
+// trySendBatchLocked non-blockingly sends a pooled copy of entries to the pool;
+// returns false (releasing the slice) if the channel is full. mu must be held.
 func (sched *AsyncReplicationScheduler) trySendBatchLocked(entries []*asyncSchedulerEntry) bool {
 	bp := sched.batchPool.Get().(*[]*asyncSchedulerEntry)
 	*bp = append((*bp)[:0], entries...)
@@ -895,12 +874,8 @@ func (sched *AsyncReplicationScheduler) trySendBatchLocked(entries []*asyncSched
 	}
 }
 
-// dispatchDueLocked pops entries whose nextRunAt has passed, coalesces them by
-// index into batches (capped at the per-index effective batch size), and sends
-// each batch to the worker pool. It stops once the channel is full (all workers
-// busy), rolling any reserved-but-unsent entries back into the heap. mu must be
-// held. Per-entry accounting (Add/inFlight/Pop ↔ Done/re-push) is balanced on
-// every path.
+// dispatchDueLocked pops due entries, coalesces by index into capped batches, and
+// sends each to the pool; rolls reserved entries back on a full channel. Held under mu.
 func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 	if sched.asyncReplicationDisabled.Get() {
 		return
@@ -934,12 +909,8 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 		}
 
 		if entry.descendDirect {
-			// Pre-filter already classified this shard as diverging: ship it as a
-			// standalone singleton (bypassing coalescing and the pre-filter) so
-			// its descent runs on any free worker instead of serializing behind a
-			// full batch. Reserve, then clear the flag only on a successful send —
-			// on a full channel rollbackReservedLocked re-queues it with the flag
-			// intact so it retries as a singleton next tick (never re-coalesced).
+			// Diverging shard: ship as a standalone singleton so its descent runs on
+			// any free worker. Clear descendDirect only on a successful send.
 			entry.shard.asyncRepWg.Add(1)
 			entry.inFlight = true
 			heap.Pop(&sched.h)
@@ -954,8 +925,7 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 
 		idx := entry.shard.index
 
-		// Reserve: Add(1) before send so Deregister+asyncRepWg.Wait() catches
-		// the cycle; pop so the loop can advance to the next due entry.
+		// Add(1) before send so Deregister+asyncRepWg.Wait() catches the cycle; pop to advance.
 		entry.shard.asyncRepWg.Add(1)
 		entry.inFlight = true
 		heap.Pop(&sched.h)
@@ -972,8 +942,8 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 		}
 	}
 
-	// Flush partial buckets. Never wait to fill: a bucket below the cap ships as
-	// a smaller batch. If the channel is full, roll the entries back instead.
+	// Flush partial buckets: a bucket below the cap ships as a smaller batch, or
+	// rolls back on a full channel.
 	for idx, entries := range sched.dispatchBuckets {
 		if len(entries) == 0 {
 			continue
@@ -996,13 +966,8 @@ func (sched *AsyncReplicationScheduler) onResultLocked(result asyncSchedulerResu
 	entry := result.entry
 	entry.inFlight = false
 
-	// Discard the result if the shard was deregistered, or deregistered and
-	// then re-registered under a fresh entry while this cycle's result was in
-	// flight. Matching on entry identity (not just shard-key presence) is
-	// required: a same-*Shard re-register (rebuildHashtree, runtime enable/
-	// disable) installs a new entry, and re-pushing this stale one would create
-	// a duplicate heap entry for the shard, letting two workers run
-	// runHashbeatCycle concurrently.
+	// Match on entry identity, not just shard presence: a same-*Shard re-register
+	// installs a new entry, and re-pushing this stale one would let two workers run.
 	if cur, ok := sched.entries[entry.shard]; !ok || cur != entry {
 		return
 	}
@@ -1013,10 +978,8 @@ func (sched *AsyncReplicationScheduler) onResultLocked(result asyncSchedulerResu
 		return
 	}
 
-	// The batched pre-filter classified this shard as diverging: re-enqueue it
-	// immediately with descendDirect set so dispatchDueLocked ships it as a
-	// standalone singleton descent rather than waiting a full cycle. Bypasses the
-	// interval computation below.
+	// Diverging: re-enqueue immediately with descendDirect so it descends as a
+	// singleton rather than waiting a full cycle. Bypasses the interval below.
 	if result.deferDescent {
 		entry.descendDirect = true
 		entry.nextRunAt = time.Now()
@@ -1097,11 +1060,8 @@ func (sched *AsyncReplicationScheduler) onRemoveLocked(s *Shard) {
 	sched.metrics.setQueueDepth(len(sched.h))
 }
 
-// drainWorkChOnExit empties workCh after the dispatcher has returned, balancing
-// the Add(1) that dispatchDueLocked did before each batched send. Dispatcher is
-// the sole producer so a single non-blocking pass suffices; channel receives are
-// atomic so concurrent workers can't double-take any batch. Iterates each
-// batch's members so every reserved entry's Add(1) is balanced.
+// drainWorkChOnExit empties workCh after the dispatcher returned, balancing each
+// reserved entry's Add(1). Single non-blocking pass suffices (sole producer).
 func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 	for {
 		select {
@@ -1121,9 +1081,8 @@ func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 
 // ----- worker goroutines ----------------------------------------------------
 
-// batchScratch holds the reusable maps a worker uses to classify a batch. Each
-// worker owns one and resets it per batch, so the pre-filter allocates no
-// per-batch maps and there is no cross-worker sharing (hence no contention).
+// batchScratch holds a worker's reusable classify maps, reset per batch: no
+// per-batch allocs and no cross-worker sharing.
 type batchScratch struct {
 	roots    map[string]hashtree.Digest
 	eligible map[string]*asyncSchedulerEntry
@@ -1247,18 +1206,16 @@ func (sched *AsyncReplicationScheduler) adjustWorkers(n int) {
 	}
 }
 
-// hasTargetNodeOverrides reports whether the shard has active target-node
-// overrides (tenant movement / manual push). Such shards are excluded from the
-// batched pre-filter and take the full per-shard path.
+// hasTargetNodeOverrides reports active target-node overrides (tenant movement /
+// manual push); such shards skip the pre-filter and take the full per-shard path.
 func (sched *AsyncReplicationScheduler) hasTargetNodeOverrides(s *Shard) bool {
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()
 	return len(s.targetNodeOverrides) > 0
 }
 
-// effectiveConfig snapshots a shard's async replication config, applying the
-// runtime global overrides the same way runEntry does. Used only to derive the
-// pre-filter RPC timeout for a batch.
+// effectiveConfig snapshots a shard's async replication config with runtime global
+// overrides applied, to derive the pre-filter RPC timeout for a batch.
 func (sched *AsyncReplicationScheduler) effectiveConfig(s *Shard) AsyncReplicationConfig {
 	s.asyncReplicationRWMux.RLock()
 	base := s.asyncReplicationConfig
@@ -1271,16 +1228,8 @@ func (sched *AsyncReplicationScheduler) effectiveConfig(s *Shard) AsyncReplicati
 	return cfg
 }
 
-// runBatch processes one dispatched batch. A single-entry batch (any collection
-// with just one due shard this cycle) goes straight to the full per-shard path.
-// For larger batches it runs the inline root pre-filter once for the whole batch
-// (Stage A, via classifyBatch), then handles each shard: in-sync shards
-// short-circuit inline with no network diff (runEntry with skip), while diverging
-// shards are handed back to the dispatcher (deferDescent) to be re-dispatched as
-// standalone singletons — so descent spreads across the whole pool instead of
-// serializing every diverging shard in this one worker. Exactly one result is
-// emitted per entry on every path, and the pooled slice is returned to batchPool
-// on exit. All entries in a batch share the same index (coalesced at dispatch).
+// runBatch pre-filters a batch once, short-circuits in-sync shards inline, and
+// defers diverging ones as singletons so descent spreads across the pool.
 func (sched *AsyncReplicationScheduler) runBatch(bp *[]*asyncSchedulerEntry, scratch *batchScratch) {
 	batch := *bp
 	defer func() {
@@ -1295,46 +1244,33 @@ func (sched *AsyncReplicationScheduler) runBatch(bp *[]*asyncSchedulerEntry, scr
 		return
 	}
 
-	// classifyBatch is panic-contained, so every entry is guaranteed to reach a
-	// runEntry call below — runEntry alone owns each entry's Done()+result, so
-	// asyncRepWg stays balanced even if the pre-filter blows up.
+	// classifyBatch is panic-contained, so every entry still reaches a runEntry
+	// call below — keeping each entry's Done()+result (asyncRepWg) balanced.
 	scratch.reset()
 	sched.classifyBatch(batch, scratch)
 	for _, entry := range batch {
 		if scratch.skip[entry] {
-			// In sync on every replica this cycle — short-circuit inline (cheap:
-			// no network descent, just the pending-rebuild check + skip metric).
+			// In sync this cycle — short-circuit inline (no network descent).
 			sched.runEntry(entry, true)
 			continue
 		}
-		// Diverging: don't descend inline (that would serialize the whole batch
-		// in this worker). Hand it back to the dispatcher for a standalone
-		// singleton descent spread across the pool.
+		// Diverging: hand back to the dispatcher for a singleton descent spread
+		// across the pool (descending inline would serialize the batch).
 		sched.deferDescent(entry)
 	}
 }
 
-// deferDescent releases a diverging batch entry back to the dispatcher without
-// descending it, so it is re-dispatched as a standalone singleton (see
-// dispatchDueLocked's descendDirect handling). It mirrors runEntry's wg/result
-// contract minimally — Done() before the send so the dispatcher's re-enqueue
-// sees a balanced asyncRepWg — but performs no runHashbeatCycle and touches no
-// workersActive metric (it never incremented one). Exactly one result per entry.
+// deferDescent releases a diverging entry back to the dispatcher (re-dispatched as
+// a singleton). Done() before the send so the re-enqueue sees a balanced asyncRepWg.
 func (sched *AsyncReplicationScheduler) deferDescent(entry *asyncSchedulerEntry) {
-	// Done() before the resultCh send, matching runEntry: inFlight (not
-	// asyncRepWg) enforces "at most one cycle per shard", and the buffered
-	// resultCh + Close()'s parallel drain keep this send non-blocking.
+	// Done() before the send, matching runEntry: inFlight (not asyncRepWg) enforces
+	// one cycle per shard; buffered resultCh + Close()'s drain keep the send non-blocking.
 	entry.shard.asyncRepWg.Done()
 	sched.resultCh <- asyncSchedulerResult{entry: entry, deferDescent: true}
 }
 
-// classifyBatch runs the inline root pre-filter for the batch, recording in
-// scratch.skip whether each entry's hashbeat descent can be skipped (confirmed
-// in sync on every replica). Ineligible shards (uninitialised hashtree or active
-// target-node overrides) and — on any pre-filter panic/failure — all shards are
-// classified "descend" (skip stays false), so correctness never depends on the
-// pre-filter succeeding. scratch is reset by the caller; its maps are reused
-// across batches. All entries share one index (coalesced at dispatch).
+// classifyBatch runs the root pre-filter, recording confirmed-in-sync entries in
+// scratch.skip; ineligible shards and any failure classify "descend" (conservative).
 func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEntry, scratch *batchScratch) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1365,9 +1301,8 @@ func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEnt
 	s0 := batch[0].shard
 	cfg := sched.effectiveConfig(s0)
 	ctx, cancel := context.WithTimeout(sched.ctx, cfg.diffPerNodeTimeout)
-	// defer so the timeout context/timer is released even if PrefilterShardRoots
-	// panics (the recover above catches it, but an inline cancel() would be
-	// skipped, leaking the timer until sched.ctx is done).
+	// defer so the timer is released even if PrefilterShardRoots panics (an inline
+	// cancel() would be skipped, leaking it until sched.ctx is done).
 	defer cancel()
 	needFull, stats := s0.index.replicator.PrefilterShardRoots(ctx, scratch.roots)
 	sched.metrics.observeRootPrefilterBatch(len(scratch.roots))
@@ -1474,9 +1409,8 @@ func (sched *AsyncReplicationScheduler) runEntry(entry *asyncSchedulerEntry, ski
 	}
 
 	if skipHashbeat {
-		// The batched root pre-filter already confirmed this shard is in sync on
-		// every replica this cycle (equal roots ⇒ no diff), so skip the network
-		// descent. Still honor a pending height-change rebuild.
+		// Pre-filter confirmed in sync this cycle (equal roots ⇒ no diff): skip the
+		// network descent, but still honor a pending height-change rebuild.
 		needsRebuild = s.asyncRepNeedsRebuild.CompareAndSwap(true, false)
 		sched.metrics.incRootPrefilterSkips()
 		return

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -418,10 +418,11 @@ type AsyncReplicationScheduler struct {
 	// for 30 s so the dispatcher wakes up promptly once the flag is cleared.
 	asyncReplicationDisabled *configRuntime.DynamicValue[bool]
 
-	// rootPrefilterBatchSize drives how many same-index shards are batched into
-	// one hashtree-root pre-filter RPC. 1 disables the pre-filter (per-shard
-	// path). Read per dispatch; invalid values (<= 0) warn once and fall back to
-	// the default, over-cap values are clamped.
+	// rootPrefilterBatchSize is a single cluster-wide value driving how many
+	// same-index (same-collection) shards are batched into one hashtree-root
+	// pre-filter RPC. 1 disables the pre-filter (per-shard path). Read per
+	// dispatch; invalid values (<= 0) warn once and fall back to the default,
+	// over-cap values are clamped.
 	rootPrefilterBatchSize *configRuntime.DynamicValue[int]
 	warnedBatchSizeInvalid atomic.Bool
 	warnedBatchSizeClamp   atomic.Bool
@@ -1270,8 +1271,8 @@ func (sched *AsyncReplicationScheduler) effectiveConfig(s *Shard) AsyncReplicati
 	return cfg
 }
 
-// runBatch processes one dispatched batch. A single-entry batch (the common case
-// for ST or a lightly-loaded MT class) goes straight to the full per-shard path.
+// runBatch processes one dispatched batch. A single-entry batch (any collection
+// with just one due shard this cycle) goes straight to the full per-shard path.
 // For larger batches it runs the inline root pre-filter once for the whole batch
 // (Stage A, via classifyBatch), then handles each shard: in-sync shards
 // short-circuit inline with no network diff (runEntry with skip), while diverging

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -994,9 +994,14 @@ func (sched *AsyncReplicationScheduler) onResultLocked(result asyncSchedulerResu
 	entry := result.entry
 	entry.inFlight = false
 
-	// If the shard is no longer in the registry it was deregistered while
-	// the cycle was running — do not re-enqueue.
-	if _, ok := sched.entries[entry.shard]; !ok {
+	// Discard the result if the shard was deregistered, or deregistered and
+	// then re-registered under a fresh entry while this cycle's result was in
+	// flight. Matching on entry identity (not just shard-key presence) is
+	// required: a same-*Shard re-register (rebuildHashtree, runtime enable/
+	// disable) installs a new entry, and re-pushing this stale one would create
+	// a duplicate heap entry for the shard, letting two workers run
+	// runHashbeatCycle concurrently.
+	if cur, ok := sched.entries[entry.shard]; !ok || cur != entry {
 		return
 	}
 

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -29,12 +29,22 @@ import (
 	"github.com/weaviate/weaviate/entities/replication"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
 const (
 	defaultAsyncReplicationSchedulerWorkers        = 10
 	defaultAsyncReplicationHashtreeInitConcurrency = 100
 	maxMaxWorkers                                  = 100
+
+	// Root pre-filter fallback batch sizes, used only when the runtime
+	// DynamicValue is nil (e.g. zero-valued config in tests); the real defaults
+	// are seeded from env. <=1 disables the batched root compare (per-shard path).
+	fallbackRootPrefilterBatchSizeMT = 512
+	fallbackRootPrefilterBatchSizeST = 1
+	// maxRootPrefilterBatchSize is the hard ceiling on shards per batch,
+	// bounding per-batch work and RPC message size regardless of runtime override.
+	maxRootPrefilterBatchSize = 4096
 
 	// asyncRepRebuildBaseBackoff is the wait after the first consecutive rebuild
 	// failure. Each subsequent failure doubles the wait up to asyncRepRebuildMaxBackoff.
@@ -158,6 +168,14 @@ type asyncReplicationSchedulerMetrics struct {
 	queueDepth prometheus.Gauge
 	// workerPoolSize is the current target worker pool size.
 	workerPoolSize prometheus.Gauge
+	// rootPrefilterSkips counts shard cycles short-circuited as in-sync by the
+	// batched root pre-filter (the "root RPC storm eliminated" headline).
+	rootPrefilterSkips prometheus.Counter
+	// rootPrefilterBatchSize observes the number of shards per pre-filter batch.
+	rootPrefilterBatchSize prometheus.Histogram
+	// rootCompareRPC counts batched root-compare RPCs by outcome
+	// (ok|error|unsupported).
+	rootCompareRPC *prometheus.CounterVec
 }
 
 func newAsyncReplicationSchedulerMetrics(prom *monitoring.PrometheusMetrics) (asyncReplicationSchedulerMetrics, error) {
@@ -215,6 +233,43 @@ func newAsyncReplicationSchedulerMetrics(prom *monitoring.PrometheusMetrics) (as
 		return m, err
 	}
 
+	m.rootPrefilterSkips, _, err = monitoring.EnsureRegisteredMetric(
+		prom.Registerer,
+		prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "weaviate",
+			Name:      "async_replication_root_prefilter_skips_total",
+			Help:      "Shard cycles short-circuited as in-sync by the batched hashtree-root pre-filter.",
+		}),
+	)
+	if err != nil {
+		return m, err
+	}
+
+	m.rootPrefilterBatchSize, _, err = monitoring.EnsureRegisteredMetric(
+		prom.Registerer,
+		prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "weaviate",
+			Name:      "async_replication_root_prefilter_batch_size",
+			Help:      "Number of shards compared in one batched hashtree-root pre-filter RPC group.",
+			Buckets:   []float64{1, 8, 32, 64, 128, 256, 512, 1024, 2048, 4096},
+		}),
+	)
+	if err != nil {
+		return m, err
+	}
+
+	m.rootCompareRPC, _, err = monitoring.EnsureRegisteredMetric(
+		prom.Registerer,
+		prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "weaviate",
+			Name:      "async_replication_root_compare_rpc_total",
+			Help:      "Batched hashtree-root compare RPCs by outcome.",
+		}, []string{"result"}),
+	)
+	if err != nil {
+		return m, err
+	}
+
 	return m, err
 }
 
@@ -251,6 +306,33 @@ func (m *asyncReplicationSchedulerMetrics) setQueueDepth(n int) {
 func (m *asyncReplicationSchedulerMetrics) setWorkerPoolSize(n int) {
 	if m.monitoring {
 		m.workerPoolSize.Set(float64(n))
+	}
+}
+
+func (m *asyncReplicationSchedulerMetrics) incRootPrefilterSkips() {
+	if m.monitoring {
+		m.rootPrefilterSkips.Inc()
+	}
+}
+
+func (m *asyncReplicationSchedulerMetrics) observeRootPrefilterBatch(n int) {
+	if m.monitoring {
+		m.rootPrefilterBatchSize.Observe(float64(n))
+	}
+}
+
+func (m *asyncReplicationSchedulerMetrics) addRootCompareRPC(ok, errored, unsupported int) {
+	if !m.monitoring {
+		return
+	}
+	if ok > 0 {
+		m.rootCompareRPC.WithLabelValues("ok").Add(float64(ok))
+	}
+	if errored > 0 {
+		m.rootCompareRPC.WithLabelValues("error").Add(float64(errored))
+	}
+	if unsupported > 0 {
+		m.rootCompareRPC.WithLabelValues("unsupported").Add(float64(unsupported))
 	}
 }
 
@@ -303,10 +385,13 @@ type AsyncReplicationScheduler struct {
 	// limit 10k concurrent scans would thrash disk and spike RSS.
 	hashtreeInitSem *semaphore.Weighted
 
-	// workCh feeds entries to the worker pool. Buffered (maxMaxWorkers) so
+	// workCh feeds batches to the worker pool. Buffered (maxMaxWorkers) so
 	// dispatchDueLocked sends in O(1) under sched.mu; a full buffer triggers
-	// "all workers busy" backpressure via the default branch.
-	workCh chan *asyncSchedulerEntry
+	// "all workers busy" backpressure via the default branch. Each item is a
+	// pooled batch of same-index entries (usually 1); a worker root-prefilters
+	// the batch then descends only the diverging shards, then returns it to
+	// batchPool. The pointer indirection lets the worker recycle the exact slice.
+	workCh chan *[]*asyncSchedulerEntry
 
 	// resultCh receives results from workers. Buffer absorbs normal-operation
 	// bursts; Close()'s parallel drain keeps runEntry's unconditional send
@@ -322,6 +407,22 @@ type AsyncReplicationScheduler struct {
 	// dispatchDueLocked skips all dispatching and timeUntilNextLocked sleeps
 	// for 30 s so the dispatcher wakes up promptly once the flag is cleared.
 	asyncReplicationDisabled *configRuntime.DynamicValue[bool]
+
+	// rootPrefilterBatchSize{MT,ST} drive how many same-index shards are batched
+	// into one hashtree-root pre-filter RPC (MT vs ST tuned separately). <=1
+	// disables the pre-filter. Read per dispatch; invalid values warn once and
+	// fall back to the default, over-cap values are clamped.
+	rootPrefilterBatchSizeMT *configRuntime.DynamicValue[int]
+	rootPrefilterBatchSizeST *configRuntime.DynamicValue[int]
+	warnedBatchSizeInvalid   atomic.Bool
+	warnedBatchSizeClamp     atomic.Bool
+
+	// batchPool recycles the []*asyncSchedulerEntry slices sent on workCh; the
+	// dispatcher acquires, the worker releases after emitting all results.
+	batchPool sync.Pool
+	// dispatchBuckets groups due entries by index during one dispatch pass.
+	// Dispatcher-owned (only touched under mu by the dispatcher goroutine).
+	dispatchBuckets map[*Index][]*asyncSchedulerEntry
 
 	metrics asyncReplicationSchedulerMetrics
 	logger  logrus.FieldLogger
@@ -380,6 +481,15 @@ func NewAsyncReplicationScheduler(
 		asyncReplicationDisabled = configRuntime.NewDynamicValue(false)
 	}
 
+	rootPrefilterBatchSizeMT := replicationCfg.AsyncReplicationRootPrefilterBatchSizeMT
+	if rootPrefilterBatchSizeMT == nil {
+		rootPrefilterBatchSizeMT = configRuntime.NewDynamicValue(fallbackRootPrefilterBatchSizeMT)
+	}
+	rootPrefilterBatchSizeST := replicationCfg.AsyncReplicationRootPrefilterBatchSizeST
+	if rootPrefilterBatchSizeST == nil {
+		rootPrefilterBatchSizeST = configRuntime.NewDynamicValue(fallbackRootPrefilterBatchSizeST)
+	}
+
 	if logger == nil {
 		logger = logrus.StandardLogger()
 	}
@@ -408,15 +518,22 @@ func NewAsyncReplicationScheduler(
 		targetWorkers:            workers,
 		maxWorkersConfig:         maxWorkersConfig,
 		scaleDownCh:              make(chan struct{}, maxMaxWorkers),
-		workCh:                   make(chan *asyncSchedulerEntry, maxMaxWorkers),
+		workCh:                   make(chan *[]*asyncSchedulerEntry, maxMaxWorkers),
 		resultCh:                 make(chan asyncSchedulerResult, maxMaxWorkers*2),
 		addCh:                    make(chan addRequest),
 		removeCh:                 make(chan removeRequest),
 		asyncReplicationDisabled: asyncReplicationDisabled,
+		rootPrefilterBatchSizeMT: rootPrefilterBatchSizeMT,
+		rootPrefilterBatchSizeST: rootPrefilterBatchSizeST,
+		dispatchBuckets:          make(map[*Index][]*asyncSchedulerEntry),
 		hashtreeInitSem:          semaphore.NewWeighted(int64(hashtreeInitConcurrency)),
 		metrics:                  m,
 		logger:                   logger,
 		runtimeClampWarner:       &asyncReplicationClampWarner{logger: logger},
+	}
+	s.batchPool.New = func() any {
+		b := make([]*asyncSchedulerEntry, 0, 64)
+		return &b
 	}
 	heap.Init(&s.h)
 
@@ -719,15 +836,79 @@ func (sched *AsyncReplicationScheduler) timeUntilNextLocked() time.Duration {
 	return d
 }
 
-// dispatchDueLocked pops entries whose nextRunAt has passed and sends them to
-// the worker pool. It stops if the channel is full (all workers busy).
-// mu must be held.
+// effectiveBatchSize returns the root pre-filter batch size for idx's tenancy
+// (MT vs ST), applying the runtime override with warn-and-default on invalid
+// values and a one-shot warn when clamped to the hard cap. <=1 means the
+// pre-filter is disabled (per-shard path). Called under mu.
+func (sched *AsyncReplicationScheduler) effectiveBatchSize(idx *Index) int {
+	dv := sched.rootPrefilterBatchSizeST
+	def := fallbackRootPrefilterBatchSizeST
+	if idx != nil && idx.partitioningEnabled {
+		dv = sched.rootPrefilterBatchSizeMT
+		def = fallbackRootPrefilterBatchSizeMT
+	}
+
+	n := def
+	if dv != nil {
+		n = dv.Get()
+	}
+	if n <= 0 {
+		if sched.warnedBatchSizeInvalid.CompareAndSwap(false, true) {
+			sched.logger.WithField("action", "async_replication_scheduler").
+				Warnf("invalid async replication root prefilter batch size %d; using default %d", n, def)
+		}
+		n = def
+	}
+	if n > maxRootPrefilterBatchSize {
+		if sched.warnedBatchSizeClamp.CompareAndSwap(false, true) {
+			sched.logger.WithField("action", "async_replication_scheduler").
+				Warnf("async replication root prefilter batch size %d exceeds max %d; clamping", n, maxRootPrefilterBatchSize)
+		}
+		n = maxRootPrefilterBatchSize
+	}
+	return n
+}
+
+// rollbackReservedLocked undoes a reserve (Add+inFlight+Pop) for an entry that
+// could not be dispatched, re-queuing it with a fresh seq. mu must be held.
+func (sched *AsyncReplicationScheduler) rollbackReservedLocked(entry *asyncSchedulerEntry) {
+	entry.inFlight = false
+	entry.shard.asyncRepWg.Done()
+	entry.seq = sched.nextSeq
+	sched.nextSeq++
+	heap.Push(&sched.h, entry)
+}
+
+// trySendBatchLocked copies entries into a pooled batch and non-blockingly sends
+// it to the worker pool. Returns false (releasing the pooled slice) if the
+// channel is full; the caller then rolls the entries back. mu must be held.
+func (sched *AsyncReplicationScheduler) trySendBatchLocked(entries []*asyncSchedulerEntry) bool {
+	bp := sched.batchPool.Get().(*[]*asyncSchedulerEntry)
+	*bp = append((*bp)[:0], entries...)
+	select {
+	case sched.workCh <- bp:
+		return true
+	default:
+		*bp = (*bp)[:0]
+		sched.batchPool.Put(bp)
+		return false
+	}
+}
+
+// dispatchDueLocked pops entries whose nextRunAt has passed, coalesces them by
+// index into batches (capped at the per-index effective batch size), and sends
+// each batch to the worker pool. It stops once the channel is full (all workers
+// busy), rolling any reserved-but-unsent entries back into the heap. mu must be
+// held. Per-entry accounting (Add/inFlight/Pop ↔ Done/re-push) is balanced on
+// every path.
 func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 	if sched.asyncReplicationDisabled.Get() {
 		return
 	}
 	now := time.Now()
-	for len(sched.h) > 0 && !sched.h[0].nextRunAt.After(now) {
+
+	full := false
+	for len(sched.h) > 0 && !sched.h[0].nextRunAt.After(now) && !full {
 		entry := sched.h[0]
 		if entry.inFlight {
 			// Invariant violation: heap entries must have inFlight=false
@@ -752,20 +933,39 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 			continue
 		}
 
-		// Add(1) before send so Deregister+asyncRepWg.Wait() catches the cycle.
+		idx := entry.shard.index
+
+		// Reserve: Add(1) before send so Deregister+asyncRepWg.Wait() catches
+		// the cycle; pop so the loop can advance to the next due entry.
 		entry.shard.asyncRepWg.Add(1)
 		entry.inFlight = true
+		heap.Pop(&sched.h)
 
-		select {
-		case sched.workCh <- entry:
-			heap.Pop(&sched.h)
-		default:
-			// All workers busy: roll back and leave entry in heap.
-			entry.inFlight = false
-			entry.shard.asyncRepWg.Done()
-			sched.metrics.setQueueDepth(len(sched.h))
-			return
+		sched.dispatchBuckets[idx] = append(sched.dispatchBuckets[idx], entry)
+		if len(sched.dispatchBuckets[idx]) >= sched.effectiveBatchSize(idx) {
+			if !sched.trySendBatchLocked(sched.dispatchBuckets[idx]) {
+				for _, e := range sched.dispatchBuckets[idx] {
+					sched.rollbackReservedLocked(e)
+				}
+				full = true
+			}
+			sched.dispatchBuckets[idx] = sched.dispatchBuckets[idx][:0]
 		}
+	}
+
+	// Flush partial buckets. Never wait to fill: a bucket below the cap ships as
+	// a smaller batch. If the channel is full, roll the entries back instead.
+	for idx, entries := range sched.dispatchBuckets {
+		if len(entries) == 0 {
+			continue
+		}
+		if full || !sched.trySendBatchLocked(entries) {
+			for _, e := range entries {
+				sched.rollbackReservedLocked(e)
+			}
+			full = true
+		}
+		sched.dispatchBuckets[idx] = entries[:0]
 	}
 	sched.metrics.setQueueDepth(len(sched.h))
 }
@@ -860,18 +1060,21 @@ func (sched *AsyncReplicationScheduler) onRemoveLocked(s *Shard) {
 }
 
 // drainWorkChOnExit empties workCh after the dispatcher has returned, balancing
-// the Add(1) that dispatchDueLocked did before each send. Dispatcher is the
-// sole producer so a single non-blocking pass suffices; channel receives are
-// atomic so concurrent workers can't double-take any entry.
+// the Add(1) that dispatchDueLocked did before each batched send. Dispatcher is
+// the sole producer so a single non-blocking pass suffices; channel receives are
+// atomic so concurrent workers can't double-take any batch. Iterates each
+// batch's members so every reserved entry's Add(1) is balanced.
 func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 	for {
 		select {
-		case entry, ok := <-sched.workCh:
-			if !ok || entry == nil {
+		case bp, ok := <-sched.workCh:
+			if !ok || bp == nil {
 				return
 			}
-			entry.inFlight = false
-			entry.shard.asyncRepWg.Done()
+			for _, entry := range *bp {
+				entry.inFlight = false
+				entry.shard.asyncRepWg.Done()
+			}
 		default:
 			return
 		}
@@ -880,16 +1083,40 @@ func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 
 // ----- worker goroutines ----------------------------------------------------
 
+// batchScratch holds the reusable maps a worker uses to classify a batch. Each
+// worker owns one and resets it per batch, so the pre-filter allocates no
+// per-batch maps and there is no cross-worker sharing (hence no contention).
+type batchScratch struct {
+	roots    map[string]hashtree.Digest
+	eligible map[string]*asyncSchedulerEntry
+	skip     map[*asyncSchedulerEntry]bool
+}
+
+func newBatchScratch() *batchScratch {
+	return &batchScratch{
+		roots:    make(map[string]hashtree.Digest),
+		eligible: make(map[string]*asyncSchedulerEntry),
+		skip:     make(map[*asyncSchedulerEntry]bool),
+	}
+}
+
+func (bs *batchScratch) reset() {
+	clear(bs.roots)
+	clear(bs.eligible)
+	clear(bs.skip)
+}
+
 func (sched *AsyncReplicationScheduler) worker() {
+	scratch := newBatchScratch()
 	for {
 		// Prioritise work over scale-down: prevents Go's random select from
 		// terminating a worker while items sit in workCh.
 		select {
-		case entry, ok := <-sched.workCh:
+		case bp, ok := <-sched.workCh:
 			if !ok {
 				return
 			}
-			sched.runEntry(entry)
+			sched.runBatch(bp, scratch)
 			continue
 		default:
 		}
@@ -900,11 +1127,11 @@ func (sched *AsyncReplicationScheduler) worker() {
 			return
 		case <-sched.scaleDownCh:
 			return
-		case entry, ok := <-sched.workCh:
+		case bp, ok := <-sched.workCh:
 			if !ok {
 				return
 			}
-			sched.runEntry(entry)
+			sched.runBatch(bp, scratch)
 		}
 	}
 }
@@ -982,7 +1209,112 @@ func (sched *AsyncReplicationScheduler) adjustWorkers(n int) {
 	}
 }
 
-func (sched *AsyncReplicationScheduler) runEntry(entry *asyncSchedulerEntry) {
+// hasTargetNodeOverrides reports whether the shard has active target-node
+// overrides (tenant movement / manual push). Such shards are excluded from the
+// batched pre-filter and take the full per-shard path.
+func (sched *AsyncReplicationScheduler) hasTargetNodeOverrides(s *Shard) bool {
+	s.asyncReplicationRWMux.RLock()
+	defer s.asyncReplicationRWMux.RUnlock()
+	return len(s.targetNodeOverrides) > 0
+}
+
+// effectiveConfig snapshots a shard's async replication config, applying the
+// runtime global overrides the same way runEntry does. Used only to derive the
+// pre-filter RPC timeout for a batch.
+func (sched *AsyncReplicationScheduler) effectiveConfig(s *Shard) AsyncReplicationConfig {
+	s.asyncReplicationRWMux.RLock()
+	base := s.asyncReplicationConfig
+	s.asyncReplicationRWMux.RUnlock()
+	cfg := base
+	if s.index != nil && s.index.globalreplicationConfig != nil {
+		sched.runtimeClampWarner.checkGlobals(*s.index.globalreplicationConfig)
+		cfg = base.Effective(*s.index.globalreplicationConfig)
+	}
+	return cfg
+}
+
+// runBatch processes one dispatched batch. A single-entry batch (the common case
+// for ST or a lightly-loaded MT class) goes straight to the full per-shard path.
+// For larger batches it runs the inline root pre-filter once for the whole batch
+// (Stage A, via classifyBatch), then descends (Stage B) only the shards that
+// diverge; in-sync shards short-circuit with no network diff. Exactly one result
+// is emitted per entry (via runEntry) on every path, and the pooled slice is
+// returned to batchPool on exit. All entries in a batch share the same index
+// (coalesced by index at dispatch).
+func (sched *AsyncReplicationScheduler) runBatch(bp *[]*asyncSchedulerEntry, scratch *batchScratch) {
+	batch := *bp
+	defer func() {
+		*bp = (*bp)[:0]
+		sched.batchPool.Put(bp)
+	}()
+
+	if len(batch) <= 1 {
+		if len(batch) == 1 {
+			sched.runEntry(batch[0], false)
+		}
+		return
+	}
+
+	// classifyBatch is panic-contained, so every entry is guaranteed to reach a
+	// runEntry call below — runEntry alone owns each entry's Done()+result, so
+	// asyncRepWg stays balanced even if the pre-filter blows up.
+	scratch.reset()
+	sched.classifyBatch(batch, scratch)
+	for _, entry := range batch {
+		sched.runEntry(entry, scratch.skip[entry])
+	}
+}
+
+// classifyBatch runs the inline root pre-filter for the batch, recording in
+// scratch.skip whether each entry's hashbeat descent can be skipped (confirmed
+// in sync on every replica). Ineligible shards (uninitialised hashtree or active
+// target-node overrides) and — on any pre-filter panic/failure — all shards are
+// classified "descend" (skip stays false), so correctness never depends on the
+// pre-filter succeeding. scratch is reset by the caller; its maps are reused
+// across batches. All entries share one index (coalesced at dispatch).
+func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEntry, scratch *batchScratch) {
+	defer func() {
+		if r := recover(); r != nil {
+			sched.logger.WithField("action", "async_replication_scheduler").
+				WithField("panic", r).
+				Error("recovered from panic in root pre-filter; forcing full descent for the batch")
+			enterrors.PrintStack(sched.logger)
+			clear(scratch.skip)
+		}
+	}()
+
+	for _, entry := range batch {
+		s := entry.shard
+		if sched.hasTargetNodeOverrides(s) {
+			continue
+		}
+		root, ok := s.HashTreeRoot()
+		if !ok {
+			continue
+		}
+		scratch.roots[s.name] = root
+		scratch.eligible[s.name] = entry
+	}
+	if len(scratch.roots) == 0 {
+		return
+	}
+
+	s0 := batch[0].shard
+	cfg := sched.effectiveConfig(s0)
+	ctx, cancel := context.WithTimeout(sched.ctx, cfg.diffPerNodeTimeout)
+	needFull, stats := s0.index.replicator.PrefilterShardRoots(ctx, scratch.roots)
+	cancel()
+	sched.metrics.observeRootPrefilterBatch(len(scratch.roots))
+	sched.metrics.addRootCompareRPC(stats.OK, stats.Errored, stats.Unsupported)
+
+	for name, entry := range scratch.eligible {
+		if _, diverges := needFull[name]; !diverges {
+			scratch.skip[entry] = true
+		}
+	}
+}
+
+func (sched *AsyncReplicationScheduler) runEntry(entry *asyncSchedulerEntry, skipHashbeat bool) {
 	sched.metrics.incWorkersActive()
 	s := entry.shard
 
@@ -1072,6 +1404,15 @@ func (sched *AsyncReplicationScheduler) runEntry(entry *asyncSchedulerEntry) {
 		// mayStopAsyncReplication fired between dispatch and now — return
 		// fast so asyncRepWg.Wait() unblocks promptly.
 		err = ctx.Err()
+		return
+	}
+
+	if skipHashbeat {
+		// The batched root pre-filter already confirmed this shard is in sync on
+		// every replica this cycle (equal roots ⇒ no diff), so skip the network
+		// descent. Still honor a pending height-change rebuild.
+		needsRebuild = s.asyncRepNeedsRebuild.CompareAndSwap(true, false)
+		sched.metrics.incRootPrefilterSkips()
 		return
 	}
 

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -39,7 +39,8 @@ const (
 
 	// Root pre-filter fallback batch size, used only when the runtime
 	// DynamicValue is nil (e.g. zero-valued config in tests); the real default
-	// is seeded from env. <=1 disables the batched root compare (per-shard path).
+	// is seeded from env. 1 disables the batched root compare (per-shard path);
+	// values <= 0 are invalid and fall back to the default.
 	fallbackRootPrefilterBatchSize = 512
 	// maxRootPrefilterBatchSize is the hard ceiling on shards per batch,
 	// bounding per-batch work and RPC message size regardless of runtime override.
@@ -417,9 +418,9 @@ type AsyncReplicationScheduler struct {
 	asyncReplicationDisabled *configRuntime.DynamicValue[bool]
 
 	// rootPrefilterBatchSize drives how many same-index shards are batched into
-	// one hashtree-root pre-filter RPC. <=1 disables the pre-filter. Read per
-	// dispatch; invalid values warn once and fall back to the default, over-cap
-	// values are clamped.
+	// one hashtree-root pre-filter RPC. 1 disables the pre-filter (per-shard
+	// path). Read per dispatch; invalid values (<= 0) warn once and fall back to
+	// the default, over-cap values are clamped.
 	rootPrefilterBatchSize *configRuntime.DynamicValue[int]
 	warnedBatchSizeInvalid atomic.Bool
 	warnedBatchSizeClamp   atomic.Bool
@@ -840,8 +841,8 @@ func (sched *AsyncReplicationScheduler) timeUntilNextLocked() time.Duration {
 
 // effectiveBatchSize returns the root pre-filter batch size, applying the
 // runtime override with warn-and-default on invalid values and a one-shot warn
-// when clamped to the hard cap. <=1 means the pre-filter is disabled (per-shard
-// path). Called under mu.
+// when clamped to the hard cap. A value of 1 disables the pre-filter (per-shard
+// path); values <= 0 are invalid and fall back to the default. Called under mu.
 func (sched *AsyncReplicationScheduler) effectiveBatchSize() int {
 	def := fallbackRootPrefilterBatchSize
 

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -27,6 +27,7 @@ import (
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/replication"
+	"github.com/weaviate/weaviate/usecases/config"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
@@ -37,14 +38,14 @@ const (
 	defaultAsyncReplicationHashtreeInitConcurrency = 100
 	maxMaxWorkers                                  = 100
 
-	// Root pre-filter fallback batch size, used only when the runtime
-	// DynamicValue is nil (e.g. zero-valued config in tests); the real default
-	// is seeded from env. 1 disables the batched root compare (per-shard path);
-	// values <= 0 are invalid and fall back to the default.
-	fallbackRootPrefilterBatchSize = 512
-	// maxRootPrefilterBatchSize is the hard ceiling on shards per batch,
-	// bounding per-batch work and RPC message size regardless of runtime override.
-	maxRootPrefilterBatchSize = 4096
+	// Root pre-filter batch defaults/cap. usecases/config is the single source of
+	// truth (also the env-parse default); these are local aliases so the scheduler
+	// reads without repeating the literals. fallback is used only when the runtime
+	// DynamicValue is nil (e.g. zero-valued config in tests). 1 disables the
+	// batched root compare (per-shard path); values <= 0 fall back to the default;
+	// the cap bounds per-batch work / RPC message size regardless of override.
+	fallbackRootPrefilterBatchSize = config.DefaultAsyncReplicationRootPrefilterBatchSize
+	maxRootPrefilterBatchSize      = config.MaxAsyncReplicationRootPrefilterBatchSize
 
 	// asyncRepRebuildBaseBackoff is the wait after the first consecutive rebuild
 	// failure. Each subsequent failure doubles the wait up to asyncRepRebuildMaxBackoff.

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -37,11 +37,10 @@ const (
 	defaultAsyncReplicationHashtreeInitConcurrency = 100
 	maxMaxWorkers                                  = 100
 
-	// Root pre-filter fallback batch sizes, used only when the runtime
-	// DynamicValue is nil (e.g. zero-valued config in tests); the real defaults
-	// are seeded from env. <=1 disables the batched root compare (per-shard path).
-	fallbackRootPrefilterBatchSizeMT = 512
-	fallbackRootPrefilterBatchSizeST = 1
+	// Root pre-filter fallback batch size, used only when the runtime
+	// DynamicValue is nil (e.g. zero-valued config in tests); the real default
+	// is seeded from env. <=1 disables the batched root compare (per-shard path).
+	fallbackRootPrefilterBatchSize = 512
 	// maxRootPrefilterBatchSize is the hard ceiling on shards per batch,
 	// bounding per-batch work and RPC message size regardless of runtime override.
 	maxRootPrefilterBatchSize = 4096
@@ -408,14 +407,13 @@ type AsyncReplicationScheduler struct {
 	// for 30 s so the dispatcher wakes up promptly once the flag is cleared.
 	asyncReplicationDisabled *configRuntime.DynamicValue[bool]
 
-	// rootPrefilterBatchSize{MT,ST} drive how many same-index shards are batched
-	// into one hashtree-root pre-filter RPC (MT vs ST tuned separately). <=1
-	// disables the pre-filter. Read per dispatch; invalid values warn once and
-	// fall back to the default, over-cap values are clamped.
-	rootPrefilterBatchSizeMT *configRuntime.DynamicValue[int]
-	rootPrefilterBatchSizeST *configRuntime.DynamicValue[int]
-	warnedBatchSizeInvalid   atomic.Bool
-	warnedBatchSizeClamp     atomic.Bool
+	// rootPrefilterBatchSize drives how many same-index shards are batched into
+	// one hashtree-root pre-filter RPC. <=1 disables the pre-filter. Read per
+	// dispatch; invalid values warn once and fall back to the default, over-cap
+	// values are clamped.
+	rootPrefilterBatchSize *configRuntime.DynamicValue[int]
+	warnedBatchSizeInvalid atomic.Bool
+	warnedBatchSizeClamp   atomic.Bool
 
 	// batchPool recycles the []*asyncSchedulerEntry slices sent on workCh; the
 	// dispatcher acquires, the worker releases after emitting all results.
@@ -481,13 +479,9 @@ func NewAsyncReplicationScheduler(
 		asyncReplicationDisabled = configRuntime.NewDynamicValue(false)
 	}
 
-	rootPrefilterBatchSizeMT := replicationCfg.AsyncReplicationRootPrefilterBatchSizeMT
-	if rootPrefilterBatchSizeMT == nil {
-		rootPrefilterBatchSizeMT = configRuntime.NewDynamicValue(fallbackRootPrefilterBatchSizeMT)
-	}
-	rootPrefilterBatchSizeST := replicationCfg.AsyncReplicationRootPrefilterBatchSizeST
-	if rootPrefilterBatchSizeST == nil {
-		rootPrefilterBatchSizeST = configRuntime.NewDynamicValue(fallbackRootPrefilterBatchSizeST)
+	rootPrefilterBatchSize := replicationCfg.AsyncReplicationRootPrefilterBatchSize
+	if rootPrefilterBatchSize == nil {
+		rootPrefilterBatchSize = configRuntime.NewDynamicValue(fallbackRootPrefilterBatchSize)
 	}
 
 	if logger == nil {
@@ -523,8 +517,7 @@ func NewAsyncReplicationScheduler(
 		addCh:                    make(chan addRequest),
 		removeCh:                 make(chan removeRequest),
 		asyncReplicationDisabled: asyncReplicationDisabled,
-		rootPrefilterBatchSizeMT: rootPrefilterBatchSizeMT,
-		rootPrefilterBatchSizeST: rootPrefilterBatchSizeST,
+		rootPrefilterBatchSize:   rootPrefilterBatchSize,
 		dispatchBuckets:          make(map[*Index][]*asyncSchedulerEntry),
 		hashtreeInitSem:          semaphore.NewWeighted(int64(hashtreeInitConcurrency)),
 		metrics:                  m,
@@ -836,21 +829,16 @@ func (sched *AsyncReplicationScheduler) timeUntilNextLocked() time.Duration {
 	return d
 }
 
-// effectiveBatchSize returns the root pre-filter batch size for idx's tenancy
-// (MT vs ST), applying the runtime override with warn-and-default on invalid
-// values and a one-shot warn when clamped to the hard cap. <=1 means the
-// pre-filter is disabled (per-shard path). Called under mu.
-func (sched *AsyncReplicationScheduler) effectiveBatchSize(idx *Index) int {
-	dv := sched.rootPrefilterBatchSizeST
-	def := fallbackRootPrefilterBatchSizeST
-	if idx != nil && idx.partitioningEnabled {
-		dv = sched.rootPrefilterBatchSizeMT
-		def = fallbackRootPrefilterBatchSizeMT
-	}
+// effectiveBatchSize returns the root pre-filter batch size, applying the
+// runtime override with warn-and-default on invalid values and a one-shot warn
+// when clamped to the hard cap. <=1 means the pre-filter is disabled (per-shard
+// path). Called under mu.
+func (sched *AsyncReplicationScheduler) effectiveBatchSize() int {
+	def := fallbackRootPrefilterBatchSize
 
 	n := def
-	if dv != nil {
-		n = dv.Get()
+	if sched.rootPrefilterBatchSize != nil {
+		n = sched.rootPrefilterBatchSize.Get()
 	}
 	if n <= 0 {
 		if sched.warnedBatchSizeInvalid.CompareAndSwap(false, true) {
@@ -942,7 +930,7 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 		heap.Pop(&sched.h)
 
 		sched.dispatchBuckets[idx] = append(sched.dispatchBuckets[idx], entry)
-		if len(sched.dispatchBuckets[idx]) >= sched.effectiveBatchSize(idx) {
+		if len(sched.dispatchBuckets[idx]) >= sched.effectiveBatchSize() {
 			if !sched.trySendBatchLocked(sched.dispatchBuckets[idx]) {
 				for _, e := range sched.dispatchBuckets[idx] {
 					sched.rollbackReservedLocked(e)

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -78,6 +78,11 @@ type asyncSchedulerEntry struct {
 	nextRunAt time.Time
 	inFlight  bool // true while a worker is executing runHashbeatCycle
 	heapIdx   int  // maintained by the heap for O(log n) Fix/Remove
+	// descendDirect marks an entry the batched pre-filter already classified as
+	// diverging: dispatchDueLocked ships it as a standalone singleton for descent
+	// (bypassing coalescing and the pre-filter) so mass-divergence descents spread
+	// across the pool instead of serializing in one worker. Guarded by sched.mu.
+	descendDirect bool
 	// seq is a monotonically-increasing counter assigned every time the entry
 	// is pushed onto the heap. Entries with the same nextRunAt are served in
 	// the order they were enqueued (FIFO within a tie).
@@ -125,6 +130,10 @@ type asyncSchedulerResult struct {
 	entry      *asyncSchedulerEntry
 	propagated bool
 	err        error
+	// deferDescent is set by deferDescent: the batched pre-filter classified this
+	// entry as diverging, so onResultLocked re-enqueues it immediately with
+	// descendDirect set rather than scheduling the next cycle at frequency.
+	deferDescent bool
 	// cfg is the effective config snapshot used for this cycle, pre-read in
 	// the worker. onResultLocked uses it to avoid acquiring
 	// asyncReplicationRWMux.RLock() while sched.mu is held.
@@ -921,6 +930,25 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 			continue
 		}
 
+		if entry.descendDirect {
+			// Pre-filter already classified this shard as diverging: ship it as a
+			// standalone singleton (bypassing coalescing and the pre-filter) so
+			// its descent runs on any free worker instead of serializing behind a
+			// full batch. Reserve, then clear the flag only on a successful send —
+			// on a full channel rollbackReservedLocked re-queues it with the flag
+			// intact so it retries as a singleton next tick (never re-coalesced).
+			entry.shard.asyncRepWg.Add(1)
+			entry.inFlight = true
+			heap.Pop(&sched.h)
+			if sched.trySendBatchLocked([]*asyncSchedulerEntry{entry}) {
+				entry.descendDirect = false
+			} else {
+				sched.rollbackReservedLocked(entry)
+				full = true
+			}
+			continue
+		}
+
 		idx := entry.shard.index
 
 		// Reserve: Add(1) before send so Deregister+asyncRepWg.Wait() catches
@@ -974,6 +1002,20 @@ func (sched *AsyncReplicationScheduler) onResultLocked(result asyncSchedulerResu
 	// Skip re-push if dispatchDueLocked's invariant-violation recovery
 	// already re-queued this entry (heapIdx >= 0 ⇒ in heap).
 	if entry.heapIdx >= 0 {
+		return
+	}
+
+	// The batched pre-filter classified this shard as diverging: re-enqueue it
+	// immediately with descendDirect set so dispatchDueLocked ships it as a
+	// standalone singleton descent rather than waiting a full cycle. Bypasses the
+	// interval computation below.
+	if result.deferDescent {
+		entry.descendDirect = true
+		entry.nextRunAt = time.Now()
+		entry.seq = sched.nextSeq
+		sched.nextSeq++
+		heap.Push(&sched.h, entry)
+		sched.metrics.setQueueDepth(len(sched.h))
 		return
 	}
 
@@ -1224,11 +1266,13 @@ func (sched *AsyncReplicationScheduler) effectiveConfig(s *Shard) AsyncReplicati
 // runBatch processes one dispatched batch. A single-entry batch (the common case
 // for ST or a lightly-loaded MT class) goes straight to the full per-shard path.
 // For larger batches it runs the inline root pre-filter once for the whole batch
-// (Stage A, via classifyBatch), then descends (Stage B) only the shards that
-// diverge; in-sync shards short-circuit with no network diff. Exactly one result
-// is emitted per entry (via runEntry) on every path, and the pooled slice is
-// returned to batchPool on exit. All entries in a batch share the same index
-// (coalesced by index at dispatch).
+// (Stage A, via classifyBatch), then handles each shard: in-sync shards
+// short-circuit inline with no network diff (runEntry with skip), while diverging
+// shards are handed back to the dispatcher (deferDescent) to be re-dispatched as
+// standalone singletons — so descent spreads across the whole pool instead of
+// serializing every diverging shard in this one worker. Exactly one result is
+// emitted per entry on every path, and the pooled slice is returned to batchPool
+// on exit. All entries in a batch share the same index (coalesced at dispatch).
 func (sched *AsyncReplicationScheduler) runBatch(bp *[]*asyncSchedulerEntry, scratch *batchScratch) {
 	batch := *bp
 	defer func() {
@@ -1249,8 +1293,31 @@ func (sched *AsyncReplicationScheduler) runBatch(bp *[]*asyncSchedulerEntry, scr
 	scratch.reset()
 	sched.classifyBatch(batch, scratch)
 	for _, entry := range batch {
-		sched.runEntry(entry, scratch.skip[entry])
+		if scratch.skip[entry] {
+			// In sync on every replica this cycle — short-circuit inline (cheap:
+			// no network descent, just the pending-rebuild check + skip metric).
+			sched.runEntry(entry, true)
+			continue
+		}
+		// Diverging: don't descend inline (that would serialize the whole batch
+		// in this worker). Hand it back to the dispatcher for a standalone
+		// singleton descent spread across the pool.
+		sched.deferDescent(entry)
 	}
+}
+
+// deferDescent releases a diverging batch entry back to the dispatcher without
+// descending it, so it is re-dispatched as a standalone singleton (see
+// dispatchDueLocked's descendDirect handling). It mirrors runEntry's wg/result
+// contract minimally — Done() before the send so the dispatcher's re-enqueue
+// sees a balanced asyncRepWg — but performs no runHashbeatCycle and touches no
+// workersActive metric (it never incremented one). Exactly one result per entry.
+func (sched *AsyncReplicationScheduler) deferDescent(entry *asyncSchedulerEntry) {
+	// Done() before the resultCh send, matching runEntry: inFlight (not
+	// asyncRepWg) enforces "at most one cycle per shard", and the buffered
+	// resultCh + Close()'s parallel drain keep this send non-blocking.
+	entry.shard.asyncRepWg.Done()
+	sched.resultCh <- asyncSchedulerResult{entry: entry, deferDescent: true}
 }
 
 // classifyBatch runs the inline root pre-filter for the batch, recording in
@@ -1290,8 +1357,11 @@ func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEnt
 	s0 := batch[0].shard
 	cfg := sched.effectiveConfig(s0)
 	ctx, cancel := context.WithTimeout(sched.ctx, cfg.diffPerNodeTimeout)
+	// defer so the timeout context/timer is released even if PrefilterShardRoots
+	// panics (the recover above catches it, but an inline cancel() would be
+	// skipped, leaking the timer until sched.ctx is done).
+	defer cancel()
 	needFull, stats := s0.index.replicator.PrefilterShardRoots(ctx, scratch.roots)
-	cancel()
 	sched.metrics.observeRootPrefilterBatch(len(scratch.roots))
 	sched.metrics.addRootCompareRPC(stats.OK, stats.Errored, stats.Unsupported)
 

--- a/adapters/repos/db/async_replication_scheduler_integration_test.go
+++ b/adapters/repos/db/async_replication_scheduler_integration_test.go
@@ -131,8 +131,8 @@ func TestAsyncSchedulerRegistrationIdempotent(t *testing.T) {
 	s.asyncRepWg.Wait()
 }
 
-// TestIndexCompareHashTreeRoots: a shard diverges iff its local root differs, is
-// missing, or its hashtree is uninitialised; an equal initialised root is omitted.
+// TestIndexCompareHashTreeRoots: a shard diverges iff its local root was read and
+// differs; missing/uninitialised roots are omitted.
 func TestIndexCompareHashTreeRoots(t *testing.T) {
 	ctx := context.Background()
 	_, idx := testShard(t, ctx, "CompareRootsClass")
@@ -153,18 +153,18 @@ func TestIndexCompareHashTreeRoots(t *testing.T) {
 		assert.Equal(t, []string{shardName}, div)
 	})
 
-	t.Run("unknown shard is diverging", func(t *testing.T) {
+	t.Run("unknown shard is omitted", func(t *testing.T) {
 		div, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{"no-such-shard": {1, 2}})
 		require.NoError(t, err)
-		assert.Equal(t, []string{"no-such-shard"}, div)
+		assert.Empty(t, div)
 	})
 
-	t.Run("uninitialised hashtree is diverging", func(t *testing.T) {
+	t.Run("uninitialised hashtree is omitted", func(t *testing.T) {
 		s.hashtreeFullyInitialized = false
 		defer func() { s.hashtreeFullyInitialized = true }()
 		div, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{shardName: localRoot})
 		require.NoError(t, err)
-		assert.Equal(t, []string{shardName}, div)
+		assert.Empty(t, div)
 	})
 }
 

--- a/adapters/repos/db/async_replication_scheduler_integration_test.go
+++ b/adapters/repos/db/async_replication_scheduler_integration_test.go
@@ -131,10 +131,8 @@ func TestAsyncSchedulerRegistrationIdempotent(t *testing.T) {
 	s.asyncRepWg.Wait()
 }
 
-// TestIndexCompareHashTreeRoots exercises the target/server side of the batched
-// root pre-filter: a shard is reported diverging iff its local root differs, it
-// is missing locally, or its hashtree is not fully initialised; an equal,
-// initialised root is omitted.
+// TestIndexCompareHashTreeRoots: a shard diverges iff its local root differs, is
+// missing, or its hashtree is uninitialised; an equal initialised root is omitted.
 func TestIndexCompareHashTreeRoots(t *testing.T) {
 	ctx := context.Background()
 	_, idx := testShard(t, ctx, "CompareRootsClass")

--- a/adapters/repos/db/async_replication_scheduler_integration_test.go
+++ b/adapters/repos/db/async_replication_scheduler_integration_test.go
@@ -131,6 +131,45 @@ func TestAsyncSchedulerRegistrationIdempotent(t *testing.T) {
 	s.asyncRepWg.Wait()
 }
 
+// TestIndexCompareHashTreeRoots exercises the target/server side of the batched
+// root pre-filter: a shard is reported diverging iff its local root differs, it
+// is missing locally, or its hashtree is not fully initialised; an equal,
+// initialised root is omitted.
+func TestIndexCompareHashTreeRoots(t *testing.T) {
+	ctx := context.Background()
+	_, idx := testShard(t, ctx, "CompareRootsClass")
+	s := firstShard(t, idx)
+	prepareShardForScheduler(t, s)
+	shardName := s.name
+	localRoot := s.hashtree.Root()
+
+	t.Run("equal root is omitted", func(t *testing.T) {
+		div, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{shardName: localRoot})
+		require.NoError(t, err)
+		assert.Empty(t, div)
+	})
+
+	t.Run("differing root is diverging", func(t *testing.T) {
+		div, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{shardName: {99, 99}})
+		require.NoError(t, err)
+		assert.Equal(t, []string{shardName}, div)
+	})
+
+	t.Run("unknown shard is diverging", func(t *testing.T) {
+		div, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{"no-such-shard": {1, 2}})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"no-such-shard"}, div)
+	})
+
+	t.Run("uninitialised hashtree is diverging", func(t *testing.T) {
+		s.hashtreeFullyInitialized = false
+		defer func() { s.hashtreeFullyInitialized = true }()
+		div, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{shardName: localRoot})
+		require.NoError(t, err)
+		assert.Equal(t, []string{shardName}, div)
+	})
+}
+
 // TestAsyncSchedulerDeregistrationIdempotent verifies that deregistering a
 // shard that was never registered is a silent no-op.
 func TestAsyncSchedulerDeregistrationIdempotent(t *testing.T) {

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"container/heap"
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
@@ -1584,3 +1586,225 @@ func TestSchedulerClose_BoundedAndCancelsContextsWhenShardsStillRegistered(t *te
 
 // durationPtr is a helper that returns a pointer to a time.Duration value.
 func durationPtr(d time.Duration) *time.Duration { return &d }
+
+// newBareScheduler builds a scheduler struct without starting any goroutines, so
+// dispatchDueLocked/effectiveBatchSize can be exercised deterministically.
+func newBareScheduler(mt, st, workChCap int) *AsyncReplicationScheduler {
+	s := &AsyncReplicationScheduler{
+		entries:                  make(map[*Shard]*asyncSchedulerEntry),
+		dispatchBuckets:          make(map[*Index][]*asyncSchedulerEntry),
+		workCh:                   make(chan *[]*asyncSchedulerEntry, workChCap),
+		asyncReplicationDisabled: configRuntime.NewDynamicValue(false),
+		rootPrefilterBatchSizeMT: configRuntime.NewDynamicValue(mt),
+		rootPrefilterBatchSizeST: configRuntime.NewDynamicValue(st),
+		logger:                   logrus.New(),
+	}
+	s.batchPool.New = func() any {
+		b := make([]*asyncSchedulerEntry, 0, 64)
+		return &b
+	}
+	heap.Init(&s.h)
+	return s
+}
+
+func drainBatchSizes(ch chan *[]*asyncSchedulerEntry) []int {
+	var sizes []int
+	for {
+		select {
+		case bp := <-ch:
+			sizes = append(sizes, len(*bp))
+		default:
+			return sizes
+		}
+	}
+}
+
+// TestRunBatchEmitsOneResultPerEntry verifies that every entry in a multi-entry
+// batch produces exactly one result via runEntry — the invariant that keeps
+// asyncRepWg balanced (runEntry alone owns each entry's Done()+result).
+func TestRunBatchEmitsOneResultPerEntry(t *testing.T) {
+	sched := newBareScheduler(512, 512, 1)
+	sched.ctx = context.Background()
+	sched.resultCh = make(chan asyncSchedulerResult, 8)
+
+	entries := make([]*asyncSchedulerEntry, 3)
+	for i := range entries {
+		s := &Shard{class: &models.Class{Class: "C"}}
+		s.asyncRepWg.Add(1)
+		entries[i] = &asyncSchedulerEntry{shard: s}
+	}
+
+	sched.runBatch(&entries, newBatchScratch())
+
+	got := map[*asyncSchedulerEntry]int{}
+	for range entries {
+		select {
+		case r := <-sched.resultCh:
+			got[r.entry]++
+		case <-time.After(time.Second):
+			t.Fatal("missing result for a batch entry")
+		}
+	}
+	for _, e := range entries {
+		assert.Equal(t, 1, got[e], "each entry must yield exactly one result")
+		e.shard.asyncRepWg.Wait()
+	}
+}
+
+// TestAsyncSchedulerConcurrentBatchedDispatch drives the real scheduler's
+// multi-entry batched path (coalesce → pooled hand-off → runBatch → per-entry
+// runEntry, plus rollback and shutdown drain) while Register/Deregister race
+// against Close. Shards share one MT index so due entries coalesce into batches
+// of >1; uninitialised hashtrees keep classifyBatch from issuing RPCs. Run under
+// -race, it guards the §concurrency-safety invariants: no data race on the batch
+// machinery, no deadlock, and balanced asyncRepWg on every path.
+func TestAsyncSchedulerConcurrentBatchedDispatch(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	sched, err := NewAsyncReplicationScheduler(context.Background(), replication.GlobalConfig{
+		AsyncReplicationSchedulerWorkers:         configRuntime.NewDynamicValue(4),
+		AsyncReplicationDisabled:                 configRuntime.NewDynamicValue(false),
+		AsyncReplicationRootPrefilterBatchSizeMT: configRuntime.NewDynamicValue(3),
+	}, nil, logger)
+	require.NoError(t, err)
+
+	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}
+	shards := make([]*Shard, 30)
+	for i := range shards {
+		shards[i] = &Shard{index: idx, class: &models.Class{Class: "MT"}, name: fmt.Sprintf("t%02d", i)}
+	}
+
+	var wg sync.WaitGroup
+	for _, s := range shards {
+		s := s
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = sched.Register(s)
+			time.Sleep(5 * time.Millisecond)
+			_ = sched.Deregister(s)
+		}()
+	}
+
+	time.Sleep(8 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		sched.Close()
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("scheduler did not terminate — possible deadlock in batched dispatch")
+	}
+
+	for _, s := range shards {
+		s.asyncRepWg.Wait()
+	}
+}
+
+// TestClassifyBatchExcludesIneligible verifies that shards with active
+// target-node overrides or an uninitialised hashtree are excluded from the
+// batched pre-filter (no RPC issued) and default to a full descent.
+func TestClassifyBatchExcludesIneligible(t *testing.T) {
+	sched := newBareScheduler(512, 512, 1)
+	sched.ctx = context.Background()
+
+	override := &Shard{class: &models.Class{Class: "C"}}
+	override.targetNodeOverrides = additional.AsyncReplicationTargetNodeOverrides{{TargetNode: "n2"}}
+	uninit := &Shard{class: &models.Class{Class: "C"}}
+
+	batch := []*asyncSchedulerEntry{{shard: override}, {shard: uninit}}
+	scratch := newBatchScratch()
+
+	sched.classifyBatch(batch, scratch)
+
+	assert.Empty(t, scratch.roots, "no eligible shard ⇒ no roots collected")
+	assert.Empty(t, scratch.eligible)
+	for _, e := range batch {
+		assert.False(t, scratch.skip[e], "ineligible shards must take the full descent")
+	}
+}
+
+func TestEffectiveBatchSize(t *testing.T) {
+	mtIdx := &Index{partitioningEnabled: true}
+	stIdx := &Index{partitioningEnabled: false}
+
+	t.Run("MT and ST pick their own value", func(t *testing.T) {
+		sched := newBareScheduler(256, 4, 1)
+		assert.Equal(t, 256, sched.effectiveBatchSize(mtIdx))
+		assert.Equal(t, 4, sched.effectiveBatchSize(stIdx))
+	})
+
+	t.Run("invalid falls back to default", func(t *testing.T) {
+		sched := newBareScheduler(0, -5, 1)
+		assert.Equal(t, fallbackRootPrefilterBatchSizeMT, sched.effectiveBatchSize(mtIdx))
+		assert.Equal(t, fallbackRootPrefilterBatchSizeST, sched.effectiveBatchSize(stIdx))
+	})
+
+	t.Run("over cap is clamped", func(t *testing.T) {
+		sched := newBareScheduler(maxRootPrefilterBatchSize+1000, 1, 1)
+		assert.Equal(t, maxRootPrefilterBatchSize, sched.effectiveBatchSize(mtIdx))
+	})
+}
+
+func TestDispatchDueCoalescing(t *testing.T) {
+	t.Run("MT coalesces up to batch size with a smaller final batch", func(t *testing.T) {
+		sched := newBareScheduler(3, 1, 16)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}, partitioningEnabled: true}
+		for range 7 {
+			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
+		}
+
+		sched.dispatchDueLocked()
+
+		assert.ElementsMatch(t, []int{3, 3, 1}, drainBatchSizes(sched.workCh))
+		assert.Empty(t, sched.h, "all due entries dispatched")
+	})
+
+	t.Run("ST dispatches singletons", func(t *testing.T) {
+		sched := newBareScheduler(512, 1, 16)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}, partitioningEnabled: false}
+		for range 4 {
+			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
+		}
+
+		sched.dispatchDueLocked()
+
+		assert.ElementsMatch(t, []int{1, 1, 1, 1}, drainBatchSizes(sched.workCh))
+	})
+
+	t.Run("distinct indexes are batched separately", func(t *testing.T) {
+		sched := newBareScheduler(512, 512, 16)
+		a := &Index{Config: IndexConfig{ClassName: "A"}, partitioningEnabled: true}
+		b := &Index{Config: IndexConfig{ClassName: "B"}, partitioningEnabled: true}
+		for range 3 {
+			sched.onAddLocked(&Shard{index: a, class: &models.Class{Class: "A"}})
+		}
+		for range 2 {
+			sched.onAddLocked(&Shard{index: b, class: &models.Class{Class: "B"}})
+		}
+
+		sched.dispatchDueLocked()
+
+		assert.ElementsMatch(t, []int{3, 2}, drainBatchSizes(sched.workCh))
+	})
+
+	t.Run("full channel rolls unsent entries back into the heap", func(t *testing.T) {
+		sched := newBareScheduler(1, 1, 2)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}, partitioningEnabled: false}
+		for range 5 {
+			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
+		}
+
+		sched.dispatchDueLocked()
+
+		assert.Len(t, drainBatchSizes(sched.workCh), 2, "channel capacity bounds dispatched batches")
+		assert.Len(t, sched.h, 3, "unsent entries rolled back into the heap")
+		for _, e := range sched.h {
+			assert.False(t, e.inFlight, "rolled-back entries must not be in-flight")
+		}
+	})
+}

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1587,8 +1587,7 @@ func TestSchedulerClose_BoundedAndCancelsContextsWhenShardsStillRegistered(t *te
 // durationPtr is a helper that returns a pointer to a time.Duration value.
 func durationPtr(d time.Duration) *time.Duration { return &d }
 
-// newBareScheduler builds a scheduler struct without starting any goroutines, so
-// dispatchDueLocked/effectiveBatchSize can be exercised deterministically.
+// newBareScheduler builds a scheduler struct without starting any goroutines.
 func newBareScheduler(batchSize, workChCap int) *AsyncReplicationScheduler {
 	s := &AsyncReplicationScheduler{
 		entries:                  make(map[*Shard]*asyncSchedulerEntry),
@@ -1642,9 +1641,7 @@ func drainResults(ch chan asyncSchedulerResult) []asyncSchedulerResult {
 	}
 }
 
-// TestRunBatchEmitsOneResultPerEntry verifies that every entry in a multi-entry
-// batch produces exactly one result via runEntry — the invariant that keeps
-// asyncRepWg balanced (runEntry alone owns each entry's Done()+result).
+// TestRunBatchEmitsOneResultPerEntry: every entry in a batch yields exactly one result.
 func TestRunBatchEmitsOneResultPerEntry(t *testing.T) {
 	sched := newBareScheduler(512, 1)
 	sched.ctx = context.Background()
@@ -1674,13 +1671,8 @@ func TestRunBatchEmitsOneResultPerEntry(t *testing.T) {
 	}
 }
 
-// TestAsyncSchedulerConcurrentBatchedDispatch drives the real scheduler's
-// multi-entry batched path (coalesce → pooled hand-off → runBatch → per-entry
-// runEntry, plus rollback and shutdown drain) while Register/Deregister race
-// against Close. Shards share one MT index so due entries coalesce into batches
-// of >1; uninitialised hashtrees keep classifyBatch from issuing RPCs. Run under
-// -race, it guards the §concurrency-safety invariants: no data race on the batch
-// machinery, no deadlock, and balanced asyncRepWg on every path.
+// TestAsyncSchedulerConcurrentBatchedDispatch races Register/Deregister against
+// Close over the batched path under -race: no race, no deadlock, balanced asyncRepWg.
 func TestAsyncSchedulerConcurrentBatchedDispatch(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	sched, err := NewAsyncReplicationScheduler(context.Background(), replication.GlobalConfig{
@@ -1728,9 +1720,8 @@ func TestAsyncSchedulerConcurrentBatchedDispatch(t *testing.T) {
 	}
 }
 
-// TestOnResultDiscardsZombieEntryAfterReRegister covers a shard deregistered
-// then re-registered (same *Shard) while its cycle result is in flight: the
-// stale entry must be discarded, not re-pushed alongside the fresh one.
+// TestOnResultDiscardsZombieEntryAfterReRegister: a stale entry re-registered
+// mid-flight must be discarded, not re-pushed alongside the fresh one.
 func TestOnResultDiscardsZombieEntryAfterReRegister(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
@@ -1746,7 +1737,6 @@ func TestOnResultDiscardsZombieEntryAfterReRegister(t *testing.T) {
 			sched.onAddLocked(s)
 			e1 := sched.entries[s]
 
-			// Simulate dispatch (Add+inFlight+Pop) then the worker's pre-send Done().
 			s.asyncRepWg.Add(1)
 			e1.inFlight = true
 			heap.Pop(&sched.h)
@@ -1767,11 +1757,8 @@ func TestOnResultDiscardsZombieEntryAfterReRegister(t *testing.T) {
 	}
 }
 
-// TestAsyncSchedulerMassDivergenceDeferDescent stresses the mass-divergence path
-// (node-restart scenario): one batch larger than the resultCh buffer, all
-// diverging, so a single runBatch blocks mid-loop on resultCh while Deregister→
-// Register race the same shards. Under -race it guards against deadlock, data
-// races, duplicate heap entries, and asyncRepWg imbalance in the widened window.
+// TestAsyncSchedulerMassDivergenceDeferDescent stresses a batch larger than the
+// resultCh buffer, all diverging, while Deregister/Register race the same shards.
 func TestAsyncSchedulerMassDivergenceDeferDescent(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	sched, err := NewAsyncReplicationScheduler(context.Background(), replication.GlobalConfig{
@@ -1781,7 +1768,6 @@ func TestAsyncSchedulerMassDivergenceDeferDescent(t *testing.T) {
 	}, nil, logger)
 	require.NoError(t, err)
 
-	// n > resultCh buffer (maxMaxWorkers*2 = 200) so one runBatch overflows it.
 	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}
 	const n = 256
 	shards := make([]*Shard, n)
@@ -1821,9 +1807,8 @@ func TestAsyncSchedulerMassDivergenceDeferDescent(t *testing.T) {
 	}
 }
 
-// TestClassifyBatchExcludesIneligible verifies that shards with active
-// target-node overrides or an uninitialised hashtree are excluded from the
-// batched pre-filter (no RPC issued) and default to a full descent.
+// TestClassifyBatchExcludesIneligible: override / uninitialised-hashtree shards are
+// excluded from the pre-filter and default to a full descent.
 func TestClassifyBatchExcludesIneligible(t *testing.T) {
 	sched := newBareScheduler(512, 1)
 	sched.ctx = context.Background()
@@ -1922,12 +1907,8 @@ func TestDispatchDueCoalescing(t *testing.T) {
 	})
 }
 
-// TestDeferDescentReDispatchesSingletons verifies the descent-spreading path:
-// a coalesced multi-entry batch of diverging shards is not descended inline;
-// each diverging entry is deferred back to the dispatcher (deferDescent) and
-// re-dispatched as a standalone singleton so descent spreads across the pool.
-// Uninitialised hashtrees make classifyBatch classify every shard as diverging
-// without issuing the pre-filter RPC.
+// TestDeferDescentReDispatchesSingletons: a coalesced batch of diverging shards is
+// deferred and re-dispatched as singletons so descent spreads across the pool.
 func TestDeferDescentReDispatchesSingletons(t *testing.T) {
 	sched := newBareScheduler(512, 16)
 	sched.ctx = context.Background()
@@ -1967,9 +1948,8 @@ func TestDeferDescentReDispatchesSingletons(t *testing.T) {
 	}
 }
 
-// TestDescendDirectSurvivesFullChannel verifies that when workCh fills mid-round,
-// unsent descendDirect entries roll back retaining the flag (so they retry as
-// singletons next round) and are never re-coalesced into a batch or lost.
+// TestDescendDirectSurvivesFullChannel: on a full workCh, unsent descendDirect
+// entries roll back retaining the flag and retry as singletons next round.
 func TestDescendDirectSurvivesFullChannel(t *testing.T) {
 	sched := newBareScheduler(512, 2)
 	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1618,6 +1618,30 @@ func drainBatchSizes(ch chan *[]*asyncSchedulerEntry) []int {
 	}
 }
 
+func drainBatches(ch chan *[]*asyncSchedulerEntry) []*[]*asyncSchedulerEntry {
+	var batches []*[]*asyncSchedulerEntry
+	for {
+		select {
+		case bp := <-ch:
+			batches = append(batches, bp)
+		default:
+			return batches
+		}
+	}
+}
+
+func drainResults(ch chan asyncSchedulerResult) []asyncSchedulerResult {
+	var results []asyncSchedulerResult
+	for {
+		select {
+		case r := <-ch:
+			results = append(results, r)
+		default:
+			return results
+		}
+	}
+}
+
 // TestRunBatchEmitsOneResultPerEntry verifies that every entry in a multi-entry
 // batch produces exactly one result via runEntry — the invariant that keeps
 // asyncRepWg balanced (runEntry alone owns each entry's Done()+result).
@@ -1803,4 +1827,77 @@ func TestDispatchDueCoalescing(t *testing.T) {
 			assert.False(t, e.inFlight, "rolled-back entries must not be in-flight")
 		}
 	})
+}
+
+// TestDeferDescentReDispatchesSingletons verifies the descent-spreading path:
+// a coalesced multi-entry batch of diverging shards is not descended inline;
+// each diverging entry is deferred back to the dispatcher (deferDescent) and
+// re-dispatched as a standalone singleton so descent spreads across the pool.
+// Uninitialised hashtrees make classifyBatch classify every shard as diverging
+// without issuing the pre-filter RPC.
+func TestDeferDescentReDispatchesSingletons(t *testing.T) {
+	sched := newBareScheduler(512, 16)
+	sched.ctx = context.Background()
+	sched.resultCh = make(chan asyncSchedulerResult, 32)
+
+	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}
+	const n = 5
+	for i := range n {
+		sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "MT"}, name: fmt.Sprintf("t%d", i)})
+	}
+
+	sched.dispatchDueLocked()
+	batches := drainBatches(sched.workCh)
+	require.Len(t, batches, 1, "the due shards coalesce into a single pre-filter batch")
+	require.Len(t, *batches[0], n)
+
+	sched.runBatch(batches[0], newBatchScratch())
+
+	results := drainResults(sched.resultCh)
+	require.Len(t, results, n, "one result per entry")
+	for _, r := range results {
+		assert.True(t, r.deferDescent, "diverging entries are deferred, not descended inline")
+		assert.NoError(t, r.err)
+		sched.onResultLocked(r)
+	}
+
+	require.Len(t, sched.entries, n)
+	for _, e := range sched.entries {
+		assert.True(t, e.descendDirect, "deferred entries are marked for direct descent")
+	}
+
+	sched.dispatchDueLocked()
+	assert.ElementsMatch(t, []int{1, 1, 1, 1, 1}, drainBatchSizes(sched.workCh),
+		"diverging shards re-dispatch as singletons, never re-coalesced into one batch")
+	for _, e := range sched.entries {
+		assert.False(t, e.descendDirect, "descendDirect cleared once the singleton is sent")
+	}
+}
+
+// TestDescendDirectSurvivesFullChannel verifies that when workCh fills mid-round,
+// unsent descendDirect entries roll back retaining the flag (so they retry as
+// singletons next round) and are never re-coalesced into a batch or lost.
+func TestDescendDirectSurvivesFullChannel(t *testing.T) {
+	sched := newBareScheduler(512, 2)
+	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}
+	const n = 5
+	for i := range n {
+		s := &Shard{index: idx, class: &models.Class{Class: "MT"}, name: fmt.Sprintf("t%d", i)}
+		sched.onAddLocked(s)
+		sched.entries[s].descendDirect = true
+	}
+
+	sched.dispatchDueLocked()
+
+	assert.ElementsMatch(t, []int{1, 1}, drainBatchSizes(sched.workCh),
+		"channel capacity bounds the singletons dispatched this round")
+	assert.Len(t, sched.h, n-2, "unsent divergers rolled back into the heap")
+	for _, e := range sched.h {
+		assert.True(t, e.descendDirect, "rolled-back divergers retain descendDirect")
+		assert.False(t, e.inFlight, "rolled-back divergers must not be in-flight")
+	}
+
+	sched.dispatchDueLocked()
+	assert.ElementsMatch(t, []int{1, 1}, drainBatchSizes(sched.workCh),
+		"remaining divergers keep dispatching as singletons")
 }

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1728,6 +1728,99 @@ func TestAsyncSchedulerConcurrentBatchedDispatch(t *testing.T) {
 	}
 }
 
+// TestOnResultDiscardsZombieEntryAfterReRegister covers a shard deregistered
+// then re-registered (same *Shard) while its cycle result is in flight: the
+// stale entry must be discarded, not re-pushed alongside the fresh one.
+func TestOnResultDiscardsZombieEntryAfterReRegister(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		deferDescent bool
+	}{
+		{name: "normal re-push"},
+		{name: "deferDescent re-push", deferDescent: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newBareScheduler(512, 1)
+
+			s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+			sched.onAddLocked(s)
+			e1 := sched.entries[s]
+
+			// Simulate dispatch (Add+inFlight+Pop) then the worker's pre-send Done().
+			s.asyncRepWg.Add(1)
+			e1.inFlight = true
+			heap.Pop(&sched.h)
+			s.asyncRepWg.Done()
+
+			sched.onRemoveLocked(s)
+			sched.onAddLocked(s)
+			e2 := sched.entries[s]
+			require.NotSame(t, e1, e2)
+
+			sched.onResultLocked(asyncSchedulerResult{entry: e1, deferDescent: tc.deferDescent})
+
+			require.Len(t, sched.h, 1, "stale entry must not be re-pushed")
+			assert.Same(t, e2, sched.h[0])
+			assert.Equal(t, -1, e1.heapIdx, "stale entry stays out of the heap")
+			s.asyncRepWg.Wait()
+		})
+	}
+}
+
+// TestAsyncSchedulerMassDivergenceDeferDescent stresses the mass-divergence path
+// (node-restart scenario): one batch larger than the resultCh buffer, all
+// diverging, so a single runBatch blocks mid-loop on resultCh while Deregister→
+// Register race the same shards. Under -race it guards against deadlock, data
+// races, duplicate heap entries, and asyncRepWg imbalance in the widened window.
+func TestAsyncSchedulerMassDivergenceDeferDescent(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	sched, err := NewAsyncReplicationScheduler(context.Background(), replication.GlobalConfig{
+		AsyncReplicationSchedulerWorkers:       configRuntime.NewDynamicValue(4),
+		AsyncReplicationDisabled:               configRuntime.NewDynamicValue(false),
+		AsyncReplicationRootPrefilterBatchSize: configRuntime.NewDynamicValue(512),
+	}, nil, logger)
+	require.NoError(t, err)
+
+	// n > resultCh buffer (maxMaxWorkers*2 = 200) so one runBatch overflows it.
+	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}
+	const n = 256
+	shards := make([]*Shard, n)
+	for i := range shards {
+		shards[i] = &Shard{index: idx, class: &models.Class{Class: "MT"}, name: fmt.Sprintf("t%03d", i)}
+		_ = sched.Register(shards[i])
+	}
+
+	var wg sync.WaitGroup
+	for _, s := range shards {
+		s := s
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 3 {
+				_ = sched.Deregister(s)
+				_ = sched.Register(s)
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		sched.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("scheduler did not terminate — possible deadlock in mass-divergence defer path")
+	}
+
+	for _, s := range shards {
+		s.asyncRepWg.Wait()
+	}
+}
+
 // TestClassifyBatchExcludesIneligible verifies that shards with active
 // target-node overrides or an uninitialised hashtree are excluded from the
 // batched pre-filter (no RPC issued) and default to a full descent.

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1589,14 +1589,13 @@ func durationPtr(d time.Duration) *time.Duration { return &d }
 
 // newBareScheduler builds a scheduler struct without starting any goroutines, so
 // dispatchDueLocked/effectiveBatchSize can be exercised deterministically.
-func newBareScheduler(mt, st, workChCap int) *AsyncReplicationScheduler {
+func newBareScheduler(batchSize, workChCap int) *AsyncReplicationScheduler {
 	s := &AsyncReplicationScheduler{
 		entries:                  make(map[*Shard]*asyncSchedulerEntry),
 		dispatchBuckets:          make(map[*Index][]*asyncSchedulerEntry),
 		workCh:                   make(chan *[]*asyncSchedulerEntry, workChCap),
 		asyncReplicationDisabled: configRuntime.NewDynamicValue(false),
-		rootPrefilterBatchSizeMT: configRuntime.NewDynamicValue(mt),
-		rootPrefilterBatchSizeST: configRuntime.NewDynamicValue(st),
+		rootPrefilterBatchSize:   configRuntime.NewDynamicValue(batchSize),
 		logger:                   logrus.New(),
 	}
 	s.batchPool.New = func() any {
@@ -1623,7 +1622,7 @@ func drainBatchSizes(ch chan *[]*asyncSchedulerEntry) []int {
 // batch produces exactly one result via runEntry — the invariant that keeps
 // asyncRepWg balanced (runEntry alone owns each entry's Done()+result).
 func TestRunBatchEmitsOneResultPerEntry(t *testing.T) {
-	sched := newBareScheduler(512, 512, 1)
+	sched := newBareScheduler(512, 1)
 	sched.ctx = context.Background()
 	sched.resultCh = make(chan asyncSchedulerResult, 8)
 
@@ -1661,9 +1660,9 @@ func TestRunBatchEmitsOneResultPerEntry(t *testing.T) {
 func TestAsyncSchedulerConcurrentBatchedDispatch(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	sched, err := NewAsyncReplicationScheduler(context.Background(), replication.GlobalConfig{
-		AsyncReplicationSchedulerWorkers:         configRuntime.NewDynamicValue(4),
-		AsyncReplicationDisabled:                 configRuntime.NewDynamicValue(false),
-		AsyncReplicationRootPrefilterBatchSizeMT: configRuntime.NewDynamicValue(3),
+		AsyncReplicationSchedulerWorkers:       configRuntime.NewDynamicValue(4),
+		AsyncReplicationDisabled:               configRuntime.NewDynamicValue(false),
+		AsyncReplicationRootPrefilterBatchSize: configRuntime.NewDynamicValue(3),
 	}, nil, logger)
 	require.NoError(t, err)
 
@@ -1709,7 +1708,7 @@ func TestAsyncSchedulerConcurrentBatchedDispatch(t *testing.T) {
 // target-node overrides or an uninitialised hashtree are excluded from the
 // batched pre-filter (no RPC issued) and default to a full descent.
 func TestClassifyBatchExcludesIneligible(t *testing.T) {
-	sched := newBareScheduler(512, 512, 1)
+	sched := newBareScheduler(512, 1)
 	sched.ctx = context.Background()
 
 	override := &Shard{class: &models.Class{Class: "C"}}
@@ -1729,31 +1728,28 @@ func TestClassifyBatchExcludesIneligible(t *testing.T) {
 }
 
 func TestEffectiveBatchSize(t *testing.T) {
-	mtIdx := &Index{partitioningEnabled: true}
-	stIdx := &Index{partitioningEnabled: false}
-
-	t.Run("MT and ST pick their own value", func(t *testing.T) {
-		sched := newBareScheduler(256, 4, 1)
-		assert.Equal(t, 256, sched.effectiveBatchSize(mtIdx))
-		assert.Equal(t, 4, sched.effectiveBatchSize(stIdx))
+	t.Run("configured value is used", func(t *testing.T) {
+		sched := newBareScheduler(256, 1)
+		assert.Equal(t, 256, sched.effectiveBatchSize())
 	})
 
 	t.Run("invalid falls back to default", func(t *testing.T) {
-		sched := newBareScheduler(0, -5, 1)
-		assert.Equal(t, fallbackRootPrefilterBatchSizeMT, sched.effectiveBatchSize(mtIdx))
-		assert.Equal(t, fallbackRootPrefilterBatchSizeST, sched.effectiveBatchSize(stIdx))
+		sched := newBareScheduler(0, 1)
+		assert.Equal(t, fallbackRootPrefilterBatchSize, sched.effectiveBatchSize())
+		sched = newBareScheduler(-5, 1)
+		assert.Equal(t, fallbackRootPrefilterBatchSize, sched.effectiveBatchSize())
 	})
 
 	t.Run("over cap is clamped", func(t *testing.T) {
-		sched := newBareScheduler(maxRootPrefilterBatchSize+1000, 1, 1)
-		assert.Equal(t, maxRootPrefilterBatchSize, sched.effectiveBatchSize(mtIdx))
+		sched := newBareScheduler(maxRootPrefilterBatchSize+1000, 1)
+		assert.Equal(t, maxRootPrefilterBatchSize, sched.effectiveBatchSize())
 	})
 }
 
 func TestDispatchDueCoalescing(t *testing.T) {
-	t.Run("MT coalesces up to batch size with a smaller final batch", func(t *testing.T) {
-		sched := newBareScheduler(3, 1, 16)
-		idx := &Index{Config: IndexConfig{ClassName: "C"}, partitioningEnabled: true}
+	t.Run("coalesces up to batch size with a smaller final batch", func(t *testing.T) {
+		sched := newBareScheduler(3, 16)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}}
 		for range 7 {
 			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
 		}
@@ -1764,9 +1760,9 @@ func TestDispatchDueCoalescing(t *testing.T) {
 		assert.Empty(t, sched.h, "all due entries dispatched")
 	})
 
-	t.Run("ST dispatches singletons", func(t *testing.T) {
-		sched := newBareScheduler(512, 1, 16)
-		idx := &Index{Config: IndexConfig{ClassName: "C"}, partitioningEnabled: false}
+	t.Run("batch size 1 dispatches singletons", func(t *testing.T) {
+		sched := newBareScheduler(1, 16)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}}
 		for range 4 {
 			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
 		}
@@ -1777,9 +1773,9 @@ func TestDispatchDueCoalescing(t *testing.T) {
 	})
 
 	t.Run("distinct indexes are batched separately", func(t *testing.T) {
-		sched := newBareScheduler(512, 512, 16)
-		a := &Index{Config: IndexConfig{ClassName: "A"}, partitioningEnabled: true}
-		b := &Index{Config: IndexConfig{ClassName: "B"}, partitioningEnabled: true}
+		sched := newBareScheduler(512, 16)
+		a := &Index{Config: IndexConfig{ClassName: "A"}}
+		b := &Index{Config: IndexConfig{ClassName: "B"}}
 		for range 3 {
 			sched.onAddLocked(&Shard{index: a, class: &models.Class{Class: "A"}})
 		}
@@ -1793,8 +1789,8 @@ func TestDispatchDueCoalescing(t *testing.T) {
 	})
 
 	t.Run("full channel rolls unsent entries back into the heap", func(t *testing.T) {
-		sched := newBareScheduler(1, 1, 2)
-		idx := &Index{Config: IndexConfig{ClassName: "C"}, partitioningEnabled: false}
+		sched := newBareScheduler(1, 2)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}}
 		for range 5 {
 			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
 		}

--- a/adapters/repos/db/fakes_for_tests.go
+++ b/adapters/repos/db/fakes_for_tests.go
@@ -576,3 +576,9 @@ func (c *FakeReplicationClient) CompareDigests(ctx context.Context, host, index,
 ) ([]types.RepairResponse, error) {
 	return nil, nil
 }
+
+func (c *FakeReplicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	return nil, nil
+}

--- a/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package lsmkv
 
 import (

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -1610,6 +1610,63 @@ func (_c *MockShardLike_HashTreeLevel_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
+// HashTreeRoot provides a mock function with no fields
+func (_m *MockShardLike) HashTreeRoot() (hashtree.Digest, bool) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for HashTreeRoot")
+	}
+
+	var r0 hashtree.Digest
+	var r1 bool
+	if rf, ok := ret.Get(0).(func() (hashtree.Digest, bool)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() hashtree.Digest); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(hashtree.Digest)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() bool); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
+// MockShardLike_HashTreeRoot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HashTreeRoot'
+type MockShardLike_HashTreeRoot_Call struct {
+	*mock.Call
+}
+
+// HashTreeRoot is a helper method to define mock.On call
+func (_e *MockShardLike_Expecter) HashTreeRoot() *MockShardLike_HashTreeRoot_Call {
+	return &MockShardLike_HashTreeRoot_Call{Call: _e.mock.On("HashTreeRoot")}
+}
+
+func (_c *MockShardLike_HashTreeRoot_Call) Run(run func()) *MockShardLike_HashTreeRoot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockShardLike_HashTreeRoot_Call) Return(root hashtree.Digest, ok bool) *MockShardLike_HashTreeRoot_Call {
+	_c.Call.Return(root, ok)
+	return _c
+}
+
+func (_c *MockShardLike_HashTreeRoot_Call) RunAndReturn(run func() (hashtree.Digest, bool)) *MockShardLike_HashTreeRoot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ID provides a mock function with no fields
 func (_m *MockShardLike) ID() string {
 	ret := _m.Called()

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -965,11 +965,9 @@ func (i *Index) IncomingHashTreeLevel(ctx context.Context,
 	return i.HashTreeLevel(ctx, shardName, level, discriminant)
 }
 
-// CompareHashTreeRoots returns the subset of the requested shards whose local
-// hashtree root differs from the provided one. A shard is reported diverging if
-// it is missing locally, not fully initialised, or its root differs — so the
-// source never wrongly skips a shard. GetShard uses ensureInit=false, so cold
-// shards are not force-loaded (they surface as diverging).
+// CompareHashTreeRoots returns the requested shards whose local hashtree root
+// differs. Missing/uninitialised/cold (ensureInit=false) shards report diverging
+// so the source never wrongly skips a shard.
 func (i *Index) CompareHashTreeRoots(ctx context.Context,
 	roots map[string]hashtree.Digest,
 ) ([]string, error) {

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -194,6 +194,14 @@ func (db *DB) HashTreeLevel(ctx context.Context, className, shardName string, le
 	return index.HashTreeLevel(ctx, shardName, level, discriminant)
 }
 
+func (db *DB) CompareHashTreeRoots(ctx context.Context, className string, roots map[string]hashtree.Digest) ([]string, error) {
+	index, pr := db.replicatedIndex(className)
+	if pr != nil {
+		return nil, pr.FirstError()
+	}
+	return index.CompareHashTreeRoots(ctx, roots)
+}
+
 func (db *DB) CountObjects(ctx context.Context, indexName string, shardName string) (int, error) {
 	index, pr := db.replicatedIndex(indexName)
 	if pr != nil {
@@ -955,6 +963,40 @@ func (i *Index) IncomingHashTreeLevel(ctx context.Context,
 	shardName string, level int, discriminant *hashtree.Bitset,
 ) (digests []hashtree.Digest, err error) {
 	return i.HashTreeLevel(ctx, shardName, level, discriminant)
+}
+
+// CompareHashTreeRoots returns the subset of the requested shards whose local
+// hashtree root differs from the provided one. A shard is reported diverging if
+// it is missing locally, not fully initialised, or its root differs — so the
+// source never wrongly skips a shard. GetShard uses ensureInit=false, so cold
+// shards are not force-loaded (they surface as diverging).
+func (i *Index) CompareHashTreeRoots(ctx context.Context,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	diverging := make([]string, 0, len(roots))
+	for shardName, sourceRoot := range roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		localRoot, ok := func() (hashtree.Digest, bool) {
+			shard, release, err := i.GetShard(ctx, shardName)
+			if err != nil || shard == nil {
+				return hashtree.Digest{}, false
+			}
+			defer release()
+			return shard.HashTreeRoot()
+		}()
+		if !ok || localRoot != sourceRoot {
+			diverging = append(diverging, shardName)
+		}
+	}
+	return diverging, nil
+}
+
+func (i *Index) IncomingCompareHashTreeRoots(ctx context.Context,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	return i.CompareHashTreeRoots(ctx, roots)
 }
 
 func (i *Index) CountObjects(ctx context.Context, shardName string) (int, error) {

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -965,9 +965,8 @@ func (i *Index) IncomingHashTreeLevel(ctx context.Context,
 	return i.HashTreeLevel(ctx, shardName, level, discriminant)
 }
 
-// CompareHashTreeRoots returns the requested shards whose local hashtree root
-// differs. Missing/uninitialised/cold (ensureInit=false) shards report diverging
-// so the source never wrongly skips a shard.
+// CompareHashTreeRoots returns shards whose local root was read and differs; not-ready
+// shards (missing/uninitialised/cold) are omitted — caught once they become ready.
 func (i *Index) CompareHashTreeRoots(ctx context.Context,
 	roots map[string]hashtree.Digest,
 ) ([]string, error) {
@@ -984,7 +983,7 @@ func (i *Index) CompareHashTreeRoots(ctx context.Context,
 			defer release()
 			return shard.HashTreeRoot()
 		}()
-		if !ok || localRoot != sourceRoot {
+		if ok && localRoot != sourceRoot {
 			diverging = append(diverging, shardName)
 		}
 	}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -113,6 +113,7 @@ type ShardLike interface {
 	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, error)
 	Aggregate(ctx context.Context, params aggregation.Params, modules *modules.Provider) (*aggregation.Result, error)
 	HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
+	HashTreeRoot() (root hashtree.Digest, ok bool)
 	MergeObject(ctx context.Context, object objects.MergeDocument) error
 	VectorDistanceForQuery(ctx context.Context, id uint64, searchVectors []models.Vector, targets []string) ([]float32, error)
 	ConvertQueue(targetVector string) error

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1253,6 +1253,21 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 	return digests[:n], nil
 }
 
+// HashTreeRoot returns the shard's async-replication hashtree root digest. ok is
+// false when the hashtree is not yet fully initialised; callers treat that as
+// "diverging" so the full per-shard path resolves it. The root is computed the
+// same way as HashTreeLevel(level=0), so batched equality matches the level-0
+// compare bit-for-bit.
+func (s *Shard) HashTreeRoot() (root hashtree.Digest, ok bool) {
+	s.asyncReplicationRWMux.RLock()
+	defer s.asyncReplicationRWMux.RUnlock()
+
+	if !s.hashtreeFullyInitialized {
+		return hashtree.Digest{}, false
+	}
+	return s.hashtree.Root(), true
+}
+
 // runHashbeatCycle runs one full hashbeat cycle and is called by a scheduler
 // worker goroutine. It uses shard-level state maps (asyncRepLast*) which are
 // only ever accessed from a single worker at a time (enforced by asyncRepWg).

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1254,10 +1254,8 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 }
 
 // HashTreeRoot returns the shard's async-replication hashtree root digest. ok is
-// false when the hashtree is not yet fully initialised; callers treat that as
-// "diverging" so the full per-shard path resolves it. The root is computed the
-// same way as HashTreeLevel(level=0), so batched equality matches the level-0
-// compare bit-for-bit.
+// false when the hashtree is not fully initialised; callers treat that as
+// "diverging". Computed like HashTreeLevel(level=0), so batched equality matches.
 func (s *Shard) HashTreeRoot() (root hashtree.Digest, ok bool) {
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1253,9 +1253,8 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 	return digests[:n], nil
 }
 
-// HashTreeRoot returns the shard's async-replication hashtree root digest. ok is
-// false when the hashtree is not fully initialised; callers treat that as
-// "diverging". Computed like HashTreeLevel(level=0), so batched equality matches.
+// HashTreeRoot returns the shard's async-replication hashtree root; ok is false when the
+// hashtree is not fully initialised. Computed like HashTreeLevel(level=0) so roots match.
 func (s *Shard) HashTreeRoot() (root hashtree.Digest, ok bool) {
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()

--- a/adapters/repos/db/shard_async_replication_unit_test.go
+++ b/adapters/repos/db/shard_async_replication_unit_test.go
@@ -22,6 +22,7 @@ import (
 	routertypes "github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
 // TestResolveObjectConflict covers all branches of resolveObjectConflict that
@@ -118,4 +119,32 @@ func TestResolveObjectConflict(t *testing.T) {
 			assert.Equal(t, tc.wantNotResolved, notResolved, "notResolved")
 		})
 	}
+}
+
+func TestHashTreeRoot(t *testing.T) {
+	t.Run("not initialized", func(t *testing.T) {
+		s := &Shard{}
+		_, ok := s.HashTreeRoot()
+		assert.False(t, ok)
+	})
+
+	t.Run("initialized matches Root and Level(0)", func(t *testing.T) {
+		ht, err := hashtree.NewCompactHashTree(1024, 4)
+		require.NoError(t, err)
+		require.NoError(t, ht.AggregateLeafWith(0, []byte("payload")))
+
+		s := &Shard{hashtree: ht, hashtreeFullyInitialized: true}
+
+		root, ok := s.HashTreeRoot()
+		require.True(t, ok)
+		assert.Equal(t, ht.Root(), root)
+
+		disc := hashtree.NewBitset(1)
+		disc.Set(0)
+		level0 := make([]hashtree.Digest, 1)
+		n, err := ht.Level(0, disc, level0)
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+		assert.Equal(t, level0[0], root)
+	})
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -700,6 +700,13 @@ func (l *LazyLoadShard) HashTreeLevel(ctx context.Context, level int, discrimina
 	return l.shard.HashTreeLevel(ctx, level, discriminant)
 }
 
+func (l *LazyLoadShard) HashTreeRoot() (root hashtree.Digest, ok bool) {
+	if !l.isLoaded() {
+		return hashtree.Digest{}, false
+	}
+	return l.shard.HashTreeRoot()
+}
+
 func (l *LazyLoadShard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, err

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -43,6 +43,12 @@ type GlobalConfig struct {
 	AsyncReplicationPropagationConcurrency    *runtime.DynamicValue[int]           `json:"async_replication_propagation_concurrency" yaml:"async_replication_propagation_concurrency"`
 	AsyncReplicationPropagationBatchSize      *runtime.DynamicValue[int]           `json:"async_replication_propagation_batch_size" yaml:"async_replication_propagation_batch_size"`
 	AsyncReplicationPropagationDelay          *runtime.DynamicValue[time.Duration] `json:"async_replication_propagation_delay" yaml:"async_replication_propagation_delay"`
+	// Root pre-filter batch size: how many shards' hashtree roots are compared in
+	// one batched RPC before deciding which need a full descent. <=1 disables the
+	// pre-filter (per-shard path, today's behavior). MT and ST classes are tuned
+	// separately (MT defaults high, ST defaults to 1 = off).
+	AsyncReplicationRootPrefilterBatchSizeMT *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size_mt" yaml:"async_replication_root_prefilter_batch_size_mt"`
+	AsyncReplicationRootPrefilterBatchSizeST *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size_st" yaml:"async_replication_root_prefilter_batch_size_st"`
 	// MinimumFactor can enforce replication. For example, with MinimumFactor set
 	// to 2, users can no longer create classes with a factor of 1, therefore
 	// forcing them to have replicated classes.

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -43,11 +43,8 @@ type GlobalConfig struct {
 	AsyncReplicationPropagationConcurrency    *runtime.DynamicValue[int]           `json:"async_replication_propagation_concurrency" yaml:"async_replication_propagation_concurrency"`
 	AsyncReplicationPropagationBatchSize      *runtime.DynamicValue[int]           `json:"async_replication_propagation_batch_size" yaml:"async_replication_propagation_batch_size"`
 	AsyncReplicationPropagationDelay          *runtime.DynamicValue[time.Duration] `json:"async_replication_propagation_delay" yaml:"async_replication_propagation_delay"`
-	// Root pre-filter batch size: a single cluster-wide knob (same value for
-	// every collection, MT or ST) capping how many same-collection hashtree roots
-	// are compared in one batched RPC before deciding which shards need a full
-	// descent. 1 disables the pre-filter (per-shard path); values <= 0 are invalid
-	// and fall back to the default.
+	// Root pre-filter batch size: cluster-wide cap on same-collection hashtree roots
+	// compared per batched RPC. 1 disables the pre-filter; <= 0 falls back to the default.
 	AsyncReplicationRootPrefilterBatchSize *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size" yaml:"async_replication_root_prefilter_batch_size"`
 	// MinimumFactor can enforce replication. For example, with MinimumFactor set
 	// to 2, users can no longer create classes with a factor of 1, therefore

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -44,8 +44,9 @@ type GlobalConfig struct {
 	AsyncReplicationPropagationBatchSize      *runtime.DynamicValue[int]           `json:"async_replication_propagation_batch_size" yaml:"async_replication_propagation_batch_size"`
 	AsyncReplicationPropagationDelay          *runtime.DynamicValue[time.Duration] `json:"async_replication_propagation_delay" yaml:"async_replication_propagation_delay"`
 	// Root pre-filter batch size: how many shards' hashtree roots are compared in
-	// one batched RPC before deciding which need a full descent. <=1 disables the
-	// pre-filter (per-shard path, today's behavior).
+	// one batched RPC before deciding which need a full descent. 1 disables the
+	// pre-filter (per-shard path, today's behavior); values <= 0 are invalid and
+	// fall back to the default.
 	AsyncReplicationRootPrefilterBatchSize *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size" yaml:"async_replication_root_prefilter_batch_size"`
 	// MinimumFactor can enforce replication. For example, with MinimumFactor set
 	// to 2, users can no longer create classes with a factor of 1, therefore

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -45,10 +45,8 @@ type GlobalConfig struct {
 	AsyncReplicationPropagationDelay          *runtime.DynamicValue[time.Duration] `json:"async_replication_propagation_delay" yaml:"async_replication_propagation_delay"`
 	// Root pre-filter batch size: how many shards' hashtree roots are compared in
 	// one batched RPC before deciding which need a full descent. <=1 disables the
-	// pre-filter (per-shard path, today's behavior). MT and ST classes are tuned
-	// separately (MT defaults high, ST defaults to 1 = off).
-	AsyncReplicationRootPrefilterBatchSizeMT *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size_mt" yaml:"async_replication_root_prefilter_batch_size_mt"`
-	AsyncReplicationRootPrefilterBatchSizeST *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size_st" yaml:"async_replication_root_prefilter_batch_size_st"`
+	// pre-filter (per-shard path, today's behavior).
+	AsyncReplicationRootPrefilterBatchSize *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size" yaml:"async_replication_root_prefilter_batch_size"`
 	// MinimumFactor can enforce replication. For example, with MinimumFactor set
 	// to 2, users can no longer create classes with a factor of 1, therefore
 	// forcing them to have replicated classes.

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -43,10 +43,11 @@ type GlobalConfig struct {
 	AsyncReplicationPropagationConcurrency    *runtime.DynamicValue[int]           `json:"async_replication_propagation_concurrency" yaml:"async_replication_propagation_concurrency"`
 	AsyncReplicationPropagationBatchSize      *runtime.DynamicValue[int]           `json:"async_replication_propagation_batch_size" yaml:"async_replication_propagation_batch_size"`
 	AsyncReplicationPropagationDelay          *runtime.DynamicValue[time.Duration] `json:"async_replication_propagation_delay" yaml:"async_replication_propagation_delay"`
-	// Root pre-filter batch size: how many shards' hashtree roots are compared in
-	// one batched RPC before deciding which need a full descent. 1 disables the
-	// pre-filter (per-shard path, today's behavior); values <= 0 are invalid and
-	// fall back to the default.
+	// Root pre-filter batch size: a single cluster-wide knob (same value for
+	// every collection, MT or ST) capping how many same-collection hashtree roots
+	// are compared in one batched RPC before deciding which shards need a full
+	// descent. 1 disables the pre-filter (per-shard path); values <= 0 are invalid
+	// and fall back to the default.
 	AsyncReplicationRootPrefilterBatchSize *runtime.DynamicValue[int] `json:"async_replication_root_prefilter_batch_size" yaml:"async_replication_root_prefilter_batch_size"`
 	// MinimumFactor can enforce replication. For example, with MinimumFactor set
 	// to 2, users can no longer create classes with a factor of 1, therefore

--- a/test/acceptance/replication/async_replication/async_repair_root_prefilter_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_root_prefilter_test.go
@@ -31,13 +31,7 @@ import (
 )
 
 // TestAsyncRepairRootPrefilterManyTenants exercises the batched hashtree-root
-// pre-filter end-to-end. A multi-tenant class replicated across 3 nodes gets many
-// tenants; one node is taken down, every tenant is written on the survivors, then
-// the node is restarted. Because MT batching is on by default, the survivors'
-// schedulers compare all tenant-shard roots against the restarted node in batched
-// pre-filter RPCs and descend the diverging ones. The test asserts every tenant
-// fully reconciles on the restarted node — proving the batched compare + descent
-// path is correct across many shards.
+// pre-filter end-to-end: a node restarts and every MT tenant reconciles via it.
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairRootPrefilterManyTenants() {
 	t := suite.T()
 	mainCtx := context.Background()

--- a/test/acceptance/replication/async_replication/async_repair_root_prefilter_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_root_prefilter_test.go
@@ -1,0 +1,142 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+// TestAsyncRepairRootPrefilterManyTenants exercises the batched hashtree-root
+// pre-filter end-to-end. A multi-tenant class replicated across 3 nodes gets many
+// tenants; one node is taken down, every tenant is written on the survivors, then
+// the node is restarted. Because MT batching is on by default, the survivors'
+// schedulers compare all tenant-shard roots against the restarted node in batched
+// pre-filter RPCs and descend the diverging ones. The test asserts every tenant
+// fully reconciles on the restarted node — proving the batched compare + descent
+// path is correct across many shards.
+func (suite *AsyncReplicationTestSuite) TestAsyncRepairRootPrefilterManyTenants() {
+	t := suite.T()
+	mainCtx := context.Background()
+
+	var (
+		clusterSize      = 3
+		tenantCount      = 12
+		objectsPerTenant = 20
+	)
+
+	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(clusterSize).
+		WithText2VecContextionary().
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	paragraphClass := articles.ParagraphsClass()
+
+	tenantNames := make([]string, tenantCount)
+	for i := range tenantNames {
+		tenantNames[i] = fmt.Sprintf("tenant-%d", i)
+	}
+
+	t.Run("create multi-tenant schema replicated with async enabled", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
+			Factor:       int64(clusterSize),
+			AsyncEnabled: true,
+		}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
+		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
+			AutoTenantActivation: true,
+			Enabled:              true,
+		}
+
+		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.CreateClass(t, paragraphClass)
+	})
+
+	t.Run("create tenants", func(t *testing.T) {
+		tenants := make([]*models.Tenant, tenantCount)
+		for i, name := range tenantNames {
+			tenants[i] = &models.Tenant{Name: name, ActivityStatus: "HOT"}
+		}
+		helper.CreateTenants(t, paragraphClass.Class, tenants)
+	})
+
+	node := 3
+
+	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, node)
+	})
+
+	t.Run("insert objects into every tenant on the surviving nodes", func(t *testing.T) {
+		for _, tenant := range tenantNames {
+			batch := make([]*models.Object, objectsPerTenant)
+			for i := range batch {
+				batch[i] = articles.NewParagraph().
+					WithContents(fmt.Sprintf("%s#%d", tenant, i)).
+					WithTenant(tenant).
+					Object()
+			}
+			common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
+		}
+	})
+
+	t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, node)
+	})
+
+	t.Run("all nodes healthy", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, clusterSize)
+			for _, n := range body.Payload.Nodes {
+				require.NotNil(ct, n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("every tenant reconciles on the restarted node via the batched pre-filter", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, tenant := range tenantNames {
+				resp := common.GQLTenantGet(t, compose.GetWeaviateNode(node).URI(),
+					paragraphClass.Class, types.ConsistencyLevelOne, tenant)
+				require.Len(ct, resp, objectsPerTenant, "tenant %s not fully reconciled", tenant)
+			}
+		}, 180*time.Second, 5*time.Second, "not all tenants were asynchronously reconciled")
+	})
+}

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -654,6 +654,12 @@ func (c *fakeReplicationClient) CompareDigests(ctx context.Context, host, index,
 	return nil, nil
 }
 
+func (c *fakeReplicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	return nil, nil
+}
+
 func (c *fakeReplicationClient) CountObjects(ctx context.Context, host, index, shard string) (int, error) {
 	return 0, nil
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1038,6 +1038,28 @@ func FromEnv(config *Config) error {
 		return err
 	}
 
+	// Out-of-range values are clamped (and warned) by the scheduler on read, so
+	// only a non-numeric override fails here.
+	if err := parseInt(
+		"ASYNC_REPLICATION_ROOT_PREFILTER_BATCH_SIZE_MT",
+		func(val int) {
+			config.Replication.AsyncReplicationRootPrefilterBatchSizeMT = configRuntime.NewDynamicValue(val)
+		},
+		DefaultAsyncReplicationRootPrefilterBatchSizeMT,
+	); err != nil {
+		return err
+	}
+
+	if err := parseInt(
+		"ASYNC_REPLICATION_ROOT_PREFILTER_BATCH_SIZE_ST",
+		func(val int) {
+			config.Replication.AsyncReplicationRootPrefilterBatchSizeST = configRuntime.NewDynamicValue(val)
+		},
+		DefaultAsyncReplicationRootPrefilterBatchSizeST,
+	); err != nil {
+		return err
+	}
+
 	// Per-shard async replication knobs. Default 0 means "not configured at the
 	// cluster level"; per-class API override or hardcoded code defaults apply.
 	if err := parsePositiveIntOrZero(
@@ -1830,12 +1852,18 @@ const (
 	// capping.
 	MaxAsyncReplicationSchedulerWorkers            = 100
 	DefaultAsyncReplicationHashtreeInitConcurrency = 10
-	DefaultMaximumAllowedCollectionsCount          = -1 // unlimited
-	DefaultMaximumAllowedObjectsCount              = -1 // unlimited
-	DefaultMaximumAllowedTenantsPerCollection      = -1 // unlimited
-	DefaultMaximumAllowedShardsPerCollection       = -1 // unlimited
-	DefaultUsageLimitsErrorMessage                 = "" // empty → usagelimits.RenderTemplate falls back to its built-in default
-	DefaultRestrictionsErrorMessage                = "" // empty → restrictions.RenderTemplate falls back to its built-in default
+	// Root pre-filter batch sizes. MT classes batch aggressively (many tenants);
+	// ST defaults to 1, which disables the batched RPC (per-shard path). The hard
+	// cap bounds message size / per-batch work regardless of runtime overrides.
+	DefaultAsyncReplicationRootPrefilterBatchSizeMT = 512
+	DefaultAsyncReplicationRootPrefilterBatchSizeST = 1
+	MaxAsyncReplicationRootPrefilterBatchSize       = 4096
+	DefaultMaximumAllowedCollectionsCount           = -1 // unlimited
+	DefaultMaximumAllowedObjectsCount               = -1 // unlimited
+	DefaultMaximumAllowedTenantsPerCollection       = -1 // unlimited
+	DefaultMaximumAllowedShardsPerCollection        = -1 // unlimited
+	DefaultUsageLimitsErrorMessage                  = "" // empty → usagelimits.RenderTemplate falls back to its built-in default
+	DefaultRestrictionsErrorMessage                 = "" // empty → restrictions.RenderTemplate falls back to its built-in default
 )
 
 const VectorizerModuleNone = "none"

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1842,10 +1842,11 @@ const (
 	// capping.
 	MaxAsyncReplicationSchedulerWorkers            = 100
 	DefaultAsyncReplicationHashtreeInitConcurrency = 10
-	// Root pre-filter batch size: how many shards' hashtree roots are compared in
-	// one batched RPC. 1 disables the batched RPC (per-shard path); values <= 0
-	// are invalid and fall back to the default. The hard cap bounds message size /
-	// per-batch work regardless of runtime overrides.
+	// Root pre-filter batch size: a single cluster-wide setting applied to every
+	// collection (MT or ST), capping how many same-collection hashtree roots are
+	// compared in one batched RPC. 1 disables the batched RPC (per-shard path);
+	// values <= 0 are invalid and fall back to the default. The hard cap bounds
+	// message size / per-batch work regardless of runtime overrides.
 	DefaultAsyncReplicationRootPrefilterBatchSize = 512
 	MaxAsyncReplicationRootPrefilterBatchSize     = 4096
 	DefaultMaximumAllowedCollectionsCount         = -1 // unlimited

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1843,8 +1843,9 @@ const (
 	MaxAsyncReplicationSchedulerWorkers            = 100
 	DefaultAsyncReplicationHashtreeInitConcurrency = 10
 	// Root pre-filter batch size: how many shards' hashtree roots are compared in
-	// one batched RPC. <=1 disables the batched RPC (per-shard path). The hard cap
-	// bounds message size / per-batch work regardless of runtime overrides.
+	// one batched RPC. 1 disables the batched RPC (per-shard path); values <= 0
+	// are invalid and fall back to the default. The hard cap bounds message size /
+	// per-batch work regardless of runtime overrides.
 	DefaultAsyncReplicationRootPrefilterBatchSize = 512
 	MaxAsyncReplicationRootPrefilterBatchSize     = 4096
 	DefaultMaximumAllowedCollectionsCount         = -1 // unlimited

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1041,21 +1041,11 @@ func FromEnv(config *Config) error {
 	// Out-of-range values are clamped (and warned) by the scheduler on read, so
 	// only a non-numeric override fails here.
 	if err := parseInt(
-		"ASYNC_REPLICATION_ROOT_PREFILTER_BATCH_SIZE_MT",
+		"ASYNC_REPLICATION_ROOT_PREFILTER_BATCH_SIZE",
 		func(val int) {
-			config.Replication.AsyncReplicationRootPrefilterBatchSizeMT = configRuntime.NewDynamicValue(val)
+			config.Replication.AsyncReplicationRootPrefilterBatchSize = configRuntime.NewDynamicValue(val)
 		},
-		DefaultAsyncReplicationRootPrefilterBatchSizeMT,
-	); err != nil {
-		return err
-	}
-
-	if err := parseInt(
-		"ASYNC_REPLICATION_ROOT_PREFILTER_BATCH_SIZE_ST",
-		func(val int) {
-			config.Replication.AsyncReplicationRootPrefilterBatchSizeST = configRuntime.NewDynamicValue(val)
-		},
-		DefaultAsyncReplicationRootPrefilterBatchSizeST,
+		DefaultAsyncReplicationRootPrefilterBatchSize,
 	); err != nil {
 		return err
 	}
@@ -1852,18 +1842,17 @@ const (
 	// capping.
 	MaxAsyncReplicationSchedulerWorkers            = 100
 	DefaultAsyncReplicationHashtreeInitConcurrency = 10
-	// Root pre-filter batch sizes. MT classes batch aggressively (many tenants);
-	// ST defaults to 1, which disables the batched RPC (per-shard path). The hard
-	// cap bounds message size / per-batch work regardless of runtime overrides.
-	DefaultAsyncReplicationRootPrefilterBatchSizeMT = 512
-	DefaultAsyncReplicationRootPrefilterBatchSizeST = 1
-	MaxAsyncReplicationRootPrefilterBatchSize       = 4096
-	DefaultMaximumAllowedCollectionsCount           = -1 // unlimited
-	DefaultMaximumAllowedObjectsCount               = -1 // unlimited
-	DefaultMaximumAllowedTenantsPerCollection       = -1 // unlimited
-	DefaultMaximumAllowedShardsPerCollection        = -1 // unlimited
-	DefaultUsageLimitsErrorMessage                  = "" // empty → usagelimits.RenderTemplate falls back to its built-in default
-	DefaultRestrictionsErrorMessage                 = "" // empty → restrictions.RenderTemplate falls back to its built-in default
+	// Root pre-filter batch size: how many shards' hashtree roots are compared in
+	// one batched RPC. <=1 disables the batched RPC (per-shard path). The hard cap
+	// bounds message size / per-batch work regardless of runtime overrides.
+	DefaultAsyncReplicationRootPrefilterBatchSize = 512
+	MaxAsyncReplicationRootPrefilterBatchSize     = 4096
+	DefaultMaximumAllowedCollectionsCount         = -1 // unlimited
+	DefaultMaximumAllowedObjectsCount             = -1 // unlimited
+	DefaultMaximumAllowedTenantsPerCollection     = -1 // unlimited
+	DefaultMaximumAllowedShardsPerCollection      = -1 // unlimited
+	DefaultUsageLimitsErrorMessage                = "" // empty → usagelimits.RenderTemplate falls back to its built-in default
+	DefaultRestrictionsErrorMessage               = "" // empty → restrictions.RenderTemplate falls back to its built-in default
 )
 
 const VectorizerModuleNone = "none"

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1842,11 +1842,8 @@ const (
 	// capping.
 	MaxAsyncReplicationSchedulerWorkers            = 100
 	DefaultAsyncReplicationHashtreeInitConcurrency = 10
-	// Root pre-filter batch size: a single cluster-wide setting applied to every
-	// collection (MT or ST), capping how many same-collection hashtree roots are
-	// compared in one batched RPC. 1 disables the batched RPC (per-shard path);
-	// values <= 0 are invalid and fall back to the default. The hard cap bounds
-	// message size / per-batch work regardless of runtime overrides.
+	// Root pre-filter batch size: cluster-wide cap on same-collection hashtree roots
+	// compared per batched RPC. 1 disables it; <= 0 falls back to the default.
 	DefaultAsyncReplicationRootPrefilterBatchSize = 512
 	MaxAsyncReplicationRootPrefilterBatchSize     = 4096
 	DefaultMaximumAllowedCollectionsCount         = -1 // unlimited

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -50,8 +50,7 @@ type WeaviateRuntimeConfig struct {
 	AsyncReplicationPropagationConcurrency    *runtime.DynamicValue[int]           `json:"async_replication_propagation_concurrency" yaml:"async_replication_propagation_concurrency"`
 	AsyncReplicationPropagationBatchSize      *runtime.DynamicValue[int]           `json:"async_replication_propagation_batch_size" yaml:"async_replication_propagation_batch_size"`
 	AsyncReplicationPropagationDelay          *runtime.DynamicValue[time.Duration] `json:"async_replication_propagation_delay" yaml:"async_replication_propagation_delay"`
-	AsyncReplicationRootPrefilterBatchSizeMT  *runtime.DynamicValue[int]           `json:"async_replication_root_prefilter_batch_size_mt" yaml:"async_replication_root_prefilter_batch_size_mt"`
-	AsyncReplicationRootPrefilterBatchSizeST  *runtime.DynamicValue[int]           `json:"async_replication_root_prefilter_batch_size_st" yaml:"async_replication_root_prefilter_batch_size_st"`
+	AsyncReplicationRootPrefilterBatchSize    *runtime.DynamicValue[int]           `json:"async_replication_root_prefilter_batch_size" yaml:"async_replication_root_prefilter_batch_size"`
 	RevectorizeCheckDisabled                  *runtime.DynamicValue[bool]          `json:"revectorize_check_disabled" yaml:"revectorize_check_disabled"`
 	ReplicaMovementMinimumAsyncWait           *runtime.DynamicValue[time.Duration] `json:"replica_movement_minimum_async_wait" yaml:"replica_movement_minimum_async_wait"`
 	TenantActivityReadLogLevel                *runtime.DynamicValue[string]        `json:"tenant_activity_read_log_level" yaml:"tenant_activity_read_log_level"`

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -50,6 +50,8 @@ type WeaviateRuntimeConfig struct {
 	AsyncReplicationPropagationConcurrency    *runtime.DynamicValue[int]           `json:"async_replication_propagation_concurrency" yaml:"async_replication_propagation_concurrency"`
 	AsyncReplicationPropagationBatchSize      *runtime.DynamicValue[int]           `json:"async_replication_propagation_batch_size" yaml:"async_replication_propagation_batch_size"`
 	AsyncReplicationPropagationDelay          *runtime.DynamicValue[time.Duration] `json:"async_replication_propagation_delay" yaml:"async_replication_propagation_delay"`
+	AsyncReplicationRootPrefilterBatchSizeMT  *runtime.DynamicValue[int]           `json:"async_replication_root_prefilter_batch_size_mt" yaml:"async_replication_root_prefilter_batch_size_mt"`
+	AsyncReplicationRootPrefilterBatchSizeST  *runtime.DynamicValue[int]           `json:"async_replication_root_prefilter_batch_size_st" yaml:"async_replication_root_prefilter_batch_size_st"`
 	RevectorizeCheckDisabled                  *runtime.DynamicValue[bool]          `json:"revectorize_check_disabled" yaml:"revectorize_check_disabled"`
 	ReplicaMovementMinimumAsyncWait           *runtime.DynamicValue[time.Duration] `json:"replica_movement_minimum_async_wait" yaml:"replica_movement_minimum_async_wait"`
 	TenantActivityReadLogLevel                *runtime.DynamicValue[string]        `json:"tenant_activity_read_log_level" yaml:"tenant_activity_read_log_level"`

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -479,14 +479,6 @@ func (f *Finder) CompareDigests(ctx context.Context,
 	return f.client.CompareDigests(ctx, host, f.class, shardName, digests)
 }
 
-// CompareShardRoots batches the level-0 hashtree-root compare for many shards of
-// this class against a single target host; see RClient.CompareHashTreeRoots.
-func (f *Finder) CompareShardRoots(ctx context.Context,
-	host string, roots map[string]hashtree.Digest,
-) ([]string, error) {
-	return f.client.CompareHashTreeRoots(ctx, host, f.class, roots)
-}
-
 // targetHostAddrsForShard resolves a shard's remote replica host addresses
 // (excluding the local node), mirroring the routing in CollectShardDifferences.
 func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -45,9 +45,8 @@ var (
 
 	ErrNoDiffFound = errors.New("no diff found")
 
-	// ErrCompareHashTreeRootsUnsupported is returned by the batched root-compare
-	// client when the target node is too old to serve the RPC (gRPC Unimplemented
-	// or REST 404). Callers fall back to the per-shard hashtree descent.
+	// ErrCompareHashTreeRootsUnsupported: target node too old to serve the RPC
+	// (gRPC Unimplemented or REST 404). Callers fall back to per-shard descent.
 	ErrCompareHashTreeRootsUnsupported = errors.New("CompareHashTreeRoots not supported by target node")
 )
 
@@ -480,7 +479,7 @@ func (f *Finder) CompareDigests(ctx context.Context,
 }
 
 // targetHostAddrsForShard resolves a shard's remote replica host addresses
-// (excluding the local node), mirroring the routing in CollectShardDifferences.
+// (excluding the local node), mirroring CollectShardDifferences.
 func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
@@ -508,25 +507,19 @@ func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
 	return hosts, nil
 }
 
-// prefilterMaxShardsPerRPC caps how many shards ride in one CompareHashTreeRoots
-// request so a large batch cannot build an oversized gRPC/REST message.
+// prefilterMaxShardsPerRPC caps shards per CompareHashTreeRoots request to bound
+// gRPC/REST message size.
 const prefilterMaxShardsPerRPC = 1000
 
-// PrefilterStats reports the outcome of the per-host root-compare RPCs in one
-// PrefilterShardRoots call, for observability.
+// PrefilterStats reports the per-host root-compare RPC outcomes for observability.
 type PrefilterStats struct {
 	OK          int
 	Errored     int
 	Unsupported int
 }
 
-// PrefilterShardRoots batches the level-0 hashtree-root compare for the given
-// shards (all of this class) against their replicas, returning the subset that
-// must take a full descent: shards that diverge on any replica, whose routing
-// cannot be resolved, or whose replica is too old to serve the batched RPC. A
-// shard absent from the result is confirmed in-sync on every replica. Requests
-// are chunked per host (prefilterMaxShardsPerRPC) and issued serially, so both
-// message size and concurrent fan-out stay bounded.
+// PrefilterShardRoots batches the level-0 root compare against replicas, returning
+// the subset needing a full descent (absent ⇒ in-sync). Chunked serially per host.
 func (f *Finder) PrefilterShardRoots(ctx context.Context,
 	roots map[string]hashtree.Digest,
 ) (map[string]struct{}, PrefilterStats) {
@@ -557,8 +550,8 @@ func (f *Finder) PrefilterShardRoots(ctx context.Context,
 		}
 		diverging, err := f.client.CompareHashTreeRoots(ctx, host, f.class, chunk)
 		if err != nil {
-			// Unsupported peer or transport error: fall back to full descent for
-			// this chunk's shards; a later cycle retries the batched path.
+			// Unsupported peer or transport error: full descent for this chunk;
+			// a later cycle retries the batched path.
 			if errors.Is(err, ErrCompareHashTreeRootsUnsupported) {
 				stats.Unsupported++
 			} else {

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -44,6 +44,11 @@ var (
 	ErrRead     = errors.New("read error")
 
 	ErrNoDiffFound = errors.New("no diff found")
+
+	// ErrCompareHashTreeRootsUnsupported is returned by the batched root-compare
+	// client when the target node is too old to serve the RPC (gRPC Unimplemented
+	// or REST 404). Callers fall back to the per-shard hashtree descent.
+	ErrCompareHashTreeRootsUnsupported = errors.New("CompareHashTreeRoots not supported by target node")
 )
 
 type (
@@ -472,6 +477,123 @@ func (f *Finder) CompareDigests(ctx context.Context,
 	shardName string, host string, digests []types.RepairResponse,
 ) ([]types.RepairResponse, error) {
 	return f.client.CompareDigests(ctx, host, f.class, shardName, digests)
+}
+
+// CompareShardRoots batches the level-0 hashtree-root compare for many shards of
+// this class against a single target host; see RClient.CompareHashTreeRoots.
+func (f *Finder) CompareShardRoots(ctx context.Context,
+	host string, roots map[string]hashtree.Digest,
+) ([]string, error) {
+	return f.client.CompareHashTreeRoots(ctx, host, f.class, roots)
+}
+
+// targetHostAddrsForShard resolves a shard's remote replica host addresses
+// (excluding the local node), mirroring the routing in CollectShardDifferences.
+func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
+	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
+	routingPlan, err := f.router.BuildReadRoutingPlan(options)
+	if err != nil {
+		return nil, fmt.Errorf("%w : class %q shard %q", err, f.class, shardName)
+	}
+
+	localNodeName := f.LocalNodeName()
+	localHostAddr, ok := f.nodeResolver.NodeHostname(localNodeName)
+	if !ok {
+		return nil, fmt.Errorf("could not resolve hostname for local node %q: class %q shard %q", localNodeName, f.class, shardName)
+	}
+
+	var hosts []string
+	for _, node := range routingPlan.NodeNames() {
+		if node == localNodeName {
+			continue
+		}
+		addr, ok := f.nodeResolver.NodeHostname(node)
+		if !ok || addr == localHostAddr {
+			continue
+		}
+		hosts = append(hosts, addr)
+	}
+	return hosts, nil
+}
+
+// prefilterMaxShardsPerRPC caps how many shards ride in one CompareHashTreeRoots
+// request so a large batch cannot build an oversized gRPC/REST message.
+const prefilterMaxShardsPerRPC = 1000
+
+// PrefilterStats reports the outcome of the per-host root-compare RPCs in one
+// PrefilterShardRoots call, for observability.
+type PrefilterStats struct {
+	OK          int
+	Errored     int
+	Unsupported int
+}
+
+// PrefilterShardRoots batches the level-0 hashtree-root compare for the given
+// shards (all of this class) against their replicas, returning the subset that
+// must take a full descent: shards that diverge on any replica, whose routing
+// cannot be resolved, or whose replica is too old to serve the batched RPC. A
+// shard absent from the result is confirmed in-sync on every replica. Requests
+// are chunked per host (prefilterMaxShardsPerRPC) and issued serially, so both
+// message size and concurrent fan-out stay bounded.
+func (f *Finder) PrefilterShardRoots(ctx context.Context,
+	roots map[string]hashtree.Digest,
+) (map[string]struct{}, PrefilterStats) {
+	needFull := make(map[string]struct{})
+	byHost := make(map[string]map[string]hashtree.Digest)
+
+	for shard, root := range roots {
+		hosts, err := f.targetHostAddrsForShard(shard)
+		if err != nil {
+			needFull[shard] = struct{}{}
+			continue
+		}
+		for _, h := range hosts {
+			sub := byHost[h]
+			if sub == nil {
+				sub = make(map[string]hashtree.Digest)
+				byHost[h] = sub
+			}
+			sub[shard] = root
+		}
+	}
+
+	var stats PrefilterStats
+	chunk := make(map[string]hashtree.Digest, prefilterMaxShardsPerRPC)
+	flush := func(host string) {
+		if len(chunk) == 0 {
+			return
+		}
+		diverging, err := f.client.CompareHashTreeRoots(ctx, host, f.class, chunk)
+		if err != nil {
+			// Unsupported peer or transport error: fall back to full descent for
+			// this chunk's shards; a later cycle retries the batched path.
+			if errors.Is(err, ErrCompareHashTreeRootsUnsupported) {
+				stats.Unsupported++
+			} else {
+				stats.Errored++
+			}
+			for s := range chunk {
+				needFull[s] = struct{}{}
+			}
+		} else {
+			stats.OK++
+			for _, s := range diverging {
+				needFull[s] = struct{}{}
+			}
+		}
+		clear(chunk)
+	}
+
+	for host, sub := range byHost {
+		for s, r := range sub {
+			chunk[s] = r
+			if len(chunk) >= prefilterMaxShardsPerRPC {
+				flush(host)
+			}
+		}
+		flush(host)
+	}
+	return needFull, stats
 }
 
 // Overwrite specified object with most recent contents

--- a/usecases/replica/finder_prefilter_test.go
+++ b/usecases/replica/finder_prefilter_test.go
@@ -1,0 +1,74 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+func TestPrefilterShardRoots(t *testing.T) {
+	const (
+		class = "C"
+		local = "A"
+		peer  = "B"
+	)
+	root := hashtree.Digest{1, 2}
+
+	newFinder := func(t *testing.T) (*fakeFactory, *replica.Finder) {
+		f := newFakeFactory(t, class, "s1", []string{local, peer}, true)
+		f.AddShard("s2", []string{local, peer})
+		return f, f.newFinder(local)
+	}
+
+	t.Run("all in sync returns empty", func(t *testing.T) {
+		f, finder := newFinder(t)
+		f.RClient.EXPECT().
+			CompareHashTreeRoots(mock.Anything, peer, class, mock.Anything).
+			Return([]string{}, nil)
+
+		needFull, stats := finder.PrefilterShardRoots(context.Background(),
+			map[string]hashtree.Digest{"s1": root, "s2": root})
+		assert.Empty(t, needFull)
+		assert.Equal(t, replica.PrefilterStats{OK: 1}, stats)
+	})
+
+	t.Run("diverging shard is flagged", func(t *testing.T) {
+		f, finder := newFinder(t)
+		f.RClient.EXPECT().
+			CompareHashTreeRoots(mock.Anything, peer, class, mock.Anything).
+			Return([]string{"s2"}, nil)
+
+		needFull, stats := finder.PrefilterShardRoots(context.Background(),
+			map[string]hashtree.Digest{"s1": root, "s2": root})
+		assert.Equal(t, map[string]struct{}{"s2": {}}, needFull)
+		assert.Equal(t, replica.PrefilterStats{OK: 1}, stats)
+	})
+
+	t.Run("unsupported peer falls back to full descent for its shards", func(t *testing.T) {
+		f, finder := newFinder(t)
+		f.RClient.EXPECT().
+			CompareHashTreeRoots(mock.Anything, peer, class, mock.Anything).
+			Return(nil, replica.ErrCompareHashTreeRootsUnsupported)
+
+		needFull, stats := finder.PrefilterShardRoots(context.Background(),
+			map[string]hashtree.Digest{"s1": root, "s2": root})
+		assert.Equal(t, map[string]struct{}{"s1": {}, "s2": {}}, needFull)
+		assert.Equal(t, replica.PrefilterStats{Unsupported: 1}, stats)
+	})
+}

--- a/usecases/replica/mock_r_client.go
+++ b/usecases/replica/mock_r_client.go
@@ -108,6 +108,67 @@ func (_c *MockRClient_CompareDigests_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// CompareHashTreeRoots provides a mock function with given fields: ctx, host, index, roots
+func (_m *MockRClient) CompareHashTreeRoots(ctx context.Context, host string, index string, roots map[string]hashtree.Digest) ([]string, error) {
+	ret := _m.Called(ctx, host, index, roots)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompareHashTreeRoots")
+	}
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]hashtree.Digest) ([]string, error)); ok {
+		return rf(ctx, host, index, roots)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, map[string]hashtree.Digest) []string); ok {
+		r0 = rf(ctx, host, index, roots)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, map[string]hashtree.Digest) error); ok {
+		r1 = rf(ctx, host, index, roots)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockRClient_CompareHashTreeRoots_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompareHashTreeRoots'
+type MockRClient_CompareHashTreeRoots_Call struct {
+	*mock.Call
+}
+
+// CompareHashTreeRoots is a helper method to define mock.On call
+//   - ctx context.Context
+//   - host string
+//   - index string
+//   - roots map[string]hashtree.Digest
+func (_e *MockRClient_Expecter) CompareHashTreeRoots(ctx interface{}, host interface{}, index interface{}, roots interface{}) *MockRClient_CompareHashTreeRoots_Call {
+	return &MockRClient_CompareHashTreeRoots_Call{Call: _e.mock.On("CompareHashTreeRoots", ctx, host, index, roots)}
+}
+
+func (_c *MockRClient_CompareHashTreeRoots_Call) Run(run func(ctx context.Context, host string, index string, roots map[string]hashtree.Digest)) *MockRClient_CompareHashTreeRoots_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(map[string]hashtree.Digest))
+	})
+	return _c
+}
+
+func (_c *MockRClient_CompareHashTreeRoots_Call) Return(divergingShards []string, err error) *MockRClient_CompareHashTreeRoots_Call {
+	_c.Call.Return(divergingShards, err)
+	return _c
+}
+
+func (_c *MockRClient_CompareHashTreeRoots_Call) RunAndReturn(run func(context.Context, string, string, map[string]hashtree.Digest) ([]string, error)) *MockRClient_CompareHashTreeRoots_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountObjects provides a mock function with given fields: ctx, host, index, shard
 func (_m *MockRClient) CountObjects(ctx context.Context, host string, index string, shard string) (int, error) {
 	ret := _m.Called(ctx, host, index, shard)

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -173,6 +173,16 @@ type DigestObjectsInRangeResp struct {
 	Digests []types.RepairResponse `json:"digests,omitempty"`
 }
 
+// CompareHashTreeRootsReq / Resp are the REST-transport payloads for the batched
+// root pre-filter. Each root is a hashtree.Digest ([2]uint64) keyed by shard.
+type CompareHashTreeRootsReq struct {
+	Roots map[string]hashtree.Digest `json:"roots"`
+}
+
+type CompareHashTreeRootsResp struct {
+	DivergingShards []string `json:"divergingShards,omitempty"`
+}
+
 // WClient is the client used to write to replicas
 type WClient interface {
 	PutObject(ctx context.Context, host, index, shard, requestID string,
@@ -232,6 +242,14 @@ type RClient interface {
 	HashTreeLevel(ctx context.Context, host, index, shard string, level int,
 		discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 
+	// CompareHashTreeRoots sends this node's local hashtree root per shard and
+	// returns the subset whose roots differ on the target (or that the target
+	// lacks / has not fully initialised). It batches the level-0 root compare of
+	// many shards into one request. Returns ErrCompareHashTreeRootsUnsupported
+	// when the target is too old to serve it, so the caller can fall back.
+	CompareHashTreeRoots(ctx context.Context, host, index string,
+		roots map[string]hashtree.Digest) (divergingShards []string, err error)
+
 	CountObjects(ctx context.Context, host, index, shard string) (int, error)
 }
 
@@ -286,6 +304,12 @@ func (fc FinderClient) CompareDigests(ctx context.Context,
 	digests []types.RepairResponse,
 ) ([]types.RepairResponse, error) {
 	return fc.cl.CompareDigests(ctx, host, index, shard, digests)
+}
+
+func (fc FinderClient) CompareHashTreeRoots(ctx context.Context,
+	host, index string, roots map[string]hashtree.Digest,
+) ([]string, error) {
+	return fc.cl.CompareHashTreeRoots(ctx, host, index, roots)
 }
 
 // FullReads read full objects

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -174,7 +174,7 @@ type DigestObjectsInRangeResp struct {
 }
 
 // CompareHashTreeRootsReq / Resp are the REST-transport payloads for the batched
-// root pre-filter. Each root is a hashtree.Digest ([2]uint64) keyed by shard.
+// root pre-filter, keyed by shard.
 type CompareHashTreeRootsReq struct {
 	Roots map[string]hashtree.Digest `json:"roots"`
 }
@@ -242,11 +242,8 @@ type RClient interface {
 	HashTreeLevel(ctx context.Context, host, index, shard string, level int,
 		discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 
-	// CompareHashTreeRoots sends this node's local hashtree root per shard and
-	// returns the subset whose roots differ on the target (or that the target
-	// lacks / has not fully initialised). It batches the level-0 root compare of
-	// many shards into one request. Returns ErrCompareHashTreeRootsUnsupported
-	// when the target is too old to serve it, so the caller can fall back.
+	// CompareHashTreeRoots batches the level-0 root compare of many shards, returning
+	// the diverging subset. Returns ErrCompareHashTreeRootsUnsupported on too-old targets.
 	CompareHashTreeRoots(ctx context.Context, host, index string,
 		roots map[string]hashtree.Digest) (divergingShards []string, err error)
 

--- a/usecases/replica/types/mock_replicator.go
+++ b/usecases/replica/types/mock_replicator.go
@@ -210,6 +210,66 @@ func (_c *MockReplicator_CompareDigests_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// CompareHashTreeRoots provides a mock function with given fields: ctx, className, roots
+func (_m *MockReplicator) CompareHashTreeRoots(ctx context.Context, className string, roots map[string]hashtree.Digest) ([]string, error) {
+	ret := _m.Called(ctx, className, roots)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompareHashTreeRoots")
+	}
+
+	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]hashtree.Digest) ([]string, error)); ok {
+		return rf(ctx, className, roots)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]hashtree.Digest) []string); ok {
+		r0 = rf(ctx, className, roots)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, map[string]hashtree.Digest) error); ok {
+		r1 = rf(ctx, className, roots)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockReplicator_CompareHashTreeRoots_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompareHashTreeRoots'
+type MockReplicator_CompareHashTreeRoots_Call struct {
+	*mock.Call
+}
+
+// CompareHashTreeRoots is a helper method to define mock.On call
+//   - ctx context.Context
+//   - className string
+//   - roots map[string]hashtree.Digest
+func (_e *MockReplicator_Expecter) CompareHashTreeRoots(ctx interface{}, className interface{}, roots interface{}) *MockReplicator_CompareHashTreeRoots_Call {
+	return &MockReplicator_CompareHashTreeRoots_Call{Call: _e.mock.On("CompareHashTreeRoots", ctx, className, roots)}
+}
+
+func (_c *MockReplicator_CompareHashTreeRoots_Call) Run(run func(ctx context.Context, className string, roots map[string]hashtree.Digest)) *MockReplicator_CompareHashTreeRoots_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(map[string]hashtree.Digest))
+	})
+	return _c
+}
+
+func (_c *MockReplicator_CompareHashTreeRoots_Call) Return(divergingShards []string, err error) *MockReplicator_CompareHashTreeRoots_Call {
+	_c.Call.Return(divergingShards, err)
+	return _c
+}
+
+func (_c *MockReplicator_CompareHashTreeRoots_Call) RunAndReturn(run func(context.Context, string, map[string]hashtree.Digest) ([]string, error)) *MockReplicator_CompareHashTreeRoots_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountObjects provides a mock function with given fields: ctx, indexName, shardName
 func (_m *MockReplicator) CountObjects(ctx context.Context, indexName string, shardName string) (int, error) {
 	ret := _m.Called(ctx, indexName, shardName)

--- a/usecases/replica/types/replicator.go
+++ b/usecases/replica/types/replicator.go
@@ -47,6 +47,11 @@ type Replicator interface {
 	CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairResponse) ([]types.RepairResponse, error)
 	HashTreeLevel(ctx context.Context, className, shardName string,
 		level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
+	// CompareHashTreeRoots compares this node's local hashtree root per shard
+	// against the provided roots, returning the shards that diverge (root differs,
+	// or shard missing / hashtree not fully initialised here).
+	CompareHashTreeRoots(ctx context.Context, className string,
+		roots map[string]hashtree.Digest) (divergingShards []string, err error)
 	FindUUIDs(ctx context.Context, indexName, shardName string, filters *filters.LocalFilter, limit int) ([]strfmt.UUID, error)
 	CountObjects(ctx context.Context, indexName, shardName string) (int, error)
 }

--- a/usecases/replica/types/replicator.go
+++ b/usecases/replica/types/replicator.go
@@ -47,9 +47,8 @@ type Replicator interface {
 	CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairResponse) ([]types.RepairResponse, error)
 	HashTreeLevel(ctx context.Context, className, shardName string,
 		level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
-	// CompareHashTreeRoots compares this node's local hashtree root per shard
-	// against the provided roots, returning the shards that diverge (root differs,
-	// or shard missing / hashtree not fully initialised here).
+	// CompareHashTreeRoots returns shards whose local root was read and differs;
+	// not-ready shards (missing/uninitialised) are omitted.
 	CompareHashTreeRoots(ctx context.Context, className string,
 		roots map[string]hashtree.Digest) (divergingShards []string, err error)
 	FindUUIDs(ctx context.Context, indexName, shardName string, filters *filters.LocalFilter, limit int) ([]strfmt.UUID, error)


### PR DESCRIPTION
## Motivation

At async-replication steady state most tenants are already in sync, yet every shard still pays ~`RF-1` `HashTreeLevel(level=0)` root RPCs **per cycle** just to learn "no diff". For a 25k-tenant cluster that is tens of thousands of round-trips per interval whose only outcome is `ErrNoDiffFound`.

This PR collapses that root-RPC storm into a **batched, inline pre-filter**: the scheduler coalesces due shards of a class into a batch; a worker sends all their local roots to each replica in **one** `CompareHashTreeRoots` RPC, gets back only the diverging shards, and descends (full hashtree diff + propagation) **only those**. In-sync shards short-circuit with no network diff — the same outcome as today's level-0 compare, discovered in one batched call instead of N.

## Design

- **Inline, no cache.** The root compare and the descent run back-to-back on the same hashtree snapshot, so there is no stale-verdict window — correctness is identical in outcome to today's `root matched → ErrNoDiffFound`.
- **New `CompareHashTreeRoots` RPC** (gRPC + REST, mirrors `CompareDigests`). The target reports a shard diverging **only when its local root was read and differs**; not-ready shards (missing / cold / uninitialised hashtree) are omitted. Async replication does not make a target shard ready, so a not-ready shard is caught once it becomes ready by other means — its root then differs — which defers detection rather than losing it, and drops the futile per-cycle descent against a target that cannot yet be repaired.
- **Batch size is a single cluster-wide knob** `ASYNC_REPLICATION_ROOT_PREFILTER_BATCH_SIZE` (`DynamicValue[int]`, default **512**), applied uniformly to every collection (MT or ST) — not a per-collection or per-tenancy setting. It caps how many same-collection shards are coalesced per compare RPC; a collection with a single due shard takes the per-shard path (exactly today's behavior). `1` disables the pre-filter for all collections; invalid values (≤ 0) warn and use the default; clamped to a hard cap (4096) with per-host request chunking (≤1000).
- **Scheduler surgery is isolated** to the dispatch→execute path. The proven heap / Register / backoff / rebuild core is unchanged; per-entry `inFlight`/`asyncRepWg`/heap accounting is preserved, and the batch dispatch keeps the same non-blocking full-channel rollback.

## Correctness / safety

- **`asyncRepWg` stays balanced on every path.** The pre-filter runs in a panic-contained `classifyBatch` (a panic ⇒ "descend everything"), and `runEntry` — which alone owns each entry's `Done()`+result — is always called exactly once per entry.
- **Lock order preserved** (`workersMu → mu → asyncReplicationRWMux`): dispatch coalescing reads only the immutable class/index under `mu`; all routing/`Root()` reads happen in the worker with no `mu` held.
- **Rolling upgrade:** older replicas return gRPC `Unimplemented` / REST 404 → mapped to a sentinel → silent per-host fallback to the per-shard path, retried each cycle until the peer is upgraded. No panic, no failed cycle.
- **Not-ready shards never cause permanent divergence.** A target shard that is missing/cold/uninitialised is omitted (skipped this cycle) rather than descended. Because readiness is driven independently of async replication, once the shard is ready its root diverges from the source and the very next compare reports it — so it is repaired then. The source-side `classifyBatch` likewise excludes shards with active target-node overrides or uninitialised local hashtrees and takes the full path.

## Metrics

- `async_replication_root_prefilter_skips_total` — shard cycles short-circuited as in-sync (the "storm eliminated" headline).
- `async_replication_root_prefilter_batch_size` — histogram of shards per batch.
- `async_replication_root_compare_rpc_total{result="ok|error|unsupported"}`.

## Key review areas

- `adapters/repos/db/async_replication_scheduler.go` — dispatch coalescing, `runBatch`/`classifyBatch`, pooling, metrics, batch-size validation.
- `usecases/replica/finder.go` — `PrefilterShardRoots` (group by host, chunk, union diverging, per-host fallback).
- `adapters/repos/db/replication.go` — `Index.CompareHashTreeRoots` target semantics: diverge **only** on a read-and-differing root; omit not-ready shards (no force-load of cold shards).
- Transport parity across gRPC/REST clients + handlers.

## Testing

- Unit: dispatch coalescing (sizes, distinct indexes, full-channel rollback), `effectiveBatchSize` (configured value, invalid→default, clamp), `classifyBatch` override/uninitialised exclusion, `runBatch` one-result-per-entry (WG balance), `PrefilterShardRoots` (in-sync / diverging / unsupported fallback), gRPC handler round-trip, `HashTreeRoot`.
- Concurrency (`-race`): `TestAsyncSchedulerConcurrentBatchedDispatch` drives the real dispatcher+worker pool over multi-entry batches while Register/Deregister race against Close — asserts no deadlock and balanced `asyncRepWg` (15× clean).
- Integration (`integrationTest`): `Index.CompareHashTreeRoots` target semantics — equal and not-ready (missing/uninitialised) roots are omitted, a read-and-differing root diverges; existing scheduler suite green under `-race`.
- Acceptance: `TestAsyncRepairRootPrefilterManyTenants` — RF=3 MT, 12 tenants, node-down write + restart, asserts every tenant reconciles via the default-on batched pre-filter. (Docker-based; not run locally — CI covers it.)
- `golangci-lint` 0 issues; goroutine linter clean; `-race` green.

## Rollout

Ships **on by default** (batch size 512), applied cluster-wide to every collection; collections with a single shard are unchanged in outcome (per-shard path). Kill switch: set `ASYNC_REPLICATION_ROOT_PREFILTER_BATCH_SIZE=1` (or the runtime config equivalent) to force the per-shard path cluster-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
