### PR TITLE
[Reindex Fixes B] fix(dtm): AddTask idempotent on RAFT re-apply of a running task

### DIFF
--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -271,8 +271,9 @@ func (m *Manager) DeleteTasksForCollection(collection string) []TaskDescriptor {
 }
 
 // AddTask registers a new distributed task from a Raft apply. The seqNum becomes the task's
-// Version, used to distinguish re-runs of the same task ID. Returns an error if a task with
-// the same namespace/ID is already running, or if no units are provided.
+// Version, used to distinguish re-runs of the same task ID. A re-apply of a still-running
+// task's own submit (e.g. a RAFT retry across a leadership change) is an idempotent no-op;
+// an error is returned only for a stale re-run of a finished task, or if no units are given.
 func (m *Manager) AddTask(c *api.ApplyRequest, seqNum uint64) error {
 	var r api.AddDistributedTaskRequest
 	if err := json.Unmarshal(c.SubCommand, &r); err != nil {
@@ -285,7 +286,13 @@ func (m *Manager) AddTask(c *api.ApplyRequest, seqNum uint64) error {
 	task := m.findTaskWithLock(r.Namespace, r.Id)
 	if task != nil {
 		if task.Status == TaskStatusStarted {
-			return fmt.Errorf("task %s/%s is already running with version %d", r.Namespace, r.Id, task.Version)
+			// Idempotent re-apply: a RAFT Execute retry across a leadership
+			// change can re-append this same submit at a later log index
+			// (raft.Apply reports ErrLeadershipLost even when the entry already
+			// committed via quorum). The task id's per-request random suffix
+			// means a duplicate id is always this same submit, already started
+			// by the first apply — so a no-op, not a spurious 500.
+			return nil
 		}
 
 		if seqNum <= task.Version {

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -132,7 +132,14 @@ func TestManager_AddTask_ConflictDetector(t *testing.T) {
 }
 
 func TestManager_AddTask_Failures(t *testing.T) {
-	t.Run("add duplicate task", func(t *testing.T) {
+	t.Run("duplicate submit of a running task is an idempotent no-op (RAFT retry)", func(t *testing.T) {
+		// A RAFT Execute retry across a leadership change can re-append the
+		// same AddTask command at a higher log index (raft.Apply may report
+		// ErrLeadershipLost after the entry has already committed via quorum).
+		// The re-apply must be a no-op, not a spurious "already running" error
+		// that surfaces as a 500 to the still-waiting submitter. Regression for
+		// the soak hit on
+		// TestMultiNode_RollingRestartDuringFinalizing_PerReplicaConsistency.
 		var (
 			h = newTestHarness(t).init(t)
 			c = toCmd(t, &cmd.AddDistributedTaskRequest{
@@ -141,14 +148,18 @@ func TestManager_AddTask_Failures(t *testing.T) {
 				SubmittedAtUnixMillis: time.Now().UnixMilli(),
 				UnitIds:               []string{"su-1"},
 			})
-			version uint64 = 100
 		)
 
-		err := h.manager.AddTask(c, version)
-		require.NoError(t, err)
+		require.NoError(t, h.manager.AddTask(c, 5))
+		// The retry re-applies the identical command at a later log index.
+		require.NoError(t, h.manager.AddTask(c, 7))
 
-		err = h.manager.AddTask(c, version)
-		require.ErrorContains(t, err, "already running")
+		// Task unchanged: still Started at the original version, exactly one.
+		tasks, err := h.manager.ListDistributedTasks(context.Background())
+		require.NoError(t, err)
+		require.Len(t, tasks["test"], 1)
+		require.Equal(t, uint64(5), tasks["test"][0].Version)
+		require.Equal(t, TaskStatusStarted, tasks["test"][0].Status)
 	})
 
 	t.Run("add task with the same version as already finished one", func(t *testing.T) {


### PR DESCRIPTION
SuperClaude here.

Group B product bug, root-caused from the 24/7 `kpop-flake-hunters` soak (a hit on `TestMultiNode_RollingRestartDuringFinalizing_PerReplicaConsistency`).

**Bug.** A single reindex submit (`PUT /v1/schema/{class}/indexes/{prop}`) can be appended to the RAFT log **twice**: `raft.Apply` reports `ErrLeadershipLost` across a leadership change even when the entry already committed via quorum, so `cluster.Execute` retries and re-appends the identical command. The task id carries a per-request random suffix, so a duplicate id is always that same submit — never a distinct one. The first apply started the task; the second hit `AddTask`'s already-running guard → error → surfaced to the still-waiting caller as **HTTP 500** (`task … is already running with version N`).

**Evidence.** In the soak log the same task id `…:aec7` appears on two distinct RAFT entries — index 5 (created, `Version=5`, `Started`) and index 7 (rejected deterministically on all 3 nodes). `seqNum == RAFT log index`, so `Version 5` is unambiguously a prior successful apply.

**Fix.** `AddTask` was the **only** distributed-task lifecycle command that hard-errored on a re-apply — `MarkTaskFinalized` and both ack paths already short-circuit idempotently ("first apply wins"). Make the `Started`-duplicate branch an idempotent no-op to match. A stale re-run of a *finished* task still errors (unchanged); genuinely-conflicting *different* submits still go through the payload `ConflictDetector` (unchanged).

**Proof.** `TestManager_AddTask_Failures/duplicate_submit_of_a_running_task…` red-without / green-with (without the fix it fails with the exact prod error string). Full `distributedtask` package `-race` green; golangci 0; gofumpt clean.

— SuperClaude (reindex soak session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_012jTefAtRKkuFX3VdNAyWn9
