### PR TITLE
fix(bm25): dedup duplicate properties (last boost wins)

### DIFF
--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -795,12 +795,7 @@ func EqualFloats(t *testing.T, expected, actual float32, significantFigures int)
 	require.Equal(t, s1[:significantFigures+1], s2[:significantFigures+1])
 }
 
-// TestBM25F_DuplicatePropertyLastBoostWins verifies that a duplicate property
-// in the search list (e.g. ["title", "title^2"]) is scored exactly once, with
-// the LAST boost winning. Without deduping, the property is processed twice —
-// its bucket is scored twice and its term frequency is double-counted — which
-// inflates the score and can reorder results. Runs against both the classic
-// WAND and the BlockMaxWAND engines.
+// A duplicate property (e.g. ["title", "title^2"]) must be scored once, with the last boost winning.
 func TestBM25F_DuplicatePropertyLastBoostWins(t *testing.T) {
 	for _, block := range []bool{false, true} {
 		name := "wand"
@@ -809,11 +804,8 @@ func TestBM25F_DuplicatePropertyLastBoostWins(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			config.DefaultUsingBlockMaxWAND = block
-			// A minimal two-text-property class is enough to prove the dedup:
-			// the query term "journey" appears in both "title" and "description"
-			// at different frequencies, so double-counting "title" shifts scores.
-			// InvertedIndexConfig picks up config.DefaultUsingBlockMaxWAND above,
-			// selecting the engine under test.
+			// "journey" appears in both properties at different frequencies,
+			// so double-counting "title" would shift scores.
 			vFalse, vTrue := false, true
 			searchableText := func(name string) *models.Property {
 				return &models.Property{
@@ -872,14 +864,12 @@ func TestBM25F_DuplicatePropertyLastBoostWins(t *testing.T) {
 				}
 			}
 
-			// Last boost is title^2, so the duplicate query must be identical to
-			// a single ["title^2", "description"] search (title counted once).
+			// Last boost (title^2) wins: must match a single ["title^2", "description"] search.
 			baseIds, baseScores := search([]string{"title^2", "description"})
 			dupIds, dupScores := search([]string{"title", "title^2", "description"})
 			assertSame(baseIds, baseScores, dupIds, dupScores)
 
-			// Last boost wins the other direction too: with title (boost 1) last,
-			// the duplicate query must match a single ["title", "description"].
+			// And the reverse: title (boost 1) last wins over title^2.
 			base2Ids, base2Scores := search([]string{"title", "description"})
 			dup2Ids, dup2Scores := search([]string{"title^2", "title", "description"})
 			assertSame(base2Ids, base2Scores, dup2Ids, dup2Scores)

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -792,6 +793,98 @@ func EqualFloats(t *testing.T, expected, actual float32, significantFigures int)
 		significantFigures = len(s2) - 1
 	}
 	require.Equal(t, s1[:significantFigures+1], s2[:significantFigures+1])
+}
+
+// TestBM25F_DuplicatePropertyLastBoostWins verifies that a duplicate property
+// in the search list (e.g. ["title", "title^2"]) is scored exactly once, with
+// the LAST boost winning. Without deduping, the property is processed twice —
+// its bucket is scored twice and its term frequency is double-counted — which
+// inflates the score and can reorder results. Runs against both the classic
+// WAND and the BlockMaxWAND engines.
+func TestBM25F_DuplicatePropertyLastBoostWins(t *testing.T) {
+	for _, block := range []bool{false, true} {
+		name := "wand"
+		if block {
+			name = "blockmaxwand"
+		}
+		t.Run(name, func(t *testing.T) {
+			config.DefaultUsingBlockMaxWAND = block
+			// A minimal two-text-property class is enough to prove the dedup:
+			// the query term "journey" appears in both "title" and "description"
+			// at different frequencies, so double-counting "title" shifts scores.
+			// InvertedIndexConfig picks up config.DefaultUsingBlockMaxWAND above,
+			// selecting the engine under test.
+			vFalse, vTrue := false, true
+			searchableText := func(name string) *models.Property {
+				return &models.Property{
+					Name:            name,
+					DataType:        schema.DataTypeText.PropString(),
+					Tokenization:    models.PropertyTokenizationWord,
+					IndexFilterable: &vFalse,
+					IndexSearchable: &vTrue,
+				}
+			}
+			class := &models.Class{
+				Class:               "DupPropClass",
+				VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+				InvertedIndexConfig: BM25FinvertedConfig(0.5, 100, "none"),
+				Properties: []*models.Property{
+					searchableText("title"),
+					searchableText("description"),
+				},
+			}
+			repo := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+
+			docs := []map[string]interface{}{
+				{"title": "journey", "description": "an unrelated description"},
+				{"title": "a distant title", "description": "journey journey journey"},
+				{"title": "journey journey", "description": "one journey here"},
+				{"title": "a journey story", "description": "the journey continues, journey on"},
+				{"title": "nothing to see", "description": "wholly unrelated content"},
+				{"title": "journey journey journey", "description": "short"},
+			}
+			for i, docProps := range docs {
+				id := strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String())
+				require.Nil(t, repo.PutObject(context.Background(),
+					&models.Object{Class: class.Class, ID: id, Properties: docProps},
+					[]float32{1, 3, 5, 0.4}, nil, nil, nil, 0))
+			}
+
+			idx := repo.GetIndex(schema.ClassName(class.Class))
+			require.NotNil(t, idx)
+
+			search := func(properties []string) ([]uint64, []float32) {
+				kwr := &searchparams.KeywordRanking{Type: "bm25", Properties: properties, Query: "journey"}
+				res, scores, err := idx.objectSearch(context.TODO(), 1000, nil, kwr, nil, nil, additional.Properties{}, nil, "", 0, []string{"title", "description"})
+				require.Nil(t, err)
+				ids := make([]uint64, len(res))
+				for i, r := range res {
+					ids[i] = r.DocID
+				}
+				return ids, scores
+			}
+
+			assertSame := func(wantIds []uint64, wantScores []float32, gotIds []uint64, gotScores []float32) {
+				require.Equal(t, wantIds, gotIds)
+				require.Equal(t, len(wantScores), len(gotScores))
+				for i := range wantScores {
+					EqualFloats(t, wantScores[i], gotScores[i], 6)
+				}
+			}
+
+			// Last boost is title^2, so the duplicate query must be identical to
+			// a single ["title^2", "description"] search (title counted once).
+			baseIds, baseScores := search([]string{"title^2", "description"})
+			dupIds, dupScores := search([]string{"title", "title^2", "description"})
+			assertSame(baseIds, baseScores, dupIds, dupScores)
+
+			// Last boost wins the other direction too: with title (boost 1) last,
+			// the duplicate query must match a single ["title", "description"].
+			base2Ids, base2Scores := search([]string{"title", "description"})
+			dup2Ids, dup2Scores := search([]string{"title^2", "title", "description"})
+			assertSame(base2Ids, base2Scores, dup2Ids, dup2Scores)
+		})
+	}
 }
 
 // Compare with previous BM25 version to ensure the algorithm functions correctly

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -178,12 +178,8 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 		}
 		propertyBoosts[property] = float32(propBoost)
 
