### PR TITLE
fix(bm25): scale WAND pivot upper bound by propertyBoost

### DIFF
--- a/adapters/repos/db/inverted/terms/terms.go
+++ b/adapters/repos/db/inverted/terms/terms.go
@@ -338,7 +338,11 @@ func (t *Terms) FindMinIDWand(minScore float64) (uint64, int, bool) {
 		if term.Exhausted() {
 			continue
 		}
-		cumScore += term.Idf()
+		// minScore is a real BM25 score carrying propertyBoost, so the per-term
+		// upper bound must too: CurrentBlockImpact is idf*propertyBoost, whereas
+		// bare Idf under-counts boosted terms and sinks the pivot too deep,
+		// skipping genuine top-K docs. Matches FindMinID (the block-max pivot).
+		cumScore += float64(term.CurrentBlockImpact())
 		if cumScore >= minScore {
 			return term.IdPointer(), i, false
 		}

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -110,7 +110,11 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			if firstNonExhausted == -1 {
 				firstNonExhausted = pivotPoint
 			}
-			cumScore += results[pivotPoint].idf
+			// worstDist is a real BM25 score (idf*tf*propertyBoost), so the per-term
+			// upper bound summed here must carry propertyBoost too; omitting it
+			// under-counts boosted terms, sinks the pivot too deep and skips genuine
+			// top-K docs.
+			cumScore += results[pivotPoint].idf * results[pivotPoint].propertyBoost
 			if cumScore >= worstDist {
 				pivotID = results[pivotPoint].idPointer
 				for i := pivotPoint + 1; i < len(results); i++ {
@@ -218,15 +222,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			}
 		} else {
 			nextList := pivotPoint
-			maxWeight := results[nextList].idf
+			maxWeight := results[nextList].idf * results[nextList].propertyBoost
 			next := uint64(math.MaxUint64) // max uint
 
 			candidates := results[:pivotPoint+1]
 			for i := range candidates {
 				t := candidates[i]
-				if i < pivotPoint && t.idf > maxWeight {
+				if w := t.idf * t.propertyBoost; i < pivotPoint && w > maxWeight {
 					nextList = i
-					maxWeight = t.idf
+					maxWeight = w
 				}
 				if t.currentBlockMaxId < next {
 					next = t.currentBlockMaxId

--- a/adapters/repos/db/lsmkv/search_segment_dowand_boost_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_dowand_boost_test.go
@@ -1,0 +1,175 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"io"
+	"math"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestDoWandPropertyBoostMatchesBruteForce is the non-block-max sibling of
+// TestBlockMaxWandPropertyBoostMatchesBruteForce: DoWand must return the same
+// top-K as a full scan that scores every posting with the SAME formula.
+//
+// It guards the pivot in Terms.FindMinIDWand, which sums per-term upper bounds
+// and compares them to worstDist (a real BM25 score carrying propertyBoost). A
+// raw-idf sum under-counts boosted terms, sinks the pivot too deep and drops
+// genuine top-K docs — invisible at propertyBoost==1, corrupting recall above it.
+func TestDoWandPropertyBoostMatchesBruteForce(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
+
+	const nDocs, vocab, termsPerDoc = 4000, 1200, 25
+	rng := rand.New(rand.NewSource(11))
+	zipf := rand.NewZipf(rng, 1.07, 1.0, uint64(vocab-1))
+	keyFor := func(id uint64) string { return "t" + strconv.FormatUint(id, 36) }
+
+	// build a posting list per term id; docs are appended in ascending id order,
+	// so each Data slice is already sorted as DoWand requires.
+	postings := make(map[uint64][]terms.DocPointerWithScore)
+	var totalLen float64
+	for d := 0; d < nDocs; d++ {
+		pl := float32(20 + rng.Intn(480))
+		totalLen += float64(pl)
+		seen := make(map[uint64]uint32, termsPerDoc)
+		for k := 0; k < termsPerDoc; k++ {
+			seen[zipf.Uint64()]++
+		}
+		for tid, tf := range seen {
+			postings[tid] = append(postings[tid], terms.DocPointerWithScore{
+				Id: uint64(d), Frequency: float32(tf), PropLength: pl,
+			})
+		}
+	}
+	avgPropLen := totalLen / float64(nDocs)
+
+	idfOf := func(tid uint64) float64 {
+		n := float64(len(postings[tid]))
+		return math.Log(1 + (float64(nDocs)-n+0.5)/(n+0.5))
+	}
+
+	// rank by document frequency; head terms have the long posting lists that
+	// make the pivot skip, the regime where the FindMinIDWand bug bites.
+	ranked := make([]uint64, 0, len(postings))
+	for tid := range postings {
+		ranked = append(ranked, tid)
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if len(postings[ranked[i]]) != len(postings[ranked[j]]) {
+			return len(postings[ranked[i]]) > len(postings[ranked[j]])
+		}
+		return ranked[i] < ranked[j]
+	})
+	require.Greater(t, len(postings[ranked[0]]), 200, "head term posting list too short to force pivoting")
+
+	query := make([]uint64, 0, 40)
+	for i := 0; i < 40 && i < len(ranked); i++ {
+		query = append(query, ranked[i])
+	}
+
+	bruteForce := func(boost float32) map[uint64]float64 {
+		scores := map[uint64]float64{}
+		for _, tid := range query {
+			idf := idfOf(tid)
+			for _, dp := range postings[tid] {
+				freq := float64(dp.Frequency)
+				tf := freq / (freq + bm25.K1*(1-bm25.B+bm25.B*float64(dp.PropLength)/avgPropLen))
+				scores[dp.Id] += tf * idf * float64(boost)
+			}
+		}
+		return scores
+	}
+
+	runWand := func(boost float32, limit int) map[uint64]float32 {
+		ts := make([]terms.TermInterface, 0, len(query))
+		for i, tid := range query {
+			tr := terms.NewTerm(keyFor(tid), i, boost, bm25)
+			tr.Data = postings[tid] // read-only in DoWand; never mutated
+			tr.SetIdf(idfOf(tid))
+			tr.SetPosPointer(0)
+			tr.SetIdPointer(tr.Data[0].Id)
+			ts = append(ts, tr)
+		}
+		tt := &terms.Terms{T: ts, Count: len(query)}
+		h := DoWand(ctx, limit, tt, avgPropLen, false, 1, logger)
+		out := map[uint64]float32{}
+		for h != nil && h.Len() > 0 {
+			it := h.Pop()
+			out[it.ID] = it.Dist
+		}
+		return out
+	}
+
+	cases := []struct {
+		name  string
+		boost float32
+		limit int
+	}{
+		{"boost0.5/k10", 0.5, 10},
+		{"boost1.0/k100", 1.0, 100},
+		{"boost2.5/k10", 2.5, 10},
+		{"boost2.5/k100", 2.5, 100},
+		{"boost7.0/k50", 7.0, 50},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			brute := bruteForce(tc.boost)
+			wand := runWand(tc.boost, tc.limit)
+
+			expectedN := tc.limit
+			if len(brute) < expectedN {
+				expectedN = len(brute)
+			}
+			require.Lenf(t, wand, expectedN, "WAND returned %d results, want %d", len(wand), expectedN)
+
+			scores := make([]float64, 0, len(brute))
+			for _, s := range brute {
+				scores = append(scores, s)
+			}
+			sort.Sort(sort.Reverse(sort.Float64Slice(scores)))
+			kth := math.Inf(-1)
+			if expectedN > 0 && len(scores) >= expectedN {
+				kth = scores[expectedN-1]
+			}
+			tol := func(v float64) float64 { return 1e-3 * (1 + math.Abs(v)) }
+
+			for id, dist := range wand {
+				b, ok := brute[id]
+				require.Truef(t, ok, "WAND returned doc %d that has no query term", id)
+				require.InDeltaf(t, b, float64(dist), tol(b),
+					"doc %d score mismatch: brute %.6f vs wand %.6f", id, b, float64(dist))
+				require.GreaterOrEqualf(t, b, kth-tol(kth),
+					"doc %d (score %.6f) ranks below the K-th best (%.6f): WAND included a non-top-K doc", id, b, kth)
+			}
+			for id, b := range brute {
+				if b > kth+tol(kth) {
+					_, ok := wand[id]
+					require.Truef(t, ok,
+						"WAND dropped genuine top-K doc %d (score %.6f > K-th best %.6f): recall bug", id, b, kth)
+				}
+			}
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/search_segment_propertyboost_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_propertyboost_test.go
@@ -1,0 +1,201 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"io"
+	"math"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestBlockMaxWandPropertyBoostMatchesBruteForce is the differential from
+// TestBlockMaxWandMatchesBruteForce, but with a non-default propertyBoost.
+//
+// It guards the else-branch "heaviest term to advance" selection in
+// DoBlockMaxWand, which seeds maxWeight from the pivot term. That seed only
+// steers which term advances (a performance heuristic) and never the returned
+// set, so a differential can only catch a selection change that also corrupts
+// the traversal — a dropped or mis-scored top-K doc. The boost is uniform
+// across every term of a call (one call == one property, see
+// bm25_searcher_block.go), so idf and idf*propertyBoost rank the terms
+// identically; this pins that boosted queries stay correct regardless.
+func TestBlockMaxWandPropertyBoostMatchesBruteForce(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+	// single flushed segment so a doc's postings are never split and the brute
+	// force is unambiguous.
+	bucket.SetMemtableThreshold(1 << 30)
+
+	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
+	const nDocs, vocab, termsPerDoc = 8000, 3000, 30
+	rng := rand.New(rand.NewSource(7))
+	zipf := rand.NewZipf(rng, 1.07, 1.0, uint64(vocab-1))
+	keyFor := func(id uint64) string { return "t" + strconv.FormatUint(id, 36) }
+
+	termDocCount := map[string]int{}
+	for d := 0; d < nDocs; d++ {
+		pl := float32(20 + rng.Intn(480))
+		seen := make(map[uint64]uint32, termsPerDoc)
+		for k := 0; k < termsPerDoc; k++ {
+			seen[zipf.Uint64()]++
+		}
+		for tid, tf := range seen {
+			key := keyFor(tid)
+			require.NoError(t, bucket.MapSet([]byte(key),
+				NewMapPairFromDocIdAndTf(uint64(d), float32(tf), pl, false)))
+			termDocCount[key]++
+		}
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+	avgPropLen, _ := bucket.GetAveragePropertyLength()
+
+	type termFreq struct {
+		key string
+		n   int
+	}
+	ranked := make([]termFreq, 0, len(termDocCount))
+	for k, n := range termDocCount {
+		ranked = append(ranked, termFreq{k, n})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].n != ranked[j].n {
+			return ranked[i].n > ranked[j].n
+		}
+		return ranked[i].key < ranked[j].key
+	})
+	require.Greaterf(t, ranked[0].n, terms.BLOCK_SIZE,
+		"corpus produced no multi-block term (max df %d <= BLOCK_SIZE %d); else branch never steps blocks",
+		ranked[0].n, terms.BLOCK_SIZE)
+
+	query := make([]string, 0, 60)
+	for i := 0; i < 60 && i < len(ranked); i++ {
+		query = append(query, ranked[i].key)
+	}
+	dupBoosts := make([]int, len(query))
+	for i := range dupBoosts {
+		dupBoosts[i] = 1
+	}
+
+	bruteForce := func(t *testing.T, boost float32) map[uint64]float64 {
+		view := bucket.GetConsistentView()
+		defer view.ReleaseView()
+		diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(nDocs), nil,
+			query, "", boost, dupBoosts, bm25)
+		require.NoError(t, err)
+		scores := map[uint64]float64{}
+		for _, segTerms := range diskTerms {
+			for _, term := range segTerms {
+				for !term.Exhausted() {
+					id, s, _ := term.Score(avgPropLen, false)
+					scores[id] += s
+					term.Advance()
+				}
+			}
+		}
+		return scores
+	}
+
+	runWand := func(t *testing.T, boost float32, limit int) map[uint64]float32 {
+		view := bucket.GetConsistentView()
+		defer view.ReleaseView()
+		diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(nDocs), nil,
+			query, "", boost, dupBoosts, bm25)
+		require.NoError(t, err)
+		out := map[uint64]float32{}
+		nonEmpty := 0
+		for _, segTerms := range diskTerms {
+			if len(segTerms) == 0 {
+				continue
+			}
+			nonEmpty++
+			h, err := DoBlockMaxWand(ctx, limit, segTerms, avgPropLen, false, len(query), 1, logger)
+			require.NoError(t, err)
+			for h != nil && h.Len() > 0 {
+				it := h.Pop()
+				out[it.ID] = it.Dist
+			}
+		}
+		require.Equalf(t, 1, nonEmpty, "expected a single flushed segment, got %d non-empty term groups", nonEmpty)
+		return out
+	}
+
+	cases := []struct {
+		name  string
+		boost float32
+		limit int
+	}{
+		{"boost0.5/k10", 0.5, 10},
+		{"boost1.0/k100", 1.0, 100},
+		{"boost2.5/k10", 2.5, 10},
+		{"boost2.5/k100", 2.5, 100},
+		{"boost7.0/k50", 7.0, 50},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			brute := bruteForce(t, tc.boost)
+			wand := runWand(t, tc.boost, tc.limit)
+
+			expectedN := tc.limit
+			if len(brute) < expectedN {
+				expectedN = len(brute)
+			}
+			require.Lenf(t, wand, expectedN, "WAND returned %d results, want %d", len(wand), expectedN)
+
+			scores := make([]float64, 0, len(brute))
+			for _, s := range brute {
+				scores = append(scores, s)
+			}
+			sort.Sort(sort.Reverse(sort.Float64Slice(scores)))
+			kth := math.Inf(-1)
+			if expectedN > 0 && len(scores) >= expectedN {
+				kth = scores[expectedN-1]
+			}
+			tol := func(v float64) float64 { return 1e-3 * (1 + math.Abs(v)) }
+
+			for id, dist := range wand {
+				b, ok := brute[id]
+				require.Truef(t, ok, "WAND returned doc %d that has no query term", id)
+				require.InDeltaf(t, b, float64(dist), tol(b),
+					"doc %d score mismatch: brute %.6f vs wand %.6f", id, b, float64(dist))
+				require.GreaterOrEqualf(t, b, kth-tol(kth),
+					"doc %d (score %.6f) ranks below the K-th best (%.6f): WAND included a non-top-K doc", id, b, kth)
+			}
+			for id, b := range brute {
+				if b > kth+tol(kth) {
+					_, ok := wand[id]
+					require.Truef(t, ok,
+						"WAND dropped genuine top-K doc %d (score %.6f > K-th best %.6f): recall bug", id, b, kth)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Both WAND pivots underestimate a term's maximum score contribution when a **property boost** is set, causing genuine top-K documents to be silently skipped (recall bug). It is invisible at the default `propertyBoost == 1` and grows worse as the boost increases.

The pivot loops accumulate a per-term upper bound and compare it against `worstDist` — the current k-th best score, which is a **real BM25 score** (`idf · tf · propertyBoost`). But the upper bound summed only raw `idf`:

- **Block-max path** — [`DoBlockMaxWand`](https://github.com/weaviate/weaviate/blob/stable/v1.37/adapters/repos/db/lsmkv/search_segment.go): `cumScore += results[pivotPoint].idf`
- **Non-block path** — [`Terms.FindMinIDWand`](https://github.com/weaviate/weaviate/blob/stable/v1.37/adapters/repos/db/inverted/terms/terms.go): `cumScore += term.Idf()`

With `boost > 1` the per-term bound is under-counted, so the pivot is placed too deep and documents that could rank in the top-K are pruned away.

## Fix

Use `idf · propertyBoost` as the per-term upper bound in both pivots. The block-max **terms** pivot (`FindMinID`) already did this via `CurrentBlockImpact()`; this makes the two WAND pivots consistent with it. The `DoBlockMaxWand` `nextList` heuristic is also made to apply `propertyBoost` consistently (seed + loop).

No result changes at `propertyBoost == 1` (the common case); the fix only affects boosted properties.

## Tests

Two differential tests compare WAND top-K against a brute-force full scan that scores every posting with the same formula, parameterized over `propertyBoost ∈ {0.5, 1.0, 2.5, 7.0}`:

- `TestBlockMaxWandPropertyBoostMatchesBruteForce` (block-max, integration)
- `TestDoWandPropertyBoostMatchesBruteForce` (non-block, in-memory unit test)

Both **fail on the old code at `boost ≥ 2.5`** (dropped/misranked top-K docs) and **pass after the fix**. The existing `TestBlockMaxWandMatchesBruteForce` (boost 1) still passes.

## Verification
- `terms` + `lsmkv` (block-max/wand/bm25, `-tags integrationTest`) suites pass
- `golangci-lint run` on both changed packages: 0 issues
- `gofmt` / `go vet` clean