### PR TITLE
fix(async-replication): deregister under the write lock and keep replication on while overrides are active

### DIFF
--- a/adapters/repos/db/async_replication_scheduler_integration_test.go
+++ b/adapters/repos/db/async_replication_scheduler_integration_test.go
@@ -47,6 +47,26 @@ func newStartedTestScheduler(t *testing.T, workers int) *AsyncReplicationSchedul
 	return sched
 }
 
+// withAsyncSchedulerDispatchDisabled installs a scheduler that Registers shards
+// but never dispatches a cycle, so tests need no stubbed replicator/router.
+func withAsyncSchedulerDispatchDisabled(t *testing.T) func(*Index) {
+	t.Helper()
+	return func(idx *Index) {
+		logger, _ := test.NewNullLogger()
+		sched, err := NewAsyncReplicationScheduler(
+			context.Background(),
+			replication.GlobalConfig{
+				AsyncReplicationSchedulerWorkers: configRuntime.NewDynamicValue(1),
+				AsyncReplicationDisabled:         configRuntime.NewDynamicValue(true),
+			},
+			nil, logger,
+		)
+		require.NoError(t, err)
+		t.Cleanup(sched.Close)
+		idx.asyncReplicationScheduler = sched
+	}
+}
+
 // firstShard extracts the single shard from an Index created by testShard.
 func firstShard(t *testing.T, idx *Index) *Shard {
 	t.Helper()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -905,6 +905,11 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 				return fmt.Errorf("updating async replication on shard %q: %w", name, err)
 			}
 		} else {
+			// An active target-node override (e.g. in-progress movement) forces async
+			// replication on; don't tear it down (removeTargetNodeOverride handles it).
+			if ctrl.hasActiveAsyncReplicationTargetOverrides() {
+				return nil
+			}
 			if err := ctrl.disableAsyncReplication(ctx); err != nil {
 				return fmt.Errorf("updating async replication on shard %q: %w", name, err)
 			}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -207,6 +207,9 @@ type ShardLike interface {
 type asyncReplicationController interface {
 	enableAsyncReplication(ctx context.Context, config AsyncReplicationConfig) error
 	disableAsyncReplication(ctx context.Context) error
+	// hasActiveAsyncReplicationTargetOverrides reports whether the shard holds
+	// target-node overrides that force async replication on.
+	hasActiveAsyncReplicationTargetOverrides() bool
 }
 
 type onAddToPropertyValueIndex func(shard *Shard, docID uint64, property *inverted.Property) error

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -961,6 +961,14 @@ func (s *Shard) disableAsyncReplication(_ context.Context) error {
 		s.hashtree = nil
 		s.hashtreeFullyInitialized = false
 
+		// Deregister under the write lock so {hashtree=nil, Deregister} is atomic:
+		// else a concurrent enable's fresh registration could be orphaned here.
+		if s.index.asyncReplicationScheduler != nil {
+			if err := s.index.asyncReplicationScheduler.Deregister(s); err != nil {
+				s.index.logger.WithField("action", "async_replication").Error(err)
+			}
+		}
+
 		needDeregister = true
 
 		if capturedHT != nil {
@@ -975,16 +983,6 @@ func (s *Shard) disableAsyncReplication(_ context.Context) error {
 		return err
 	}
 	if needDeregister {
-		// Remove from the scheduler. The context has already been cancelled so
-		// any in-flight cycle will exit promptly; we do not wait for it here.
-		// Deregister may return context.Canceled if the scheduler is shutting
-		// down concurrently; that is safe to ignore because the rebuild path
-		// does not require a strict happens-before with the scheduler's shutdown.
-		if s.index.asyncReplicationScheduler != nil {
-			if err := s.index.asyncReplicationScheduler.Deregister(s); err != nil {
-				s.index.logger.WithField("action", "async_replication").Error(err)
-			}
-		}
 		// Clear stats outside asyncReplicationRWMux to avoid nesting
 		// asyncReplicationStatsMux inside a write lock.
 		s.asyncReplicationStatsMux.Lock()
@@ -1082,6 +1080,12 @@ func (s *Shard) removeTargetNodeOverride(ctx context.Context, targetNodeOverride
 		return s.disableAsyncReplication(ctx)
 	}
 	return nil
+}
+
+func (s *Shard) hasActiveAsyncReplicationTargetOverrides() bool {
+	s.asyncReplicationRWMux.RLock()
+	defer s.asyncReplicationRWMux.RUnlock()
+	return len(s.targetNodeOverrides) > 0
 }
 
 func (s *Shard) removeAllTargetNodeOverrides(ctx context.Context) error {

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -1330,3 +1330,146 @@ func TestResolveObjectConflictTimeBasedNoClobber(t *testing.T) {
 		})
 	}
 }
+
+// TestDisableConcurrentReEnableConsistency is a deadlock + consistency guard for disable Deregistering under the write lock: hammer concurrent enable/disable and assert the enabled<=>registered invariant holds (see PR for why it is not a deterministic reproduction).
+func TestDisableConcurrentReEnableConsistency(t *testing.T) {
+	ctx := context.Background()
+	const class = "DisableRacesReEnable"
+	const iterations = 100
+
+	sl, _ := testShard(t, ctx, class, withAsyncSchedulerDispatchDisabled(t))
+	s := concreteShard(t, sl)
+	sched := s.index.asyncReplicationScheduler
+
+	cfg := minAsyncReplicationConfig()
+
+	awaitWg := func() {
+		t.Helper()
+		done := make(chan struct{})
+		go func() { s.asyncRepWg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("asyncRepWg did not drain within timeout — goroutine leak or deadlock")
+		}
+	}
+
+	for i := range iterations {
+		require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+		awaitHashtreeInitialized(t, s)
+		awaitWg()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = s.disableAsyncReplication(ctx) }()
+		go func() { defer wg.Done(); _ = s.enableAsyncReplication(ctx, cfg) }()
+		wg.Wait()
+
+		awaitWg()
+
+		s.asyncReplicationRWMux.RLock()
+		enabled := s.hashtree != nil
+		s.asyncReplicationRWMux.RUnlock()
+
+		sched.mu.Lock()
+		_, registered := sched.entries[s]
+		sched.mu.Unlock()
+
+		require.Equalf(t, enabled, registered,
+			"enabled<=>registered invariant violated at iteration %d: hashtree!=nil=%v registered=%v "+
+				"(enabled-but-unregistered means a disable Deregister orphaned a concurrent re-enable's registration)",
+			i, enabled, registered)
+
+		require.NoError(t, s.disableAsyncReplication(ctx))
+		awaitWg()
+	}
+}
+
+// TestUpdateReplicationConfigKeepsAsyncReplicationWhileOverridesActive verifies a config-disable does not tear down async replication while the shard holds an active target-node override.
+func TestUpdateReplicationConfigKeepsAsyncReplicationWhileOverridesActive(t *testing.T) {
+	ctx := context.Background()
+	const class = "UpdateCfgKeepsOverride"
+
+	sl, _ := testShard(t, ctx, class, withAsyncSchedulerDispatchDisabled(t))
+	s := concreteShard(t, sl)
+	sched := s.index.asyncReplicationScheduler
+
+	s.index.replicationConfigLock.Lock()
+	s.index.Config.AsyncReplicationConfig = minAsyncReplicationConfig()
+	s.index.replicationConfigLock.Unlock()
+
+	override := additional.AsyncReplicationTargetNodeOverride{
+		CollectionID:   class,
+		ShardID:        s.name,
+		SourceNode:     "nodeA",
+		TargetNode:     "nodeB",
+		UpperTimeBound: time.Now().Add(time.Hour).UnixMilli(),
+	}
+	require.NoError(t, s.addTargetNodeOverride(ctx, override))
+	awaitHashtreeInitialized(t, s)
+
+	requireRegistered := func(want bool) {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			sched.mu.Lock()
+			_, ok := sched.entries[s]
+			sched.mu.Unlock()
+			return ok == want
+		}, 10*time.Second, 10*time.Millisecond, "registered=%v not reached", want)
+	}
+	hashtreePresent := func() bool {
+		s.asyncReplicationRWMux.RLock()
+		defer s.asyncReplicationRWMux.RUnlock()
+		return s.hashtree != nil
+	}
+
+	requireRegistered(true)
+	require.True(t, hashtreePresent(), "hashtree must be present while override is active")
+
+	require.NoError(t, s.index.updateReplicationConfig(ctx,
+		&models.ReplicationConfig{Factor: 1, AsyncEnabled: false}))
+
+	require.True(t, hashtreePresent(),
+		"hashtree must NOT be torn down by a config-disable while an override is active")
+	requireRegistered(true)
+	require.True(t, s.hasActiveAsyncReplicationTargetOverrides(),
+		"override must still be active after config-disable")
+
+	require.NoError(t, s.removeAllTargetNodeOverrides(ctx))
+	require.False(t, hashtreePresent(),
+		"hashtree must be torn down once the last override is gone and the class is disabled")
+	requireRegistered(false)
+}
+
+// TestUpdateReplicationConfigDisablesWhenNoActiveOverrides verifies the override guard does not break normal config-driven teardown when no override is held.
+func TestUpdateReplicationConfigDisablesWhenNoActiveOverrides(t *testing.T) {
+	ctx := context.Background()
+	const class = "UpdateCfgDisablesNoOverride"
+
+	sl, _ := testShard(t, ctx, class, withAsyncSchedulerDispatchDisabled(t))
+	s := concreteShard(t, sl)
+	sched := s.index.asyncReplicationScheduler
+
+	require.NoError(t, s.index.updateReplicationConfig(ctx,
+		&models.ReplicationConfig{Factor: 2, AsyncEnabled: true}))
+	awaitHashtreeInitialized(t, s)
+	require.Eventually(t, func() bool {
+		sched.mu.Lock()
+		_, ok := sched.entries[s]
+		sched.mu.Unlock()
+		return ok
+	}, 10*time.Second, 10*time.Millisecond, "shard must be registered after config-enable")
+
+	require.NoError(t, s.index.updateReplicationConfig(ctx,
+		&models.ReplicationConfig{Factor: 1, AsyncEnabled: false}))
+
+	require.Eventually(t, func() bool {
+		s.asyncReplicationRWMux.RLock()
+		ht := s.hashtree
+		s.asyncReplicationRWMux.RUnlock()
+		sched.mu.Lock()
+		_, ok := sched.entries[s]
+		sched.mu.Unlock()
+		return ht == nil && !ok
+	}, 10*time.Second, 10*time.Millisecond, "shard must be disabled and deregistered after config-disable with no override")
+}

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -319,6 +319,17 @@ func (l *LazyLoadShard) disableAsyncReplication(ctx context.Context) error {
 	return l.shard.disableAsyncReplication(ctx)
 }
 
