### PR TITLE
fix(reindex): multi-node clock skew reopens the double-write gap — make the backfill scan skew-immune (#11692)

### DIFF
--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -475,11 +475,36 @@ func TestValidateRebuildFilterableDataType(t *testing.T) {
 
 	t.Run("rebuild rejected for reference type", func(t *testing.T) {
 		// Reference (non-primitive) data types have no inverted bucket.
+		// This rejection is ALSO load-bearing for migration correctness:
+		// batch-reference writes update the ref-beacon and __meta_count
+		// buckets directly, bypassing the reindex double-write callbacks —
+		// a migration targeting those buckets would silently miss
+		// post-cursor batch-ref mutations. As long as ref properties can
+		// never be migration targets, that mirror-coverage hole is
+		// unreachable (weaviate/weaviate#11692 review; weaviate/weaviate#12210
+		// adds the full-prop-set mirror on main).
 		prop := &models.Property{Name: "p", DataType: []string{"SomeClass"}}
 		err := validateRebuildFilterableDataType(prop)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "does not support a filterable inverted index")
 		require.Contains(t, err.Error(), "nothing to rebuild")
+	})
+
+	t.Run("rebuild rejected for object (nested) type", func(t *testing.T) {
+		// object/object[] are Nested data types, not primitives, so
+		// AsPrimitive rejects them. Load-bearing beyond UX: nested-property
+		// buckets (helpers.BucketNestedFromPropNameLSM namespace, written by
+		// shard_write_inverted_lsm_nested.go) never fire the reindex
+		// double-write callbacks, so a migration that could target them
+		// would lose every concurrent nested write. This gate keeps that
+		// path unreachable; if nested migrations ever ship, the tee must
+		// learn to mirror nested writes first.
+		for _, dt := range []string{"object", "object[]"} {
+			prop := &models.Property{Name: "p", DataType: []string{dt}}
+			err := validateRebuildFilterableDataType(prop)
+			require.Errorf(t, err, "data type %q must be rejected", dt)
+			require.Contains(t, err.Error(), "does not support a filterable inverted index")
+		}
 	})
 }
 
