### PR TITLE
[Reindex Fixes A] fix: idempotent recovery-swap marking after mid-FINALIZING restart

### DIFF
--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2197,9 +2197,8 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 				propName, mainExists, backupExists, ingestExists)
 		}
 
-		// runtimeSwap may have set the sentinel before a mid-FINALIZING
-		// restart; markSwappedProp creates with O_EXCL, so an unguarded
-		// re-mark fails recovery with "file exists".
+		// markSwappedProp creates with O_EXCL; a mid-FINALIZING restart may
+		// have already set the sentinel.
 		if !rt.IsSwappedProp(propName) {
 			if err := rt.markSwappedProp(propName); err != nil {
 				return fmt.Errorf("marking swapped prop %q: %w", propName, err)

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2197,8 +2197,16 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 				propName, mainExists, backupExists, ingestExists)
 		}
 
-		if err := rt.markSwappedProp(propName); err != nil {
-			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
+		// The sentinel may already exist: runtimeSwap sets IsSwappedProp
+		// after the in-memory flip, and a restart inside the FINALIZING
+		// window re-enters here (the dir-rename switch above correctly
+		// ignores the sentinel — disk state is authoritative for renames).
+		// markSwappedProp creates with O_EXCL, so an unguarded re-mark
+		// fails the whole unit with "file exists".
+		if !rt.IsSwappedProp(propName) {
+			if err := rt.markSwappedProp(propName); err != nil {
+				return fmt.Errorf("marking swapped prop %q: %w", propName, err)
+			}
 		}
 		// Recovery re-establishes the overlay for the same reason as the happy path.
 		if t.onPropSwapped != nil {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2197,12 +2197,9 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 				propName, mainExists, backupExists, ingestExists)
 		}
 
