### PR TITLE
fix(queue): recover from corrupt chunk headers instead of failing to load

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -57,10 +57,23 @@ const (
 	chunkFileFmt = "chunk-%d.bin"
 
 	magicHeader = "WV8Q"
+
+	// chunkHeaderSize is the size of a chunk file header:
+	// magic + version + record count.
+	chunkHeaderSize = len(magicHeader) + 1 + 8
 )
 
-// regex pattern for the chunk files
-var chunkFilePattern = regexp.MustCompile(`chunk-\d+\.bin`)
+// regex pattern for the chunk files.
+// It is anchored so that derived files (e.g. .processed tombstones or
+// .corrupt quarantined chunks) never match.
+var chunkFilePattern = regexp.MustCompile(`^chunk-\d+\.bin$`)
+
+// errBadMagic and errUnknownVersion let init-time recovery distinguish a
+// corrupt header from a well-formed header written by a newer version.
+var (
+	errBadMagic       = errors.New("invalid magic header")
+	errUnknownVersion = errors.New("invalid version")
+)
 
 // regex pattern for processed chunk tombstone files
 var processedChunkFilePattern = regexp.MustCompile(`^chunk-\d+\.bin\.processed$`)
@@ -660,12 +673,17 @@ func (q *DiskQueue) analyzeDisk() ([]string, error) {
 			continue
 		}
 
-		q.diskUsage += fi.Size()
-
 		count, err := q.readChunkRecordCount(filePath)
 		if err != nil {
-			return nil, err
+			// a crash may have left a chunk file with an unreadable header.
+			// It must not prevent the queue from starting.
+			if err := q.salvageUnreadableChunk(filePath, fi.Size(), err); err != nil {
+				return nil, err
+			}
+			continue
 		}
+
+		q.diskUsage += fi.Size()
 
 		// partial chunk
 		if count == 0 {
@@ -679,6 +697,39 @@ func (q *DiskQueue) analyzeDisk() ([]string, error) {
 	}
 
 	return chunkList, nil
+}
+
+// salvageUnreadableChunk handles a chunk file whose header cannot be parsed,
+// typically the leftover of a crash (power loss, disk full) while the chunk
+// was being created.
+// A file too short to contain a full header provably holds no records
+// (records are only ever written after the header) and is removed.
+// A full-size file with unreadable framing is renamed to <name>.corrupt so it
+// no longer blocks startup but remains available for inspection.
+// A well-formed header with an unknown version is not salvaged: it was likely
+// written by a newer version of weaviate and discarding it would lose valid
+// data, so the error is returned and initialization fails.
+func (q *DiskQueue) salvageUnreadableChunk(path string, size int64, cause error) error {
+	if errors.Is(cause, errUnknownVersion) {
+		return cause
+	}
+
+	if size < int64(chunkHeaderSize) {
+		if err := os.Remove(path); err != nil {
+			return errors.Wrap(err, "failed to remove chunk with incomplete header")
+		}
+		q.Logger.WithField("file", path).
+			Warnf("removed chunk with incomplete header (%d bytes), likely due to a crash: %v", size, cause)
+		return nil
+	}
+
+	quarantinePath := path + ".corrupt"
+	if err := os.Rename(path, quarantinePath); err != nil {
+		return errors.Wrap(err, "failed to quarantine corrupt chunk")
+	}
+	q.Logger.WithField("file", quarantinePath).
+		Errorf("quarantined chunk with unreadable header, its tasks are lost: %v", cause)
+	return nil
 }
 
 // ListFiles returns a list of all chunk files in the queue directory.
@@ -721,13 +772,10 @@ func (q *DiskQueue) listFilesNoLock(ctx context.Context, basePath string) ([]str
 			continue
 		}
 