@@ -615,6 +640,14 @@ func TestValidateEnableFilterableProperty(t *testing.T) {
 
 		// References are non-primitive.
 		{"reference rejected", &models.Property{Name: "p", DataType: []string{"OtherClass"}}, "does not support"},
+
+		// object/object[] are Nested, not primitive. Nested-property buckets
+		// are outside the reindex double-write tee
+		// (shard_write_inverted_lsm_nested.go fires no callbacks), so this
+		// gate keeps them unreachable as migration targets — see the sibling
+		// note on TestValidateRebuildFilterableDataType.
+		{"object rejected", &models.Property{Name: "p", DataType: []string{"object"}}, "does not support"},
+		{"object[] rejected", &models.Property{Name: "p", DataType: []string{"object[]"}}, "does not support"},
 
 		// Already-filterable rejected.
 		{"already filterable", &models.Property{Name: "p", DataType: []string{"text"}, IndexFilterable: boolPtr(true)}, "already has a filterable index"},

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -475,14 +475,9 @@ func TestValidateRebuildFilterableDataType(t *testing.T) {
 
 	t.Run("rebuild rejected for reference type", func(t *testing.T) {
 		// Reference (non-primitive) data types have no inverted bucket.
-		// This rejection is ALSO load-bearing for migration correctness:
-		// batch-reference writes update the ref-beacon and __meta_count
-		// buckets directly, bypassing the reindex double-write callbacks —
-		// a migration targeting those buckets would silently miss
-		// post-cursor batch-ref mutations. As long as ref properties can
-		// never be migration targets, that mirror-coverage hole is
-		// unreachable (weaviate/weaviate#11692 review; weaviate/weaviate#12210
-		// adds the full-prop-set mirror on main).
+		// Also load-bearing: batch-ref writes bypass the reindex
+		// double-write tee, so ref properties must stay unreachable as
+		// migration targets (weaviate/weaviate#11692).
 		prop := &models.Property{Name: "p", DataType: []string{"SomeClass"}}
 		err := validateRebuildFilterableDataType(prop)
 		require.Error(t, err)
@@ -491,14 +486,10 @@ func TestValidateRebuildFilterableDataType(t *testing.T) {
 	})
 
 	t.Run("rebuild rejected for object (nested) type", func(t *testing.T) {
-		// object/object[] are Nested data types, not primitives, so
-		// AsPrimitive rejects them. Load-bearing beyond UX: nested-property
-		// buckets (helpers.BucketNestedFromPropNameLSM namespace, written by
-		// shard_write_inverted_lsm_nested.go) never fire the reindex
-		// double-write callbacks, so a migration that could target them
-		// would lose every concurrent nested write. This gate keeps that
-		// path unreachable; if nested migrations ever ship, the tee must
-		// learn to mirror nested writes first.
+		// object/object[] are Nested, not primitive. Also load-bearing:
+		// nested-property buckets never fire the reindex double-write tee,
+		// so this gate must keep them unreachable as migration targets
+		// (weaviate/weaviate#11692).
 		for _, dt := range []string{"object", "object[]"} {
 			prop := &models.Property{Name: "p", DataType: []string{dt}}
 			err := validateRebuildFilterableDataType(prop)
@@ -641,11 +632,8 @@ func TestValidateEnableFilterableProperty(t *testing.T) {
 		// References are non-primitive.
 		{"reference rejected", &models.Property{Name: "p", DataType: []string{"OtherClass"}}, "does not support"},
 
-		// object/object[] are Nested, not primitive. Nested-property buckets
-		// are outside the reindex double-write tee
-		// (shard_write_inverted_lsm_nested.go fires no callbacks), so this
-		// gate keeps them unreachable as migration targets — see the sibling
-		// note on TestValidateRebuildFilterableDataType.
+		// Nested types must stay unreachable as migration targets — see the
+		// sibling note on TestValidateRebuildFilterableDataType.
 		{"object rejected", &models.Property{Name: "p", DataType: []string{"object"}}, "does not support"},
 		{"object[] rejected", &models.Property{Name: "p", DataType: []string{"object[]"}}, "does not support"},
 

--- a/adapters/repos/db/inverted_reindex_colocated_write_skew_test.go
+++ b/adapters/repos/db/inverted_reindex_colocated_write_skew_test.go
@@ -1,0 +1,256 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+// colocatedSkewClass builds a class with three co-located properties: a
+// searchable text prop (the reindex target), a filterable-only text prop, and
+// a self-reference. MapToBlockmax targets only the searchable prop; the other
+// two stand in for "co-located data a concurrent write touches while the
+// searchable prop is being reindexed".
+func colocatedSkewClass(className string) *models.Class {
+	return &models.Class{
+		Class:             className,
+		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			CleanupIntervalSeconds: 60,
+			Stopwords:              &models.StopwordConfig{Preset: "none"},
+			IndexNullState:         true,
+			IndexPropertyLength:    true,
+			UsingBlockMaxWAND:      false, // force MapCollection so MapToBlockmax has a source
+		},
+		Properties: []*models.Property{
+			{
+				Name:         "title",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWord,
+			},
+			{
+				Name:            "extra",
+				DataType:        schema.DataTypeText.PropString(),
+				Tokenization:    models.PropertyTokenizationField,
+				IndexFilterable: boolPtr(true),
+				IndexSearchable: boolPtr(false),
+			},
+			{
+				Name:     "toRef",
+				DataType: []string{className},
+			},
+		},
+	}
+}
+
+func makeColocatedSkewObject(className, id, title, extra string, ts int64) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:                 strfmt.UUID(id),
+			Class:              className,
+			CreationTimeUnix:   ts,
+			LastUpdateTimeUnix: ts,
+			Properties: map[string]interface{}{
+				"title": title,
+				"extra": extra,
+			},
+		},
+	}
+}
+
+func colocatedBatchRefTo(className, sourceID, targetID string, updateTime int64) objects.BatchReference {
+	return objects.BatchReference{
+		From: &crossref.RefSource{
+			Local:    true,
+			PeerName: "localhost",
+			Class:    schema.ClassName(className),
+			Property: schema.PropertyName("toRef"),
+			TargetID: strfmt.UUID(sourceID),
+		},
+		To: &crossref.Ref{
+			Local:    true,
+			PeerName: "localhost",
+			Class:    className,
+			TargetID: strfmt.UUID(targetID),
+		},
+		UpdateTime: updateTime,
+	}
+}
+
+// TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp covers the
+// co-located-property leg of the batch-references / delta-merge
+// mirror-coverage hole (weaviate/0-weaviate-issues#318, flagged on the
+// weaviate/weaviate#11996 review): the batch-reference and merge write paths
+// bump an object's LastUpdateTimeUnix WITHOUT firing the double-write
+// callbacks for its unchanged co-located properties. Under the pre-fix
+// timestamp-cutoff scan (weaviate/weaviate#11692) the bump pushed the object
+// past the watermark, so it was neither scanned nor mirrored — its searchable
+// title silently vanished from the migrated index.
+//
+// The skew-immune scan closes this leg by construction: the backfill analyzes
+// every object it sees regardless of the bumped timestamp, so the unchanged
+// co-located value is always captured from the on-disk row. (Mutations of the
+// REF property's own buckets by post-cursor batch-ref writes remain outside
+// the double-write tee, but no migration can target ref-property buckets:
+// repair-filterable rejects non-primitive data types —
+// TestValidateRebuildFilterableDataType. weaviate/weaviate#12210 adds the
+// full-prop-set mirror on main.)
+//
+// Each case seeds a "victim" whose searchable title is unique, starts a
+// MapToBlockmax reindex of title, performs a concurrent timestamp-bumping
+// write against the victim, drives the reindex to swap, and asserts the
+// victim's title posting survived.
+func TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp(t *testing.T) {
+	const (
+		pastTS         = int64(1_000)
+		victimToken    = "victimtoken"
+		controlToken   = "controltoken"
+		numControlObjs = 3
+	)
+
+	cases := []struct {
+		name string
+		// preloadRef adds a reference before the reindex starts so the
+		// concurrent batch write bumps ref-count 1->2, exercising the
+		// batch-ref delete leg alongside the add leg.
+		preloadRef bool
+		mutate     func(t *testing.T, ctx context.Context, shard *Shard, className, victimID string, updateTime int64)
+	}{
+		{
+			name: "batch_ref_add_first_ref",
+			mutate: func(t *testing.T, ctx context.Context, shard *Shard, className, victimID string, updateTime int64) {
+				errs := shard.AddReferencesBatch(ctx, objects.BatchReferences{
+					colocatedBatchRefTo(className, victimID, uuid.NewString(), updateTime),
+				})
+				for _, err := range errs {
+					require.NoError(t, err)
+				}
+			},
+		},
+		{
+			name:       "batch_ref_add_second_ref_delete_leg",
+			preloadRef: true,
+			mutate: func(t *testing.T, ctx context.Context, shard *Shard, className, victimID string, updateTime int64) {
+				errs := shard.AddReferencesBatch(ctx, objects.BatchReferences{
+					colocatedBatchRefTo(className, victimID, uuid.NewString(), updateTime),
+				})
+				for _, err := range errs {
+					require.NoError(t, err)
+				}
+			},
+		},
+		{
+			name: "single_reference_merge",
+			mutate: func(t *testing.T, ctx context.Context, shard *Shard, className, victimID string, updateTime int64) {
+				require.NoError(t, shard.MergeObject(ctx, objects.MergeDocument{
+					Class:      className,
+					ID:         strfmt.UUID(victimID),
+					UpdateTime: updateTime,
+					References: objects.BatchReferences{
+						colocatedBatchRefTo(className, victimID, uuid.NewString(), updateTime),
+					},
+				}))
+			},
+		},
+		{
+			name: "single_patch_unrelated_prop",
+			mutate: func(t *testing.T, ctx context.Context, shard *Shard, className, victimID string, updateTime int64) {
+				require.NoError(t, shard.MergeObject(ctx, objects.MergeDocument{
+					Class:           className,
+					ID:              strfmt.UUID(victimID),
+					UpdateTime:      updateTime,
+					PrimitiveSchema: map[string]interface{}{"extra": "changed"},
+				}))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			className := "ColocSkew_" + uuid.NewString()[:8]
+			class := colocatedSkewClass(className)
+
+			shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+				false, false, false)
+			shard := shd.(*Shard)
+			defer shard.Shutdown(ctx)
+
+			for i := 0; i < numControlObjs; i++ {
+				require.NoError(t, shard.PutObject(ctx,
+					makeColocatedSkewObject(className, uuid.NewString(), controlToken, "c", pastTS)))
+			}
+
+			victimID := uuid.NewString()
+			require.NoError(t, shard.PutObject(ctx,
+				makeColocatedSkewObject(className, victimID, victimToken, "orig", pastTS)))
+
+			if tc.preloadRef {
+				errs := shard.AddReferencesBatch(ctx, objects.BatchReferences{
+					colocatedBatchRefTo(className, victimID, uuid.NewString(), pastTS),
+				})
+				for _, err := range errs {
+					require.NoError(t, err)
+				}
+			}
+
+			// Start the reindex: registers the double-write callbacks and
+			// stamps reindexStarted = now (>> pastTS).
+			strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
+			task := newTestTask(idx.logger, strategy)
+			require.NoError(t, task.OnAfterLsmInit(ctx, shard))
+
+			// The concurrent write bumps the victim's LastUpdateTimeUnix an
+			// hour past the watermark without firing the callbacks for the
+			// unchanged title. Pre-fix, the backfill skipped the victim and
+			// the title was lost.
+			futureTS := time.Now().UnixMilli() + int64(time.Hour/time.Millisecond)
+			tc.mutate(t, ctx, shard, className, victimID, futureTS)
+
+			for {
+				rerunAt, _, err := task.OnAfterLsmInitAsync(ctx, shard)
+				require.NoError(t, err)
+				if rerunAt.IsZero() {
+					break
+				}
+			}
+			require.True(t, strategy.migrationCompleted)
+
+			bucket := shard.store.Bucket(helpers.BucketSearchableFromPropNameLSM("title"))
+			require.NotNil(t, bucket)
+			require.Equal(t, lsmkv.StrategyInverted, bucket.Strategy())
+
+			fp := fingerprintInvertedBucket(t, bucket)
+			require.Lenf(t, fp[controlToken], numControlObjs,
+				"control objects (never concurrently written) must survive the reindex — harness sanity")
+			require.NotEmptyf(t, fp[victimToken],
+				"co-located searchable 'title' for the concurrently-written object was dropped "+
+					"from the new index generation (case %q)", tc.name)
+		})
+	}
+}

--- a/adapters/repos/db/inverted_reindex_colocated_write_skew_test.go
+++ b/adapters/repos/db/inverted_reindex_colocated_write_skew_test.go
@@ -30,11 +30,9 @@ import (
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
-// colocatedSkewClass builds a class with three co-located properties: a
-// searchable text prop (the reindex target), a filterable-only text prop, and
-// a self-reference. MapToBlockmax targets only the searchable prop; the other
-// two stand in for "co-located data a concurrent write touches while the
-// searchable prop is being reindexed".
+// colocatedSkewClass has a searchable reindex-target prop plus a
+// filterable prop and a self-reference, standing in for co-located data a
+// concurrent write touches during reindexing.
 func colocatedSkewClass(className string) *models.Class {
 	return &models.Class{
 		Class:             className,
@@ -102,29 +100,10 @@ func colocatedBatchRefTo(className, sourceID, targetID string, updateTime int64)
 	}
 }
 
-// TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp covers the
-// co-located-property leg of the batch-references / delta-merge
-// mirror-coverage hole (weaviate/0-weaviate-issues#318, flagged on the
-// weaviate/weaviate#11996 review): the batch-reference and merge write paths
-// bump an object's LastUpdateTimeUnix WITHOUT firing the double-write
-// callbacks for its unchanged co-located properties. Under the pre-fix
-// timestamp-cutoff scan (weaviate/weaviate#11692) the bump pushed the object
-// past the watermark, so it was neither scanned nor mirrored — its searchable
-// title silently vanished from the migrated index.
-//
-// The skew-immune scan closes this leg by construction: the backfill analyzes
-// every object it sees regardless of the bumped timestamp, so the unchanged
-// co-located value is always captured from the on-disk row. (Mutations of the
-// REF property's own buckets by post-cursor batch-ref writes remain outside
-// the double-write tee, but no migration can target ref-property buckets:
-// repair-filterable rejects non-primitive data types —
-// TestValidateRebuildFilterableDataType. weaviate/weaviate#12210 adds the
-// full-prop-set mirror on main.)
-//
-// Each case seeds a "victim" whose searchable title is unique, starts a
-// MapToBlockmax reindex of title, performs a concurrent timestamp-bumping
-// write against the victim, drives the reindex to swap, and asserts the
-// victim's title posting survived.
+// TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp pins that a
+// batch-ref/merge write bumping LastUpdateTimeUnix without touching a
+// co-located searchable prop must not drop that prop's posting from the
+// migrated index (weaviate/0-weaviate-issues#318, weaviate/weaviate#11692).
 func TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp(t *testing.T) {
 	const (
 		pastTS         = int64(1_000)
@@ -135,9 +114,7 @@ func TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp(t *testing.T)
 
 	cases := []struct {
 		name string
-		// preloadRef adds a reference before the reindex starts so the
-		// concurrent batch write bumps ref-count 1->2, exercising the
-		// batch-ref delete leg alongside the add leg.
+		// preloadRef exercises the batch-ref delete leg by bumping ref-count 1->2.
 		preloadRef bool
 		mutate     func(t *testing.T, ctx context.Context, shard *Shard, className, victimID string, updateTime int64)
 	}{
@@ -219,16 +196,12 @@ func TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp(t *testing.T)
 				}
 			}
 
-			// Start the reindex: registers the double-write callbacks and
-			// stamps reindexStarted = now (>> pastTS).
 			strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
 			task := newTestTask(idx.logger, strategy)
 			require.NoError(t, task.OnAfterLsmInit(ctx, shard))
 
-			// The concurrent write bumps the victim's LastUpdateTimeUnix an
-			// hour past the watermark without firing the callbacks for the
-			// unchanged title. Pre-fix, the backfill skipped the victim and
-			// the title was lost.
+			// Bumps LastUpdateTimeUnix an hour past the watermark without
+			// mirroring the unchanged title.
 			futureTS := time.Now().UnixMilli() + int64(time.Hour/time.Millisecond)
 			tc.mutate(t, ctx, shard, className, victimID, futureTS)
 

--- a/adapters/repos/db/inverted_reindex_delete_convergence_test.go
+++ b/adapters/repos/db/inverted_reindex_delete_convergence_test.go
@@ -1,0 +1,293 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// This file pins the convergence invariant that lets the backfill scan analyze
+// EVERY object unconditionally (the skew-immune fix for
+// weaviate/weaviate#11692): a posting the scan writes into the reindex bucket
+// is always shadowed by a newer ingest-bucket mirror write for the same key.
+// That holds because
+//
+//  1. runtimeSwap prepends reindex segments BEFORE ingest segments
+//     ([lsmkv.SegmentGroup.PrependSegmentsFromBucket]), so ingest writes are
+//     strictly newer in LSM merge order, and
+//  2. ingest buckets keep tombstones until the merge
+//     (loadIngestBuckets is called with keepTombstones=!isMerged), so a
+//     mirror-side delete survives as a tombstone that kills the prepended
+//     posting at read time and across compaction.
+//
+// The journey per strategy: the victim object is scanned into the reindex
+// bucket (RunReindexOnlyOnShard completes the iteration), THEN deleted or
+// updated while the double-write callbacks are still armed, then the swap
+// runs. If either invariant breaks, the victim's stale posting resurrects in
+// the migrated bucket: a filter/search on the old value false-positives. Each
+// migration-target bucket strategy (RoaringSetRange, RoaringSet,
+// MapCollection, Inverted) has its own tombstone semantics, so each gets a
+// case.
+//
+// The lsmkv-level companion (TestSegmentGroup_PrependedAddShadowedByNewerDelete)
+// pins the same ordering in isolation, including explicit compaction.
+
+// deleteConvergenceHarness abstracts one strategy's setup and probes.
+type deleteConvergenceHarness struct {
+	// propName is the migrated property; used to resolve the ingest bucket.
+	propName string
+	// prepare creates class+shard+corpus+victim and the migration task.
+	// oldMarker/newMarker presence is checked via probe after the swap.
+	prepare func(t *testing.T, ctx context.Context) (shard *Shard, task *ShardReindexTaskGeneric,
+		victimID strfmt.UUID, update func(t *testing.T), probe func(t *testing.T, marker string) bool)
+}
+
+func runDeleteConvergence(t *testing.T, h deleteConvergenceHarness, op string) {
+	ctx := testCtx()
+	shard, task, victimID, update, probe := h.prepare(t, ctx)
+
+	// Scan completes with the victim's OLD value in the reindex bucket;
+	// double-write callbacks remain armed until RunSwapOnShard.
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+
+	switch op {
+	case "delete":
+		require.NoError(t, shard.DeleteObject(ctx, victimID, time.Now()),
+			"mid-migration delete must succeed")
+	case "update":
+		update(t)
+	}
+
+	// Force the mirror write out of the ingest memtable into a segment so
+	// the tombstone must survive a flush — this makes the ingest bucket's
+	// keepTombstones=!isMerged option (loadIngestBuckets) load-bearing in
+	// this test rather than incidentally covered by memtable reads.
+	ingest := shard.store.Bucket(task.ingestBucketName(h.propName))
+	require.NotNil(t, ingest, "ingest bucket must exist while callbacks are armed")
+	require.NoError(t, ingest.FlushAndSwitch())
+
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+
+	require.Truef(t, probe(t, "corpus"),
+		"positive control: the scanned corpus must be present in the migrated bucket")
+
+	assert.Falsef(t, probe(t, "old"),
+		"resurrection: the victim was scanned into the reindex bucket and then %sd "+
+			"while callbacks were armed, but its OLD posting is still readable in the "+
+			"migrated bucket — the ingest tombstone did not shadow the prepended "+
+			"reindex segment (keepTombstones lifetime or prepend order broke)", op)
+	if op == "update" {
+		assert.Truef(t, probe(t, "new"),
+			"the victim's NEW value must be present in the migrated bucket via the "+
+				"double-write mirror")
+	}
+}
+
+// TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting runs the
+// delete and update journeys against every migration-target bucket strategy.
+func TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting(t *testing.T) {
+	const numCorpus = 25
+
+	harnesses := map[string]deleteConvergenceHarness{
+		"rangeable (RoaringSetRange target)": {
+			propName: filterableToRangeablePropName,
+			prepare: func(t *testing.T, ctx context.Context) (*Shard, *ShardReindexTaskGeneric,
+				strfmt.UUID, func(t *testing.T), func(t *testing.T, marker string) bool,
+			) {
+				const oldValue, newValue = int64(4242), int64(4343)
+				propName := filterableToRangeablePropName
+				className := "DelConvRange_" + uuid.NewString()[:8]
+				class := newFilterableToRangeableTestClass(className)
+
+				shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+					false, false, false)
+				shard := shd.(*Shard)
+				t.Cleanup(func() { shard.Shutdown(context.Background()) })
+
+				for _, obj := range makeFilterableToRangeableTestObjects(t, numCorpus, className) {
+					require.NoError(t, shard.PutObject(ctx, obj))
+				}
+				victimID := strfmt.UUID(uuid.NewString())
+				putValue := func(v int64) {
+					require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+						MarshallerVersion: 1,
+						Object: models.Object{
+							ID:         victimID,
+							Class:      className,
+							Properties: map[string]interface{}{propName: v},
+						},
+					}))
+				}
+				putValue(oldValue)
+
+				task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+				probe := func(t *testing.T, marker string) bool {
+					b := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+					require.NotNil(t, b, "post-swap rangeable bucket must exist")
+					switch marker {
+					case "corpus":
+						return len(readRangeableDocIDs(t, b, 0)) > 0
+					case "old":
+						return len(readRangeableDocIDs(t, b, oldValue)) > 0
+					default:
+						return len(readRangeableDocIDs(t, b, newValue)) > 0
+					}
+				}
+				return shard, task, victimID, func(t *testing.T) { putValue(newValue) }, probe
+			},
+		},
+
+		"roaringset refresh (RoaringSet target)": {
+			propName: "title",
+			prepare: func(t *testing.T, ctx context.Context) (*Shard, *ShardReindexTaskGeneric,
+				strfmt.UUID, func(t *testing.T), func(t *testing.T, marker string) bool,
+			) {
+				return prepareTitleTokenHarness(t, ctx, "DelConvRoaring_",
+					func(t *testing.T, _ *Shard, idx *Index, className string) *ShardReindexTaskGeneric {
+						task, _ := newRoaringSetRefreshTask(t, idx)
+						return task
+					},
+					helpers.BucketFromPropNameLSM("title"), roaringSetHasTerm)
+			},
+		},
+
+		"searchable retokenize (MapCollection target)": {
+			propName: "title",
+			prepare: func(t *testing.T, ctx context.Context) (*Shard, *ShardReindexTaskGeneric,
+				strfmt.UUID, func(t *testing.T), func(t *testing.T, marker string) bool,
+			) {
+				return prepareTitleTokenHarness(t, ctx, "DelConvMap_",
+					func(t *testing.T, shard *Shard, idx *Index, className string) *ShardReindexTaskGeneric {
+						// WORD→WORD keeps tokens comparable across scan and
+						// mirror; the case under test is tombstone shadowing,
+						// not retokenization.
+						preStrategy := shard.store.Bucket(helpers.BucketSearchableFromPropNameLSM("title")).Strategy()
+						task, _ := newSearchableRetokenizeTask(t, idx, className, "title",
+							models.PropertyTokenizationWord, preStrategy)
+						return task
+					},
+					helpers.BucketSearchableFromPropNameLSM("title"), mapBucketHasTerm)
+			},
+		},
+
+		"map to blockmax (Inverted target)": {
+			propName: "title",
+			prepare: func(t *testing.T, ctx context.Context) (*Shard, *ShardReindexTaskGeneric,
+				strfmt.UUID, func(t *testing.T), func(t *testing.T, marker string) bool,
+			) {
+				return prepareTitleTokenHarness(t, ctx, "DelConvBlockmax_",
+					func(t *testing.T, _ *Shard, idx *Index, className string) *ShardReindexTaskGeneric {
+						strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
+						return newTestTask(idx.logger, strategy)
+					},
+					helpers.BucketSearchableFromPropNameLSM("title"), mapBucketHasTerm)
+			},
+		},
+	}
+
+	for name, h := range harnesses {
+		for _, op := range []string{"delete", "update"} {
+			t.Run(name+"/"+op, func(t *testing.T) {
+				runDeleteConvergence(t, h, op)
+			})
+		}
+	}
+}
+
+// mapBucketHasTerm probes term presence via MapList — the tombstone-applying
+// read path shared by MapCollection and Inverted buckets. Deliberately NOT the
+// raw MapCursor (fingerprintInvertedBucket): that cursor does not apply
+// inverted docID tombstones across segments, so it would report a
+// tombstone-shadowed posting from a prepended reindex segment as present even
+// though every query path (MapList, WAND, BlockMax) correctly hides it.
+func mapBucketHasTerm(t *testing.T, b *lsmkv.Bucket, term string) bool {
+	t.Helper()
+	pairs, err := b.MapList(context.Background(), []byte(term))
+	require.NoError(t, err)
+	return len(pairs) > 0
+}
+
+// roaringSetHasTerm probes term presence via the roaringset cursor
+// (fingerprintRoaringSetBucket), which merges additions and deletions across
+// segments — unlike the raw inverted MapCursor, it is deletion-accurate.
+// (RoaringSetGet would be the query path but requires the shard's bitmap
+// buffer pool, which the test shard does not wire up.)
+func roaringSetHasTerm(t *testing.T, b *lsmkv.Bucket, term string) bool {
+	t.Helper()
+	fp := fingerprintRoaringSetBucket(t, b)
+	return len(fp[term]) > 0
+}
+
+// prepareTitleTokenHarness is the shared setup for the token-bucket strategies
+// (roaringset refresh, searchable retokenize, map→blockmax): a "title" class,
+// a scanned corpus, and a victim whose unique old/new tokens are probed in the
+// post-swap bucket named bucketName via hasTerm.
+func prepareTitleTokenHarness(t *testing.T, ctx context.Context, classPrefix string,
+	makeTask func(t *testing.T, shard *Shard, idx *Index, className string) *ShardReindexTaskGeneric,
+	bucketName string, hasTerm func(t *testing.T, b *lsmkv.Bucket, term string) bool,
+) (*Shard, *ShardReindexTaskGeneric, strfmt.UUID, func(t *testing.T), func(t *testing.T, marker string) bool) {
+	const oldToken, newToken = "victimoldtoken", "victimnewtoken"
+
+	className := classPrefix + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"title"})
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	t.Cleanup(func() { shard.Shutdown(context.Background()) })
+
+	for _, obj := range makeConvergenceTestObjects(t, 25, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+	victimID := strfmt.UUID(uuid.NewString())
+	putText := func(text string) {
+		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:         victimID,
+				Class:      className,
+				Properties: map[string]interface{}{"title": text},
+			},
+		}))
+	}
+	putText(oldToken)
+
+	task := makeTask(t, shard, idx, className)
+	probe := func(t *testing.T, marker string) bool {
+		b := shard.store.Bucket(bucketName)
+		require.NotNil(t, b, "post-swap bucket %q must exist", bucketName)
+		switch marker {
+		case "corpus":
+			// "victor" is a makeConvergenceTestObjects dictionary token.
+			return hasTerm(t, b, "victor")
+		case "old":
+			return hasTerm(t, b, oldToken)
+		default:
+			return hasTerm(t, b, newToken)
+		}
+	}
+	return shard, task, victimID, func(t *testing.T) { putText(newToken) }, probe
+}

