### PR TITLE
fix(lsmkv): honor cancellation cleanly in bucket/segmentgroup shutdown

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1505,8 +1505,12 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		return err
 	}
 
-	if err := b.flushCallbackCtrl.Unregister(ctx); err != nil {
-		return fmt.Errorf("long-running flush in progress: %w", ctx.Err())
+	// Same contract as the compaction cycle above (SegmentGroup.shutdown): a
+	// cancelled caller ctx must not abandon the unregister before the in-flight
+	// flush is signalled to abort, or shutdown leaves state half-applied and
+	// mislabels it. Decouple from the caller's cancellation.
+	if err := b.flushCallbackCtrl.Unregister(context.WithoutCancel(ctx)); err != nil {
+		return fmt.Errorf("unregister flush cycle: %w", err)
 	}
 
 	b.flushLock.Lock()

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1505,10 +1505,8 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		return err
 	}
 
-	// Same contract as the compaction cycle above (SegmentGroup.shutdown): a
-	// cancelled caller ctx must not abandon the unregister before the in-flight
-	// flush is signalled to abort, or shutdown leaves state half-applied and
-	// mislabels it. Decouple from the caller's cancellation.
+	// Same contract as SegmentGroup.shutdown: must run on an uncancellable ctx
+	// so an in-flight flush is always signalled to abort, not left half-applied.
 	if err := b.flushCallbackCtrl.Unregister(context.WithoutCancel(ctx)); err != nil {
 		return fmt.Errorf("unregister flush cycle: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -871,8 +871,19 @@ func (sg *SegmentGroup) countWithSegmentList(segments []Segment) int {
 }
 
 func (sg *SegmentGroup) shutdown(ctx context.Context) error {
-	if err := sg.compactionCallbackCtrl.Unregister(ctx); err != nil {
-		return fmt.Errorf("long-running compaction in progress: %w", ctx.Err())
+	// Unregistering the compaction cycle both stops future compactions and
+	// signals any in-flight one to abort (shouldAbort -> ctx bridge in
+	// compactOrCleanup); it must complete before the teardown below, since a
+	// live compaction holds segment refs and races segment close. The caller's
+	// ctx is often already cancelled here (e.g. a node terminating mid-swap,
+	// weaviate/0-weaviate-issues#213). Passing it through made Unregister return
+	// early without ever setting shouldAbort, so the compaction ran on, the
+	// higher-level shutdown was left half-applied, and the error was mislabelled
+	// "long-running compaction in progress". Decouple from the caller's
+	// cancellation so the abort is always signalled and awaited; the compactor
+	// honours it within a bounded window.
+	if err := sg.compactionCallbackCtrl.Unregister(context.WithoutCancel(ctx)); err != nil {
+		return fmt.Errorf("unregister compaction cycle: %w", err)
 	}
 	if err := sg.segmentCleaner.close(); err != nil {
 		return err

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -871,17 +871,10 @@ func (sg *SegmentGroup) countWithSegmentList(segments []Segment) int {
 }
 
 func (sg *SegmentGroup) shutdown(ctx context.Context) error {
-	// Unregistering the compaction cycle both stops future compactions and
-	// signals any in-flight one to abort (shouldAbort -> ctx bridge in
-	// compactOrCleanup); it must complete before the teardown below, since a
-	// live compaction holds segment refs and races segment close. The caller's
-	// ctx is often already cancelled here (e.g. a node terminating mid-swap,
-	// weaviate/0-weaviate-issues#213). Passing it through made Unregister return
-	// early without ever setting shouldAbort, so the compaction ran on, the
-	// higher-level shutdown was left half-applied, and the error was mislabelled
-	// "long-running compaction in progress". Decouple from the caller's
-	// cancellation so the abort is always signalled and awaited; the compactor
-	// honours it within a bounded window.
+	// Must run on an uncancellable ctx: this both stops future compactions and
+	// signals any in-flight one to abort (shouldAbort in compactOrCleanup). A
+	// live compaction holds segment refs and races segment close, so it must
+	// finish before the teardown below runs.
 	if err := sg.compactionCallbackCtrl.Unregister(context.WithoutCancel(ctx)); err != nil {
 		return fmt.Errorf("unregister compaction cycle: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/shutdown_cancel_integration_test.go
+++ b/adapters/repos/db/lsmkv/shutdown_cancel_integration_test.go
@@ -1,0 +1,111 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestBucket_ShutdownWithCancelledContext pins the Shutdown-cancellation
+// contract from weaviate/0-weaviate-issues#213.
+//
+// A node terminating mid-swap calls Bucket.Shutdown with an already-cancelled
+// ctx. Before the fix, that ctx was threaded straight into the compaction (and
+// flush) cycle Unregister, which returned early on the dead ctx WITHOUT ever
+// signalling the in-flight compaction to abort. The compaction ran on, the
+// higher-level shutdown (a runtime-reindex swap) was left half-applied, and the
+// caller saw a mislabelled "long-running compaction in progress: context
+// canceled" error.
+//
+// The bucket is wired with real (non-noop) compaction and flush cycles so the
+// test drives the genuine cyclemanager unregister path, then Shutdown is called
+// with a cancelled ctx while the compaction cycle is live. Shutdown must return
+// no error, must not hang, and the store must reopen with every key intact.
+func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	const segments = 2
+	const perSegment = 20000
+
+	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", nullLogger(), 1)
+	compactionCycle := cyclemanager.NewManager("compaction",
+		cyclemanager.NewFixedTicker(10*time.Millisecond),
+		compactionCallbacks.CycleCallback, nullLogger())
+	compactionCycle.Start()
+
+	flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
+	flushCycle := cyclemanager.NewManager("flush",
+		cyclemanager.NewFixedTicker(10*time.Millisecond),
+		flushCallbacks.CycleCallback, nullLogger())
+	flushCycle.Start()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		compactionCallbacks, flushCallbacks, WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	bucket.SetMemtableThreshold(1e9)
+
+	// two on-disk segments so the compaction cycle has real work to merge/abort
+	for seg := 0; seg < segments; seg++ {
+		for i := 0; i < perSegment; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+			require.NoError(t, bucket.Put(key, []byte(fmt.Sprintf("value-%d-%d", seg, i))))
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
+		"need at least two segments on disk so a compaction can be in flight")
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	// Shutdown on a dead ctx must still complete cleanly and promptly.
+	done := make(chan error, 1)
+	go func() { done <- bucket.Shutdown(cancelledCtx) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("Bucket.Shutdown hung on a cancelled context")
+	}
+
+	require.NoError(t, compactionCycle.StopAndWait(ctx))
+	require.NoError(t, flushCycle.StopAndWait(ctx))
+
+	// Reopen the store on the same dir: proves the shutdown (with a possibly
+	// aborted compaction) left consistent on-disk state. init() cleans any
+	// orphaned .tmp from the aborted merge.
+	reopened, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	defer reopened.Shutdown(ctx)
+
+	for seg := 0; seg < segments; seg++ {
+		for i := 0; i < perSegment; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+			got, err := reopened.Get(key)
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("value-%d-%d", seg, i), string(got),
+				"key %q lost or corrupted after shutdown-during-compaction", key)
+		}
+	}
+}

--- a/adapters/repos/db/lsmkv/shutdown_cancel_integration_test.go
+++ b/adapters/repos/db/lsmkv/shutdown_cancel_integration_test.go
@@ -24,20 +24,9 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// TestBucket_ShutdownWithCancelledContext pins the Shutdown-cancellation
-// contract from weaviate/0-weaviate-issues#213.
-//
-// A node terminating mid-swap calls Bucket.Shutdown with an already-cancelled
-// ctx. Before the fix, that ctx was threaded straight into the compaction (and
-// flush) cycle Unregister, which returned early on the dead ctx WITHOUT ever
-// signalling the in-flight compaction to abort. The compaction ran on, the
-// higher-level shutdown (a runtime-reindex swap) was left half-applied, and the
-// caller saw a mislabelled "long-running compaction in progress: context
-// canceled" error.
-//
-// The bucket is wired with real (non-noop) compaction and flush cycles so the
-// test drives the genuine cyclemanager unregister path. Shutdown must return no
-// error, must not hang, and the store must reopen with every key intact.
+// TestBucket_ShutdownWithCancelledContext pins weaviate/0-weaviate-issues#213:
+// Shutdown on an already-cancelled ctx must still abort in-flight compaction
+// instead of letting it run.
 func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
@@ -69,10 +58,8 @@ func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
 		require.NoError(t, bucket.FlushAndSwitch())
 	}
 
-	// Len() reads the segment list under the segment group's maintenance lock.
-	// The tickers are deliberately still stopped here: once compaction runs it
-	// merges these two segments into one, so the count is only a stable
-	// precondition while nothing can compact yet.
+	// Tickers aren't started yet, so the count is stable: compaction would
+	// otherwise merge these two segments into one.
 	require.Equal(t, segments, bucket.disk.Len(),
 		"both flushed segments must be on disk before the compaction cycle starts")
 
@@ -95,9 +82,8 @@ func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
 	require.NoError(t, compactionCycle.StopAndWait(ctx))
 	require.NoError(t, flushCycle.StopAndWait(ctx))
 
-	// Reopen the store on the same dir: proves the shutdown (with a possibly
-	// aborted compaction) left consistent on-disk state. init() cleans any
-	// orphaned .tmp from the aborted merge.
+	// Reopening on the same dir proves shutdown left consistent on-disk state,
+	// even with a compaction aborted mid-merge.
 	reopened, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))

--- a/adapters/repos/db/lsmkv/shutdown_cancel_integration_test.go
+++ b/adapters/repos/db/lsmkv/shutdown_cancel_integration_test.go
@@ -36,9 +36,8 @@ import (
 // canceled" error.
 //
 // The bucket is wired with real (non-noop) compaction and flush cycles so the
-// test drives the genuine cyclemanager unregister path, then Shutdown is called
-// with a cancelled ctx while the compaction cycle is live. Shutdown must return
-// no error, must not hang, and the store must reopen with every key intact.
+// test drives the genuine cyclemanager unregister path. Shutdown must return no
+// error, must not hang, and the store must reopen with every key intact.
 func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
@@ -50,13 +49,11 @@ func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
 	compactionCycle := cyclemanager.NewManager("compaction",
 		cyclemanager.NewFixedTicker(10*time.Millisecond),
 		compactionCallbacks.CycleCallback, nullLogger())
-	compactionCycle.Start()
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
 	flushCycle := cyclemanager.NewManager("flush",
 		cyclemanager.NewFixedTicker(10*time.Millisecond),
 		flushCallbacks.CycleCallback, nullLogger())
-	flushCycle.Start()
 
 	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
 		compactionCallbacks, flushCallbacks, WithStrategy(StrategyReplace))
@@ -71,8 +68,16 @@ func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
 		}
 		require.NoError(t, bucket.FlushAndSwitch())
 	}