-		// skip tombstone files (they match chunkFilePattern since it's unanchored)
-		if processedChunkFilePattern.MatchString(entry.Name()) {
-			continue
-		}
-
-		// check if the entry name matches the regex pattern of a chunk file
-		if !chunkFilePattern.Match([]byte(entry.Name())) {
+		// check if the entry name matches the regex pattern of a chunk file.
+		// This also excludes derived files such as .processed tombstones and
+		// .corrupt quarantined chunks, since the pattern is anchored.
+		if !chunkFilePattern.MatchString(entry.Name()) {
 			continue
 		}
 
@@ -880,7 +928,7 @@ func (c *chunk) Close() error {
 
 func readChunkHeader(r io.Reader) (uint64, error) {
 	// read the header
-	header := make([]byte, len(magicHeader)+1+8)
+	header := make([]byte, chunkHeaderSize)
 	_, err := io.ReadFull(r, header)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to read header")
@@ -888,12 +936,12 @@ func readChunkHeader(r io.Reader) (uint64, error) {
 
 	// check the magic number
 	if !bytes.Equal(header[:len(magicHeader)], []byte(magicHeader)) {
-		return 0, errors.New("invalid magic header")
+		return 0, errBadMagic
 	}
 
 	// check the version
 	if header[len(magicHeader)] != 1 {
-		return 0, errors.New("invalid version")
+		return 0, errUnknownVersion
 	}
 
 	// read the number of records
@@ -1038,7 +1086,7 @@ func (w *chunkWriter) Create() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to write size")
 	}
-	w.size = uint64(len(magicHeader) + 1 + 8)
+	w.size = uint64(chunkHeaderSize)
 
 	return nil
 }
@@ -1049,11 +1097,20 @@ func (w *chunkWriter) Open() error {
 		return errors.Wrap(err, "failed to read directory")
 	}
 
-	if len(entries) == 0 {
-		return nil
+	// adopt the most recent chunk file as the write target. The directory may
+	// also contain derived files (e.g. .corrupt quarantined chunks): those
+	// must never be written to.
+	var lastChunk string
+	for _, entry := range entries {
+		if entry.IsDir() || !chunkFilePattern.MatchString(entry.Name()) {
+			continue
+		}
+		lastChunk = entry.Name()
 	}
 
-	lastChunk := entries[len(entries)-1].Name()
+	if lastChunk == "" {
+		return nil
+	}
 
 	w.f, err = os.OpenFile(filepath.Join(w.dir, lastChunk), os.O_RDWR, 0o644)
 	if err != nil {
@@ -1086,7 +1143,7 @@ func (w *chunkWriter) Open() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to write size")
 		}
-		w.size = uint64(len(magicHeader) + 1 + 8)
+		w.size = uint64(chunkHeaderSize)
 
 		return nil
 	}

--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -706,11 +706,16 @@ func (q *DiskQueue) analyzeDisk() ([]string, error) {
 // (records are only ever written after the header) and is removed.
 // A full-size file with unreadable framing is renamed to <name>.corrupt so it
 // no longer blocks startup but remains available for inspection.
-// A well-formed header with an unknown version is not salvaged: it was likely
-// written by a newer version of weaviate and discarding it would lose valid
-// data, so the error is returned and initialization fails.
+// Only errors that are evidence of a corrupt or torn header are salvaged.
+// Anything else is returned and fails initialization: an environmental error
+// (e.g. permissions, I/O) does not mean the chunk is bad, and a well-formed
+// header with an unknown version was likely written by a newer version of
+// weaviate, so removing or hiding the chunk in those cases could drop valid
+// tasks.
 func (q *DiskQueue) salvageUnreadableChunk(path string, size int64, cause error) error {
-	if errors.Is(cause, errUnknownVersion) {
+	if !errors.Is(cause, errBadMagic) &&
+		!errors.Is(cause, io.EOF) &&
+		!errors.Is(cause, io.ErrUnexpectedEOF) {
 		return cause
 	}
 

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -595,7 +595,7 @@ func TestCorruptChunkHeaderRecovery(t *testing.T) {
 				// backups must not pick it up
 				files, err := q.ListFiles(t.Context(), tmpDir)
 				require.NoError(t, err)
-				require.Len(t, files, 1)
+				require.Contains(t, files, filepath.Base(validChunk))
 				for _, f := range files {
 					require.False(t, strings.HasSuffix(f, ".corrupt"), "quarantined chunk should not appear in backup list")
 				}

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -491,7 +491,7 @@ func TestPartialChunkRecovery(t *testing.T) {
 
 // chunkHeader builds a chunk file header with the given version and record count.
 func chunkHeader(version byte, count uint64) []byte {
-	buf := make([]byte, len(magicHeader)+1+8)
+	buf := make([]byte, chunkHeaderSize)
 	copy(buf, magicHeader)
 	buf[len(magicHeader)] = version
 	binary.BigEndian.PutUint64(buf[len(magicHeader)+1:], count)
@@ -516,7 +516,7 @@ func TestCorruptChunkHeaderRecovery(t *testing.T) {
 		sortsAfter  = "chunk-9999999999999999.bin"
 	)
 
-	badMagic := append([]byte("XXXX"), chunkHeader(1, 3)[4:]...)
+	badMagic := append(bytes.Repeat([]byte("X"), len(magicHeader)), chunkHeader(1, 3)[len(magicHeader):]...)
 	badMagic = append(badMagic, 0xDE, 0xAD, 0xBE, 0xEF)
 
 	tests := []struct {

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -641,6 +641,63 @@ func TestCorruptChunkHeaderRecovery(t *testing.T) {
 	}
 }
 
+// An error opening or reading a chunk file (e.g. permissions, I/O) is not
+// evidence of corruption: quarantining or removing the chunk in that case
+// could silently drop valid tasks, so initialization must fail fast and leave
+// the file untouched.
+func TestCorruptChunkHeaderRecoveryUnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission errors are not enforced for root")
+	}
+
+	s := makeScheduler(t)
+	s.Start()
+	defer s.Close(t.Context())
+
+	tmpDir := t.TempDir()
+	decoder := discardExecutor()
+
+	// write one sealed chunk with 3 records
+	q := makeQueueWith(t, s, decoder, 50, tmpDir)
+	q.Pause(t.Context())
+	pushMany(t, q, 1, 100, 200, 300)
+	err := q.w.Promote()
+	require.NoError(t, err)
+	err = q.Close(t.Context())
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	validChunk := filepath.Join(tmpDir, entries[0].Name())
+
+	// make the chunk unreadable: opening it fails with a permission error
+	err = os.Chmod(validChunk, 0o000)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chmod(validChunk, 0o644) })
+
+	q, err = NewDiskQueue(DiskQueueOptions{
+		ID:           "test_queue",
+		Scheduler:    s,
+		Logger:       newTestLogger(),
+		Dir:          tmpDir,
+		TaskDecoder:  decoder,
+		StaleTimeout: 500 * time.Millisecond,
+		ChunkSize:    50,
+	})
+	require.NoError(t, err)
+
+	// the queue must fail fast instead of discarding a chunk it cannot read
+	err = q.Init()
+	require.Error(t, err, "an unreadable chunk file must fail initialization, not be salvaged")
+
+	// the chunk file must be left untouched
+	_, err = os.Stat(validChunk)
+	require.NoError(t, err)
+	_, err = os.Stat(validChunk + ".corrupt")
+	require.ErrorIs(t, err, os.ErrNotExist, "an unreadable chunk file must not be quarantined")
+}
+
 func TestQueueAutoReleaseResources(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -489,6 +489,158 @@ func TestPartialChunkRecovery(t *testing.T) {
 	}
 }
 
+// chunkHeader builds a chunk file header with the given version and record count.
+func chunkHeader(version byte, count uint64) []byte {
+	buf := make([]byte, len(magicHeader)+1+8)
+	copy(buf, magicHeader)
+	buf[len(magicHeader)] = version
+	binary.BigEndian.PutUint64(buf[len(magicHeader)+1:], count)
+	return buf
+}
+
+// A crash (power loss, disk full during chunk creation) can leave a chunk file
+// with a truncated or garbage header. Such a file must not prevent the queue
+// from starting: a file too short to contain a full header provably holds no
+// records and should be removed, while a full-size file with unreadable framing
+// should be quarantined as .corrupt for forensics. Only a well-formed header
+// with an unknown version (likely written by a newer weaviate) should keep
+// failing Init, since discarding that data would be wrong.
+func TestCorruptChunkHeaderRecovery(t *testing.T) {
+	// chunk files created during the test are named chunk-<unixmicro>.bin with
+	// a 16-digit timestamp starting with 1. sortsBefore/sortsAfter place the
+	// corrupt file on either side of the valid chunk in directory order: the
+	// "after" position additionally guards chunkWriter.Open, which adopts the
+	// last file in the directory as its write target.
+	const (
+		sortsBefore = "chunk-1.bin"
+		sortsAfter  = "chunk-9999999999999999.bin"
+	)
+
+	badMagic := append([]byte("XXXX"), chunkHeader(1, 3)[4:]...)
+	badMagic = append(badMagic, 0xDE, 0xAD, 0xBE, 0xEF)
+
+	tests := []struct {
+		name            string
+		file            string
+		content         []byte
+		wantInitErr     bool
+		wantQuarantined bool
+	}{
+		{name: "empty file", file: sortsBefore, content: nil},
+		{name: "torn header", file: sortsBefore, content: chunkHeader(1, 0)[:2]},
+		{name: "torn header almost complete", file: sortsBefore, content: chunkHeader(1, 0)[:12]},
+		{name: "torn header sorts last", file: sortsAfter, content: chunkHeader(1, 0)[:5]},
+		{name: "bad magic", file: sortsBefore, content: badMagic, wantQuarantined: true},
+		{name: "bad magic sorts last", file: sortsAfter, content: badMagic, wantQuarantined: true},
+		{name: "unknown version", file: sortsBefore, content: chunkHeader(2, 3), wantInitErr: true},
+	}
+
+	s := makeScheduler(t)
+	s.Start()
+	defer s.Close(t.Context())
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			decoder := discardExecutor()
+
+			// write one sealed chunk with 3 records
+			q := makeQueueWith(t, s, decoder, 50, tmpDir)
+			q.Pause(t.Context())
+			pushMany(t, q, 1, 100, 200, 300)
+			err := q.w.Promote()
+			require.NoError(t, err)
+			err = q.Close(t.Context())
+			require.NoError(t, err)
+
+			entries, err := os.ReadDir(tmpDir)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			validChunk := filepath.Join(tmpDir, entries[0].Name())
+
+			// simulate a crash that left a chunk file with an unreadable header
+			corruptFile := filepath.Join(tmpDir, test.file)
+			err = os.WriteFile(corruptFile, test.content, 0o644)
+			require.NoError(t, err)
+
+			// reopen the queue
+			q, err = NewDiskQueue(DiskQueueOptions{
+				ID:           "test_queue",
+				Scheduler:    s,
+				Logger:       newTestLogger(),
+				Dir:          tmpDir,
+				TaskDecoder:  decoder,
+				StaleTimeout: 500 * time.Millisecond,
+				ChunkSize:    50,
+			})
+			require.NoError(t, err)
+
+			err = q.Init()
+			if test.wantInitErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err, "a chunk file with an unreadable header must not prevent the queue from starting")
+
+			// the valid chunk must be untouched and its records still counted
+			_, err = os.Stat(validChunk)
+			require.NoError(t, err)
+			require.EqualValues(t, 3, q.Size())
+
+			if test.wantQuarantined {
+				// the corrupt file is set aside for forensics, not deleted
+				_, err = os.Stat(corruptFile + ".corrupt")
+				require.NoError(t, err, "corrupt chunk should be quarantined as .corrupt")
+
+				// backups must not pick it up
+				files, err := q.ListFiles(t.Context(), tmpDir)
+				require.NoError(t, err)
+				require.Len(t, files, 1)
+				for _, f := range files {
+					require.False(t, strings.HasSuffix(f, ".corrupt"), "quarantined chunk should not appear in backup list")
+				}
+			}
+
+			// either way, the corrupt file no longer blocks the queue's path
+			_, err = os.Stat(corruptFile)
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			// the valid records must still be dequeueable
+			batch, err := q.DequeueBatch()
+			require.NoError(t, err)
+			require.NotNil(t, batch)
+			require.Len(t, batch.Tasks, 3)
+			batch.Done()
+
+			// the queue must accept new pushes
+			err = q.Push(makeRecord(1, 400))
+			require.NoError(t, err)
+
+			err = q.Close(t.Context())
+			require.NoError(t, err)
+
+			// a restart must not trip over what recovery left behind, in
+			// particular the writer must not adopt a .corrupt file as its
+			// write target
+			q, err = NewDiskQueue(DiskQueueOptions{
+				ID:           "test_queue",
+				Scheduler:    s,
+				Logger:       newTestLogger(),
+				Dir:          tmpDir,
+				TaskDecoder:  decoder,
+				StaleTimeout: 500 * time.Millisecond,
+				ChunkSize:    50,
+			})
+			require.NoError(t, err)
+			err = q.Init()
+			require.NoError(t, err, "restart after recovery must succeed")
+			require.EqualValues(t, 1, q.Size())
+			err = q.Close(t.Context())
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestQueueAutoReleaseResources(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### What's being changed:

Fixes a crash-safety bug in the disk-backed queue (`adapters/repos/db/queue`) that could leave a shard permanently unable to load.

**The bug:** A crash — power loss, or disk-full while a new chunk file is being created — can leave a chunk file with a truncated or garbage header. On the next startup, `analyzeDisk` fails `readChunkHeader` on that file, which fails `Init()` and prevents the shard from loading. The condition is sticky: the same file is re-listed on every subsequent restart, so the shard never recovers on its own and needs manual intervention. Since this queue is the durability layer for pending vector-index work, an unloadable shard means its vectors stay missing from search until an operator removes the file by hand.

**The fix:** `analyzeDisk` now recovers from a corrupt header instead of aborting:
- A file too short to hold a full header provably contains no records (records are only ever written after the header) and is **removed**.
- A full-size file with unreadable framing is **quarantined** as `<name>.corrupt` — kept on disk for inspection, excluded from backups — so it no longer blocks startup.

Salvaging is strictly limited to errors that are actual evidence of a torn or corrupt header (`errBadMagic`, `io.EOF`, `io.ErrUnexpectedEOF`). Everything else fails `Init` and leaves the file untouched, so a chunk that might hold valid tasks is never discarded:
- **Environmental errors** (permissions, I/O errors while opening/reading the file) may resolve themselves and say nothing about the chunk's content.
- A well-formed header with an **unknown version** was most likely written by a newer Weaviate (e.g. after a downgrade), and silently discarding that data would be wrong.

Supporting changes:
- `readChunkHeader` returns `errBadMagic` / `errUnknownVersion` sentinels so recovery can distinguish corruption from a version mismatch.
- `chunkFilePattern` is now anchored (`^chunk-\d+\.bin$`) so derived files (`.corrupt`, `.processed` tombstones) never match; this also folds away a now-redundant tombstone skip in `ListFiles`.
- `chunkWriter.Open` adopts the last *pattern-matching* chunk as its write target instead of the last directory entry, so a quarantined file that sorts last can never be picked up and written to.

Quarantined/removed chunks are deliberately excluded from `Size()` and `diskUsage`: both track the live queue, and several call sites gate on `Size()` (shard `INDEXING`/`READY` status, scheduler polling, resource release), so counting records that can never be dequeued would leave a shard stuck in `INDEXING` forever. A dedicated quarantined-chunks metric is planned as a follow-up for operator visibility.

Each fix is preceded by a failing (red) regression test in the commit history. `TestCorruptChunkHeaderRecovery` covers empty/torn/bad-magic/unknown-version headers in both directory-sort positions; `TestCorruptChunkHeaderRecoveryUnreadableFile` pins the fail-fast behavior for unreadable files.

This is finding #1 from a broader crash-safety/corruption review of the package; the remaining findings (torn sealed chunks, decode-time panics that kill the scheduler, deadline-error retry hot-loop, per-batch panic isolation) are tracked separately.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
