### PR TITLE
Prebuild metric handles to avoid allocations

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -805,11 +805,11 @@ func (b *Bucket) getBySecondaryCore(ctx context.Context, pos int, seckey []byte,
 }
 
 func (b *Bucket) getFromMemtable(key []byte, memtable memtable, component string) (v []byte, err error) {
-	metrics := b.metrics.readOp(readOpGet, component)
+	opMetrics := b.metrics.readOp(readOpGet, component)
 
 	start := time.Now()
-	metrics.incCount()
-	metrics.incOngoing()
+	opMetrics.incCount()
+	opMetrics.incOngoing()
 
 	defer func() {
 		if duration := time.Since(start); duration > 100*time.Millisecond {
@@ -819,12 +819,12 @@ func (b *Bucket) getFromMemtable(key []byte, memtable memtable, component string
 			}).Debug("Waited more than 100ms to retrieve object from memtable")
 		}
 
-		metrics.decOngoing()
+		opMetrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			metrics.incFailure()
+			opMetrics.incFailure()
 			return
 		}
-		metrics.observeDuration(time.Since(start))
+		opMetrics.observeDuration(time.Since(start))
 	}()
 
 	return memtable.get(key)
@@ -832,11 +832,11 @@ func (b *Bucket) getFromMemtable(key []byte, memtable memtable, component string
 
 func (b *Bucket) getBySecondaryFromMemtable(pos int, seckey []byte, memtable memtable, component string,
 ) (k []byte, v []byte, err error) {
-	metrics := b.metrics.readOp(readOpGetBySecondary, component)
+	opMetrics := b.metrics.readOp(readOpGetBySecondary, component)
 
 	start := time.Now()
-	metrics.incCount()
-	metrics.incOngoing()
+	opMetrics.incCount()
+	opMetrics.incOngoing()
 
 	defer func() {
 		if duration := time.Since(start); duration > 100*time.Millisecond {
@@ -846,31 +846,31 @@ func (b *Bucket) getBySecondaryFromMemtable(pos int, seckey []byte, memtable mem
 			}).Debug("Waited more than 100ms to retrieve object from memtable")
 		}
 
-		metrics.decOngoing()
+		opMetrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			metrics.incFailure()
+			opMetrics.incFailure()
 			return
 		}
-		metrics.observeDuration(time.Since(start))
+		opMetrics.observeDuration(time.Since(start))
 	}()
 
 	return memtable.getBySecondary(pos, seckey)
 }
 
 func (b *Bucket) getFromSegmentGroup(key []byte, segments []Segment) (v []byte, err error) {
-	metrics := b.metrics.readOp(readOpGet, componentSegmentGroup)
+	opMetrics := b.metrics.readOp(readOpGet, componentSegmentGroup)
 
 	start := time.Now()
-	metrics.incCount()
-	metrics.incOngoing()
+	opMetrics.incCount()
+	opMetrics.incOngoing()
 
 	defer func() {
-		metrics.decOngoing()
+		opMetrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			metrics.incFailure()
+			opMetrics.incFailure()
 			return
 		}
-		metrics.observeDuration(time.Since(start))
+		opMetrics.observeDuration(time.Since(start))
 	}()
 
 	return b.disk.getWithSegmentList(key, segments)
