### PR TITLE
Incremental backups: Bugfix collection

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -46,13 +46,7 @@ var errShardNoLocalData = errors.New("shard has no local data")
 const (
 	lsmDir        = "lsm"
 	migrationsDir = ".migrations"
-	dbExt         = ".db"
-	bloomExt      = ".bloom"
 	tmpExt        = ".tmp"
-	cnaExt        = ".cna"
-	metadataExt   = ".metadata"
-	condensedExt  = ".condensed"
-	snapshotExt   = ".snapshot"
 )
 
 // Backupable returns whether all given class can be backed up.
@@ -410,7 +404,7 @@ func (i *Index) backupInactiveShardWithHardlinks(name string, sd *backup.ShardDe
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return fmt.Errorf("create staging subdir for inactive shard %s file %s: %w", name, relPath, err)
 		}
-		if isImmutableFile(relPath) {
+		if backup.IsImmutableFile(relPath) {
 			if err := os.Link(src, dst); err != nil {
 				return fmt.Errorf("hardlink inactive shard %s file %s to staging: %w", name, relPath, err)
 			}
@@ -427,35 +421,6 @@ func (i *Index) backupInactiveShardWithHardlinks(name string, sd *backup.ShardDe
 	}
 
 	return nil
-}
-
-// isImmutableFile reports whether a backup file (relative path) is guaranteed
-// never to be modified in place after a COLD/INACTIVE shard is activated.
-// Only these files are safe to hard-link during backup; all other files are
-// copied to avoid post-snapshot corruption from in-place writes.
-func isImmutableFile(relPath string) bool {
-	base := filepath.Base(relPath)
-	ext := filepath.Ext(base)
-
-	// LSM segment data files — written once during flush/compaction, never modified.
-	// Excludes meta*.db (flat index BoltDB, mmap writes) and index.db (dynamic index BoltDB).
-	if ext == dbExt && !strings.HasPrefix(base, "meta") && base != "index.db" {
-		return true
-	}
-	// LSM segment companion files — written once during segment init, never modified.
-	// .bloom = bloom filter, .cna = count net additions, .metadata = combined metadata.
-	if ext == bloomExt || ext == cnaExt || ext == metadataExt {
-		return true
-	}
-	// Condensed HNSW commitlogs — produced by compaction, never reopened for writes.
-	if ext == condensedExt {
-		return true
-	}
-	// HNSW snapshots — point-in-time captures, never modified after creation.
-	if ext == snapshotExt {
-		return true
-	}
-	return false
 }
 
 // copyFile creates an independent copy of src at dst, fsyncing the destination.

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -248,39 +248,6 @@ func TestListInactiveShardFiles(t *testing.T) {
 	assert.Equal(t, expected, files)
 }
 
-func TestIsImmutableFile(t *testing.T) {
-	tests := []struct {
-		relPath string
-		want    bool
-		desc    string
-	}{
-		// Immutable files (safe to hardlink):
-		{"myclass/shard1/lsm/objects/segment-0001.db", true, "LSM segment (immutable)"},
-		{"myclass/shard1/main.hnsw.commitlog.d/1709203456.condensed", true, "condensed HNSW commitlog (immutable)"},
-		{"myclass/shard1/main.hnsw.snapshot.d/1709203456.snapshot", true, "HNSW snapshot (immutable)"},
-
-		// Mutable files (must be copied):
-		{"myclass/shard1/lsm/objects/segment-123.wal", false, "LSM WAL"},
-		{"myclass/shard1/main/meta.db", false, "flat index BoltDB (single vector)"},
-		{"myclass/shard1/main_custom/meta_custom.db", false, "flat index BoltDB (multi-vector)"},
-		{"myclass/shard1/main.hnsw.commitlog.d/1709203456", false, "non-condensed HNSW commitlog"},
-		{"myclass/shard1/main.queue.d/chunk-1709203456000000.bin", false, "async indexing queue chunk"},
-		{"myclass/shard1/index.db", false, "dynamic vector index BoltDB"},
-
-		// Unknown files default to mutable (safe — will be copied):
-		{"myclass/shard1/lsm/.migrations/m1", false, "migration file (unknown, copied)"},
-		{"myclass/shard1/lsm/objects/segment.db.tmp", false, "tmp file (unknown, copied)"},
-		{"myclass/shard1/hashtree_uuid/hashtree-abc.ht", false, "hashtree (unknown, copied)"},
-		{"myclass/shard1/some-new-file.bin", false, "unknown file type (copied by default)"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			got := isImmutableFile(tc.relPath)
-			assert.Equal(t, tc.want, got, "isImmutableFile(%q)", tc.relPath)
-		})
-	}
-}
-
 func TestBackupInactiveShardCopyVsHardlink(t *testing.T) {
 	rootDir := t.TempDir()
 	indexID := "myclass"

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -243,6 +243,10 @@ func (d *DistributedBackupDescriptor) GetCompressionType() CompressionType {
 	return d.CompressionType
 }
 
+func (d *DistributedBackupDescriptor) GetStartedAt() time.Time {
+	return d.StartedAt
+}
+
 // ShardDescriptor contains everything needed to completely restore a partition of a specific class
 type ShardDescriptor struct {
 	Name                  string                 `json:"name"`
@@ -521,6 +525,10 @@ func (d *BackupDescriptor) List() []string {
 
 func (d *BackupDescriptor) GetBaseBackupID() string {
 	return d.BaseBackupID
+}
+
+func (d *BackupDescriptor) GetStartedAt() time.Time {
+	return d.StartedAt
 }
 
 // AllExist checks if all classes exist in d.

--- a/entities/backup/descriptor_test.go
+++ b/entities/backup/descriptor_test.go
@@ -63,6 +63,35 @@ func TestIncludeClasses(t *testing.T) {
 	}
 }
 
+// GetClassDescriptor drives per-class incremental dedup: a class found in the
+// base is deduplicated against it, a class absent from the base (added since)
+// returns nil and is uploaded in full.
+func TestGetClassDescriptor(t *testing.T) {
+	base := BackupDescriptor{Classes: []ClassDescriptor{{Name: "A"}, {Name: "B"}}}
+	tests := []struct {
+		name      string
+		in        BackupDescriptor
+		query     string
+		wantClass string // "" means expect nil (full upload)
+	}{
+		{name: "ExistingClassDedups", in: base, query: "A", wantClass: "A"},
+		{name: "OtherExistingClassDedups", in: base, query: "B", wantClass: "B"},
+		{name: "NewClassNotInBase", in: base, query: "C", wantClass: ""},
+		{name: "EmptyBase", in: BackupDescriptor{}, query: "A", wantClass: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.in.GetClassDescriptor(tc.query)
+			if tc.wantClass == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantClass, got.Name)
+		})
+	}
+}
+
 func TestAllExist(t *testing.T) {
 	x := BackupDescriptor{Classes: []ClassDescriptor{{Name: "a"}}}
 	if y := x.AllExist(nil); y != "" {

--- a/entities/backup/immutable_files.go
+++ b/entities/backup/immutable_files.go
@@ -1,0 +1,57 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package backup
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	dbExt        = ".db"
+	bloomExt     = ".bloom"
+	cnaExt       = ".cna"
+	metadataExt  = ".metadata"
+	condensedExt = ".condensed"
+	snapshotExt  = ".snapshot"
+)
+
+// IsImmutableFile reports whether a backup file (relative path) is guaranteed
+// never to be modified in place after it is written. Such files are safe to
+// hard-link during backup, and safe to deduplicate across incremental backups by
+// comparing size+mtime. Every other file is copied and re-uploaded on each
+// incremental: an in-place rewrite can change its content while keeping the same
+// size, so size+mtime is not a reliable unchanged signal for it.
+func IsImmutableFile(relPath string) bool {
+	base := filepath.Base(relPath)
+	ext := filepath.Ext(base)
+
+	// LSM segment data files — written once during flush/compaction, never modified.
+	// Excludes meta*.db (flat index BoltDB, mmap writes) and index.db (dynamic index BoltDB).
+	if ext == dbExt && !strings.HasPrefix(base, "meta") && base != "index.db" {
+		return true
+	}
+	// LSM segment companion files — written once during segment init, never modified.
+	// .bloom = bloom filter, .cna = count net additions, .metadata = combined metadata.
+	if ext == bloomExt || ext == cnaExt || ext == metadataExt {
+		return true
+	}
+	// Condensed HNSW commitlogs — produced by compaction, never reopened for writes.
+	if ext == condensedExt {
+		return true
+	}
+	// HNSW snapshots — point-in-time captures, never modified after creation.
+	if ext == snapshotExt {
+		return true
+	}
+	return false
+}

--- a/entities/backup/immutable_files_test.go
+++ b/entities/backup/immutable_files_test.go
@@ -1,0 +1,54 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsImmutableFile(t *testing.T) {
+	tests := []struct {
+		relPath string
+		want    bool
+		desc    string
+	}{
+		// Immutable files (hard-linked and dedup-eligible):
+		{"myclass/shard1/lsm/objects/segment-0001.db", true, "LSM segment (immutable)"},
+		{"myclass/shard1/lsm/objects/segment-0001.bloom", true, "LSM bloom filter (immutable)"},
+		{"myclass/shard1/lsm/objects/segment-0001.cna", true, "LSM count-net-additions (immutable)"},
+		{"myclass/shard1/lsm/objects/segment-0001.metadata", true, "LSM combined metadata (immutable)"},
+		{"myclass/shard1/main.hnsw.commitlog.d/1709203456.condensed", true, "condensed HNSW commitlog (immutable)"},
+		{"myclass/shard1/main.hnsw.snapshot.d/1709203456.snapshot", true, "HNSW snapshot (immutable)"},
+
+		// Mutable files (copied and re-uploaded every incremental):
+		{"myclass/shard1/lsm/objects/segment-123.wal", false, "LSM WAL"},
+		{"myclass/shard1/main/meta.db", false, "flat index BoltDB (single vector)"},
+		{"myclass/shard1/main_custom/meta_custom.db", false, "flat index BoltDB (multi-vector)"},
+		{"myclass/shard1/main.hnsw.commitlog.d/1709203456", false, "non-condensed HNSW commitlog"},
+		{"myclass/shard1/main.queue.d/chunk-1709203456000000.bin", false, "async indexing queue chunk"},
+		{"myclass/shard1/index.db", false, "dynamic vector index BoltDB"},
+
+		// Unknown files default to mutable (safe — copied and re-uploaded):
+		{"myclass/shard1/lsm/.migrations/m1", false, "migration file (unknown, copied)"},
+		{"myclass/shard1/lsm/objects/segment.db.tmp", false, "tmp file (unknown, copied)"},
+		{"myclass/shard1/hashtree_uuid/hashtree-abc.ht", false, "hashtree (unknown, copied)"},
+		{"myclass/shard1/some-new-file.bin", false, "unknown file type (copied by default)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := IsImmutableFile(tc.relPath)
+			assert.Equal(t, tc.want, got, "IsImmutableFile(%q)", tc.relPath)
+		})
+	}
+}

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -131,7 +131,8 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 		logFields := logrus.Fields{"action": "create_backup", "backup_id": req.ID, "override_bucket": req.Bucket, "override_path": req.Path, "routine_pool_size": provider.GoPoolSize}
 
 		baseBackupID := req.BaseBackupID
