### PR TITLE
fix(async-replication): repair REST root-prefilter JSON and bound request size

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -331,7 +331,11 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
 	roots map[string]hashtree.Digest,
 ) ([]string, error) {
-	body, err := json.Marshal(replica.CompareHashTreeRootsReq{Roots: roots})
+	wireRoots := make(map[string][2]uint64, len(roots))
+	for shard, root := range roots {
+		wireRoots[shard] = [2]uint64(root)
+	}
+	body, err := json.Marshal(replica.CompareHashTreeRootsReq{Roots: wireRoots})
 	if err != nil {
 		return nil, fmt.Errorf("marshal compare hashtree roots request: %w", err)
 	}

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -275,6 +275,10 @@ func (s *ReplicationService) HashTreeLevel(ctx context.Context, req *pb.HashTree
 
 func (s *ReplicationService) CompareHashTreeRoots(ctx context.Context, req *pb.CompareHashTreeRootsRequest) (*pb.CompareHashTreeRootsResponse, error) {
 	shards := req.GetShardRootDigests()
+	if len(shards) > replica.CompareHashTreeRootsMaxShardsPerRequest {
+		return nil, status.Errorf(codes.InvalidArgument, "too many shards: %d exceeds maximum %d",
+			len(shards), replica.CompareHashTreeRootsMaxShardsPerRequest)
+	}
 	roots := make(map[string]hashtree.Digest, len(shards))
 	for _, sr := range shards {
 		roots[sr.GetShard()] = hashtree.Digest{sr.GetRootHashHigh(), sr.GetRootHashLow()}

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -14,6 +14,7 @@ package grpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -121,5 +122,24 @@ func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("rejects a request exceeding the shard cap without calling the replicator", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		shards := make([]*pb.ShardRootDigest, replica.CompareHashTreeRootsMaxShardsPerRequest+1)
+		for i := range shards {
+			shards[i] = &pb.ShardRootDigest{Shard: fmt.Sprintf("shard-%d", i)}
+		}
+
+		_, err := svc.CompareHashTreeRoots(context.Background(), &pb.CompareHashTreeRootsRequest{
+			Index:            index,
+			ShardRootDigests: shards,
+		})
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
 	})
 }

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -524,12 +524,23 @@ func (i *replicatedIndices) postCompareHashTreeRoots() http.Handler {
 		defer r.Body.Close()
 
 		var req replica.CompareHashTreeRootsReq
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		body := http.MaxBytesReader(w, r.Body, maxDecompressedReplicaBody)
+		if err := json.NewDecoder(body).Decode(&req); err != nil {
 			http.Error(w, "unmarshal compare hashtree roots request: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+		if len(req.Roots) > replica.CompareHashTreeRootsMaxShardsPerRequest {
+			http.Error(w, fmt.Sprintf("too many shards: %d exceeds maximum %d",
+				len(req.Roots), replica.CompareHashTreeRootsMaxShardsPerRequest), http.StatusBadRequest)
+			return
+		}
 
-		diverging, err := i.replicator.CompareHashTreeRoots(r.Context(), index, req.Roots)
+		roots := make(map[string]hashtree.Digest, len(req.Roots))
+		for shard, root := range req.Roots {
+			roots[shard] = hashtree.Digest(root)
+		}
+
+		diverging, err := i.replicator.CompareHashTreeRoots(r.Context(), index, roots)
 		if err != nil {
 			http.Error(w, "compare hashtree roots: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_test.go
@@ -1,0 +1,118 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clusterapi_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/clients"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
+	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
+)
+
+// prefilterClient is the subset of the REST replication client the round-trip tests
+// exercise; it lets the helper return the unexported concrete client via an interface.
+type prefilterClient interface {
+	CompareHashTreeRoots(ctx context.Context, host, index string, roots map[string]hashtree.Digest) ([]string, error)
+}
+
+func newPrefilterTestServer(t *testing.T, replicator replicaTypes.Replicator) (prefilterClient, string) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	indices := clusterapi.NewReplicatedIndices(
+		replicator,
+		clusterapi.NewNoopAuthHandler(),
+		func() bool { return false },
+		logger,
+		func() bool { return true },
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/replicas/indices/", indices.Indices())
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client, err := clients.NewReplicationClient(&http.Client{})
+	require.NoError(t, err)
+	return client, strings.TrimPrefix(server.URL, "http://")
+}
+
+// TestCompareHashTreeRootsRESTRoundTrip drives the real REST client against the real
+// handler and proves the pre-filter reports exactly the diverging shards while
+// preserving digests bit-for-bit (including high-bit-set words). It fails on the
+// pre-fix wire type, where the Digest map JSON-marshals as an array but decodes via
+// the pointer-only UnmarshalJSON, yielding an HTTP 400.
+func TestCompareHashTreeRootsRESTRoundTrip(t *testing.T) {
+	const index = "MyClass"
+
+	d := func(hi, lo uint64) hashtree.Digest { return hashtree.Digest{hi, lo} }
+	sourceRoots := map[string]hashtree.Digest{
+		"in-sync":   d(0xFFFFFFFFFFFFFFFF, 1),
+		"also-sync": d(0, 0),
+		"diverging": d(2, 0xDEADBEEFCAFEBABE),
+	}
+	localRoots := map[string]hashtree.Digest{
+		"in-sync":   d(0xFFFFFFFFFFFFFFFF, 1),
+		"also-sync": d(0, 0),
+		"diverging": d(9, 9),
+	}
+
+	mockReplicator := replicaTypes.NewMockReplicator(t)
+	var received map[string]hashtree.Digest
+	mockReplicator.EXPECT().
+		CompareHashTreeRoots(mock.Anything, index, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, roots map[string]hashtree.Digest) ([]string, error) {
+			received = roots
+			var diverging []string
+			for shard, root := range roots {
+				if local, ok := localRoots[shard]; !ok || local != root {
+					diverging = append(diverging, shard)
+				}
+			}
+			return diverging, nil
+		})
+
+	client, host := newPrefilterTestServer(t, mockReplicator)
+
+	diverging, err := client.CompareHashTreeRoots(context.Background(), host, index, sourceRoots)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"diverging"}, diverging)
+	assert.Equal(t, sourceRoots, received, "handler must receive the exact source digests")
+}
+
+func TestCompareHashTreeRootsRESTRejectsOverCap(t *testing.T) {
+	const index = "MyClass"
+
+	// No expectation is set: the handler must reject before reaching the replicator.
+	mockReplicator := replicaTypes.NewMockReplicator(t)
+	client, host := newPrefilterTestServer(t, mockReplicator)
+
+	roots := make(map[string]hashtree.Digest, replica.CompareHashTreeRootsMaxShardsPerRequest+1)
+	for i := 0; i <= replica.CompareHashTreeRootsMaxShardsPerRequest; i++ {
+		roots[fmt.Sprintf("shard-%d", i)] = hashtree.Digest{uint64(i), 0}
+	}
+
+	_, err := client.CompareHashTreeRoots(context.Background(), host, index, roots)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many shards")
+}

--- a/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_test.go
@@ -57,11 +57,7 @@ func newPrefilterTestServer(t *testing.T, replicator replicaTypes.Replicator) (p
 	return client, strings.TrimPrefix(server.URL, "http://")
 }
 
-// TestCompareHashTreeRootsRESTRoundTrip drives the real REST client against the real
-// handler and proves the pre-filter reports exactly the diverging shards while
-// preserving digests bit-for-bit (including high-bit-set words). It fails on the
-// pre-fix wire type, where the Digest map JSON-marshals as an array but decodes via
-// the pointer-only UnmarshalJSON, yielding an HTTP 400.
+// TestCompareHashTreeRootsRESTRoundTrip proves the real REST client+handler report exactly the diverging shards and preserve digests bit-for-bit.
 func TestCompareHashTreeRootsRESTRoundTrip(t *testing.T) {
 	const index = "MyClass"
 

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -511,10 +511,7 @@ func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
 // gRPC/REST message size.
 const prefilterMaxShardsPerRPC = 1000
 
-// CompareHashTreeRootsMaxShardsPerRequest bounds the shard map a receiver accepts
-// in one CompareHashTreeRoots request, so a misbehaving peer can't force an
-// unbounded allocation. Kept well above prefilterMaxShardsPerRPC (the sender's cap)
-// for headroom.
+// CompareHashTreeRootsMaxShardsPerRequest bounds the shard map a receiver accepts, above the sender's prefilterMaxShardsPerRPC.
 const CompareHashTreeRootsMaxShardsPerRequest = 10_000
 
 // PrefilterStats reports the per-host root-compare RPC outcomes for observability.

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -511,6 +511,12 @@ func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
 // gRPC/REST message size.
 const prefilterMaxShardsPerRPC = 1000
 
+// CompareHashTreeRootsMaxShardsPerRequest bounds the shard map a receiver accepts
+// in one CompareHashTreeRoots request, so a misbehaving peer can't force an
+// unbounded allocation. Kept well above prefilterMaxShardsPerRPC (the sender's cap)
+// for headroom.
+const CompareHashTreeRootsMaxShardsPerRequest = 10_000
+
 // PrefilterStats reports the per-host root-compare RPC outcomes for observability.
 type PrefilterStats struct {
 	OK          int

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -174,9 +174,14 @@ type DigestObjectsInRangeResp struct {
 }
 
 // CompareHashTreeRootsReq / Resp are the REST-transport payloads for the batched
-// root pre-filter, keyed by shard.
+// root pre-filter, keyed by shard. Roots are carried as raw [high, low] word pairs
+// rather than hashtree.Digest: Digest's JSON methods are pointer-receiver, so
+// json.Marshal skips them for non-addressable map values (emitting a plain array)
+// while json.Decode invokes them for addressable map elements (expecting base64) —
+// an asymmetry that made the REST path fail. [2]uint64 has no custom codec, so it
+// round-trips symmetrically.
 type CompareHashTreeRootsReq struct {
-	Roots map[string]hashtree.Digest `json:"roots"`
+	Roots map[string][2]uint64 `json:"roots"`
 }
 
 type CompareHashTreeRootsResp struct {

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -173,13 +173,7 @@ type DigestObjectsInRangeResp struct {
 	Digests []types.RepairResponse `json:"digests,omitempty"`
 }
 
-// CompareHashTreeRootsReq / Resp are the REST-transport payloads for the batched
-// root pre-filter, keyed by shard. Roots are carried as raw [high, low] word pairs
-// rather than hashtree.Digest: Digest's JSON methods are pointer-receiver, so
-// json.Marshal skips them for non-addressable map values (emitting a plain array)
-// while json.Decode invokes them for addressable map elements (expecting base64) —
-// an asymmetry that made the REST path fail. [2]uint64 has no custom codec, so it
-// round-trips symmetrically.
+// CompareHashTreeRootsReq / Resp are the REST payloads for the batched root pre-filter; roots use raw [high,low] pairs since Digest's pointer-receiver JSON breaks for map values.
 type CompareHashTreeRootsReq struct {
 	Roots map[string][2]uint64 `json:"roots"`
 }


### PR DESCRIPTION
## Motivation

Stacked on #12044. A deep review of the batched hashtree-root pre-filter (part of the v1.37→v1.38 merge, #12029) surfaced two defects in the new `CompareHashTreeRoots` path.

### 1. REST transport was 100% broken (asymmetric JSON) — HIGH
`CompareHashTreeRootsReq.Roots` was `map[string]hashtree.Digest`, and `Digest`'s `MarshalJSON`/`UnmarshalJSON` are **pointer-receiver**. `json.Marshal` skips them for non-addressable map values (emitting a `[high,low]` array), while `json.Decode` invokes them for addressable map elements (expecting base64). Every REST request therefore failed with **HTTP 400** and the source silently fell back to a full descent — convergence-safe, but the optimization never worked and it logged an error every hashbeat cycle whenever `replication_grpc_enabled=false`. The gRPC path was already correct.

**Fix:** carry roots as raw `[2]uint64` `[high,low]` word pairs on the REST wire (no custom codec → symmetric round-trip); convert at the client and handler boundaries. The shared `hashtree.Digest` type and the gRPC path are untouched.

### 2. Unbounded server-side request — SHOULD-FIX
The gRPC and REST receivers built the shard map from a peer request with no upper bound (unlike the sibling checkpoint RPCs). Added `CompareHashTreeRootsMaxShardsPerRequest = 10_000` (headroom over the 1k sender cap `prefilterMaxShardsPerRPC`), enforced on both transports (gRPC `InvalidArgument`, REST 400), and wrapped the REST body in `http.MaxBytesReader` to match the sibling replica handlers #12044 just hardened.

## Tests
- **`TestCompareHashTreeRootsRESTRoundTrip`**: drives the real REST client through the real handler with a `MockReplicator`, asserting the exact diverging set is returned and digests survive **bit-for-bit** (including high-bit-set words like `0xFFFFFFFFFFFFFFFF`). Verified **red on the old wire type** (`400: invalid Digest serialization`), green after the fix — this pins the bug.
- Over-cap rejection covered on both transports (`TestCompareHashTreeRootsRESTRejectsOverCap`, new gRPC sub-test → `InvalidArgument`).
- `go build` + `-race` on `usecases/replica`, `adapters/clients`, `adapters/handlers/rest/clusterapi{,/grpc}` all pass; `golangci-lint` clean.

## Review notes
- Base is #12044 (`fix/replica-async-rep-hardening-v1.37`); this is a stacked follow-up on the same subsystem and needs forward-porting to `main`/`v1.38` alongside it.
- Deferred (documented in the #12029 review, not this PR): observability for persistently not-ready targets masked as in-sync skips; a defensive gate on the scheduler's inFlight-recovery re-dispatch; a batch-level panic recover in `runBatch`.