### PR TITLE
fix(async-replication): hoist hashtree-init wait out of RLock in merge paths

### DIFF
--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -968,6 +969,124 @@ func TestConcurrentEnableDisable(t *testing.T) {
 	wg.Wait()
 
 	_ = s.disableAsyncReplication(ctx)
+}
+
+// TestMergeWritesNoDeadlockUnderAsyncReplicationFlapping guards against the recursive-RLock deadlock where the merge paths called waitForMinimalHashTreeInitialization while holding asyncReplicationRWMux.RLock(); pre-fix it hangs (watchdog fires), post-fix it completes. Run with -race.
+func TestMergeWritesNoDeadlockUnderAsyncReplicationFlapping(t *testing.T) {
+	const (
+		writers    = 8
+		iterations = 150
+		watchdog   = 30 * time.Second
+	)
+
+	ids := []strfmt.UUID{uuidLow, uuidMid, uuidHigh}
+
+	tests := []struct {
+		name  string
+		write func(s *Shard, id strfmt.UUID, updateTime int64) error
+	}{
+		{
+			// Exercises mergeObjectInStorage via the public MergeObject entry point.
+			name: "MergeObject",
+			write: func(s *Shard, id strfmt.UUID, updateTime int64) error {
+				return s.MergeObject(context.Background(), objects.MergeDocument{
+					Class:      s.class.Class,
+					ID:         id,
+					UpdateTime: updateTime,
+				})
+			},
+		},
+		{
+			// Exercises mutableMergeObjectLSM directly (the AddReferencesBatch path).
+			name: "mutableMergeObjectLSM",
+			write: func(s *Shard, id strfmt.UUID, updateTime int64) error {
+				idBytes, err := bytesFromUUID(id)
+				if err != nil {
+					return err
+				}
+				_, err = s.mutableMergeObjectLSM(context.Background(), objects.MergeDocument{
+					Class:      s.class.Class,
+					ID:         id,
+					UpdateTime: updateTime,
+				}, idBytes)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			sl, _ := testShard(t, ctx, "MergeDeadlock"+tc.name, withAsyncScheduler(t))
+			s := concreteShard(t, sl)
+			t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+			for _, id := range ids {
+				require.NoError(t, sl.PutObject(ctx, testObjWithTime(s.class.Class, id, tsFarPast)))
+			}
+			require.NoError(t, s.store.FlushMemtables(ctx))
+
+			cfg := minAsyncReplicationConfig()
+			require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+			awaitHashtreeInitialized(t, s)
+
+			var (
+				clock      atomic.Int64
+				writeErrs  atomic.Int64
+				toggleErrs atomic.Int64
+				wg         sync.WaitGroup
+			)
+			clock.Store(tsFarPast)
+
+			// Writers: hammer the merge path.
+			for w := range writers {
+				wg.Add(1)
+				go func(w int) {
+					defer wg.Done()
+					for range iterations {
+						id := ids[w%len(ids)]
+						if err := tc.write(s, id, clock.Add(1)); err != nil {
+							writeErrs.Add(1)
+						}
+					}
+				}(w)
+			}
+
+			// Toggler: flap async replication so a write-lock acquisition is frequently pending — the precondition for the deadlock.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range iterations {
+					if err := s.disableAsyncReplication(ctx); err != nil {
+						toggleErrs.Add(1)
+					}
+					if err := s.enableAsyncReplication(ctx, cfg); err != nil {
+						toggleErrs.Add(1)
+					}
+				}
+			}()
+
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+
+			select {
+			case <-done:
+			case <-time.After(watchdog):
+				t.Fatalf("merge writes deadlocked under async-replication flapping "+
+					"(recursive RLock in %s path): workload did not finish within %s", tc.name, watchdog)
+			}
+
+			// Write/toggle errors during flapping are benign (write lands while momentarily disabled); log, do not fail.
+			if n := writeErrs.Load(); n > 0 {
+				t.Logf("%d/%d merge writes returned a non-fatal error during flapping", n, writers*iterations)
+			}
+			if n := toggleErrs.Load(); n > 0 {
+				t.Logf("%d enable/disable toggles returned a non-fatal error during flapping", n)
+			}
+
+			require.NoError(t, s.disableAsyncReplication(ctx))
+		})
+	}
 }
 
 // TestDisableRacingInitLeavesNoRegistration is a targeted test for the TOCTOU

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -126,19 +126,20 @@ func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDoc
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
 