+func (l *LazyLoadShard) hasActiveAsyncReplicationTargetOverrides() bool {
+	l.mutex.Lock()
+	loaded := l.loaded
+	l.mutex.Unlock()
+	if !loaded {
+		// An unloaded shard holds no in-memory overrides.
+		return false
+	}
+	return l.shard.hasActiveAsyncReplicationTargetOverrides()
+}
+
 func (l *LazyLoadShard) addTargetNodeOverride(ctx context.Context, targetNodeOverride additional.AsyncReplicationTargetNodeOverride) error {
 	if err := l.Load(ctx); err != nil {
 		return err


### PR DESCRIPTION
## What

Two independent async-replication correctness fixes, both targeting `stable/v1.37`.

### 1. Deregister-vs-re-enable race → silent divergence (`shard_async_replication.go`)

`disableAsyncReplication` nil-ed the hashtree, **released** `asyncReplicationRWMux`, and only then called `scheduler.Deregister(s)`. A concurrent `enableAsyncReplication` (e.g. `addTargetNodeOverride` during a replica movement) could, in that gap, take the write lock, install a new hashtree, and `Register` a fresh `*Shard`-keyed entry — which disable's trailing `Deregister(s)` then removed (it matches purely by `*Shard` pointer). The shard ended up **enabled but unregistered → never dispatched → silent replica divergence**.

**Fix:** move `Deregister` **inside** the write-lock critical section so `{hashtree=nil, Deregister}` is atomic.

**Why it works:** any concurrent `enableAsyncReplication` needs the same write lock to install a hashtree and register, so it is totally ordered before or after this critical section and can never interleave a registration between the nil and the `Deregister`. The residual case — an in-flight `Register` goroutine from an earlier enable running after a disable — is already handled by the existing self-deregister guards. Calling `Deregister` under the lock cannot deadlock: the scheduler dispatcher's synchronous handlers never acquire `asyncReplicationRWMux` (the documented `mu → asyncReplicationRWMux` lock ordering), and the init-scan self-deregister guards already hold the lock across a `Deregister` today.

### 2. Config-disable tears down override-forced replication mid-movement (`index.go`)

`updateReplicationConfig`'s disable branch called `disableAsyncReplication` unconditionally, without consulting `targetNodeOverrides` (unlike `removeTargetNodeOverride`). During a replica movement that forced replication on via an override, any `UpdateReplicationConfig` disabling async for the class nil-ed the hashtree and deregistered the shard — the movement's writes stopped propagating and `waitForAsyncReplication` stalled.

**Fix:** skip teardown while the shard holds active target-node overrides, via a new `hasActiveAsyncReplicationTargetOverrides()` on the `asyncReplicationController` interface (implemented on `*Shard`, forwarded by `*LazyLoadShard`).

**Why it works:** the override forces async replication on regardless of the class-level config, mirroring the hashbeat gate (`AsyncReplicationEnabled || len(targetNodeOverrides) > 0`). The last `removeTargetNodeOverride`/`removeAllTargetNodeOverrides` drives the eventual disable once the movement completes. The guard is placed in the **caller**, not inside `disableAsyncReplication`, on purpose: the other `disableAsyncReplication` callers (`rebuildHashtree` stop→restart, `RevertAsyncReplicationOnShard`, the shutdown-cleanup path) must tear down regardless of overrides, so a centralized guard would break the rebuild and leak entries at shutdown.

## Testing

- `TestUpdateReplicationConfigKeepsAsyncReplicationWhileOverridesActive` — deterministic; verified to **fail without the fix** (hashtree torn down) and pass with it. Also asserts teardown resumes once the last override is removed.
- `TestUpdateReplicationConfigDisablesWhenNoActiveOverrides` — negative guard: normal config-driven teardown still works when no override is held.
- `TestDisableConcurrentReEnableConsistency` — deadlock + consistency guard for fix #1 under `-race`. Note: the orphan window is too narrow to reproduce deterministically without a code hook, so this guards against deadlock/regression rather than reproducing the race; correctness rests on the atomicity argument above.
- Full async-replication integration suite + scheduler unit tests pass under `-race`. `golangci-lint`, `gofmt`, and the goroutine linter are clean.