-		// Dedupe (e.g. ["title", "title^2"], last boost wins): a duplicate
-		// property must be processed only once. propertyBoosts is keyed by
-		// property name and is overwritten above every iteration, so the last
-		// occurrence's boost always wins; without this guard the property is
-		// appended to props (and thus propNamesByTokenization) twice, so its
-		// bucket is scored twice and its term frequency is double-counted.
+		// Skip duplicates: propertyBoosts already holds the last boost for
+		// this property; processing it again would double-count its score.
 		if _, dup := seenProps[property]; dup {
 			continue
 		}

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -164,6 +164,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 	}
 
 	props := make([]propInfo, 0, len(params.Properties))
+	seenProps := make(map[string]struct{}, len(params.Properties))
 	neededTokenizations := map[string]struct{}{}
 	needsASCIIFold := map[string]struct{}{}
 
@@ -176,6 +177,17 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 			propBoost, _ = strconv.Atoi(boostStr)
 		}
 		propertyBoosts[property] = float32(propBoost)
+
+		// Dedupe (e.g. ["title", "title^2"], last boost wins): a duplicate
+		// property must be processed only once. propertyBoosts is keyed by
+		// property name and is overwritten above every iteration, so the last
+		// occurrence's boost always wins; without this guard the property is
+		// appended to props (and thus propNamesByTokenization) twice, so its
+		// bucket is scored twice and its term frequency is double-counted.
+		if _, dup := seenProps[property]; dup {
+			continue
+		}
+		seenProps[property] = struct{}{}
 
 		propMean, err := b.GetPropertyLengthTracker().PropertyMean(property)
 		if err != nil {


### PR DESCRIPTION
SuperClaude here.

Per André's "one PR per change" rule, this PR is now scoped to a **single**
BM25 ("BMW") correctness fix: deduping duplicate query properties. The
error-propagation fix that previously rode along here has moved to its own PR,
[weaviate/weaviate#12007](https://github.com/weaviate/weaviate/pull/12007).

Both are standalone correctness bugs spun out of
[weaviate/weaviate#11540](https://github.com/weaviate/weaviate/issues/11540)
(branch `qa-lq-atomic-overlay-swap`) so they can land on `stable/v1.37`
independently of #11540's pin/overlay machinery (which `v1.37` does not have).

## The fix — dedup duplicate query properties (last boost wins)

In `generateQueryTermsAndStats` (`bm25_searcher.go`), a property list like
`["title", "title^2"]` was appended to `props` — and therefore to
`propNamesByTokenization` — **twice**. Downstream, `createTerm` iterates that
property-name list and scores the property's bucket once per entry, so the
duplicate caused the property's postings to be added twice: its term frequency
was double-counted, inflating the score and reordering results.

`propertyBoosts` is keyed by property name and overwritten every iteration, so
the **last** boost already wins; the added `seenProps` guard simply ensures the
property is *processed* only once. On #11540 the same guard exists but its
comment ties it to the pin machinery — on `v1.37` there is no pin machinery, so
this is a plain double-counting fix.

## Test

**`TestBM25F_DuplicatePropertyLastBoostWins`** (integration): a duplicate
property scores identically to the equivalent single-property query, with the
last boost winning in **both** directions (`title^2` last ⇒ boost 2;
`title` last ⇒ boost 1). Runs against both the WAND and BlockMaxWAND engines.
Verified **red** without the dedup guard (results reorder), **green** with it.

## Verification (full local CI-equivalent)

- `./tools/gen-code-from-swagger.sh` produces no diff.
- `golangci-lint run ./...` — 0 issues (whole module).
- `gofmt -l` and `gofumpt -l` (v0.9.2) both clean.
- `go build ./adapters/repos/db/...` clean.
- `TestBM25F_DuplicatePropertyLastBoostWins` green under `-race` (both engines),
  red without the guard; full `./adapters/repos/db/inverted/` suite green under
  `-race`.

— SuperClaude