### PR TITLE
Wrap ErrNotFound in GetShardsQueueSize so a non-existing index returns 404, not 500

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -527,7 +527,8 @@ func (m *Migrator) GetShardsQueueSize(ctx context.Context, className, tenant str
 
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
-		return nil, errors.Errorf("cannot get shards status for a non-existing index for %s", className)
+		// index not yet local (RAFT schema not applied on this node) or class does not exist
+		return nil, fmt.Errorf("cannot get shards queue size for a non-existing index for %s: %w", className, schemaUC.ErrNotFound)
 	}
 
 	return idx.getShardsQueueSize(ctx, tenant)

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -359,6 +359,13 @@ func TestShardsStatusNonExistingIndexWrapsNotFound(t *testing.T) {
 			},
 		},
 		{
+			name: "GetShardsQueueSize",
+			call: func() error {
+				_, err := migrator.GetShardsQueueSize(context.Background(), "DoesNotExist", "")
+				return err
+			},
+		},
+		{
 			name: "UpdateShardStatus",
 			call: func() error {
 				return migrator.UpdateShardStatus(context.Background(), "DoesNotExist", "shard1", models.TenantActivityStatusHOT, 0)


### PR DESCRIPTION
## Motivation

`3e6d2ad6` ("Return proper error code from shard endpoints when index is not found") made `GetShardsStatus` and `UpdateShardStatus` wrap `schemaUC.ErrNotFound` when the index isn't local yet — *"RAFT schema not applied on this node, or the class doesn't exist"* — so the REST handler maps them to **404** instead of **500**. That's the right call: it's a transient, retryable condition during index propagation, not a server fault.

Its sibling `GetShardsQueueSize` was missed. Its `idx == nil` branch still returns a plain `errors.Errorf(...)` (and, via copy-paste, even the wrong message — *"shards status"* inside a queue-size method), so it surfaces as a **500**.

This bites in practice: on builds where the shard-status response merges the vector queue size, the Python client's `get_shards()` reads `vectorQueueSize`, so `GET /schema/{class}/shards` invokes this path. During index propagation on a multi-node cluster the queue-size lookup hits `idx == nil` and the whole call fails with **500** instead of a retryable **404**. It surfaced in `weaviate-e2e-tests` CI, where shard-readiness polling (`wait_for_all_shards_ready`) raced index registration and couldn't distinguish this transient state from a real failure — forcing brittle **error-message string matching** on the client side to decide whether to retry.

## Change

Wrap `schemaUC.ErrNotFound` in `GetShardsQueueSize`'s `idx == nil` branch, exactly as `3e6d2ad6` did for the two siblings. **No handler change is needed** — the existing `errors.Is(err, schemaUC.ErrNotFound)` case in `getShardsStatus` already returns 404 once the sentinel is present. Also corrects the copy-pasted error message.

## Testing

Extends the existing `TestShardsStatusNonExistingIndexWrapsNotFound` (added by `3e6d2ad6`) with a `GetShardsQueueSize` case asserting `require.ErrorIs(err, schemaUC.ErrNotFound)`. Passes; `gofumpt`, `golangci-lint`, and the goroutine linter are clean on the change.

## Known follow-up (not in this PR)

There is a second path that still leaks a 500 for the same logical condition: the **coordinator fan-out to a peer**. When the coordinator has the index but a replica shard's owner hasn't registered it yet, the peer returns `ErrUnprocessable` ("local index %q not found", HTTP 422), and `Index.getShardsStatus`/`getShardsQueueSize` wrap it with `errors.Wrapf(err, "shard %s")`, dropping the not-found semantics → 500. Mapping that to 404 cleanly needs the remote client (`adapters/clients/remote_index.go`) to return a **typed** error carrying the status code instead of a formatted string, so I've left it as a separate change to keep this one small and low-risk. Happy to follow up.

## Open question for reviewers — 404 vs 503

This makes the transient "index not local yet" condition a **404**, consistent with `3e6d2ad6`. Arguably a *transient* "not ready, retry shortly" is better modeled as **503**, since 404 is ambiguous with a genuinely-missing collection. I went with 404 for minimal, consistent change; happy to switch to a 503 / dedicated "not ready" signal if the team prefers — that would also let clients retry purely on status code and drop the message-matching entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
