### PR TITLE
fix(async-replication): don't let TimeBased repair clobber a newer local write

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1600,13 +1600,20 @@ func (s *Shard) resolveObjectConflict(
 		// Deletion conflict detected but auto-resolution is disabled.
 		return false, true, nil
 	}
-	if deletionStrategy == models.ReplicationConfigDeletionStrategyDeleteOnConflict ||
-		(deletionStrategy == models.ReplicationConfigDeletionStrategyTimeBasedResolution &&
-			r.UpdateTime > localUpdateTimes[strfmt.UUID(r.ID)]) {
+	if deletionStrategy == models.ReplicationConfigDeletionStrategyDeleteOnConflict {
 		if err := s.DeleteObject(ctx, strfmt.UUID(r.ID), time.UnixMilli(r.UpdateTime)); err != nil {
 			return false, false, fmt.Errorf("deleting local objects: %w", err)
 		}
 		return true, false, nil
+	}
+	if deletionStrategy == models.ReplicationConfigDeletionStrategyTimeBasedResolution &&
+		r.UpdateTime > localUpdateTimes[strfmt.UUID(r.ID)] {
+		// skipIfLocalNewer re-checks the live time under docIdLock so a write landing after the propagation snapshot is not clobbered by an older tombstone.
+		deleted, err := s.deleteObject(ctx, strfmt.UUID(r.ID), time.UnixMilli(r.UpdateTime), true)
+		if err != nil {
+			return false, false, fmt.Errorf("deleting local objects: %w", err)
+		}
+		return deleted, false, nil
 	}
 	return false, false, nil
 }

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -1282,3 +1282,51 @@ func TestLoadHashtreeIgnoresTmpFile(t *testing.T) {
 
 	require.NoError(t, s.disableAsyncReplication(ctx))
 }
+
+// TestResolveObjectConflictTimeBasedNoClobber pins that a TimeBased repair keeps a live local object at least as new as the remote deletion, even when the stale pre-RPC snapshot said it was older.
+func TestResolveObjectConflictTimeBasedNoClobber(t *testing.T) {
+	ctx := context.Background()
+	const (
+		class      = "TimeBasedNoClobber"
+		targetNode = "node-B"
+		snapshot   = int64(100) // stale digest-time snapshot; always < remoteDel so the outer gate passes
+		remoteDel  = int64(150)
+	)
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+
+	tests := []struct {
+		name        string
+		liveTime    int64
+		wantDeleted bool
+		wantExists  bool
+	}{
+		{"live newer than remote deletion is kept", 200, false, true},
+		{"live older than remote deletion is deleted", 100, true, false},
+		{"live equal to remote deletion is kept", 150, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sl, _ := testShard(t, ctx, class)
+			s := concreteShard(t, sl)
+			t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tc.liveTime)))
+
+			deleted, notResolved, err := s.resolveObjectConflict(
+				ctx,
+				routerTypes.RepairResponse{ID: id.String(), Deleted: true, UpdateTime: remoteDel},
+				models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+				targetNode, nil,
+				map[strfmt.UUID]int64{id: snapshot},
+			)
+			require.NoError(t, err)
+			assert.False(t, notResolved, "notResolved")
+			assert.Equal(t, tc.wantDeleted, deleted, "deleted")
+
+			obj, err := s.ObjectByID(ctx, id, nil, additional.Properties{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantExists, obj != nil, "object exists")
+		})
+	}
+}

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -25,14 +25,22 @@ import (
 )
 
 func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
+	_, err := s.deleteObject(ctx, id, deletionTime, false)
+	return err
+}
+
+// deleteObject tombstones the object (reporting whether it did); with skipIfLocalNewer it keeps a live copy at least as new as deletionTime, since lsmkv does not timestamp-arbitrate and an older repair tombstone would otherwise clobber a newer write.
+func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time,
+	skipIfLocalNewer bool,
+) (bool, error) {
 	if err := s.isReadOnly(); err != nil {
-		return err
+		return false, err
 	}
 
 	// Wait for hashtree initialization before acquiring the RLock.
 	// See shard_write_put.go for the deadlock explanation.
 	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {
-		return err
+		return false, err
 	}
 
 	s.asyncReplicationRWMux.RLock()
@@ -40,7 +48,7 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
@@ -53,19 +61,23 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 
 	existing, err := bucket.Get([]byte(idBytes))
 	if err != nil {
-		return fmt.Errorf("unexpected error on previous lookup: %w", err)
+		return false, fmt.Errorf("unexpected error on previous lookup: %w", err)
 	}
 
 	if existing == nil {
 		// nothing to do
-		return nil
+		return false, nil
 	}
 
 	// we need the doc ID so we can clean up inverted indices currently
 	// pointing to this object
 	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(existing)
 	if err != nil {
-		return fmt.Errorf("get existing doc id from object binary: %w", err)
+		return false, fmt.Errorf("get existing doc id from object binary: %w", err)
+	}
+
+	if skipIfLocalNewer && !deletionTime.IsZero() && updateTime >= deletionTime.UnixMilli() {
+		return false, nil // live local object is newer; keep it (TimeBased)
 	}
 
 	docIDBytes := make([]byte, 8)
@@ -77,20 +89,20 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		err = bucket.DeleteWith(idBytes, deletionTime, withSecondary)
 	}
 	if err != nil {
-		return fmt.Errorf("delete object from bucket: %w", err)
+		return false, fmt.Errorf("delete object from bucket: %w", err)
 	}
 
 	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {
-		return fmt.Errorf("object deletion in hashtree: %w", err)
+		return false, fmt.Errorf("object deletion in hashtree: %w", err)
 	}
 
 	err = s.cleanupInvertedIndexOnDelete(existing, docID)
 	if err != nil {
-		return fmt.Errorf("delete object from bucket: %w", err)
+		return false, fmt.Errorf("delete object from bucket: %w", err)
 	}
 
 	if err = s.store.WriteWALs(); err != nil {
-		return fmt.Errorf("flush all buffered WALs: %w", err)
+		return false, fmt.Errorf("flush all buffered WALs: %w", err)
 	}
 
 	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
