### PR TITLE
docs: add Zenith to installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Weaviate offers multiple installation and deployment options:
 - [Docker](https://docs.weaviate.io/deploy/installation-guides/docker-installation)
 - [Kubernetes](https://docs.weaviate.io/deploy/installation-guides/k8s-installation)
 - [Weaviate Cloud](https://console.weaviate.cloud)
+- [Zenith](https://zenith.hosting/host/weaviate?ref=gh)
 
 See the [installation docs](https://docs.weaviate.io/deploy) for more deployment options, such as [AWS](https://docs.weaviate.io/deploy/installation-guides/aws-marketplace) and [GCP](https://docs.weaviate.io/deploy/installation-guides/gcp-marketplace).
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Weaviate to our marketplace, so this PR adds a small Zenith entry in the Installation options (links to https://zenith.hosting/host/weaviate?ref=gh).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

### What's being changed:

Docs-only: adds a Zenith entry to the Installation options.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: this PR
- [ ] Chaos pipeline run or not necessary. N/A (docs-only change)
- [ ] All new code is covered by tests where it is reasonable. N/A (docs-only change, no code)
- [ ] Performance tests have been run or not necessary. N/A (docs-only change)

AI usage: No LLMs were involved.
