### PR TITLE
fix(distributedtask): Restore must replace FSM state, not merge it

### DIFF
--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -257,12 +257,14 @@ func (m *Manager) Restore(bytes []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for namespace, tasks := range s.Tasks {
-		for _, task := range tasks {
-			if _, ok := m.tasks[namespace]; !ok {
-				m.tasks[namespace] = make(map[string]*Task)
-			}
+	// FSM contract: Restore must REPLACE state, not merge into it. The snapshot
+	// is the canonical truth; tasks absent from it were cleaned up cluster-wide
+	// and must not survive as phantom entries on a follower that installs it.
+	m.tasks = make(map[string]map[string]*Task, len(s.Tasks))
 
+	for namespace, tasks := range s.Tasks {
+		m.tasks[namespace] = make(map[string]*Task, len(tasks))
+		for _, task := range tasks {
 			m.tasks[namespace][task.ID] = task
 		}
 	}

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -409,6 +409,46 @@ func TestManager_SnapshotRestore(t *testing.T) {
 	assertTasks(t, expectedTasks, tasks)
 }
 
+// TestManager_Restore_ReplacesState pins the Raft FSM contract: Restore must
+// REPLACE the manager's task state, not merge into it. A task present before
+// the restore but absent from the snapshot must not survive, otherwise a
+// follower that installs a snapshot accumulates phantom tasks no other node
+// knows about (weaviate/0-weaviate-issues#241).
+func TestManager_Restore_ReplacesState(t *testing.T) {
+	var (
+		h   = newTestHarness(t).init(t)
+		now = h.clock.Now().Truncate(time.Millisecond)
+	)
+
+	// Seed the target manager with a stale task that the snapshot will omit.
+	require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+		Namespace:             "ns1",
+		Id:                    "stale-task",
+		Payload:               []byte("stale"),
+		SubmittedAtUnixMillis: now.UnixMilli(),
+	}), 1))
+
+	// Produce a snapshot from an independent manager holding only the fresh
+	// task, in the same namespace, so a merge would leave both tasks behind.
+	source := newTestHarness(t).init(t)
+	require.NoError(t, source.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+		Namespace:             "ns1",
+		Id:                    "fresh-task",
+		Payload:               []byte("fresh"),
+		SubmittedAtUnixMillis: now.UnixMilli(),
+	}), 2))
+	snap, err := source.manager.Snapshot()
+	require.NoError(t, err)
+
+	require.NoError(t, h.manager.Restore(snap))
+
+	tasks, err := h.manager.ListDistributedTasks(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, tasks["ns1"], 1, "restore must replace state, not merge the stale task in")
+	require.Equal(t, "fresh-task", tasks["ns1"][0].ID)
+}
+
 func ingestSampleTasks(t *testing.T, m *Manager, now time.Time) map[string][]*Task {
 	require.NoError(t, m.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
 		Namespace:             "ns1",


### PR DESCRIPTION
`SuperClaude here.`

## Mechanism (verified against `main`)

`Manager.Restore` in `cluster/distributedtask/manager.go` violated the
hashicorp/raft FSM snapshot contract: it **merged** the snapshot into the
existing `m.tasks` map instead of **replacing** it. The docstring even claimed
it "replaces the Manager's in-memory state", but the loop only wrote snapshot
entries into the live map and never cleared pre-existing ones:

```go
for namespace, tasks := range s.Tasks {
    for _, task := range tasks {
        if _, ok := m.tasks[namespace]; !ok {
            m.tasks[namespace] = make(map[string]*Task)
        }
        m.tasks[namespace][task.ID] = task   // union, never a reset
    }
}
```

Consequence: a follower that applied `AddTask(T1)`, fell behind, then installed
a leader snapshot that omitted `T1` (cleaned up cluster-wide) keeps `T1` as a
phantom task. Its scheduler keeps ticking on `T1`, firing `OnTaskCompleted` /
finalize callbacks for a task no other node has — silent per-node FSM
divergence. Confirmed present at the tip of `main`.

## Fix

Reset `m.tasks` before repopulating from the snapshot. Only `m.tasks` is FSM
state (the configure-time registries — conflict detectors, providers — are
untouched, matching the issue's guidance).

## Evidence (red-without / green-with)

Regression test `TestManager_Restore_ReplacesState`: seed a manager with a
stale task in `ns1`, restore a snapshot holding only a fresh task in `ns1`,
assert the stale task is gone.

- **Red (fix reverted to `main`):**
  ```
  --- FAIL: TestManager_Restore_ReplacesState
      "[...]" should have 1 item(s), but has 2
      restore must replace state, not merge the stale task in
  ```
- **Green (with fix):** `ok  github.com/weaviate/weaviate/cluster/distributedtask`

Full verification:
- `go build ./cluster/...` — clean
- `go test -race ./cluster/distributedtask/...` — `ok` (6.4s)
- `gofmt -l` — clean

Closes weaviate/0-weaviate-issues#241

— SuperClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jTefAtRKkuFX3VdNAyWn9