--- a/adapters/repos/db/inverted_reindex_delete_convergence_test.go
+++ b/adapters/repos/db/inverted_reindex_delete_convergence_test.go
@@ -28,38 +28,21 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// This file pins the convergence invariant that lets the backfill scan analyze
-// EVERY object unconditionally (the skew-immune fix for
-// weaviate/weaviate#11692): a posting the scan writes into the reindex bucket
-// is always shadowed by a newer ingest-bucket mirror write for the same key.
-// That holds because
-//
-//  1. runtimeSwap prepends reindex segments BEFORE ingest segments
-//     ([lsmkv.SegmentGroup.PrependSegmentsFromBucket]), so ingest writes are
-//     strictly newer in LSM merge order, and
-//  2. ingest buckets keep tombstones until the merge
-//     (loadIngestBuckets is called with keepTombstones=!isMerged), so a
-//     mirror-side delete survives as a tombstone that kills the prepended
-//     posting at read time and across compaction.
-//
-// The journey per strategy: the victim object is scanned into the reindex
-// bucket (RunReindexOnlyOnShard completes the iteration), THEN deleted or
-// updated while the double-write callbacks are still armed, then the swap
-// runs. If either invariant breaks, the victim's stale posting resurrects in
-// the migrated bucket: a filter/search on the old value false-positives. Each
-// migration-target bucket strategy (RoaringSetRange, RoaringSet,
-// MapCollection, Inverted) has its own tombstone semantics, so each gets a
-// case.
-//
-// The lsmkv-level companion (TestSegmentGroup_PrependedAddShadowedByNewerDelete)
-// pins the same ordering in isolation, including explicit compaction.
+// Pins the invariant that lets the backfill scan analyze every object
+// unconditionally (weaviate/weaviate#11692): a reindex-bucket posting is
+// always shadowed by the ingest bucket's newer mirror write/tombstone for
+// the same key, because runtimeSwap prepends reindex segments before ingest
+// segments and ingest buckets keep tombstones until merged
+// (loadIngestBuckets, keepTombstones=!isMerged). One case per
+// migration-target bucket strategy, since each has its own tombstone
+// semantics. Companion: TestSegmentGroup_PrependedAddShadowedByNewerDelete
+// (lsmkv), same invariant in isolation with explicit compaction.
 
 // deleteConvergenceHarness abstracts one strategy's setup and probes.
 type deleteConvergenceHarness struct {
 	// propName is the migrated property; used to resolve the ingest bucket.
 	propName string
 	// prepare creates class+shard+corpus+victim and the migration task.
-	// oldMarker/newMarker presence is checked via probe after the swap.
 	prepare func(t *testing.T, ctx context.Context) (shard *Shard, task *ShardReindexTaskGeneric,
 		victimID strfmt.UUID, update func(t *testing.T), probe func(t *testing.T, marker string) bool)
 }
@@ -80,10 +63,7 @@ func runDeleteConvergence(t *testing.T, h deleteConvergenceHarness, op string) {
 		update(t)
 	}
 
-	// Force the mirror write out of the ingest memtable into a segment so
-	// the tombstone must survive a flush — this makes the ingest bucket's
-	// keepTombstones=!isMerged option (loadIngestBuckets) load-bearing in
-	// this test rather than incidentally covered by memtable reads.
+	// Flush so the tombstone must survive on disk, not just in the memtable.
 	ingest := shard.store.Bucket(task.ingestBucketName(h.propName))
 	require.NotNil(t, ingest, "ingest bucket must exist while callbacks are armed")
 	require.NoError(t, ingest.FlushAndSwitch())