@@ -878,19 +878,19 @@ func (b *Bucket) getFromSegmentGroup(key []byte, segments []Segment) (v []byte, 
 
 func (b *Bucket) getBySecondaryFromSegmentGroup(pos int, seckey []byte, buffer []byte, segments []Segment,
 ) (k, v []byte, buf []byte, segmentId int, err error) {
-	metrics := b.metrics.readOp(readOpGetBySecondary, componentSegmentGroup)
+	opMetrics := b.metrics.readOp(readOpGetBySecondary, componentSegmentGroup)
 
 	start := time.Now()
-	metrics.incCount()
-	metrics.incOngoing()
+	opMetrics.incCount()
+	opMetrics.incOngoing()
 
 	defer func() {
-		metrics.decOngoing()
+		opMetrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			metrics.incFailure()
+			opMetrics.incFailure()
 			return
 		}
-		metrics.observeDuration(time.Since(start))
+		opMetrics.observeDuration(time.Since(start))
 	}()
 
 	return b.disk.getBySecondaryWithSegmentList(pos, seckey, buffer, segments)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -67,6 +67,14 @@ const (
 // memtableNames is used for error messages and metrics when iterating memtables
 var memtableNames = [2]string{"active_memtable", "flushing_memtable"}
 
+// Read-op metric label values. Bundled with memtableNames into the pre-resolved
+// metric handles built in NewMetrics.
+const (
+	readOpGet             = "get"
+	readOpGetBySecondary  = "getbysecondary"
+	componentSegmentGroup = "segment_group"
+)
+
 type BucketCreator interface {
 	NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
 		metrics *Metrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
@@ -797,11 +805,11 @@ func (b *Bucket) getBySecondaryCore(ctx context.Context, pos int, seckey []byte,
 }
 
 func (b *Bucket) getFromMemtable(key []byte, memtable memtable, component string) (v []byte, err error) {
-	op := "get"
+	metrics := b.metrics.readOp(readOpGet, component)
 
 	start := time.Now()
-	b.metrics.IncBucketReadOpCountByComponent(op, component)
-	b.metrics.IncBucketReadOpOngoingByComponent(op, component)
+	metrics.incCount()
+	metrics.incOngoing()
 
 	defer func() {
 		if duration := time.Since(start); duration > 100*time.Millisecond {
@@ -811,12 +819,12 @@ func (b *Bucket) getFromMemtable(key []byte, memtable memtable, component string
 			}).Debug("Waited more than 100ms to retrieve object from memtable")
 		}
 
-		b.metrics.DecBucketReadOpOngoingByComponent(op, component)
+		metrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			b.metrics.IncBucketReadOpFailureCountByComponent(op, component)
+			metrics.incFailure()
 			return
 		}
-		b.metrics.ObserveBucketReadOpDurationByComponent(op, component, time.Since(start))
+		metrics.observeDuration(time.Since(start))
 	}()
 
 	return memtable.get(key)
@@ -824,11 +832,11 @@ func (b *Bucket) getFromMemtable(key []byte, memtable memtable, component string
 
 func (b *Bucket) getBySecondaryFromMemtable(pos int, seckey []byte, memtable memtable, component string,
 ) (k []byte, v []byte, err error) {
-	op := "getbysecondary"
+	metrics := b.metrics.readOp(readOpGetBySecondary, component)
 
 	start := time.Now()
-	b.metrics.IncBucketReadOpCountByComponent(op, component)
-	b.metrics.IncBucketReadOpOngoingByComponent(op, component)
+	metrics.incCount()
+	metrics.incOngoing()
 
 	defer func() {
 		if duration := time.Since(start); duration > 100*time.Millisecond {
@@ -838,32 +846,31 @@ func (b *Bucket) getBySecondaryFromMemtable(pos int, seckey []byte, memtable mem
 			}).Debug("Waited more than 100ms to retrieve object from memtable")
 		}
 
-		b.metrics.DecBucketReadOpOngoingByComponent(op, component)
+		metrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			b.metrics.IncBucketReadOpFailureCountByComponent(op, component)
+			metrics.incFailure()
 			return
 		}
-		b.metrics.ObserveBucketReadOpDurationByComponent(op, component, time.Since(start))
+		metrics.observeDuration(time.Since(start))
 	}()
 
 	return memtable.getBySecondary(pos, seckey)
 }
 
 func (b *Bucket) getFromSegmentGroup(key []byte, segments []Segment) (v []byte, err error) {
-	op := "get"
-	component := "segment_group"
+	metrics := b.metrics.readOp(readOpGet, componentSegmentGroup)
 
 	start := time.Now()
-	b.metrics.IncBucketReadOpCountByComponent(op, component)
-	b.metrics.IncBucketReadOpOngoingByComponent(op, component)
+	metrics.incCount()
+	metrics.incOngoing()
 
 	defer func() {
-		b.metrics.DecBucketReadOpOngoingByComponent(op, component)
+		metrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			b.metrics.IncBucketReadOpFailureCountByComponent(op, component)
+			metrics.incFailure()
 			return
 		}
-		b.metrics.ObserveBucketReadOpDurationByComponent(op, component, time.Since(start))
+		metrics.observeDuration(time.Since(start))
 	}()
 
 	return b.disk.getWithSegmentList(key, segments)
@@ -871,20 +878,19 @@ func (b *Bucket) getFromSegmentGroup(key []byte, segments []Segment) (v []byte, 
 
 func (b *Bucket) getBySecondaryFromSegmentGroup(pos int, seckey []byte, buffer []byte, segments []Segment,
 ) (k, v []byte, buf []byte, segmentId int, err error) {
-	op := "getbysecondary"
-	component := "segment_group"
+	metrics := b.metrics.readOp(readOpGetBySecondary, componentSegmentGroup)
 
 	start := time.Now()
-	b.metrics.IncBucketReadOpCountByComponent(op, component)
-	b.metrics.IncBucketReadOpOngoingByComponent(op, component)
+	metrics.incCount()
+	metrics.incOngoing()
 
 	defer func() {
-		b.metrics.DecBucketReadOpOngoingByComponent(op, component)
+		metrics.decOngoing()
 		if err != nil && !lsmkv.IsDeletedOrNotFound(err) {
-			b.metrics.IncBucketReadOpFailureCountByComponent(op, component)
+			metrics.incFailure()
 			return
 		}
-		b.metrics.ObserveBucketReadOpDurationByComponent(op, component, time.Since(start))
+		metrics.observeDuration(time.Since(start))
 	}()
 
 	return b.disk.getBySecondaryWithSegmentList(pos, seckey, buffer, segments)

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -41,9 +41,9 @@ var (
 	readComponents = []string{memtableNames[0], memtableNames[1], componentSegmentGroup}
 )
 
-// readOpsLabels is the single source of truth for the operation/component pairs
-// the read path emits: it zero-initialises those series and, via
-// buildReadOpHandles, pre-resolves their metric handles.
+// readOpsLabels is the source of truth for the operation/component pairs the
+// read path emits: it zero-initialises those series and pre-resolves their
+// metric handles.
 var readOpsLabels = func() [][]string {
 	labels := make([][]string, 0, len(readOps)*len(readComponents))
 	for _, op := range readOps {
@@ -61,7 +61,7 @@ type readOpKey struct {
 }
 
 // readOpHandle bundles the metric children for one bucket read operation so the
-// read path resolves them once instead of looking each up per call.
+// read path resolves them once instead of per call.
 type readOpHandle struct {
 	count    prometheus.Counter
 	ongoing  prometheus.Gauge
@@ -104,8 +104,24 @@ func (h *readOpHandle) observeDuration(duration time.Duration) {
 	h.duration.Observe(duration.Seconds())
 }
 
-// buildReadOpHandles resolves the metric children for every operation/component
-// pair the read path emits, so per-read calls skip the per-metric vec lookup.
+// newReadOpHandle resolves the metric children for one operation/component pair.
+func newReadOpHandle(
+	count *prometheus.CounterVec,
+	ongoing *prometheus.GaugeVec,
+	failure *prometheus.CounterVec,
+	duration *prometheus.HistogramVec,
+	op, component string,
+) *readOpHandle {
+	return &readOpHandle{
+		count:    count.WithLabelValues(op, component),
+		ongoing:  ongoing.WithLabelValues(op, component),
+		failure:  failure.WithLabelValues(op, component),
+		duration: duration.WithLabelValues(op, component),
+	}
+}
+
+// buildReadOpHandles pre-resolves the metric children for every read-path
+// operation/component pair, so per-read calls skip the vec lookup.
 func buildReadOpHandles(
 	count *prometheus.CounterVec,
 	ongoing *prometheus.GaugeVec,
@@ -115,12 +131,7 @@ func buildReadOpHandles(
 	handles := make(map[readOpKey]*readOpHandle, len(readOpsLabels))
 	for _, label := range readOpsLabels {
 		op, component := label[0], label[1]
-		handles[readOpKey{op, component}] = &readOpHandle{
-			count:    count.WithLabelValues(op, component),
-			ongoing:  ongoing.WithLabelValues(op, component),
-			failure:  failure.WithLabelValues(op, component),
-			duration: duration.WithLabelValues(op, component),
-		}
+		handles[readOpKey{op, component}] = newReadOpHandle(count, ongoing, failure, duration, op, component)
 	}
 	return handles
 }
@@ -925,10 +936,9 @@ func (m *Metrics) ObserveBucketCursorDurationByStrategy(strategy string, duratio
 	m.bucketCursorDurationByStrategy.WithLabelValues(strategy).Observe(duration.Seconds())
 }
 
-// readOp returns the metric handle for a bucket read operation. Handles for the
-// operation/component pairs the read path emits are resolved once in
-// NewMetrics; any other pair is resolved on demand. A nil receiver yields a nil
-// handle, whose methods are no-ops.
+// readOp returns the metric handle for a bucket read operation. Known pairs are
+// resolved once in NewMetrics; any other pair is resolved on demand. A nil
+// receiver yields a nil handle, whose methods are no-ops.
 func (m *Metrics) readOp(op, component string) *readOpHandle {
 	if m == nil {
 		return nil
@@ -936,12 +946,13 @@ func (m *Metrics) readOp(op, component string) *readOpHandle {
 	if h, ok := m.readOpHandles[readOpKey{op, component}]; ok {
 		return h
 	}
-	return &readOpHandle{
-		count:    m.bucketReadOpCountByComponent.WithLabelValues(op, component),
-		ongoing:  m.bucketReadOpOngoingByComponent.WithLabelValues(op, component),
-		failure:  m.bucketReadOpFailureCountByComponent.WithLabelValues(op, component),
-		duration: m.bucketReadOpDurationByComponent.WithLabelValues(op, component),
-	}
+	return newReadOpHandle(
+		m.bucketReadOpCountByComponent,
+		m.bucketReadOpOngoingByComponent,
+		m.bucketReadOpFailureCountByComponent,
+		m.bucketReadOpDurationByComponent,
+		op, component,
+	)
 }
 
 func (m *Metrics) IncBucketWriteOpCount(op string) {

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -36,11 +36,23 @@ var bucketStrategiesLabels = [][]string{
 	{StrategyInverted},
 }
 
-var readOpsLabels = [][]string{
-	{readOpGet, memtableNames[0]},
-	{readOpGet, memtableNames[1]},
-	{readOpGet, componentSegmentGroup},
-}
+var (
+	readOps        = []string{readOpGet, readOpGetBySecondary}
+	readComponents = []string{memtableNames[0], memtableNames[1], componentSegmentGroup}
+)
+
+// readOpsLabels is the single source of truth for the operation/component pairs
+// the read path emits: it zero-initialises those series and, via
+// buildReadOpHandles, pre-resolves their metric handles.
+var readOpsLabels = func() [][]string {
+	labels := make([][]string, 0, len(readOps)*len(readComponents))
+	for _, op := range readOps {
+		for _, component := range readComponents {
+			labels = append(labels, []string{op, component})
+		}
+	}
+	return labels
+}()
 
 // readOpKey identifies a bucket read metric series by operation and component.
 type readOpKey struct {
@@ -100,18 +112,14 @@ func buildReadOpHandles(
 	failure *prometheus.CounterVec,
 	duration *prometheus.HistogramVec,
 ) map[readOpKey]*readOpHandle {
-	ops := []string{readOpGet, readOpGetBySecondary}
-	components := []string{memtableNames[0], memtableNames[1], componentSegmentGroup}
-
-	handles := make(map[readOpKey]*readOpHandle, len(ops)*len(components))
-	for _, op := range ops {
-		for _, component := range components {
-			handles[readOpKey{op, component}] = &readOpHandle{
-				count:    count.WithLabelValues(op, component),
-				ongoing:  ongoing.WithLabelValues(op, component),
-				failure:  failure.WithLabelValues(op, component),
-				duration: duration.WithLabelValues(op, component),
-			}
+	handles := make(map[readOpKey]*readOpHandle, len(readOpsLabels))
+	for _, label := range readOpsLabels {
+		op, component := label[0], label[1]
+		handles[readOpKey{op, component}] = &readOpHandle{
+			count:    count.WithLabelValues(op, component),
+			ongoing:  ongoing.WithLabelValues(op, component),
+			failure:  failure.WithLabelValues(op, component),
+			duration: duration.WithLabelValues(op, component),
 		}
 	}
 	return handles

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -37,9 +37,84 @@ var bucketStrategiesLabels = [][]string{
 }
 
 var readOpsLabels = [][]string{
-	{"get", "active_memtable"},
-	{"get", "flushing_memtable"},
-	{"get", "segment_group"},
+	{readOpGet, memtableNames[0]},
+	{readOpGet, memtableNames[1]},
+	{readOpGet, componentSegmentGroup},
+}
+
+// readOpKey identifies a bucket read metric series by operation and component.
+type readOpKey struct {
+	op        string
+	component string
+}
+
+// readOpHandle bundles the metric children for one bucket read operation so the
+// read path resolves them once instead of looking each up per call.
+type readOpHandle struct {
+	count    prometheus.Counter
+	ongoing  prometheus.Gauge
+	failure  prometheus.Counter
+	duration prometheus.Observer
+}
+
+func (h *readOpHandle) incCount() {
+	if h == nil {
+		return
+	}
+	h.count.Inc()
+}
+
+func (h *readOpHandle) incOngoing() {
+	if h == nil {
+		return
+	}
+	h.ongoing.Inc()
+}
+
+func (h *readOpHandle) decOngoing() {
+	if h == nil {
+		return
+	}
+	h.ongoing.Dec()
+}
+
+func (h *readOpHandle) incFailure() {
+	if h == nil {
+		return
+	}
+	h.failure.Inc()
+}
+
+func (h *readOpHandle) observeDuration(duration time.Duration) {
+	if h == nil {
+		return
+	}
+	h.duration.Observe(duration.Seconds())
+}
+
+// buildReadOpHandles resolves the metric children for every operation/component
+// pair the read path emits, so per-read calls skip the per-metric vec lookup.
+func buildReadOpHandles(
+	count *prometheus.CounterVec,
+	ongoing *prometheus.GaugeVec,
+	failure *prometheus.CounterVec,
+	duration *prometheus.HistogramVec,
+) map[readOpKey]*readOpHandle {
+	ops := []string{readOpGet, readOpGetBySecondary}
+	components := []string{memtableNames[0], memtableNames[1], componentSegmentGroup}
+
+	handles := make(map[readOpKey]*readOpHandle, len(ops)*len(components))
+	for _, op := range ops {
+		for _, component := range components {
+			handles[readOpKey{op, component}] = &readOpHandle{
+				count:    count.WithLabelValues(op, component),
+				ongoing:  ongoing.WithLabelValues(op, component),
+				failure:  failure.WithLabelValues(op, component),
+				duration: duration.WithLabelValues(op, component),
+			}
+		}
+	}
+	return handles
 }
 
 var writeOpsLabels = [][]string{
@@ -77,6 +152,7 @@ type Metrics struct {
 	bucketReadOpOngoingByComponent      *prometheus.GaugeVec
 	bucketReadOpFailureCountByComponent *prometheus.CounterVec
 	bucketReadOpDurationByComponent     *prometheus.HistogramVec
+	readOpHandles                       map[readOpKey]*readOpHandle
 
 	bucketWriteOpCount        *prometheus.CounterVec
 	bucketWriteOpOngoing      *prometheus.GaugeVec
@@ -651,6 +727,12 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		bucketReadOpOngoingByComponent:      bucketReadOpOngoingByComponent,
 		bucketReadOpFailureCountByComponent: bucketReadOpFailureCountByComponent,
 		bucketReadOpDurationByComponent:     bucketReadOpDurationByComponent,
+		readOpHandles: buildReadOpHandles(
+			bucketReadOpCountByComponent,
+			bucketReadOpOngoingByComponent,
+			bucketReadOpFailureCountByComponent,
+			bucketReadOpDurationByComponent,
+		),
 
 		bucketWriteOpCount:        bucketWriteOpCount,
 		bucketWriteOpOngoing:      bucketWriteOpOngoing,
@@ -835,39 +917,23 @@ func (m *Metrics) ObserveBucketCursorDurationByStrategy(strategy string, duratio
 	m.bucketCursorDurationByStrategy.WithLabelValues(strategy).Observe(duration.Seconds())
 }
 
-func (m *Metrics) IncBucketReadOpCountByComponent(op, component string) {
+// readOp returns the metric handle for a bucket read operation. Handles for the
+// operation/component pairs the read path emits are resolved once in
+// NewMetrics; any other pair is resolved on demand. A nil receiver yields a nil
+// handle, whose methods are no-ops.
+func (m *Metrics) readOp(op, component string) *readOpHandle {
 	if m == nil {
-		return
+		return nil
 	}
-	m.bucketReadOpCountByComponent.WithLabelValues(op, component).Inc()
-}
-
-func (m *Metrics) IncBucketReadOpOngoingByComponent(op, component string) {
-	if m == nil {
-		return
+	if h, ok := m.readOpHandles[readOpKey{op, component}]; ok {
+		return h
 	}
-	m.bucketReadOpOngoingByComponent.WithLabelValues(op, component).Inc()
-}
-
-func (m *Metrics) DecBucketReadOpOngoingByComponent(op, component string) {
-	if m == nil {
-		return
+	return &readOpHandle{
+		count:    m.bucketReadOpCountByComponent.WithLabelValues(op, component),
+		ongoing:  m.bucketReadOpOngoingByComponent.WithLabelValues(op, component),
+		failure:  m.bucketReadOpFailureCountByComponent.WithLabelValues(op, component),
+		duration: m.bucketReadOpDurationByComponent.WithLabelValues(op, component),
 	}
-	m.bucketReadOpOngoingByComponent.WithLabelValues(op, component).Dec()
-}
-
-func (m *Metrics) IncBucketReadOpFailureCountByComponent(op, component string) {
-	if m == nil {
-		return
-	}
-	m.bucketReadOpFailureCountByComponent.WithLabelValues(op, component).Inc()
-}
-
-func (m *Metrics) ObserveBucketReadOpDurationByComponent(op, component string, duration time.Duration) {
-	if m == nil {
-		return
-	}
-	m.bucketReadOpDurationByComponent.WithLabelValues(op, component).Observe(duration.Seconds())
 }
 
 func (m *Metrics) IncBucketWriteOpCount(op string) {

--- a/adapters/repos/db/lsmkv/metrics_test.go
+++ b/adapters/repos/db/lsmkv/metrics_test.go
@@ -1,0 +1,135 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+func newReadOpVecs() (count, failure *prometheus.CounterVec, ongoing *prometheus.GaugeVec, duration *prometheus.HistogramVec) {
+	labels := []string{"operation", "component"}
+	count = prometheus.NewCounterVec(prometheus.CounterOpts{Name: "read_count"}, labels)
+	failure = prometheus.NewCounterVec(prometheus.CounterOpts{Name: "read_failure"}, labels)
+	ongoing = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "read_ongoing"}, labels)
+	duration = prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "read_duration"}, labels)
+	return
+}
+
+// TestBuildReadOpHandles verifies the pre-resolved handles cover every
+// operation/component pair the read path emits, and that each handle method
+// targets the matching (operation, component) series.
+func TestBuildReadOpHandles(t *testing.T) {
+	count, failure, ongoing, duration := newReadOpVecs()
+	handles := buildReadOpHandles(count, ongoing, failure, duration)
+
+	wantOps := []string{readOpGet, readOpGetBySecondary}
+	wantComponents := []string{memtableNames[0], memtableNames[1], componentSegmentGroup}
+	require.Len(t, handles, len(wantOps)*len(wantComponents))
+	for _, op := range wantOps {
+		for _, component := range wantComponents {
+			require.Contains(t, handles, readOpKey{op, component})
+		}
+	}
+
+	h := handles[readOpKey{readOpGet, componentSegmentGroup}]
+	h.incCount()
+	h.incOngoing()
+	h.incOngoing()
+	h.decOngoing()
+	h.incFailure()
+	h.observeDuration(0)
+
+	require.Equal(t, 1.0, testutil.ToFloat64(count.WithLabelValues(readOpGet, componentSegmentGroup)))
+	require.Equal(t, 1.0, testutil.ToFloat64(ongoing.WithLabelValues(readOpGet, componentSegmentGroup)))
+	require.Equal(t, 1.0, testutil.ToFloat64(failure.WithLabelValues(readOpGet, componentSegmentGroup)))
+
+	// a different pair must stay untouched
+	require.Equal(t, 0.0, testutil.ToFloat64(count.WithLabelValues(readOpGetBySecondary, memtableNames[0])))
+}
+
+func TestMetricsReadOp(t *testing.T) {
+	count, failure, ongoing, duration := newReadOpVecs()
+	handles := buildReadOpHandles(count, ongoing, failure, duration)
+	m := &Metrics{
+		bucketReadOpCountByComponent:        count,
+		bucketReadOpOngoingByComponent:      ongoing,
+		bucketReadOpFailureCountByComponent: failure,
+		bucketReadOpDurationByComponent:     duration,
+		readOpHandles:                       handles,
+	}
+
+	t.Run("known pair returns the pre-resolved handle", func(t *testing.T) {
+		got := m.readOp(readOpGet, memtableNames[0])
+		require.Same(t, handles[readOpKey{readOpGet, memtableNames[0]}], got)
+	})
+
+	t.Run("unknown pair resolves on demand", func(t *testing.T) {
+		got := m.readOp("compaction", "unknown")
+		require.NotNil(t, got)
+		got.incCount()
+		require.Equal(t, 1.0, testutil.ToFloat64(count.WithLabelValues("compaction", "unknown")))
+	})
+
+	t.Run("nil metrics yields a nil handle whose methods are no-ops", func(t *testing.T) {
+		var nilMetrics *Metrics
+		h := nilMetrics.readOp(readOpGet, componentSegmentGroup)
+		require.Nil(t, h)
+		require.NotPanics(t, func() {
+			h.incCount()
+			h.incOngoing()
+			h.decOngoing()
+			h.incFailure()
+			h.observeDuration(0)
+		})
+	})
+}
+
+// TestBucketGetReadOpMetrics drives a real Bucket.Get against an on-disk segment
+// and asserts the read increments the (get, segment_group) series. This guards
+// the operation/component constants at the getFromSegmentGroup call site, which
+// the isolated handle tests above cannot see.
+func TestBucketGetReadOpMetrics(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	metrics, err := NewMetrics(monitoring.GetMetrics(), "TestClass", "TestShard")
+	require.NoError(t, err)
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, metrics,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	key, value := []byte("key"), []byte("value")
+	require.NoError(t, b.Put(key, value))
+	// move the object to a disk segment so Get reaches the segment-group path
+	require.NoError(t, b.FlushAndSwitch())
+
+	counter := metrics.bucketReadOpCountByComponent.WithLabelValues(readOpGet, componentSegmentGroup)
+	before := testutil.ToFloat64(counter)
+
+	got, err := b.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+
+	require.Equal(t, before+1, testutil.ToFloat64(counter))
+}

--- a/usecases/traverser/metrics.go
+++ b/usecases/traverser/metrics.go
@@ -19,11 +19,12 @@ import (
 )
 
 type Metrics struct {
-	queriesCount       *prometheus.GaugeVec
-	queriesDurations   *prometheus.HistogramVec
-	dimensions         *prometheus.CounterVec
-	dimensionsCombined prometheus.Counter
-	groupClasses       bool
+	queriesAggregateCount *prometheus.GaugeVec
+	queriesGetCount       *prometheus.GaugeVec
+	queriesGetDurations   prometheus.ObserverVec
+	dimensions            *prometheus.CounterVec
+	dimensionsCombined    prometheus.Counter
+	groupClasses          bool
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -32,11 +33,12 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 	}
 
 	return &Metrics{
-		queriesCount:       prom.QueriesCount,
-		queriesDurations:   prom.QueriesDurations,
-		dimensions:         prom.QueryDimensions,
-		dimensionsCombined: prom.QueryDimensionsCombined,
-		groupClasses:       prom.Group,
+		queriesAggregateCount: prom.QueriesCount.MustCurryWith(prometheus.Labels{"query_type": "aggregate"}),
+		queriesGetCount:       prom.QueriesCount.MustCurryWith(prometheus.Labels{"query_type": "get_graphql"}),
+		queriesGetDurations:   prom.QueriesDurations.MustCurryWith(prometheus.Labels{"query_type": "get_graphql"}),
+		dimensions:            prom.QueryDimensions,
+		dimensionsCombined:    prom.QueryDimensionsCombined,
+		groupClasses:          prom.Group,
 	}
 }
 
@@ -49,10 +51,7 @@ func (m *Metrics) QueriesAggregateInc(className string) {
 		className = "n/a"
 	}
 
-	m.queriesCount.With(prometheus.Labels{
-		"class_name": className,
-		"query_type": "aggregate",
-	}).Inc()
+	m.queriesAggregateCount.WithLabelValues(className).Inc()
 }
 
 func (m *Metrics) QueriesAggregateDec(className string) {
@@ -64,10 +63,7 @@ func (m *Metrics) QueriesAggregateDec(className string) {
 		className = "n/a"
 	}
 
-	m.queriesCount.With(prometheus.Labels{
-		"class_name": className,
-		"query_type": "aggregate",
-	}).Dec()
+	m.queriesAggregateCount.WithLabelValues(className).Dec()
 }
 
 func (m *Metrics) QueriesGetInc(className string) {
@@ -79,10 +75,7 @@ func (m *Metrics) QueriesGetInc(className string) {
 		className = "n/a"
 	}
 
-	m.queriesCount.With(prometheus.Labels{
-		"class_name": className,
-		"query_type": "get_graphql",
-	}).Inc()
+	m.queriesGetCount.WithLabelValues(className).Inc()
 }
 
 func (m *Metrics) QueriesObserveDuration(className string, startMs int64) {
@@ -96,10 +89,7 @@ func (m *Metrics) QueriesObserveDuration(className string, startMs int64) {
 
 	took := float64(time.Now().UnixMilli() - startMs)
 
-	m.queriesDurations.With(prometheus.Labels{
-		"class_name": className,
-		"query_type": "get_graphql",
-	}).Observe(float64(took))
+	m.queriesGetDurations.WithLabelValues(className).Observe(took)
 }
 
 func (m *Metrics) QueriesGetDec(className string) {
@@ -111,10 +101,7 @@ func (m *Metrics) QueriesGetDec(className string) {
 		className = "n/a"
 	}
 
-	m.queriesCount.With(prometheus.Labels{
-		"class_name": className,
-		"query_type": "get_graphql",
-	}).Dec()
+	m.queriesGetCount.WithLabelValues(className).Dec()
 }
 
 func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dims int) {
@@ -126,10 +113,6 @@ func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dim
 		className = "n/a"
 	}
 
-	m.dimensions.With(prometheus.Labels{
-		"class_name": className,
-		"operation":  operation,
-		"query_type": queryType,
-	}).Add(float64(dims))
+	m.dimensions.WithLabelValues(queryType, operation, className).Add(float64(dims))
 	m.dimensionsCombined.Add(float64(dims))
 }

--- a/usecases/traverser/metrics_test.go
+++ b/usecases/traverser/metrics_test.go
@@ -1,0 +1,153 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package traverser
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// TestMetricsLabels pins the label values each Metrics method emits. Currying
+// query_type at construction and switching to WithLabelValues must keep the same
+// (class_name, query_type) / (query_type, operation, class_name) mapping, so a
+// wrong label order here would flip these assertions.
+func TestMetricsLabels(t *testing.T) {
+	newMetrics := func(group bool) (*Metrics, *prometheus.Registry) {
+		reg := prometheus.NewRegistry()
+		queriesCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "concurrent_queries_count",
+		}, []string{"class_name", "query_type"})
+		queriesDurations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "queries_durations_ms",
+		}, []string{"class_name", "query_type"})
+		dimensions := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "query_dimensions_total",
+		}, []string{"query_type", "operation", "class_name"})
+		dimensionsCombined := prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "query_dimensions_combined_total",
+		})
+		reg.MustRegister(queriesCount, queriesDurations, dimensions, dimensionsCombined)
+
+		m := NewMetrics(&monitoring.PrometheusMetrics{
+			QueriesCount:            queriesCount,
+			QueriesDurations:        queriesDurations,
+			QueryDimensions:         dimensions,
+			QueryDimensionsCombined: dimensionsCombined,
+			Group:                   group,
+		})
+		return m, reg
+	}
+
+	t.Run("queries count aggregate and get use distinct query_type", func(t *testing.T) {
+		m, reg := newMetrics(false)
+
+		m.QueriesAggregateInc("Foo")
+		m.QueriesGetInc("Foo")
+		m.QueriesGetInc("Foo")
+		m.QueriesGetDec("Foo")
+
+		require.Equal(t, 1.0, gaugeValue(t, reg, "concurrent_queries_count", map[string]string{
+			"class_name": "Foo", "query_type": "aggregate",
+		}))
+		require.Equal(t, 1.0, gaugeValue(t, reg, "concurrent_queries_count", map[string]string{
+			"class_name": "Foo", "query_type": "get_graphql",
+		}))
+	})
+
+	t.Run("observe duration records under get_graphql", func(t *testing.T) {
+		m, reg := newMetrics(false)
+
+		m.QueriesObserveDuration("Foo", 0)
+
+		require.Equal(t, uint64(1), histogramCount(t, reg, "queries_durations_ms", map[string]string{
+			"class_name": "Foo", "query_type": "get_graphql",
+		}))
+	})
+
+	t.Run("usage dimensions keep query_type/operation/class_name order", func(t *testing.T) {
+		m, reg := newMetrics(false)
+
+		m.AddUsageDimensions("Foo", "get", "objects", 5)
+
+		require.Equal(t, 5.0, counterValue(t, reg, "query_dimensions_total", map[string]string{
+			"query_type": "get", "operation": "objects", "class_name": "Foo",
+		}))
+		require.Equal(t, 5.0, counterValue(t, reg, "query_dimensions_combined_total", nil))
+	})
+
+	t.Run("group mode collapses class_name to n/a", func(t *testing.T) {
+		m, reg := newMetrics(true)
+
+		m.QueriesGetInc("Foo")
+
+		require.Equal(t, 1.0, gaugeValue(t, reg, "concurrent_queries_count", map[string]string{
+			"class_name": "n/a", "query_type": "get_graphql",
+		}))
+	})
+
+	t.Run("nil metrics is a no-op", func(t *testing.T) {
+		var m *Metrics
+		require.NotPanics(t, func() {
+			m.QueriesAggregateInc("Foo")
+			m.QueriesGetInc("Foo")
+			m.QueriesGetDec("Foo")
+			m.QueriesObserveDuration("Foo", 0)
+			m.AddUsageDimensions("Foo", "get", "objects", 1)
+		})
+	})
+}
+
+func findMetric(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			if labelsMatch(m, labels) {
+				return m
+			}
+		}
+	}
+	require.Failf(t, "metric not found", "%s with labels %v", name, labels)
+	return nil
+}
+
+func labelsMatch(m *dto.Metric, labels map[string]string) bool {
+	if len(m.GetLabel()) != len(labels) {
+		return false
+	}
+	for _, l := range m.GetLabel() {
+		if labels[l.GetName()] != l.GetValue() {
+			return false
+		}
+	}
+	return true
+}
+
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	return findMetric(t, reg, name, labels).GetGauge().GetValue()
+}
+
+func counterValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	return findMetric(t, reg, name, labels).GetCounter().GetValue()
+}
+
+func histogramCount(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) uint64 {
+	return findMetric(t, reg, name, labels).GetHistogram().GetSampleCount()
+}

--- a/usecases/traverser/metrics_test.go
+++ b/usecases/traverser/metrics_test.go
@@ -22,80 +22,70 @@ import (
 
 // TestMetricsLabels pins the label values each Metrics method emits. Currying
 // query_type at construction and switching to WithLabelValues must keep the same
-// (class_name, query_type) / (query_type, operation, class_name) mapping, so a
-// wrong label order here would flip these assertions.
+// (class_name, query_type) / (query_type, operation, class_name) mapping. It
+// drives off the real monitoring.GetMetrics() vecs so that reordering a label
+// list in prometheus.go — which would silently mislabel the positional
+// AddUsageDimensions call — flips these assertions. Because those vecs live on
+// the shared default registry, assertions measure deltas around each action.
 func TestMetricsLabels(t *testing.T) {
-	newMetrics := func(group bool) (*Metrics, *prometheus.Registry) {
-		reg := prometheus.NewRegistry()
-		queriesCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "concurrent_queries_count",
-		}, []string{"class_name", "query_type"})
-		queriesDurations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: "queries_durations_ms",
-		}, []string{"class_name", "query_type"})
-		dimensions := prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "query_dimensions_total",
-		}, []string{"query_type", "operation", "class_name"})
-		dimensionsCombined := prometheus.NewCounter(prometheus.CounterOpts{
-			Name: "query_dimensions_combined_total",
-		})
-		reg.MustRegister(queriesCount, queriesDurations, dimensions, dimensionsCombined)
+	prom := monitoring.GetMetrics()
 
