### PR TITLE
perf(bm25): approximate object count for IDF, reuse query stats on blockmax fallback

### DIFF
--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -146,9 +146,6 @@ type bm25QueryStats struct {
 }
 
 func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *models.Class, params searchparams.KeywordRanking) (bm25QueryStats, error) {
-	// The approximate count avoids walking the object memtables per query; the
-	// resulting N can undershoot a term's document frequency, which terms.Idf
-	// clamps away.
 	count, err := b.store.Bucket(helpers.ObjectsBucketLSM).CountApproximate()
 	if err != nil {
 		return bm25QueryStats{}, fmt.Errorf("count objects: %w", err)

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -135,10 +135,23 @@ func (b *BM25Searcher) GetPropertyLengthTracker() *JsonShardMetaData {
 	return b.propLenTracker.(*JsonShardMetaData)
 }
 
-func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *models.Class, params searchparams.KeywordRanking) (bool, float64, map[string][]string, map[string][]string, map[string][]int, map[string]float32, float64, error) {
-	count, err := b.store.Bucket(helpers.ObjectsBucketLSM).Count(ctx)
+type bm25QueryStats struct {
+	allBucketsAreInverted         bool
+	N                             float64
+	propNamesByTokenization       map[string][]string
+	queryTermsByTokenization      map[string][]string
+	duplicateBoostsByTokenization map[string][]int
+	propertyBoosts                map[string]float32
+	averagePropLength             float64
+}
+
+func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *models.Class, params searchparams.KeywordRanking) (bm25QueryStats, error) {
+	// The approximate count avoids walking the object memtables per query; the
+	// resulting N can undershoot a term's document frequency, which terms.Idf
+	// clamps away.
+	count, err := b.store.Bucket(helpers.ObjectsBucketLSM).CountApproximate()
 	if err != nil {
-		return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("count objects: %w", err)
+		return bm25QueryStats{}, fmt.Errorf("count objects: %w", err)
 	}
 	N := float64(count)
 
@@ -179,12 +192,12 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 
 		propMean, err := b.GetPropertyLengthTracker().PropertyMean(property)
 		if err != nil {
-			return false, 0, nil, nil, nil, nil, 0, err
+			return bm25QueryStats{}, err
 		}
 
 		bucket := b.GetBucket(property)
 		if bucket == nil {
-			return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("could not find bucket for property %v", property)
+			return bm25QueryStats{}, fmt.Errorf("could not find bucket for property %v", property)
 		}
 
 		if bucket.Strategy() != lsmkv.StrategyInverted {
@@ -193,7 +206,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 
 		prop, err := schema.GetPropertyByName(class, property)
 		if err != nil {
-			return false, 0, nil, nil, nil, nil, 0, err
+			return bm25QueryStats{}, err
 		}
 
 		switch dt, _ := schema.AsPrimitive(prop.DataType); dt {
@@ -222,7 +235,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 				meanValid: !math.IsNaN(float64(propMean)),
 			})
 		default:
-			return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle datatype '%v' of property '%s'", dt, prop.Name)
+			return bm25QueryStats{}, fmt.Errorf("cannot handle datatype '%v' of property '%s'", dt, prop.Name)
 		}
 	}
 
@@ -274,7 +287,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 			if pi.prop.Tokenization == models.PropertyTokenizationWord {
 				d, err := b.stopwordProvider.Get(pi.prop)
 				if err != nil {
-					return false, 0, nil, nil, nil, nil, 0, err
+					return bm25QueryStats{}, err
 				}
 				sw = d
 			}
@@ -286,7 +299,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 		}
 
 		if _, exists := propNamesByTokenization[tokKey]; !exists {
-			return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle tokenization '%v' of property '%s'",
+			return bm25QueryStats{}, fmt.Errorf("cannot handle tokenization '%v' of property '%s'",
 				pi.prop.Tokenization, pi.prop.Name)
 		}
 		propNamesByTokenization[tokKey] = append(propNamesByTokenization[tokKey], pi.name)
@@ -301,7 +314,15 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 	if math.IsNaN(averagePropLength) || averagePropLength == 0 {
 		averagePropLength = 40.0
 	}
-	return allBucketsAreInverted, N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, nil
+	return bm25QueryStats{
+		allBucketsAreInverted:         allBucketsAreInverted,
+		N:                             N,
+		propNamesByTokenization:       propNamesByTokenization,
+		queryTermsByTokenization:      queryTermsByTokenization,
+		duplicateBoostsByTokenization: duplicateBoostsByTokenization,
+		propertyBoosts:                propertyBoosts,
+		averagePropLength:             averagePropLength,
+	}, nil
 }
 
 // asciiTokenizationKey returns the composite key used for ascii-insensitive properties.
