### PR TITLE
[Reindex Fixes A] test: tolerate transient post-restart reads in reindex per-replica checks

### DIFF
--- a/test/acceptance/reindex_multinode/finalizing_crash_test.go
+++ b/test/acceptance/reindex_multinode/finalizing_crash_test.go
@@ -13,7 +13,6 @@ package reindex_multinode
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -164,42 +163,8 @@ func TestMultiNode_RollingRestartDuringFinalizing_PerReplicaConsistency(t *testi
 	// directly 30 times (90 total) to verify post-convergence stability.
 	// Every poll on every replica must return expectedPathCount; any other
 	// value is a per-replica divergence (flap after convergence).
-	const pollsPerReplica = 30
-	histogram := make(map[string]map[int]int) // nodeID -> count -> N
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		nodeKey := fmt.Sprintf("node-%d", nodeIdx)
-		histogram[nodeKey] = map[int]int{}
-		for i := 0; i < pollsPerReplica; i++ {
-			postURI := restURIOf(compose, nodeIdx)
-			got, err := equalCount(postURI, className, "path", paths[0])
-			if err != nil {
-				histogram[nodeKey][-1]++
-				continue
-			}
-			histogram[nodeKey][got]++
-		}
-	}
-
-	// Render histogram on failure so the per-replica flap shape is
-	// visible in CI logs.
-	allCorrect := true
-	for _, perNode := range histogram {
-		for value, n := range perNode {
-			if value != expectedPathCount || n != pollsPerReplica {
-				allCorrect = false
-			}
-		}
-	}
-	if !allCorrect {
-		msg := fmt.Sprintf("per-replica divergence on %q after rolling restart "+
-			"during FINALIZING (expected %d, %d polls/replica):",
-			"path", expectedPathCount, pollsPerReplica)
-		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-			nodeKey := fmt.Sprintf("node-%d", nodeIdx)
-			msg += fmt.Sprintf("\n  %s: %v", nodeKey, histogram[nodeKey])
-		}
-		t.Fatal(msg)
-	}
+	assertNoPerReplicaPathDivergence(t, compose, className, paths[0], expectedPathCount,
+		"after rolling restart during FINALIZING")
 }
 
 // TestMultiNode_UngracefulStopDuringFinalizing_PerReplicaConsistency
@@ -310,38 +275,6 @@ func TestMultiNode_UngracefulStopDuringFinalizing_PerReplicaConsistency(t *testi
 		"per-replica path count never converged to %d on all 3 replicas after SIGKILL during FINALIZING",
 		expectedPathCount)
 
-	const pollsPerReplica = 30
-	histogram := make(map[string]map[int]int)
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		nodeKey := fmt.Sprintf("node-%d", nodeIdx)
-		histogram[nodeKey] = map[int]int{}
-		for i := 0; i < pollsPerReplica; i++ {
-			postURI := restURIOf(compose, nodeIdx)
-			got, err := equalCount(postURI, className, "path", paths[0])
-			if err != nil {
-				histogram[nodeKey][-1]++
-				continue
-			}
-			histogram[nodeKey][got]++
-		}
-	}
-
-	allCorrect := true
-	for _, perNode := range histogram {
-		for value, n := range perNode {
-			if value != expectedPathCount || n != pollsPerReplica {
-				allCorrect = false
-			}
-		}
-	}
-	if !allCorrect {
-		msg := fmt.Sprintf("per-replica divergence on %q after SIGKILL "+
-			"during FINALIZING (expected %d, %d polls/replica):",
-			"path", expectedPathCount, pollsPerReplica)
-		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-			nodeKey := fmt.Sprintf("node-%d", nodeIdx)
-			msg += fmt.Sprintf("\n  %s: %v", nodeKey, histogram[nodeKey])
-		}
-		t.Fatal(msg)
-	}
+	assertNoPerReplicaPathDivergence(t, compose, className, paths[0], expectedPathCount,
+		"after SIGKILL during FINALIZING")
 }

--- a/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
+++ b/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
@@ -229,6 +229,73 @@ func restURIOf(compose *docker.DockerCompose, nodeIdx int) string {
 	return compose.GetWeaviateNode(nodeIdx).URI()
 }
 
