### PR TITLE
Fix RBAC leak in node handler

### DIFF
--- a/test/acceptance/authz/nodes_test.go
+++ b/test/acceptance/authz/nodes_test.go
@@ -44,6 +44,7 @@ func TestAuthzNodesFilter(t *testing.T) {
 	helper.CreateClassAuth(t, clsP, adminKey)
 	helper.CreateClassAuth(t, clsA, adminKey)
 	helper.CreateObjectsBatchAuth(t, []*models.Object{articles.NewArticle().WithTitle("article1").Object()}, adminKey)
+	helper.CreateObjectsBatchAuth(t, []*models.Object{articles.NewParagraph().WithContents("p1").Object()}, adminKey)
 
 	helper.DeleteRole(t, adminKey, roleName)
 	defer helper.DeleteRole(t, adminKey, roleName)
@@ -52,16 +53,28 @@ func TestAuthzNodesFilter(t *testing.T) {
 	}})
 	helper.AssignRoleToUser(t, adminKey, roleName, customUser)
 
-	// only permissions for one of the classes
+	// Confined caller sees only its own class. The node-wide Stats must be rebuilt
+	// from the visible shard (ShardCount is 1, not the cluster's 2) and the
+	// non-reconstructable BatchStats dropped, so neither leaks the hidden class.
+	// ObjectCount is a disk-async counter that lags unflushed writes, so it is not
+	// asserted.
 	resp, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithOutput(String(verbosity.OutputVerbose)), helper.CreateAuth(customKey))
-	require.NoError(t, err)
-	require.Len(t, resp.Payload.Nodes[0].Shards, 1)
-	require.Equal(t, resp.Payload.Nodes[0].Shards[0].Class, clsA.Class)
+	require.Nil(t, err)
+	node := resp.Payload.Nodes[0]
+	require.Len(t, node.Shards, 1)
+	require.Equal(t, clsA.Class, node.Shards[0].Class)
+	require.NotNil(t, node.Stats)
+	require.Equal(t, int64(1), node.Stats.ShardCount, "shard count must reflect only the visible shard")
+	require.Nil(t, node.BatchStats, "cluster-wide batch stats must be dropped for a confined caller")
 
-	// admin gets back shards for two classes
+	// Admin sees both classes with untouched cluster-wide Stats and BatchStats.
 	resp, err = helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithOutput(String(verbosity.OutputVerbose)), helper.CreateAuth(adminKey))
-	require.NoError(t, err)
-	require.Len(t, resp.Payload.Nodes[0].Shards, 2)
+	require.Nil(t, err)
+	node = resp.Payload.Nodes[0]
+	require.Len(t, node.Shards, 2)
+	require.NotNil(t, node.Stats)
+	require.Equal(t, int64(2), node.Stats.ShardCount)
+	require.NotNil(t, node.BatchStats, "admin keeps cluster-wide batch stats")
 }
 
 func TestAuthzNodes(t *testing.T) {

--- a/test/acceptance/authz/nodes_test.go
+++ b/test/acceptance/authz/nodes_test.go
@@ -54,8 +54,9 @@ func TestAuthzNodesFilter(t *testing.T) {
 	helper.AssignRoleToUser(t, adminKey, roleName, customUser)
 
 	// Confined caller sees only its own class. The node-wide Stats must be rebuilt
-	// from the visible shard (ShardCount is 1, not the cluster's 2) and the
-	// non-reconstructable BatchStats dropped, so neither leaks the hidden class.
+	// from the visible shard (ShardCount is 1, not the cluster's 2) so it doesn't
+	// leak the hidden class. BatchStats is node-wide queue/throughput telemetry
+	// with no per-class data, so it stays intact for the caller's dynamic batching.
 	// ObjectCount is a disk-async counter that lags unflushed writes, so it is not
 	// asserted.
 	resp, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithOutput(String(verbosity.OutputVerbose)), helper.CreateAuth(customKey))
@@ -65,7 +66,7 @@ func TestAuthzNodesFilter(t *testing.T) {
 	require.Equal(t, clsA.Class, node.Shards[0].Class)
 	require.NotNil(t, node.Stats)
 	require.Equal(t, int64(1), node.Stats.ShardCount, "shard count must reflect only the visible shard")
-	require.Nil(t, node.BatchStats, "cluster-wide batch stats must be dropped for a confined caller")
+	require.NotNil(t, node.BatchStats, "node-wide batch stats leak no per-class data and must be preserved")
 
 	// Admin sees both classes with untouched cluster-wide Stats and BatchStats.
 	resp, err = helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithOutput(String(verbosity.OutputVerbose)), helper.CreateAuth(adminKey))

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -84,14 +84,14 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 			if len(filtered) == len(nodeS.Shards) {
 				continue // caller is authorized for every shard on this node
 			}
-			// Hidden shards mean the node-wide Stats and BatchStats still cover
-			// classes the caller can't see. Rebuild Stats from the visible shards;
-			// BatchStats can't be rebuilt from per-shard data, so drop it.
+			// Hidden shards mean the node-wide Stats still aggregate classes the
+			// caller can't see, so rebuild them from the visible shards. BatchStats
+			// is node-wide queue/throughput telemetry with no per-class data, so it
+			// leaks nothing and is left intact for the caller's dynamic batching.
 			status[i].Shards = filtered
 			if status[i].Stats != nil {
 				status[i].Stats = statsFromShards(filtered)
 			}
-			status[i].BatchStats = nil
 		}
 	}
 

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -72,7 +72,7 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 		resourceFilter := filter.New[*models.NodeShardStatus](m.authorizer, m.rbacconfig)
 
 		for i, nodeS := range status {
-			status[i].Shards = resourceFilter.Filter(
+			filtered := resourceFilter.Filter(
 				ctx,
 				principal,
 				nodeS.Shards,
@@ -81,10 +81,34 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 					return authorization.Nodes(verbosityString, shard.Class)[0]
 				},
 			)
+			if len(filtered) == len(nodeS.Shards) {
+				continue // caller is authorized for every shard on this node
+			}
+			// Hidden shards mean the node-wide Stats and BatchStats still cover
+			// classes the caller can't see. Rebuild Stats from the visible shards;
+			// BatchStats can't be rebuilt from per-shard data, so drop it.
+			status[i].Shards = filtered
+			if status[i].Stats != nil {
+				status[i].Stats = statsFromShards(filtered)
+			}
+			status[i].BatchStats = nil
 		}
 	}
 
 	return status, nil