@@ -181,9 +161,7 @@ func TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting(t *testin
 			) {
 				return prepareTitleTokenHarness(t, ctx, "DelConvMap_",
 					func(t *testing.T, shard *Shard, idx *Index, className string) *ShardReindexTaskGeneric {
-						// WORD→WORD keeps tokens comparable across scan and
-						// mirror; the case under test is tombstone shadowing,
-						// not retokenization.
+						// WORD→WORD: the case under test is tombstone shadowing, not retokenization.
 						preStrategy := shard.store.Bucket(helpers.BucketSearchableFromPropNameLSM("title")).Strategy()
 						task, _ := newSearchableRetokenizeTask(t, idx, className, "title",
 							models.PropertyTokenizationWord, preStrategy)
@@ -217,12 +195,9 @@ func TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting(t *testin
 	}
 }
 
-// mapBucketHasTerm probes term presence via MapList — the tombstone-applying
-// read path shared by MapCollection and Inverted buckets. Deliberately NOT the
-// raw MapCursor (fingerprintInvertedBucket): that cursor does not apply
-// inverted docID tombstones across segments, so it would report a
-// tombstone-shadowed posting from a prepended reindex segment as present even
-// though every query path (MapList, WAND, BlockMax) correctly hides it.
+// mapBucketHasTerm uses MapList, not the raw MapCursor: the cursor doesn't
+// apply cross-segment tombstones, so it would report a shadowed posting as
+// present.
 func mapBucketHasTerm(t *testing.T, b *lsmkv.Bucket, term string) bool {
 	t.Helper()
 	pairs, err := b.MapList(context.Background(), []byte(term))
@@ -230,11 +205,9 @@ func mapBucketHasTerm(t *testing.T, b *lsmkv.Bucket, term string) bool {
 	return len(pairs) > 0
 }
 
-// roaringSetHasTerm probes term presence via the roaringset cursor
-// (fingerprintRoaringSetBucket), which merges additions and deletions across
-// segments — unlike the raw inverted MapCursor, it is deletion-accurate.
-// (RoaringSetGet would be the query path but requires the shard's bitmap
-// buffer pool, which the test shard does not wire up.)
+// roaringSetHasTerm uses the roaringset cursor, which merges deletions
+// across segments (RoaringSetGet would be the query path, but needs a
+// bitmap buffer pool the test shard doesn't wire up).
 func roaringSetHasTerm(t *testing.T, b *lsmkv.Bucket, term string) bool {
 	t.Helper()
 	fp := fingerprintRoaringSetBucket(t, b)

--- a/adapters/repos/db/inverted_reindex_iterator_no_clock_skip_test.go
+++ b/adapters/repos/db/inverted_reindex_iterator_no_clock_skip_test.go
@@ -1,0 +1,114 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestUuidObjectsIterator_AnalyzesEveryObjectRegardlessOfTimestamp is the
+// unit-level pin for the skew-immune backfill decision
+// (weaviate/weaviate#11692). [uuidObjectsIteratorAsync] must analyze every
+// object the on-disk cursor yields and must NOT consult LastUpdateTimeUnix:
+// that stamp comes from the write coordinator's clock, so any comparison
+// against a locally-captured watermark misclassifies under multi-node clock
+// skew. The pre-fix iterator skipped objects timestamped at/after the task's
+// reindexStarted watermark (yielding a migrationData with empty props), which
+// silently dropped unmirrored pre-registration writes from the migrated index.
+//
+// The table spans the timestamp classes that straddled the old cutoff: far
+// past, present, and far future (a coordinator a day ahead). If anyone
+// reintroduces a wall-clock skip, the future-timestamp row fails here in
+// milliseconds instead of in a multi-node acceptance run.
+func TestUuidObjectsIterator_AnalyzesEveryObjectRegardlessOfTimestamp(t *testing.T) {
+	ctx := testCtx()
+	const propName = "title"
+
+	className := "IterNoClockSkip_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{propName})
+
+	shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	timestamps := map[string]int64{
+		"far past":                    time.Now().Add(-24 * time.Hour).UnixMilli(),
+		"now":                         time.Now().UnixMilli(),
+		"future (coordinator skewed)": time.Now().Add(24 * time.Hour).UnixMilli(),
+		"far future (extreme skew)":   time.Now().Add(365 * 24 * time.Hour).UnixMilli(),
+	}
+	idToLabel := map[string]string{}
+	for label, ts := range timestamps {
+		id := uuid.NewString()
+		idToLabel[id] = label
+		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:                 strfmt.UUID(id),
+				Class:              className,
+				Properties:         map[string]interface{}{propName: "some searchable text"},
+				CreationTimeUnix:   ts,
+				LastUpdateTimeUnix: ts,
+			},
+		}))
+	}
+
+	// The production path flushes before creating the on-disk cursor; mirror
+	// that so the writes above are visible to CursorOnDisk.
+	require.NoError(t, shard.store.Bucket(helpers.ObjectsBucketLSM).FlushAndSwitch())
+
+	propExtraction := storobj.NewPropExtraction()
+	propExtraction.Add(propName)
+
+	// breakCh protocol (see asyncReindex): primed with one false, then fed
+	// one value per received migrationData.
+	breakCh := make(chan bool, 1)
+	breakCh <- false
+
+	logger, _ := logrustest.NewNullLogger()
+	_, mdCh := uuidObjectsIteratorAsync(logger, shard, nil, (&UuidKeyParser{}).FromBytes,
+		propExtraction, breakCh, nil)
+
+	analyzed := map[string]bool{}
+	for md := range mdCh {
+		if md == nil {
+			break
+		}
+		require.NoError(t, md.err)
+		if label, ok := idToLabel[md.key.String()]; ok {
+			analyzed[label] = len(md.props) > 0
+		}
+		breakCh <- false
+	}
+
+	require.Len(t, analyzed, len(timestamps), "every written object must be scanned")
+	for label, wasAnalyzed := range analyzed {
+		assert.Truef(t, wasAnalyzed,
+			"object with %s timestamp was scanned but NOT analyzed (empty props) — "+
+				"the backfill iterator is making a wall-clock skip decision again; "+
+				"under multi-node clock skew that silently loses unmirrored writes "+
+				"(weaviate/weaviate#11692)", label)
+	}
+}

--- a/adapters/repos/db/inverted_reindex_iterator_no_clock_skip_test.go
+++ b/adapters/repos/db/inverted_reindex_iterator_no_clock_skip_test.go
@@ -27,20 +27,10 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// TestUuidObjectsIterator_AnalyzesEveryObjectRegardlessOfTimestamp is the
-// unit-level pin for the skew-immune backfill decision
-// (weaviate/weaviate#11692). [uuidObjectsIteratorAsync] must analyze every
-// object the on-disk cursor yields and must NOT consult LastUpdateTimeUnix:
-// that stamp comes from the write coordinator's clock, so any comparison
-// against a locally-captured watermark misclassifies under multi-node clock
-// skew. The pre-fix iterator skipped objects timestamped at/after the task's
-// reindexStarted watermark (yielding a migrationData with empty props), which
-// silently dropped unmirrored pre-registration writes from the migrated index.
-//
-// The table spans the timestamp classes that straddled the old cutoff: far
-// past, present, and far future (a coordinator a day ahead). If anyone
-// reintroduces a wall-clock skip, the future-timestamp row fails here in
-// milliseconds instead of in a multi-node acceptance run.
+// TestUuidObjectsIterator_AnalyzesEveryObjectRegardlessOfTimestamp pins that
+// uuidObjectsIteratorAsync must not gate analysis on LastUpdateTimeUnix (a
+// coordinator-clock stamp) vs. the locally-captured watermark, which
+// misclassifies under multi-node clock skew (weaviate/weaviate#11692).
 func TestUuidObjectsIterator_AnalyzesEveryObjectRegardlessOfTimestamp(t *testing.T) {
 	ctx := testCtx()
 	const propName = "title"

--- a/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
+++ b/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
@@ -55,70 +55,13 @@ func readRangeableDocIDs(t *testing.T, b *lsmkv.Bucket, value int64) []uint64 {
 	return ids
 }
 
-// TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap is the regression pin
-// for weaviate/weaviate#11692 — the multi-node residual that the single-clock
-// fix (weaviate/weaviate#11688, capture reindexStarted after registration,
-// ms-ceiled) did NOT close. It went red against the pre-fix code (the backfill
-// skipped any object whose LastUpdateTimeUnix was at/after the replica-local
-// reindexStarted watermark) and is green since [uuidObjectsIteratorAsync]
-// analyzes every scanned object unconditionally.
-//
-// # The bug this pins
-//
-// The pre-fix backfill iterator classified every object it scanned by one
-// comparison:
-//
-//	obj.LastUpdateTimeUnix() < reindexStarted.UnixMilli()  → backfill (analyze)
-//	obj.LastUpdateTimeUnix() >= reindexStarted.UnixMilli() → skip (assume mirrored)
-//
-// The "skip" branch was only sound if every object with a timestamp at/after
-// reindexStarted was in fact captured by the double-write callbacks. That holds
-// under a SINGLE clock: reindexStarted is captured after callback registration,
-// so any write timestamped >= reindexStarted physically happened after the
-// callbacks were live and was mirrored.
-//
-// It does NOT hold across nodes. LastUpdateTimeUnix is stamped on the
-// coordinator that received the write (usecases/objects/*.go: `LastUpdateTimeUnix
-// = m.timeSource.Now()`), and the replica preserves that stamp verbatim
-// (no re-stamp on the shard write path). reindexStarted is stamped on the
-// replica's own clock (markStarted(time.Now())). With the coordinator's clock
-// ahead of the replica's, a write could:
-//
-//   - arrive at the replica BEFORE callback registration (so it is NOT
-//     mirrored), yet
-//   - carry a coordinator timestamp >= reindexStarted (so the backfill SKIPPED
-//     it, assuming it was mirrored).
-//
-// Skipped AND unmirrored ⇒ the row was permanently missing from the migrated
-// index after the migration reported FINISHED.
-//
-// # How this test models the skew, and what it does NOT show
-//
-// A replica preserves whatever LastUpdateTimeUnix the coordinator stamped, so a
-// coordinator whose clock is ahead is modeled exactly by putting an object with
-// a future LastUpdateTimeUnix on a single shard. The skip decision was a pure
-// local timestamp comparison, so this stand-in is faithful for the
-// classification leg. It deliberately does NOT demonstrate the reachability
-// leg — a replicated write racing callback registration under real replication
-// timing; that ordering claim rests on the code reading of the
-// markStarted-after-registration sequence (weaviate/weaviate#11688), not on
-// this test.
-//
-// Probes (all written BEFORE the migration starts, i.e. before callback
-// registration — so none is mirrored; the double-write path cannot save any of
-// them; the ONLY variable is the coordinator timestamp):
-//
-//   - control (controlValue): honest past timestamp → must be backfilled.
-//     Same journey as the skewed insert minus the skew — proves the harness
-//     covers pre-registration writes when the timestamp is honest.
-//   - skewed insert (skewValue): timestamp a full DAY ahead (so the pin stays
-//     red through #11688's ms-ceil fix — this is the residual, not the
-//     single-clock bug) → pre-fix skipped-and-unmirrored → lost.
-//   - skewed update (updateOldValue → updateNewValue): the delete-side
-//     companion. Pre-fix, the add leg lost updateNewValue the same way; the
-//     migrated bucket must ALSO not resurrect updateOldValue.
-//   - skewed delete (deletedValue): an object deleted pre-registration (with a
-//     future deletion time) must not leave its posting in the migrated bucket.
+// TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap pins the multi-node
+// residual left open by the single-clock fix in weaviate/weaviate#11688:
+// LastUpdateTimeUnix is coordinator-clock, reindexStarted is replica-clock,
+// so a coordinator-ahead write can land pre-registration (unmirrored) yet
+// carry a timestamp >= reindexStarted (skipped by the old cutoff-based
+// backfill) — permanently lost (weaviate/weaviate#11692). Covers the insert,
+// update, and delete legs.
 func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 	const (
 		numCorpus      = 25         // baseline population, all timestamp 0 → all backfilled
@@ -139,10 +82,7 @@ func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 	shard := shd.(*Shard)
 	defer shard.Shutdown(context.Background())
 
-	// Positive-control corpus: all timestamp 0, all strictly below any
-	// reindexStarted, so the backfill indexes every one. If the bucket ends up
-	// empty the skew assertion would be vacuous, so we assert one corpus value
-	// is present below.
+	// Positive-control corpus, so the skew assertion below isn't vacuous.
 	for _, obj := range makeFilterableToRangeableTestObjects(t, numCorpus, className) {
 		require.NoError(t, shard.PutObject(ctx, obj))
 	}
@@ -160,33 +100,26 @@ func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 		}))
 	}
 
-	// All probes land BEFORE the migration → before callback registration →
-	// none is mirrored. The only variable is the coordinator timestamp.
-	//
-	//   control: an hour in the PAST — the honest-timestamp baseline.
-	//   skewed:  a DAY in the FUTURE, modeling a coordinator clock far ahead
-	//            of this replica; pre-fix this landed at/above the local
-	//            watermark and was skipped by the backfill.
+	// All probes are written before the migration starts, so none is
+	// mirrored; only the coordinator timestamp varies (control: honest
+	// past; skewed: a day ahead, modeling a coordinator-ahead clock).
 	controlTs := time.Now().Add(-time.Hour).UnixMilli()
 	skewTs := time.Now().Add(24 * time.Hour).UnixMilli()
 	putWithTimestamp(uuid.NewString(), controlValue, controlTs)
 	putWithTimestamp(uuid.NewString(), skewValue, skewTs)
 
-	// Skewed UPDATE: created with an honest timestamp, then overwritten
-	// pre-registration by a coordinator-ahead write. The migrated bucket must
-	// carry the NEW value and must not resurrect the OLD one.
+	// Skewed update: honest timestamp, then overwritten pre-registration by
+	// a coordinator-ahead write.
 	updateID := uuid.NewString()
 	putWithTimestamp(updateID, updateOldValue, controlTs)
 	putWithTimestamp(updateID, updateNewValue, skewTs)
 
