### PR TITLE
[Reindex Fixes B] fix: partial-state cleanup deleted live class-level deferred-finalize dirs

### DIFF
--- a/adapters/repos/db/inverted_reindex_cleanup_preserve_classlevel_test.go
+++ b/adapters/repos/db/inverted_reindex_cleanup_preserve_classlevel_test.go
@@ -1,0 +1,268 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// mkTrackerDir creates .migrations/<name>/ under lsmPath with the given
+// sentinel files.
+func mkTrackerDir(t *testing.T, lsmPath, name string, sentinels ...string) {
+	t.Helper()
+	dir := filepath.Join(lsmPath, ".migrations", name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for _, s := range sentinels {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, s), []byte("x"), 0o644))
+	}
+}
+
+// mkSidecarDir creates a fake on-disk sidecar bucket dir under lsmPath.
+func mkSidecarDir(t *testing.T, lsmPath, name string) {
+	t.Helper()
+	dir := filepath.Join(lsmPath, name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "segment-0.db"), []byte("x"), 0o644))
+}
+
+func dirExistsAt(t *testing.T, lsmPath, name string) bool {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(lsmPath, name))
+	if err != nil {
+		require.True(t, os.IsNotExist(err), "unexpected stat error: %v", err)
+		return false
+	}
+	return info.IsDir()
+}
+
+// TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize
+// pins the soak-observed data-loss bug (issue #295): a completed
+// class-level migration (filterable_roaringset_refresh /
+// searchable_map_to_blockmax) in deferred-finalize state has its live
+// ingest sidecar dir on disk (the in-memory main bucket pointer's backing
+// store). A subsequent CleanStalePartialReindexState for the same
+// (prop, indexType) — e.g. pre-submit defense-in-depth for an unrelated
+// per-prop migration — must NOT delete that ingest dir. Before the fix,
+// the preserve set was computed only from the per-prop tracker prefixes,
+// so the class-level gen was invisible and the live dir was wiped:
+// silent index loss on next restart, ENOENT on the next migration's swap.
+func TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize(t *testing.T) {
+	tests := []struct {
+		name      string
+		propName  string
+		indexType string
+		// class-level completed tracker + its live ingest sidecar
+		classTracker string
+		liveSidecar  string
+		// per-prop completed tracker + its live ingest sidecar
+		propTracker     string
+		propLiveSidecar string
+		// genuinely stale sidecar of a cancelled class-level attempt
+		// (tracker without tidied/merged) — must still be deleted
+		staleTracker string
+		staleSidecar string
+	}{
+		{
+			name:            "filterable: roaringset refresh gen 2 survives",
+			propName:        "category",
+			indexType:       "filterable",
+			classTracker:    "filterable_roaringset_refresh_2",
+			liveSidecar:     "property_category__roaringset_ingest_2",
+			propTracker:     "enable_filterable_category_1",
+			propLiveSidecar: "property_category__enable_filterable_ingest_1",
+			staleTracker:    "filterable_roaringset_refresh_3",
+			staleSidecar:    "property_category__roaringset_ingest_3",
+		},
+		{
+			name:            "searchable: map_to_blockmax gen 2 survives",
+			propName:        "descr",
+			indexType:       "searchable",
+			classTracker:    "searchable_map_to_blockmax_2",
+			liveSidecar:     "property_descr_searchable__blockmax_ingest_2",
+			propTracker:     "searchable_retokenize_descr_1",
+			propLiveSidecar: "property_descr_searchable__retokenize_ingest_1",
+			staleTracker:    "searchable_map_to_blockmax_3",
+			staleSidecar:    "property_descr_searchable__blockmax_ingest_3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			className := "CleanupPreserve_" + uuid.NewString()[:8]
+			class := newTestClassWithProps(className, []string{tc.propName})
+			shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+				false, false, false)
+			shard := shd.(*Shard)
+			defer shard.Shutdown(ctx)
+			lsm := shard.pathLSM()
+
+			// Completed class-level migration in deferred-finalize state.
+			mkTrackerDir(t, lsm, tc.classTracker,
+				"started.mig", "merged.mig", "swapped.mig", "tidied.mig", "properties.mig")
+			mkSidecarDir(t, lsm, tc.liveSidecar)
+
+			// Completed per-prop migration in deferred-finalize state.
+			mkTrackerDir(t, lsm, tc.propTracker,
+				"started.mig", "merged.mig", "swapped.mig", "tidied.mig")
+			mkSidecarDir(t, lsm, tc.propLiveSidecar)
+
+			// Cancelled (partial) class-level attempt: stale, must be wiped.
+			mkTrackerDir(t, lsm, tc.staleTracker, "started.mig")
+			mkSidecarDir(t, lsm, tc.staleSidecar)
+
+			require.NoError(t,
+				shard.CleanStalePartialReindexState(ctx, tc.propName, tc.indexType))
+
+			require.True(t, dirExistsAt(t, lsm, tc.liveSidecar),
+				"live class-level deferred-finalize ingest dir %s must survive cleanup; "+
+					"deleting it is silent index loss on next restart (issue #295)",
+				tc.liveSidecar)
+			require.True(t, dirExistsAt(t, lsm, tc.propLiveSidecar),
+				"live per-prop deferred-finalize ingest dir %s must survive cleanup",
+				tc.propLiveSidecar)
+			require.False(t, dirExistsAt(t, lsm, tc.staleSidecar),
+				"stale sidecar %s of a cancelled attempt must be wiped", tc.staleSidecar)
+
+			// Tracker-deletion semantics are unchanged: class-level tracker
+			// dirs are never deleted by the per-prop sweep; the completed
+			// per-prop tracker is preserved by the existing tidied/merged gate.
+			require.True(t,
+				dirExistsAt(t, filepath.Join(lsm, ".migrations"), tc.classTracker),
+				"class-level tracker %s must not be touched by per-prop cleanup",
+				tc.classTracker)
+			require.True(t,
+				dirExistsAt(t, filepath.Join(lsm, ".migrations"), tc.propTracker),
+				"completed per-prop tracker %s must be preserved", tc.propTracker)
+		})
+	}
+}
+
+// TestCleanStalePartialReindexState_GenCollisionAcrossStrategies pins the
+// second flaw from issue #295: preservation used to be keyed by BARE
+// generation int, so a completed migration of strategy A at gen N
+// accidentally preserved (and, symmetrically, could fail to protect) a
+// DIFFERENT strategy's sidecar at the same gen. Preservation must be
+// keyed by (sidecar-suffix-base, gen): a roaringset ingest dir survives
+// iff a completed roaringset-refresh tracker of the SAME gen exists.
+func TestCleanStalePartialReindexState_GenCollisionAcrossStrategies(t *testing.T) {
+	t.Run("completed enable_filterable gen 1 must not preserve stale roaringset ingest_1", func(t *testing.T) {
+		ctx := testCtx()
+		className := "CleanupGenCollide_" + uuid.NewString()[:8]
+		class := newTestClassWithProps(className, []string{"category"})
+		shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+			false, false, false)
+		shard := shd.(*Shard)
+		defer shard.Shutdown(ctx)
+		lsm := shard.pathLSM()
+
+		// Completed per-prop migration at gen 1 → its own ingest_1 is live.
+		mkTrackerDir(t, lsm, "enable_filterable_category_1",
+			"started.mig", "merged.mig", "swapped.mig", "tidied.mig")
+		mkSidecarDir(t, lsm, "property_category__enable_filterable_ingest_1")
+
+		// Cancelled roaringset refresh, ALSO at gen 1 — its ingest_1 is stale.
+		mkTrackerDir(t, lsm, "filterable_roaringset_refresh_1", "started.mig")
+		mkSidecarDir(t, lsm, "property_category__roaringset_ingest_1")
+
+		require.NoError(t,
+			shard.CleanStalePartialReindexState(ctx, "category", "filterable"))
+
+		require.True(t,
+			dirExistsAt(t, lsm, "property_category__enable_filterable_ingest_1"),
+			"live enable_filterable ingest_1 must survive")
+		require.False(t,
+			dirExistsAt(t, lsm, "property_category__roaringset_ingest_1"),
+			"stale roaringset ingest_1 must be wiped even though an unrelated "+
+				"completed migration shares gen 1 (bare-int keying bug, issue #295)")
+	})
+
+	t.Run("completed roaringset gen 2 must not preserve stale enable_filterable ingest_2", func(t *testing.T) {
+		ctx := testCtx()
+		className := "CleanupGenCollide_" + uuid.NewString()[:8]
+		class := newTestClassWithProps(className, []string{"category"})
+		shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+			false, false, false)
+		shard := shd.(*Shard)
+		defer shard.Shutdown(ctx)
+		lsm := shard.pathLSM()
+
+		mkTrackerDir(t, lsm, "filterable_roaringset_refresh_2",
+			"started.mig", "merged.mig", "swapped.mig", "tidied.mig", "properties.mig")
+		mkSidecarDir(t, lsm, "property_category__roaringset_ingest_2")
+
+		mkTrackerDir(t, lsm, "enable_filterable_category_2", "started.mig")
+		mkSidecarDir(t, lsm, "property_category__enable_filterable_ingest_2")
+
+		require.NoError(t,
+			shard.CleanStalePartialReindexState(ctx, "category", "filterable"))
+
+		require.True(t,
+			dirExistsAt(t, lsm, "property_category__roaringset_ingest_2"),
+			"live roaringset ingest_2 must survive")
+		require.False(t,
+			dirExistsAt(t, lsm, "property_category__enable_filterable_ingest_2"),
+			"stale enable_filterable ingest_2 must be wiped even though the "+
+				"completed roaringset migration shares gen 2")
+	})
+}
+
+// TestCleanStalePartialReindexState_ShutdownSkipKeyedBySuffix pins the
+// bucket-shutdown half of the same keying bug: the skip that protects a
+// LIVE loaded sidecar bucket from being shut down must match by
+// (suffix-base, gen), and must recognize class-level completed gens.
+// Shutting the live bucket down and deleting its dir tears the backing
+// store out from under the in-memory main bucket pointer.
+func TestCleanStalePartialReindexState_ShutdownSkipKeyedBySuffix(t *testing.T) {
+	ctx := testCtx()
+	className := "CleanupShutdownSkip_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"category"})
+	shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+	lsm := shard.pathLSM()
+
+	// Completed class-level migration at gen 2; its ingest bucket is loaded
+	// (it IS the main bucket's backing store until next-restart finalize).
+	mkTrackerDir(t, lsm, "filterable_roaringset_refresh_2",
+		"started.mig", "merged.mig", "swapped.mig", "tidied.mig", "properties.mig")
+	liveName := "property_category__roaringset_ingest_2"
+	require.NoError(t, shard.store.CreateOrLoadBucket(ctx, liveName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+
+	// Cancelled per-prop attempt at the same gen; its bucket is stale.
+	mkTrackerDir(t, lsm, "enable_filterable_category_2", "started.mig")
+	staleName := "property_category__enable_filterable_ingest_2"
+	require.NoError(t, shard.store.CreateOrLoadBucket(ctx, staleName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+
+	require.NoError(t,
+		shard.CleanStalePartialReindexState(ctx, "category", "filterable"))
+
+	require.NotNil(t, shard.store.Bucket(liveName),
+		"live deferred-finalize sidecar bucket must not be shut down")
+	require.True(t, dirExistsAt(t, lsm, liveName),
+		"live deferred-finalize sidecar dir must survive")
+	require.Nil(t, shard.store.Bucket(staleName),
+		"stale sidecar bucket must be shut down despite sharing gen 2 with "+
+			"the completed class-level migration")
+	require.False(t, dirExistsAt(t, lsm, staleName),
+		"stale sidecar dir must be wiped")
+}

--- a/adapters/repos/db/inverted_reindex_cleanup_preserve_classlevel_test.go
+++ b/adapters/repos/db/inverted_reindex_cleanup_preserve_classlevel_test.go
@@ -162,65 +162,61 @@ func TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize(t *te
 // keyed by (sidecar-suffix-base, gen): a roaringset ingest dir survives
 // iff a completed roaringset-refresh tracker of the SAME gen exists.
 func TestCleanStalePartialReindexState_GenCollisionAcrossStrategies(t *testing.T) {
-	t.Run("completed enable_filterable gen 1 must not preserve stale roaringset ingest_1", func(t *testing.T) {
-		ctx := testCtx()
-		className := "CleanupGenCollide_" + uuid.NewString()[:8]
-		class := newTestClassWithProps(className, []string{"category"})
-		shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-			false, false, false)
-		shard := shd.(*Shard)
-		defer shard.Shutdown(ctx)
-		lsm := shard.pathLSM()
+	cases := []struct {
+		name                 string
+		completedTracker     string
+		completedTrackerMigs []string
+		liveSidecar          string
+		staleTracker         string
+		staleSidecar         string
+		wipeReason           string
+	}{
+		{
+			name:                 "completed enable_filterable gen 1 must not preserve stale roaringset ingest_1",
+			completedTracker:     "enable_filterable_category_1",
+			completedTrackerMigs: []string{"started.mig", "merged.mig", "swapped.mig", "tidied.mig"},
+			liveSidecar:          "property_category__enable_filterable_ingest_1",
+			staleTracker:         "filterable_roaringset_refresh_1",
+			staleSidecar:         "property_category__roaringset_ingest_1",
+			wipeReason: "stale roaringset ingest_1 must be wiped even though an unrelated " +
+				"completed migration shares gen 1 (bare-int keying bug, issue #295)",
+		},
+		{
+			name:                 "completed roaringset gen 2 must not preserve stale enable_filterable ingest_2",
+			completedTracker:     "filterable_roaringset_refresh_2",
+			completedTrackerMigs: []string{"started.mig", "merged.mig", "swapped.mig", "tidied.mig", "properties.mig"},
+			liveSidecar:          "property_category__roaringset_ingest_2",
+			staleTracker:         "enable_filterable_category_2",
+			staleSidecar:         "property_category__enable_filterable_ingest_2",
+			wipeReason: "stale enable_filterable ingest_2 must be wiped even though the " +
+				"completed roaringset migration shares gen 2",
+		},
+	}
 
-		// Completed per-prop migration at gen 1 → its own ingest_1 is live.
-		mkTrackerDir(t, lsm, "enable_filterable_category_1",
-			"started.mig", "merged.mig", "swapped.mig", "tidied.mig")
-		mkSidecarDir(t, lsm, "property_category__enable_filterable_ingest_1")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			className := "CleanupGenCollide_" + uuid.NewString()[:8]
+			class := newTestClassWithProps(className, []string{"category"})
+			shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+				false, false, false)
+			shard := shd.(*Shard)
+			defer shard.Shutdown(ctx)
+			lsm := shard.pathLSM()
 
-		// Cancelled roaringset refresh, ALSO at gen 1 — its ingest_1 is stale.
-		mkTrackerDir(t, lsm, "filterable_roaringset_refresh_1", "started.mig")
-		mkSidecarDir(t, lsm, "property_category__roaringset_ingest_1")
+			mkTrackerDir(t, lsm, tc.completedTracker, tc.completedTrackerMigs...)
+			mkSidecarDir(t, lsm, tc.liveSidecar)
+			mkTrackerDir(t, lsm, tc.staleTracker, "started.mig")
+			mkSidecarDir(t, lsm, tc.staleSidecar)
 
-		require.NoError(t,
-			shard.CleanStalePartialReindexState(ctx, "category", "filterable"))
+			require.NoError(t,
+				shard.CleanStalePartialReindexState(ctx, "category", "filterable"))
 
-		require.True(t,
-			dirExistsAt(t, lsm, "property_category__enable_filterable_ingest_1"),
-			"live enable_filterable ingest_1 must survive")
-		require.False(t,
-			dirExistsAt(t, lsm, "property_category__roaringset_ingest_1"),
-			"stale roaringset ingest_1 must be wiped even though an unrelated "+
-				"completed migration shares gen 1 (bare-int keying bug, issue #295)")
-	})
-
-	t.Run("completed roaringset gen 2 must not preserve stale enable_filterable ingest_2", func(t *testing.T) {
-		ctx := testCtx()
-		className := "CleanupGenCollide_" + uuid.NewString()[:8]
-		class := newTestClassWithProps(className, []string{"category"})
-		shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-			false, false, false)
-		shard := shd.(*Shard)
-		defer shard.Shutdown(ctx)
-		lsm := shard.pathLSM()
-
-		mkTrackerDir(t, lsm, "filterable_roaringset_refresh_2",
-			"started.mig", "merged.mig", "swapped.mig", "tidied.mig", "properties.mig")
-		mkSidecarDir(t, lsm, "property_category__roaringset_ingest_2")
-
-		mkTrackerDir(t, lsm, "enable_filterable_category_2", "started.mig")
-		mkSidecarDir(t, lsm, "property_category__enable_filterable_ingest_2")
-
-		require.NoError(t,
-			shard.CleanStalePartialReindexState(ctx, "category", "filterable"))
-
-		require.True(t,
-			dirExistsAt(t, lsm, "property_category__roaringset_ingest_2"),
-			"live roaringset ingest_2 must survive")
-		require.False(t,
-			dirExistsAt(t, lsm, "property_category__enable_filterable_ingest_2"),
-			"stale enable_filterable ingest_2 must be wiped even though the "+
-				"completed roaringset migration shares gen 2")
-	})
+			require.True(t, dirExistsAt(t, lsm, tc.liveSidecar),
+				"live completed-migration sidecar must survive")
+			require.False(t, dirExistsAt(t, lsm, tc.staleSidecar), tc.wipeReason)
+		})
+	}
 }
 
 // TestCleanStalePartialReindexState_ShutdownSkipKeyedBySuffix pins the

