### PR TITLE
fix(replication): avoid nil-pointer deref in read-repair when a live winner's refetch fails

### DIFF
--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -467,7 +467,8 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 		m := make(map[string]int, len(ids)/2) //
 
 		for j, x := range lastTimes {
-			if !x.Deleted && result[j] == nil {
+			deleted := x.Deleted && lastDeletionTimes[j] == x.T
+			if !deleted && result[j] == nil {
 				// latest object could not be fetched
 				continue
 			}
@@ -509,8 +510,6 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 				var vector []float32
 				var vectors map[string][]float32
 				var multiVectors map[string][][]float32
-
-				deleted := x.Deleted && lastDeletionTimes[j] == x.T
 
 				if !deleted {
 					latestObject = &result[j].Object

--- a/usecases/replica/repairer_internal_test.go
+++ b/usecases/replica/repairer_internal_test.go
@@ -1,0 +1,71 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch pins that a live winner whose refetch fails does not nil-deref under TimeBasedResolution (regression for the repairBatchPart guard).
+func TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch(t *testing.T) {
+	ctx := context.Background()
+	const (
+		class = "C1"
+		shard = "S1"
+	)
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+	ids := []strfmt.UUID{id}
+
+	rc := NewMockRClient(t)
+	// Winner refetch fails so result stays nil (repairer.go err branch after FullReads).
+	rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("refetch failed")).Maybe()
+	rc.EXPECT().OverwriteObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).Maybe()
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	r := &repairer{
+		class:               class,
+		getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyTimeBasedResolution },
+		client:              NewFinderClient(rc),
+		metrics:             metrics,
+		logger:              logger,
+	}
+
+	// content live@100, digest B live@150 (winner, refetch fails → result nil), digest C deleted@80 (older delete OR'd in).
+	contentObj := &storobj.Object{MarshallerVersion: 1, Object: models.Object{ID: id, LastUpdateTimeUnix: 100}}
+	votes := []Vote{
+		{BatchReply: BatchReply{Sender: "A", FullData: []Replica{{ID: id, Object: contentObj}}}, Count: make([]int, len(ids))},
+		{BatchReply: BatchReply{Sender: "B", IsDigest: true, DigestData: []types.RepairResponse{{ID: id.String(), UpdateTime: 150}}}, Count: make([]int, len(ids))},
+		{BatchReply: BatchReply{Sender: "C", IsDigest: true, DigestData: []types.RepairResponse{{ID: id.String(), UpdateTime: 80, Deleted: true}}}, Count: make([]int, len(ids))},
+	}
+
+	require.NotPanics(t, func() {
+		_, err = r.repairBatchPart(ctx, shard, ids, votes, 0)
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Motivation

`repairer.repairBatchPart` can panic with a nil-pointer dereference during read-repair under the **default** `TimeBasedResolution` strategy.

The repair loop uses two different notions of "deleted":
- the nil-guard skips on the **raw** OR-across-votes flag: `if !x.Deleted && result[j] == nil { continue }`
- the deref decision recomputes a **time-checked** flag: `deleted := x.Deleted && lastDeletionTimes[j] == x.T`, then `if !deleted { latestObject = &result[j].Object }`.

When the winning (most-recent) version is **live** but an older delete was OR'd in from another replica, `x.Deleted` is true (raw guard does not skip) yet `deleted` is false. If the live winner's refetch failed — the fetch path only decrements the vote count and never sets `result[idx]` — then `result[j]` is nil and the deref panics.

Only the TimeBased path reaches the deref (`NoAutomatedResolution` and `DeleteOnConflict` are handled earlier). The triggering state (live winner on one replica + older delete on another + a transient `FullReads` failure) is normal during repair. The panic is recovered at the goroutine boundary, so it fails the read-repair request rather than crashing the node — but the object then goes unrepaired.

## Change

Hoist the time-checked `deleted` to the top of the loop and use it in the nil-guard (`if !deleted && result[j] == nil { continue }`), matching the missing-content skip already used earlier in the function. An object whose live winner could not be refetched is now skipped (retried next round) instead of dereferenced. The `DeleteOnConflict` and non-TimeBased branches keep using the raw `x.Deleted` flag, so their behavior is unchanged. Net production change is −1 line.

## Risk

Low. The only behavioral change is: the live-winner + nil-result case is skipped instead of panicking. Confirmed regression-free: the `usecases/replica` suite has **zero** `TimeBasedResolution`/`DeleteOnConflict` coverage today (all factory helpers hardcode `NoAutomatedResolution`), and under `NoAutomatedResolution` the guard change is outcome-neutral (deleted objects already `continue` before the deref).

## Testing

Adds `TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch` (internal `package replica` test calling `repairBatchPart` directly, since the deref is in the function's main body): content node live@100, digest winner live@150, digest delete@80, with a failing refetch so `result` stays nil. **Verified it panics (nil deref) without the guard change and passes with it**, under `-race`. The full `usecases/replica` suite passes with `-race`; `golangci-lint` and the goroutine linter are clean.

## Key review areas

- The nil-guard now matches the earlier missing-content skip's notion of "winner is a delete" (`x.Deleted && lastDeletionTimes[j] == x.T`).
- `deleted` is hoisted once and reused at the deref site (no duplicate computation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)