-	// Skewed DELETE: created with an honest timestamp, then deleted
-	// pre-registration with a coordinator-ahead deletion time. The migrated
-	// bucket must not contain its posting.
+	// Skewed delete: honest timestamp, then deleted pre-registration with a
+	// coordinator-ahead deletion time.
 	deleteID := uuid.NewString()
 	putWithTimestamp(deleteID, deletedValue, controlTs)
 	require.NoError(t, shard.DeleteObject(ctx, strfmt.UUID(deleteID), time.Now().Add(24*time.Hour)))
 
-	// Drive the production migration path to completion.
 	task, wrapped := newFilterableToRangeableTask(t, idx, className, propName)
 	require.NoError(t, task.OnAfterLsmInit(ctx, shard))
 	for {
@@ -201,22 +134,16 @@ func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 	rangeBucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
 	require.NotNil(t, rangeBucket, "post-migration rangeable bucket must exist")
 
-	// Positive control 1: a corpus value must be backfilled, else the migration
-	// populated nothing and the skew assertion below would prove nothing.
+	// Positive control: else the skew assertion below would be vacuous.
 	require.NotEmpty(t, readRangeableDocIDs(t, rangeBucket, 0),
 		"positive control: backfilled corpus value 0 must be present")
 
-	// Positive control 2: the un-skewed pre-registration write (past timestamp)
-	// is picked up by the backfill. This is the SAME situation as the skewed
-	// write minus the clock skew — it survives, proving the harness indexes
-	// pre-registration writes when the timestamp is honest.
+	// Control: same situation as the skewed write, minus the skew.
 	assert.Lenf(t, readRangeableDocIDs(t, rangeBucket, controlValue), 1,
 		"control: an unmirrored pre-registration write with an honest (past) "+
 			"timestamp must be backfilled under value %d", controlValue)
 
-	// THE GAP. Same unmirrored pre-registration write, only the timestamp is
-	// coordinator-ahead. Pre-fix the backfill skipped it as "already mirrored"
-	// while the mirror never saw it. The skew-immune scan must index it.
+	// The gap: same write, coordinator-ahead timestamp instead.
 	assert.Lenf(t, readRangeableDocIDs(t, rangeBucket, skewValue), 1,
 		"GAP (weaviate/weaviate#11692): an unmirrored pre-registration write whose "+
 			"coordinator timestamp (%d) is ahead of the replica's reindexStarted is "+
@@ -224,10 +151,8 @@ func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 			"permanently lost from the migrated index. value %d absent",
 		skewTs, skewValue)
 
-	// Delete-side companions (weaviate/weaviate#11692 has a resurrection
-	// failure mode, not just a loss one): the skewed update's CURRENT value
-	// must be indexed, its OVERWRITTEN value must not resurrect, and the
-	// deleted object must not appear at all.
+	// Resurrection legs: the bug also has a resurrect-stale-value mode, not
+	// just a loss mode.
 	assert.Lenf(t, readRangeableDocIDs(t, rangeBucket, updateNewValue), 1,
 		"GAP (weaviate/weaviate#11692, update add leg): the current value %d of an "+
 			"object overwritten pre-registration by a coordinator-ahead write is "+

--- a/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
+++ b/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
@@ -55,25 +55,23 @@ func readRangeableDocIDs(t *testing.T, b *lsmkv.Bucket, value int64) []uint64 {
 	return ids
 }
 
-// TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap is the reproduction pin
+// TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap is the regression pin
 // for weaviate/weaviate#11692 — the multi-node residual that the single-clock
 // fix (weaviate/weaviate#11688, capture reindexStarted after registration,
-// ms-ceiled) does NOT close.
+// ms-ceiled) did NOT close. It went red against the pre-fix code (the backfill
+// skipped any object whose LastUpdateTimeUnix was at/after the replica-local
+// reindexStarted watermark) and is green since [uuidObjectsIteratorAsync]
+// analyzes every scanned object unconditionally.
 //
-// RED PIN. This test asserts the CORRECT (skew-immune) behavior and therefore
-// FAILS against current main. It is committed red on purpose: it is the
-// reproduction case for the architectural gap, not a regression against a fix
-// that already exists. See the PR body (issue #11692) for the design options.
+// # The bug this pins
 //
-// # The invariant and why skew breaks it
-//
-// The backfill iterator ([uuidObjectsIteratorAsync]) classifies every object
-// it scans by one comparison:
+// The pre-fix backfill iterator classified every object it scanned by one
+// comparison:
 //
 //	obj.LastUpdateTimeUnix() < reindexStarted.UnixMilli()  → backfill (analyze)
 //	obj.LastUpdateTimeUnix() >= reindexStarted.UnixMilli() → skip (assume mirrored)
 //
-// The "skip" branch is only sound if every object with a timestamp at/after
+// The "skip" branch was only sound if every object with a timestamp at/after
 // reindexStarted was in fact captured by the double-write callbacks. That holds
 // under a SINGLE clock: reindexStarted is captured after callback registration,
 // so any write timestamped >= reindexStarted physically happened after the
@@ -84,41 +82,51 @@ func readRangeableDocIDs(t *testing.T, b *lsmkv.Bucket, value int64) []uint64 {
 // = m.timeSource.Now()`), and the replica preserves that stamp verbatim
 // (no re-stamp on the shard write path). reindexStarted is stamped on the
 // replica's own clock (markStarted(time.Now())). With the coordinator's clock
-// ahead of the replica's, a write can:
+// ahead of the replica's, a write could:
 //
 //   - arrive at the replica BEFORE callback registration (so it is NOT
 //     mirrored), yet
-//   - carry a coordinator timestamp >= reindexStarted (so the backfill SKIPS
+//   - carry a coordinator timestamp >= reindexStarted (so the backfill SKIPPED
 //     it, assuming it was mirrored).
 //
-// Skipped AND unmirrored ⇒ the row is permanently missing from the migrated
-// index after the migration reports FINISHED.
+// Skipped AND unmirrored ⇒ the row was permanently missing from the migrated
+// index after the migration reported FINISHED.
 //
-// # How this test models the skew
+// # How this test models the skew, and what it does NOT show
 //
 // A replica preserves whatever LastUpdateTimeUnix the coordinator stamped, so a
 // coordinator whose clock is ahead is modeled exactly by putting an object with
-// a future LastUpdateTimeUnix. Both the skewed object and a control object are
-// written BEFORE the migration starts, i.e. before callback registration — so
-// neither is mirrored; the double-write path cannot save either. The ONLY
-// difference between them is the timestamp:
+// a future LastUpdateTimeUnix on a single shard. The skip decision was a pure
+// local timestamp comparison, so this stand-in is faithful for the
+// classification leg. It deliberately does NOT demonstrate the reachability
+// leg — a replicated write racing callback registration under real replication
+// timing; that ordering claim rests on the code reading of the
+// markStarted-after-registration sequence (weaviate/weaviate#11688), not on
+// this test.
 //
-//   - control (value controlValue): a normal past timestamp → below cutoff →
-//     backfilled → survives.
-//   - skewed  (value skewValue):    a future coordinator timestamp → at/above
-//     cutoff → skipped → LOST.
+// Probes (all written BEFORE the migration starts, i.e. before callback
+// registration — so none is mirrored; the double-write path cannot save any of
+// them; the ONLY variable is the coordinator timestamp):
 //
-// control present + skewed absent isolates cross-node skew as the sole cause.
-// (On current main the object would also be lost via the pre-#11688 ordering
-// bug; the skew here is a full day so the gap survives #11688's fix too — the
-// residual this pin is about.)
+//   - control (controlValue): honest past timestamp → must be backfilled.
+//     Same journey as the skewed insert minus the skew — proves the harness
+//     covers pre-registration writes when the timestamp is honest.
+//   - skewed insert (skewValue): timestamp a full DAY ahead (so the pin stays
+//     red through #11688's ms-ceil fix — this is the residual, not the
+//     single-clock bug) → pre-fix skipped-and-unmirrored → lost.
+//   - skewed update (updateOldValue → updateNewValue): the delete-side
+//     companion. Pre-fix, the add leg lost updateNewValue the same way; the
+//     migrated bucket must ALSO not resurrect updateOldValue.
+//   - skewed delete (deletedValue): an object deleted pre-registration (with a
+//     future deletion time) must not leave its posting in the migrated bucket.
 func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
-	t.Skip("RFC weaviate/weaviate#11692: reproduces the multi-node clock-skew double-write gap (a coordinator-stamped write with timestamp >= the replica's reindexStarted is skipped by backfill AND unmirrored). Un-skip when the skew-immune cutoff fix lands.")
-
 	const (
-		numCorpus    = 25         // baseline population, all timestamp 0 → all backfilled
-		controlValue = int64(100) // distinct from corpus values 0..4 and from skewValue
-		skewValue    = int64(999) // distinct sentinel; its loss is unambiguous
+		numCorpus      = 25         // baseline population, all timestamp 0 → all backfilled
+		controlValue   = int64(100) // distinct from corpus values 0..4 and from the sentinels below
+		skewValue      = int64(999) // skewed-insert sentinel; its loss is unambiguous
+		updateOldValue = int64(555) // overwritten pre-registration; must NOT resurrect
+		updateNewValue = int64(556) // the update's current value; must survive
+		deletedValue   = int64(777) // deleted pre-registration; must NOT appear
 	)
 	propName := filterableToRangeablePropName
 
@@ -139,11 +147,11 @@ func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 		require.NoError(t, shard.PutObject(ctx, obj))
 	}
 
-	putWithTimestamp := func(value, tsMillis int64) {
+	putWithTimestamp := func(id string, value, tsMillis int64) {
 		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
 			MarshallerVersion: 1,
 			Object: models.Object{
-				ID:                 strfmt.UUID(uuid.NewString()),
+				ID:                 strfmt.UUID(id),
 				Class:              className,
 				Properties:         map[string]interface{}{propName: value},
 				CreationTimeUnix:   tsMillis,
@@ -152,16 +160,31 @@ func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 		}))
 	}
 
-	// Both written BEFORE the migration → before callback registration → neither
-	// is mirrored. The only variable is the timestamp.
+	// All probes land BEFORE the migration → before callback registration →
+	// none is mirrored. The only variable is the coordinator timestamp.
 	//
-	//   control: an hour in the PAST → below cutoff → must be backfilled.
-	//   skewed:  a DAY in the FUTURE, modeling a coordinator clock far ahead of
-	//            this replica → at/above cutoff → skipped by the backfill.
+	//   control: an hour in the PAST — the honest-timestamp baseline.
+	//   skewed:  a DAY in the FUTURE, modeling a coordinator clock far ahead
+	//            of this replica; pre-fix this landed at/above the local
+	//            watermark and was skipped by the backfill.
 	controlTs := time.Now().Add(-time.Hour).UnixMilli()
 	skewTs := time.Now().Add(24 * time.Hour).UnixMilli()
-	putWithTimestamp(controlValue, controlTs)
-	putWithTimestamp(skewValue, skewTs)
+	putWithTimestamp(uuid.NewString(), controlValue, controlTs)
+	putWithTimestamp(uuid.NewString(), skewValue, skewTs)
+
+	// Skewed UPDATE: created with an honest timestamp, then overwritten
+	// pre-registration by a coordinator-ahead write. The migrated bucket must
+	// carry the NEW value and must not resurrect the OLD one.
+	updateID := uuid.NewString()
+	putWithTimestamp(updateID, updateOldValue, controlTs)
+	putWithTimestamp(updateID, updateNewValue, skewTs)
+
+	// Skewed DELETE: created with an honest timestamp, then deleted
+	// pre-registration with a coordinator-ahead deletion time. The migrated
+	// bucket must not contain its posting.
+	deleteID := uuid.NewString()
+	putWithTimestamp(deleteID, deletedValue, controlTs)
+	require.NoError(t, shard.DeleteObject(ctx, strfmt.UUID(deleteID), time.Now().Add(24*time.Hour)))
 
 	// Drive the production migration path to completion.
 	task, wrapped := newFilterableToRangeableTask(t, idx, className, propName)
@@ -191,14 +214,30 @@ func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
 		"control: an unmirrored pre-registration write with an honest (past) "+
 			"timestamp must be backfilled under value %d", controlValue)
 