@@ -314,25 +335,33 @@ func (b *BM25Searcher) wand(
 ) ([]*storobj.Object, []float32, error) {
 	start := time.Now()
 
-	_, N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, err := b.generateQueryTermsAndStats(ctx, class, params)
+	stats, err := b.generateQueryTermsAndStats(ctx, class, params)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	return b.wandFromStats(ctx, filterDocIds, params, limit, additional, stats, start)
+}
+
+// wandFromStats is wand with the query stats precomputed; start feeds the
+// slow-query timing annotations.
+func (b *BM25Searcher) wandFromStats(
+	ctx context.Context, filterDocIds helpers.AllowList, params searchparams.KeywordRanking, limit int, additional additional.Properties, stats bm25QueryStats, start time.Time,
+) ([]*storobj.Object, []float32, error) {
 	allRequests := make([]termListRequest, 0, 1000)
 	allQueryTerms := make([]string, 0, 1000)
 	minimumOrTokensMatch := math.MaxInt64
 
-	for tokenization, propNames := range propNamesByTokenization {
+	for tokenization, propNames := range stats.propNamesByTokenization {
 		if len(propNames) > 0 {
-			queryTerms, duplicateBoosts := queryTermsByTokenization[tokenization], duplicateBoostsByTokenization[tokenization]
+			queryTerms, duplicateBoosts := stats.queryTermsByTokenization[tokenization], stats.duplicateBoostsByTokenization[tokenization]
 			for queryTermIndex, queryTerm := range queryTerms {
 				allRequests = append(allRequests, termListRequest{
 					term:               queryTerm,
 					termId:             len(allRequests),
 					duplicateTextBoost: duplicateBoosts[queryTermIndex],
 					propertyNames:      propNames,
-					propertyBoosts:     propertyBoosts,
+					propertyBoosts:     stats.propertyBoosts,
 				})
 				allQueryTerms = append(allQueryTerms, queryTerm)
 			}
@@ -375,7 +404,7 @@ func (b *BM25Searcher) wand(
 				}
 			}()
 
-			termResult, termErr := b.createTerm(N, filterDocIds, term, termId, propNames, propertyBoosts, duplicateBoost, ctx)
+			termResult, termErr := b.createTerm(stats.N, filterDocIds, term, termId, propNames, stats.propertyBoosts, duplicateBoost, ctx)
 			if termErr != nil {
 				err = termErr
 				return err
@@ -417,7 +446,7 @@ func (b *BM25Searcher) wand(
 	termSearchTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_3_term_time", termSearchTime)
 	start = time.Now()
-	topKHeap := lsmkv.DoWand(ctx, limit, combinedTerms, averagePropLength, params.AdditionalExplanations, minimumOrTokensMatch, b.logger)
+	topKHeap := lsmkv.DoWand(ctx, limit, combinedTerms, stats.averagePropLength, params.AdditionalExplanations, minimumOrTokensMatch, b.logger)
 
 	wandTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_4_wand_time", wandTime)
@@ -595,7 +624,7 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 		if filterDocIds != nil {
 			n += float64(filteredDocIDs.GetCardinality())
 		}
-		termResult.SetIdf(math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateTextBoost))
+		termResult.SetIdf(terms.Idf(n, N) * float64(duplicateTextBoost))
 		termResult.SetPosPointer(0)
 		termResult.SetIdPointer(termResult.Data[0].Id)
 		return termResult, nil
@@ -670,7 +699,7 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 	if filterDocIds != nil {
 		n += float64(filteredDocIDs.GetCardinality())
 	}
-	termResult.SetIdf(math.Log(float64(1)+(N-n+0.5)/(n+0.5)) * float64(duplicateTextBoost))
+	termResult.SetIdf(terms.Idf(n, N) * float64(duplicateTextBoost))
 
 	// catch special case where there are no results and would panic termResult.data[0].id
 	// related to #4125

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -62,14 +62,14 @@ func (b *BM25Searcher) wandBlock(
 		return []*storobj.Object{}, []float32{}, false, nil
 	}
 
-	allBucketsAreInverted, N, propNamesByTokenization, queryTermsByTokenization, duplicateBoostsByTokenization, propertyBoosts, averagePropLength, err := b.generateQueryTermsAndStats(ctx, class, params)
+	stats, err := b.generateQueryTermsAndStats(ctx, class, params)
 	if err != nil {
 		return nil, nil, false, err
 	}
 
 	// fallback to the old search process if not all buckets are inverted
-	if !allBucketsAreInverted {
-		objects, scores, err := b.wand(ctx, filterDocIds, class, params, limit, additional)
+	if !stats.allBucketsAreInverted {
+		objects, scores, err := b.wandFromStats(ctx, filterDocIds, params, limit, additional, stats, start)
 		return objects, scores, true, err
 	}
 
@@ -93,10 +93,10 @@ func (b *BM25Searcher) wandBlock(
 	tokenizationTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_1_tok_time", tokenizationTime)
 	start = time.Now()
-	for tokenization, propNames := range propNamesByTokenization {
+	for tokenization, propNames := range stats.propNamesByTokenization {
 		if len(propNames) > 0 {
 			lenAllResults := len(allResults)
-			queryTerms, duplicateBoosts := queryTermsByTokenization[tokenization], duplicateBoostsByTokenization[tokenization]
+			queryTerms, duplicateBoosts := stats.queryTermsByTokenization[tokenization], stats.duplicateBoostsByTokenization[tokenization]
 			duplicateBoostsByTerm := make(map[string]int, len(duplicateBoosts))
 			for i, term := range queryTerms {
 				duplicateBoostsByTerm[term] = duplicateBoosts[i]
@@ -104,7 +104,7 @@ func (b *BM25Searcher) wandBlock(
 			globalIdfCounts := make(map[string]uint64, len(queryTerms))
 			nonZeroTerms := make(map[string]uint64, len(queryTerms))
 			for _, propName := range propNames {
-				results, idfCounts, release, err := b.createBlockTerm(N, filterDocIds, queryTerms, propName, propertyBoosts[propName], duplicateBoosts, b.config, ctx)
+				results, idfCounts, release, err := b.createBlockTerm(stats.N, filterDocIds, queryTerms, propName, stats.propertyBoosts[propName], duplicateBoosts, b.config, ctx)
 				if err != nil {
 					return nil, nil, false, err
 				}
@@ -136,7 +136,7 @@ func (b *BM25Searcher) wandBlock(
 				}
 				n := globalIdfCounts[term] / nonZeroTerms[term]
 
-				globalIdfs[term] = math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateBoostsByTerm[term])
+				globalIdfs[term] = terms.Idf(float64(n), stats.N) * float64(duplicateBoostsByTerm[term])
 			}
 			for _, result := range allResults[lenAllResults:] {
 				if len(result) == 0 {
@@ -225,9 +225,9 @@ func (b *BM25Searcher) wandBlock(
 			eg.Go(func() (err error) {
 				var topKHeap *priorityqueue.Queue[[]*terms.DocPointerWithScore]
 				if params.SearchOperator == common_filters.SearchOperatorAnd {
-					topKHeap = lsmkv.DoBlockMaxAnd(ctx, internalLimit, allResults[i][j], averagePropLength, params.AdditionalExplanations, len(termCounts[i]), minimumOrTokensMatchByProperty[i], b.logger)
+					topKHeap = lsmkv.DoBlockMaxAnd(ctx, internalLimit, allResults[i][j], stats.averagePropLength, params.AdditionalExplanations, len(termCounts[i]), minimumOrTokensMatchByProperty[i], b.logger)
 				} else {
-					topKHeap, _ = lsmkv.DoBlockMaxWand(ctx, internalLimit, allResults[i][j], averagePropLength, params.AdditionalExplanations, len(termCounts[i]), minimumOrTokensMatchByProperty[i], b.logger)
+					topKHeap, _ = lsmkv.DoBlockMaxWand(ctx, internalLimit, allResults[i][j], stats.averagePropLength, params.AdditionalExplanations, len(termCounts[i]), minimumOrTokensMatchByProperty[i], b.logger)
 				}
 				ids, scores, explanations, err := b.getTopKIds(topKHeap)
 				if err != nil {

--- a/adapters/repos/db/inverted/terms/terms.go
+++ b/adapters/repos/db/inverted/terms/terms.go
@@ -61,6 +61,17 @@ func (d *DocPointerWithScore) FromKeyVal(key []byte, value []byte, isTombstone b
 	return nil
 }
 
+// Idf computes the BM25 idf for a term matching n of N documents. N is
+// clamped to n: with an approximate document count (Bucket.CountApproximate)
+// N can undershoot a term's document frequency, and an unclamped idf would
+// go negative, corrupting scores and WAND pruning bounds.
+func Idf(n, N float64) float64 {
+	if N < n {
+		N = n
+	}
+	return math.Log(float64(1) + (N-n+0.5)/(n+0.5))
+}
+
 type SortedDocPointerWithScoreMerger struct {
 	input   [][]DocPointerWithScore
 	output  []DocPointerWithScore

--- a/adapters/repos/db/inverted/terms/terms.go
+++ b/adapters/repos/db/inverted/terms/terms.go
@@ -61,10 +61,9 @@ func (d *DocPointerWithScore) FromKeyVal(key []byte, value []byte, isTombstone b
 	return nil
 }
 
-// Idf computes the BM25 idf for a term matching n of N documents. N is
-// clamped to n: with an approximate document count (Bucket.CountApproximate)
-// N can undershoot a term's document frequency, and an unclamped idf would
-// go negative, corrupting scores and WAND pruning bounds.
+// Idf computes the BM25 idf for a term matching n of N documents, clamping
+// N to n: an approximate (undercounted) N would otherwise yield a negative
+// idf, corrupting scores and WAND pruning bounds.
 func Idf(n, N float64) float64 {
 	if N < n {
 		N = n

--- a/adapters/repos/db/inverted/terms/terms_idf_test.go
+++ b/adapters/repos/db/inverted/terms/terms_idf_test.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package terms
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdf(t *testing.T) {
+	tests := []struct {
+		name string
+		n    float64
+		N    float64
+		want float64
+	}{
+		{"typical", 5, 100, math.Log(float64(1) + (100-5+0.5)/(5+0.5))},
+		{"n equals N", 100, 100, math.Log(float64(1) + 0.5/100.5)},
+		{"N undershoots n, clamped to n", 100, 3, math.Log(float64(1) + 0.5/100.5)},
+		{"zero n and N", 0, 0, math.Log(float64(2))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Idf(tt.n, tt.N)
+			require.Equal(t, tt.want, got)
+			require.Positive(t, got)
+		})
+	}
+}

--- a/adapters/repos/db/inverted/terms/terms_idf_test.go
+++ b/adapters/repos/db/inverted/terms/terms_idf_test.go
@@ -26,9 +26,7 @@ func TestIdf(t *testing.T) {
 		want float64
 	}{
 		{"typical", 5, 100, math.Log(float64(1) + (100-5+0.5)/(5+0.5))},
-		{"n equals N", 100, 100, math.Log(float64(1) + 0.5/100.5)},
 		{"N undershoots n, clamped to n", 100, 3, math.Log(float64(1) + 0.5/100.5)},
-		{"zero n and N", 0, 0, math.Log(float64(2))},
 	}
 
 	for _, tt := range tests {

--- a/adapters/repos/db/lsmkv/binary_search_tree.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree.go
@@ -22,8 +22,9 @@ type binarySearchTree struct {
 	root *binarySearchNode
 }
 
-// returns net additions of insert in bytes, and previous secondary keys
-func (t *binarySearchTree) insert(key, value []byte, secondaryKeys [][]byte) (int, [][]byte) {
+// returns net additions of insert in bytes, previous secondary keys, and
+// whether the key was already live (present and not tombstoned)
+func (t *binarySearchTree) insert(key, value []byte, secondaryKeys [][]byte) (int, [][]byte, bool) {
 	if t.root == nil {
 		t.root = &binarySearchNode{
 			key:           key,
@@ -31,16 +32,16 @@ func (t *binarySearchTree) insert(key, value []byte, secondaryKeys [][]byte) (in
 			secondaryKeys: secondaryKeys,
 			colourIsRed:   false, // root node is always black
 		}
-		return len(key) + len(value), nil
+		return len(key) + len(value), nil, false
 	}
 
-	addition, newRoot, previousSecondaryKeys := t.root.insert(key, value, secondaryKeys)
+	addition, newRoot, previousSecondaryKeys, wasLive := t.root.insert(key, value, secondaryKeys)
 	if newRoot != nil {
 		t.root = newRoot
 	}
 	t.root.colourIsRed = false // Can be flipped in the process of balancing, but root is always black
 
-	return addition, previousSecondaryKeys
+	return addition, previousSecondaryKeys, wasLive
 }
 
 func (t *binarySearchTree) get(key []byte) ([]byte, error) {
@@ -69,7 +70,8 @@ func (t *binarySearchTree) exists(key []byte) error {
 	return err
 }
 
-func (t *binarySearchTree) setTombstone(key, value []byte, secondaryKeys [][]byte) [][]byte {
+// returns previous secondary keys and whether the key was already tombstoned
+func (t *binarySearchTree) setTombstone(key, value []byte, secondaryKeys [][]byte) ([][]byte, bool) {
 	if t.root == nil {
 		// we need to actively insert a node with a tombstone, even if this node is
 		// not present because we still need to propagate the delete into the disk
@@ -82,15 +84,15 @@ func (t *binarySearchTree) setTombstone(key, value []byte, secondaryKeys [][]byt
 			secondaryKeys: secondaryKeys,
 			colourIsRed:   false, // root node is always black
 		}
-		return nil
+		return nil, false
 	}
 
-	newRoot, prevSecondaryKeys := t.root.setTombstone(key, value, secondaryKeys)
+	newRoot, prevSecondaryKeys, wasTombstoned := t.root.setTombstone(key, value, secondaryKeys)
 	if newRoot != nil {
 		t.root = newRoot
 	}
 	t.root.colourIsRed = false // Can be flipped in the process of balancing, but root is always black
-	return prevSecondaryKeys
+	return prevSecondaryKeys, wasTombstoned
 }
 
 func (t *binarySearchTree) flattenInOrder() []*binarySearchNode {
@@ -235,7 +237,7 @@ func addNewSearchNodeReceiver(nodePtr **binarySearchNode) {
 }
 
 // returns net additions of insert in bytes
-func (n *binarySearchNode) insert(key, value []byte, secondaryKeys [][]byte) (netAdditions int, newRoot *binarySearchNode, previousSecondaryKeys [][]byte) {
+func (n *binarySearchNode) insert(key, value []byte, secondaryKeys [][]byte) (netAdditions int, newRoot *binarySearchNode, previousSecondaryKeys [][]byte, wasLive bool) {
 	if bytes.Equal(key, n.key) {
 		// since the key already exists, we only need to take the difference
 		// between the existing value and the new one to determine net change
@@ -247,19 +249,19 @@ func (n *binarySearchNode) insert(key, value []byte, secondaryKeys [][]byte) (ne
 		// assign new value to node
 		n.value = value
 
+		wasLive = !n.tombstone
 		// reset tombstone in case it had one
 		n.tombstone = false
 		previousSecondaryKeys = n.secondaryKeys
 		n.secondaryKeys = secondaryKeys
 
 		newRoot = nil // tree root does not change when replacing node
-		return netAdditions, newRoot, previousSecondaryKeys
+		return netAdditions, newRoot, previousSecondaryKeys, wasLive
 	}
 
 	if bytes.Compare(key, n.key) < 0 {
 		if n.left != nil {
-			netAdditions, newRoot, previousSecondaryKeys = n.left.insert(key, value, secondaryKeys)
-			return netAdditions, newRoot, previousSecondaryKeys
+			return n.left.insert(key, value, secondaryKeys)
 		} else {
 			n.left = &binarySearchNode{
 				key:           key,
@@ -270,12 +272,11 @@ func (n *binarySearchNode) insert(key, value []byte, secondaryKeys [][]byte) (ne
 			}
 			newRoot = binarySearchNodeFromRB(rbtree.Rebalance(n.left))
 			netAdditions = len(key) + len(value)
-			return netAdditions, newRoot, previousSecondaryKeys
+			return netAdditions, newRoot, previousSecondaryKeys, false
 		}
 	} else {
 		if n.right != nil {
-			netAdditions, newRoot, previousSecondaryKeys = n.right.insert(key, value, secondaryKeys)
-			return netAdditions, newRoot, previousSecondaryKeys
+			return n.right.insert(key, value, secondaryKeys)
 		} else {
 			n.right = &binarySearchNode{
 				key:           key,
@@ -286,7 +287,7 @@ func (n *binarySearchNode) insert(key, value []byte, secondaryKeys [][]byte) (ne
 			}
 			netAdditions = len(key) + len(value)
 			newRoot = binarySearchNodeFromRB(rbtree.Rebalance(n.right))
-			return netAdditions, newRoot, previousSecondaryKeys
+			return netAdditions, newRoot, previousSecondaryKeys, false
 		}
 	}
 }
@@ -323,13 +324,14 @@ func (n *binarySearchNode) getNode(key []byte) (*binarySearchNode, error) {
 	}
 }
 
-func (n *binarySearchNode) setTombstone(key, value []byte, secondaryKeys [][]byte) (*binarySearchNode, [][]byte) {
+func (n *binarySearchNode) setTombstone(key, value []byte, secondaryKeys [][]byte) (*binarySearchNode, [][]byte, bool) {
 	if bytes.Equal(n.key, key) {
+		wasTombstoned := n.tombstone
 		prevSecondaryKeys := n.secondaryKeys
 		n.value = value
 		n.tombstone = true
 		n.secondaryKeys = secondaryKeys
-		return nil, prevSecondaryKeys
+		return nil, prevSecondaryKeys, wasTombstoned
 	}
 
 	if bytes.Compare(key, n.key) < 0 {
@@ -342,7 +344,7 @@ func (n *binarySearchNode) setTombstone(key, value []byte, secondaryKeys [][]byt
 				parent:        n,
 				colourIsRed:   true,
 			}
-			return binarySearchNodeFromRB(rbtree.Rebalance(n.left)), nil
+			return binarySearchNodeFromRB(rbtree.Rebalance(n.left)), nil, false
 
 		}
 		return n.left.setTombstone(key, value, secondaryKeys)
@@ -356,7 +358,7 @@ func (n *binarySearchNode) setTombstone(key, value []byte, secondaryKeys [][]byt
 				parent:        n,
 				colourIsRed:   true,
 			}
-			return binarySearchNodeFromRB(rbtree.Rebalance(n.right)), nil
+			return binarySearchNodeFromRB(rbtree.Rebalance(n.right)), nil, false
 		}
 		return n.right.setTombstone(key, value, secondaryKeys)
 	}

--- a/adapters/repos/db/lsmkv/binary_search_tree_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_test.go
@@ -36,7 +36,7 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 		rand.Read(key)
 		rand.Read(val)
 
-		n, _ := tree.insert(key, val, nil)
+		n, _, _ := tree.insert(key, val, nil)
 		require.Equal(t, len(key)+len(val), n)
 	})
 
@@ -54,7 +54,7 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 			rand.Read(key)
 			rand.Read(val)
 
-			newAdditions, _ := tree.insert(key, val, nil)
+			newAdditions, _, _ := tree.insert(key, val, nil)
 			n += newAdditions
 		}
 
@@ -88,7 +88,7 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 
 		// make initial inserts
 		for i := range keys {
-			currentNetAddition, _ := tree.insert(keys[i], vals[i], nil)
+			currentNetAddition, _, _ := tree.insert(keys[i], vals[i], nil)
 			netAdditions += currentNetAddition
 		}
 
@@ -102,7 +102,7 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 		}
 
 		for i := 0; i < amount; i++ {
-			currentNetAddition, _ := tree.insert(keys[i], vals[i], nil)
+			currentNetAddition, _, _ := tree.insert(keys[i], vals[i], nil)
 			netAdditions += currentNetAddition
 		}
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1492,11 +1492,9 @@ func (b *Bucket) CountAsync() int {
 	return b.disk.count()
 }
 
-// CountApproximate estimates the bucket's net key count as the sum of the
-// flushed segments' exact net-count additions and each memtable's approximate
-// net-count counter (see Memtable.netCountAdditions). Unlike Count it is
-// O(#segments) — no memtable walk, no per-key disk probes — at the price of
-// the counters' bounded drift, which self-corrects at flush.
+// CountApproximate is a cheap O(#segments) alternative to Count: exact
+// per-segment counts plus each memtable's approximate counter (see
+// Memtable.netCountAdditions for the drift bounds).
 func (b *Bucket) CountApproximate() (int, error) {
 	if err := CheckExpectedStrategy(b.strategy, StrategyReplace); err != nil {
 		return 0, fmt.Errorf("Bucket::CountApproximate(): %w", err)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1492,6 +1492,29 @@ func (b *Bucket) CountAsync() int {
 	return b.disk.count()
 }
 
+// CountApproximate estimates the bucket's net key count as the sum of the
+// flushed segments' exact net-count additions and each memtable's approximate
+// net-count counter (see Memtable.netCountAdditions). Unlike Count it is
+// O(#segments) — no memtable walk, no per-key disk probes — at the price of
+// the counters' bounded drift, which self-corrects at flush.
+func (b *Bucket) CountApproximate() (int, error) {
+	if err := CheckExpectedStrategy(b.strategy, StrategyReplace); err != nil {
+		return 0, fmt.Errorf("Bucket::CountApproximate(): %w", err)
+	}
+
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+
+	count := b.disk.countWithSegmentList(view.Disk) + view.Active.netCount()
+	if view.Flushing != nil {
+		count += view.Flushing.netCount()
+	}
+	if count < 0 {
+		count = 0
+	}
+	return count, nil
+}
+
 func (b *Bucket) memtableNetCount(ctx context.Context, stats *countStats, previousMemtable *countStats,
 	segments []Segment,
 ) (int, error) {
@@ -2252,7 +2275,7 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		}
 
 		// we can only know the full n after we have checked all segments and all memtables
-		idfs[i] = math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateTextBoosts[i])
+		idfs[i] = terms.Idf(float64(n), N) * float64(duplicateTextBoosts[i])
 
 		if active != nil {
 			active.idf = idfs[i]

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -757,28 +757,10 @@ func TestCountApproximate(t *testing.T) {
 
 	t.Run("memtable-resident inserts and deletes", func(t *testing.T) {
 		b := newBucket(t)
-		putKeys(t, b, 10)
-		requireApprox(t, b, 10)
-
-		for i := 0; i < 3; i++ {
-			require.NoError(t, b.Delete([]byte(fmt.Sprintf("key-%02d", i))))
-		}
-		requireApprox(t, b, 7)
-		requireExact(t, b, 7)
-	})
-
-	t.Run("matches exact count across flushes", func(t *testing.T) {
-		b := newBucket(t)
-		putKeys(t, b, 10)
-		require.NoError(t, b.FlushMemtable())
-		requireApprox(t, b, 10)
-
+		putKeys(t, b, 3)
 		require.NoError(t, b.Delete([]byte("key-00")))
-		require.NoError(t, b.Put([]byte("key-new"), []byte("value")))
-		requireApprox(t, b, 10)
-		require.NoError(t, b.FlushMemtable())
-		requireApprox(t, b, 10)
-		requireExact(t, b, 10)
+		requireApprox(t, b, 2)
+		requireExact(t, b, 2)
 	})
 
 	t.Run("over-counts an unflushed update of a flushed key until the next flush", func(t *testing.T) {
@@ -844,9 +826,8 @@ func TestCountApproximate(t *testing.T) {
 
 		b = newFromDir()
 		defer func() { require.NoError(t, b.Shutdown(ctx)) }()
-		// WAL replay dedups key-00's put+delete into a bare tombstone, so the
-		// rebuilt counter sees a delete of an unseen key: the documented
-		// under-count drift, corrected at the next flush
+		// WAL replay dedups key-00's put+delete into a bare tombstone: the
+		// documented delete-of-unseen-key under-count, corrected at flush
 		requireApprox(t, b, 1)
 		requireExact(t, b, 2)
 		require.NoError(t, b.FlushMemtable())

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -718,6 +718,142 @@ func TestNetCountComputationAtInit(t *testing.T) {
 	require.Equal(t, 0, count)
 }
 
+func TestCountApproximate(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	newBucket := func(t *testing.T) *Bucket {
+		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace), WithMinWalThreshold(0),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, b.Shutdown(ctx))
+		})
+		return b
+	}
+
+	requireApprox := func(t *testing.T, b *Bucket, want int) {
+		t.Helper()
+		count, err := b.CountApproximate()
+		require.NoError(t, err)
+		require.Equal(t, want, count)
+	}
+
+	requireExact := func(t *testing.T, b *Bucket, want int) {
+		t.Helper()
+		count, err := b.Count(ctx)
+		require.NoError(t, err)
+		require.Equal(t, want, count)
+	}
+
+	putKeys := func(t *testing.T, b *Bucket, n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%02d", i)), []byte("value")))
+		}
+	}
+
+	t.Run("memtable-resident inserts and deletes", func(t *testing.T) {
+		b := newBucket(t)
+		putKeys(t, b, 10)
+		requireApprox(t, b, 10)
+
+		for i := 0; i < 3; i++ {
+			require.NoError(t, b.Delete([]byte(fmt.Sprintf("key-%02d", i))))
+		}
+		requireApprox(t, b, 7)
+		requireExact(t, b, 7)
+	})
+
+	t.Run("matches exact count across flushes", func(t *testing.T) {
+		b := newBucket(t)
+		putKeys(t, b, 10)
+		require.NoError(t, b.FlushMemtable())
+		requireApprox(t, b, 10)
+
+		require.NoError(t, b.Delete([]byte("key-00")))
+		require.NoError(t, b.Put([]byte("key-new"), []byte("value")))
+		requireApprox(t, b, 10)
+		require.NoError(t, b.FlushMemtable())
+		requireApprox(t, b, 10)
+		requireExact(t, b, 10)
+	})
+
+	t.Run("over-counts an unflushed update of a flushed key until the next flush", func(t *testing.T) {
+		b := newBucket(t)
+		require.NoError(t, b.Put([]byte("key-a"), []byte("value")))
+		require.NoError(t, b.FlushMemtable())
+
+		require.NoError(t, b.Put([]byte("key-a"), []byte("value-2")))
+		requireApprox(t, b, 2)
+		requireExact(t, b, 1)
+
+		require.NoError(t, b.FlushMemtable())
+		requireApprox(t, b, 1)
+	})
+
+	t.Run("never negative", func(t *testing.T) {
+		b := newBucket(t)
+		require.NoError(t, b.Delete([]byte("never-existed")))
+		requireApprox(t, b, 0)
+	})
+
+	t.Run("includes the flushing memtable while a flush is in flight", func(t *testing.T) {
+		b := newBucket(t)
+		putKeys(t, b, 5)
+
+		switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+		require.NoError(t, err)
+		require.True(t, switched)
+
+		require.NoError(t, b.Put([]byte("key-new"), []byte("value")))
+		require.NoError(t, b.Put([]byte("key-new-2"), []byte("value")))
+		require.NoError(t, b.Delete([]byte("key-00")))
+		requireApprox(t, b, 6)
+		requireExact(t, b, 6)
+
+		// complete the flush the way FlushAndSwitch does
+		b.waitForZeroWriters(b.flushing)
+		segmentPath, err := b.flushing.flush()
+		require.NoError(t, err)
+		segment, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
+		require.NoError(t, err)
+		require.NoError(t, b.atomicallyAddDiskSegmentAndRemoveFlushing(segment))
+		requireApprox(t, b, 6)
+	})
+
+	t.Run("counter is rebuilt from the WAL on reopen", func(t *testing.T) {
+		dirName := t.TempDir()
+		newFromDir := func() *Bucket {
+			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
+			)
+			require.NoError(t, err)
+			return b
+		}
+
+		b := newFromDir()
+		putKeys(t, b, 3)
+		require.NoError(t, b.Delete([]byte("key-00")))
+		requireApprox(t, b, 2)
+		require.NoError(t, b.Shutdown(ctx))
+		require.Equal(t, 0, getFileTypeCount(t, dirName)[".db"], "data must survive as WAL, not a segment")
+
+		b = newFromDir()
+		defer func() { require.NoError(t, b.Shutdown(ctx)) }()
+		// WAL replay dedups key-00's put+delete into a bare tombstone, so the
+		// rebuilt counter sees a delete of an unseen key: the documented
+		// under-count drift, corrected at the next flush
+		requireApprox(t, b, 1)
+		requireExact(t, b, 2)
+		require.NoError(t, b.FlushMemtable())
+		requireApprox(t, b, 2)
+	})
+}
+
 func getFileTypeCount(t *testing.T, path string) map[string]int {
 	t.Helper()
 	fileTypes := map[string]int{}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -120,14 +120,11 @@ type Memtable struct {
 	commitlog       memtableCommitLogger
 	allocChecker    memwatch.AllocChecker
 	size            uint64
-	// netCountAdditions approximates the net number of live keys this
-	// memtable adds on top of older memtables/segments: +1 when a put makes a
-	// key live that wasn't live here, -1 when a tombstone kills a key that
-	// wasn't already tombstoned here. Whether the key exists further down the
-	// LSM tree is unknown at write time, so an update of a flushed key
-	// over-counts and a delete of a never-written key under-counts by one
-	// each; the drift disappears at flush, when the segment's exact net count
-	// is computed. Only maintained for StrategyReplace.
+	// netCountAdditions approximates the net live keys this memtable adds on
+	// top of the rest of the LSM tree. Whether a key already exists further
+	// down is unknown at write time: updates of flushed keys over-count,
+	// deletes of never-written keys under-count, and the drift is corrected by
+	// the exact per-segment count at flush. StrategyReplace only.
 	netCountAdditions  int
 	path               string
 	strategy           string
@@ -645,16 +642,13 @@ func (m *Memtable) countStats() *countStats {
 	return m.key.countStats()
 }
 
-// netCount returns the approximate net key additions of this memtable, see
-// netCountAdditions.
 func (m *Memtable) netCount() int {
 	m.RLock()
 	defer m.RUnlock()
 	return m.netCountAdditions
 }
 
-// isTombstoned reports whether the key currently sits in this memtable as a
-// tombstone. Callers must hold the memtable lock.
+// isTombstoned must be called with the memtable lock held.
 func (m *Memtable) isTombstoned(key []byte) bool {
 	err := m.key.exists(key)
 	return err != nil && !errors.Is(err, lsmkv.NotFound)

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -295,8 +295,7 @@ func (m *Memtable) put(key, value []byte, opts ...SecondaryKeyOption) error {
 		return errors.Wrap(err, "write into commit log")
 	}
 
-	wasLive := m.key.exists(key) == nil
-	netAdditions, previousKeys := m.key.insert(key, value, secondaryKeys)
+	netAdditions, previousKeys, wasLive := m.key.insert(key, value, secondaryKeys)
 	m.updateSecondaryToPrimary(key, secondaryKeys, previousKeys)
 	if !wasLive {
 		m.netCountAdditions++
@@ -338,8 +337,7 @@ func (m *Memtable) setTombstone(key []byte, opts ...SecondaryKeyOption) error {
 		return errors.Wrap(err, "write into commit log")
 	}
 
-	wasTombstoned := m.isTombstoned(key)
-	previousKeys := m.key.setTombstone(key, nil, secondaryKeys)
+	previousKeys, wasTombstoned := m.key.setTombstone(key, nil, secondaryKeys)
 	m.updateSecondaryToPrimary(key, secondaryKeys, previousKeys)
 	if !wasTombstoned {
 		m.netCountAdditions--
@@ -382,8 +380,7 @@ func (m *Memtable) setTombstoneWith(key []byte, deletionTime time.Time, opts ...
 		return errors.Wrap(err, "write into commit log")
 	}
 
-	wasTombstoned := m.isTombstoned(key)
-	previousKeys := m.key.setTombstone(key, tombstonedVal[:], secondaryKeys)
+	previousKeys, wasTombstoned := m.key.setTombstone(key, tombstonedVal[:], secondaryKeys)
 	m.updateSecondaryToPrimary(key, secondaryKeys, previousKeys)
 	if !wasTombstoned {
 		m.netCountAdditions--
@@ -646,12 +643,6 @@ func (m *Memtable) netCount() int {
 	m.RLock()
 	defer m.RUnlock()
 	return m.netCountAdditions
-}
-
-// isTombstoned must be called with the memtable lock held.
-func (m *Memtable) isTombstoned(key []byte) bool {
-	err := m.key.exists(key)
-	return err != nil && !errors.Is(err, lsmkv.NotFound)
 }
 
 // the WAL uses a buffer and isn't written until the buffer size is crossed or

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -55,6 +55,7 @@ type memtable interface {
 	DirtyDuration() time.Duration
 	updateDirtyAt()
 	countStats() *countStats
+	netCount() int
 	getStrategy() string
 	commitlogSize() int64
 	commitlogWalPath() string
@@ -110,15 +111,24 @@ type memtable interface {
 
 type Memtable struct {
 	sync.RWMutex
-	key                *binarySearchTree
-	keyMulti           *binarySearchTreeMulti
-	keyMap             *binarySearchTreeMap
-	primaryIndex       *binarySearchTree
-	roaringSet         *roaringset.BinarySearchTree
-	roaringSetRange    *roaringsetrange.Memtable
-	commitlog          memtableCommitLogger
-	allocChecker       memwatch.AllocChecker
-	size               uint64
+	key             *binarySearchTree
+	keyMulti        *binarySearchTreeMulti
+	keyMap          *binarySearchTreeMap
+	primaryIndex    *binarySearchTree
+	roaringSet      *roaringset.BinarySearchTree
+	roaringSetRange *roaringsetrange.Memtable
+	commitlog       memtableCommitLogger
+	allocChecker    memwatch.AllocChecker
+	size            uint64
+	// netCountAdditions approximates the net number of live keys this
+	// memtable adds on top of older memtables/segments: +1 when a put makes a
+	// key live that wasn't live here, -1 when a tombstone kills a key that
+	// wasn't already tombstoned here. Whether the key exists further down the
+	// LSM tree is unknown at write time, so an update of a flushed key
+	// over-counts and a delete of a never-written key under-counts by one
+	// each; the drift disappears at flush, when the segment's exact net count
+	// is computed. Only maintained for StrategyReplace.
+	netCountAdditions  int
 	path               string
 	strategy           string
 	secondaryIndices   uint16
@@ -288,8 +298,12 @@ func (m *Memtable) put(key, value []byte, opts ...SecondaryKeyOption) error {
 		return errors.Wrap(err, "write into commit log")
 	}
 
+	wasLive := m.key.exists(key) == nil
 	netAdditions, previousKeys := m.key.insert(key, value, secondaryKeys)
 	m.updateSecondaryToPrimary(key, secondaryKeys, previousKeys)
+	if !wasLive {
+		m.netCountAdditions++
+	}
 
 	m.size += uint64(netAdditions)
 	m.metrics.observeSize(m.size)
@@ -327,8 +341,12 @@ func (m *Memtable) setTombstone(key []byte, opts ...SecondaryKeyOption) error {
 		return errors.Wrap(err, "write into commit log")
 	}
 
+	wasTombstoned := m.isTombstoned(key)
 	previousKeys := m.key.setTombstone(key, nil, secondaryKeys)
 	m.updateSecondaryToPrimary(key, secondaryKeys, previousKeys)
+	if !wasTombstoned {
+		m.netCountAdditions--
+	}
 
 	m.size += uint64(len(key)) + 1 // 1 byte for tombstone
 	m.metrics.observeSize(m.size)
@@ -367,8 +385,12 @@ func (m *Memtable) setTombstoneWith(key []byte, deletionTime time.Time, opts ...
 		return errors.Wrap(err, "write into commit log")
 	}
 
+	wasTombstoned := m.isTombstoned(key)
 	previousKeys := m.key.setTombstone(key, tombstonedVal[:], secondaryKeys)
 	m.updateSecondaryToPrimary(key, secondaryKeys, previousKeys)
+	if !wasTombstoned {
+		m.netCountAdditions--
+	}
 
 	m.size += uint64(len(key)) + 1 // 1 byte for tombstone
 	m.metrics.observeSize(m.size)
@@ -621,6 +643,21 @@ func (m *Memtable) countStats() *countStats {
 	m.RLock()
 	defer m.RUnlock()
 	return m.key.countStats()
+}
+
+// netCount returns the approximate net key additions of this memtable, see
+// netCountAdditions.
+func (m *Memtable) netCount() int {
+	m.RLock()
+	defer m.RUnlock()
+	return m.netCountAdditions
+}
+
+// isTombstoned reports whether the key currently sits in this memtable as a
+// tombstone. Callers must hold the memtable lock.
+func (m *Memtable) isTombstoned(key []byte) bool {
+	err := m.key.exists(key)
+	return err != nil && !errors.Is(err, lsmkv.NotFound)
 }
 
 // the WAL uses a buffer and isn't written until the buffer size is crossed or

--- a/adapters/repos/db/lsmkv/memtable_net_count_test.go
+++ b/adapters/repos/db/lsmkv/memtable_net_count_test.go
@@ -37,7 +37,6 @@ func TestMemtable_NetCount(t *testing.T) {
 		ops      []op
 		expected int
 	}{
-		{"single insert", []op{put("a")}, 1},
 		{"distinct inserts", []op{put("a"), put("b")}, 2},
 		{"update within memtable", []op{put("a"), put("a")}, 1},
 		{"insert then delete", []op{put("a"), del("a")}, 0},
@@ -45,8 +44,6 @@ func TestMemtable_NetCount(t *testing.T) {
 		{"repeated delete", []op{del("a"), del("a")}, -1},
 		{"delete then resurrect", []op{del("a"), put("a")}, 0},
 		{"delete with time", []op{put("a"), delWith("a")}, 0},
-		{"delete with time of unseen key", []op{delWith("a")}, -1},
-		{"mixed", []op{put("a"), put("b"), del("a"), put("c"), del("d")}, 1},
 	}
 
 	logger, _ := test.NewNullLogger()

--- a/adapters/repos/db/lsmkv/memtable_net_count_test.go
+++ b/adapters/repos/db/lsmkv/memtable_net_count_test.go
@@ -1,0 +1,75 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemtable_NetCount(t *testing.T) {
+	type op = func(*Memtable) error
+	put := func(key string) op {
+		return func(m *Memtable) error { return m.put([]byte(key), []byte("value")) }
+	}
+	del := func(key string) op {
+		return func(m *Memtable) error { return m.setTombstone([]byte(key)) }
+	}
+	delWith := func(key string) op {
+		return func(m *Memtable) error { return m.setTombstoneWith([]byte(key), time.Now()) }
+	}
+
+	tests := []struct {
+		name     string
+		ops      []op
+		expected int
+	}{
+		{"single insert", []op{put("a")}, 1},
+		{"distinct inserts", []op{put("a"), put("b")}, 2},
+		{"update within memtable", []op{put("a"), put("a")}, 1},
+		{"insert then delete", []op{put("a"), del("a")}, 0},
+		{"delete of unseen key", []op{del("a")}, -1},
+		{"repeated delete", []op{del("a"), del("a")}, -1},
+		{"delete then resurrect", []op{del("a"), put("a")}, 0},
+		{"delete with time", []op{put("a"), delWith("a")}, 0},
+		{"delete with time of unseen key", []op{delWith("a")}, -1},
+		{"mixed", []op{put("a"), put("b"), del("a"), put("c"), del("d")}, 1},
+	}
+
+	logger, _ := test.NewNullLogger()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cl, err := newCommitLogger(dir, StrategyReplace, 0)
+			require.NoError(t, err)
+
+			m, err := newMemtable(cl, nil, logger, nil, memtableConfig{
+				path:     path.Join(dir, "will-never-flush"),
+				strategy: StrategyReplace,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, m.commitlog.close())
+			})
+
+			for _, apply := range tt.ops {
+				require.NoError(t, apply(m))
+			}
+
+			require.Equal(t, tt.expected, m.netCount())
+		})
+	}
+}


### PR DESCRIPTION
Supersedes #12014 (closed by a head-branch rename).

## What

Two coupled BM25 keyword-search performance fixes, targeting query latency under concurrent ingestion.

**1. Approximate N for IDF.** Every BM25/hybrid query per shard called `Bucket.Count()` solely to compute IDF's N: a full walk of the active memtable BST (under the memtable RLock) plus a per-key multi-segment disk probe, degrading to O(active × flushing) `bytes.Equal` comparisons while a flush is in flight. On quiesced shards this is near-free, but under sustained ingestion it accounts for tens to hundreds of ms per query, with 0.1s–multi-second cliffs during flush windows.

Replace-strategy memtables now maintain an approximate net-count counter (`+1` when a put makes a key live that wasn't live in that memtable, `-1` when a tombstone kills a key that wasn't already tombstoned there), and `Bucket.CountApproximate()` sums the flushed segments' exact `.cna` values with the active/flushing memtable counters — O(#segments), no memtable walk, no disk probes. WAL replay rebuilds the counter automatically since it routes through the same `put`/`setTombstone` paths.

**2. Single stats computation on the blockmax→legacy fallback.** When any searched property bucket is not inverted-strategy, `wandBlock` fell back to `wand`, which re-ran `generateQueryTermsAndStats` — doubling the count + tokenization cost on every query against legacy (map-strategy) shards. The stats are now computed once and passed through (`bm25QueryStats` / `wandFromStats`).

## Accuracy trade-off

The memtable counter cannot see whether a written key already exists on disk: an update of a flushed key over-counts by one, a delete of a never-written key under-counts by one. The drift is bounded by memtable churn and self-corrects at every flush, when the segment's exact net count is computed (existing `.cna` machinery). Since an undercounted N could otherwise drive `N < n` and produce a negative idf (corrupting scores and WAND pruning bounds), all four idf sites now go through `terms.Idf`, which clamps N up to the term's document frequency. Near-tie result reordering from small IDF shifts on unflushed updates/deletes is accepted; exact `Count()` is unchanged and still used everywhere else.

## Testing

- New: `TestMemtable_NetCount` (counter transition matrix incl. tombstone-with-time), `TestCountApproximate` (memtable-resident agreement, documented over-count drift + flush self-correction, mid-flush window via manual memtable switch, WAL-replay reconstruction incl. the replay-dedup drift, never-negative clamp), `TestIdf` (clamp).
- Existing suites green: lsmkv unit + integration (`-race`), `inverted` package, and the BM25 scoring integration suite (`TestBM25FJourney*`, `TestBM25FCompare*`, filters, memtable variants — legacy and block paths, which also covers the fallback refactor).
- `golangci-lint` and the goroutine linter pass.