### PR TITLE
fix(schema): merge Tokenization in MergeProps for downgrade compatibility (#238)

### DIFF
--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -220,6 +220,15 @@ func MergeProps(old, new []*models.Property) []*models.Property {
 			mergedProps[oldIdx].IndexRangeFilters = new[idx].IndexRangeFilters
 			mergedProps[oldIdx].IndexFilterable = new[idx].IndexFilterable
 			mergedProps[oldIdx].IndexSearchable = new[idx].IndexSearchable
+			if new[idx].Tokenization != "" {
+				// v1.38 runtime-reindex commits a change-tokenization migration as
+				// an UpdateProperty carrying the new tokenization. Without merging
+				// it, a node downgraded to this version keeps the old tokenization
+				// and silently returns 0 hits (0-weaviate-issues#238). Native
+				// v1.37 never mutates an existing property's tokenization, so the
+				// incoming value equals the stored one here and this is a no-op.
+				mergedProps[oldIdx].Tokenization = new[idx].Tokenization
+			}
 
 			nestedProperties, merged := entSchema.MergeRecursivelyNestedProperties(
 				mergedProps[oldIdx].NestedProperties,

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -227,6 +227,11 @@ func MergeProps(old, new []*models.Property) []*models.Property {
 				// and silently returns 0 hits (0-weaviate-issues#238). Native
 				// v1.37 never mutates an existing property's tokenization, so the
 				// incoming value equals the stored one here and this is a no-op.
+				// Downgrade envelope: this assumes v1.38.x persists reindexed
+				// data at the unsuffixed canonical bucket path (true today — no
+				// live BucketGeneration producer); a release that activates
+				// generation-suffixed bucket paths re-breaks the v1.37 downgrade
+				// and must re-evaluate this backport.
 				mergedProps[oldIdx].Tokenization = new[idx].Tokenization
 			}
 

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -221,17 +221,10 @@ func MergeProps(old, new []*models.Property) []*models.Property {
 			mergedProps[oldIdx].IndexFilterable = new[idx].IndexFilterable
 			mergedProps[oldIdx].IndexSearchable = new[idx].IndexSearchable
 			if new[idx].Tokenization != "" {
-				// v1.38 runtime-reindex commits a change-tokenization migration as
-				// an UpdateProperty carrying the new tokenization. Without merging
-				// it, a node downgraded to this version keeps the old tokenization
-				// and silently returns 0 hits (0-weaviate-issues#238). Native
-				// v1.37 never mutates an existing property's tokenization, so the
-				// incoming value equals the stored one here and this is a no-op.
-				// Downgrade envelope: this assumes v1.38.x persists reindexed
-				// data at the unsuffixed canonical bucket path (true today — no
-				// live BucketGeneration producer); a release that activates
-				// generation-suffixed bucket paths re-breaks the v1.37 downgrade
-				// and must re-evaluate this backport.
+				// Backport for weaviate/0-weaviate-issues#238: v1.38 change-tokenization
+				// migrations replay as an UpdateProperty; skipping this merge leaves a
+				// downgraded v1.37 node on stale tokenization, silently returning 0 hits.
+				// Holds only while v1.38.x reindexes to the unsuffixed bucket path.
 				mergedProps[oldIdx].Tokenization = new[idx].Tokenization
 			}
 

--- a/cluster/schema/meta_class_test.go
+++ b/cluster/schema/meta_class_test.go
@@ -1,0 +1,62 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// TestMergeProps_MergesTokenization pins weaviate/0-weaviate-issues#238: a
+// v1.38 runtime-reindex change-tokenization migration commits the flip as an
+// UpdateProperty carrying the new tokenization. If a node is downgraded to this
+// (patched) v1.37 and replays that log entry, MergeProps must apply the new
+// tokenization — otherwise the property keeps its AddClass-time value and every
+// query is tokenized against a mismatched index, silently returning 0 hits.
+func TestMergeProps_MergesTokenization(t *testing.T) {
+	old := []*models.Property{{
+		Name:         "title",
+		DataType:     []string{"text"},
+		Tokenization: models.PropertyTokenizationWord,
+	}}
+	updated := []*models.Property{{
+		Name:         "title",
+		DataType:     []string{"text"},
+		Tokenization: models.PropertyTokenizationField,
+	}}
+
+	merged := MergeProps(old, updated)
+
+	require.Len(t, merged, 1)
+	require.Equal(t, models.PropertyTokenizationField, merged[0].Tokenization,
+		"the migrated tokenization must be merged so a downgraded node reads it")
+}
+
+// TestMergeProps_KeepsTokenizationWhenIncomingEmpty guards the backport's
+// no-op-for-native-v1.37 property: an UpdateProperty that carries no
+// tokenization (e.g. a plain index-only update) must not wipe the stored value.
+func TestMergeProps_KeepsTokenizationWhenIncomingEmpty(t *testing.T) {
+	old := []*models.Property{{
+		Name:         "title",
+		Tokenization: models.PropertyTokenizationWord,
+	}}
+	updated := []*models.Property{{Name: "title"}}
+
+	merged := MergeProps(old, updated)
+
+	require.Len(t, merged, 1)
+	require.Equal(t, models.PropertyTokenizationWord, merged[0].Tokenization,
+		"an UpdateProperty with no tokenization must not clear the existing one")
+}

--- a/cluster/schema/meta_class_test.go
+++ b/cluster/schema/meta_class_test.go
@@ -19,44 +19,125 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// TestMergeProps_MergesTokenization pins weaviate/0-weaviate-issues#238: a
-// v1.38 runtime-reindex change-tokenization migration commits the flip as an
-// UpdateProperty carrying the new tokenization. If a node is downgraded to this
-// (patched) v1.37 and replays that log entry, MergeProps must apply the new
-// tokenization — otherwise the property keeps its AddClass-time value and every
-// query is tokenized against a mismatched index, silently returning 0 hits.
-func TestMergeProps_MergesTokenization(t *testing.T) {
-	old := []*models.Property{{
-		Name:         "title",
-		DataType:     []string{"text"},
-		Tokenization: models.PropertyTokenizationWord,
-	}}
-	updated := []*models.Property{{
-		Name:         "title",
-		DataType:     []string{"text"},
-		Tokenization: models.PropertyTokenizationField,
-	}}
+// TestMergeProps_Tokenization pins the Tokenization-merge behavior backported
+// for weaviate/0-weaviate-issues#238: a v1.38 runtime-reindex
+// change-tokenization migration commits the flip as an UpdateProperty carrying
+// the new tokenization. If a node is downgraded to this (patched) v1.37 and
+// replays that log entry, MergeProps must apply the new tokenization —
+// otherwise the property keeps its AddClass-time value and every query is
+// tokenized against a mismatched index, silently returning 0 hits.
+func TestMergeProps_Tokenization(t *testing.T) {
+	tests := []struct {
+		name               string
+		old                []*models.Property
+		new                []*models.Property
+		expectTokenization string
+		expectNestedNames  []string
+	}{
+		{
+			// The #238 repro: replaying a v1.38-written migration must apply
+			// the flipped tokenization. Red without the backport.
+			name: "migration flips tokenization",
+			old: []*models.Property{{
+				Name:         "title",
+				DataType:     []string{"text"},
+				Tokenization: models.PropertyTokenizationWord,
+			}},
+			new: []*models.Property{{
+				Name:         "title",
+				DataType:     []string{"text"},
+				Tokenization: models.PropertyTokenizationField,
+			}},
+			expectTokenization: models.PropertyTokenizationField,
+		},
+		{
+			// The no-op guard: an UpdateProperty carrying no tokenization
+			// (e.g. a plain index-only update) must not wipe the stored value.
+			name: "empty incoming tokenization keeps stored value",
+			old: []*models.Property{{
+				Name:         "title",
+				Tokenization: models.PropertyTokenizationWord,
+			}},
+			new:                []*models.Property{{Name: "title"}},
+			expectTokenization: models.PropertyTokenizationWord,
+		},
+		{
+			// The native-v1.37 neutrality invariant the backport's safety
+			// argument rests on: native v1.37 never mutates an existing
+			// property's tokenization, so the incoming value always equals
+			// the stored one and the merge must be a no-op. Green with and
+			// without the backport by design — it pins the invariant rather
+			// than reproducing #238.
+			name: "same incoming tokenization is a no-op",
+			old: []*models.Property{{
+				Name:         "title",
+				DataType:     []string{"text"},
+				Tokenization: models.PropertyTokenizationWord,
+			}},
+			new: []*models.Property{{
+				Name:         "title",
+				DataType:     []string{"text"},
+				Tokenization: models.PropertyTokenizationWord,
+			}},
+			expectTokenization: models.PropertyTokenizationWord,
+		},
+		{
+			// MergeProps keys on strings.ToLower(Name): a differently-cased
+			// incoming name must still merge into the existing property
+			// instead of appending a duplicate.
+			name: "case-insensitive name match merges tokenization",
+			old: []*models.Property{{
+				Name:         "Title",
+				DataType:     []string{"text"},
+				Tokenization: models.PropertyTokenizationWord,
+			}},
+			new: []*models.Property{{
+				Name:         "title",
+				DataType:     []string{"text"},
+				Tokenization: models.PropertyTokenizationField,
+			}},
+			expectTokenization: models.PropertyTokenizationField,
+		},
+		{
+			// The nested-merge branch replaces the merged property with a
+			// copy (propCopy := *mergedProps[oldIdx]) after the tokenization
+			// assignment; the flip must survive that copy.
+			name: "tokenization flip survives copy-on-nested-merge",
+			old: []*models.Property{{
+				Name:         "info",
+				DataType:     []string{"object"},
+				Tokenization: models.PropertyTokenizationWord,
+				NestedProperties: []*models.NestedProperty{
+					{Name: "street", DataType: []string{"text"}},
+				},
+			}},
+			new: []*models.Property{{
+				Name:         "info",
+				DataType:     []string{"object"},
+				Tokenization: models.PropertyTokenizationField,
+				NestedProperties: []*models.NestedProperty{
+					{Name: "zip", DataType: []string{"text"}},
+				},
+			}},
+			expectTokenization: models.PropertyTokenizationField,
+			expectNestedNames:  []string{"street", "zip"},
+		},
+	}
 
-	merged := MergeProps(old, updated)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged := MergeProps(tt.old, tt.new)
 
-	require.Len(t, merged, 1)
-	require.Equal(t, models.PropertyTokenizationField, merged[0].Tokenization,
-		"the migrated tokenization must be merged so a downgraded node reads it")
-}
+			require.Len(t, merged, 1, "matching names must merge, not append")
+			require.Equal(t, tt.expectTokenization, merged[0].Tokenization)
 
-// TestMergeProps_KeepsTokenizationWhenIncomingEmpty guards the backport's
-// no-op-for-native-v1.37 property: an UpdateProperty that carries no
-// tokenization (e.g. a plain index-only update) must not wipe the stored value.
-func TestMergeProps_KeepsTokenizationWhenIncomingEmpty(t *testing.T) {
-	old := []*models.Property{{
-		Name:         "title",
-		Tokenization: models.PropertyTokenizationWord,
-	}}
-	updated := []*models.Property{{Name: "title"}}
-
-	merged := MergeProps(old, updated)
-
-	require.Len(t, merged, 1)
-	require.Equal(t, models.PropertyTokenizationWord, merged[0].Tokenization,
-		"an UpdateProperty with no tokenization must not clear the existing one")
+			if tt.expectNestedNames != nil {
+				nestedNames := make([]string, 0, len(merged[0].NestedProperties))
+				for _, np := range merged[0].NestedProperties {
+					nestedNames = append(nestedNames, np.Name)
+				}
+				require.ElementsMatch(t, tt.expectNestedNames, nestedNames)
+			}
+		})
+	}
 }

--- a/cluster/schema/meta_class_test.go
+++ b/cluster/schema/meta_class_test.go
@@ -19,13 +19,9 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// TestMergeProps_Tokenization pins the Tokenization-merge behavior backported
-// for weaviate/0-weaviate-issues#238: a v1.38 runtime-reindex
-// change-tokenization migration commits the flip as an UpdateProperty carrying
-// the new tokenization. If a node is downgraded to this (patched) v1.37 and
-// replays that log entry, MergeProps must apply the new tokenization —
-// otherwise the property keeps its AddClass-time value and every query is
-// tokenized against a mismatched index, silently returning 0 hits.
+// TestMergeProps_Tokenization pins weaviate/0-weaviate-issues#238: a downgraded
+// v1.37 node replaying a v1.38 tokenization migration must apply it, not
+// silently keep the stale value and return 0 hits.
 func TestMergeProps_Tokenization(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -35,8 +31,7 @@ func TestMergeProps_Tokenization(t *testing.T) {
 		expectNestedNames  []string
 	}{
 		{
-			// The #238 repro: replaying a v1.38-written migration must apply
-			// the flipped tokenization. Red without the backport.
+			// #238 repro: replaying a v1.38 migration must flip the tokenization.
 			name: "migration flips tokenization",
 			old: []*models.Property{{
 				Name:         "title",
@@ -51,8 +46,7 @@ func TestMergeProps_Tokenization(t *testing.T) {
 			expectTokenization: models.PropertyTokenizationField,
 		},
 		{
-			// The no-op guard: an UpdateProperty carrying no tokenization
-			// (e.g. a plain index-only update) must not wipe the stored value.
+			// An index-only update (no tokenization) must not wipe the stored value.
 			name: "empty incoming tokenization keeps stored value",
 			old: []*models.Property{{
 				Name:         "title",
@@ -62,12 +56,8 @@ func TestMergeProps_Tokenization(t *testing.T) {
 			expectTokenization: models.PropertyTokenizationWord,
 		},
 		{
-			// The native-v1.37 neutrality invariant the backport's safety
-			// argument rests on: native v1.37 never mutates an existing
-			// property's tokenization, so the incoming value always equals
-			// the stored one and the merge must be a no-op. Green with and
-			// without the backport by design — it pins the invariant rather
-			// than reproducing #238.
+			// Invariant the backport relies on: native v1.37 never changes
+			// tokenization, so this merge is always a no-op.
 			name: "same incoming tokenization is a no-op",
 			old: []*models.Property{{
 				Name:         "title",
@@ -82,9 +72,7 @@ func TestMergeProps_Tokenization(t *testing.T) {
 			expectTokenization: models.PropertyTokenizationWord,
 		},
 		{
-			// MergeProps keys on strings.ToLower(Name): a differently-cased
-			// incoming name must still merge into the existing property
-			// instead of appending a duplicate.
+			// A differently-cased incoming name must still merge, not duplicate.
 			name: "case-insensitive name match merges tokenization",
 			old: []*models.Property{{
 				Name:         "Title",
@@ -99,9 +87,7 @@ func TestMergeProps_Tokenization(t *testing.T) {
 			expectTokenization: models.PropertyTokenizationField,
 		},
 		{
-			// The nested-merge branch replaces the merged property with a
-			// copy (propCopy := *mergedProps[oldIdx]) after the tokenization
-			// assignment; the flip must survive that copy.
+			// The tokenization flip must survive the nested-merge copy path.
 			name: "tokenization flip survives copy-on-nested-merge",
 			old: []*models.Property{{
 				Name:         "info",


### PR DESCRIPTION
SuperClaude here.

Runtime property reindex (v1.38, Preview) commits a change-tokenization migration as a standard `TYPE_UPDATE_PROPERTY` carrying the new tokenization. This version's `MergeProps` merges the index flags for an existing property but **drops `Tokenization`**. So a node downgraded to v1.37 that replays that log entry keeps the property's `AddClass`-time tokenization, tokenizes every query against the mismatched (migrated) index, and silently returns 0 hits — the schema-report half of weaviate/0-weaviate-issues#238.

**Fix.** Merge `Tokenization`, guarded by a non-empty check — a backport of v1.38's `MergePropsMasked` behavior (`cluster/schema/meta_class.go`):

```go
if new[idx].Tokenization != "" {
    mergedProps[oldIdx].Tokenization = new[idx].Tokenization
}
```

**Why it's safe.** Native v1.37 never mutates an existing property's tokenization — the API validator rejects it — so the incoming value always equals the stored one (or is empty, guarded out). The merge is therefore a no-op for native v1.37 operations and only takes effect when replaying a v1.38-written migration. Index-flag migrations (enable-*) were already downgrade-safe; only tokenization was dropped.

**Scope — narrowed.** This is a necessary building block for the v1.38→v1.37 downgrade, **not** a complete fix for weaviate/0-weaviate-issues#238's online-reindex path. It makes the downgraded node's schema correct; it cannot relocate data. The downgrade is safe **only after the on-disk ingest→canonical bucket swap has been persisted on v1.38**, which today happens only at the next v1.38 process start after the reindex (`FinalizeCompletedMigrations`, `adapters/repos/db/shard_init.go:162`; `OnBeforeLsmInit` → `recoverRuntimeSwapBuckets`, `adapters/repos/db/inverted_reindex_task_generic.go:2174` on stable/v1.38). Downgrading straight after a FINISHED reindex (graceful `compose down`, volumes up on patched v1.37) leaves the canonical searchable bucket absent — data still in `property_<name>_searchable__retokenize_ingest_<N>` — and BM25 returns 0 hits with a correct schema, as Claudette's empirical review below demonstrates. That restart dependency is a v1.38/main defect in its own right, tracked in weaviate/0-weaviate-issues#320.

**Supported downgrade procedure (release-note material).**
1. Patch **every** v1.37.x node to this patch release before downgrading any node.
2. After any runtime reindex on v1.38, restart the v1.38 node(s) and verify BM25 results before downgrading — the restart persists the on-disk bucket swap.

**Hazards if step 1 is skipped.**
- Mixed patched/unpatched v1.37.x nodes replaying the same v1.38-written `UPDATE_PROPERTY` diverge silently: the patched node merges `field`, the unpatched node keeps `word`, and replicas answer the same BM25 query differently.
- Snapshot poisoning: an unpatched node that snapshots after applying the migration entry bakes the wrong tokenization into the snapshot; it survives a later upgrade to the patched binary (no self-heal). A stale `UPDATE_PROPERTY(word)` written by an unpatched node likewise re-poisons a patched node on a later replay (last-write-wins merge).

**Forward-compat envelope.** The fix assumes v1.38.x persists reindexed data at the unsuffixed canonical bucket path — true today, there is no live `BucketGeneration` producer. A future release that activates generation-suffixed bucket paths re-breaks the v1.37 downgrade and must re-evaluate this backport. Pinned as a code comment at the merge site.

**Snapshot-install downgrade (verified by code reading).** v1.37 decodes a v1.38-authored FSM snapshot via `encoding/json` without `DisallowUnknownFields` (`cluster/store_snapshot.go:112-113` on stable/v1.37), so the only v1.38-new top-level section (`namespaces`) is silently dropped. `distributed_tasks` is a section v1.37 already knows (`cluster/fsm/snapshot.go:33`) and restores namespace-agnostically (`cluster/distributedtask/manager.go:371-391`); v1.38 reindex tasks land inert in memory. No error, no panic — the snapshot-install path behaves like the verified log-replay path.

**Tests** (`cluster/schema/meta_class_test.go`, table-driven `TestMergeProps_Tokenization`): migration flip (red without the fix), empty-incoming no-clobber (green both ways), same-value neutrality — the native-v1.37 invariant the safety argument rests on, green both ways by design — case-insensitive name match (red without), and tokenization flip surviving the copy-on-nested-merge branch (red without). Full `cluster/schema` package green.

Contributes to weaviate/0-weaviate-issues#238 (schema-report half; the data-location half is weaviate/0-weaviate-issues#320).

— SuperClaude