-	// THE GAP (RED). Same unmirrored pre-registration write, only the timestamp
-	// is coordinator-ahead. Under skew the backfill skips it as "already
-	// mirrored" while the mirror never saw it. A skew-immune mechanism must
-	// still index it.
+	// THE GAP. Same unmirrored pre-registration write, only the timestamp is
+	// coordinator-ahead. Pre-fix the backfill skipped it as "already mirrored"
+	// while the mirror never saw it. The skew-immune scan must index it.
 	assert.Lenf(t, readRangeableDocIDs(t, rangeBucket, skewValue), 1,
 		"GAP (weaviate/weaviate#11692): an unmirrored pre-registration write whose "+
 			"coordinator timestamp (%d) is ahead of the replica's reindexStarted is "+
 			"skipped by the backfill AND missed by the double-write callbacks — "+
 			"permanently lost from the migrated index. value %d absent",
 		skewTs, skewValue)
+
+	// Delete-side companions (weaviate/weaviate#11692 has a resurrection
+	// failure mode, not just a loss one): the skewed update's CURRENT value
+	// must be indexed, its OVERWRITTEN value must not resurrect, and the
+	// deleted object must not appear at all.
+	assert.Lenf(t, readRangeableDocIDs(t, rangeBucket, updateNewValue), 1,
+		"GAP (weaviate/weaviate#11692, update add leg): the current value %d of an "+
+			"object overwritten pre-registration by a coordinator-ahead write is "+
+			"missing from the migrated index", updateNewValue)
+	assert.Emptyf(t, readRangeableDocIDs(t, rangeBucket, updateOldValue),
+		"resurrection (weaviate/weaviate#11692, update delete leg): the OVERWRITTEN "+
+			"value %d of a pre-registration skewed update is still queryable in the "+
+			"migrated index — a filter on the stale value false-positives", updateOldValue)
+	assert.Emptyf(t, readRangeableDocIDs(t, rangeBucket, deletedValue),
+		"resurrection (weaviate/weaviate#11692, delete): an object deleted "+
+			"pre-registration (deletion time coordinator-ahead) still has its posting "+
+			"%d in the migrated index", deletedValue)
 }

--- a/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
+++ b/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
@@ -113,10 +113,12 @@ func readRangeableDocIDs(t *testing.T, b *lsmkv.Bucket, value int64) []uint64 {
 // bug; the skew here is a full day so the gap survives #11688's fix too — the
 // residual this pin is about.)
 func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
+	t.Skip("RFC weaviate/weaviate#11692: reproduces the multi-node clock-skew double-write gap (a coordinator-stamped write with timestamp >= the replica's reindexStarted is skipped by backfill AND unmirrored). Un-skip when the skew-immune cutoff fix lands.")
+
 	const (
-		numCorpus    = 25            // baseline population, all timestamp 0 → all backfilled
-		controlValue = int64(100)    // distinct from corpus values 0..4 and from skewValue
-		skewValue    = int64(999)    // distinct sentinel; its loss is unambiguous
+		numCorpus    = 25         // baseline population, all timestamp 0 → all backfilled
+		controlValue = int64(100) // distinct from corpus values 0..4 and from skewValue
+		skewValue    = int64(999) // distinct sentinel; its loss is unambiguous
 	)
 	propName := filterableToRangeablePropName
 

--- a/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
+++ b/adapters/repos/db/inverted_reindex_multinode_clock_skew_gap_test.go
@@ -1,0 +1,202 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/filters"
+	entinverted "github.com/weaviate/weaviate/entities/inverted"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// readRangeableDocIDs returns the docIDs indexed under a single int64 value in
+// a RoaringSetRange (rangeable) bucket. Same read path as
+// [filterableToRangeableFingerprint], narrowed to one value so a test can
+// assert presence/absence of one specific write.
+func readRangeableDocIDs(t *testing.T, b *lsmkv.Bucket, value int64) []uint64 {
+	t.Helper()
+	require.NotNil(t, b, "rangeable bucket must exist")
+	lex, err := entinverted.LexicographicallySortableInt64(value)
+	require.NoError(t, err)
+	key := binary.BigEndian.Uint64(lex)
+	reader := b.ReaderRoaringSetRange()
+	defer reader.Close()
+	bm, release, err := reader.Read(context.Background(), key, filters.OperatorEqual)
+	require.NoError(t, err)
+	var ids []uint64
+	if bm != nil {
+		ids = bm.ToArray()
+	}
+	if release != nil {
+		release()
+	}
+	return ids
+}
+
+// TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap is the reproduction pin
+// for weaviate/weaviate#11692 — the multi-node residual that the single-clock
+// fix (weaviate/weaviate#11688, capture reindexStarted after registration,
+// ms-ceiled) does NOT close.
+//
+// RED PIN. This test asserts the CORRECT (skew-immune) behavior and therefore
+// FAILS against current main. It is committed red on purpose: it is the
+// reproduction case for the architectural gap, not a regression against a fix
+// that already exists. See the PR body (issue #11692) for the design options.
+//
+// # The invariant and why skew breaks it
+//
+// The backfill iterator ([uuidObjectsIteratorAsync]) classifies every object
+// it scans by one comparison:
+//
+//	obj.LastUpdateTimeUnix() < reindexStarted.UnixMilli()  → backfill (analyze)
+//	obj.LastUpdateTimeUnix() >= reindexStarted.UnixMilli() → skip (assume mirrored)
+//
+// The "skip" branch is only sound if every object with a timestamp at/after
+// reindexStarted was in fact captured by the double-write callbacks. That holds
+// under a SINGLE clock: reindexStarted is captured after callback registration,
+// so any write timestamped >= reindexStarted physically happened after the
+// callbacks were live and was mirrored.
+//
+// It does NOT hold across nodes. LastUpdateTimeUnix is stamped on the
+// coordinator that received the write (usecases/objects/*.go: `LastUpdateTimeUnix
+// = m.timeSource.Now()`), and the replica preserves that stamp verbatim
+// (no re-stamp on the shard write path). reindexStarted is stamped on the
+// replica's own clock (markStarted(time.Now())). With the coordinator's clock
+// ahead of the replica's, a write can:
+//
+//   - arrive at the replica BEFORE callback registration (so it is NOT
+//     mirrored), yet
+//   - carry a coordinator timestamp >= reindexStarted (so the backfill SKIPS
+//     it, assuming it was mirrored).
+//
+// Skipped AND unmirrored ⇒ the row is permanently missing from the migrated
+// index after the migration reports FINISHED.
+//
+// # How this test models the skew
+//
+// A replica preserves whatever LastUpdateTimeUnix the coordinator stamped, so a
+// coordinator whose clock is ahead is modeled exactly by putting an object with
+// a future LastUpdateTimeUnix. Both the skewed object and a control object are
+// written BEFORE the migration starts, i.e. before callback registration — so
+// neither is mirrored; the double-write path cannot save either. The ONLY
+// difference between them is the timestamp:
+//
+//   - control (value controlValue): a normal past timestamp → below cutoff →
+//     backfilled → survives.
+//   - skewed  (value skewValue):    a future coordinator timestamp → at/above
+//     cutoff → skipped → LOST.
+//
+// control present + skewed absent isolates cross-node skew as the sole cause.
+// (On current main the object would also be lost via the pre-#11688 ordering
+// bug; the skew here is a full day so the gap survives #11688's fix too — the
+// residual this pin is about.)
+func TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap(t *testing.T) {
+	const (
+		numCorpus    = 25            // baseline population, all timestamp 0 → all backfilled
+		controlValue = int64(100)    // distinct from corpus values 0..4 and from skewValue
+		skewValue    = int64(999)    // distinct sentinel; its loss is unambiguous
+	)
+	propName := filterableToRangeablePropName
+
+	ctx := testCtx()
+	className := "MultiNodeClockSkewGap_" + uuid.NewString()[:8]
+	class := newFilterableToRangeableTestClass(className)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(context.Background())
+
+	// Positive-control corpus: all timestamp 0, all strictly below any
+	// reindexStarted, so the backfill indexes every one. If the bucket ends up
+	// empty the skew assertion would be vacuous, so we assert one corpus value
+	// is present below.
+	for _, obj := range makeFilterableToRangeableTestObjects(t, numCorpus, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+
+	putWithTimestamp := func(value, tsMillis int64) {
+		require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:                 strfmt.UUID(uuid.NewString()),
+				Class:              className,
+				Properties:         map[string]interface{}{propName: value},
+				CreationTimeUnix:   tsMillis,
+				LastUpdateTimeUnix: tsMillis,
+			},
+		}))
+	}
+
+	// Both written BEFORE the migration → before callback registration → neither
+	// is mirrored. The only variable is the timestamp.
+	//
+	//   control: an hour in the PAST → below cutoff → must be backfilled.
+	//   skewed:  a DAY in the FUTURE, modeling a coordinator clock far ahead of
+	//            this replica → at/above cutoff → skipped by the backfill.
+	controlTs := time.Now().Add(-time.Hour).UnixMilli()
+	skewTs := time.Now().Add(24 * time.Hour).UnixMilli()
+	putWithTimestamp(controlValue, controlTs)
+	putWithTimestamp(skewValue, skewTs)
+
+	// Drive the production migration path to completion.
+	task, wrapped := newFilterableToRangeableTask(t, idx, className, propName)
+	require.NoError(t, task.OnAfterLsmInit(ctx, shard))
+	for {
+		rerunAt, _, err := task.OnAfterLsmInitAsync(ctx, shard)
+		require.NoError(t, err)
+		if rerunAt.IsZero() {
+			break
+		}
+	}
+	require.True(t, wrapped.migrationCompleted, "migration must complete")
+
+	rangeBucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, rangeBucket, "post-migration rangeable bucket must exist")
+
+	// Positive control 1: a corpus value must be backfilled, else the migration
+	// populated nothing and the skew assertion below would prove nothing.
+	require.NotEmpty(t, readRangeableDocIDs(t, rangeBucket, 0),
+		"positive control: backfilled corpus value 0 must be present")
+
+	// Positive control 2: the un-skewed pre-registration write (past timestamp)
+	// is picked up by the backfill. This is the SAME situation as the skewed
+	// write minus the clock skew — it survives, proving the harness indexes
+	// pre-registration writes when the timestamp is honest.
+	assert.Lenf(t, readRangeableDocIDs(t, rangeBucket, controlValue), 1,
+		"control: an unmirrored pre-registration write with an honest (past) "+
+			"timestamp must be backfilled under value %d", controlValue)
+
+	// THE GAP (RED). Same unmirrored pre-registration write, only the timestamp
+	// is coordinator-ahead. Under skew the backfill skips it as "already
+	// mirrored" while the mirror never saw it. A skew-immune mechanism must
+	// still index it.
+	assert.Lenf(t, readRangeableDocIDs(t, rangeBucket, skewValue), 1,
+		"GAP (weaviate/weaviate#11692): an unmirrored pre-registration write whose "+
+			"coordinator timestamp (%d) is ahead of the replica's reindexStarted is "+
+			"skipped by the backfill AND missed by the double-write callbacks — "+
+			"permanently lost from the migrated index. value %d absent",
+		skewTs, skewValue)
+}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1363,6 +1363,13 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		return zerotime, false, nil
 	}
 
