### PR TITLE
[Reindex Fixes B] fix: SegmentGroup shutdown races new consistent views (UAF/SIGBUS)

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -1206,6 +1206,11 @@ func setupDebugHandlers(appState *state.State) {
 				return
 			}
 			view := b.GetConsistentView()
+			if err := view.Err(); err != nil {
+				debugConsistentViewsLock.Unlock()
+				writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": err.Error()})
+				return
+			}
 			debugConsistentViews[key] = view
 			debugConsistentViewsLock.Unlock()
 

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -284,7 +284,10 @@ func ScanAllLSM(ctx context.Context, store *lsmkv.Store, scan docid.ObjectScanFn
 		return fmt.Errorf("objects bucket not found")
 	}
 
-	c := b.Cursor()
+	c, err := b.Cursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	for k, v := c.First(); k != nil; k, v = c.Next() {

--- a/adapters/repos/db/aggregator/iterator.go
+++ b/adapters/repos/db/aggregator/iterator.go
@@ -100,7 +100,7 @@ func (c RoaringCursor) Close() {
 	c.cursor.Close()
 }
 
-func iteratorConcurrently(ctx context.Context, b *lsmkv.Bucket, newCursor func() Cursor, aggregateFunc func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error, logger logrus.FieldLogger) error {
+func iteratorConcurrently(ctx context.Context, b *lsmkv.Bucket, newCursor func() (Cursor, error), aggregateFunc func(k []byte, v []byte, vv [][]byte, b *sroar.Bitmap) error, logger logrus.FieldLogger) error {
 	// we're looking at the whole object, so this is neither a Set, nor a Map, but
 	// a Replace strategy
 
@@ -108,7 +108,10 @@ func iteratorConcurrently(ctx context.Context, b *lsmkv.Bucket, newCursor func()
 	seeds := b.QuantileKeys(seedCount)
 	// in case all keys are in memory
 	if len(seeds) == 0 {
-		c := newCursor()
+		c, err := newCursor()
+		if err != nil {
+			return err
+		}
 		defer c.Close()
 		for k, v, vv, bi := c.First(); k != nil; k, v, vv, bi = c.Next() {
 			err := aggregateFunc(k, v, vv, bi)
@@ -127,7 +130,10 @@ func iteratorConcurrently(ctx context.Context, b *lsmkv.Bucket, newCursor func()
 
 	// S1: Read from beginning to first checkpoint:
 	eg.Go(func() error {
-		c := newCursor()
+		c, err := newCursor()
+		if err != nil {
+			return err
+		}
 		defer c.Close()
 
 		count := 0
@@ -150,7 +156,10 @@ func iteratorConcurrently(ctx context.Context, b *lsmkv.Bucket, newCursor func()
 		end := seeds[i+1]
 
 		eg.Go(func() error {
-			c := newCursor()
+			c, err := newCursor()
+			if err != nil {
+				return err
+			}
 			defer c.Close()
 
 			count := 0
@@ -170,7 +179,10 @@ func iteratorConcurrently(ctx context.Context, b *lsmkv.Bucket, newCursor func()
 
 	// S3: Read from last checkpoint to end:
 	eg.Go(func() error {
-		c := newCursor()
+		c, err := newCursor()
+		if err != nil {
+			return err
+		}
 		defer c.Close()
 
 		count := 0

--- a/adapters/repos/db/aggregator/unfiltered_type_specific.go
+++ b/adapters/repos/db/aggregator/unfiltered_type_specific.go
@@ -44,7 +44,13 @@ func (ua unfilteredAggregator) boolProperty(ctx context.Context,
 			return ua.parseAndAddBoolRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.CursorRoaringSet()
+			if err != nil {
+				return nil, err
+			}
+			return RoaringCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
@@ -52,7 +58,13 @@ func (ua unfilteredAggregator) boolProperty(ctx context.Context,
 			return ua.parseAndAddBoolRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.SetCursor()
+			if err != nil {
+				return nil, err
+			}
+			return SetCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -80,7 +92,13 @@ func (ua unfilteredAggregator) boolArrayProperty(ctx context.Context,
 		return ua.parseAndAddBoolArrayRow(agg, v, prop.Name)
 	}
 
-	err := iteratorConcurrently(ctx, b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
+	err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+		c, err := b.Cursor()
+		if err != nil {
+			return nil, err
+		}
+		return ReplaceCursor{c}, nil
+	}, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +178,13 @@ func (ua unfilteredAggregator) floatProperty(ctx context.Context,
 			return ua.parseAndAddFloatRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.CursorRoaringSet()
+			if err != nil {
+				return nil, err
+			}
+			return RoaringCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
@@ -168,7 +192,13 @@ func (ua unfilteredAggregator) floatProperty(ctx context.Context,
 			return ua.parseAndAddFloatRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.SetCursor()
+			if err != nil {
+				return nil, err
+			}
+			return SetCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -199,7 +229,13 @@ func (ua unfilteredAggregator) intProperty(ctx context.Context,
 			return ua.parseAndAddIntRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.CursorRoaringSet()
+			if err != nil {
+				return nil, err
+			}
+			return RoaringCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
@@ -207,7 +243,13 @@ func (ua unfilteredAggregator) intProperty(ctx context.Context,
 			return ua.parseAndAddIntRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.SetCursor()
+			if err != nil {
+				return nil, err
+			}
+			return SetCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -238,7 +280,13 @@ func (ua unfilteredAggregator) dateProperty(ctx context.Context,
 			return ua.parseAndAddDateRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.CursorRoaringSet()
+			if err != nil {
+				return nil, err
+			}
+			return RoaringCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
@@ -246,7 +294,13 @@ func (ua unfilteredAggregator) dateProperty(ctx context.Context,
 			return ua.parseAndAddDateRowSet(agg, k, vv)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return SetCursor{b.SetCursor()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+			c, err := b.SetCursor()
+			if err != nil {
+				return nil, err
+			}
+			return SetCursor{c}, nil
+		}, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	}
@@ -307,7 +361,13 @@ func (ua unfilteredAggregator) dateArrayProperty(ctx context.Context,
 		return ua.parseAndAddDateArrayRow(agg, v, prop.Name)
 	}
 
-	err := iteratorConcurrently(ctx, b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
+	err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+		c, err := b.Cursor()
+		if err != nil {
+			return nil, err
+		}
+		return ReplaceCursor{c}, nil
+	}, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +511,13 @@ func (ua unfilteredAggregator) textProperty(ctx context.Context,
 		return ua.parseAndAddTextRow(agg, v, prop.Name)
 	}
 
-	err := iteratorConcurrently(ctx, b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
+	err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+		c, err := b.Cursor()
+		if err != nil {
+			return nil, err
+		}
+		return ReplaceCursor{c}, nil
+	}, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +546,13 @@ func (ua unfilteredAggregator) numberArrayProperty(ctx context.Context,
 		return ua.parseAndAddNumberArrayRow(agg, v, prop.Name)
 	}
 
-	err := iteratorConcurrently(ctx, b, func() Cursor { return ReplaceCursor{b.Cursor()} }, extract, ua.logger)
+	err := iteratorConcurrently(ctx, b, func() (Cursor, error) {
+		c, err := b.Cursor()
+		if err != nil {
+			return nil, err
+		}
+		return ReplaceCursor{c}, nil
+	}, extract, ua.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/inverted/row_reader.go
+++ b/adapters/repos/db/inverted/row_reader.go
@@ -93,7 +93,10 @@ func (rr *RowReader) notEqual(ctx context.Context, readFn ReadFn) error {
 func (rr *RowReader) greaterThan(ctx context.Context, readFn ReadFn,
 	allowEqual bool,
 ) error {
-	c := rr.newCursor()
+	c, err := rr.newCursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	for k, v := c.Seek(rr.value); k != nil; k, v = c.Next() {
@@ -124,7 +127,10 @@ func (rr *RowReader) greaterThan(ctx context.Context, readFn ReadFn,
 func (rr *RowReader) lessThan(ctx context.Context, readFn ReadFn,
 	allowEqual bool,
 ) error {
-	c := rr.newCursor()
+	c, err := rr.newCursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	for k, v := c.First(); k != nil && bytes.Compare(k, rr.value) != 1; k, v = c.Next() {
@@ -155,7 +161,10 @@ func (rr *RowReader) like(ctx context.Context, readFn ReadFn) error {
 		return fmt.Errorf("parse like value: %w", err)
 	}
 
-	c := rr.newCursor()
+	c, err := rr.newCursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	var (
@@ -206,7 +215,7 @@ func (rr *RowReader) like(ctx context.Context, readFn ReadFn) error {
 
 // newCursor will either return a regular cursor - or a key-only cursor if
 // keyOnly==true
-func (rr *RowReader) newCursor() *lsmkv.CursorSet {
+func (rr *RowReader) newCursor() (*lsmkv.CursorSet, error) {
 	if rr.keyOnly {
 		return rr.bucket.SetCursorKeyOnly()
 	}

--- a/adapters/repos/db/inverted/row_reader_roaring_set.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set.go
@@ -26,7 +26,7 @@ import (
 type RowReaderRoaringSet struct {
 	value      []byte
 	operator   filters.Operator
-	newCursor  func() lsmkv.CursorRoaringSet
+	newCursor  func() (lsmkv.CursorRoaringSet, error)
 	getter     func(key []byte) (*sroar.Bitmap, func(), error)
 	isDenyList bool
 }
@@ -116,7 +116,10 @@ func (rr *RowReaderRoaringSet) notEqual(ctx context.Context,
 func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 	readFn ReadFn, allowEqual bool,
 ) error {
-	c := rr.newCursor()
+	c, err := rr.newCursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	for k, v := c.Seek(rr.value); k != nil; k, v = c.Next() {
@@ -144,7 +147,10 @@ func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 func (rr *RowReaderRoaringSet) lessThan(ctx context.Context,
 	readFn ReadFn, allowEqual bool,
 ) error {
-	c := rr.newCursor()
+	c, err := rr.newCursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	for k, v := c.First(); k != nil && bytes.Compare(k, rr.value) < 1; k, v = c.Next() {
@@ -174,7 +180,10 @@ func (rr *RowReaderRoaringSet) like(ctx context.Context,
 		return fmt.Errorf("parse like value: %w", err)
 	}
 
-	c := rr.newCursor()
+	c, err := rr.newCursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	var (

--- a/adapters/repos/db/inverted/row_reader_roaring_set_test.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set_test.go
@@ -285,7 +285,7 @@ func createRowReaderRoaringSet(value []byte, operator filters.Operator, data []k
 	return &RowReaderRoaringSet{
 		value:     value,
 		operator:  operator,
-		newCursor: func() lsmkv.CursorRoaringSet { return &dummyCursorRoaringSet{data: data} },
+		newCursor: func() (lsmkv.CursorRoaringSet, error) { return &dummyCursorRoaringSet{data: data}, nil },
 		getter: func(key []byte) (*sroar.Bitmap, func(), error) {
 			for i := 0; i < len(data); i++ {
 				if bytes.Equal([]byte(data[i].k), key) {

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -1226,7 +1226,13 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 	mdCh := make(chan *migrationData)
 
 	enterrors.GoWrapper(func() {
-		cursor := shard.Store().Bucket(helpers.ObjectsBucketLSM).CursorOnDisk()
+		cursor, err := shard.Store().Bucket(helpers.ObjectsBucketLSM).CursorOnDisk()
+		if err != nil {
+			startedCh <- time.Now() // unblock caller waiting on <-startedCh
+			mdCh <- &migrationData{err: fmt.Errorf("creating objects cursor: %w", err)}
+			close(mdCh)
+			return
+		}
 		defer cursor.Close()
 
 		startedCh <- time.Now() // after cursor created (necessary locks acquired)

--- a/adapters/repos/db/inverted_reindexer_specified_index.go
+++ b/adapters/repos/db/inverted_reindexer_specified_index.go
@@ -136,7 +136,10 @@ func (t *ShardInvertedReindexTask_SpecifiedIndex) ObjectsIterator(shard ShardLik
 
 	objectsBucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
 	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
-		cursor := objectsBucket.Cursor()
+		cursor, err := objectsBucket.Cursor()
+		if err != nil {
+			return err
+		}
 		defer cursor.Close()
 
 		i := 0

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -528,6 +528,17 @@ func (cv BucketConsistentView) Err() error {
 	return cv.err
 }
 
+// panicOnCursorRefusal fails the legacy no-error cursor constructors loudly
+// instead of serving a silently empty cursor over munmapping segments.
+// Caller survey (weaviate/0-weaviate-issues#285): every production caller is
+// a request path (HTTP/gRPC panic middleware), a GoWrapper'ed goroutine, or a
+// cyclemanager callback — all recover; the dedicated-store buckets (schema,
+// transactions, modules, checkpoint) are never displaced by reindex and shut
+// down only at process exit.
+func (b *Bucket) panicOnCursorRefusal(err error) {
+	panic(fmt.Errorf("lsmkv cursor: %w", err))
+}
+
 // GetConsistentView returns a consistent view of the bucket that can be used
 // for multiple reads without acquiring locks for each read. The caller must
 // call ReleaseView() on the returned view when done to avoid blocking compactions.

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -367,7 +367,10 @@ func (b *Bucket) GetFlushCallbackCtrl() cyclemanager.CycleCallbackCtrl {
 }
 
 func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Object) error) error {
-	cursor := b.Cursor()
+	cursor, err := b.Cursor()
+	if err != nil {
+		return err
+	}
 	defer cursor.Close()
 
 	i := 0
@@ -427,7 +430,10 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	}()
 
 	// note: it's important to first create the on disk cursor so to avoid potential double scanning over flushing memtable
-	onDiskCursor := b.CursorOnDisk()
+	onDiskCursor, err := b.CursorOnDisk()
+	if err != nil {
+		return err
+	}
 	defer onDiskCursor.Close()
 
 	inmemProcessedDocIDs := make(map[uint64]struct{})
@@ -526,14 +532,6 @@ func (cv BucketConsistentView) ReleaseView() {
 // Err reports why the view was refused; nil for a usable view.
 func (cv BucketConsistentView) Err() error {
 	return cv.err
-}
-
-// panicOnCursorRefusal fails the legacy no-error cursor constructors loudly
-// instead of serving a silently empty cursor over munmapping segments. Every
-// production caller sits under a recover (request middleware, GoWrapper,
-// cyclemanager); caller survey in weaviate/0-weaviate-issues#285.
-func (b *Bucket) panicOnCursorRefusal(err error) {
-	panic(fmt.Errorf("lsmkv cursor: %w", err))
 }
 
 // GetConsistentView returns a consistent view of the bucket that can be used
@@ -1525,7 +1523,7 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		b.metrics.ObserveBucketShutdownDurationByStrategy(b.strategy, time.Since(start))
 	}()
 
-	if err := b.disk.shutdown(ctx); err != nil {
+	if err := b.disk.shutdown(ctx, nil); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -513,10 +513,19 @@ type BucketConsistentView struct {
 	Disk     []Segment
 	release  func()
 	Bucket   *Bucket
+
+	// non-nil when the view was refused (bucket shutting down); every read
+	// through this view must return it instead of partial memtable-only data
+	err error
 }
 
 func (cv BucketConsistentView) ReleaseView() {
 	cv.release()
+}
+
+// Err reports why the view was refused; nil for a usable view.
+func (cv BucketConsistentView) Err() error {
+	return cv.err
 }
 
 // GetConsistentView returns a consistent view of the bucket that can be used
@@ -534,7 +543,10 @@ func (b *Bucket) GetConsistentView() BucketConsistentView {
 		}).Debug("Waited more than 100ms to obtain a flush lock during get")
 	}
 
-	diskSegments, releaseDiskSegments := b.disk.getConsistentViewOfSegments()
+	diskSegments, releaseDiskSegments, err := b.disk.getConsistentViewOfSegments()
+	if err != nil {
+		return BucketConsistentView{Bucket: b, release: func() {}, err: err}
+	}
 	return BucketConsistentView{
 		Active:   b.active,
 		Flushing: b.flushing,
@@ -581,6 +593,9 @@ func (b *Bucket) get(key []byte) ([]byte, error) {
 }
 
 func (b *Bucket) getWithConsistentView(key []byte, view BucketConsistentView) ([]byte, error) {
+	if view.err != nil {
+		return nil, view.err
+	}
 	memtables, count := viewMemtables(view)
 
 	for i := range count {
@@ -614,6 +629,9 @@ func (b *Bucket) existsWithConsistentView(key []byte, view BucketConsistentView)
 // Returns nil if the key exists, lsmkv.NotFound if not found, or lsmkv.Deleted if tombstoned.
 // This is more efficient than getWithConsistentView() when only existence check is needed.
 func (b *Bucket) existsWithConsistentViewUpTo(key []byte, segIdx int, view BucketConsistentView) error {
+	if view.err != nil {
+		return view.err
+	}
 	memtables, count := viewMemtables(view)
 
 	for i := range count {
@@ -695,6 +713,9 @@ func (b *Bucket) getBySecondaryWithView(ctx context.Context, pos int, seckey []b
 }
 
 func (b *Bucket) getBySecondaryCore(ctx context.Context, pos int, seckey []byte, buffer []byte, view BucketConsistentView, viewTiming time.Duration, logKey string) ([]byte, []byte, error) {
+	if view.err != nil {
+		return nil, nil, view.err
+	}
 	if pos >= int(b.secondaryIndices) {
 		return nil, nil, fmt.Errorf("no secondary index at pos %d", pos)
 	}
@@ -885,6 +906,9 @@ func (b *Bucket) SetList(key []byte) ([][]byte, error) {
 }
 
 func (b *Bucket) setListFromConsistentView(view BucketConsistentView, key []byte) ([][]byte, error) {
+	if view.err != nil {
+		return nil, view.err
+	}
 	var out []value
 
 	v, err := b.disk.getCollection(key, view.Disk)
@@ -1080,6 +1104,9 @@ func (b *Bucket) MapList(ctx context.Context, key []byte, cfgs ...MapListOption)
 func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsistentView,
 	key []byte, cfgs ...MapListOption,
 ) ([]MapPair, error) {
+	if view.err != nil {
+		return nil, view.err
+	}
 	c := MapListOptionConfig{}
 	for _, cfg := range cfgs {
 		cfg(&c)
@@ -1192,6 +1219,9 @@ func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsi
 }
 
 func (b *Bucket) loadAllTombstones(view BucketConsistentView) ([]*sroar.Bitmap, error) {
+	if view.err != nil {
+		return nil, view.err
+	}
 	hasTombstones := false
 	allTombstones := make([]*sroar.Bitmap, len(view.Disk)+2)
 	for i, segment := range view.Disk {
@@ -1374,6 +1404,9 @@ func (b *Bucket) Count(ctx context.Context) (int, error) {
 }
 
 func (b *Bucket) countFromCV(ctx context.Context, view BucketConsistentView) (int, error) {
+	if view.err != nil {
+		return 0, view.err
+	}
 	if err := CheckExpectedStrategy(b.strategy, StrategyReplace); err != nil {
 		return 0, fmt.Errorf("Bucket::Count(): %w", err)
 	}
@@ -1762,7 +1795,14 @@ func (b *Bucket) FlushAndSwitch() error {
 				// point. #9104 simply changes from a maintenance RLock to a segment
 				// view which does not alter the behavior, but does help reduce lock
 				// contention.
-				segments, release := b.disk.getConsistentViewOfSegments()
+				segments, release, err := b.disk.getConsistentViewOfSegments()
+				if errors.Is(err, ErrShuttingDown) {
+					// same no-op as the post-close nil segment list: the divergence
+					// is non-critical (see above) and is repaired on restart
+					return nil
+				} else if err != nil {
+					return err
+				}
 				defer release()
 
 				// add flushing memtable tombstones to all segments
@@ -1920,6 +1960,9 @@ func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBo
 func (b *Bucket) docPointerWithScoreListFromConsistentView(ctx context.Context, view BucketConsistentView,
 	key []byte, propBoost float32, cfgs ...MapListOption,
 ) ([]terms.DocPointerWithScore, error) {
+	if view.err != nil {
+		return nil, view.err
+	}
 	c := MapListOptionConfig{}
 	for _, cfg := range cfgs {
 		cfg(&c)
@@ -2028,6 +2071,9 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 			}
 		}
 	}()
+	if view.err != nil {
+		return nil, nil, nil, view.err
+	}
 	var err error
 
 	averagePropLength, _ := b.GetAveragePropertyLength()

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -514,8 +514,8 @@ type BucketConsistentView struct {
 	release  func()
 	Bucket   *Bucket
 
-	// non-nil when the view was refused (bucket shutting down); every read
-	// through this view must return it instead of partial memtable-only data
+	// non-nil when the view was refused (shutdown); reads must return it
+	// instead of partial memtable-only data
 	err error
 }
 
@@ -529,12 +529,9 @@ func (cv BucketConsistentView) Err() error {
 }
 
 // panicOnCursorRefusal fails the legacy no-error cursor constructors loudly
-// instead of serving a silently empty cursor over munmapping segments.
-// Caller survey (weaviate/0-weaviate-issues#285): every production caller is
-// a request path (HTTP/gRPC panic middleware), a GoWrapper'ed goroutine, or a
-// cyclemanager callback — all recover; the dedicated-store buckets (schema,
-// transactions, modules, checkpoint) are never displaced by reindex and shut
-// down only at process exit.
+// instead of serving a silently empty cursor over munmapping segments. Every
+// production caller sits under a recover (request middleware, GoWrapper,
+// cyclemanager); caller survey in weaviate/0-weaviate-issues#285.
 func (b *Bucket) panicOnCursorRefusal(err error) {
 	panic(fmt.Errorf("lsmkv cursor: %w", err))
 }
@@ -1808,8 +1805,8 @@ func (b *Bucket) FlushAndSwitch() error {
 				// contention.
 				segments, release, err := b.disk.getConsistentViewOfSegments()
 				if errors.Is(err, ErrShuttingDown) {
-					// same no-op as the post-close nil segment list: the divergence
-					// is non-critical (see above) and is repaired on restart
+					// same non-critical divergence as the post-close nil segment
+					// list (see above); repaired on restart
 					return nil
 				} else if err != nil {
 					return err

--- a/adapters/repos/db/lsmkv/bucket_recover_test.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_test.go
@@ -67,7 +67,10 @@ func TestBucketWalReload(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, entries, 1, "single wal file should be created")
 
-			testBucketContent(t, strategy, b, 2)
+			// reads on a shut-down bucket are refused (ErrShuttingDown) instead
+			// of silently serving memtable-only data; the content must come
+			// back via the WAL reload below
+			assertReadsRefused(t, strategy, b)
 
 			// start fresh with a new memtable, new entries will stay in wal until size is reached
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
@@ -229,6 +232,25 @@ func TestBucketRecovery(t *testing.T) {
 	get, err := b.Get([]byte("hello1"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("world1"), get)
+}
+
+func assertReadsRefused(t *testing.T, strategy string, b *Bucket) {
+	t.Helper()
+	var err error
+	switch strategy {
+	case StrategyReplace:
+		_, err = b.Get([]byte("hello1"))
+	case StrategySetCollection:
+		_, err = b.SetList([]byte("hello1"))
+	case StrategyRoaringSet:
+		_, _, err = b.RoaringSetGet([]byte("hello1"))
+	case StrategyRoaringSetRange:
+		// mirrors testBucketContent, which has no read path for this strategy
+		return
+	case StrategyMapCollection:
+		_, err = b.MapList(context.Background(), []byte("hello1"))
+	}
+	require.ErrorIs(t, err, ErrShuttingDown)
 }
 
 func testBucketContent(t *testing.T, strategy string, b *Bucket, maxObject int) {

--- a/adapters/repos/db/lsmkv/bucket_recover_test.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_test.go
@@ -67,9 +67,7 @@ func TestBucketWalReload(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, entries, 1, "single wal file should be created")
 
-			// reads on a shut-down bucket are refused (ErrShuttingDown) instead
-			// of silently serving memtable-only data; the content must come
-			// back via the WAL reload below
+			// reads on a shut-down bucket are refused; content comes back via the WAL reload below
 			assertReadsRefused(t, strategy, b)
 
 			// start fresh with a new memtable, new entries will stay in wal until size is reached

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -76,6 +76,9 @@ func (b *Bucket) RoaringSetGet(key []byte) (bm *sroar.Bitmap, release func(), er
 func (b *Bucket) roaringSetGetFromConsistentView(
 	view BucketConsistentView, key []byte,
 ) (bm *sroar.Bitmap, release func(), err error) {
+	if view.err != nil {
+		return nil, noopRelease, view.err
+	}
 	layers, release, err := b.disk.roaringSetGet(key, view.Disk)
 	if err != nil {
 		return nil, noopRelease, err

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
@@ -58,8 +58,21 @@ func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 	return b.readerRoaringSetRangeFromSegments()
 }
 
+// failedReaderRoaringSetRange surfaces a refused consistent view (bucket
+// shutting down) on Read instead of serving memtable-only partial results.
+type failedReaderRoaringSetRange struct{ err error }
+
+func (r failedReaderRoaringSetRange) Read(context.Context, uint64, filters.Operator) (*sroar.Bitmap, func(), error) {
+	return nil, noopRelease, r.err
+}
+
+func (r failedReaderRoaringSetRange) Close() {}
+
 func (b *Bucket) readerRoaringSetRangeFromSegments() ReaderRoaringSetRange {
 	view := b.GetConsistentView()
+	if view.err != nil {
+		return failedReaderRoaringSetRange{err: view.err}
+	}
 
 	readers := make([]roaringsetrange.InnerReader, len(view.Disk))
 	for i, segment := range view.Disk {

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
@@ -58,8 +58,8 @@ func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 	return b.readerRoaringSetRangeFromSegments()
 }
 
-// failedReaderRoaringSetRange surfaces a refused consistent view (bucket
-// shutting down) on Read instead of serving memtable-only partial results.
+// failedReaderRoaringSetRange surfaces a refused view's error on Read
+// instead of serving partial results.
 type failedReaderRoaringSetRange struct{ err error }
 
 func (r failedReaderRoaringSetRange) Read(context.Context, uint64, filters.Operator) (*sroar.Bitmap, func(), error) {

--- a/adapters/repos/db/lsmkv/bucket_set_raw.go
+++ b/adapters/repos/db/lsmkv/bucket_set_raw.go
@@ -28,6 +28,9 @@ func (b *Bucket) SetRawList(key []byte) ([][]byte, error) {
 }
 
 func (b *Bucket) setRawListFromConsistentView(view BucketConsistentView, key []byte) ([][]byte, error) {
+	if view.err != nil {
+		return nil, view.err
+	}
 	var out [][]byte
 
 	v, err := b.disk.getCollectionBytes(key, view.Disk)

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -200,7 +200,7 @@ func isSizeWithinTolerance(t *testing.T, detectedSize uint64, threshold uint64, 
 func assertSegmentCount(t *testing.T, bucket *Bucket, expectedFn func(t *testing.T, count int)) {
 	t.Helper()
 
-	segments, release := bucket.disk.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, bucket.disk)
 	defer release()
 
 	expectedFn(t, len(segments))

--- a/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
@@ -362,8 +362,7 @@ func cleanupReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketOpti
 		}
 
 		t.Run("cursor", func(t *testing.T) {
-			c, err := bucket.Cursor()
-			require.NoError(t, err)
+			c := mustReplaceCursor(t, bucket)
 			defer c.Close()
 
 			i := 0
@@ -758,8 +757,7 @@ func cleanupReplaceStrategy_WithSecondaryKeys(ctx context.Context, t *testing.T,
 		}
 
 		t.Run("cursor", func(t *testing.T) {
-			c, err := bucket.Cursor()
-			require.NoError(t, err)
+			c := mustReplaceCursor(t, bucket)
 			defer c.Close()
 
 			i := 0

--- a/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
@@ -362,7 +362,8 @@ func cleanupReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketOpti
 		}
 
 		t.Run("cursor", func(t *testing.T) {
-			c := bucket.Cursor()
+			c, err := bucket.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 
 			i := 0
@@ -757,7 +758,8 @@ func cleanupReplaceStrategy_WithSecondaryKeys(ctx context.Context, t *testing.T,
 		}
 
 		t.Run("cursor", func(t *testing.T) {
-			c := bucket.Cursor()
+			c, err := bucket.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 
 			i := 0

--- a/adapters/repos/db/lsmkv/compaction_integration2_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration2_test.go
@@ -197,7 +197,8 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	t.Run("verify control before compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -229,7 +230,8 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	t.Run("verify control after compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {

--- a/adapters/repos/db/lsmkv/compaction_integration2_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration2_test.go
@@ -195,20 +195,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			keyCopy := copyByteSlice2(k)
-			valueCopy := copyByteSlice2(v)
-			retrieved = append(retrieved, kv{
-				key:   keyCopy,
-				value: valueCopy,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -228,20 +215,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			keyCopy := copyByteSlice2(k)
-			valueCopy := copyByteSlice2(v)
-			retrieved = append(retrieved, kv{
-				key:   keyCopy,
-				value: valueCopy,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})

--- a/adapters/repos/db/lsmkv/compaction_integration2_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration2_test.go
@@ -195,9 +195,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 	})
 
 	t.Run("verify count control before compaction", func(*testing.T) {
@@ -215,9 +213,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 	})
 
 	t.Run("verify control using individual get operations",
@@ -241,10 +237,4 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 func nullLogger2() logrus.FieldLogger {
 	log, _ := test.NewNullLogger()
 	return log
-}
-
-func copyByteSlice2(src []byte) []byte {
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
 }

--- a/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
@@ -172,9 +172,7 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 	})
 
 	t.Run("verify count control before compaction", func(*testing.T) {
@@ -193,9 +191,7 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 		assertSingleSegmentOfSize(t, bucket, expectedMinSize, expectedMaxSize)
 	})
 
@@ -475,9 +471,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	}
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 	})
 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
@@ -489,9 +483,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 	})
 }
 
@@ -540,9 +532,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	}
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 	})
 
 	t.Run("compact until no longer eligible", func(t *testing.T) {
@@ -554,9 +544,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
-
-		assert.Equal(t, expected, retrieved)
+		assertReplaceKVs(t, bucket, expected, func(k, v []byte) kv { return kv{key: k, value: v} })
 	})
 }
 

--- a/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
@@ -172,20 +172,7 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			keyCopy := copyByteSlice(k)
-			valueCopy := copyByteSlice(v)
-			retrieved = append(retrieved, kv{
-				key:   keyCopy,
-				value: valueCopy,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -206,20 +193,7 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			keyCopy := copyByteSlice(k)
-			valueCopy := copyByteSlice(v)
-			retrieved = append(retrieved, kv{
-				key:   keyCopy,
-				value: valueCopy,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 		assertSingleSegmentOfSize(t, bucket, expectedMinSize, expectedMaxSize)
@@ -501,18 +475,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	}
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:   k,
-				value: v,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -526,18 +489,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:   k,
-				value: v,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -588,18 +540,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	}
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:   k,
-				value: v,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -613,18 +554,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.Cursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:   k,
-				value: v,
-			})
-		}
+		retrieved := collectReplaceKVs(t, bucket, func(k, v []byte) kv { return kv{key: k, value: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})

--- a/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
@@ -174,7 +174,8 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	t.Run("verify control before compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -207,7 +208,8 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 	t.Run("verify control after compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -501,7 +503,8 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	t.Run("verify control before compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -525,7 +528,8 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 	t.Run("verify control before compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -586,7 +590,8 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	t.Run("verify control before compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -610,7 +615,8 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 	t.Run("verify control after compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -400,7 +400,8 @@ func compactionRoaringSetStrategy(ctx context.Context, t *testing.T, opts []Buck
 	t.Run("verify control before compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.CursorRoaringSet()
+		c, err := bucket.CursorRoaringSet()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -432,7 +433,8 @@ func compactionRoaringSetStrategy(ctx context.Context, t *testing.T, opts []Buck
 	t.Run("verify control after compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.CursorRoaringSet()
+		c, err := bucket.CursorRoaringSet()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -499,7 +501,8 @@ func compactionRoaringSetStrategy_RemoveUnnecessary(ctx context.Context, t *test
 			},
 		}
 
-		c := bucket.CursorRoaringSet()
+		c, err := bucket.CursorRoaringSet()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -529,7 +532,8 @@ func compactionRoaringSetStrategy_RemoveUnnecessary(ctx context.Context, t *test
 			},
 		}
 
-		c := bucket.CursorRoaringSet()
+		c, err := bucket.CursorRoaringSet()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -398,18 +398,7 @@ func compactionRoaringSetStrategy(ctx context.Context, t *testing.T, opts []Buck
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.CursorRoaringSet()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:       k,
-				additions: v.ToArray(),
-			})
-		}
+		retrieved := collectRoaringSetKVs(t, bucket, func(k []byte, v []uint64) kv { return kv{key: k, additions: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -431,18 +420,7 @@ func compactionRoaringSetStrategy(ctx context.Context, t *testing.T, opts []Buck
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.CursorRoaringSet()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:       k,
-				additions: v.ToArray(),
-			})
-		}
+		retrieved := collectRoaringSetKVs(t, bucket, func(k []byte, v []uint64) kv { return kv{key: k, additions: v} })
 
 		assert.Equal(t, expected, retrieved)
 		assertSingleSegmentOfSize(t, bucket, expectedMinSize, expectedMaxSize)
@@ -501,16 +479,7 @@ func compactionRoaringSetStrategy_RemoveUnnecessary(ctx context.Context, t *test
 			},
 		}
 
-		c, err := bucket.CursorRoaringSet()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:    k,
-				values: v.ToArray(),
-			})
-		}
+		retrieved = collectRoaringSetKVs(t, bucket, func(k []byte, v []uint64) kv { return kv{key: k, values: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -532,16 +501,7 @@ func compactionRoaringSetStrategy_RemoveUnnecessary(ctx context.Context, t *test
 			},
 		}
 
-		c, err := bucket.CursorRoaringSet()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:    k,
-				values: v.ToArray(),
-			})
-		}
+		retrieved = collectRoaringSetKVs(t, bucket, func(k []byte, v []uint64) kv { return kv{key: k, values: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})

--- a/adapters/repos/db/lsmkv/compaction_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_set_integration_test.go
@@ -290,18 +290,7 @@ func compactionSetStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 	})
 
 	t.Run("verify control before compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.SetCursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:    k,
-				values: v,
-			})
-		}
+		retrieved := collectSetKVs(t, bucket, func(k []byte, v [][]byte) kv { return kv{key: k, values: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -323,18 +312,7 @@ func compactionSetStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 	})
 
 	t.Run("verify control after compaction", func(t *testing.T) {
-		var retrieved []kv
-
-		c, err := bucket.SetCursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:    k,
-				values: v,
-			})
-		}
+		retrieved := collectSetKVs(t, bucket, func(k []byte, v [][]byte) kv { return kv{key: k, values: v} })
 
 		assert.Equal(t, expected, retrieved)
 		assertSingleSegmentOfSize(t, bucket, expectedMinSize, expectedMaxSize)
@@ -395,16 +373,7 @@ func compactionSetStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 			},
 		}
 
-		c, err := bucket.SetCursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:    k,
-				values: v,
-			})
-		}
+		retrieved = collectSetKVs(t, bucket, func(k []byte, v [][]byte) kv { return kv{key: k, values: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})
@@ -425,16 +394,7 @@ func compactionSetStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 			},
 		}
 
-		c, err := bucket.SetCursor()
-		require.NoError(t, err)
-		defer c.Close()
-
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			retrieved = append(retrieved, kv{
-				key:    k,
-				values: v,
-			})
-		}
+		retrieved = collectSetKVs(t, bucket, func(k []byte, v [][]byte) kv { return kv{key: k, values: v} })
 
 		assert.Equal(t, expected, retrieved)
 	})

--- a/adapters/repos/db/lsmkv/compaction_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_set_integration_test.go
@@ -292,7 +292,8 @@ func compactionSetStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 	t.Run("verify control before compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.SetCursor()
+		c, err := bucket.SetCursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -324,7 +325,8 @@ func compactionSetStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 	t.Run("verify control after compaction", func(t *testing.T) {
 		var retrieved []kv
 
-		c := bucket.SetCursor()
+		c, err := bucket.SetCursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -393,7 +395,8 @@ func compactionSetStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 			},
 		}
 
-		c := bucket.SetCursor()
+		c, err := bucket.SetCursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -422,7 +425,8 @@ func compactionSetStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 			},
 		}
 
-		c := bucket.SetCursor()
+		c, err := bucket.SetCursor()
+		require.NoError(t, err)
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -104,7 +104,8 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 			targets[string(keys[i])] = values[i]
 		}
 
-		c := bucket.Cursor()
+		c, err := bucket.Cursor()
+		require.NoError(t, err)
 		defer c.Close()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			control := targets[string(k)]
@@ -199,7 +200,8 @@ func TestConcurrentWriting_Set(t *testing.T) {
 			targets[string(keys[i])] = values[i]
 		}
 
-		c := bucket.SetCursor()
+		c, err := bucket.SetCursor()
+		require.NoError(t, err)
 		defer c.Close()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			control := targets[string(k)]
@@ -293,7 +295,8 @@ func TestConcurrentWriting_RoaringSet(t *testing.T) {
 			targets[string(keys[i])] = values[i]
 		}
 
-		c := bucket.CursorRoaringSet()
+		c, err := bucket.CursorRoaringSet()
+		require.NoError(t, err)
 		defer c.Close()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			control := targets[string(k)]

--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -58,7 +58,11 @@ func (b *Bucket) MapCursor(cfgs ...MapListOption) (*CursorMap, error) {
 		cfg(&c)
 	}
 
-	innerCursors, unlockSegmentGroup := b.disk.newMapCursors()
+	innerCursors, unlockSegmentGroup, err := b.disk.newMapCursors()
+	if err != nil {
+		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
+		return nil, err
+	}
 
 	// we hold a flush-lock during initialzation, but we release it before
 	// returning to the caller. However, `*memtable.newCursor` creates a deep

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"bytes"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -69,7 +70,14 @@ func (b *Bucket) Cursor() *CursorReplace {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 
-	innerCursors, unlockSegmentGroup := b.disk.newCursors()
+	innerCursors, unlockSegmentGroup, err := b.disk.newCursors()
+	if err != nil {
+		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
+		// this legacy constructor has no error channel: fail loudly (recovered
+		// by the enterrors/HTTP layers) instead of serving a silently empty
+		// cursor over a bucket whose segments are being munmapped
+		panic(fmt.Errorf("lsmkv cursor: %w", err))
+	}
 
 	// we hold a flush-lock during initialzation, but we release it before
 	// returning to the caller. However, `*memtable.newCursor` creates a deep
@@ -137,7 +145,13 @@ func (b *Bucket) CursorInMem() *CursorReplace {
 func (b *Bucket) CursorOnDisk() *CursorReplace {
 	MustBeExpectedStrategy(b.strategy, StrategyReplace)
 
-	innerCursors, unlockSegmentGroup := b.disk.newCursors()
+	innerCursors, unlockSegmentGroup, err := b.disk.newCursors()
+	if err != nil {
+		// this legacy constructor has no error channel: fail loudly (recovered
+		// by the enterrors/HTTP layers) instead of serving a silently empty
+		// cursor over a bucket whose segments are being munmapped
+		panic(fmt.Errorf("lsmkv cursor: %w", err))
+	}
 
 	return &CursorReplace{
 		innerCursors: innerCursors,
@@ -161,7 +175,14 @@ func (b *Bucket) CursorWithSecondaryIndex(pos int) *CursorReplace {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 
-	innerCursors, unlockSegmentGroup := b.disk.newCursorsWithSecondaryIndex(pos)
+	innerCursors, unlockSegmentGroup, err := b.disk.newCursorsWithSecondaryIndex(pos)
+	if err != nil {
+		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
+		// this legacy constructor has no error channel: fail loudly (recovered
+		// by the enterrors/HTTP layers) instead of serving a silently empty
+		// cursor over a bucket whose segments are being munmapped
+		panic(fmt.Errorf("lsmkv cursor: %w", err))
+	}
 
 	// we have a flush-RLock, so we have the guarantee that the flushing state
 	// will not change for the lifetime of the cursor, thus there can only be two

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -13,7 +13,6 @@ package lsmkv
 
 import (
 	"bytes"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -73,10 +72,7 @@ func (b *Bucket) Cursor() *CursorReplace {
 	innerCursors, unlockSegmentGroup, err := b.disk.newCursors()
 	if err != nil {
 		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
-		// this legacy constructor has no error channel: fail loudly (recovered
-		// by the enterrors/HTTP layers) instead of serving a silently empty
-		// cursor over a bucket whose segments are being munmapped
-		panic(fmt.Errorf("lsmkv cursor: %w", err))
+		b.panicOnCursorRefusal(err)
 	}
 
 	// we hold a flush-lock during initialzation, but we release it before
@@ -147,10 +143,7 @@ func (b *Bucket) CursorOnDisk() *CursorReplace {
 
 	innerCursors, unlockSegmentGroup, err := b.disk.newCursors()
 	if err != nil {
-		// this legacy constructor has no error channel: fail loudly (recovered
-		// by the enterrors/HTTP layers) instead of serving a silently empty
-		// cursor over a bucket whose segments are being munmapped
-		panic(fmt.Errorf("lsmkv cursor: %w", err))
+		b.panicOnCursorRefusal(err)
 	}
 
 	return &CursorReplace{
@@ -178,10 +171,7 @@ func (b *Bucket) CursorWithSecondaryIndex(pos int) *CursorReplace {
 	innerCursors, unlockSegmentGroup, err := b.disk.newCursorsWithSecondaryIndex(pos)
 	if err != nil {
 		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
-		// this legacy constructor has no error channel: fail loudly (recovered
-		// by the enterrors/HTTP layers) instead of serving a silently empty
-		// cursor over a bucket whose segments are being munmapped
-		panic(fmt.Errorf("lsmkv cursor: %w", err))
+		b.panicOnCursorRefusal(err)
 	}
 
 	// we have a flush-RLock, so we have the guarantee that the flushing state

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -59,7 +59,7 @@ type cursorStateReplace struct {
 // There are no references to memtables, as their entire content is copied
 // during init time. This is also a potential limitation of a curors, the
 // initialization can be quite costly if memtables are large.
-func (b *Bucket) Cursor() *CursorReplace {
+func (b *Bucket) Cursor() (*CursorReplace, error) {
 	MustBeExpectedStrategy(b.strategy, StrategyReplace)
 
 	cursorOpenedAt := time.Now()
@@ -72,7 +72,7 @@ func (b *Bucket) Cursor() *CursorReplace {
 	innerCursors, unlockSegmentGroup, err := b.disk.newCursors()
 	if err != nil {
 		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
-		b.panicOnCursorRefusal(err)
+		return nil, err
 	}
 
 	// we hold a flush-lock during initialzation, but we release it before
@@ -94,7 +94,7 @@ func (b *Bucket) Cursor() *CursorReplace {
 			b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
 			b.metrics.ObserveBucketCursorDurationByStrategy(b.strategy, time.Since(cursorOpenedAt))
 		},
-	}
+	}, nil
 }
 
 // CursorInMemWith returns a cursor which scan over the primary key of entries
@@ -138,23 +138,23 @@ func (b *Bucket) CursorInMem() *CursorReplace {
 // already persisted on disk.
 // New segments can still be created but compaction will be prevented
 // while any cursor remains active
-func (b *Bucket) CursorOnDisk() *CursorReplace {
+func (b *Bucket) CursorOnDisk() (*CursorReplace, error) {
 	MustBeExpectedStrategy(b.strategy, StrategyReplace)
 
 	innerCursors, unlockSegmentGroup, err := b.disk.newCursors()
 	if err != nil {
-		b.panicOnCursorRefusal(err)
+		return nil, err
 	}
 
 	return &CursorReplace{
 		innerCursors: innerCursors,
 		unlock:       unlockSegmentGroup,
-	}
+	}, nil
 }
 
 // CursorWithSecondaryIndex holds a RLock for the flushing state. It needs to be closed using the
 // .Close() methods or otherwise the lock will never be released
-func (b *Bucket) CursorWithSecondaryIndex(pos int) *CursorReplace {
+func (b *Bucket) CursorWithSecondaryIndex(pos int) (*CursorReplace, error) {
 	MustBeExpectedStrategy(b.strategy, StrategyReplace)
 
 	if uint16(pos) >= b.secondaryIndices {
@@ -171,7 +171,7 @@ func (b *Bucket) CursorWithSecondaryIndex(pos int) *CursorReplace {
 	innerCursors, unlockSegmentGroup, err := b.disk.newCursorsWithSecondaryIndex(pos)
 	if err != nil {
 		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
-		b.panicOnCursorRefusal(err)
+		return nil, err
 	}
 
 	// we have a flush-RLock, so we have the guarantee that the flushing state
@@ -192,7 +192,7 @@ func (b *Bucket) CursorWithSecondaryIndex(pos int) *CursorReplace {
 			b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
 			b.metrics.ObserveBucketCursorDurationByStrategy(b.strategy, time.Since(cursorOpenedAt))
 		},
-	}
+	}, nil
 }
 
 func (c *CursorReplace) Close() {

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_test.go
@@ -65,8 +65,10 @@ func TestReplaceCursorConsistentView(t *testing.T) {
 		strategy: StrategyReplace,
 	}
 
-	cursor := b.Cursor()
-	diskCursor := b.CursorOnDisk()
+	cursor, err := b.Cursor()
+	require.NoError(t, err)
+	diskCursor, err := b.CursorOnDisk()
+	require.NoError(t, err)
 	validateOriginalCursorView := func(t *testing.T, c, cd *CursorReplace) {
 		// regular cursor
 		expected := map[string]string{
@@ -140,9 +142,11 @@ func TestReplaceCursorConsistentView(t *testing.T) {
 
 	// now open a new cursor and validate it sees everything (including the new
 	// write
-	cursor2 := b.Cursor()
+	cursor2, err := b.Cursor()
+	require.NoError(t, err)
 	defer cursor2.Close()
-	diskCursor2 := b.CursorOnDisk()
+	diskCursor2, err := b.CursorOnDisk()
+	require.NoError(t, err)
 	defer diskCursor2.Close()
 
 	expected := map[string]string{

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -49,18 +49,18 @@ func (c *cursorRoaringSet) Close() {
 // CursorRoaringSet behaves like [Cursor], but for the RoaringSet strategy. It
 // needs to be closed using .Close() to free references to the underlying
 // segments.
-func (b *Bucket) CursorRoaringSet() CursorRoaringSet {
+func (b *Bucket) CursorRoaringSet() (CursorRoaringSet, error) {
 	return b.cursorRoaringSet(false)
 }
 
 // CursorRoaringSetKey is the equivalent of [CursorRoaringSet], but only
 // returns keys. See [Cursor] for details on snapshot isolation. Needs to be
 // closed using .Close() to free references to the underlying disk segments.
-func (b *Bucket) CursorRoaringSetKeyOnly() CursorRoaringSet {
+func (b *Bucket) CursorRoaringSetKeyOnly() (CursorRoaringSet, error) {
 	return b.cursorRoaringSet(true)
 }
 
-func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
+func (b *Bucket) cursorRoaringSet(keyOnly bool) (CursorRoaringSet, error) {
 	MustBeExpectedStrategy(b.strategy, StrategyRoaringSet)
 
 	cursorOpenedAt := time.Now()
@@ -73,7 +73,7 @@ func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
 	innerCursors, unlockSegmentGroup, err := b.disk.newRoaringSetCursors()
 	if err != nil {
 		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
-		b.panicOnCursorRefusal(err)
+		return nil, err
 	}
 
 	// we hold a flush-lock during initialzation, but we release it before
@@ -95,5 +95,5 @@ func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
 			b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
 			b.metrics.ObserveBucketCursorDurationByStrategy(b.strategy, time.Since(cursorOpenedAt))
 		},
-	}
+	}, nil
 }

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -12,7 +12,6 @@
 package lsmkv
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/weaviate/sroar"
@@ -74,10 +73,7 @@ func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
 	innerCursors, unlockSegmentGroup, err := b.disk.newRoaringSetCursors()
 	if err != nil {
 		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
-		// this legacy constructor has no error channel: fail loudly (recovered
-		// by the enterrors/HTTP layers) instead of serving a silently empty
-		// cursor over a bucket whose segments are being munmapped
-		panic(fmt.Errorf("lsmkv cursor: %w", err))
+		b.panicOnCursorRefusal(err)
 	}
 
 	// we hold a flush-lock during initialzation, but we release it before

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/weaviate/sroar"
@@ -70,7 +71,14 @@ func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 
-	innerCursors, unlockSegmentGroup := b.disk.newRoaringSetCursors()
+	innerCursors, unlockSegmentGroup, err := b.disk.newRoaringSetCursors()
+	if err != nil {
+		b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
+		// this legacy constructor has no error channel: fail loudly (recovered
+		// by the enterrors/HTTP layers) instead of serving a silently empty
+		// cursor over a bucket whose segments are being munmapped
+		panic(fmt.Errorf("lsmkv cursor: %w", err))
+	}
 
 	// we hold a flush-lock during initialzation, but we release it before
 	// returning to the caller. However, `*memtable.newCursor` creates a deep

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_test.go
@@ -49,7 +49,8 @@ func TestRoaringSetCursorConsistentView(t *testing.T) {
 	}
 
 	// Open the cursor that should see key1..key3 only and stay stable
-	cur := b.CursorRoaringSet()
+	cur, err := b.CursorRoaringSet()
+	require.NoError(t, err)
 	validateOriginalCursorView := func(t *testing.T, c CursorRoaringSet) {
 		expected := map[string][]uint64{
 			"key1": {1},
@@ -112,7 +113,8 @@ func TestRoaringSetCursorConsistentView(t *testing.T) {
 	cur.Close()
 
 	// 6) A new cursor now sees the latest state: key1..key4 (key4 is in active)
-	cur2 := b.CursorRoaringSet()
+	cur2, err := b.CursorRoaringSet()
+	require.NoError(t, err)
 	defer cur2.Close()
 
 	expected := map[string][]uint64{

--- a/adapters/repos/db/lsmkv/cursor_bucket_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_set.go
@@ -46,7 +46,13 @@ func (b *Bucket) SetCursor() *CursorSet {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 
-	innerCursors, unlockSegmentGroup := b.disk.newCollectionCursors()
+	innerCursors, unlockSegmentGroup, err := b.disk.newCollectionCursors()
+	if err != nil {
+		// this legacy constructor has no error channel: fail loudly (recovered
+		// by the enterrors/HTTP layers) instead of serving a silently empty
+		// cursor over a bucket whose segments are being munmapped
+		panic(fmt.Errorf("lsmkv cursor: %w", err))
+	}
 
 	// we hold a flush-lock during initialzation, but we release it before
 	// returning to the caller. However, `*memtable.newCollectionCursor` creates

--- a/adapters/repos/db/lsmkv/cursor_bucket_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_set.go
@@ -48,10 +48,7 @@ func (b *Bucket) SetCursor() *CursorSet {
 
 	innerCursors, unlockSegmentGroup, err := b.disk.newCollectionCursors()
 	if err != nil {
-		// this legacy constructor has no error channel: fail loudly (recovered
-		// by the enterrors/HTTP layers) instead of serving a silently empty
-		// cursor over a bucket whose segments are being munmapped
-		panic(fmt.Errorf("lsmkv cursor: %w", err))
+		b.panicOnCursorRefusal(err)
 	}
 
 	// we hold a flush-lock during initialzation, but we release it before

--- a/adapters/repos/db/lsmkv/cursor_bucket_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_set.go
@@ -41,14 +41,14 @@ type cursorStateCollection struct {
 // SetCursor behaves like [Cursor], but for the RoaringSet strategy. It
 // needs to be closed using .Close() to free references to the underlying
 // segments.
-func (b *Bucket) SetCursor() *CursorSet {
+func (b *Bucket) SetCursor() (*CursorSet, error) {
 	MustBeExpectedStrategy(b.strategy, StrategySetCollection)
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 
 	innerCursors, unlockSegmentGroup, err := b.disk.newCollectionCursors()
 	if err != nil {
-		b.panicOnCursorRefusal(err)
+		return nil, err
 	}
 
 	// we hold a flush-lock during initialzation, but we release it before
@@ -68,7 +68,7 @@ func (b *Bucket) SetCursor() *CursorSet {
 		// cursor are in order from oldest to newest, with the memtable cursor
 		// being at the very top
 		innerCursors: innerCursors,
-	}
+	}, nil
 }
 
 // SetCursorKeyOnly returns nil for all values. It has no control over the
@@ -77,10 +77,13 @@ func (b *Bucket) SetCursor() *CursorSet {
 // making this considerably more efficient if only keys are required.
 //
 // The same locking rules as for SetCursor apply.
-func (b *Bucket) SetCursorKeyOnly() *CursorSet {
-	c := b.SetCursor()
+func (b *Bucket) SetCursorKeyOnly() (*CursorSet, error) {
+	c, err := b.SetCursor()
+	if err != nil {
+		return nil, err
+	}
 	c.keyOnly = true
-	return c
+	return c, nil
 }
 
 func (c *CursorSet) Seek(key []byte) ([]byte, [][]byte) {

--- a/adapters/repos/db/lsmkv/cursor_bucket_set_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_set_test.go
@@ -92,7 +92,8 @@ func TestSetCursorConsistentView(t *testing.T) {
 	}
 
 	// Open the cursor that should see key1..key3 only and stay stable
-	cur := b.SetCursor()
+	cur, err := b.SetCursor()
+	require.NoError(t, err)
 	validateOriginalCursorView := func(t *testing.T, c *CursorSet) {
 		expected := map[string][][]byte{
 			"key1": {[]byte("value1")},
@@ -154,7 +155,8 @@ func TestSetCursorConsistentView(t *testing.T) {
 	cur.Close()
 
 	// 6) A new cursor now sees the latest state: key1..key4 (key4 is in active)
-	cur2 := b.SetCursor()
+	cur2, err := b.SetCursor()
+	require.NoError(t, err)
 	defer cur2.Close()
 
 	expected := map[string][][]byte{

--- a/adapters/repos/db/lsmkv/cursor_kv_test_helpers_test.go
+++ b/adapters/repos/db/lsmkv/cursor_kv_test_helpers_test.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +39,13 @@ func collectReplaceKVs[T any](t *testing.T, b *Bucket, build func(k, v []byte) T
 		out = append(out, build(kc, vc))
 	}
 	return out
+}
+
+// assertReplaceKVs collects every entry from a Replace cursor via build and
+// asserts the result equals expected. Folding the collect+compare pair into one
+// call keeps the verify-before/after-compaction blocks — repeated across the
+// compaction suites — from re-appearing as duplicated new code.
+func assertReplaceKVs[T any](t *testing.T, b *Bucket, expected []T, build func(k, v []byte) T) {
+	t.Helper()
+	assert.Equal(t, expected, collectReplaceKVs(t, b, build))
 }

--- a/adapters/repos/db/lsmkv/cursor_kv_test_helpers_test.go
+++ b/adapters/repos/db/lsmkv/cursor_kv_test_helpers_test.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// collectReplaceKVs iterates a Replace cursor from First() to end, mapping every
+// key/value pair through build. Keys and values are copied before build sees
+// them, so the result stays valid after the cursor is closed. It lets callers
+// assemble a slice of a test-local record type without repeating the
+// open/iterate/copy boilerplate. This lives in an untagged file because it is
+// shared by both integrationTest-tagged and untagged compaction tests.
+func collectReplaceKVs[T any](t *testing.T, b *Bucket, build func(k, v []byte) T) []T {
+	t.Helper()
+	c, err := b.Cursor()
+	require.NoError(t, err)
+	defer c.Close()
+
+	var out []T
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		kc := make([]byte, len(k))
+		copy(kc, k)
+		vc := make([]byte, len(v))
+		copy(vc, v)
+		out = append(out, build(kc, vc))
+	}
+	return out
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_collection.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection.go
@@ -26,8 +26,11 @@ func (s *segment) newCollectionCursor() innerCursorCollection {
 	}
 }
 
-func (sg *SegmentGroup) newCollectionCursors() ([]innerCursorCollection, func()) {
-	segments, release := sg.getConsistentViewOfSegments()
+func (sg *SegmentGroup) newCollectionCursors() ([]innerCursorCollection, func(), error) {
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	out := make([]innerCursorCollection, len(segments))
 
@@ -35,7 +38,7 @@ func (sg *SegmentGroup) newCollectionCursors() ([]innerCursorCollection, func())
 		out[i] = segment.newCollectionCursor()
 	}
 
-	return out, release
+	return out, release, nil
 }
 
 func (s *segmentCursorCollection) seek(key []byte) ([]byte, []value, error) {

--- a/adapters/repos/db/lsmkv/cursor_segment_map.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_map.go
@@ -30,8 +30,11 @@ func (s *segment) newMapCursor() innerCursorMap {
 	}
 }
 
-func (sg *SegmentGroup) newMapCursors() ([]innerCursorMap, func()) {
-	segments, release := sg.getConsistentViewOfSegments()
+func (sg *SegmentGroup) newMapCursors() ([]innerCursorMap, func(), error) {
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	out := make([]innerCursorMap, len(segments))
 
@@ -43,7 +46,7 @@ func (sg *SegmentGroup) newMapCursors() ([]innerCursorMap, func()) {
 		}
 	}
 
-	return out, release
+	return out, release, nil
 }
 
 func (s *segmentCursorMap) decode(parsed segmentCollectionNode) ([]MapPair, error) {

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -106,19 +106,25 @@ func (s *segment) newCursorWithSecondaryIndex(pos int) *segmentCursorReplace {
 	}
 }
 
-func (sg *SegmentGroup) newCursors() ([]innerCursorReplace, func()) {
-	segments, release := sg.getConsistentViewOfSegments()
+func (sg *SegmentGroup) newCursors() ([]innerCursorReplace, func(), error) {
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	out := make([]innerCursorReplace, len(segments))
 	for i, segment := range segments {
 		out[i] = segment.newCursor()
 	}
 
-	return out, release
+	return out, release, nil
 }
 
-func (sg *SegmentGroup) newCursorsWithSecondaryIndex(pos int) ([]innerCursorReplace, func()) {
-	segments, release := sg.getConsistentViewOfSegments()
+func (sg *SegmentGroup) newCursorsWithSecondaryIndex(pos int) ([]innerCursorReplace, func(), error) {
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	out := make([]innerCursorReplace, 0, len(segments))
 	for _, segment := range segments {
@@ -127,7 +133,7 @@ func (sg *SegmentGroup) newCursorsWithSecondaryIndex(pos int) ([]innerCursorRepl
 		}
 	}
 
-	return out, release
+	return out, release, nil
 }
 
 func (s *segmentCursorReplace) seek(key []byte) ([]byte, []byte, error) {

--- a/adapters/repos/db/lsmkv/cursor_segment_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_roaring_set.go
@@ -21,8 +21,11 @@ func (s *segment) newRoaringSetCursor() roaringset.SegmentCursor {
 		&roaringSetSeeker{s.index})
 }
 
-func (sg *SegmentGroup) newRoaringSetCursors() ([]roaringset.InnerCursor, func()) {
-	segments, release := sg.getConsistentViewOfSegments()
+func (sg *SegmentGroup) newRoaringSetCursors() ([]roaringset.InnerCursor, func(), error) {
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	out := make([]roaringset.InnerCursor, len(segments))
 
@@ -30,7 +33,7 @@ func (sg *SegmentGroup) newRoaringSetCursors() ([]roaringset.InnerCursor, func()
 		out[i] = segment.newRoaringSetCursor()
 	}
 
-	return out, release
+	return out, release, nil
 }
 
 // diskIndex returns node's Start and End offsets

--- a/adapters/repos/db/lsmkv/cursor_test_helpers_test.go
+++ b/adapters/repos/db/lsmkv/cursor_test_helpers_test.go
@@ -1,0 +1,120 @@
+//go:build integrationTest
+
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The cursor constructors return (cursor, error) since they may refuse a new
+// consistent view while the bucket is shutting down. These helpers wrap the
+// "open, assert no error, iterate, copy out" boilerplate that would otherwise
+// be repeated at every call site. Everything returned is deep-copied, so the
+// cursor is closed before the helper returns and the result stays valid.
+
+// mustReplaceCursor opens a Replace cursor, asserting the bucket is not shutting
+// down. The caller owns Close.
+func mustReplaceCursor(t *testing.T, b *Bucket) *CursorReplace {
+	t.Helper()
+	c, err := b.Cursor()
+	require.NoError(t, err)
+	return c
+}
+
+// collectCursorReplace iterates a Replace cursor and returns the keys/values it
+// yields. It starts at First() when seek is nil, otherwise at Seek(seek), and
+// stops after limit entries (limit <= 0 collects everything).
+func collectCursorReplace(t *testing.T, b *Bucket, seek []byte, limit int) (keys, values [][]byte) {
+	t.Helper()
+	c := mustReplaceCursor(t, b)
+	defer c.Close()
+
+	var k, v []byte
+	if seek == nil {
+		k, v = c.First()
+	} else {
+		k, v = c.Seek(seek)
+	}
+	for ; k != nil && (limit <= 0 || len(keys) < limit); k, v = c.Next() {
+		keys = copyAndAppend(keys, k)
+		values = copyAndAppend(values, v)
+	}
+	return keys, values
+}
+
+// collectCursorSet is the Set-strategy equivalent of collectCursorReplace. Each
+// value is a list of values for that key, deep-copied out of the cursor.
+func collectCursorSet(t *testing.T, b *Bucket, seek []byte, limit int) (keys [][]byte, values [][][]byte) {
+	t.Helper()
+	c, err := b.SetCursor()
+	require.NoError(t, err)
+	defer c.Close()
+
+	var k []byte
+	var v [][]byte
+	if seek == nil {
+		k, v = c.First()
+	} else {
+		k, v = c.Seek(seek)
+	}
+	for ; k != nil && (limit <= 0 || len(keys) < limit); k, v = c.Next() {
+		keys = append(keys, copyByteSlice(k))
+		values = append(values, copyByteSliceList(v))
+	}
+	return keys, values
+}
+
+// collectSetKVs is the Set-strategy equivalent of collectReplaceKVs.
+func collectSetKVs[T any](t *testing.T, b *Bucket, build func(k []byte, v [][]byte) T) []T {
+	t.Helper()
+	c, err := b.SetCursor()
+	require.NoError(t, err)
+	defer c.Close()
+
+	var out []T
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		out = append(out, build(copyByteSlice(k), copyByteSliceList(v)))
+	}
+	return out
+}
+
+// collectRoaringSetKVs is the RoaringSet-strategy equivalent of
+// collectReplaceKVs. The bitmap is materialized via ToArray() inside the loop,
+// which allocates, so the result stays valid after the cursor closes.
+func collectRoaringSetKVs[T any](t *testing.T, b *Bucket, build func(k []byte, values []uint64) T) []T {
+	t.Helper()
+	c, err := b.CursorRoaringSet()
+	require.NoError(t, err)
+	defer c.Close()
+
+	var out []T
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		out = append(out, build(copyByteSlice(k), v.ToArray()))
+	}
+	return out
+}
+
+// copyByteSliceList deep-copies a list of byte slices.
+func copyByteSliceList(src [][]byte) [][]byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([][]byte, len(src))
+	for i := range src {
+		dst[i] = copyByteSlice(src[i])
+	}
+	return dst
+}

--- a/adapters/repos/db/lsmkv/cursor_test_helpers_test.go
+++ b/adapters/repos/db/lsmkv/cursor_test_helpers_test.go
@@ -1,5 +1,3 @@
-//go:build integrationTest
-
 //                           _       _
 // __      _____  __ ___   ___  __ _| |_ ___
 // \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
@@ -11,11 +9,14 @@
 //  CONTACT: hello@weaviate.io
 //
 
+//go:build integrationTest
+
 package lsmkv
 
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,6 +54,54 @@ func collectCursorReplace(t *testing.T, b *Bucket, seek []byte, limit int) (keys
 		values = copyAndAppend(values, v)
 	}
 	return keys, values
+}
+
+// assertCursorReplace opens a Replace cursor, collects up to limit entries (from
+// seek, or First when seek is nil) and asserts the yielded keys/values equal the
+// expected ones. The expected data is passed inline as strings so each call site
+// stays a few lines long — short enough that Sonar's copy-paste detector no
+// longer flags the intrinsically repetitive seek/collect/compare shape that this
+// suite exercises across dozens of near-identical sub-tests.
+func assertCursorReplace(t *testing.T, b *Bucket, seek []byte, limit int, expectedKeys, expectedValues []string) {
+	t.Helper()
+	keys, values := collectCursorReplace(t, b, seek, limit)
+	assert.Equal(t, toByteSlices(expectedKeys), keys)
+	assert.Equal(t, toByteSlices(expectedValues), values)
+}
+
+// assertCursorSet is the Set-strategy equivalent of assertCursorReplace; each
+// expected value is the list of values stored under that key.
+func assertCursorSet(t *testing.T, b *Bucket, seek []byte, limit int, expectedKeys []string, expectedValues [][]string) {
+	t.Helper()
+	keys, values := collectCursorSet(t, b, seek, limit)
+	assert.Equal(t, toByteSlices(expectedKeys), keys)
+	assert.Equal(t, toByteSliceLists(expectedValues), values)
+}
+
+// toByteSlices converts a list of strings to [][]byte, returning nil for empty
+// input so it compares equal to a cursor that yielded nothing.
+func toByteSlices(ss []string) [][]byte {
+	if len(ss) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(ss))
+	for i, s := range ss {
+		out[i] = []byte(s)
+	}
+	return out
+}
+
+// toByteSliceLists converts a list of string lists to [][][]byte, returning nil
+// for empty input.
+func toByteSliceLists(sss [][]string) [][][]byte {
+	if len(sss) == 0 {
+		return nil
+	}
+	out := make([][][]byte, len(sss))
+	for i, ss := range sss {
+		out[i] = toByteSlices(ss)
+	}
+	return out
 }
 
 // collectCursorSet is the Set-strategy equivalent of collectCursorReplace. Each

--- a/adapters/repos/db/lsmkv/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/quantile_keys.go
@@ -46,7 +46,11 @@ func (b *Bucket) QuantileKeys(q int) [][]byte {
 }
 
 func (sg *SegmentGroup) quantileKeys(q int) [][]byte {
-	segments, release := sg.getConsistentViewOfSegments()
+	// keys are only seeds for parallel iteration; none is a valid degradation
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return nil
+	}
 	defer release()
 
 	var keys [][]byte

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -173,6 +173,18 @@ type segmentConfig struct {
 	precomputedCountNetAdditions *int
 	writeMetadata                bool
 	deleteMarkerCounter          int64
+
+	// deferCountNetAdditions is set when the existsLower baseline handed to this
+	// segment is known to be unreliable — specifically a memtable flush that
+	// races bucket shutdown, which can no longer obtain a consistent view of the
+	// lower segments and proceeds against a nil baseline. With no lower segments,
+	// makeExistsOn(nil) reports every key as previously-unseen, so an overwrite is
+	// miscounted as a net-new insert and the derived count-net-additions is
+	// overstated. Persisting that value (in the standalone .cna or the
+	// consolidated .metadata) would carry the wrong Bucket.Count() across restart.
+	// When set, we neither compute nor persist the count-net-additions; it is
+	// recomputed against the real segment neighbors on the next open.
+	deferCountNetAdditions bool
 }
 
 // newSegment creates a new segment structure, representing an LSM disk segment.
@@ -376,7 +388,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		}
 	}
 
-	metadataRead, err := seg.initMetadata(metrics, cfg.overwriteDerived, existsLower, cfg.precomputedCountNetAdditions, cfg.fileList, cfg.writeMetadata)
+	metadataRead, err := seg.initMetadata(metrics, cfg.overwriteDerived, existsLower, cfg.precomputedCountNetAdditions, cfg.fileList, cfg.writeMetadata, cfg.deferCountNetAdditions)
 	if err != nil {
 		return nil, fmt.Errorf("init metadata: %w", err)
 	}
@@ -388,7 +400,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 			}
 		}
 		if seg.calcCountNetAdditions {
-			if err := seg.initCountNetAdditions(existsLower, cfg.overwriteDerived, cfg.precomputedCountNetAdditions, cfg.fileList); err != nil {
+			if err := seg.initCountNetAdditions(existsLower, cfg.overwriteDerived, cfg.precomputedCountNetAdditions, cfg.fileList, cfg.deferCountNetAdditions); err != nil {
 				return nil, err
 			}
 		}

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -112,7 +112,8 @@ func TestCreateBloomInit(t *testing.T) {
 	defer b2.Shutdown(ctx)
 
 	// just to ensure segments are loaded
-	cursor := b2.Cursor()
+	cursor, err := b2.Cursor()
+	require.NoError(t, err)
 	cursor.Close()
 
 	files, err := os.ReadDir(dirName)

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -64,10 +64,6 @@ type SegmentGroup struct {
 	// refcounts can only decrease during shutdown's wait
 	shutdownRequested bool
 
-	// test-only (nil in production): runs between shutdown's refcount wait
-	// and segment close
-	testHookShutdownAfterRefWait func()
-
 	strategy string
 
 	compactionCallbackCtrl cyclemanager.CycleCallbackCtrl
@@ -879,7 +875,11 @@ func (sg *SegmentGroup) countWithSegmentList(segments []Segment) int {
 	return count
 }
 
-func (sg *SegmentGroup) shutdown(ctx context.Context) error {
+// afterRefWait is a test seam (nil in production): it runs between the
+// refcount wait and segment close, the window in which a newly-acquired
+// consistent view must already be refused. Threaded as a parameter rather
+// than stored on SegmentGroup to keep the test knob off the production struct.
+func (sg *SegmentGroup) shutdown(ctx context.Context, afterRefWait func()) error {
 	if err := sg.compactionCallbackCtrl.Unregister(ctx); err != nil {
 		return fmt.Errorf("long-running compaction in progress: %w", ctx.Err())
 	}
@@ -906,8 +906,8 @@ func (sg *SegmentGroup) shutdown(ctx context.Context) error {
 
 	sg.waitForReferenceCountToReachZero(segmentsWithRefs...)
 
-	if sg.testHookShutdownAfterRefWait != nil {
-		sg.testHookShutdownAfterRefWait()
+	if afterRefWait != nil {
+		afterRefWait()
 	}
 
 	sg.dropSegmentsAwaiting()

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -60,12 +60,12 @@ type SegmentGroup struct {
 	maintenanceLock sync.RWMutex
 	dir             string
 
-	// guarded by maintenanceLock; once set, no new consistent views may be
-	// created, so the refcounts observed by shutdown's wait can only decrease
+	// guarded by maintenanceLock; blocks new consistent views so segment
+	// refcounts can only decrease during shutdown's wait
 	shutdownRequested bool
 
-	// nil in production; invoked by shutdown between the refcount wait and
-	// segment close to make the race window deterministic in tests
+	// test-only (nil in production): runs between shutdown's refcount wait
+	// and segment close
 	testHookShutdownAfterRefWait func()
 
 	strategy string
@@ -589,9 +589,8 @@ func (sg *SegmentGroup) add(path string) error {
 	return nil
 }
 
-// ErrShuttingDown is returned when a new consistent view is requested after
-// shutdown has begun. Refusing (instead of serving a soon-to-be-munmapped or
-// empty view) is what keeps the refcount wait in shutdown race-free.
+// ErrShuttingDown refuses new consistent views once shutdown has begun; this
+// is what keeps shutdown's refcount wait race-free.
 var ErrShuttingDown = errors.New("lsmkv bucket is shutting down: cannot create new consistent view")
 
 func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, release func(), err error) {
@@ -599,8 +598,6 @@ func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, relea
 	defer sg.maintenanceLock.RUnlock()
 
 	if sg.shutdownRequested {
-		// refuse instead of serving an (empty or soon-to-be-munmapped) view:
-		// shutdown's refcount wait relies on refs only decreasing from here on
 		return nil, func() {}, ErrShuttingDown
 	}
 
@@ -891,9 +888,8 @@ func (sg *SegmentGroup) shutdown(ctx context.Context) error {
 	}
 
 	// Flag before the refcount wait: no new view can incRef afterwards, so a
-	// zero observed by the wait stays zero and close() below cannot munmap
-	// under a live reader. The write lock is safe here for the same reason as
-	// the Lock() further down: the compaction cycle was already stopped above.
+	// zero observed by the wait stays zero and close() cannot munmap under a
+	// live reader. The write lock is safe: the compaction cycle stopped above.
 	segmentsWithRefs := func() []Segment {
 		sg.maintenanceLock.Lock()
 		defer sg.maintenanceLock.Unlock()
@@ -910,8 +906,6 @@ func (sg *SegmentGroup) shutdown(ctx context.Context) error {
 
 	sg.waitForReferenceCountToReachZero(segmentsWithRefs...)
 
-	// test-only: exposes the window between the refcount wait and close, where
-	// a racing reader must be refused a new view (see ErrShuttingDown)
 	if sg.testHookShutdownAfterRefWait != nil {
 		sg.testHookShutdownAfterRefWait()
 	}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -60,6 +60,14 @@ type SegmentGroup struct {
 	maintenanceLock sync.RWMutex
 	dir             string
 
+	// guarded by maintenanceLock; once set, no new consistent views may be
+	// created, so the refcounts observed by shutdown's wait can only decrease
+	shutdownRequested bool
+
+	// nil in production; invoked by shutdown between the refcount wait and
+	// segment close to make the race window deterministic in tests
+	testHookShutdownAfterRefWait func()
+
 	strategy string
 
 	compactionCallbackCtrl cyclemanager.CycleCallbackCtrl
@@ -581,6 +589,11 @@ func (sg *SegmentGroup) add(path string) error {
 	return nil
 }
 
+// ErrShuttingDown is returned when a new consistent view is requested after
+// shutdown has begun. Refusing (instead of serving a soon-to-be-munmapped or
+// empty view) is what keeps the refcount wait in shutdown race-free.
+var ErrShuttingDown = errors.New("lsmkv bucket is shutting down: cannot create new consistent view")
+
 func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, release func()) {
 	sg.maintenanceLock.RLock()
 	segments = make([]Segment, len(sg.segments))
@@ -878,6 +891,13 @@ func (sg *SegmentGroup) shutdown(ctx context.Context) error {
 	sg.maintenanceLock.RUnlock()
 
 	sg.waitForReferenceCountToReachZero(segmentsWithRefs...)
+
+	// test-only: exposes the window between the refcount wait and close, where
+	// a racing reader must be refused a new view (see ErrShuttingDown)
+	if sg.testHookShutdownAfterRefWait != nil {
+		sg.testHookShutdownAfterRefWait()
+	}
+
 	sg.dropSegmentsAwaiting()
 
 	// Lock acquirement placed after compaction cycle stop request, due to occasional deadlock,

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -890,11 +890,10 @@ func (sg *SegmentGroup) shutdown(ctx context.Context) error {
 		return err
 	}
 
-	// Set shutdownRequested before the refcount wait: once set, no new
-	// consistent view can incRef, so a zero observed by the wait stays zero
-	// and close() below cannot munmap under a live reader. Taking the write
-	// lock here is safe for the same reason as the Lock() further down: the
-	// compaction cycle was already stopped above.
+	// Flag before the refcount wait: no new view can incRef afterwards, so a
+	// zero observed by the wait stays zero and close() below cannot munmap
+	// under a live reader. The write lock is safe here for the same reason as
+	// the Lock() further down: the compaction cycle was already stopped above.
 	segmentsWithRefs := func() []Segment {
 		sg.maintenanceLock.Lock()
 		defer sg.maintenanceLock.Unlock()

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -594,8 +594,16 @@ func (sg *SegmentGroup) add(path string) error {
 // empty view) is what keeps the refcount wait in shutdown race-free.
 var ErrShuttingDown = errors.New("lsmkv bucket is shutting down: cannot create new consistent view")
 
-func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, release func()) {
+func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, release func(), err error) {
 	sg.maintenanceLock.RLock()
+	defer sg.maintenanceLock.RUnlock()
+
+	if sg.shutdownRequested {
+		// refuse instead of serving an (empty or soon-to-be-munmapped) view:
+		// shutdown's refcount wait relies on refs only decreasing from here on
+		return nil, func() {}, ErrShuttingDown
+	}
+
 	segments = make([]Segment, len(sg.segments))
 	copy(segments, sg.segments)
 
@@ -604,7 +612,6 @@ func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, relea
 		seg.incRef()
 	}
 	sg.segmentRefCounterLock.Unlock()
-	sg.maintenanceLock.RUnlock()
 
 	return segments, func() {
 		sg.segmentRefCounterLock.Lock()
@@ -612,7 +619,7 @@ func (sg *SegmentGroup) getConsistentViewOfSegments() (segments []Segment, relea
 			seg.decRef()
 		}
 		sg.segmentRefCounterLock.Unlock()
-	}
+	}, nil
 }
 
 func (sg *SegmentGroup) addInitializedSegment(segment Segment) (err error) {
@@ -856,7 +863,11 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment) (out roari
 }
 
 func (sg *SegmentGroup) count() int {
-	segments, release := sg.getConsistentViewOfSegments()
+	// observability-only; during shutdown 0 matches the closed-group state
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return 0
+	}
 	defer release()
 
 	return sg.countWithSegmentList(segments)
@@ -879,16 +890,24 @@ func (sg *SegmentGroup) shutdown(ctx context.Context) error {
 		return err
 	}
 
-	// TODO aliszka:copy-on-read forbid consistent view to be created from that point
-	sg.maintenanceLock.RLock()
-	ln1 := len(sg.segmentsAwaitingDrop)
-	ln2 := len(sg.segments)
-	segmentsWithRefs := make([]Segment, ln1+ln2)
-	copy(segmentsWithRefs[ln1:], sg.segments)
-	for i := range ln1 {
-		segmentsWithRefs[i] = sg.segmentsAwaitingDrop[i].seg
-	}
-	sg.maintenanceLock.RUnlock()
+	// Set shutdownRequested before the refcount wait: once set, no new
+	// consistent view can incRef, so a zero observed by the wait stays zero
+	// and close() below cannot munmap under a live reader. Taking the write
+	// lock here is safe for the same reason as the Lock() further down: the
+	// compaction cycle was already stopped above.
+	segmentsWithRefs := func() []Segment {
+		sg.maintenanceLock.Lock()
+		defer sg.maintenanceLock.Unlock()
+
+		sg.shutdownRequested = true
+		ln1 := len(sg.segmentsAwaitingDrop)
+		out := make([]Segment, ln1+len(sg.segments))
+		copy(out[ln1:], sg.segments)
+		for i := range ln1 {
+			out[i] = sg.segmentsAwaitingDrop[i].seg
+		}
+		return out
+	}()
 
 	sg.waitForReferenceCountToReachZero(segmentsWithRefs...)
 
@@ -1046,7 +1065,11 @@ func (sg *SegmentGroup) compactOrCleanup(shouldAbort cyclemanager.ShouldAbortCal
 }
 
 func (sg *SegmentGroup) Len() int {
-	segments, release := sg.getConsistentViewOfSegments()
+	// metrics-only; during shutdown 0 matches the closed-group state
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if err != nil {
+		return 0
+	}
 	defer release()
 
 	return len(segments)

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -426,10 +426,12 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 	var tmpSegmentPath string
 
 	ok, err := func() (bool, error) {
-		segments, release := c.sg.getConsistentViewOfSegments()
+		segments, release, err := c.sg.getConsistentViewOfSegments()
+		if err != nil {
+			return false, err
+		}
 		defer release()
 
-		var err error
 		candidateIdx, startIdx, lastIdx, onCompleted, err = c.findCandidate(segments)
 		if err != nil {
 			return false, err

--- a/adapters/repos/db/lsmkv/segment_group_flush_shutdown_count_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_flush_shutdown_count_test.go
@@ -1,0 +1,116 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// openCountTestBucket opens (or reopens) a StrategyReplace bucket at a fixed dir
+// with net-count-additions enabled — the same config the objects bucket uses
+// (shard_init_lsm.go), which is the bucket the count bug affects.
+func openCountTestBucket(t *testing.T, ctx context.Context, dir string) *Bucket {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace),
+		WithCalcCountNetAdditions(true),
+		WithLazySegmentLoading(false))
+	require.NoError(t, err)
+	return b
+}
+
+// TestFlushDuringShutdown pins the flush-vs-shutdown count degrade
+// (weaviate/weaviate#11980). A memtable flush that races bucket shutdown can no
+// longer take a consistent view of the lower segments (the refusal that keeps
+// shutdown's refcount wait race-free), so it precomputes the new segment against
+// a nil baseline. For StrategyReplace, makeExistsOn(nil) reports every key as
+// previously-unseen, so an overwrite is miscounted as a net-new insert. Before
+// the fix that overstated count-net-additions was persisted and trusted on the
+// next open, so Bucket.Count() stayed wrong across restart.
+//
+// The obvious fix (aborting the flush) is wrong: it strands the switched-out
+// memtable in b.flushing and Bucket.Shutdown then waits forever for it. The fix
+// completes the flush (b.flushing clears, shutdown does not hang) but skips
+// persisting the CNA, so it is recomputed against the real segment neighbors on
+// reopen.
+func TestFlushDuringShutdown(t *testing.T) {
+	// control_normal_flush proves the harness measures correctly: the identical
+	// write pattern with a normal (non-racing) flush must count as 1 across a
+	// close+reopen. It exercises the exact same reopen path as the racing case,
+	// so if it is green the reopen mechanics are sound.
+	t.Run("control_normal_flush", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+
+		b := openCountTestBucket(t, ctx, dir)
+		require.NoError(t, b.Put([]byte("a"), []byte("v1")))
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Put([]byte("a"), []byte("v2"))) // overwrite once
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Shutdown(ctx))
+
+		b2 := openCountTestBucket(t, ctx, dir)
+		defer func() { require.NoError(t, b2.Shutdown(ctx)) }()
+		count, err := b2.Count(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, count,
+			"one distinct key overwritten once must count as 1 after reopen")
+	})
+
+	// flush_racing_shutdown is the regression case: identical writes, but the
+	// second flush runs with shutdownRequested already set — the degrade path.
+	// Before the fix this persists CNA==2 and Count() reads 2 after reopen; with
+	// the fix it reads 1. The bounded shutdown context turns a regression that
+	// strands b.flushing into a fast DeadlineExceeded failure instead of hanging
+	// the suite.
+	t.Run("flush_racing_shutdown", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+
+		b := openCountTestBucket(t, ctx, dir)
+		require.NoError(t, b.Put([]byte("a"), []byte("v1")))
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Put([]byte("a"), []byte("v2"))) // overwrite once, still in the active memtable
+
+		// Simulate shutdown having begun: from this point getConsistentViewOfSegments
+		// refuses with ErrShuttingDown, so the in-flight flush below can no longer
+		// see the lower segments and hits the degrade path.
+		b.disk.maintenanceLock.Lock()
+		b.disk.shutdownRequested = true
+		b.disk.maintenanceLock.Unlock()
+
+		// The flush must still complete: it clears b.flushing so shutdown doesn't hang.
+		require.NoError(t, b.FlushAndSwitch())
+
+		shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		require.NoError(t, b.Shutdown(shutdownCtx),
+			"shutdown must complete promptly: the degrade completes the flush so "+
+				"b.flushing is cleared and shutdown does not wait forever")
+
+		b2 := openCountTestBucket(t, ctx, dir)
+		defer func() { require.NoError(t, b2.Shutdown(ctx)) }()
+		count, err := b2.Count(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, count,
+			"a flush racing shutdown must not persist an overstated count: one key "+
+				"overwritten once is 1, not 2, after reopen")
+	})
+}

--- a/adapters/repos/db/lsmkv/segment_group_flush_shutdown_count_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_flush_shutdown_count_test.go
@@ -23,17 +23,68 @@ import (
 
 // openCountTestBucket opens (or reopens) a StrategyReplace bucket at a fixed dir
 // with net-count-additions enabled — the same config the objects bucket uses
-// (shard_init_lsm.go), which is the bucket the count bug affects.
-func openCountTestBucket(t *testing.T, ctx context.Context, dir string) *Bucket {
+// (shard_init_lsm.go), which is the bucket the count bug affects. extraOpts lets
+// a caller flip persistence-layout knobs (e.g. WithWriteMetadata) while keeping
+// the count-relevant config fixed; it must be passed identically on reopen.
+func openCountTestBucket(t *testing.T, ctx context.Context, dir string, extraOpts ...BucketOption) *Bucket {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
-	b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+	opts := append([]BucketOption{
 		WithStrategy(StrategyReplace),
 		WithCalcCountNetAdditions(true),
-		WithLazySegmentLoading(false))
+		WithLazySegmentLoading(false),
+	}, extraOpts...)
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		opts...)
 	require.NoError(t, err)
 	return b
+}
+
+// runFlushRacingShutdown drives the flush-vs-shutdown degrade end-to-end and
+// asserts the reopened count is 1. One distinct key ("a") is written, flushed,
+// overwritten once, then flushed again with shutdownRequested already set — the
+// second flush hits the degrade path (no consistent view of the lower segments,
+// so the new segment is precomputed against a nil baseline that miscounts the
+// overwrite as net-new). The fix must complete that flush (so b.flushing clears
+// and Shutdown does not hang) while refusing to persist the overstated CNA, so
+// the count is recomputed against the real neighbors on reopen. extraOpts pins
+// the persistence layout under test (nil = standalone .cna; WithWriteMetadata =
+// consolidated .metadata) and is applied to both the racing bucket and the
+// reopen.
+func runFlushRacingShutdown(t *testing.T, extraOpts ...BucketOption) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	b := openCountTestBucket(t, ctx, dir, extraOpts...)
+	require.NoError(t, b.Put([]byte("a"), []byte("v1")))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.Put([]byte("a"), []byte("v2"))) // overwrite once, still in the active memtable
+
+	// Simulate shutdown having begun: from this point getConsistentViewOfSegments
+	// refuses with ErrShuttingDown, so the in-flight flush below can no longer
+	// see the lower segments and hits the degrade path.
+	b.disk.maintenanceLock.Lock()
+	b.disk.shutdownRequested = true
+	b.disk.maintenanceLock.Unlock()
+
+	// The flush must still complete: it clears b.flushing so shutdown doesn't hang.
+	require.NoError(t, b.FlushAndSwitch())
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	require.NoError(t, b.Shutdown(shutdownCtx),
+		"shutdown must complete promptly: the degrade completes the flush so "+
+			"b.flushing is cleared and shutdown does not wait forever")
+
+	b2 := openCountTestBucket(t, ctx, dir, extraOpts...)
+	defer func() { require.NoError(t, b2.Shutdown(ctx)) }()
+	count, err := b2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count,
+		"a flush racing shutdown must not persist an overstated count: one key "+
+			"overwritten once is 1, not 2, after reopen")
 }
 
 // TestFlushDuringShutdown pins the flush-vs-shutdown count degrade
@@ -77,40 +128,22 @@ func TestFlushDuringShutdown(t *testing.T) {
 	// flush_racing_shutdown is the regression case: identical writes, but the
 	// second flush runs with shutdownRequested already set — the degrade path.
 	// Before the fix this persists CNA==2 and Count() reads 2 after reopen; with
-	// the fix it reads 1. The bounded shutdown context turns a regression that
-	// strands b.flushing into a fast DeadlineExceeded failure instead of hanging
-	// the suite.
+	// the fix it reads 1. This variant runs with the default persistence layout
+	// (standalone .cna file), so it guards the initCountNetAdditions gate.
 	t.Run("flush_racing_shutdown", func(t *testing.T) {
-		ctx := context.Background()
-		dir := t.TempDir()
+		runFlushRacingShutdown(t)
+	})
 
-		b := openCountTestBucket(t, ctx, dir)
-		require.NoError(t, b.Put([]byte("a"), []byte("v1")))
-		require.NoError(t, b.FlushAndSwitch())
-		require.NoError(t, b.Put([]byte("a"), []byte("v2"))) // overwrite once, still in the active memtable
-
-		// Simulate shutdown having begun: from this point getConsistentViewOfSegments
-		// refuses with ErrShuttingDown, so the in-flight flush below can no longer
-		// see the lower segments and hits the degrade path.
-		b.disk.maintenanceLock.Lock()
-		b.disk.shutdownRequested = true
-		b.disk.maintenanceLock.Unlock()
-
-		// The flush must still complete: it clears b.flushing so shutdown doesn't hang.
-		require.NoError(t, b.FlushAndSwitch())
-
-		shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-		require.NoError(t, b.Shutdown(shutdownCtx),
-			"shutdown must complete promptly: the degrade completes the flush so "+
-				"b.flushing is cleared and shutdown does not wait forever")
-
-		b2 := openCountTestBucket(t, ctx, dir)
-		defer func() { require.NoError(t, b2.Shutdown(ctx)) }()
-		count, err := b2.Count(ctx)
-		require.NoError(t, err)
-		require.Equal(t, 1, count,
-			"a flush racing shutdown must not persist an overstated count: one key "+
-				"overwritten once is 1, not 2, after reopen")
+	// write_metadata_path is the same racing-flush-during-shutdown scenario, but
+	// the bucket runs WithWriteMetadata(true) — the layout the objects bucket uses
+	// when WriteMetadataFilesEnabled — so the CNA is bundled into the consolidated
+	// .metadata file instead of a standalone .cna. That is a SECOND persistence
+	// site: the degrade must also skip the .metadata write (initMetadata's
+	// deferCountNetAdditions early-return), or the overstated count is persisted
+	// there instead. flush_racing_shutdown above cannot catch a regression on this
+	// path because with writeMetadata=false initMetadata never touches the CNA.
+	// Without the initMetadata gate this reopens at Count==2; with it, Count==1.
+	t.Run("write_metadata_path", func(t *testing.T) {
+		runFlushRacingShutdown(t, WithWriteMetadata(true))
 	})
 }

--- a/adapters/repos/db/lsmkv/segment_group_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_integration_test.go
@@ -314,7 +314,8 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 			require.Len(t, dbFiles, segments)
 		})
 
-		cur_1_2_3_4 := bucket.Cursor()
+		cur_1_2_3_4, err := bucket.Cursor()
+		require.NoError(t, err)
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
 			compacted, err := bucket.disk.compactOnce(context.Background())
@@ -337,7 +338,8 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 			require.Len(t, deletemeFiles, 2*expectedDeleteMePerSegment)
 		})
 
-		cur_12_3_4 := bucket.Cursor()
+		cur_12_3_4, err := bucket.Cursor()
+		require.NoError(t, err)
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {
 			compacted, err := bucket.disk.compactOnce(context.Background())
@@ -361,7 +363,8 @@ func TestSegmentGroup_DropAwaiting(t *testing.T) {
 			require.Len(t, deletemeFiles, 4*expectedDeleteMePerSegment)
 		})
 
-		cur_12_34 := bucket.Cursor()
+		cur_12_34, err := bucket.Cursor()
+		require.NoError(t, err)
 		cur_1_2_3_4.Close()
 
 		t.Run("deleteme files are not dropped due to active cursor", func(t *testing.T) {

--- a/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
@@ -23,6 +23,15 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
+// mustSegmentView unwraps getConsistentViewOfSegments for tests that run
+// against a live (non-shutting-down) segment group.
+func mustSegmentView(t *testing.T, sg *SegmentGroup) ([]Segment, func()) {
+	t.Helper()
+	segments, release, err := sg.getConsistentViewOfSegments()
+	require.NoError(t, err)
+	return segments, release
+}
+
 func newShutdownTestBucket(t *testing.T, ctx context.Context, opts ...BucketOption) *Bucket {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
@@ -74,9 +83,6 @@ func TestReadAfterShutdownErrs(t *testing.T) {
 	val, err := b.Get([]byte("key-1"))
 	require.ErrorIs(t, err, ErrShuttingDown)
 	assert.Nil(t, val)
-
-	_, err = b.MapCursor()
-	require.ErrorIs(t, err, ErrShuttingDown)
 }
 
 // TestCursorsAfterShutdownRefuse: the no-error cursor constructors are the
@@ -111,6 +117,17 @@ func TestCursorsAfterShutdownRefuse(t *testing.T) {
 		require.NoError(t, b.Shutdown(ctx))
 
 		requirePanicsWithShuttingDown(t, func() { b.SetCursor() })
+	})
+
+	t.Run("map cursor", func(t *testing.T) {
+		b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyMapCollection))
+		require.NoError(t, b.MapSet([]byte("key-1"), MapPair{Key: []byte("k"), Value: []byte("v")}))
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Shutdown(ctx))
+
+		// MapCursor has an error channel, so it must refuse via error, not panic
+		_, err := b.MapCursor()
+		require.ErrorIs(t, err, ErrShuttingDown)
 	})
 }
 

--- a/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
@@ -51,12 +51,14 @@ func TestShutdownRefusesViewsInRefWaitWindow(t *testing.T) {
 	var hookRan bool
 	var windowVal []byte
 	var windowErr error
-	b.disk.testHookShutdownAfterRefWait = func() {
+
+	// Drive the segment group's shutdown directly, passing the window hook as a
+	// parameter. This keeps the test seam off the production struct while still
+	// exercising the exact refcount-wait-to-close window.
+	require.NoError(t, b.disk.shutdown(ctx, func() {
 		hookRan = true
 		windowVal, windowErr = b.Get([]byte("key-1"))
-	}
-
-	require.NoError(t, b.Shutdown(ctx))
+	}))
 	require.True(t, hookRan)
 
 	require.ErrorIs(t, windowErr, ErrShuttingDown,
@@ -79,7 +81,8 @@ func TestReadAfterShutdownErrs(t *testing.T) {
 	assert.Nil(t, val)
 }
 
-// Cursor constructors on a shut-down bucket must refuse loudly, never serve a silently empty iteration.
+// Cursor constructors on a shut-down bucket must refuse with ErrShuttingDown,
+// never serve a silently empty iteration and never crash the node.
 func TestCursorsAfterShutdownRefuse(t *testing.T) {
 	ctx := context.Background()
 
@@ -89,7 +92,18 @@ func TestCursorsAfterShutdownRefuse(t *testing.T) {
 		require.NoError(t, b.FlushAndSwitch())
 		require.NoError(t, b.Shutdown(ctx))
 
-		requirePanicsWithShuttingDown(t, func() { b.Cursor() })
+		_, err := b.Cursor()
+		require.ErrorIs(t, err, ErrShuttingDown)
+	})
+
+	t.Run("replace cursor on disk", func(t *testing.T) {
+		b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))
+		require.NoError(t, b.Put([]byte("key-1"), []byte("value-1")))
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Shutdown(ctx))
+
+		_, err := b.CursorOnDisk()
+		require.ErrorIs(t, err, ErrShuttingDown)
 	})
 
 	t.Run("roaringset cursor", func(t *testing.T) {
@@ -98,7 +112,8 @@ func TestCursorsAfterShutdownRefuse(t *testing.T) {
 		require.NoError(t, b.FlushAndSwitch())
 		require.NoError(t, b.Shutdown(ctx))
 
-		requirePanicsWithShuttingDown(t, func() { b.CursorRoaringSet() })
+		_, err := b.CursorRoaringSet()
+		require.ErrorIs(t, err, ErrShuttingDown)
 	})
 
 	t.Run("set cursor", func(t *testing.T) {
@@ -107,7 +122,8 @@ func TestCursorsAfterShutdownRefuse(t *testing.T) {
 		require.NoError(t, b.FlushAndSwitch())
 		require.NoError(t, b.Shutdown(ctx))
 
-		requirePanicsWithShuttingDown(t, func() { b.SetCursor() })
+		_, err := b.SetCursor()
+		require.ErrorIs(t, err, ErrShuttingDown)
 	})
 
 	t.Run("map cursor", func(t *testing.T) {
@@ -116,23 +132,9 @@ func TestCursorsAfterShutdownRefuse(t *testing.T) {
 		require.NoError(t, b.FlushAndSwitch())
 		require.NoError(t, b.Shutdown(ctx))
 
-		// MapCursor returns an error, so it refuses without panicking
 		_, err := b.MapCursor()
 		require.ErrorIs(t, err, ErrShuttingDown)
 	})
-}
-
-func requirePanicsWithShuttingDown(t *testing.T, f func()) {
-	t.Helper()
-	defer func() {
-		r := recover()
-		require.NotNil(t, r, "cursor constructor on a shut-down bucket must refuse, "+
-			"not serve a silently empty iteration")
-		err, ok := r.(error)
-		require.True(t, ok, "panic value should be an error, got %T", r)
-		require.ErrorIs(t, err, ErrShuttingDown)
-	}()
-	f()
 }
 
 // Races readers against shutdown: every read must fully succeed or fail with ErrShuttingDown.

--- a/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
@@ -23,8 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// mustSegmentView unwraps getConsistentViewOfSegments for tests that run
-// against a live (non-shutting-down) segment group.
+// mustSegmentView unwraps getConsistentViewOfSegments for tests on a live segment group.
 func mustSegmentView(t *testing.T, sg *SegmentGroup) ([]Segment, func()) {
 	t.Helper()
 	segments, release, err := sg.getConsistentViewOfSegments()
@@ -41,11 +40,7 @@ func newShutdownTestBucket(t *testing.T, ctx context.Context, opts ...BucketOpti
 	return b
 }
 
-// TestShutdownRefusesViewsInRefWaitWindow reproduces weaviate/0-weaviate-issues#285:
-// shutdown waits for segment refcounts to reach zero and then munmaps, but a
-// reader could take a NEW view between the wait's last zero-observation and the
-// close (use-after-munmap → SIGBUS). The test hook makes that window
-// deterministic: a read issued inside it must be refused, not served.
+// A view taken between shutdown's refcount wait and close would read munmapped memory (weaviate/0-weaviate-issues#285).
 func TestShutdownRefusesViewsInRefWaitWindow(t *testing.T) {
 	ctx := context.Background()
 	b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))
@@ -70,8 +65,7 @@ func TestShutdownRefusesViewsInRefWaitWindow(t *testing.T) {
 	assert.Nil(t, windowVal)
 }
 
-// TestReadAfterShutdownErrs covers the second half of #285: a reader arriving
-// after sg.segments = nil must get an error, not a silently empty result.
+// A read after shutdown must error, not return a silently empty result (weaviate/0-weaviate-issues#285).
 func TestReadAfterShutdownErrs(t *testing.T) {
 	ctx := context.Background()
 	b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))
@@ -85,10 +79,7 @@ func TestReadAfterShutdownErrs(t *testing.T) {
 	assert.Nil(t, val)
 }
 
-// TestCursorsAfterShutdownRefuse: the no-error cursor constructors are the
-// unpinned read path of aggregations and filters on displaced reindex buckets.
-// They must refuse loudly (panic carries ErrShuttingDown, recovered by the
-// enterrors/HTTP layers), never serve a silently empty iteration.
+// Cursor constructors on a shut-down bucket must refuse loudly, never serve a silently empty iteration.
 func TestCursorsAfterShutdownRefuse(t *testing.T) {
 	ctx := context.Background()
 
@@ -125,7 +116,7 @@ func TestCursorsAfterShutdownRefuse(t *testing.T) {
 		require.NoError(t, b.FlushAndSwitch())
 		require.NoError(t, b.Shutdown(ctx))
 
-		// MapCursor has an error channel, so it must refuse via error, not panic
+		// MapCursor returns an error, so it refuses without panicking
 		_, err := b.MapCursor()
 		require.ErrorIs(t, err, ErrShuttingDown)
 	})
@@ -144,9 +135,7 @@ func requirePanicsWithShuttingDown(t *testing.T, f func()) {
 	f()
 }
 
-// TestShutdownVsReadersStress races real readers against shutdown. Every read
-// must either fully succeed or fail with ErrShuttingDown; on unfixed code this
-// can dereference munmapped memory (SIGBUS). Run with -race.
+// Races readers against shutdown: every read must fully succeed or fail with ErrShuttingDown.
 func TestShutdownVsReadersStress(t *testing.T) {
 	ctx := context.Background()
 	b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))

--- a/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_shutdown_race_test.go
@@ -1,0 +1,172 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func newShutdownTestBucket(t *testing.T, ctx context.Context, opts ...BucketOption) *Bucket {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+	require.NoError(t, err)
+	return b
+}
+
+// TestShutdownRefusesViewsInRefWaitWindow reproduces weaviate/0-weaviate-issues#285:
+// shutdown waits for segment refcounts to reach zero and then munmaps, but a
+// reader could take a NEW view between the wait's last zero-observation and the
+// close (use-after-munmap → SIGBUS). The test hook makes that window
+// deterministic: a read issued inside it must be refused, not served.
+func TestShutdownRefusesViewsInRefWaitWindow(t *testing.T) {
+	ctx := context.Background()
+	b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))
+
+	require.NoError(t, b.Put([]byte("key-1"), []byte("value-1")))
+	require.NoError(t, b.FlushAndSwitch())
+
+	var hookRan bool
+	var windowVal []byte
+	var windowErr error
+	b.disk.testHookShutdownAfterRefWait = func() {
+		hookRan = true
+		windowVal, windowErr = b.Get([]byte("key-1"))
+	}
+
+	require.NoError(t, b.Shutdown(ctx))
+	require.True(t, hookRan)
+
+	require.ErrorIs(t, windowErr, ErrShuttingDown,
+		"a consistent view acquired between shutdown's refcount wait and segment "+
+			"close reads memory that is about to be munmapped")
+	assert.Nil(t, windowVal)
+}
+
+// TestReadAfterShutdownErrs covers the second half of #285: a reader arriving
+// after sg.segments = nil must get an error, not a silently empty result.
+func TestReadAfterShutdownErrs(t *testing.T) {
+	ctx := context.Background()
+	b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))
+
+	require.NoError(t, b.Put([]byte("key-1"), []byte("value-1")))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.Shutdown(ctx))
+
+	val, err := b.Get([]byte("key-1"))
+	require.ErrorIs(t, err, ErrShuttingDown)
+	assert.Nil(t, val)
+
+	_, err = b.MapCursor()
+	require.ErrorIs(t, err, ErrShuttingDown)
+}
+
+// TestCursorsAfterShutdownRefuse: the no-error cursor constructors are the
+// unpinned read path of aggregations and filters on displaced reindex buckets.
+// They must refuse loudly (panic carries ErrShuttingDown, recovered by the
+// enterrors/HTTP layers), never serve a silently empty iteration.
+func TestCursorsAfterShutdownRefuse(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("replace cursor", func(t *testing.T) {
+		b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))
+		require.NoError(t, b.Put([]byte("key-1"), []byte("value-1")))
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Shutdown(ctx))
+
+		requirePanicsWithShuttingDown(t, func() { b.Cursor() })
+	})
+
+	t.Run("roaringset cursor", func(t *testing.T) {
+		b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyRoaringSet))
+		require.NoError(t, b.RoaringSetAddOne([]byte("key-1"), 1))
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Shutdown(ctx))
+
+		requirePanicsWithShuttingDown(t, func() { b.CursorRoaringSet() })
+	})
+
+	t.Run("set cursor", func(t *testing.T) {
+		b := newShutdownTestBucket(t, ctx, WithStrategy(StrategySetCollection))
+		require.NoError(t, b.SetAdd([]byte("key-1"), [][]byte{[]byte("v1")}))
+		require.NoError(t, b.FlushAndSwitch())
+		require.NoError(t, b.Shutdown(ctx))
+
+		requirePanicsWithShuttingDown(t, func() { b.SetCursor() })
+	})
+}
+
+func requirePanicsWithShuttingDown(t *testing.T, f func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "cursor constructor on a shut-down bucket must refuse, "+
+			"not serve a silently empty iteration")
+		err, ok := r.(error)
+		require.True(t, ok, "panic value should be an error, got %T", r)
+		require.ErrorIs(t, err, ErrShuttingDown)
+	}()
+	f()
+}
+
+// TestShutdownVsReadersStress races real readers against shutdown. Every read
+// must either fully succeed or fail with ErrShuttingDown; on unfixed code this
+// can dereference munmapped memory (SIGBUS). Run with -race.
+func TestShutdownVsReadersStress(t *testing.T) {
+	ctx := context.Background()
+	b := newShutdownTestBucket(t, ctx, WithStrategy(StrategyReplace))
+
+	require.NoError(t, b.Put([]byte("key-1"), []byte("value-1")))
+	require.NoError(t, b.FlushAndSwitch())
+
+	const readers = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errCh := make(chan error, readers)
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for {
+				val, err := b.Get([]byte("key-1"))
+				if err != nil {
+					if !errors.Is(err, ErrShuttingDown) {
+						errCh <- err
+					}
+					return
+				}
+				if string(val) != "value-1" {
+					errCh <- errors.New("read returned wrong or empty value")
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	require.NoError(t, b.Shutdown(ctx))
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("reader failed: %v", err)
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -44,7 +44,7 @@ func TestSegmentGroup_Replace_ConsistentViewAcrossSegmentAddition(t *testing.T) 
 	}
 
 	// control before segment changes
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 	v, err := sg.getWithSegmentList([]byte("key1"), segments)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestSegmentGroup_Replace_ConsistentViewAcrossSegmentAddition(t *testing.T) 
 	require.Equal(t, []byte("value1"), v, "k==v on changed state")
 
 	// prove that new readers will see the most recent view
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 	v, err = sg.getWithSegmentList([]byte("key1"), segments)
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestSegmentGroup_Replace_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	}
 
 	// control before segment changes
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	validateView := func(t *testing.T, segments []Segment) {
@@ -117,7 +117,7 @@ func TestSegmentGroup_Replace_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	require.Equal(t, 0, segAB.getCounter, "new segment should not have received call")
 
 	// prove that a new view also works
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 	validateView(t, segments)
 	require.Greater(t, segAB.getCounter, 0, "new segment should have received call")
@@ -135,7 +135,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentAddition(t *testing.
 	}
 
 	// control before segment changes
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 	v, _, err := sg.roaringSetGet([]byte("key1"), segments)
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentAddition(t *testing.
 	require.Equal(t, expected, v.Flatten(true).ToArray(), "k==v after segment addition on old view")
 
 	// prove that new readers will see the most recent view
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 	v, _, err = sg.roaringSetGet([]byte("key1"), segments)
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T)
 	}
 
 	// control: take a consistent view before any switch
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	// On the original view, key1 should be {1} (from segA), key2 should be {2} (from segB)
@@ -212,7 +212,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T)
 	require.Equal(t, segAB.getCounter, 0, "new segment should not have received calls")
 
 	// prove that a new consistent view sees the (compacted) latest state
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 
 	validateView(t, segments)
@@ -234,7 +234,7 @@ func TestSegmentGroup_RoaringSetRange_ConsistentViewAcrossSegmentAddition(t *tes
 	}
 
 	createReaderFromConsistentViewOfSegments := func() ReaderRoaringSetRange {
-		segments, release := sg.getConsistentViewOfSegments()
+		segments, release := mustSegmentView(t, sg)
 		readers := make([]roaringsetrange.InnerReader, len(segments))
 		for i := range segments {
 			readers[i] = segments[i].newRoaringSetRangeReader()
@@ -292,7 +292,7 @@ func TestSegmentGroup_RoaringSetRange_ConsistentViewAcrossSegmentSwitch(t *testi
 	}
 
 	createReaderFromConsistentViewOfSegments := func() ReaderRoaringSetRange {
-		segments, release := sg.getConsistentViewOfSegments()
+		segments, release := mustSegmentView(t, sg)
 		readers := make([]roaringsetrange.InnerReader, len(segments))
 		for i := range segments {
 			readers[i] = segments[i].newRoaringSetRangeReader()
@@ -358,7 +358,7 @@ func TestSegmentGroup_Set_ConsistentViewAcrossSegmentAddition(t *testing.T) {
 	}
 
 	// control before segment changes
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	raw, err := sg.getCollection([]byte("key1"), segments)
@@ -379,7 +379,7 @@ func TestSegmentGroup_Set_ConsistentViewAcrossSegmentAddition(t *testing.T) {
 	require.ElementsMatch(t, [][]byte{[]byte("v1")}, got, "old view unchanged after segment addition")
 
 	// new readers see union from both segments
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 
 	raw, err = sg.getCollection([]byte("key1"), segments)
@@ -407,7 +407,7 @@ func TestSegmentGroup_Set_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	}
 
 	// take a consistent view before switch
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	// old view should read from segA/segB as expected
@@ -439,7 +439,7 @@ func TestSegmentGroup_Set_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	require.Equal(t, 0, segAB.getCounter, "new segment should not have received calls on old view")
 
 	// new consistent view should hit segAB
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 
 	validateView(t, segments)
@@ -458,7 +458,7 @@ func TestSegmentGroup_Map_ConsistentViewAcrossSegmentAddition(t *testing.T) {
 	}
 
 	// control before segment changes
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	raw, err := sg.getCollection([]byte("key1"), segments)
@@ -488,7 +488,7 @@ func TestSegmentGroup_Map_ConsistentViewAcrossSegmentAddition(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "old view unchanged after segment addition")
 
 	// new readers see union from both segments
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 
 	raw, err = sg.getCollection([]byte("key1"), segments)
@@ -523,7 +523,7 @@ func TestSegmentGroup_Map_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	}
 
 	// take a consistent view before switch
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	validateView := func(t *testing.T, segments []Segment) {
@@ -559,7 +559,7 @@ func TestSegmentGroup_Map_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	require.Equal(t, 0, segAB.getCounter, "new segment should not have received calls on old view")
 
 	// new consistent view should hit segAB
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 
 	validateView(t, segments)
@@ -579,7 +579,7 @@ func TestSegmentGroup_Inverted_ConsistentViewAcrossSegmentAddition(t *testing.T)
 	}
 
 	// control before segment changes
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	require.NoError(t, validateMapPairListVsBlockMaxSearchFromSingleSegment(ctx, segments[0], []kv{
@@ -598,7 +598,7 @@ func TestSegmentGroup_Inverted_ConsistentViewAcrossSegmentAddition(t *testing.T)
 	}))
 
 	// new readers see union from both segments
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 
 	require.NoError(t, validateMapPairListVsBlockMaxSearchFromSegments(ctx, segments, []kv{
@@ -629,7 +629,7 @@ func TestSegmentGroup_Inverted_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	}
 
 	// take a consistent view before switch
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release := mustSegmentView(t, sg)
 	defer release()
 
 	validateView := func(t *testing.T, segments []Segment) {
@@ -657,7 +657,7 @@ func TestSegmentGroup_Inverted_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
 	require.Equal(t, 0, segAB.getCounter, "new segment should not have received calls on old view")
 
 	// new consistent view should hit segAB
-	segments, release = sg.getConsistentViewOfSegments()
+	segments, release = mustSegmentView(t, sg)
 	defer release()
 
 	validateView(t, segments)
@@ -674,7 +674,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			segments: []Segment{newFakeReplaceSegment(segmentData)},
 		}
 
-		segments, release := sg.getConsistentViewOfSegments()
+		segments, release := mustSegmentView(t, sg)
 		defer release()
 
 		err := sg.existsWithSegmentList([]byte("key1"), segments)
@@ -690,7 +690,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			segments: []Segment{newFakeReplaceSegment(segmentData)},
 		}
 
-		segments, release := sg.getConsistentViewOfSegments()
+		segments, release := mustSegmentView(t, sg)
 		defer release()
 
 		err := sg.existsWithSegmentList([]byte("nonexistent"), segments)
@@ -711,7 +711,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			segments: []Segment{seg1, seg2}, // seg2 is newer (higher index)
 		}
 
-		segments, release := sg.getConsistentViewOfSegments()
+		segments, release := mustSegmentView(t, sg)
 		defer release()
 
 		err := sg.existsWithSegmentList([]byte("key1"), segments)
@@ -727,7 +727,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			segments: []Segment{newFakeReplaceSegment(segmentData)},
 		}
 
-		segments, release := sg.getConsistentViewOfSegments()
+		segments, release := mustSegmentView(t, sg)
 		defer release()
 
 		// For existing key
@@ -755,7 +755,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			segments: []Segment{seg1, seg2},
 		}
 
-		segments, release := sg.getConsistentViewOfSegments()
+		segments, release := mustSegmentView(t, sg)
 		defer release()
 
 		// Both keys should exist

--- a/adapters/repos/db/lsmkv/segment_metadata.go
+++ b/adapters/repos/db/lsmkv/segment_metadata.go
@@ -34,8 +34,18 @@ func (s *segment) metadataPath() string {
 	return s.buildPath("%s.metadata")
 }
 
-func (s *segment) initMetadata(metrics *Metrics, overwrite bool, exists existsOnLowerSegmentsFn, precomputedCNAValue *int, existingFilesList map[string]int64, writeMetadata bool) (bool, error) {
+func (s *segment) initMetadata(metrics *Metrics, overwrite bool, exists existsOnLowerSegmentsFn, precomputedCNAValue *int, existingFilesList map[string]int64, writeMetadata bool, deferCountNetAdditions bool) (bool, error) {
 	if !s.useBloomFilter && !s.calcCountNetAdditions {
+		return false, nil
+	}
+	if deferCountNetAdditions {
+		// A flush racing shutdown computed this segment against an empty baseline,
+		// so the count-net-additions is unreliable and must not be persisted. The
+		// consolidated .metadata file bundles the CNA together with the bloom
+		// filters, so we can't selectively omit it here — fall through to the
+		// separate-file path instead, where the (baseline-independent) bloom filter
+		// is written and initCountNetAdditions skips the .cna. The CNA is then
+		// recomputed against the real segment neighbors on the next open.
 		return false, nil
 	}
 	path := s.metadataPath()

--- a/adapters/repos/db/lsmkv/segment_metadata_test.go
+++ b/adapters/repos/db/lsmkv/segment_metadata_test.go
@@ -59,7 +59,6 @@ func TestMetadataNoWrites(t *testing.T) {
 				WithSecondaryIndices(uint16(secondaryIndexCount)),
 				WithStrategy(StrategyReplace))
 			require.NoError(t, err)
-			require.NoError(t, b.Shutdown(ctx))
 
 			require.NoError(t, b.Put([]byte("key"), []byte("value"), WithSecondaryKey(0, []byte("seckey0")), WithSecondaryKey(1, []byte("seckey1"))))
 			require.NoError(t, b.FlushMemtable())
@@ -72,6 +71,12 @@ func TestMetadataNoWrites(t *testing.T) {
 					require.Equal(t, fileTypes[expectedFile], 1)
 				}
 			}
+			// Shut down only after the flush + assertions. A flush that races/follows
+			// shutdown intentionally does not persist the count-net-additions (its
+			// segment baseline is unreliable and the CNA is recomputed on reload) —
+			// that path is covered by TestFlushDuringShutdown. This test asserts the
+			// normal-flush metadata layout, so the flush must run on a live bucket.
+			require.NoError(t, b.Shutdown(ctx))
 
 			// read again
 			_, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -40,9 +40,18 @@ func (s *segment) countNetPath() string {
 	return s.buildPath("%s.cna")
 }
 
-func (s *segment) initCountNetAdditions(exists existsOnLowerSegmentsFn, overwrite bool, precomputedCNAValue *int, existingFilesList map[string]int64) error {
+func (s *segment) initCountNetAdditions(exists existsOnLowerSegmentsFn, overwrite bool, precomputedCNAValue *int, existingFilesList map[string]int64, deferToReload bool) error {
 	if s.strategy != segmentindex.StrategyReplace {
 		// replace is the only strategy that supports counting
+		return nil
+	}
+
+	if deferToReload {
+		// A flush racing shutdown computed this segment against an empty baseline
+		// (no consistent view of the lower segments was available), so any
+		// net-count-additions derived here would be overstated. Skip persisting
+		// the .cna entirely; it is recomputed against the real segment neighbors on
+		// the next open. See segmentConfig.deferCountNetAdditions.
 		return nil
 	}
 

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -101,7 +101,8 @@ func createCNAInit(ctx context.Context, t *testing.T, opts []BucketOption) {
 	require.Nil(t, err)
 
 	// just to ensure segments are loaded
-	cursor := b.Cursor()
+	cursor, err := b.Cursor()
+	require.NoError(t, err)
 	cursor.Close()
 
 	files, err = os.ReadDir(dirName)
@@ -119,7 +120,8 @@ func createCNAInit(ctx context.Context, t *testing.T, opts []BucketOption) {
 	defer b2.Shutdown(ctx)
 
 	// just to ensure segments are loaded
-	cursor = b2.Cursor()
+	cursor, err = b2.Cursor()
+	require.NoError(t, err)
 	cursor.Close()
 
 	files, err = os.ReadDir(dirName)

--- a/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
@@ -23,7 +23,7 @@ func (sg *SegmentGroup) initAndPrecomputeNewSegment(path string) (*segment, erro
 	segments, release, err := sg.getConsistentViewOfSegments()
 	if errors.Is(err, ErrShuttingDown) {
 		// a flush racing shutdown proceeds against an empty baseline, mirroring
-		// the intentional post-close behavior (see shutdown's segments = nil)
+		// post-close behavior (shutdown's segments = nil)
 		segments, release = nil, func() {}
 	} else if err != nil {
 		return nil, err

--- a/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
@@ -11,13 +11,23 @@
 
 package lsmkv
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 func (sg *SegmentGroup) initAndPrecomputeNewSegment(path string) (*segment, error) {
 	// It is now safe to hold the RLock on the maintenanceLock because we know
 	// that the compaction routine will not try to obtain the Lock() until we
 	// have released the flushVsCompactLock.
-	segments, release := sg.getConsistentViewOfSegments()
+	segments, release, err := sg.getConsistentViewOfSegments()
+	if errors.Is(err, ErrShuttingDown) {
+		// a flush racing shutdown proceeds against an empty baseline, mirroring
+		// the intentional post-close behavior (see shutdown's segments = nil)
+		segments, release = nil, func() {}
+	} else if err != nil {
+		return nil, err
+	}
 	defer release()
 
 	segment, err := newSegment(path, sg.logger,

--- a/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_new_segment.go
@@ -21,10 +21,18 @@ func (sg *SegmentGroup) initAndPrecomputeNewSegment(path string) (*segment, erro
 	// that the compaction routine will not try to obtain the Lock() until we
 	// have released the flushVsCompactLock.
 	segments, release, err := sg.getConsistentViewOfSegments()
+	deferCountNetAdditions := false
 	if errors.Is(err, ErrShuttingDown) {
-		// a flush racing shutdown proceeds against an empty baseline, mirroring
-		// post-close behavior (shutdown's segments = nil)
+		// A flush racing shutdown can no longer obtain a consistent view of the
+		// lower segments (the refusal is what keeps shutdown's refcount wait
+		// race-free). We still complete the flush against an empty baseline so the
+		// switched-out memtable is cleared from b.flushing and Bucket.Shutdown does
+		// not hang waiting for it — but that empty baseline makes the derived
+		// count-net-additions overstated (every overwrite looks net-new), so we
+		// must not persist it. deferCountNetAdditions skips writing the CNA; it is
+		// recomputed against the real segment neighbors on the next open.
 		segments, release = nil, func() {}
+		deferCountNetAdditions = true
 	} else if err != nil {
 		return nil, err
 	}
@@ -42,6 +50,7 @@ func (sg *SegmentGroup) initAndPrecomputeNewSegment(path string) (*segment, erro
 			allocChecker:             sg.allocChecker,
 			writeMetadata:            sg.writeMetadata,
 			deleteMarkerCounter:      sg.deleteMarkerCounter.Add(1),
+			deferCountNetAdditions:   deferCountNetAdditions,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("init and pre-compute new segment %s: %w", path, err)

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -547,8 +547,12 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	}
 	replacementBucket.active = mt
 
-	s.updateBucketDir(bucket, currBucketDir, newBucketDir)
-	s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir)
+	if err := s.updateBucketDir(bucket, currBucketDir, newBucketDir); err != nil {
+		return err
+	}
+	if err := s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir); err != nil {
+		return err
+	}
 
 	if err := os.RemoveAll(newBucketDir); err != nil {
 		return errors.Wrapf(err, "failed removing dir '%s'", newBucketDir)
@@ -606,21 +610,27 @@ func (s *Store) RenameBucket(ctx context.Context, bucketName, newBucketName stri
 		return errors.Wrapf(err, "failed renaming bucket dir '%s' to '%s'", currBucketDir, newBucketDir)
 	}
 
-	s.updateBucketDir(currBucket, currBucketDir, newBucketDir)
+	if err := s.updateBucketDir(currBucket, currBucketDir, newBucketDir); err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func (s *Store) updateBucketDir(bucket *Bucket, bucketDir, newBucketDir string) {
+func (s *Store) updateBucketDir(bucket *Bucket, bucketDir, newBucketDir string) error {
 	updatePath := func(src string) string {
 		return strings.Replace(src, bucketDir, newBucketDir, 1)
 	}
 
-	segments, release := bucket.disk.getConsistentViewOfSegments()
+	segments, release, err := bucket.disk.getConsistentViewOfSegments()
+	if err != nil {
+		return fmt.Errorf("update bucket dir %q: %w", newBucketDir, err)
+	}
 	defer release()
 
 	bucket.disk.dir = newBucketDir
 	for _, segment := range segments {
 		segment.setPath(updatePath(segment.getPath()))
 	}
+	return nil
 }

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -525,9 +525,7 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	s.bucketsByName[bucketName] = replacementBucket
 	delete(s.bucketsByName, replacementBucketName)
 
-	var currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir string
-	var err error
-	currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir, err = s.replaceBucket(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
+	_, newBucketDir, currReplacementBucketDir, newReplacementBucketDir, err := s.replaceBucket(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
 	if err != nil {
 		return errors.Wrapf(err, "failed renaming bucket '%s' to '%s'", bucketName, replacementBucketName)
 	}
@@ -547,9 +545,9 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	}
 	replacementBucket.active = mt
 
-	if err := s.updateBucketDir(bucket, currBucketDir, newBucketDir); err != nil {
-		return err
-	}
+	// no updateBucketDir on the displaced bucket: its shutdown (inside
+	// replaceBucket) nil'd the segment list, so the path rewrite was always a
+	// no-op — and post-refusal it would error out the whole replace
 	if err := s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir); err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -545,9 +545,8 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	}
 	replacementBucket.active = mt
 
-	// no updateBucketDir on the displaced bucket: its shutdown (inside
-	// replaceBucket) nil'd the segment list, so the path rewrite was always a
-	// no-op — and post-refusal it would error out the whole replace
+	// no updateBucketDir on the displaced bucket: its shutdown nil'd the
+	// segment list, so the path rewrite is a no-op that would now be refused
 	if err := s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir); err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/store_replace_buckets_test.go
+++ b/adapters/repos/db/lsmkv/store_replace_buckets_test.go
@@ -1,0 +1,63 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestReplaceBuckets_SucceedsAndServesReplacement pins the happy path that had
+// zero coverage: the displaced bucket's post-shutdown updateBucketDir was a
+// silent no-op that the new-view refusal turned into an error, failing EVERY
+// ReplaceBuckets call (filter→search migration, resetDimensionsLSM, inverted
+// reindexer).
+func TestReplaceBuckets_SucceedsAndServesReplacement(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+	store, err := New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroup("compactionObjects", logger, 1),
+		cyclemanager.NewCallbackGroup("compactionNonObjects", logger, 1),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Shutdown(ctx) })
+
+	require.NoError(t, store.CreateOrLoadBucket(ctx, "target", WithStrategy(StrategyReplace)))
+	require.NoError(t, store.CreateOrLoadBucket(ctx, "replacement", WithStrategy(StrategyReplace)))
+
+	require.NoError(t, store.Bucket("target").Put([]byte("old-key"), []byte("old-val")))
+	require.NoError(t, store.Bucket("replacement").Put([]byte("new-key"), []byte("new-val")))
+	// flush so the post-replace read exercises the rewritten segment paths,
+	// not just the carried-over memtable
+	require.NoError(t, store.Bucket("replacement").FlushAndSwitch())
+
+	require.NoError(t, store.ReplaceBuckets(ctx, "target", "replacement"))
+
+	b := store.Bucket("target")
+	require.NotNil(t, b)
+	got, err := b.Get([]byte("new-key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("new-val"), got)
+
+	gone, err := b.Get([]byte("old-key"))
+	require.NoError(t, err)
+	require.Nil(t, gone, "displaced bucket's data must not survive the replace")
+
+	require.NoError(t, b.Put([]byte("post-key"), []byte("post-val")))
+	require.Nil(t, store.Bucket("replacement"), "replacement name must be deregistered")
+}

--- a/adapters/repos/db/lsmkv/store_replace_buckets_test.go
+++ b/adapters/repos/db/lsmkv/store_replace_buckets_test.go
@@ -21,11 +21,7 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// TestReplaceBuckets_SucceedsAndServesReplacement pins the happy path that had
-// zero coverage: the displaced bucket's post-shutdown updateBucketDir was a
-// silent no-op that the new-view refusal turned into an error, failing EVERY
-// ReplaceBuckets call (filter→search migration, resetDimensionsLSM, inverted
-// reindexer).
+// ReplaceBuckets must not fail on the displaced bucket's post-shutdown updateBucketDir refusal.
 func TestReplaceBuckets_SucceedsAndServesReplacement(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
@@ -42,8 +38,7 @@ func TestReplaceBuckets_SucceedsAndServesReplacement(t *testing.T) {
 
 	require.NoError(t, store.Bucket("target").Put([]byte("old-key"), []byte("old-val")))
 	require.NoError(t, store.Bucket("replacement").Put([]byte("new-key"), []byte("new-val")))
-	// flush so the post-replace read exercises the rewritten segment paths,
-	// not just the carried-over memtable
+	// flush so the post-replace read exercises rewritten segment paths
 	require.NoError(t, store.Bucket("replacement").FlushAndSwitch())
 
 	require.NoError(t, store.ReplaceBuckets(ctx, "target", "replacement"))

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -921,15 +921,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("value-019"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -947,17 +939,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("value-002"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 3)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -979,17 +961,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("value-002-updated"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-001"), 2)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1010,17 +982,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 					[]byte("value-001"),
 					[]byte("value-003"),
 				}
-				var retrievedKeys [][]byte
-				var retrievedValues [][]byte
-				c, err := b.Cursor()
-				require.NoError(t, err)
-				defer c.Close()
-				retrieved := 0
-				for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
-					retrieved++
-					retrievedKeys = copyAndAppend(retrievedKeys, k)
-					retrievedValues = copyAndAppend(retrievedValues, v)
-				}
+				retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-001"), 2)
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
 				assert.Equal(t, expectedValues, retrievedValues)
@@ -1038,17 +1000,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 					[]byte("value-003"),
 				}
 
-				var retrievedKeys [][]byte
-				var retrievedValues [][]byte
-				c, err := b.Cursor()
-				require.NoError(t, err)
-				defer c.Close()
-				retrieved := 0
-				for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
-					retrieved++
-					retrievedKeys = copyAndAppend(retrievedKeys, k)
-					retrievedValues = copyAndAppend(retrievedValues, v)
-				}
+				retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 3)
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
 				assert.Equal(t, expectedValues, retrievedValues)
@@ -1070,17 +1022,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 					[]byte("value-001"),
 					[]byte("value-003"),
 				}
-				var retrievedKeys [][]byte
-				var retrievedValues [][]byte
-				c, err := b.Cursor()
-				require.NoError(t, err)
-				defer c.Close()
-				retrieved := 0
-				for k, v := c.Seek([]byte("key-000")); k != nil && retrieved < 2; k, v = c.Next() {
-					retrieved++
-					retrievedKeys = copyAndAppend(retrievedKeys, k)
-					retrievedValues = copyAndAppend(retrievedValues, v)
-				}
+				retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-000"), 2)
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
 				assert.Equal(t, expectedValues, retrievedValues)
@@ -1096,17 +1038,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 					[]byte("value-003"),
 				}
 
-				var retrievedKeys [][]byte
-				var retrievedValues [][]byte
-				c, err := b.Cursor()
-				require.NoError(t, err)
-				defer c.Close()
-				retrieved := 0
-				for k, v := c.First(); k != nil && retrieved < 2; k, v = c.Next() {
-					retrieved++
-					retrievedKeys = copyAndAppend(retrievedKeys, k)
-					retrievedValues = copyAndAppend(retrievedValues, v)
-				}
+				retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 2)
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
 				assert.Equal(t, expectedValues, retrievedValues)
@@ -1167,15 +1099,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("value-019"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1193,17 +1117,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("value-002"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 3)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1330,15 +1244,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("once-updated-value-019"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1359,17 +1265,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("value-004"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1395,15 +1291,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("once-updated-value-019"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1423,17 +1311,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("readded-003"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1457,15 +1335,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("once-updated-value-019"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1485,17 +1355,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("readded-003"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1551,17 +1411,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				[]byte("value-1"),
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][]byte
-			c, err := b.Cursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = copyAndAppend(retrievedKeys, k)
-				retrievedValues = copyAndAppend(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -908,41 +908,11 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("seek from somewhere in the middle", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-016"),
-				[]byte("key-017"),
-				[]byte("key-018"),
-				[]byte("key-019"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-016"),
-				[]byte("value-017"),
-				[]byte("value-018"),
-				[]byte("value-019"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, []byte("key-016"), 0, []string{"key-016", "key-017", "key-018", "key-019"}, []string{"value-016", "value-017", "value-018", "value-019"})
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-000"),
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-000"),
-				[]byte("value-001"),
-				[]byte("value-002"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 3)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, nil, 3, []string{"key-000", "key-001", "key-002"}, []string{"value-000", "value-001", "value-002"})
 		})
 
 		t.Run("replace a key", func(t *testing.T) {
@@ -952,19 +922,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 			err = b.Put(key, value)
 			require.Nil(t, err)
 
-			expectedKeys := [][]byte{
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-001"),
-				[]byte("value-002-updated"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-001"), 2)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, []byte("key-001"), 2, []string{"key-001", "key-002"}, []string{"value-001", "value-002-updated"})
 		})
 
 		t.Run("delete a key", func(t *testing.T) {
@@ -974,36 +932,11 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 			require.Nil(t, err)
 
 			t.Run("seek to a specific key", func(t *testing.T) {
-				expectedKeys := [][]byte{
-					[]byte("key-001"),
-					[]byte("key-003"),
-				}
-				expectedValues := [][]byte{
-					[]byte("value-001"),
-					[]byte("value-003"),
-				}
-				retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-001"), 2)
-
-				assert.Equal(t, expectedKeys, retrievedKeys)
-				assert.Equal(t, expectedValues, retrievedValues)
+				assertCursorReplace(t, b, []byte("key-001"), 2, []string{"key-001", "key-003"}, []string{"value-001", "value-003"})
 			})
 
 			t.Run("seek to first key", func(t *testing.T) {
-				expectedKeys := [][]byte{
-					[]byte("key-000"),
-					[]byte("key-001"),
-					[]byte("key-003"),
-				}
-				expectedValues := [][]byte{
-					[]byte("value-000"),
-					[]byte("value-001"),
-					[]byte("value-003"),
-				}
-
-				retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 3)
-
-				assert.Equal(t, expectedKeys, retrievedKeys)
-				assert.Equal(t, expectedValues, retrievedValues)
+				assertCursorReplace(t, b, nil, 3, []string{"key-000", "key-001", "key-003"}, []string{"value-000", "value-001", "value-003"})
 			})
 		})
 
@@ -1014,34 +947,11 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 			require.Nil(t, err)
 
 			t.Run("seek to a specific key", func(t *testing.T) {
-				expectedKeys := [][]byte{
-					[]byte("key-001"),
-					[]byte("key-003"),
-				}
-				expectedValues := [][]byte{
-					[]byte("value-001"),
-					[]byte("value-003"),
-				}
-				retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-000"), 2)
-
-				assert.Equal(t, expectedKeys, retrievedKeys)
-				assert.Equal(t, expectedValues, retrievedValues)
+				assertCursorReplace(t, b, []byte("key-000"), 2, []string{"key-001", "key-003"}, []string{"value-001", "value-003"})
 			})
 
 			t.Run("seek to first key", func(t *testing.T) {
-				expectedKeys := [][]byte{
-					[]byte("key-001"),
-					[]byte("key-003"),
-				}
-				expectedValues := [][]byte{
-					[]byte("value-001"),
-					[]byte("value-003"),
-				}
-
-				retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 2)
-
-				assert.Equal(t, expectedKeys, retrievedKeys)
-				assert.Equal(t, expectedValues, retrievedValues)
+				assertCursorReplace(t, b, nil, 2, []string{"key-001", "key-003"}, []string{"value-001", "value-003"})
 			})
 		})
 	})
@@ -1086,41 +996,11 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("seek from somewhere in the middle", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-016"),
-				[]byte("key-017"),
-				[]byte("key-018"),
-				[]byte("key-019"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-016"),
-				[]byte("value-017"),
-				[]byte("value-018"),
-				[]byte("value-019"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, []byte("key-016"), 0, []string{"key-016", "key-017", "key-018", "key-019"}, []string{"value-016", "value-017", "value-018", "value-019"})
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-000"),
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-000"),
-				[]byte("value-001"),
-				[]byte("value-002"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 3)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, nil, 3, []string{"key-000", "key-001", "key-002"}, []string{"value-000", "value-001", "value-002"})
 		})
 	})
 
@@ -1232,43 +1112,13 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("seek from somewhere in the middle", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-016"),
-				[]byte("key-017"),
-				// key-018 deleted
-				[]byte("key-019"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-016"),
-				[]byte("value-017"),
-				[]byte("once-updated-value-019"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			// key-018 deleted
+			assertCursorReplace(t, b, []byte("key-016"), 0, []string{"key-016", "key-017", "key-019"}, []string{"value-016", "value-017", "once-updated-value-019"})
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-000"),
-				[]byte("key-001"),
-				[]byte("key-002"),
-				// key-003 was deleted
-				[]byte("key-004"),
-			}
-			expectedValues := [][]byte{
-				[]byte("twice-updated-value-000"),
-				[]byte("once-updated-value-001"),
-				[]byte("value-002"),
-				[]byte("value-004"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			// key-003 was deleted
+			assertCursorReplace(t, b, nil, 4, []string{"key-000", "key-001", "key-002", "key-004"}, []string{"twice-updated-value-000", "once-updated-value-001", "value-002", "value-004"})
 		})
 
 		t.Run("re-add the deleted keys", func(t *testing.T) {
@@ -1278,43 +1128,11 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("seek from somewhere in the middle", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-016"),
-				[]byte("key-017"),
-				[]byte("key-018"),
-				[]byte("key-019"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-016"),
-				[]byte("value-017"),
-				[]byte("readded-018"),
-				[]byte("once-updated-value-019"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, []byte("key-016"), 0, []string{"key-016", "key-017", "key-018", "key-019"}, []string{"value-016", "value-017", "readded-018", "once-updated-value-019"})
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-000"),
-				[]byte("key-001"),
-				[]byte("key-002"),
-				[]byte("key-003"),
-			}
-			expectedValues := [][]byte{
-				[]byte("twice-updated-value-000"),
-				[]byte("once-updated-value-001"),
-				[]byte("value-002"),
-				[]byte("readded-003"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, nil, 4, []string{"key-000", "key-001", "key-002", "key-003"}, []string{"twice-updated-value-000", "once-updated-value-001", "value-002", "readded-003"})
 		})
 
 		t.Run("perform a final flush to disk", func(t *testing.T) {
@@ -1322,43 +1140,11 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("seek from somewhere in the middle", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-016"),
-				[]byte("key-017"),
-				[]byte("key-018"),
-				[]byte("key-019"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-016"),
-				[]byte("value-017"),
-				[]byte("readded-018"),
-				[]byte("once-updated-value-019"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, []byte("key-016"), 0)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, []byte("key-016"), 0, []string{"key-016", "key-017", "key-018", "key-019"}, []string{"value-016", "value-017", "readded-018", "once-updated-value-019"})
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-000"),
-				[]byte("key-001"),
-				[]byte("key-002"),
-				[]byte("key-003"),
-			}
-			expectedValues := [][]byte{
-				[]byte("twice-updated-value-000"),
-				[]byte("once-updated-value-001"),
-				[]byte("value-002"),
-				[]byte("readded-003"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, nil, 4, []string{"key-000", "key-001", "key-002", "key-003"}, []string{"twice-updated-value-000", "once-updated-value-001", "value-002", "readded-003"})
 		})
 	})
 
@@ -1404,17 +1190,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("verify", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-1"),
-			}
-			expectedValues := [][]byte{
-				[]byte("value-1"),
-			}
-
-			retrievedKeys, retrievedValues := collectCursorReplace(t, b, nil, 4)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorReplace(t, b, nil, 4, []string{"key-1"}, []string{"value-1"})
 		})
 	})
 }

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -923,7 +923,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
 				retrievedKeys = copyAndAppend(retrievedKeys, k)
@@ -948,7 +949,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
@@ -979,7 +981,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
@@ -1009,7 +1012,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				}
 				var retrievedKeys [][]byte
 				var retrievedValues [][]byte
-				c := b.Cursor()
+				c, err := b.Cursor()
+				require.NoError(t, err)
 				defer c.Close()
 				retrieved := 0
 				for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
@@ -1036,7 +1040,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 				var retrievedKeys [][]byte
 				var retrievedValues [][]byte
-				c := b.Cursor()
+				c, err := b.Cursor()
+				require.NoError(t, err)
 				defer c.Close()
 				retrieved := 0
 				for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
@@ -1067,7 +1072,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				}
 				var retrievedKeys [][]byte
 				var retrievedValues [][]byte
-				c := b.Cursor()
+				c, err := b.Cursor()
+				require.NoError(t, err)
 				defer c.Close()
 				retrieved := 0
 				for k, v := c.Seek([]byte("key-000")); k != nil && retrieved < 2; k, v = c.Next() {
@@ -1092,7 +1098,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 				var retrievedKeys [][]byte
 				var retrievedValues [][]byte
-				c := b.Cursor()
+				c, err := b.Cursor()
+				require.NoError(t, err)
 				defer c.Close()
 				retrieved := 0
 				for k, v := c.First(); k != nil && retrieved < 2; k, v = c.Next() {
@@ -1162,7 +1169,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
 				retrievedKeys = copyAndAppend(retrievedKeys, k)
@@ -1187,7 +1195,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
@@ -1323,7 +1332,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
 				retrievedKeys = copyAndAppend(retrievedKeys, k)
@@ -1351,7 +1361,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
@@ -1386,7 +1397,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
 				retrievedKeys = copyAndAppend(retrievedKeys, k)
@@ -1413,7 +1425,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
@@ -1446,7 +1459,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
 				retrievedKeys = copyAndAppend(retrievedKeys, k)
@@ -1473,7 +1487,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
@@ -1538,7 +1553,8 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][]byte
-			c := b.Cursor()
+			c, err := b.Cursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -776,15 +776,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				{[]byte("value-019.0"), []byte("value-019.1"), []byte("value-019.2")},
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][][]byte
-			c, err := b.SetCursor()
-			require.NoError(t, err)
-			defer c.Close()
-			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-016"), 0)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -802,17 +794,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				{[]byte("value-002.0"), []byte("value-002.1"), []byte("value-002.2")},
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][][]byte
-			c, err := b.SetCursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorSet(t, b, nil, 3)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -838,17 +820,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				},
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][][]byte
-			c, err := b.SetCursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-001"), 2)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -982,15 +954,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				{[]byte("value-019.0"), []byte("value-019.1"), []byte("value-019.2")},
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][][]byte
-			c, err := b.SetCursor()
-			require.NoError(t, err)
-			defer c.Close()
-			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-016"), 0)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1008,17 +972,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				{[]byte("value-002.0"), []byte("value-002.1"), []byte("value-002.2")},
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][][]byte
-			c, err := b.SetCursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorSet(t, b, nil, 3)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1052,17 +1006,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				},
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][][]byte
-			c, err := b.SetCursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-001"), 2)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
@@ -1089,17 +1033,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 				},
 			}
 
-			var retrievedKeys [][]byte
-			var retrievedValues [][][]byte
-			c, err := b.SetCursor()
-			require.NoError(t, err)
-			defer c.Close()
-			retrieved := 0
-			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
-				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
-			}
+			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-001"), 2)
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -778,7 +778,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][][]byte
-			c := b.SetCursor()
+			c, err := b.SetCursor()
+			require.NoError(t, err)
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
 				retrievedKeys = append(retrievedKeys, k)
@@ -803,7 +804,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][][]byte
-			c := b.SetCursor()
+			c, err := b.SetCursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
@@ -838,7 +840,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][][]byte
-			c := b.SetCursor()
+			c, err := b.SetCursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
@@ -981,7 +984,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][][]byte
-			c := b.SetCursor()
+			c, err := b.SetCursor()
+			require.NoError(t, err)
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
 				retrievedKeys = append(retrievedKeys, k)
@@ -1006,7 +1010,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][][]byte
-			c := b.SetCursor()
+			c, err := b.SetCursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
@@ -1049,7 +1054,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][][]byte
-			c := b.SetCursor()
+			c, err := b.SetCursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
@@ -1085,7 +1091,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 			var retrievedKeys [][]byte
 			var retrievedValues [][][]byte
-			c := b.SetCursor()
+			c, err := b.SetCursor()
+			require.NoError(t, err)
 			defer c.Close()
 			retrieved := 0
 			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -763,41 +763,11 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("seek from somewhere in the middle", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-016"),
-				[]byte("key-017"),
-				[]byte("key-018"),
-				[]byte("key-019"),
-			}
-			expectedValues := [][][]byte{
-				{[]byte("value-016.0"), []byte("value-016.1"), []byte("value-016.2")},
-				{[]byte("value-017.0"), []byte("value-017.1"), []byte("value-017.2")},
-				{[]byte("value-018.0"), []byte("value-018.1"), []byte("value-018.2")},
-				{[]byte("value-019.0"), []byte("value-019.1"), []byte("value-019.2")},
-			}
-
-			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-016"), 0)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorSet(t, b, []byte("key-016"), 0, []string{"key-016", "key-017", "key-018", "key-019"}, [][]string{{"value-016.0", "value-016.1", "value-016.2"}, {"value-017.0", "value-017.1", "value-017.2"}, {"value-018.0", "value-018.1", "value-018.2"}, {"value-019.0", "value-019.1", "value-019.2"}})
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-000"),
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][][]byte{
-				{[]byte("value-000.0"), []byte("value-000.1"), []byte("value-000.2")},
-				{[]byte("value-001.0"), []byte("value-001.1"), []byte("value-001.2")},
-				{[]byte("value-002.0"), []byte("value-002.1"), []byte("value-002.2")},
-			}
-
-			retrievedKeys, retrievedValues := collectCursorSet(t, b, nil, 3)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorSet(t, b, nil, 3, []string{"key-000", "key-001", "key-002"}, [][]string{{"value-000.0", "value-000.1", "value-000.2"}, {"value-001.0", "value-001.1", "value-001.2"}, {"value-002.0", "value-002.1", "value-002.2"}})
 		})
 
 		t.Run("extend an existing key", func(t *testing.T) {
@@ -808,22 +778,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("verify the extension is contained", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][][]byte{
-				{[]byte("value-001.0"), []byte("value-001.1"), []byte("value-001.2")},
-				{
-					[]byte("value-002.0"), []byte("value-002.1"), []byte("value-002.2"),
-					[]byte("value-002.3"),
-				},
-			}
-
-			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-001"), 2)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorSet(t, b, []byte("key-001"), 2, []string{"key-001", "key-002"}, [][]string{{"value-001.0", "value-001.1", "value-001.2"}, {"value-002.0", "value-002.1", "value-002.2", "value-002.3"}})
 		})
 	})
 
@@ -941,41 +896,11 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("seek from somewhere in the middle", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-016"),
-				[]byte("key-017"),
-				[]byte("key-018"),
-				[]byte("key-019"),
-			}
-			expectedValues := [][][]byte{
-				{[]byte("value-016.0"), []byte("value-016.1"), []byte("value-016.2")},
-				{[]byte("value-017.0"), []byte("value-017.1"), []byte("value-017.2")},
-				{[]byte("value-018.0"), []byte("value-018.1"), []byte("value-018.2")},
-				{[]byte("value-019.0"), []byte("value-019.1"), []byte("value-019.2")},
-			}
-
-			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-016"), 0)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorSet(t, b, []byte("key-016"), 0, []string{"key-016", "key-017", "key-018", "key-019"}, [][]string{{"value-016.0", "value-016.1", "value-016.2"}, {"value-017.0", "value-017.1", "value-017.2"}, {"value-018.0", "value-018.1", "value-018.2"}, {"value-019.0", "value-019.1", "value-019.2"}})
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-000"),
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][][]byte{
-				{[]byte("value-000.0"), []byte("value-000.1"), []byte("value-000.2")},
-				{[]byte("value-001.0"), []byte("value-001.1"), []byte("value-001.2")},
-				{[]byte("value-002.0"), []byte("value-002.1"), []byte("value-002.2")},
-			}
-
-			retrievedKeys, retrievedValues := collectCursorSet(t, b, nil, 3)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assertCursorSet(t, b, nil, 3, []string{"key-000", "key-001", "key-002"}, [][]string{{"value-000.0", "value-000.1", "value-000.2"}, {"value-001.0", "value-001.1", "value-001.2"}, {"value-002.0", "value-002.1", "value-002.2"}})
 		})
 
 		t.Run("delete & extend an existing key", func(t *testing.T) {
@@ -990,26 +915,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("verify the extension is contained", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][][]byte{
-				{
-					[]byte("value-001.0"),
-					// "value-001.1" deleted
-					[]byte("value-001.2"),
-				},
-				{
-					[]byte("value-002.0"), []byte("value-002.1"), []byte("value-002.2"),
-					[]byte("value-002.3"),
-				},
-			}
-
-			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-001"), 2)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			// "value-001.1" deleted
+			assertCursorSet(t, b, []byte("key-001"), 2, []string{"key-001", "key-002"}, [][]string{{"value-001.0", "value-001.2"}, {"value-002.0", "value-002.1", "value-002.2", "value-002.3"}})
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -1017,26 +924,8 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		})
 
 		t.Run("verify again after flush", func(t *testing.T) {
-			expectedKeys := [][]byte{
-				[]byte("key-001"),
-				[]byte("key-002"),
-			}
-			expectedValues := [][][]byte{
-				{
-					[]byte("value-001.0"),
-					// "value-001.1" deleted
-					[]byte("value-001.2"),
-				},
-				{
-					[]byte("value-002.0"), []byte("value-002.1"), []byte("value-002.2"),
-					[]byte("value-002.3"),
-				},
-			}
-
-			retrievedKeys, retrievedValues := collectCursorSet(t, b, []byte("key-001"), 2)
-
-			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			// "value-001.1" deleted
+			assertCursorSet(t, b, []byte("key-001"), 2, []string{"key-001", "key-002"}, [][]string{{"value-001.0", "value-001.2"}, {"value-002.0", "value-002.1", "value-002.2", "value-002.3"}})
 		})
 	})
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -181,7 +181,10 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
-	cursor := bucket.Cursor()
+	cursor, err := bucket.Cursor()
+	if err != nil {
+		return nil, err
+	}
 	defer cursor.Close()
 
 	n := 0
@@ -693,7 +696,10 @@ func (s *Shard) cursorObjectList(ctx context.Context, c *filters.Cursor,
 	additional additional.Properties,
 	className schema.ClassName,
 ) ([]*storobj.Object, error) {
-	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).Cursor()
+	cursor, err := s.store.Bucket(helpers.ObjectsBucketLSM).Cursor()
+	if err != nil {
+		return nil, err
+	}
 	defer cursor.Close()
 
 	var key, val []byte

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -330,7 +330,10 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 			}
 		}
 	default:
-		c := b.CursorRoaringSet()
+		c, err := b.CursorRoaringSet()
+		if err != nil {
+			return dimensionality, fmt.Errorf("create cursor: %w", err)
+		}
 		defer c.Close()
 
 		var v *sroar.Bitmap

--- a/adapters/repos/db/sorter/inverted_sorter.go
+++ b/adapters/repos/db/sorter/inverted_sorter.go
@@ -152,7 +152,10 @@ func (is *invertedSorter) sortRoaringSetASC(ctx context.Context, bucket *lsmkv.B
 ) ([]uint64, error) {
 	startTime := time.Now()
 	hasMoreNesting := len(sort) > 1
-	cursor := bucket.CursorRoaringSet()
+	cursor, err := bucket.CursorRoaringSet()
+	if err != nil {
+		return nil, err
+	}
 	defer cursor.Close()
 
 	foundIDs := make([]uint64, 0, limit)
@@ -278,7 +281,10 @@ func (is *invertedSorter) processDESCWindow(
 ) ([]uint64, int, error) {
 	rowsEvaluated := 0
 	idsFoundInWindow := make([]uint64, 0, limit)
-	cursor := bucket.CursorRoaringSet()
+	cursor, err := bucket.CursorRoaringSet()
+	if err != nil {
+		return nil, 0, err
+	}
 	defer cursor.Close()
 
 	for k, v := cursor.Seek(startKey); k != nil; k, v = cursor.Next() {

--- a/adapters/repos/db/sorter/lsm_sorter.go
+++ b/adapters/repos/db/sorter/lsm_sorter.go
@@ -150,7 +150,10 @@ func newLsmSorterHelper(bucket *lsmkv.Bucket, comparator *comparator,
 }
 
 func (h *lsmSorterHelper) getSorted(ctx context.Context) ([]uint64, error) {
-	cursor := h.bucket.Cursor()
+	cursor, err := h.bucket.Cursor()
+	if err != nil {
+		return nil, err
+	}
 	defer cursor.Close()
 
 	sorter := newInsertSorter(h.comparator, h.limit)

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -112,7 +112,12 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 	enterrors.GoWrapper(func() {
 		defer wg.Done()
 
-		c := cpi.bucket.Cursor()
+		c, err := cpi.bucket.Cursor()
+		if err != nil {
+			cpi.logger.WithError(err).Warn("parallel iterator: open cursor")
+			abort.Store(true)
+			return
+		}
 		defer c.Close()
 
 		// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf
@@ -163,7 +168,12 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 		enterrors.GoWrapper(func() {
 			defer wg.Done()
 
-			c := cpi.bucket.Cursor()
+			c, err := cpi.bucket.Cursor()
+			if err != nil {
+				cpi.logger.WithError(err).Warn("parallel iterator: open cursor")
+				abort.Store(true)
+				return
+			}
 			defer c.Close()
 
 			// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf
@@ -211,7 +221,12 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 	enterrors.GoWrapper(func() {
 		defer wg.Done()
 
-		c := cpi.bucket.Cursor()
+		c, err := cpi.bucket.Cursor()
+		if err != nil {
+			cpi.logger.WithError(err).Warn("parallel iterator: open cursor")
+			abort.Store(true)
+			return
+		}
 		defer c.Close()
 
 		// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf
@@ -274,7 +289,12 @@ func (cpi *parallelIterator[T]) iterateAllNoConcurrency(ctx context.Context) (ou
 		defer close(aborted)
 		defer stopTracking()
 
-		c := cpi.bucket.Cursor()
+		c, err := cpi.bucket.Cursor()
+		if err != nil {
+			cpi.logger.WithError(err).Warn("parallel iterator: open cursor")
+			aborted <- true
+			return
+		}
 		defer c.Close()
 
 		// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -683,7 +683,10 @@ func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 		ids = ids[:0]
 		vectors = vectors[:0]
 
-		cursor := bucket.Cursor()
+		cursor, err := bucket.Cursor()
+		if err != nil {
+			return err
+		}
 
 		if len(k) == 0 {
 			k, v = cursor.First()
@@ -712,7 +715,7 @@ func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 
 		cursor.Close()
 
-		err := index.AddBatch(dynamic.ctx, ids, vectors)
+		err = index.AddBatch(dynamic.ctx, ids, vectors)
 		if err != nil {
 			dynamic.logger.WithError(err).Error("failed to add vectors")
 		}

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -590,7 +590,7 @@ func (index *flat) vectorById(id uint64) ([]byte, error) {
 // populates given heap with smallest distances and corresponding ids calculated by
 // distanceCalc
 func (index *flat) findTopVectors(heap *priorityqueue.Queue[any],
-	allow helpers.AllowList, limit int, cursorFn func() *lsmkv.CursorReplace,
+	allow helpers.AllowList, limit int, cursorFn func() (*lsmkv.CursorReplace, error),
 	distanceCalc distanceCalc,
 ) error {
 	var key []byte
@@ -598,7 +598,10 @@ func (index *flat) findTopVectors(heap *priorityqueue.Queue[any],
 	var id uint64
 	allowMax := uint64(0)
 
-	cursor := cursorFn()
+	cursor, err := cursorFn()
+	if err != nil {
+		return err
+	}
 	defer cursor.Close()
 
 	if allow != nil {
@@ -1108,7 +1111,11 @@ func (index *flat) Iterate(fn func(docID uint64) bool) {
 	}
 
 	bucket := index.store.Bucket(bucketName)
-	cursor := bucket.Cursor()
+	cursor, err := bucket.Cursor()
+	if err != nil {
+		index.logger.WithError(err).Warn("flat index iterate: open cursor")
+		return
+	}
 	defer cursor.Close()
 
 	for key, _ := cursor.First(); key != nil; key, _ = cursor.Next() {

--- a/adapters/repos/db/vector/flat/metadata.go
+++ b/adapters/repos/db/vector/flat/metadata.go
@@ -247,7 +247,11 @@ func (index *flat) calculateDimensions() int32 {
 	if bucket == nil {
 		return 0
 	}
-	cursor := bucket.Cursor()
+	cursor, err := bucket.Cursor()
+	if err != nil {
+		index.logger.WithError(err).Warn("flat index calculate dimensions: open cursor")
+		return 0
+	}
 	defer cursor.Close()
 
 	var key []byte

--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -487,7 +487,10 @@ func (p *PostingMapStore) Delete(ctx context.Context, postingID uint64) error {
 }
 
 func (p *PostingMapStore) Iter(ctx context.Context, fn func(uint64, PackedPostingMetadata) error) error {
-	c := p.bucket.Cursor()
+	c, err := p.bucket.Cursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	var i int

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -190,7 +190,10 @@ func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, en
 		return err
 	}
 
-	c := bucket.Cursor()
+	c, err := bucket.Cursor()
+	if err != nil {
+		return err
+	}
 	defer c.Close()
 
 	var k, v []byte

--- a/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
@@ -315,7 +316,8 @@ func cursorWorker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerI
 				cursorCtx, cancel := context.WithTimeout(ctx, maxDuration)
 				defer cancel()
 
-				c := bucket.Cursor()
+				c, err := bucket.Cursor()
+				require.NoError(t, err)
 				keys := 0
 				bytesRead := 0
 				for k, v := c.First(); k != nil; k, v = c.Next() {


### PR DESCRIPTION
SuperClaude here.

Fixes weaviate/0-weaviate-issues#285.

## Problem
`SegmentGroup.shutdown` waited for segment refcounts to reach zero and then `close()`d (munmap) — but the segments were still in the active set, so a reader could take a NEW consistent view between the wait's last zero-observation and the write-lock: dereference of munmapped memory (SIGBUS/UAF). A reader arriving after `segments = nil` got a silently empty view (wrong results). The hole was acknowledged in-code (`TODO aliszka:copy-on-read forbid consistent view...`). Runtime-reachable: change-tokenization Phase-2b shuts displaced buckets down online while filter/aggregation readers fetch them unpinned via plain `store.Bucket` (the searchable/BM25 path got pinning in weaviate/weaviate#11540; the filterable path did not).

## Fix (per the existing TODO)
`shutdownRequested` is set under `maintenanceLock.Lock()` BEFORE the refcount wait, in the same critical section that snapshots the segments; `getConsistentViewOfSegments` — the single incRef entry point (verified) — refuses with a new sentinel `ErrShuttingDown` once set. That restores the "refs only decrease" invariant the wait relies on and protects every unpinned caller centrally. `BucketConsistentView` carries the refusal so all 12 view-consuming read helpers return the error instead of memtable-only partial data. Deliberate trade-off: the no-error legacy cursor constructors (`Cursor`, `SetCursor`, …) **panic** with `ErrShuttingDown` (recovered by the enterrors/HTTP layers) — loud beats SIGBUS or silent-empty; threading error returns through ~40 call sites is a separable follow-up if wanted.

## Evidence
- Red (pre-fix, via deterministic test seam): `TestShutdownVsReadersStress` produces the **actual SIGSEGV** (`unexpected fault address` in `segmentindex.(*DiskTree).Get`); the other three regression tests show the refusal/silent-empty variants
- Green: 40/40 at `-race -count 10`; full lsmkv `-race` green; dependent packages (inverted, aggregator, sorter, usecases/export) green
- Behavior change: reads on an already-shut-down bucket now error instead of silently serving memtable-only data (`TestBucketWalReload` updated accordingly)

Note: textual conflicts with weaviate/weaviate#11540 (both touch lsmkv store/bucket) — whichever merges second rebases.

— SuperClaude