### PR TITLE
fix(queue): validate chunk record count and length against file size

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -61,6 +61,10 @@ const (
 	// chunkHeaderSize is the size of a chunk file header:
 	// magic + version + record count.
 	chunkHeaderSize = len(magicHeader) + 1 + 8
+
+	// minEncodedRecordSize is the smallest possible record footprint in a
+	// chunk payload: a 4-byte length prefix plus at least 1 byte of record data.
+	minEncodedRecordSize = 4 + 1
 )
 
 // regex pattern for the chunk files.
@@ -361,11 +365,10 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 
 	// The record count comes from disk and may be corrupt. It is only used as
 	// a capacity hint: cap it by the number of records that could possibly
-	// fit in the chunk payload, i.e. a 4-byte length prefix plus at least
-	// one byte each.
+	// fit in the chunk payload.
 	payloadSize := c.size - uint64(chunkHeaderSize)
 	count := c.count
-	if maxRecords := payloadSize / 5; count > maxRecords {
+	if maxRecords := payloadSize / minEncodedRecordSize; count > maxRecords {
 		q.Logger.WithField("file", c.path).
 			Warnf("chunk header claims %d records, but at most %d fit in %d bytes of payload; the header is likely corrupt", c.count, maxRecords, payloadSize)
 		count = maxRecords
@@ -379,7 +382,7 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 	// ends mid-record. The records before the corruption are still valid:
 	// salvage them and quarantine the file, otherwise the chunk is never
 	// removed and its records stay counted, so the queue never drains.
-	var corruptChunk error
+	var corruptChunkErr error
 
 	buf := make([]byte, 4)
 	for {
@@ -391,7 +394,7 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 			break
 		}
 		if errors.Is(err, io.ErrUnexpectedEOF) {
-			corruptChunk = errors.Wrap(err, "chunk ends mid-record")
+			corruptChunkErr = errors.Wrap(err, "chunk ends mid-record")
 			break
 		}
 		if err != nil {
@@ -399,14 +402,14 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 		}
 		length := binary.BigEndian.Uint32(buf)
 		if length == 0 {
-			corruptChunk = errors.New("invalid record length")
+			corruptChunkErr = errors.New("invalid record length")
 			break
 		}
 		// the length prefix comes from disk and may be corrupt: a record
 		// cannot be larger than the chunk payload that contains it. Validate
 		// before allocating.
 		if uint64(length) > payloadSize-4 {
-			corruptChunk = errors.Errorf("invalid record length %d, chunk payload is only %d bytes", length, payloadSize)
+			corruptChunkErr = errors.Errorf("invalid record length %d, chunk payload is only %d bytes", length, payloadSize)
 			break
 		}
 
@@ -418,7 +421,7 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 		}
 		_, err = io.ReadFull(c.r, buf)
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-			corruptChunk = errors.Wrap(err, "chunk ends mid-record")
+			corruptChunkErr = errors.Wrap(err, "chunk ends mid-record")
 			break
 		}
 		if err != nil {
@@ -439,12 +442,12 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 		q.Logger.WithField("file", c.path).WithError(err).Warn("failed to close chunk file")
 	}
 
