### PR TITLE
feat: introduce `/grpc-web` endpoint

### DIFF
--- a/adapters/handlers/grpc/grpcweb/server.go
+++ b/adapters/handlers/grpc/grpcweb/server.go
@@ -48,9 +48,13 @@ func NewHandler(grpcServer *grpc.Server, state *state.State) (http.Handler, erro
 // operator-configured allowlists plus the grpc-web protocol headers browsers
 // send, with the gRPC trailers exposed so the browser can read the RPC status.
 func corsOptions(cfg config.CORS) cors.Options {
-	// grpc-web protocol headers not present in the general REST allowlist.
-	headers := append([]string{"X-Grpc-Web", "X-User-Agent", "Grpc-Timeout", "X-Weaviate-Client"},
-		splitTrim(cfg.AllowHeaders)...)
+	// grpc-web/Connect protocol headers not present in the general REST
+	// allowlist. Connect-Protocol-Version is mandatory for Connect-JSON clients
+	headers := append([]string{
+		"X-Grpc-Web", "X-User-Agent", "Grpc-Timeout",
+		"Connect-Protocol-Version", "Connect-Timeout-Ms",
+		"X-Weaviate-Client",
+	}, splitTrim(cfg.AllowHeaders)...)
 	return cors.Options{
 		AllowedOrigins: splitTrim(cfg.AllowOrigin),
 		AllowedMethods: []string{http.MethodPost}, // grpc-web is POST-only

--- a/adapters/handlers/grpc/grpcweb/server.go
+++ b/adapters/handlers/grpc/grpcweb/server.go
@@ -1,0 +1,111 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package grpcweb exposes the gRPC API over grpc-web/Connect so browsers can
+// reach it directly. The transcoder is mounted on the existing REST port under
+// a path prefix (see Mount) instead of a dedicated listener, so operators do
+// not have to expose a second port.
+package grpcweb
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	"connectrpc.com/vanguard"
+	"connectrpc.com/vanguard/vanguardgrpc"
+	"github.com/rs/cors"
+	"google.golang.org/grpc"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// NewHandler transcodes grpc-web/Connect requests into calls against the
+// existing gRPC server. It carries its own CORS layer (grpc-web is routed
+// outside the REST middleware chain; see Mount) and exposes the gRPC trailer
+// headers so browsers can read the RPC status.
+func NewHandler(grpcServer *grpc.Server, state *state.State) (http.Handler, error) {
+	opts := []vanguard.ServiceOption{}
+	opts = append(opts, vanguard.WithMaxMessageBufferBytes(msgBufferLimit(state.ServerConfig.Config.GRPC.MaxMsgSize)))
+	transcoder, err := vanguardgrpc.NewTranscoder(grpcServer, vanguard.WithDefaultServiceOptions(opts...))
+	if err != nil {
+		return nil, fmt.Errorf("build grpc-web transcoder: %w", err)
+	}
+	return cors.New(corsOptions(state.ServerConfig.Config.CORS)).Handler(transcoder), nil
+}
+
+// corsOptions builds the CORS config for the grpc-web handler: the
+// operator-configured allowlists plus the grpc-web protocol headers browsers
+// send, with the gRPC trailers exposed so the browser can read the RPC status.
+func corsOptions(cfg config.CORS) cors.Options {
+	// grpc-web protocol headers not present in the general REST allowlist.
+	headers := append([]string{"X-Grpc-Web", "X-User-Agent", "Grpc-Timeout", "X-Weaviate-Client"},
+		splitTrim(cfg.AllowHeaders)...)
+	return cors.Options{
+		AllowedOrigins: splitTrim(cfg.AllowOrigin),
+		AllowedMethods: []string{http.MethodPost}, // grpc-web is POST-only
+		AllowedHeaders: headers,
+		ExposedHeaders: []string{"Grpc-Status", "Grpc-Message", "Grpc-Status-Details-Bin"},
+		// No CORS credentials mode: Weaviate auth is a bearer token in the
+		// Authorization header (not cookies), so it buys nothing, and
+		// Allow-Credentials:true with a wildcard Allow-Origin is a combo
+		// browsers reject. Matches the REST handler's posture.
+		AllowCredentials: false,
+	}
+}
+
+func msgBufferLimit(maxMsgSize int) uint32 {
+	if maxMsgSize <= 0 || uint64(maxMsgSize) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(maxMsgSize)
+}
+
+// splitTrim splits a comma-separated config value and trims each element.
+// The trim is critical: DefaultCORSAllowHeaders is ", "-separated and
+// rs/cors matches header names verbatim, so a leading space on " Authorization"
+// would silently fail the browser's preflight and block authenticated requests.
+func splitTrim(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Mount routes requests under prefix to grpcWeb (with prefix stripped, so the
+// transcoder sees the canonical /<pkg>.<Service>/<Method> path) and everything
+// else to next. The grpc-web branch deliberately sits outside the REST
+// middleware chain: the gRPC server's interceptors enforce auth and maintenance
+// mode, whereas the REST operational-mode gate would misclassify /weaviate.v1.*
+// paths.
+//
+// enabled is consulted per request, but only for prefix-matching paths, so a
+// runtime toggle changes routing without a restart while plain REST requests pay
+// nothing for the check. When it returns false, grpc-web paths fall through to
+// next (the REST handler) instead of being served.
+func Mount(prefix string, grpcWeb, next http.Handler, enabled func() bool) http.Handler {
+	stripped := http.StripPrefix(prefix, grpcWeb)
+	prefixSlash := prefix + "/"
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == prefix || strings.HasPrefix(r.URL.Path, prefixSlash) {
+			if enabled() {
+				stripped.ServeHTTP(w, r)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/adapters/handlers/grpc/grpcweb/server_test.go
+++ b/adapters/handlers/grpc/grpcweb/server_test.go
@@ -48,9 +48,18 @@ func TestCORSPreflightAllowsConfiguredHeaders(t *testing.T) {
 		"x-user-agent",
 		"grpc-timeout",
 		"x-weaviate-client",
+		// Connect protocol headers a connect-es JSON client sends: the version
+		// header is mandatory for the JSON path (vanguard classifies a bare JSON
+		// POST as REST without it), so a preflight rejecting it blocks every
+		// Connect-JSON browser call; the timeout header accompanies it whenever
+		// the client sets a deadline.
+		"connect-protocol-version",
+		"connect-timeout-ms",
 		"authorization,content-type",
 		// the full unmodified-client preflight, all at once.
 		"authorization,content-type,x-user-agent,grpc-timeout,x-weaviate-client",
+		// the full Connect-JSON browser preflight, all at once.
+		"authorization,content-type,connect-protocol-version,connect-timeout-ms",
 	}
 	for _, sh := range shapes {
 		t.Run(sh.name, func(t *testing.T) {

--- a/adapters/handlers/grpc/grpcweb/server_test.go
+++ b/adapters/handlers/grpc/grpcweb/server_test.go
@@ -61,7 +61,7 @@ func TestCORSPreflightAllowsConfiguredHeaders(t *testing.T) {
 			})).Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 			for _, reqHeaders := range requestHeaderCases {
 				t.Run(reqHeaders, func(t *testing.T) {
-					req := httptest.NewRequest(http.MethodOptions, "/grpc-web/weaviate.v1.Weaviate/Search", nil)
+					req := httptest.NewRequest(http.MethodOptions, "/v1/grpc-web/weaviate.v1.Weaviate/Search", nil)
 					req.Header.Set("Origin", "http://localhost:3000")
 					req.Header.Set("Access-Control-Request-Method", http.MethodPost)
 					req.Header.Set("Access-Control-Request-Headers", reqHeaders)
@@ -80,19 +80,19 @@ func TestCORSPreflightAllowsConfiguredHeaders(t *testing.T) {
 }
 
 func TestMount(t *testing.T) {
-	const prefix = "/grpc-web"
+	const prefix = "/v1/grpc-web"
 	tests := []struct {
 		name      string
 		path      string
 		wantRoute string // "grpcweb" or "next"
 		wantPath  string // path the grpc-web handler observes after prefix strip
 	}{
-		{"service method", "/grpc-web/weaviate.v1.Weaviate/Search", "grpcweb", "/weaviate.v1.Weaviate/Search"},
-		{"bare prefix", "/grpc-web", "grpcweb", ""},
-		{"prefix root slash", "/grpc-web/", "grpcweb", "/"},
+		{"service method", "/v1/grpc-web/weaviate.v1.Weaviate/Search", "grpcweb", "/weaviate.v1.Weaviate/Search"},
+		{"bare prefix", "/v1/grpc-web", "grpcweb", ""},
+		{"prefix root slash", "/v1/grpc-web/", "grpcweb", "/"},
 		{"rest path", "/v1/objects", "next", ""},
 		{"root", "/", "next", ""},
-		{"prefix lookalike not stolen", "/grpc-web-extra", "next", ""},
+		{"prefix lookalike not stolen", "/v1/grpc-web-extra", "next", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -130,7 +130,7 @@ func TestMountRuntimeToggle(t *testing.T) {
 	var gotRoute string
 	grpcWeb := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { gotRoute = "grpcweb" })
 	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { gotRoute = "next" })
-	handler := Mount("/grpc-web", grpcWeb, next, enabled.Get)
+	handler := Mount("/v1/grpc-web", grpcWeb, next, enabled.Get)
 
 	route := func(path string) string {
 		gotRoute = ""
@@ -138,7 +138,7 @@ func TestMountRuntimeToggle(t *testing.T) {
 		return gotRoute
 	}
 
-	const grpcPath = "/grpc-web/weaviate.v1.Weaviate/Search"
+	const grpcPath = "/v1/grpc-web/weaviate.v1.Weaviate/Search"
 	const restPath = "/v1/objects"
 
 	// default (enabled): grpc-web served, REST untouched

--- a/adapters/handlers/grpc/grpcweb/server_test.go
+++ b/adapters/handlers/grpc/grpcweb/server_test.go
@@ -1,0 +1,157 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package grpcweb
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/cors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+)
+
+// TestCORSPreflightAllowsConfiguredHeaders pins the trim bug across several
+// CORS_ALLOW_HEADERS separator styles: an untrimmed split leaves " Authorization"
+// for the default ", "-separated value, which rs/cors rejects, blocking
+// authenticated browser grpc-web requests. Every shape must allow Authorization
+// (and the grpc-web protocol headers) regardless of separator whitespace.
+func TestCORSPreflightAllowsConfiguredHeaders(t *testing.T) {
+	shapes := []struct {
+		name         string
+		allowHeaders string
+	}{
+		{`default ", "-separated`, config.DefaultCORSAllowHeaders},
+		{"comma-only, no spaces", "Content-Type,Authorization"},
+		{"irregular whitespace", "Content-Type ,  Authorization ,Batch"},
+	}
+	// Allowed in every shape: Content-Type/Authorization are present in all the
+	// configured values above, and X-Grpc-Web is always appended by corsOptions.
+	requestHeaderCases := []string{
+		"authorization", // the header the bug silently dropped
+		"content-type",
+		// grpc-web protocol + Weaviate client headers an unmodified browser
+		// client sends; appended by corsOptions, not part of CORS_ALLOW_HEADERS.
+		"x-grpc-web",
+		"x-user-agent",
+		"grpc-timeout",
+		"x-weaviate-client",
+		"authorization,content-type",
+		// the full unmodified-client preflight, all at once.
+		"authorization,content-type,x-user-agent,grpc-timeout,x-weaviate-client",
+	}
+	for _, sh := range shapes {
+		t.Run(sh.name, func(t *testing.T) {
+			handler := cors.New(corsOptions(config.CORS{
+				AllowOrigin:  config.DefaultCORSAllowOrigin,
+				AllowMethods: config.DefaultCORSAllowMethods,
+				AllowHeaders: sh.allowHeaders,
+			})).Handler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			for _, reqHeaders := range requestHeaderCases {
+				t.Run(reqHeaders, func(t *testing.T) {
+					req := httptest.NewRequest(http.MethodOptions, "/grpc-web/weaviate.v1.Weaviate/Search", nil)
+					req.Header.Set("Origin", "http://localhost:3000")
+					req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+					req.Header.Set("Access-Control-Request-Headers", reqHeaders)
+					rec := httptest.NewRecorder()
+					handler.ServeHTTP(rec, req)
+
+					// rs/cors signals "allowed" by echoing Access-Control-Allow-Origin;
+					// a rejected preflight omits it entirely.
+					require.NotEmpty(t, rec.Header().Get("Access-Control-Allow-Origin"),
+						"preflight for %q rejected (ACAH=%q)", reqHeaders,
+						rec.Header().Get("Access-Control-Allow-Headers"))
+				})
+			}
+		})
+	}
+}
+
+func TestMount(t *testing.T) {
+	const prefix = "/grpc-web"
+	tests := []struct {
+		name      string
+		path      string
+		wantRoute string // "grpcweb" or "next"
+		wantPath  string // path the grpc-web handler observes after prefix strip
+	}{
+		{"service method", "/grpc-web/weaviate.v1.Weaviate/Search", "grpcweb", "/weaviate.v1.Weaviate/Search"},
+		{"bare prefix", "/grpc-web", "grpcweb", ""},
+		{"prefix root slash", "/grpc-web/", "grpcweb", "/"},
+		{"rest path", "/v1/objects", "next", ""},
+		{"root", "/", "next", ""},
+		{"prefix lookalike not stolen", "/grpc-web-extra", "next", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotRoute, gotPath string
+			grpcWeb := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				gotRoute, gotPath = "grpcweb", r.URL.Path
+			})
+			next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				gotRoute = "next"
+			})
+
+			Mount(prefix, grpcWeb, next, func() bool { return true }).ServeHTTP(
+				httptest.NewRecorder(),
+				httptest.NewRequest(http.MethodPost, tt.path, nil),
+			)
+
+			if gotRoute != tt.wantRoute {
+				t.Fatalf("path %q routed to %q, want %q", tt.path, gotRoute, tt.wantRoute)
+			}
+			if tt.wantRoute == "grpcweb" && gotPath != tt.wantPath {
+				t.Fatalf("path %q: grpc-web handler saw %q, want %q", tt.path, gotPath, tt.wantPath)
+			}
+		})
+	}
+}
+
+// TestMountRuntimeToggle pins the genuinely-dynamic behaviour: the enable switch
+// is read per request off a live DynamicValue (as the grpc_web_enabled runtime
+// override would be), so flipping it changes routing on a single already-built
+// handler without a restart. Disabling must route grpc-web paths to next (REST)
+// rather than 500/hang, and plain REST paths must be unaffected in every state.
+func TestMountRuntimeToggle(t *testing.T) {
+	enabled := runtime.NewDynamicValue(true)
+
+	var gotRoute string
+	grpcWeb := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { gotRoute = "grpcweb" })
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { gotRoute = "next" })
+	handler := Mount("/grpc-web", grpcWeb, next, enabled.Get)
+
+	route := func(path string) string {
+		gotRoute = ""
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, path, nil))
+		return gotRoute
+	}
+
+	const grpcPath = "/grpc-web/weaviate.v1.Weaviate/Search"
+	const restPath = "/v1/objects"
+
+	// default (enabled): grpc-web served, REST untouched
+	require.Equal(t, "grpcweb", route(grpcPath))
+	require.Equal(t, "next", route(restPath))
+
+	// flip off on the live handler: grpc-web now falls through to REST
+	require.NoError(t, enabled.SetValue(false))
+	require.Equal(t, "next", route(grpcPath))
+	require.Equal(t, "next", route(restPath), "plain REST unaffected while disabled")
+
+	// flip back on: grpc-web served again, no rebuild
+	require.NoError(t, enabled.SetValue(true))
+	require.Equal(t, "grpcweb", route(grpcPath))
+	require.Equal(t, "next", route(restPath))
+}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1573,9 +1573,9 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	setupMCPHandlers(api, appState, objectsManager)
 
 	restHandler := setupGlobalMiddleware(api.Serve(setupMiddlewares))
-	// Serve grpc-web on the REST port under /grpc-web/ rather than a dedicated listener
-	return grpcweb.Mount("/grpc-web", grpcWebHandler, restHandler,
-		func() bool { return appState.ServerConfig.Config.GRPC.WebEnabledOrDefault() })
+	// Serve grpc-web on the REST port under /v1/grpc-web/ rather than a dedicated listener
+	return grpcweb.Mount("/v1/grpc-web", grpcWebHandler, restHandler,
+		func() bool { return appState.ServerConfig.Config.GRPC.GrpcWebEnabledOrDefault() })
 }
 
 func startBackupScheduler(appState *state.State) *backup.Scheduler {
@@ -2658,7 +2658,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.MCPEnabled = appState.ServerConfig.Config.MCP.Enabled
 		registered.MCPWriteAccessEnabled = appState.ServerConfig.Config.MCP.WriteAccessEnabled
 		registered.DebugEndpointsEnabled = appState.ServerConfig.Config.Profiling.DebugEndpointsEnabled
-		registered.GRPCWebEnabled = appState.ServerConfig.Config.GRPC.WebEnabled
+		registered.GRPCWebEnabled = appState.ServerConfig.Config.GRPC.GrpcWebEnabled
 
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
 			registered.OIDCIssuer = appState.ServerConfig.Config.Authentication.OIDC.Issuer

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -52,6 +52,7 @@ import (
 
 	"github.com/weaviate/fgprof"
 	"github.com/weaviate/weaviate/adapters/clients"
+	"github.com/weaviate/weaviate/adapters/handlers/grpc/grpcweb"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/authz"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
 	clusterapigrpc "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc"
@@ -1437,6 +1438,11 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	}
 
 	grpcServer, batchDrain := createGrpcServer(appState, telemeter.GetClientTracker(), telemeter.GetIntegrationTracker(), grpcInstrument...)
+	grpcWebHandler, err := grpcweb.NewHandler(grpcServer, appState)
+	if err != nil {
+		appState.Logger.WithField("action", "grpc_web_startup").
+			Fatalf("init grpc-web handler: %v", err)
+	}
 
 	setupMiddlewares := makeSetupMiddlewares(appState)
 	setupGlobalMiddleware := makeSetupGlobalMiddleware(appState, api.Context(), telemeter)
@@ -1565,7 +1571,11 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	startGrpcServer(grpcServer, appState)
 	setupMCPHandlers(api, appState, objectsManager)
-	return setupGlobalMiddleware(api.Serve(setupMiddlewares))
+
+	restHandler := setupGlobalMiddleware(api.Serve(setupMiddlewares))
+	// Serve grpc-web on the REST port under /grpc-web/ rather than a dedicated listener
+	return grpcweb.Mount("/grpc-web", grpcWebHandler, restHandler,
+		func() bool { return appState.ServerConfig.Config.GRPC.WebEnabledOrDefault() })
 }
 
 func startBackupScheduler(appState *state.State) *backup.Scheduler {
@@ -2648,6 +2658,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.MCPEnabled = appState.ServerConfig.Config.MCP.Enabled
 		registered.MCPWriteAccessEnabled = appState.ServerConfig.Config.MCP.WriteAccessEnabled
 		registered.DebugEndpointsEnabled = appState.ServerConfig.Config.Profiling.DebugEndpointsEnabled
+		registered.GRPCWebEnabled = appState.ServerConfig.Config.GRPC.WebEnabled
 
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
 			registered.OIDCIssuer = appState.ServerConfig.Config.Authentication.OIDC.Issuer

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/weaviate/weaviate
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/storage v1.60.0
+	connectrpc.com/vanguard v0.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/KimMachineGun/automemlimit v0.7.5
@@ -118,6 +119,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
+	connectrpc.com/connect v1.19.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+buf.build/gen/go/connectrpc/eliza/connectrpc/go v1.11.1-20230822171018-8b8b971d6fde.1 h1:VxlBIOBOYa4k5dHcmduPVF1OXJwhiGmsVhqdbPd33Mo=
+buf.build/gen/go/connectrpc/eliza/connectrpc/go v1.11.1-20230822171018-8b8b971d6fde.1/go.mod h1:FapnC4TeZc01ECYAUKV30mpI5J0R60dZrIeqfOSPbMk=
+buf.build/gen/go/connectrpc/eliza/protocolbuffers/go v1.31.0-20230822171018-8b8b971d6fde.1 h1:JUxbUtCrCK/nPCkWcucuBKRH9mbwSElgeWoORg16IrI=
+buf.build/gen/go/connectrpc/eliza/protocolbuffers/go v1.31.0-20230822171018-8b8b971d6fde.1/go.mod h1:QiftkbxA+bQUTeN1ke64YoIoxt6diVLfuolQi3ORa9c=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -22,6 +26,10 @@ cloud.google.com/go/storage v1.60.0 h1:oBfZrSOCimggVNz9Y/bXY35uUcts7OViubeddTTVz
 cloud.google.com/go/storage v1.60.0/go.mod h1:q+5196hXfejkctrnx+VYU8RKQr/L3c0cBIlrjmiAKE0=
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
+connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
+connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+connectrpc.com/vanguard v0.4.0 h1:lx23IDorlJnaR1mNbjgP0LXiI5yBwo0eWeXA5qSBNoY=
+connectrpc.com/vanguard v0.4.0/go.mod h1:VbDkW6OqfRPOi144sbE+OuLiLmhLfCxkQjzKErJsoT0=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=

--- a/test/acceptance/grpc/grpc_web_test.go
+++ b/test/acceptance/grpc/grpc_web_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // TestGRPCWebSearchOverRESTPort exercises the grpc-web feature end to end: a
-// browser-shaped Connect-protocol JSON POST to /grpc-web/weaviate.v1.Weaviate/Search
+// browser-shaped Connect-protocol JSON POST to /v1/grpc-web/weaviate.v1.Weaviate/Search
 // on the REST port must be transcoded to the in-process gRPC Search and return the
 // objects that were inserted over REST. It is deliberately non-vacuous: a REST 404
 // fallthrough (grpc-web unmounted/misrouted), an empty result set, or an undecodable
@@ -87,7 +87,7 @@ func TestGRPCWebSearchOverRESTPort(t *testing.T) {
 		want[b.title] = b.wordCount
 	}
 
-	endpoint := fmt.Sprintf("http://%s/grpc-web/weaviate.v1.Weaviate/Search", compose.GetWeaviate().URI())
+	endpoint := fmt.Sprintf("http://%s/v1/grpc-web/weaviate.v1.Weaviate/Search", compose.GetWeaviate().URI())
 	// Connect-protocol unary JSON body (protojson lowerCamelCase field names). uses127Api
 	// is the modern, non-deprecated variant of the uses_12X_api flags used by the sibling
 	// gRPC search tests; returnAllNonrefProperties makes the values come back under

--- a/test/acceptance/grpc/grpc_web_test.go
+++ b/test/acceptance/grpc/grpc_web_test.go
@@ -1,0 +1,149 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// TestGRPCWebSearchOverRESTPort exercises the grpc-web feature end to end: a
+// browser-shaped Connect-protocol JSON POST to /grpc-web/weaviate.v1.Weaviate/Search
+// on the REST port must be transcoded to the in-process gRPC Search and return the
+// objects that were inserted over REST. It is deliberately non-vacuous: a REST 404
+// fallthrough (grpc-web unmounted/misrouted), an empty result set, or an undecodable
+// body each fail loudly, so it guards the wiring the unit-level grpcweb tests cannot
+// reach (the real configure_api composition serving on the live REST listener).
+func TestGRPCWebSearchOverRESTPort(t *testing.T) {
+	ctx := context.Background()
+
+	// REST-port-only node: the transcoder wraps the in-process gRPC server object,
+	// so grpc-web is served on the REST listener with no gRPC port exposed.
+	compose, err := docker.New().
+		WithWeaviate().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	class := &models.Class{
+		Class:      "GRPCWebSearch",
+		Vectorizer: "none",
+		Properties: []*models.Property{
+			{Name: "title", DataType: []string{"text"}},
+			{Name: "wordCount", DataType: []string{"int"}},
+		},
+	}
+	helper.CreateClass(t, class)
+	defer helper.DeleteClass(t, class.Class)
+
+	books := []struct {
+		title     string
+		wordCount int64
+	}{
+		{"Dune", 412},
+		{"Foundation", 255},
+		{"Neuromancer", 271},
+	}
+	// Order-insensitive expectation keyed by title: a plain Search returns objects in
+	// no guaranteed order.
+	want := make(map[string]int64, len(books))
+	for _, b := range books {
+		require.NoError(t, helper.CreateObject(t, &models.Object{
+			Class: class.Class,
+			ID:    strfmt.UUID(uuid.NewString()),
+			Properties: map[string]interface{}{
+				"title":     b.title,
+				"wordCount": b.wordCount,
+			},
+		}))
+		want[b.title] = b.wordCount
+	}
+
+	endpoint := fmt.Sprintf("http://%s/grpc-web/weaviate.v1.Weaviate/Search", compose.GetWeaviate().URI())
+	// Connect-protocol unary JSON body (protojson lowerCamelCase field names). uses127Api
+	// is the modern, non-deprecated variant of the uses_12X_api flags used by the sibling
+	// gRPC search tests; returnAllNonrefProperties makes the values come back under
+	// nonRefProps.fields, and metadata.uuid proves the id round-trips too.
+	reqBody := fmt.Sprintf(
+		`{"collection":%q,"limit":100,"uses127Api":true,"metadata":{"uuid":true},"properties":{"returnAllNonrefProperties":true}}`,
+		class.Class,
+	)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		status, contentType, body, err := grpcWebSearch(ctx, endpoint, reqBody)
+		require.NoError(ct, err)
+		require.Equalf(ct, http.StatusOK, status,
+			"grpc-web Search must return 200 (a REST 404 fallthrough means the mount is not serving); body=%s", body)
+		require.Truef(ct, strings.HasPrefix(contentType, "application/json"),
+			"grpc-web Search must reply as Connect JSON; got content-type %q body=%s", contentType, body)
+
+		// Strict decode: protojson rejects unknown fields by default, so a Connect error
+		// envelope or an HTML/JSON error page fails here rather than passing vacuously.
+		var reply pb.SearchReply
+		require.NoErrorf(ct, protojson.Unmarshal(body, &reply), "strict-decode SearchReply; body=%s", body)
+		require.Lenf(ct, reply.GetResults(), len(books),
+			"returned result count must equal inserted count; body=%s", body)
+
+		got := make(map[string]int64, len(books))
+		for _, r := range reply.GetResults() {
+			require.NotEmptyf(ct, r.GetMetadata().GetId(), "each result must carry its uuid; body=%s", body)
+			fields := r.GetProperties().GetNonRefProps().GetFields()
+			got[fields["title"].GetTextValue()] = fields["wordCount"].GetIntValue()
+		}
+		require.Equal(ct, want, got, "returned property values must equal the inserted values")
+	}, 30*time.Second, 2*time.Second, "grpc-web Search did not return the inserted objects in time")
+}
+
+// grpcWebSearch POSTs a Connect-protocol JSON Search request to the grpc-web mount on
+// the REST port and returns the status, content type and raw body for strict validation.
+func grpcWebSearch(ctx context.Context, endpoint, reqJSON string) (int, string, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(reqJSON))
+	if err != nil {
+		return 0, "", nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Vanguard classifies a bare application/json POST as REST (transcoder.go
+	// classifyRequest); the Connect-Protocol-Version header is what selects the
+	// Connect unary protocol so the body is decoded as the request message.
+	req.Header.Set("Connect-Protocol-Version", "1")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, resp.Header.Get("Content-Type"), nil, err
+	}
+	return resp.StatusCode, resp.Header.Get("Content-Type"), body, nil
+}

--- a/test/acceptance/grpc/grpc_web_test.go
+++ b/test/acceptance/grpc/grpc_web_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -41,20 +40,9 @@ import (
 func TestGRPCWebSearchOverRESTPort(t *testing.T) {
 	ctx := context.Background()
 
-	// REST-port-only node: the transcoder wraps the in-process gRPC server object,
-	// so grpc-web is served on the REST listener with no gRPC port exposed.
-	compose, err := docker.New().
-		WithWeaviate().
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
-
-	helper.SetupClient(compose.GetWeaviate().URI())
-
+	collectionName := "GRPCWebSearch"
 	class := &models.Class{
-		Class:      "GRPCWebSearch",
+		Class:      collectionName,
 		Vectorizer: "none",
 		Properties: []*models.Property{
 			{Name: "title", DataType: []string{"text"}},
@@ -87,7 +75,7 @@ func TestGRPCWebSearchOverRESTPort(t *testing.T) {
 		want[b.title] = b.wordCount
 	}
 
-	endpoint := fmt.Sprintf("http://%s/v1/grpc-web/weaviate.v1.Weaviate/Search", compose.GetWeaviate().URI())
+	endpoint := "http://localhost:8080/v1/grpc-web/weaviate.v1.Weaviate/Search"
 	// Connect-protocol unary JSON body (protojson lowerCamelCase field names). uses127Api
 	// is the modern, non-deprecated variant of the uses_12X_api flags used by the sibling
 	// gRPC search tests; returnAllNonrefProperties makes the values come back under

--- a/test/acceptance/grpc/grpc_web_test.go
+++ b/test/acceptance/grpc/grpc_web_test.go
@@ -125,6 +125,9 @@ func TestGRPCWebSearchOverRESTPort(t *testing.T) {
 // grpcWebSearch POSTs a Connect-protocol JSON Search request to the grpc-web mount on
 // the REST port and returns the status, content type and raw body for strict validation.
 func grpcWebSearch(ctx context.Context, endpoint, reqJSON string) (int, string, []byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(reqJSON))
 	if err != nil {
 		return 0, "", nil, err

--- a/test/acceptance/grpc/list_value_return_test.go
+++ b/test/acceptance/grpc/list_value_return_test.go
@@ -69,7 +69,6 @@ func TestGRPC_ListValueReturn(t *testing.T) {
 			},
 		},
 	})
-	defer helper.DeleteClass(t, collectionNameLVR)
 
 	var buf bytes.Buffer
 	err := binary.Write(&buf, binary.LittleEndian, []float64{1.1, 2.2})

--- a/test/acceptance/grpc/list_value_return_test.go
+++ b/test/acceptance/grpc/list_value_return_test.go
@@ -69,6 +69,7 @@ func TestGRPC_ListValueReturn(t *testing.T) {
 			},
 		},
 	})
+	defer helper.DeleteClass(t, collectionNameLVR)
 
 	var buf bytes.Buffer
 	err := binary.Write(&buf, binary.LittleEndian, []float64{1.1, 2.2})

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -868,12 +868,18 @@ type Contextionary struct {
 
 // Support independent TLS credentials for gRPC
 type GRPC struct {
-	Port            int           `json:"port" yaml:"port"`
-	CertFile        string        `json:"certFile" yaml:"certFile"`
-	KeyFile         string        `json:"keyFile" yaml:"keyFile"`
-	MaxMsgSize      int           `json:"maxMsgSize" yaml:"maxMsgSize"`
-	MaxOpenConns    int           `json:"maxOpenConns" yaml:"maxOpenConns"`
-	IdleConnTimeout time.Duration `json:"idleConnTimeout" yaml:"idleConnTimeout"`
+	Port            int                         `json:"port" yaml:"port"`
+	CertFile        string                      `json:"certFile" yaml:"certFile"`
+	KeyFile         string                      `json:"keyFile" yaml:"keyFile"`
+	MaxMsgSize      int                         `json:"maxMsgSize" yaml:"maxMsgSize"`
+	MaxOpenConns    int                         `json:"maxOpenConns" yaml:"maxOpenConns"`
+	IdleConnTimeout time.Duration               `json:"idleConnTimeout" yaml:"idleConnTimeout"`
+	WebEnabled      *runtime.DynamicValue[bool] `json:"webEnabled" yaml:"webEnabled"`
+}
+
+// WebEnabledOrDefault reports whether grpc-web serving is enabled, defaulting to true
+func (g GRPC) WebEnabledOrDefault() bool {
+	return g.WebEnabled == nil || g.WebEnabled.Get()
 }
 
 type MCP struct {
@@ -1078,7 +1084,7 @@ type Namespaces struct {
 const (
 	DefaultCORSAllowOrigin  = "*"
 	DefaultCORSAllowMethods = "*"
-	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Azure-Deployment-Id, X-Azure-Resource-Name, X-Azure-Concurrency, X-Azure-Block-Size, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Goog-Api-Key, X-Goog-Vertex-Api-Key, X-Goog-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key, X-Anthropic-Baseurl, X-Anthropic-Api-Key, X-Databricks-Endpoint, X-Databricks-Token, X-Databricks-User-Agent, X-Friendli-Token, X-Friendli-Baseurl, X-Weaviate-Api-Key, X-Weaviate-Cluster-Url, X-Nvidia-Api-Key, X-Nvidia-Baseurl, X-ContextualAI-Baseurl, X-ContextualAI-Api-Key, X-Digitalocean-Baseurl, X-Digitalocean-Api-Key, X-Deepseek-Baseurl, X-Deepseek-Api-Key"
+	DefaultCORSAllowHeaders = "Content-Type, Authorization, Batch, X-Openai-Api-Key, X-Openai-Organization, X-Openai-Baseurl, X-Anyscale-Baseurl, X-Anyscale-Api-Key, X-Cohere-Api-Key, X-Cohere-Baseurl, X-Huggingface-Api-Key, X-Azure-Api-Key, X-Azure-Deployment-Id, X-Azure-Resource-Name, X-Azure-Concurrency, X-Azure-Block-Size, X-Google-Api-Key, X-Google-Vertex-Api-Key, X-Google-Studio-Api-Key, X-Goog-Api-Key, X-Goog-Vertex-Api-Key, X-Goog-Studio-Api-Key, X-Palm-Api-Key, X-Jinaai-Api-Key, X-Aws-Access-Key, X-Aws-Secret-Key, X-Voyageai-Baseurl, X-Voyageai-Api-Key, X-Mistral-Baseurl, X-Mistral-Api-Key, X-Anthropic-Baseurl, X-Anthropic-Api-Key, X-Databricks-Endpoint, X-Databricks-Token, X-Databricks-User-Agent, X-Friendli-Token, X-Friendli-Baseurl, X-Weaviate-Api-Key, X-Weaviate-Cluster-Url, X-Weaviate-Client, X-Nvidia-Api-Key, X-Nvidia-Baseurl, X-ContextualAI-Baseurl, X-ContextualAI-Api-Key, X-Digitalocean-Baseurl, X-Digitalocean-Api-Key, X-Deepseek-Baseurl, X-Deepseek-Api-Key"
 )
 
 func (r ResourceUsage) Validate() error {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -874,12 +874,12 @@ type GRPC struct {
 	MaxMsgSize      int                         `json:"maxMsgSize" yaml:"maxMsgSize"`
 	MaxOpenConns    int                         `json:"maxOpenConns" yaml:"maxOpenConns"`
 	IdleConnTimeout time.Duration               `json:"idleConnTimeout" yaml:"idleConnTimeout"`
-	WebEnabled      *runtime.DynamicValue[bool] `json:"webEnabled" yaml:"webEnabled"`
+	GrpcWebEnabled  *runtime.DynamicValue[bool] `json:"grpcWebEnabled" yaml:"grpcWebEnabled"`
 }
 
-// WebEnabledOrDefault reports whether grpc-web serving is enabled, defaulting to true
-func (g GRPC) WebEnabledOrDefault() bool {
-	return g.WebEnabled == nil || g.WebEnabled.Get()
+// GrpcWebEnabledOrDefault reports whether grpc-web serving is enabled, defaulting to true
+func (g GRPC) GrpcWebEnabledOrDefault() bool {
+	return g.GrpcWebEnabled == nil || g.GrpcWebEnabled.Get()
 }
 
 type MCP struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -950,6 +950,9 @@ func FromEnv(config *Config) error {
 	if v := os.Getenv("GRPC_KEY_FILE"); v != "" {
 		config.GRPC.KeyFile = v
 	}
+	if config.GRPC.WebEnabled == nil {
+		config.GRPC.WebEnabled = configRuntime.NewDynamicValue(true)
+	}
 
 	if err := parsePositiveInt(
 		"GRPC_MAX_OPEN_CONNS",

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -950,8 +950,8 @@ func FromEnv(config *Config) error {
 	if v := os.Getenv("GRPC_KEY_FILE"); v != "" {
 		config.GRPC.KeyFile = v
 	}
-	if config.GRPC.WebEnabled == nil {
-		config.GRPC.WebEnabled = configRuntime.NewDynamicValue(true)
+	if config.GRPC.GrpcWebEnabled == nil {
+		config.GRPC.GrpcWebEnabled = configRuntime.NewDynamicValue(true)
 	}
 
 	if err := parsePositiveInt(

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -634,12 +634,12 @@ func TestEnvironmentGRPCPort(t *testing.T) {
 // otherwise be false and silently disable the default).
 func TestEnvironmentGRPCWebEnabledDefaultsTrue(t *testing.T) {
 	t.Run("bare Config resolves true via accessor", func(t *testing.T) {
-		require.True(t, Config{}.GRPC.WebEnabledOrDefault())
+		require.True(t, Config{}.GRPC.GrpcWebEnabledOrDefault())
 	})
 
-	// The config file is parsed into GRPC.WebEnabled before FromEnv runs, so
+	// The config file is parsed into GRPC.GrpcWebEnabled before FromEnv runs, so
 	// FromEnv must only default when nothing set the value. Anything already there
-	// (an operator's grpc.webEnabled off-switch, in particular) has to survive.
+	// (an operator's grpc.grpcWebEnabled off-switch, in particular) has to survive.
 	preset := []struct {
 		name string
 		seed *configRuntime.DynamicValue[bool]
@@ -652,11 +652,11 @@ func TestEnvironmentGRPCWebEnabledDefaultsTrue(t *testing.T) {
 	for _, tt := range preset {
 		t.Run("FromEnv preserves file value: "+tt.name, func(t *testing.T) {
 			conf := Config{}
-			conf.GRPC.WebEnabled = tt.seed
+			conf.GRPC.GrpcWebEnabled = tt.seed
 			require.NoError(t, FromEnv(&conf))
-			require.NotNil(t, conf.GRPC.WebEnabled, "runtime override needs a live value to toggle")
-			require.Equal(t, tt.want, conf.GRPC.WebEnabled.Get())
-			require.Equal(t, tt.want, conf.GRPC.WebEnabledOrDefault())
+			require.NotNil(t, conf.GRPC.GrpcWebEnabled, "runtime override needs a live value to toggle")
+			require.Equal(t, tt.want, conf.GRPC.GrpcWebEnabled.Get())
+			require.Equal(t, tt.want, conf.GRPC.GrpcWebEnabledOrDefault())
 		})
 	}
 }

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -627,6 +627,40 @@ func TestEnvironmentGRPCPort(t *testing.T) {
 	}
 }
 
+// TestEnvironmentGRPCWebEnabledDefaultsTrue pins that grpc-web is on by default
+// on every construction path now that the enable env var is gone: FromEnv seeds a
+// non-nil DynamicValue(true) (so the runtime override has a live value to flip),
+// and a bare Config resolves true via the nil-safe accessor (nil.Get() would
+// otherwise be false and silently disable the default).
+func TestEnvironmentGRPCWebEnabledDefaultsTrue(t *testing.T) {
+	t.Run("bare Config resolves true via accessor", func(t *testing.T) {
+		require.True(t, Config{}.GRPC.WebEnabledOrDefault())
+	})
+
+	// The config file is parsed into GRPC.WebEnabled before FromEnv runs, so
+	// FromEnv must only default when nothing set the value. Anything already there
+	// (an operator's grpc.webEnabled off-switch, in particular) has to survive.
+	preset := []struct {
+		name string
+		seed *configRuntime.DynamicValue[bool]
+		want bool
+	}{
+		{name: "nil is seeded to default true", seed: nil, want: true},
+		{name: "file-set false survives", seed: configRuntime.NewDynamicValue(false), want: false},
+		{name: "file-set true survives", seed: configRuntime.NewDynamicValue(true), want: true},
+	}
+	for _, tt := range preset {
+		t.Run("FromEnv preserves file value: "+tt.name, func(t *testing.T) {
+			conf := Config{}
+			conf.GRPC.WebEnabled = tt.seed
+			require.NoError(t, FromEnv(&conf))
+			require.NotNil(t, conf.GRPC.WebEnabled, "runtime override needs a live value to toggle")
+			require.Equal(t, tt.want, conf.GRPC.WebEnabled.Get())
+			require.Equal(t, tt.want, conf.GRPC.WebEnabledOrDefault())
+		})
+	}
+}
+
 func TestEnvironmentCORS_Methods(t *testing.T) {
 	factors := []struct {
 		name        string

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -74,6 +74,7 @@ type WeaviateRuntimeConfig struct {
 	AllowedCompressionTypes                   *runtime.DynamicValue[[]string]      `yaml:"allowed_compression_types" json:"allowed_compression_types"`
 	RestrictionsErrorMessage                  *runtime.DynamicValue[string]        `yaml:"restrictions_error_message" json:"restrictions_error_message"`
 	DebugEndpointsEnabled                     *runtime.DynamicValue[bool]          `json:"debug_endpoints_enabled" yaml:"debug_endpoints_enabled"`
+	GRPCWebEnabled                            *runtime.DynamicValue[bool]          `json:"grpc_web_enabled" yaml:"grpc_web_enabled"`
 
 	NamespaceCleanupInterval *runtime.DynamicValue[time.Duration] `json:"namespace_cleanup_interval" yaml:"namespace_cleanup_interval"`
 

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -464,6 +464,26 @@ maximum_allowed_collections_count: 13`)
 		assert.Equal(t, 0*time.Second, raftDrainSleep.Get())
 	})
 
+	t.Run("updating grpc_web_enabled (default true)", func(t *testing.T) {
+		// registered default is true (grpc-web on by default); pin that the
+		// snake_case key toggles it off and that removing the override restores
+		// the default rather than sticking at false.
+		reg := &WeaviateRuntimeConfig{
+			GRPCWebEnabled: runtime.NewDynamicValue(true),
+		}
+		assert.Equal(t, true, reg.GRPCWebEnabled.Get())
+
+		parsed, err := ParseRuntimeConfig([]byte(`grpc_web_enabled: false`))
+		require.NoError(t, err)
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
+		assert.Equal(t, false, reg.GRPCWebEnabled.Get())
+
+		parsed, err = ParseRuntimeConfig([]byte(``))
+		require.NoError(t, err)
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
+		assert.Equal(t, true, reg.GRPCWebEnabled.Get())
+	})
+
 	t.Run("updating raft_timeouts_multiplier", func(t *testing.T) {
 		var raftTimeoutsMultiplier runtime.DynamicValue[int]
 


### PR DESCRIPTION
This PR adds grpc-web support to Weaviate on `stable/v1.38`, served on the existing REST port under the `/grpc-web/` path prefix. Browser-based clients can now call the gRPC API directly (via grpc-web or Connect JSON) without operators having to expose a second port. It is a port of the grpc-web work that previously targeted `main` (issue #11672), rebased onto the stable branch, with the enable switch reworked from an environment variable into a runtime config value.

### What's being changed

- A new `adapters/handlers/grpc/grpcweb` package builds a transcoder (connectrpc.com/vanguard) around the existing in-process gRPC server and mounts it on the REST listener under `/grpc-web/`; all other paths are routed to the REST handler unchanged.
- The grpc-web handler carries its own CORS configuration: the configured allow-header list is split and trimmed (so a default such as "Content-Type, Authorization" no longer fails browser preflight on the space before "Authorization"), the grpc-web protocol headers are appended, the gRPC status trailers are exposed so browsers can read RPC results, and credentials mode is off to match the REST posture.
- The transcoder's maximum message buffer is capped at the configured gRPC max message size.
- grpc-web is enabled by default. A new `grpc_web_enabled` runtime override (default true) can turn it off and back on at runtime: the value is checked per request, only for `/grpc-web` paths, so no restart is needed and plain REST requests pay no extra cost. When disabled, `/grpc-web` paths fall through to the REST handler and return a normal 404.
- A value set in the config file (`grpc.webEnabled`) is respected: environment parsing only seeds the default when nothing else set the value.
- `X-Weaviate-Client` is added to the default CORS allow-header list so unmodified Weaviate clients pass preflight.
- Tests: unit coverage for the CORS preflight across several allow-header shapes, the path-prefix routing, the live runtime toggle, the config default and file-value preservation, and the runtime override parsing; plus an end-to-end acceptance test that starts a one-node cluster, inserts data, POSTs a Connect JSON Search request to `/grpc-web/weaviate.v1.Weaviate/Search` on the REST port, and asserts the inserted data comes back.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
