### PR TITLE
[Reindex Fixes A] test: consistency_level=ALL for score/tenant corpus imports (soak EnableRangeable flake)

### DIFF
--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -508,7 +508,10 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 	}
 }
 
-// importObjectWithScore imports an object with text and score fields.
+// importObjectWithScore imports an object with text and score fields, with
+// consistency_level=ALL (like importObjects): a later enable-* reindex must run
+// against a fully-replicated corpus, or a lagging replica reindexes a store
+// missing the write and permanently diverges from its peers.
 func importObjectWithScore(t *testing.T, restURI, className, text string, score int) {
 	t.Helper()
 
@@ -524,7 +527,7 @@ func importObjectWithScore(t *testing.T, restURI, className, text string, score 
 	require.NoError(t, err)
 
 	resp, err := http.Post(
-		fmt.Sprintf("http://%s/v1/objects", restURI),
+		fmt.Sprintf("http://%s/v1/objects?consistency_level=ALL", restURI),
 		"application/json",
 		bytes.NewReader(body),
 	)

--- a/test/acceptance/reindex_multinode/round_trip_adjacent_helpers_test.go
+++ b/test/acceptance/reindex_multinode/round_trip_adjacent_helpers_test.go
@@ -88,7 +88,10 @@ func createTenants(t *testing.T, restURI, className string, tenants []string) {
 		"create tenants failed: %s", string(respBody))
 }
 
-// importObjectsTenant imports the given texts into the given tenant.
+// importObjectsTenant imports the given texts into the given tenant, with
+// consistency_level=ALL (like importObjectsTwoProps): the MT round-trip test
+// captures a per-replica baseline immediately after import, so a lagging
+// replica would fail the n1==n2==n3 baseline assertion.
 func importObjectsTenant(
 	t *testing.T, restURI, className, tenant string, texts []string,
 ) {
@@ -107,7 +110,7 @@ func importObjectsTenant(
 		require.NoError(t, err)
 
 		resp, err := http.Post(
-			fmt.Sprintf("http://%s/v1/objects", restURI),
+			fmt.Sprintf("http://%s/v1/objects?consistency_level=ALL", restURI),
 			"application/json",
 			bytes.NewReader(body),
 		)


### PR DESCRIPTION
SuperClaude here.

Group A test hardening — the 24/7 `kpop-flake-hunters` soak surfaced a rare (~1/6600) per-replica flake in `TestMultiNode_HappyPath/EnableRangeable`: after enable-rangeable on `score`, node 1 returned 15 range hits vs node 2's 14.

**Root cause (test-side).** `importObjectWithScore` imported the corpus without `consistency_level=ALL`, so an object hadn't replicated to node 2 when the migration ran → node 2 reindexed an under-replicated store and permanently diverged. Same class the `importObjects` / `importObjectsTwoProps` siblings were already hardened against (the R0 flake); this helper was a miss.

**Fix.** `consistency_level=ALL` on `importObjectWithScore`. A coverage audit caught the identical latent gap in `importObjectsTenant` (feeds `TestMultiNode_ChangeTokenization_MTRoundTrip`'s immediate `n1==n2==n3` baseline assert) — hardened too. `tryImportObject` left as-is (Raft write-readiness poll, intentionally default-consistency).

Test-only, +10/−4; gofumpt clean, package compiles.

— SuperClaude (reindex soak session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012jTefAtRKkuFX3VdNAyWn9
