### PR TITLE
[Reindex Fixes B] fix: leader gRPC conn closed under in-flight RPCs on leader change

### DIFF
--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -97,19 +97,29 @@ type rpcAddressResolver interface {
 	Address(raftAddress string) (string, error)
 }
 
+// refConn pairs the leader conn with a reference count so that a leader change
+// can retire the conn without closing it underneath an in-flight RPC (closing
+// it mid-RPC surfaced as "grpc: the client connection is closing" errors on
+// leader-forwarded requests during rolling restarts).
+type refConn struct {
+	conn *grpc.ClientConn
+	// addr is the raft address this conn was dialed for
+	addr string
+	// refs counts in-flight RPCs holding this conn; guarded by Client.connLock
+	refs int
+	// retired means a newer leader conn replaced this one; the last release closes it
+	retired bool
+}
+
 // Client is used for communication with remote nodes in a RAFT cluster
 // It wraps the gRPC client to our gRPC server that is running on the raft port on each node
 type Client struct {
 	addrResolver rpcAddressResolver
-	// connLock is used to ensure that we are trying to establish/close the connection to the leader while no request
-	// are in progress
+	// connLock guards leaderRpcConn and its refcount state
 	connLock sync.Mutex
-	// leaderRaftAddr is the raft address of the current leader. It is updated at the same time as the leaderConn below
-	// when leader is changing
-	leaderRaftAddr string
-	// leaderConn is the gRPC client to the leader node of the RAFT cluster. It is used for queries that must be sent to
-	// the leader to have strong read consistency
-	leaderRpcConn *grpc.ClientConn
+	// leaderRpcConn is the refcounted gRPC conn to the current RAFT leader. It is used for queries that must be sent
+	// to the leader to have strong read consistency
+	leaderRpcConn *refConn
 	// rpcMessageMaxSize is the maximum size allows for gRPC call. As we re-instantiate the client when the leader
 	// change we store that setting to re-use it. We set a custom limit to ensure that big queries that would exceed the
 	// default maximum can still get through
@@ -120,6 +130,10 @@ type Client struct {
 
 	// logger is the logger to log client warns etc.
 	logger *logrus.Logger
+
+	// testOnConnAcquired runs between conn acquisition and the RPC call so tests
+	// can force a leader change into that window. Always nil in production.
+	testOnConnAcquired func()
 }
 
 // NewClient returns a Client using the rpcAddressResolver to resolve raft nodes and configured with rpcMessageMaxSize
@@ -132,10 +146,11 @@ func NewClient(r rpcAddressResolver, rpcMessageMaxSize int, sentryEnabled bool, 
 // Returns an error if an RPC connection to leaderRaftAddr can't be established
 // Returns an error if joining the node fails
 func (cl *Client) Join(ctx context.Context, leaderRaftAddr string, req *cmd.JoinPeerRequest) (*cmd.JoinPeerResponse, error) {
-	conn, err := cl.getConn(ctx, leaderRaftAddr)
+	conn, release, err := cl.getConn(ctx, leaderRaftAddr)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	return cmd.NewClusterServiceClient(conn).JoinPeer(ctx, req)
 }
@@ -179,10 +194,11 @@ func (cl *Client) Notify(ctx context.Context, remoteAddr string, req *cmd.Notify
 // Returns the server response to the remove request
 // Returns an error if an RPC connection to leaderRaftAddr can't be established
 func (cl *Client) Remove(ctx context.Context, leaderRaftAddr string, req *cmd.RemovePeerRequest) (*cmd.RemovePeerResponse, error) {
-	conn, err := cl.getConn(ctx, leaderRaftAddr)
+	conn, release, err := cl.getConn(ctx, leaderRaftAddr)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	return cmd.NewClusterServiceClient(conn).RemovePeer(ctx, req)
 }
@@ -192,10 +208,11 @@ func (cl *Client) Remove(ctx context.Context, leaderRaftAddr string, req *cmd.Re
 // Returns an error if an RPC connection to leaderRaftAddr can't be established
 // Returns an error if the apply command fails
 func (cl *Client) Apply(ctx context.Context, leaderRaftAddr string, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error) {
-	conn, err := cl.getConn(ctx, leaderRaftAddr)
+	conn, release, err := cl.getConn(ctx, leaderRaftAddr)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	return cmd.NewClusterServiceClient(conn).Apply(ctx, req)
 }
@@ -205,9 +222,14 @@ func (cl *Client) Apply(ctx context.Context, leaderRaftAddr string, req *cmd.App
 // Returns an error if an RPC connection to leaderRaftAddr can't be established
 // Returns an error if the query command fails
 func (cl *Client) Query(ctx context.Context, leaderRaftAddr string, req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
-	conn, err := cl.getConn(ctx, leaderRaftAddr)
+	conn, release, err := cl.getConn(ctx, leaderRaftAddr)
 	if err != nil {
 		return nil, err
+	}
+	defer release()
+
+	if cl.testOnConnAcquired != nil {
+		cl.testOnConnAcquired()
 	}
 
 	resp, err := cmd.NewClusterServiceClient(conn).Query(ctx, req)
@@ -216,47 +238,35 @@ func (cl *Client) Query(ctx context.Context, leaderRaftAddr string, req *cmd.Que
 
 // Close the client and allocated resources
 func (cl *Client) Close() {
-	if cl.leaderRpcConn == nil {
-		return
-	}
-
-	if err := cl.leaderRpcConn.Close(); err != nil {
-		cl.logger.WithFields(
-			logrus.Fields{
-				"error":       err,
-				"leader_addr": cl.leaderRaftAddr,
-			},
-		).Warn("error closing the leader gRPC connection")
-	}
-}
-
-// getConn either returns the cached connection in the client to the leader or will instantiate a new one towards
-// leaderRaftAddr and close the old one
-// Returns the gRPC client connection to leaderRaftAddr
-// Returns an error if an RPC connection to leaderRaftAddr can't be established
-func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.ClientConn, error) {
 	cl.connLock.Lock()
 	defer cl.connLock.Unlock()
 
-	if cl.leaderRpcConn != nil && leaderRaftAddr == cl.leaderRaftAddr {
-		return cl.leaderRpcConn, nil
+	if cl.leaderRpcConn == nil {
+		return
+	}
+	cl.retireLocked()
+}
+
+// getConn either returns the cached connection in the client to the leader or will instantiate a new one towards
+// leaderRaftAddr and retire the old one
+// Returns the gRPC client connection to leaderRaftAddr and a release func the caller must invoke once its RPC is done
+// Returns an error if an RPC connection to leaderRaftAddr can't be established
+func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.ClientConn, func(), error) {
+	cl.connLock.Lock()
+	defer cl.connLock.Unlock()
+
+	if cl.leaderRpcConn != nil && leaderRaftAddr == cl.leaderRpcConn.addr {
+		conn, release := cl.acquireLocked()
+		return conn, release, nil
 	}
 
 	if cl.leaderRpcConn != nil {
-		if err := cl.leaderRpcConn.Close(); err != nil {
-			cl.logger.WithFields(
-				logrus.Fields{
-					"error":                  err,
-					"closing_on_leader_addr": cl.leaderRaftAddr,
-					"new_leader_addr":        leaderRaftAddr,
-				},
-			).Warn("error closing the leader gRPC connection")
-		}
+		cl.retireLocked()
 	}
 
 	addr, err := cl.addrResolver.Address(leaderRaftAddr)
 	if err != nil {
-		return nil, fmt.Errorf("resolve address: %w", err)
+		return nil, nil, fmt.Errorf("resolve address: %w", err)
 	}
 
 	options := []grpc.DialOption{
@@ -269,14 +279,56 @@ func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.Cli
 		options = append(options, grpc.WithUnaryInterceptor(grpc_sentry.UnaryClientInterceptor()))
 	}
 
-	cl.leaderRpcConn, err = grpc.NewClient(addr, options...)
+	conn, err := grpc.NewClient(addr, options...)
 	if err != nil {
-		return nil, fmt.Errorf("dial: %w", err)
+		return nil, nil, fmt.Errorf("dial: %w", err)
 	}
 
-	cl.leaderRaftAddr = leaderRaftAddr
+	cl.leaderRpcConn = &refConn{conn: conn, addr: leaderRaftAddr}
 
-	return cl.leaderRpcConn, nil
+	acquired, release := cl.acquireLocked()
+	return acquired, release, nil
+}
+
+// acquireLocked hands out the current conn plus a release func that closes it
+// only once it is both retired and idle, so a leader change observed by a
+// concurrent getConn never closes a conn with RPCs still in flight.
+// Callers must hold connLock.
+func (cl *Client) acquireLocked() (*grpc.ClientConn, func()) {
+	rc := cl.leaderRpcConn
+	rc.refs++
+	release := func() {
+		cl.connLock.Lock()
+		defer cl.connLock.Unlock()
+		rc.refs--
+		if rc.retired && rc.refs == 0 {
+			cl.closeRefConn(rc)
+		}
+	}
+	return rc.conn, release
+}
+
+// retireLocked detaches the current leader conn: idle conns close immediately,
+// busy ones close when the last in-flight RPC releases its reference.
+// Callers must hold connLock.
+func (cl *Client) retireLocked() {
+	rc := cl.leaderRpcConn
+	cl.leaderRpcConn = nil
+	rc.retired = true
+	if rc.refs == 0 {
+		cl.closeRefConn(rc)
+	}
+}
+
+func (cl *Client) closeRefConn(rc *refConn) {
+	if err := rc.conn.Close(); err != nil {
+		cl.logger.WithFields(
+			logrus.Fields{
+				"error":       err,
+				"leader_addr": rc.addr,
+			},
+		).Warn("error closing the leader gRPC connection")
+	}
 }
 
 // fromRPCError parses the error sent by rpc server

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -128,10 +128,6 @@ type Client struct {
 
 	// logger is the logger to log client warns etc.
 	logger *logrus.Logger
-
-	// testOnConnAcquired runs between conn acquisition and the RPC call so tests
-	// can force a leader change into that window. Always nil in production.
-	testOnConnAcquired func()
 }
 
 // NewClient returns a Client using the rpcAddressResolver to resolve raft nodes and configured with rpcMessageMaxSize
@@ -225,10 +221,6 @@ func (cl *Client) Query(ctx context.Context, leaderRaftAddr string, req *cmd.Que
 		return nil, err
 	}
 	defer release()
-
-	if cl.testOnConnAcquired != nil {
-		cl.testOnConnAcquired()
-	}
 
 	resp, err := cmd.NewClusterServiceClient(conn).Query(ctx, req)
 	return resp, fromRPCError(err)

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -97,10 +97,8 @@ type rpcAddressResolver interface {
 	Address(raftAddress string) (string, error)
 }
 
-// refConn pairs the leader conn with a reference count so that a leader change
-// can retire the conn without closing it underneath an in-flight RPC (closing
-// it mid-RPC surfaced as "grpc: the client connection is closing" errors on
-// leader-forwarded requests during rolling restarts).
+// refConn pairs the leader conn with a reference count so a leader change can
+// retire the conn without closing it underneath an in-flight RPC.
 type refConn struct {
 	conn *grpc.ClientConn
 	// addr is the raft address this conn was dialed for
@@ -247,10 +245,8 @@ func (cl *Client) Close() {
 	cl.retireLocked()
 }
 
-// getConn either returns the cached connection in the client to the leader or will instantiate a new one towards
-// leaderRaftAddr and retire the old one
-// Returns the gRPC client connection to leaderRaftAddr and a release func the caller must invoke once its RPC is done
-// Returns an error if an RPC connection to leaderRaftAddr can't be established
+// getConn returns the cached conn to the leader, or dials leaderRaftAddr and
+// retires the old conn. Callers must invoke release once their RPC is done.
 func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.ClientConn, func(), error) {
 	cl.connLock.Lock()
 	defer cl.connLock.Unlock()
@@ -290,15 +286,12 @@ func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.Cli
 	return acquired, release, nil
 }
 
-// acquireLocked hands out the current conn plus a release func that closes it
-// only once it is both retired and idle, so a leader change observed by a
-// concurrent getConn never closes a conn with RPCs still in flight.
-// Callers must hold connLock.
+// acquireLocked hands out the current conn plus a release func; release closes
+// the conn once it is both retired and idle. Callers must hold connLock.
 func (cl *Client) acquireLocked() (*grpc.ClientConn, func()) {
 	rc := cl.leaderRpcConn
 	rc.refs++
-	// Once-guarded: a double release would drive refs negative and break the
-	// refs==0 close trigger, leaking the conn.
+	// a double release would drive refs negative and leak the conn
 	var once sync.Once
 	release := func() {
 		once.Do(func() {

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -297,13 +297,18 @@ func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.Cli
 func (cl *Client) acquireLocked() (*grpc.ClientConn, func()) {
 	rc := cl.leaderRpcConn
 	rc.refs++
+	// Once-guarded: a double release would drive refs negative and break the
+	// refs==0 close trigger, leaking the conn.
+	var once sync.Once
 	release := func() {
-		cl.connLock.Lock()
-		defer cl.connLock.Unlock()
-		rc.refs--
-		if rc.retired && rc.refs == 0 {
-			cl.closeRefConn(rc)
-		}
+		once.Do(func() {
+			cl.connLock.Lock()
+			defer cl.connLock.Unlock()
+			rc.refs--
+			if rc.retired && rc.refs == 0 {
+				cl.closeRefConn(rc)
+			}
+		})
 	}
 	return rc.conn, release
 }

--- a/cluster/rpc/client_leader_change_test.go
+++ b/cluster/rpc/client_leader_change_test.go
@@ -1,0 +1,120 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rpc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"google.golang.org/grpc/connectivity"
+)
+
+// TestClient_Query_LeaderChangeMidRPC reproduces weaviate/0-weaviate-issues#284:
+// a concurrent getConn observing a new leader used to Close() the conn another
+// RPC had just acquired, surfacing "grpc: the client connection is closing" on
+// leader-forwarded requests during rolling restarts. The hook deterministically
+// forces the leader change into the window between getConn and the RPC call.
+func TestClient_Query_LeaderChangeMidRPC(t *testing.T) {
+	addr1, stop1 := startTestServer(t, &testServer{})
+	defer stop1()
+	addr2, stop2 := startTestServer(t, &testServer{})
+	defer stop2()
+
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		cl := NewClient(&testResolver{}, fourMiB, false, logrus.StandardLogger())
+
+		var fired atomic.Bool
+		cl.testOnConnAcquired = func() {
+			// fire only for the outer Query; the nested Query must not recurse
+			if !fired.CompareAndSwap(false, true) {
+				return
+			}
+			_, err := cl.Query(ctx, addr2, &cmd.QueryRequest{})
+			require.NoError(t, err)
+		}
+
+		_, err := cl.Query(ctx, addr1, &cmd.QueryRequest{})
+		require.NoError(t, err, "iteration %d: leader change mid-RPC must not kill the in-flight query", i)
+		cl.Close()
+	}
+}
+
+// TestClient_getConn_RetiredConnClosesAfterLastRelease pins the drain half of
+// the swap-then-drain contract: a conn retired by a leader change must still be
+// closed once its last in-flight RPC releases it, otherwise every leader change
+// would leak a conn.
+func TestClient_getConn_RetiredConnClosesAfterLastRelease(t *testing.T) {
+	addr1, stop1 := startTestServer(t, &testServer{})
+	defer stop1()
+	addr2, stop2 := startTestServer(t, &testServer{})
+	defer stop2()
+
+	ctx := context.Background()
+	cl := NewClient(&testResolver{}, fourMiB, false, logrus.StandardLogger())
+	defer cl.Close()
+
+	conn1, release1, err := cl.getConn(ctx, addr1)
+	require.NoError(t, err)
+
+	// leader change retires conn1 but must not close it: a ref is still held
+	_, release2, err := cl.getConn(ctx, addr2)
+	require.NoError(t, err)
+	release2()
+	require.NotEqual(t, connectivity.Shutdown, conn1.GetState())
+
+	release1()
+	require.Equal(t, connectivity.Shutdown, conn1.GetState())
+}
+
+// TestClient_Query_ConcurrentLeaderFlap hammers Query with the client's view of
+// the leader flapping between two nodes; no request may ever observe its conn
+// closed underneath it, regardless of interleaving.
+func TestClient_Query_ConcurrentLeaderFlap(t *testing.T) {
+	addr1, stop1 := startTestServer(t, &testServer{})
+	defer stop1()
+	addr2, stop2 := startTestServer(t, &testServer{})
+	defer stop2()
+
+	cl := NewClient(&testResolver{}, fourMiB, false, logrus.StandardLogger())
+	defer cl.Close()
+
+	ctx := context.Background()
+	addrs := []string{addr1, addr2}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 4)
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(addr string) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				if _, err := cl.Query(ctx, addr, &cmd.QueryRequest{}); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(addrs[g%2])
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("query failed during leader flap: %v", err)
+	}
+}

--- a/cluster/rpc/client_leader_change_test.go
+++ b/cluster/rpc/client_leader_change_test.go
@@ -23,6 +23,33 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
+// ClientWithTest keeps the leader-change test seam off the production Client
+// surface. The hook has to fire between conn acquisition and the RPC call, and
+// Go embedding is not virtual dispatch, so Client.Query can't see a field on the
+// wrapper. Query is reproduced here to reach that window while reusing the real
+// getConn/refConn machinery under test.
+type ClientWithTest struct {
+	*Client
+	// testOnConnAcquired runs in the acquire->RPC window so a test can force a
+	// leader change into it.
+	testOnConnAcquired func()
+}
+
+func (c *ClientWithTest) Query(ctx context.Context, leaderRaftAddr string, req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
+	conn, release, err := c.getConn(ctx, leaderRaftAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	if c.testOnConnAcquired != nil {
+		c.testOnConnAcquired()
+	}
+
+	resp, err := cmd.NewClusterServiceClient(conn).Query(ctx, req)
+	return resp, fromRPCError(err)
+}
+
 // Pins the race where a leader change closes the conn underneath an in-flight
 // RPC (weaviate/0-weaviate-issues#284).
 func TestClient_Query_LeaderChangeMidRPC(t *testing.T) {
@@ -34,7 +61,7 @@ func TestClient_Query_LeaderChangeMidRPC(t *testing.T) {
 	ctx := context.Background()
 
 	for i := 0; i < 10; i++ {
-		cl := NewClient(&testResolver{}, fourMiB, false, logrus.StandardLogger())
+		cl := &ClientWithTest{Client: NewClient(&testResolver{}, fourMiB, false, logrus.StandardLogger())}
 
 		var fired atomic.Bool
 		cl.testOnConnAcquired = func() {

--- a/cluster/rpc/client_leader_change_test.go
+++ b/cluster/rpc/client_leader_change_test.go
@@ -23,11 +23,8 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-// TestClient_Query_LeaderChangeMidRPC reproduces weaviate/0-weaviate-issues#284:
-// a concurrent getConn observing a new leader used to Close() the conn another
-// RPC had just acquired, surfacing "grpc: the client connection is closing" on
-// leader-forwarded requests during rolling restarts. The hook deterministically
-// forces the leader change into the window between getConn and the RPC call.
+// Pins the race where a leader change closes the conn underneath an in-flight
+// RPC (weaviate/0-weaviate-issues#284).
 func TestClient_Query_LeaderChangeMidRPC(t *testing.T) {
 	addr1, stop1 := startTestServer(t, &testServer{})
 	defer stop1()
@@ -55,10 +52,7 @@ func TestClient_Query_LeaderChangeMidRPC(t *testing.T) {
 	}
 }
 
-// TestClient_getConn_RetiredConnClosesAfterLastRelease pins the drain half of
-// the swap-then-drain contract: a conn retired by a leader change must still be
-// closed once its last in-flight RPC releases it, otherwise every leader change
-// would leak a conn.
+// Pins that a retired conn still closes (is not leaked) once its last in-flight RPC releases it.
 func TestClient_getConn_RetiredConnClosesAfterLastRelease(t *testing.T) {
 	addr1, stop1 := startTestServer(t, &testServer{})
 	defer stop1()
@@ -82,9 +76,7 @@ func TestClient_getConn_RetiredConnClosesAfterLastRelease(t *testing.T) {
 	require.Equal(t, connectivity.Shutdown, conn1.GetState())
 }
 
-// TestClient_Query_ConcurrentLeaderFlap hammers Query with the client's view of
-// the leader flapping between two nodes; no request may ever observe its conn
-// closed underneath it, regardless of interleaving.
+// Pins that no query observes its conn closed underneath it while the leader flaps.
 func TestClient_Query_ConcurrentLeaderFlap(t *testing.T) {
 	addr1, stop1 := startTestServer(t, &testServer{})
 	defer stop1()


### PR DESCRIPTION
SuperClaude here.

Fixes weaviate/0-weaviate-issues#284.

## Problem
`Client.getConn` returned the cached leader conn under `connLock`, but the RPC executed after the lock was released. A concurrent `getConn` observing a new leader `Close()`d that conn mid-RPC, surfacing `grpc: the client connection is closing` as HTTP 500s on leader-forwarded requests (e.g. `GET /v1/tasks` via `Raft.Query`) during rolling restarts. `Raft.Execute` wraps the same error in `backoff.Permanent`, so writes died too, not just reads.

## Fix: swap-then-drain (refcounted conn)
`refConn` pairs the conn with a refcount under the existing `connLock`. A leader change **retires** the old conn instead of closing it: closed immediately if idle, otherwise by the last in-flight RPC's `release()`. All four leader-conn methods (Join/Remove/Apply/Query) acquire+release. Retry-once was rejected: a mid-flight close can kill an RPC the server already applied, so a blanket retry gives unjustified at-least-once Apply semantics; gRPC's built-in retryPolicy can't recover either variant (stays pinned to the closed ClientConn, `codes.Canceled` not retryable).

## Evidence
- `TestClient_Query_LeaderChangeMidRPC`: deterministic repro via unexported test seam — red 10/10 with the exact production error string pre-fix, green 10/10 `-count=10 -race` post-fix
- `TestClient_getConn_RetiredConnClosesAfterLastRelease`: retired conn stays open while referenced, reaches `connectivity.Shutdown` after last release (no conn leak per leader change)
- `TestClient_Query_ConcurrentLeaderFlap`: 4 goroutines × 50 queries under leader flapping, zero closed-conn errors
- Full `cluster/rpc` package `-race` green (27.5s)

Found via soak-flake analysis of `TestMultiNode_DeleteRecreateCleansReindexTasks` (weaviate/weaviate#11530 tolerates the symptom test-side; this fixes the mechanism).

— SuperClaude