### PR TITLE
fix(queue): back off on recoverable task errors, contain task and dispatch panics

### DIFF
--- a/adapters/repos/db/queue/scheduler.go
+++ b/adapters/repos/db/queue/scheduler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -466,6 +467,7 @@ func (s *Scheduler) dispatchQueue(q *queueState) (taskCount int64, err error) {
 	// restarted. Contain it so the scheduler moves on to the other queues.
 	defer func() {
 		if r := recover(); r != nil {
+			entsentry.Recover(r)
 			enterrors.PrintStack(s.Logger)
 			err = errors.Errorf("recovered from panic while dispatching queue: %v", r)
 		}

--- a/adapters/repos/db/queue/scheduler.go
+++ b/adapters/repos/db/queue/scheduler.go
@@ -468,7 +468,7 @@ func (s *Scheduler) dispatchQueue(q *queueState) (taskCount int64, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			entsentry.Recover(r)
-			enterrors.PrintStack(s.Logger)
+			enterrors.PrintStack(s.Logger.WithField("queue_id", q.q.ID()))
 			err = errors.Errorf("recovered from panic while dispatching queue: %v", r)
 		}
 	}()

--- a/adapters/repos/db/queue/scheduler.go
+++ b/adapters/repos/db/queue/scheduler.go
@@ -460,7 +460,17 @@ func (s *Scheduler) scheduleQueues() (nothingScheduled bool) {
 	return nothingScheduled
 }
 
-func (s *Scheduler) dispatchQueue(q *queueState) (int64, error) {
+func (s *Scheduler) dispatchQueue(q *queueState) (taskCount int64, err error) {
+	// a panic here (e.g. while dequeuing or decoding a corrupt chunk) would
+	// kill the scheduler goroutine, which is shared by every queue and never
+	// restarted. Contain it so the scheduler moves on to the other queues.
+	defer func() {
+		if r := recover(); r != nil {
+			enterrors.PrintStack(s.Logger)
+			err = errors.Errorf("recovered from panic while dispatching queue: %v", r)
+		}
+	}()
+
 	if q.ctx.Err() != nil {
 		return 0, nil
 	}
@@ -475,7 +485,6 @@ func (s *Scheduler) dispatchQueue(q *queueState) (int64, error) {
 
 	partitions := make([][]Task, s.Workers)
 
-	var taskCount int64
 	for _, t := range batch.Tasks {
 		// TODO: introduce other partitioning strategies if needed
 		slot := t.Key() % uint64(s.Workers)

--- a/adapters/repos/db/queue/scheduler_test.go
+++ b/adapters/repos/db/queue/scheduler_test.go
@@ -441,6 +441,48 @@ func TestScheduler(t *testing.T) {
 	})
 }
 
+// panickingQueue implements Queue and panics when dequeued, simulating e.g.
+// a decoder panic on corrupt data.
+type panickingQueue struct {
+	id      string
+	metrics *Metrics
+}
+
+func (p *panickingQueue) ID() string                    { return p.id }
+func (p *panickingQueue) Size() int64                   { return 1 }
+func (p *panickingQueue) DequeueBatch() (*Batch, error) { panic("simulated dequeue panic") }
+func (p *panickingQueue) Metrics() *Metrics             { return p.metrics }
+
+// A panic while dispatching one queue must not kill the scheduler goroutine:
+// it is shared by every queue on the node and never restarted, so async
+// indexing would silently halt node-wide.
+func TestSchedulerSurvivesPanickingQueue(t *testing.T) {
+	s := makeScheduler(t, 1)
+	s.Start()
+	defer s.Close(t.Context())
+
+	// register a queue that panics on every dispatch and give the scheduler
+	// time to trip on it
+	s.RegisterQueue(&panickingQueue{
+		id:      "panicking_queue",
+		metrics: NewMetrics(newTestLogger(), nil, nil),
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	// a healthy queue registered afterwards must still be processed
+	ch, decoder := streamExecutor()
+	q := makeQueueWith(t, s, decoder, 0, t.TempDir())
+	defer q.Close(t.Context())
+
+	pushMany(t, q, 1, 100)
+
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("scheduler died after a queue panicked during dispatch")
+	}
+}
+
 func makeScheduler(t testing.TB, workers ...int) *Scheduler {
 	t.Helper()
 

--- a/adapters/repos/db/queue/worker.go
+++ b/adapters/repos/db/queue/worker.go
@@ -14,6 +14,7 @@ package queue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -53,6 +54,17 @@ func (w *Worker) Run(ctx context.Context) {
 
 func (w *Worker) do(batch *Batch) (err error) {
 	defer func() {
+		// a panicking task must not kill the worker goroutine: it is never
+		// restarted, and the batch would never be marked done or canceled,
+		// leaving the queue's active tasks gauge stuck so the queue is never
+		// scheduled again.
+		if r := recover(); r != nil {
+			w.logger.Errorf("recovered from panic while executing batch: %v", r)
+			enterrors.PrintStack(w.logger)
+			err = fmt.Errorf("panic while executing batch: %v", r)
+			batch.Cancel()
+			return
+		}
 		if err != nil {
 			batch.Cancel()
 		} else {

--- a/adapters/repos/db/queue/worker.go
+++ b/adapters/repos/db/queue/worker.go
@@ -106,27 +106,29 @@ func (w *Worker) do(batch *Batch) (err error) {
 			return nil
 		}
 
-		hasTransientErrs := hasTransientErrors(errs)
-		if hasTransientErrs {
-			retryIn := w.calculateBackoff(attempts)
-			w.logger.
-				WithError(errors.Join(errs...)).
-				WithField("failed", len(failed)).
-				WithField("attempts", attempts).
-				WithField("retry_in", retryIn).
-				Warnf("transient errors detected, retrying batch in %s", retryIn)
+		// the remaining errors are recoverable: transient errors, or timeouts,
+		// which are deliberately excluded from the permanent classification.
+		// Retry the failed tasks with a backoff. Every failure must either
+		// discard the batch, return, or sleep before the next attempt,
+		// otherwise this loop spins at full speed.
+		retryIn := w.calculateBackoff(attempts)
+		w.logger.
+			WithError(errors.Join(errs...)).
+			WithField("failed", len(failed)).
+			WithField("attempts", attempts).
+			WithField("retry_in", retryIn).
+			Warnf("recoverable errors detected, retrying batch in %s", retryIn)
 
-			attempts++
-			retryTimer := time.NewTimer(retryIn)
-			select {
-			case <-batch.Ctx.Done():
-				if !retryTimer.Stop() {
-					<-retryTimer.C
-				}
-				return batch.Ctx.Err()
-			case <-retryTimer.C:
-				// try again
+		attempts++
+		retryTimer := time.NewTimer(retryIn)
+		select {
+		case <-batch.Ctx.Done():
+			if !retryTimer.Stop() {
+				<-retryTimer.C
 			}
+			return batch.Ctx.Err()
+		case <-retryTimer.C:
+			// try again
 		}
 	}
 }
@@ -140,16 +142,6 @@ func (w *Worker) calculateBackoff(attempts int) time.Duration {
 	}
 
 	return time.Second << (attempts - 1)
-}
-
-func hasTransientErrors(errs []error) bool {
-	for _, err := range errs {
-		if enterrors.IsTransient(err) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func hasPermanentErrors(errs []error) bool {

--- a/adapters/repos/db/queue/worker.go
+++ b/adapters/repos/db/queue/worker.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	entsentry "github.com/weaviate/weaviate/entities/sentry"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 )
@@ -60,6 +61,7 @@ func (w *Worker) do(batch *Batch) (err error) {
 		// scheduled again.
 		if r := recover(); r != nil {
 			w.logger.Errorf("recovered from panic while executing batch: %v", r)
+			entsentry.Recover(r)
 			enterrors.PrintStack(w.logger)
 			err = fmt.Errorf("panic while executing batch: %v", r)
 			batch.Cancel()

--- a/adapters/repos/db/queue/worker_test.go
+++ b/adapters/repos/db/queue/worker_test.go
@@ -310,6 +310,64 @@ func TestWorker_DeadlineExceededBacksOff(t *testing.T) {
 	require.LessOrEqual(t, atomic.LoadInt32(&execCount), int32(2), "deadline errors must be retried with backoff, not in a tight loop")
 }
 
+// A panicking task must not kill the worker goroutine: it is never restarted,
+// and the batch would never be marked done or canceled, leaving the queue's
+// active tasks gauge stuck so the queue is never scheduled again.
+func TestWorker_RecoversFromPanickingTask(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	worker, ch := NewWorker(logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	enterrors.GoWrapper(func() { worker.Run(ctx) }, logger)
+
+	canceled := make(chan struct{})
+	panicking := &Batch{
+		Ctx: ctx,
+		Tasks: []Task{&mockWorkerTask{
+			executeFunc: func(ctx context.Context) error {
+				panic("simulated task panic")
+			},
+		}},
+		OnCanceled: func() { close(canceled) },
+	}
+
+	select {
+	case ch <- panicking:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not accept the batch")
+	}
+
+	// the batch must be marked canceled so the scheduler's gauges are released
+	select {
+	case <-canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("panicking batch was not marked canceled")
+	}
+
+	// the worker must survive and process subsequent batches
+	done := make(chan struct{})
+	healthy := &Batch{
+		Ctx:    ctx,
+		Tasks:  []Task{&mockWorkerTask{}},
+		OnDone: func() { close(done) },
+	}
+
+	select {
+	case ch <- healthy:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker died after a panicking task")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not process the batch after a panic")
+	}
+}
+
 func TestWorker_ContextCancellationDuringRetry(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	w := &Worker{

--- a/adapters/repos/db/queue/worker_test.go
+++ b/adapters/repos/db/queue/worker_test.go
@@ -259,6 +259,57 @@ func TestWorker_ExponentialBackoff(t *testing.T) {
 	}
 }
 
+// context.DeadlineExceeded is deliberately excluded from both the permanent
+// and the transient classification. It must still take the backoff path:
+// falling through both used to re-execute the failed tasks immediately, in a
+// tight loop with no sleep and no exit, pegging the worker at 100% CPU.
+func TestWorker_DeadlineExceededBacksOff(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	w := &Worker{
+		logger: logger,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// task that always fails with a deadline error, e.g. from an internal
+	// timeout
+	execCount := int32(0)
+	task := &mockWorkerTask{
+		executeFunc: func(ctx context.Context) error {
+			atomic.AddInt32(&execCount, 1)
+			return fmt.Errorf("internal timeout: %w", context.DeadlineExceeded)
+		},
+	}
+
+	batch := &Batch{
+		Ctx:   ctx,
+		Tasks: []Task{task},
+	}
+
+	// cancel the batch context after 500ms: the retry loop must exit
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.do(batch)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "should return context error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker is stuck retrying deadline errors in a tight loop")
+	}
+
+	// with a backoff after the first attempt, the task must not have been
+	// re-executed before the context was canceled
+	require.LessOrEqual(t, atomic.LoadInt32(&execCount), int32(2), "deadline errors must be retried with backoff, not in a tight loop")
+}
+
 func TestWorker_ContextCancellationDuringRetry(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	w := &Worker{


### PR DESCRIPTION
### What's being changed:

Two robustness fixes for the disk-backed queue's task execution (`adapters/repos/db/queue`), each pinned by a failing regression test in the commit history.

**1. A task failing with a deadline error hot-loops the worker at 100% CPU.**

`context.DeadlineExceeded` is deliberately excluded from the permanent-error classification (so timeouts don't discard the batch), but it isn't transient either — so it fell through both branches of the worker's retry loop. The failed tasks were re-executed immediately, in a tight loop with no sleep and no exit: even canceling the batch context didn't stop it, since only the transient branch checked the context. Any task returning a wrapped deadline error from an internal timeout pegged a worker core forever and pinned the queue's active-task gauge so the queue was never scheduled again.

The fix makes the retry loop take the backoff path for every non-permanent failure — after the permanent-error discard, only transient errors and timeouts can remain. The loop now maintains a simple invariant: every failure either discards the batch, returns, or sleeps before the next attempt. Transient-error behavior is unchanged (verified by the existing real-time backoff tests).

**2. A panicking task or a panicking dequeue kills goroutines that are never restarted.**

`Task.Execute` runs decoder output straight from disk and `DequeueBatch` parses untrusted bytes — both can panic. A panic unwinds into `GoWrapper`, which recovers and logs, but the goroutine exits for good:

- A **worker** dies permanently, and the in-flight batch is never marked done or canceled — the queue's active-task gauge stays stuck, the scheduler skips that queue forever, and `Close` hangs until its context expires. Each panic also permanently shrinks the worker pool.
- The **scheduler** goroutine is shared by every queue on the node, so one corrupt chunk silently halts async indexing node-wide, recurring after every restart.

The fix contains panics at the two boundaries: `Worker.do` recovers, logs the panic with its stack, and marks the batch canceled (releasing the gauges; the chunk is retained for retry after restart, consistent with existing cancel semantics). `Scheduler.dispatchQueue` recovers into its error return, so a panicking queue is logged as a failed dispatch and the scheduler moves on to the other queues.

Regression tests: `TestWorker_DeadlineExceededBacksOff`, `TestWorker_RecoversFromPanickingTask` (runs a real worker via `GoWrapper` and asserts it survives and processes subsequent batches), and `TestSchedulerSurvivesPanickingQueue` (asserts a healthy queue is still processed after another queue panics during dispatch).

These are findings #10 and #11 (the last two) from a broader crash-safety/corruption review of the package. Related: #12006 (merged), #12009, #12012.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