--- a/adapters/repos/db/inverted_reindex_cleanup_preserve_classlevel_test.go
+++ b/adapters/repos/db/inverted_reindex_cleanup_preserve_classlevel_test.go
@@ -22,8 +22,6 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// mkTrackerDir creates .migrations/<name>/ under lsmPath with the given
-// sentinel files.
 func mkTrackerDir(t *testing.T, lsmPath, name string, sentinels ...string) {
 	t.Helper()
 	dir := filepath.Join(lsmPath, ".migrations", name)
@@ -33,7 +31,6 @@ func mkTrackerDir(t *testing.T, lsmPath, name string, sentinels ...string) {
 	}
 }
 
-// mkSidecarDir creates a fake on-disk sidecar bucket dir under lsmPath.
 func mkSidecarDir(t *testing.T, lsmPath, name string) {
 	t.Helper()
 	dir := filepath.Join(lsmPath, name)
@@ -51,17 +48,9 @@ func dirExistsAt(t *testing.T, lsmPath, name string) bool {
 	return info.IsDir()
 }
 
-// TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize
-// pins the soak-observed data-loss bug (issue #295): a completed
-// class-level migration (filterable_roaringset_refresh /
-// searchable_map_to_blockmax) in deferred-finalize state has its live
-// ingest sidecar dir on disk (the in-memory main bucket pointer's backing
-// store). A subsequent CleanStalePartialReindexState for the same
-// (prop, indexType) — e.g. pre-submit defense-in-depth for an unrelated
-// per-prop migration — must NOT delete that ingest dir. Before the fix,
-// the preserve set was computed only from the per-prop tracker prefixes,
-// so the class-level gen was invisible and the live dir was wiped:
-// silent index loss on next restart, ENOENT on the next migration's swap.
+// TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize pins
+// issue #295: cleanup must not wipe the live ingest sidecar of a completed
+// class-level migration awaiting deferred finalize.
 func TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -73,8 +62,7 @@ func TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize(t *te
 		// per-prop completed tracker + its live ingest sidecar
 		propTracker     string
 		propLiveSidecar string
-		// genuinely stale sidecar of a cancelled class-level attempt
-		// (tracker without tidied/merged) — must still be deleted
+		// stale cancelled class-level attempt, must still be deleted
 		staleTracker string
 		staleSidecar string
 	}{
@@ -140,9 +128,7 @@ func TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize(t *te
 			require.False(t, dirExistsAt(t, lsm, tc.staleSidecar),
 				"stale sidecar %s of a cancelled attempt must be wiped", tc.staleSidecar)
 
-			// Tracker-deletion semantics are unchanged: class-level tracker
-			// dirs are never deleted by the per-prop sweep; the completed
-			// per-prop tracker is preserved by the existing tidied/merged gate.
+			// Tracker-deletion semantics must be unchanged by the fix.
 			require.True(t,
 				dirExistsAt(t, filepath.Join(lsm, ".migrations"), tc.classTracker),
 				"class-level tracker %s must not be touched by per-prop cleanup",
@@ -155,12 +141,8 @@ func TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize(t *te
 }
 
 // TestCleanStalePartialReindexState_GenCollisionAcrossStrategies pins the
-// second flaw from issue #295: preservation used to be keyed by BARE
-// generation int, so a completed migration of strategy A at gen N
-// accidentally preserved (and, symmetrically, could fail to protect) a
-// DIFFERENT strategy's sidecar at the same gen. Preservation must be
-// keyed by (sidecar-suffix-base, gen): a roaringset ingest dir survives
-// iff a completed roaringset-refresh tracker of the SAME gen exists.
+// bare-gen keying flaw (issue #295): preservation must key on
+// (suffix-base, gen), not the generation int alone.
 func TestCleanStalePartialReindexState_GenCollisionAcrossStrategies(t *testing.T) {
 	cases := []struct {
 		name                 string
@@ -220,11 +202,7 @@ func TestCleanStalePartialReindexState_GenCollisionAcrossStrategies(t *testing.T
 }
 
 // TestCleanStalePartialReindexState_ShutdownSkipKeyedBySuffix pins the
-// bucket-shutdown half of the same keying bug: the skip that protects a
-// LIVE loaded sidecar bucket from being shut down must match by
-// (suffix-base, gen), and must recognize class-level completed gens.
-// Shutting the live bucket down and deleting its dir tears the backing
-// store out from under the in-memory main bucket pointer.
+// bucket-shutdown half of the bare-gen keying bug (issue #295).
 func TestCleanStalePartialReindexState_ShutdownSkipKeyedBySuffix(t *testing.T) {
 	ctx := testCtx()
 	className := "CleanupShutdownSkip_" + uuid.NewString()[:8]
@@ -235,8 +213,7 @@ func TestCleanStalePartialReindexState_ShutdownSkipKeyedBySuffix(t *testing.T) {
 	defer shard.Shutdown(ctx)
 	lsm := shard.pathLSM()
 
-	// Completed class-level migration at gen 2; its ingest bucket is loaded
-	// (it IS the main bucket's backing store until next-restart finalize).
+	// Completed class-level migration at gen 2 with its ingest bucket loaded.
 	mkTrackerDir(t, lsm, "filterable_roaringset_refresh_2",
 		"started.mig", "merged.mig", "swapped.mig", "tidied.mig", "properties.mig")
 	liveName := "property_category__roaringset_ingest_2"

--- a/adapters/repos/db/inverted_reindex_finalize.go
+++ b/adapters/repos/db/inverted_reindex_finalize.go
@@ -117,10 +117,49 @@ func maxMigrationGeneration(lsmPath, migrationDirPrefix, propNamesSuffix string)
 // [migrationDirsForPropertyIndex] for the (propName, indexType) tuple.
 func completedMigrationGens(lsmPath string, prefixes []string) map[int]bool {
 	out := map[int]bool{}
+	forEachCompletedMigration(lsmPath, prefixes, func(base string, gen int) {
+		out[gen] = true
+	})
+	return out
+}
+
+// completedMigrationSidecarSuffixes returns the gen-suffixed sidecar dir
+// suffixes (e.g. "__roaringset_ingest_2") owned by completed-but-deferred
+// migrations matching `prefixes`. Keying preservation by (suffix-base, gen)
+// instead of bare gen prevents a completed strategy's generation from
+// shielding — or failing to shield — a DIFFERENT strategy's sidecar that
+// happens to share the generation int.
+//
+// Used by [Shard.CleanStalePartialReindexState] for both the bucket-
+// shutdown skip and the sidecar-dir sweep; membership is tested against
+// the sidecar name's portion after the main bucket name (which starts
+// with "__", same as the suffix bases below).
+func completedMigrationSidecarSuffixes(lsmPath string, prefixes []string) map[string]bool {
+	out := map[string]bool{}
+	forEachCompletedMigration(lsmPath, prefixes, func(base string, gen int) {
+		suffixes := migrationSuffixes(base)
+		if suffixes == nil {
+			return
+		}
+		tail := genSuffix(gen)
+		out[suffixes.ingestSuffix+tail] = true
+		out[suffixes.backupSuffix+tail] = true
+		if rs := reindexSuffixForFinalize(base); rs != "" {
+			out[rs+tail] = true
+		}
+	})
+	return out
+}
+
+// forEachCompletedMigration invokes fn for every tracker dir under
+// lsmPath/.migrations whose (prefix, gen) parse matches one of `prefixes`
+// and that carries tidied.mig or merged.mig — i.e. migrations that
+// completed in-process and await next-restart finalize.
+func forEachCompletedMigration(lsmPath string, prefixes []string, fn func(base string, gen int)) {
 	migrationsDir := filepath.Join(lsmPath, ".migrations")
 	entries, err := os.ReadDir(migrationsDir)
 	if err != nil {
-		return out
+		return
 	}
 	prefixSet := map[string]bool{}
 	for _, p := range prefixes {
@@ -139,10 +178,9 @@ func completedMigrationGens(lsmPath string, prefixes []string) map[int]bool {
 		}
 		dirPath := filepath.Join(migrationsDir, entry.Name())
 		if fileExistsInDir(dirPath, "tidied.mig") || fileExistsInDir(dirPath, "merged.mig") {
-			out[gen] = true
+			fn(base, gen)
 		}
 	}
-	return out
 }
 
 // fileExistsInDir is a small helper for [completedMigrationGens]; returns

--- a/adapters/repos/db/inverted_reindex_finalize.go
+++ b/adapters/repos/db/inverted_reindex_finalize.go
@@ -125,15 +125,9 @@ func completedMigrationGens(lsmPath string, prefixes []string) map[int]bool {
 
 // completedMigrationSidecarSuffixes returns the gen-suffixed sidecar dir
 // suffixes (e.g. "__roaringset_ingest_2") owned by completed-but-deferred
-// migrations matching `prefixes`. Keying preservation by (suffix-base, gen)
-// instead of bare gen prevents a completed strategy's generation from
-// shielding — or failing to shield — a DIFFERENT strategy's sidecar that
-// happens to share the generation int.
-//
-// Used by [Shard.CleanStalePartialReindexState] for both the bucket-
-// shutdown skip and the sidecar-dir sweep; membership is tested against
-// the sidecar name's portion after the main bucket name (which starts
-// with "__", same as the suffix bases below).
+// migrations matching `prefixes`. Keying by (suffix-base, gen) instead of
+// bare gen stops one strategy's completed gen from shielding — or failing
+// to shield — a different strategy's sidecar at the same gen (issue #295).
 func completedMigrationSidecarSuffixes(lsmPath string, prefixes []string) map[string]bool {
 	out := map[string]bool{}
 	forEachCompletedMigration(lsmPath, prefixes, func(base string, gen int) {
@@ -152,9 +146,8 @@ func completedMigrationSidecarSuffixes(lsmPath string, prefixes []string) map[st
 }
 
 // forEachCompletedMigration invokes fn for every tracker dir under
-// lsmPath/.migrations whose (prefix, gen) parse matches one of `prefixes`
-// and that carries tidied.mig or merged.mig — i.e. migrations that
-// completed in-process and await next-restart finalize.
+// lsmPath/.migrations matching `prefixes` that carries tidied.mig or
+// merged.mig (completed in-process, awaiting next-restart finalize).
 func forEachCompletedMigration(lsmPath string, prefixes []string, fn func(base string, gen int)) {
 	migrationsDir := filepath.Join(lsmPath, ".migrations")
 	entries, err := os.ReadDir(migrationsDir)

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -149,8 +149,9 @@ func classLevelMigrationDirForIndexType(indexType string) (string, bool) {
 		return MigrationDirFilterableRoaringsetRefresh, true
 	case "searchable":
 		return MigrationDirSearchableMapToBlockmax, true
+	default:
+		return "", false
 	}
-	return "", false
 }
 
 // migrationDirsForPropertyIndex returns the per-property migration

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -140,11 +140,9 @@ func parseMigrationDirName(name string) (prefix string, generation int, ok bool)
 }
 
 // classLevelMigrationDirForIndexType returns the class-level strategy's
-// migration dir prefix for an indexType. Class-level dirs are excluded
-// from [migrationDirsForPropertyIndex] (deleting them on a per-prop event
-// would corrupt the class-wide migration), but their completed gens must
-// still feed the sidecar PRESERVE set in CleanStalePartialReindexState —
-// their ingest dirs are live per-prop data awaiting next-restart finalize.
+// migration dir prefix for an indexType. Excluded from deletion in
+// [migrationDirsForPropertyIndex], but its completed gens must still feed
+// the preserve set in CleanStalePartialReindexState: their sidecars are live.
 func classLevelMigrationDirForIndexType(indexType string) (string, bool) {
 	switch indexType {
 	case "filterable":

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -156,6 +156,22 @@ func parseMigrationDirName(name string) (prefix string, generation int, ok bool)
 // Wholesale-deleting them on a single property's DELETE would corrupt
 // the class-level migration; their per-property entries are pruned by
 // the strategy's own bookkeeping.
+// classLevelMigrationDirForIndexType returns the class-level strategy's
+// migration dir prefix for an indexType. Class-level dirs are excluded
+// from [migrationDirsForPropertyIndex] (deleting them on a per-prop event
+// would corrupt the class-wide migration), but their completed gens must
+// still feed the sidecar PRESERVE set in CleanStalePartialReindexState —
+// their ingest dirs are live per-prop data awaiting next-restart finalize.
+func classLevelMigrationDirForIndexType(indexType string) (string, bool) {
+	switch indexType {
+	case "filterable":
+		return MigrationDirFilterableRoaringsetRefresh, true
+	case "searchable":
+		return MigrationDirSearchableMapToBlockmax, true
+	}
+	return "", false
+}
+
 func migrationDirsForPropertyIndex(propName, indexType string) []string {
 	switch indexType {
 	case "filterable":

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -139,6 +139,22 @@ func parseMigrationDirName(name string) (prefix string, generation int, ok bool)
 	return name[:idx], gen, true
 }
 
+// classLevelMigrationDirForIndexType returns the class-level strategy's
+// migration dir prefix for an indexType. Class-level dirs are excluded
+// from [migrationDirsForPropertyIndex] (deleting them on a per-prop event
+// would corrupt the class-wide migration), but their completed gens must
+// still feed the sidecar PRESERVE set in CleanStalePartialReindexState —
+// their ingest dirs are live per-prop data awaiting next-restart finalize.
+func classLevelMigrationDirForIndexType(indexType string) (string, bool) {
+	switch indexType {
+	case "filterable":
+		return MigrationDirFilterableRoaringsetRefresh, true
+	case "searchable":
+		return MigrationDirSearchableMapToBlockmax, true
+	}
+	return "", false
+}
+
 // migrationDirsForPropertyIndex returns the per-property migration
 // directory names that — if marked tidied on disk — would lie after the
 // given (propName, indexType) bucket has been removed. Called from
@@ -156,22 +172,6 @@ func parseMigrationDirName(name string) (prefix string, generation int, ok bool)
 // Wholesale-deleting them on a single property's DELETE would corrupt
 // the class-level migration; their per-property entries are pruned by
 // the strategy's own bookkeeping.
-// classLevelMigrationDirForIndexType returns the class-level strategy's
-// migration dir prefix for an indexType. Class-level dirs are excluded
-// from [migrationDirsForPropertyIndex] (deleting them on a per-prop event
-// would corrupt the class-wide migration), but their completed gens must
-// still feed the sidecar PRESERVE set in CleanStalePartialReindexState —
-// their ingest dirs are live per-prop data awaiting next-restart finalize.
-func classLevelMigrationDirForIndexType(indexType string) (string, bool) {
-	switch indexType {
-	case "filterable":
-		return MigrationDirFilterableRoaringsetRefresh, true
-	case "searchable":
-		return MigrationDirSearchableMapToBlockmax, true
-	}
-	return "", false
-}
-
 func migrationDirsForPropertyIndex(propName, indexType string) []string {
 	switch indexType {
 	case "filterable":

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -279,17 +279,10 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 		"operation":   "CleanStalePartialReindexState",
 	})
 
-	// Compute the completed-but-deferred sidecar suffixes for this
-	// (prop, indexType). Any tracker dir with tidied.mig or merged.mig
-	// represents a successfully finished in-process migration whose ingest
-	// sidecar dir is the live backing store of the in-memory main bucket
-	// pointer — wiping it here is the #10675-shape silent data loss this
-	// gate exists to prevent (R2/R2b on the controller node).
-	//
-	// The preserve set deliberately spans MORE prefixes than the tracker-
-	// deletion sweep: class-level strategies are excluded from deletion
-	// (their tracker aggregates every prop of the class) but their completed
-	// gens' sidecars are just as live for this prop and must survive.
+	// Preserve sidecars of completed-but-deferred migrations: they back the
+	// live in-memory bucket pointer; wiping them is #10675-shape data loss.
+	// The preserve set spans MORE prefixes than the tracker-deletion sweep:
+	// class-level gens are excluded from deletion but their sidecars are live.
 	preservePrefixes := migrationDirsForPropertyIndex(propName, indexType)
 	if classDir, ok := classLevelMigrationDirForIndexType(indexType); ok {
 		preservePrefixes = append(preservePrefixes, classDir)
@@ -310,11 +303,9 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 		if bucketName == mainBucketName {
 			continue
 		}
-		// Skip live sidecar buckets that back a completed-but-deferred
-		// migration (in-memory bucket pointer still references them; their
-		// dir on disk is the canonical bucket's data until next-restart
-		// finalize renames it). Matched by (suffix-base, gen), not bare gen,
-		// so an unrelated strategy's completed gen never shields this bucket.
+		// Skip live sidecar buckets backing a completed-but-deferred
+		// migration. Matched by (suffix-base, gen), not bare gen, so an
+		// unrelated strategy's completed gen never shields this bucket.
 		if preserveSidecars[strings.TrimPrefix(bucketName, mainBucketName)] {
 			continue
 		}
@@ -336,9 +327,8 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 		WithField("preserved_sidecars", preserveSidecarsSlice(preserveSidecars)).
 		Info("partial-reindex cleanup: sidecar buckets shut down")
 
-	// Step 2 + 3: remove the sidecar dirs and migration dir. Both call the
-	// existing helpers, which log errors rather than panic. Pass through
-	// the preserved sidecar suffixes so the deferred-finalize state survives.
+	// Steps 2 + 3: remove sidecar dirs and migration dir. The helpers log
+	// errors rather than fail; preserved suffixes survive.
 	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, preserveSidecars)
 	s.cleanStaleMigrationDirs(propName, indexType)
 	logger.Info("partial-reindex cleanup: sidecar dirs + migration dir cleaned")
@@ -406,20 +396,10 @@ func (s *Shard) cleanStaleSidecarDirs(mainBucketName string) {
 	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, nil)
 }
 
-// cleanStaleSidecarDirsWithPreserved is the preserve-aware variant used by
-// the CANCEL→retry and pre-submit defense-in-depth paths. `preserveSidecars`
-// lists the gen-suffixed sidecar suffixes (e.g. "__roaringset_ingest_2",
-// from [completedMigrationSidecarSuffixes]) whose dirs MUST be kept on disk
-// because they belong to a completed-but-deferred migration (their tracker
-// dir has tidied.mig / merged.mig). Wiping those out from under the
-// in-memory bucket pointer produces #10675-shape silent data loss on the
-// next submit-without-restart sequence. Keyed by (suffix-base, gen), never
-// bare gen: a completed strategy's generation must not shield a different
-// strategy's sidecar that shares the int.
-//
-// Pass nil to wipe every matching sidecar dir (the DELETE→re-enable
-// callers, which already removed the main bucket and have no live state
-// to protect).
+// cleanStaleSidecarDirsWithPreserved removes matching sidecar dirs except
+// those in `preserveSidecars` (from [completedMigrationSidecarSuffixes]):
+// they back live completed-but-deferred migrations; wiping them is
+// #10675-shape silent data loss. Pass nil to wipe everything.
 func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preserveSidecars map[string]bool) {
 	entries, err := os.ReadDir(s.pathLSM())
 	if err != nil {

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -279,14 +279,22 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 		"operation":   "CleanStalePartialReindexState",
 	})
 
-	// Compute the set of completed-but-deferred migration generations for
-	// this (prop, indexType). Any tracker dir with tidied.mig or merged.mig
+	// Compute the completed-but-deferred sidecar suffixes for this
+	// (prop, indexType). Any tracker dir with tidied.mig or merged.mig
 	// represents a successfully finished in-process migration whose ingest
 	// sidecar dir is the live backing store of the in-memory main bucket
 	// pointer — wiping it here is the #10675-shape silent data loss this
 	// gate exists to prevent (R2/R2b on the controller node).
+	//
+	// The preserve set deliberately spans MORE prefixes than the tracker-
+	// deletion sweep: class-level strategies are excluded from deletion
+	// (their tracker aggregates every prop of the class) but their completed
+	// gens' sidecars are just as live for this prop and must survive.
 	preservePrefixes := migrationDirsForPropertyIndex(propName, indexType)
-	preserveGens := completedMigrationGens(s.pathLSM(), preservePrefixes)
+	if classDir, ok := classLevelMigrationDirForIndexType(indexType); ok {
+		preservePrefixes = append(preservePrefixes, classDir)
+	}
+	preserveSidecars := completedMigrationSidecarSuffixes(s.pathLSM(), preservePrefixes)
 
 	prefix := mainBucketName + "__"
 	loaded := s.store.GetBucketsByName()
@@ -305,11 +313,10 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 		// Skip live sidecar buckets that back a completed-but-deferred
 		// migration (in-memory bucket pointer still references them; their
 		// dir on disk is the canonical bucket's data until next-restart
-		// finalize renames it).
-		if len(preserveGens) > 0 {
-			if _, gen, ok := parseMigrationDirName(bucketName); ok && preserveGens[gen] {
-				continue
-			}
+		// finalize renames it). Matched by (suffix-base, gen), not bare gen,
+		// so an unrelated strategy's completed gen never shields this bucket.
+		if preserveSidecars[strings.TrimPrefix(bucketName, mainBucketName)] {
+			continue
 		}
 		if err := s.store.ShutdownBucket(ctx, bucketName); err != nil {
 			if errors.Is(err, lsmkv.ErrBucketNotFound) {
@@ -326,27 +333,27 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 		shutDown = append(shutDown, bucketName)
 	}
 	logger.WithField("buckets_shut_down", shutDown).
-		WithField("preserved_gens", preserveGensSlice(preserveGens)).
+		WithField("preserved_sidecars", preserveSidecarsSlice(preserveSidecars)).
 		Info("partial-reindex cleanup: sidecar buckets shut down")
 
 	// Step 2 + 3: remove the sidecar dirs and migration dir. Both call the
 	// existing helpers, which log errors rather than panic. Pass through
-	// the preserved gens so the deferred-finalize state survives.
-	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, preserveGens)
+	// the preserved sidecar suffixes so the deferred-finalize state survives.
+	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, preserveSidecars)
 	s.cleanStaleMigrationDirs(propName, indexType)
 	logger.Info("partial-reindex cleanup: sidecar dirs + migration dir cleaned")
 
 	return nil
 }
 
-// preserveGensSlice flattens a preserved-gens set into a sorted []int for
-// stable structured-log output.
-func preserveGensSlice(preserveGens map[int]bool) []int {
-	out := make([]int, 0, len(preserveGens))
-	for g := range preserveGens {
-		out = append(out, g)
+// preserveSidecarsSlice flattens a preserved-sidecar-suffix set into a
+// sorted []string for stable structured-log output.
+func preserveSidecarsSlice(preserveSidecars map[string]bool) []string {
+	out := make([]string, 0, len(preserveSidecars))
+	for s := range preserveSidecars {
+		out = append(out, s)
 	}
-	sort.Ints(out)
+	sort.Strings(out)
 	return out
 }
 
@@ -399,18 +406,21 @@ func (s *Shard) cleanStaleSidecarDirs(mainBucketName string) {
 	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, nil)
 }
 
-// cleanStaleSidecarDirsWithPreserved is the gen-aware variant used by the
-// CANCEL→retry and pre-submit defense-in-depth paths. `preserveGens` lists
-// the generations whose sidecar dirs MUST be kept on disk because they
-// belong to a completed-but-deferred migration (their tracker dir has
-// tidied.mig / merged.mig). Wiping those out from under the in-memory
-// bucket pointer produces #10675-shape silent data loss on the next
-// submit-without-restart sequence.
+// cleanStaleSidecarDirsWithPreserved is the preserve-aware variant used by
+// the CANCEL→retry and pre-submit defense-in-depth paths. `preserveSidecars`
+// lists the gen-suffixed sidecar suffixes (e.g. "__roaringset_ingest_2",
+// from [completedMigrationSidecarSuffixes]) whose dirs MUST be kept on disk
+// because they belong to a completed-but-deferred migration (their tracker
+// dir has tidied.mig / merged.mig). Wiping those out from under the
+// in-memory bucket pointer produces #10675-shape silent data loss on the
+// next submit-without-restart sequence. Keyed by (suffix-base, gen), never
+// bare gen: a completed strategy's generation must not shield a different
+// strategy's sidecar that shares the int.
 //
 // Pass nil to wipe every matching sidecar dir (the DELETE→re-enable
 // callers, which already removed the main bucket and have no live state
 // to protect).
-func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preserveGens map[int]bool) {
+func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preserveSidecars map[string]bool) {
 	entries, err := os.ReadDir(s.pathLSM())
 	if err != nil {
 		s.index.logger.WithField("path", s.pathLSM()).
@@ -425,13 +435,11 @@ func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preser
 		if !strings.HasPrefix(entry.Name(), prefix) {
 			continue
 		}
-		if len(preserveGens) > 0 {
-			if _, gen, ok := parseMigrationDirName(entry.Name()); ok && preserveGens[gen] {
-				s.index.logger.WithField("path", filepath.Join(s.pathLSM(), entry.Name())).
-					WithField("gen", gen).
-					Info("partial-reindex cleanup: preserving deferred-finalize sidecar dir (live bucket pointer)")
-				continue
-			}
+		if suffix := strings.TrimPrefix(entry.Name(), mainBucketName); preserveSidecars[suffix] {
+			s.index.logger.WithField("path", filepath.Join(s.pathLSM(), entry.Name())).
+				WithField("suffix", suffix).
+				Info("partial-reindex cleanup: preserving deferred-finalize sidecar dir (live bucket pointer)")
+			continue
 		}
 		path := filepath.Join(s.pathLSM(), entry.Name())
 		// Drop the registry entry BEFORE removing the dir. The reverse order


### PR DESCRIPTION
SuperClaude here.

Fixes weaviate/0-weaviate-issues#295. Root-caused from a soak failure on the combined build (`repair-filterable` task FAILED on `rename ..._roaringset_ingest_2 -> ..._backup_3: ENOENT`); full forensic chain on the issue.

## Problem
`CleanStalePartialReindexState` computed its preserve set from `migrationDirsForPropertyIndex`, which deliberately omits the class-level strategies (correct for the tracker-DELETION sweep it also feeds, wrong for preservation), and keyed sidecar preservation by **bare generation int**. Result: after a completed class-level migration (RoaringSetRefresh / MapToBlockmax) whose live main bucket sits on a deferred-finalize `ingest_<gen>` dir, any submit/cancel/terminal cleanup for the same (prop, indexType) **deleted the live dir** unless an unrelated per-prop gen happened to collide with the same int. The in-memory bucket keeps serving from unlinked files until restart — silent index loss — and the next migration's swap fails loudly on ENOENT. Feature-base bug (3f6e94f233), not introduced by the [Reindex Fixes A] stack.

## Fix
Preserve and delete sets now come from different prefix lists — preserve additionally includes the class-level prefix for the indexType (`classLevelMigrationDirForIndexType`) — and preservation is keyed by the gen-suffixed sidecar suffix (`__roaringset_ingest_2`), never a bare int, in both the sidecar sweep and the loaded-bucket shutdown skip. Tracker-deletion semantics unchanged.

## Evidence
- `TestCleanStalePartialReindexState_PreservesClassLevelDeferredFinalize` (soak repro, both class-level strategies), `_GenCollisionAcrossStrategies` (bare-int pinning, both directions), `_ShutdownSkipKeyedBySuffix`: **red 30/30 pre-fix** on exactly the pinned assertions, **green 30/30 post-fix**, `-race -count 10`
- Full `./adapters/repos/db` `-race` green (51.6s)
- Caller audit on the thread-visible five call sites (submit pre-clean, cancel, terminal auto-cleanup, orphan audit, DELETE→re-enable): none depends on the old over-deletion; the orphan-audit path now correctly lets next-restart finalize promote a completed orphan's sidecars

— SuperClaude