### PR TITLE
fix(async-replication): close hashtree-init channel on early goroutine exit to unblock parked merges

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -468,6 +468,9 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig, cached hasht
 
 	s.hashtreeFullyInitialized = false
 	s.minimalHashtreeInitializationCh = make(chan struct{})
+	// The init goroutine closes the channel it owns, not the shard field, which a
+	// concurrent enable may have swapped out under flapping. See closeInitCh.
+	initCh := s.minimalHashtreeInitializationCh
 
 	// asyncRepWg tracks this goroutine so that rebuildHashtree's
 	// asyncRepWg.Wait() serialises rebuilds against it, preventing the old
@@ -478,6 +481,27 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig, cached hasht
 	s.asyncRepWg.Add(1)
 	enterrors.GoWrapper(func() {
 		defer s.asyncRepWg.Done()
+
+		// closeInitCh closes this goroutine's owned channel exactly once, unblocking
+		// merges parked in waitForMinimalHashTreeInitialization. It runs as both
+		// initHashtree's afterInMemCallback and a defer covering the early exits
+		// (scheduler nil, slot acquisition cancelled) that never reach initHashtree
+		// and would otherwise leave the channel open forever. The retry loop replaces
+		// ownedCh per attempt.
+		//
+		// No lock: ownedCh/ownedClosed are goroutine-local and close() already
+		// synchronizes with receivers. It must NOT take asyncReplicationRWMux — it
+		// runs while writes hold the RLock, so becoming a pending writer would, under
+		// Go's writer-priority RWMutex, block every new RLock and deadlock them.
+		ownedCh := initCh
+		ownedClosed := false
+		closeInitCh := func() {
+			if !ownedClosed {
+				ownedClosed = true
+				close(ownedCh)
+			}
+		}
+		defer closeInitCh()
 
 		if s.index.asyncReplicationScheduler == nil {
 			return
@@ -500,7 +524,7 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig, cached hasht
 			// the goroutine boundary, after the deferred release fires).
 			err := func() error {
 				defer s.index.asyncReplicationScheduler.releaseHashtreeInitSlot()
-				return s.initHashtree(ctx, effectiveConfig, bucket)
+				return s.initHashtree(ctx, effectiveConfig, bucket, closeInitCh)
 			}()
 
 			if err == nil {
@@ -543,13 +567,13 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig, cached hasht
 				return
 			}
 			s.hashtree.Reset()
-			// releaseInitialization (the afterInMemCallback passed to
-			// ApplyToObjectDigests) always closes minimalHashtreeInitializationCh
-			// before initHashtree returns — even on error — so the channel is
-			// already closed here. Closing it again would panic. Replace it with
-			// a fresh channel for the next attempt so write paths that arrive
-			// during the retry wait for that attempt's releaseInitialization.
-			s.minimalHashtreeInitializationCh = make(chan struct{})
+			// initHashtree already closed ownedCh (afterInMemCallback fires once, even
+			// on error); take ownership of a fresh channel so writes arriving during
+			// the retry block until the next attempt completes.
+			newCh := make(chan struct{})
+			s.minimalHashtreeInitializationCh = newCh
+			ownedCh = newCh
+			ownedClosed = false
 			s.asyncReplicationRWMux.Unlock()
 		}
 	}, s.index.logger)
@@ -654,7 +678,10 @@ func (s *Shard) tryLoadHashtreeFromDisk(expectedHeight int) (hashtree.Aggregated
 // released so that concurrent reads and writes are not blocked. Progress is
 // logged at loggingFrequency intervals. The scan is gated by hashtreeInitSem
 // to bound concurrent I/O across all shards at startup.
-func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig, bucket *lsmkv.Bucket) (err error) {
+//
+// releaseInit runs once the in-memory scan completes (as ApplyToObjectDigests'
+// afterInMemCallback, which fires exactly once even on error).
+func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig, bucket *lsmkv.Bucket, releaseInit func()) (err error) {
 	start := time.Now()
 
 	s.metrics.IncAsyncReplicationHashTreeInitCount()
@@ -671,24 +698,10 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 		s.metrics.ObserveAsyncReplicationHashTreeInitDuration(time.Since(start))
 	}()
 
-	// releaseInitialization closes minimalHashtreeInitializationCh under RLock
-	// so it serializes with the write-lock path in the retry loop that replaces
-	// the channel. RLock is the correct lock here (not Lock): we are only
-	// reading the channel field and closing it; the retry path replaces the
-	// field under Lock. Invariant: this closure is called exactly once per
-	// initHashtree attempt (ApplyToObjectDigests guarantees it fires the
-	// afterInMemCallback exactly once), so there is no risk of double-close.
-	releaseInitialization := func() {
-		s.asyncReplicationRWMux.RLock()
-		defer s.asyncReplicationRWMux.RUnlock()
-
-		close(s.minimalHashtreeInitializationCh)
-	}
-
 	objCount := 0
 	prevProgressLogging := time.Now()
 
