### PR TITLE
fix(async-replication): serialize hashtree rebuild against shard shutdown

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -1427,10 +1427,10 @@ func (sched *AsyncReplicationScheduler) rebuildHashtree(s *Shard) {
 	// Wait for any cycle dispatched between our Done() and the disable below.
 	s.asyncRepWg.Wait()
 
-	// Skip if the shard store is being torn down. performShutdown sets
-	// s.shut=true before calling mayStopAsyncReplication, so this is a
-	// reliable happens-before. Re-enabling now would race with store shutdown
-	// and leak an init-scan goroutine past scheduler.Close().
+	// Serialize disable→enable against performShutdown, which holds shutdownLock.Lock() across store teardown; under the RLock the enable (and the init-scan it spawns) either completes before shutdown or is skipped — no re-enable onto a closing store.
+	s.shutdownLock.RLock()
+	defer s.shutdownLock.RUnlock()
+
 	if s.shut.Load() {
 		return
 	}

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -1427,7 +1427,8 @@ func (sched *AsyncReplicationScheduler) rebuildHashtree(s *Shard) {
 	// Wait for any cycle dispatched between our Done() and the disable below.
 	s.asyncRepWg.Wait()
 
-	// Serialize disable→enable against performShutdown, which holds shutdownLock.Lock() across store teardown; under the RLock the enable (and the init-scan it spawns) either completes before shutdown or is skipped — no re-enable onto a closing store.
+	// Serialize disable→enable against performShutdown (holds shutdownLock.Lock()
+	// across store teardown): enable either finishes before shutdown or is skipped.
 	s.shutdownLock.RLock()
 	defer s.shutdownLock.RUnlock()
 
@@ -1435,8 +1436,9 @@ func (sched *AsyncReplicationScheduler) rebuildHashtree(s *Shard) {
 		return
 	}
 
-	// sched.ctx so disable/enable respect scheduler shutdown.
-	if err := s.disableAsyncReplication(sched.ctx); err != nil {
+	// persist=false: old-height tree is discarded on reload; skipping its dump
+	// keeps the fsync out of the shutdownLock.RLock region below.
+	if err := s.disableAsyncReplicationWithPersist(false); err != nil {
 		if sched.logger != nil {
 			sched.logger.
 				WithField("action", "async_replication_rebuild").
@@ -1483,11 +1485,11 @@ func (sched *AsyncReplicationScheduler) rebuildHashtree(s *Shard) {
 	s.asyncRepRebuildFailures.Store(0)
 	s.asyncRepRebuildBackoffUntil.Store(0)
 
-	// If Close() fired during enableAsyncReplication, or performShutdown set
-	// s.shut between the entry-time check and now, the enable touched a store
-	// being torn down or registered against a cancelled scheduler. Disable to
-	// clean up; disableAsyncReplication's fsync is bounded by hashtreeDumpTimeout.
+	// Close()/performShutdown fired: the enable touched a store being torn down.
+	// Clean up (persist=false: nothing to dump, keeps the fsync out of the RLock).
 	if sched.ctx.Err() != nil || s.shut.Load() {
-		s.disableAsyncReplication(sched.ctx)
+		if err := s.disableAsyncReplicationWithPersist(false); err != nil {
+			s.index.logger.WithField("action", "async_replication_rebuild").Error(err)
+		}
 	}
 }

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -606,8 +606,9 @@ func TestRebuildHashtreeEnableFailureRearmsNeedsRebuild(t *testing.T) {
 	// Index with nil scheduler → enableAsyncReplication returns an error immediately.
 	idx := &Index{Config: IndexConfig{ClassName: "TestClass"}}
 	s := &Shard{
-		class: &models.Class{Class: "TestClass"},
-		index: idx,
+		class:        &models.Class{Class: "TestClass"},
+		index:        idx,
+		shutdownLock: new(sync.RWMutex),
 		// hashtree is nil → disableAsyncReplication is a no-op (idempotent).
 	}
 
@@ -955,8 +956,9 @@ func TestRebuildHashtreeCancelledContext(t *testing.T) {
 
 	idx := &Index{Config: IndexConfig{ClassName: "TestClass"}}
 	s := &Shard{
-		class: &models.Class{Class: "TestClass"},
-		index: idx,
+		class:        &models.Class{Class: "TestClass"},
+		index:        idx,
+		shutdownLock: new(sync.RWMutex),
 	}
 
 	require.False(t, s.asyncRepNeedsRebuild.Load(), "precondition: rebuild not needed yet")
@@ -968,6 +970,46 @@ func TestRebuildHashtreeCancelledContext(t *testing.T) {
 	// enableAsyncReplication is reached, so asyncRepNeedsRebuild is not re-armed.
 	assert.False(t, s.asyncRepNeedsRebuild.Load(),
 		"asyncRepNeedsRebuild must not be set when context is already cancelled at entry")
+}
+
+// TestRebuildHashtreeSkipsWhileShutdownHoldsLock verifies rebuildHashtree blocks on shutdownLock while performShutdown holds the write lock, then skips the re-enable once s.shut is set under it.
+func TestRebuildHashtreeSkipsWhileShutdownHoldsLock(t *testing.T) {
+	sched := newSchedulerForUnitTest(t)
+
+	idx := &Index{Config: IndexConfig{ClassName: "TestClass"}}
+	s := &Shard{
+		class:        &models.Class{Class: "TestClass"},
+		index:        idx,
+		shutdownLock: new(sync.RWMutex),
+	}
+
+	// Simulate performShutdown in progress: hold the write lock across the teardown.
+	s.shutdownLock.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		sched.rebuildHashtree(s)
+		close(done)
+	}()
+
+	// rebuildHashtree must block on shutdownLock.RLock() while shutdown holds the write lock.
+	select {
+	case <-done:
+		t.Fatal("rebuildHashtree proceeded while performShutdown held shutdownLock")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// performShutdown sets s.shut under the write lock, then releases.
+	s.shut.Store(true)
+	s.shutdownLock.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("rebuildHashtree did not return after shutdown released the lock")
+	}
+
+	assert.False(t, s.asyncRepNeedsRebuild.Load(), "skip path must not reach enableAsyncReplication")
 }
 
 // TestRegisterAfterCloseReturnsErrSchedulerClosed verifies that Register returns

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -938,6 +938,12 @@ func (s *Shard) enableAsyncReplication(ctx context.Context, config AsyncReplicat
 // completion should use mayStopAsyncReplication instead, or call Deregister
 // followed by asyncRepWg.Wait() explicitly.
 func (s *Shard) disableAsyncReplication(_ context.Context) error {
+	return s.disableAsyncReplicationWithPersist(true)
+}
+
+// disableAsyncReplicationWithPersist is disableAsyncReplication with control over
+// the dump: persist=false discards the captured tree instead of fsync'ing it.
+func (s *Shard) disableAsyncReplicationWithPersist(persist bool) error {
 	var afterRelease func()
 	var needDeregister bool
 
@@ -954,7 +960,7 @@ func (s *Shard) disableAsyncReplication(_ context.Context) error {
 		// Capture before clearing so afterRelease can persist the hashtree
 		// outside the write lock (same pattern as mayStopAsyncReplication).
 		var capturedHT hashtree.AggregatedHashTree
-		if s.hashtreeFullyInitialized {
+		if persist && s.hashtreeFullyInitialized {
 			capturedHT = s.hashtree
 		}
 

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -745,6 +745,45 @@ func TestMayStopAsyncReplicationDumpsHashtreeOnSuccess(t *testing.T) {
 		"persisted hashtree root must be non-zero: on-disk objects must have been registered")
 }
 
+// TestDisableAsyncReplicationPersist verifies the dump happens only when persist is true; the rebuild path uses persist=false to keep the fsync out of its shutdownLock.RLock region.
+func TestDisableAsyncReplicationPersist(t *testing.T) {
+	tests := []struct {
+		name        string
+		class       string
+		persist     bool
+		wantHTFiles int
+	}{
+		{name: "persist dumps hashtree", class: "DisablePersistTrue", persist: true, wantHTFiles: 1},
+		{name: "no-persist skips dump", class: "DisablePersistFalse", persist: false, wantHTFiles: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			sl, _ := testShard(t, ctx, tt.class, withAsyncScheduler(t))
+			s := concreteShard(t, sl)
+			t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+			for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+				require.NoError(t, sl.PutObject(ctx, testObjWithTime(tt.class, id, tsFarPast)))
+			}
+			flushShard(t, ctx, sl)
+
+			require.NoError(t, s.enableAsyncReplication(ctx, minAsyncReplicationConfig()))
+			awaitHashtreeInitialized(t, s)
+
+			htPath := s.pathHashTree()
+			require.NoError(t, s.disableAsyncReplicationWithPersist(tt.persist))
+
+			require.Len(t, htFilesInDir(t, htPath), tt.wantHTFiles)
+
+			s.asyncReplicationRWMux.RLock()
+			require.Nil(t, s.hashtree)
+			s.asyncReplicationRWMux.RUnlock()
+		})
+	}
+}
+
 // ─── Fix: disk I/O outside the write lock ────────────────────────────────────
 //
 // The following tests cover the fix that moved tryLoadHashtreeFromDisk outside


### PR DESCRIPTION
## Motivation

`AsyncReplicationScheduler.rebuildHashtree` stops then restarts async replication on a shard to pick up a runtime hashtree-height change. It runs on `sched.wg` (spawned from `runEntry`'s defer), **not** on `asyncRepWg` — so `mayStopAsyncReplication`'s `asyncRepWg.Wait()` gives it no happens-before against shard shutdown.

Its only shutdown guard is a lock-free pre-check `if s.shut.Load() { return }`. Nothing serializes the following `disableAsyncReplication` → `enableAsyncReplication` against `performShutdown` closing the LSM store. So a rebuild whose pre-check passed can race a concurrent `performShutdown`: `enableAsyncReplication` then reads hashtree files and spawns an init-scan goroutine (`asyncRepWg.Add`) that reads the store — while / after the store is closed (use-after-close).

**Trigger:** a runtime height change (sets `asyncRepNeedsRebuild`) concurrent with a per-tenant shard unload, rebalance, or node drain. `asyncRepCtx` derives from `sched.ctx` (not the shard's shutdown ctx), so it stays live through a per-tenant unload and does not cancel the new init-scan.

## Change

`performShutdown` holds `s.shutdownLock.Lock()` across the **entire** teardown (sets `s.shut=true`, `mayStopAsyncReplication`, `store.Shutdown`). Take `s.shutdownLock.RLock()` across the disable→enable region and re-check `s.shut` under it (mirroring `preventShutdown`). Because `performShutdown` takes the write lock before teardown, the enable — and the init-scan it spawns — either completes fully before shutdown starts or is skipped entirely.

`s.asyncRepWg.Wait()` stays before the RLock (drains the prior cycle without holding the lock during a possible network wait).

**No full-hashtree dump inside the RLock region.** `performShutdown` takes `shutdownLock.Lock()` as its first teardown step, so anything the RLock spans directly delays shutdown. `disableAsyncReplication` persists the hashtree with an `f.Sync()` bounded by `hashtreeDumpTimeout` (30s), so a shutdown concurrent with a rebuild could park up to 30s behind that fsync. That dump is also wasted work here: a rebuild only fires on a **height change**, so the old-height tree is discarded by `tryLoadHashtreeFromDisk(newHeight)` on the immediately-following reload (and on any restart, which loads at the new height). `disableAsyncReplication` is split into the interface method (`persist=true`, unchanged) and `disableAsyncReplicationWithPersist(persist)`; the rebuild path uses `persist=false`, discarding the captured tree instead of dumping it. The lock's correctness job is preserved — the init-scan still runs on `asyncRepWg` outside the region and is ctx-cancelled + drained by `mayStopAsyncReplication` (bounded by `asyncReplicationWorkerDrainTimeout`, 10s).

Residual I/O under the RLock is bounded and small: the disable is now in-memory bookkeeping + `Deregister`, and `enableAsyncReplication`'s `tryLoadHashtreeFromDisk` does a `ReadDir` plus — only if a stale `.ht` file is present, which the steady-state rebuild path does not produce — one file read + a directory `fsync`. No full-tree dump and nothing object-count-proportional.

## Risk

Low. Verified **deadlock-safe on both axes**:
- **No recursive RLock:** the only two `shutdownLock` sites in the repo are `performShutdown`/`preventShutdown`; nothing reachable from `disableAsyncReplication`/`enableAsyncReplication`/`initAsyncReplication`/`initHashtree`/`Register`/`Deregister` takes `shutdownLock` or calls `preventShutdown`.
- **No lock-order inversion:** `shutdownLock` is only ever acquired *before* `asyncReplicationRWMux` / `sched.mu` (in `performShutdown` → `mayStopAsyncReplication` → `Deregister`), matching the fix's direction.

**Shutdown latency:** with `persist=false` the RLock region no longer spans the full-hashtree dump — a `performShutdown` blocked on `shutdownLock.Lock()` now waits only on the disable's in-memory bookkeeping, the dispatcher rendezvous (`Deregister`/`Register`, each with a `sched.ctx.Done()` escape), and `tryLoadHashtreeFromDisk`'s bounded `ReadDir` (+ a small file read and directory `fsync` only if a stale `.ht` is present). Not the 30s dump fsync, and not the object-count-proportional rebuild scan (which runs on `asyncRepWg` outside the region).

## Testing

Adds `TestRebuildHashtreeSkipsWhileShutdownHoldsLock`: a test goroutine holds `shutdownLock.Lock()` (simulating `performShutdown` in progress); `rebuildHashtree` must **block** on `RLock`, then **skip** the re-enable once `s.shut` is set under the lock. **Verified it fails (rebuild proceeds) without the fix**, passes with it, under `-race`. The two existing rebuild tests get `shutdownLock` initialized in their fixtures (production always sets it via `new(sync.RWMutex)`).

Adds table-driven `TestDisableAsyncReplicationPersist`: `persist=true` writes exactly one `.ht` file, `persist=false` writes none, and both leave the hashtree nil'd (still disabled) — proving the rebuild path no longer dumps under the lock.

The scheduler unit suite and the async-replication + shutdown integration suite pass with `-race`; `golangci-lint` and the goroutine linter are clean.

## Key review areas

- `shutdownLock.RLock()` is the correct primitive (not `asyncRepWg`): `mayStopAsyncReplication` drains only `asyncRepWg`, but the rebuild runs on `sched.wg`, so only the lock `performShutdown` holds through `store.Shutdown` can serialize them.
- The `defer RUnlock()` covers the post-enable cleanup disable too — safe given the no-recursion/no-inversion audit; that cleanup also uses `persist=false` (nothing worth dumping on a torn-down tree) and now logs its error.
- Skipping the dump in the rebuild path loses nothing: the old-height tree is unconditionally discarded on reload, so the removed fsync only ever produced a file the next step deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