@@ -100,7 +112,7 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	err = s.ForEachGeoQueue(func(propName string, queue *VectorIndexQueue) error {
@@ -110,7 +122,7 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
@@ -120,7 +132,7 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	err = s.ForEachGeoQueue(func(propName string, queue *VectorIndexQueue) error {
@@ -130,10 +142,10 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	return true, nil
 }
 
 func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) error {


### PR DESCRIPTION
## Motivation

Async-replication repair can silently lose an acknowledged write under the **default** deletion strategy (`TimeBasedResolution`).

When a hashbeat cycle propagates an object and the remote reports it deleted, `resolveObjectConflict` decides whether to delete the local copy using `localUpdateTimes[r.ID]` — a snapshot captured back at digest-collection time, never refreshed — and then calls `DeleteObject`, which reads the live object's update time under `docIdLock` but writes the tombstone **unconditionally** (no comparison against the deletion time).

So a client write that lands **after** the propagation snapshot but **before** the repair delete is silently tombstoned even though it is newer than the remote deletion. Confirmed crux: **lsmkv does not timestamp-arbitrate** — the read path and compaction both pick the winner by write-recency (memtable > newer segment > older segment), and the stored `deletionTime` is only a reportable payload. The later repair tombstone therefore permanently shadows the newer put; both replicas then agree on the tombstone and no future hashbeat re-propagates it — the acknowledged write is lost forever.

All relevant timestamps (`DocIDAndTimeFromBinary` updateTime, `r.UpdateTime`, `localUpdateTimes`, tombstone `deletionTime`) are Unix ms, so the comparison is unit-consistent.

## Change

Refactor `DeleteObject`'s body into an unexported `deleteObject(..., skipIfLocalNewer bool) (bool, error)` core; the public `DeleteObject` is a thin wrapper with identical behavior. Under the same `docIdLock` (between the live-time read and the tombstone write), when `skipIfLocalNewer` is set the tombstone is skipped if `updateTime >= deletionTime.UnixMilli()` (equal ⇒ local wins, matching existing semantics).

`resolveObjectConflict` routes only the `TimeBasedResolution` branch through the guarded core (returning its actual `deleted` result). `DeleteOnConflict` (unconditional by contract) and plain client `DeleteObject` are unchanged. The outer stale `r.UpdateTime > localUpdateTimes[...]` check is kept as a cheap pre-filter — it also keeps the store-less `TestResolveObjectConflict` unit test cases from ever reaching a delete call.

Skipping a delete returns `(deleted=false, notResolved=false, nil)` — the correct benign outcome (object kept); the `conflictDeletionCount`/`objectsNotResolved` stats are observability-only, so a skip is accurately not counted as a deletion.

## Risk

Low and narrowly scoped. Only the TimeBased repair path changes behavior — and only in the exact race it is meant to fix (skip a tombstone that would clobber a strictly-newer live object). The `DeleteObject` refactor is signature-preserving; all other callers are untouched.

## Testing

Adds `TestResolveObjectConflictTimeBasedNoClobber` (table: live newer / older / equal against the remote deletion) driving `resolveObjectConflict` against a live store. Live-newer and equal keep the object; live-older deletes it. Verified the live-newer/equal cases **fail (object deleted) when the guard is removed** and pass with it, under `-race`. The existing `TestResolveObjectConflict` unit test and the async-replication + delete + digest-compare suites pass with `-race`; `golangci-lint` and the goroutine linter are clean.

## Key review areas

- `deleteObject` return conversion: only the outer returns became 2-value; the `ForEach*Queue` closures still return `error`.
- The `>=` (not `>`) in the guard, matching the "equal timestamps → local wins" semantics already asserted by `TestResolveObjectConflict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)