### PR TITLE
fix(async-indexing): vector queue stays paused forever after a failed index upgrade

### DIFF
--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -173,8 +173,11 @@ type dynamic struct {
 	MakeBucketOptions            lsmkv.MakeBucketOptions
 	AsyncIndexingEnabled         bool
 
-	// doUpgradeHookForTest, when set, replaces doUpgrade's body (test-only).
-	doUpgradeHookForTest func() error
+	// upgradeFn performs the flat→HNSW rebuild. New wires it to the doUpgrade
+	// method; keeping it as an injected field (like the *Thunk dependencies
+	// above) lets tests substitute a failing or blocking rebuild without a
+	// test-only branch in the production path. Production always runs doUpgrade.
+	upgradeFn func() error
 }
 
 func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
@@ -228,6 +231,7 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 		MakeBucketOptions:            cfg.MakeBucketOptions,
 		AsyncIndexingEnabled:         cfg.AsyncIndexingEnabled,
 	}
+	index.upgradeFn = index.doUpgrade
 
 	upgraded, err := index.init(&cfg)
 	if err != nil {
@@ -630,7 +634,7 @@ func (dynamic *dynamic) Upgrade(callback func()) error {
 		}()
 		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW started")
 
-		err := dynamic.doUpgrade()
+		err := dynamic.upgradeFn()
 		if err != nil {
 			dynamic.logger.WithError(err).Error("failed to upgrade index")
 			return
@@ -642,10 +646,6 @@ func (dynamic *dynamic) Upgrade(callback func()) error {
 }
 
 func (dynamic *dynamic) doUpgrade() error {
-	if dynamic.doUpgradeHookForTest != nil {
-		return dynamic.doUpgradeHookForTest()
-	}
-
 	// The read lock keeps the current index alive (not dropped/closed) while
 	// the new one is built; searches continue throughout. Closure so the
 	// unlock is deferred and panic-safe.

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -621,13 +621,18 @@ func (dynamic *dynamic) Upgrade(callback func()) error {
 
 	enterrors.GoWrapper(func() {
 		defer callback()
+		// re-arm on error AND panic (GoWrapper recovers): a later Upgrade call
+		// must be able to retry. doUpgrade flips status only on success.
+		defer func() {
+			if !dynamic.status.IsUpgraded() {
+				dynamic.status.Reset()
+			}
+		}()
 		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW started")
 
 		err := dynamic.doUpgrade()
 		if err != nil {
 			dynamic.logger.WithError(err).Error("failed to upgrade index")
-			// re-arm: a later Upgrade call must be able to retry.
-			dynamic.status.Reset()
 			return
 		}
 		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW completed")
@@ -641,54 +646,54 @@ func (dynamic *dynamic) doUpgrade() error {
 		return dynamic.doUpgradeHookForTest()
 	}
 
-	// Start with a read lock to prevent reading from the index
-	// while it's being dropped or closed.
-	// This allows search operations to continue while the index is being
-	// upgraded.
-	dynamic.RLock()
+	// The read lock keeps the current index alive (not dropped/closed) while
+	// the new one is built; searches continue throughout. Closure so the
+	// unlock is deferred and panic-safe.
+	index, err := func() (*hnsw.HNSW, error) {
+		dynamic.RLock()
+		defer dynamic.RUnlock()
 
-	index, err := hnsw.New(
-		hnsw.Config{
-			Logger:                       dynamic.logger,
-			RootPath:                     dynamic.rootPath,
-			ID:                           dynamic.id,
-			ShardName:                    dynamic.shardName,
-			ClassName:                    dynamic.className,
-			PrometheusMetrics:            dynamic.prometheusMetrics,
-			VectorForIDThunk:             dynamic.vectorForIDThunk,
-			GetViewThunk:                 dynamic.getViewThunk,
-			TempVectorForIDWithViewThunk: dynamic.tempVectorForIDWithViewThunk,
-			DistanceProvider:             dynamic.distanceProvider,
-			MakeCommitLoggerThunk:        dynamic.makeCommitLoggerThunk,
-			DisableSnapshots:             dynamic.hnswDisableSnapshots,
-			SnapshotOnStartup:            dynamic.hnswSnapshotOnStartup,
-			WaitForCachePrefill:          dynamic.hnswWaitForCachePrefill,
-			AllocChecker:                 dynamic.AllocChecker,
-			MakeBucketOptions:            dynamic.MakeBucketOptions,
-			AsyncIndexingEnabled:         dynamic.AsyncIndexingEnabled,
-		},
-		dynamic.uc.HnswUC,
-		dynamic.tombstoneCallbacks,
-		dynamic.store,
-	)
+		index, err := hnsw.New(
+			hnsw.Config{
+				Logger:                       dynamic.logger,
+				RootPath:                     dynamic.rootPath,
+				ID:                           dynamic.id,
+				ShardName:                    dynamic.shardName,
+				ClassName:                    dynamic.className,
+				PrometheusMetrics:            dynamic.prometheusMetrics,
+				VectorForIDThunk:             dynamic.vectorForIDThunk,
+				GetViewThunk:                 dynamic.getViewThunk,
+				TempVectorForIDWithViewThunk: dynamic.tempVectorForIDWithViewThunk,
+				DistanceProvider:             dynamic.distanceProvider,
+				MakeCommitLoggerThunk:        dynamic.makeCommitLoggerThunk,
+				DisableSnapshots:             dynamic.hnswDisableSnapshots,
+				SnapshotOnStartup:            dynamic.hnswSnapshotOnStartup,
+				WaitForCachePrefill:          dynamic.hnswWaitForCachePrefill,
+				AllocChecker:                 dynamic.AllocChecker,
+				MakeBucketOptions:            dynamic.MakeBucketOptions,
+				AsyncIndexingEnabled:         dynamic.AsyncIndexingEnabled,
+			},
+			dynamic.uc.HnswUC,
+			dynamic.tombstoneCallbacks,
+			dynamic.store,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := dynamic.copyToVectorIndex(index); err != nil {
+			return nil, err
+		}
+
+		// Start commit-log maintenance on the new HNSW index. The cache prefill
+		// is a no-op because cachePrefilled was already set during init (fresh
+		// index with no commit-log state) and the cache is populated by AddBatch.
+		index.PostStartup(dynamic.ctx)
+		return index, nil
+	}()
 	if err != nil {
-		dynamic.RUnlock()
 		return err
 	}
-
-	err = dynamic.copyToVectorIndex(index)
-	if err != nil {
-		dynamic.RUnlock()
-		return err
-	}
-
-	// Start commit-log maintenance on the new HNSW index. The cache prefill
-	// is a no-op because cachePrefilled was already set during init (fresh
-	// index with no commit-log state) and the cache is populated by AddBatch.
-	index.PostStartup(dynamic.ctx)
-
-	// end of read-only zone
-	dynamic.RUnlock()
 
 	// Lock the index for writing but check if it was already
 	// closed in the meantime

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -134,9 +134,8 @@ func (s *status) Upgraded() {
 	(*atomic.Pointer[string])(s).Store(&upgraded)
 }
 
-// TryUpgrading atomically transitions status from unset to upgrading, returning
-// true only to the caller that wins the transition. This replaces a one-shot
-// sync.Once so a Reset (failed attempt) can be retried by a later Upgrade call.
+// TryUpgrading claims the upgrade attempt; only the winning caller gets true,
+// so a Reset after a failed attempt lets a later call retry.
 func (s *status) TryUpgrading() bool {
 	if s == nil {
 		return false
@@ -174,8 +173,7 @@ type dynamic struct {
 	MakeBucketOptions            lsmkv.MakeBucketOptions
 	AsyncIndexingEnabled         bool
 
-	// doUpgradeHookForTest, when set, replaces doUpgrade's body. Test-only seam
-	// for forcing/timing upgrade failures without touching hnsw/bbolt.
+	// doUpgradeHookForTest, when set, replaces doUpgrade's body (test-only).
 	doUpgradeHookForTest func() error
 }
 

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -118,14 +118,6 @@ func (s *status) IsUpgrading() bool {
 	return v != nil && *v == upgrading
 }
 
-// Upgrading sets the status to upgrading. This is used to indicate that the index is currently being upgraded from flat to HNSW.
-func (s *status) Upgrading() {
-	if s == nil {
-		return
-	}
-	(*atomic.Pointer[string])(s).Store(&upgrading)
-}
-
 // Reset sets the status to nil. This is used to indicate that the index is neither upgraded nor upgrading.
 func (s *status) Reset() {
 	if s == nil {
@@ -140,6 +132,16 @@ func (s *status) Upgraded() {
 		return
 	}
 	(*atomic.Pointer[string])(s).Store(&upgraded)
+}
+
+// TryUpgrading atomically transitions status from unset to upgrading, returning
+// true only to the caller that wins the transition. This replaces a one-shot
+// sync.Once so a Reset (failed attempt) can be retried by a later Upgrade call.
+func (s *status) TryUpgrading() bool {
+	if s == nil {
+		return false
+	}
+	return (*atomic.Pointer[string])(s).CompareAndSwap(nil, &upgrading)
 }
 
 type dynamic struct {
@@ -160,7 +162,6 @@ type dynamic struct {
 	threshold                    uint64
 	index                        VectorIndex
 	status                       status
-	upgradeOnce                  sync.Once
 	tombstoneCallbacks           cyclemanager.CycleCallbackGroup
 	uc                           ent.UserConfig
 	db                           *bbolt.DB
@@ -172,6 +173,10 @@ type dynamic struct {
 	AllocChecker                 memwatch.AllocChecker
 	MakeBucketOptions            lsmkv.MakeBucketOptions
 	AsyncIndexingEnabled         bool
+
+	// doUpgradeHookForTest, when set, replaces doUpgrade's body. Test-only seam
+	// for forcing/timing upgrade failures without touching hnsw/bbolt.
+	doUpgradeHookForTest func() error
 }
 
 func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
@@ -599,7 +604,9 @@ func float32SliceFromByteSlice(vector []byte, slice []float32) []float32 {
 
 func (dynamic *dynamic) Upgrade(callback func()) error {
 	if dynamic.ctx.Err() != nil {
-		// already closed
+		// no goroutine will run to fire the callback, so the pause/resume
+		// contract must be resolved synchronously here.
+		callback()
 		return dynamic.ctx.Err()
 	}
 
@@ -607,26 +614,35 @@ func (dynamic *dynamic) Upgrade(callback func()) error {
 		return dynamic.index.(upgradableIndexer).Upgrade(callback)
 	}
 
-	dynamic.upgradeOnce.Do(func() {
-		dynamic.status.Upgrading()
-		enterrors.GoWrapper(func() {
-			defer callback()
-			dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW started")
+	if !dynamic.status.TryUpgrading() {
+		// an attempt is already in flight (or just finished) and owns its own
+		// callback; resolve this caller's separately instead of blocking on it.
+		callback()
+		return nil
+	}
 
-			err := dynamic.doUpgrade()
-			if err != nil {
-				dynamic.logger.WithError(err).Error("failed to upgrade index")
-				dynamic.status.Reset()
-				return
-			}
-			dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW completed")
-		}, dynamic.logger)
-	})
+	enterrors.GoWrapper(func() {
+		defer callback()
+		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW started")
+
+		err := dynamic.doUpgrade()
+		if err != nil {
+			dynamic.logger.WithError(err).Error("failed to upgrade index")
+			// re-arm: a later Upgrade call must be able to retry.
+			dynamic.status.Reset()
+			return
+		}
+		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW completed")
+	}, dynamic.logger)
 
 	return nil
 }
 
 func (dynamic *dynamic) doUpgrade() error {
+	if dynamic.doUpgradeHookForTest != nil {
+		return dynamic.doUpgradeHookForTest()
+	}
+
 	// Start with a read lock to prevent reading from the index
 	// while it's being dropped or closed.
 	// This allows search operations to continue while the index is being

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -441,7 +441,8 @@ func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
 				t.Skip("panic recovery disabled")
 			}
 			dyn := newUpgradeTestDynamic(t, 10)
-			dyn.doUpgradeHookForTest = tc.hook
+			realUpgrade := dyn.upgradeFn
+			dyn.upgradeFn = tc.hook
 
 			firstCallback := make(chan struct{})
 			require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
@@ -452,8 +453,8 @@ func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
 			}
 			require.False(t, dyn.IsUpgraded(), "a failed attempt must not report as upgraded")
 
-			// clear the injected failure so the retry can actually complete.
-			dyn.doUpgradeHookForTest = nil
+			// restore the real rebuild so the retry can actually complete.
+			dyn.upgradeFn = realUpgrade
 
 			secondCallback := make(chan struct{})
 			require.NoError(t, dyn.Upgrade(func() { close(secondCallback) }))
@@ -473,7 +474,7 @@ func TestDynamicUpgradeMidFlightInvokesCallerCallbackImmediately(t *testing.T) {
 	dyn := newUpgradeTestDynamic(t, 10)
 
 	block := make(chan struct{})
-	dyn.doUpgradeHookForTest = func() error {
+	dyn.upgradeFn = func() error {
 		<-block
 		return nil
 	}

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -13,6 +13,7 @@ package dynamic
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -355,6 +356,158 @@ func TestDynamicUpgradeCancelation(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("upgrade callback was not called")
 	}
+}
+
+// newUpgradeTestDynamic builds a minimal dynamic index with vectorsSize vectors
+// already indexed and ShouldUpgrade()==true, for exercising Upgrade's retry and
+// re-entrancy paths without paying for a full recall/latency-style test.
+func newUpgradeTestDynamic(t *testing.T, vectorsSize int) *dynamic {
+	t.Helper()
+	ctx := context.Background()
+	dimensions := 4
+
+	db, err := bbolt.Open(filepath.Join(t.TempDir(), "index.db"), 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	vectors, _ := testinghelpers.RandomVecs(vectorsSize, 0, dimensions)
+	dist := distancer.NewL2SquaredProvider()
+	noopCallback := cyclemanager.NewCallbackGroupNoop()
+	fuc := flatent.UserConfig{}
+	fuc.SetDefaults()
+	hnswuc := hnswent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 1_000_000,
+	}
+
+	dyn, err := New(Config{
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		RootPath:              t.TempDir(),
+		ID:                    "upgrade-retry-test",
+		MakeCommitLoggerThunk: hnsw.MakeNoopCommitLogger,
+		DistanceProvider:      dist,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			vec := vectors[int(id)]
+			if vec == nil {
+				return nil, storobj.NewErrNotFoundf(id, "nil vec")
+			}
+			return vec, nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		TombstoneCallbacks:           noopCallback,
+		SharedDB:                     db,
+		MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+		AsyncIndexingEnabled:         true,
+	}, ent.UserConfig{
+		Threshold: uint64(vectorsSize),
+		Distance:  dist.Type(),
+		HnswUC:    hnswuc,
+		FlatUC:    fuc,
+	}, testinghelpers.NewDummyStore(t))
+	require.NoError(t, err)
+
+	for i, v := range vectors {
+		require.NoError(t, dyn.Add(ctx, uint64(i), v))
+	}
+
+	shouldUpgrade, _ := dyn.ShouldUpgrade()
+	require.True(t, shouldUpgrade)
+	require.False(t, dyn.Upgraded())
+
+	return dyn
+}
+
+// Regression test for weaviate/0-weaviate-issues#296 defect 1: upgradeOnce was
+// consumed by the first (failed) attempt, so every later Upgrade call returned
+// nil without ever invoking its callback -- the caller's paused queue (see
+// VectorIndexQueue.BeforeSchedule) stayed paused forever.
+func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
+	dyn := newUpgradeTestDynamic(t, 10)
+
+	dyn.doUpgradeHookForTest = func() error {
+		return errors.New("injected upgrade failure")
+	}
+
+	firstCallback := make(chan struct{})
+	require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
+	select {
+	case <-firstCallback:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first upgrade callback was not invoked")
+	}
+	require.False(t, dyn.IsUpgraded(), "a failed attempt must not report as upgraded")
+
+	// clear the injected failure so the retry can actually complete.
+	dyn.doUpgradeHookForTest = nil
+
+	secondCallback := make(chan struct{})
+	require.NoError(t, dyn.Upgrade(func() { close(secondCallback) }))
+	select {
+	case <-secondCallback:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second upgrade callback was not invoked -- retry never ran")
+	}
+	require.True(t, dyn.IsUpgraded(), "the retried upgrade must actually complete")
+}
+
+// Regression test: a second Upgrade call arriving while an attempt is already
+// in flight must not block on it -- it must invoke its own caller's callback
+// immediately, since that caller (e.g. BeforeSchedule) owns its own pause and
+// the in-flight attempt owns a different one.
+func TestDynamicUpgradeMidFlightInvokesCallerCallbackImmediately(t *testing.T) {
+	dyn := newUpgradeTestDynamic(t, 10)
+
+	block := make(chan struct{})
+	dyn.doUpgradeHookForTest = func() error {
+		<-block
+		return nil
+	}
+
+	firstCallback := make(chan struct{})
+	require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
+	// TryUpgrading flips the status synchronously before Upgrade returns, so a
+	// second caller below is guaranteed to observe "mid-upgrade".
+	require.True(t, dyn.status.IsUpgrading())
+
+	secondCallback := make(chan struct{})
+	require.NoError(t, dyn.Upgrade(func() { close(secondCallback) }))
+
+	select {
+	case <-secondCallback:
+	default:
+		t.Fatal("a mid-upgrade Upgrade call must invoke its own callback synchronously")
+	}
+
+	select {
+	case <-firstCallback:
+		t.Fatal("the in-flight attempt's callback must not have fired yet")
+	default:
+	}
+
+	close(block)
+	select {
+	case <-firstCallback:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first upgrade callback was never invoked after unblocking")
+	}
+}
+
+// Regression test: Upgrade called after Shutdown returns ctx.Err() synchronously
+// with no goroutine spawned to ever invoke the callback, so it must invoke it
+// inline -- otherwise a caller that paused its queue expecting a resume never
+// gets one.
+func TestDynamicUpgradeAfterShutdownInvokesCallbackSynchronously(t *testing.T) {
+	dyn := newUpgradeTestDynamic(t, 10)
+
+	require.NoError(t, dyn.Shutdown(context.Background()))
+
+	called := false
+	err := dyn.Upgrade(func() { called = true })
+	require.Error(t, err)
+	require.True(t, called, "Upgrade must invoke the callback even when it short-circuits on a closed context")
 }
 
 func TestDynamicUpgradeCompression(t *testing.T) {

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -358,9 +358,8 @@ func TestDynamicUpgradeCancelation(t *testing.T) {
 	}
 }
 
-// newUpgradeTestDynamic builds a minimal dynamic index with vectorsSize vectors
-// already indexed and ShouldUpgrade()==true, for exercising Upgrade's retry and
-// re-entrancy paths without paying for a full recall/latency-style test.
+// newUpgradeTestDynamic builds a minimal dynamic index with vectorsSize indexed
+// vectors and ShouldUpgrade()==true, for exercising Upgrade's retry/re-entrancy paths.
 func newUpgradeTestDynamic(t *testing.T, vectorsSize int) *dynamic {
 	t.Helper()
 	ctx := context.Background()
@@ -420,10 +419,8 @@ func newUpgradeTestDynamic(t *testing.T, vectorsSize int) *dynamic {
 	return dyn
 }
 
-// Regression test for weaviate/0-weaviate-issues#296 defect 1: upgradeOnce was
-// consumed by the first (failed) attempt, so every later Upgrade call returned
-// nil without ever invoking its callback -- the caller's paused queue (see
-// VectorIndexQueue.BeforeSchedule) stayed paused forever.
+// Regression test (weaviate/0-weaviate-issues#296): a failed upgrade attempt
+// must not block a later Upgrade call from retrying.
 func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
 	dyn := newUpgradeTestDynamic(t, 10)
 
@@ -453,10 +450,8 @@ func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
 	require.True(t, dyn.IsUpgraded(), "the retried upgrade must actually complete")
 }
 
-// Regression test: a second Upgrade call arriving while an attempt is already
-// in flight must not block on it -- it must invoke its own caller's callback
-// immediately, since that caller (e.g. BeforeSchedule) owns its own pause and
-// the in-flight attempt owns a different one.
+// Regression test: a mid-upgrade Upgrade call must invoke its own callback
+// immediately instead of blocking on the in-flight attempt.
 func TestDynamicUpgradeMidFlightInvokesCallerCallbackImmediately(t *testing.T) {
 	dyn := newUpgradeTestDynamic(t, 10)
 
@@ -468,8 +463,7 @@ func TestDynamicUpgradeMidFlightInvokesCallerCallbackImmediately(t *testing.T) {
 
 	firstCallback := make(chan struct{})
 	require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
-	// TryUpgrading flips the status synchronously before Upgrade returns, so a
-	// second caller below is guaranteed to observe "mid-upgrade".
+	// TryUpgrading flips status synchronously, so this is guaranteed "mid-upgrade".
 	require.True(t, dyn.status.IsUpgrading())
 
 	secondCallback := make(chan struct{})
@@ -495,10 +489,8 @@ func TestDynamicUpgradeMidFlightInvokesCallerCallbackImmediately(t *testing.T) {
 	}
 }
 
-// Regression test: Upgrade called after Shutdown returns ctx.Err() synchronously
-// with no goroutine spawned to ever invoke the callback, so it must invoke it
-// inline -- otherwise a caller that paused its queue expecting a resume never
-// gets one.
+// Regression test: Upgrade after Shutdown must invoke the callback inline,
+// since no goroutine is spawned to do it later.
 func TestDynamicUpgradeAfterShutdownInvokesCallbackSynchronously(t *testing.T) {
 	dyn := newUpgradeTestDynamic(t, 10)
 

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -419,65 +419,45 @@ func newUpgradeTestDynamic(t *testing.T, vectorsSize int) *dynamic {
 	return dyn
 }
 
-// Regression test (weaviate/0-weaviate-issues#296): a failed upgrade attempt
-// must not block a later Upgrade call from retrying.
+// Regression test (weaviate/0-weaviate-issues#296): a failed or panicked
+// upgrade attempt (GoWrapper recovers the panic) must still fire the callback
+// and re-arm status so a later Upgrade call can retry.
 func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
-	dyn := newUpgradeTestDynamic(t, 10)
-
-	dyn.doUpgradeHookForTest = func() error {
-		return errors.New("injected upgrade failure")
+	cases := []struct {
+		name string
+		hook func() error
+	}{
+		{"error", func() error { return errors.New("injected upgrade failure") }},
+		{"panic", func() error { panic("injected upgrade panic") }},
 	}
 
-	firstCallback := make(chan struct{})
-	require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
-	select {
-	case <-firstCallback:
-	case <-time.After(5 * time.Second):
-		t.Fatal("first upgrade callback was not invoked")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dyn := newUpgradeTestDynamic(t, 10)
+			dyn.doUpgradeHookForTest = tc.hook
+
+			firstCallback := make(chan struct{})
+			require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
+			select {
+			case <-firstCallback:
+			case <-time.After(5 * time.Second):
+				t.Fatal("first upgrade callback was not invoked")
+			}
+			require.False(t, dyn.IsUpgraded(), "a failed attempt must not report as upgraded")
+
+			// clear the injected failure so the retry can actually complete.
+			dyn.doUpgradeHookForTest = nil
+
+			secondCallback := make(chan struct{})
+			require.NoError(t, dyn.Upgrade(func() { close(secondCallback) }))
+			select {
+			case <-secondCallback:
+			case <-time.After(5 * time.Second):
+				t.Fatal("second upgrade callback was not invoked -- status stuck, retry never ran")
+			}
+			require.True(t, dyn.IsUpgraded(), "the retried upgrade must actually complete")
+		})
 	}
-	require.False(t, dyn.IsUpgraded(), "a failed attempt must not report as upgraded")
-
-	// clear the injected failure so the retry can actually complete.
-	dyn.doUpgradeHookForTest = nil
-
-	secondCallback := make(chan struct{})
-	require.NoError(t, dyn.Upgrade(func() { close(secondCallback) }))
-	select {
-	case <-secondCallback:
-	case <-time.After(5 * time.Second):
-		t.Fatal("second upgrade callback was not invoked -- retry never ran")
-	}
-	require.True(t, dyn.IsUpgraded(), "the retried upgrade must actually complete")
-}
-
-// Regression test: a panic inside doUpgrade (recovered by GoWrapper) must
-// still fire the callback and re-arm status so a later attempt can retry.
-func TestDynamicUpgradeRetriesAfterPanickedAttempt(t *testing.T) {
-	dyn := newUpgradeTestDynamic(t, 10)
-
-	dyn.doUpgradeHookForTest = func() error {
-		panic("injected upgrade panic")
-	}
-
-	firstCallback := make(chan struct{})
-	require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
-	select {
-	case <-firstCallback:
-	case <-time.After(5 * time.Second):
-		t.Fatal("callback was not invoked after a panicked attempt")
-	}
-	require.False(t, dyn.IsUpgraded(), "a panicked attempt must not report as upgraded")
-
-	dyn.doUpgradeHookForTest = nil
-
-	secondCallback := make(chan struct{})
-	require.NoError(t, dyn.Upgrade(func() { close(secondCallback) }))
-	select {
-	case <-secondCallback:
-	case <-time.After(5 * time.Second):
-		t.Fatal("second upgrade callback was not invoked -- panic left status stuck at upgrading")
-	}
-	require.True(t, dyn.IsUpgraded(), "the retried upgrade must actually complete")
 }
 
 // Regression test: a mid-upgrade Upgrade call must invoke its own callback

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -33,6 +34,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/noop"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/storobj"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
@@ -433,6 +435,11 @@ func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "panic" && entcfg.Enabled(os.Getenv("DISABLE_RECOVERY_ON_PANIC")) {
+				// without GoWrapper's recover the panic kills the process by
+				// design; retry-after-panic only exists in recovery mode.
+				t.Skip("panic recovery disabled")
+			}
 			dyn := newUpgradeTestDynamic(t, 10)
 			dyn.doUpgradeHookForTest = tc.hook
 

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -450,6 +450,36 @@ func TestDynamicUpgradeRetriesAfterFailedAttempt(t *testing.T) {
 	require.True(t, dyn.IsUpgraded(), "the retried upgrade must actually complete")
 }
 
+// Regression test: a panic inside doUpgrade (recovered by GoWrapper) must
+// still fire the callback and re-arm status so a later attempt can retry.
+func TestDynamicUpgradeRetriesAfterPanickedAttempt(t *testing.T) {
+	dyn := newUpgradeTestDynamic(t, 10)
+
+	dyn.doUpgradeHookForTest = func() error {
+		panic("injected upgrade panic")
+	}
+
+	firstCallback := make(chan struct{})
+	require.NoError(t, dyn.Upgrade(func() { close(firstCallback) }))
+	select {
+	case <-firstCallback:
+	case <-time.After(5 * time.Second):
+		t.Fatal("callback was not invoked after a panicked attempt")
+	}
+	require.False(t, dyn.IsUpgraded(), "a panicked attempt must not report as upgraded")
+
+	dyn.doUpgradeHookForTest = nil
+
+	secondCallback := make(chan struct{})
+	require.NoError(t, dyn.Upgrade(func() { close(secondCallback) }))
+	select {
+	case <-secondCallback:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second upgrade callback was not invoked -- panic left status stuck at upgrading")
+	}
+	require.True(t, dyn.IsUpgraded(), "the retried upgrade must actually complete")
+}
+
 // Regression test: a mid-upgrade Upgrade call must invoke its own callback
 // immediately instead of blocking on the in-flight attempt.
 func TestDynamicUpgradeMidFlightInvokesCallerCallbackImmediately(t *testing.T) {

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -312,9 +312,8 @@ func (iq *VectorIndexQueue) checkCompressionSettings() (skip bool) {
 		})
 		if err != nil {
 			iq.DiskQueue.Logger.WithError(err).Error("failed to upgrade vector index")
-			// Upgrade may fail before it can guarantee its own callback runs
-			// (e.g. ctx cancelled during shutdown); resume here so the pause
-			// above never leaks. Idempotent if the callback already resumed it.
+			// Upgrade can fail without guaranteeing its callback ran; resume here
+			// so the pause never leaks (idempotent if it already did).
 			iq.scheduler.ResumeQueue(iq.DiskQueue.ID())
 		}
 

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -312,6 +312,10 @@ func (iq *VectorIndexQueue) checkCompressionSettings() (skip bool) {
 		})
 		if err != nil {
 			iq.DiskQueue.Logger.WithError(err).Error("failed to upgrade vector index")
+			// Upgrade may fail before it can guarantee its own callback runs
+			// (e.g. ctx cancelled during shutdown); resume here so the pause
+			// above never leaks. Idempotent if the callback already resumed it.
+			iq.scheduler.ResumeQueue(iq.DiskQueue.ID())
 		}
 
 		return true

--- a/adapters/repos/db/vector_index_queue_movement_test.go
+++ b/adapters/repos/db/vector_index_queue_movement_test.go
@@ -47,8 +47,8 @@ type movementFakeUpgradable struct {
 	indexed       uint64
 	upgraded      bool
 	upgradeCalled bool
-	// upgradeErr, when set, is returned by Upgrade WITHOUT invoking callback --
-	// modeling dynamic.Upgrade's synchronous ctx.Err() failure mode.
+	// upgradeErr, when set, is returned by Upgrade without invoking callback
+	// (models dynamic.Upgrade's synchronous ctx.Err() path).
 	upgradeErr error
 }
 

--- a/adapters/repos/db/vector_index_queue_movement_test.go
+++ b/adapters/repos/db/vector_index_queue_movement_test.go
@@ -47,8 +47,8 @@ type movementFakeUpgradable struct {
 	indexed       uint64
 	upgraded      bool
 	upgradeCalled bool
-	// upgradeErr, when set, is returned by Upgrade without invoking callback
-	// (models dynamic.Upgrade's synchronous ctx.Err() path).
+	// upgradeErr, when set, is returned by Upgrade without invoking callback —
+	// the misbehaving-indexer case BeforeSchedule must not leak a pause on.
 	upgradeErr error
 }
 

--- a/adapters/repos/db/vector_index_queue_movement_test.go
+++ b/adapters/repos/db/vector_index_queue_movement_test.go
@@ -47,6 +47,9 @@ type movementFakeUpgradable struct {
 	indexed       uint64
 	upgraded      bool
 	upgradeCalled bool
+	// upgradeErr, when set, is returned by Upgrade WITHOUT invoking callback --
+	// modeling dynamic.Upgrade's synchronous ctx.Err() failure mode.
+	upgradeErr error
 }
 
 func (f *movementFakeUpgradable) ShouldUpgrade() (bool, int) { return f.shouldUpgrade, f.upgradeAt }
@@ -56,6 +59,9 @@ func (f *movementFakeUpgradable) UpgradeInProgress() bool    { return false }
 
 func (f *movementFakeUpgradable) Upgrade(callback func()) error {
 	f.upgradeCalled = true
+	if f.upgradeErr != nil {
+		return f.upgradeErr
+	}
 	if callback != nil {
 		callback()
 	}

--- a/adapters/repos/db/vector_index_queue_upgrade_pause_test.go
+++ b/adapters/repos/db/vector_index_queue_upgrade_pause_test.go
@@ -1,0 +1,77 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+)
+
+// newPausableTestQueue wires a VectorIndexQueue to a real, started Scheduler and
+// a real DiskQueue -- unlike newMovementTestQueue's zero-value scheduler, this
+// one actually tracks pause state, so IsQueuePaused reflects reality instead of
+// trivially returning false. ScheduleInterval is set far beyond the test's
+// lifetime so the scheduler's own background tick never fires BeforeSchedule
+// concurrently with the test's direct call.
+func newPausableTestQueue(t *testing.T, vi VectorIndex) *VectorIndexQueue {
+	t.Helper()
+
+	s := queue.NewScheduler(queue.SchedulerOptions{ScheduleInterval: time.Hour})
+	s.Start()
+	t.Cleanup(func() { _ = s.Close(context.Background()) })
+
+	viq := &VectorIndexQueue{
+		scheduler:   s,
+		shard:       &Shard{},
+		vectorIndex: vi,
+	}
+
+	dq, err := queue.NewDiskQueue(queue.DiskQueueOptions{
+		ID:          "vector_index_queue_upgrade_pause_test",
+		Scheduler:   s,
+		Dir:         t.TempDir(),
+		TaskDecoder: &vectorIndexQueueDecoder{q: viq},
+	})
+	require.NoError(t, err)
+	require.NoError(t, dq.Init())
+	viq.DiskQueue = dq
+
+	s.RegisterQueue(viq)
+
+	return viq
+}
+
+// Regression test for weaviate/0-weaviate-issues#296 defect 2: BeforeSchedule
+// paused the queue before calling ci.Upgrade, but only logged the error if
+// Upgrade failed -- leaking the pause forever whenever Upgrade returns an error
+// without having invoked its callback (e.g. dynamic.Upgrade's ctx.Err() path).
+func TestVectorIndexQueue_BeforeSchedule_DoesNotLeakPauseOnUpgradeError(t *testing.T) {
+	fake := &movementFakeUpgradable{
+		shouldUpgrade: true,
+		upgradeAt:     0,
+		indexed:       1,
+		upgradeErr:    errors.New("ctx cancelled during shutdown"),
+	}
+	iq := newPausableTestQueue(t, fake)
+
+	skip := iq.BeforeSchedule()
+
+	require.True(t, skip, "the upgrade branch must have been taken")
+	require.True(t, fake.upgradeCalled)
+	require.False(t, iq.scheduler.IsQueuePaused(iq.ID()),
+		"BeforeSchedule must resume the queue itself when Upgrade errors without having called its callback")
+}

--- a/adapters/repos/db/vector_index_queue_upgrade_pause_test.go
+++ b/adapters/repos/db/vector_index_queue_upgrade_pause_test.go
@@ -45,6 +45,10 @@ func newPausableTestQueue(t *testing.T, vi VectorIndex) *VectorIndexQueue {
 	})
 	require.NoError(t, err)
 	require.NoError(t, dq.Init())
+	// Scheduler.Close does not close registered queues, so close the DiskQueue
+	// ourselves (runs before the scheduler cleanup via t.Cleanup's LIFO order)
+	// to avoid leaking its file descriptors/goroutines across tests.
+	t.Cleanup(func() { _ = dq.Close(context.Background()) })
 	viq.DiskQueue = dq
 
 	s.RegisterQueue(viq)

--- a/adapters/repos/db/vector_index_queue_upgrade_pause_test.go
+++ b/adapters/repos/db/vector_index_queue_upgrade_pause_test.go
@@ -21,12 +21,9 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 )
 
-// newPausableTestQueue wires a VectorIndexQueue to a real, started Scheduler and
-// a real DiskQueue -- unlike newMovementTestQueue's zero-value scheduler, this
-// one actually tracks pause state, so IsQueuePaused reflects reality instead of
-// trivially returning false. ScheduleInterval is set far beyond the test's
-// lifetime so the scheduler's own background tick never fires BeforeSchedule
-// concurrently with the test's direct call.
+// newPausableTestQueue uses a real, started Scheduler (not newMovementTestQueue's
+// zero-value one) so IsQueuePaused reflects actual state; ScheduleInterval is set
+// huge so the scheduler's own tick can't race the test's direct BeforeSchedule call.
 func newPausableTestQueue(t *testing.T, vi VectorIndex) *VectorIndexQueue {
 	t.Helper()
 
@@ -55,10 +52,8 @@ func newPausableTestQueue(t *testing.T, vi VectorIndex) *VectorIndexQueue {
 	return viq
 }
 
-// Regression test for weaviate/0-weaviate-issues#296 defect 2: BeforeSchedule
-// paused the queue before calling ci.Upgrade, but only logged the error if
-// Upgrade failed -- leaking the pause forever whenever Upgrade returns an error
-// without having invoked its callback (e.g. dynamic.Upgrade's ctx.Err() path).
+// Regression test (weaviate/0-weaviate-issues#296): BeforeSchedule must resume
+// the queue itself if Upgrade errors without having invoked its callback.
 func TestVectorIndexQueue_BeforeSchedule_DoesNotLeakPauseOnUpgradeError(t *testing.T) {
 	fake := &movementFakeUpgradable{
 		shouldUpgrade: true,


### PR DESCRIPTION
SuperClaude here.

Fixes weaviate/0-weaviate-issues#296 (defects 1+2; defect 3 — unbounded compress retry — stays issue-only pending a backoff design). Root-caused from weaviate/0-weaviate-issues#292's QPS-benchmark hang: a shard whose vector queue never drains reports `vectorQueueSize>0` forever, hanging every `wait_for_vector_indexing` caller.

## Problems
1. `dynamic.Upgrade`: after one failed `doUpgrade`, `status.Reset()` intends retry but `upgradeOnce` is consumed — every later call returns nil **without invoking the caller's resume callback**. `VectorIndexQueue.BeforeSchedule` has already re-paused the queue → paused forever, async indexing dead for the shard.
2. `BeforeSchedule` leaks its pause whenever `ci.Upgrade` returns an error (e.g. dynamic's synchronous `ctx.Err()` during shutdown) — the error branch only logged.

## Fix
CAS-based `status.TryUpgrading()` replaces the `sync.Once` (Reset re-arms retry); every early-return path resolves the caller's callback (closed → synchronous invoke; mid-flight → immediate invoke, the in-flight attempt owns its own); BeforeSchedule resumes the queue on Upgrade error (double-resume is a no-op — scheduler pause is a bool, not a counter).

## Evidence
- 4 regression tests, each proven red on the unfixed code by reverting the fixes in isolation, green 10/10 `-race -count 10`: retry-after-failure, mid-flight callback, post-shutdown callback, BeforeSchedule pause-leak (with a real started scheduler so pause state is observable)
- Full `vector/dynamic` package + all VectorIndexQueue tests `-race` green; `golangci-lint` clean
- Caller audit: all three non-test `.Upgrade(` sites verified (BeforeSchedule fixed; dynamic→hnsw delegate already callback-safe; hnsw's internal call unaffected); `flat.Upgrade` never fires callbacks but is unreachable from BeforeSchedule (`ShouldUpgrade()==false`)

— SuperClaude