### PR TITLE
Fix geo queue backup preparation timeout

### DIFF
--- a/adapters/repos/db/shard_autoresume_maintenance_test.go
+++ b/adapters/repos/db/shard_autoresume_maintenance_test.go
@@ -17,10 +17,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	dbqueue "github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/backup"
 )
@@ -205,6 +207,69 @@ func TestShard_HaltForTransferZeroPreparationTimeout(t *testing.T) {
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
 }
 
+func TestShard_HaltForTransferTimeoutBoundsGeoQueuePreparation(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+
+	shd, idx := testShard(t, ctx, className, func(idx *Index) {
+		idx.Config.HaltForTransferTimeout = 10 * time.Millisecond
+	})
+	s := shd.(*Shard)
+
+	taskStarted := make(chan struct{})
+	releaseTask := make(chan struct{})
+	defer close(releaseTask)
+
+	scheduler := dbqueue.NewScheduler(dbqueue.SchedulerOptions{
+		Logger:           s.index.logger,
+		Workers:          1,
+		ScheduleInterval: time.Millisecond,
+	})
+	scheduler.Start()
+	defer scheduler.Close(t.Context())
+
+	q, err := dbqueue.NewDiskQueue(dbqueue.DiskQueueOptions{
+		ID:           "geo-backup-timeout",
+		Scheduler:    scheduler,
+		Logger:       s.index.logger,
+		Dir:          t.TempDir(),
+		TaskDecoder:  &blockingBackupTaskDecoder{started: taskStarted, release: releaseTask},
+		StaleTimeout: time.Millisecond,
+		ChunkSize:    50,
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.Init())
+	scheduler.RegisterQueue(q)
+
+	s.propertyIndicesLock.Lock()
+	s.geoQueues["location"] = &VectorIndexQueue{DiskQueue: q}
+	s.propertyIndicesLock.Unlock()
+
+	require.NoError(t, q.Push([]byte{1}))
+	require.NoError(t, q.Flush())
+
+	<-taskStarted
+
+	outerCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- shd.HaltForTransfer(outerCtx, false, 0)
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(100 * time.Millisecond):
+		cancel()
+		require.FailNow(t, "HaltForTransfer did not respect HaltForTransferTimeout for geo queue preparation")
+	}
+
+	require.Nil(t, idx.drop())
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
 func TestShard_ConcurrentTransfers(t *testing.T) {
 	ctx := testCtx()
 	className := "TestClass"
@@ -285,6 +350,40 @@ func TestShard_ConcurrentTransfers(t *testing.T) {
 
 	require.Nil(t, idx.drop())
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+}
+
+type blockingBackupTaskDecoder struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (d *blockingBackupTaskDecoder) DecodeTask([]byte) (dbqueue.Task, error) {
+	return &blockingBackupTask{started: d.started, release: d.release, once: &d.once}, nil
+}
+
+type blockingBackupTask struct {
+	started chan struct{}
+	release chan struct{}
+	once    *sync.Once
+}
+
+func (t *blockingBackupTask) Op() uint8 {
+	return 1
+}
+
+func (t *blockingBackupTask) Key() uint64 {
+	return 0
+}
+
+func (t *blockingBackupTask) Execute(ctx context.Context) error {
+	t.once.Do(func() { close(t.started) })
+	select {
+	case <-t.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func TestShard_ListBackupFilesExtendsInactivityDeadline(t *testing.T) {

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -98,7 +98,7 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 		return fmt.Errorf("flush vector index queues: %w", err)
 	}
 	err = s.ForEachGeoQueue(func(_ string, q *VectorIndexQueue) error {
-		if err = q.PrepareForBackup(ctx); err != nil {
+		if err = q.PrepareForBackup(innerCtx); err != nil {
 			return fmt.Errorf("prepare for backup of geo index: %w", err)
 		}
 		return nil


### PR DESCRIPTION
### What's being changed:

- Use the bounded halt-for-transfer preparation context when preparing geo index queues for backup.
- Add an integration regression test that verifies geo queue preparation returns within `HaltForTransferTimeout` instead of waiting on the outer transfer context.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary; internal bug fix.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary; context propagation bug fix.