+// pollPerReplicaHistogram hits each of the 3 replicas `polls` times with
+// query() and reports whether every (node, poll) returned `expected`, plus a
+// rendered per-node histogram for the failure message. A read that errors is
+// retried (a replica rejoining RAFT / reopening buckets right after a restart
+// can briefly fail one Aggregate read); a *successful* query is never retried,
+// so a wrong count is recorded as-is and still fails — GH #212 divergence
+// detection is preserved, only transient read errors are tolerated.
+func pollPerReplicaHistogram(
+	compose *docker.DockerCompose, polls, expected int,
+	query func(postURI string) (int, error),
+) (ok bool, rendered string) {
+	const (
+		readAttempts = 5
+		readBackoff  = 200 * time.Millisecond
+	)
+	ok = true
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		counts := map[int]int{}
+		postURI := restURIOf(compose, nodeIdx)
+		for i := 0; i < polls; i++ {
+			var (
+				got int
+				err error
+			)
+			for a := 0; a < readAttempts; a++ {
+				if got, err = query(postURI); err == nil {
+					break
+				}
+				if a < readAttempts-1 {
+					time.Sleep(readBackoff)
+				}
+			}
+			if err != nil {
+				counts[-1]++
+				continue
+			}
+			counts[got]++
+		}
+		for value, n := range counts {
+			if value != expected || n != polls {
+				ok = false
+			}
+		}
+		rendered += fmt.Sprintf("\n  node-%d: %v", nodeIdx, counts)
+	}
+	return ok, rendered
+}
+
+// assertNoPerReplicaPathDivergence is the finalizing-journey wrapper around
+// pollPerReplicaHistogram for the `path` change-tokenization property. It
+// fails the test with the per-replica flap shape if any replica disagrees
+// after the given event (e.g. "after rolling restart during FINALIZING").
+func assertNoPerReplicaPathDivergence(
+	t *testing.T, compose *docker.DockerCompose, className, path string, expected int, afterEvent string,
+) {
+	t.Helper()
+	const pollsPerReplica = 30
+	ok, rendered := pollPerReplicaHistogram(compose, pollsPerReplica, expected,
+		func(postURI string) (int, error) {
+			return equalCount(postURI, className, "path", path)
+		})
+	if !ok {
+		t.Fatalf("per-replica divergence on %q %s (expected %d, %d polls/replica):%s",
+			"path", afterEvent, expected, pollsPerReplica, rendered)
+	}
+}
+
 // batchImportNumeric posts `total` objects in 200-object batches, each with
 // a unique `name` and a `score` produced by scoreFor(i). consistency_level=
 // ALL ensures the cluster is in a fully-replicated baseline state before

--- a/test/acceptance/reindex_multinode/migration_journeys_test.go
+++ b/test/acceptance/reindex_multinode/migration_journeys_test.go
@@ -452,54 +452,23 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 		{"category", "equal", categories[0], expectedCatCount},
 		{"path", "equal", paths[0], expectedPathCount},
 	} {
-		histogram := make(map[string]map[int]int) // nodeID -> count -> N
-		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-			nodeKey := fmt.Sprintf("node-%d", nodeIdx)
-			histogram[nodeKey] = map[int]int{}
-			for i := 0; i < pollsPerReplica; i++ {
-				postURI := restURIOf(compose, nodeIdx)
-				var got int
-				var err error
+		ok, rendered := pollPerReplicaHistogram(compose, pollsPerReplica, prop.expected,
+			func(postURI string) (int, error) {
 				switch prop.kind {
 				case "range":
-					got, err = rangeCount(postURI, className, prop.name, priceLo, priceHi)
+					return rangeCount(postURI, className, prop.name, priceLo, priceHi)
 				case "equal":
-					got, err = equalCount(postURI, className, prop.name, prop.value)
+					return equalCount(postURI, className, prop.name, prop.value)
+				default:
+					return 0, fmt.Errorf("unknown prop kind %q", prop.kind)
 				}
-				if err != nil {
-					// Treat a query error as a distinct histogram bucket
-					// at -1 so it's visible in the failure log.
-					histogram[nodeKey][-1]++
-					continue
-				}
-				histogram[nodeKey][got]++
-			}
-		}
-
-		// Pass condition: every (node, poll) returned the expected count.
-		allCorrect := true
-		for _, perNode := range histogram {
-			for value, n := range perNode {
-				if value != prop.expected || n != pollsPerReplica {
-					allCorrect = false
-				}
-			}
-		}
-
-		if !allCorrect {
-			// Render histogram in the failure message so the per-replica
-			// flap shape is visible — this is the smoking gun for
-			// per-replica bucket-pointer divergence.
-			lines := []string{
-				fmt.Sprintf("GH #212 per-replica divergence on %q (expected %d, %d polls/replica):",
-					prop.name, prop.expected, pollsPerReplica),
-			}
-			for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-				nodeKey := fmt.Sprintf("node-%d", nodeIdx)
-				lines = append(lines,
-					fmt.Sprintf("  %s: %+v", nodeKey, histogram[nodeKey]))
-			}
-			assert.Fail(t, "per-replica divergence", "%s", joinLines(lines))
+			})
+		if !ok {
+			// rendered shows the per-replica flap shape — the smoking gun
+			// for per-replica bucket-pointer divergence.
+			assert.Fail(t, "per-replica divergence",
+				"GH #212 per-replica divergence on %q (expected %d, %d polls/replica):%s",
+				prop.name, prop.expected, pollsPerReplica, rendered)
 		}
 	}
 
@@ -517,15 +486,4 @@ func TestMultiNode_RepeatedParallelMigrationJourney_PerReplicaConsistency(t *tes
 			"GH #212 LB-side path query #%d (node %d) = %d, expected %d",
 			i+1, nodeIdx, gotPath, expectedPathCount)
 	}
-}
-
-func joinLines(lines []string) string {
-	var b []byte
-	for i, l := range lines {
-		if i > 0 {
-			b = append(b, '\n')
-		}
-		b = append(b, l...)
-	}
-	return string(b)
 }

