### PR TITLE
gh-12041 return 422 for batch delete with missing match fields

### DIFF
--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -124,16 +124,19 @@ func (b *BatchManager) toResponse(match *models.BatchDeleteMatch, output string,
 func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *models.Principal,
 	match *models.BatchDeleteMatch, dryRun *bool, output *string,
 ) (*BatchDeleteParams, uint64, error) {
+	// Missing required match fields are caller input, so classify them as
+	// ErrInvalidUserInput (→ 422). Otherwise the REST handler maps these to a
+	// 500. The message wording is preserved for callers/tests.
 	if match == nil {
-		return nil, 0, errors.New("empty match clause")
+		return nil, 0, NewErrInvalidUserInput("empty match clause")
 	}
 
 	if len(match.Class) == 0 {
-		return nil, 0, errors.New("empty match.class clause")
+		return nil, 0, NewErrInvalidUserInput("empty match.class clause")
 	}
 
 	if match.Where == nil {
-		return nil, 0, errors.New("empty match.where clause")
+		return nil, 0, NewErrInvalidUserInput("empty match.where clause")
 	}
 
 	// GetCachedClass authorizes READ; preserve Forbidden (→ 403), classify

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -194,6 +194,25 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 		var invalid ErrInvalidUserInput
 		require.True(t, errors.As(err, &invalid), "expected ErrInvalidUserInput, got %T: %v", err, err)
 	})
+
+	t.Run("missing required match fields classify as ErrInvalidUserInput", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			match *models.BatchDeleteMatch
+		}{
+			{name: "no match", match: nil},
+			{name: "empty match.class", match: &models.BatchDeleteMatch{Class: ""}},
+			{name: "missing match.where", match: &models.BatchDeleteMatch{Class: "Foo"}},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := manager.DeleteObjects(ctx, nil, test.match, nil, nil, ptString(verbosity.OutputVerbose), nil, "")
+				require.Error(t, err)
+				var invalid ErrInvalidUserInput
+				require.True(t, errors.As(err, &invalid), "expected ErrInvalidUserInput, got %T: %v", err, err)
+			})
+		}
+	})
 }
 
 // Test_BatchDelete_NamespaceResolution proves DeleteObjects routes the


### PR DESCRIPTION
### What's being changed:

closes #12041. Batch delete throws a 500 when you leave out a required match field (`match.class` or `match.where`). That's just bad input, should be a 422.

The three nil-checks in `validateBatchDelete` returned a plain error, which the handler turns into a 500. The cases right below them (class not found, bad where filter) already return `NewErrInvalidUserInput` and get a 422 from #11497, so this just does the same for the missing-field checks. Messages stay the same. Added a table test that fails without the change.

One thing for you: went with 422 to match the other validation cases here, but 400 works too if you'd rather.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
