### PR TITLE
fix(lsmkv): pass k1/b in correct order when flushing block-max impacts

### DIFF
--- a/adapters/repos/db/lsmkv/memtable_flush_inverted.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted.go
@@ -143,7 +143,7 @@ func (m *Memtable) flushDataInverted(f *segmentindex.SegmentFile, ogF *diskio.Me
 				k1 = m.bm25config.K1
 			}
 
-			blocksEncoded, _ := createAndEncodeBlocksWithLengths(mapNode.values, docIdEncoder, tfEncoder, float64(b), float64(k1), m.averagePropLength)
+			blocksEncoded, _ := createAndEncodeBlocksWithLengths(mapNode.values, docIdEncoder, tfEncoder, float64(k1), float64(b), m.averagePropLength)
 
 			if _, err := bw.Write(blocksEncoded); err != nil {
 				return nil, nil, err

--- a/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
@@ -1,0 +1,71 @@
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestInvertedFlushBakesImpactArgmax pins the k1/b argument order on the
+// memtable-flush block-serialization path: the flushed block's
+// (MaxImpactTf, MaxImpactPropLength) pair must be the argmax of the BM25
+// impact tf/(tf + k1*(1-b + b*pl/avg)). With the arguments transposed, the
+// baked pair recomputes to a bound below the block's true maximum score and
+// BlockMax-WAND wrongly prunes the true top-1 doc.
+func TestInvertedFlushBakesImpactArgmax(t *testing.T) {
+	const term = "impactterm"
+	ctx := context.Background()
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLoggerB(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	put := func(id uint64, key string, tf, pl float32) {
+		require.NoError(t, b.MapSet([]byte(key), NewMapPairFromDocIdAndTf(id, tf, pl, false)))
+	}
+
+	// One posting block (14 docs), k1=1.2 / b=0.75, corpus average exactly 100:
+	//   docs 1-12 (tf=6,  pl=150): impact 0.7843
+	//   doc  13   (tf=10, pl=150): impact 0.8584 <- correct argmax
+	//   doc  14   (tf=1,  pl=2):   impact 0.7587, but 1.152 under the k1/b-swapped
+	//                              formula tf/(tf + b*(1-k1 + k1*pl/avg)) <- its argmax
+	// A baked (1,2) pair bounds the block at 0.7587 < 0.7843, so WAND prunes the
+	// block once doc 1 fills the top-1 heap and never scores doc 13.
+	for i := uint64(1); i <= 12; i++ {
+		put(i, term, 6, 150)
+	}
+	put(13, term, 10, 150)
+	put(14, term, 1, 2)
+	// 138 fillers of length 96: (12*150 + 150 + 2 + 138*96) / 152 = 100 exactly
+	for i := 0; i < 138; i++ {
+		put(uint64(100+i), fmt.Sprintf("filler%05d", i), 1, 96)
+	}
+	require.NoError(t, b.FlushAndSwitch())
+
+	avg, count := b.GetAveragePropertyLength()
+	require.EqualValues(t, 152, count)
+	require.InDelta(t, 100.0, avg, 1e-9, "geometry requires the exact average")
+
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1)
+	sbm := view.Disk[0].newSegmentBlockMax(nil, []byte(term), 0, 1, 1,
+		nil, nil, nil, avg, schema.BM25Config{K1: 1.2, B: 0.75})
+	require.NotNil(t, sbm)
+	require.Len(t, sbm.blockEntries, 1, "probe postings must share one block")
+	require.Equal(t, uint32(10), sbm.blockEntries[0].MaxImpactTf,
+		"flushed block must bake the impact-argmax pair (k1/b order)")
+	require.Equal(t, uint32(150), sbm.blockEntries[0].MaxImpactPropLength,
+		"flushed block must bake the impact-argmax pair (k1/b order)")
+
+	got := runBlockMaxWand(t, b, []string{term}, 152, 1)
+	require.Len(t, got, 1)
+	require.Contains(t, got, uint64(13), "true top-1 pruned: flush baked an unsound block-max bound")
+}


### PR DESCRIPTION
### What's being changed:

The memtable flush path passed (b, k1) into
createAndEncodeBlocksWithLengths(..., k1, b, avgPropLen), so freshly flushed inverted segments baked the block-max (tf, propLength) pair chosen by a transposed impact formula. The pair is recomputed at query time with the correct formula, so the block upper bound could fall below the block's true maximum score and BlockMax-WAND wrongly pruned genuine top-k documents. Compaction passes the arguments correctly, silently repairing results once a segment is compacted — flush and compaction disagreed on identical data.

TestInvertedFlushBakesImpactArgmax pins the flush path: it engineers a single block whose correct and transposed argmax docs differ at an exact corpus average, then asserts both the baked pair and the end-to-end WAND top-1.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