-	err = bucket.ApplyToObjectDigests(ctx, releaseInitialization, func(uuidBytes []byte, updateTime int64) error {
+	err = bucket.ApplyToObjectDigests(ctx, releaseInit, func(uuidBytes []byte, updateTime int64) error {
 		if time.Since(prevProgressLogging) >= config.loggingFrequency {
 			s.index.logger.
 				WithField("action", "async_replication").

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -38,6 +38,7 @@ import (
 	entreplication "github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/cluster"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -1086,6 +1087,74 @@ func TestMergeWritesNoDeadlockUnderAsyncReplicationFlapping(t *testing.T) {
 
 			require.NoError(t, s.disableAsyncReplication(ctx))
 		})
+	}
+}
+
+// TestMergeUnblocksWhenInitBailsBeforeHashtreeScan deterministically drives the
+// deadlock that TestMergeWritesNoDeadlockUnderAsyncReplicationFlapping only hits
+// under load: holding the single init slot parks the init goroutine before
+// initHashtree, then disableAsyncReplication cancels its context so it exits
+// without ever running the scan that closes minimalHashtreeInitializationCh.
+// Without the fix the channel leaks and the in-flight merge blocks forever.
+func TestMergeUnblocksWhenInitBailsBeforeHashtreeScan(t *testing.T) {
+	ctx := context.Background()
+
+	// Scheduler with a single hashtree-init slot so the test can starve the scan.
+	logger, _ := test.NewNullLogger()
+	sched, err := NewAsyncReplicationScheduler(context.Background(), entreplication.GlobalConfig{
+		AsyncReplicationSchedulerWorkers:        configRuntime.NewDynamicValue(1),
+		AsyncReplicationHashtreeInitConcurrency: configRuntime.NewDynamicValue(1),
+		AsyncReplicationDisabled:                configRuntime.NewDynamicValue(false),
+	}, nil, logger)
+	require.NoError(t, err)
+	t.Cleanup(sched.Close)
+
+	sl, _ := testShard(t, ctx, "MergeUnblocksInitBail", func(idx *Index) {
+		idx.asyncReplicationScheduler = sched
+	})
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(s.class.Class, id, tsFarPast)))
+	}
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	// Occupy the only init slot so the shard's init goroutine blocks in
+	// acquireHashtreeInitSlot before it reaches initHashtree.
+	require.NoError(t, sched.hashtreeInitSem.Acquire(context.Background(), 1))
+	defer sched.hashtreeInitSem.Release(1)
+
+	// Spawns the init goroutine, which parks on the held slot with the hashtree
+	// set but not yet initialized.
+	require.NoError(t, s.enableAsyncReplication(ctx, minAsyncReplicationConfig()))
+
+	// The merge captures the open init channel and blocks in
+	// waitForMinimalHashTreeInitialization.
+	mergeDone := make(chan error, 1)
+	go func() {
+		mergeDone <- s.MergeObject(ctx, objects.MergeDocument{
+			Class:      s.class.Class,
+			ID:         uuidLow,
+			UpdateTime: tsFarPast + 1,
+		})
+	}()
+
+	// Precondition: the merge must actually be parked while init is stalled.
+	select {
+	case <-mergeDone:
+		t.Fatal("merge completed while hashtree init was stalled — precondition not met")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Disable cancels the shard's async context; the init goroutine returns from
+	// acquireHashtreeInitSlot and exits without running initHashtree.
+	require.NoError(t, s.disableAsyncReplication(ctx))
+
+	select {
+	case <-mergeDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("merge did not unblock after async replication was disabled — init channel leaked")
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

Fixes a deadlock where in-flight merge writes can block forever.

**Bug:** the hashtree-init goroutine creates `minimalHashtreeInitializationCh` but only closes it once `initHashtree` runs. When the goroutine exits *before* that — scheduler nil, or `acquireHashtreeInitSlot` cancelled (e.g. async replication disabled during flapping) — the channel leaks. Every merge parked in `waitForMinimalHashTreeInitialization` then blocks indefinitely, jamming the shard and its shutdown on `asyncReplicationRWMux`.

**Fix:** each init goroutine owns its channel and closes it exactly once on *every* exit path, via a `closeInitCh` closure used both as `initHashtree`'s in-mem-scan callback and as a `defer`. It closes the goroutine-owned channel (not the shard field, which a concurrent enable may have swapped) and takes no lock — locals plus `close()` self-synchronize, and taking the write lock would itself deadlock under Go's writer-priority RWMutex.

Pre-existing bug, identical on v1.37/v1.38, surfaced by `TestMergeWritesNoDeadlockUnderAsyncReplicationFlapping`. Adds `TestMergeUnblocksWhenInitBailsBeforeHashtreeScan`, a deterministic regression test that fails without the fix and passes with it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