+	// Wait outside the RLock; see shard_write_put.go (calling it under RLock is a recursive read-lock deadlock).
+	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {
+		return nil, objectInsertStatus{}, err
+	}
+
 	// wrapped in function to handle lock/unlock
 	if err := func() error {
 		s.asyncReplicationRWMux.RLock()
 		defer s.asyncReplicationRWMux.RUnlock()
 
-		err := s.waitForMinimalHashTreeInitialization(ctx)
-		if err != nil {
-			return err
-		}
-
 		lock.Lock()
 		defer lock.Unlock()
 
+		var err error
 		prevObj, err = fetchObject(bucket, idBytes)
 		if err != nil {
 			return errors.Wrap(err, "get bucket")
@@ -215,13 +216,13 @@ func (s *Shard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDo
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	out := mutableMergeResult{}
 
-	s.asyncReplicationRWMux.RLock()
-	defer s.asyncReplicationRWMux.RUnlock()
-
-	err := s.waitForMinimalHashTreeInitialization(ctx)
-	if err != nil {
+	// Wait outside the RLock; see shard_write_put.go (calling it under RLock is a recursive read-lock deadlock).
+	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {
 		return out, err
 	}
+
+	s.asyncReplicationRWMux.RLock()
+	defer s.asyncReplicationRWMux.RUnlock()
 
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]


### PR DESCRIPTION
## Motivation

`mergeObjectInStorage` and `mutableMergeObjectLSM` (`adapters/repos/db/shard_write_merge.go`) hold `s.asyncReplicationRWMux.RLock()` and then, still holding it, call `waitForMinimalHashTreeInitialization`, which acquires `RLock()` **again**.

Go's `sync.RWMutex` forbids recursive read-locking: once any goroutine calls `Lock()` and blocks, it excludes all new readers (to prevent writer starvation). So the inner `RLock` parks behind that pending writer — while the writer parks behind the merge goroutine's own outer `RLock`. That is a permanent self-deadlock, and once the writer is pending, every subsequent RLock caller on the shard (put/delete/read/hashbeat) also blocks → the whole shard freezes until restart.

The write `Lock()` is taken by async-replication `enable`/`disable`, the **automatic** hashtree-height rebuild (fires as object count grows), and shard shutdown — all of which run concurrently with request-handler writes. The bug is reachable from `MergeObject`/PATCH and from `AddReferencesBatch` (→ `mutableMergeObjectLSM`).

`waitForMinimalHashTreeInitialization`'s own doc comment already states it must not be called while holding the mutex; the sibling write paths (`putObjectLSM`, `DeleteObject`, `batchDeleteObject`) all call it **before** taking the RLock. The two merge sites were the only violators.

## Change

Hoist `waitForMinimalHashTreeInitialization(ctx)` above the `RLock` in both merge functions, matching the put/delete ordering. Behavior-preserving: `waitFor` depends only on `ctx` and reads nothing the merge computes under the lock; every caller already threads the same `ctx`.

## Scope / audit

Audited every `waitForMinimalHashTreeInitialization` call site and every write-path `asyncReplicationRWMux.RLock()`. Only these two merge sites were wrong. **Batch object insert and update are safe** (they call `putObjectLSM` per object, correct ordering); single/batch delete are safe. No other path needs changes.

## Risk

Low. Lock-ordering only; no functional change to merge semantics. The wait now happens fractionally earlier (outside the RLock), exactly as put/delete already do.

## Testing

Adds `TestMergeWritesNoDeadlockUnderAsyncReplicationFlapping` (table-driven over `MergeObject` and `mutableMergeObjectLSM`): concurrent merge writes vs. `enable`/`disable` flapping under a watchdog. Verified it **hangs on the pre-fix code** (watchdog fires) and **passes with the fix** under `-race` (~4.6s). The async-replication + merge suites pass with `-race`; `golangci-lint` and the goroutine linter are clean.

## Key review areas

- The `mergeObjectInStorage` closure now needs an explicit `var err error` before `prevObj, err = fetchObject(...)` (the closure previously declared `err` via the removed `waitFor` call).
- Confirm the terse deadlock comment matches the sibling convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)