### PR TITLE
fix(reindex): concurrent writes during migration converge into the new bucket (#11688, #298)

### DIFF
--- a/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
+++ b/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
@@ -37,9 +37,8 @@ func writeBlockmaxSearchablePostings(shard ShardLike, bucket *lsmkv.Bucket,
 	return nil
 }
 
-// swapFallbackNamer maps a property to its canonical (main) bucket name, used
-// when the sidecar name no longer resolves post-swap; nil means "skip on
-// missing sidecar" (backup-phase callbacks). See resolveDoubleWriteBucket.
+// swapFallbackNamer is the canonical-name fallback passed to
+// resolveDoubleWriteBucket; nil skips on a missing sidecar (backup phase).
 func blockmaxSearchableAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onAddToPropertyValueIndex {

--- a/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
+++ b/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
@@ -44,16 +44,9 @@ func blockmaxSearchableAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onAddToPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if swapFallbackNamer != nil {
-			swapFallback = swapFallbackNamer(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, swapFallbackNamer, swapFallbackNamer != nil)
+		if skip {
 			return nil
 		}
 		propLen := calcPropLenInverted(property.Items)
@@ -71,16 +64,9 @@ func blockmaxSearchableDeleteCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if swapFallbackNamer != nil {
-			swapFallback = swapFallbackNamer(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, swapFallbackNamer, swapFallbackNamer != nil)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {

--- a/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
+++ b/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
@@ -37,15 +37,25 @@ func writeBlockmaxSearchablePostings(shard ShardLike, bucket *lsmkv.Bucket,
 	return nil
 }
 
+// swapFallbackNamer maps a property to its canonical (main) bucket name, used
+// when the sidecar name no longer resolves post-swap; nil means "skip on
+// missing sidecar" (backup-phase callbacks). See resolveDoubleWriteBucket.
 func blockmaxSearchableAddCallback(bucketNamer func(string) string,
-	propsByName map[string]struct{},
+	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onAddToPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		if _, ok := propsByName[property.Name]; !ok {
 			return nil
 		}
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if swapFallbackNamer != nil {
+			swapFallback = swapFallbackNamer(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			return nil
+		}
 		propLen := calcPropLenInverted(property.Items)
 		for _, item := range property.Items {
 			pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
@@ -58,14 +68,21 @@ func blockmaxSearchableAddCallback(bucketNamer func(string) string,
 }
 
 func blockmaxSearchableDeleteCallback(bucketNamer func(string) string,
-	propsByName map[string]struct{},
+	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		if _, ok := propsByName[property.Name]; !ok {
 			return nil
 		}
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if swapFallbackNamer != nil {
+			swapFallback = swapFallbackNamer(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
 				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -11,7 +11,10 @@
 
 package db
 
-import "github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+import (
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+)
 
 // resolveDoubleWriteBucket resolves the bucket a runtime-reindex double-write
 // callback should mirror into. Every strategy MakeAddCallback/MakeDeleteCallback
@@ -51,4 +54,28 @@ func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string
 		return nil
 	}
 	return shard.store.Bucket(swapFallbackName)
+}
+
+// resolveScopedDoubleWriteBucket is the shared prologue every strategy's
+// double-write callback runs: scope filter, then swap-window-aware resolution
+// via [resolveDoubleWriteBucket]. forTargetStrategy=false is the backup-phase
+// callback (skip on a tidied sidecar); true resolves the canonical name via
+// sourceBucketName across the swap window. skip=true means the callback must
+// no-op — the prop is out of scope, or the backup sidecar was already tidied.
+// bucketName is returned for error context. Callers keep only their
+// strategy-specific index guard.
+func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
+	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
+	forTargetStrategy bool,
+) (bucket *lsmkv.Bucket, bucketName string, skip bool) {
+	if _, ok := propsByName[property.Name]; !ok {
+		return nil, "", true
+	}
+	bucketName = bucketNamer(property.Name)
+	var swapFallback string
+	if forTargetStrategy {
+		swapFallback = sourceBucketName(property.Name)
+	}
+	bucket = resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+	return bucket, bucketName, bucket == nil
 }

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -16,36 +16,16 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
-// resolveDoubleWriteBucket resolves the bucket a runtime-reindex double-write
-// callback should mirror into. Every strategy MakeAddCallback/MakeDeleteCallback
-// MUST use this instead of a bare store.Bucket(sidecarName) lookup.
+// resolveDoubleWriteBucket resolves the bucket a double-write callback should
+// mirror into. Callers MUST use this instead of a bare store.Bucket(sidecarName)
+// lookup: callbacks stay armed until disableCallbacks runs at the end of
+// runtimeSwap, but SwapBucketPointer deletes the sidecar-name entry at the
+// flip, so a bare lookup can resolve nil and panic (weaviate/weaviate#11688).
 //
-// Why: the double-write callbacks stay registered across the swap —
-// [ShardReindexTaskGeneric.disableCallbacks] runs in a defer at the END of
-// runtimeSwap, after the per-prop pointer flips. [lsmkv.Store.SwapBucketPointer]
-// re-registers the ingest bucket under the canonical (main) name and DELETES
-// its sidecar-name entry (store.go: `delete(s.bucketsByName, sourceName)`), so
-// from the flip until the callbacks disable, store.Bucket(ingestName) is nil.
-// Pre-fix every strategy dereferenced that nil (lsmkv.MustBeExpectedStrategy on
-// b.Strategy()): the write goroutine panicked, the REST panic middleware
-// recovered without writing a response (client sees an empty 200), and the
-// inverted writes of that call were silently lost while the objects bucket kept
-// the new value. On this branch the inline callback is suppressed for scope
-// props, so the write depends ENTIRELY on this resolution — skipping = loss.
-// One of the loss mechanisms behind weaviate/weaviate#11688.
-//
-// Resolution semantics:
-//   - sidecar resolves (common case, pre-swap): mirror into it. If the flip
-//     lands right after this lookup, the returned *Bucket IS the bucket that
-//     just became main — writing through it is still correct.
-//   - sidecar gone + swapFallbackName given (ingest-phase callbacks): resolve
-//     the canonical main name, which post-flip denotes the same physical bucket
-//     and is never unregistered. Also closes the sub-window where the direct
-//     leg resolved main pre-flip (old, discarded bucket) and the mirror leg
-//     resolved the sidecar post-flip.
-//   - sidecar gone + no fallback (backup-phase callbacks): return nil — the
-//     backup is tidied, rollback is impossible, and the canonical bucket
-//     already gets direct writes. Callers MUST treat nil as "skip the mirror".
+//   - sidecar resolves (pre-swap): mirror into it.
+//   - sidecar gone + swapFallbackName set (ingest phase): resolve the
+//     canonical name instead — post-flip it denotes the same physical bucket.
+//   - sidecar gone + no fallback (backup phase): nil means skip the mirror.
 func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string) *lsmkv.Bucket {
 	if b := shard.store.Bucket(sidecarName); b != nil {
 		return b
@@ -56,14 +36,10 @@ func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string
 	return shard.store.Bucket(swapFallbackName)
 }
 
-// resolveScopedDoubleWriteBucket is the shared prologue every strategy's
-// double-write callback runs: scope filter, then swap-window-aware resolution
-// via [resolveDoubleWriteBucket]. forTargetStrategy=false is the backup-phase
-// callback (skip on a tidied sidecar); true resolves the canonical name via
-// sourceBucketName across the swap window. skip=true means the callback must
-// no-op — the prop is out of scope, or the backup sidecar was already tidied.
-// bucketName is returned for error context. Callers keep only their
-// strategy-specific index guard.
+// resolveScopedDoubleWriteBucket is the shared prologue for every strategy's
+// double-write callback: scope-filters the property, then resolves the bucket
+// via [resolveDoubleWriteBucket] (forTargetStrategy arms the swap fallback).
+// skip=true means the callback must no-op.
 func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
 	forTargetStrategy bool,

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -1,0 +1,54 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import "github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+
+// resolveDoubleWriteBucket resolves the bucket a runtime-reindex double-write
+// callback should mirror into. Every strategy MakeAddCallback/MakeDeleteCallback
+// MUST use this instead of a bare store.Bucket(sidecarName) lookup.
+//
+// Why: the double-write callbacks stay registered across the swap —
+// [ShardReindexTaskGeneric.disableCallbacks] runs in a defer at the END of
+// runtimeSwap, after the per-prop pointer flips. [lsmkv.Store.SwapBucketPointer]
+// re-registers the ingest bucket under the canonical (main) name and DELETES
+// its sidecar-name entry (store.go: `delete(s.bucketsByName, sourceName)`), so
+// from the flip until the callbacks disable, store.Bucket(ingestName) is nil.
+// Pre-fix every strategy dereferenced that nil (lsmkv.MustBeExpectedStrategy on
+// b.Strategy()): the write goroutine panicked, the REST panic middleware
+// recovered without writing a response (client sees an empty 200), and the
+// inverted writes of that call were silently lost while the objects bucket kept
+// the new value. On this branch the inline callback is suppressed for scope
+// props, so the write depends ENTIRELY on this resolution — skipping = loss.
+// One of the loss mechanisms behind weaviate/weaviate#11688.
+//
+// Resolution semantics:
+//   - sidecar resolves (common case, pre-swap): mirror into it. If the flip
+//     lands right after this lookup, the returned *Bucket IS the bucket that
+//     just became main — writing through it is still correct.
+//   - sidecar gone + swapFallbackName given (ingest-phase callbacks): resolve
+//     the canonical main name, which post-flip denotes the same physical bucket
+//     and is never unregistered. Also closes the sub-window where the direct
+//     leg resolved main pre-flip (old, discarded bucket) and the mirror leg
+//     resolved the sidecar post-flip.
+//   - sidecar gone + no fallback (backup-phase callbacks): return nil — the
+//     backup is tidied, rollback is impossible, and the canonical bucket
+//     already gets direct writes. Callers MUST treat nil as "skip the mirror".
+func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string) *lsmkv.Bucket {
+	if b := shard.store.Bucket(sidecarName); b != nil {
+		return b
+	}
+	if swapFallbackName == "" {
+		return nil
+	}
+	return shard.store.Bucket(swapFallbackName)
+}

--- a/adapters/repos/db/inverted_reindex_strategy_blockmax.go
+++ b/adapters/repos/db/inverted_reindex_strategy_blockmax.go
@@ -99,7 +99,16 @@ func (s *MapToBlockmaxStrategy) MakeAddCallback(bucketNamer func(string) string,
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		propLen := calcPropLen(property.Items)
 		for _, item := range property.Items {
 			pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
@@ -123,7 +132,16 @@ func (s *MapToBlockmaxStrategy) MakeDeleteCallback(bucketNamer func(string) stri
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
 				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)

--- a/adapters/repos/db/inverted_reindex_strategy_blockmax.go
+++ b/adapters/repos/db/inverted_reindex_strategy_blockmax.go
@@ -94,19 +94,9 @@ func (s *MapToBlockmaxStrategy) MakeAddCallback(bucketNamer func(string) string,
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		propLen := calcPropLen(property.Items)
@@ -127,19 +117,9 @@ func (s *MapToBlockmaxStrategy) MakeDeleteCallback(bucketNamer func(string) stri
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {

--- a/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
@@ -101,7 +101,16 @@ func (s *EnableFilterableStrategy) MakeAddCallback(bucketNamer func(string) stri
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.addToPropertySetBucket(bucket, docID, item.Data); err != nil {
 				return fmt.Errorf("adding prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
@@ -120,7 +129,16 @@ func (s *EnableFilterableStrategy) MakeDeleteCallback(bucketNamer func(string) s
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.deleteFromPropertySetBucket(bucket, docID, item.Data); err != nil {
 				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)

--- a/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
@@ -96,19 +96,9 @@ func (s *EnableFilterableStrategy) MakeAddCallback(bucketNamer func(string) stri
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		// Don't gate on HasFilterableIndex — it's false on the target
 		// property until OnMigrationComplete flips it.
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {
@@ -124,19 +114,9 @@ func (s *EnableFilterableStrategy) MakeDeleteCallback(bucketNamer func(string) s
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {

--- a/adapters/repos/db/inverted_reindex_strategy_enable_searchable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_searchable.go
@@ -86,13 +86,21 @@ func (s *EnableSearchableStrategy) ShouldProcessProperty(property *inverted.Prop
 func (s *EnableSearchableStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {
-	return blockmaxSearchableAddCallback(bucketNamer, propsByName)
+	var swapFallbackNamer func(string) string
+	if forTargetStrategy {
+		swapFallbackNamer = s.SourceBucketName
+	}
+	return blockmaxSearchableAddCallback(bucketNamer, propsByName, swapFallbackNamer)
 }
 
 func (s *EnableSearchableStrategy) MakeDeleteCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onDeleteFromPropertyValueIndex {
-	return blockmaxSearchableDeleteCallback(bucketNamer, propsByName)
+	var swapFallbackNamer func(string) string
+	if forTargetStrategy {
+		swapFallbackNamer = s.SourceBucketName
+	}
+	return blockmaxSearchableDeleteCallback(bucketNamer, propsByName, swapFallbackNamer)
 }
 
 // PreReindexHook creates empty blockmax searchable buckets for the targeted

--- a/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
@@ -112,7 +112,16 @@ func (s *FilterableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 
 		var items []inverted.Countable
 		if forTargetStrategy && len(property.RawValues) > 0 {
@@ -150,7 +159,16 @@ func (s *FilterableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 
 		var items []inverted.Countable
 		if forTargetStrategy && len(property.RawValues) > 0 {

--- a/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
@@ -107,19 +107,9 @@ func (s *FilterableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 
@@ -154,19 +144,9 @@ func (s *FilterableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 

--- a/adapters/repos/db/inverted_reindex_strategy_rangeable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rangeable.go
@@ -126,7 +126,16 @@ func (s *FilterableToRangeableStrategy) MakeAddCallback(bucketNamer func(string)
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.addToPropertyRangeBucket(bucket, docID, item.Data); err != nil {
 				return fmt.Errorf("adding rangeable prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
@@ -146,7 +155,16 @@ func (s *FilterableToRangeableStrategy) MakeDeleteCallback(bucketNamer func(stri
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.deleteFromPropertyRangeBucket(bucket, docID, item.Data); err != nil {
 				return fmt.Errorf("deleting rangeable prop '%s' from bucket '%s': %w", item.Data, bucketName, err)

--- a/adapters/repos/db/inverted_reindex_strategy_rangeable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rangeable.go
@@ -121,19 +121,9 @@ func (s *FilterableToRangeableStrategy) MakeAddCallback(bucketNamer func(string)
 		// IndexFilterable=false, and we still need to populate the
 		// rangeable bucket from the live write. Scope is enforced via
 		// propsByName.
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {
@@ -150,19 +140,9 @@ func (s *FilterableToRangeableStrategy) MakeDeleteCallback(bucketNamer func(stri
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		// Don't gate on HasFilterableIndex — see MakeAddCallback.
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {

--- a/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
@@ -67,15 +67,23 @@ func (s *RebuildSearchableStrategy) WriteToReindexBucket(shard ShardLike, bucket
 func (s *RebuildSearchableStrategy) ShouldProcessProperty(_ *inverted.Property) bool { return true }
 
 func (s *RebuildSearchableStrategy) MakeAddCallback(bucketNamer func(string) string,
-	propsByName map[string]struct{}, _ bool,
+	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {
-	return blockmaxSearchableAddCallback(bucketNamer, propsByName)
+	var swapFallbackNamer func(string) string
+	if forTargetStrategy {
+		swapFallbackNamer = s.SourceBucketName
+	}
+	return blockmaxSearchableAddCallback(bucketNamer, propsByName, swapFallbackNamer)
 }
 
 func (s *RebuildSearchableStrategy) MakeDeleteCallback(bucketNamer func(string) string,
-	propsByName map[string]struct{}, _ bool,
+	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onDeleteFromPropertyValueIndex {
-	return blockmaxSearchableDeleteCallback(bucketNamer, propsByName)
+	var swapFallbackNamer func(string) string
+	if forTargetStrategy {
+		swapFallbackNamer = s.SourceBucketName
+	}
+	return blockmaxSearchableDeleteCallback(bucketNamer, propsByName, swapFallbackNamer)
 }
 
 // PreReindexHook is a no-op — the target BlockMax bucket already exists

--- a/adapters/repos/db/inverted_reindex_strategy_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_retokenize.go
@@ -122,7 +122,16 @@ func (s *SearchableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 
 		var items []inverted.Countable
 		if forTargetStrategy && len(property.RawValues) > 0 {
@@ -164,7 +173,16 @@ func (s *SearchableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 
 		var items []inverted.Countable
 		if forTargetStrategy && len(property.RawValues) > 0 {

--- a/adapters/repos/db/inverted_reindex_strategy_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_retokenize.go
@@ -117,19 +117,9 @@ func (s *SearchableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 
@@ -168,19 +158,9 @@ func (s *SearchableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 

--- a/adapters/repos/db/inverted_reindex_strategy_roaringset.go
+++ b/adapters/repos/db/inverted_reindex_strategy_roaringset.go
@@ -92,7 +92,16 @@ func (s *RoaringSetRefreshStrategy) MakeAddCallback(bucketNamer func(string) str
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.addToPropertySetBucket(bucket, docID, item.Data); err != nil {
 				return fmt.Errorf("adding prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
@@ -114,7 +123,16 @@ func (s *RoaringSetRefreshStrategy) MakeDeleteCallback(bucketNamer func(string) 
 		}
 
 		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
+		var swapFallback string
+		if forTargetStrategy {
+			swapFallback = s.SourceBucketName(property.Name)
+		}
+		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
+		if bucket == nil {
+			// Backup sidecar already tidied — skip the mirror write. See
+			// resolveDoubleWriteBucket for the post-swap nil semantics.
+			return nil
+		}
 		for _, item := range property.Items {
 			if err := shard.deleteFromPropertySetBucket(bucket, docID, item.Data); err != nil {
 				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)

--- a/adapters/repos/db/inverted_reindex_strategy_roaringset.go
+++ b/adapters/repos/db/inverted_reindex_strategy_roaringset.go
@@ -87,19 +87,9 @@ func (s *RoaringSetRefreshStrategy) MakeAddCallback(bucketNamer func(string) str
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {
@@ -118,19 +108,9 @@ func (s *RoaringSetRefreshStrategy) MakeDeleteCallback(bucketNamer func(string) 
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		var swapFallback string
-		if forTargetStrategy {
-			swapFallback = s.SourceBucketName(property.Name)
-		}
-		bucket := resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-		if bucket == nil {
-			// Backup sidecar already tidied — skip the mirror write. See
-			// resolveDoubleWriteBucket for the post-swap nil semantics.
+		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if skip {
 			return nil
 		}
 		for _, item := range property.Items {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2544,11 +2544,9 @@ func (t *ShardReindexTaskGeneric) registerDoubleWriteCallbacks(shard *Shard, pro
 
 	var disable func()
 	if forTargetStrategy {
-		// Ingest window only: arm the migration double-write scope together
-		// with the callbacks in one atomic store, so a concurrent write to
-		// these props is analyzed under the TARGET schema (via the overlay +
-		// RawValues) instead of being source-tokenized into the ingest bucket.
-		// weaviate/0-weaviate-issues#298.
+		// Ingest window: arm the scope atomically with the callbacks, or a
+		// concurrent write gets source-tokenized into the ingest bucket
+		// (weaviate/0-weaviate-issues#298).
 		disable = shard.registerDoubleWriteWithScope(addCb, delCb, props, t.strategy.AnalyzerOverlay(props))
 	} else {
 		// Backup window: mirror source-analyzed writes as-is; no scope.

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -222,6 +222,13 @@ type ShardReindexTaskGeneric struct {
 	// drop()-vs-MkdirAll race deterministic. Always set — no test-only
 	// branch runs in production.
 	trackerMkdirGuard func(shard ShardLike) func(func() error) error
+
+	// TEST-ONLY: fires in [onAfterLsmInitWithTracker] right before the ingest
+	// double-write callbacks are registered (and before reindexStarted is
+	// captured) — the exact spot where the pre-fix ordering lost a concurrent
+	// write (weaviate/weaviate#11688). Tests inject writes here to make the
+	// markStarted→register race deterministic. Nil in production.
+	onBeforeDoubleWriteRegistration func()
 }
 
 // NewShardReindexTaskGeneric creates a new generic reindex task.
@@ -1134,12 +1141,10 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 		return nil
 	}
 
-	if !isStarted {
-		if err = rt.markStarted(time.Now()); err != nil {
-			err = fmt.Errorf("marking reindex started: %w", err)
-			return err
-		}
-	}
+	// markStarted is intentionally deferred to after the ingest double-write
+	// callbacks are registered — see the markStarted call at the end of this
+	// function. Capturing reindexStarted here (the pre-fix ordering) lost live
+	// writes in the register gap (weaviate/weaviate#11688).
 
 	// Torn-state recovery: if rt.IsReindexed() is true but the reindex
 	// bucket dirs that markReindexed() must have populated are missing on
@@ -1226,7 +1231,30 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 			err = fmt.Errorf("starting ingest buckets:%w", err)
 			return err
 		}
-		t.registerDoubleWriteCallbacks(shard, props, t.ingestBucketName, true)
+		if t.onBeforeDoubleWriteRegistration != nil {
+			t.onBeforeDoubleWriteRegistration()
+		}
+		disableJustRegistered := t.registerDoubleWriteCallbacks(shard, props, t.ingestBucketName, true)
+
+		// Capture reindexStarted only now, after the callbacks are live, so
+		// every write the iterator skips (LastUpdateTimeUnix >= reindexStarted)
+		// was mirrored into ingest — no skipped-and-unmirrored gap. Ceiled up
+		// one ms because LastUpdateTimeUnix has ms resolution and the predicate
+		// is `<`; else a write sharing the truncated ms could be skipped yet
+		// land before registration. Overlap writes (after registration, before
+		// reindexStarted) are both mirrored and backfilled; they converge since
+		// reindex segments precede ingest in merge order and writes are per-key
+		// idempotent.
+		if !isStarted {
+			startedAt := time.Now().Truncate(time.Millisecond).Add(time.Millisecond)
+			if err = rt.markStarted(startedAt); err != nil {
+				// Disable only the pair registered above; the task may hold
+				// live registrations for other shards.
+				disableJustRegistered()
+				err = fmt.Errorf("marking reindex started: %w", err)
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -2531,9 +2559,14 @@ func dirExists(path string) bool {
 	return err == nil && info.IsDir()
 }
 
+// registerDoubleWriteCallbacks arms the strategy's add/delete mirror
+// callbacks and stores their disable func for the eventual [disableCallbacks].
+// The returned func disables ONLY the pair registered by this call (each
+// disable is idempotent), for failure paths that must not touch registrations
+// the same task made for other shards.
 func (t *ShardReindexTaskGeneric) registerDoubleWriteCallbacks(shard *Shard, props []string,
 	bucketNamer func(string) string, forTargetStrategy bool,
-) {
+) func() {
 	propsByName := map[string]struct{}{}
 	for i := range props {
 		propsByName[props[i]] = struct{}{}
@@ -2558,6 +2591,8 @@ func (t *ShardReindexTaskGeneric) registerDoubleWriteCallbacks(shard *Shard, pro
 	t.callbackDisableFuncsMu.Lock()
 	t.callbackDisableFuncs = append(t.callbackDisableFuncs, disable)
 	t.callbackDisableFuncsMu.Unlock()
+
+	return disable
 }
 
 // disableCallbacks calls all stored callback disable functions collected

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -198,6 +198,15 @@ type ShardReindexTaskGeneric struct {
 	// method; tests substitute a wrapper.
 	processOneTidyPropFn func(propIdx int, propName, lsmPath string) error
 
+	// registerDoubleWriteCallbacksFn dispatches OnAfterLsmInit's ingest-window
+	// double-write registration. Defaults to [registerDoubleWriteCallbacks] in
+	// [NewShardReindexTaskGeneric]; tests wrap it to drive a write into the
+	// markStarted→register window the production ordering must not lose
+	// (weaviate/weaviate#11688). Always set — no test-only branch runs in
+	// production.
+	registerDoubleWriteCallbacksFn func(shard *Shard, props []string,
+		bucketNamer func(string) string, forTargetStrategy bool) func()
+
 	// onPropSwapped runs inside the Phase 2a tight loop right after each
 	// bucket-pointer flip, so a query never observes overlay≠bucket for
 	// longer than one in-memory map write. Runs on the swap goroutine, so
@@ -222,11 +231,6 @@ type ShardReindexTaskGeneric struct {
 	// drop()-vs-MkdirAll race deterministic. Always set — no test-only
 	// branch runs in production.
 	trackerMkdirGuard func(shard ShardLike) func(func() error) error
-
-	// TEST-ONLY: fires right before the ingest double-write callbacks
-	// register, letting tests inject a write into the markStarted→register
-	// gap (weaviate/weaviate#11688). Nil in production.
-	onBeforeDoubleWriteRegistration func()
 }
 
 // NewShardReindexTaskGeneric creates a new generic reindex task.
@@ -259,6 +263,7 @@ func NewShardReindexTaskGeneric(name string, logger logrus.FieldLogger,
 	t.trackerMkdirGuard = func(shard ShardLike) func(func() error) error {
 		return shard.Index().withCloseRLockGuard
 	}
+	t.registerDoubleWriteCallbacksFn = t.registerDoubleWriteCallbacks
 	return t
 }
 
@@ -1228,10 +1233,7 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 			err = fmt.Errorf("starting ingest buckets:%w", err)
 			return err
 		}
-		if t.onBeforeDoubleWriteRegistration != nil {
-			t.onBeforeDoubleWriteRegistration()
-		}
-		disableJustRegistered := t.registerDoubleWriteCallbacks(shard, props, t.ingestBucketName, true)
+		disableJustRegistered := t.registerDoubleWriteCallbacksFn(shard, props, t.ingestBucketName, true)
 
 		// Captured only after callbacks are live, so every write the iterator
 		// skips (LastUpdateTimeUnix >= reindexStarted) is guaranteed mirrored

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -223,11 +223,9 @@ type ShardReindexTaskGeneric struct {
 	// branch runs in production.
 	trackerMkdirGuard func(shard ShardLike) func(func() error) error
 
-	// TEST-ONLY: fires in [onAfterLsmInitWithTracker] right before the ingest
-	// double-write callbacks are registered (and before reindexStarted is
-	// captured) — the exact spot where the pre-fix ordering lost a concurrent
-	// write (weaviate/weaviate#11688). Tests inject writes here to make the
-	// markStarted→register race deterministic. Nil in production.
+	// TEST-ONLY: fires right before the ingest double-write callbacks
+	// register, letting tests inject a write into the markStarted→register
+	// gap (weaviate/weaviate#11688). Nil in production.
 	onBeforeDoubleWriteRegistration func()
 }
 
@@ -1141,10 +1139,9 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 		return nil
 	}
 
-	// markStarted is intentionally deferred to after the ingest double-write
-	// callbacks are registered — see the markStarted call at the end of this
-	// function. Capturing reindexStarted here (the pre-fix ordering) lost live
-	// writes in the register gap (weaviate/weaviate#11688).
+	// markStarted is deferred until after the double-write callbacks are
+	// registered below — capturing it earlier opens a lost-write gap
+	// (weaviate/weaviate#11688).
 
 	// Torn-state recovery: if rt.IsReindexed() is true but the reindex
 	// bucket dirs that markReindexed() must have populated are missing on
@@ -1236,15 +1233,13 @@ func (t *ShardReindexTaskGeneric) onAfterLsmInitWithTracker(ctx context.Context,
 		}
 		disableJustRegistered := t.registerDoubleWriteCallbacks(shard, props, t.ingestBucketName, true)
 
-		// Capture reindexStarted only now, after the callbacks are live, so
-		// every write the iterator skips (LastUpdateTimeUnix >= reindexStarted)
-		// was mirrored into ingest — no skipped-and-unmirrored gap. Ceiled up
-		// one ms because LastUpdateTimeUnix has ms resolution and the predicate
-		// is `<`; else a write sharing the truncated ms could be skipped yet
-		// land before registration. Overlap writes (after registration, before
-		// reindexStarted) are both mirrored and backfilled; they converge since
-		// reindex segments precede ingest in merge order and writes are per-key
-		// idempotent.
+		// Captured only after callbacks are live, so every write the iterator
+		// skips (LastUpdateTimeUnix >= reindexStarted) is guaranteed mirrored
+		// into ingest. Ceiled up one ms: LastUpdateTimeUnix has ms resolution
+		// and the skip predicate is `<`, so a write sharing the truncated ms
+		// could otherwise land before registration. Overlap writes converge
+		// because reindex segments precede ingest in merge order and writes
+		// are per-key idempotent.
 		if !isStarted {
 			startedAt := time.Now().Truncate(time.Millisecond).Add(time.Millisecond)
 			if err = rt.markStarted(startedAt); err != nil {
@@ -1786,13 +1781,11 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	// Always disable the double-write callbacks registered by this task
 	// instance, regardless of whether the swap completes successfully.
 	//
-	// On the happy path this runs after the in-memory pointer flip. The
-	// callbacks stay armed until this defer, so a live write between
-	// SwapBucketPointer and here still fires them. SwapBucketPointer deletes
-	// the ingest-name entry, so each callback resolves its bucket via
-	// [resolveDoubleWriteBucket] and falls back to the canonical main name —
-	// which now denotes the same physical bucket — landing the mirror write
-	// in the surviving bucket instead of dereferencing a nil one.
+	// On the happy path this runs after the in-memory pointer flip. Callbacks
+	// stay armed until this defer, so a live write in between still fires
+	// them; [resolveDoubleWriteBucket] falls back to the canonical name once
+	// SwapBucketPointer deletes the ingest-name entry, landing the mirror
+	// write in the surviving bucket instead of dereferencing nil.
 	//
 	// On an error path this is the load-bearing case: without it,
 	// callbacks would keep firing against buckets that may be mid-swap,
@@ -2561,11 +2554,10 @@ func dirExists(path string) bool {
 	return err == nil && info.IsDir()
 }
 
-// registerDoubleWriteCallbacks arms the strategy's add/delete mirror
-// callbacks and stores their disable func for the eventual [disableCallbacks].
-// The returned func disables ONLY the pair registered by this call (each
-// disable is idempotent), for failure paths that must not touch registrations
-// the same task made for other shards.
+// registerDoubleWriteCallbacks arms the strategy's add/delete mirror callbacks
+// for [disableCallbacks]. The returned func disables only this call's pair
+// (idempotent), for failure paths that must not touch other shards'
+// registrations.
 func (t *ShardReindexTaskGeneric) registerDoubleWriteCallbacks(shard *Shard, props []string,
 	bucketNamer func(string) string, forTargetStrategy bool,
 ) func() {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1786,11 +1786,13 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	// Always disable the double-write callbacks registered by this task
 	// instance, regardless of whether the swap completes successfully.
 	//
-	// On the happy path this runs after the in-memory pointer flip:
-	// the main bucket pointer has already been swapped, so any callback
-	// invocations between markSwappedProp and this defer would have been
-	// harmless redundant writes (the ingest bucket is reachable under
-	// both the main and ingest names).
+	// On the happy path this runs after the in-memory pointer flip. The
+	// callbacks stay armed until this defer, so a live write between
+	// SwapBucketPointer and here still fires them. SwapBucketPointer deletes
+	// the ingest-name entry, so each callback resolves its bucket via
+	// [resolveDoubleWriteBucket] and falls back to the canonical main name —
+	// which now denotes the same physical bucket — landing the mirror write
+	// in the surviving bucket instead of dereferencing a nil one.
 	//
 	// On an error path this is the load-bearing case: without it,
 	// callbacks would keep firing against buckets that may be mid-swap,

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2539,13 +2539,26 @@ func (t *ShardReindexTaskGeneric) registerDoubleWriteCallbacks(shard *Shard, pro
 		propsByName[props[i]] = struct{}{}
 	}
 
-	disableAdd := shard.registerAddToPropertyValueIndex(
-		t.strategy.MakeAddCallback(bucketNamer, propsByName, forTargetStrategy))
-	disableDelete := shard.registerDeleteFromPropertyValueIndex(
-		t.strategy.MakeDeleteCallback(bucketNamer, propsByName, forTargetStrategy))
+	addCb := t.strategy.MakeAddCallback(bucketNamer, propsByName, forTargetStrategy)
+	delCb := t.strategy.MakeDeleteCallback(bucketNamer, propsByName, forTargetStrategy)
+
+	var disable func()
+	if forTargetStrategy {
+		// Ingest window only: arm the migration double-write scope together
+		// with the callbacks in one atomic store, so a concurrent write to
+		// these props is analyzed under the TARGET schema (via the overlay +
+		// RawValues) instead of being source-tokenized into the ingest bucket.
+		// weaviate/0-weaviate-issues#298.
+		disable = shard.registerDoubleWriteWithScope(addCb, delCb, props, t.strategy.AnalyzerOverlay(props))
+	} else {
+		// Backup window: mirror source-analyzed writes as-is; no scope.
+		disableAdd := shard.registerAddToPropertyValueIndex(addCb)
+		disableDelete := shard.registerDeleteFromPropertyValueIndex(delCb)
+		disable = func() { disableAdd(); disableDelete() }
+	}
 
 	t.callbackDisableFuncsMu.Lock()
-	t.callbackDisableFuncs = append(t.callbackDisableFuncs, disableAdd, disableDelete)
+	t.callbackDisableFuncs = append(t.callbackDisableFuncs, disable)
 	t.callbackDisableFuncsMu.Unlock()
 }
 

--- a/adapters/repos/db/inverted_reindex_write_during_enable_rangeable_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_enable_rangeable_test.go
@@ -30,9 +30,8 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// newNoLiveIndexRangeableTestClass forces IndexFilterable false (and leaves
-// IndexRangeFilters nil), so the property has no live index and AnalyzeObject
-// skips it on ordinary writes — the case only the double-write can cover.
+// newNoLiveIndexRangeableTestClass forces IndexFilterable false, so the
+// property has no live index and only the double-write can cover it.
 func newNoLiveIndexRangeableTestClass(className string) *models.Class {
 	c := newFilterableToRangeableTestClass(className)
 	noIndex := false
@@ -63,9 +62,8 @@ func readRangeableIDs(t *testing.T, b *lsmkv.Bucket, v int64) []uint64 {
 }
 
 // TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost pins
-// weaviate/0-weaviate-issues#298: a write during the enable-rangeable window
-// targets a property with no live index, so only the migration double-write
-// (not ordinary AnalyzeObject) can make it survive the swap.
+// weaviate/0-weaviate-issues#298: a write to a no-live-index property during
+// an enable-rangeable migration must survive the swap via the double-write.
 func TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost(t *testing.T) {
 	ctx := testCtx()
 	const propName = filterableToRangeablePropName

--- a/adapters/repos/db/inverted_reindex_write_during_enable_rangeable_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_enable_rangeable_test.go
@@ -1,0 +1,135 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/filters"
+	entinverted "github.com/weaviate/weaviate/entities/inverted"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// newNoLiveIndexRangeableTestClass builds the FilterableToRangeable class with
+// the numeric property carrying NO live inverted index at all: IndexFilterable
+// forced false (the base builder leaves it nil → defaults true) and
+// IndexRangeFilters left nil → false. AnalyzeObject therefore skips the
+// property on ordinary writes, which is precisely the "absent input" case the
+// enable-rangeable double-write must cover.
+func newNoLiveIndexRangeableTestClass(className string) *models.Class {
+	c := newFilterableToRangeableTestClass(className)
+	noIndex := false
+	c.Properties[0].IndexFilterable = &noIndex
+	return c
+}
+
+// readRangeableIDs returns the docIDs stored under a single int64 value in a
+// RoaringSetRange bucket. Sibling of filterableToRangeableFingerprint, but for
+// one caller-chosen value (the concurrent write uses a value outside the 0..N
+// corpus so it can be queried in isolation).
+func readRangeableIDs(t *testing.T, b *lsmkv.Bucket, v int64) []uint64 {
+	t.Helper()
+	require.Equal(t, lsmkv.StrategyRoaringSetRange, b.Strategy(),
+		"readRangeableIDs requires a RoaringSetRange bucket")
+	reader := b.ReaderRoaringSetRange()
+	defer reader.Close()
+	lex, err := entinverted.LexicographicallySortableInt64(v)
+	require.NoError(t, err)
+	key := binary.BigEndian.Uint64(lex)
+	bm, release, err := reader.Read(context.Background(), key, filters.OperatorEqual)
+	require.NoError(t, err)
+	if release != nil {
+		defer release()
+	}
+	if bm == nil {
+		return nil
+	}
+	return bm.ToArray()
+}
+
+// TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost is the
+// enable-an-index shape of weaviate/0-weaviate-issues#298 (the retokenize
+// shapes live in inverted_reindex_write_during_finalize_test.go). The property
+// has NO live inverted index, so the ordinary write path's AnalyzeObject skips
+// it and the inline double-write has nothing to mirror — only the migration
+// pass, analyzing under the strategy's ForceRangeable overlay, makes the
+// property present and writes it to the new rangeable bucket.
+//
+// RED before the fix: with no migration double-write the concurrent value is
+// silently dropped and a range query misses it after the swap.
+//
+// Positive control: the iterator-backfilled corpus IS present in the same
+// bucket, proving the target-population path works and the concurrent write's
+// absence is specifically the enable-X double-write failing.
+func TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost(t *testing.T) {
+	ctx := testCtx()
+	const propName = filterableToRangeablePropName
+	const numObjects = 25
+	// Distinct from the 0..(filterableToRangeableNumDistinctValues-1) corpus so
+	// its posting list is unambiguously the concurrent write.
+	const concurrentValue = int64(4242)
+
+	className := "EnableRangeableConc_" + uuid.NewString()[:8]
+	class := newNoLiveIndexRangeableTestClass(className)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	for _, obj := range makeFilterableToRangeableTestObjects(t, numObjects, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+
+	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+
+	// Drive to reindexed-but-not-swapped: iterator done, double-write live.
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+
+	// Concurrent write in the FINALIZING window, value outside the corpus.
+	require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      className,
+			Properties: map[string]interface{}{propName: concurrentValue},
+		},
+	}))
+
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+
+	rangeBucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, rangeBucket, "post-swap rangeable bucket must exist")
+
+	// Positive control: the backfilled corpus reached the rangeable bucket.
+	require.NotEmptyf(t, readRangeableIDs(t, rangeBucket, 0),
+		"positive control: iterator-backfilled corpus (value 0) must be present in the rangeable bucket; "+
+			"got none — the migration never populated it and the assertion below would prove nothing")
+
+	// The concurrent write's value must survive the swap.
+	ids := readRangeableIDs(t, rangeBucket, concurrentValue)
+	assert.NotEmptyf(t, ids,
+		"#298 enable-rangeable: object written during the reindex window is NOT under the target rangeable value "+
+			"%d — its ForceRangeable double-write was lost, so a range query misses it after the swap", concurrentValue)
+}

--- a/adapters/repos/db/inverted_reindex_write_during_enable_rangeable_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_enable_rangeable_test.go
@@ -30,12 +30,9 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// newNoLiveIndexRangeableTestClass builds the FilterableToRangeable class with
-// the numeric property carrying NO live inverted index at all: IndexFilterable
-// forced false (the base builder leaves it nil → defaults true) and
-// IndexRangeFilters left nil → false. AnalyzeObject therefore skips the
-// property on ordinary writes, which is precisely the "absent input" case the
-// enable-rangeable double-write must cover.
+// newNoLiveIndexRangeableTestClass forces IndexFilterable false (and leaves
+// IndexRangeFilters nil), so the property has no live index and AnalyzeObject
+// skips it on ordinary writes — the case only the double-write can cover.
 func newNoLiveIndexRangeableTestClass(className string) *models.Class {
 	c := newFilterableToRangeableTestClass(className)
 	noIndex := false
@@ -43,10 +40,8 @@ func newNoLiveIndexRangeableTestClass(className string) *models.Class {
 	return c
 }
 
-// readRangeableIDs returns the docIDs stored under a single int64 value in a
-// RoaringSetRange bucket. Sibling of filterableToRangeableFingerprint, but for
-// one caller-chosen value (the concurrent write uses a value outside the 0..N
-// corpus so it can be queried in isolation).
+// readRangeableIDs returns docIDs for one int64 value in a RoaringSetRange
+// bucket; sibling of filterableToRangeableFingerprint for a single value.
 func readRangeableIDs(t *testing.T, b *lsmkv.Bucket, v int64) []uint64 {
 	t.Helper()
 	require.Equal(t, lsmkv.StrategyRoaringSetRange, b.Strategy(),
@@ -67,26 +62,15 @@ func readRangeableIDs(t *testing.T, b *lsmkv.Bucket, v int64) []uint64 {
 	return bm.ToArray()
 }
 
-// TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost is the
-// enable-an-index shape of weaviate/0-weaviate-issues#298 (the retokenize
-// shapes live in inverted_reindex_write_during_finalize_test.go). The property
-// has NO live inverted index, so the ordinary write path's AnalyzeObject skips
-// it and the inline double-write has nothing to mirror — only the migration
-// pass, analyzing under the strategy's ForceRangeable overlay, makes the
-// property present and writes it to the new rangeable bucket.
-//
-// RED before the fix: with no migration double-write the concurrent value is
-// silently dropped and a range query misses it after the swap.
-//
-// Positive control: the iterator-backfilled corpus IS present in the same
-// bucket, proving the target-population path works and the concurrent write's
-// absence is specifically the enable-X double-write failing.
+// TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost pins
+// weaviate/0-weaviate-issues#298: a write during the enable-rangeable window
+// targets a property with no live index, so only the migration double-write
+// (not ordinary AnalyzeObject) can make it survive the swap.
 func TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost(t *testing.T) {
 	ctx := testCtx()
 	const propName = filterableToRangeablePropName
 	const numObjects = 25
-	// Distinct from the 0..(filterableToRangeableNumDistinctValues-1) corpus so
-	// its posting list is unambiguously the concurrent write.
+	// Outside the corpus so its posting list is unambiguously this write.
 	const concurrentValue = int64(4242)
 
 	className := "EnableRangeableConc_" + uuid.NewString()[:8]
@@ -106,7 +90,7 @@ func TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost(t *testing.T) {
 	// Drive to reindexed-but-not-swapped: iterator done, double-write live.
 	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
 
-	// Concurrent write in the FINALIZING window, value outside the corpus.
+	// The concurrent write: lands in the FINALIZING window, before swap.
 	require.NoError(t, shard.PutObject(ctx, &storobj.Object{
 		MarshallerVersion: 1,
 		Object: models.Object{
@@ -122,12 +106,10 @@ func TestReindex_ConcurrentWriteDuringEnableRangeable_NotLost(t *testing.T) {
 	rangeBucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
 	require.NotNil(t, rangeBucket, "post-swap rangeable bucket must exist")
 
-	// Positive control: the backfilled corpus reached the rangeable bucket.
 	require.NotEmptyf(t, readRangeableIDs(t, rangeBucket, 0),
 		"positive control: iterator-backfilled corpus (value 0) must be present in the rangeable bucket; "+
 			"got none — the migration never populated it and the assertion below would prove nothing")
 
-	// The concurrent write's value must survive the swap.
 	ids := readRangeableIDs(t, rangeBucket, concurrentValue)
 	assert.NotEmptyf(t, ids,
 		"#298 enable-rangeable: object written during the reindex window is NOT under the target rangeable value "+

--- a/adapters/repos/db/inverted_reindex_write_during_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_finalize_test.go
@@ -1,0 +1,331 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// objWithIDText builds a test object with a caller-controlled UUID so a later
+// PutObject with the same ID is an update (delete-old + add-new), not a fresh
+// insert.
+func objWithIDText(className, id, text string) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(id),
+			Class:      className,
+			Properties: map[string]interface{}{"title": text},
+		},
+	}
+}
+
+// TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized answers the
+// concurrent-write convergence question from
+// weaviate/0-weaviate-issues#298 for a WORD→FIELD SearchableRetokenize.
+//
+// RED on this commit — and NOT the data-loss failure #298 predicted.
+//
+// An object written while the migration is reindexed-but-not-swapped DOES
+// reach the post-swap bucket (no data loss), but it is indexed with the
+// SOURCE (WORD) tokenization instead of the TARGET (FIELD) tokenization the
+// migration exists to produce. Once the migration finishes and the schema
+// flips to FIELD, that object is queryable only under its WORD terms, never
+// under the FIELD whole-phrase term → silent wrong results for any write
+// that overlaps a retokenize migration.
+//
+// Root cause (traced in code, not inferred from the number):
+// SearchableRetokenizeStrategy.MakeAddCallback re-tokenizes to the target
+// ONLY when property.RawValues is populated, else it falls back to the
+// source-tokenized property.Items. RawValues is captured solely by
+// Shard.AnalyzeObjectForMigrationWithOverlay (the iterator's backfill scan);
+// the normal write path (PutObject → AnalyzeObject) never populates it, so
+// the double-write of a concurrent object silently uses the old tokenization.
+// FilterableRetokenizeStrategy carries the identical RawValues guard.
+//
+// Built-in positive control: the iterator-reindexed corpus IS correctly
+// FIELD-tokenized in the same bucket (multi-word phrase terms), proving the
+// target tokenization path works when RawValues is present. So the
+// concurrent write's WORD form is specifically the double-write path
+// failing, not a harness artifact or a broken swap.
+func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T) {
+	ctx := testCtx()
+	const propName = "title"
+	const numObjects = 25
+
+	className := "ConcurrentRetok_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{propName})
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	// Existing corpus: 3-word phrases from the 25-token dictionary. Under the
+	// FIELD target each phrase collapses to a single whole-value term; the
+	// tokens do not collide with the unique mid-window tokens below.
+	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+
+	searchBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
+	preStrategy := shard.store.Bucket(searchBucketName).Strategy()
+
+	task, _ := newSearchableRetokenizeTask(t, idx, className, propName,
+		models.PropertyTokenizationField, preStrategy)
+
+	// Drive to reindexed-but-not-swapped: iterator done, double-write live.
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+
+	// Concurrent write in the FINALIZING window. Under the FIELD target these
+	// two words must collapse to the single term "midalpha midbeta"; under
+	// the source WORD tokenization they split into "midalpha" / "midbeta".
+	const midText = "midalpha midbeta"
+	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
+
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+
+	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
+
+	// Positive control: the reindexed corpus is FIELD-tokenized (phrase terms
+	// carry a space). If this is zero the premise is off and the assertions
+	// below prove nothing.
+	phraseTerms := 0
+	for term := range fp {
+		if strings.Contains(term, " ") {
+			phraseTerms++
+		}
+	}
+	require.Positivef(t, phraseTerms,
+		"positive control: iterator-reindexed corpus must be FIELD-tokenized (phrase terms); got none")
+
+	// The concurrent write must be TARGET (FIELD) tokenized: present under
+	// the whole-value term, absent as separate WORD terms.
+	fieldIDs, fieldOK := fp[midText] // FIELD tokenization = whole value, lowercased
+	assert.Truef(t, fieldOK && len(fieldIDs) > 0,
+		"#298 wrong-tokenization: object written during the retokenize window is NOT under the "+
+			"target FIELD term %q — it survived the swap but was SOURCE(WORD)-tokenized, so it is "+
+			"unqueryable under the migration's target tokenization", midText)
+
+	_, wordAlpha := fp["midalpha"]
+	_, wordBeta := fp["midbeta"]
+	assert.Falsef(t, wordAlpha || wordBeta,
+		"#298 wrong-tokenization: concurrent write is indexed under SOURCE(WORD) terms "+
+			"(midalpha=%v, midbeta=%v) in a FIELD-target bucket", wordAlpha, wordBeta)
+}
+
+// TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord is the
+// FIELD→WORD mirror — the direction the field↔word reindex soak actually
+// exercises. Same defect, and the more impactful shape: the concurrent write
+// keeps its SOURCE (FIELD) whole-value term, so after the flip a WORD
+// single-word query (the common case) misses it entirely.
+//
+// Confirms the "by symmetry" claim in the WORD→FIELD report empirically, so
+// the team can weigh whether this mechanism contributes to soak short-counts
+// (a concurrent writer overlapping the migration would leave objects
+// unqueryable under single-word terms).
+func TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord(t *testing.T) {
+	ctx := testCtx()
+	const propName = "title"
+	const numObjects = 25
+
+	className := "ConcurrentRetokRev_" + uuid.NewString()[:8]
+	// FIELD-source class (the shared helper hardcodes WORD).
+	class := newTestClassWithProps(className, []string{propName})
+	class.Properties[0].Tokenization = models.PropertyTokenizationField
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	// Under FIELD source each 3-word phrase is a single whole-value term.
+	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+
+	searchBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
+	preStrategy := shard.store.Bucket(searchBucketName).Strategy()
+
+	task, _ := newSearchableRetokenizeTask(t, idx, className, propName,
+		models.PropertyTokenizationWord, preStrategy)
+
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+
+	// Concurrent write in the window. Under the WORD target it must split into
+	// "revalpha" / "revbeta"; under the source FIELD it stays one whole term.
+	const midText = "revalpha revbeta"
+	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
+
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+
+	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
+
+	// Positive control: the iterator-reindexed corpus is WORD-tokenized
+	// (single-word dictionary tokens present, no spaces).
+	_, dictWord := fp["victor"]
+	require.Truef(t, dictWord,
+		"positive control: iterator-reindexed corpus must be WORD-tokenized (dictionary token 'victor' present); "+
+			"got terms without it — premise is off")
+
+	// The concurrent write must be TARGET (WORD) tokenized: present under the
+	// split single-word terms, absent under the whole-value FIELD term.
+	_, wordAlpha := fp["revalpha"]
+	_, wordBeta := fp["revbeta"]
+	assert.Truef(t, wordAlpha && wordBeta,
+		"#298 wrong-tokenization (FIELD→WORD): concurrent write is NOT under the target WORD terms "+
+			"revalpha/revbeta — a single-word query misses it (revalpha=%v, revbeta=%v)", wordAlpha, wordBeta)
+
+	fieldIDs, fieldTerm := fp[midText] // FIELD whole-value term
+	assert.Falsef(t, fieldTerm && len(fieldIDs) > 0,
+		"#298 wrong-tokenization (FIELD→WORD): concurrent write kept its SOURCE(FIELD) whole-value term %q "+
+			"in a WORD-target bucket", midText)
+}
+
+// TestReindex_ConcurrentWriteDuringRetokenize_Filterable proves the defect is
+// not searchable-specific: FilterableRetokenizeStrategy carries the identical
+// `RawValues > 0` guard in its own Add callback, so a concurrent write during
+// a WORD→FIELD filterable retokenize lands SOURCE(WORD)-tokenized in the
+// TARGET (RoaringSet) filterable bucket — a `where` filter on the field value
+// then misses it after the flip.
+func TestReindex_ConcurrentWriteDuringRetokenize_Filterable(t *testing.T) {
+	ctx := testCtx()
+	const propName = "title"
+	const numObjects = 25
+
+	className := "ConcurrentRetokFilt_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{propName})
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+
+	filtBucketName := helpers.BucketFromPropNameLSM(propName)
+
+	task, _ := newFilterableRetokenizeTask(t, idx, className, propName,
+		models.PropertyTokenizationField)
+
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+
+	const midText = "filtalpha filtbeta"
+	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
+
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+
+	fp := fingerprintRoaringSetBucket(t, shard.store.Bucket(filtBucketName))
+
+	// Positive control: iterator-reindexed corpus is FIELD-tokenized (phrase terms).
+	phraseTerms := 0
+	for term := range fp {
+		if strings.Contains(term, " ") {
+			phraseTerms++
+		}
+	}
+	require.Positivef(t, phraseTerms,
+		"positive control: iterator-reindexed filterable corpus must be FIELD-tokenized (phrase terms); got none")
+
+	fieldIDs, fieldOK := fp[midText]
+	assert.Truef(t, fieldOK && len(fieldIDs) > 0,
+		"#298 wrong-tokenization (filterable): concurrent write is NOT under the target FIELD term %q — "+
+			"a `where` filter on the field value misses it after the flip", midText)
+
+	_, wordAlpha := fp["filtalpha"]
+	_, wordBeta := fp["filtbeta"]
+	assert.Falsef(t, wordAlpha || wordBeta,
+		"#298 wrong-tokenization (filterable): concurrent write is under SOURCE(WORD) terms "+
+			"(filtalpha=%v, filtbeta=%v) in a FIELD-target filterable bucket", wordAlpha, wordBeta)
+}
+
+// TestReindex_UpdateDuringRetokenize_GhostAndLostValue pins the update variant,
+// which is strictly worse than the insert case. An object reindexed by the
+// iterator (so its OLD value is a FIELD phrase term in the ingest bucket) is
+// then UPDATED mid-window. The delete double-write callback re-tokenizes to
+// target only when RawValues is populated (it never is on the live path), so
+// it tries to delete the OLD value's SOURCE(WORD) terms — which are not in the
+// target bucket — leaving the iterator's FIELD phrase term for the OLD value
+// behind. The add callback writes the NEW value SOURCE(WORD)-tokenized. Net
+// post-swap state:
+//   - the object still matches its OLD (overwritten) value  → stale ghost
+//   - the object does NOT match its NEW (current) value      → current value lost
+//
+// Positive control: the iterator DID produce the OLD value's FIELD phrase term
+// (that is the ghost we observe), proving the target-tokenization path works
+// and the failure is specifically the update double-write.
+func TestReindex_UpdateDuringRetokenize_GhostAndLostValue(t *testing.T) {
+	ctx := testCtx()
+	const propName = "title"
+	const numObjects = 25
+	const oldValue = "ghostalpha ghostbeta"
+	const newValue = "ghostgamma ghostdelta"
+
+	className := "UpdateRetok_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{propName})
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+	// Tracked object X imported BEFORE the migration so the iterator reindexes
+	// its OLD value to the FIELD phrase term.
+	xID := uuid.NewString()
+	require.NoError(t, shard.PutObject(ctx, objWithIDText(className, xID, oldValue)))
+
+	searchBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
+	preStrategy := shard.store.Bucket(searchBucketName).Strategy()
+	task, _ := newSearchableRetokenizeTask(t, idx, className, propName,
+		models.PropertyTokenizationField, preStrategy)
+
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+
+	// Mid-window UPDATE of X (same ID) → delete-old + add-new double-write.
+	require.NoError(t, shard.PutObject(ctx, objWithIDText(className, xID, newValue)))
+
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+
+	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
+
+	// Current value must be queryable under the target FIELD phrase term.
+	newIDs, newOK := fp[newValue]
+	assert.Truef(t, newOK && len(newIDs) > 0,
+		"#298 update: object's CURRENT value %q is NOT under the target FIELD term — a search for its "+
+			"actual value misses it after the flip", newValue)
+
+	// Old value must be gone — the object was updated away from it.
+	oldIDs, oldOK := fp[oldValue]
+	assert.Falsef(t, oldOK && len(oldIDs) > 0,
+		"#298 update: object still matches its OLD (overwritten) value %q (stale ghost ids=%v) — the delete "+
+			"double-write could not remove the iterator's FIELD phrase term", oldValue, oldIDs)
+}

--- a/adapters/repos/db/inverted_reindex_write_during_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_finalize_test.go
@@ -26,8 +26,9 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// objWithIDText builds a test object with a caller-controlled UUID, so a
-// later PutObject with the same ID is an update, not a fresh insert.
+// objWithIDText builds a test object with a caller-controlled UUID so a later
+// PutObject with the same ID is an update (delete-old + add-new), not a fresh
+// insert.
 func objWithIDText(className, id, text string) *storobj.Object {
 	return &storobj.Object{
 		MarshallerVersion: 1,
@@ -39,54 +40,111 @@ func objWithIDText(className, id, text string) *storobj.Object {
 	}
 }
 
-// TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized pins
-// weaviate/0-weaviate-issues#298: a write racing a WORD→FIELD retokenize
-// survives the swap but keeps SOURCE tokenization instead of TARGET.
-func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T) {
+// retokenizeScenario declares one concurrent-write-during-retokenize journey
+// for weaviate/0-weaviate-issues#298. run() drives the shared lifecycle —
+// import a 25-phrase corpus, start the migration, inject one write in the
+// reindexed-but-not-swapped window, swap — and returns the post-swap bucket
+// fingerprint (term → docIDs). Each test supplies only its tokenization
+// direction and its assertions; the scaffold is here so the four journeys
+// don't repeat it.
+type retokenizeScenario struct {
+	// sourceTok overrides the corpus tokenization; "" leaves the class default
+	// (WORD). Set to FIELD for the reverse (FIELD→WORD) direction.
+	sourceTok string
+	// targetTok is the migration's target tokenization.
+	targetTok string
+	// filterable drives FilterableRetokenizeStrategy (RoaringSet bucket)
+	// instead of the searchable strategy.
+	filterable bool
+	// preImportText, if set, imports one tracked object (preImportID) BEFORE
+	// the migration so the iterator reindexes it — used by the update journey.
+	preImportID   string
+	preImportText string
+	// midText is the value written during the FINALIZING window. midID == ""
+	// makes it a fresh insert; a non-empty midID (matching preImportID) makes
+	// it an update of the tracked object.
+	midID   string
+	midText string
+}
+
+func (sc retokenizeScenario) run(t *testing.T) map[string][]uint64 {
+	t.Helper()
 	ctx := testCtx()
 	const propName = "title"
 	const numObjects = 25
 
-	className := "ConcurrentRetok_" + uuid.NewString()[:8]
+	className := "Retok_" + uuid.NewString()[:8]
 	class := newTestClassWithProps(className, []string{propName})
+	if sc.sourceTok != "" {
+		class.Properties[0].Tokenization = sc.sourceTok
+	}
 
 	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
 		false, false, false)
 	shard := shd.(*Shard)
-	defer shard.Shutdown(ctx)
+	// Cleanup (not defer): the shard must outlive the caller's assertions.
+	t.Cleanup(func() { shard.Shutdown(ctx) })
 
-	// Corpus is 3-word phrases; under FIELD they collapse to one term each
-	// and don't collide with the mid-window text below.
 	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
 		require.NoError(t, shard.PutObject(ctx, obj))
 	}
+	if sc.preImportText != "" {
+		require.NoError(t, shard.PutObject(ctx,
+			objWithIDText(className, sc.preImportID, sc.preImportText)))
+	}
 
-	searchBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
-	preStrategy := shard.store.Bucket(searchBucketName).Strategy()
-
-	task, _ := newSearchableRetokenizeTask(t, idx, className, propName,
-		models.PropertyTokenizationField, preStrategy)
+	var task *ShardReindexTaskGeneric
+	var bucketName string
+	if sc.filterable {
+		bucketName = helpers.BucketFromPropNameLSM(propName)
+		task, _ = newFilterableRetokenizeTask(t, idx, className, propName, sc.targetTok)
+	} else {
+		bucketName = helpers.BucketSearchableFromPropNameLSM(propName)
+		preStrategy := shard.store.Bucket(bucketName).Strategy()
+		task, _ = newSearchableRetokenizeTask(t, idx, className, propName, sc.targetTok, preStrategy)
+	}
 
 	// Drive to reindexed-but-not-swapped: iterator done, double-write live.
 	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
 
-	// Concurrent write in the FINALIZING window; FIELD collapses it to one
-	// term, WORD splits it in two.
-	const midText = "midalpha midbeta"
-	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
+	if sc.midID != "" {
+		require.NoError(t, shard.PutObject(ctx, objWithIDText(className, sc.midID, sc.midText)))
+	} else {
+		require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, sc.midText)))
+	}
 
 	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
 	require.NoError(t, task.RunSwapOnShard(ctx, shard))
 
-	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
+	if sc.filterable {
+		return fingerprintRoaringSetBucket(t, shard.store.Bucket(bucketName))
+	}
+	return fingerprintInvertedBucket(t, shard.store.Bucket(bucketName))
+}
 
-	phraseTerms := 0
+// countPhraseTerms is the positive control for a FIELD target: the
+// iterator-reindexed corpus must collapse each 3-word phrase to one
+// space-bearing term. Zero means the migration produced nothing and the
+// concurrent-write assertions below would prove nothing.
+func countPhraseTerms(fp map[string][]uint64) int {
+	n := 0
 	for term := range fp {
 		if strings.Contains(term, " ") {
-			phraseTerms++
+			n++
 		}
 	}
-	require.Positivef(t, phraseTerms,
+	return n
+}
+
+// TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized pins the core
+// weaviate/0-weaviate-issues#298 defect for the searchable WORD→FIELD case: a
+// write in the reindexed-but-not-swapped window survives the swap but keeps
+// SOURCE tokenization instead of TARGET.
+func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T) {
+	const midText = "midalpha midbeta"
+	fp := retokenizeScenario{targetTok: models.PropertyTokenizationField, midText: midText}.run(t)
+
+	require.Positivef(t, countPhraseTerms(fp),
 		"positive control: iterator-reindexed corpus must be FIELD-tokenized (phrase terms); got none")
 
 	fieldIDs, fieldOK := fp[midText] // FIELD tokenization = whole value, lowercased
@@ -103,44 +161,15 @@ func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T)
 }
 
 // TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord is the
-// FIELD→WORD mirror of weaviate/0-weaviate-issues#298: the concurrent write
-// keeps its SOURCE term, so a WORD query misses it after the flip.
+// FIELD→WORD mirror: the concurrent write keeps its SOURCE whole-value term, so
+// a WORD single-word query misses it after the flip.
 func TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord(t *testing.T) {
-	ctx := testCtx()
-	const propName = "title"
-	const numObjects = 25
-
-	className := "ConcurrentRetokRev_" + uuid.NewString()[:8]
-	// FIELD-source class (the shared helper hardcodes WORD).
-	class := newTestClassWithProps(className, []string{propName})
-	class.Properties[0].Tokenization = models.PropertyTokenizationField
-
-	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-		false, false, false)
-	shard := shd.(*Shard)
-	defer shard.Shutdown(ctx)
-
-	// Under FIELD source each 3-word phrase is a single whole-value term.
-	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
-		require.NoError(t, shard.PutObject(ctx, obj))
-	}
-
-	searchBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
-	preStrategy := shard.store.Bucket(searchBucketName).Strategy()
-
-	task, _ := newSearchableRetokenizeTask(t, idx, className, propName,
-		models.PropertyTokenizationWord, preStrategy)
-
-	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
-
-	// Concurrent write; WORD target splits it, FIELD source keeps it whole.
 	const midText = "revalpha revbeta"
-	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
-
-	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
-	require.NoError(t, task.RunSwapOnShard(ctx, shard))
-
-	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
+	fp := retokenizeScenario{
+		sourceTok: models.PropertyTokenizationField,
+		targetTok: models.PropertyTokenizationWord,
+		midText:   midText,
+	}.run(t)
 
 	_, dictWord := fp["victor"]
 	require.Truef(t, dictWord,
@@ -159,48 +188,18 @@ func TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord(t *testing.T
 			"in a WORD-target bucket", midText)
 }
 
-// TestReindex_ConcurrentWriteDuringRetokenize_Filterable pins
-// weaviate/0-weaviate-issues#298 for FilterableRetokenizeStrategy: the same
-// wrong-tokenization defect, not searchable-specific.
+// TestReindex_ConcurrentWriteDuringRetokenize_Filterable pins the same
+// wrong-tokenization defect for FilterableRetokenizeStrategy — it is not
+// searchable-specific.
 func TestReindex_ConcurrentWriteDuringRetokenize_Filterable(t *testing.T) {
-	ctx := testCtx()
-	const propName = "title"
-	const numObjects = 25
-
-	className := "ConcurrentRetokFilt_" + uuid.NewString()[:8]
-	class := newTestClassWithProps(className, []string{propName})
-
-	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-		false, false, false)
-	shard := shd.(*Shard)
-	defer shard.Shutdown(ctx)
-
-	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
-		require.NoError(t, shard.PutObject(ctx, obj))
-	}
-
-	filtBucketName := helpers.BucketFromPropNameLSM(propName)
-
-	task, _ := newFilterableRetokenizeTask(t, idx, className, propName,
-		models.PropertyTokenizationField)
-
-	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
-
 	const midText = "filtalpha filtbeta"
-	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
+	fp := retokenizeScenario{
+		targetTok:  models.PropertyTokenizationField,
+		filterable: true,
+		midText:    midText,
+	}.run(t)
 
-	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
-	require.NoError(t, task.RunSwapOnShard(ctx, shard))
-
-	fp := fingerprintRoaringSetBucket(t, shard.store.Bucket(filtBucketName))
-
-	phraseTerms := 0
-	for term := range fp {
-		if strings.Contains(term, " ") {
-			phraseTerms++
-		}
-	}
-	require.Positivef(t, phraseTerms,
+	require.Positivef(t, countPhraseTerms(fp),
 		"positive control: iterator-reindexed filterable corpus must be FIELD-tokenized (phrase terms); got none")
 
 	fieldIDs, fieldOK := fp[midText]
@@ -215,46 +214,23 @@ func TestReindex_ConcurrentWriteDuringRetokenize_Filterable(t *testing.T) {
 			"(filtalpha=%v, filtbeta=%v) in a FIELD-target filterable bucket", wordAlpha, wordBeta)
 }
 
-// TestReindex_UpdateDuringRetokenize_GhostAndLostValue pins
-// weaviate/0-weaviate-issues#298's update variant: an object updated
-// mid-migration leaves a stale OLD-value ghost and loses its NEW value.
+// TestReindex_UpdateDuringRetokenize_GhostAndLostValue pins the update variant:
+// an object updated mid-migration leaves a stale OLD-value ghost (the delete
+// double-write cannot remove the iterator's FIELD phrase term) and loses its
+// NEW value under the target tokenization.
 func TestReindex_UpdateDuringRetokenize_GhostAndLostValue(t *testing.T) {
-	ctx := testCtx()
-	const propName = "title"
-	const numObjects = 25
 	const oldValue = "ghostalpha ghostbeta"
 	const newValue = "ghostgamma ghostdelta"
-
-	className := "UpdateRetok_" + uuid.NewString()[:8]
-	class := newTestClassWithProps(className, []string{propName})
-
-	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-		false, false, false)
-	shard := shd.(*Shard)
-	defer shard.Shutdown(ctx)
-
-	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
-		require.NoError(t, shard.PutObject(ctx, obj))
-	}
-	// Tracked object X imported BEFORE the migration so the iterator reindexes
-	// its OLD value to the FIELD phrase term.
 	xID := uuid.NewString()
-	require.NoError(t, shard.PutObject(ctx, objWithIDText(className, xID, oldValue)))
-
-	searchBucketName := helpers.BucketSearchableFromPropNameLSM(propName)
-	preStrategy := shard.store.Bucket(searchBucketName).Strategy()
-	task, _ := newSearchableRetokenizeTask(t, idx, className, propName,
-		models.PropertyTokenizationField, preStrategy)
-
-	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
-
-	// Mid-window UPDATE of X (same ID) → delete-old + add-new double-write.
-	require.NoError(t, shard.PutObject(ctx, objWithIDText(className, xID, newValue)))
-
-	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
-	require.NoError(t, task.RunSwapOnShard(ctx, shard))
-
-	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
+	fp := retokenizeScenario{
+		targetTok: models.PropertyTokenizationField,
+		// Import X before the migration so the iterator reindexes its OLD value,
+		// then update it (same ID) mid-window.
+		preImportID:   xID,
+		preImportText: oldValue,
+		midID:         xID,
+		midText:       newValue,
+	}.run(t)
 
 	newIDs, newOK := fp[newValue]
 	assert.Truef(t, newOK && len(newIDs) > 0,

--- a/adapters/repos/db/inverted_reindex_write_during_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_finalize_test.go
@@ -26,9 +26,8 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// objWithIDText builds a test object with a caller-controlled UUID so a later
-// PutObject with the same ID is an update (delete-old + add-new), not a fresh
-// insert.
+// objWithIDText builds a test object with a caller-controlled UUID, so a
+// later PutObject with the same ID is an update, not a fresh insert.
 func objWithIDText(className, id, text string) *storobj.Object {
 	return &storobj.Object{
 		MarshallerVersion: 1,
@@ -40,34 +39,9 @@ func objWithIDText(className, id, text string) *storobj.Object {
 	}
 }
 
-// TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized answers the
-// concurrent-write convergence question from
-// weaviate/0-weaviate-issues#298 for a WORD→FIELD SearchableRetokenize.
-//
-// RED on this commit — and NOT the data-loss failure #298 predicted.
-//
-// An object written while the migration is reindexed-but-not-swapped DOES
-// reach the post-swap bucket (no data loss), but it is indexed with the
-// SOURCE (WORD) tokenization instead of the TARGET (FIELD) tokenization the
-// migration exists to produce. Once the migration finishes and the schema
-// flips to FIELD, that object is queryable only under its WORD terms, never
-// under the FIELD whole-phrase term → silent wrong results for any write
-// that overlaps a retokenize migration.
-//
-// Root cause (traced in code, not inferred from the number):
-// SearchableRetokenizeStrategy.MakeAddCallback re-tokenizes to the target
-// ONLY when property.RawValues is populated, else it falls back to the
-// source-tokenized property.Items. RawValues is captured solely by
-// Shard.AnalyzeObjectForMigrationWithOverlay (the iterator's backfill scan);
-// the normal write path (PutObject → AnalyzeObject) never populates it, so
-// the double-write of a concurrent object silently uses the old tokenization.
-// FilterableRetokenizeStrategy carries the identical RawValues guard.
-//
-// Built-in positive control: the iterator-reindexed corpus IS correctly
-// FIELD-tokenized in the same bucket (multi-word phrase terms), proving the
-// target tokenization path works when RawValues is present. So the
-// concurrent write's WORD form is specifically the double-write path
-// failing, not a harness artifact or a broken swap.
+// TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized pins
+// weaviate/0-weaviate-issues#298: a write racing a WORD→FIELD retokenize
+// survives the swap but keeps SOURCE tokenization instead of TARGET.
 func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T) {
 	ctx := testCtx()
 	const propName = "title"
@@ -81,9 +55,8 @@ func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T)
 	shard := shd.(*Shard)
 	defer shard.Shutdown(ctx)
 
-	// Existing corpus: 3-word phrases from the 25-token dictionary. Under the
-	// FIELD target each phrase collapses to a single whole-value term; the
-	// tokens do not collide with the unique mid-window tokens below.
+	// Corpus is 3-word phrases; under FIELD they collapse to one term each
+	// and don't collide with the mid-window text below.
 	for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
 		require.NoError(t, shard.PutObject(ctx, obj))
 	}
@@ -97,9 +70,8 @@ func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T)
 	// Drive to reindexed-but-not-swapped: iterator done, double-write live.
 	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
 
-	// Concurrent write in the FINALIZING window. Under the FIELD target these
-	// two words must collapse to the single term "midalpha midbeta"; under
-	// the source WORD tokenization they split into "midalpha" / "midbeta".
+	// Concurrent write in the FINALIZING window; FIELD collapses it to one
+	// term, WORD splits it in two.
 	const midText = "midalpha midbeta"
 	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
 
@@ -108,9 +80,6 @@ func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T)
 
 	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
 
-	// Positive control: the reindexed corpus is FIELD-tokenized (phrase terms
-	// carry a space). If this is zero the premise is off and the assertions
-	// below prove nothing.
 	phraseTerms := 0
 	for term := range fp {
 		if strings.Contains(term, " ") {
@@ -120,8 +89,6 @@ func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T)
 	require.Positivef(t, phraseTerms,
 		"positive control: iterator-reindexed corpus must be FIELD-tokenized (phrase terms); got none")
 
-	// The concurrent write must be TARGET (FIELD) tokenized: present under
-	// the whole-value term, absent as separate WORD terms.
 	fieldIDs, fieldOK := fp[midText] // FIELD tokenization = whole value, lowercased
 	assert.Truef(t, fieldOK && len(fieldIDs) > 0,
 		"#298 wrong-tokenization: object written during the retokenize window is NOT under the "+
@@ -136,15 +103,8 @@ func TestReindex_ConcurrentWriteDuringRetokenize_IsTargetTokenized(t *testing.T)
 }
 
 // TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord is the
-// FIELD→WORD mirror — the direction the field↔word reindex soak actually
-// exercises. Same defect, and the more impactful shape: the concurrent write
-// keeps its SOURCE (FIELD) whole-value term, so after the flip a WORD
-// single-word query (the common case) misses it entirely.
-//
-// Confirms the "by symmetry" claim in the WORD→FIELD report empirically, so
-// the team can weigh whether this mechanism contributes to soak short-counts
-// (a concurrent writer overlapping the migration would leave objects
-// unqueryable under single-word terms).
+// FIELD→WORD mirror of weaviate/0-weaviate-issues#298: the concurrent write
+// keeps its SOURCE term, so a WORD query misses it after the flip.
 func TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord(t *testing.T) {
 	ctx := testCtx()
 	const propName = "title"
@@ -173,8 +133,7 @@ func TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord(t *testing.T
 
 	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
 
-	// Concurrent write in the window. Under the WORD target it must split into
-	// "revalpha" / "revbeta"; under the source FIELD it stays one whole term.
+	// Concurrent write; WORD target splits it, FIELD source keeps it whole.
 	const midText = "revalpha revbeta"
 	require.NoError(t, shard.PutObject(ctx, createTestObjectWithText(className, midText)))
 
@@ -183,15 +142,11 @@ func TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord(t *testing.T
 
 	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
 
-	// Positive control: the iterator-reindexed corpus is WORD-tokenized
-	// (single-word dictionary tokens present, no spaces).
 	_, dictWord := fp["victor"]
 	require.Truef(t, dictWord,
 		"positive control: iterator-reindexed corpus must be WORD-tokenized (dictionary token 'victor' present); "+
 			"got terms without it — premise is off")
 
-	// The concurrent write must be TARGET (WORD) tokenized: present under the
-	// split single-word terms, absent under the whole-value FIELD term.
 	_, wordAlpha := fp["revalpha"]
 	_, wordBeta := fp["revbeta"]
 	assert.Truef(t, wordAlpha && wordBeta,
@@ -204,12 +159,9 @@ func TestReindex_ConcurrentWriteDuringRetokenize_ReverseFieldToWord(t *testing.T
 			"in a WORD-target bucket", midText)
 }
 
-// TestReindex_ConcurrentWriteDuringRetokenize_Filterable proves the defect is
-// not searchable-specific: FilterableRetokenizeStrategy carries the identical
-// `RawValues > 0` guard in its own Add callback, so a concurrent write during
-// a WORD→FIELD filterable retokenize lands SOURCE(WORD)-tokenized in the
-// TARGET (RoaringSet) filterable bucket — a `where` filter on the field value
-// then misses it after the flip.
+// TestReindex_ConcurrentWriteDuringRetokenize_Filterable pins
+// weaviate/0-weaviate-issues#298 for FilterableRetokenizeStrategy: the same
+// wrong-tokenization defect, not searchable-specific.
 func TestReindex_ConcurrentWriteDuringRetokenize_Filterable(t *testing.T) {
 	ctx := testCtx()
 	const propName = "title"
@@ -242,7 +194,6 @@ func TestReindex_ConcurrentWriteDuringRetokenize_Filterable(t *testing.T) {
 
 	fp := fingerprintRoaringSetBucket(t, shard.store.Bucket(filtBucketName))
 
-	// Positive control: iterator-reindexed corpus is FIELD-tokenized (phrase terms).
 	phraseTerms := 0
 	for term := range fp {
 		if strings.Contains(term, " ") {
@@ -264,21 +215,9 @@ func TestReindex_ConcurrentWriteDuringRetokenize_Filterable(t *testing.T) {
 			"(filtalpha=%v, filtbeta=%v) in a FIELD-target filterable bucket", wordAlpha, wordBeta)
 }
 
-// TestReindex_UpdateDuringRetokenize_GhostAndLostValue pins the update variant,
-// which is strictly worse than the insert case. An object reindexed by the
-// iterator (so its OLD value is a FIELD phrase term in the ingest bucket) is
-// then UPDATED mid-window. The delete double-write callback re-tokenizes to
-// target only when RawValues is populated (it never is on the live path), so
-// it tries to delete the OLD value's SOURCE(WORD) terms — which are not in the
-// target bucket — leaving the iterator's FIELD phrase term for the OLD value
-// behind. The add callback writes the NEW value SOURCE(WORD)-tokenized. Net
-// post-swap state:
-//   - the object still matches its OLD (overwritten) value  → stale ghost
-//   - the object does NOT match its NEW (current) value      → current value lost
-//
-// Positive control: the iterator DID produce the OLD value's FIELD phrase term
-// (that is the ghost we observe), proving the target-tokenization path works
-// and the failure is specifically the update double-write.
+// TestReindex_UpdateDuringRetokenize_GhostAndLostValue pins
+// weaviate/0-weaviate-issues#298's update variant: an object updated
+// mid-migration leaves a stale OLD-value ghost and loses its NEW value.
 func TestReindex_UpdateDuringRetokenize_GhostAndLostValue(t *testing.T) {
 	ctx := testCtx()
 	const propName = "title"
@@ -317,13 +256,11 @@ func TestReindex_UpdateDuringRetokenize_GhostAndLostValue(t *testing.T) {
 
 	fp := fingerprintInvertedBucket(t, shard.store.Bucket(searchBucketName))
 
-	// Current value must be queryable under the target FIELD phrase term.
 	newIDs, newOK := fp[newValue]
 	assert.Truef(t, newOK && len(newIDs) > 0,
 		"#298 update: object's CURRENT value %q is NOT under the target FIELD term — a search for its "+
 			"actual value misses it after the flip", newValue)
 
-	// Old value must be gone — the object was updated away from it.
 	oldIDs, oldOK := fp[oldValue]
 	assert.Falsef(t, oldOK && len(oldIDs) > 0,
 		"#298 update: object still matches its OLD (overwritten) value %q (stale ghost ids=%v) — the delete "+

--- a/adapters/repos/db/inverted_reindex_write_during_registration_gap_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_registration_gap_test.go
@@ -26,38 +26,10 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// TestReindex_ConcurrentWriteInRegistrationGap_NotLost is the regression test
-// for the markStarted→registerDoubleWriteCallbacks write-loss window
-// (weaviate/weaviate#11688). Ported from 323bcf22f5 (originally on
-// columnar-v2, enable-columnar) and adapted to the enable-rangeable
-// scaffolding on this branch.
-//
-// Pre-fix, onAfterLsmInitWithTracker captured the reindexStarted timestamp
-// BEFORE loading the ingest buckets and registering the double-write
-// callbacks. A write landing in that window was
-//
-//	(a) skipped by the backfill iterator, because its LastUpdateTimeUnix is
-//	    >= reindexStarted (the iterator assumes such writes are
-//	    double-written), AND
-//	(b) NOT double-written into the ingest bucket, because the callbacks
-//	    were not registered yet
-//
-// so the row never reached the target bucket — permanently missing after
-// the migration reported FINISHED.
-//
-// The onBeforeDoubleWriteRegistration hook fires at the exact spot of the old
-// gap (after the old markStarted position, before callback registration).
-// Updates injected there change each object's score to a value outside the
-// corpus; each MUST survive under its new value after the swap. Against the
-// pre-fix ordering the gap assertions fail with numGapUpdates values missing;
-// with the fix (timestamp captured after registration, ceiled up one ms) they
-// pass because reindexStarted now sorts strictly after every gap write, so the
-// iterator backfills them.
-//
-// A second batch of updates lands after OnAfterLsmInit returns (callbacks
-// active, iteration not yet started); those survive only via the double-write
-// path (the iterator skips them), pinning the mechanism the iterator-skip
-// predicate relies on.
+// TestReindex_ConcurrentWriteInRegistrationGap_NotLost pins
+// weaviate/weaviate#11688: a write landing in the markStarted→register gap is
+// skipped by the backfill iterator (LastUpdateTimeUnix >= reindexStarted) and
+// unmirrored by the not-yet-registered double-write — permanently lost.
 func TestReindex_ConcurrentWriteInRegistrationGap_NotLost(t *testing.T) {
 	const (
 		numObjects        = 25
@@ -82,10 +54,8 @@ func TestReindex_ConcurrentWriteInRegistrationGap_NotLost(t *testing.T) {
 		require.NoError(t, shard.PutObject(ctx, obj))
 	}
 
-	// update overwrites object i with a fresh score and a CURRENT
-	// LastUpdateTimeUnix — exactly what a live PATCH/PUT does. The timestamp
-	// is what makes the backfill iterator skip the object once it is
-	// >= reindexStarted.
+	// update sets a CURRENT LastUpdateTimeUnix — what makes the backfill
+	// iterator skip the object once it is >= reindexStarted.
 	update := func(i int, val int64) {
 		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
 			MarshallerVersion: 1,
@@ -130,13 +100,10 @@ func TestReindex_ConcurrentWriteInRegistrationGap_NotLost(t *testing.T) {
 	rangeBucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
 	require.NotNil(t, rangeBucket, "post-migration rangeable bucket must exist")
 
-	// Positive control: an unmodified corpus value must be backfilled, else
-	// the migration populated nothing and the gap assertions prove nothing.
 	require.NotEmptyf(t, readRangeableIDs(t, rangeBucket, 0),
 		"positive control: iterator-backfilled corpus value 0 must be present")
 
-	// The gap writes: each updated object must be served under its new value.
-	// Missing here means the write in the markStarted→register gap was lost.
+	// Gap writes: served via the fixed markStarted ordering.
 	for i := 0; i < numGapUpdates; i++ {
 		val := gapValueBase + int64(i)
 		assert.Lenf(t, readRangeableIDs(t, rangeBucket, val), 1,
@@ -144,7 +111,7 @@ func TestReindex_ConcurrentWriteInRegistrationGap_NotLost(t *testing.T) {
 				"the markStarted→registerDoubleWriteCallbacks gap lost it", i, val)
 	}
 
-	// The post-registration writes: served only via the double-write path.
+	// Post-registration writes: served only via the double-write path.
 	for i := numGapUpdates; i < numGapUpdates+numPostInitUpdate; i++ {
 		val := postValueBase + int64(i)
 		assert.Lenf(t, readRangeableIDs(t, rangeBucket, val), 1,
@@ -152,9 +119,8 @@ func TestReindex_ConcurrentWriteInRegistrationGap_NotLost(t *testing.T) {
 				"via the double-write path", i, val)
 	}
 
-	// Convergence: every object appears exactly once across the expected
-	// values — no lost rows (count < numObjects) and no ghosts (a docID under
-	// two values). Reads the corpus values plus every injected value.
+	// Convergence: every object must appear exactly once — no lost rows, no
+	// ghosts under a second value.
 	seen := map[uint64]int{}
 	countValue := func(v int64) {
 		for _, id := range readRangeableIDs(t, rangeBucket, v) {

--- a/adapters/repos/db/inverted_reindex_write_during_registration_gap_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_registration_gap_test.go
@@ -71,16 +71,23 @@ func TestReindex_ConcurrentWriteInRegistrationGap_NotLost(t *testing.T) {
 
 	task, wrapped := newFilterableToRangeableTask(t, idx, className, propName)
 
+	// Wrap the ingest-window registration to land the gap writes at exactly
+	// the markStarted→register seam #11688 is about — right before callbacks
+	// arm, so only the fixed markStarted ordering keeps them.
 	gapWritesDone := false
-	task.onBeforeDoubleWriteRegistration = func() {
+	origRegister := task.registerDoubleWriteCallbacksFn
+	task.registerDoubleWriteCallbacksFn = func(shard *Shard, props []string,
+		bucketNamer func(string) string, forTargetStrategy bool,
+	) func() {
 		for i := 0; i < numGapUpdates; i++ {
 			update(i, gapValueBase+int64(i))
 		}
 		gapWritesDone = true
+		return origRegister(shard, props, bucketNamer, forTargetStrategy)
 	}
 
 	require.NoError(t, task.OnAfterLsmInit(ctx, shard))
-	require.True(t, gapWritesDone, "hook must have fired during OnAfterLsmInit")
+	require.True(t, gapWritesDone, "registration wrapper must have fired during OnAfterLsmInit")
 
 	// Callbacks are registered now; these updates must reach the rangeable
 	// bucket via the double-write path (the iterator will skip them).

--- a/adapters/repos/db/inverted_reindex_write_during_registration_gap_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_registration_gap_test.go
@@ -1,0 +1,178 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestReindex_ConcurrentWriteInRegistrationGap_NotLost is the regression test
+// for the markStarted→registerDoubleWriteCallbacks write-loss window
+// (weaviate/weaviate#11688). Ported from 323bcf22f5 (originally on
+// columnar-v2, enable-columnar) and adapted to the enable-rangeable
+// scaffolding on this branch.
+//
+// Pre-fix, onAfterLsmInitWithTracker captured the reindexStarted timestamp
+// BEFORE loading the ingest buckets and registering the double-write
+// callbacks. A write landing in that window was
+//
+//	(a) skipped by the backfill iterator, because its LastUpdateTimeUnix is
+//	    >= reindexStarted (the iterator assumes such writes are
+//	    double-written), AND
+//	(b) NOT double-written into the ingest bucket, because the callbacks
+//	    were not registered yet
+//
+// so the row never reached the target bucket — permanently missing after
+// the migration reported FINISHED.
+//
+// The onBeforeDoubleWriteRegistration hook fires at the exact spot of the old
+// gap (after the old markStarted position, before callback registration).
+// Updates injected there change each object's score to a value outside the
+// corpus; each MUST survive under its new value after the swap. Against the
+// pre-fix ordering the gap assertions fail with numGapUpdates values missing;
+// with the fix (timestamp captured after registration, ceiled up one ms) they
+// pass because reindexStarted now sorts strictly after every gap write, so the
+// iterator backfills them.
+//
+// A second batch of updates lands after OnAfterLsmInit returns (callbacks
+// active, iteration not yet started); those survive only via the double-write
+// path (the iterator skips them), pinning the mechanism the iterator-skip
+// predicate relies on.
+func TestReindex_ConcurrentWriteInRegistrationGap_NotLost(t *testing.T) {
+	const (
+		numObjects        = 25
+		numGapUpdates     = 10 // updated inside the (old) gap via the hook
+		numPostInitUpdate = 5  // updated after callbacks are active
+		gapValueBase      = int64(1000)
+		postValueBase     = int64(2000)
+	)
+	const propName = filterableToRangeablePropName
+
+	ctx := testCtx()
+	className := "EnableRangeableGapWrites_" + uuid.NewString()[:8]
+	class := newFilterableToRangeableTestClass(className)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(context.Background())
+
+	objs := makeFilterableToRangeableTestObjects(t, numObjects, className)
+	for _, obj := range objs {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+
+	// update overwrites object i with a fresh score and a CURRENT
+	// LastUpdateTimeUnix — exactly what a live PATCH/PUT does. The timestamp
+	// is what makes the backfill iterator skip the object once it is
+	// >= reindexStarted.
+	update := func(i int, val int64) {
+		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:                 objs[i].ID(),
+				Class:              className,
+				Properties:         map[string]interface{}{propName: val},
+				CreationTimeUnix:   time.Now().UnixMilli(),
+				LastUpdateTimeUnix: time.Now().UnixMilli(),
+			},
+		}))
+	}
+
+	task, wrapped := newFilterableToRangeableTask(t, idx, className, propName)
+
+	gapWritesDone := false
+	task.onBeforeDoubleWriteRegistration = func() {
+		for i := 0; i < numGapUpdates; i++ {
+			update(i, gapValueBase+int64(i))
+		}
+		gapWritesDone = true
+	}
+
+	require.NoError(t, task.OnAfterLsmInit(ctx, shard))
+	require.True(t, gapWritesDone, "hook must have fired during OnAfterLsmInit")
+
+	// Callbacks are registered now; these updates must reach the rangeable
+	// bucket via the double-write path (the iterator will skip them).
+	for i := numGapUpdates; i < numGapUpdates+numPostInitUpdate; i++ {
+		update(i, postValueBase+int64(i))
+	}
+
+	for {
+		rerunAt, _, err := task.OnAfterLsmInitAsync(ctx, shard)
+		require.NoError(t, err)
+		if rerunAt.IsZero() {
+			break
+		}
+	}
+	require.True(t, wrapped.migrationCompleted, "migration must complete")
+
+	rangeBucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, rangeBucket, "post-migration rangeable bucket must exist")
+
+	// Positive control: an unmodified corpus value must be backfilled, else
+	// the migration populated nothing and the gap assertions prove nothing.
+	require.NotEmptyf(t, readRangeableIDs(t, rangeBucket, 0),
+		"positive control: iterator-backfilled corpus value 0 must be present")
+
+	// The gap writes: each updated object must be served under its new value.
+	// Missing here means the write in the markStarted→register gap was lost.
+	for i := 0; i < numGapUpdates; i++ {
+		val := gapValueBase + int64(i)
+		assert.Lenf(t, readRangeableIDs(t, rangeBucket, val), 1,
+			"gap-updated object %d must survive under value %d — a miss means "+
+				"the markStarted→registerDoubleWriteCallbacks gap lost it", i, val)
+	}
+
+	// The post-registration writes: served only via the double-write path.
+	for i := numGapUpdates; i < numGapUpdates+numPostInitUpdate; i++ {
+		val := postValueBase + int64(i)
+		assert.Lenf(t, readRangeableIDs(t, rangeBucket, val), 1,
+			"post-registration-updated object %d must survive under value %d "+
+				"via the double-write path", i, val)
+	}
+
+	// Convergence: every object appears exactly once across the expected
+	// values — no lost rows (count < numObjects) and no ghosts (a docID under
+	// two values). Reads the corpus values plus every injected value.
+	seen := map[uint64]int{}
+	countValue := func(v int64) {
+		for _, id := range readRangeableIDs(t, rangeBucket, v) {
+			seen[id]++
+		}
+	}
+	for v := int64(0); v < filterableToRangeableNumDistinctValues; v++ {
+		countValue(v)
+	}
+	for i := 0; i < numGapUpdates; i++ {
+		countValue(gapValueBase + int64(i))
+	}
+	for i := numGapUpdates; i < numGapUpdates+numPostInitUpdate; i++ {
+		countValue(postValueBase + int64(i))
+	}
+	assert.Len(t, seen, numObjects,
+		"every object must be present exactly once across the expected values")
+	for id, n := range seen {
+		assert.Equalf(t, 1, n, "docID %d appears under %d values (ghost)", id, n)
+	}
+}

--- a/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
@@ -51,21 +51,11 @@ func rangeableDocIDsAtLeast(t *testing.T, b *lsmkv.Bucket, v int64) []uint64 {
 	return bm.ToArray()
 }
 
-// TestReindex_ConcurrentWriteDuringSwapWindow_NotLost pins the third loss
-// mechanism of weaviate/weaviate#11688: a live write landing between
-// [lsmkv.Store.SwapBucketPointer] (which UNREGISTERS the ingest name) and the
-// deferred disableCallbacks at the end of runtimeSwap. The property has no
-// live index (IndexFilterable=false), so the write depends ENTIRELY on the
-// double-write callback; pre-fix that callback resolved store.Bucket(ingestName)
-// to nil and dereferenced it (lsmkv.MustBeExpectedStrategy on b.Strategy()) —
-// a nil-pointer panic in the write goroutine that, through the REST stack,
-// becomes an empty 200 with every inverted write of the call lost.
-//
-// The write is an UPDATE of an existing object, so it exercises BOTH callback
-// legs in the window: the delete-old leg (removing the pre-value from the
-// index) and the add-new leg. Post-fix (resolveDoubleWriteBucket) both fall
-// back to the canonical bucket name — the same physical bucket the ingest name
-// used to denote — and the update must be range-queryable after the migration.
+// TestReindex_ConcurrentWriteDuringSwapWindow_NotLost pins
+// weaviate/weaviate#11688: a write landing between SwapBucketPointer
+// (unregisters the ingest name) and disableCallbacks must not be lost —
+// pre-fix the double-write callback dereferenced a nil bucket. The write is
+// an UPDATE, exercising both the delete-old and add-new callback legs.
 func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
 	ctx := testCtx()
 	const propName = filterableToRangeablePropName
@@ -90,9 +80,8 @@ func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
 
 	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
 
-	// Inject the update right after the production per-prop pointer flip: the
-	// ingest name is unregistered, the callbacks are still armed (their disable
-	// is deferred to the end of runtimeSwap), and the migration scope is active.
+	// Inject the update right after the per-prop pointer flip: the ingest name
+	// is unregistered but the callbacks are still armed.
 	swapWindowWriteDone := false
 	origSwap := task.processOneSwapPropFn
 	task.processOneSwapPropFn = func(ctx context.Context, store *lsmkv.Store, rt reindexTracker, propIdx int, prop string) (*lsmkv.Bucket, error) {
@@ -138,12 +127,8 @@ func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
 }
 
 // TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost is the delete-only
-// counterpart of TestReindex_ConcurrentWriteDuringSwapWindow_NotLost: a mid-swap
-// object DELETE routes through the same double-write callback, which had the
-// same unchecked store.Bucket(ingestName) deref. Pre-fix the delete callback
-// paniced on the nil bucket (deleteFromPropertyRangeBucket → b.Strategy());
-// post-fix it resolves the canonical bucket and the delete's inverted removal
-// lands, so the deleted object is gone from the post-migration index.
+// counterpart of TestReindex_ConcurrentWriteDuringSwapWindow_NotLost
+// (weaviate/weaviate#11688): a mid-swap DELETE hits the same nil-bucket deref.
 func TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost(t *testing.T) {
 	ctx := testCtx()
 	const propName = filterableToRangeablePropName
@@ -198,20 +183,10 @@ func TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost(t *testing.T) {
 		"exactly one object must be removed from the rangeable index after the swap-window delete")
 }
 
-// TestResolveDoubleWriteBucket_FallsBackAfterSwap is the hook-free unit
-// counterpart to the two swap-window pins above: it asserts the resolution
-// truth table of resolveDoubleWriteBucket directly against the exact store
-// state SwapBucketPointer produces — no task, no swap orchestration, no
-// timing. This is the pure seam behind the weaviate/weaviate#11688 fix, so the
-// branch that panicked is proven in-place rather than only through a driven
-// swap:
-//
-//	sidecar present            → sidecar bucket (the normal double-write target)
-//	sidecar gone, fallback set → canonical bucket (ingest phase: the swap
-//	                             renamed ingest→canonical, so the mirror write
-//	                             must still land — pre-fix this was a nil deref)
-//	sidecar gone, fallback ""  → nil (backup phase: the source is genuinely
-//	                             torn down, so skipping is correct, not loss)
+// TestResolveDoubleWriteBucket_FallsBackAfterSwap is the hook-free unit test
+// for resolveDoubleWriteBucket against the exact store state SwapBucketPointer
+// produces (weaviate/weaviate#11688) — see that function's doc for the
+// resolution rules.
 func TestResolveDoubleWriteBucket_FallsBackAfterSwap(t *testing.T) {
 	ctx := testCtx()
 	className := "ResolveDoubleWrite_" + uuid.NewString()[:8]
@@ -230,28 +205,25 @@ func TestResolveDoubleWriteBucket_FallsBackAfterSwap(t *testing.T) {
 	require.NoError(t, shard.store.CreateOrLoadBucket(ctx, canonicalName,
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
 
-	// Pre-swap: the sidecar exists, so it is resolved directly.
+	// Pre-swap: sidecar resolves directly.
 	require.Same(t, shard.store.Bucket(sidecarName),
 		resolveDoubleWriteBucket(shard, sidecarName, canonicalName),
 		"pre-swap the sidecar bucket must be resolved directly")
 
-	// The production swap: canonical now points at the sidecar's physical
-	// bucket and the sidecar NAME is unregistered — the exact window state a
-	// concurrent write's callback observes.
+	// The production swap: canonical takes over the sidecar's physical bucket
+	// and the sidecar NAME is unregistered.
 	_, err := shard.store.SwapBucketPointer(ctx, canonicalName, sidecarName)
 	require.NoError(t, err)
 	require.Nil(t, shard.store.Bucket(sidecarName),
 		"sanity: SwapBucketPointer must unregister the sidecar name")
 
-	// Ingest-phase resolution: sidecar gone → fall back to the canonical name
-	// (non-nil), so the callback writes instead of dereferencing nil.
+	// Ingest-phase: sidecar gone, falls back to canonical (not nil).
 	require.Same(t, shard.store.Bucket(canonicalName),
 		resolveDoubleWriteBucket(shard, sidecarName, canonicalName),
 		"#11688: post-swap the resolver must fall back to the canonical bucket, "+
 			"not return nil (the pre-fix nil deref that paniced the write)")
 
-	// Backup-phase resolution: no fallback name → nil is correct (the source is
-	// genuinely gone; a nil-skip here is a no-op, not data loss).
+	// Backup-phase: no fallback, nil is correct (no-op, not loss).
 	require.Nil(t, resolveDoubleWriteBucket(shard, sidecarName, ""),
 		"with no swap-fallback name the resolver must return nil (backup phase)")
 }

--- a/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
@@ -61,7 +61,7 @@ const (
 // NO live index (so the write depends entirely on the double-write callback),
 // start the FilterableToRangeable migration, inject one op right after the
 // per-prop pointer flip (ingest name unregistered, callbacks still armed), then
-// swap. inject must not fail — pre-fix it paniced on the nil ingest bucket.
+// swap. inject must not fail — pre-fix it panicked on the nil ingest bucket.
 // run returns the post-swap rangeable bucket for the caller's assertions.
 type swapWindowScenario struct {
 	inject func(t *testing.T, ctx context.Context, shard *Shard, objs []*storobj.Object)
@@ -127,14 +127,14 @@ func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
 					CreationTimeUnix:   time.Now().UnixMilli(),
 					LastUpdateTimeUnix: time.Now().UnixMilli(),
 				},
-			}), "live write during the swap window must not fail (pre-fix it paniced in the double-write callback)")
+			}), "live write during the swap window must not fail (pre-fix it panicked in the double-write callback)")
 		},
 	}.run(t)
 
 	// add-new leg: the updated value is range-queryable at exactly its docID.
 	assert.Lenf(t, readRangeableIDs(t, bucket, mark), 1,
 		"#11688 swap-window: the update written during the swap window is NOT under the "+
-			"target value %d — its double-write add leg was lost or paniced", mark)
+			"target value %d — its double-write add leg was lost or panicked", mark)
 
 	// delete-old leg: objs[0] no longer contributes to value 0.
 	assert.Lenf(t, readRangeableIDs(t, bucket, 0), swapWindowPerValue-1,
@@ -153,14 +153,14 @@ func TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost(t *testing.T) {
 	bucket := swapWindowScenario{
 		inject: func(t *testing.T, ctx context.Context, shard *Shard, objs []*storobj.Object) {
 			require.NoError(t, shard.DeleteObject(ctx, objs[0].ID(), time.Now()),
-				"live delete during the swap window must not fail (pre-fix it paniced in the double-write delete callback)")
+				"live delete during the swap window must not fail (pre-fix it panicked in the double-write delete callback)")
 		},
 	}.run(t)
 
 	// The deleted object's contribution to value 0 is gone.
 	assert.Lenf(t, readRangeableIDs(t, bucket, 0), swapWindowPerValue-1,
 		"#11688 swap-window: the delete written during the swap window did not remove "+
-			"the object from value 0 — its double-write delete leg was lost or paniced")
+			"the object from value 0 — its double-write delete leg was lost or panicked")
 
 	// One fewer object in the whole index.
 	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), swapWindowNumObjects-1,
@@ -205,7 +205,7 @@ func TestResolveDoubleWriteBucket_FallsBackAfterSwap(t *testing.T) {
 	require.Same(t, shard.store.Bucket(canonicalName),
 		resolveDoubleWriteBucket(shard, sidecarName, canonicalName),
 		"#11688: post-swap the resolver must fall back to the canonical bucket, "+
-			"not return nil (the pre-fix nil deref that paniced the write)")
+			"not return nil (the pre-fix nil deref that panicked the write)")
 
 	// Backup-phase: no fallback, nil is correct (no-op, not loss).
 	require.Nil(t, resolveDoubleWriteBucket(shard, sidecarName, ""),

--- a/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
@@ -197,3 +197,61 @@ func TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost(t *testing.T) {
 	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), numObjects-1,
 		"exactly one object must be removed from the rangeable index after the swap-window delete")
 }
+
+// TestResolveDoubleWriteBucket_FallsBackAfterSwap is the hook-free unit
+// counterpart to the two swap-window pins above: it asserts the resolution
+// truth table of resolveDoubleWriteBucket directly against the exact store
+// state SwapBucketPointer produces — no task, no swap orchestration, no
+// timing. This is the pure seam behind the weaviate/weaviate#11688 fix, so the
+// branch that panicked is proven in-place rather than only through a driven
+// swap:
+//
+//	sidecar present            → sidecar bucket (the normal double-write target)
+//	sidecar gone, fallback set → canonical bucket (ingest phase: the swap
+//	                             renamed ingest→canonical, so the mirror write
+//	                             must still land — pre-fix this was a nil deref)
+//	sidecar gone, fallback ""  → nil (backup phase: the source is genuinely
+//	                             torn down, so skipping is correct, not loss)
+func TestResolveDoubleWriteBucket_FallsBackAfterSwap(t *testing.T) {
+	ctx := testCtx()
+	className := "ResolveDoubleWrite_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"category"})
+	shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	// Synthetic names decoupled from any shard-managed bucket, so the resolver
+	// (a pure store map lookup) is exercised in isolation.
+	const sidecarName = "dw_resolver_ingest_sidecar"
+	const canonicalName = "dw_resolver_canonical"
+	require.NoError(t, shard.store.CreateOrLoadBucket(ctx, sidecarName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+	require.NoError(t, shard.store.CreateOrLoadBucket(ctx, canonicalName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+
+	// Pre-swap: the sidecar exists, so it is resolved directly.
+	require.Same(t, shard.store.Bucket(sidecarName),
+		resolveDoubleWriteBucket(shard, sidecarName, canonicalName),
+		"pre-swap the sidecar bucket must be resolved directly")
+
+	// The production swap: canonical now points at the sidecar's physical
+	// bucket and the sidecar NAME is unregistered — the exact window state a
+	// concurrent write's callback observes.
+	_, err := shard.store.SwapBucketPointer(ctx, canonicalName, sidecarName)
+	require.NoError(t, err)
+	require.Nil(t, shard.store.Bucket(sidecarName),
+		"sanity: SwapBucketPointer must unregister the sidecar name")
+
+	// Ingest-phase resolution: sidecar gone → fall back to the canonical name
+	// (non-nil), so the callback writes instead of dereferencing nil.
+	require.Same(t, shard.store.Bucket(canonicalName),
+		resolveDoubleWriteBucket(shard, sidecarName, canonicalName),
+		"#11688: post-swap the resolver must fall back to the canonical bucket, "+
+			"not return nil (the pre-fix nil deref that paniced the write)")
+
+	// Backup-phase resolution: no fallback name → nil is correct (the source is
+	// genuinely gone; a nil-skip here is a no-op, not data loss).
+	require.Nil(t, resolveDoubleWriteBucket(shard, sidecarName, ""),
+		"with no swap-fallback name the resolver must return nil (backup phase)")
+}

--- a/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
@@ -51,65 +51,85 @@ func rangeableDocIDsAtLeast(t *testing.T, b *lsmkv.Bucket, v int64) []uint64 {
 	return bm.ToArray()
 }
 
-// TestReindex_ConcurrentWriteDuringSwapWindow_NotLost pins
-// weaviate/weaviate#11688: a write landing between SwapBucketPointer
-// (unregisters the ingest name) and disableCallbacks must not be lost —
-// pre-fix the double-write callback dereferenced a nil bucket. The write is
-// an UPDATE, exercising both the delete-old and add-new callback legs.
-func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
-	ctx := testCtx()
-	const propName = filterableToRangeablePropName
-	const numObjects = 25
-	const perValue = numObjects / filterableToRangeableNumDistinctValues
-	// Outside the corpus so its posting list is unambiguously this write.
-	const mark = int64(999999)
+const (
+	swapWindowNumObjects = 25
+	swapWindowPerValue   = swapWindowNumObjects / filterableToRangeableNumDistinctValues
+)
 
-	className := "SwapWindowUpdate_" + uuid.NewString()[:8]
+// swapWindowScenario drives the shared lifecycle for a concurrent op landing in
+// the swap window of weaviate/weaviate#11688: import 25 rangeable objects with
+// NO live index (so the write depends entirely on the double-write callback),
+// start the FilterableToRangeable migration, inject one op right after the
+// per-prop pointer flip (ingest name unregistered, callbacks still armed), then
+// swap. inject must not fail — pre-fix it paniced on the nil ingest bucket.
+// run returns the post-swap rangeable bucket for the caller's assertions.
+type swapWindowScenario struct {
+	inject func(t *testing.T, ctx context.Context, shard *Shard, objs []*storobj.Object)
+}
+
+func (sc swapWindowScenario) run(t *testing.T) *lsmkv.Bucket {
+	t.Helper()
+	ctx := testCtx()
+	className := "SwapWindow_" + uuid.NewString()[:8]
 	class := newNoLiveIndexRangeableTestClass(className)
 
 	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
 		false, false, false)
 	shard := shd.(*Shard)
-	defer shard.Shutdown(ctx)
+	t.Cleanup(func() { shard.Shutdown(ctx) })
 
-	objs := makeFilterableToRangeableTestObjects(t, numObjects, className)
+	objs := makeFilterableToRangeableTestObjects(t, swapWindowNumObjects, className)
 	for _, obj := range objs {
 		require.NoError(t, shard.PutObject(ctx, obj))
 	}
-	// objs[0] carries value 0 (0 % numDistinct); we update it to mark below.
+	// objs[0] carries value 0 (0 % numDistinct); the injected op targets it.
 
-	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+	task, _ := newFilterableToRangeableTask(t, idx, className, filterableToRangeablePropName)
 
-	// Inject the update right after the per-prop pointer flip: the ingest name
-	// is unregistered but the callbacks are still armed.
-	swapWindowWriteDone := false
+	injected := false
 	origSwap := task.processOneSwapPropFn
 	task.processOneSwapPropFn = func(ctx context.Context, store *lsmkv.Store, rt reindexTracker, propIdx int, prop string) (*lsmkv.Bucket, error) {
 		oldMain, err := origSwap(ctx, store, rt, propIdx, prop)
 		if err != nil {
 			return oldMain, err
 		}
-		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
-			MarshallerVersion: 1,
-			Object: models.Object{
-				ID:                 objs[0].ID(),
-				Class:              className,
-				Properties:         map[string]interface{}{propName: mark},
-				CreationTimeUnix:   time.Now().UnixMilli(),
-				LastUpdateTimeUnix: time.Now().UnixMilli(),
-			},
-		}), "live write during the swap window must not fail (pre-fix it paniced in the double-write callback)")
-		swapWindowWriteDone = true
+		sc.inject(t, ctx, shard, objs)
+		injected = true
 		return oldMain, nil
 	}
 
 	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
 	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
 	require.NoError(t, task.RunSwapOnShard(ctx, shard))
-	require.True(t, swapWindowWriteDone, "swap-window write hook must have fired")
+	require.True(t, injected, "swap-window injection hook must have fired")
 
-	bucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	bucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(filterableToRangeablePropName))
 	require.NotNil(t, bucket, "post-swap rangeable bucket must exist")
+	return bucket
+}
+
+// TestReindex_ConcurrentWriteDuringSwapWindow_NotLost pins
+// weaviate/weaviate#11688: a write landing between SwapBucketPointer
+// (unregisters the ingest name) and disableCallbacks must not be lost —
+// pre-fix the double-write callback dereferenced a nil bucket. The write is
+// an UPDATE, exercising both the delete-old and add-new callback legs.
+func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
+	// Outside the corpus so its posting list is unambiguously this write.
+	const mark = int64(999999)
+	bucket := swapWindowScenario{
+		inject: func(t *testing.T, ctx context.Context, shard *Shard, objs []*storobj.Object) {
+			require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+				MarshallerVersion: 1,
+				Object: models.Object{
+					ID:                 objs[0].ID(),
+					Class:              string(objs[0].Class()),
+					Properties:         map[string]interface{}{filterableToRangeablePropName: mark},
+					CreationTimeUnix:   time.Now().UnixMilli(),
+					LastUpdateTimeUnix: time.Now().UnixMilli(),
+				},
+			}), "live write during the swap window must not fail (pre-fix it paniced in the double-write callback)")
+		},
+	}.run(t)
 
 	// add-new leg: the updated value is range-queryable at exactly its docID.
 	assert.Lenf(t, readRangeableIDs(t, bucket, mark), 1,
@@ -117,12 +137,12 @@ func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
 			"target value %d — its double-write add leg was lost or paniced", mark)
 
 	// delete-old leg: objs[0] no longer contributes to value 0.
-	assert.Lenf(t, readRangeableIDs(t, bucket, 0), perValue-1,
+	assert.Lenf(t, readRangeableIDs(t, bucket, 0), swapWindowPerValue-1,
 		"#11688 swap-window: the update's delete-old leg did not remove the pre-value "+
 			"from the index — value 0 still has the stale docID")
 
 	// Every object present exactly once — objs[0] moved from 0 to mark.
-	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), numObjects,
+	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), swapWindowNumObjects,
 		"every object must be in the rangeable index exactly once after the swap")
 }
 
@@ -130,56 +150,20 @@ func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
 // counterpart of TestReindex_ConcurrentWriteDuringSwapWindow_NotLost
 // (weaviate/weaviate#11688): a mid-swap DELETE hits the same nil-bucket deref.
 func TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost(t *testing.T) {
-	ctx := testCtx()
-	const propName = filterableToRangeablePropName
-	const numObjects = 25
-	const perValue = numObjects / filterableToRangeableNumDistinctValues
-
-	className := "SwapWindowDelete_" + uuid.NewString()[:8]
-	class := newNoLiveIndexRangeableTestClass(className)
-
-	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-		false, false, false)
-	shard := shd.(*Shard)
-	defer shard.Shutdown(ctx)
-
-	objs := makeFilterableToRangeableTestObjects(t, numObjects, className)
-	for _, obj := range objs {
-		require.NoError(t, shard.PutObject(ctx, obj))
-	}
-	// objs[0] carries value 0; the backfill indexes it, then we delete it
-	// inside the swap window.
-
-	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
-
-	swapWindowDeleteDone := false
-	origSwap := task.processOneSwapPropFn
-	task.processOneSwapPropFn = func(ctx context.Context, store *lsmkv.Store, rt reindexTracker, propIdx int, prop string) (*lsmkv.Bucket, error) {
-		oldMain, err := origSwap(ctx, store, rt, propIdx, prop)
-		if err != nil {
-			return oldMain, err
-		}
-		require.NoError(t, shard.DeleteObject(ctx, objs[0].ID(), time.Now()),
-			"live delete during the swap window must not fail (pre-fix it paniced in the double-write delete callback)")
-		swapWindowDeleteDone = true
-		return oldMain, nil
-	}
-
-	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
-	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
-	require.NoError(t, task.RunSwapOnShard(ctx, shard))
-	require.True(t, swapWindowDeleteDone, "swap-window delete hook must have fired")
-
-	bucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
-	require.NotNil(t, bucket, "post-swap rangeable bucket must exist")
+	bucket := swapWindowScenario{
+		inject: func(t *testing.T, ctx context.Context, shard *Shard, objs []*storobj.Object) {
+			require.NoError(t, shard.DeleteObject(ctx, objs[0].ID(), time.Now()),
+				"live delete during the swap window must not fail (pre-fix it paniced in the double-write delete callback)")
+		},
+	}.run(t)
 
 	// The deleted object's contribution to value 0 is gone.
-	assert.Lenf(t, readRangeableIDs(t, bucket, 0), perValue-1,
+	assert.Lenf(t, readRangeableIDs(t, bucket, 0), swapWindowPerValue-1,
 		"#11688 swap-window: the delete written during the swap window did not remove "+
 			"the object from value 0 — its double-write delete leg was lost or paniced")
 
 	// One fewer object in the whole index.
-	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), numObjects-1,
+	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), swapWindowNumObjects-1,
 		"exactly one object must be removed from the rangeable index after the swap-window delete")
 }
 

--- a/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
+++ b/adapters/repos/db/inverted_reindex_write_during_swap_window_test.go
@@ -1,0 +1,199 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/filters"
+	entinverted "github.com/weaviate/weaviate/entities/inverted"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// rangeableDocIDsAtLeast returns every docID whose value is >= v in a
+// RoaringSetRange bucket, used to count the whole index (v=0 with all-positive
+// data) without per-value cursor iteration.
+func rangeableDocIDsAtLeast(t *testing.T, b *lsmkv.Bucket, v int64) []uint64 {
+	t.Helper()
+	reader := b.ReaderRoaringSetRange()
+	defer reader.Close()
+	lex, err := entinverted.LexicographicallySortableInt64(v)
+	require.NoError(t, err)
+	key := binary.BigEndian.Uint64(lex)
+	bm, release, err := reader.Read(context.Background(), key, filters.OperatorGreaterThanEqual)
+	require.NoError(t, err)
+	if release != nil {
+		defer release()
+	}
+	if bm == nil {
+		return nil
+	}
+	return bm.ToArray()
+}
+
+// TestReindex_ConcurrentWriteDuringSwapWindow_NotLost pins the third loss
+// mechanism of weaviate/weaviate#11688: a live write landing between
+// [lsmkv.Store.SwapBucketPointer] (which UNREGISTERS the ingest name) and the
+// deferred disableCallbacks at the end of runtimeSwap. The property has no
+// live index (IndexFilterable=false), so the write depends ENTIRELY on the
+// double-write callback; pre-fix that callback resolved store.Bucket(ingestName)
+// to nil and dereferenced it (lsmkv.MustBeExpectedStrategy on b.Strategy()) —
+// a nil-pointer panic in the write goroutine that, through the REST stack,
+// becomes an empty 200 with every inverted write of the call lost.
+//
+// The write is an UPDATE of an existing object, so it exercises BOTH callback
+// legs in the window: the delete-old leg (removing the pre-value from the
+// index) and the add-new leg. Post-fix (resolveDoubleWriteBucket) both fall
+// back to the canonical bucket name — the same physical bucket the ingest name
+// used to denote — and the update must be range-queryable after the migration.
+func TestReindex_ConcurrentWriteDuringSwapWindow_NotLost(t *testing.T) {
+	ctx := testCtx()
+	const propName = filterableToRangeablePropName
+	const numObjects = 25
+	const perValue = numObjects / filterableToRangeableNumDistinctValues
+	// Outside the corpus so its posting list is unambiguously this write.
+	const mark = int64(999999)
+
+	className := "SwapWindowUpdate_" + uuid.NewString()[:8]
+	class := newNoLiveIndexRangeableTestClass(className)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	objs := makeFilterableToRangeableTestObjects(t, numObjects, className)
+	for _, obj := range objs {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+	// objs[0] carries value 0 (0 % numDistinct); we update it to mark below.
+
+	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+
+	// Inject the update right after the production per-prop pointer flip: the
+	// ingest name is unregistered, the callbacks are still armed (their disable
+	// is deferred to the end of runtimeSwap), and the migration scope is active.
+	swapWindowWriteDone := false
+	origSwap := task.processOneSwapPropFn
+	task.processOneSwapPropFn = func(ctx context.Context, store *lsmkv.Store, rt reindexTracker, propIdx int, prop string) (*lsmkv.Bucket, error) {
+		oldMain, err := origSwap(ctx, store, rt, propIdx, prop)
+		if err != nil {
+			return oldMain, err
+		}
+		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:                 objs[0].ID(),
+				Class:              className,
+				Properties:         map[string]interface{}{propName: mark},
+				CreationTimeUnix:   time.Now().UnixMilli(),
+				LastUpdateTimeUnix: time.Now().UnixMilli(),
+			},
+		}), "live write during the swap window must not fail (pre-fix it paniced in the double-write callback)")
+		swapWindowWriteDone = true
+		return oldMain, nil
+	}
+
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+	require.True(t, swapWindowWriteDone, "swap-window write hook must have fired")
+
+	bucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, bucket, "post-swap rangeable bucket must exist")
+
+	// add-new leg: the updated value is range-queryable at exactly its docID.
+	assert.Lenf(t, readRangeableIDs(t, bucket, mark), 1,
+		"#11688 swap-window: the update written during the swap window is NOT under the "+
+			"target value %d — its double-write add leg was lost or paniced", mark)
+
+	// delete-old leg: objs[0] no longer contributes to value 0.
+	assert.Lenf(t, readRangeableIDs(t, bucket, 0), perValue-1,
+		"#11688 swap-window: the update's delete-old leg did not remove the pre-value "+
+			"from the index — value 0 still has the stale docID")
+
+	// Every object present exactly once — objs[0] moved from 0 to mark.
+	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), numObjects,
+		"every object must be in the rangeable index exactly once after the swap")
+}
+
+// TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost is the delete-only
+// counterpart of TestReindex_ConcurrentWriteDuringSwapWindow_NotLost: a mid-swap
+// object DELETE routes through the same double-write callback, which had the
+// same unchecked store.Bucket(ingestName) deref. Pre-fix the delete callback
+// paniced on the nil bucket (deleteFromPropertyRangeBucket → b.Strategy());
+// post-fix it resolves the canonical bucket and the delete's inverted removal
+// lands, so the deleted object is gone from the post-migration index.
+func TestReindex_ConcurrentDeleteDuringSwapWindow_NotLost(t *testing.T) {
+	ctx := testCtx()
+	const propName = filterableToRangeablePropName
+	const numObjects = 25
+	const perValue = numObjects / filterableToRangeableNumDistinctValues
+
+	className := "SwapWindowDelete_" + uuid.NewString()[:8]
+	class := newNoLiveIndexRangeableTestClass(className)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	objs := makeFilterableToRangeableTestObjects(t, numObjects, className)
+	for _, obj := range objs {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+	// objs[0] carries value 0; the backfill indexes it, then we delete it
+	// inside the swap window.
+
+	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+
+	swapWindowDeleteDone := false
+	origSwap := task.processOneSwapPropFn
+	task.processOneSwapPropFn = func(ctx context.Context, store *lsmkv.Store, rt reindexTracker, propIdx int, prop string) (*lsmkv.Bucket, error) {
+		oldMain, err := origSwap(ctx, store, rt, propIdx, prop)
+		if err != nil {
+			return oldMain, err
+		}
+		require.NoError(t, shard.DeleteObject(ctx, objs[0].ID(), time.Now()),
+			"live delete during the swap window must not fail (pre-fix it paniced in the double-write delete callback)")
+		swapWindowDeleteDone = true
+		return oldMain, nil
+	}
+
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+	require.True(t, swapWindowDeleteDone, "swap-window delete hook must have fired")
+
+	bucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, bucket, "post-swap rangeable bucket must exist")
+
+	// The deleted object's contribution to value 0 is gone.
+	assert.Lenf(t, readRangeableIDs(t, bucket, 0), perValue-1,
+		"#11688 swap-window: the delete written during the swap window did not remove "+
+			"the object from value 0 — its double-write delete leg was lost or paniced")
+
+	// One fewer object in the whole index.
+	assert.Lenf(t, rangeableDocIDsAtLeast(t, bucket, 0), numObjects-1,
+		"exactly one object must be removed from the rangeable index after the swap-window delete")
+}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -479,9 +479,8 @@ type Shard struct {
 
 	reindexer ShardReindexerV3
 
-	// Folded snapshot (see propValueIndexState) for lock-free reads on the hot
-	// write path; registration/arm/disarm publish a fresh copy behind
-	// propertyValueIndexCallbacksMu.
+	// Folded snapshot (propValueIndexState) for lock-free reads on the write
+	// path; registration/arm/disarm publish a fresh copy under the mutex.
 	propValueIndexState           atomic.Value // *propValueIndexState
 	propertyValueIndexCallbacksMu sync.Mutex
 	// stores names of properties that are searchable and use buckets of

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -479,11 +479,9 @@ type Shard struct {
 
 	reindexer ShardReindexerV3
 
-	// Folded copy-on-write snapshot ({add,del,scope}, see propValueIndexState)
-	// stored in atomic.Value for lock-free reads on the hot write path.
-	// Registration/arm/disarm (rare) each publish a fresh copy behind
-	// propertyValueIndexCallbacksMu; every object write loads one consistent
-	// snapshot without locking.
+	// Folded snapshot (see propValueIndexState) for lock-free reads on the hot
+	// write path; registration/arm/disarm publish a fresh copy behind
+	// propertyValueIndexCallbacksMu.
 	propValueIndexState           atomic.Value // *propValueIndexState
 	propertyValueIndexCallbacksMu sync.Mutex
 	// stores names of properties that are searchable and use buckets of

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -479,13 +479,13 @@ type Shard struct {
 
 	reindexer ShardReindexerV3
 
-	// Copy-on-write callback slices stored in atomic.Value for lock-free reads
-	// on the hot write path. Registration (rare) copies the slice behind
-	// propertyValueIndexCallbacksMu; iteration (every object write) loads the
-	// current snapshot without locking.
-	callbacksAddToPropertyValueIndex      atomic.Value // []onAddToPropertyValueIndex
-	callbacksRemoveFromPropertyValueIndex atomic.Value // []onDeleteFromPropertyValueIndex
-	propertyValueIndexCallbacksMu         sync.Mutex
+	// Folded copy-on-write snapshot ({add,del,scope}, see propValueIndexState)
+	// stored in atomic.Value for lock-free reads on the hot write path.
+	// Registration/arm/disarm (rare) each publish a fresh copy behind
+	// propertyValueIndexCallbacksMu; every object write loads one consistent
+	// snapshot without locking.
+	propValueIndexState           atomic.Value // *propValueIndexState
+	propertyValueIndexCallbacksMu sync.Mutex
 	// stores names of properties that are searchable and use buckets of
 	// inverted strategy. for such properties delta analyzer should avoid
 	// computing delta between previous and current values of properties
@@ -974,16 +974,10 @@ func (s *Shard) registerAddToPropertyValueIndex(callback onAddToPropertyValueInd
 		return callback(shard, docID, property)
 	}
 
-	s.propertyValueIndexCallbacksMu.Lock()
-	var current []onAddToPropertyValueIndex
-	if v := s.callbacksAddToPropertyValueIndex.Load(); v != nil {
-		current = v.([]onAddToPropertyValueIndex)
-	}
-	updated := make([]onAddToPropertyValueIndex, len(current)+1)
-	copy(updated, current)
-	updated[len(current)] = wrapped
-	s.callbacksAddToPropertyValueIndex.Store(updated)
-	s.propertyValueIndexCallbacksMu.Unlock()
+	s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
+		cur.add = appendAddCallback(cur.add, wrapped)
+		return cur
+	})
 
 	return func() { disabled.Store(true) }
 }
@@ -997,16 +991,10 @@ func (s *Shard) registerDeleteFromPropertyValueIndex(callback onDeleteFromProper
 		return callback(shard, docID, property)
 	}
 
-	s.propertyValueIndexCallbacksMu.Lock()
-	var current []onDeleteFromPropertyValueIndex
-	if v := s.callbacksRemoveFromPropertyValueIndex.Load(); v != nil {
-		current = v.([]onDeleteFromPropertyValueIndex)
-	}
-	updated := make([]onDeleteFromPropertyValueIndex, len(current)+1)
-	copy(updated, current)
-	updated[len(current)] = wrapped
-	s.callbacksRemoveFromPropertyValueIndex.Store(updated)
-	s.propertyValueIndexCallbacksMu.Unlock()
+	s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
+		cur.del = appendDeleteCallback(cur.del, wrapped)
+		return cur
+	})
 
 	return func() { disabled.Store(true) }
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -962,38 +962,45 @@ func (s *Shard) Activity() (int32, int32) {
 	return s.activityTrackerRead.Load(), s.activityTrackerWrite.Load()
 }
 
+// registerAddToPropertyValueIndex appends callback to the folded write-path
+// snapshot and returns a disarm func that REMOVES it again (by id, copy-on-write
+// under the mutex). Removing rather than flagging keeps the slice bounded: the
+// backup-window migration path (re)registers a pair per run, so a
+// flag-and-keep disarm would leak one entry per migration onto the hot path for
+// the life of the shard. Disarm is idempotent — a second call finds no matching
+// id and no-ops.
 func (s *Shard) registerAddToPropertyValueIndex(callback onAddToPropertyValueIndex) func() {
-	disabled := &atomic.Bool{}
-	wrapped := func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if disabled.Load() {
-			return nil
-		}
-		return callback(shard, docID, property)
-	}
-
+	var id uint64
 	s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
-		cur.add = appendAddCallback(cur.add, wrapped)
+		id = cur.nextCallbackID
+		cur.nextCallbackID++
+		cur.add = appendAddCallback(cur.add, id, callback)
 		return cur
 	})
 
-	return func() { disabled.Store(true) }
+	return func() {
+		s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
+			cur.add = removeAddCallback(cur.add, id)
+			return cur
+		})
+	}
 }
 
 func (s *Shard) registerDeleteFromPropertyValueIndex(callback onDeleteFromPropertyValueIndex) func() {
-	disabled := &atomic.Bool{}
-	wrapped := func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if disabled.Load() {
-			return nil
-		}
-		return callback(shard, docID, property)
-	}
-
+	var id uint64
 	s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
-		cur.del = appendDeleteCallback(cur.del, wrapped)
+		id = cur.nextCallbackID
+		cur.nextCallbackID++
+		cur.del = appendDeleteCallback(cur.del, id, callback)
 		return cur
 	})
 
-	return func() { disabled.Store(true) }
+	return func() {
+		s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
+			cur.del = removeDeleteCallback(cur.del, id)
+			return cur
+		})
+	}
 }
 
 // AnyActiveMovement reports whether a replica movement is in flight for this shard.

--- a/adapters/repos/db/shard_callbacks_test.go
+++ b/adapters/repos/db/shard_callbacks_test.go
@@ -213,8 +213,7 @@ func TestShardCallbacks_DualWriteMigration(t *testing.T) {
 	// (via addToPropertyValueIndex) which also triggers callbacks.
 	writeDoc := func(t *testing.T, docID uint64, term string) {
 		t.Helper()
-		// Load the snapshot fresh each write so the callback registered
-		// mid-test is observed, mirroring the production write path.
+		// Reload each write so mid-test callback registration is observed.
 		err := s.addToPropertyValueIndex(docID, inverted.Property{
 			Name:               propName,
 			Items:              []inverted.Countable{{Data: []byte(term)}},

--- a/adapters/repos/db/shard_callbacks_test.go
+++ b/adapters/repos/db/shard_callbacks_test.go
@@ -213,11 +213,13 @@ func TestShardCallbacks_DualWriteMigration(t *testing.T) {
 	// (via addToPropertyValueIndex) which also triggers callbacks.
 	writeDoc := func(t *testing.T, docID uint64, term string) {
 		t.Helper()
+		// Load the snapshot fresh each write so the callback registered
+		// mid-test is observed, mirroring the production write path.
 		err := s.addToPropertyValueIndex(docID, inverted.Property{
 			Name:               propName,
 			Items:              []inverted.Countable{{Data: []byte(term)}},
 			HasFilterableIndex: true,
-		})
+		}, s.loadPropValueIndexState())
 		require.NoError(t, err)
 	}
 

--- a/adapters/repos/db/shard_callbacks_test.go
+++ b/adapters/repos/db/shard_callbacks_test.go
@@ -348,4 +348,131 @@ func TestShardCallbacks_ConcurrentRegistrationAndWrites(t *testing.T) {
 
 	// The base callback must have been invoked at least once (sanity).
 	assert.Greater(t, baseCount.Load(), int64(0))
+
+	// Every concurrent registration disarmed itself, so the folded snapshot
+	// must be back to exactly the one base callback. A disarm that only flagged
+	// (rather than removed) its closure would leave numRegistrations leaked
+	// entries here — the unbounded-growth leak this guards against.
+	assert.Len(t, s.loadPropValueIndexState().add, 1,
+		"disarm must REMOVE each registration; the slice must not accumulate disarmed closures")
+}
+
+// TestShardCallbacks_DisarmRemovesCallbacks_NoUnboundedGrowth is the regression
+// test for the callback-slice leak (PR #11985 reviewer finding S1;
+// weaviate/0-weaviate-issues#298 family). Disarm must REMOVE a registration's
+// closures from the folded write-path snapshot, not merely flag them disabled.
+// Before the fix, every past migration's closures stayed on the hot write path
+// forever — O(migrations) per-write cost and a slow leak on long-lived shards.
+//
+// The shrink is asserted through observable behavior — the number of callback
+// invocations per fire tracks the number of *currently armed* callbacks — so a
+// future append-without-remove regression makes the leaked closures fire and
+// inflates the count. No test-only seam is added to production code; the slice
+// is read via the production loadPropValueIndexState snapshot.
+func TestShardCallbacks_DisarmRemovesCallbacks_NoUnboundedGrowth(t *testing.T) {
+	const numMigrations = 100
+
+	t.Run("single-callback add path", func(t *testing.T) {
+		s := &Shard{}
+		var invocations atomic.Int64
+		countingAdd := func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			invocations.Add(1)
+			return nil
+		}
+
+		// A witness callback stays armed for the whole test.
+		s.registerAddToPropertyValueIndex(countingAdd)
+
+		// Simulate many migrations: each arms a counting callback then disarms it.
+		for i := 0; i < numMigrations; i++ {
+			s.registerAddToPropertyValueIndex(countingAdd)()
+		}
+
+		require.Len(t, s.loadPropValueIndexState().add, 1,
+			"only the witness callback may remain after %d arm+disarm cycles", numMigrations)
+
+		invocations.Store(0)
+		require.NoError(t, s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "p"}))
+		assert.Equal(t, int64(1), invocations.Load(),
+			"exactly one armed callback must fire; a leak would inflate this to 1+%d", numMigrations)
+	})
+
+	t.Run("single-callback delete path", func(t *testing.T) {
+		s := &Shard{}
+		var invocations atomic.Int64
+		countingDel := func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			invocations.Add(1)
+			return nil
+		}
+
+		s.registerDeleteFromPropertyValueIndex(countingDel)
+		for i := 0; i < numMigrations; i++ {
+			s.registerDeleteFromPropertyValueIndex(countingDel)()
+		}
+
+		require.Len(t, s.loadPropValueIndexState().del, 1,
+			"only the witness callback may remain after %d arm+disarm cycles", numMigrations)
+
+		invocations.Store(0)
+		require.NoError(t, s.onDeleteFromPropertyValueIndex(1, &inverted.Property{Name: "p"}))
+		assert.Equal(t, int64(1), invocations.Load(),
+			"exactly one armed callback must fire; a leak would inflate this to 1+%d", numMigrations)
+	})
+
+	t.Run("double-write scope path", func(t *testing.T) {
+		s := &Shard{}
+		var addInvocations, delInvocations atomic.Int64
+		props := []string{"p"}
+
+		// Each migration arms the add+delete pair AND the scope, then disarms
+		// all three in one atomic mutate.
+		for i := 0; i < numMigrations; i++ {
+			s.registerDoubleWriteWithScope(
+				func(_ *Shard, _ uint64, _ *inverted.Property) error { addInvocations.Add(1); return nil },
+				func(_ *Shard, _ uint64, _ *inverted.Property) error { delInvocations.Add(1); return nil },
+				props, nil,
+			)()
+		}
+
+		st := s.loadPropValueIndexState()
+		assert.Empty(t, st.add, "every disarm must remove its add closure")
+		assert.Empty(t, st.del, "every disarm must remove its delete closure")
+		assert.Empty(t, st.scope.props, "disarm must collapse the scope back to the idle fast path")
+
+		// Firing must invoke nothing — all pairs were removed, not just flagged.
+		require.NoError(t, s.fireAddToPropertyValueIndex(st, 1, &inverted.Property{Name: "p"}))
+		require.NoError(t, s.fireDeleteFromPropertyValueIndex(st, 1, &inverted.Property{Name: "p"}))
+		assert.Equal(t, int64(0), addInvocations.Load(),
+			"all add closures must be removed on disarm; a leak would fire %d of them", numMigrations)
+		assert.Equal(t, int64(0), delInvocations.Load(),
+			"all delete closures must be removed on disarm; a leak would fire %d of them", numMigrations)
+	})
+
+	t.Run("interleaved arm/disarm leaves only the still-armed callbacks", func(t *testing.T) {
+		s := &Shard{}
+		var invocations atomic.Int64
+		countingAdd := func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			invocations.Add(1)
+			return nil
+		}
+
+		// Arm three, disarm the middle one — order must not matter for removal.
+		d0 := s.registerAddToPropertyValueIndex(countingAdd)
+		d1 := s.registerAddToPropertyValueIndex(countingAdd)
+		d2 := s.registerAddToPropertyValueIndex(countingAdd)
+		_ = d0
+		_ = d2
+		d1()
+
+		require.Len(t, s.loadPropValueIndexState().add, 2,
+			"disarming one of three must leave exactly two armed")
+		require.NoError(t, s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "p"}))
+		assert.Equal(t, int64(2), invocations.Load(), "the two still-armed callbacks must fire")
+
+		// Disarm the remaining two; the slice must be empty.
+		d0()
+		d2()
+		assert.Empty(t, s.loadPropValueIndexState().add,
+			"disarming all registrations must leave an empty slice")
+	})
 }

--- a/adapters/repos/db/shard_callbacks_test.go
+++ b/adapters/repos/db/shard_callbacks_test.go
@@ -27,6 +27,18 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
+// onAddToPropertyValueIndex and onDeleteFromPropertyValueIndex are test-only
+// shorthands that fire the registered add/delete callbacks against the shard's
+// default (no-scope) index state. Production code fires callbacks via
+// fire{Add,Delete}FromPropertyValueIndex directly with an explicit scope state.
+func (s *Shard) onAddToPropertyValueIndex(docID uint64, property *inverted.Property) error {
+	return s.fireAddToPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
+}
+
+func (s *Shard) onDeleteFromPropertyValueIndex(docID uint64, property *inverted.Property) error {
+	return s.fireDeleteFromPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
+}
+
 func TestShardCallbacks_AddToPropertyValueIndex(t *testing.T) {
 	t.Run("callback fires", func(t *testing.T) {
 		s := &Shard{}

--- a/adapters/repos/db/shard_migration_double_write.go
+++ b/adapters/repos/db/shard_migration_double_write.go
@@ -20,16 +20,11 @@ import (
 )
 
 // migrationDoubleWriteScope names the properties whose live double-write must
-// be analyzed under the migration's TARGET schema instead of the source
-// schema, plus the analyzer overlay that produces that target analysis. It is
-// empty (nil maps) whenever no reindex migration is ingesting on this shard,
-// which is the overwhelmingly common case; a nil-map lookup on the write path
-// then costs nothing.
-//
-// The scope is DERIVED from the registered ingest-window double-write
-// callbacks, never persisted: OnAfterLsmInit re-registers the callbacks on
-// every boot and re-arms the scope, so a restart rebuilds it with no on-disk
-// format.
+// be analyzed under the migration's TARGET schema (via overlay), so an
+// overlapping write mirrors the same terms the backfill produced. Empty (nil
+// maps) when no migration is ingesting, so the write-path lookup then costs
+// nothing. Derived from the ingest-window callbacks (re-armed on every boot),
+// never persisted.
 type migrationDoubleWriteScope struct {
 	props   map[string]struct{}
 	overlay map[string]inverted.PropertyOverlay
@@ -96,13 +91,11 @@ func insertUnlessIn(dst map[string]struct{}, key string, drop []string) map[stri
 	return dst
 }
 
-// propValueIndexState is the single copy-on-write snapshot behind the write
-// path's one atomic Load: the add/delete property-value-index callback slices
-// PLUS the migration double-write scope. Folding all three into one value is
-// what makes a write observe a CONSISTENT triple — a concurrent arm/disarm can
-// never expose "callbacks registered but scope not yet armed" (a source-schema
-// leak into the ingest bucket) or "scope armed but callbacks gone" (a target
-// write silently dropped).
+// propValueIndexState folds the add/delete callback slices and the migration
+// scope into one atomic snapshot so a write observes a CONSISTENT triple: a
+// concurrent arm/disarm can never expose callbacks-without-scope (source-schema
+// leak into the ingest bucket) or scope-without-callbacks (dropped target
+// write).
 type propValueIndexState struct {
 	add   []onAddToPropertyValueIndex
 	del   []onDeleteFromPropertyValueIndex
@@ -122,13 +115,6 @@ func (s *Shard) loadPropValueIndexState() *propValueIndexState {
 		return v.(*propValueIndexState)
 	}
 	return emptyPropValueIndexState
-}
-
-// migrationDoubleWriteScope exposes just the scope of the current snapshot for
-// callers that do not need the callback slices. The hot write path uses the
-// full state's .scope instead so it Loads only once.
-func (s *Shard) migrationDoubleWriteScope() *migrationDoubleWriteScope {
-	return &s.loadPropValueIndexState().scope
 }
 
 // mutatePropValueIndexState is the SOLE writer of the folded snapshot: it
@@ -203,12 +189,11 @@ func (s *Shard) analyzeForDoubleWrite(obj *storobj.Object, st *propValueIndexSta
 	return filtered, nil
 }
 
-// migrationDoubleWrite mirrors an object write into the reindex ingest bucket
-// under the migration's TARGET analysis, for the scope properties whose inline
-// callback the write path suppressed. It deletes the previous object's target
-// terms then adds the new object's, matching the main path's delete-then-add
-// order; the ingest bucket is a write-only sidecar until swap, so the full
-// re-add per write is idempotent and invisible to queries.
+// migrationDoubleWrite mirrors an object write into the ingest bucket under the
+// migration's TARGET analysis for the scope props whose inline callback the
+// write path suppressed. Delete-old then add-new (main-path order); the ingest
+// bucket is a write-only sidecar until swap, so full per-write churn is
+// idempotent and invisible to queries.
 func (s *Shard) migrationDoubleWrite(st *propValueIndexState, object, prevObject *storobj.Object,
 	status objectInsertStatus,
 ) error {

--- a/adapters/repos/db/shard_migration_double_write.go
+++ b/adapters/repos/db/shard_migration_double_write.go
@@ -1,0 +1,282 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync/atomic"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// migrationDoubleWriteScope names the properties whose live double-write must
+// be analyzed under the migration's TARGET schema instead of the source
+// schema, plus the analyzer overlay that produces that target analysis. It is
+// empty (nil maps) whenever no reindex migration is ingesting on this shard,
+// which is the overwhelmingly common case; a nil-map lookup on the write path
+// then costs nothing.
+//
+// The scope is DERIVED from the registered ingest-window double-write
+// callbacks, never persisted: OnAfterLsmInit re-registers the callbacks on
+// every boot and re-arms the scope, so a restart rebuilds it with no on-disk
+// format.
+type migrationDoubleWriteScope struct {
+	props   map[string]struct{}
+	overlay map[string]inverted.PropertyOverlay
+}
+
+// withArmed returns a copy-on-write scope that additionally covers props and
+// merges overlay. Callers hold propertyValueIndexCallbacksMu; the returned
+// maps are fresh so a concurrent lock-free reader keeps observing the old
+// snapshot until the atomic Store publishes this one.
+func (sc migrationDoubleWriteScope) withArmed(props []string,
+	overlay map[string]inverted.PropertyOverlay,
+) migrationDoubleWriteScope {
+	next := migrationDoubleWriteScope{
+		props:   make(map[string]struct{}, len(sc.props)+len(props)),
+		overlay: make(map[string]inverted.PropertyOverlay, len(sc.overlay)+len(overlay)),
+	}
+	for k := range sc.props {
+		next.props[k] = struct{}{}
+	}
+	for _, p := range props {
+		next.props[p] = struct{}{}
+	}
+	for k, v := range sc.overlay {
+		next.overlay[k] = v
+	}
+	for k, v := range overlay {
+		next.overlay[k] = v
+	}
+	return next
+}
+
+// withDisarmed returns a copy-on-write scope with props and overlay's keys
+// removed. An emptied scope collapses back to nil maps so the write path's
+// fast path (len(scope.props) == 0) re-engages once the migration ends.
+func (sc migrationDoubleWriteScope) withDisarmed(props []string,
+	overlay map[string]inverted.PropertyOverlay,
+) migrationDoubleWriteScope {
+	var next migrationDoubleWriteScope
+	for k := range sc.props {
+		next.props = insertUnlessIn(next.props, k, props)
+	}
+	for k, v := range sc.overlay {
+		if _, drop := overlay[k]; drop {
+			continue
+		}
+		if next.overlay == nil {
+			next.overlay = make(map[string]inverted.PropertyOverlay, len(sc.overlay))
+		}
+		next.overlay[k] = v
+	}
+	return next
+}
+
+func insertUnlessIn(dst map[string]struct{}, key string, drop []string) map[string]struct{} {
+	for _, d := range drop {
+		if d == key {
+			return dst
+		}
+	}
+	if dst == nil {
+		dst = map[string]struct{}{}
+	}
+	dst[key] = struct{}{}
+	return dst
+}
+
+// propValueIndexState is the single copy-on-write snapshot behind the write
+// path's one atomic Load: the add/delete property-value-index callback slices
+// PLUS the migration double-write scope. Folding all three into one value is
+// what makes a write observe a CONSISTENT triple — a concurrent arm/disarm can
+// never expose "callbacks registered but scope not yet armed" (a source-schema
+// leak into the ingest bucket) or "scope armed but callbacks gone" (a target
+// write silently dropped).
+type propValueIndexState struct {
+	add   []onAddToPropertyValueIndex
+	del   []onDeleteFromPropertyValueIndex
+	scope migrationDoubleWriteScope
+}
+
+// emptyPropValueIndexState is returned by loadPropValueIndexState before any
+// callback has ever been registered, so callers never nil-check the Load.
+var emptyPropValueIndexState = &propValueIndexState{}
+
+// loadPropValueIndexState returns the current folded snapshot without locking.
+// The whole write path takes exactly one of these per object so inline
+// suppression, migAdd/migDel computation, and the migration callback pass all
+// read the same consistent {add,del,scope}.
+func (s *Shard) loadPropValueIndexState() *propValueIndexState {
+	if v := s.propValueIndexState.Load(); v != nil {
+		return v.(*propValueIndexState)
+	}
+	return emptyPropValueIndexState
+}
+
+// migrationDoubleWriteScope exposes just the scope of the current snapshot for
+// callers that do not need the callback slices. The hot write path uses the
+// full state's .scope instead so it Loads only once.
+func (s *Shard) migrationDoubleWriteScope() *migrationDoubleWriteScope {
+	return &s.loadPropValueIndexState().scope
+}
+
+// mutatePropValueIndexState is the SOLE writer of the folded snapshot: it
+// applies fn to a copy under propertyValueIndexCallbacksMu and publishes the
+// result with one atomic Store, so registration, arm, and disarm each land as
+// a single indivisible transition for lock-free readers. fn must copy any
+// slice/map it grows rather than appending in place.
+func (s *Shard) mutatePropValueIndexState(fn func(cur propValueIndexState) propValueIndexState) {
+	s.propertyValueIndexCallbacksMu.Lock()
+	defer s.propertyValueIndexCallbacksMu.Unlock()
+
+	var cur propValueIndexState
+	if v := s.propValueIndexState.Load(); v != nil {
+		cur = *(v.(*propValueIndexState))
+	}
+	next := fn(cur)
+	s.propValueIndexState.Store(&next)
+}
+
+func appendAddCallback(cur []onAddToPropertyValueIndex, cb onAddToPropertyValueIndex) []onAddToPropertyValueIndex {
+	updated := make([]onAddToPropertyValueIndex, len(cur)+1)
+	copy(updated, cur)
+	updated[len(cur)] = cb
+	return updated
+}
+
+func appendDeleteCallback(cur []onDeleteFromPropertyValueIndex, cb onDeleteFromPropertyValueIndex) []onDeleteFromPropertyValueIndex {
+	updated := make([]onDeleteFromPropertyValueIndex, len(cur)+1)
+	copy(updated, cur)
+	updated[len(cur)] = cb
+	return updated
+}
+
+// fireAddToPropertyValueIndex invokes every registered add callback against
+// the given (already target-analyzed) property. The migration pass calls this
+// directly to BYPASS the scope suppression that the inline write path applies —
+// suppressing here would drop the very write the migration exists to make.
+func (s *Shard) fireAddToPropertyValueIndex(st *propValueIndexState, docID uint64, property *inverted.Property) error {
+	ec := errorcompounder.New()
+	for _, cb := range st.add {
+		ec.Add(cb(s, docID, property))
+	}
+	return ec.ToError()
+}
+
+// fireDeleteFromPropertyValueIndex is the delete-side counterpart of
+// fireAddToPropertyValueIndex.
+func (s *Shard) fireDeleteFromPropertyValueIndex(st *propValueIndexState, docID uint64, property *inverted.Property) error {
+	ec := errorcompounder.New()
+	for _, cb := range st.del {
+		ec.Add(cb(s, docID, property))
+	}
+	return ec.ToError()
+}
+
+// analyzeForDoubleWrite produces the TARGET-schema analysis of obj that the
+// migration double-write needs: AnalyzeObjectForMigrationWithOverlay (which
+// captures RawValues and applies the Force*/tokenization overlay) restricted
+// to the properties currently in migration scope. Non-scope properties are
+// dropped so the migration pass never touches a bucket it does not own.
+func (s *Shard) analyzeForDoubleWrite(obj *storobj.Object, st *propValueIndexState) ([]inverted.Property, error) {
+	props, _, err := s.AnalyzeObjectForMigrationWithOverlay(obj, st.scope.overlay)
+	if err != nil {
+		return nil, err
+	}
+	filtered := props[:0]
+	for i := range props {
+		if _, ok := st.scope.props[props[i].Name]; ok {
+			filtered = append(filtered, props[i])
+		}
+	}
+	return filtered, nil
+}
+
+// migrationDoubleWrite mirrors an object write into the reindex ingest bucket
+// under the migration's TARGET analysis, for the scope properties whose inline
+// callback the write path suppressed. It deletes the previous object's target
+// terms then adds the new object's, matching the main path's delete-then-add
+// order; the ingest bucket is a write-only sidecar until swap, so the full
+// re-add per write is idempotent and invisible to queries.
+func (s *Shard) migrationDoubleWrite(st *propValueIndexState, object, prevObject *storobj.Object,
+	status objectInsertStatus,
+) error {
+	if len(st.scope.props) == 0 {
+		return nil
+	}
+
+	if prevObject != nil {
+		migDel, err := s.analyzeForDoubleWrite(prevObject, st)
+		if err != nil {
+			return err
+		}
+		for i := range migDel {
+			if err := s.fireDeleteFromPropertyValueIndex(st, status.oldDocID, &migDel[i]); err != nil {
+				return err
+			}
+		}
+	}
+
+	migAdd, err := s.analyzeForDoubleWrite(object, st)
+	if err != nil {
+		return err
+	}
+	for i := range migAdd {
+		if err := s.fireAddToPropertyValueIndex(st, status.docID, &migAdd[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// registerDoubleWriteWithScope registers the ingest-window add+delete
+// double-write callbacks AND arms the migration scope in ONE atomic Store, so
+// a concurrent writer never sees the callbacks without the scope (which would
+// leak source-tokenized terms into the ingest bucket — the weaviate#298 bug).
+// The returned disable func tears both down again.
+func (s *Shard) registerDoubleWriteWithScope(add onAddToPropertyValueIndex, del onDeleteFromPropertyValueIndex,
+	props []string, overlay map[string]inverted.PropertyOverlay,
+) func() {
+	disabled := &atomic.Bool{}
+	wrappedAdd := func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if disabled.Load() {
+			return nil
+		}
+		return add(shard, docID, property)
+	}
+	wrappedDelete := func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if disabled.Load() {
+			return nil
+		}
+		return del(shard, docID, property)
+	}
+
+	s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
+		cur.add = appendAddCallback(cur.add, wrappedAdd)
+		cur.del = appendDeleteCallback(cur.del, wrappedDelete)
+		cur.scope = cur.scope.withArmed(props, overlay)
+		return cur
+	})
+
+	return func() {
+		// Stop the callbacks first (lock-free) so they cannot write to the
+		// post-swap ingest bucket, then drop the scope so the inline path
+		// resumes owning these props.
+		disabled.Store(true)
+		s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
+			cur.scope = cur.scope.withDisarmed(props, overlay)
+			return cur
+		})
+	}
+}

--- a/adapters/repos/db/shard_migration_double_write.go
+++ b/adapters/repos/db/shard_migration_double_write.go
@@ -12,8 +12,6 @@
 package db
 
 import (
-	"sync/atomic"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -85,13 +83,34 @@ func insertUnlessIn(dst map[string]struct{}, key string, drop []string) map[stri
 	return dst
 }
 
+// addCallbackEntry pairs a registered add callback with the id its disarm func
+// removes it by. Go forbids comparing func values, so an explicit id lets
+// disarm drop exactly this registration from the copy-on-write slice — the
+// callback is REMOVED, not just flagged, so the slice can never grow without
+// bound across a long-lived shard's migration history.
+type addCallbackEntry struct {
+	id uint64
+	fn onAddToPropertyValueIndex
+}
+
+// deleteCallbackEntry is addCallbackEntry's delete-side counterpart.
+type deleteCallbackEntry struct {
+	id uint64
+	fn onDeleteFromPropertyValueIndex
+}
+
 // propValueIndexState folds the callback slices and migration scope into one
 // atomic snapshot, so a concurrent arm/disarm can never expose
 // callbacks-without-scope or scope-without-callbacks to a write.
+//
+// nextCallbackID hands out per-registration ids under mutatePropValueIndexState's
+// mutex; it is carried by copy across mutations so every registration gets a
+// distinct id its disarm can remove by.
 type propValueIndexState struct {
-	add   []onAddToPropertyValueIndex
-	del   []onDeleteFromPropertyValueIndex
-	scope migrationDoubleWriteScope
+	add            []addCallbackEntry
+	del            []deleteCallbackEntry
+	scope          migrationDoubleWriteScope
+	nextCallbackID uint64
 }
 
 // emptyPropValueIndexState is returned by loadPropValueIndexState before any
@@ -124,17 +143,57 @@ func (s *Shard) mutatePropValueIndexState(fn func(cur propValueIndexState) propV
 	s.propValueIndexState.Store(&next)
 }
 
-func appendAddCallback(cur []onAddToPropertyValueIndex, cb onAddToPropertyValueIndex) []onAddToPropertyValueIndex {
-	updated := make([]onAddToPropertyValueIndex, len(cur)+1)
+// appendAddCallback returns a fresh slice (copy-on-write) with cb appended
+// under id, so a lock-free reader iterating the old slice is never mutated.
+func appendAddCallback(cur []addCallbackEntry, id uint64, cb onAddToPropertyValueIndex) []addCallbackEntry {
+	updated := make([]addCallbackEntry, len(cur)+1)
 	copy(updated, cur)
-	updated[len(cur)] = cb
+	updated[len(cur)] = addCallbackEntry{id: id, fn: cb}
 	return updated
 }
 
-func appendDeleteCallback(cur []onDeleteFromPropertyValueIndex, cb onDeleteFromPropertyValueIndex) []onDeleteFromPropertyValueIndex {
-	updated := make([]onDeleteFromPropertyValueIndex, len(cur)+1)
+func appendDeleteCallback(cur []deleteCallbackEntry, id uint64, cb onDeleteFromPropertyValueIndex) []deleteCallbackEntry {
+	updated := make([]deleteCallbackEntry, len(cur)+1)
 	copy(updated, cur)
-	updated[len(cur)] = cb
+	updated[len(cur)] = deleteCallbackEntry{id: id, fn: cb}
+	return updated
+}
+
+// removeAddCallback returns a fresh slice (copy-on-write) with the entry
+// carrying id dropped, so disarm shrinks the slice a lock-free reader may be
+// iterating without mutating that reader's copy. Returns cur unchanged (same
+// backing array) when id is absent, making a double-disarm a no-op.
+func removeAddCallback(cur []addCallbackEntry, id uint64) []addCallbackEntry {
+	idx := -1
+	for i := range cur {
+		if cur[i].id == id {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return cur
+	}
+	updated := make([]addCallbackEntry, 0, len(cur)-1)
+	updated = append(updated, cur[:idx]...)
+	updated = append(updated, cur[idx+1:]...)
+	return updated
+}
+
+func removeDeleteCallback(cur []deleteCallbackEntry, id uint64) []deleteCallbackEntry {
+	idx := -1
+	for i := range cur {
+		if cur[i].id == id {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return cur
+	}
+	updated := make([]deleteCallbackEntry, 0, len(cur)-1)
+	updated = append(updated, cur[:idx]...)
+	updated = append(updated, cur[idx+1:]...)
 	return updated
 }
 
@@ -143,7 +202,7 @@ func appendDeleteCallback(cur []onDeleteFromPropertyValueIndex, cb onDeleteFromP
 func (s *Shard) fireAddToPropertyValueIndex(st *propValueIndexState, docID uint64, property *inverted.Property) error {
 	ec := errorcompounder.New()
 	for _, cb := range st.add {
-		ec.Add(cb(s, docID, property))
+		ec.Add(cb.fn(s, docID, property))
 	}
 	return ec.ToError()
 }
@@ -151,7 +210,7 @@ func (s *Shard) fireAddToPropertyValueIndex(st *propValueIndexState, docID uint6
 func (s *Shard) fireDeleteFromPropertyValueIndex(st *propValueIndexState, docID uint64, property *inverted.Property) error {
 	ec := errorcompounder.New()
 	for _, cb := range st.del {
-		ec.Add(cb(s, docID, property))
+		ec.Add(cb.fn(s, docID, property))
 	}
 	return ec.ToError()
 }
@@ -230,35 +289,40 @@ func (s *Shard) migrationDoubleWriteDelete(st *propValueIndexState, prevObject *
 // callbacks in ONE atomic Store, so a concurrent writer never sees callbacks
 // without the scope and leaks source-tokenized terms into the ingest bucket
 // (weaviate/0-weaviate-issues#298). Returned func disarms both.
+//
+// Disarm REMOVES the callbacks (by id) in the SAME atomic mutate that drops the
+// scope. Two consequences:
+//
+//   - No unbounded growth. Earlier this only flagged the closures disabled and
+//     left them in the slice, so every past migration's pair stayed on the hot
+//     write path forever — O(migrations) per-write cost plus a slow leak on
+//     long-lived shards. Removing them keeps the slice bounded by the number of
+//     migrations in flight.
+//   - No disabled-flag guard needed. A flag was only ever required because the
+//     old disarm dropped the scope while leaving the callbacks present,
+//     transiently exposing a {scope-absent, callback-present} state a writer
+//     would double-write through. Removing callback and scope together makes
+//     that torn state unobservable, so the flag is redundant. Any in-flight
+//     writer still holding the pre-disarm snapshot fires the callback safely:
+//     resolveScopedDoubleWriteBucket lands the mirror in the surviving canonical
+//     bucket (target phase) or no-ops when the sidecar is gone (backup phase).
 func (s *Shard) registerDoubleWriteWithScope(add onAddToPropertyValueIndex, del onDeleteFromPropertyValueIndex,
 	props []string, overlay map[string]inverted.PropertyOverlay,
 ) func() {
-	disabled := &atomic.Bool{}
-	wrappedAdd := func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if disabled.Load() {
-			return nil
-		}
-		return add(shard, docID, property)
-	}
-	wrappedDelete := func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if disabled.Load() {
-			return nil
-		}
-		return del(shard, docID, property)
-	}
-
+	var id uint64
 	s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
-		cur.add = appendAddCallback(cur.add, wrappedAdd)
-		cur.del = appendDeleteCallback(cur.del, wrappedDelete)
+		id = cur.nextCallbackID
+		cur.nextCallbackID++
+		cur.add = appendAddCallback(cur.add, id, add)
+		cur.del = appendDeleteCallback(cur.del, id, del)
 		cur.scope = cur.scope.withArmed(props, overlay)
 		return cur
 	})
 
 	return func() {
-		// Disable callbacks before dropping the scope, so none can write the
-		// post-swap ingest bucket while the inline path resumes owning these props.
-		disabled.Store(true)
 		s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
+			cur.add = removeAddCallback(cur.add, id)
+			cur.del = removeDeleteCallback(cur.del, id)
 			cur.scope = cur.scope.withDisarmed(props, overlay)
 			return cur
 		})

--- a/adapters/repos/db/shard_migration_double_write.go
+++ b/adapters/repos/db/shard_migration_double_write.go
@@ -240,6 +240,25 @@ func (s *Shard) migrationDoubleWrite(st *propValueIndexState, object, prevObject
 	return nil
 }
 
+// migrationDoubleWriteDelete is the delete-only counterpart of
+// migrationDoubleWrite, for the pure object-delete path: it removes the
+// deleted object's TARGET terms from the ingest bucket for scope properties.
+func (s *Shard) migrationDoubleWriteDelete(st *propValueIndexState, prevObject *storobj.Object, docID uint64) error {
+	if len(st.scope.props) == 0 || prevObject == nil {
+		return nil
+	}
+	migDel, err := s.analyzeForDoubleWrite(prevObject, st)
+	if err != nil {
+		return err
+	}
+	for i := range migDel {
+		if err := s.fireDeleteFromPropertyValueIndex(st, docID, &migDel[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // registerDoubleWriteWithScope registers the ingest-window add+delete
 // double-write callbacks AND arms the migration scope in ONE atomic Store, so
 // a concurrent writer never sees the callbacks without the scope (which would

--- a/adapters/repos/db/shard_migration_double_write.go
+++ b/adapters/repos/db/shard_migration_double_write.go
@@ -20,17 +20,15 @@ import (
 )
 
 // migrationDoubleWriteScope names properties needing TARGET-schema analysis
-// (via overlay), so an overlapping write mirrors the backfill. Nil maps when
-// idle keep the write-path lookup free. Derived from ingest callbacks and
-// re-armed each boot; never persisted.
+// via overlay, so an overlapping write mirrors the backfill. Nil maps mean
+// idle — no migration in flight.
 type migrationDoubleWriteScope struct {
 	props   map[string]struct{}
 	overlay map[string]inverted.PropertyOverlay
 }
 
-// withArmed returns copy-on-write scope additions: callers hold
-// propertyValueIndexCallbacksMu, and the fresh maps let a concurrent
-// lock-free reader keep seeing the old snapshot until Store publishes this one.
+// withArmed copies rather than mutates, so a concurrent lock-free reader keeps
+// seeing the old snapshot until Store publishes the new one.
 func (sc migrationDoubleWriteScope) withArmed(props []string,
 	overlay map[string]inverted.PropertyOverlay,
 ) migrationDoubleWriteScope {
@@ -88,9 +86,8 @@ func insertUnlessIn(dst map[string]struct{}, key string, drop []string) map[stri
 }
 
 // propValueIndexState folds the callback slices and migration scope into one
-// atomic snapshot, so a write sees a consistent triple: a concurrent arm/
-// disarm can never expose callbacks-without-scope (source leak into the
-// ingest bucket) or scope-without-callbacks (dropped target write).
+// atomic snapshot, so a concurrent arm/disarm can never expose
+// callbacks-without-scope or scope-without-callbacks to a write.
 type propValueIndexState struct {
 	add   []onAddToPropertyValueIndex
 	del   []onDeleteFromPropertyValueIndex
@@ -101,9 +98,9 @@ type propValueIndexState struct {
 // callback has ever been registered, so callers never nil-check the Load.
 var emptyPropValueIndexState = &propValueIndexState{}
 
-// loadPropValueIndexState returns the current snapshot without locking. The
-// write path loads exactly once per object so suppression, migAdd/migDel, and
-// the migration pass all see the same consistent {add,del,scope}.
+// loadPropValueIndexState returns the current snapshot without locking. Load
+// once per object so suppression and the migration pass see the same
+// {add,del,scope}.
 func (s *Shard) loadPropValueIndexState() *propValueIndexState {
 	if v := s.propValueIndexState.Load(); v != nil {
 		return v.(*propValueIndexState)
@@ -112,9 +109,9 @@ func (s *Shard) loadPropValueIndexState() *propValueIndexState {
 }
 
 // mutatePropValueIndexState is the sole writer of the folded snapshot: fn runs
-// on a copy under propertyValueIndexCallbacksMu and the result publishes via
-// one atomic Store, so registration/arm/disarm land as one indivisible
-// transition. fn must copy, not mutate in place, any slice/map it grows.
+// under the mutex and the result publishes via one atomic Store, so
+// registration/arm/disarm land as one indivisible transition. fn must copy,
+// not mutate in place, any slice/map it grows.
 func (s *Shard) mutatePropValueIndexState(fn func(cur propValueIndexState) propValueIndexState) {
 	s.propertyValueIndexCallbacksMu.Lock()
 	defer s.propertyValueIndexCallbacksMu.Unlock()
@@ -141,9 +138,8 @@ func appendDeleteCallback(cur []onDeleteFromPropertyValueIndex, cb onDeleteFromP
 	return updated
 }
 
-// fireAddToPropertyValueIndex invokes every add callback. The migration pass
-// calls this directly to bypass the inline write path's scope suppression —
-// suppressing here would drop the very write the migration exists to make.
+// fireAddToPropertyValueIndex invokes every add callback, bypassing the
+// inline write path's scope suppression (the migration pass needs it fired).
 func (s *Shard) fireAddToPropertyValueIndex(st *propValueIndexState, docID uint64, property *inverted.Property) error {
 	ec := errorcompounder.New()
 	for _, cb := range st.add {
@@ -160,9 +156,9 @@ func (s *Shard) fireDeleteFromPropertyValueIndex(st *propValueIndexState, docID 
 	return ec.ToError()
 }
 
-// analyzeForDoubleWrite runs AnalyzeObjectForMigrationWithOverlay (RawValues +
-// Force*/tokenization overlay) and filters to scope properties, so the
-// migration pass never touches a bucket it does not own.
+// analyzeForDoubleWrite filters AnalyzeObjectForMigrationWithOverlay's result
+// to scope properties, so the migration pass never touches a bucket it does
+// not own.
 func (s *Shard) analyzeForDoubleWrite(obj *storobj.Object, st *propValueIndexState) ([]inverted.Property, error) {
 	props, _, err := s.AnalyzeObjectForMigrationWithOverlay(obj, st.scope.overlay)
 	if err != nil {
@@ -178,9 +174,9 @@ func (s *Shard) analyzeForDoubleWrite(obj *storobj.Object, st *propValueIndexSta
 }
 
 // migrationDoubleWrite mirrors a write into the ingest bucket under TARGET
-// analysis, for scope props whose inline callback was suppressed. Delete-old
-// then add-new; the ingest bucket is a write-only sidecar until swap, so
-// per-write churn is idempotent and invisible to queries.
+// analysis, for scope props whose inline callback was suppressed. The ingest
+// bucket is a write-only sidecar until swap, so per-write churn is idempotent
+// and invisible to queries.
 func (s *Shard) migrationDoubleWrite(st *propValueIndexState, object, prevObject *storobj.Object,
 	status objectInsertStatus,
 ) error {
@@ -230,10 +226,10 @@ func (s *Shard) migrationDoubleWriteDelete(st *propValueIndexState, prevObject *
 	return nil
 }
 
-// registerDoubleWriteWithScope arms the migration scope and registers the
-// add+delete callbacks in ONE atomic Store, so a concurrent writer never sees
-// callbacks without the scope — which would leak source-tokenized terms into
-// the ingest bucket (the weaviate#298 bug). The returned func disarms both.
+// registerDoubleWriteWithScope arms the scope and registers the add+delete
+// callbacks in ONE atomic Store, so a concurrent writer never sees callbacks
+// without the scope and leaks source-tokenized terms into the ingest bucket
+// (weaviate/0-weaviate-issues#298). Returned func disarms both.
 func (s *Shard) registerDoubleWriteWithScope(add onAddToPropertyValueIndex, del onDeleteFromPropertyValueIndex,
 	props []string, overlay map[string]inverted.PropertyOverlay,
 ) func() {
@@ -259,9 +255,8 @@ func (s *Shard) registerDoubleWriteWithScope(add onAddToPropertyValueIndex, del 
 	})
 
 	return func() {
-		// Disable callbacks first so none can write the post-swap ingest
-		// bucket, then drop the scope so the inline path resumes owning these
-		// props.
+		// Disable callbacks before dropping the scope, so none can write the
+		// post-swap ingest bucket while the inline path resumes owning these props.
 		disabled.Store(true)
 		s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
 			cur.scope = cur.scope.withDisarmed(props, overlay)

--- a/adapters/repos/db/shard_migration_double_write.go
+++ b/adapters/repos/db/shard_migration_double_write.go
@@ -19,21 +19,18 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-// migrationDoubleWriteScope names the properties whose live double-write must
-// be analyzed under the migration's TARGET schema (via overlay), so an
-// overlapping write mirrors the same terms the backfill produced. Empty (nil
-// maps) when no migration is ingesting, so the write-path lookup then costs
-// nothing. Derived from the ingest-window callbacks (re-armed on every boot),
-// never persisted.
+// migrationDoubleWriteScope names properties needing TARGET-schema analysis
+// (via overlay), so an overlapping write mirrors the backfill. Nil maps when
+// idle keep the write-path lookup free. Derived from ingest callbacks and
+// re-armed each boot; never persisted.
 type migrationDoubleWriteScope struct {
 	props   map[string]struct{}
 	overlay map[string]inverted.PropertyOverlay
 }
 
-// withArmed returns a copy-on-write scope that additionally covers props and
-// merges overlay. Callers hold propertyValueIndexCallbacksMu; the returned
-// maps are fresh so a concurrent lock-free reader keeps observing the old
-// snapshot until the atomic Store publishes this one.
+// withArmed returns copy-on-write scope additions: callers hold
+// propertyValueIndexCallbacksMu, and the fresh maps let a concurrent
+// lock-free reader keep seeing the old snapshot until Store publishes this one.
 func (sc migrationDoubleWriteScope) withArmed(props []string,
 	overlay map[string]inverted.PropertyOverlay,
 ) migrationDoubleWriteScope {
@@ -56,9 +53,8 @@ func (sc migrationDoubleWriteScope) withArmed(props []string,
 	return next
 }
 
-// withDisarmed returns a copy-on-write scope with props and overlay's keys
-// removed. An emptied scope collapses back to nil maps so the write path's
-// fast path (len(scope.props) == 0) re-engages once the migration ends.
+// withDisarmed removes props/overlay keys and collapses to nil maps when
+// empty, so the write path's zero-scope fast path re-engages after migration.
 func (sc migrationDoubleWriteScope) withDisarmed(props []string,
 	overlay map[string]inverted.PropertyOverlay,
 ) migrationDoubleWriteScope {
@@ -91,11 +87,10 @@ func insertUnlessIn(dst map[string]struct{}, key string, drop []string) map[stri
 	return dst
 }
 
-// propValueIndexState folds the add/delete callback slices and the migration
-// scope into one atomic snapshot so a write observes a CONSISTENT triple: a
-// concurrent arm/disarm can never expose callbacks-without-scope (source-schema
-// leak into the ingest bucket) or scope-without-callbacks (dropped target
-// write).
+// propValueIndexState folds the callback slices and migration scope into one
+// atomic snapshot, so a write sees a consistent triple: a concurrent arm/
+// disarm can never expose callbacks-without-scope (source leak into the
+// ingest bucket) or scope-without-callbacks (dropped target write).
 type propValueIndexState struct {
 	add   []onAddToPropertyValueIndex
 	del   []onDeleteFromPropertyValueIndex
@@ -106,10 +101,9 @@ type propValueIndexState struct {
 // callback has ever been registered, so callers never nil-check the Load.
 var emptyPropValueIndexState = &propValueIndexState{}
 
-// loadPropValueIndexState returns the current folded snapshot without locking.
-// The whole write path takes exactly one of these per object so inline
-// suppression, migAdd/migDel computation, and the migration callback pass all
-// read the same consistent {add,del,scope}.
+// loadPropValueIndexState returns the current snapshot without locking. The
+// write path loads exactly once per object so suppression, migAdd/migDel, and
+// the migration pass all see the same consistent {add,del,scope}.
 func (s *Shard) loadPropValueIndexState() *propValueIndexState {
 	if v := s.propValueIndexState.Load(); v != nil {
 		return v.(*propValueIndexState)
@@ -117,11 +111,10 @@ func (s *Shard) loadPropValueIndexState() *propValueIndexState {
 	return emptyPropValueIndexState
 }
 
-// mutatePropValueIndexState is the SOLE writer of the folded snapshot: it
-// applies fn to a copy under propertyValueIndexCallbacksMu and publishes the
-// result with one atomic Store, so registration, arm, and disarm each land as
-// a single indivisible transition for lock-free readers. fn must copy any
-// slice/map it grows rather than appending in place.
+// mutatePropValueIndexState is the sole writer of the folded snapshot: fn runs
+// on a copy under propertyValueIndexCallbacksMu and the result publishes via
+// one atomic Store, so registration/arm/disarm land as one indivisible
+// transition. fn must copy, not mutate in place, any slice/map it grows.
 func (s *Shard) mutatePropValueIndexState(fn func(cur propValueIndexState) propValueIndexState) {
 	s.propertyValueIndexCallbacksMu.Lock()
 	defer s.propertyValueIndexCallbacksMu.Unlock()
@@ -148,9 +141,8 @@ func appendDeleteCallback(cur []onDeleteFromPropertyValueIndex, cb onDeleteFromP
 	return updated
 }
 
-// fireAddToPropertyValueIndex invokes every registered add callback against
-// the given (already target-analyzed) property. The migration pass calls this
-// directly to BYPASS the scope suppression that the inline write path applies —
+// fireAddToPropertyValueIndex invokes every add callback. The migration pass
+// calls this directly to bypass the inline write path's scope suppression —
 // suppressing here would drop the very write the migration exists to make.
 func (s *Shard) fireAddToPropertyValueIndex(st *propValueIndexState, docID uint64, property *inverted.Property) error {
 	ec := errorcompounder.New()
@@ -160,8 +152,6 @@ func (s *Shard) fireAddToPropertyValueIndex(st *propValueIndexState, docID uint6
 	return ec.ToError()
 }
 
-// fireDeleteFromPropertyValueIndex is the delete-side counterpart of
-// fireAddToPropertyValueIndex.
 func (s *Shard) fireDeleteFromPropertyValueIndex(st *propValueIndexState, docID uint64, property *inverted.Property) error {
 	ec := errorcompounder.New()
 	for _, cb := range st.del {
@@ -170,11 +160,9 @@ func (s *Shard) fireDeleteFromPropertyValueIndex(st *propValueIndexState, docID 
 	return ec.ToError()
 }
 
-// analyzeForDoubleWrite produces the TARGET-schema analysis of obj that the
-// migration double-write needs: AnalyzeObjectForMigrationWithOverlay (which
-// captures RawValues and applies the Force*/tokenization overlay) restricted
-// to the properties currently in migration scope. Non-scope properties are
-// dropped so the migration pass never touches a bucket it does not own.
+// analyzeForDoubleWrite runs AnalyzeObjectForMigrationWithOverlay (RawValues +
+// Force*/tokenization overlay) and filters to scope properties, so the
+// migration pass never touches a bucket it does not own.
 func (s *Shard) analyzeForDoubleWrite(obj *storobj.Object, st *propValueIndexState) ([]inverted.Property, error) {
 	props, _, err := s.AnalyzeObjectForMigrationWithOverlay(obj, st.scope.overlay)
 	if err != nil {
@@ -189,11 +177,10 @@ func (s *Shard) analyzeForDoubleWrite(obj *storobj.Object, st *propValueIndexSta
 	return filtered, nil
 }
 
-// migrationDoubleWrite mirrors an object write into the ingest bucket under the
-// migration's TARGET analysis for the scope props whose inline callback the
-// write path suppressed. Delete-old then add-new (main-path order); the ingest
-// bucket is a write-only sidecar until swap, so full per-write churn is
-// idempotent and invisible to queries.
+// migrationDoubleWrite mirrors a write into the ingest bucket under TARGET
+// analysis, for scope props whose inline callback was suppressed. Delete-old
+// then add-new; the ingest bucket is a write-only sidecar until swap, so
+// per-write churn is idempotent and invisible to queries.
 func (s *Shard) migrationDoubleWrite(st *propValueIndexState, object, prevObject *storobj.Object,
 	status objectInsertStatus,
 ) error {
@@ -225,9 +212,8 @@ func (s *Shard) migrationDoubleWrite(st *propValueIndexState, object, prevObject
 	return nil
 }
 
-// migrationDoubleWriteDelete is the delete-only counterpart of
-// migrationDoubleWrite, for the pure object-delete path: it removes the
-// deleted object's TARGET terms from the ingest bucket for scope properties.
+// migrationDoubleWriteDelete is migrationDoubleWrite's delete-only
+// counterpart for the pure object-delete path.
 func (s *Shard) migrationDoubleWriteDelete(st *propValueIndexState, prevObject *storobj.Object, docID uint64) error {
 	if len(st.scope.props) == 0 || prevObject == nil {
 		return nil
@@ -244,11 +230,10 @@ func (s *Shard) migrationDoubleWriteDelete(st *propValueIndexState, prevObject *
 	return nil
 }
 
-// registerDoubleWriteWithScope registers the ingest-window add+delete
-// double-write callbacks AND arms the migration scope in ONE atomic Store, so
-// a concurrent writer never sees the callbacks without the scope (which would
-// leak source-tokenized terms into the ingest bucket — the weaviate#298 bug).
-// The returned disable func tears both down again.
+// registerDoubleWriteWithScope arms the migration scope and registers the
+// add+delete callbacks in ONE atomic Store, so a concurrent writer never sees
+// callbacks without the scope — which would leak source-tokenized terms into
+// the ingest bucket (the weaviate#298 bug). The returned func disarms both.
 func (s *Shard) registerDoubleWriteWithScope(add onAddToPropertyValueIndex, del onDeleteFromPropertyValueIndex,
 	props []string, overlay map[string]inverted.PropertyOverlay,
 ) func() {
@@ -274,9 +259,9 @@ func (s *Shard) registerDoubleWriteWithScope(add onAddToPropertyValueIndex, del 
 	})
 
 	return func() {
-		// Stop the callbacks first (lock-free) so they cannot write to the
-		// post-swap ingest bucket, then drop the scope so the inline path
-		// resumes owning these props.
+		// Disable callbacks first so none can write the post-swap ingest
+		// bucket, then drop the scope so the inline path resumes owning these
+		// props.
 		disabled.Store(true)
 		s.mutatePropValueIndexState(func(cur propValueIndexState) propValueIndexState {
 			cur.scope = cur.scope.withDisarmed(props, overlay)

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -189,9 +189,8 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 		return fmt.Errorf("put inverted indices props: %w", err)
 	}
 
-	// Migration double-write: remove the deleted object's TARGET terms from
-	// the ingest bucket for scope props (the inline delete callback above was
-	// suppressed for them). No-op when no migration is ingesting.
+	// Mirrors the delete into the ingest bucket for scope props suppressed
+	// above; no-op absent a migration.
 	if err = s.migrationDoubleWriteDelete(st, previousObject, docID); err != nil {
 		return fmt.Errorf("migration double-write delete: %w", err)
 	}

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -183,9 +183,17 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 	// For any NotEquals filter, we do an Equals filter and invert it's results.
 	s.bitmapFactory.RemoveIds(docID)
 
-	err = s.deleteFromInvertedIndicesLSM(previousProps, previousNilProps, docID)
+	st := s.loadPropValueIndexState()
+	err = s.deleteFromInvertedIndicesLSM(previousProps, previousNilProps, docID, st)
 	if err != nil {
 		return fmt.Errorf("put inverted indices props: %w", err)
+	}
+
+	// Migration double-write: remove the deleted object's TARGET terms from
+	// the ingest bucket for scope props (the inline delete callback above was
+	// suppressed for them). No-op when no migration is ingesting.
+	if err = s.migrationDoubleWriteDelete(st, previousObject, docID); err != nil {
+		return fmt.Errorf("migration double-write delete: %w", err)
 	}
 
 	if err = s.deleteNestedInvertedIndicesLSM(previousNestedProps, docID); err != nil {

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -126,10 +126,8 @@ func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property
 		}
 	}
 
-	// Suppress the inline callback for props under migration: their target
-	// double-write is handled by migrationDoubleWrite with the correct
-	// TARGET analysis (the inline callback would only see the source-schema
-	// property here). Non-scope props keep firing inline exactly as before.
+	// Scope props are suppressed here; migrationDoubleWrite fires them under
+	// the TARGET analysis instead of this source-schema view.
 	if _, migrating := st.scope.props[property.Name]; !migrating {
 		if err := s.fireAddToPropertyValueIndex(st, docID, &property); err != nil {
 			return err
@@ -317,10 +315,8 @@ func (s *Shard) resetDimensionsLSM(ctx context.Context) error {
 	return nil
 }
 
-// onAddToPropertyValueIndex fires every registered add callback (no scope
-// suppression). The suppressing write path uses the threaded-snapshot variant
-// via addToPropertyValueIndex; this convenience form loads its own snapshot
-// and is used by callers outside a threaded write (and the callback tests).
+// onAddToPropertyValueIndex fires all add callbacks with no scope
+// suppression; used outside the threaded write path (and by tests).
 func (s *Shard) onAddToPropertyValueIndex(docID uint64, property *inverted.Property) error {
 	return s.fireAddToPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
 }

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
@@ -312,13 +311,12 @@ func (s *Shard) resetDimensionsLSM(ctx context.Context) error {
 	return nil
 }
 
+// onAddToPropertyValueIndex fires every registered add callback (no scope
+// suppression). The suppressing write path uses the threaded-snapshot variant
+// via addToPropertyValueIndex; this convenience form loads its own snapshot
+// and is used by callers outside a threaded write (and the callback tests).
 func (s *Shard) onAddToPropertyValueIndex(docID uint64, property *inverted.Property) error {
-	callbacks, _ := s.callbacksAddToPropertyValueIndex.Load().([]onAddToPropertyValueIndex)
-	ec := errorcompounder.New()
-	for _, cb := range callbacks {
-		ec.Add(cb(s, docID, property))
-	}
-	return ec.ToError()
+	return s.fireAddToPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
 }
 
 func isMetaCountProperty(property inverted.Property) bool {

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -315,12 +315,6 @@ func (s *Shard) resetDimensionsLSM(ctx context.Context) error {
 	return nil
 }
 
-// onAddToPropertyValueIndex fires all add callbacks with no scope
-// suppression; used outside the threaded write path (and by tests).
-func (s *Shard) onAddToPropertyValueIndex(docID uint64, property *inverted.Property) error {
-	return s.fireAddToPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
-}
-
 func isMetaCountProperty(property inverted.Property) bool {
 	return len(property.Name) > len(schema.InternalMetaCountSuffix) &&
 		strings.HasSuffix(property.Name, schema.InternalMetaCountSuffix)

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -27,10 +27,10 @@ import (
 )
 
 func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []inverted.NilProperty,
-	docID uint64,
+	docID uint64, st *propValueIndexState,
 ) error {
 	for _, prop := range props {
-		if err := s.addToPropertyValueIndex(docID, prop); err != nil {
+		if err := s.addToPropertyValueIndex(docID, prop, st); err != nil {
 			return err
 		}
 
@@ -71,7 +71,7 @@ func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []i
 	return nil
 }
 
-func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property) error {
+func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property, st *propValueIndexState) error {
 	if property.HasFilterableIndex {
 		bucketValue := s.store.Bucket(helpers.BucketFromPropNameLSM(property.Name))
 		if bucketValue == nil {
@@ -126,8 +126,14 @@ func (s *Shard) addToPropertyValueIndex(docID uint64, property inverted.Property
 		}
 	}
 
-	if err := s.onAddToPropertyValueIndex(docID, &property); err != nil {
-		return err
+	// Suppress the inline callback for props under migration: their target
+	// double-write is handled by migrationDoubleWrite with the correct
+	// TARGET analysis (the inline callback would only see the source-schema
+	// property here). Non-scope props keep firing inline exactly as before.
+	if _, migrating := st.scope.props[property.Name]; !migrating {
+		if err := s.fireAddToPropertyValueIndex(st, docID, &property); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -183,9 +183,3 @@ func (s *Shard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64
 
 	return bucket.RoaringSetRangeRemove(binary.BigEndian.Uint64(key), docID)
 }
-
-// onDeleteFromPropertyValueIndex fires all delete callbacks with no scope
-// suppression; used outside the threaded write path (and by tests).
-func (s *Shard) onDeleteFromPropertyValueIndex(docID uint64, property *inverted.Property) error {
-	return s.fireDeleteFromPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
-}

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -184,9 +184,8 @@ func (s *Shard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64
 	return bucket.RoaringSetRangeRemove(binary.BigEndian.Uint64(key), docID)
 }
 
-// onDeleteFromPropertyValueIndex fires every registered delete callback (no
-// scope suppression); the delete-then-suppress write path uses the
-// threaded-snapshot variant inside deleteFromInvertedIndicesLSM.
+// onDeleteFromPropertyValueIndex fires all delete callbacks with no scope
+// suppression; used outside the threaded write path (and by tests).
 func (s *Shard) onDeleteFromPropertyValueIndex(docID uint64, property *inverted.Property) error {
 	return s.fireDeleteFromPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
 }

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps []inverted.NilProperty,
-	docID uint64,
+	docID uint64, st *propValueIndexState,
 ) error {
 	for _, prop := range props {
 		if prop.HasFilterableIndex {
@@ -67,8 +67,12 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 			}
 		}
 
-		if err := s.onDeleteFromPropertyValueIndex(docID, &prop); err != nil {
-			return err
+		// Suppress the inline callback for props under migration; their
+		// target-schema delete double-write is handled by the migration pass.
+		if _, migrating := st.scope.props[prop.Name]; !migrating {
+			if err := s.fireDeleteFromPropertyValueIndex(st, docID, &prop); err != nil {
+				return err
+			}
 		}
 
 		// add non-nil properties to the null-state inverted index, but skip internal properties (__meta_count, _id etc)

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -19,7 +19,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/entities/errorcompounder"
 )
 
 func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps []inverted.NilProperty,
@@ -181,11 +180,9 @@ func (s *Shard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64
 	return bucket.RoaringSetRangeRemove(binary.BigEndian.Uint64(key), docID)
 }
 
+// onDeleteFromPropertyValueIndex fires every registered delete callback (no
+// scope suppression); the delete-then-suppress write path uses the
+// threaded-snapshot variant inside deleteFromInvertedIndicesLSM.
 func (s *Shard) onDeleteFromPropertyValueIndex(docID uint64, property *inverted.Property) error {
-	callbacks, _ := s.callbacksRemoveFromPropertyValueIndex.Load().([]onDeleteFromPropertyValueIndex)
-	ec := errorcompounder.New()
-	for _, cb := range callbacks {
-		ec.Add(cb(s, docID, property))
-	}
-	return ec.ToError()
+	return s.fireDeleteFromPropertyValueIndex(s.loadPropValueIndexState(), docID, property)
 }

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -520,6 +520,11 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "analyze next object")
 	}
 
+	// One snapshot for the whole write: the source-schema props above drive the
+	// MAIN buckets, while st.scope (if a migration is ingesting) redirects the
+	// scope props' double-write to a TARGET-schema pass below.
+	st := s.loadPropValueIndexState()
+
 	var prevProps []inverted.Property
 	var prevNilprops []inverted.NilProperty
 	var prevNestedProps []inverted.NestedProperty
@@ -573,7 +578,7 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 
 	if prevObject != nil {
 		// TODO: metrics
-		if err := s.deleteFromInvertedIndicesLSM(propsToDel, nilpropsToDel, status.oldDocID); err != nil {
+		if err := s.deleteFromInvertedIndicesLSM(propsToDel, nilpropsToDel, status.oldDocID, st); err != nil {
 			return fmt.Errorf("delete inverted indices props: %w", err)
 		}
 		if err := s.deleteNestedInvertedIndicesLSM(prevNestedProps, status.oldDocID); err != nil {
@@ -593,7 +598,7 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 	}
 
 	before := time.Now()
-	if err := s.extendInvertedIndicesLSM(propsToAdd, nilpropsToAdd, status.docID); err != nil {
+	if err := s.extendInvertedIndicesLSM(propsToAdd, nilpropsToAdd, status.docID, st); err != nil {
 		return fmt.Errorf("put inverted indices props: %w", err)
 	}
 	if err := s.extendNestedInvertedIndicesLSM(nestedProps, status.docID); err != nil {
@@ -611,6 +616,14 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		if err != nil {
 			return err
 		}
+	}
+
+	// Migration double-write: for scope props whose inline callback we
+	// suppressed above, mirror this write into the ingest bucket under the
+	// TARGET analysis (delete-old then add-new). No-op when no migration is
+	// ingesting.
+	if err := s.migrationDoubleWrite(st, object, prevObject, status); err != nil {
+		return fmt.Errorf("migration double-write: %w", err)
 	}
 
 	return nil

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -520,9 +520,8 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		return errors.Wrap(err, "analyze next object")
 	}
 
-	// One snapshot for the whole write: the source-schema props above drive the
-	// MAIN buckets, while st.scope (if a migration is ingesting) redirects the
-	// scope props' double-write to a TARGET-schema pass below.
+	// One snapshot for the whole write, so the double-write pass below sees
+	// the same {add,del,scope} as the inline suppression above.
 	st := s.loadPropValueIndexState()
 
 	var prevProps []inverted.Property
@@ -618,10 +617,8 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		}
 	}
 
-	// Migration double-write: for scope props whose inline callback we
-	// suppressed above, mirror this write into the ingest bucket under the
-	// TARGET analysis (delete-old then add-new). No-op when no migration is
-	// ingesting.
+	// Mirrors this write into the ingest bucket under the TARGET analysis for
+	// scope props suppressed above; no-op absent a migration.
 	if err := s.migrationDoubleWrite(st, object, prevObject, status); err != nil {
 		return fmt.Errorf("migration double-write: %w", err)
 	}

--- a/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
+++ b/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
@@ -1,0 +1,406 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_multinode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+// TestMultiNode_EnableRangeable_ConcurrentUpdatesNoLossNoPanic is the 3-node
+// RF3 port of QA's donated f10 repro for weaviate/weaviate#11688 (fixed by
+// this PR). Object UPDATES that race the enable-rangeable per-shard swap under
+// replication caused two distinct failures on a build without the fix:
+//
+//  1. nil-deref panics in the reindex double-write DELETE callback
+//     (adapters/repos/db/inverted_reindex_strategy_rangeable.go MakeDeleteCallback
+//     → resolveScopedDoubleWriteBucket → Bucket.Strategy on a nil bucket that
+//     is being swapped out mid-write), surfaced to clients as a REST
+//     "panic serving" line and a swallowed empty-200 PATCH response, and
+//  2. durable, silent rangeable write-loss: a PATCH acked 204, its new value
+//     landed in the objects (source-of-truth) bucket, but the concurrent swap
+//     discarded the double-write into the rangeable index, so a range query
+//     over the updated band came up short — and stayed short across a restart
+//     because the on-disk rangeable segments were missing the entries.
+//
+// The migrated property (dateInt) starts with IndexRangeFilters=false, so the
+// rangeable index only exists after the runtime migration. Once the migration
+// finishes and the rangeable index is ready, a range query over the moved band
+// is served from that index alone, so a short count is a rangeable write-loss.
+//
+// The test PATCHes every mover into a sentinel band far above every initial
+// value while the migration runs, then asserts, on every replica and again
+// after a rolling restart: zero "panic serving" lines, and a rangeable count
+// over the sentinel band that equals the mover count (no lost update). A
+// pre-check confirms the movers' new values are durably present in the objects
+// store, so any index shortfall is a silent index loss, not a failed write.
+func TestMultiNode_EnableRangeable_ConcurrentUpdatesNoLossNoPanic(t *testing.T) {
+	ctx := context.Background()
+
+	compose, cleanup := start3NodeReindexCluster(ctx, t)
+	defer cleanup()
+	defer dumpContainerLogs(ctx, t, compose)
+
+	const (
+		className = "EnableRangeableConcurrentUpdates"
+		propName  = "dateInt"
+		// Enough objects that the per-shard backfill+swap window is wide
+		// enough for the PATCH storm to overlap it, small enough to stay well
+		// under the 5-minute target on a 3-node RF3 cluster.
+		totalObjects = 12_000
+		// Every moverStride-th object is a mover: 1_500 concurrently-updated
+		// objects, plenty of writes to hit the swap window on every shard.
+		moverStride = 8
+		// sentinelBase sits far above every initial dateInt (initial values are
+		// the seq itself, < totalObjects), so a range query dateInt >=
+		// sentinelBase counts exactly the movers.
+		sentinelBase  = 8_000_000
+		updateThreads = 8
+	)
+
+	trueVal, falseVal := true, false
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, []*models.Property{
+		{
+			Name:              "seq",
+			DataType:          []string{"int"},
+			IndexFilterable:   &trueVal,
+			IndexRangeFilters: &falseVal,
+		},
+		{
+			// The migrated property. IndexFilterable=true matches the reported
+			// repro and the working multi-node enable-rangeable journey. Once
+			// the migration finishes and the rangeable index is ready, range
+			// queries are served from the rangeable index only (the
+			// filterable bucket-walk fallback applies only while the rangeable
+			// bucket is still being built), so a short count over the sentinel
+			// band after FINISHED is an unambiguous rangeable write-loss.
+			Name:              propName,
+			DataType:          []string{"int"},
+			IndexFilterable:   &trueVal,
+			IndexRangeFilters: &falseVal,
+		},
+	})
+	// Closure, not a direct defer: the rolling restart below re-maps node
+	// ports, so the URI must be resolved at cleanup time, not now.
+	defer func() { deleteCollection(t, restURIOf(compose, 1), className) }()
+
+	batchImportSeqDateInt(t, restURIOf(compose, 1), className, totalObjects)
+
+	movers := make([]int, 0, totalObjects/moverStride)
+	for s := 0; s < totalObjects; s += moverStride {
+		movers = append(movers, s)
+	}
+	sentinelHi := sentinelBase + 10*totalObjects // wide upper bound; only movers land in the band
+
+	// Submit enable-rangeable, then fire the PATCH storm so it overlaps the
+	// whole migration window (backfill → per-shard swap → schema flip).
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURIOf(compose, 1), className, propName,
+		`{"rangeable":{"enabled":true}}`)
+	t.Logf("submitted enable-rangeable task: %s", taskID)
+
+	// stormCtx bounds the storm even if the test goroutine aborts (e.g. the
+	// migration times out), so the update goroutines can never outlive the run.
+	stormCtx, cancelStorm := context.WithTimeout(ctx, 240*time.Second)
+	defer cancelStorm()
+
+	var (
+		patchOK   atomic.Int64
+		patchErr  atomic.Int64
+		stormWG   sync.WaitGroup
+		logger    = logrus.New()
+		restURINd = restURIOf(compose, 1)
+	)
+	for th := 0; th < updateThreads; th++ {
+		chunk := make([]int, 0, len(movers)/updateThreads+1)
+		for i := th; i < len(movers); i += updateThreads {
+			chunk = append(chunk, movers[i])
+		}
+		stormWG.Add(1)
+		enterrors.GoWrapper(func() {
+			defer stormWG.Done()
+			// Alternate the target value every pass so each PATCH is a real
+			// value change (delete-old + add-new), maximising the number of
+			// double-write DELETE callbacks that hit the swap window.
+			for round := 0; stormCtx.Err() == nil; round++ {
+				band := sentinelBase
+				if round%2 == 1 {
+					band = sentinelBase + totalObjects
+				}
+				for _, s := range chunk {
+					if stormCtx.Err() != nil {
+						break
+					}
+					if err := patchDateInt(restURINd, className, detUUID(className, s), band+s); err != nil {
+						patchErr.Add(1)
+						continue
+					}
+					patchOK.Add(1)
+				}
+			}
+		}, logger)
+	}
+
+	reindexhelpers.AwaitReindexFinished(t, restURINd, taskID, reindexhelpers.WithTimeout(180*time.Second))
+	cancelStorm()
+	stormWG.Wait()
+	t.Logf("update storm during migration: ok=%d transient_err=%d", patchOK.Load(), patchErr.Load())
+
+	// Authoritative post-swap pass: PATCH every mover to a single known
+	// in-band value and require 204. This guarantees the objects store holds
+	// the new value for every mover, so a later index shortfall is provably a
+	// silent index loss and not a dropped write. It is also a real change from
+	// whatever the storm left, so it re-exercises the write path once more.
+	for _, s := range movers {
+		var lastErr error
+		for attempt := 0; attempt < 5; attempt++ {
+			if lastErr = patchDateInt(restURINd, className, detUUID(className, s), sentinelBase+s); lastErr == nil {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		require.NoErrorf(t, lastErr, "authoritative PATCH of mover seq=%d must succeed", s)
+	}
+
+	// Schema flip must have committed on every node.
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		cls := getClassFromNode(t, restURIOf(compose, nodeIdx), className)
+		var flipped bool
+		for _, prop := range cls.Properties {
+			if prop.Name == propName && prop.IndexRangeFilters != nil && *prop.IndexRangeFilters {
+				flipped = true
+				break
+			}
+		}
+		assert.Truef(t, flipped, "node %d: IndexRangeFilters must be true after migration", nodeIdx)
+	}
+
+	// Every mover's new value must be durable in the objects store. If this
+	// holds but the range count below is short, the loss is in the index.
+	assertMoversDurableInObjectStore(t, restURINd, className, movers, sentinelBase)
+
+	// No handler panicked during the storm (the nil-bucket DELETE-callback
+	// deref surfaced as a "panic serving" REST line).
+	assert.Equalf(t, 0, scanPanicLines(ctx, t, compose),
+		"expected zero 'panic serving' lines across all nodes during concurrent-update enable-rangeable")
+
+	// Core assertion, pre-restart: every replica serves all movers over the
+	// sentinel band. A short count is a #11688 silent rangeable write-loss.
+	assertRangeCountAllNodes(t, compose, className, propName, sentinelBase, sentinelHi, len(movers), "pre-restart")
+
+	// Durability: the loss (if any) survives a restart because it is on disk.
+	// A clean cluster must still serve every mover after a rolling restart.
+	rollingRestartCluster(ctx, t, compose)
+	assertRangeCountAllNodes(t, compose, className, propName, sentinelBase, sentinelHi, len(movers), "post-restart")
+
+	// Re-scan: a panic could also fire during post-restart shard init/replay.
+	assert.Equalf(t, 0, scanPanicLines(ctx, t, compose),
+		"expected zero 'panic serving' lines across all nodes after rolling restart")
+}
+
+// detUUID returns a deterministic UUID for a seq so the storm and the
+// verification pass address the exact objects that were imported.
+func detUUID(className string, seq int) string {
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(fmt.Sprintf("%s-%d", className, seq))).String()
+}
+
+// batchImportSeqDateInt imports totalObjects with deterministic IDs, seq=i and
+// an initial dateInt=i (< sentinelBase). consistency_level=ALL leaves the
+// cluster fully replicated before the migration starts.
+func batchImportSeqDateInt(t *testing.T, restURI, className string, total int) {
+	t.Helper()
+	const batchSize = 1_000
+	for start := 0; start < total; start += batchSize {
+		end := start + batchSize
+		if end > total {
+			end = total
+		}
+		objects := make([]map[string]interface{}, 0, end-start)
+		for i := start; i < end; i++ {
+			objects = append(objects, map[string]interface{}{
+				"class": className,
+				"id":    detUUID(className, i),
+				"properties": map[string]interface{}{
+					"seq":     i,
+					"dateInt": i,
+				},
+			})
+		}
+		body, err := json.Marshal(map[string]interface{}{"objects": objects})
+		require.NoError(t, err)
+		resp, err := http.Post(
+			fmt.Sprintf("http://%s/v1/batch/objects?consistency_level=ALL", restURI),
+			"application/json",
+			bytes.NewReader(body),
+		)
+		require.NoError(t, err)
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.Equalf(t, http.StatusOK, resp.StatusCode, "batch %d-%d failed: %s", start, end, string(respBody))
+
+		var batchResp []struct {
+			Result struct {
+				Errors *struct {
+					Error []struct {
+						Message string `json:"message"`
+					} `json:"error"`
+				} `json:"errors,omitempty"`
+			} `json:"result"`
+		}
+		require.NoError(t, json.Unmarshal(respBody, &batchResp))
+		for i, br := range batchResp {
+			if br.Result.Errors != nil && len(br.Result.Errors.Error) > 0 {
+				t.Fatalf("batch %d-%d object %d errored: %s", start, end, i, br.Result.Errors.Error[0].Message)
+			}
+		}
+	}
+}
+
+// patchDateInt PATCHes one object's dateInt via REST. Raw HTTP keeps it
+// goroutine-safe (no testify off the test goroutine). A strict 204 doubles as a
+// panic probe: the REST panic middleware recovers without writing a body, so a
+// panicked handler surfaces as an empty 200 rather than the expected 204.
+func patchDateInt(restURI, className, id string, value int) error {
+	body, err := json.Marshal(map[string]interface{}{
+		"class":      className,
+		"id":         id,
+		"properties": map[string]interface{}{"dateInt": value},
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPatch,
+		fmt.Sprintf("http://%s/v1/objects/%s/%s", restURI, className, id), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status %d (want 204): %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// assertMoversDurableInObjectStore spot-checks that sampled movers hold a
+// dateInt >= sentinelBase in the objects (source-of-truth) store, proving the
+// storm's writes are durable there before the index count is asserted.
+func assertMoversDurableInObjectStore(t *testing.T, restURI, className string, movers []int, sentinelBase int) {
+	t.Helper()
+	const sampleStride = 97 // coprime-ish stride so the sample spreads across the keyspace
+	for i := 0; i < len(movers); i += sampleStride {
+		s := movers[i]
+		val, ok := fetchObjectDateInt(restURI, className, detUUID(className, s))
+		require.Truef(t, ok, "mover seq=%d must be fetchable from the objects store", s)
+		require.GreaterOrEqualf(t, val, sentinelBase,
+			"mover seq=%d objects-store dateInt=%d must be in the sentinel band (write must be durable)", s, val)
+	}
+}
+
+// fetchObjectDateInt GETs a single object and returns its dateInt.
+func fetchObjectDateInt(restURI, className, id string) (int, bool) {
+	resp, err := http.Get(fmt.Sprintf("http://%s/v1/objects/%s/%s", restURI, className, id))
+	if err != nil {
+		return 0, false
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return 0, false
+	}
+	var obj struct {
+		Properties struct {
+			DateInt float64 `json:"dateInt"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return 0, false
+	}
+	return int(obj.Properties.DateInt), true
+}
+
+// assertRangeCountAllNodes requires that every replica serves exactly want
+// objects over [lo, hi] on propName within the convergence window. A durable
+// loss never converges and fails the poll; a transient replication lag
+// converges quickly.
+func assertRangeCountAllNodes(t *testing.T, compose *docker.DockerCompose, className, propName string, lo, hi, want int, phase string) {
+	t.Helper()
+	var last [3]int
+	ok := assert.Eventuallyf(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			count, err := rangeCount(restURIOf(compose, nodeIdx), className, propName, lo, hi)
+			if err != nil {
+				return false
+			}
+			last[nodeIdx-1] = count
+			if count != want {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond,
+		"%s: every replica must serve all %d updated objects over the sentinel band", phase, want)
+	if !ok {
+		t.Errorf("%s rangeable counts per node = %v, want %d on every node (silent rangeable write-loss)", phase, last, want)
+	}
+}
+
+// scanPanicLines counts "panic serving" lines across every node's container
+// logs. docker restart preserves logs, so a single end-of-test scan captures
+// panics from both the storm and any post-restart replay.
+func scanPanicLines(ctx context.Context, t *testing.T, compose *docker.DockerCompose) int {
+	t.Helper()
+	total := 0
+	for i := 1; i <= 3; i++ {
+		node := compose.GetWeaviateNode(i)
+		if node == nil {
+			continue
+		}
+		reader, err := node.Container().Logs(ctx)
+		if err != nil {
+			t.Logf("panic scan: failed to read logs for node %d: %v", i, err)
+			continue
+		}
+		logs, _ := io.ReadAll(reader)
+		reader.Close()
+		for _, line := range strings.Split(string(logs), "\n") {
+			if strings.Contains(line, "panic serving") {
+				total++
+				t.Logf("panic scan: node %d: %s", i, line)
+			}
+		}
+	}
+	return total
+}

--- a/test/acceptance/reindex_rangeable/concurrent_writes_test.go
+++ b/test/acceptance/reindex_rangeable/concurrent_writes_test.go
@@ -1,0 +1,335 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package reindex_rangeable_concurrent_writes is the black-box regression
+// suite for weaviate/weaviate#11688: live writes racing an enable-rangeable
+// runtime migration must not be dropped from the rangeable index.
+//
+// It ports QA's repro (f10, rangeable variant): N objects with an int
+// property that has indexFilterable=false (no other enabled inverted index
+// — the exposed property state), M concurrent PATCHes setting the property
+// to a marker value while PUT /v1/schema/{class}/indexes/{prop}
+// {"rangeable":{"enabled":true}} runs. After the migration completes, an
+// Aggregate over `prop >= MARK` must count exactly M. A live control (the
+// same write storm against a class whose rangeable index was enabled at
+// create time, i.e. no migration) pins that the storm itself loses
+// nothing.
+package reindex_rangeable_concurrent_writes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
+)
+
+const (
+	// numObjects keeps the backfill long enough that the M concurrent
+	// PATCHes overlap the migration window, while keeping CI runtime sane.
+	numObjects = 4000
+	// numUpdates is the number of concurrent PATCHes racing the migration.
+	numUpdates = 500
+	// updateThreads fans the PATCHes out, mirroring QA's repro.
+	updateThreads = 4
+	// mark is the post-update property value; far above every initial
+	// value so `vint >= mark` counts exactly the updated objects.
+	mark = 777777
+
+	propName = "vint"
+)
+
+func TestEnableRangeable_ConcurrentWrites(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviate().
+		// 1s scheduler tick keeps the submit→migration-start latency low so
+		// the PATCH storm reliably overlaps the migration window.
+		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	restURI := compose.GetWeaviate().URI()
+
+	// Dump container logs on failure.
+	container := compose.GetWeaviate().Container()
+	defer func() {
+		if t.Failed() {
+			reader, err := container.Logs(ctx)
+			if err != nil {
+				t.Logf("failed to get container logs: %v", err)
+				return
+			}
+			defer reader.Close()
+			logs, _ := io.ReadAll(reader)
+			if len(logs) > 16384 {
+				logs = logs[len(logs)-16384:]
+			}
+			t.Logf("=== Container logs (tail) ===\n%s", string(logs))
+		}
+	}()
+
+	// Live control FIRST: the same write storm against a class whose
+	// rangeable index existed from the start. Proves the storm itself
+	// (batching, PATCH concurrency, aggregation) loses nothing, so a
+	// migration-case failure isolates the migration as the cause.
+	t.Run("live control (no migration)", func(t *testing.T) {
+		className := "F10RangeableLive"
+		ids := setupClassWithObjects(t, className, true)
+		runUpdateStorm(t, restURI, className, ids)
+
+		require.Eventually(t, func() bool {
+			return aggregateCountWhereGTE(t, className, propName, mark) == numUpdates
+		}, 60*time.Second, time.Second,
+			"control: all %d updated objects must be served at >= %d", numUpdates, mark)
+	})
+
+	t.Run("enable-rangeable migration with concurrent writes", func(t *testing.T) {
+		className := "F10RangeableMig"
+		ids := setupClassWithObjects(t, className, false)
+
+		taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, propName,
+			`{"rangeable":{"enabled":true}}`)
+		t.Logf("submitted enable-rangeable task: %s", taskID)
+
+		// Fire the PATCH storm immediately so it overlaps the migration
+		// window (markStarted → backfill → swap → schema flip).
+		runUpdateStorm(t, restURI, className, ids)
+
+		reindexhelpers.AwaitReindexViaIndexes(t, restURI, className, propName, "rangeable")
+		reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+
+		// Schema flag must be flipped.
+		updatedClass := helper.GetClass(t, className)
+		for _, prop := range updatedClass.Properties {
+			if prop.Name == propName {
+				require.NotNil(t, prop.IndexRangeFilters)
+				require.True(t, *prop.IndexRangeFilters)
+			}
+		}
+
+		// The core assertion: every concurrently PATCHed object must be
+		// range-queryable. Pre-fix this lost a stable double-digit
+		// percentage of the M updates (weaviate/weaviate#11688).
+		var got int
+		require.Eventuallyf(t, func() bool {
+			got = aggregateCountWhereGTE(t, className, propName, mark)
+			return got == numUpdates
+		}, 60*time.Second, time.Second,
+			"migration must not drop concurrent writes from the rangeable index: "+
+				"Aggregate(vint >= %d) = %d, want %d", mark, got, numUpdates)
+
+		// Sanity: total object count unchanged.
+		require.Equal(t, numObjects, aggregateCountAll(t, className),
+			"total object count must be unchanged by the migration")
+	})
+}
+
+// setupClassWithObjects creates the test class and imports numObjects
+// objects with vint cycling 0..99. rangeableAtCreate toggles the control
+// (true: index exists from the start, no migration needed) vs the
+// migration scenario (false: indexRangeFilters off, to be enabled at
+// runtime). indexFilterable is false in BOTH cases — the property state
+// that exposed the bug (no other enabled inverted index).
+func setupClassWithObjects(t *testing.T, className string, rangeableAtCreate bool) []string {
+	t.Helper()
+	vFalse := false
+	class := &models.Class{
+		Class:      className,
+		Vectorizer: "none",
+		Properties: []*models.Property{
+			{
+				Name:     "grp",
+				DataType: schema.DataTypeInt.PropString(),
+			},
+			{
+				Name:              propName,
+				DataType:          schema.DataTypeInt.PropString(),
+				IndexFilterable:   &vFalse,
+				IndexRangeFilters: &rangeableAtCreate,
+			},
+		},
+	}
+	helper.CreateClass(t, class)
+	t.Cleanup(func() { helper.DeleteClass(t, className) })
+
+	ids := make([]string, numObjects)
+	for i := 0; i < numObjects; i++ {
+		ids[i] = uuid.NewSHA1(uuid.NameSpaceDNS, []byte(fmt.Sprintf("%s-%d", className, i))).String()
+	}
+
+	const batchSize = 1000
+	for from := 0; from < numObjects; from += batchSize {
+		to := from + batchSize
+		if to > numObjects {
+			to = numObjects
+		}
+		batch := make([]*models.Object, 0, to-from)
+		for i := from; i < to; i++ {
+			batch = append(batch, &models.Object{
+				Class: className,
+				ID:    strfmt.UUID(ids[i]),
+				Properties: map[string]interface{}{
+					"grp":    int64(1),
+					propName: int64(i % 100),
+				},
+			})
+		}
+		helper.CreateObjectsBatch(t, batch)
+	}
+	return ids
+}
+
+// runUpdateStorm PATCHes numUpdates objects (ids[1000:1000+numUpdates]) to
+// vint=mark across updateThreads goroutines and waits for completion.
+// Every PATCH must succeed — a failed write would make the count
+// assertion ambiguous.
+func runUpdateStorm(t *testing.T, restURI, className string, ids []string) {
+	t.Helper()
+	logger := logrus.New()
+
+	targets := ids[1000 : 1000+numUpdates]
+	errCh := make(chan error, numUpdates)
+	var wg sync.WaitGroup
+	for th := 0; th < updateThreads; th++ {
+		chunk := make([]string, 0, numUpdates/updateThreads+1)
+		for i := th; i < len(targets); i += updateThreads {
+			chunk = append(chunk, targets[i])
+		}
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			for _, id := range chunk {
+				if err := patchVint(restURI, className, id); err != nil {
+					errCh <- fmt.Errorf("patch %s: %w", id, err)
+				}
+			}
+		}, logger)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("update storm: %v", err)
+	}
+	require.False(t, t.Failed(), "all %d PATCHes must succeed", numUpdates)
+	t.Logf("update storm complete: %d PATCHes", numUpdates)
+}
+
+// patchVint PATCHes a single object's vint to mark via the REST API —
+// exactly what QA's repro does. Raw HTTP keeps error handling
+// goroutine-safe (no testify asserts off the test goroutine).
+func patchVint(restURI, className, id string) error {
+	body, err := json.Marshal(map[string]interface{}{
+		"class":      className,
+		"id":         id,
+		"properties": map[string]interface{}{propName: mark},
+	})
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("http://%s/v1/objects/%s/%s", restURI, className, id)
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	// Strictly 204: a successful PATCH returns 204 No Content. An empty 200
+	// is the signature of a panicked handler — the REST panic middleware
+	// recovers WITHOUT writing a response, so net/http defaults to 200 with
+	// an empty body while the write was only half-applied (this is exactly
+	// how the pre-fix swap-window nil-bucket panic surfaced to clients).
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status %d (want 204): %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// aggregateCountWhereGTE returns Aggregate{meta{count}} for prop >= value
+// — served by the rangeable index once the schema flag is on.
+func aggregateCountWhereGTE(t *testing.T, className, prop string, value int) int {
+	t.Helper()
+	query := fmt.Sprintf(`{
+		Aggregate {
+			%s(where: {path:[%q], operator: GreaterThanEqual, valueInt: %d}) {
+				meta { count }
+			}
+		}
+	}`, className, prop, value)
+	return aggregateMetaCount(t, className, query)
+}
+
+// aggregateCountAll returns the unfiltered Aggregate{meta{count}}.
+func aggregateCountAll(t *testing.T, className string) int {
+	t.Helper()
+	query := fmt.Sprintf(`{
+		Aggregate {
+			%s {
+				meta { count }
+			}
+		}
+	}`, className)
+	return aggregateMetaCount(t, className, query)
+}
+
+func aggregateMetaCount(t *testing.T, className, query string) int {
+	t.Helper()
+	resp, err := graphqlhelper.QueryGraphQL(t, nil, "", query, nil)
+	require.NoError(t, err)
+	require.Empty(t, resp.Errors, "graphql errors: %+v", resp.Errors)
+
+	var data map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(mustMarshal(t, resp.Data), &data))
+	var agg map[string][]struct {
+		Meta struct {
+			Count int `json:"count"`
+		} `json:"meta"`
+	}
+	require.NoError(t, json.Unmarshal(data["Aggregate"], &agg))
+	require.NotEmpty(t, agg[className], "Aggregate returned no rows for %s", className)
+	return agg[className][0].Meta.Count
+}
+
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/test/acceptance/reindex_rangeable/concurrent_writes_test.go
+++ b/test/acceptance/reindex_rangeable/concurrent_writes_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -42,8 +43,9 @@ import (
 )
 
 const (
-	// numObjects keeps the backfill long enough that the M concurrent
-	// PATCHes overlap the migration window, while keeping CI runtime sane.
+	// numObjects keeps the backfill long enough that the numUpdates
+	// concurrent PATCHes overlap the migration window, while keeping CI
+	// runtime sane.
 	numObjects = 4000
 	numUpdates = 500
 	// updateThreads fans the PATCHes out across goroutines.
@@ -132,12 +134,14 @@ func TestEnableRangeable_ConcurrentWrites(t *testing.T) {
 		// The core assertion: every concurrently PATCHed object must be
 		// range-queryable (weaviate/weaviate#11688).
 		var got int
-		require.Eventuallyf(t, func() bool {
+		ok := assert.Eventually(t, func() bool {
 			got = aggregateCountWhereGTE(t, className, propName, mark)
 			return got == numUpdates
-		}, 60*time.Second, time.Second,
-			"migration must not drop concurrent writes from the rangeable index: "+
+		}, 60*time.Second, time.Second)
+		if !ok {
+			t.Fatalf("migration must not drop concurrent writes from the rangeable index: "+
 				"Aggregate(vint >= %d) = %d, want %d", mark, got, numUpdates)
+		}
 
 		// Sanity: total object count unchanged.
 		require.Equal(t, numObjects, aggregateCountAll(t, className),

--- a/test/acceptance/reindex_rangeable/concurrent_writes_test.go
+++ b/test/acceptance/reindex_rangeable/concurrent_writes_test.go
@@ -11,16 +11,8 @@
 
 // Package reindex_rangeable_concurrent_writes is the black-box regression
 // suite for weaviate/weaviate#11688: live writes racing an enable-rangeable
-// runtime migration must not be dropped from the rangeable index.
-//
-// It ports QA's repro (f10, rangeable variant): N objects with an int
-// property that has indexFilterable=false (no other enabled inverted index
-// — the exposed property state), M concurrent PATCHes setting the property
-// to a marker value while PUT /v1/schema/{class}/indexes/{prop}
-// {"rangeable":{"enabled":true}} runs. After the migration completes, an
-// Aggregate over `prop >= MARK` must count exactly M. A live control (the
-// same write storm against a class whose rangeable index was enabled at
-// create time, i.e. no migration) pins that the storm itself loses
+// runtime migration must not be dropped from the rangeable index. A live
+// control class (no migration) pins that the write storm itself loses
 // nothing.
 package reindex_rangeable_concurrent_writes
 
@@ -53,9 +45,8 @@ const (
 	// numObjects keeps the backfill long enough that the M concurrent
 	// PATCHes overlap the migration window, while keeping CI runtime sane.
 	numObjects = 4000
-	// numUpdates is the number of concurrent PATCHes racing the migration.
 	numUpdates = 500
-	// updateThreads fans the PATCHes out, mirroring QA's repro.
+	// updateThreads fans the PATCHes out across goroutines.
 	updateThreads = 4
 	// mark is the post-update property value; far above every initial
 	// value so `vint >= mark` counts exactly the updated objects.
@@ -101,10 +92,8 @@ func TestEnableRangeable_ConcurrentWrites(t *testing.T) {
 		}
 	}()
 
-	// Live control FIRST: the same write storm against a class whose
-	// rangeable index existed from the start. Proves the storm itself
-	// (batching, PATCH concurrency, aggregation) loses nothing, so a
-	// migration-case failure isolates the migration as the cause.
+	// Live control FIRST: same storm, no migration — isolates the migration
+	// as the cause if only the migration case fails.
 	t.Run("live control (no migration)", func(t *testing.T) {
 		className := "F10RangeableLive"
 		ids := setupClassWithObjects(t, className, true)
@@ -141,8 +130,7 @@ func TestEnableRangeable_ConcurrentWrites(t *testing.T) {
 		}
 
 		// The core assertion: every concurrently PATCHed object must be
-		// range-queryable. Pre-fix this lost a stable double-digit
-		// percentage of the M updates (weaviate/weaviate#11688).
+		// range-queryable (weaviate/weaviate#11688).
 		var got int
 		require.Eventuallyf(t, func() bool {
 			got = aggregateCountWhereGTE(t, className, propName, mark)
@@ -157,12 +145,10 @@ func TestEnableRangeable_ConcurrentWrites(t *testing.T) {
 	})
 }
 
-// setupClassWithObjects creates the test class and imports numObjects
-// objects with vint cycling 0..99. rangeableAtCreate toggles the control
-// (true: index exists from the start, no migration needed) vs the
-// migration scenario (false: indexRangeFilters off, to be enabled at
-// runtime). indexFilterable is false in BOTH cases — the property state
-// that exposed the bug (no other enabled inverted index).
+// setupClassWithObjects creates the test class and imports numObjects objects
+// with vint cycling 0..99. rangeableAtCreate toggles the live-control class
+// (index enabled at create) vs the migration class (enabled at runtime);
+// indexFilterable is false in both, the property state that exposed the bug.
 func setupClassWithObjects(t *testing.T, className string, rangeableAtCreate bool) []string {
 	t.Helper()
 	vFalse := false
@@ -212,10 +198,8 @@ func setupClassWithObjects(t *testing.T, className string, rangeableAtCreate boo
 	return ids
 }
 
-// runUpdateStorm PATCHes numUpdates objects (ids[1000:1000+numUpdates]) to
-// vint=mark across updateThreads goroutines and waits for completion.
-// Every PATCH must succeed — a failed write would make the count
-// assertion ambiguous.
+// runUpdateStorm PATCHes numUpdates objects to vint=mark and waits for
+// completion. Every PATCH must succeed, else the count assertion is ambiguous.
 func runUpdateStorm(t *testing.T, restURI, className string, ids []string) {
 	t.Helper()
 	logger := logrus.New()
@@ -247,9 +231,9 @@ func runUpdateStorm(t *testing.T, restURI, className string, ids []string) {
 	t.Logf("update storm complete: %d PATCHes", numUpdates)
 }
 
-// patchVint PATCHes a single object's vint to mark via the REST API —
-// exactly what QA's repro does. Raw HTTP keeps error handling
-// goroutine-safe (no testify asserts off the test goroutine).
+// patchVint PATCHes a single object's vint to mark via the REST API. Raw
+// HTTP keeps error handling goroutine-safe (no testify asserts off the test
+// goroutine).
 func patchVint(restURI, className, id string) error {
 	body, err := json.Marshal(map[string]interface{}{
 		"class":      className,
@@ -271,11 +255,9 @@ func patchVint(restURI, className, id string) error {
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
-	// Strictly 204: a successful PATCH returns 204 No Content. An empty 200
-	// is the signature of a panicked handler — the REST panic middleware
-	// recovers WITHOUT writing a response, so net/http defaults to 200 with
-	// an empty body while the write was only half-applied (this is exactly
-	// how the pre-fix swap-window nil-bucket panic surfaced to clients).
+	// Strictly 204: an empty 200 is the signature of a panicked handler — the
+	// REST panic middleware recovers without writing a response, so net/http
+	// defaults to 200 with an empty body while the write was half-applied.
 	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("status %d (want 204): %s", resp.StatusCode, string(respBody))
 	}

--- a/test/run.sh
+++ b/test/run.sh
@@ -786,13 +786,13 @@ function run_acceptance_reindex_multinode() {
   #   -scale      : TestMultiNode_HappyPath, _QueryConsistencyDuringReindex,
   #                 _ConcurrentDifferentMigrations*,
   #                 _EnableRangeable_* (NoPartialCountsInFlight +
-  #                 ConcurrentUpdatesNoLossNoPanic)
+  #                 ConcurrentUpdatesNoLossNoPanic) +
+  #                 _PostRestartReapplyMigrations_* (moved back off
+  #                 -changetok for wall-clock, 2026-07)
   #   -changetok  : TestMultiNode_ChangeTokenization_* (non-AJ) +
   #                 TestMultiNode_BackToBackChangeTokenization_* +
   #                 TestLiveQueriesDuringChangeTokenization +
-  #                 TestPartialResultsDuringChangeTokenization +
-  #                 _PostRestartReapplyMigrations_* (rebalanced off -scale
-  #                 for wall-clock, 2026-07)
+  #                 TestPartialResultsDuringChangeTokenization
   #
   # IMPORTANT: when adding a new sub-shard, also add its top-level test
   # prefixes to the SKIP regex below to prevent the catch-all from
@@ -859,23 +859,28 @@ function run_acceptance_reindex_multinode_restart_b() {
 function run_acceptance_reindex_multinode_scale() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-multinode-scale"
-  # Scale / orchestration tests. 5 tests:
+  # Scale / orchestration tests. 6 tests:
   #   TestMultiNode_HappyPath
   #   TestMultiNode_QueryConsistencyDuringReindex
   #   TestMultiNode_ConcurrentDifferentMigrations_ExactCountsPostSettle
   #   TestMultiNode_EnableRangeable_NoPartialCountsInFlight
   #   TestMultiNode_EnableRangeable_ConcurrentUpdatesNoLossNoPanic
+  #   TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas
   #
-  # Rebalanced 2026-07: once the RF3 concurrent-update rangeable test
-  # (EnableRangeable_ConcurrentUpdatesNoLossNoPanic) was wired in here the
-  # shard hit 11m27s in CI, over the ~10 min acceptance budget. The two
-  # heaviest orchestration tests were moved onto shards with headroom to
-  # bring this one back under budget, NOT dropped:
-  #   RepeatedParallelMigrationJourney_PerReplicaConsistency  -> -restart-b
-  #   PostRestartReapplyMigrations_ExactCountsAcrossReplicas  -> -changetok
-  # Measured CI package total: 354.5s (7 tests) -> ~198s (5 tests);
-  # job wall-clock 11m27s -> ~8m51s.
-  AOF_GROUP_RUN='TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_)' \
+  # 2026-07 rebalance history: this shard hit 11m27s once the RF3
+  # concurrent-update rangeable test was wired in, so the two heaviest
+  # orchestration tests (RepeatedParallelMigrationJourney -> -restart-b,
+  # PostRestartReapplyMigrations -> -changetok) were moved off and it
+  # landed at a measured 8m19s.
+  #
+  # Follow-up (2026-07): PostRestartReapplyMigrations (~62s CI) is moved
+  # back HERE off -changetok. -changetok had overshot to a measured
+  # 10m27s (its 8m15s->9m17s projection ran ~70s optimistic: a ~62s test
+  # cost it ~132s of wall-clock because it pushed that shard into a
+  # superlinear regime). scale has headroom at 8m19s and stays linear, so
+  # the add costs ~62s: projected ~9m21s (~39s margin). Watch this shard
+  # on the next CI run -- it now carries the thinnest scale margin.
+  AOF_GROUP_RUN='TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_|PostRestartReapplyMigrations)' \
     run_aof_group "reindex-multinode-scale" test/acceptance/reindex_multinode
 }
 
@@ -883,15 +888,17 @@ function run_acceptance_reindex_multinode_changetok() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-multinode-changetok"
   # Change-tokenization tests (non-AJ; AJ has its own -aj shard) plus the
-  # FINALIZING-window probe tests, plus PostRestartReapplyMigrations.
+  # FINALIZING-window probe tests.
   #
-  # PostRestartReapplyMigrations_ExactCountsAcrossReplicas was rebalanced
-  # here off -scale (2026-07, measured ~62s CI) to relieve that shard's
-  # over-budget wall-clock. It is an orchestration test parked in this
-  # shard for wall-clock balance, not a change-tokenization test.
-  # Measured CI package total: 226s (7 tests) -> ~288s (8 tests);
-  # job wall-clock 8m15s -> ~9m17s.
-  AOF_GROUP_RUN='TestMultiNode_ChangeTokenization_(RestartThenRoundTrip|MTRoundTrip|ConcurrentDifferentProps|RoundTrip)|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization|TestMultiNode_PostRestartReapplyMigrations' \
+  # 2026-07: PostRestartReapplyMigrations_ExactCountsAcrossReplicas was
+  # briefly parked here off -scale, but it pushed this shard to a measured
+  # 10m27s (the 8m15s->9m17s projection ran ~70s optimistic; the ~62s test
+  # actually cost ~132s of wall-clock, i.e. 62s + ~70s of superlinear
+  # slowdown from crossing this shard's stress threshold). It has been
+  # moved back to -scale, which has headroom. Removing it drops this shard
+  # by ~62s + that ~70s of relief, back to its ~8m15s pre-add baseline
+  # (~1m45s margin under the ~10m budget).
+  AOF_GROUP_RUN='TestMultiNode_ChangeTokenization_(RestartThenRoundTrip|MTRoundTrip|ConcurrentDifferentProps|RoundTrip)|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization' \
     run_aof_group "reindex-multinode-changetok" test/acceptance/reindex_multinode
 }
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -782,7 +782,8 @@ function run_acceptance_reindex_multinode() {
   #   -rm         : TestMultiNode_RestartMatrix             (parametrised restart)
   #   -restart    : TestMultiNode_*Restart* / *Crash* (excl. AJ + Matrix)
   #   -scale      : TestMultiNode_HappyPath, _ConcurrentDifferent*,
-  #                 _EnableRangeable_NoPartialCountsInFlight,
+  #                 _EnableRangeable_* (NoPartialCountsInFlight +
+  #                 ConcurrentUpdatesNoLossNoPanic),
   #                 _RepeatedParallelMigrationJourney_*,
   #                 _PostRestartReapplyMigrations_*
   #   -changetok  : TestMultiNode_ChangeTokenization_* (non-AJ) +
@@ -793,7 +794,7 @@ function run_acceptance_reindex_multinode() {
   # IMPORTANT: when adding a new sub-shard, also add its top-level test
   # prefixes to the SKIP regex below to prevent the catch-all from
   # double-running the same tests.
-  AOF_GROUP_SKIP='TestMultiNode_ChangeTokenization_AJ_|TestMultiNode_RestartMatrix|TestMultiNode_(Rolling|Graceful|Crash|MajorityCrash|UngracefulStop|PostRestartMigration)|TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_NoPartialCountsInFlight|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)|TestMultiNode_ChangeTokenization_|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization' \
+  AOF_GROUP_SKIP='TestMultiNode_ChangeTokenization_AJ_|TestMultiNode_RestartMatrix|TestMultiNode_(Rolling|Graceful|Crash|MajorityCrash|UngracefulStop|PostRestartMigration)|TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)|TestMultiNode_ChangeTokenization_|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization' \
     run_aof_group "reindex-multinode" test/acceptance/reindex_multinode
 }
 
@@ -851,7 +852,7 @@ function run_acceptance_reindex_multinode_scale() {
   # test in the whole package (PostRestartReapplyMigrations_ExactCounts
   # AcrossReplicas, 135s) lives here so it's amortised against the
   # smaller orchestration tests.
-  AOF_GROUP_RUN='TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_NoPartialCountsInFlight|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)' \
+  AOF_GROUP_RUN='TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)' \
     run_aof_group "reindex-multinode-scale" test/acceptance/reindex_multinode
 }
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -580,6 +580,7 @@ function get_fast_acceptance_packages() {
     | grep -v 'test/acceptance/reindex_multinode' \
     | grep -v 'test/acceptance/reindex_singlenode' \
     | grep -v 'test/acceptance/reindex_concurrent' \
+    | grep -v 'test/acceptance/reindex_rangeable' \
     | grep -v 'test/acceptance/reindex_mt' \
     | grep -v 'test/acceptance/reindex_backup' \
     | grep -v 'test/acceptance/distributed_tasks' \
@@ -972,8 +973,15 @@ function run_acceptance_reindex_concurrent() {
   # TestParallelEnableFilterableAndRangeable). TestParallelConflictMatrix
   # historically runs the longest of the three. Split out of the
   # singlenode bundle for fast feedback.
+  #
+  # reindex_rangeable (TestEnableRangeable_ConcurrentWrites) is co-located here
+  # rather than left to the fast-acceptance catch-all: it is a single-node
+  # concurrent-reindex test that belongs with its siblings, and folding it into
+  # this existing named job keeps it named without a new CI matrix entry. It is
+  # excluded from get_fast_acceptance_packages so it runs exactly once.
   run_aof_group "reindex-concurrent" \
-    test/acceptance/reindex_concurrent
+    test/acceptance/reindex_concurrent \
+    test/acceptance/reindex_rangeable
 }
 
 function run_acceptance_reindex_mt() {

--- a/test/run.sh
+++ b/test/run.sh
@@ -780,16 +780,19 @@ function run_acceptance_reindex_multinode() {
   # _rm, _restart, _scale, _changetok):
   #   -aj         : TestMultiNode_ChangeTokenization_AJ_*  (adjacent journeys)
   #   -rm         : TestMultiNode_RestartMatrix             (parametrised restart)
-  #   -restart    : TestMultiNode_*Restart* / *Crash* (excl. AJ + Matrix)
-  #   -scale      : TestMultiNode_HappyPath, _ConcurrentDifferent*,
+  #   -restart    : TestMultiNode_*Restart* / *Crash* (excl. AJ + Matrix);
+  #                 -restart-b also carries _RepeatedParallelMigrationJourney_*
+  #                 (rebalanced off -scale for wall-clock, 2026-07)
+  #   -scale      : TestMultiNode_HappyPath, _QueryConsistencyDuringReindex,
+  #                 _ConcurrentDifferentMigrations*,
   #                 _EnableRangeable_* (NoPartialCountsInFlight +
-  #                 ConcurrentUpdatesNoLossNoPanic),
-  #                 _RepeatedParallelMigrationJourney_*,
-  #                 _PostRestartReapplyMigrations_*
+  #                 ConcurrentUpdatesNoLossNoPanic)
   #   -changetok  : TestMultiNode_ChangeTokenization_* (non-AJ) +
   #                 TestMultiNode_BackToBackChangeTokenization_* +
   #                 TestLiveQueriesDuringChangeTokenization +
-  #                 TestPartialResultsDuringChangeTokenization
+  #                 TestPartialResultsDuringChangeTokenization +
+  #                 _PostRestartReapplyMigrations_* (rebalanced off -scale
+  #                 for wall-clock, 2026-07)
   #
   # IMPORTANT: when adding a new sub-shard, also add its top-level test
   # prefixes to the SKIP regex below to prevent the catch-all from
@@ -830,39 +833,65 @@ function run_acceptance_reindex_multinode_restart_a() {
 function run_acceptance_reindex_multinode_restart_b() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-multinode-restart-b (finalizing-window restarts + post-restart migration)"
-  # 3 tests:
+  # 4 tests:
   #   TestMultiNode_RollingRestartDuringFinalizing_PerReplicaConsistency
   #   TestMultiNode_UngracefulStopDuringFinalizing_PerReplicaConsistency
   #   TestMultiNode_PostRestartMigration_NoStallPlateau
+  #   TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency
   #
-  # The "narrow timing window" bucket — every test here is about a
-  # specific moment in the migration state machine (FINALIZING window
-  # races) or about the post-restart migration replay path. Same
+  # The first three are the "narrow timing window" bucket — every one is
+  # about a specific moment in the migration state machine (FINALIZING
+  # window races) or about the post-restart migration replay path. Same
   # rationale as -restart-a: per-test cluster lifecycle is structural,
   # not optional.
-  AOF_GROUP_RUN='TestMultiNode_(RollingRestartDuringFinalizing|UngracefulStopDuringFinalizing|PostRestartMigration)' \
+  #
+  # RepeatedParallelMigrationJourney was rebalanced here off -scale
+  # (2026-07, measured ~94s CI) to relieve that shard's over-budget
+  # wall-clock. It is a repeated-parallel-migration orchestration test
+  # parked in this shard for wall-clock balance; it fits the "cluster
+  # lifecycle per test" theme even if it is not itself a restart test.
+  # Measured CI package total: 217.6s (3 tests) -> ~312s (4 tests);
+  # job wall-clock 7m51s -> ~9m25s.
+  AOF_GROUP_RUN='TestMultiNode_(RollingRestartDuringFinalizing|UngracefulStopDuringFinalizing|PostRestartMigration|RepeatedParallelMigrationJourney)' \
     run_aof_group "reindex-multinode-restart-b" test/acceptance/reindex_multinode
 }
 
 function run_acceptance_reindex_multinode_scale() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-multinode-scale"
-  # Scale / orchestration tests. Locally measured wall-clock ≈ 283s
-  # across 5 tests; +CI overhead → ~8-9 min total. The single longest
-  # test in the whole package (PostRestartReapplyMigrations_ExactCounts
-  # AcrossReplicas, 135s) lives here so it's amortised against the
-  # smaller orchestration tests.
-  AOF_GROUP_RUN='TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)' \
+  # Scale / orchestration tests. 5 tests:
+  #   TestMultiNode_HappyPath
+  #   TestMultiNode_QueryConsistencyDuringReindex
+  #   TestMultiNode_ConcurrentDifferentMigrations_ExactCountsPostSettle
+  #   TestMultiNode_EnableRangeable_NoPartialCountsInFlight
+  #   TestMultiNode_EnableRangeable_ConcurrentUpdatesNoLossNoPanic
+  #
+  # Rebalanced 2026-07: once the RF3 concurrent-update rangeable test
+  # (EnableRangeable_ConcurrentUpdatesNoLossNoPanic) was wired in here the
+  # shard hit 11m27s in CI, over the ~10 min acceptance budget. The two
+  # heaviest orchestration tests were moved onto shards with headroom to
+  # bring this one back under budget, NOT dropped:
+  #   RepeatedParallelMigrationJourney_PerReplicaConsistency  -> -restart-b
+  #   PostRestartReapplyMigrations_ExactCountsAcrossReplicas  -> -changetok
+  # Measured CI package total: 354.5s (7 tests) -> ~198s (5 tests);
+  # job wall-clock 11m27s -> ~8m51s.
+  AOF_GROUP_RUN='TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_)' \
     run_aof_group "reindex-multinode-scale" test/acceptance/reindex_multinode
 }
 
 function run_acceptance_reindex_multinode_changetok() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-multinode-changetok"
-  # Change-tokenization tests (non-AJ; AJ has its own -aj shard) plus
-  # the FINALIZING-window probe tests. Locally measured wall-clock
-  # ≈ 171s across 7 tests; +CI overhead → ~7-8 min total.
-  AOF_GROUP_RUN='TestMultiNode_ChangeTokenization_(RestartThenRoundTrip|MTRoundTrip|ConcurrentDifferentProps|RoundTrip)|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization' \
+  # Change-tokenization tests (non-AJ; AJ has its own -aj shard) plus the
+  # FINALIZING-window probe tests, plus PostRestartReapplyMigrations.
+  #
+  # PostRestartReapplyMigrations_ExactCountsAcrossReplicas was rebalanced
+  # here off -scale (2026-07, measured ~62s CI) to relieve that shard's
+  # over-budget wall-clock. It is an orchestration test parked in this
+  # shard for wall-clock balance, not a change-tokenization test.
+  # Measured CI package total: 226s (7 tests) -> ~288s (8 tests);
+  # job wall-clock 8m15s -> ~9m17s.
+  AOF_GROUP_RUN='TestMultiNode_ChangeTokenization_(RestartThenRoundTrip|MTRoundTrip|ConcurrentDifferentProps|RoundTrip)|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization|TestMultiNode_PostRestartReapplyMigrations' \
     run_aof_group "reindex-multinode-changetok" test/acceptance/reindex_multinode
 }
 


### PR DESCRIPTION
SuperClaude here.

Runtime property reindex mirrors live writes into the migration's ingest bucket via double-write callbacks. Three windows let a concurrent write escape that mirror, so it lands under the wrong tokenization or is lost. This closes all three for the single-node / single-clock case.

**Mechanisms fixed**

1. **Overlay drop (weaviate/0-weaviate-issues#298).** The inline write path analyzed the concurrent write under the *old* schema, so a retokenize migration mirrored source-tokenized terms into the target bucket (or dropped the prop). The double-write now analyzes under the target schema via an overlay, folded with the callback slices into one atomic snapshot so a writer never sees callbacks-without-scope.
2. **Registration-gap timestamp window (weaviate/weaviate#11688).** `reindexStarted` was captured *before* the double-write callbacks were registered, so a write in that gap was neither backfilled (its timestamp predated the cutoff) nor mirrored. Capture now happens after registration, ceil-rounded to the ms.
3. **Swap-window nil bucket (weaviate/weaviate#11688).** A write landing between `SwapBucketPointer` (which unregisters the ingest name) and the deferred callback-disable dereferenced a nil bucket → panic → silent loss under REST error suppression. Resolution now falls back to the canonical bucket during ingest, nil-skips only during backup.

**Tests** — all green under `-race`: 8 deterministic unit pins (overlay / timestamp / swap-window × add/delete/update), a hook-free unit test of the resolver truth table, and a black-box acceptance repro (enable-rangeable, no filterable index).

**Residual**: multi-node coordinator-clock skew (weaviate/weaviate#11692) is not addressed here — the timestamp fix is single-clock. Tracked separately.

Fixes #11688
Closes weaviate/0-weaviate-issues#298

— SuperClaude