-		baseDescrs, err := resolveBaseBackupChain(ctx, baseBackupID, store.bucket, store.path, compressionType, store.MetaForBackupID)
+		startedAt := time.Now().UTC()
+		baseDescrs, err := resolveBaseBackupChain(ctx, baseBackupID, startedAt, store.bucket, store.path, compressionType, store.MetaForBackupID)
 		if err != nil {
 			if !errors.As(err, &backup.ErrNotFound{}) {
 				b.logger.WithFields(logFields).Error(err)
@@ -148,7 +149,7 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 		}
 
 		result := backup.BackupDescriptor{
-			StartedAt:       time.Now().UTC(),
+			StartedAt:       startedAt,
 			ID:              id,
 			Classes:         make([]backup.ClassDescriptor, 0, len(req.Classes)),
 			Version:         Version,
@@ -175,19 +176,26 @@ type ChainDescriptor interface {
 	GetBaseBackupID() string
 	GetCompressionType() backup.CompressionType
 	GetStatus() backup.Status
+	GetStartedAt() time.Time
 }
 
 // resolveBaseBackupChain follows the chain of base backups and validates them.
 // It returns all base backup descriptors in the chain, ordered from the most recent
 // (the requested baseBackupID) to the oldest (the full backup).
+// childStartedAt is the StartedAt of the backup that references baseBackupID.
 // It validates:
-// - No circular references in the backup chain
-// - All backups in the chain exist
-// - All backups have compression type set
-// - All backups have the same compression type as requested
+//   - No circular references in the backup chain
+//   - All backups in the chain exist
+//   - All backups have compression type set
+//   - All backups have the same compression type as requested
+//   - Each base started strictly before the backup that depends on it. A base whose
+//     StartedAt is not older was re-created after its dependent (backup ids reuse the
+//     same object paths), so the dependent no longer points at the bytes it was built
+//     from and restoring it would silently return the wrong data.
 func resolveBaseBackupChain[T ChainDescriptor](
 	ctx context.Context,
 	baseBackupID string,
+	childStartedAt time.Time,
 	bucket, path string,
 	compression backup.CompressionType,
 	fetchMeta func(ctx context.Context, backupID, bucket, path string) (T, error),
@@ -221,12 +229,19 @@ func resolveBaseBackupChain[T ChainDescriptor](
 			return nil, fmt.Errorf("backup %q has status %q, expected %q", nextID, baseDescr.GetStatus(), backup.Success)
 		}
 
+		startedAt := baseDescr.GetStartedAt()
+		if !startedAt.Before(childStartedAt) {
+			return nil, fmt.Errorf("base backup %q started at %s is not older than the backup that depends on it (started at %s): the base was re-created and the chain is no longer valid",
+				nextID, startedAt.UTC().Format(time.RFC3339), childStartedAt.UTC().Format(time.RFC3339))
+		}
+
 		baseDescrs = append(baseDescrs, baseDescr)
 
 		// Check if we've reached the end of the chain
 		if baseDescr.GetBaseBackupID() == "" {
 			break
 		}
+		childStartedAt = startedAt
 		nextID = baseDescr.GetBaseBackupID()
 	}
 

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -133,9 +133,18 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 		baseBackupID := req.BaseBackupID
 		baseDescrs, err := resolveBaseBackupChain(ctx, baseBackupID, store.bucket, store.path, compressionType, store.MetaForBackupID)
 		if err != nil {
-			b.logger.WithFields(logFields).Error(err)
-			b.lastAsyncError = err
-			return
+			if !errors.As(err, &backup.ErrNotFound{}) {
+				b.logger.WithFields(logFields).Error(err)
+				b.lastAsyncError = err
+				return
+			}
+			// This node was absent from the base backup (it joined the cluster
+			// since, or a shard landed on it after the base was taken), so it has
+			// no descriptor there: back it up in full instead of failing the whole backup.
+			b.logger.WithFields(logFields).Warn("node not present in base backup, uploading full backup for this node")
+			baseDescrs = nil
+			// Clear the base ID so the descriptor reflects the full backup we actually took.
+			baseBackupID = ""
 		}
 
 		result := backup.BackupDescriptor{

--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -469,11 +469,20 @@ func TestResolveBaseBackupChain(t *testing.T) {
 	bucket := "test-bucket"
 	path := "test-path"
 
+	// t0 is the oldest; a valid chain has strictly increasing StartedAt from the
+	// full backup up to the backup that depends on it (childStartedAt).
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+	t2 := t0.Add(2 * time.Hour)
+	t3 := t0.Add(3 * time.Hour)
+	t4 := t0.Add(4 * time.Hour)
+
 	type fetchMetaFunc func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error)
 
 	tests := []struct {
 		name              string
 		baseBackupID      string
+		childStartedAt    time.Time
 		compressionType   backup.CompressionType
 		setupFetchMeta    func() fetchMetaFunc
 		errorContains     []string
@@ -482,6 +491,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		{
 			name:            "EmptyBaseBackupID",
 			baseBackupID:    "",
+			childStartedAt:  t1,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
 				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
@@ -494,6 +504,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		{
 			name:            "SingleBaseBackup",
 			baseBackupID:    "backup-1",
+			childStartedAt:  t1,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
 				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
@@ -502,6 +513,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 						CompressionType: &gzipCompression,
 						BaseBackupID:    "",
 						Status:          backup.Success,
+						StartedAt:       t0,
 					}, nil
 				}
 			},
@@ -510,6 +522,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		{
 			name:            "ChainOfMultipleBackups",
 			baseBackupID:    "backup-3",
+			childStartedAt:  t4,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
 				descriptors := map[string]*backup.BackupDescriptor{
@@ -518,18 +531,21 @@ func TestResolveBaseBackupChain(t *testing.T) {
 						CompressionType: &gzipCompression,
 						BaseBackupID:    "",
 						Status:          backup.Success,
+						StartedAt:       t0,
 					},
 					"backup-2": {
 						ID:              "backup-2",
 						CompressionType: &gzipCompression,
 						BaseBackupID:    "backup-1",
 						Status:          backup.Success,
+						StartedAt:       t1,
 					},
 					"backup-3": {
 						ID:              "backup-3",
 						CompressionType: &gzipCompression,
 						BaseBackupID:    "backup-2",
 						Status:          backup.Success,
+						StartedAt:       t2,
 					},
 				}
 				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
@@ -539,8 +555,83 @@ func TestResolveBaseBackupChain(t *testing.T) {
 			expectedResultIDs: []string{"backup-3", "backup-2", "backup-1"},
 		},
 		{
+			// Base re-created after its dependent: same id, newer StartedAt.
+			name:            "BaseNewerThanChild",
+			baseBackupID:    "backup-1",
+			childStartedAt:  t1,
+			compressionType: gzipCompression,
+			setupFetchMeta: func() fetchMetaFunc {
+				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
+					return &backup.BackupDescriptor{
+						ID:              "backup-1",
+						CompressionType: &gzipCompression,
+						BaseBackupID:    "",
+						Status:          backup.Success,
+						StartedAt:       t2,
+					}, nil
+				}
+			},
+			errorContains: []string{"base backup \"backup-1\"", "is not older", "re-created"},
+		},
+		{
+			// Equal StartedAt is rejected: the base must be strictly older.
+			name:            "BaseEqualToChild",
+			baseBackupID:    "backup-1",
+			childStartedAt:  t1,
+			compressionType: gzipCompression,
+			setupFetchMeta: func() fetchMetaFunc {
+				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
+					return &backup.BackupDescriptor{
+						ID:              "backup-1",
+						CompressionType: &gzipCompression,
+						BaseBackupID:    "",
+						Status:          backup.Success,
+						StartedAt:       t1,
+					}, nil
+				}
+			},
+			errorContains: []string{"base backup \"backup-1\"", "is not older"},
+		},
+		{
+			// A deeper link was re-created: backup-2 is newer than backup-3 which depends on it.
+			name:            "StaleBaseMidChain",
+			baseBackupID:    "backup-3",
+			childStartedAt:  t4,
+			compressionType: gzipCompression,
+			setupFetchMeta: func() fetchMetaFunc {
+				descriptors := map[string]*backup.BackupDescriptor{
+					"backup-1": {
+						ID:              "backup-1",
+						CompressionType: &gzipCompression,
+						BaseBackupID:    "",
+						Status:          backup.Success,
+						StartedAt:       t0,
+					},
+					"backup-2": {
+						ID:              "backup-2",
+						CompressionType: &gzipCompression,
+						BaseBackupID:    "backup-1",
+						Status:          backup.Success,
+						StartedAt:       t3,
+					},
+					"backup-3": {
+						ID:              "backup-3",
+						CompressionType: &gzipCompression,
+						BaseBackupID:    "backup-2",
+						Status:          backup.Success,
+						StartedAt:       t2,
+					},
+				}
+				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
+					return descriptors[backupID], nil
+				}
+			},
+			errorContains: []string{"base backup \"backup-2\"", "is not older"},
+		},
+		{
 			name:            "CircularReferenceDetection",
 			baseBackupID:    "backup-1",
+			childStartedAt:  t2,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
 				descriptors := map[string]*backup.BackupDescriptor{
@@ -549,12 +640,14 @@ func TestResolveBaseBackupChain(t *testing.T) {
 						CompressionType: &gzipCompression,
 						BaseBackupID:    "backup-2",
 						Status:          backup.Success,
+						StartedAt:       t1,
 					},
 					"backup-2": {
 						ID:              "backup-2",
 						CompressionType: &gzipCompression,
 						BaseBackupID:    "backup-1",
 						Status:          backup.Success,
+						StartedAt:       t0,
 					},
 				}
 				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
@@ -566,6 +659,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		{
 			name:            "ErrorFetchingBackup",
 			baseBackupID:    "backup-1",
+			childStartedAt:  t1,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
 				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
@@ -577,6 +671,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		{
 			name:            "SelfReferentialBackup",
 			baseBackupID:    "backup-1",
+			childStartedAt:  t1,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
 				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
@@ -585,6 +680,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 						CompressionType: &gzipCompression,
 						BaseBackupID:    "backup-1",
 						Status:          backup.Success,
+						StartedAt:       t0,
 					}, nil
 				}
 			},
@@ -593,6 +689,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		{
 			name:            "WrongCompressionType",
 			baseBackupID:    "backup-1",
+			childStartedAt:  t1,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
 				noneCompression := backup.CompressionNone
@@ -602,6 +699,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 						CompressionType: &noneCompression,
 						BaseBackupID:    "",
 						Status:          backup.Success,
+						StartedAt:       t0,
 					}, nil
 				}
 			},
