### PR TITLE
fix(dtm): fail/retry reindex task on OnTaskCompleted schema-flip failure (#297)

### DIFF
--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1560,7 +1560,15 @@ func (p *ReindexProvider) onSwapRequestedRunPhaseForUnit(
 // Skips the flip on non-SWAPPING terminal states (FAILED / CANCELLED) so
 // the schema remains pre-migration when the cluster-wide migration didn't
 // succeed.
-func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
+//
+// Returns a non-nil error on the SWAPPING path when the flip did not commit
+// so the scheduler withholds FINISHED and retries (weaviate/0-weaviate-issues
+// #297). A deterministically-unrecoverable failure (unparsable payload,
+// target property gone at finalize) is wrapped in
+// [distributedtask.ErrTaskCompletionPermanent] so the scheduler fails the
+// task instead of retrying forever; every other flip error is transient.
+// Terminal-status (FAILED/CANCELLED) cleanup is best-effort and returns nil.
+func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) error {
 	// Clear caches up-front so a failed-task early return doesn't leak.
 	payload, payloadErr := p.loadPayload(task)
 	p.clearTaskCaches(task.TaskDescriptor)
@@ -1587,15 +1595,16 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 				// OnTaskCompleted; FINISHED tidies via the swap pipeline.
 			}
 		}
-		return
+		return nil
 	}
 	if payloadErr != nil {
 		logger.Errorf("reindex provider: task-completion: failed to load payload; schema flip will not run: %v", payloadErr)
-		return
+		// An unparsable payload never becomes parsable — permanent.
+		return fmt.Errorf("load payload for schema flip: %w: %w", payloadErr, distributedtask.ErrTaskCompletionPermanent)
 	}
 	if !IsSemanticMigration(payload.MigrationType) {
 		// Format-only migrations flip their metadata inside RunSwapOnShard.
-		return
+		return nil
 	}
 
 	// p.serverCtx outlives the per-task ctx (which is gone by the time the
@@ -1606,7 +1615,9 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 		// Leave the overlay in place: buckets are NEW-tokenized but the
 		// schema is still pre-flip on this node — the overlay keeps queries
 		// aligned until either a retry lands or TokenizationFor self-clears.
-		return
+		// The error (permanent-wrapped inside flipSemanticMigrationSchema for
+		// property-gone, plain otherwise) tells the scheduler to retry-or-fail.
+		return fmt.Errorf("schema flip: %w", err)
 	}
 
 	if IsTokenizationChangingMigration(payload.MigrationType) {
@@ -1629,6 +1640,10 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 			})
 		}
 	}
+
+	// Flip committed; the overlay clear above is best-effort (self-heals on
+	// query). The cutover succeeded, so the scheduler may finalize.
+	return nil
 }
 
 // autoCleanupAfterTerminal runs on every node when a semantic migration
@@ -2034,9 +2049,11 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 			return fmt.Errorf("flip tokenization: %w", err)
 		}
 		if len(missing) > 0 {
-			// Single-property migration; a missing property between submit
-			// and finalize is a hard error.
-			return fmt.Errorf("property %v not found in class %q at finalize", missing, payload.Collection)
+			// Single-property migration; a property deleted between submit
+			// and finalize can never be flipped — permanent, so the
+			// scheduler fails the task rather than retrying (issue #297).
+			return fmt.Errorf("property %v not found in class %q at finalize: %w",
+				missing, payload.Collection, distributedtask.ErrTaskCompletionPermanent)
 		}
 		logger.WithField("tokenization", payload.TargetTokenization).
 			Info("reindex provider: change-tokenization cutover committed")

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1561,13 +1561,10 @@ func (p *ReindexProvider) onSwapRequestedRunPhaseForUnit(
 // the schema remains pre-migration when the cluster-wide migration didn't
 // succeed.
 //
-// Returns a non-nil error on the SWAPPING path when the flip did not commit
-// so the scheduler withholds FINISHED and retries (weaviate/0-weaviate-issues
-// #297). A deterministically-unrecoverable failure (unparsable payload,
-// target property gone at finalize) is wrapped in
-// [distributedtask.ErrTaskCompletionPermanent] so the scheduler fails the
-// task instead of retrying forever; every other flip error is transient.
-// Terminal-status (FAILED/CANCELLED) cleanup is best-effort and returns nil.
+// Returns a non-nil error on the SWAPPING path when the flip fails: wrapped
+// in [distributedtask.ErrTaskCompletionPermanent] when unrecoverable, plain
+// when transient (weaviate/0-weaviate-issues#297). Terminal-status cleanup
+// always returns nil.
 func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) error {
 	// Clear caches up-front so a failed-task early return doesn't leak.
 	payload, payloadErr := p.loadPayload(task)
@@ -1615,8 +1612,6 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) error {
 		// Leave the overlay in place: buckets are NEW-tokenized but the
 		// schema is still pre-flip on this node — the overlay keeps queries
 		// aligned until either a retry lands or TokenizationFor self-clears.
-		// The error (permanent-wrapped inside flipSemanticMigrationSchema for
-		// property-gone, plain otherwise) tells the scheduler to retry-or-fail.
 		return fmt.Errorf("schema flip: %w", err)
 	}
 
@@ -1641,8 +1636,6 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) error {
 		}
 	}
 
-	// Flip committed; the overlay clear above is best-effort (self-heals on
-	// query). The cutover succeeded, so the scheduler may finalize.
 	return nil
 }
 
@@ -2049,9 +2042,8 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 			return fmt.Errorf("flip tokenization: %w", err)
 		}
 		if len(missing) > 0 {
-			// Single-property migration; a property deleted between submit
-			// and finalize can never be flipped — permanent, so the
-			// scheduler fails the task rather than retrying (issue #297).
+			// Single-property migration: a property deleted between submit
+			// and finalize can never be flipped — permanent (weaviate/0-weaviate-issues#297).
 			return fmt.Errorf("property %v not found in class %q at finalize: %w",
 				missing, payload.Collection, distributedtask.ErrTaskCompletionPermanent)
 		}

--- a/adapters/repos/db/reindex_provider_completion_classification_test.go
+++ b/adapters/repos/db/reindex_provider_completion_classification_test.go
@@ -1,0 +1,148 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/schema"
+)
+
+// The reindex provider is the PRODUCER of the permanent-vs-transient
+// decision the scheduler acts on: a permanent failure (wrapped in
+// [distributedtask.ErrTaskCompletionPermanent]) FAILs the task
+// immediately, a transient one is retried up to the per-task bound. A
+// transient failure mislabeled permanent would prematurely FAIL a
+// recoverable migration; the inverse would spin the retry budget on a
+// call that can never succeed. Both classes are pinned here against the
+// real classification code, on the sentinel via errors.Is — never on
+// message substrings.
+
+// classReaderStub supplies only ReadOnlyClass, the single schema
+// dependency the finalize classification consults on the missing-property
+// and unreadable-class paths. Every other SchemaReader method is promoted
+// from the nil embedded interface: a call would panic, surfacing an
+// unexpected dependency instead of passing silently.
+type classReaderStub struct {
+	schema.SchemaReader
+	class *models.Class
+}
+
+func (r classReaderStub) ReadOnlyClass(string) *models.Class { return r.class }
+
+// newClassificationProvider builds a ReindexProvider wired with just the
+// schema reader the flip path reads from. ReadOnlyClass returns cls (nil
+// models a class that is not locally readable). The Manager's Handler is
+// left zero-valued: the missing-property and unreadable-class paths never
+// reach the RAFT UpdateProperty call, so no FSM wiring is needed.
+func newClassificationProvider(cls *models.Class) *ReindexProvider {
+	logger, _ := test.NewNullLogger()
+	return &ReindexProvider{
+		logger:        logger,
+		schemaManager: &schema.Manager{SchemaReader: classReaderStub{class: cls}},
+		payloads:      make(map[distributedtask.TaskDescriptor]*ReindexTaskPayload),
+		reindexTasks:  make(map[distributedtask.TaskDescriptor]map[string][]*ShardReindexTaskGeneric),
+	}
+}
+
+func TestOnTaskCompletedClassification(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	t.Run("unparsable payload is permanent", func(t *testing.T) {
+		// A payload that no longer parses can never parse on retry, so
+		// OnTaskCompleted classifies it permanent up front rather than
+		// re-firing the flip forever.
+		p := &ReindexProvider{
+			logger:       logger,
+			payloads:     make(map[distributedtask.TaskDescriptor]*ReindexTaskPayload),
+			reindexTasks: make(map[distributedtask.TaskDescriptor]map[string][]*ShardReindexTaskGeneric),
+		}
+		task := &distributedtask.Task{
+			Namespace:      "reindex",
+			TaskDescriptor: distributedtask.TaskDescriptor{ID: "t1", Version: 1},
+			Status:         distributedtask.TaskStatusSwapping,
+			Payload:        []byte("{ this is not valid json"),
+		}
+		err := p.OnTaskCompleted(task)
+		require.Error(t, err)
+		require.ErrorIs(t, err, distributedtask.ErrTaskCompletionPermanent)
+	})
+
+	t.Run("change-tokenization target property gone is permanent", func(t *testing.T) {
+		// The class survives but the target property was deleted between
+		// submit and finalize: applyPerPropertySchemaUpdate reports it in
+		// missing, and a single-property tokenization flip against an
+		// absent property can never commit.
+		p := newClassificationProvider(&models.Class{Class: "Docs"})
+		payload := &ReindexTaskPayload{
+			MigrationType:      ReindexTypeChangeTokenization,
+			Collection:         "Docs",
+			Properties:         []string{"title"},
+			TargetTokenization: models.PropertyTokenizationWord,
+		}
+		err := p.flipSemanticMigrationSchema(ctx, payload, logger)
+		require.Error(t, err)
+		require.ErrorIs(t, err, distributedtask.ErrTaskCompletionPermanent)
+	})
+
+	t.Run("change-tokenization non-missing flip error is transient", func(t *testing.T) {
+		// A flip error that is NOT the property-gone case (here the class
+		// is not locally readable, standing in for any RAFT/apply error)
+		// flows through the shared `if err != nil` return in
+		// flipSemanticMigrationSchema — the exact line a RAFT apply error
+		// takes. It must stay plain so the scheduler retries within its
+		// bound instead of FAILing a recoverable migration.
+		p := newClassificationProvider(nil)
+		payload := &ReindexTaskPayload{
+			MigrationType:      ReindexTypeChangeTokenization,
+			Collection:         "Docs",
+			Properties:         []string{"title"},
+			TargetTokenization: models.PropertyTokenizationWord,
+		}
+		err := p.flipSemanticMigrationSchema(ctx, payload, logger)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, distributedtask.ErrTaskCompletionPermanent)
+	})
+
+	t.Run("enable-filterable tolerates a missing property", func(t *testing.T) {
+		// enable-* discard the missing list — a dropped property is the
+		// same end state as "already filterable". A missing property must
+		// not surface as any error, let alone permanent.
+		p := newClassificationProvider(&models.Class{Class: "Docs"})
+		payload := &ReindexTaskPayload{
+			MigrationType: ReindexTypeEnableFilterable,
+			Collection:    "Docs",
+			Properties:    []string{"title"},
+		}
+		err := p.flipSemanticMigrationSchema(ctx, payload, logger)
+		require.NoError(t, err)
+	})
+
+	t.Run("enable-searchable tolerates a missing property", func(t *testing.T) {
+		p := newClassificationProvider(&models.Class{Class: "Docs"})
+		payload := &ReindexTaskPayload{
+			MigrationType:      ReindexTypeEnableSearchable,
+			Collection:         "Docs",
+			Properties:         []string{"title"},
+			TargetTokenization: models.PropertyTokenizationWord,
+		}
+		err := p.flipSemanticMigrationSchema(ctx, payload, logger)
+		require.NoError(t, err)
+	})
+}

--- a/adapters/repos/db/reindex_provider_completion_classification_test.go
+++ b/adapters/repos/db/reindex_provider_completion_classification_test.go
@@ -23,21 +23,11 @@ import (
 	"github.com/weaviate/weaviate/usecases/schema"
 )
 
-// The reindex provider is the PRODUCER of the permanent-vs-transient
-// decision the scheduler acts on: a permanent failure (wrapped in
-// [distributedtask.ErrTaskCompletionPermanent]) FAILs the task
-// immediately, a transient one is retried up to the per-task bound. A
-// transient failure mislabeled permanent would prematurely FAIL a
-// recoverable migration; the inverse would spin the retry budget on a
-// call that can never succeed. Both classes are pinned here against the
-// real classification code, on the sentinel via errors.Is — never on
-// message substrings.
+// Pins OnTaskCompleted's permanent-vs-transient error classification
+// (weaviate/0-weaviate-issues#297), asserted via errors.Is, never message substrings.
 