-	require.GreaterOrEqual(t, len(bucket.disk.segments), 2,
-		"need at least two segments on disk so a compaction can be in flight")
+
+	// Len() reads the segment list under the segment group's maintenance lock.
+	// The tickers are deliberately still stopped here: once compaction runs it
+	// merges these two segments into one, so the count is only a stable
+	// precondition while nothing can compact yet.
+	require.Equal(t, segments, bucket.disk.Len(),
+		"both flushed segments must be on disk before the compaction cycle starts")
+
+	compactionCycle.Start()
+	flushCycle.Start()
 
 	cancelledCtx, cancel := context.WithCancel(ctx)
 	cancel()
@@ -97,7 +102,7 @@ func TestBucket_ShutdownWithCancelledContext(t *testing.T) {
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		WithStrategy(StrategyReplace))
 	require.NoError(t, err)
-	defer reopened.Shutdown(ctx)
+	defer func() { require.NoError(t, reopened.Shutdown(ctx)) }()
 
 	for seg := 0; seg < segments; seg++ {
 		for i := 0; i < perSegment; i++ {


### PR DESCRIPTION
SuperClaude here.

## Mechanism (verified against current main, not the issue text)

`Bucket.Shutdown(ctx)` → `SegmentGroup.shutdown(ctx)` threaded the caller's
ctx straight into the compaction-cycle `Unregister`:

```go
if err := sg.compactionCallbackCtrl.Unregister(ctx); err != nil {
    return fmt.Errorf("long-running compaction in progress: %w", ctx.Err())
}
```

`Unregister` → `cyclemanager.mutateCallback` opens with an early bail:

```go
if ctx.Err() != nil {
    return ctx.Err()   // returns BEFORE meta.shouldAbort = true is set
}
```

So when a node terminates mid-swap and the caller's ctx is already
cancelled, the in-flight compaction is **never signalled to abort**. It
runs to natural completion while `shutdown` bails immediately with a
mislabelled *"long-running compaction in progress: context canceled"* —
and the higher-level shutdown work (a runtime-reindex swap) is left
half-applied. This reproduces even with **zero** compactions running: the
error string is a lie whenever the ctx is dead.

### Root cause vs. the mitigations already on main

This is the **root-cause** fix. The following are downstream band-aids
that mask the symptom but leave the LSM contract broken:

- **`b6a5c6bd62`** (`RecoveryAwareProvider` retry hook) — re-fires
  `OnGroupCompleted` after a ctx-cancelled mid-swap. Retry, not fix.
- reindex `runPerUnitPhase` routing `SawContextCanceled` → `%w`-wrapped
  `context.Canceled` → transient-recovery. Recovers the symptom downstream.
- **`weaviate#11461`** — a *partial* root-cause fix: it made all 6
  compactor strategies honor `shouldAbort` via a `shouldAbort → ctx`
  bridge in `compactOrCleanup`. Necessary but **not sufficient**: the
  shutdown `Unregister` still short-circuited on the dead ctx *before*
  the bridge could ever fire, so the issue's contract stayed broken. This
  PR closes that last gap.

## Fix

Decouple the shutdown-path `Unregister` calls (compaction in
`SegmentGroup.shutdown`, flush in `Bucket.Shutdown`) from the caller's
cancellation with `context.WithoutCancel`. The abort is now always
signalled and awaited; the compactor honors it within a bounded window
(`weaviate#11461`'s 50 ms poll + per-N-key ctx check). This is consistent
with the unbounded `waitForReferenceCountToReachZero` already sitting a
few lines below in the same teardown — shutdown is a must-complete
operation, and a genuinely deadlocked compaction should surface as a
visible hang, not be masked by orphaning it and corrupting on-disk state.

The mislabelled error strings are corrected to name the actual operation.

## Evidence

New `TestBucket_ShutdownWithCancelledContext` (integrationTest) wires a
bucket with **real** (non-noop) compaction + flush cycles, seeds two
on-disk segments, then calls `Bucket.Shutdown` with an already-cancelled
ctx while the compaction cycle is live, and reopens the store to prove
every key survived.

- **Red** (fix reverted): fails with the exact issue error
  `long-running compaction in progress: context canceled`.
- **Green** (fix applied): passes, `-race`, in ~1.3 s; store reopens with
  all 40k keys intact.
- Existing `TestCompactor_AbortOnShouldAbort` (all 6 strategies) green
  under `-race`; full non-integration lsmkv package green under `-race`.

Closes weaviate/0-weaviate-issues#213

— SuperClaude