@@ -610,19 +708,20 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		{
 			name:            "FailedBackupStatus",
 			baseBackupID:    "backup-1",
+			childStartedAt:  t1,
 			compressionType: gzipCompression,
 			setupFetchMeta: func() fetchMetaFunc {
-				noneCompression := backup.CompressionNone
 				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
 					return &backup.BackupDescriptor{
 						ID:              "backup-1",
-						CompressionType: &noneCompression,
+						CompressionType: &gzipCompression,
 						BaseBackupID:    "",
 						Status:          backup.Failed,
+						StartedAt:       t0,
 					}, nil
 				}
 			},
-			errorContains: []string{"backup \"backup-1\" has compression type", "expected"},
+			errorContains: []string{"backup \"backup-1\" has status", "expected"},
 		},
 	}
 
@@ -630,7 +729,7 @@ func TestResolveBaseBackupChain(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fetchMeta := tt.setupFetchMeta()
 
-			result, err := resolveBaseBackupChain(ctx, tt.baseBackupID, bucket, path, tt.compressionType, fetchMeta)
+			result, err := resolveBaseBackupChain(ctx, tt.baseBackupID, tt.childStartedAt, bucket, path, tt.compressionType, fetchMeta)
 
 			if len(tt.errorContains) > 0 {
 				assert.Error(t, err)

--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -242,6 +242,53 @@ func TestManagerCoordinatedBackup(t *testing.T) {
 		assert.Equal(t, "", errMsg)
 	})
 
+	t.Run("NodeMissingFromBaseBackupUploadsFull", func(t *testing.T) {
+		var (
+			sourcePath = t.TempDir()
+			sourcer    = &fakeSourcer{}
+			backend    = newFakeBackend()
+			baseID     = "base-1"
+			baseHome   = baseID + "/" + nodeName
+		)
+
+		// capture the base descriptors passed to the uploader to prove this
+		// node deduplicates against nothing (full upload)
+		var gotBaseDescrs []*backup.BackupDescriptor
+		sourcer.On("Backupable", ctx, req.Classes).Return(nil)
+		ch := fakeBackupDescriptor(genClassDescriptions(t, sourcePath, cls, cls2)...)
+		sourcer.On("BackupDescriptors", any, backupID, mock.Anything, mock.Anything).Return(ch).Run(func(a mock.Arguments) {
+			gotBaseDescrs = a.Get(3).([]*backup.BackupDescriptor)
+		})
+		sourcer.On("ReleaseBackup", ctx, backupID, mock.Anything).Return(nil)
+
+		backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		backend.On("SourceDataPath").Return(sourcePath)
+		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(nil, errNotFound)
+		// this node has no descriptor in the base backup
+		backend.On("GetObject", any, baseHome, BackupFile).Return(nil, errNotFound)
+		backend.On("Initialize", ctx, nodeHome).Return(nil)
+		backend.On("PutObject", mock.Anything, nodeHome, BackupFile, mock.Anything).Return(nil).Once()
+		backend.On("Write", mock.Anything, nodeHome, mock.Anything, mock.Anything).Return(any, nil)
+		m := createManager(sourcer, nil, backend, nil)
+
+		req := req
+		req.Duration = time.Hour
+		req.BaseBackupID = baseID
+		got := m.OnCanCommit(ctx, &req)
+		want := &CanCommitResponse{OpCreate, req.ID, _TimeoutShardCommit, ""}
+		assert.Equal(t, got, want)
+
+		err := m.OnCommit(ctx, &StatusRequest{OpCreate, req.ID, backendName, "", "", ""})
+		assert.NoError(t, err)
+		m.backupper.waitForCompletion(20, 50)
+		status, errMsg := backend.getMetaStatus()
+		assert.Equal(t, backup.Success, status)
+		assert.Equal(t, "", errMsg)
+		assert.Empty(t, gotBaseDescrs)
+		// the descriptor must reflect the full backup we took, not advertise a base
+		assert.Empty(t, backend.getMetaBaseBackupID())
+	})
+
 	t.Run("AbortBeforeCommit", func(t *testing.T) {
 		var (
 			sourcePath = t.TempDir()

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -88,6 +88,12 @@ func (fb *fakeBackend) getMetaStatus() (backup.Status, string) {
 	return fb.meta.Status, fb.meta.Error
 }
 
+func (fb *fakeBackend) getMetaBaseBackupID() string {
+	fb.RLock()
+	defer fb.RUnlock()
+	return fb.meta.BaseBackupID
+}
+
 func newFakeBackend() *fakeBackend {
 	return &fakeBackend{
 		doneChan: make(chan bool),

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -731,6 +731,14 @@ func (s *Scheduler) validateRestoreRequest(ctx context.Context, store coordStore
 	if v := meta.Version; v[0] > Version[0] {
 		return nil, fmt.Errorf("%s: %s > %s", errMsgHigherVersion, v, Version)
 	}
+
+	// Base backups are only read mid-restore, after users and RBAC are already
+	// overwritten. Resolve the chain upfront so a missing or invalid base is
+	// rejected before any side effects begin.
+	if _, err := resolveBaseBackupChain(ctx, meta.BaseBackupID, req.Bucket, req.Path, meta.GetCompressionType(), store.MetaForBackupID); err != nil {
+		return nil, fmt.Errorf("resolve base backup chain: %w", err)
+	}
+
 	cs := meta.Classes()
 
 	// Expand wildcards in Include list against backup's classes

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -678,7 +678,7 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 	if err != nil {
 		return nil, fmt.Errorf("get compression type: %w", err)
 	}
-	if _, err := resolveBaseBackupChain(ctx, req.BaseBackupID, req.Bucket, req.Path, compressionType, store.MetaForBackupID); err != nil {
+	if _, err := resolveBaseBackupChain(ctx, req.BaseBackupID, time.Now().UTC(), req.Bucket, req.Path, compressionType, store.MetaForBackupID); err != nil {
 		return nil, fmt.Errorf("resolve base backup chain: %w", err)
 	}
 
@@ -735,7 +735,7 @@ func (s *Scheduler) validateRestoreRequest(ctx context.Context, store coordStore
 	// Base backups are only read mid-restore, after users and RBAC are already
 	// overwritten. Resolve the chain upfront so a missing or invalid base is
 	// rejected before any side effects begin.
-	if _, err := resolveBaseBackupChain(ctx, meta.BaseBackupID, req.Bucket, req.Path, meta.GetCompressionType(), store.MetaForBackupID); err != nil {
+	if _, err := resolveBaseBackupChain(ctx, meta.BaseBackupID, meta.StartedAt, req.Bucket, req.Path, meta.GetCompressionType(), store.MetaForBackupID); err != nil {
 		return nil, fmt.Errorf("resolve base backup chain: %w", err)
 	}
 

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -713,6 +713,41 @@ func TestSchedulerRestoration(t *testing.T) {
 		assert.Contains(t, fs.backend.glMeta.Error, "")
 	})
 
+	t.Run("SuccessWithBaseBackup", func(t *testing.T) {
+		baseID := "base-1"
+		metaWithBase := meta
+		metaWithBase.CompressionType = backup.CompressionGZIP
+		metaWithBase.BaseBackupID = baseID
+		baseMeta := backup.DistributedBackupDescriptor{
+			ID:              baseID,
+			Status:          backup.Success,
+			CompressionType: backup.CompressionGZIP,
+		}
+
+		fs := newFakeScheduler(newFakeNodeResolver([]string{nodeA, nodeB}))
+		bytes := marshalCoordinatorMeta(metaWithBase)
+		fs.backend.On("Initialize", ctx, mock.Anything).Return(nil)
+		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(bytes, nil)
+		fs.backend.On("GetObject", ctx, backupID, GlobalRestoreFile).Return(bytes, nil)
+		fs.backend.On("GetObject", ctx, baseID, GlobalBackupFile).Return(marshalCoordinatorMeta(baseMeta), nil)
+		fs.backend.On("GetObject", ctx, keyNodeA, BackupFile).Return(metaBytes1, nil)
+		fs.backend.On("GetObject", ctx, keyNodeB, BackupFile).Return(metaBytes2, nil)
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		fs.backend.On("PutObject", mock.Anything, mock.Anything, GlobalRestoreFile, mock.AnythingOfType("[]uint8")).Return(nil)
+		fs.client.On("CanCommit", any, nodeA, any).Return(cResp, nil)
+		fs.client.On("Commit", any, nodeA, sReq).Return(nil)
+		fs.client.On("Status", any, nodeA, sReq).Return(sresp, nil)
+		fs.client.On("CanCommit", any, nodeB, any).Return(cResp, nil)
+		fs.client.On("Commit", any, nodeB, sReq).Return(nil)
+		fs.client.On("Status", any, nodeB, sReq).Return(sresp, nil)
+
+		s := fs.scheduler()
+		req := BackupRequest{ID: backupID, Include: []string{cls}, Backend: backendName}
+		resp, err := s.Restore(ctx, nil, &req, false)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
 	t.Run("NodeMappingPassedCorrectly", func(t *testing.T) {
 		oldNodeA := "Old-Node-A"
 		oldNodeB := "Old-Node-B"
@@ -967,6 +1002,39 @@ func TestSchedulerRestoreRequestValidation(t *testing.T) {
 		_, err := fs.scheduler().Restore(ctx, nil, &BackupRequest{ID: id, Exclude: []string{cls}}, false)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), cls)
+	})
+
+	t.Run("MissingBaseBackup", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		metaWithBase := meta
+		metaWithBase.CompressionType = backup.CompressionGZIP
+		metaWithBase.BaseBackupID = "base-1"
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(marshalCoordinatorMeta(metaWithBase), nil)
+		fs.backend.On("GetObject", ctx, "base-1", GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		_, err := fs.scheduler().Restore(ctx, nil, req, false)
+		require.Error(t, err)
+		assert.IsType(t, backup.ErrUnprocessable{}, err)
+		assert.ErrorContains(t, err, "resolve base backup chain")
+	})
+
+	t.Run("BaseBackupNotSuccessful", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		metaWithBase := meta
+		metaWithBase.CompressionType = backup.CompressionGZIP
+		metaWithBase.BaseBackupID = "base-1"
+		baseMeta := backup.DistributedBackupDescriptor{
+			ID:              "base-1",
+			Status:          backup.Failed,
+			CompressionType: backup.CompressionGZIP,
+		}
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(marshalCoordinatorMeta(metaWithBase), nil)
+		fs.backend.On("GetObject", ctx, "base-1", GlobalBackupFile).Return(marshalCoordinatorMeta(baseMeta), nil)
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		_, err := fs.scheduler().Restore(ctx, nil, req, false)
+		require.Error(t, err)
+		assert.IsType(t, backup.ErrUnprocessable{}, err)
+		assert.ErrorContains(t, err, "resolve base backup chain")
 	})
 }
 

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -322,7 +322,10 @@ func (z *zip) WriteRegular(ctx context.Context, sd *entBackup.ShardDescriptor, r
 		return 0, remainingSplitFile, nil
 	}
 
-	if fileSize >= z.bigFileThreshold {
+	// Only immutable files are tracked for incremental dedup. Mutable files can be
+	// rewritten in place without a reliable size+mtime change signal, so they are
+	// re-uploaded on every incremental rather than deduplicated.
+	if fileSize >= z.bigFileThreshold && entBackup.IsImmutableFile(relPath) {
 		sd.TrackBigFileChunk(relPath, fileSize, info.ModTime(), chunkKey)
 	}
 
@@ -410,8 +413,11 @@ func (z *zip) WriteSplitFile(ctx context.Context, sd *entBackup.ShardDescriptor,
 	splitFile.AlreadyWritten += amountToWrite
 	preCompressionSize.Add(amountToWrite)
 
-	// Track this chunk key in BigFilesChunk
-	sd.TrackBigFileChunk(splitFile.RelPath, splitFile.FileInfo.Size(), splitFile.FileInfo.ModTime(), chunkKey)
+	// Only immutable files are tracked for incremental dedup; a mutable file rewritten
+	// in place has no reliable size+mtime change signal, so it is re-uploaded every time.
+	if entBackup.IsImmutableFile(splitFile.RelPath) {
+		sd.TrackBigFileChunk(splitFile.RelPath, splitFile.FileInfo.Size(), splitFile.FileInfo.ModTime(), chunkKey)
+	}
 
 	if splitFile.AlreadyWritten < splitFile.FileInfo.Size() {
 		return splitFile, nil

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -625,6 +625,107 @@ func TestWriteRegulars(t *testing.T) {
 		require.Equal(t, int64(2000), bigInfo.Size)
 		require.Equal(t, []string{"chunk2"}, bigInfo.ChunkKeys)
 	})
+
+	// A mutable big file (bbolt meta.db) must be fully archived but NOT tracked for
+	// dedup: it can be rewritten in place without a size+mtime change signal, so
+	// tracking it would let an incremental wrongly skip a changed file.
+	t.Run("mutable big file is written but not tracked in BigFilesChunk", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "source")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard"), os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "shard", "meta.db"), bytes.Repeat([]byte("M"), 2000), 0o644))
+
+		sd := backup.ShardDescriptor{Name: "shard", Node: "node1"}
+		fileList := &backup.FileList{
+			Files:     []string{"shard/meta.db"},
+			FileSizes: map[string]int64{"shard/meta.db": 2000},
+		}
+
+		z, rc, err := NewZip(dir, int(NoCompression), 10000, 500, 0)
+		require.NoError(t, err)
+		preComp := &atomic.Int64{}
+		var writeErr error
+		go func() {
+			_, _, writeErr = z.WriteRegulars(context.Background(), &sd, fileList, preComp, "chunk1")
+			z.Close()
+		}()
+
+		buf := bytes.NewBuffer(nil)
+		_, err = io.Copy(buf, rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+		require.NoError(t, writeErr)
+		require.Equal(t, 0, fileList.Len(), "meta.db should be written")
+
+		// meta.db is fully archived...
+		tr := tar.NewReader(buf)
+		var tarFiles []string
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			tarFiles = append(tarFiles, hdr.Name)
+		}
+		require.Equal(t, []string{"shard/meta.db"}, tarFiles)
+
+		// ...but not registered as a dedup candidate.
+		_, ok := sd.BigFilesChunk["shard/meta.db"]
+		require.False(t, ok, "mutable meta.db must not be tracked in BigFilesChunk")
+	})
+
+	// The split path (WriteSplitFile) is the one most mutable big files hit — a raw
+	// commitlog large enough to span several chunks. It must be fully archived across
+	// those chunks yet never registered as a dedup candidate.
+	t.Run("mutable split file is archived across chunks but not tracked", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "source")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard", "main.hnsw.commitlog.d"), os.ModePerm))
+		relPath := "shard/main.hnsw.commitlog.d/1709203456"
+		const total = 5000
+		require.NoError(t, os.WriteFile(filepath.Join(dir, relPath), bytes.Repeat([]byte("C"), total), 0o644))
+
+		sd := backup.ShardDescriptor{Name: "shard", Node: "node1"}
+		fileList := &backup.FileList{
+			Files:     []string{relPath},
+			FileSizes: map[string]int64{relPath: total},
+		}
+
+		// splitFileSize 1000 forces the 5000-byte file into 5 parts.
+		var split *SplitFile
+		runZipChunk(t, dir, func(z *zip, pc *atomic.Int64) {
+			_, split, _ = z.WriteRegulars(context.Background(), &sd, fileList, pc, "chunk0")
+		})
+		// Drive the remaining parts like the production producer does: one chunk each.
+		for i := 1; split != nil; i++ {
+			require.Less(t, i, 100, "split file did not converge")
+			next, chunkKey := split, fmt.Sprintf("chunk%d", i)
+			runZipChunk(t, dir, func(z *zip, pc *atomic.Int64) {
+				split, _ = z.WriteSplitFile(context.Background(), &sd, next, pc, chunkKey)
+			})
+		}
+
+		// The loop exited with split == nil, so every byte was archived across the
+		// chunks — yet the file is not a dedup candidate.
+		_, ok := sd.BigFilesChunk[relPath]
+		require.False(t, ok, "mutable split commitlog must not be tracked in BigFilesChunk")
+	})
+}
+
+// runZipChunk runs one backup chunk: it creates a zip with a 1000-byte split size,
+// invokes write in a goroutine, and drains the reader so the write can't block on
+// the pipe. Used to drive a split file across multiple chunks.
+func runZipChunk(t *testing.T, sourceDir string, write func(z *zip, pc *atomic.Int64)) {
+	t.Helper()
+	z, rc, err := NewZip(sourceDir, int(NoCompression), 1000, 1000, 1000)
+	require.NoError(t, err)
+	pc := &atomic.Int64{}
+	go func() {
+		write(&z, pc)
+		z.Close()
+	}()
+	_, err = io.Copy(io.Discard, rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
 }
 
 // TestWriteShardFirstChunkRespectsInMemoryFiles verifies that when WriteShard


### PR DESCRIPTION
### What's being changed:

Contains one bugfix per commit:
1. Skip mutable files from being deduplicated in incremental backup
2. Validate full incremental backup chain before starting backup restore
3. Take full backup if a node has no base descriptors. This fixes making an incremental backup after a new node has joined the cluster
4. Validate that all startedAt dates in incremental backup chain are strictly monotone. This makes sure that no member of the chain was replaced by a newer backup

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