-	if corruptChunk != nil {
-		q.quarantineChunk(c, corruptChunk)
+	if corruptChunkErr != nil {
+		q.quarantineChunk(c, corruptChunkErr)
 	}
 
 	if len(tasks) == 0 {
-		if corruptChunk == nil {
+		if corruptChunkErr == nil {
 			// empty chunk, remove it
 			q.removeChunk(c)
 		}
@@ -454,7 +457,7 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 	doneFn := func() {
 		// a quarantined chunk is already renamed and removed from the
 		// queue's accounting
-		if corruptChunk == nil {
+		if corruptChunkErr == nil {
 			q.removeChunk(c)
 		}
 		if q.onBatchProcessed != nil {

--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -361,11 +361,13 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 
 	// The record count comes from disk and may be corrupt. It is only used as
 	// a capacity hint: cap it by the number of records that could possibly
-	// fit in the chunk, i.e. a 4-byte length prefix plus at least one byte each.
+	// fit in the chunk payload, i.e. a 4-byte length prefix plus at least
+	// one byte each.
+	payloadSize := c.size - uint64(chunkHeaderSize)
 	count := c.count
-	if maxRecords := c.size / 5; count > maxRecords {
+	if maxRecords := payloadSize / 5; count > maxRecords {
 		q.Logger.WithField("file", c.path).
-			Warnf("chunk header claims %d records, but at most %d fit in %d bytes; the header is likely corrupt", c.count, maxRecords, c.size)
+			Warnf("chunk header claims %d records, but at most %d fit in %d bytes of payload; the header is likely corrupt", c.count, maxRecords, payloadSize)
 		count = maxRecords
 	}
 
@@ -390,10 +392,10 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 			return nil, errors.New("invalid record length")
 		}
 		// the length prefix comes from disk and may be corrupt: a record
-		// cannot be larger than the chunk file that contains it. Validate
+		// cannot be larger than the chunk payload that contains it. Validate
 		// before allocating.
-		if uint64(length) > c.size {
-			return nil, errors.Errorf("invalid record length %d, chunk file is only %d bytes", length, c.size)
+		if uint64(length) > payloadSize-4 {
+			return nil, errors.Errorf("invalid record length %d, chunk payload is only %d bytes", length, payloadSize)
 		}
 
 		// read the record

--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -359,9 +359,19 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 	}
 	defer c.Close()
 
+	// The record count comes from disk and may be corrupt. It is only used as
+	// a capacity hint: cap it by the number of records that could possibly
+	// fit in the chunk, i.e. a 4-byte length prefix plus at least one byte each.
+	count := c.count
+	if maxRecords := c.size / 5; count > maxRecords {
+		q.Logger.WithField("file", c.path).
+			Warnf("chunk header claims %d records, but at most %d fit in %d bytes; the header is likely corrupt", c.count, maxRecords, c.size)
+		count = maxRecords
+	}
+
 	// decode all tasks from the chunk
 	// and partition them by worker
-	tasks := make([]Task, 0, c.count)
+	tasks := make([]Task, 0, count)
 
 	buf := make([]byte, 4)
 	for {
@@ -378,6 +388,12 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 		length := binary.BigEndian.Uint32(buf)
 		if length == 0 {
 			return nil, errors.New("invalid record length")
+		}
+		// the length prefix comes from disk and may be corrupt: a record
+		// cannot be larger than the chunk file that contains it. Validate
+		// before allocating.
+		if uint64(length) > c.size {
+			return nil, errors.Errorf("invalid record length %d, chunk file is only %d bytes", length, c.size)
 		}
 
 		// read the record

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -696,6 +697,103 @@ func TestCorruptChunkHeaderRecoveryUnreadableFile(t *testing.T) {
 	require.NoError(t, err)
 	_, err = os.Stat(validChunk + ".corrupt")
 	require.ErrorIs(t, err, os.ErrNotExist, "an unreadable chunk file must not be quarantined")
+}
+
+// writeSealedChunk creates a queue with a single sealed chunk containing
+// 3 records and returns the chunk file path.
+func writeSealedChunk(t *testing.T, s *Scheduler, dir string) string {
+	t.Helper()
+
+	q := makeQueueWith(t, s, discardExecutor(), 50, dir)
+	q.Pause(t.Context())
+	pushMany(t, q, 1, 100, 200, 300)
+	err := q.w.Promote()
+	require.NoError(t, err)
+	err = q.Close(t.Context())
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	return filepath.Join(dir, entries[0].Name())
+}
+
+func patchFile(t *testing.T, path string, off int64, data []byte) {
+	t.Helper()
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	require.NoError(t, err)
+	defer f.Close()
+
+	_, err = f.WriteAt(data, off)
+	require.NoError(t, err)
+}
+
+// The record count in a chunk header and the per-record length prefixes are
+// read from disk and may be corrupt. DequeueBatch must not size allocations
+// from them unvalidated: a corrupt count panics the scheduler goroutine,
+// which is never restarted, silently halting async indexing for every queue
+// on the node, and a corrupt length can allocate up to 4GB.
+func TestDequeueBatchCorruptChunk(t *testing.T) {
+	s := makeScheduler(t)
+	s.Start()
+	defer s.Close(t.Context())
+
+	newQueue := func(t *testing.T, dir string) *DiskQueue {
+		q, err := NewDiskQueue(DiskQueueOptions{
+			ID:           "test_queue",
+			Scheduler:    s,
+			Logger:       newTestLogger(),
+			Dir:          dir,
+			TaskDecoder:  discardExecutor(),
+			StaleTimeout: 500 * time.Millisecond,
+			ChunkSize:    50,
+		})
+		require.NoError(t, err)
+		err = q.Init()
+		require.NoError(t, err)
+		return q
+	}
+
+	t.Run("corrupt record count", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		chunkFile := writeSealedChunk(t, s, tmpDir)
+
+		// corrupt the header's record count with an absurdly large value
+		var countBuf [8]byte
+		binary.BigEndian.PutUint64(countBuf[:], math.MaxUint64)
+		patchFile(t, chunkFile, int64(len(magicHeader)+1), countBuf[:])
+
+		q := newQueue(t, tmpDir)
+
+		// the corrupt count must not be trusted to size allocations,
+		// and the valid records must still be returned
+		var batch *Batch
+		var err error
+		require.NotPanics(t, func() {
+			batch, err = q.DequeueBatch()
+		})
+		require.NoError(t, err)
+		require.NotNil(t, batch)
+		require.Len(t, batch.Tasks, 3)
+	})
+
+	t.Run("corrupt record length", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		chunkFile := writeSealedChunk(t, s, tmpDir)
+
+		// corrupt the first record's length prefix, located right after the header
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], 1<<31)
+		patchFile(t, chunkFile, int64(len(magicHeader)+1+8), lenBuf[:])
+
+		q := newQueue(t, tmpDir)
+
+		// the corrupt length must be rejected before any allocation
+		batch, err := q.DequeueBatch()
+		require.ErrorContains(t, err, "invalid record length")
+		require.Nil(t, batch)
+	})
 }
 
 func TestQueueAutoReleaseResources(t *testing.T) {

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -942,6 +942,7 @@ func TestDequeueBatchTornChunk(t *testing.T) {
 		})
 	}
 }
+
 func TestQueueAutoReleaseResources(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -14,6 +14,7 @@ package queue
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 	"math"
@@ -752,6 +753,9 @@ func TestDequeueBatchCorruptChunk(t *testing.T) {
 		require.NoError(t, err)
 		err = q.Init()
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = q.Close(context.Background())
+		})
 		return q
 	}
 