+}
+
+// statsFromShards sums the object count over the given shards and reports how
+// many there are.
+func statsFromShards(shards []*models.NodeShardStatus) *models.NodeStats {
+	var objectCount int64
+	for _, shard := range shards {
+		objectCount += shard.ObjectCount
+	}
+	return &models.NodeStats{
+		ObjectCount: objectCount,
+		ShardCount:  int64(len(shards)),
+	}
 }
 
 func (m *Manager) GetNodeStatistics(ctx context.Context,

--- a/usecases/nodes/handler_test.go
+++ b/usecases/nodes/handler_test.go
@@ -106,6 +106,8 @@ func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
 		}}
 	}
 
+	// BatchStats is node-wide queue/throughput telemetry with no per-class data,
+	// so it is always preserved regardless of how many shards the caller can see.
 	tests := []struct {
 		name             string
 		rbacEnabled      bool
@@ -113,7 +115,6 @@ func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
 		wantShardClasses []string
 		wantObjectCount  int64
 		wantShardCount   int64
-		wantBatchNil     bool
 	}{
 		{
 			name:             "rbac disabled leaves everything untouched",
@@ -122,25 +123,22 @@ func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
 			wantShardClasses: []string{"Mine", "Other"},
 			wantObjectCount:  102,
 			wantShardCount:   2,
-			wantBatchNil:     false,
 		},
 		{
-			name:             "confined caller sees only own class in shards, stats and batch",
+			name:             "confined caller sees only own class in shards and stats, keeps batch",
 			rbacEnabled:      true,
 			allowed:          []string{nodeResource("Mine")},
 			wantShardClasses: []string{"Mine"},
 			wantObjectCount:  2,
 			wantShardCount:   1,
-			wantBatchNil:     true,
 		},
 		{
-			name:             "caller with no access sees zeroed stats and no batch",
+			name:             "caller with no access sees zeroed stats, keeps batch",
 			rbacEnabled:      true,
 			allowed:          []string{},
 			wantShardClasses: []string{},
 			wantObjectCount:  0,
 			wantShardCount:   0,
-			wantBatchNil:     true,
 		},
 		{
 			name:             "caller with full access keeps cluster-wide stats",
@@ -149,7 +147,6 @@ func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
 			wantShardClasses: []string{"Mine", "Other"},
 			wantObjectCount:  102,
 			wantShardCount:   2,
-			wantBatchNil:     false,
 		},
 	}
 
@@ -174,11 +171,8 @@ func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
 			require.Equal(t, tt.wantObjectCount, status[0].Stats.ObjectCount)
 			require.Equal(t, tt.wantShardCount, status[0].Stats.ShardCount)
 
-			if tt.wantBatchNil {
-				require.Nil(t, status[0].BatchStats)
-			} else {
-				require.NotNil(t, status[0].BatchStats)
-			}
+			require.NotNil(t, status[0].BatchStats,
+				"node-wide batch stats leak no per-class data and must always be preserved")
 		})
 	}
 }

