### PR TITLE
fix(gemini): remove default values from gemini genconfig

### DIFF
--- a/modules/generative-google/clients/google.go
+++ b/modules/generative-google/clients/google.go
@@ -281,20 +281,16 @@ func (v *google) getParameters(cfg moduletools.ClassConfig, options interface{},
 		params.Model = model
 	}
 	if params.Temperature == nil {
-		temperature := settings.Temperature()
-		params.Temperature = &temperature
+		params.Temperature = settings.TemperaturePointer()
 	}
 	if params.TopP == nil {
-		topP := settings.TopP()
-		params.TopP = &topP
+		params.TopP = settings.TopPPointer()
 	}
 	if params.TopK == nil {
-		topK := settings.TopK()
-		params.TopK = &topK
+		params.TopK = settings.TopKPointer()
 	}
 	if params.MaxTokens == nil {
-		maxTokens := settings.TokenLimit()
-		params.MaxTokens = &maxTokens
+		params.MaxTokens = settings.TokenLimitPointer()
 	}
 
 	params.Images = generative.ParseImageProperties(params.Images, params.ImageProperties, imagePropertiesArray)

--- a/modules/generative-google/config/class_settings.go
+++ b/modules/generative-google/config/class_settings.go
@@ -71,6 +71,11 @@ type ClassSettings interface {
 	TopK() int
 	// 0.0 - 1.0
 	TopP() float64
+
+	TemperaturePointer() *float64
+	TokenLimitPointer() *int
+	TopKPointer() *int
+	TopPPointer() *float64
 }
 
 type classSettings struct {
@@ -212,3 +217,28 @@ func (ic *classSettings) TopK() int {
 func (ic *classSettings) TopP() float64 {
 	return ic.getFloatProperty(topPProperty, DefaultGoogleTopP)
 }
+
+func (ic *classSettings) TemperaturePointer() *float64 {
+	return ic.getFloatPropertyPointer(temperatureProperty)
+}
+
+func (ic *classSettings) TokenLimitPointer() *int {
+	return ic.getIntPropertyPointer(tokenLimitProperty)
+}
+
+func (ic *classSettings) TopKPointer() *int {
+	return ic.getIntPropertyPointer(topKProperty)
+}
+
+func (ic *classSettings) TopPPointer() *float64 {
+	return ic.getFloatPropertyPointer(topPProperty)
+}
+
+func (ic *classSettings) getFloatPropertyPointer(name string) *float64 {
+	return ic.propertyValuesHelper.GetPropertyAsFloat64WithNotExists(ic.cfg, name, nil, nil)
+}
+
+func (ic *classSettings) getIntPropertyPointer(name string) *int {
+	return ic.propertyValuesHelper.GetPropertyAsIntWithNotExists(ic.cfg, name, nil, nil)
+}
+

--- a/modules/generative-google/config/class_settings_test.go
+++ b/modules/generative-google/config/class_settings_test.go
@@ -199,6 +199,22 @@ func Test_classSettings_Validate(t *testing.T) {
 				assert.Equal(t, tt.wantTokenLimit, ic.TokenLimit())
 				assert.Equal(t, tt.wantTopK, ic.TopK())
 				assert.Equal(t, tt.wantTopP, ic.TopP())
+
+				if tt.name == "custom values" {
+					assert.NotNil(t, ic.TemperaturePointer())
+					assert.Equal(t, 0.25, *ic.TemperaturePointer())
+					assert.NotNil(t, ic.TokenLimitPointer())
+					assert.Equal(t, 254, *ic.TokenLimitPointer())
+					assert.NotNil(t, ic.TopKPointer())
+					assert.Equal(t, 30, *ic.TopKPointer())
+					assert.NotNil(t, ic.TopPPointer())
+					assert.Equal(t, 0.97, *ic.TopPPointer())
+				} else if tt.name == "default settings" {
+					assert.Nil(t, ic.TemperaturePointer())
+					assert.Nil(t, ic.TokenLimitPointer())
+					assert.Nil(t, ic.TopKPointer())
+					assert.Nil(t, ic.TopPPointer())
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:

Gemini 3+ models may throw errors if a default value is set for parameters like temperature, top-p, etc.

The 2.5 and 3-series models use 1.0 as the default temperature, so this should be a backwards-compatible change.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
