### PR TITLE
fix(queue): salvage and quarantine torn sealed chunks

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -672,11 +672,11 @@ func (q *DiskQueue) quarantineChunk(c *chunk, cause error) {
 	}
 
 	q.m.Lock()
+	defer q.m.Unlock()
 	q.recordCount -= c.count
 	q.diskUsage -= int64(c.size)
 	q.metrics.DiskUsage(q.diskUsage)
 	q.metrics.Size(q.recordCount)
-	q.m.Unlock()
 
 	q.Logger.WithField("file", quarantinePath).
 		Errorf("chunk is truncated or corrupt, quarantined it; records beyond the corruption are lost: %v", cause)

--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -363,6 +363,12 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 	// and partition them by worker
 	tasks := make([]Task, 0, c.count)
 
+	// a chunk torn by a crash (e.g. power loss before its tail reached disk)
+	// ends mid-record. The records before the tear are still valid: salvage
+	// them and quarantine the file, otherwise the chunk is never removed and
+	// its records stay counted, so the queue never drains.
+	var torn error
+
 	buf := make([]byte, 4)
 	for {
 		buf = buf[:4]
@@ -372,12 +378,17 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 		if errors.Is(err, io.EOF) {
 			break
 		}
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			torn = errors.Wrap(err, "chunk ends mid-record")
+			break
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read record length")
 		}
 		length := binary.BigEndian.Uint32(buf)
 		if length == 0 {
-			return nil, errors.New("invalid record length")
+			torn = errors.New("invalid record length")
+			break
 		}
 
 		// read the record
@@ -387,6 +398,10 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 			buf = buf[:length]
 		}
 		_, err = io.ReadFull(c.r, buf)
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			torn = errors.Wrap(err, "chunk ends mid-record")
+			break
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read record")
 		}
@@ -405,14 +420,24 @@ func (q *DiskQueue) DequeueBatch() (batch *Batch, err error) {
 		q.Logger.WithField("file", c.path).WithError(err).Warn("failed to close chunk file")
 	}
 
+	if torn != nil {
+		q.quarantineChunk(c, torn)
+	}
+
 	if len(tasks) == 0 {
-		// empty chunk, remove it
-		q.removeChunk(c)
+		if torn == nil {
+			// empty chunk, remove it
+			q.removeChunk(c)
+		}
 		return nil, nil
 	}
 
 	doneFn := func() {
-		q.removeChunk(c)
+		// a quarantined chunk is already renamed and removed from the
+		// queue's accounting
+		if torn == nil {
+			q.removeChunk(c)
+		}
 		if q.onBatchProcessed != nil {
 			q.onBatchProcessed()
 		}
@@ -628,6 +653,33 @@ func (q *DiskQueue) removeChunk(c *chunk) {
 	q.metrics.DiskUsage(q.diskUsage)
 	q.metrics.Size(q.recordCount)
 	q.m.Unlock()
+}
+
+// quarantineChunk renames a torn or corrupt chunk file to <name>.corrupt so
+// it is no longer scheduled, and removes its records from the queue's
+// accounting so the queue can drain. The file is kept on disk for inspection.
+func (q *DiskQueue) quarantineChunk(c *chunk, cause error) {
+	q.rmLock.Lock()
+	defer q.rmLock.Unlock()
+
+	q.r.ReleaseChunk(c)
+
+	quarantinePath := c.path + ".corrupt"
+	err := os.Rename(c.path, quarantinePath)
+	if err != nil {
+		q.Logger.WithField("file", c.path).Errorf("failed to quarantine corrupt chunk: %v", err)
+		return
+	}
+
+	q.m.Lock()
+	q.recordCount -= c.count
+	q.diskUsage -= int64(c.size)
+	q.metrics.DiskUsage(q.diskUsage)
+	q.metrics.Size(q.recordCount)
+	q.m.Unlock()
+
+	q.Logger.WithField("file", quarantinePath).
+		Errorf("chunk is truncated or corrupt, quarantined it; records beyond the corruption are lost: %v", cause)
 }
 
 // analyzeDisk is a slow method that determines the number of records

--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -698,6 +698,133 @@ func TestCorruptChunkHeaderRecoveryUnreadableFile(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist, "an unreadable chunk file must not be quarantined")
 }
 