-		m := NewMetrics(&monitoring.PrometheusMetrics{
-			QueriesCount:            queriesCount,
-			QueriesDurations:        queriesDurations,
-			QueryDimensions:         dimensions,
-			QueryDimensionsCombined: dimensionsCombined,
+	newMetrics := func(group bool) *Metrics {
+		return NewMetrics(&monitoring.PrometheusMetrics{
+			QueriesCount:            prom.QueriesCount,
+			QueriesDurations:        prom.QueriesDurations,
+			QueryDimensions:         prom.QueryDimensions,
+			QueryDimensionsCombined: prom.QueryDimensionsCombined,
 			Group:                   group,
 		})
-		return m, reg
 	}
 
 	t.Run("queries count aggregate and get use distinct query_type", func(t *testing.T) {
-		m, reg := newMetrics(false)
+		m := newMetrics(false)
+		aggregate := map[string]string{"class_name": "Foo", "query_type": "aggregate"}
+		get := map[string]string{"class_name": "Foo", "query_type": "get_graphql"}
+		beforeAggregate := gaugeValue(t, "concurrent_queries_count", aggregate)
+		beforeGet := gaugeValue(t, "concurrent_queries_count", get)
 
 		m.QueriesAggregateInc("Foo")
 		m.QueriesGetInc("Foo")
 		m.QueriesGetInc("Foo")
 		m.QueriesGetDec("Foo")
 
-		require.Equal(t, 1.0, gaugeValue(t, reg, "concurrent_queries_count", map[string]string{
-			"class_name": "Foo", "query_type": "aggregate",
-		}))
-		require.Equal(t, 1.0, gaugeValue(t, reg, "concurrent_queries_count", map[string]string{
-			"class_name": "Foo", "query_type": "get_graphql",
-		}))
+		require.Equal(t, 1.0, gaugeValue(t, "concurrent_queries_count", aggregate)-beforeAggregate)
+		require.Equal(t, 1.0, gaugeValue(t, "concurrent_queries_count", get)-beforeGet)
 	})
 
 	t.Run("observe duration records under get_graphql", func(t *testing.T) {
-		m, reg := newMetrics(false)
+		m := newMetrics(false)
+		get := map[string]string{"class_name": "Foo", "query_type": "get_graphql"}
+		before := histogramCount(t, "queries_durations_ms", get)
 
 		m.QueriesObserveDuration("Foo", 0)
 
-		require.Equal(t, uint64(1), histogramCount(t, reg, "queries_durations_ms", map[string]string{
-			"class_name": "Foo", "query_type": "get_graphql",
-		}))
+		require.Equal(t, uint64(1), histogramCount(t, "queries_durations_ms", get)-before)
 	})
 
 	t.Run("usage dimensions keep query_type/operation/class_name order", func(t *testing.T) {
-		m, reg := newMetrics(false)
+		m := newMetrics(false)
+		dims := map[string]string{"query_type": "get", "operation": "objects", "class_name": "Foo"}
+		beforeDims := counterValue(t, "query_dimensions_total", dims)
+		beforeCombined := counterValue(t, "query_dimensions_combined_total", nil)
 
 		m.AddUsageDimensions("Foo", "get", "objects", 5)
 
-		require.Equal(t, 5.0, counterValue(t, reg, "query_dimensions_total", map[string]string{
-			"query_type": "get", "operation": "objects", "class_name": "Foo",
-		}))
-		require.Equal(t, 5.0, counterValue(t, reg, "query_dimensions_combined_total", nil))
+		require.Equal(t, 5.0, counterValue(t, "query_dimensions_total", dims)-beforeDims)
+		require.Equal(t, 5.0, counterValue(t, "query_dimensions_combined_total", nil)-beforeCombined)
 	})
 
 	t.Run("group mode collapses class_name to n/a", func(t *testing.T) {
-		m, reg := newMetrics(true)
+		m := newMetrics(true)
+		na := map[string]string{"class_name": "n/a", "query_type": "get_graphql"}
+		before := gaugeValue(t, "concurrent_queries_count", na)
 
 		m.QueriesGetInc("Foo")
 
-		require.Equal(t, 1.0, gaugeValue(t, reg, "concurrent_queries_count", map[string]string{
-			"class_name": "n/a", "query_type": "get_graphql",
-		}))
+		require.Equal(t, 1.0, gaugeValue(t, "concurrent_queries_count", na)-before)
 	})
 
 	t.Run("nil metrics is a no-op", func(t *testing.T) {
@@ -110,9 +100,11 @@ func TestMetricsLabels(t *testing.T) {
 	})
 }
 
-func findMetric(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) *dto.Metric {
+// findMetric returns the sample matching name+labels from the default registry,
+// or nil if that series has not been emitted yet (so callers read 0 as baseline).
+func findMetric(t *testing.T, name string, labels map[string]string) *dto.Metric {
 	t.Helper()
-	families, err := reg.Gather()
+	families, err := prometheus.DefaultGatherer.Gather()
 	require.NoError(t, err)
 	for _, fam := range families {
 		if fam.GetName() != name {
@@ -124,7 +116,6 @@ func findMetric(t *testing.T, reg *prometheus.Registry, name string, labels map[
 			}
 		}
 	}
-	require.Failf(t, "metric not found", "%s with labels %v", name, labels)
 	return nil
 }
 
@@ -140,14 +131,14 @@ func labelsMatch(m *dto.Metric, labels map[string]string) bool {
 	return true
 }
 
-func gaugeValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
-	return findMetric(t, reg, name, labels).GetGauge().GetValue()
+func gaugeValue(t *testing.T, name string, labels map[string]string) float64 {
+	return findMetric(t, name, labels).GetGauge().GetValue()
 }
 
-func counterValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
-	return findMetric(t, reg, name, labels).GetCounter().GetValue()
+func counterValue(t *testing.T, name string, labels map[string]string) float64 {
+	return findMetric(t, name, labels).GetCounter().GetValue()
 }
 
-func histogramCount(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) uint64 {
-	return findMetric(t, reg, name, labels).GetHistogram().GetSampleCount()
+func histogramCount(t *testing.T, name string, labels map[string]string) uint64 {
+	return findMetric(t, name, labels).GetHistogram().GetSampleCount()
 }


### PR DESCRIPTION
## Motivation

The bucket read path and the GraphQL/aggregate query path both emit Prometheus metrics on every operation. Each emission went through `WithLabelValues(...)` / `With(prometheus.Labels{...})`, which does a map lookup (and, for the `Labels{}` form, an allocation plus a per-call hash of the label map) to find the metric child before touching it. On hot read paths this per-call resolution is pure overhead — the set of label combinations is tiny and fixed, so the child pointers can be resolved once at construction and reused.

Microbenchmarks (uncontended, monitoring enabled):

| Path | Before | After |
|---|---|---|
| lsmkv read metrics per `Get` (disk path, 12 metric touches) | 414 ns/op, 0 allocs | 72 ns/op, 0 allocs |
| traverser per query-metric call | 153 ns/op, 336 B, 2 allocs | 25 ns/op, 0 allocs |

This is worth roughly 0.5–1% of a top-100 vector search (`limit: 100`) when monitoring is on, and nothing when it's off.

## Approach

Two independent call sites, same idea — resolve the metric child once, keep the pointer:

- **lsmkv bucket reads** (`metrics.go`, `bucket.go`): `NewMetrics` now pre-resolves a `readOpHandle` (count / ongoing / failure / duration children) for every `{op, component}` pair the read path actually emits — the cartesian product of `{get, getbysecondary}` × `{active_memtable, flushing_memtable, segment_group}`. The read path calls `b.metrics.readOp(op, component)` once and then invokes cheap methods on the returned handle, replacing up to 12 hashed-and-locked vec lookups per `Get` with 3 lock-free map reads. The op/component string literals scattered across `bucket.go` are lifted into named constants so the pre-built set and the call sites can't silently drift apart. A single `readOpsLabels` enumeration now feeds both the pre-built handle set and the startup zero-initialization, so all six emitted series (including the previously-uninitialized `getbysecondary` pairs) are zero-valued at boot.

- **traverser queries** (`usecases/traverser/metrics.go`): the `query_type` label is constant per method, so it's pre-curried with `MustCurryWith` into dedicated `queriesAggregateCount` / `queriesGetCount` / `queriesGetDurations` vecs, and the remaining `class_name` label is set via positional `WithLabelValues`. This drops the per-call `prometheus.Labels{}` map construction entirely.

Rejected alternative: caching handles lazily on first use (sync.Map or similar). Pre-building is simpler and the label space is fully known up front, so there's no reason to pay for lazy synchronization.

## Key areas for review

- `adapters/repos/db/lsmkv/metrics.go` — `readOp()` returns a pre-built handle for known pairs and falls back to resolving on demand for any other pair (e.g. a future component), preserving the old behavior. Nil-receiver safety is preserved: a nil `*Metrics` yields a nil `*readOpHandle` whose methods are no-ops.
- `usecases/traverser/metrics.go` — the `MustCurryWith` currying and the positional `WithLabelValues` argument order. This is the one place a mistake would be silent.

## Risks and mitigations

- **Positional label order mismatch** (the only real risk): switching from map-keyed `With(Labels{})` to positional `WithLabelValues(...)` means arg order must match each vec's declared label order. Verified against `usecases/monitoring/prometheus.go`: `concurrent_queries_count` / `queries_durations_ms` declare `{class_name, query_type}` (curried on `query_type`, leaving `class_name`), and `query_dimensions_total` declares `{query_type, operation, class_name}` — matching the new `WithLabelValues(queryType, operation, className)`. `TestMetricsLabels` drives off the real `monitoring.GetMetrics()` vecs, so reordering a label list in `prometheus.go` flips its assertions instead of silently passing.
- **Metric identity / behavior change**: none. The pre-curried traverser vecs curry from the same underlying `prom.QueriesCount` family, so emitted series are byte-identical to before. The lsmkv handles point at the same `*Vec` children the old accessors resolved.

## Testing

- `usecases/traverser/metrics_test.go` — new `TestMetricsLabels` drives off the real `monitoring.GetMetrics()` vecs (measuring deltas on the shared default registry) and asserts: aggregate vs get land under distinct `query_type` values, durations record under `get_graphql`, `AddUsageDimensions` preserves `query_type/operation/class_name` order, group-mode collapses `class_name` to `n/a`, and a nil `*Metrics` is a no-op.
- `adapters/repos/db/lsmkv/metrics_test.go` — `TestBuildReadOpHandles` checks the full 6-pair set is built and each handle mutates only its own series; `TestMetricsReadOp` covers known-pair (same pointer returned), unknown-pair on-demand fallback, and nil-receiver no-op; `TestBucketGetReadOpMetrics` drives a real `Bucket.Get` through the on-disk segment path and asserts the `(get, segment_group)` counter increments — guarding the constants at the actual call site, which the isolated handle tests can't see.

No breaking changes — metric names and label sets are unchanged.