--- a/test/acceptance/reindex_multinode/post_restart_test.go
+++ b/test/acceptance/reindex_multinode/post_restart_test.go
@@ -415,22 +415,26 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 	// reallocates ports across stop+start.
 
 	// Post-restart baseline: every replica still serves the
-	// already-migrated buckets correctly.
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		uri := restURIOf(compose, nodeIdx)
-		gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
-		require.NoError(t, err)
-		require.Equalf(t, expectedPriceCount, gotPrice,
-			"post-restart node %d price = %d (expected %d) — restart corrupted the rangeable bucket", nodeIdx, gotPrice, expectedPriceCount)
-		gotCat, err := equalCount(uri, className, "category", categories[0])
-		require.NoError(t, err)
-		require.Equalf(t, expectedCatCount, gotCat,
-			"post-restart node %d category = %d (expected %d) — restart corrupted the filterable bucket", nodeIdx, gotCat, expectedCatCount)
-		gotPath, err := equalCount(uri, className, "path", paths[0])
-		require.NoError(t, err)
-		require.Equalf(t, expectedPathCount, gotPath,
-			"post-restart node %d path = %d (expected %d) — restart corrupted the searchable bucket", nodeIdx, gotPath, expectedPathCount)
-	}
+	// already-migrated buckets correctly. Poll (50ms) — a just-cycled node
+	// can transiently EOF a query before its graphql endpoint is serving;
+	// a genuine bucket corruption stays wrong past the timeout.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			uri := restURIOf(compose, nodeIdx)
+			gotPrice, err := rangeCount(uri, className, "price", priceLo, priceHi)
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedPriceCount, gotPrice,
+				"post-restart node %d price = %d (expected %d) — restart corrupted the rangeable bucket", nodeIdx, gotPrice, expectedPriceCount)
+			gotCat, err := equalCount(uri, className, "category", categories[0])
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedCatCount, gotCat,
+				"post-restart node %d category = %d (expected %d) — restart corrupted the filterable bucket", nodeIdx, gotCat, expectedCatCount)
+			gotPath, err := equalCount(uri, className, "path", paths[0])
+			assert.NoError(c, err)
+			assert.Equalf(c, expectedPathCount, gotPath,
+				"post-restart node %d path = %d (expected %d) — restart corrupted the searchable bucket", nodeIdx, gotPath, expectedPathCount)
+		}
+	}, 30*time.Second, 50*time.Millisecond)
 
 	// === Phase 8-final equivalent: re-apply migrations as a
 	// repeat-forward. Use three concurrent rebuild-style ops on the
@@ -502,9 +506,18 @@ func TestMultiNode_PostRestartReapplyMigrations_ExactCountsAcrossReplicas(t *tes
 		}
 	}, 30*time.Second, 50*time.Millisecond)
 
-	// LB-side 3-call stability spot check.
+	// LB-side 3-call stability spot check. Retry a transient post-restart
+	// read (graphql briefly unavailable on a just-cycled node) so only a
+	// real count mismatch — a flap — fails.
 	for i := 0; i < 3; i++ {
-		gotPath, err := equalCount(restURIOf(compose, 1), className, "path", paths[0])
+		var gotPath int
+		var err error
+		for a := 0; a < 5; a++ {
+			if gotPath, err = equalCount(restURIOf(compose, 1), className, "path", paths[0]); err == nil {
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
 		require.NoError(t, err)
 		assert.Equalf(t, expectedPathCount, gotPath,
 			"GH #212 Issue G regression: post-restart LB-side path call #%d = %d (expected %d)",


### PR DESCRIPTION
SuperClaude here.

**Group A — test hardening (soak-found).** Multi-node reindex acceptance tests query replicas right after a rolling restart / SIGKILL. A just-cycled node can transiently EOF or error a query before its graphql endpoint is serving (container-ready ≠ graphql-ready). The 24/7 `kpop-flake-hunters` soak surfaced this as two distinct flakes on the all-fixes image:

- **Per-replica stability histograms** (`migration_journeys` + the two `finalizing_crash` histograms) recorded any query error as a terminal `-1` divergence bucket → `RepeatedParallelMigrationJourney` failed with `node-2: {5000:29, -1:1}`.
- **`post_restart`'s post-restart baseline loop** used a bare `require.NoError` (one EOF → hard fail), unlike the tolerant `EventuallyWithT` pre-restart check right above it → `PostRestartReapplyMigrations` failed with `graphql POST: EOF`.

**Fix.** Shared `pollPerReplicaHistogram` (retries on **error only**) for the histograms; wrap `post_restart`'s baseline in `EventuallyWithT`; retry the LB-side spot check. A *successful* query is never retried and a wrong count still fails, so GH #212 divergence detection is preserved. Same spirit as [#11530](https://github.com/weaviate/weaviate/pull/11530)'s transient tolerance.

**Proof.** `RepeatedParallelMigrationJourney`, `RollingRestartDuringFinalizing`, and `PostRestartReapplyMigrations` all green locally against a `stable/v1.38` image; gofumpt/gofmt/vet clean. Soak confirms under load.

— SuperClaude