+// A sealed chunk can be torn mid-file by a crash (e.g. power loss before its
+// tail reached disk). The records before the tear are still valid and must be
+// salvaged, and the file must be quarantined: otherwise the chunk is never
+// removed and its records stay counted, so the queue never drains and the
+// shard reports INDEXING forever.
+func TestDequeueBatchTornChunk(t *testing.T) {
+	s := makeScheduler(t)
+	s.Start()
+	defer s.Close(t.Context())
+
+	truncateBy := func(t *testing.T, path string, delta int64) {
+		t.Helper()
+
+		fi, err := os.Stat(path)
+		require.NoError(t, err)
+		err = os.Truncate(path, fi.Size()+delta)
+		require.NoError(t, err)
+	}
+
+	// each record is 4 bytes of length prefix + 9 bytes of payload
+	tests := []struct {
+		name    string
+		corrupt func(t *testing.T, path string)
+		tasks   int
+	}{
+		{
+			name: "torn mid record",
+			corrupt: func(t *testing.T, path string) {
+				truncateBy(t, path, -2)
+			},
+			tasks: 2,
+		},
+		{
+			name: "torn mid length prefix",
+			corrupt: func(t *testing.T, path string) {
+				truncateBy(t, path, -11)
+			},
+			tasks: 2,
+		},
+		{
+			name: "torn before first record",
+			corrupt: func(t *testing.T, path string) {
+				fi, err := os.Stat(path)
+				require.NoError(t, err)
+				err = os.Truncate(path, fi.Size()-3*13+1)
+				require.NoError(t, err)
+			},
+			tasks: 0,
+		},
+		{
+			name: "zero record length",
+			corrupt: func(t *testing.T, path string) {
+				// zero out the third record's length prefix
+				f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+				require.NoError(t, err)
+				defer f.Close()
+				_, err = f.WriteAt(make([]byte, 4), int64(chunkHeaderSize+2*13))
+				require.NoError(t, err)
+			},
+			tasks: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			decoder := discardExecutor()
+
+			// write one sealed chunk with 3 records
+			q := makeQueueWith(t, s, decoder, 50, tmpDir)
+			q.Pause(t.Context())
+			pushMany(t, q, 1, 100, 200, 300)
+			err := q.w.Promote()
+			require.NoError(t, err)
+			err = q.Close(t.Context())
+			require.NoError(t, err)
+
+			entries, err := os.ReadDir(tmpDir)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			chunkFile := filepath.Join(tmpDir, entries[0].Name())
+
+			test.corrupt(t, chunkFile)
+
+			// reopen the queue: the header is intact, so the chunk is listed
+			// with its full record count
+			q, err = NewDiskQueue(DiskQueueOptions{
+				ID:           "test_queue",
+				Scheduler:    s,
+				Logger:       newTestLogger(),
+				Dir:          tmpDir,
+				TaskDecoder:  decoder,
+				StaleTimeout: 500 * time.Millisecond,
+				ChunkSize:    50,
+			})
+			require.NoError(t, err)
+			err = q.Init()
+			require.NoError(t, err)
+			require.EqualValues(t, 3, q.Size())
+
+			// the records before the tear must be salvaged
+			batch, err := q.DequeueBatch()
+			require.NoError(t, err, "a torn chunk must be salvaged, not fail the dequeue")
+			if test.tasks == 0 {
+				require.Nil(t, batch)
+			} else {
+				require.NotNil(t, batch)
+				require.Len(t, batch.Tasks, test.tasks)
+				batch.Done()
+			}
+
+			// the torn chunk must be quarantined so it is no longer scheduled
+			_, err = os.Stat(chunkFile + ".corrupt")
+			require.NoError(t, err, "torn chunk should be quarantined as .corrupt")
+			_, err = os.Stat(chunkFile)
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			// its records must no longer be counted, so the queue can drain
+			require.EqualValues(t, 0, q.Size())
+
+			batch, err = q.DequeueBatch()
+			require.NoError(t, err)
+			require.Nil(t, batch)
+		})
+	}
+}
+
 func TestQueueAutoReleaseResources(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### What's being changed:

Fixes a crash-safety bug in the disk-backed queue (`adapters/repos/db/queue`) where a torn chunk file wedges the queue permanently.

**The bug:** A sealed chunk can be torn mid-file by a crash — e.g. power loss before the chunk's tail reached disk (nothing on the promote path fsyncs). The header is intact, so on the next startup the chunk is listed with its full record count, but `DequeueBatch` fails partway through reading it. The reader's cursor has already advanced past the chunk, so it is never retried and never removed, and its records stay in `recordCount`. The consequences compound:
- `Size()` never reaches zero, so the queue never drains;
- the shard reports `INDEXING` forever (clients polling `wait_for_vector_indexing` hang);
- the scheduler polls the queue every tick indefinitely, and `isInactive()` never releases resources;
- every restart re-lists the same chunk and hits the same wall.

This is the dequeue-time counterpart to #12006, which handled corruption discovered at startup (a bad header). Here the header is fine and the corruption is in the body.

**The fix:** `DequeueBatch` now treats a tear as recoverable instead of fatal. A tear-shaped error — unexpected EOF on either the length-prefix or the record read, or a zero record length — stops the read loop, returns the records decoded before the tear as the batch, and quarantines the file. The new `quarantineChunk` mirrors the existing `removeChunk`: it releases the reader's file handle, renames the file to `<name>.corrupt` (kept on disk for inspection, excluded from backups by the anchored `chunkFilePattern`), and subtracts the chunk's records from `recordCount`/`diskUsage` immediately so the queue can drain. The batch's `OnDone` skips `removeChunk` for a quarantined chunk, since the file is already renamed and accounted for.

Only tear-shaped errors are salvaged. Environmental read errors (I/O, permissions) and `DecodeTask` failures are unchanged, so a genuine I/O problem still surfaces rather than being mistaken for corruption and discarded.

Each fix is preceded by a failing (red) regression test in the commit history. `TestDequeueBatchTornChunk` seals a real 3-record chunk and tears it four ways (truncate mid-record, truncate mid-length-prefix, truncate before the first record, and a zeroed length prefix), asserting the records before the tear are salvaged, the file is quarantined, and `Size()` drops so the queue drains.

**Known limitation (called out deliberately):** if a chunk is found torn *while a backup is in progress* (maintenance mode), the rename can move the file out from under an in-flight copy, failing that one file's upload with a clear ENOENT rather than uploading a silently-truncated chunk. The pre-existing behavior in that window was the permanent wedge, so this is strictly better, but it does diverge from maintenance mode's "selected files are not modified during backup" guarantee. Making `quarantineChunk` respect `maintenanceMode` (deferring the rename via a tombstone, like `removeChunk` does) is left as a follow-up together with a `queue_chunks_quarantined` metric.

This is finding #2 from a broader crash-safety/corruption review of the package. Related: #12006 (corrupt header at startup, merged), #12009 (unvalidated allocation from corrupt chunk data, in review). Still open: worker/scheduler panic isolation, and the deadline-error retry hot-loop.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
