### PR TITLE
Resolve class only once on GRPC layer

### DIFF
--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -71,7 +71,7 @@ func NewReplier(
 	}
 }
 
-func (r *Replier) Search(res []interface{}, start time.Time, searchParams dto.GetParams, scheme schema.Schema) (*pb.SearchReply, error) {
+func (r *Replier) Search(res []interface{}, start time.Time, searchParams dto.GetParams, resolver *schemaResolver) (*pb.SearchReply, error) {
 	tookSeconds := float64(time.Since(start)) / float64(time.Second)
 	out := &pb.SearchReply{
 		Took:                    float32(tookSeconds),
@@ -81,7 +81,7 @@ func (r *Replier) Search(res []interface{}, start time.Time, searchParams dto.Ge
 	if searchParams.GroupBy != nil {
 		out.GroupByResults = make([]*pb.GroupByResult, len(res))
 		for i, raw := range res {
-			group, generativeGroupResponse, err := r.extractGroup(raw, searchParams, scheme)
+			group, generativeGroupResponse, err := r.extractGroup(raw, searchParams, resolver)
 			if err != nil {
 				return nil, err
 			}
@@ -91,7 +91,7 @@ func (r *Replier) Search(res []interface{}, start time.Time, searchParams dto.Ge
 			out.GroupByResults[i] = group
 		}
 	} else {
-		objects, generativeGroupedResult, generativeGroupedResults, err := r.extractObjectsToResults(res, searchParams, scheme, false)
+		objects, generativeGroupedResult, generativeGroupedResults, err := r.extractObjectsToResults(res, searchParams, resolver, false)
 		if err != nil {
 			return nil, err
 		}
@@ -145,7 +145,7 @@ func (r *Replier) extractQueryProfile(res []interface{}) *pb.QueryProfile {
 	return &pb.QueryProfile{Shards: shards}
 }
 
-func (r *Replier) extractObjectsToResults(res []interface{}, searchParams dto.GetParams, scheme schema.Schema, fromGroup bool) ([]*pb.SearchResult, string, *pb.GenerativeResult, error) {
+func (r *Replier) extractObjectsToResults(res []interface{}, searchParams dto.GetParams, resolver *schemaResolver, fromGroup bool) ([]*pb.SearchResult, string, *pb.GenerativeResult, error) {
 	results := make([]*pb.SearchResult, len(res))
 	generativeGroupResultsReturnDeprecated := ""
 	var generativeGroupResults *pb.GenerativeResult
@@ -159,7 +159,7 @@ func (r *Replier) extractObjectsToResults(res []interface{}, searchParams dto.Ge
 		var props *pb.PropertiesResult
 		var err error
 
-		props, err = r.extractPropertiesAnswer(scheme, asMap, searchParams.Properties, searchParams.ClassName, searchParams.Alias, searchParams.AdditionalProperties)
+		props, err = r.extractPropertiesAnswer(resolver, asMap, searchParams.Properties, searchParams.ClassName, searchParams.Alias, searchParams.AdditionalProperties)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -417,7 +417,7 @@ func (r *Replier) extractAdditionalProps(asMap map[string]any, additionalPropsPa
 	return addProps, nil
 }
 
-func (r *Replier) extractGroup(raw any, searchParams dto.GetParams, scheme schema.Schema) (*pb.GroupByResult, string, error) {
+func (r *Replier) extractGroup(raw any, searchParams dto.GetParams, resolver *schemaResolver) (*pb.GroupByResult, string, error) {
 	generativeSearchRaw, generativeSearchEnabled := searchParams.AdditionalProperties.ModuleParams["generate"]
 	_, rerankEnabled := searchParams.AdditionalProperties.ModuleParams["rerank"]
 	asMap, ok := raw.(map[string]interface{})
@@ -514,7 +514,7 @@ func (r *Replier) extractGroup(raw any, searchParams dto.GetParams, scheme schem
 		returnObjectsUntyped[i] = group.Hits[i]
 	}
 
-	objects, _, _, err := r.extractObjectsToResults(returnObjectsUntyped, searchParams, scheme, true)
+	objects, _, _, err := r.extractObjectsToResults(returnObjectsUntyped, searchParams, resolver, true)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "extracting hits from group")
 	}
@@ -524,7 +524,7 @@ func (r *Replier) extractGroup(raw any, searchParams dto.GetParams, scheme schem
 	return ret, groupedGenerativeResults, nil
 }
 
-func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className, alias string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
+func (r *Replier) extractPropertiesAnswer(resolver *schemaResolver, results map[string]interface{}, properties search.SelectProperties, className, alias string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
 	nonRefProps := &pb.Properties{
 		Fields: make(map[string]*pb.Value, 0),
 	}
@@ -539,11 +539,11 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 			continue
 		}
 		if prop.IsPrimitive {
-			class := scheme.GetClass(className)
-			if class == nil {
-				return nil, fmt.Errorf("could not find class %s in schema", className)
+			class, err := resolver.resolve(className)
+			if err != nil {
+				return nil, err
 			}
-			dataType, err := schema.GetPropertyDataType(class, prop.Name)
+			dataType, err := class.primitiveDataType(prop.Name)
 			if err != nil {
 				return nil, errors.Wrap(err, "getting primitive property datatype")
 			}
@@ -555,11 +555,11 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 			continue
 		}
 		if prop.IsObject {
-			class := scheme.GetClass(className)
-			if class == nil {
-				return nil, fmt.Errorf("could not find class %s in schema", className)
+			class, err := resolver.resolve(className)
+			if err != nil {
+				return nil, err
 			}
-			nested, err := schema.GetPropertyByName(class, prop.Name)
+			nested, err := class.property(prop.Name)
 			if err != nil {
 				return nil, errors.Wrap(err, "getting nested property")
 			}
@@ -580,7 +580,7 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 			if !ok {
 				continue
 			}
-			extractedRefProp, err := r.extractPropertiesAnswer(scheme, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, "", additionalPropsParams)
+			extractedRefProp, err := r.extractPropertiesAnswer(resolver, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, "", additionalPropsParams)
 			if err != nil {
 				continue
 			}

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -1329,7 +1329,8 @@ func TestGRPCReply(t *testing.T) {
 	for _, tt := range tests {
 		replier := NewReplier(false, fakeGenerativeParams{}, nil)
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := replier.Search(tt.res, time.Now(), tt.searchParams, scheme)
+			getClass := func(className string) (*models.Class, error) { return scheme.GetClass(className), nil }
+			out, err := replier.Search(tt.res, time.Now(), tt.searchParams, newSchemaResolver(getClass))
 			if tt.hasError {
 				require.NotNil(t, err)
 			} else {

--- a/adapters/handlers/grpc/v1/schema_resolver.go
+++ b/adapters/handlers/grpc/v1/schema_resolver.go
@@ -1,0 +1,86 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package v1
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// schemaResolver memoizes property lookups for a single reply: it resolves each
+// class once through getClass and caches its property datatypes, so mapping N
+// results scans each class's properties once rather than once per result.
+// getClass is the same authorized, cloning getter used to parse the request, so
+// each class is authorized and cloned once per request.
+type schemaResolver struct {
+	getClass func(className string) (*models.Class, error)
+	classes  map[string]*resolvedClass
+}
+
+type resolvedClass struct {
+	class     *models.Class
+	dataTypes map[string]*schema.DataType
+	props     map[string]*models.Property
+}
+
+func newSchemaResolver(getClass func(className string) (*models.Class, error)) *schemaResolver {
+	return &schemaResolver{
+		getClass: getClass,
+		classes:  map[string]*resolvedClass{},
+	}
+}
+
+func (s *schemaResolver) resolve(className string) (*resolvedClass, error) {
+	if rc, ok := s.classes[className]; ok {
+		return rc, nil
+	}
+	class, err := s.getClass(className)
+	if err != nil {
+		return nil, err
+	}
+	if class == nil {
+		return nil, fmt.Errorf("could not find class %s in schema", className)
+	}
+	rc := &resolvedClass{
+		class:     class,
+		dataTypes: map[string]*schema.DataType{},
+		props:     map[string]*models.Property{},
+	}
+	s.classes[className] = rc
+	return rc, nil
+}
+
+func (rc *resolvedClass) primitiveDataType(propName string) (*schema.DataType, error) {
+	if dt, ok := rc.dataTypes[propName]; ok {
+		return dt, nil
+	}
+	dt, err := schema.GetPropertyDataType(rc.class, propName)
+	if err != nil {
+		return nil, err
+	}
+	rc.dataTypes[propName] = dt
+	return dt, nil
+}
+
+func (rc *resolvedClass) property(propName string) (*models.Property, error) {
+	if p, ok := rc.props[propName]; ok {
+		return p, nil
+	}
+	p, err := schema.GetPropertyByName(rc.class, propName)
+	if err != nil {
+		return nil, err
+	}
+	rc.props[propName] = p
+	return p, nil
+}

--- a/adapters/handlers/grpc/v1/schema_resolver_test.go
+++ b/adapters/handlers/grpc/v1/schema_resolver_test.go
@@ -1,0 +1,128 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package v1
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestSchemaResolver(t *testing.T) {
+	class := &models.Class{
+		Class: "Article",
+		Properties: []*models.Property{
+			{Name: "title", DataType: schema.DataTypeText.PropString()},
+			{Name: "wordCount", DataType: []string{"int"}},
+		},
+	}
+
+	// countingGetClass returns class for its own name and nil for anything else,
+	// counting every invocation so tests can assert memoization.
+	countingGetClass := func(calls *int) func(string) (*models.Class, error) {
+		return func(className string) (*models.Class, error) {
+			*calls++
+			if className == class.Class {
+				return class, nil
+			}
+			return nil, nil
+		}
+	}
+
+	t.Run("resolve", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			getClass  func(string) (*models.Class, error)
+			className string
+			wantErr   string
+		}{
+			{
+				name:      "existing class resolves",
+				getClass:  func(string) (*models.Class, error) { return class, nil },
+				className: "Article",
+			},
+			{
+				name:      "nil class returns not-found",
+				getClass:  func(string) (*models.Class, error) { return nil, nil },
+				className: "Unknown",
+				wantErr:   "could not find class Unknown in schema",
+			},
+			{
+				name:      "getClass error is propagated",
+				getClass:  func(n string) (*models.Class, error) { return nil, fmt.Errorf("not authorized for %s", n) },
+				className: "Article",
+				wantErr:   "not authorized for Article",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rc, err := newSchemaResolver(tt.getClass).resolve(tt.className)
+				if tt.wantErr != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tt.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				require.NotNil(t, rc)
+			})
+		}
+	})
+
+	t.Run("property lookups", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			prop         string
+			wantDataType schema.DataType
+			wantErr      bool
+		}{
+			{name: "primitive int property", prop: "wordCount", wantDataType: schema.DataTypeInt},
+			{name: "primitive text property", prop: "title", wantDataType: schema.DataTypeText},
+			{name: "unknown property errors", prop: "missing", wantErr: true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var calls int
+				rc, err := newSchemaResolver(countingGetClass(&calls)).resolve("Article")
+				require.NoError(t, err)
+
+				dt, dtErr := rc.primitiveDataType(tt.prop)
+				prop, propErr := rc.property(tt.prop)
+				if tt.wantErr {
+					require.Error(t, dtErr)
+					require.Error(t, propErr)
+					return
+				}
+				require.NoError(t, dtErr)
+				require.Equal(t, tt.wantDataType, *dt)
+				require.NoError(t, propErr)
+				require.Equal(t, tt.prop, prop.Name)
+			})
+		}
+	})
+
+	t.Run("memoizes across repeated lookups", func(t *testing.T) {
+		var calls int
+		rs := newSchemaResolver(countingGetClass(&calls))
+
+		for i := 0; i < 5; i++ {
+			rc, err := rs.resolve("Article")
+			require.NoError(t, err)
+			_, err = rc.primitiveDataType("wordCount")
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, 1, calls, "getClass must be called once per distinct class, not once per lookup")
+	})
+}

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -104,9 +104,8 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	parser := NewAggregateParser(
-		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
-	)
+	getClass := s.classGetterWithAuthzFunc(ctx, principal, req.Tenant)
+	parser := NewAggregateParser(getClass)
 
 	params, err := parser.Aggregate(req)
 	if err != nil {
@@ -118,10 +117,7 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 		return nil, fmt.Errorf("aggregate: %w", err)
 	}
 
-	replier := NewAggregateReplier(
-		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
-		params,
-	)
+	replier := NewAggregateReplier(getClass, params)
 	reply, err := replier.Aggregate(res, params.GroupBy != nil)
 	if err != nil {
 		return nil, fmt.Errorf("prepare reply: %w", err)
@@ -291,9 +287,10 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
+	getClass := s.classGetterWithAuthzFunc(ctx, principal, req.Tenant)
 	parser := NewParser(
 		req.Uses_127Api,
-		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
+		getClass,
 		s.aliasGetter(),
 	)
 	replier := NewReplier(
@@ -307,7 +304,7 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 		return nil, err
 	}
 
-	if err := s.validateClassAndProperty(searchParams); err != nil {
+	if err := s.validateClassAndProperty(getClass, searchParams); err != nil {
 		return nil, err
 	}
 
@@ -316,14 +313,13 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 		return nil, err
 	}
 
-	scheme := s.schemaManager.GetSchemaSkipAuth()
-	return replier.Search(res, before, searchParams, scheme)
+	return replier.Search(res, before, searchParams, newSchemaResolver(getClass))
 }
 
-func (s *Service) validateClassAndProperty(searchParams dto.GetParams) error {
-	class := s.schemaManager.ReadOnlyClass(searchParams.ClassName)
-	if class == nil {
-		return fmt.Errorf("could not find class %s in schema", searchParams.ClassName)
+func (s *Service) validateClassAndProperty(getClass classGetterWithAuthzFunc, searchParams dto.GetParams) error {
+	class, err := getClass(searchParams.ClassName)
+	if err != nil {
+		return err
 	}
 
 	for _, prop := range searchParams.Properties {


### PR DESCRIPTION
### What's being changed:

Fetch the class only a single time in the GRPC layer and reuse (authorized) classes in subsequent usages


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