+	// The started sentinel gates the lifecycle (OnAfterLsmInit must have
+	// registered the double-write callbacks and marked the task started
+	// before any scan pass runs). Its TIMESTAMP is informational only: the
+	// scan analyzes every object unconditionally, because comparing a
+	// coordinator-stamped LastUpdateTimeUnix against a replica-captured
+	// watermark is unsound under multi-node clock skew
+	// (weaviate/weaviate#11692) — see [uuidObjectsIteratorAsync].
 	var reindexStarted time.Time
 	if !rt.IsStarted() {
 		err = fmt.Errorf("missing reindex started")
@@ -1462,7 +1469,7 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	schemaOverlay := t.strategy.AnalyzerOverlay(props)
 
 	processingStarted, mdCh := t.objectsIteratorAsync(logger, shard, lastStoredKey, t.keyParser.FromBytes,
-		propExtraction, reindexStarted, breakCh, schemaOverlay)
+		propExtraction, breakCh, schemaOverlay)
 
 	for md := range mdCh {
 		if md == nil {
@@ -2697,11 +2704,11 @@ type migrationData struct {
 	err   error
 }
 
-type objectsIteratorAsync func(logger logrus.FieldLogger, shard ShardLike, lastKey indexKey, keyParse func([]byte) indexKey, propExtraction *storobj.PropertyExtraction, reindexStarted time.Time, breakCh <-chan bool, schemaOverlay map[string]inverted.PropertyOverlay,
+type objectsIteratorAsync func(logger logrus.FieldLogger, shard ShardLike, lastKey indexKey, keyParse func([]byte) indexKey, propExtraction *storobj.PropertyExtraction, breakCh <-chan bool, schemaOverlay map[string]inverted.PropertyOverlay,
 ) (time.Time, <-chan *migrationData)
 
 func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKey indexKey, keyParse func([]byte) indexKey,
-	propExtraction *storobj.PropertyExtraction, reindexStarted time.Time, breakCh <-chan bool,
+	propExtraction *storobj.PropertyExtraction, breakCh <-chan bool,
 	schemaOverlay map[string]inverted.PropertyOverlay,
 ) (time.Time, <-chan *migrationData) {
 	startedCh := make(chan time.Time)
@@ -2743,27 +2750,42 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 				break
 			}
 
-			if obj.LastUpdateTimeUnix() < reindexStarted.UnixMilli() {
-				// The overlay is required by from-scratch strategies whose
-				// target inverted-index flag is still false on the live
-				// schema during backfill. It is nil for retokenize / refresh
-				// strategies. See MigrationStrategy.AnalyzerOverlay.
-				props, _, err := shard.AnalyzeObjectForMigrationWithOverlay(obj, schemaOverlay)
-				if err != nil {
-					mdCh <- &migrationData{err: fmt.Errorf("analyzing object '%s': %w", ik.String(), err)}
-					break
-				}
-
-				if <-breakCh {
-					break
-				}
-				mdCh <- &migrationData{key: ik.Clone(), props: props, docID: obj.DocID}
-			} else {
-				if <-breakCh {
-					break
-				}
-				mdCh <- &migrationData{key: ik.Clone()}
+			// Every scanned object is analyzed and indexed — deliberately
+			// including objects whose LastUpdateTimeUnix is at/after the
+			// task's reindexStarted watermark. An earlier version skipped
+			// those as "written after the double-write callbacks armed,
+			// hence already mirrored", but that inference compares a
+			// COORDINATOR-stamped write time against a REPLICA-captured
+			// watermark: two different clocks. Under multi-node clock skew
+			// a pre-registration (unmirrored) write can carry a timestamp
+			// past the local watermark, making it skipped AND unmirrored —
+			// silent, permanent loss (weaviate/weaviate#11692).
+			//
+			// Unconditional analysis makes the scan skew-immune by
+			// construction: every write is covered by the scan (if it
+			// predates the on-disk cursor) or by the mirror (if it
+			// postdates callback arming) or both. Overlap converges
+			// because runtimeSwap prepends reindex segments BEFORE ingest
+			// segments, so a mirror write/tombstone always shadows the
+			// scan's posting for the same key, and each strategy's writes
+			// are per-key idempotent. Pinned by
+			// TestSegmentGroup_PrependedAddShadowedByNewerDelete (lsmkv) and
+			// TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting.
+			//
+			// The overlay is required by from-scratch strategies whose
+			// target inverted-index flag is still false on the live
+			// schema during backfill. It is nil for retokenize / refresh
+			// strategies. See MigrationStrategy.AnalyzerOverlay.
+			props, _, err := shard.AnalyzeObjectForMigrationWithOverlay(obj, schemaOverlay)
+			if err != nil {
+				mdCh <- &migrationData{err: fmt.Errorf("analyzing object '%s': %w", ik.String(), err)}
+				break
 			}
+
+			if <-breakCh {
+				break
+			}
+			mdCh <- &migrationData{key: ik.Clone(), props: props, docID: obj.DocID}
 		}
 		if k == nil {
 			<-breakCh

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1363,13 +1363,8 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		return zerotime, false, nil
 	}
 
-	// The started sentinel gates the lifecycle (OnAfterLsmInit must have
-	// registered the double-write callbacks and marked the task started
-	// before any scan pass runs). Its TIMESTAMP is informational only: the
-	// scan analyzes every object unconditionally, because comparing a
-	// coordinator-stamped LastUpdateTimeUnix against a replica-captured
-	// watermark is unsound under multi-node clock skew
-	// (weaviate/weaviate#11692) — see [uuidObjectsIteratorAsync].
+	// Gates lifecycle ordering; the timestamp itself is no longer used to
+	// filter the scan (see uuidObjectsIteratorAsync).
 	var reindexStarted time.Time
 	if !rt.IsStarted() {
 		err = fmt.Errorf("missing reindex started")
@@ -2750,27 +2745,15 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 				break
 			}
 
-			// Every scanned object is analyzed and indexed — deliberately
-			// including objects whose LastUpdateTimeUnix is at/after the
-			// task's reindexStarted watermark. An earlier version skipped
-			// those as "written after the double-write callbacks armed,
-			// hence already mirrored", but that inference compares a
-			// COORDINATOR-stamped write time against a REPLICA-captured
-			// watermark: two different clocks. Under multi-node clock skew
-			// a pre-registration (unmirrored) write can carry a timestamp
-			// past the local watermark, making it skipped AND unmirrored —
-			// silent, permanent loss (weaviate/weaviate#11692).
-			//
-			// Unconditional analysis makes the scan skew-immune by
-			// construction: every write is covered by the scan (if it
-			// predates the on-disk cursor) or by the mirror (if it
-			// postdates callback arming) or both. Overlap converges
-			// because runtimeSwap prepends reindex segments BEFORE ingest
+			// Analyzed unconditionally, including objects timestamped
+			// at/after reindexStarted: that comparison mixes a
+			// coordinator-stamped write time with a replica-captured
+			// watermark and is unsound under multi-node clock skew
+			// (weaviate/weaviate#11692). Correctness instead relies on
+			// runtimeSwap prepending reindex segments before ingest
 			// segments, so a mirror write/tombstone always shadows the
 			// scan's posting for the same key, and each strategy's writes
-			// are per-key idempotent. Pinned by
-			// TestSegmentGroup_PrependedAddShadowedByNewerDelete (lsmkv) and
-			// TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting.
+			// are per-key idempotent.
 			//
 			// The overlay is required by from-scratch strategies whose
 			// target inverted-index flag is still false on the live

--- a/adapters/repos/db/lsmkv/segment_group_prepend_tombstone_shadow_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend_tombstone_shadow_test.go
@@ -1,0 +1,214 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+// TestSegmentGroup_PrependedAddShadowedByNewerDelete pins the convergence
+// invariant the runtime-reindex always-backfill design depends on
+// (weaviate/weaviate#11692): when reindex segments are prepended into the
+// ingest bucket ([SegmentGroup.PrependSegmentsFromBucket]), a DELETE the
+// ingest bucket recorded (mirrored from a live write while the scan was
+// running) must shadow an ADD of the same posting sitting in the prepended
+// (older) segments — at read time AND after compaction. If a strategy's
+// tombstone semantics or the prepend ordering ever regress, a mid-migration
+// delete would resurrect the deleted posting in the migrated index.
+//
+// The ingest bucket is created with keepTombstones=true, mirroring
+// loadIngestBuckets's keepTombstones=!isMerged (the delete must survive as a
+// tombstone until the merged bucket is compacted with the prepended
+// segments). Every migration-target strategy is covered: RoaringSet,
+// RoaringSetRange, MapCollection, Inverted.
+//
+// The db-level companion
+// (TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting) drives
+// the same invariant through the production migration lifecycle.
+func TestSegmentGroup_PrependedAddShadowedByNewerDelete(t *testing.T) {
+	newBucket := func(t *testing.T, ctx context.Context, dir, strategy string, keepTombstones bool) *Bucket {
+		t.Helper()
+		logger, _ := test.NewNullLogger()
+		opts := []BucketOption{
+			WithStrategy(strategy),
+			WithKeepTombstones(keepTombstones),
+		}
+		if strategy == StrategyRoaringSet {
+			opts = append(opts, WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+		}
+		b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		require.NoError(t, err)
+		b.SetMemtableThreshold(1e9)
+		return b
+	}
+
+	compactFully := func(t *testing.T, ctx context.Context, b *Bucket) {
+		t.Helper()
+		for {
+			compacted, err := b.disk.compactOnce(ctx)
+			require.NoError(t, err)
+			if !compacted {
+				break
+			}
+		}
+	}
+
+	cases := []struct {
+		strategy string
+		// add writes the victim posting (plus a survivor control) into the
+		// reindex-side bucket.
+		add func(t *testing.T, b *Bucket)
+		// del records the mirror-side delete of the victim posting in the
+		// ingest bucket.
+		del func(t *testing.T, b *Bucket)
+		// assertShadowed fails if the victim posting is readable (the
+		// survivor control must remain readable).
+		assertShadowed func(t *testing.T, b *Bucket)
+	}{
+		{
+			strategy: StrategyRoaringSet,
+			add: func(t *testing.T, b *Bucket) {
+				require.NoError(t, b.RoaringSetAddList([]byte("victim-key"), []uint64{7}))
+				require.NoError(t, b.RoaringSetAddList([]byte("survivor-key"), []uint64{8}))
+			},
+			del: func(t *testing.T, b *Bucket) {
+				require.NoError(t, b.RoaringSetRemoveOne([]byte("victim-key"), 7))
+			},
+			assertShadowed: func(t *testing.T, b *Bucket) {
+				ctx := context.Background()
+				bm, release, err := b.RoaringSetGet(ctx, []byte("victim-key"))
+				require.NoError(t, err)
+				require.Falsef(t, bm.Contains(7),
+					"RoaringSet: deleted docID 7 resurrected from the prepended reindex segment")
+				release()
+				bm, release, err = b.RoaringSetGet(ctx, []byte("survivor-key"))
+				require.NoError(t, err)
+				require.Truef(t, bm.Contains(8), "RoaringSet: survivor posting must remain readable")
+				release()
+			},
+		},
+		{
+			strategy: StrategyRoaringSetRange,
+			add: func(t *testing.T, b *Bucket) {
+				require.NoError(t, b.RoaringSetRangeAdd(42, 7))
+				require.NoError(t, b.RoaringSetRangeAdd(43, 8))
+			},
+			del: func(t *testing.T, b *Bucket) {
+				require.NoError(t, b.RoaringSetRangeRemove(42, 7))
+			},
+			assertShadowed: func(t *testing.T, b *Bucket) {
+				read := func(key uint64) []uint64 {
+					reader := b.ReaderRoaringSetRange()
+					defer reader.Close()
+					bm, release, err := reader.Read(context.Background(), key, filters.OperatorEqual)
+					require.NoError(t, err)
+					if release != nil {
+						defer release()
+					}
+					if bm == nil {
+						return nil
+					}
+					return bm.ToArray()
+				}
+				require.Emptyf(t, read(42),
+					"RoaringSetRange: deleted docID 7 resurrected from the prepended reindex segment")
+				require.Equalf(t, []uint64{8}, read(43),
+					"RoaringSetRange: survivor posting must remain readable")
+			},
+		},
+		{
+			strategy: StrategyMapCollection,
+			add: func(t *testing.T, b *Bucket) {
+				require.NoError(t, b.MapSet([]byte("victim-row"),
+					MapPair{Key: []byte("doc-7"), Value: []byte("v")}))
+				require.NoError(t, b.MapSet([]byte("survivor-row"),
+					MapPair{Key: []byte("doc-8"), Value: []byte("v")}))
+			},
+			del: func(t *testing.T, b *Bucket) {
+				require.NoError(t, b.MapDeleteKey([]byte("victim-row"), []byte("doc-7")))
+			},
+			assertShadowed: func(t *testing.T, b *Bucket) {
+				pairs, err := b.MapList(context.Background(), []byte("victim-row"))
+				require.NoError(t, err)
+				require.Emptyf(t, pairs,
+					"MapCollection: deleted map key resurrected from the prepended reindex segment")
+				pairs, err = b.MapList(context.Background(), []byte("survivor-row"))
+				require.NoError(t, err)
+				require.Lenf(t, pairs, 1, "MapCollection: survivor pair must remain readable")
+			},
+		},
+		{
+			strategy: StrategyInverted,
+			add: func(t *testing.T, b *Bucket) {
+				require.NoError(t, b.MapSet([]byte("victimterm"),
+					NewMapPairFromDocIdAndTf(7, 1, 1, false)))
+				require.NoError(t, b.MapSet([]byte("survivorterm"),
+					NewMapPairFromDocIdAndTf(8, 1, 1, false)))
+			},
+			del: func(t *testing.T, b *Bucket) {
+				pair := NewMapPairFromDocIdAndTf(7, 1, 1, false)
+				require.NoError(t, b.MapDeleteKey([]byte("victimterm"), pair.Key))
+			},
+			assertShadowed: func(t *testing.T, b *Bucket) {
+				pairs, err := b.MapList(context.Background(), []byte("victimterm"))
+				require.NoError(t, err)
+				require.Emptyf(t, pairs,
+					"Inverted: deleted posting resurrected from the prepended reindex segment")
+				pairs, err = b.MapList(context.Background(), []byte("survivorterm"))
+				require.NoError(t, err)
+				require.Lenf(t, pairs, 1, "Inverted: survivor posting must remain readable")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.strategy, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Reindex-side bucket: holds the scanned (stale) posting.
+			srcDir := t.TempDir()
+			src := newBucket(t, ctx, srcDir, tc.strategy, false)
+			tc.add(t, src)
+			require.NoError(t, src.FlushAndSwitch())
+			require.NoError(t, src.Shutdown(ctx))
+
+			// Ingest-side bucket: holds the mirrored delete, tombstones kept
+			// (production: loadIngestBuckets keepTombstones=!isMerged).
+			tgtDir := t.TempDir()
+			tgt := newBucket(t, ctx, tgtDir, tc.strategy, true)
+			defer tgt.Shutdown(ctx)
+			tc.del(t, tgt)
+			require.NoError(t, tgt.FlushAndSwitch())
+
+			// The runtimeSwap merge: reindex segments become the OLDER
+			// segments of the ingest bucket.
+			require.NoError(t, tgt.PrependSegmentsFromBucket(ctx, srcDir))
+
+			// Read-time shadowing.
+			tc.assertShadowed(t, tgt)
+
+			// And across compaction: merging the prepended add with the
+			// newer tombstone must not resurrect the posting.
+			compactFully(t, ctx, tgt)
+			tc.assertShadowed(t, tgt)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_group_prepend_tombstone_shadow_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend_tombstone_shadow_test.go
@@ -24,24 +24,11 @@ import (
 )
 
 // TestSegmentGroup_PrependedAddShadowedByNewerDelete pins the convergence
-// invariant the runtime-reindex always-backfill design depends on
-// (weaviate/weaviate#11692): when reindex segments are prepended into the
-// ingest bucket ([SegmentGroup.PrependSegmentsFromBucket]), a DELETE the
-// ingest bucket recorded (mirrored from a live write while the scan was
-// running) must shadow an ADD of the same posting sitting in the prepended
-// (older) segments — at read time AND after compaction. If a strategy's
-// tombstone semantics or the prepend ordering ever regress, a mid-migration
-// delete would resurrect the deleted posting in the migrated index.
-//
-// The ingest bucket is created with keepTombstones=true, mirroring
-// loadIngestBuckets's keepTombstones=!isMerged (the delete must survive as a
-// tombstone until the merged bucket is compacted with the prepended
-// segments). Every migration-target strategy is covered: RoaringSet,
-// RoaringSetRange, MapCollection, Inverted.
-//
-// The db-level companion
-// (TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting) drives
-// the same invariant through the production migration lifecycle.
+// invariant unconditional-scan reindexing depends on (weaviate/weaviate#11692):
+// after PrependSegmentsFromBucket, a mirrored ingest-bucket delete must
+// shadow an add sitting in the older prepended segments, at read time and
+// after compaction, for every migration-target strategy. Companion:
+// TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting (db).
 func TestSegmentGroup_PrependedAddShadowedByNewerDelete(t *testing.T) {
 	newBucket := func(t *testing.T, ctx context.Context, dir, strategy string, keepTombstones bool) *Bucket {
 		t.Helper()


### PR DESCRIPTION
SuperClaude here.

Fixes #11692 — the multi-node clock-skew residual of #11688 that PR #11985's single-clock fixes do not close. This PR now ships the fix, the (previously skip-guarded) reproduction pin un-skipped and green, and the convergence pins the fix's safety argument rests on.

## The defect

The runtime-reindex backfill iterator (`uuidObjectsIteratorAsync`, `inverted_reindex_task_generic.go`) classified every scanned object with one comparison:

```go
obj.LastUpdateTimeUnix() < reindexStarted.UnixMilli()  → backfill (analyze, index into reindex bucket)
obj.LastUpdateTimeUnix() >= reindexStarted.UnixMilli() → skip (assume it was double-written)
```

The skip branch is sound only under a single clock. `LastUpdateTimeUnix` is stamped on the **coordinator** that received the write (`usecases/objects/add.go`, `update.go`, `merge.go`: `m.timeSource.Now()`) and preserved verbatim by the replica; `reindexStarted` is stamped on the **replica's own** clock (`markStarted`). With the coordinator's clock ahead, a write can arrive at the replica *before* callback registration (never mirrored) yet carry a timestamp at/above `reindexStarted` (skipped as "already mirrored"). Skipped and unmirrored ⇒ silently missing from the migrated index after the migration reports FINISHED. #11688's ms-ceil protects the single-node boundary only.

## The fix

**Remove the wall-clock comparison from the mirror-coverage decision entirely: the backfill analyzes every object the on-disk cursor yields.** (Option (b) from the RFC discussion; the timestamp parameter is dropped from the iterator signature so a future caller cannot quietly reintroduce a skip.)

This is skew-immune by construction — no cross-node clock comparison remains. Coverage: callbacks arm in `OnAfterLsmInit` before the scan's on-disk cursor is created, so every write is scanned (it predates the cursor), mirrored (it postdates arming), or both. Overlap converges on two invariants that this PR pins with tests:

1. **Merge order.** `runtimeSwap` prepends reindex segments *before* ingest segments (`PrependSegmentsFromBucket`), so a mirror write/tombstone is strictly newer in LSM order than the scan's posting for the same key.
2. **Tombstone lifetime.** Ingest buckets are created with `keepTombstones=!isMerged`, so a mirror-side delete survives flush and shadows a prepended posting at read time and across compaction — per target strategy (RoaringSet, RoaringSetRange, MapCollection, Inverted).

Cost: objects written during the migration window are now analyzed instead of skipped — bounded by write-rate × migration duration, on the already-throttled single producer goroutine. For updated keys the ingest mirror wins by merge order, so this is analysis cost, not storage divergence. The skip it replaces saved work only for that same write-during-migration slice, which is negligible against the full-corpus scan.

Composition with #11985 (merges first): its diff rewrites callback registration, `markStarted` ordering, and swap-window resolution; this diff touches the iterator and its call site — disjoint regions, clean merge. Post-merge, #11985's ms-ceiled post-registration watermark remains as tracker lifecycle state; it simply no longer gates correctness.

## Rejected alternatives

- **(a) Coordinator/logical cutoff** — a coordinator *wall-clock* cutoff still skews between coordinators; a real fix needs a logical stamp (HLC/RAFT index) that writes don't carry today. Right long-term shape, wrong cost now.
- **(c) Per-replica monotonic receive-sequence** (skip only writes with `seq >= registrationSeq` — note the earlier RFC text had this predicate inverted) — skew-immune but needs a new per-write monotonic stamp: a persisted field or unbounded per-migration memory.
- **Skew-margined watermark** (`reindexStarted - maxSkew`) — turns correctness into an NTP operational property with a magic constant; strictly dominated by (b), which is its `maxSkew → ∞` limit and needs the identical convergence audit.

## Review items from the assessment (2026-07-06)

- **Batch-references mirror-coverage hole** — two legs. The *co-located-property* leg (a batch-ref/merge bumps `LastUpdateTimeUnix` past the watermark without firing callbacks for unchanged props → pre-fix the scan skipped the object and dropped them) is closed here by construction and pinned (`TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp`, red if a wall-clock skip returns). The *ref-bucket-target* leg (post-cursor batch-ref mutations of the ref-beacon/`__meta_count` buckets are unmirrored) is unreachable on this base: no migration verb accepts a ref property (`validateRebuildFilterableDataType` rejects non-primitives — now explicitly pinned with a note on why that rejection is load-bearing). #12210 adds the full-prop-set mirror on `main` for when that changes.
- **Nested-property path** (`shard_write_inverted_lsm_nested.go`) — verified: nested buckets live in a separate name namespace no strategy resolves, nested writes fire no callbacks, and object/object[] are Nested (non-primitive) types every migration verb rejects. Pinned via explicit object/object[] rejection rows on both validator tests, with comments stating the tee-coverage consequence if the gate is ever relaxed.
- **Convergence invariants not test-guarded** — now pinned twice: `TestSegmentGroup_PrependedAddShadowedByNewerDelete` (lsmkv; add-in-prepended-segment vs tombstone-in-newer-segment, per strategy, at read and after full compaction) and `TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting` (db; the production lifecycle with an explicit ingest flush so `keepTombstones` is load-bearing, delete + update journeys × 4 target strategies). The StrategyInverted full-item-set discipline was already exhaustively covered by `TestDeltaAnalyzer_SkipSearchable`.
- **Delete-side skew companion** — the pin now also covers a pre-registration skewed *update* (new value present, overwritten value must not resurrect) and a pre-registration skewed *delete* (posting absent), and the delete-convergence suite covers mid-scan deletes (the resurrection journey).
- **`t.Skip` contradiction** — gone; the pin runs live and green, doc comment rewritten as a regression pin with the reachability-scoping line (the single-shard future-timestamp model covers the classification leg; the write-before-registration interleaving claim rests on #11985's markStarted-after-registration ordering, not this test).
- **Inverted (c) predicate text** — corrected above.

## Tests (red without / green with)

Reverting the fix (reintroducing a wall-clock skip in the iterator) fails all three families; with the fix all pass under `-race`:

```
--- FAIL: TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap            (pre-fix: value 999 absent)
--- FAIL: TestUuidObjectsIterator_AnalyzesEveryObjectRegardlessOfTimestamp
--- FAIL: TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp
```

- `TestReindex_MultiNodeClockSkew_ReopensDoubleWriteGap` — the acceptance pin, un-skipped, extended with skewed-update/skewed-delete probes. Runs in CI's `Unit-Tests` job (`test/run.sh --unit-only` runs `adapters/repos/db` with no `-run` filter or build tag) and again in both `Integration-Tests` matrix jobs.
- `TestUuidObjectsIterator_AnalyzesEveryObjectRegardlessOfTimestamp` — ms-fast unit pin on the decision itself; the next bug in this class fails in milliseconds, not CI-minutes.
- `TestReindexColocatedWrite_TimestampBumpDoesNotDropScannedProp` — batch-ref add (first + second ref), single-ref merge, unrelated-prop patch.
- `TestReindexDeleteConvergence_IngestTombstoneShadowsScannedPosting`, `TestSegmentGroup_PrependedAddShadowedByNewerDelete` — the convergence pins above.
- Validator rejection rows for object/object[] (+ load-bearing comments on the reference rejection).

Full `adapters/repos/db`, `lsmkv`, `inverted`, and `handlers/rest` suites green locally under `-race`.

— SuperClaude