-// classReaderStub supplies only ReadOnlyClass, the single schema
-// dependency the finalize classification consults on the missing-property
-// and unreadable-class paths. Every other SchemaReader method is promoted
-// from the nil embedded interface: a call would panic, surfacing an
-// unexpected dependency instead of passing silently.
+// classReaderStub implements only ReadOnlyClass; other SchemaReader calls
+// panic via the nil embedded interface, surfacing unexpected dependencies.
 type classReaderStub struct {
 	schema.SchemaReader
 	class *models.Class
@@ -45,11 +35,8 @@ type classReaderStub struct {
 
 func (r classReaderStub) ReadOnlyClass(string) *models.Class { return r.class }
 
-// newClassificationProvider builds a ReindexProvider wired with just the
-// schema reader the flip path reads from. ReadOnlyClass returns cls (nil
-// models a class that is not locally readable). The Manager's Handler is
-// left zero-valued: the missing-property and unreadable-class paths never
-// reach the RAFT UpdateProperty call, so no FSM wiring is needed.
+// newClassificationProvider wires a ReindexProvider with just the schema
+// reader the flip path reads; cls=nil models a class that's not locally readable.
 func newClassificationProvider(cls *models.Class) *ReindexProvider {
 	logger, _ := test.NewNullLogger()
 	return &ReindexProvider{
@@ -65,9 +52,7 @@ func TestOnTaskCompletedClassification(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	t.Run("unparsable payload is permanent", func(t *testing.T) {
-		// A payload that no longer parses can never parse on retry, so
-		// OnTaskCompleted classifies it permanent up front rather than
-		// re-firing the flip forever.
+		// Never becomes parsable, so this must be permanent, not transient.
 		p := &ReindexProvider{
 			logger:       logger,
 			payloads:     make(map[distributedtask.TaskDescriptor]*ReindexTaskPayload),
@@ -85,10 +70,8 @@ func TestOnTaskCompletedClassification(t *testing.T) {
 	})
 
 	t.Run("change-tokenization target property gone is permanent", func(t *testing.T) {
-		// The class survives but the target property was deleted between
-		// submit and finalize: applyPerPropertySchemaUpdate reports it in
-		// missing, and a single-property tokenization flip against an
-		// absent property can never commit.
+		// Property deleted between submit and finalize can never be
+		// flipped — permanent, not transient.
 		p := newClassificationProvider(&models.Class{Class: "Docs"})
 		payload := &ReindexTaskPayload{
 			MigrationType:      ReindexTypeChangeTokenization,
@@ -102,12 +85,8 @@ func TestOnTaskCompletedClassification(t *testing.T) {
 	})
 
 	t.Run("change-tokenization non-missing flip error is transient", func(t *testing.T) {
-		// A flip error that is NOT the property-gone case (here the class
-		// is not locally readable, standing in for any RAFT/apply error)
-		// flows through the shared `if err != nil` return in
-		// flipSemanticMigrationSchema — the exact line a RAFT apply error
-		// takes. It must stay plain so the scheduler retries within its
-		// bound instead of FAILing a recoverable migration.
+		// Any non-property-gone flip error (here: class not locally
+		// readable) must stay plain, or the scheduler would FAIL a recoverable migration.
 		p := newClassificationProvider(nil)
 		payload := &ReindexTaskPayload{
 			MigrationType:      ReindexTypeChangeTokenization,
@@ -121,9 +100,7 @@ func TestOnTaskCompletedClassification(t *testing.T) {
 	})
 
 	t.Run("enable-filterable tolerates a missing property", func(t *testing.T) {
-		// enable-* discard the missing list — a dropped property is the
-		// same end state as "already filterable". A missing property must
-		// not surface as any error, let alone permanent.
+		// enable-* treat a dropped property as already-filterable, not an error.
 		p := newClassificationProvider(&models.Class{Class: "Docs"})
 		payload := &ReindexTaskPayload{
 			MigrationType: ReindexTypeEnableFilterable,

--- a/cluster/distributedtask/errors.go
+++ b/cluster/distributedtask/errors.go
@@ -88,15 +88,11 @@ var (
 )
 
 // ErrTaskCompletionPermanent marks an [UnitAwareProvider.OnTaskCompleted]
-// failure the [Scheduler] must NOT retry: the post-completion work is
-// deterministically unrecoverable (the migration's target property was
-// deleted mid-flight, so the cluster-wide schema flip can never succeed; or
-// the task payload no longer parses). The scheduler transitions the task
-// straight to FAILED instead of spending the retry budget on a call that
-// cannot succeed. A plain (non-wrapped) OnTaskCompleted error is treated as
-// transient and retried up to the per-task bound. Distinct from
-// [ErrPermanentRejection], which classifies FSM apply rejections crossing
-// the RAFT/gRPC boundary.
+// failure as deterministically unrecoverable (e.g. target property deleted
+// mid-flight, payload unparsable): the [Scheduler] fails the task
+// immediately instead of retrying. A plain error is transient and retried
+// up to the per-task bound. Distinct from [ErrPermanentRejection] (FSM
+// apply rejections crossing the RAFT/gRPC boundary).
 var ErrTaskCompletionPermanent = errors.New("permanent task-completion failure")
 
 // PermanentRejectionRPCCode is the gRPC status code used to discriminate

--- a/cluster/distributedtask/errors.go
+++ b/cluster/distributedtask/errors.go
@@ -87,6 +87,18 @@ var (
 	ErrTaskNotInFinalizingState = errors.New("task is not in finalizing state")
 )
 
+// ErrTaskCompletionPermanent marks an [UnitAwareProvider.OnTaskCompleted]
+// failure the [Scheduler] must NOT retry: the post-completion work is
+// deterministically unrecoverable (the migration's target property was
+// deleted mid-flight, so the cluster-wide schema flip can never succeed; or
+// the task payload no longer parses). The scheduler transitions the task
+// straight to FAILED instead of spending the retry budget on a call that
+// cannot succeed. A plain (non-wrapped) OnTaskCompleted error is treated as
+// transient and retried up to the per-task bound. Distinct from
+// [ErrPermanentRejection], which classifies FSM apply rejections crossing
+// the RAFT/gRPC boundary.
+var ErrTaskCompletionPermanent = errors.New("permanent task-completion failure")
+
 // PermanentRejectionRPCCode is the gRPC status code used to discriminate
 // permanent FSM rejections from generic Internal errors on the wire. It
 // is intentionally codes.FailedPrecondition: the FSM is internally

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -691,19 +691,14 @@ func (m *Manager) MarkTaskFinalized(c *api.ApplyRequest) error {
 	return nil
 }
 
-// MarkTaskFailed transitions a task from SWAPPING to FAILED. The scheduler
-// issues this when a node's [UnitAwareProvider.OnTaskCompleted] returns a
-// terminal error — a permanent schema-flip failure or a transient one that
-// exhausted the retry budget — so a swallowed cutover failure can no longer
-// let the task reach FINISHED with an un-flipped schema
-// (weaviate/0-weaviate-issues#297).
+// MarkTaskFailed transitions SWAPPING → FAILED when a node's
+// [UnitAwareProvider.OnTaskCompleted] returns a terminal error, so a
+// swallowed cutover failure can't leave the task FINISHED with an
+// un-flipped schema (weaviate/0-weaviate-issues#297).
 //
-// Idempotent at the FSM layer: every node's scheduler may fire this after
-// its local OnTaskCompleted fails. The first commit flips SWAPPING → FAILED;
-// a later commit for an already-FAILED task is a no-op, and one that races a
-// peer's FINISHED / a CANCELLED is refused so the first terminal transition
-// wins. FinishedAt is left at the AllUnitsTerminal moment, matching the other
-// FAILED paths.
+// Idempotent at the FSM layer: the first commit wins; a later call on an
+// already-FAILED task is a no-op, and one racing a peer's FINISHED/CANCELLED
+// is refused. FinishedAt stays at the AllUnitsTerminal moment.
 func (m *Manager) MarkTaskFailed(c *api.ApplyRequest) error {
 	var r api.MarkTaskFailedRequest
 	if err := json.Unmarshal(c.SubCommand, &r); err != nil {
@@ -723,7 +718,6 @@ func (m *Manager) MarkTaskFailed(c *api.ApplyRequest) error {
 		// Idempotent: another node's MarkTaskFailed already committed.
 		return nil
 	case TaskStatusSwapping:
-		// Normal transition.
 	default:
 		// FINISHED / CANCELLED / STARTED — refuse so a stale command can't
 		// overwrite a terminal status a peer (or the operator) committed.

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -691,6 +691,59 @@ func (m *Manager) MarkTaskFinalized(c *api.ApplyRequest) error {
 	return nil
 }
 
+// MarkTaskFailed transitions a task from SWAPPING to FAILED. The scheduler
+// issues this when a node's [UnitAwareProvider.OnTaskCompleted] returns a
+// terminal error — a permanent schema-flip failure or a transient one that
+// exhausted the retry budget — so a swallowed cutover failure can no longer
+// let the task reach FINISHED with an un-flipped schema
+// (weaviate/0-weaviate-issues#297).
+//
+// Idempotent at the FSM layer: every node's scheduler may fire this after
+// its local OnTaskCompleted fails. The first commit flips SWAPPING → FAILED;
+// a later commit for an already-FAILED task is a no-op, and one that races a
+// peer's FINISHED / a CANCELLED is refused so the first terminal transition
+// wins. FinishedAt is left at the AllUnitsTerminal moment, matching the other
+// FAILED paths.
+func (m *Manager) MarkTaskFailed(c *api.ApplyRequest) error {
+	var r api.MarkTaskFailedRequest
+	if err := json.Unmarshal(c.SubCommand, &r); err != nil {
+		return fmt.Errorf("unmarshal mark task failed request: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	task, err := m.findVersionedTaskWithLock(r.Namespace, r.Id, r.Version)
+	if err != nil {
+		return err
+	}
+
+	switch task.Status {
+	case TaskStatusFailed:
+		// Idempotent: another node's MarkTaskFailed already committed.
+		return nil
+	case TaskStatusSwapping:
+		// Normal transition.
+	default:
+		// FINISHED / CANCELLED / STARTED — refuse so a stale command can't
+		// overwrite a terminal status a peer (or the operator) committed.
+		return wrapPermanent(ErrTaskNotInFinalizingState,
+			fmt.Sprintf("task %s/%s/%d cannot be failed from status %s",
+				r.Namespace, r.Id, task.Version, task.Status))
+	}
+
+	task.Status = TaskStatusFailed
+	if r.Error != "" {
+		if task.Error != "" {
+			task.Error = task.Error + "; " + r.Error
+		} else {
+			task.Error = r.Error
+		}
+	}
+	m.notifySchedulerWithLock()
+	return nil
+}
+
 // UpdateUnitProgress also handles initial node assignment: the first progress update for an
 // unassigned unit sets its NodeID, claiming it for that node. After assignment, updates from
 // other nodes are rejected. Progress updates to terminal units are silently ignored (no error)

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -1355,6 +1355,78 @@ func TestManager_RecordPostCompletionAck_DropsAcksForTerminalStatus(t *testing.T
 		"late ack must not be recorded on a terminal task")
 }
 
+// TestManager_MarkTaskFailed pins the SWAPPING → FAILED FSM path the
+// scheduler uses when OnTaskCompleted returns a terminal error
+// (weaviate/0-weaviate-issues#297): the transition records the error, is
+// idempotent, and refuses to overwrite a task that already reached FINISHED.
+func TestManager_MarkTaskFailed(t *testing.T) {
+	markFailed := func(t *testing.T, h *testHarness, ns, id string, version uint64, errMsg string) error {
+		return h.manager.MarkTaskFailed(toCmd(t, &cmd.MarkTaskFailedRequest{
+			Namespace:          ns,
+			Id:                 id,
+			Version:            version,
+			Error:              errMsg,
+			FailedAtUnixMillis: h.clock.Now().UnixMilli(),
+		}))
+	}
+
+	t.Run("transitions SWAPPING to FAILED and records the error", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		var version uint64 = 10
+		addTaskWithUnits(t, h, "ns", "task1", version, []string{"u"})
+		completeUnit(t, h, "ns", "task1", version, "node-1", "u")
+
+		tasks, _ := h.manager.ListDistributedTasks(context.Background())
+		require.Equal(t, TaskStatusSwapping, tasks["ns"][0].Status)
+		finishedAt := tasks["ns"][0].FinishedAt
+
+		require.NoError(t, markFailed(t, h, "ns", "task1", version, "schema flip failed at finalize"))
+
+		tasks, _ = h.manager.ListDistributedTasks(context.Background())
+		task := tasks["ns"][0]
+		require.Equal(t, TaskStatusFailed, task.Status)
+		require.Contains(t, task.Error, "schema flip failed at finalize")
+		require.Equal(t, finishedAt, task.FinishedAt,
+			"FinishedAt must stay at the AllUnitsTerminal moment, matching other FAILED paths")
+	})
+
+	t.Run("is idempotent: second call on FAILED is a no-op", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		var version uint64 = 10
+		addTaskWithUnits(t, h, "ns", "task1", version, []string{"u"})
+		completeUnit(t, h, "ns", "task1", version, "node-1", "u")
+
+		require.NoError(t, markFailed(t, h, "ns", "task1", version, "first failure"))
+		require.NoError(t, markFailed(t, h, "ns", "task1", version, "second failure"))
+
+		tasks, _ := h.manager.ListDistributedTasks(context.Background())
+		require.Equal(t, TaskStatusFailed, tasks["ns"][0].Status)
+		require.Contains(t, tasks["ns"][0].Error, "first failure")
+		require.NotContains(t, tasks["ns"][0].Error, "second failure",
+			"idempotent second call must not append another error")
+	})
+
+	t.Run("refuses to fail a task that already reached FINISHED", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		var version uint64 = 10
+		addTaskWithUnits(t, h, "ns", "task1", version, []string{"u"})
+		completeUnit(t, h, "ns", "task1", version, "node-1", "u")
+		require.NoError(t, h.manager.MarkTaskFinalized(toCmd(t, &cmd.MarkTaskFinalizedRequest{
+			Namespace:             "ns",
+			Id:                    "task1",
+			Version:               version,
+			FinalizedAtUnixMillis: h.clock.Now().UnixMilli(),
+		})))
+
+		err := markFailed(t, h, "ns", "task1", version, "too late")
+		require.Error(t, err, "the first terminal transition must win")
+		require.ErrorIs(t, err, ErrTaskNotInFinalizingState)
+
+		tasks, _ := h.manager.ListDistributedTasks(context.Background())
+		require.Equal(t, TaskStatusFinished, tasks["ns"][0].Status)
+	})
+}
+
 // TestManager_SnapshotRestore_WithPostCompletionAcks pins the
 // crash-safety property the https://github.com/weaviate/0-weaviate-issues/issues/214 Gap A fix relies on:
 // the per-node acks survive RAFT snapshot/restore. Without this, a

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -1355,10 +1355,8 @@ func TestManager_RecordPostCompletionAck_DropsAcksForTerminalStatus(t *testing.T
 		"late ack must not be recorded on a terminal task")
 }
 
-// TestManager_MarkTaskFailed pins the SWAPPING → FAILED FSM path the
-// scheduler uses when OnTaskCompleted returns a terminal error
-// (weaviate/0-weaviate-issues#297): the transition records the error, is
-// idempotent, and refuses to overwrite a task that already reached FINISHED.
+// TestManager_MarkTaskFailed pins the SWAPPING → FAILED FSM path
+// (weaviate/0-weaviate-issues#297): idempotent, refuses to overwrite FINISHED.
 func TestManager_MarkTaskFailed(t *testing.T) {
 	markFailed := func(t *testing.T, h *testHarness, ns, id string, version uint64, errMsg string) error {
 		return h.manager.MarkTaskFailed(toCmd(t, &cmd.MarkTaskFailedRequest{

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -60,18 +60,15 @@ type taskSchedulerState struct {
 	preparationAckEmitted            bool
 	postCompletionGroupErrors        map[string]error
 	preparationCompletionGroupErrors map[string]error
-	// completedCallbackAttempts counts SWAPPING-path OnTaskCompleted calls
-	// that returned a transient error. On reaching [maxCompletedCallbackAttempts]
-	// the scheduler stops retrying and fails the task, so a persistently
-	// erroring flip can't loop SWAPPING forever (weaviate/0-weaviate-issues#297).
+	// completedCallbackAttempts counts transient OnTaskCompleted failures on
+	// the SWAPPING path; at [maxCompletedCallbackAttempts] the scheduler stops
+	// retrying and fails the task (weaviate/0-weaviate-issues#297).
 	completedCallbackAttempts int
 }
 
 // maxCompletedCallbackAttempts bounds transient OnTaskCompleted retries on
-// the SWAPPING path. One attempt fires per scheduler tick; once exhausted the
-// task is transitioned to FAILED rather than retried indefinitely. Permanent
-// failures ([ErrTaskCompletionPermanent]) bypass this and fail on the first
-// attempt.
+// the SWAPPING path before the task is FAILED. [ErrTaskCompletionPermanent]
+// failures bypass this and fail on the first attempt.
 const maxCompletedCallbackAttempts = 5
 
 // Scheduler is the component which is responsible for polling the active tasks in the cluster (via the Manager)
@@ -604,11 +601,9 @@ func (s *Scheduler) tick() {
 				// SWAPPING path wait until every node has acked: the schema
 				// flip can't commit while any replica's swap is undetermined.
 				//
-				// A non-nil OnTaskCompleted error on the SWAPPING path clears
-				// completedCallbackFired so runFinalizePhase below withholds
-				// FINISHED and the next tick retries the flip; a permanent or
-				// retry-exhausted error transitions the task to FAILED
-				// instead (weaviate/0-weaviate-issues#297).
+				// A non-nil OnTaskCompleted error on the SWAPPING path withholds
+				// FINISHED and retries or fails the task; see
+				// runCompletedCallbackPhase (weaviate/0-weaviate-issues#297).
 				s.runCompletedCallbackPhase(namespace, desc, task, suProvider, effectiveStatus)
 			}
 		}
@@ -1052,19 +1047,16 @@ func (s *Scheduler) runSwapPhase(
 // runCompletedCallbackPhase fires OnTaskCompleted for a single task in
 // Phase 2 (SWAPPING/FAILED/FINISHED/CANCELLED).
 //
-// Owns its own lock lifecycle: acquires s.mu to decide eligibility + set
+// Owns its own lock lifecycle: acquires s.mu to decide eligibility and set
 // completedCallbackFired pre-callback, releases for the slow callback, then
-// re-acquires to react to the callback's error. Providers implementing
-// [UnitAwareProvider.OnTaskCompleted] MUST be safe to invoke more than once
-// per task — see the "Idempotency contract" note at the rollback site.
+// re-acquires to react to its error. [UnitAwareProvider.OnTaskCompleted]
+// implementations MUST tolerate being invoked more than once per task —
+// see the "Idempotency contract" note at the rollback site.
 //
 // SWAPPING-path error handling (weaviate/0-weaviate-issues#297): a non-nil
-// error clears completedCallbackFired so runFinalizePhase withholds FINISHED
-// and the next tick re-fires the callback. A permanent error
-// ([ErrTaskCompletionPermanent]) or one that exhausted
-// [maxCompletedCallbackAttempts] transitions the task to FAILED instead of
-// retrying forever. Errors on terminal-status invocations are best-effort
-// cleanup and never reopen the task.
+// error withholds FINISHED and retries next tick; [ErrTaskCompletionPermanent]
+// or exhausting [maxCompletedCallbackAttempts] fails the task instead.
+// Terminal-status errors are best-effort cleanup and never reopen the task.
 func (s *Scheduler) runCompletedCallbackPhase(
 	namespace string,
 	desc TaskDescriptor,
@@ -1107,18 +1099,16 @@ func (s *Scheduler) runCompletedCallbackPhase(
 		return
 	}
 
-	// Only the SWAPPING cutover retries/fails. A terminal-status callback
-	// (FAILED/CANCELLED/FINISHED cleanup) that errors must not reopen the
-	// task — leave the fired mark set so it doesn't re-fire.
+	// Only the SWAPPING cutover retries/fails; a terminal-status error is
+	// best-effort cleanup — leave the fired mark set so it doesn't re-fire.
 	if effectiveStatus != TaskStatusSwapping {
 		s.loggerWithTask(namespace, desc).
 			Warnf("OnTaskCompleted returned an error on terminal status %s; ignoring (best-effort cleanup): %v", effectiveStatus, cbErr)
 		return
 	}
 
-	// Withhold finalize (clear the fired mark so the next tick re-fires) and
-	// decide whether this failure is terminal. A permanent error fails now;
-	// a transient one fails only once the retry budget is exhausted.
+	// Clear the fired mark so the next tick re-fires; a permanent error fails
+	// now, a transient one only once the retry budget is exhausted.
 	failMsg := func() string {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -1143,10 +1133,8 @@ func (s *Scheduler) runCompletedCallbackPhase(
 		return
 	}
 
-	// Terminal failure: transition SWAPPING → FAILED without the lock. The
-	// fired mark stays cleared so a transient MarkDistributedTaskFailed error
-	// re-fires and re-attempts the transition (idempotent at the FSM layer);
-	// once FAILED, the next tick re-fires OnTaskCompleted for terminal cleanup.
+	// Fired mark stays cleared so a failed MarkDistributedTaskFailed call
+	// retries next tick (idempotent at the FSM layer).
 	if s.taskFinalizer == nil {
 		return
 	}
@@ -1223,9 +1211,8 @@ func (s *Scheduler) runFinalizePhase(
 		}
 		s.loggerWithTask(namespace, w.desc).
 			Warnf("failed to mark distributed task finalized; will retry on next tick or wake: %v", finErr)
-		// Clearing completedCallbackFired re-fires OnTaskCompleted next tick.
-		// Safe because [UnitAwareProvider.OnTaskCompleted] now requires
-		// idempotency (types.go); a re-fire that succeeds finalizes then.
+		// Clearing completedCallbackFired re-fires OnTaskCompleted next tick;
+		// safe now that [UnitAwareProvider.OnTaskCompleted] requires idempotency.
 		if providerIsUnitAware {
 			if rollbackState := s.perTaskStateLocked(w.desc); rollbackState != nil {
 				rollbackState.completedCallbackFired = false

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -60,7 +60,19 @@ type taskSchedulerState struct {
 	preparationAckEmitted            bool
 	postCompletionGroupErrors        map[string]error
 	preparationCompletionGroupErrors map[string]error
+	// completedCallbackAttempts counts SWAPPING-path OnTaskCompleted calls
+	// that returned a transient error. On reaching [maxCompletedCallbackAttempts]
+	// the scheduler stops retrying and fails the task, so a persistently
+	// erroring flip can't loop SWAPPING forever (weaviate/0-weaviate-issues#297).
+	completedCallbackAttempts int
 }
+
+// maxCompletedCallbackAttempts bounds transient OnTaskCompleted retries on
+// the SWAPPING path. One attempt fires per scheduler tick; once exhausted the
+// task is transitioned to FAILED rather than retried indefinitely. Permanent
+// failures ([ErrTaskCompletionPermanent]) bypass this and fail on the first
+// attempt.
+const maxCompletedCallbackAttempts = 5
 
 // Scheduler is the component which is responsible for polling the active tasks in the cluster (via the Manager)
 // and making sure that the tasks are running on the local node.
@@ -592,14 +604,12 @@ func (s *Scheduler) tick() {
 				// SWAPPING path wait until every node has acked: the schema
 				// flip can't commit while any replica's swap is undetermined.
 				//
-				// Snapshot/process/commit: snapshot the "should fire" decision
-				// (and set completedCallbackFired pre-callback) under s.mu;
-				// drop s.mu for the single OnTaskCompleted call; re-acquire
-				// on the way out. There is no per-result commit beyond the
-				// pre-set fired mark — OnTaskCompleted's failure mode is
-				// handled by the MarkDistributedTaskFinalized rollback
-				// (it clears completedCallbackFired so the next tick retries).
-				s.runCompletedCallbackPhase(desc, task, suProvider, effectiveStatus)
+				// A non-nil OnTaskCompleted error on the SWAPPING path clears
+				// completedCallbackFired so runFinalizePhase below withholds
+				// FINISHED and the next tick retries the flip; a permanent or
+				// retry-exhausted error transitions the task to FAILED
+				// instead (weaviate/0-weaviate-issues#297).
+				s.runCompletedCallbackPhase(namespace, desc, task, suProvider, effectiveStatus)
 			}
 		}
 
@@ -1042,15 +1052,21 @@ func (s *Scheduler) runSwapPhase(
 // runCompletedCallbackPhase fires OnTaskCompleted for a single task in
 // Phase 2 (SWAPPING/FAILED/FINISHED/CANCELLED).
 //
-// Owns its own lock lifecycle: acquires s.mu to decide eligibility +
-// set completedCallbackFired pre-callback, releases for the slow
-// callback, returns. No commit step needed — the pre-set fired mark
-// records the attempt; OnTaskCompleted's failure mode is handled by the
-// MarkDistributedTaskFinalized rollback (it clears completedCallbackFired
-// so the next tick retries). Providers implementing
-// [UnitAwareProvider.OnTaskCompleted] MUST be safe to invoke more than
-// once per task — see the "Idempotency contract" note at the rollback site.
+// Owns its own lock lifecycle: acquires s.mu to decide eligibility + set
+// completedCallbackFired pre-callback, releases for the slow callback, then
+// re-acquires to react to the callback's error. Providers implementing
+// [UnitAwareProvider.OnTaskCompleted] MUST be safe to invoke more than once
+// per task — see the "Idempotency contract" note at the rollback site.
+//
+// SWAPPING-path error handling (weaviate/0-weaviate-issues#297): a non-nil
+// error clears completedCallbackFired so runFinalizePhase withholds FINISHED
+// and the next tick re-fires the callback. A permanent error
+// ([ErrTaskCompletionPermanent]) or one that exhausted
+// [maxCompletedCallbackAttempts] transitions the task to FAILED instead of
+// retrying forever. Errors on terminal-status invocations are best-effort
+// cleanup and never reopen the task.
 func (s *Scheduler) runCompletedCallbackPhase(
+	namespace string,
 	desc TaskDescriptor,
 	task *Task,
 	suProvider UnitAwareProvider,
@@ -1086,7 +1102,63 @@ func (s *Scheduler) runCompletedCallbackPhase(
 
 	// Fire OnTaskCompleted without the lock. See the "Idempotency contract"
 	// note at the matching rollback site in runFinalizePhase.
-	suProvider.OnTaskCompleted(task)
+	cbErr := suProvider.OnTaskCompleted(task)
+	if cbErr == nil {
+		return
+	}
+
+	// Only the SWAPPING cutover retries/fails. A terminal-status callback
+	// (FAILED/CANCELLED/FINISHED cleanup) that errors must not reopen the
+	// task — leave the fired mark set so it doesn't re-fire.
+	if effectiveStatus != TaskStatusSwapping {
+		s.loggerWithTask(namespace, desc).
+			Warnf("OnTaskCompleted returned an error on terminal status %s; ignoring (best-effort cleanup): %v", effectiveStatus, cbErr)
+		return
+	}
+
+	// Withhold finalize (clear the fired mark so the next tick re-fires) and
+	// decide whether this failure is terminal. A permanent error fails now;
+	// a transient one fails only once the retry budget is exhausted.
+	failMsg := func() string {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		state := s.perTaskStateLocked(desc)
+		if state == nil {
+			// Local cleanup deleted the entry between callback and commit —
+			// nothing to record or retry.
+			return ""
+		}
+		state.completedCallbackFired = false
+		state.completedCallbackAttempts++
+		permanent := errors.Is(cbErr, ErrTaskCompletionPermanent)
+		if permanent || state.completedCallbackAttempts >= maxCompletedCallbackAttempts {
+			return cbErr.Error()
+		}
+		s.loggerWithTask(namespace, desc).
+			Warnf("OnTaskCompleted failed (attempt %d/%d); withholding finalize, will retry next tick: %v",
+				state.completedCallbackAttempts, maxCompletedCallbackAttempts, cbErr)
+		return ""
+	}()
+	if failMsg == "" {
+		return
+	}
+
+	// Terminal failure: transition SWAPPING → FAILED without the lock. The
+	// fired mark stays cleared so a transient MarkDistributedTaskFailed error
+	// re-fires and re-attempts the transition (idempotent at the FSM layer);
+	// once FAILED, the next tick re-fires OnTaskCompleted for terminal cleanup.
+	if s.taskFinalizer == nil {
+		return
+	}
+	if err := s.taskFinalizer.MarkDistributedTaskFailed(
+		context.Background(), namespace, task.ID, task.Version, failMsg,
+	); err != nil {
+		s.loggerWithTask(namespace, desc).
+			Warnf("failed to mark distributed task failed after OnTaskCompleted error; will retry on next tick: %v", err)
+		return
+	}
+	s.loggerWithTask(namespace, desc).
+		Errorf("distributed task transitioned to FAILED: OnTaskCompleted did not succeed: %s", failMsg)
 }
 
 // finalizeWork captures one finalize-phase task identity. Populated under
@@ -1151,12 +1223,9 @@ func (s *Scheduler) runFinalizePhase(
 		}
 		s.loggerWithTask(namespace, w.desc).
 			Warnf("failed to mark distributed task finalized; will retry on next tick or wake: %v", finErr)
-		// TODO(scheduler): clearing completedCallbackFired here causes
-		// OnTaskCompleted to re-fire on the next tick. Safe today because
-		// the reindex provider's OnTaskCompleted is idempotent, but
-		// [UnitAwareProvider.OnTaskCompleted] (in types.go) doesn't yet
-		// declare the requirement. See the matching "Idempotency contract"
-		// note in [Scheduler.runCompletedCallbackPhase].
+		// Clearing completedCallbackFired re-fires OnTaskCompleted next tick.
+		// Safe because [UnitAwareProvider.OnTaskCompleted] now requires
+		// idempotency (types.go); a re-fire that succeeds finalizes then.
 		if providerIsUnitAware {
 			if rollbackState := s.perTaskStateLocked(w.desc); rollbackState != nil {
 				rollbackState.completedCallbackFired = false

--- a/cluster/distributedtask/scheduler_flip_failure_pin_test.go
+++ b/cluster/distributedtask/scheduler_flip_failure_pin_test.go
@@ -21,15 +21,9 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-// flipFailingProvider is a unit-aware provider that models the reindex
-// provider's cluster-wide schema flip (adapters/repos/db/reindex_provider.go:
-// OnTaskCompleted -> flipSemanticMigrationSchema).
-//
-// When flipShouldFail is set it records the attempt, leaves
-// schemaFlipped=false, and returns a transient (non-permanent) error — the
-// #297 fix gives OnTaskCompleted an error return so the scheduler can observe
-// the failed flip, withhold FINISHED, and retry. Before the fix the method
-// was void and the failure was invisible, so the task finalized anyway.
+// flipFailingProvider models the reindex provider's schema-flip cutover
+// (OnTaskCompleted -> flipSemanticMigrationSchema); flipShouldFail simulates
+// a transient flip failure (weaviate/0-weaviate-issues#297).
 type flipFailingProvider struct {
 	*testTaskProvider
 
@@ -55,17 +49,13 @@ func (p *flipFailingProvider) OnSwapRequested(_ *Task, _ string, _ []string) err
 	return nil
 }
 
-// OnTaskCompleted models the cluster-wide schema flip. On the failure path it
-// returns a transient error (schema stays pre-migration); the scheduler must
-// then withhold FINISHED and retry rather than commit the divergence #297
-// describes.
+// OnTaskCompleted simulates the schema flip failing transiently; the
+// scheduler must withhold FINISHED and retry (weaviate/0-weaviate-issues#297).
 func (p *flipFailingProvider) OnTaskCompleted(task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.completedCalls++
 	if p.flipShouldFail && task.Status == TaskStatusSwapping {
-		// Mirrors flipSemanticMigrationSchema returning a transient error:
-		// the flip did not commit, so the scheduler must not finalize.
 		return errors.New("simulated transient schema-flip failure")
 	}
 	p.schemaFlipped = true
@@ -78,11 +68,8 @@ func (p *flipFailingProvider) snapshot() (calls int, flipped bool) {
 	return p.completedCalls, p.schemaFlipped
 }
 
-// runFlipScenario builds a single-node harness with prov, drives one
-// non-barrier task through STARTED -> SWAPPING (via unit completion), then
-// lets the scheduler tick: Phase 2 fires OnTaskCompleted (the flip), and
-// runFinalizePhase issues SWAPPING -> FINISHED. Returns the task's final
-// status plus the provider's observed flip result.
+// runFlipScenario drives one task STARTED -> SWAPPING -> (attempted) FINISHED
+// and returns the final status plus the observed flip result.
 func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, bool) {
 	t.Helper()
 
@@ -90,9 +77,8 @@ func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, 
 	h.registeredProviders = map[string]Provider{h.tasksNamespace: prov}
 	h.provider = prov.testTaskProvider
 	h = h.init(t)
-	// init() rebuilds testProviders from the two known concrete provider
-	// types; flipFailingProvider isn't one of them, so register its base
-	// provider explicitly for drain/leaktest.
+	// init() only wires the two known concrete provider types for
+	// drain/leaktest; register flipFailingProvider's base explicitly.
 	h.testProviders = append(h.testProviders, prov.testTaskProvider)
 
 	const taskID = "flip-task"
@@ -102,9 +88,8 @@ func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, 
 		Id:                    taskID,
 		SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
 		UnitIds:               []string{"u-1"},
-		// NeedsPreparationBarrier omitted (false): on unit completion the task
-		// jumps STARTED -> SWAPPING (manager.go:438-444), the state where the
-		// scheduler fires OnTaskCompleted then finalizes.
+		// NeedsPreparationBarrier omitted: on unit completion the task jumps
+		// STARTED -> SWAPPING directly, where OnTaskCompleted fires.
 	}), 1))
 
 	// Drive the unit to completion -> task becomes SWAPPING.
@@ -118,9 +103,7 @@ func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, 
 	h.startScheduler(t)
 	defer h.Close()
 
-	// One tick suffices (Phase 2 fires OnTaskCompleted, then runFinalizePhase
-	// commits SWAPPING -> FINISHED). Advance a few extra ticks to give any
-	// hypothetical retry path a chance and to confirm exactly-once firing.
+	// Extra ticks give a hypothetical retry a chance; confirms exactly-once firing.
 	h.advanceClock(h.schedulerTickInterval)
 	h.advanceClock(h.schedulerTickInterval)
 	h.advanceClock(h.schedulerTickInterval)
@@ -131,19 +114,12 @@ func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, 
 	return final[0].Status, calls, flipped
 }
 
-// TestOnTaskCompletedFlipFailure_TaskDoesNotReachFinished pins issue #297:
-// a schema-flip failure inside OnTaskCompleted must keep the task out of
-// FINISHED, honoring the TaskStatusFinished contract (types.go: "the task
-// succeeded on every node AND every per-node post-completion callback has
-// run"). Before the fix OnTaskCompleted was void: a swallowed flip failure
-// never cleared completedCallbackFired, so runFinalizePhase committed FINISHED
-// with an un-flipped schema. The fix gives OnTaskCompleted an error return;
-// the scheduler withholds finalize and retries on a transient error, so the
-// task stays SWAPPING (not FINISHED) while the flip keeps failing.
+// TestOnTaskCompletedFlipFailure_TaskDoesNotReachFinished: a schema-flip
+// failure in OnTaskCompleted must not let the task reach FINISHED
+// (weaviate/0-weaviate-issues#297).
 func TestOnTaskCompletedFlipFailure_TaskDoesNotReachFinished(t *testing.T) {
-	// Positive control: the flip SUCCEEDS. Proves the harness drives a task
-	// SWAPPING -> FINISHED and that FINISHED lines up with schemaFlipped=true.
-	// This rules out a trivially-red pin (broken harness that never finalizes).
+	// Positive control: proves the harness reaches FINISHED normally, ruling
+	// out a trivially-red pin below.
 	t.Run("positive_control_flip_succeeds", func(t *testing.T) {
 		defer leaktest.Check(t)()
 		prov := newFlipFailingProvider(t, false)
@@ -155,10 +131,8 @@ func TestOnTaskCompletedFlipFailure_TaskDoesNotReachFinished(t *testing.T) {
 			"successful flip: schema must be flipped once FINISHED")
 	})
 
-	// Bug case: the flip FAILS inside OnTaskCompleted. The desired (post-fix)
-	// behaviour is that the scheduler withholds finalize, so the task does NOT
-	// reach FINISHED while the schema is un-flipped. On current code it DOES,
-	// which makes this assertion RED, proving #297 is live.
+	// Bug case: the scheduler must withhold FINISHED while the flip keeps
+	// failing (weaviate/0-weaviate-issues#297).
 	t.Run("flip_failure_must_block_finished", func(t *testing.T) {
 		defer leaktest.Check(t)()
 		prov := newFlipFailingProvider(t, true)
@@ -168,10 +142,7 @@ func TestOnTaskCompletedFlipFailure_TaskDoesNotReachFinished(t *testing.T) {
 		require.False(t, flipped,
 			"sanity: the injected failure means the schema was never flipped")
 
-		// #297 load-bearing assertion. FINISHED must mean "every
-		// post-completion callback ran successfully" (types.go:376-379). A
-		// task that reaches FINISHED with an un-flipped schema is exactly the
-		// status/schema divergence #297 describes.
+		// #297: FINISHED must mean the schema flip succeeded too.
 		require.NotEqual(t, TaskStatusFinished, status,
 			"#297: task reached FINISHED while the schema flip failed inside "+
 				"OnTaskCompleted (schemaFlipped=%v, OnTaskCompleted calls=%d) "+

--- a/cluster/distributedtask/scheduler_flip_failure_pin_test.go
+++ b/cluster/distributedtask/scheduler_flip_failure_pin_test.go
@@ -12,6 +12,7 @@
 package distributedtask
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -24,12 +25,11 @@ import (
 // provider's cluster-wide schema flip (adapters/repos/db/reindex_provider.go:
 // OnTaskCompleted -> flipSemanticMigrationSchema).
 //
-// The real OnTaskCompleted has a VOID signature and swallows a failed flip
-// (reindex_provider.go:1606-1611): it logs the error and returns, so the
-// scheduler has no way to observe that the schema was NOT flipped. This fake
-// reproduces exactly that seam: when flipShouldFail is set it records the
-// attempt, leaves schemaFlipped=false, and returns normally. The void return
-// means the scheduler cannot tell a successful flip from a failed one.
+// When flipShouldFail is set it records the attempt, leaves
+// schemaFlipped=false, and returns a transient (non-permanent) error — the
+// #297 fix gives OnTaskCompleted an error return so the scheduler can observe
+// the failed flip, withhold FINISHED, and retry. Before the fix the method
+// was void and the failure was invisible, so the task finalized anyway.
 type flipFailingProvider struct {
 	*testTaskProvider
 
@@ -56,19 +56,20 @@ func (p *flipFailingProvider) OnSwapRequested(_ *Task, _ string, _ []string) err
 }
 
 // OnTaskCompleted models the cluster-wide schema flip. On the failure path it
-// CANNOT signal the failure to the scheduler because the interface method is
-// void, which is the defect #297 describes.
-func (p *flipFailingProvider) OnTaskCompleted(_ *Task) {
+// returns a transient error (schema stays pre-migration); the scheduler must
+// then withhold FINISHED and retry rather than commit the divergence #297
+// describes.
+func (p *flipFailingProvider) OnTaskCompleted(task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.completedCalls++
-	if p.flipShouldFail {
-		// Mirrors reindex_provider.go:1606-1611: flipSemanticMigrationSchema
-		// returns an error, it is logged and swallowed, and the schema stays
-		// pre-migration. The void return leaves the scheduler none the wiser.
-		return
+	if p.flipShouldFail && task.Status == TaskStatusSwapping {
+		// Mirrors flipSemanticMigrationSchema returning a transient error:
+		// the flip did not commit, so the scheduler must not finalize.
+		return errors.New("simulated transient schema-flip failure")
 	}
 	p.schemaFlipped = true
+	return nil
 }
 
 func (p *flipFailingProvider) snapshot() (calls int, flipped bool) {
@@ -130,22 +131,16 @@ func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, 
 	return final[0].Status, calls, flipped
 }
 
-// TestOnTaskCompletedFlipFailure_TaskStillReachesFinished pins issue #297:
-// a schema-flip failure inside the void OnTaskCompleted callback is invisible
-// to the DTM scheduler, so the task still finalizes to FINISHED while the
-// schema stays un-flipped, violating the TaskStatusFinished contract
-// (types.go:376-379: "the task succeeded on every node AND every per-node
-// post-completion callback has run") and the scheduler comment at
-// scheduler.go:508-512 ("the FINISHED transition is committed ... only AFTER
-// OnTaskCompleted returns successfully").
-//
-// The finalize-rollback retry (runFinalizePhase, scheduler.go:1147-1165) does
-// NOT cover this: it clears completedCallbackFired only when
-// MarkDistributedTaskFinalized itself returns an error, a DIFFERENT failure
-// than the flip failing inside OnTaskCompleted. Because OnTaskCompleted is
-// void, a failed flip never clears completedCallbackFired, so runFinalizePhase
-// still sees the fired mark and commits FINISHED.
-func TestOnTaskCompletedFlipFailure_TaskStillReachesFinished(t *testing.T) {
+// TestOnTaskCompletedFlipFailure_TaskDoesNotReachFinished pins issue #297:
+// a schema-flip failure inside OnTaskCompleted must keep the task out of
+// FINISHED, honoring the TaskStatusFinished contract (types.go: "the task
+// succeeded on every node AND every per-node post-completion callback has
+// run"). Before the fix OnTaskCompleted was void: a swallowed flip failure
+// never cleared completedCallbackFired, so runFinalizePhase committed FINISHED
+// with an un-flipped schema. The fix gives OnTaskCompleted an error return;
+// the scheduler withholds finalize and retries on a transient error, so the
+// task stays SWAPPING (not FINISHED) while the flip keeps failing.
+func TestOnTaskCompletedFlipFailure_TaskDoesNotReachFinished(t *testing.T) {
 	// Positive control: the flip SUCCEEDS. Proves the harness drives a task
 	// SWAPPING -> FINISHED and that FINISHED lines up with schemaFlipped=true.
 	// This rules out a trivially-red pin (broken harness that never finalizes).

--- a/cluster/distributedtask/scheduler_flip_failure_pin_test.go
+++ b/cluster/distributedtask/scheduler_flip_failure_pin_test.go
@@ -70,29 +70,29 @@ func (p *flipFailingProvider) snapshot() (calls int, flipped bool) {
 
 // runFlipScenario drives one task STARTED -> SWAPPING -> (attempted) FINISHED
 // and returns the final status plus the observed flip result.
-func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, bool) {
+// submitTaskToSwapping wires prov into a fresh harness, adds one non-barrier
+// task, drives its unit to completion so the task reaches SWAPPING (where
+// OnTaskCompleted fires), asserts that precondition, and starts the scheduler.
+// base is prov's embedded testTaskProvider, registered explicitly so
+// drain/leaktest see its goroutines. Shared by the flip-failure and retry pins;
+// the caller owns h.Close().
+func submitTaskToSwapping(t *testing.T, prov Provider, base *testTaskProvider, taskID string) *testHarness {
 	t.Helper()
 
 	h := newTestHarness(t)
 	h.registeredProviders = map[string]Provider{h.tasksNamespace: prov}
-	h.provider = prov.testTaskProvider
+	h.provider = base
 	h = h.init(t)
-	// init() only wires the two known concrete provider types for
-	// drain/leaktest; register flipFailingProvider's base explicitly.
-	h.testProviders = append(h.testProviders, prov.testTaskProvider)
-
-	const taskID = "flip-task"
+	h.testProviders = append(h.testProviders, base)
 
 	require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
 		Namespace:             h.tasksNamespace,
 		Id:                    taskID,
 		SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
 		UnitIds:               []string{"u-1"},
-		// NeedsPreparationBarrier omitted: on unit completion the task jumps
-		// STARTED -> SWAPPING directly, where OnTaskCompleted fires.
+		// Non-barrier: unit completion jumps STARTED -> SWAPPING directly.
 	}), 1))
 
-	// Drive the unit to completion -> task becomes SWAPPING.
 	completeUnit(t, h, h.tasksNamespace, taskID, 1, h.localNodeID, "u-1")
 
 	pre := h.listManagerTasks(t)[h.tasksNamespace]
@@ -101,6 +101,12 @@ func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, 
 		"precondition: task must be SWAPPING before the scheduler ticks")
 
 	h.startScheduler(t)
+	return h
+}
+
+func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, bool) {
+	t.Helper()
+	h := submitTaskToSwapping(t, prov, prov.testTaskProvider, "flip-task")
 	defer h.Close()
 
 	// Extra ticks give a hypothetical retry a chance; confirms exactly-once firing.

--- a/cluster/distributedtask/scheduler_flip_failure_pin_test.go
+++ b/cluster/distributedtask/scheduler_flip_failure_pin_test.go
@@ -1,0 +1,185 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package distributedtask
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/require"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+)
+
+// flipFailingProvider is a unit-aware provider that models the reindex
+// provider's cluster-wide schema flip (adapters/repos/db/reindex_provider.go:
+// OnTaskCompleted -> flipSemanticMigrationSchema).
+//
+// The real OnTaskCompleted has a VOID signature and swallows a failed flip
+// (reindex_provider.go:1606-1611): it logs the error and returns, so the
+// scheduler has no way to observe that the schema was NOT flipped. This fake
+// reproduces exactly that seam: when flipShouldFail is set it records the
+// attempt, leaves schemaFlipped=false, and returns normally. The void return
+// means the scheduler cannot tell a successful flip from a failed one.
+type flipFailingProvider struct {
+	*testTaskProvider
+
+	flipShouldFail bool
+
+	mu             sync.Mutex
+	completedCalls int
+	schemaFlipped  bool
+}
+
+func newFlipFailingProvider(t *testing.T, flipShouldFail bool) *flipFailingProvider {
+	return &flipFailingProvider{
+		testTaskProvider: newTestTaskProvider(t, nil),
+		flipShouldFail:   flipShouldFail,
+	}
+}
+
+func (p *flipFailingProvider) OnGroupCompleted(_ *Task, _ string, _ []string) error {
+	return nil
+}
+
+func (p *flipFailingProvider) OnSwapRequested(_ *Task, _ string, _ []string) error {
+	return nil
+}
+
+// OnTaskCompleted models the cluster-wide schema flip. On the failure path it
+// CANNOT signal the failure to the scheduler because the interface method is
+// void, which is the defect #297 describes.
+func (p *flipFailingProvider) OnTaskCompleted(_ *Task) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.completedCalls++
+	if p.flipShouldFail {
+		// Mirrors reindex_provider.go:1606-1611: flipSemanticMigrationSchema
+		// returns an error, it is logged and swallowed, and the schema stays
+		// pre-migration. The void return leaves the scheduler none the wiser.
+		return
+	}
+	p.schemaFlipped = true
+}
+
+func (p *flipFailingProvider) snapshot() (calls int, flipped bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.completedCalls, p.schemaFlipped
+}
+
+// runFlipScenario builds a single-node harness with prov, drives one
+// non-barrier task through STARTED -> SWAPPING (via unit completion), then
+// lets the scheduler tick: Phase 2 fires OnTaskCompleted (the flip), and
+// runFinalizePhase issues SWAPPING -> FINISHED. Returns the task's final
+// status plus the provider's observed flip result.
+func runFlipScenario(t *testing.T, prov *flipFailingProvider) (TaskStatus, int, bool) {
+	t.Helper()
+
+	h := newTestHarness(t)
+	h.registeredProviders = map[string]Provider{h.tasksNamespace: prov}
+	h.provider = prov.testTaskProvider
+	h = h.init(t)
+	// init() rebuilds testProviders from the two known concrete provider
+	// types; flipFailingProvider isn't one of them, so register its base
+	// provider explicitly for drain/leaktest.
+	h.testProviders = append(h.testProviders, prov.testTaskProvider)
+
+	const taskID = "flip-task"
+
+	require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+		Namespace:             h.tasksNamespace,
+		Id:                    taskID,
+		SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
+		UnitIds:               []string{"u-1"},
+		// NeedsPreparationBarrier omitted (false): on unit completion the task
+		// jumps STARTED -> SWAPPING (manager.go:438-444), the state where the
+		// scheduler fires OnTaskCompleted then finalizes.
+	}), 1))
+
+	// Drive the unit to completion -> task becomes SWAPPING.
+	completeUnit(t, h, h.tasksNamespace, taskID, 1, h.localNodeID, "u-1")
+
+	pre := h.listManagerTasks(t)[h.tasksNamespace]
+	require.Len(t, pre, 1)
+	require.Equal(t, TaskStatusSwapping, pre[0].Status,
+		"precondition: task must be SWAPPING before the scheduler ticks")
+
+	h.startScheduler(t)
+	defer h.Close()
+
+	// One tick suffices (Phase 2 fires OnTaskCompleted, then runFinalizePhase
+	// commits SWAPPING -> FINISHED). Advance a few extra ticks to give any
+	// hypothetical retry path a chance and to confirm exactly-once firing.
+	h.advanceClock(h.schedulerTickInterval)
+	h.advanceClock(h.schedulerTickInterval)
+	h.advanceClock(h.schedulerTickInterval)
+
+	final := h.listManagerTasks(t)[h.tasksNamespace]
+	require.Len(t, final, 1)
+	calls, flipped := prov.snapshot()
+	return final[0].Status, calls, flipped
+}
+
+// TestOnTaskCompletedFlipFailure_TaskStillReachesFinished pins issue #297:
+// a schema-flip failure inside the void OnTaskCompleted callback is invisible
+// to the DTM scheduler, so the task still finalizes to FINISHED while the
+// schema stays un-flipped, violating the TaskStatusFinished contract
+// (types.go:376-379: "the task succeeded on every node AND every per-node
+// post-completion callback has run") and the scheduler comment at
+// scheduler.go:508-512 ("the FINISHED transition is committed ... only AFTER
+// OnTaskCompleted returns successfully").
+//
+// The finalize-rollback retry (runFinalizePhase, scheduler.go:1147-1165) does
+// NOT cover this: it clears completedCallbackFired only when
+// MarkDistributedTaskFinalized itself returns an error, a DIFFERENT failure
+// than the flip failing inside OnTaskCompleted. Because OnTaskCompleted is
+// void, a failed flip never clears completedCallbackFired, so runFinalizePhase
+// still sees the fired mark and commits FINISHED.
+func TestOnTaskCompletedFlipFailure_TaskStillReachesFinished(t *testing.T) {
+	// Positive control: the flip SUCCEEDS. Proves the harness drives a task
+	// SWAPPING -> FINISHED and that FINISHED lines up with schemaFlipped=true.
+	// This rules out a trivially-red pin (broken harness that never finalizes).
+	t.Run("positive_control_flip_succeeds", func(t *testing.T) {
+		defer leaktest.Check(t)()
+		prov := newFlipFailingProvider(t, false)
+		status, calls, flipped := runFlipScenario(t, prov)
+		require.GreaterOrEqual(t, calls, 1, "OnTaskCompleted must fire")
+		require.Equal(t, TaskStatusFinished, status,
+			"successful flip: task must reach FINISHED")
+		require.True(t, flipped,
+			"successful flip: schema must be flipped once FINISHED")
+	})
+
+	// Bug case: the flip FAILS inside OnTaskCompleted. The desired (post-fix)
+	// behaviour is that the scheduler withholds finalize, so the task does NOT
+	// reach FINISHED while the schema is un-flipped. On current code it DOES,
+	// which makes this assertion RED, proving #297 is live.
+	t.Run("flip_failure_must_block_finished", func(t *testing.T) {
+		defer leaktest.Check(t)()
+		prov := newFlipFailingProvider(t, true)
+		status, calls, flipped := runFlipScenario(t, prov)
+		require.GreaterOrEqual(t, calls, 1,
+			"OnTaskCompleted must have been attempted")
+		require.False(t, flipped,
+			"sanity: the injected failure means the schema was never flipped")
+
+		// #297 load-bearing assertion. FINISHED must mean "every
+		// post-completion callback ran successfully" (types.go:376-379). A
+		// task that reaches FINISHED with an un-flipped schema is exactly the
+		// status/schema divergence #297 describes.
+		require.NotEqual(t, TaskStatusFinished, status,
+			"#297: task reached FINISHED while the schema flip failed inside "+
+				"OnTaskCompleted (schemaFlipped=%v, OnTaskCompleted calls=%d) "+
+				"- silent status/schema divergence", flipped, calls)
+	})
+}

--- a/cluster/distributedtask/scheduler_multinode_barrier_test.go
+++ b/cluster/distributedtask/scheduler_multinode_barrier_test.go
@@ -100,11 +100,12 @@ func (p *barrierRecordingProvider) OnSwapRequested(task *Task, _ string, _ []str
 	return nil
 }
 
-func (p *barrierRecordingProvider) OnTaskCompleted(task *Task) {
+func (p *barrierRecordingProvider) OnTaskCompleted(task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.taskCalls = append(p.taskCalls, task.ID)
 	p.taskCallsBy[task.ID]++
+	return nil
 }
 
 func (p *barrierRecordingProvider) SetGroupCompletedError(err error) {

--- a/cluster/distributedtask/scheduler_multinode_test.go
+++ b/cluster/distributedtask/scheduler_multinode_test.go
@@ -122,11 +122,12 @@ func (p *recordingUnitAwareProvider) SetGroupCompletedError(err error) {
 	p.groupCompletedErr = err
 }
 
-func (p *recordingUnitAwareProvider) OnTaskCompleted(task *Task) {
+func (p *recordingUnitAwareProvider) OnTaskCompleted(task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.taskCalls = append(p.taskCalls, task.ID)
 	p.taskCallsBy[task.ID]++
+	return nil
 }
 
 func (p *recordingUnitAwareProvider) taskCompletedCount(taskID string) int {

--- a/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
+++ b/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
@@ -21,20 +21,9 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-// retryFlipProvider models the reindex OnTaskCompleted schema flip with
-// configurable failure behavior so the scheduler's #297 retry/fail policy can
-// be driven deterministically:
-//
-//   - failFirstNSwaps: fail this many SWAPPING-path calls with a transient
-//     error, then succeed (models a flip that recovers after a RAFT blip).
-//   - permanent: every SWAPPING-path call returns an [ErrTaskCompletionPermanent]
-//     error (models the target property being deleted mid-flight).
-//   - alwaysFail: every SWAPPING-path call returns a transient error (models a
-//     flip that never recovers — exercises the bounded-retry exhaustion path).
-//
-// Terminal-status invocations (the FAILED-status re-fire the scheduler makes
-// for cleanup) return nil and do not touch schemaFlipped, mirroring the real
-// provider's best-effort terminal cleanup.
+// retryFlipProvider models the reindex OnTaskCompleted schema flip for the
+// #297 retry/fail policy: failFirstNSwaps recovers after N failures,
+// permanent is unrecoverable, alwaysFail exhausts the retry budget.
 type retryFlipProvider struct {
 	*testTaskProvider
 
@@ -90,9 +79,8 @@ func (p *retryFlipProvider) snapshot() (swappingAttempts int, flipped bool, bySt
 	return p.swappingAttempts, p.schemaFlipped, byStatus
 }
 
-// startRetryScenario builds a single-node harness, drives one non-barrier task
-// to SWAPPING, and starts the scheduler. Callers then advance the clock to
-// drive ticks (one OnTaskCompleted attempt per tick) and inspect the outcome.
+// startRetryScenario drives one task to SWAPPING and starts the scheduler;
+// callers advance the clock to drive ticks.
 func startRetryScenario(t *testing.T, prov *retryFlipProvider) (*testHarness, string) {
 	t.Helper()
 
@@ -132,10 +120,8 @@ func statusOf(t *testing.T, h *testHarness) TaskStatus {
 	return tasks[0].Status
 }
 
-// TestOnTaskCompleted_TransientFlipFailure_RetriesThenFinishes covers the
-// transient path (#297): the flip fails once, the scheduler withholds FINISHED
-// and re-fires on the next tick, the retry succeeds, and only then does the
-// task reach FINISHED with the schema flipped.
+// TestOnTaskCompleted_TransientFlipFailure_RetriesThenFinishes: a transient
+// flip failure retries before FINISHED (weaviate/0-weaviate-issues#297).
 func TestOnTaskCompleted_TransientFlipFailure_RetriesThenFinishes(t *testing.T) {
 	defer leaktest.Check(t)()
 
@@ -144,13 +130,10 @@ func TestOnTaskCompleted_TransientFlipFailure_RetriesThenFinishes(t *testing.T) 
 	h, _ := startRetryScenario(t, prov)
 	defer h.Close()
 
-	// Tick 1: OnTaskCompleted fails transiently → finalize withheld, task
-	// must stay SWAPPING (NOT FINISHED).
 	h.advanceClock(h.schedulerTickInterval)
 	require.Equal(t, TaskStatusSwapping, statusOf(t, h),
 		"transient flip failure must withhold FINISHED and leave the task SWAPPING")
 
-	// Tick 2: retry succeeds → task finalizes to FINISHED.
 	h.advanceClock(h.schedulerTickInterval)
 	require.Equal(t, TaskStatusFinished, statusOf(t, h),
 		"a successful retry must let the task reach FINISHED")
@@ -159,16 +142,13 @@ func TestOnTaskCompleted_TransientFlipFailure_RetriesThenFinishes(t *testing.T) 
 	require.Equal(t, 2, attempts, "flip must be attempted exactly twice (fail, then succeed)")
 	require.True(t, flipped, "schema must be flipped once the task is FINISHED")
 
-	// Idempotency: extra ticks must not re-fire on the now-FINISHED task.
 	h.advanceClock(h.schedulerTickInterval)
 	attemptsAfter, _, _ := prov.snapshot()
 	require.Equal(t, 2, attemptsAfter, "no further flip attempts after FINISHED")
 }
 
-// TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately covers the
-// permanent path (#297): a deterministically-unrecoverable flip failure (the
-// target property was deleted) transitions the task straight to FAILED without
-// burning the retry budget, and never reaches FINISHED.
+// TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately: a permanent
+// flip failure fails the task immediately, no retry (weaviate/0-weaviate-issues#297).
 func TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately(t *testing.T) {
 	defer leaktest.Check(t)()
 
@@ -177,7 +157,6 @@ func TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately(t *testing.T) {
 	h, _ := startRetryScenario(t, prov)
 	defer h.Close()
 
-	// One tick: the permanent error fails the task immediately.
 	h.advanceClock(h.schedulerTickInterval)
 	require.Equal(t, TaskStatusFailed, statusOf(t, h),
 		"a permanent flip failure must transition the task to FAILED, not FINISHED")
@@ -187,8 +166,7 @@ func TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately(t *testing.T) {
 		"permanent failure must NOT retry: exactly one SWAPPING-path attempt")
 	require.False(t, flipped, "schema must never be flipped on the permanent-failure path")
 
-	// Extra ticks: task stays FAILED and the flip is never re-attempted at
-	// SWAPPING (the FAILED-status re-fire is cleanup only).
+	// FAILED-status re-fire is cleanup only; no further SWAPPING attempts.
 	h.advanceClock(h.schedulerTickInterval)
 	h.advanceClock(h.schedulerTickInterval)
 	require.Equal(t, TaskStatusFailed, statusOf(t, h))
@@ -196,10 +174,9 @@ func TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately(t *testing.T) {
 	require.Equal(t, 1, attemptsAfter, "no SWAPPING-path flip attempts after FAILED")
 }
 
-// TestOnTaskCompleted_TransientFlipFailure_ExhaustsRetriesThenFails covers the
-// bounded-retry exhaustion path (#297): a transient-looking flip that never
-// recovers is retried up to maxCompletedCallbackAttempts and then FAILED — it
-// must NOT loop SWAPPING forever.
+// TestOnTaskCompleted_TransientFlipFailure_ExhaustsRetriesThenFails: retries
+// exhaust at maxCompletedCallbackAttempts, then FAILS instead of looping
+// forever (weaviate/0-weaviate-issues#297).
 func TestOnTaskCompleted_TransientFlipFailure_ExhaustsRetriesThenFails(t *testing.T) {
 	defer leaktest.Check(t)()
 
@@ -208,14 +185,12 @@ func TestOnTaskCompleted_TransientFlipFailure_ExhaustsRetriesThenFails(t *testin
 	h, _ := startRetryScenario(t, prov)
 	defer h.Close()
 
-	// Drive one tick per attempt up to (and one past) the bound. The task
-	// stays SWAPPING while the budget lasts, then flips to FAILED.
+	// Ticks up to the bound; the task must stay SWAPPING until it's exhausted.
 	for i := 1; i < maxCompletedCallbackAttempts; i++ {
 		h.advanceClock(h.schedulerTickInterval)
 		require.Equal(t, TaskStatusSwapping, statusOf(t, h),
 			"task must stay SWAPPING while the retry budget is not yet exhausted (after %d attempts)", i)
 	}
-	// The maxCompletedCallbackAttempts-th failing attempt exhausts the budget.
 	h.advanceClock(h.schedulerTickInterval)
 	require.Equal(t, TaskStatusFailed, statusOf(t, h),
 		"task must FAIL once the retry budget is exhausted, never loop forever")
@@ -225,8 +200,7 @@ func TestOnTaskCompleted_TransientFlipFailure_ExhaustsRetriesThenFails(t *testin
 		"SWAPPING-path flip must be attempted exactly maxCompletedCallbackAttempts times")
 	require.False(t, flipped)
 
-	// Cap check: many extra ticks must not grow the SWAPPING attempt count —
-	// the FAILED task is terminal and the flip is not re-attempted.
+	// Cap check: extra ticks must not grow the attempt count once FAILED.
 	for i := 0; i < 5; i++ {
 		h.advanceClock(h.schedulerTickInterval)
 	}

--- a/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
+++ b/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/require"
-	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
 // retryFlipProvider models the reindex OnTaskCompleted schema flip for the
@@ -83,34 +82,8 @@ func (p *retryFlipProvider) snapshot() (swappingAttempts int, flipped bool, bySt
 // callers advance the clock to drive ticks.
 func startRetryScenario(t *testing.T, prov *retryFlipProvider) (*testHarness, string) {
 	t.Helper()
-
-	h := newTestHarness(t)
-	h.registeredProviders = map[string]Provider{h.tasksNamespace: prov}
-	h.provider = prov.testTaskProvider
-	h = h.init(t)
-	// init() only knows the two concrete provider types; register the base
-	// explicitly so drain/leaktest see this provider's run goroutines.
-	h.testProviders = append(h.testProviders, prov.testTaskProvider)
-
 	const taskID = "retry-flip-task"
-
-	require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
-		Namespace:             h.tasksNamespace,
-		Id:                    taskID,
-		SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
-		UnitIds:               []string{"u-1"},
-	}), 1))
-
-	// Unit completion jumps STARTED → SWAPPING (non-barrier task).
-	completeUnit(t, h, h.tasksNamespace, taskID, 1, h.localNodeID, "u-1")
-
-	pre := h.listManagerTasks(t)[h.tasksNamespace]
-	require.Len(t, pre, 1)
-	require.Equal(t, TaskStatusSwapping, pre[0].Status,
-		"precondition: task must be SWAPPING before the scheduler ticks")
-
-	h.startScheduler(t)
-	return h, taskID
+	return submitTaskToSwapping(t, prov, prov.testTaskProvider, taskID), taskID
 }
 
 func statusOf(t *testing.T, h *testHarness) TaskStatus {

--- a/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
+++ b/cluster/distributedtask/scheduler_ontaskcompleted_retry_test.go
@@ -1,0 +1,237 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package distributedtask
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/require"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+)
+
+// retryFlipProvider models the reindex OnTaskCompleted schema flip with
+// configurable failure behavior so the scheduler's #297 retry/fail policy can
+// be driven deterministically:
+//
+//   - failFirstNSwaps: fail this many SWAPPING-path calls with a transient
+//     error, then succeed (models a flip that recovers after a RAFT blip).
+//   - permanent: every SWAPPING-path call returns an [ErrTaskCompletionPermanent]
+//     error (models the target property being deleted mid-flight).
+//   - alwaysFail: every SWAPPING-path call returns a transient error (models a
+//     flip that never recovers — exercises the bounded-retry exhaustion path).
+//
+// Terminal-status invocations (the FAILED-status re-fire the scheduler makes
+// for cleanup) return nil and do not touch schemaFlipped, mirroring the real
+// provider's best-effort terminal cleanup.
+type retryFlipProvider struct {
+	*testTaskProvider
+
+	failFirstNSwaps int
+	permanent       bool
+	alwaysFail      bool
+
+	mu               sync.Mutex
+	swappingAttempts int
+	callsByStatus    map[TaskStatus]int
+	schemaFlipped    bool
+}
+
+func newRetryFlipProvider(t *testing.T) *retryFlipProvider {
+	return &retryFlipProvider{
+		testTaskProvider: newTestTaskProvider(t, nil),
+		callsByStatus:    map[TaskStatus]int{},
+	}
+}
+
+func (p *retryFlipProvider) OnGroupCompleted(_ *Task, _ string, _ []string) error { return nil }
+func (p *retryFlipProvider) OnSwapRequested(_ *Task, _ string, _ []string) error  { return nil }
+
+func (p *retryFlipProvider) OnTaskCompleted(task *Task) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.callsByStatus[task.Status]++
+	if task.Status != TaskStatusSwapping {
+		// Terminal-status cleanup re-fire: best-effort, never reopens the task.
+		return nil
+	}
+	p.swappingAttempts++
+	switch {
+	case p.permanent:
+		return fmt.Errorf("simulated permanent flip failure: %w", ErrTaskCompletionPermanent)
+	case p.alwaysFail:
+		return fmt.Errorf("simulated persistent transient flip failure")
+	case p.swappingAttempts <= p.failFirstNSwaps:
+		return fmt.Errorf("simulated transient flip failure (attempt %d)", p.swappingAttempts)
+	default:
+		p.schemaFlipped = true
+		return nil
+	}
+}
+
+func (p *retryFlipProvider) snapshot() (swappingAttempts int, flipped bool, byStatus map[TaskStatus]int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	byStatus = make(map[TaskStatus]int, len(p.callsByStatus))
+	for k, v := range p.callsByStatus {
+		byStatus[k] = v
+	}
+	return p.swappingAttempts, p.schemaFlipped, byStatus
+}
+
+// startRetryScenario builds a single-node harness, drives one non-barrier task
+// to SWAPPING, and starts the scheduler. Callers then advance the clock to
+// drive ticks (one OnTaskCompleted attempt per tick) and inspect the outcome.
+func startRetryScenario(t *testing.T, prov *retryFlipProvider) (*testHarness, string) {
+	t.Helper()
+
+	h := newTestHarness(t)
+	h.registeredProviders = map[string]Provider{h.tasksNamespace: prov}
+	h.provider = prov.testTaskProvider
+	h = h.init(t)
+	// init() only knows the two concrete provider types; register the base
+	// explicitly so drain/leaktest see this provider's run goroutines.
+	h.testProviders = append(h.testProviders, prov.testTaskProvider)
+
+	const taskID = "retry-flip-task"
+
+	require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+		Namespace:             h.tasksNamespace,
+		Id:                    taskID,
+		SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
+		UnitIds:               []string{"u-1"},
+	}), 1))
+
+	// Unit completion jumps STARTED → SWAPPING (non-barrier task).
+	completeUnit(t, h, h.tasksNamespace, taskID, 1, h.localNodeID, "u-1")
+
+	pre := h.listManagerTasks(t)[h.tasksNamespace]
+	require.Len(t, pre, 1)
+	require.Equal(t, TaskStatusSwapping, pre[0].Status,
+		"precondition: task must be SWAPPING before the scheduler ticks")
+
+	h.startScheduler(t)
+	return h, taskID
+}
+
+func statusOf(t *testing.T, h *testHarness) TaskStatus {
+	t.Helper()
+	tasks := h.listManagerTasks(t)[h.tasksNamespace]
+	require.Len(t, tasks, 1)
+	return tasks[0].Status
+}
+
+// TestOnTaskCompleted_TransientFlipFailure_RetriesThenFinishes covers the
+// transient path (#297): the flip fails once, the scheduler withholds FINISHED
+// and re-fires on the next tick, the retry succeeds, and only then does the
+// task reach FINISHED with the schema flipped.
+func TestOnTaskCompleted_TransientFlipFailure_RetriesThenFinishes(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	prov := newRetryFlipProvider(t)
+	prov.failFirstNSwaps = 1 // fail once, then succeed
+	h, _ := startRetryScenario(t, prov)
+	defer h.Close()
+
+	// Tick 1: OnTaskCompleted fails transiently → finalize withheld, task
+	// must stay SWAPPING (NOT FINISHED).
+	h.advanceClock(h.schedulerTickInterval)
+	require.Equal(t, TaskStatusSwapping, statusOf(t, h),
+		"transient flip failure must withhold FINISHED and leave the task SWAPPING")
+
+	// Tick 2: retry succeeds → task finalizes to FINISHED.
+	h.advanceClock(h.schedulerTickInterval)
+	require.Equal(t, TaskStatusFinished, statusOf(t, h),
+		"a successful retry must let the task reach FINISHED")
+
+	attempts, flipped, _ := prov.snapshot()
+	require.Equal(t, 2, attempts, "flip must be attempted exactly twice (fail, then succeed)")
+	require.True(t, flipped, "schema must be flipped once the task is FINISHED")
+
+	// Idempotency: extra ticks must not re-fire on the now-FINISHED task.
+	h.advanceClock(h.schedulerTickInterval)
+	attemptsAfter, _, _ := prov.snapshot()
+	require.Equal(t, 2, attemptsAfter, "no further flip attempts after FINISHED")
+}
+
+// TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately covers the
+// permanent path (#297): a deterministically-unrecoverable flip failure (the
+// target property was deleted) transitions the task straight to FAILED without
+// burning the retry budget, and never reaches FINISHED.
+func TestOnTaskCompleted_PermanentFlipFailure_FailsImmediately(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	prov := newRetryFlipProvider(t)
+	prov.permanent = true
+	h, _ := startRetryScenario(t, prov)
+	defer h.Close()
+
+	// One tick: the permanent error fails the task immediately.
+	h.advanceClock(h.schedulerTickInterval)
+	require.Equal(t, TaskStatusFailed, statusOf(t, h),
+		"a permanent flip failure must transition the task to FAILED, not FINISHED")
+
+	attempts, flipped, _ := prov.snapshot()
+	require.Equal(t, 1, attempts,
+		"permanent failure must NOT retry: exactly one SWAPPING-path attempt")
+	require.False(t, flipped, "schema must never be flipped on the permanent-failure path")
+
+	// Extra ticks: task stays FAILED and the flip is never re-attempted at
+	// SWAPPING (the FAILED-status re-fire is cleanup only).
+	h.advanceClock(h.schedulerTickInterval)
+	h.advanceClock(h.schedulerTickInterval)
+	require.Equal(t, TaskStatusFailed, statusOf(t, h))
+	attemptsAfter, _, _ := prov.snapshot()
+	require.Equal(t, 1, attemptsAfter, "no SWAPPING-path flip attempts after FAILED")
+}
+
+// TestOnTaskCompleted_TransientFlipFailure_ExhaustsRetriesThenFails covers the
+// bounded-retry exhaustion path (#297): a transient-looking flip that never
+// recovers is retried up to maxCompletedCallbackAttempts and then FAILED — it
+// must NOT loop SWAPPING forever.
+func TestOnTaskCompleted_TransientFlipFailure_ExhaustsRetriesThenFails(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	prov := newRetryFlipProvider(t)
+	prov.alwaysFail = true
+	h, _ := startRetryScenario(t, prov)
+	defer h.Close()
+
+	// Drive one tick per attempt up to (and one past) the bound. The task
+	// stays SWAPPING while the budget lasts, then flips to FAILED.
+	for i := 1; i < maxCompletedCallbackAttempts; i++ {
+		h.advanceClock(h.schedulerTickInterval)
+		require.Equal(t, TaskStatusSwapping, statusOf(t, h),
+			"task must stay SWAPPING while the retry budget is not yet exhausted (after %d attempts)", i)
+	}
+	// The maxCompletedCallbackAttempts-th failing attempt exhausts the budget.
+	h.advanceClock(h.schedulerTickInterval)
+	require.Equal(t, TaskStatusFailed, statusOf(t, h),
+		"task must FAIL once the retry budget is exhausted, never loop forever")
+
+	attempts, flipped, _ := prov.snapshot()
+	require.Equal(t, maxCompletedCallbackAttempts, attempts,
+		"SWAPPING-path flip must be attempted exactly maxCompletedCallbackAttempts times")
+	require.False(t, flipped)
+
+	// Cap check: many extra ticks must not grow the SWAPPING attempt count —
+	// the FAILED task is terminal and the flip is not re-attempted.
+	for i := 0; i < 5; i++ {
+		h.advanceClock(h.schedulerTickInterval)
+	}
+	attemptsAfter, _, _ := prov.snapshot()
+	require.Equal(t, maxCompletedCallbackAttempts, attemptsAfter,
+		"no additional SWAPPING-path flip attempts after the task is FAILED (no infinite loop)")
+	require.Equal(t, TaskStatusFailed, statusOf(t, h))
+}

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -671,6 +671,16 @@ func (d *directFinalizer) MarkDistributedTaskFinalized(_ context.Context, namesp
 	}))
 }
 
+func (d *directFinalizer) MarkDistributedTaskFailed(_ context.Context, namespace, taskID string, taskVersion uint64, errMsg string) error {
+	return d.manager.MarkTaskFailed(toCmd(d.t, &cmd.MarkTaskFailedRequest{
+		Namespace:          namespace,
+		Id:                 taskID,
+		Version:            taskVersion,
+		Error:              errMsg,
+		FailedAtUnixMillis: d.manager.clock.Now().UnixMilli(),
+	}))
+}
+
 func (h *testHarness) advanceClock(duration time.Duration) {
 	h.clock.Advance(duration)
 	h.clockAdvancedSoFar += duration
@@ -1083,10 +1093,11 @@ func (p *unitAwareTestProvider) OnSwapRequested(_ *Task, _ string, _ []string) e
 	return nil
 }
 
-func (p *unitAwareTestProvider) OnTaskCompleted(task *Task) {
+func (p *unitAwareTestProvider) OnTaskCompleted(task *Task) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.onTaskCompletedCalls = append(p.onTaskCompletedCalls, task.ID)
+	return nil
 }
 
 func (p *unitAwareTestProvider) snapshotCalls() (groups, tasks []string) {

--- a/cluster/distributedtask/shard_noop_provider.go
+++ b/cluster/distributedtask/shard_noop_provider.go
@@ -246,7 +246,7 @@ func (p *ShardNoopProvider) OnSwapRequested(_ *Task, _ string, _ []string) error
 	return nil
 }
 
-func (p *ShardNoopProvider) OnTaskCompleted(task *Task) {
+func (p *ShardNoopProvider) OnTaskCompleted(task *Task) error {
 	p.completedTasksMu.Lock()
 	defer p.completedTasksMu.Unlock()
 	p.completedTasks[task.TaskDescriptor] = true
@@ -280,6 +280,7 @@ func (p *ShardNoopProvider) OnTaskCompleted(task *Task) {
 
 	p.logger.WithField("taskID", task.ID).WithField("status", task.Status).
 		Info("shard-noop provider: task-completion fired")
+	return nil
 }
 
 func (p *ShardNoopProvider) IsTaskCompleted(desc TaskDescriptor) bool {

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -46,26 +46,21 @@ type TaskCleaner interface {
 	CleanUpDistributedTask(ctx context.Context, namespace, taskID string, taskVersion uint64) error
 }
 
-// TaskFinalizer is the interface the [Scheduler] uses to issue a task's
-// terminal transition out of [TaskStatusSwapping] once its local
-// [UnitAwareProvider.OnTaskCompleted] has returned. Both methods are
-// idempotent at the FSM layer — every node's scheduler issues them
-// independently, and only the first commit actually flips the status.
+// TaskFinalizer is how the [Scheduler] transitions a task out of
+// [TaskStatusSwapping] once local [UnitAwareProvider.OnTaskCompleted] has
+// returned. Both methods are idempotent at the FSM layer: only the first
+// commit flips the status.
 type TaskFinalizer interface {
 	// MarkDistributedTaskFinalized transitions SWAPPING → FINISHED after
-	// OnTaskCompleted returned nil, so the FSM-level FINISHED state lines up
-	// with "every post-completion callback committed cluster-wide" (not just
-	// "every unit terminal"). See the godoc on [TaskStatusSwapping] for the
-	// underlying race this discipline fixes.
+	// OnTaskCompleted returns nil, so FINISHED means "every post-completion
+	// callback committed cluster-wide," not just "every unit terminal." See
+	// [TaskStatusSwapping] for the race this fixes.
 	MarkDistributedTaskFinalized(ctx context.Context, namespace, taskID string, taskVersion uint64) error
 
 	// MarkDistributedTaskFailed transitions SWAPPING → FAILED when
-	// OnTaskCompleted returned a terminal error: a permanent failure
-	// ([ErrTaskCompletionPermanent]) or a transient one that exhausted the
-	// per-task retry budget. errMsg is recorded on the task for forensics.
-	// This closes weaviate/0-weaviate-issues#297, where a swallowed
-	// schema-flip failure let the task reach FINISHED with an un-flipped
-	// schema.
+	// OnTaskCompleted returns a terminal error: permanent
+	// ([ErrTaskCompletionPermanent]) or retry-exhausted transient. errMsg is
+	// recorded on the task (weaviate/0-weaviate-issues#297).
 	MarkDistributedTaskFailed(ctx context.Context, namespace, taskID string, taskVersion uint64, errMsg string) error
 }
 
@@ -324,16 +319,11 @@ type UnitAwareProvider interface {
 	// implementations MUST preserve this contract.
 	//
 	// Return value (weaviate/0-weaviate-issues#297): a non-nil error on the
-	// SWAPPING path (the cluster-wide cutover, e.g. the schema flip)
-	// withholds finalize — the scheduler does NOT commit FINISHED and
-	// instead re-fires OnTaskCompleted on the next tick. Wrap the error in
-	// [ErrTaskCompletionPermanent] when it is deterministically
-	// unrecoverable (target property gone, payload unparsable): the
-	// scheduler then transitions the task to FAILED immediately. A plain
-	// error is transient and retried up to a bounded count before the task
-	// is failed. Errors returned on terminal-status invocations
-	// (FAILED/CANCELLED/FINISHED cleanup) are best-effort and do NOT reopen
-	// the task; return nil there.
+	// SWAPPING path withholds finalize and retries next tick. Wrap in
+	// [ErrTaskCompletionPermanent] for a deterministically-unrecoverable
+	// failure to fail the task immediately; a plain error is transient and
+	// retried up to a bounded count before failing. Errors on terminal-status
+	// invocations are best-effort and must not reopen the task (return nil).
 	OnTaskCompleted(task *Task) error
 }
 

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -46,17 +46,27 @@ type TaskCleaner interface {
 	CleanUpDistributedTask(ctx context.Context, namespace, taskID string, taskVersion uint64) error
 }
 
-// TaskFinalizer is an interface for issuing a request to transition a task
-// from [TaskStatusSwapping] to [TaskStatusFinished]. The [Scheduler] calls
-// this from its tick after [Provider.OnTaskCompleted] returns successfully so
-// the FSM-level FINISHED state lines up with "every post-completion callback
-// committed cluster-wide" (not just "every unit terminal"). Idempotent at the
-// FSM layer — every node's scheduler issues this independently after its
-// local OnTaskCompleted returns; only the first commit actually flips the
-// status. See the godoc on [TaskStatusSwapping] for the underlying race
-// this discipline fixes.
+// TaskFinalizer is the interface the [Scheduler] uses to issue a task's
+// terminal transition out of [TaskStatusSwapping] once its local
+// [UnitAwareProvider.OnTaskCompleted] has returned. Both methods are
+// idempotent at the FSM layer — every node's scheduler issues them
+// independently, and only the first commit actually flips the status.
 type TaskFinalizer interface {
+	// MarkDistributedTaskFinalized transitions SWAPPING → FINISHED after
+	// OnTaskCompleted returned nil, so the FSM-level FINISHED state lines up
+	// with "every post-completion callback committed cluster-wide" (not just
+	// "every unit terminal"). See the godoc on [TaskStatusSwapping] for the
+	// underlying race this discipline fixes.
 	MarkDistributedTaskFinalized(ctx context.Context, namespace, taskID string, taskVersion uint64) error
+
+	// MarkDistributedTaskFailed transitions SWAPPING → FAILED when
+	// OnTaskCompleted returned a terminal error: a permanent failure
+	// ([ErrTaskCompletionPermanent]) or a transient one that exhausted the
+	// per-task retry budget. errMsg is recorded on the task for forensics.
+	// This closes weaviate/0-weaviate-issues#297, where a swallowed
+	// schema-flip failure let the task reach FINISHED with an un-flipped
+	// schema.
+	MarkDistributedTaskFailed(ctx context.Context, namespace, taskID string, taskVersion uint64, errMsg string) error
 }
 
 // PostCompletionAckRecorder is the RAFT-apply hook the [Scheduler] uses
@@ -312,7 +322,19 @@ type UnitAwareProvider interface {
 	// twice, etc.). Today's concrete provider (db/reindex_provider.go's
 	// OnTaskCompleted → autoCleanupAfterTerminal) already is; new
 	// implementations MUST preserve this contract.
-	OnTaskCompleted(task *Task)
+	//
+	// Return value (weaviate/0-weaviate-issues#297): a non-nil error on the
+	// SWAPPING path (the cluster-wide cutover, e.g. the schema flip)
+	// withholds finalize — the scheduler does NOT commit FINISHED and
+	// instead re-fires OnTaskCompleted on the next tick. Wrap the error in
+	// [ErrTaskCompletionPermanent] when it is deterministically
+	// unrecoverable (target property gone, payload unparsable): the
+	// scheduler then transitions the task to FAILED immediately. A plain
+	// error is transient and retried up to a bounded count before the task
+	// is failed. Errors returned on terminal-status invocations
+	// (FAILED/CANCELLED/FINISHED cleanup) are best-effort and do NOT reopen
+	// the task; return nil there.
+	OnTaskCompleted(task *Task) error
 }
 
 type UnitStatus string

--- a/cluster/proto/api/message.pb.go
+++ b/cluster/proto/api/message.pb.go
@@ -88,6 +88,7 @@ const (
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_MARK_FINALIZED                  ApplyRequest_Type = 306
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_POST_COMPLETION_ACK      ApplyRequest_Type = 307
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_PREPARATION_COMPLETE_ACK ApplyRequest_Type = 308
+	ApplyRequest_TYPE_DISTRIBUTED_TASK_MARK_FAILED                     ApplyRequest_Type = 309
 )
 
 // Enum value maps for ApplyRequest_Type.
@@ -154,6 +155,7 @@ var (
 		306: "TYPE_DISTRIBUTED_TASK_MARK_FINALIZED",
 		307: "TYPE_DISTRIBUTED_TASK_RECORD_POST_COMPLETION_ACK",
 		308: "TYPE_DISTRIBUTED_TASK_RECORD_PREPARATION_COMPLETE_ACK",
+		309: "TYPE_DISTRIBUTED_TASK_MARK_FAILED",
 	}
 	ApplyRequest_Type_value = map[string]int32{
 		"TYPE_UNSPECIFIED":                                                0,
@@ -217,6 +219,7 @@ var (
 		"TYPE_DISTRIBUTED_TASK_MARK_FINALIZED":                            306,
 		"TYPE_DISTRIBUTED_TASK_RECORD_POST_COMPLETION_ACK":                307,
 		"TYPE_DISTRIBUTED_TASK_RECORD_PREPARATION_COMPLETE_ACK":           308,
+		"TYPE_DISTRIBUTED_TASK_MARK_FAILED":                               309,
 	}
 )
 
@@ -2116,6 +2119,90 @@ func (x *MarkTaskFinalizedRequest) GetFinalizedAtUnixMillis() int64 {
 	return 0
 }
 
+// MarkTaskFailedRequest transitions a task from SWAPPING to FAILED when the
+// scheduler's OnTaskCompleted returns a terminal error: a permanent
+// schema-flip failure (the target property was deleted mid-flight, so the
+// cluster-wide flip can never succeed), or a transient one that exhausted
+// the per-task retry budget. Without it a swallowed flip failure let the
+// task finalize to FINISHED with an un-flipped schema
+// (weaviate/0-weaviate-issues#297). Idempotent at the FSM layer: SWAPPING →
+// FAILED once; a later commit for an already-terminal task is a no-op.
+type MarkTaskFailedRequest struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Namespace          string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Id                 string                 `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	Version            uint64                 `protobuf:"varint,3,opt,name=version,proto3" json:"version,omitempty"`
+	Error              string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
+	FailedAtUnixMillis int64                  `protobuf:"varint,5,opt,name=failed_at_unix_millis,json=failedAtUnixMillis,proto3" json:"failed_at_unix_millis,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *MarkTaskFailedRequest) Reset() {
+	*x = MarkTaskFailedRequest{}
+	mi := &file_api_message_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MarkTaskFailedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MarkTaskFailedRequest) ProtoMessage() {}
+
+func (x *MarkTaskFailedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_message_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MarkTaskFailedRequest.ProtoReflect.Descriptor instead.
+func (*MarkTaskFailedRequest) Descriptor() ([]byte, []int) {
+	return file_api_message_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *MarkTaskFailedRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *MarkTaskFailedRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *MarkTaskFailedRequest) GetVersion() uint64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *MarkTaskFailedRequest) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *MarkTaskFailedRequest) GetFailedAtUnixMillis() int64 {
+	if x != nil {
+		return x.FailedAtUnixMillis
+	}
+	return 0
+}
+
 // RecordDistributedTaskPostCompletionAckRequest captures one node's
 // SWAP-phase callback result (OnGroupCompleted for non-barrier tasks,
 // OnSwapRequested for barrier tasks) — i.e. did every local unit's
@@ -2152,7 +2239,7 @@ type RecordDistributedTaskPostCompletionAckRequest struct {
 
 func (x *RecordDistributedTaskPostCompletionAckRequest) Reset() {
 	*x = RecordDistributedTaskPostCompletionAckRequest{}
-	mi := &file_api_message_proto_msgTypes[28]
+	mi := &file_api_message_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2251,7 @@ func (x *RecordDistributedTaskPostCompletionAckRequest) String() string {
 func (*RecordDistributedTaskPostCompletionAckRequest) ProtoMessage() {}
 
 func (x *RecordDistributedTaskPostCompletionAckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_message_proto_msgTypes[28]
+	mi := &file_api_message_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2264,7 @@ func (x *RecordDistributedTaskPostCompletionAckRequest) ProtoReflect() protorefl
 
 // Deprecated: Use RecordDistributedTaskPostCompletionAckRequest.ProtoReflect.Descriptor instead.
 func (*RecordDistributedTaskPostCompletionAckRequest) Descriptor() ([]byte, []int) {
-	return file_api_message_proto_rawDescGZIP(), []int{28}
+	return file_api_message_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *RecordDistributedTaskPostCompletionAckRequest) GetNamespace() string {
@@ -2244,7 +2331,7 @@ type RecordDistributedTaskPreparationCompleteAckRequest struct {
 
 func (x *RecordDistributedTaskPreparationCompleteAckRequest) Reset() {
 	*x = RecordDistributedTaskPreparationCompleteAckRequest{}
-	mi := &file_api_message_proto_msgTypes[29]
+	mi := &file_api_message_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2256,7 +2343,7 @@ func (x *RecordDistributedTaskPreparationCompleteAckRequest) String() string {
 func (*RecordDistributedTaskPreparationCompleteAckRequest) ProtoMessage() {}
 
 func (x *RecordDistributedTaskPreparationCompleteAckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_message_proto_msgTypes[29]
+	mi := &file_api_message_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2269,7 +2356,7 @@ func (x *RecordDistributedTaskPreparationCompleteAckRequest) ProtoReflect() prot
 
 // Deprecated: Use RecordDistributedTaskPreparationCompleteAckRequest.ProtoReflect.Descriptor instead.
 func (*RecordDistributedTaskPreparationCompleteAckRequest) Descriptor() ([]byte, []int) {
-	return file_api_message_proto_rawDescGZIP(), []int{29}
+	return file_api_message_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *RecordDistributedTaskPreparationCompleteAckRequest) GetNamespace() string {
@@ -2339,13 +2426,13 @@ const file_api_message_proto_rawDesc = "" +
 	"\x11NotifyPeerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x14\n" +
-	"\x12NotifyPeerResponse\"\xdc\x12\n" +
+	"\x12NotifyPeerResponse\"\x84\x13\n" +
 	"\fApplyRequest\x12@\n" +
 	"\x04type\x18\x01 \x01(\x0e2,.weaviate.internal.cluster.ApplyRequest.TypeR\x04type\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x04R\aversion\x12\x1f\n" +
 	"\vsub_command\x18\x04 \x01(\fR\n" +
-	"subCommand\"\xb8\x11\n" +
+	"subCommand\"\xe0\x11\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eTYPE_ADD_CLASS\x10\x01\x12\x15\n" +
@@ -2408,7 +2495,8 @@ const file_api_message_proto_rawDesc = "" +
 	"*TYPE_DISTRIBUTED_TASK_UPDATE_UNIT_PROGRESS\x10\xb1\x02\x12)\n" +
 	"$TYPE_DISTRIBUTED_TASK_MARK_FINALIZED\x10\xb2\x02\x125\n" +
 	"0TYPE_DISTRIBUTED_TASK_RECORD_POST_COMPLETION_ACK\x10\xb3\x02\x12:\n" +
-	"5TYPE_DISTRIBUTED_TASK_RECORD_PREPARATION_COMPLETE_ACK\x10\xb4\x02\"\x04\bc\x10c\"A\n" +
+	"5TYPE_DISTRIBUTED_TASK_RECORD_PREPARATION_COMPLETE_ACK\x10\xb4\x02\x12&\n" +
+	"!TYPE_DISTRIBUTED_TASK_MARK_FAILED\x10\xb5\x02\"\x04\bc\x10c\"A\n" +
 	"\rApplyResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x04R\aversion\x12\x16\n" +
 	"\x06leader\x18\x02 \x01(\tR\x06leader\"\xaa\b\n" +
@@ -2543,7 +2631,13 @@ const file_api_message_proto_rawDesc = "" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x04R\aversion\x127\n" +
-	"\x18finalized_at_unix_millis\x18\x04 \x01(\x03R\x15finalizedAtUnixMillis\"\xf1\x01\n" +
+	"\x18finalized_at_unix_millis\x18\x04 \x01(\x03R\x15finalizedAtUnixMillis\"\xa8\x01\n" +
+	"\x15MarkTaskFailedRequest\x12\x1c\n" +
+	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x0e\n" +
+	"\x02id\x18\x02 \x01(\tR\x02id\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\x04R\aversion\x12\x14\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\x121\n" +
+	"\x15failed_at_unix_millis\x18\x05 \x01(\x03R\x12failedAtUnixMillis\"\xf1\x01\n" +
 	"-RecordDistributedTaskPostCompletionAckRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x18\n" +
@@ -2583,7 +2677,7 @@ func file_api_message_proto_rawDescGZIP() []byte {
 }
 
 var file_api_message_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_api_message_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
+var file_api_message_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_api_message_proto_goTypes = []any{
 	(ApplyRequest_Type)(0),                                     // 0: weaviate.internal.cluster.ApplyRequest.Type
 	(QueryRequest_Type)(0),                                     // 1: weaviate.internal.cluster.QueryRequest.Type
@@ -2617,8 +2711,9 @@ var file_api_message_proto_goTypes = []any{
 	(*RecordDistributedTaskUnitCompletionRequest)(nil),         // 29: weaviate.internal.cluster.RecordDistributedTaskUnitCompletionRequest
 	(*UpdateDistributedTaskUnitProgressRequest)(nil),           // 30: weaviate.internal.cluster.UpdateDistributedTaskUnitProgressRequest
 	(*MarkTaskFinalizedRequest)(nil),                           // 31: weaviate.internal.cluster.MarkTaskFinalizedRequest
-	(*RecordDistributedTaskPostCompletionAckRequest)(nil),      // 32: weaviate.internal.cluster.RecordDistributedTaskPostCompletionAckRequest
-	(*RecordDistributedTaskPreparationCompleteAckRequest)(nil), // 33: weaviate.internal.cluster.RecordDistributedTaskPreparationCompleteAckRequest
+	(*MarkTaskFailedRequest)(nil),                              // 32: weaviate.internal.cluster.MarkTaskFailedRequest
+	(*RecordDistributedTaskPostCompletionAckRequest)(nil),      // 33: weaviate.internal.cluster.RecordDistributedTaskPostCompletionAckRequest
+	(*RecordDistributedTaskPreparationCompleteAckRequest)(nil), // 34: weaviate.internal.cluster.RecordDistributedTaskPreparationCompleteAckRequest
 }
 var file_api_message_proto_depIdxs = []int32{
 	0,  // 0: weaviate.internal.cluster.ApplyRequest.type:type_name -> weaviate.internal.cluster.ApplyRequest.Type
@@ -2659,7 +2754,7 @@ func file_api_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_message_proto_rawDesc), len(file_api_message_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   30,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cluster/proto/api/message.pb.go
+++ b/cluster/proto/api/message.pb.go
@@ -2119,14 +2119,10 @@ func (x *MarkTaskFinalizedRequest) GetFinalizedAtUnixMillis() int64 {
 	return 0
 }
 
-// MarkTaskFailedRequest transitions a task from SWAPPING to FAILED when the
-// scheduler's OnTaskCompleted returns a terminal error: a permanent
-// schema-flip failure (the target property was deleted mid-flight, so the
-// cluster-wide flip can never succeed), or a transient one that exhausted
-// the per-task retry budget. Without it a swallowed flip failure let the
-// task finalize to FINISHED with an un-flipped schema
-// (weaviate/0-weaviate-issues#297). Idempotent at the FSM layer: SWAPPING →
-// FAILED once; a later commit for an already-terminal task is a no-op.
+// MarkTaskFailedRequest transitions a task SWAPPING → FAILED when
+// OnTaskCompleted returns a terminal error: permanent schema-flip failure
+// or retry-exhausted transient one (weaviate/0-weaviate-issues#297).
+// Idempotent at the FSM layer: a later commit on a terminal task is a no-op.
 type MarkTaskFailedRequest struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	Namespace          string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`

--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -308,14 +308,10 @@ message MarkTaskFinalizedRequest {
   int64 finalized_at_unix_millis = 4;
 }
 
-// MarkTaskFailedRequest transitions a task from SWAPPING to FAILED when the
-// scheduler's OnTaskCompleted returns a terminal error: a permanent
-// schema-flip failure (the target property was deleted mid-flight, so the
-// cluster-wide flip can never succeed), or a transient one that exhausted
-// the per-task retry budget. Without it a swallowed flip failure let the
-// task finalize to FINISHED with an un-flipped schema
-// (weaviate/0-weaviate-issues#297). Idempotent at the FSM layer: SWAPPING →
-// FAILED once; a later commit for an already-terminal task is a no-op.
+// MarkTaskFailedRequest transitions a task SWAPPING → FAILED when
+// OnTaskCompleted returns a terminal error: permanent schema-flip failure
+// or retry-exhausted transient one (weaviate/0-weaviate-issues#297).
+// Idempotent at the FSM layer: a later commit on a terminal task is a no-op.
 message MarkTaskFailedRequest {
   string namespace = 1;
   string id = 2;

--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -112,6 +112,7 @@ message ApplyRequest {
     TYPE_DISTRIBUTED_TASK_MARK_FINALIZED = 306;
     TYPE_DISTRIBUTED_TASK_RECORD_POST_COMPLETION_ACK = 307;
     TYPE_DISTRIBUTED_TASK_RECORD_PREPARATION_COMPLETE_ACK = 308;
+    TYPE_DISTRIBUTED_TASK_MARK_FAILED = 309;
   }
   Type type = 1;
   string class = 2;
@@ -305,6 +306,22 @@ message MarkTaskFinalizedRequest {
   string id = 2;
   uint64 version = 3;
   int64 finalized_at_unix_millis = 4;
+}
+
+// MarkTaskFailedRequest transitions a task from SWAPPING to FAILED when the
+// scheduler's OnTaskCompleted returns a terminal error: a permanent
+// schema-flip failure (the target property was deleted mid-flight, so the
+// cluster-wide flip can never succeed), or a transient one that exhausted
+// the per-task retry budget. Without it a swallowed flip failure let the
+// task finalize to FINISHED with an un-flipped schema
+// (weaviate/0-weaviate-issues#297). Idempotent at the FSM layer: SWAPPING →
+// FAILED once; a later commit for an already-terminal task is a no-op.
+message MarkTaskFailedRequest {
+  string namespace = 1;
+  string id = 2;
+  uint64 version = 3;
+  string error = 4;
+  int64 failed_at_unix_millis = 5;
 }
 
 // RecordDistributedTaskPostCompletionAckRequest captures one node's

--- a/cluster/raft_distributed_tasks_apply_endpoints.go
+++ b/cluster/raft_distributed_tasks_apply_endpoints.go
@@ -168,10 +168,6 @@ func (s *Raft) MarkDistributedTaskFinalized(ctx context.Context, namespace, task
 	})
 }
 
-// MarkDistributedTaskFailed transitions a task SWAPPING → FAILED when the
-// scheduler's OnTaskCompleted returned a terminal error (permanent flip
-// failure or retry-exhausted transient one). See
-// [distributedtask.TaskFinalizer] and weaviate/0-weaviate-issues#297.
 func (s *Raft) MarkDistributedTaskFailed(ctx context.Context, namespace, taskID string, taskVersion uint64, errMsg string) error {
 	return s.applyDistributedTaskCommand(ctx, cmd.ApplyRequest_TYPE_DISTRIBUTED_TASK_MARK_FAILED, &cmd.MarkTaskFailedRequest{
 		Namespace:          namespace,

--- a/cluster/raft_distributed_tasks_apply_endpoints.go
+++ b/cluster/raft_distributed_tasks_apply_endpoints.go
@@ -168,6 +168,20 @@ func (s *Raft) MarkDistributedTaskFinalized(ctx context.Context, namespace, task
 	})
 }
 
+// MarkDistributedTaskFailed transitions a task SWAPPING → FAILED when the
+// scheduler's OnTaskCompleted returned a terminal error (permanent flip
+// failure or retry-exhausted transient one). See
+// [distributedtask.TaskFinalizer] and weaviate/0-weaviate-issues#297.
+func (s *Raft) MarkDistributedTaskFailed(ctx context.Context, namespace, taskID string, taskVersion uint64, errMsg string) error {
+	return s.applyDistributedTaskCommand(ctx, cmd.ApplyRequest_TYPE_DISTRIBUTED_TASK_MARK_FAILED, &cmd.MarkTaskFailedRequest{
+		Namespace:          namespace,
+		Id:                 taskID,
+		Version:            taskVersion,
+		Error:              errMsg,
+		FailedAtUnixMillis: time.Now().UnixMilli(),
+	})
+}
+
 // RecordDistributedTaskPostCompletionAck commits one node's SWAP-phase
 // callback result to the FSM (OnGroupCompleted for non-barrier tasks,
 // OnSwapRequested for barrier tasks). The scheduler tick on each node

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -497,6 +497,10 @@ func (st *Store) Apply(l *raft.Log) any {
 		f = func() {
 			ret.Error = st.distributedTasksManager.MarkTaskFinalized(&cmd)
 		}
+	case api.ApplyRequest_TYPE_DISTRIBUTED_TASK_MARK_FAILED:
+		f = func() {
+			ret.Error = st.distributedTasksManager.MarkTaskFailed(&cmd)
+		}
 	case api.ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_POST_COMPLETION_ACK:
 		f = func() {
 			ret.Error = st.distributedTasksManager.RecordPostCompletionAck(&cmd)

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -511,8 +511,10 @@ func (st *Store) Apply(l *raft.Log) any {
 		}
 
 	default:
-		// This could occur when a new command has been introduced in a later app version
-		// At this point, we need to panic so that the app undergo an upgrade during restart
+		// A command introduced by a newer app version. Log and no-op rather than
+		// panic: a crash would wedge the FSM on every unknown entry during a
+		// rolling upgrade. The applied index still advances, so the node stays
+		// consistent and skips the command's effect until it upgrades.
 		const msg = "consider upgrading to newer version"
 		st.log.WithFields(logrus.Fields{
 			"type":  cmd.Type,

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -101,6 +101,7 @@ var nonNamespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_UNIT_COMPLETED:                     {},
 	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_UPDATE_UNIT_PROGRESS:                      {},
 	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_MARK_FINALIZED:                            {},
+	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_MARK_FAILED:                               {},
 	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_POST_COMPLETION_ACK:                {},
 	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_PREPARATION_COMPLETE_ACK:           {},
 }


### PR DESCRIPTION
SuperClaude here.

A distributed reindex task's `OnTaskCompleted` swallowed schema-flip errors, so the task could reach `FINISHED` with the tokenization schema never flipped — a silently-inconsistent migration (weaviate/0-weaviate-issues#297).

**Fix.** `OnTaskCompleted` now returns its error. The scheduler classifies it:

- **Permanent** (unparsable payload; change-tokenization with the target property gone) → the task transitions straight to `FAILED` via a new RAFT command, `TYPE_DISTRIBUTED_TASK_MARK_FAILED` (op 309).
- **Transient** (any other flip/apply error) → bounded retry (≤5 ticks), then `FAILED`.

The `FAILED` transition is first-terminal-wins and idempotent, symmetric with `MarkTaskFinalized` (each refuses the other's terminal state).

**Validation principle.** Guaranteed failures — e.g. an empty `TargetTokenization` — are rejected at submit-time validation and never reach this path. The retry here is a TOCTOU safety net (schema changed under the task mid-flight), not a substitute for validation.

**Mixed-version safety.** Op 309 is a no-op on older nodes: the `store_apply` default case logs "unknown command" and advances the applied index without touching `sub_command` — verified on both `origin/main` and `v1.38.2`, no panic, no FSM wedge. It mirrors op 307's already-shipped `SWAPPING→FAILED` transition.

**Tests** (all `-race` green): the pin (swallowed flip → wrongly-`FINISHED`, asymmetric red-without/green-with); a `reindex_provider` classification unit test (permanent vs transient, mutation-proven both directions); retry-then-succeed; permanent→immediate-fail; retry-bound exhaustion; and `MarkTaskFailed` FSM race/idempotency.

Closes weaviate/0-weaviate-issues#297

— SuperClaude