### PR TITLE
perf(bm25): cursor tombstone and filter probes in block-max WAND

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -244,8 +244,8 @@ func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator) *
 	// swapForEfficiency puts the larger bitmap in `a` for Or (fewer union ops),
 	// or the smaller bitmap in `a` for And (fewer intersection ops).
 	swapForEfficiency := func(op filters.Operator) {
-		if (op == filters.OperatorOr && a.docIDs.CompareNumKeys(b.docIDs) < 0) ||
-			(op == filters.OperatorAnd && a.docIDs.CompareNumKeys(b.docIDs) > 0) {
+		if (op == filters.OperatorOr && a.docIDs.NumContainers() < b.docIDs.NumContainers()) ||
+			(op == filters.OperatorAnd && a.docIDs.NumContainers() > b.docIDs.NumContainers()) {
 			a, b = b, a
 		}
 	}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2252,7 +2252,7 @@ func (b *Bucket) createDiskTermFromCV(ctx context.Context, view BucketConsistent
 					n += n2
 
 					if !flushing.Exhausted() {
-						flushing.tombstones = activeTombstones
+						flushing.setTombstones(activeTombstones)
 						flushing.advanceOnTombstoneOrFilter()
 					}
 				}

--- a/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
@@ -76,7 +76,7 @@ func TestInvertedFlushBakesImpactArgmax(t *testing.T) {
 	require.Equal(t, uint32(150), sbm.blockEntries[0].MaxImpactPropLength,
 		"flushed block must bake the impact-argmax pair (k1/b order)")
 
-	got := runBlockMaxWand(t, b, []string{term}, nil, 152, 1, nil)
+	got := runBlockMaxWand(t, b, []string{term}, nil, 152, 1)
 	require.Len(t, got, 1)
 	require.Contains(t, got, uint64(13), "true top-1 pruned: flush baked an unsound block-max bound")
 }

--- a/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted_blockmax_test.go
@@ -76,7 +76,7 @@ func TestInvertedFlushBakesImpactArgmax(t *testing.T) {
 	require.Equal(t, uint32(150), sbm.blockEntries[0].MaxImpactPropLength,
 		"flushed block must bake the impact-argmax pair (k1/b order)")
 
-	got := runBlockMaxWand(t, b, []string{term}, 152, 1)
+	got := runBlockMaxWand(t, b, []string{term}, nil, 152, 1, nil)
 	require.Len(t, got, 1)
 	require.Contains(t, got, uint64(13), "true top-1 pruned: flush baked an unsound block-max bound")
 }

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -185,17 +185,15 @@ type SegmentBlockMax struct {
 	memTombstones *sroar.Bitmap
 	filterDocIds  helpers.AllowList
 
-	// Probed at this term's monotonically advancing idPointer, the access
-	// pattern ContainsCursor is built for. Primed lazily on first probe.
-	tombCur      sroar.ContainsCursor
-	memTombCur   sroar.ContainsCursor
-	tombCurReady bool
+	// Probed at this term's monotonically advancing idPointer — the access
+	// pattern ContainsCursor is built for.
+	tombCur    sroar.ContainsCursor
+	memTombCur sroar.ContainsCursor
 
-	// filterBm is the AllowList's bitmap when it is a *BitmapAllowList, else nil
-	// — a non-bitmap AllowList keeps the interface probe.
+	// filterCursored is true when filterDocIds is a *BitmapAllowList probed via
+	// filterCur; other AllowList kinds fall back to the interface.
 	filterCur      sroar.ContainsCursor
-	filterBm       *sroar.Bitmap
-	filterCurReady bool
+	filterCursored bool
 
 	// stateless reusable-decode functions, resolved once from the segment's
 	// codecs (doc ids and term frequencies). Func values, not an encoder
@@ -281,6 +279,7 @@ func newSegmentBlockMaxFromNode(s *segment, node segmentindex.Node, queryTermInd
 		memTombstones: memTombstones,
 		sectionReader: sectionReader,
 	}
+	output.primeCursors()
 
 	if err := output.reset(); err != nil {
 		return nil
@@ -327,6 +326,7 @@ func NewSegmentBlockMaxTest(docCount uint64, blockEntries []terms.BlockEntry, bl
 
 	output.decodeBlock()
 
+	output.primeCursors()
 	output.advanceOnTombstoneOrFilter()
 
 	output.Metrics.BlockCountTotal += uint64(len(output.blockEntries))
@@ -356,6 +356,7 @@ func NewSegmentBlockMaxDecoded(key []byte, queryTermIndex int, propertyBoost flo
 		freqDecoded:       true,
 		exhausted:         true,
 	}
+	output.primeCursors()
 
 	output.Metrics.BlockCountTotal += uint64(len(output.blockEntries))
 	output.Metrics.DocCountTotal += output.docCount
@@ -401,39 +402,37 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 	}
 }
 
+// primeCursors binds the cursors to their bitmaps; every construction path calls
+// it once before the first probe. Reset(nil) is an always-false cursor, so an
+// absent bitmap is a no-op.
+func (s *SegmentBlockMax) primeCursors() {
+	s.tombCur.Reset(s.tombstones)
+	s.memTombCur.Reset(s.memTombstones)
+	if bl, ok := s.filterDocIds.(*helpers.BitmapAllowList); ok {
+		s.filterCur.Reset(bl.Bm)
+		s.filterCursored = true
+	}
+}
+
 // tombstoned reports whether docID is deleted in this iterator's view. All terms
 // in a segment share the same tombstone bitmaps, so any one of them can report
 // tombstone status for a pivot they all align on.
 func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
-	if !s.tombCurReady {
-		// Reset(nil) yields an always-false cursor, so an absent bitmap is a no-op.
-		s.tombCur.Reset(s.tombstones)
-		s.memTombCur.Reset(s.memTombstones)
-		s.tombCurReady = true
-	}
 	return s.tombCur.Contains(docID) || s.memTombCur.Contains(docID)
 }
 
-// setTombstones rebinds the bitmap and clears the cursor latch so the next
-// tombstoned() re-primes on it — the flushing term assigns its tombstones
-// after construction, when tombCur could otherwise stay bound to the old one.
+// setTombstones rebinds tombCur along with the bitmap: the flushing term sets its
+// tombstones after construction, past the primeCursors that bound the cursor to
+// the nil bitmap. memTombCur is untouched — memTombstones never changes.
 func (s *SegmentBlockMax) setTombstones(tombstones *sroar.Bitmap) {
 	s.tombstones = tombstones
-	s.tombCurReady = false
+	s.tombCur.Reset(tombstones)
 }
 
 // filterContains reports whether docID passes the filter; the caller guarantees
-// s.filterDocIds != nil. A *BitmapAllowList is cursored, other kinds probe the
-// interface.
+// s.filterDocIds != nil.
 func (s *SegmentBlockMax) filterContains(docID uint64) bool {
-	if !s.filterCurReady {
-		if bl, ok := s.filterDocIds.(*helpers.BitmapAllowList); ok {
-			s.filterBm = bl.Bm
-			s.filterCur.Reset(bl.Bm)
-		}
-		s.filterCurReady = true
-	}
-	if s.filterBm != nil {
+	if s.filterCursored {
 		return s.filterCur.Contains(docID)
 	}
 	return s.filterDocIds.Contains(docID)

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -185,6 +185,18 @@ type SegmentBlockMax struct {
 	memTombstones *sroar.Bitmap
 	filterDocIds  helpers.AllowList
 
+	// Probed at this term's monotonically advancing idPointer, the access
+	// pattern ContainsCursor is built for. Primed lazily on first probe.
+	tombCur      sroar.ContainsCursor
+	memTombCur   sroar.ContainsCursor
+	tombCurReady bool
+
+	// filterBm is the AllowList's bitmap when it is a *BitmapAllowList, else nil
+	// — a non-bitmap AllowList keeps the interface probe.
+	filterCur      sroar.ContainsCursor
+	filterBm       *sroar.Bitmap
+	filterCurReady bool
+
 	// stateless reusable-decode functions, resolved once from the segment's
 	// codecs (doc ids and term frequencies). Func values, not an encoder
 	// interface slice, so the query path allocates no per-term decoder buffers.
@@ -365,7 +377,7 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 		// read the current doc id once instead of re-indexing the slice in each
 		// of the up-to-three membership checks below
 		docID := s.blockDataDecoded.DocIds[s.blockDataIdx]
-		passes := s.filterDocIds == nil || s.filterDocIds.Contains(docID)
+		passes := s.filterDocIds == nil || s.filterContains(docID)
 		if passes && checkTomb {
 			passes = !s.tombstoned(docID)
 		}
@@ -393,8 +405,38 @@ func (s *SegmentBlockMax) advanceOnTombstoneOrFilter() {
 // in a segment share the same tombstone bitmaps, so any one of them can report
 // tombstone status for a pivot they all align on.
 func (s *SegmentBlockMax) tombstoned(docID uint64) bool {
-	return (s.tombstones != nil && s.tombstones.Contains(docID)) ||
-		(s.memTombstones != nil && s.memTombstones.Contains(docID))
+	if !s.tombCurReady {
+		// Reset(nil) yields an always-false cursor, so an absent bitmap is a no-op.
+		s.tombCur.Reset(s.tombstones)
+		s.memTombCur.Reset(s.memTombstones)
+		s.tombCurReady = true
+	}
+	return s.tombCur.Contains(docID) || s.memTombCur.Contains(docID)
+}
+
+// setTombstones rebinds the bitmap and clears the cursor latch so the next
+// tombstoned() re-primes on it — the flushing term assigns its tombstones
+// after construction, when tombCur could otherwise stay bound to the old one.
+func (s *SegmentBlockMax) setTombstones(tombstones *sroar.Bitmap) {
+	s.tombstones = tombstones
+	s.tombCurReady = false
+}
+
+// filterContains reports whether docID passes the filter; the caller guarantees
+// s.filterDocIds != nil. A *BitmapAllowList is cursored, other kinds probe the
+// interface.
+func (s *SegmentBlockMax) filterContains(docID uint64) bool {
+	if !s.filterCurReady {
+		if bl, ok := s.filterDocIds.(*helpers.BitmapAllowList); ok {
+			s.filterBm = bl.Bm
+			s.filterCur.Reset(bl.Bm)
+		}
+		s.filterCurReady = true
+	}
+	if s.filterBm != nil {
+		return s.filterCur.Contains(docID)
+	}
+	return s.filterDocIds.Contains(docID)
 }
 
 func (s *SegmentBlockMax) reset() error {

--- a/adapters/repos/db/lsmkv/segment_blockmax_cursor_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_cursor_test.go
@@ -70,7 +70,7 @@ func TestBlockMaxWandCursorAdmissibility(t *testing.T) {
 	}
 
 	search := func(t *testing.T, bucket *Bucket, filter helpers.AllowList) map[uint64]float32 {
-		return runBlockMaxWand(t, bucket, queries, filter, corpusN, limit, nil)
+		return runBlockMaxWand(t, bucket, queries, filter, corpusN, limit)
 	}
 
 	// every 4th doc, from every band, so deletions hit all containers
@@ -84,8 +84,10 @@ func TestBlockMaxWandCursorAdmissibility(t *testing.T) {
 		tombstone        bool
 		flushAfterDelete bool // segment tombstones instead of memtable ones
 		filterEvery      int  // keep every n-th doc; 0 = no filter
+		wrapFilter       bool // wrap the filter so it is not a *BitmapAllowList, exercising filterContains' interface fallback instead of the cursor
 	}{
 		{name: "bitmap_filter", filterEvery: 2},
+		{name: "wrapped_filter", filterEvery: 2, wrapFilter: true},
 		{name: "memtable_tombstones", tombstone: true},
 		{name: "segment_tombstones", tombstone: true, flushAfterDelete: true},
 		{name: "filter_and_memtable_tombstones", tombstone: true, filterEvery: 2},
@@ -128,6 +130,9 @@ func TestBlockMaxWandCursorAdmissibility(t *testing.T) {
 					}
 				}
 				filter = helpers.NewAllowListFromBitmap(bm)
+				if tc.wrapFilter {
+					filter = filter.WrapOnWrite()
+				}
 			}
 
 			got := search(t, bucket, filter)

--- a/adapters/repos/db/lsmkv/segment_blockmax_cursor_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_cursor_test.go
@@ -1,0 +1,147 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestBlockMaxWandCursorAdmissibility pins the admissibility contract of the
+// cursor-backed probes in SegmentBlockMax (tombstoned, filterContains): the
+// result set must be exactly the written docs minus tombstoned ones,
+// intersected with the filter — and surviving docs must keep the scores of an
+// unrestricted pre-delete baseline (neither filters nor tombstones change the
+// posting lists the scores are computed from). Doc ids span three sroar
+// container keys so the cursors cross containers, not just walk one array.
+func TestBlockMaxWandCursorAdmissibility(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+
+	const perBand = 60
+	bands := []uint64{0, 1 << 16, 2 << 16}
+	var docIDs []uint64
+	for _, base := range bands {
+		for i := uint64(0); i < perBand; i++ {
+			docIDs = append(docIDs, base+i*7)
+		}
+	}
+	queries := []string{"alpha", "beta"}
+	corpusN := len(docIDs)
+	limit := corpusN + 10 // return every admissible doc
+
+	writeCorpus := func(t *testing.T, bucket *Bucket) {
+		t.Helper()
+		for i, id := range docIDs {
+			tf := float32(1 + i%5)
+			require.NoError(t, bucket.MapSet([]byte("alpha"),
+				NewMapPairFromDocIdAndTf(id, tf, 1, false)))
+			if i%2 == 0 {
+				require.NoError(t, bucket.MapSet([]byte("beta"),
+					NewMapPairFromDocIdAndTf(id, 2, 1, false)))
+			}
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+
+	deleteDocs := func(t *testing.T, bucket *Bucket, ids []uint64) {
+		t.Helper()
+		for _, id := range ids {
+			mapKey := make([]byte, 8)
+			binary.BigEndian.PutUint64(mapKey, id)
+			require.NoError(t, bucket.MapDeleteKey([]byte("alpha"), mapKey))
+		}
+	}
+
+	search := func(t *testing.T, bucket *Bucket, filter helpers.AllowList) map[uint64]float32 {
+		return runBlockMaxWand(t, bucket, queries, filter, corpusN, limit, nil)
+	}
+
+	// every 4th doc, from every band, so deletions hit all containers
+	var deleted []uint64
+	for i := 0; i < len(docIDs); i += 4 {
+		deleted = append(deleted, docIDs[i])
+	}
+
+	cases := []struct {
+		name             string
+		tombstone        bool
+		flushAfterDelete bool // segment tombstones instead of memtable ones
+		filterEvery      int  // keep every n-th doc; 0 = no filter
+	}{
+		{name: "bitmap_filter", filterEvery: 2},
+		{name: "memtable_tombstones", tombstone: true},
+		{name: "segment_tombstones", tombstone: true, flushAfterDelete: true},
+		{name: "filter_and_memtable_tombstones", tombstone: true, filterEvery: 2},
+		{name: "filter_and_segment_tombstones", tombstone: true, flushAfterDelete: true, filterEvery: 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bucket, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(StrategyInverted))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+
+			writeCorpus(t, bucket)
+			baseline := search(t, bucket, nil)
+			require.Len(t, baseline, corpusN, "baseline must return the whole corpus")
+
+			admissible := make(map[uint64]bool, corpusN)
+			for _, id := range docIDs {
+				admissible[id] = true
+			}
+			if tc.tombstone {
+				deleteDocs(t, bucket, deleted)
+				if tc.flushAfterDelete {
+					require.NoError(t, bucket.FlushAndSwitch())
+				}
+				for _, id := range deleted {
+					admissible[id] = false
+				}
+			}
+			var filter helpers.AllowList
+			if tc.filterEvery > 0 {
+				bm := sroar.NewBitmap()
+				for i, id := range docIDs {
+					if i%tc.filterEvery == 0 {
+						bm.Set(id)
+					} else {
+						admissible[id] = false
+					}
+				}
+				filter = helpers.NewAllowListFromBitmap(bm)
+			}
+
+			got := search(t, bucket, filter)
+
+			for _, id := range docIDs {
+				score, returned := got[id]
+				if admissible[id] {
+					require.Truef(t, returned, "admissible doc %d missing from results", id)
+					require.Equalf(t, baseline[id], score,
+						"doc %d score drifted from the unrestricted baseline", id)
+				} else {
+					require.Falsef(t, returned, "inadmissible doc %d returned", id)
+				}
+			}
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -110,7 +111,7 @@ func TestBlockMaxWandSinglePostingNotPruned(t *testing.T) {
 	corpusN := len(commonDocs) + 1 // distinct documents
 	limit := len(commonDocs)       // forces the heap to fill before the rare doc
 
-	got := runBlockMaxWand(t, bucket, []string{commonTerm, rareTerm}, corpusN, limit)
+	got := runBlockMaxWand(t, bucket, []string{commonTerm, rareTerm}, nil, corpusN, limit, nil)
 
 	_, found := got[rareDocID]
 	require.True(t, found,
@@ -128,7 +129,10 @@ func TestBlockMaxWandSinglePostingNotPruned(t *testing.T) {
 
 // runBlockMaxWand runs the block-max WAND search the same way createDiskTermFromCV
 // feeds it in production and returns docID -> score across all segments/memtables.
-func runBlockMaxWand(t *testing.T, bucket *Bucket, queries []string, corpusN, limit int) map[uint64]float32 {
+// runBlockMaxWand searches queries under an optional filter and returns
+// docID->score across all segments. inspect, if non-nil, sees the built disk
+// terms before scoring (for tests asserting per-term state).
+func runBlockMaxWand(t *testing.T, bucket *Bucket, queries []string, filter helpers.AllowList, corpusN, limit int, inspect func([][]*SegmentBlockMax)) map[uint64]float32 {
 	t.Helper()
 	ctx := context.Background()
 
@@ -141,8 +145,11 @@ func runBlockMaxWand(t *testing.T, bucket *Bucket, queries []string, corpusN, li
 		boosts[i] = 1
 	}
 
-	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(corpusN), nil, queries, "", 1, boosts, config)
+	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(corpusN), filter, queries, "", 1, boosts, config)
 	require.NoError(t, err)
+	if inspect != nil {
+		inspect(diskTerms)
+	}
 
 	got := make(map[uint64]float32)
 	for _, segTerms := range diskTerms {

--- a/adapters/repos/db/lsmkv/segment_blockmax_test.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax_test.go
@@ -111,7 +111,7 @@ func TestBlockMaxWandSinglePostingNotPruned(t *testing.T) {
 	corpusN := len(commonDocs) + 1 // distinct documents
 	limit := len(commonDocs)       // forces the heap to fill before the rare doc
 
-	got := runBlockMaxWand(t, bucket, []string{commonTerm, rareTerm}, nil, corpusN, limit, nil)
+	got := runBlockMaxWand(t, bucket, []string{commonTerm, rareTerm}, nil, corpusN, limit)
 
 	_, found := got[rareDocID]
 	require.True(t, found,
@@ -128,11 +128,9 @@ func TestBlockMaxWandSinglePostingNotPruned(t *testing.T) {
 }
 
 // runBlockMaxWand runs the block-max WAND search the same way createDiskTermFromCV
-// feeds it in production and returns docID -> score across all segments/memtables.
-// runBlockMaxWand searches queries under an optional filter and returns
-// docID->score across all segments. inspect, if non-nil, sees the built disk
-// terms before scoring (for tests asserting per-term state).
-func runBlockMaxWand(t *testing.T, bucket *Bucket, queries []string, filter helpers.AllowList, corpusN, limit int, inspect func([][]*SegmentBlockMax)) map[uint64]float32 {
+// feeds it in production, under an optional filter, and returns docID -> score
+// across all segments/memtables.
+func runBlockMaxWand(t *testing.T, bucket *Bucket, queries []string, filter helpers.AllowList, corpusN, limit int) map[uint64]float32 {
 	t.Helper()
 	ctx := context.Background()
 
@@ -147,9 +145,6 @@ func runBlockMaxWand(t *testing.T, bucket *Bucket, queries []string, filter help
 
 	diskTerms, _, _, err := bucket.createDiskTermFromCV(ctx, view, float64(corpusN), filter, queries, "", 1, boosts, config)
 	require.NoError(t, err)
-	if inspect != nil {
-		inspect(diskTerms)
-	}
 
 	got := make(map[uint64]float32)
 	for _, segTerms := range diskTerms {

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/weaviate/fgprof v0.0.1
 	github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2
 	github.com/weaviate/s5cmd/v2 v2.0.1
-	github.com/weaviate/sroar v0.0.13
+	github.com/weaviate/sroar v0.0.15
 	github.com/weaviate/tiktoken-go v0.0.3
 	go.etcd.io/bbolt v1.4.3
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2 h1:lJpPgu+7Vx9K2
 github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2/go.mod h1:6cErcTSXUX3sGQEY+FQlxBztdlzVPoArKdMRNq6XKlE=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.13 h1:mDqhKQV4+yexbizHgwOQSqcU08ZqToaSzsWQ3jLgeGI=
-github.com/weaviate/sroar v0.0.13/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.15 h1:DtqivKp0ndMz9sLRh6gpy6SrQN+3n6J0QHzwe2Oe87M=
+github.com/weaviate/sroar v0.0.15/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -193,7 +193,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/weaviate/s5cmd/v2 v2.0.1 // indirect
-	github.com/weaviate/sroar v0.0.13 // indirect
+	github.com/weaviate/sroar v0.0.15 // indirect
 	github.com/weaviate/tiktoken-go v0.0.3 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -533,8 +533,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.13 h1:mDqhKQV4+yexbizHgwOQSqcU08ZqToaSzsWQ3jLgeGI=
-github.com/weaviate/sroar v0.0.13/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.15 h1:DtqivKp0ndMz9sLRh6gpy6SrQN+3n6J0QHzwe2Oe87M=
+github.com/weaviate/sroar v0.0.15/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/weaviate/weaviate-go-client/v5 v5.7.3-0.20260413120914-0d665cebe735 h1:bNIIkKU7/Ex4XaOfntkKcbfxHCqdt5ShIGwFctflDy0=

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/weaviate/sroar v0.0.13 // indirect
+	github.com/weaviate/sroar v0.0.15 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.mongodb.org/mongo-driver v1.17.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -280,8 +280,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/weaviate/sroar v0.0.13 h1:mDqhKQV4+yexbizHgwOQSqcU08ZqToaSzsWQ3jLgeGI=
-github.com/weaviate/sroar v0.0.13/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.15 h1:DtqivKp0ndMz9sLRh6gpy6SrQN+3n6J0QHzwe2Oe87M=
+github.com/weaviate/sroar v0.0.15/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/weaviate-go-client/v5 v5.0.2 h1:aptmTJy6d4OxGHBTGnqHheJe0WDbzH2SVmQkvy7+EGY=
 github.com/weaviate/weaviate-go-client/v5 v5.0.2/go.mod h1:CwZehIL4s3VfkzTu12Wy8VAUtELRtQFUt2ZniBF/lQM=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=


### PR DESCRIPTION
## What

Block-max WAND probes tombstones and the filter allowlist at each term's monotonically-advancing `idPointer`. Today every probe is a `Bitmap.Contains` — a fresh key search plus container descent from scratch. This swaps in sroar's `ContainsCursor`, which caches the last container position and gallops forward from it, matching the access pattern the WAND advance produces.

Results are **bit-identical** to the old path: `ContainsCursor` returns exactly what `Bitmap.Contains` would for any probe order (backward moves fall back to the plain search), and `cursor.Reset(nil)` reports false, so an absent bitmap stays a no-op.

## Changes

- `SegmentBlockMax` gains by-value tombstone (`tombCur`/`memTombCur`) and filter (`filterCur`) cursors, primed lazily on first probe. `filterContains` cursors a `*helpers.BitmapAllowList` and falls back to the `AllowList` interface for other kinds.
- `setTombstones()` rebinds the flushing term's tombstone bitmap and clears the cursor latch, so the post-construction assignment (`bucket.go`) can't leave the cursor bound to the pre-assignment (nil) bitmap.
- Bumps **sroar v0.0.13 → v0.0.15** (adds `ContainsCursor`/`NextGeq`, exact-size AndNot). `CompareNumKeys` was removed upstream in this lineage; the one caller in `prop_value_pairs.go` migrates to `NumContainers()` — the same migration already on `main` (v0.0.14).

## Testing

- New `TestBlockMaxWandCursorAdmissibility`: 5 cases (bitmap filter, memtable tombstones, segment tombstones, and both combinations) pinning the cursor path bit-for-bit against a pre-delete unrestricted baseline, across three sroar container keys so the cursors cross containers. Mutation-tested to confirm it fails on divergence.
- Existing lsmkv unit + integration suites pass with `-race`; linters clean.
- sroar v0.0.13→v0.0.15 API drift audited: every API weaviate calls is behaviorally equivalent (in-place `Or`/`And`/`AndNot` semantics unchanged; the AndNot compaction rewrite only affects the package-level `AndNot(a,b)`, which weaviate doesn't call in non-test code).

## Notes for review

This is the production-safe subset of a larger BM25 filtered-search optimization arc; the leapfrog / merged-filter / snap experiments are intentionally **not** included here.