--- a/usecases/nodes/handler_test.go
+++ b/usecases/nodes/handler_test.go
@@ -1,0 +1,184 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package nodes
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
+)
+
+// allowlistAuthorizer authorizes only the resources it was seeded with, letting
+// a test simulate a caller confined to a subset of classes.
+type allowlistAuthorizer struct {
+	allowed []string
+}
+
+func (a *allowlistAuthorizer) authorized(resources ...string) bool {
+	for _, r := range resources {
+		if !slices.Contains(a.allowed, r) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *allowlistAuthorizer) Authorize(ctx context.Context, principal *models.Principal, verb string, resources ...string) error {
+	if !a.authorized(resources...) {
+		return errForbidden
+	}
+	return nil
+}
+
+func (a *allowlistAuthorizer) AuthorizeSilent(ctx context.Context, principal *models.Principal, verb string, resources ...string) error {
+	return a.Authorize(ctx, principal, verb, resources...)
+}
+
+func (a *allowlistAuthorizer) FilterAuthorizedResources(ctx context.Context, principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	filtered := make([]string, 0, len(resources))
+	for _, r := range resources {
+		if a.authorized(r) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered, nil
+}
+
+var errForbidden = &forbiddenError{}
+
+type forbiddenError struct{}
+
+func (*forbiddenError) Error() string { return "forbidden" }
+
+// fakeDB returns a single node's verbose status with shards from two classes
+// plus cluster-wide Stats and BatchStats, mirroring what LocalNodeStatus builds.
+type fakeDB struct {
+	status []*models.NodeStatus
+}
+
+func (f *fakeDB) GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error) {
+	return f.status, nil
+}
+
+func (f *fakeDB) GetNodeStatistics(ctx context.Context) ([]*models.Statistics, error) {
+	return nil, nil
+}
+
+func nodeResource(class string) string {
+	return authorization.Nodes(verbosity.OutputVerbose, class)[0]
+}
+
+func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	// One node holding shards from "Mine" (2 objects) and "Other" (100 objects).
+	// Stats and BatchStats reflect the cluster-wide totals across both.
+	newStatus := func() []*models.NodeStatus {
+		healthy := models.NodeStatusStatusHEALTHY
+		queueLen := int64(7)
+		return []*models.NodeStatus{{
+			Name:   "node1",
+			Status: &healthy,
+			Shards: []*models.NodeShardStatus{
+				{Name: "s1", Class: "Mine", ObjectCount: 2},
+				{Name: "s2", Class: "Other", ObjectCount: 100},
+			},
+			Stats:      &models.NodeStats{ObjectCount: 102, ShardCount: 2},
+			BatchStats: &models.BatchStats{RatePerSecond: 5, QueueLength: &queueLen},
+		}}
+	}
+
+	tests := []struct {
+		name             string
+		rbacEnabled      bool
+		allowed          []string
+		wantShardClasses []string
+		wantObjectCount  int64
+		wantShardCount   int64
+		wantBatchNil     bool
+	}{
+		{
+			name:             "rbac disabled leaves everything untouched",
+			rbacEnabled:      false,
+			allowed:          []string{nodeResource("")}, // wildcard: upfront authorize gate
+			wantShardClasses: []string{"Mine", "Other"},
+			wantObjectCount:  102,
+			wantShardCount:   2,
+			wantBatchNil:     false,
+		},
+		{
+			name:             "confined caller sees only own class in shards, stats and batch",
+			rbacEnabled:      true,
+			allowed:          []string{nodeResource("Mine")},
+			wantShardClasses: []string{"Mine"},
+			wantObjectCount:  2,
+			wantShardCount:   1,
+			wantBatchNil:     true,
+		},
+		{
+			name:             "caller with no access sees zeroed stats and no batch",
+			rbacEnabled:      true,
+			allowed:          []string{},
+			wantShardClasses: []string{},
+			wantObjectCount:  0,
+			wantShardCount:   0,
+			wantBatchNil:     true,
+		},
+		{
+			name:             "caller with full access keeps cluster-wide stats",
+			rbacEnabled:      true,
+			allowed:          []string{nodeResource("Mine"), nodeResource("Other")},
+			wantShardClasses: []string{"Mine", "Other"},
+			wantObjectCount:  102,
+			wantShardCount:   2,
+			wantBatchNil:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authz := &allowlistAuthorizer{allowed: tt.allowed}
+			m := NewManager(logger, authz, &fakeDB{status: newStatus()}, nil,
+				rbacconf.Config{Enabled: tt.rbacEnabled}, time.Second)
+
+			status, err := m.GetNodeStatus(context.Background(), &models.Principal{},
+				"", "", verbosity.OutputVerbose)
+			require.NoError(t, err)
+			require.Len(t, status, 1)
+
+			gotClasses := make([]string, 0, len(status[0].Shards))
+			for _, s := range status[0].Shards {
+				gotClasses = append(gotClasses, s.Class)
+			}
+			require.ElementsMatch(t, tt.wantShardClasses, gotClasses)
+
+			require.NotNil(t, status[0].Stats)
+			require.Equal(t, tt.wantObjectCount, status[0].Stats.ObjectCount)
+			require.Equal(t, tt.wantShardCount, status[0].Stats.ShardCount)
+
+			if tt.wantBatchNil {
+				require.Nil(t, status[0].BatchStats)
+			} else {
+				require.NotNil(t, status[0].BatchStats)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

GET /nodes?output=verbose (no class) filtered per-shard status by RBAC but left Stats (ObjectCount/ShardCount)  as node-wide aggregates summed across every class, leaking the existence and data volume of classes the caller can't see. When the shard filter hides anything on a node, recompute Stats from the retained shards; when nothing is hidden, leave the aggregates intact.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