### PR DESCRIPTION
### What's being changed:

Hardens the disk-backed queue (`adapters/repos/db/queue`) against a single corrupted byte in a chunk file taking down async indexing for an entire node.

**The bug:** `DequeueBatch` sizes two allocations from values read straight off disk, with no validation:
- the chunk header's **record count**, used as the capacity of the task slice (`make([]Task, 0, c.count)`);
- each record's **length prefix**, used to allocate the read buffer (`make([]byte, length)`).

Either can be corrupt (bit rot, torn write). A corrupt count large enough to overflow the allocation size panics `makeslice` — and that runs inside the scheduler's single goroutine, which is shared by every queue on the node and is **not restarted** after `GoWrapper` recovers the panic. The result is that async indexing silently stops for the whole node and recurs on every restart, since the bad chunk is still on disk. Moderately large corrupt counts don't even panic: they request an absurd, lazily-mapped allocation that becomes an OOM kill on a memory-capped host. A corrupt length prefix allocates up to 4GB before the read fails.

**The fix:** bound both values by the chunk's actual file size.
- The record count is only a capacity hint, so it's clamped to the maximum number of records that could physically fit in the chunk (a 4-byte prefix plus at least one byte each) and a warning is logged. The records themselves are still read to EOF and returned, so a valid chunk with a corrupt-only count still yields all its tasks.
- A record length prefix larger than the chunk file cannot be valid and is rejected before any allocation, instead of being discovered through a failed multi-GB read.

Each fix is preceded by a failing (red) regression test in the commit history. `TestDequeueBatchCorruptChunk` seals a real 3-record chunk, then patches the header count (`math.MaxUint64`) or the first length prefix (`2^31`) and asserts `DequeueBatch` neither panics nor trusts the values.

This is finding #6 from a broader crash-safety/corruption review of the package. Related: #12006 (corrupt chunk header prevents shard load). Still open and tracked separately: torn sealed chunks that wedge the queue, worker/scheduler panic isolation, and the deadline-error retry hot-loop.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