-		// The sentinel may already exist: runtimeSwap sets IsSwappedProp
-		// after the in-memory flip, and a restart inside the FINALIZING
-		// window re-enters here (the dir-rename switch above correctly
-		// ignores the sentinel — disk state is authoritative for renames).
-		// markSwappedProp creates with O_EXCL, so an unguarded re-mark
-		// fails the whole unit with "file exists".
+		// runtimeSwap may have set the sentinel before a mid-FINALIZING
+		// restart; markSwappedProp creates with O_EXCL, so an unguarded
+		// re-mark fails recovery with "file exists".
 		if !rt.IsSwappedProp(propName) {
 			if err := rt.markSwappedProp(propName); err != nil {
 				return fmt.Errorf("marking swapped prop %q: %w", propName, err)

--- a/adapters/repos/db/inverted_reindex_task_generic_test.go
+++ b/adapters/repos/db/inverted_reindex_task_generic_test.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -335,9 +336,10 @@ func TestMapToBlockmaxMigration_RuntimeSwap_ThenRestart(t *testing.T) {
 // cover the end-to-end multi-node convergence assertion.
 func TestRunSwapOnShard_SentinelAwareDispatch(t *testing.T) {
 	tests := []struct {
-		name     string
-		setupRT  func(rt reindexTracker)
-		wantPath string
+		name      string
+		setupRT   func(rt reindexTracker)
+		setupDisk func(t *testing.T, shard *Shard, task *ShardReindexTaskGeneric)
+		wantPath  string
 	}{
 		{
 			name: "IsTidied/idempotent",
@@ -362,6 +364,33 @@ func TestRunSwapOnShard_SentinelAwareDispatch(t *testing.T) {
 			},
 			wantPath: "swapped",
 		},
+		{
+			// A rolling restart inside the FINALIZING window: runtimeSwap
+			// already flipped in-memory AND set the per-prop swapped
+			// sentinel, then the node restarted before markSwapped(). The
+			// disk renames converged pre-restart (main + backup both
+			// exist → recovery's rename switch no-ops), so the ONLY work
+			// left for recoverRuntimeSwapBuckets is the marking — which
+			// must tolerate the pre-existing sentinel (markSwappedProp
+			// creates with O_EXCL; an unguarded re-mark fails the unit
+			// with "file exists" and flips the whole task to FAILED —
+			// observed in CI as TestMultiNode_RollingRestartDuring
+			// Finalizing_PerReplicaConsistency, weaviate/weaviate run
+			// 28709084881 job 85139507951).
+			name: "IsMerged/prop_sentinel_preset/recovery_mark_idempotent",
+			setupRT: func(rt reindexTracker) {
+				require.NoError(t, rt.markStarted(time.Now()))
+				require.NoError(t, rt.markReindexed())
+				require.NoError(t, rt.markPrepended())
+				require.NoError(t, rt.markMerged())
+				require.NoError(t, rt.markSwappedProp("title"))
+			},
+			setupDisk: func(t *testing.T, shard *Shard, task *ShardReindexTaskGeneric) {
+				backupDir := filepath.Join(shard.pathLSM(), task.backupBucketName("title"))
+				require.NoError(t, os.MkdirAll(backupDir, 0o777))
+			},
+			wantPath: "merged-recovery",
+		},
 	}
 
 	for _, tc := range tests {
@@ -383,6 +412,9 @@ func TestRunSwapOnShard_SentinelAwareDispatch(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, rt.saveProps([]string{"title"}))
 			tc.setupRT(rt)
+			if tc.setupDisk != nil {
+				tc.setupDisk(t, shard, task)
+			}
 
 			// Call RunSwapOnShard — the new dispatch must route through
 			// the recovery branch matching the sentinel state and

--- a/adapters/repos/db/inverted_reindex_task_generic_test.go
+++ b/adapters/repos/db/inverted_reindex_task_generic_test.go
@@ -365,18 +365,10 @@ func TestRunSwapOnShard_SentinelAwareDispatch(t *testing.T) {
 			wantPath: "swapped",
 		},
 		{
-			// A rolling restart inside the FINALIZING window: runtimeSwap
-			// already flipped in-memory AND set the per-prop swapped
-			// sentinel, then the node restarted before markSwapped(). The
-			// disk renames converged pre-restart (main + backup both
-			// exist → recovery's rename switch no-ops), so the ONLY work
-			// left for recoverRuntimeSwapBuckets is the marking — which
-			// must tolerate the pre-existing sentinel (markSwappedProp
-			// creates with O_EXCL; an unguarded re-mark fails the unit
-			// with "file exists" and flips the whole task to FAILED —
-			// observed in CI as TestMultiNode_RollingRestartDuring
-			// Finalizing_PerReplicaConsistency, weaviate/weaviate run
-			// 28709084881 job 85139507951).
+			// Restart mid-FINALIZING: sentinel already set, disk renames
+			// already converged → recovery's only remaining work is the
+			// re-mark, which must tolerate the existing O_EXCL sentinel.
+			// Regression for the CI failure in run 28709084881.
 			name: "IsMerged/prop_sentinel_preset/recovery_mark_idempotent",
 			setupRT: func(rt reindexTracker) {
 				require.NoError(t, rt.markStarted(time.Now()))

--- a/adapters/repos/db/inverted_reindex_task_generic_test.go
+++ b/adapters/repos/db/inverted_reindex_task_generic_test.go
@@ -365,10 +365,7 @@ func TestRunSwapOnShard_SentinelAwareDispatch(t *testing.T) {
 			wantPath: "swapped",
 		},
 		{
-			// Restart mid-FINALIZING: sentinel already set, disk renames
-			// already converged → recovery's only remaining work is the
-			// re-mark, which must tolerate the existing O_EXCL sentinel.
-			// Regression for the CI failure in run 28709084881.
+			// pins: recovery re-mark of an already-set O_EXCL swap sentinel must not fail
 			name: "IsMerged/prop_sentinel_preset/recovery_mark_idempotent",
 			setupRT: func(rt reindexTracker) {
 				require.NoError(t, rt.markStarted(time.Now()))


### PR DESCRIPTION
## What

A rolling restart inside the FINALIZING window fails the whole reindex task with `swapped.mig.<prop>: file exists`: `runtimeSwap` flips in-memory and writes the per-prop swapped sentinel; on restart, recovery re-enters the `IsMerged` branch and `recoverRuntimeSwapBuckets` correctly no-ops the dir renames (disk state is authoritative) — but re-marked the sentinel unconditionally, and `markSwappedProp` creates with `O_CREATE|O_EXCL`. Crash-recovery that fails because recovery was already half-done is the defect.

## Design

One guard: skip the re-mark when `IsSwappedProp` is already set. This was the only unguarded marking site — `processOneSwapProp` checks `IsSwappedProp` first, and `swapIngestAndBackupBuckets` gates its goroutine on `!IsSwappedProp`. `markSwapped()` at the end of recovery cannot double-fire: once set, dispatch takes the `IsSwapped` branch and never re-enters.

## Proof

- CI hit with the exact signature: [run 28709084881 / job 85139507951](https://github.com/weaviate/weaviate/actions/runs/28709084881/job/85139507951) (3 units failed identically; the fix lives in the shared generic recovery path, covering both the filterable strategy seen in CI and the searchable one the unit test drives).
- `TestRunSwapOnShard_SentinelAwareDispatch/IsMerged/prop_sentinel_preset/recovery_mark_idempotent` reproduces it deterministically: red without the guard (same `file exists` error), green with it.
- The soak's `UngracefulStopDuringFinalizing`/`RollingRestartDuringFinalizing` long tail fits the same mechanism.
