### PR TITLE
fix(bm25): apply propertyBoost to WAND pivot and block-impact bounds

### DIFF
--- a/adapters/repos/db/inverted/terms/terms.go
+++ b/adapters/repos/db/inverted/terms/terms.go
@@ -338,7 +338,9 @@ func (t *Terms) FindMinIDWand(minScore float64) (uint64, int, bool) {
 		if term.Exhausted() {
 			continue
 		}
-		cumScore += term.Idf()
+		// compared against minScore, a boosted score, so use idf*propertyBoost
+		// (CurrentBlockImpact); bare Idf skips top-K docs for boosted properties.
+		cumScore += float64(term.CurrentBlockImpact())
 		if cumScore >= minScore {
 			return term.IdPointer(), i, false
 		}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2254,13 +2254,16 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 		// we can only know the full n after we have checked all segments and all memtables
 		idfs[i] = math.Log(float64(1)+(N-float64(n)+0.5)/(float64(n)+0.5)) * float64(duplicateTextBoosts[i])
 
+		// currentBlockImpact is a max-score upper bound, so it must carry
+		// propertyBoost like Score and computeCurrentBlockImpact; bare idf
+		// under-counts boosted terms and prunes genuine top-K docs.
 		if active != nil {
 			active.idf = idfs[i]
-			active.currentBlockImpact = float32(idfs[i])
+			active.currentBlockImpact = float32(idfs[i] * active.propertyBoost)
 		}
 		if flushing != nil {
 			flushing.idf = idfs[i]
-			flushing.currentBlockImpact = float32(idfs[i])
+			flushing.currentBlockImpact = float32(idfs[i] * flushing.propertyBoost)
 		}
 
 		idfCounts[queryTerm] = n

--- a/adapters/repos/db/lsmkv/search_segment.go
+++ b/adapters/repos/db/lsmkv/search_segment.go
@@ -110,7 +110,9 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			if firstNonExhausted == -1 {
 				firstNonExhausted = pivotPoint
 			}
-			cumScore += results[pivotPoint].idf
+			// compared against worstDist, a boosted score, so the bound must carry
+			// propertyBoost too; bare idf skips top-K docs for boosted properties.
+			cumScore += results[pivotPoint].idf * results[pivotPoint].propertyBoost
 			if cumScore >= worstDist {
 				pivotID = results[pivotPoint].idPointer
 				for i := pivotPoint + 1; i < len(results); i++ {
@@ -218,15 +220,15 @@ func DoBlockMaxWand(ctx context.Context, limit int, results Terms, averagePropLe
 			}
 		} else {
 			nextList := pivotPoint
-			maxWeight := results[nextList].idf
+			maxWeight := results[nextList].idf * results[nextList].propertyBoost
 			next := uint64(math.MaxUint64) // max uint
 
 			candidates := results[:pivotPoint+1]
 			for i := range candidates {
 				t := candidates[i]
-				if i < pivotPoint && t.idf > maxWeight {
+				if w := t.idf * t.propertyBoost; i < pivotPoint && w > maxWeight {
 					nextList = i
-					maxWeight = t.idf
+					maxWeight = w
 				}
 				if t.currentBlockMaxId < next {
 					next = t.currentBlockMaxId

--- a/adapters/repos/db/lsmkv/search_segment_bruteforce_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_bruteforce_test.go
@@ -15,14 +15,13 @@ package lsmkv
 
 import (
 	"context"
-	"io"
 	"math"
 	"math/rand"
 	"sort"
 	"strconv"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -44,8 +43,7 @@ import (
 // termination watchdog (the only other test in this regime) cannot see.
 func TestBlockMaxWandMatchesBruteForce(t *testing.T) {
 	ctx := context.Background()
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
+	logger, _ := test.NewNullLogger()
 	dir := t.TempDir()
 	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),

--- a/adapters/repos/db/lsmkv/search_segment_dowand_boost_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_dowand_boost_test.go
@@ -1,0 +1,163 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"io"
+	"math"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// zipfCorpus builds a deterministic zipf-distributed corpus: one posting list
+// per term (appended in ascending doc-id order, as WAND requires) and the mean
+// property length. Shared by the block-max and non-block boost tests.
+func zipfCorpus(seed int64, nDocs, vocab, termsPerDoc int) (map[uint64][]terms.DocPointerWithScore, float64) {
+	rng := rand.New(rand.NewSource(seed))
+	zipf := rand.NewZipf(rng, 1.07, 1.0, uint64(vocab-1))
+	postings := make(map[uint64][]terms.DocPointerWithScore)
+	var totalLen float64
+	for d := 0; d < nDocs; d++ {
+		pl := float32(20 + rng.Intn(480))
+		totalLen += float64(pl)
+		seen := make(map[uint64]uint32, termsPerDoc)
+		for k := 0; k < termsPerDoc; k++ {
+			seen[zipf.Uint64()]++
+		}
+		for tid, tf := range seen {
+			postings[tid] = append(postings[tid], terms.DocPointerWithScore{
+				Id: uint64(d), Frequency: float32(tf), PropLength: pl,
+			})
+		}
+	}
+	return postings, totalLen / float64(nDocs)
+}
+
+// topTermsByDF returns the n most frequent term ids — the long posting lists
+// that make the WAND pivot skip, the regime the boost fixes touch.
+func topTermsByDF(postings map[uint64][]terms.DocPointerWithScore, n int) []uint64 {
+	ranked := make([]uint64, 0, len(postings))
+	for tid := range postings {
+		ranked = append(ranked, tid)
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if len(postings[ranked[i]]) != len(postings[ranked[j]]) {
+			return len(postings[ranked[i]]) > len(postings[ranked[j]])
+		}
+		return ranked[i] < ranked[j]
+	})
+	return ranked[:n]
+}
+
+func idfOf(nDocs, docFreq int) float64 {
+	n := float64(docFreq)
+	return math.Log(1 + (float64(nDocs)-n+0.5)/(n+0.5))
+}
+
+// requireWandTopK asserts a WAND result matches the brute-force top-K. Every
+// returned doc must carry the brute score and rank within a boundary band of the
+// K-th best; every doc firmly above that band must be returned. The band absorbs
+// block-max WAND's inherent boundary approximation (~0.2% of score, from per-
+// block bounds); a bound that drops propertyBoost mis-prunes docs far above the
+// cutoff (well beyond the band), so this still fails on it.
+func requireWandTopK(t *testing.T, brute map[uint64]float64, wand map[uint64]float32, limit int) {
+	t.Helper()
+	n := limit
+	if len(brute) < n {
+		n = len(brute)
+	}
+	require.Lenf(t, wand, n, "want %d results, got %d", n, len(wand))
+
+	scores := make([]float64, 0, len(brute))
+	for _, s := range brute {
+		scores = append(scores, s)
+	}
+	sort.Sort(sort.Reverse(sort.Float64Slice(scores)))
+	kth := math.Inf(-1)
+	if n > 0 && len(scores) >= n {
+		kth = scores[n-1]
+	}
+	band := 0.01 * (1 + math.Abs(kth))
+
+	for id, dist := range wand {
+		b, ok := brute[id]
+		require.Truef(t, ok, "WAND returned doc %d that has no query term", id)
+		require.InDeltaf(t, b, float64(dist), 1e-3*(1+math.Abs(b)), "doc %d score mismatch", id)
+		require.GreaterOrEqualf(t, b, kth-band, "doc %d (%.4f) ranks firmly below K-th best (%.4f): included a non-top-K doc", id, b, kth)
+	}
+	for id, b := range brute {
+		if b > kth+band {
+			_, ok := wand[id]
+			require.Truef(t, ok, "WAND dropped firmly-top-K doc %d (%.4f > K-th %.4f): recall bug", id, b, kth)
+		}
+	}
+}
+
+// TestDoWandPropertyBoost exercises the non-block WAND pivot
+// (Terms.FindMinIDWand) for propertyBoost consistency; see requireWandTopK.
+// Fails on a bare-idf pivot bound at boost > 1.
+func TestDoWandPropertyBoost(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
+
+	const nDocs, limit = 4000, 10
+	postings, avgPropLen := zipfCorpus(11, nDocs, 800, 20)
+	query := topTermsByDF(postings, 40)
+
+	bruteForce := func(boost float32) map[uint64]float64 {
+		scores := map[uint64]float64{}
+		for _, tid := range query {
+			idf := idfOf(nDocs, len(postings[tid]))
+			for _, dp := range postings[tid] {
+				freq := float64(dp.Frequency)
+				tf := freq / (freq + bm25.K1*(1-bm25.B+bm25.B*float64(dp.PropLength)/avgPropLen))
+				scores[dp.Id] += tf * idf * float64(boost)
+			}
+		}
+		return scores
+	}
+
+	runWand := func(boost float32) map[uint64]float32 {
+		ts := make([]terms.TermInterface, 0, len(query))
+		for i, tid := range query {
+			tr := terms.NewTerm(strconv.FormatUint(tid, 10), i, boost, bm25)
+			tr.Data = postings[tid] // read-only in DoWand
+			tr.SetIdf(idfOf(nDocs, len(postings[tid])))
+			tr.SetPosPointer(0)
+			tr.SetIdPointer(tr.Data[0].Id)
+			ts = append(ts, tr)
+		}
+		h := DoWand(ctx, limit, &terms.Terms{T: ts, Count: len(query)}, avgPropLen, false, 1, logger)
+		out := map[uint64]float32{}
+		for h != nil && h.Len() > 0 {
+			it := h.Pop()
+			out[it.ID] = it.Dist
+		}
+		return out
+	}
+
+	for _, boost := range []float32{1, 5} {
+		t.Run(strconv.FormatFloat(float64(boost), 'g', -1, 32), func(t *testing.T) {
+			requireWandTopK(t, bruteForce(boost), runWand(boost), limit)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/search_segment_dowand_boost_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_dowand_boost_test.go
@@ -13,14 +13,13 @@ package lsmkv
 
 import (
 	"context"
-	"io"
 	"math"
 	"math/rand"
 	"sort"
 	"strconv"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -115,8 +114,7 @@ func requireWandTopK(t *testing.T, brute map[uint64]float64, wand map[uint64]flo
 // Fails on a bare-idf pivot bound at boost > 1.
 func TestDoWandPropertyBoost(t *testing.T) {
 	ctx := context.Background()
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
+	logger, _ := test.NewNullLogger()
 	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
 
 	const nDocs, limit = 4000, 10

--- a/adapters/repos/db/lsmkv/search_segment_longquery_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_longquery_test.go
@@ -15,13 +15,12 @@ package lsmkv
 
 import (
 	"context"
-	"io"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -32,8 +31,7 @@ import (
 // timeout. (Repro authored by QA Claude.)
 func TestBlockMaxWandLongQueryTerminates(t *testing.T) {
 	ctx := context.Background()
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
+	logger, _ := test.NewNullLogger()
 	dir := t.TempDir()
 	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),

--- a/adapters/repos/db/lsmkv/search_segment_propertyboost_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_propertyboost_test.go
@@ -15,11 +15,10 @@ package lsmkv
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -32,8 +31,7 @@ import (
 // the unflushed active/flushing bounds. Fails on any bare-idf bound at boost > 1.
 func TestBlockMaxWandPropertyBoost(t *testing.T) {
 	ctx := context.Background()
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
+	logger, _ := test.NewNullLogger()
 	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
 
 	const nDocs, limit = 4000, 10

--- a/adapters/repos/db/lsmkv/search_segment_propertyboost_test.go
+++ b/adapters/repos/db/lsmkv/search_segment_propertyboost_test.go
@@ -1,0 +1,125 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestBlockMaxWandPropertyBoost exercises the block-max WAND pivot
+// (DoBlockMaxWand) and the per-block impact bounds for propertyBoost
+// consistency; see requireWandTopK in search_segment_dowand_boost_test.go. The
+// "flushed" case covers the disk segment (computeCurrentBlockImpact), "memtable"
+// the unflushed active/flushing bounds. Fails on any bare-idf bound at boost > 1.
+func TestBlockMaxWandPropertyBoost(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	bm25 := schema.BM25Config{K1: 1.2, B: 0.75}
+
+	const nDocs, limit = 4000, 10
+	postings, _ := zipfCorpus(7, nDocs, 800, 20)
+	queryIDs := topTermsByDF(postings, 40)
+	keyFor := func(id uint64) string { return "t" + strconv.FormatUint(id, 36) }
+	query := make([]string, len(queryIDs))
+	for i, id := range queryIDs {
+		query[i] = keyFor(id)
+	}
+	dupBoosts := make([]int, len(query))
+	for i := range dupBoosts {
+		dupBoosts[i] = 1
+	}
+
+	for _, flush := range []bool{true, false} {
+		name := "memtable"
+		if flush {
+			name = "flushed"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(StrategyInverted))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+			bucket.SetMemtableThreshold(1 << 30) // single segment / one memtable
+
+			for tid, dps := range postings {
+				key := keyFor(tid)
+				for _, dp := range dps {
+					require.NoError(t, bucket.MapSet([]byte(key),
+						NewMapPairFromDocIdAndTf(dp.Id, dp.Frequency, dp.PropLength, false)))
+				}
+			}
+			if flush {
+				require.NoError(t, bucket.FlushAndSwitch())
+			}
+			avgPropLen, _ := bucket.GetAveragePropertyLength()
+
+			bruteForce := func(boost float32) map[uint64]float64 {
+				view := bucket.GetConsistentView()
+				defer view.ReleaseView()
+				diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(nDocs), nil,
+					query, "", boost, dupBoosts, bm25)
+				require.NoError(t, err)
+				scores := map[uint64]float64{}
+				for _, segTerms := range diskTerms {
+					for _, term := range segTerms {
+						for !term.Exhausted() {
+							id, s, _ := term.Score(avgPropLen, false)
+							scores[id] += s
+							term.Advance()
+						}
+					}
+				}
+				return scores
+			}
+
+			runWand := func(boost float32) map[uint64]float32 {
+				view := bucket.GetConsistentView()
+				defer view.ReleaseView()
+				diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(nDocs), nil,
+					query, "", boost, dupBoosts, bm25)
+				require.NoError(t, err)
+				out := map[uint64]float32{}
+				for _, segTerms := range diskTerms {
+					if len(segTerms) == 0 {
+						continue
+					}
+					h, err := DoBlockMaxWand(ctx, limit, segTerms, avgPropLen, false, len(query), 1, logger)
+					require.NoError(t, err)
+					for h != nil && h.Len() > 0 {
+						it := h.Pop()
+						out[it.ID] = it.Dist
+					}
+				}
+				return out
+			}
+
+			for _, boost := range []float32{1, 5} {
+				t.Run(strconv.FormatFloat(float64(boost), 'g', -1, 32), func(t *testing.T) {
+					requireWandTopK(t, bruteForce(boost), runWand(boost), limit)
+				})
+			}
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -671,9 +671,11 @@ func (s *SegmentBlockMax) computeCurrentBlockImpact() float32 {
 	if s.exhausted {
 		return 0
 	}
-	// for the fully decode blocks return the idf
+	// fully-decoded blocks have no per-block max metadata; bound the impact by
+	// idf*propertyBoost (tf<=1). propertyBoost must match Score and the paged
+	// path below, else boosted terms are under-counted and top-K docs pruned.
 	if len(s.blockEntries) == 0 {
-		return float32(s.idf)
+		return float32(s.idf * s.propertyBoost)
 	}
 	freq := float64(s.blockEntries[s.blockEntryIdx].MaxImpactTf)
 	propLength := float64(s.blockEntries[s.blockEntryIdx].MaxImpactPropLength)


### PR DESCRIPTION
## Problem

WAND compares each term's **max-score upper bound** against `worstDist`/`minScore` — the current k-th best score, a real BM25 score `idf · tf · propertyBoost`. Several of these upper bounds omitted `propertyBoost`. For a boosted property (`boost > 1`) they under-count terms, so the search prunes too aggressively and **drops genuine top-K documents**. Silent at the default `propertyBoost == 1`; worsens as the boost grows.

## Fixes

Four bounds now carry `propertyBoost`:

| Path | Site | Change |
|---|---|---|
| Block-max pivot | `DoBlockMaxWand` (`search_segment.go`) | `idf` → `idf * propertyBoost` |
| Non-block pivot | `Terms.FindMinIDWand` (`terms.go`) | `Idf()` → `CurrentBlockImpact()` (= `idf*boost`), matching block-max `FindMinID` |
| Block impact (disk) | `computeCurrentBlockImpact` fully-decoded branch (`segment_blockmax.go`) | `idf` → `idf * propertyBoost` |
| Block impact (memtable) | `createDiskTermFromCV` active/flushing seed (`bucket.go`) | `idf` → `idf * propertyBoost` |

The `DoBlockMaxWand` `nextList` heuristic is also made to apply the boost consistently. No behavior change at `propertyBoost == 1`.

## Tests

Two tests compare WAND's top-K against a brute-force full scan at **boost 1 and 5**:
- `TestDoWandPropertyBoost` — non-block (`DoWand`) path, in-memory.
- `TestBlockMaxWandPropertyBoost` — block-max (`DoBlockMaxWand`) path, over both a **flushed disk segment** and an **unflushed memtable** (covering the two block-impact seeds).

A boundary band absorbs block-max WAND's inherent top-K approximation (~0.2% of score, from per-block bounds) while staying far tighter than a dropped-boost bug (which mis-prunes docs >5% from the cutoff). Each of the pivot/memtable fixes is verified to break its test when reverted individually.

## Verification
- `terms` + `lsmkv` (block-max/wand/bm25, `-tags integrationTest`) suites pass
- `golangci-lint` 0 issues; `gofmt`/`go vet` clean

Supersedes the earlier #12016 (closed on branch rename).