### PR TITLE
fix(bm25): propagate combineResults error (was silent empty results)

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -253,7 +253,10 @@ func (b *BM25Searcher) wandBlock(
 	start = time.Now()
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_4_bmw_time", blockSearchTime)
 
-	objects, scores := b.combineResults(allIds, allScores, allExplanation, termCounts, additional, limit)
+	objects, scores, err := b.combineResults(allIds, allScores, allExplanation, termCounts, additional, limit)
+	if err != nil {
+		return nil, nil, false, err
+	}
 
 	combineTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_5_objects_time", combineTime)
@@ -262,7 +265,7 @@ func (b *BM25Searcher) wandBlock(
 	return objects, scores, false, nil
 }
 
-func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int) ([]*storobj.Object, []float32) {
+func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int) ([]*storobj.Object, []float32, error) {
 	// Preallocate by the real upper bound (total result rows across
 	// properties/segments), not limit*len(allIds): for unlimited (limit==0)
 	// queries the caller inflates limit to the sum of all term counts, which
@@ -301,11 +304,12 @@ func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float
 
 	limit = int(math.Min(float64(limit), float64(len(combinedIds))))
 
+	// Swallowing this error produced silent empty results.
 	combinedObjects, combinedScores, err := b.getObjectsAndScores(combinedIds, combinedScores, combinedExplanations, combinedTerms, additional, limit)
 	if err != nil {
-		return nil, nil
+		return nil, nil, err
 	}
-	return combinedObjects, combinedScores
+	return combinedObjects, combinedScores, nil
 }
 
 type aggregate func(float32, float32) float32

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -304,7 +304,6 @@ func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float
 
 	limit = int(math.Min(float64(limit), float64(len(combinedIds))))
 
-	// Swallowing this error produced silent empty results.
 	combinedObjects, combinedScores, err := b.getObjectsAndScores(combinedIds, combinedScores, combinedExplanations, combinedTerms, additional, limit)
 	if err != nil {
 		return nil, nil, err

--- a/adapters/repos/db/inverted/bm25_searcher_block_test.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block_test.go
@@ -25,11 +25,8 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// TestCombineResults_PropagatesGetObjectsError verifies that combineResults
-// surfaces an error from getObjectsAndScores to its caller instead of
-// swallowing it and returning silent empty results. The store here has no
-// objects bucket, so getObjectsAndScores fails to load the objects — that
-// failure must reach the caller.
+// TestCombineResults_PropagatesGetObjectsError pins combineResults forwarding
+// a getObjectsAndScores error instead of swallowing it.
 func TestCombineResults_PropagatesGetObjectsError(t *testing.T) {
 	logger := logrus.New()
 	dirName := t.TempDir()
@@ -41,9 +38,7 @@ func TestCombineResults_PropagatesGetObjectsError(t *testing.T) {
 	require.Nil(t, err)
 	defer store.Shutdown(context.Background())
 
-	// Create the objects bucket but deliberately WITHOUT a class name, so the
-	// object decode in getObjectsAndScores fails (ClassName() errors). This
-	// exercises the load-error path rather than a nil-bucket path.
+	// No class name set, so the object decode in getObjectsAndScores fails.
 	require.Nil(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
 		lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1)))
 	require.NotNil(t, store.Bucket(helpers.ObjectsBucketLSM))
@@ -53,8 +48,6 @@ func TestCombineResults_PropagatesGetObjectsError(t *testing.T) {
 		logger: logger,
 	}
 
-	// One property, one segment, one candidate doc id — enough to make
-	// getObjectsAndScores attempt (and fail) an objects lookup.
 	allIds := [][][]uint64{{{1}}}
 	allScores := [][][]float32{{{0.5}}}
 	allExplanation := [][][][]*terms.DocPointerWithScore{{{{nil}}}}

--- a/adapters/repos/db/inverted/bm25_searcher_block_test.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block_test.go
@@ -1,0 +1,67 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestCombineResults_PropagatesGetObjectsError verifies that combineResults
+// surfaces an error from getObjectsAndScores to its caller instead of
+// swallowing it and returning silent empty results. The store here has no
+// objects bucket, so getObjectsAndScores fails to load the objects — that
+// failure must reach the caller.
+func TestCombineResults_PropagatesGetObjectsError(t *testing.T) {
+	logger := logrus.New()
+	dirName := t.TempDir()
+
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.Nil(t, err)
+	defer store.Shutdown(context.Background())
+
+	// Create the objects bucket but deliberately WITHOUT a class name, so the
+	// object decode in getObjectsAndScores fails (ClassName() errors). This
+	// exercises the load-error path rather than a nil-bucket path.
+	require.Nil(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1)))
+	require.NotNil(t, store.Bucket(helpers.ObjectsBucketLSM))
+
+	b := &BM25Searcher{
+		store:  store,
+		logger: logger,
+	}
+
+	// One property, one segment, one candidate doc id — enough to make
+	// getObjectsAndScores attempt (and fail) an objects lookup.
+	allIds := [][][]uint64{{{1}}}
+	allScores := [][][]float32{{{0.5}}}
+	allExplanation := [][][][]*terms.DocPointerWithScore{{{{nil}}}}
+	queryTerms := [][]string{{"journey"}}
+
+	objects, scores, err := b.combineResults(allIds, allScores, allExplanation, queryTerms, additional.Properties{}, 10)
+	require.Error(t, err, "combineResults must propagate the objects-loading error rather than swallow it")
+	require.Nil(t, objects)
+	require.Nil(t, scores)
+}


### PR DESCRIPTION
SuperClaude here.

Per André's "one PR per change" rule, this PR carries a **single** BM25 ("BMW")
correctness fix: propagate the `combineResults` error instead of swallowing it.
It was split out of [weaviate/weaviate#12004](https://github.com/weaviate/weaviate/pull/12004),
which now carries only the duplicate-property dedup fix. Both are standalone
correctness bugs spun out of
[weaviate/weaviate#11540](https://github.com/weaviate/weaviate/issues/11540),
independent of #11540's pin/overlay machinery (which `v1.37` does not have).

## The fix — propagate the combine-path error instead of swallowing it

In `combineResults` (`bm25_searcher_block.go`) the error from
`getObjectsAndScores` was assigned and then dropped — `combineResults` returned
only `(objects, scores)`, so a failed objects load surfaced as **silent empty
results** rather than an error. `combineResults` now returns the error and
`wandBlock` forwards it:

```go
objects, scores, err := b.combineResults(...)
if err != nil {
    return nil, nil, false, err
}
```

## Test

**`TestCombineResults_PropagatesGetObjectsError`** (unit): an objects-load
failure inside `getObjectsAndScores` surfaces out of `combineResults` instead
of yielding silent empty results. Verified **red** when the error is swallowed,
**green** once it is propagated.

## Verification (full local CI-equivalent)

- `./tools/gen-code-from-swagger.sh` produces no diff.
- `golangci-lint run ./...` — 0 issues (whole module).
- `gofmt -l` and `gofumpt -l` (v0.9.2) both clean.
- `go build ./adapters/repos/db/...` clean.
- `go test -race ./adapters/repos/db/inverted/...` green; the new unit test is
  red without the fix, green with it.

— SuperClaude