### PR TITLE
docs: remove duplicate word in GraphQL network Get description

### DIFF
--- a/adapters/handlers/graphql/descriptions/get.go
+++ b/adapters/handlers/graphql/descriptions/get.go
@@ -39,7 +39,7 @@ const (
 )
 
 const (
-	NetworkGetObjectsObj = "An object containing the Objects objects on this network Weaviate instance."
+	NetworkGetObjectsObj = "An object containing the Objects on this network Weaviate instance."
 )
 
 const NetworkGetClassUUID = "The UUID of a Object, assigned by the Weaviate network" // TODO check this with @lauraham


### PR DESCRIPTION
### What's being changed:

Removes a duplicated word in the `NetworkGetObjectsObj` GraphQL description string. "An object containing the Objects objects on this network Weaviate instance." becomes "An object containing the Objects on this network Weaviate instance.", matching the phrasing of sibling description constants.

### Review checklist

- [x] Documentation has been updated, if necessary. Not necessary: this is an internal GraphQL description string only.
- [x] Chaos pipeline run or not necessary. Not necessary.
- [x] All new code is covered by tests where it is reasonable. Not applicable: no code logic changed.
- [x] Performance tests have been run or not necessary. Not necessary.

### Cross-functional impact

No cross-functional impact. This is a wording fix in an internal description string.
