### PR TITLE
feat(drop-vector-index): expose segment edit-op cleanup metrics

### DIFF
--- a/adapters/repos/db/drop_vector_index_provider.go
+++ b/adapters/repos/db/drop_vector_index_provider.go
@@ -472,9 +472,11 @@ func (p *DropVectorIndexProvider) pollUntilEmpty(
 // the scheduler skips any record still inside completedTaskTTL before it ever
 // consults a retainer, so a retainer can extend retention and never shorten
 // it. A fast-failing round loop (one FAILED record per nudge) therefore
-// accumulates records for the whole TTL window; what bounds the pile is the
-// requeue cap that stops such a loop (see lsmkv.maxQuarantineRequeues), not
-// this. The marker check is memoized per drop and fails toward retaining; see
+// accumulates records for the whole TTL window, and NOTHING here bounds that
+// pile — do not read lsmkv.maxQuarantineRequeues as a backstop: once a segment
+// exhausts that cap it stops being requeued, so every later round fails
+// immediately, which makes the loop faster rather than stopping it. The marker
+// check is memoized per drop and fails toward retaining; see
 // retainVerdictForDrop.
 func (p *DropVectorIndexProvider) ShouldRetainCompletedTask(task *distributedtask.Task,
 	namespaceTasks map[distributedtask.TaskDescriptor]*distributedtask.Task,

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -14,11 +14,14 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
 	entschema "github.com/weaviate/weaviate/entities/schema"
@@ -106,8 +109,93 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 			otherTargetVectors(class, target)); err != nil {
 			return err
 		}
+		if err := removeDimensionsForDroppedVector(idx, shardName, target); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// removeDimensionsForDroppedVector clears target's dimension rows on one shard.
+// The route has to branch: this callback re-fires over loaded units too, and a
+// loaded shard holds the bucket open through its own store.
+//
+// A shard that finishes loading between the routing decision and the open takes
+// the same registry claim, which TryAdd reports at once instead of waiting. One
+// retry re-resolves it and goes through the store that won.
+func removeDimensionsForDroppedVector(idx *Index, shardName, target string) error {
+	ctx := context.Background()
+	err := removeDimensionsOnShard(ctx, idx, shardName, target)
+	if errors.Is(err, lsmkv.ErrBucketAlreadyRegistered) {
+		err = removeDimensionsOnShard(ctx, idx, shardName, target)
+	}
+	if err != nil {
+		return err
+	}
+	return invalidateComputedUsage(idx, shardName)
+}
+
+// invalidateComputedUsage drops a cold shard's saved usage record, which is
+// keyed only by a hash of the active vector configs. Dropping a vector and
+// re-creating it with the same config produces the same hash, so a record
+// written before the drop is served again afterwards — reporting the old
+// vector's count against a vector that holds nothing. Nothing else invalidates
+// it: NewShard is the only other caller, and re-creating a vector does not load
+// a cold shard.
+func invalidateComputedUsage(idx *Index, shardName string) error {
+	if err := shardusage.RemoveComputedUsageDataForUnloadedShard(idx.path(), shardName); err != nil {
+		return fmt.Errorf("invalidate computed usage for shard %q: %w", shardName, err)
+	}
+	return nil
+}
+
+func removeDimensionsOnShard(ctx context.Context, idx *Index, shardName, target string) error {
+	switch shard := idx.shards.Load(shardName).(type) {
+	case *Shard:
+		release, err := shard.preventShutdown()
+		if err != nil {
+			// Tearing down: the store is on its way out, so take the disk route
+			// rather than write through a handle that is about to disappear.
+			break
+		}
+		defer release()
+		if err := shard.removeAllDimensionsLSM(ctx, target); !errors.Is(err, errAlreadyShutdown) {
+			return err
+		}
+	case *LazyLoadShard:
+		return removeDimensionsOnLazyShard(ctx, idx, shardName, target, shard)
+	}
+
+	return shardusage.RemoveUnloadedTargetVectorDimensions(ctx, idx.logger,
+		idx.path(), shardName, target)
+}
+
+// removeDimensionsOnLazyShard commits to the answer it reads under l.mutex. A
+// loaded shard's reference is taken before the lock is released, so a
+// deactivation cannot blank the store in between — Store.Shutdown clears
+// bucketsByName before draining, and a nil bucket would read as nothing to do.
+// The cold branch keeps the lock, because loadIfCold holds it across the whole
+// of NewShard: released early, this would open a bucket that store is opening
+// at the same moment and one of the two would lose the registry claim.
+func removeDimensionsOnLazyShard(ctx context.Context, idx *Index,
+	shardName, target string, l *LazyLoadShard,
+) error {
+	l.mutex.Lock()
+	if l.loaded && l.shard != nil {
+		if release, err := l.shard.preventShutdown(); err == nil {
+			inner := l.shard
+			l.mutex.Unlock()
+			defer release()
+			if err := inner.removeAllDimensionsLSM(ctx, target); !errors.Is(err, errAlreadyShutdown) {
+				return err
+			}
+			return shardusage.RemoveUnloadedTargetVectorDimensions(ctx, idx.logger,
+				idx.path(), shardName, target)
+		}
+	}
+	defer l.mutex.Unlock()
+	return shardusage.RemoveUnloadedTargetVectorDimensions(ctx, idx.logger,
+		idx.path(), shardName, target)
 }
 
 // schemaClassUpdater is the slice of the schema manager the finalizer needs: read a

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -556,7 +556,13 @@ func (b *Bucket) DeleteEditOpIfDrained(opID string) (deleted bool, pending, quar
 	if !b.HasEditOps() {
 		return false, 0, 0, fmt.Errorf("edit ops not enabled for this bucket")
 	}
-	return b.disk.editOps.DeleteOpIfDrained(opID)
+	deleted, pending, quarantined, err = b.disk.editOps.DeleteOpIfDrained(opID)
+	if err == nil && deleted {
+		// The op's series must go with it, or its gauges keep reporting a
+		// value forever (refresh is self-reconciling and forgets vanished ops).
+		b.disk.refreshEditOpsMetrics()
+	}
+	return deleted, pending, quarantined, err
 }
 
 // EditOpsHaveRows reports whether ANY edit op on this bucket still has

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -521,7 +521,16 @@ func (b *Bucket) RegisterEditOp(opID string, desc OpDescriptor) error {
 		// quarantined by an earlier round get a fresh retry budget — otherwise
 		// a single exhausted budget would wedge the drop permanently (the op
 		// and its quarantine rows outlive FAILED rounds by design).
-		return b.disk.requeueQuarantinedEditOps(opID)
+		// Refresh: a requeue moves segments out of quarantine and back into the
+		// queue, which is exactly the transition that clears the owed-above-
+		// queued signature a stalled drop is recognised by. Without this the
+		// stale "stalled" reading persists until the next cleanup pass, and on
+		// a READONLY segment group that pass never comes.
+		if err := b.disk.requeueQuarantinedEditOps(opID); err != nil {
+			return err
+		}
+		b.disk.refreshEditOpsMetrics()
+		return nil
 	}
 	if err := b.flushAndSwitchLocked(); err != nil {
 		return fmt.Errorf("flush before edit-op snapshot: %w", err)
@@ -556,7 +565,13 @@ func (b *Bucket) DeleteEditOpIfDrained(opID string) (deleted bool, pending, quar
 	if !b.HasEditOps() {
 		return false, 0, 0, fmt.Errorf("edit ops not enabled for this bucket")
 	}
-	return b.disk.editOps.DeleteOpIfDrained(opID)
+	deleted, pending, quarantined, err = b.disk.editOps.DeleteOpIfDrained(opID)
+	if err == nil && deleted {
+		// The op's series must go with it, or its gauges keep reporting a
+		// value forever (refresh is self-reconciling and forgets vanished ops).
+		b.disk.refreshEditOpsMetrics()
+	}
+	return deleted, pending, quarantined, err
 }
 
 // EditOpsHaveRows reports whether ANY edit op on this bucket still has

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -123,6 +123,9 @@ type Metrics struct {
 
 	groupClasses        bool
 	criticalBucketsOnly bool
+
+	// editOps holds the segment-edit-op series (drop-vector cleanup). nil-safe.
+	editOps *monitoring.SegmentEditOpsMetrics
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
@@ -627,10 +630,16 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		"path":       "n/a",
 	})
 
+	editOpsMetrics, err := monitoring.NewSegmentEditOpsMetrics(register, shardName)
+	if err != nil {
+		return nil, fmt.Errorf("register segment edit ops metrics: %w", err)
+	}
+
 	return &Metrics{
 		register:            register,
 		groupClasses:        promMetrics.Group,
 		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
+		editOps:             editOpsMetrics,
 
 		// bucket metrics
 		bucketInitCountByStrategy:        bucketInitCountByStrategy,
@@ -1109,4 +1118,49 @@ func (m *Metrics) ObjectCount(count int) {
 	}
 
 	m.objectCount.Set(float64(count))
+}
+
+// segment edit-op metrics (drop-vector cleanup). All delegate to the nil-safe
+// monitoring helper, so a nil *Metrics or disabled monitoring is a no-op.
+
+func (m *Metrics) SetEditOpsActive(opType string, n int) {
+	if m == nil {
+		return
+	}
+	m.editOps.SetActive(opType, n)
+}
+
+func (m *Metrics) SetEditOpsPendingSegments(opID string, n int) {
+	if m == nil {
+		return
+	}
+	m.editOps.SetPendingSegments(opID, n)
+}
+
+func (m *Metrics) SetEditOpsForcedCleanupRemaining(opID string, n int) {
+	if m == nil {
+		return
+	}
+	m.editOps.SetForcedCleanupRemaining(opID, n)
+}
+
+func (m *Metrics) ObserveEditOpsTransformerDuration(opType string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.editOps.ObserveTransformerDuration(opType, seconds)
+}
+
+func (m *Metrics) AddEditOpsBytesReclaimed(opType string, bytes int64) {
+	if m == nil {
+		return
+	}
+	m.editOps.AddBytesReclaimed(opType, bytes)
+}
+
+func (m *Metrics) ForgetEditOp(opID string) {
+	if m == nil {
+		return
+	}
+	m.editOps.ForgetOp(opID)
 }

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -123,6 +123,9 @@ type Metrics struct {
 
 	groupClasses        bool
 	criticalBucketsOnly bool
+
+	// editOps holds the segment-edit-op series (drop-vector cleanup). nil-safe.
+	editOps *monitoring.SegmentEditOpsMetrics
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
@@ -627,10 +630,16 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		"path":       "n/a",
 	})
 
+	editOpsMetrics, err := monitoring.NewSegmentEditOpsMetrics(register, className, shardName, promMetrics.Group)
+	if err != nil {
+		return nil, fmt.Errorf("register segment edit ops metrics: %w", err)
+	}
+
 	return &Metrics{
 		register:            register,
 		groupClasses:        promMetrics.Group,
 		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
+		editOps:             editOpsMetrics,
 
 		// bucket metrics
 		bucketInitCountByStrategy:        bucketInitCountByStrategy,
@@ -1109,4 +1118,76 @@ func (m *Metrics) ObjectCount(count int) {
 	}
 
 	m.objectCount.Set(float64(count))
+}
+
+// segment edit-op metrics (drop-vector cleanup). All delegate to the nil-safe
+// monitoring helper, so a nil *Metrics or disabled monitoring is a no-op.
+
+func (m *Metrics) SetEditOpsActive(opType string, n int) {
+	if m == nil {
+		return
+	}
+	m.editOps.SetActive(opType, n)
+}
+
+func (m *Metrics) SetEditOpsPendingSegments(opID string, n int) {
+	if m == nil {
+		return
+	}
+	m.editOps.SetPendingSegments(opID, n)
+}
+
+func (m *Metrics) SetEditOpsSegmentsOwed(opID string, n int) {
+	if m == nil {
+		return
+	}
+	m.editOps.SetSegmentsOwed(opID, n)
+}
+
+func (m *Metrics) ObserveEditOpsTransformerDuration(opType string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.editOps.ObserveTransformerDuration(opType, seconds)
+}
+
+func (m *Metrics) editOpsEnabled() bool {
+	return m != nil && m.editOps != nil && m.editOps.PerShardGaugesEnabled()
+}
+
+// ReapEditOpsShardSeries drops the edit-op series of a shard with no live
+// Store to reap through — an UNLOADED shard being deleted. A loaded one goes
+// via Store.ReapEditOpsMetrics; both exist because an unload deliberately
+// keeps a stalled shard's gauges (see SegmentGroup.shutdown), so a delete has
+// to retire them explicitly whichever state the shard is in. No-op when
+// monitoring is off.
+func ReapEditOpsShardSeries(promMetrics *monitoring.PrometheusMetrics, className, shardName string) error {
+	if promMetrics == nil {
+		return nil
+	}
+	if promMetrics.Group {
+		className, shardName = "n/a", "n/a"
+	}
+	editOps, err := monitoring.NewSegmentEditOpsMetrics(
+		promMetrics.Registerer, className, shardName, promMetrics.Group)
+	if err != nil {
+		return fmt.Errorf("edit-op metrics for shard reap: %w", err)
+	}
+	editOps.DeleteOwnShard()
+	return nil
+}
+
+// DeleteEditOpsShardSeries drops every edit-op series this shard owns.
+func (m *Metrics) DeleteEditOpsShardSeries() {
+	if m == nil {
+		return
+	}
+	m.editOps.DeleteOwnShard()
+}
+
+func (m *Metrics) ForgetEditOp(opID string) {
+	if m == nil {
+		return
+	}
+	m.editOps.ForgetOp(opID)
 }

--- a/adapters/repos/db/lsmkv/segment_edit_ops.go
+++ b/adapters/repos/db/lsmkv/segment_edit_ops.go
@@ -675,15 +675,27 @@ func (s *SegmentEditOps) Pending(opID string) ([]string, error) {
 func (s *SegmentEditOps) AllPending() ([]PendingSegment, error) {
 	var out []PendingSegment
 	if err := s.withReadTx(func(tx *bolt.Tx) error {
-		return tx.Bucket(editOpsBucketPending).ForEachBucket(func(opID []byte) error {
-			return tx.Bucket(editOpsBucketPending).Bucket(opID).ForEach(func(segID, v []byte) error {
-				ps, err := decodePending(string(opID), string(segID), v)
-				if err != nil {
-					return err
-				}
-				out = append(out, ps)
-				return nil
-			})
+		var err error
+		out, err = segmentRowsTx(tx, editOpsBucketPending)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// segmentRowsTx walks every (op, segment) row in one of the two per-op segment
+// buckets (pending or quarantine) within an existing transaction.
+func segmentRowsTx(tx *bolt.Tx, bucket []byte) ([]PendingSegment, error) {
+	var out []PendingSegment
+	if err := tx.Bucket(bucket).ForEachBucket(func(opID []byte) error {
+		return tx.Bucket(bucket).Bucket(opID).ForEach(func(segID, v []byte) error {
+			ps, err := decodePending(string(opID), string(segID), v)
+			if err != nil {
+				return err
+			}
+			out = append(out, ps)
+			return nil
 		})
 	}); err != nil {
 		return nil, err
@@ -837,7 +849,19 @@ func (s *SegmentEditOps) RequeueQuarantined(opID string, liveSegIDs []string) er
 		}
 		for segID, meta := range rows {
 			if meta.Requeues >= maxQuarantineRequeues {
-				continue // budget spent: the verdict is now permanent
+				// Budget spent: the verdict is now permanent, and no later round
+				// will move this segment. Said once per round rather than
+				// silently, because from here the gauges alone cannot tell a drop
+				// that is retrying from one that never will — segments_owed holds
+				// above pending in both cases.
+				if s.logger != nil {
+					s.logger.WithField("action", "lsm_editops_requeue").
+						WithField("op_id", opID).
+						WithField("segment", segID).
+						Warnf("segment stays quarantined for good: %d requeues exhausted the budget of %d; this drop cannot finish without intervention",
+							meta.Requeues, maxQuarantineRequeues)
+				}
+				continue
 			}
 			if err := sub.Delete([]byte(segID)); err != nil {
 				return err
@@ -883,20 +907,38 @@ func (s *SegmentEditOps) addPendingWithMetaTx(tx *bolt.Tx, opID, segID string, m
 func (s *SegmentEditOps) Quarantined() ([]PendingSegment, error) {
 	var out []PendingSegment
 	if err := s.withReadTx(func(tx *bolt.Tx) error {
-		return tx.Bucket(editOpsBucketQuarantine).ForEachBucket(func(opID []byte) error {
-			return tx.Bucket(editOpsBucketQuarantine).Bucket(opID).ForEach(func(segID, v []byte) error {
-				ps, err := decodePending(string(opID), string(segID), v)
-				if err != nil {
-					return err
-				}
-				out = append(out, ps)
-				return nil
-			})
-		})
+		var err error
+		out, err = segmentRowsTx(tx, editOpsBucketQuarantine)
+		return err
 	}); err != nil {
 		return nil, err
 	}
 	return out, nil
+}
+
+// MetricsSnapshot reads the ops, pending and quarantined sets in ONE read
+// transaction. The three fields must be mutually consistent, not merely each
+// fresh: the gauges derive "owed" as pending plus quarantined, so a Quarantine
+// commit landing between two separate reads would show the same segment in
+// both and count it twice — inflating precisely the gauge that is read as the
+// stalled-drop signal, in the direction that fabricates a stall.
+func (s *SegmentEditOps) MetricsSnapshot() (ops []ActiveOp, pending, quarantined []PendingSegment, err error) {
+	if err := s.withReadTx(func(tx *bolt.Tx) error {
+		var err error
+		if ops, err = s.loadOpsTx(tx); err != nil {
+			return fmt.Errorf("load ops: %w", err)
+		}
+		if pending, err = segmentRowsTx(tx, editOpsBucketPending); err != nil {
+			return fmt.Errorf("load pending: %w", err)
+		}
+		if quarantined, err = segmentRowsTx(tx, editOpsBucketQuarantine); err != nil {
+			return fmt.Errorf("load quarantined: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+	return ops, pending, quarantined, nil
 }
 
 // DeleteOp removes an operation and all of its pending and quarantined rows.

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -109,6 +109,13 @@ type SegmentGroup struct {
 	// group.
 	editOps *SegmentEditOps
 
+	// editOpsMetricsLock guards the seen-series state below, which lets
+	// refreshEditOpsMetrics reconcile op-id series and op-type counts for ops
+	// that vanished since the previous refresh.
+	editOpsMetricsLock sync.Mutex
+	editOpsSeenOpIDs   map[string]struct{}
+	editOpsSeenTypes   map[OpType]struct{}
+
 	roaringSetRangeSegmentInMemory *roaringsetrange.SegmentInMemory
 	bitmapBufPool                  roaringset.BitmapBufPool
 	// bitmapBufPool wrapped with baseLayerHeadroomFactor for roaringSetGet's
@@ -829,9 +836,13 @@ func (sg *SegmentGroup) recoverEditOps(ctx context.Context) error {
 	sg.maintenanceLock.RLock()
 	ids := sg.currentSegmentIDsLocked()
 	sg.maintenanceLock.RUnlock()
-	return sg.editOps.Recover(ids,
+	if err := sg.editOps.Recover(ids,
 		func() map[string]struct{} { return sg.liveEditOpIDs(ctx, false) },
-		func() map[string]struct{} { return sg.liveEditOpIDs(ctx, true) })
+		func() map[string]struct{} { return sg.liveEditOpIDs(ctx, true) }); err != nil {
+		return err
+	}
+	sg.refreshEditOpsMetrics()
+	return nil
 }
 
 // liveEditOpIDs resolves the live-op set for the orphan sweep via the package
@@ -860,6 +871,83 @@ func (sg *SegmentGroup) liveEditOpIDs(ctx context.Context, fresh bool) map[strin
 	return live
 }
 
+// refreshEditOpsMetrics recomputes the edit-op gauges from the sidecar's current
+// state: active ops per type, and pending / forced-cleanup-remaining segment
+// counts per op. Deriving from ground truth (rather than incrementing on each
+// transition) keeps the gauges drift-free across crashes and resumes. Ops that
+// vanished since the previous refresh (completion or orphan sweep) are
+// reconciled too: their op-id series are dropped and their type count zeroed,
+// so a finished drop never lingers as a stale "active" reading. Called only on
+// op-lifecycle changes and once per cleanup pass — never on a hot path.
+func (sg *SegmentGroup) refreshEditOpsMetrics() {
+	if sg.editOps == nil {
+		return
+	}
+	ops, err := sg.editOps.LoadOps()
+	if err != nil {
+		sg.logger.WithField("action", "lsm_editops_metrics").
+			Warnf("refresh edit-op metrics: load ops: %v", err)
+		return
+	}
+	pending, err := sg.editOps.AllPending()
+	if err != nil {
+		sg.logger.WithField("action", "lsm_editops_metrics").
+			Warnf("refresh edit-op metrics: load pending: %v", err)
+		return
+	}
+
+	sg.editOpsMetricsLock.Lock()
+	defer sg.editOpsMetricsLock.Unlock()
+
+	perOp := make(map[string]int, len(ops))
+	for _, p := range pending {
+		perOp[p.OpID]++
+	}
+	perType := make(map[OpType]int, len(ops))
+	opIDs := make(map[string]struct{}, len(ops))
+	for _, op := range ops {
+		perType[op.Descriptor.Type]++
+		opIDs[op.ID] = struct{}{}
+		n := perOp[op.ID]
+		sg.metrics.SetEditOpsPendingSegments(op.ID, n)
+		sg.metrics.SetEditOpsForcedCleanupRemaining(op.ID, n)
+	}
+	for id := range sg.editOpsSeenOpIDs {
+		if _, ok := opIDs[id]; !ok {
+			sg.metrics.ForgetEditOp(id)
+		}
+	}
+	for opType := range sg.editOpsSeenTypes {
+		if _, ok := perType[opType]; !ok {
+			perType[opType] = 0
+		}
+	}
+	seenTypes := make(map[OpType]struct{}, len(perType))
+	for opType, n := range perType {
+		sg.metrics.SetEditOpsActive(string(opType), n)
+		if n > 0 {
+			seenTypes[opType] = struct{}{}
+		}
+	}
+	sg.editOpsSeenOpIDs = opIDs
+	sg.editOpsSeenTypes = seenTypes
+}
+
+// distinctOpTypes returns the unique op types in ops, the label set for the
+// per-pass transformer/bytes metrics (one pass applies every active op at once).
+func distinctOpTypes(ops []ActiveOp) []string {
+	seen := make(map[OpType]struct{}, len(ops))
+	var out []string
+	for _, op := range ops {
+		if _, ok := seen[op.Descriptor.Type]; ok {
+			continue
+		}
+		seen[op.Descriptor.Type] = struct{}{}
+		out = append(out, string(op.Descriptor.Type))
+	}
+	return out
+}
+
 // registerEditOpAndSnapshot registers opID and snapshots the current on-disk
 // segments in one write. Idempotent via the snapshot guard (not the descriptor),
 // so a resume completes an interrupted register rather than skipping it, and one
@@ -879,8 +967,13 @@ func (sg *SegmentGroup) registerEditOpAndSnapshot(opID string, desc OpDescriptor
 	}
 
 	sg.maintenanceLock.RLock()
-	defer sg.maintenanceLock.RUnlock()
-	return sg.editOps.RegisterOpWithSnapshot(opID, desc, sg.currentSegmentIDsLocked())
+	err = sg.editOps.RegisterOpWithSnapshot(opID, desc, sg.currentSegmentIDsLocked())
+	sg.maintenanceLock.RUnlock()
+	if err != nil {
+		return err
+	}
+	sg.refreshEditOpsMetrics()
+	return nil
 }
 
 // requeueQuarantinedEditOps returns opID's quarantined segments to pending with

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -109,6 +109,21 @@ type SegmentGroup struct {
 	// group.
 	editOps *SegmentEditOps
 
+	// editOpsMetricsLock guards the seen-series state below, which lets
+	// refreshEditOpsMetrics reconcile op-id series and op-type counts for ops
+	// that vanished since the previous refresh.
+	editOpsMetricsLock sync.Mutex
+	editOpsSeenOpIDs   map[string]struct{}
+	editOpsSeenTypes   map[OpType]struct{}
+	// editOpsMetricsReaped latches this shard's series as retired, because a
+	// bare reap can be undone with no second reap ever coming: a shutdown that
+	// fails at Unregister leaves the cycle callback live (commitIdle rolls its
+	// abort mark back on timeout) and skips editOps.Close(), so the pass
+	// republishes; a discarded segment group publishes from recovery and is
+	// thrown away; a removed sidecar reads empty without error and republishes
+	// a zero-valued child. Guarded by editOpsMetricsLock.
+	editOpsMetricsReaped bool
+
 	roaringSetRangeSegmentInMemory *roaringsetrange.SegmentInMemory
 	bitmapBufPool                  roaringset.BitmapBufPool
 	// bitmapBufPool wrapped with baseLayerHeadroomFactor for roaringSetGet's
@@ -537,6 +552,11 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 					sg.logger.WithField("path", cfg.dir).
 						Warnf("close edit-ops sidecar after failed init: %v", closeErr)
 				}
+				// The series go with it. recoverEditOps publishes on success and
+				// on non-timeout failure (a stalled shard is what the gauges are
+				// for), but a discarded sg never reaches shutdown, so this is
+				// its only chance to be reaped.
+				sg.reapEditOpsMetrics()
 			}
 		}()
 	}
@@ -821,16 +841,31 @@ func (sg *SegmentGroup) segmentAtPositionHasID(pos int, id string) bool {
 // (segments born from WAL replay were already durably pended by the recovery
 // itself; see mayRecoverFromCommitLogs). Runs before the compaction cycle
 // registers, so no pass races the segment-set read.
-func (sg *SegmentGroup) recoverEditOps(ctx context.Context) error {
+func (sg *SegmentGroup) recoverEditOps(ctx context.Context) (err error) {
 	if sg.editOps == nil {
 		return nil
 	}
 	sg.maintenanceLock.RLock()
 	ids := sg.currentSegmentIDsLocked()
 	sg.maintenanceLock.RUnlock()
-	return sg.editOps.Recover(ids,
+	// Deferred, so a shard whose recovery fails non-fatally (see the caller)
+	// still publishes the stalled state the gauges exist to show — provided the
+	// sidecar is readable; the ErrTimeout guard exists because on that path it
+	// is not: the flock is still held, the refresh would re-open bolt and eat a
+	// second BoltFlockTimeout on a load that is already failing, and the failed
+	// load discards this group, whose init rollback reaps instead.
+	defer func() {
+		if errors.Is(err, bolterrors.ErrTimeout) {
+			return
+		}
+		sg.refreshEditOpsMetrics()
+	}()
+	if err = sg.editOps.Recover(ids,
 		func() map[string]struct{} { return sg.liveEditOpIDs(ctx, false) },
-		func() map[string]struct{} { return sg.liveEditOpIDs(ctx, true) })
+		func() map[string]struct{} { return sg.liveEditOpIDs(ctx, true) }); err != nil {
+		return err
+	}
+	return nil
 }
 
 // liveEditOpIDs resolves the live-op set for the orphan sweep via the package
@@ -859,6 +894,126 @@ func (sg *SegmentGroup) liveEditOpIDs(ctx context.Context, fresh bool) map[strin
 	return live
 }
 
+// editOpsOwesWork reports whether the sidecar still holds an armed op, i.e.
+// whether this shard's gauges are still describing live work. Read errors
+// answer TRUE: keeping a series that should have gone costs a stale reading
+// until the next load, while dropping one that should have stayed hides a
+// stalled drop for good.
+func (sg *SegmentGroup) editOpsOwesWork() bool {
+	has, err := sg.editOps.HasOps()
+	if err != nil {
+		sg.logger.WithField("action", "lsm_editops_metrics").
+			Warnf("check for live edit ops before reaping metrics: %v", err)
+		return true
+	}
+	return has
+}
+
+// reapEditOpsMetrics retires this shard's edit-op series for good. The latch is
+// set and the series deleted under the SAME lock hold, so a refresh cannot slip
+// between the two and republish what was just deleted; every later refresh
+// returns at the latch. Safe to call more than once, and safe to call on a
+// segment group that never published.
+func (sg *SegmentGroup) reapEditOpsMetrics() {
+	sg.editOpsMetricsLock.Lock()
+	defer sg.editOpsMetricsLock.Unlock()
+
+	sg.editOpsMetricsReaped = true
+	sg.metrics.DeleteEditOpsShardSeries()
+}
+
+// refreshEditOpsMetrics recomputes the edit-op gauges from the sidecar's current
+// state: active ops per type, and pending / forced-cleanup-remaining segment
+// counts per op. Deriving from ground truth (rather than incrementing on each
+// transition) keeps the gauges drift-free across crashes and resumes. Ops that
+// vanished since the previous refresh (completion or orphan sweep) are
+// reconciled too: their op-id series are dropped and their type count zeroed,
+// so a finished drop never lingers as a stale "active" reading. Called on
+// op-lifecycle changes, once per cleanup pass, and after compaction retires
+// pending rows — never per read or write.
+func (sg *SegmentGroup) refreshEditOpsMetrics() {
+	if sg.editOps == nil || !sg.metrics.editOpsEnabled() {
+		return
+	}
+
+	sg.editOpsMetricsLock.Lock()
+	defer sg.editOpsMetricsLock.Unlock()
+
+	if sg.editOpsMetricsReaped {
+		return
+	}
+
+	// Read the sidecar INSIDE the lock. Two refreshes racing here would other-
+	// wise interleave their reads and writes, and the one holding the older
+	// snapshot could re-publish an op the other had just forgotten. The lock
+	// does not cover the writers, which is why the three sets come from one
+	// transaction rather than three — see MetricsSnapshot.
+	ops, pending, quarantined, err := sg.editOps.MetricsSnapshot()
+	if err != nil {
+		sg.logger.WithField("action", "lsm_editops_metrics").
+			Warnf("refresh edit-op metrics: %v", err)
+		return
+	}
+
+	queued := make(map[string]int, len(ops))
+	for _, p := range pending {
+		queued[p.OpID]++
+	}
+	owed := make(map[string]int, len(ops))
+	for id, n := range queued {
+		owed[id] = n
+	}
+	for _, q := range quarantined {
+		owed[q.OpID]++
+	}
+
+	perType := make(map[OpType]int, len(ops))
+	opIDs := make(map[string]struct{}, len(ops))
+	for _, op := range ops {
+		perType[op.Descriptor.Type]++
+		opIDs[op.ID] = struct{}{}
+		// Queued excludes quarantined; owed includes it. They diverge exactly
+		// when the retry budget gave up on a segment, which is what makes a
+		// stalled drop distinguishable from a finished one.
+		sg.metrics.SetEditOpsPendingSegments(op.ID, queued[op.ID])
+		sg.metrics.SetEditOpsSegmentsOwed(op.ID, owed[op.ID])
+	}
+	for id := range sg.editOpsSeenOpIDs {
+		if _, ok := opIDs[id]; !ok {
+			sg.metrics.ForgetEditOp(id)
+		}
+	}
+	for opType := range sg.editOpsSeenTypes {
+		if _, ok := perType[opType]; !ok {
+			perType[opType] = 0
+		}
+	}
+	seenTypes := make(map[OpType]struct{}, len(perType))
+	for opType, n := range perType {
+		sg.metrics.SetEditOpsActive(string(opType), n)
+		if n > 0 {
+			seenTypes[opType] = struct{}{}
+		}
+	}
+	sg.editOpsSeenOpIDs = opIDs
+	sg.editOpsSeenTypes = seenTypes
+}
+
+// distinctOpTypes returns the unique op types in ops, the label set for the
+// per-pass transformer duration metric (one pass applies every active op at once).
+func distinctOpTypes(ops []ActiveOp) []string {
+	seen := make(map[OpType]struct{}, len(ops))
+	var out []string
+	for _, op := range ops {
+		if _, ok := seen[op.Descriptor.Type]; ok {
+			continue
+		}
+		seen[op.Descriptor.Type] = struct{}{}
+		out = append(out, string(op.Descriptor.Type))
+	}
+	return out
+}
+
 // registerEditOpAndSnapshot registers opID and snapshots the current on-disk
 // segments in one write. Idempotent via the snapshot guard (not the descriptor),
 // so a resume completes an interrupted register rather than skipping it, and one
@@ -877,9 +1032,22 @@ func (sg *SegmentGroup) registerEditOpAndSnapshot(opID string, desc OpDescriptor
 		return nil
 	}
 
-	sg.maintenanceLock.RLock()
-	defer sg.maintenanceLock.RUnlock()
-	return sg.editOps.RegisterOpWithSnapshot(opID, desc, sg.currentSegmentIDsLocked())
+	// The closure exists to scope maintenanceLock to the snapshot itself, so the
+	// metrics refresh below runs outside it: the refresh opens a bolt read
+	// transaction, and holding maintenanceLock across it would block compaction
+	// for the duration. (Flush is serialized with arming regardless — the caller
+	// holds flushAndSwitchMu across this whole call.) Keeping the unlock
+	// deferred means an error or panic in the snapshot still releases it.
+	err = func() error {
+		sg.maintenanceLock.RLock()
+		defer sg.maintenanceLock.RUnlock()
+		return sg.editOps.RegisterOpWithSnapshot(opID, desc, sg.currentSegmentIDsLocked())
+	}()
+	if err != nil {
+		return err
+	}
+	sg.refreshEditOpsMetrics()
+	return nil
 }
 
 // requeueQuarantinedEditOps returns opID's quarantined segments to pending with
@@ -1200,6 +1368,23 @@ func (sg *SegmentGroup) countWithSegmentList(segments []Segment) int {
 }
 
 func (sg *SegmentGroup) shutdown(ctx context.Context) error {
+	// Reap on unload ONLY when this shard owes nothing. An unload is not a
+	// delete: tenant deactivation takes this same path (Migrator's
+	// tenants_to_cold), and a drop stalled on a cold tenant is exactly what
+	// these gauges exist to show — blanking it there makes a stalled drop read
+	// identically to no drop. Every sibling per-shard LSM gauge survives an
+	// unload for the same reason and is reaped only on delete; Store.
+	// ReapEditOpsMetrics is this metric's equivalent, called from Shard.drop.
+	//
+	// Reaped on EVERY exit below, the failure returns included: a shard whose
+	// teardown fails is torn, not retried (sticky teardownErr, heals only on
+	// process restart), so a reap skipped here never happens. Ordering against
+	// still-live refreshes is the latch's job, not this defer's — a failed
+	// Unregister leaves the cycle callback running (see editOpsMetricsReaped).
+	// The decision is taken before Unregister so the failure paths inherit it.
+	if sg.editOps != nil && !sg.editOpsOwesWork() {
+		defer sg.reapEditOpsMetrics()
+	}
 	if err := sg.compactionCallbackCtrl.Unregister(ctx); err != nil {
 		return fmt.Errorf("long-running compaction in progress: %w", ctx.Err())
 	}

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -657,6 +657,10 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 	sweepCtx, sweepCancel := context.WithTimeout(context.Background(), editOpsSweepTimeout)
 	c.sg.editOps.SweepOrphans(sweepCtx)
 	sweepCancel()
+	// Both the sweep and this pass mutate op state (delete, mark-done, bump, or
+	// quarantine); resync the gauges from ground truth on the way out, whichever
+	// branch we return on.
+	defer c.sg.refreshEditOpsMetrics()
 
 	pending, err := c.sg.editOps.AllPending()
 	if err != nil {
@@ -721,7 +725,8 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 		if len(strippedRows) == 0 {
 			continue
 		}
-		idx, tmpPath, found, cerr := c.cleanPendingSegmentToTmp(segID, transformer, shouldAbort)
+		rewriteStart := time.Now()
+		idx, tmpPath, oldSize, newSize, found, cerr := c.cleanPendingSegmentToTmp(segID, transformer, shouldAbort)
 		if cerr != nil {
 			if errors.Is(cerr, errCleanupPaused) || errors.Is(cerr, errCleanupAborted) {
 				// Memory pressure (pause) or a cycle-manager abort (e.g. shutdown):
@@ -793,6 +798,16 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 		if e := c.markRowsDone(strippedRows); e != nil {
 			return true, true, e
 		}
+
+		// One pass applies every active op's transformer at once, so attribute
+		// the rewrite cost to each op type present. Bytes reclaimed is the 1:1
+		// rewrite's shrinkage (input minus output); AddEditOpsBytesReclaimed
+		// drops it when the transformer did not shrink the segment.
+		elapsed := time.Since(rewriteStart).Seconds()
+		for _, opType := range distinctOpTypes(builtOps) {
+			c.sg.metrics.ObserveEditOpsTransformerDuration(opType, elapsed)
+			c.sg.metrics.AddEditOpsBytesReclaimed(opType, oldSize-newSize)
+		}
 		return true, true, nil
 	}
 	return false, true, nil
@@ -805,7 +820,7 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 // errCleanupPaused if memory pressure should pause the pass before the rewrite.
 func (c *segmentCleanerCommon) cleanPendingSegmentToTmp(segID string,
 	transformer valueTransformer, shouldAbort cyclemanager.ShouldAbortCallback,
-) (idx int, tmpPath string, found bool, err error) {
+) (idx int, tmpPath string, oldSize, newSize int64, found bool, err error) {
 	segments, release := c.sg.getConsistentViewOfSegments()
 	defer release()
 
@@ -817,7 +832,7 @@ func (c *segmentCleanerCommon) cleanPendingSegmentToTmp(segID string,
 		}
 	}
 	if idx == emptyIdx {
-		return emptyIdx, "", false, nil
+		return emptyIdx, "", 0, 0, false, nil
 	}
 
 	// Mirror the heuristic path's OOM guard: a rewrite produces a full copy of the
@@ -825,16 +840,17 @@ func (c *segmentCleanerCommon) cleanPendingSegmentToTmp(segID string,
 	// than push the system further. A pause must not count as a failed attempt.
 	if c.sg.allocChecker != nil {
 		if err := c.sg.allocChecker.CheckAlloc(cleanupAllocCheckBytes); err != nil {
-			return emptyIdx, "", false, errCleanupPaused
+			return emptyIdx, "", 0, 0, false, errCleanupPaused
 		}
 	}
 
 	oldSegment := segments[idx]
+	oldSize = oldSegment.Size()
 	tmpPath = c.sg.tmpSegmentPath(oldSegment, segID)
 
 	file, err := os.Create(tmpPath)
 	if err != nil {
-		return emptyIdx, "", false, err
+		return emptyIdx, "", 0, 0, false, err
 	}
 
 	// The last segment has no newer segments to shadow it; it is rewritten
@@ -851,17 +867,21 @@ func (c *segmentCleanerCommon) cleanPendingSegmentToTmp(segID string,
 		c.sg.enableChecksumValidation, transformer)
 	if err := cleaner.do(shouldAbort); err != nil {
 		file.Close()
-		return emptyIdx, "", false, err
+		return emptyIdx, "", 0, 0, false, err
 	}
 	if err := file.Sync(); err != nil {
 		file.Close()
-		return emptyIdx, "", false, fmt.Errorf("fsync cleaned segment file: %w", err)
+		return emptyIdx, "", 0, 0, false, fmt.Errorf("fsync cleaned segment file: %w", err)
 	}
 	if err := file.Close(); err != nil {
-		return emptyIdx, "", false, fmt.Errorf("close cleaned segment file: %w", err)
+		return emptyIdx, "", 0, 0, false, fmt.Errorf("close cleaned segment file: %w", err)
 	}
 
-	return idx, tmpPath, true, nil
+	if fi, statErr := os.Stat(tmpPath); statErr == nil {
+		newSize = fi.Size()
+	}
+
+	return idx, tmpPath, oldSize, newSize, true, nil
 }
 
 // tmpSegmentPath returns the .tmp path a cleaned/rewritten segment with the given

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -658,6 +658,10 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 	sweepCtx, sweepCancel := context.WithTimeout(context.Background(), editOpsSweepTimeout)
 	c.sg.editOps.SweepOrphans(sweepCtx)
 	sweepCancel()
+	// Both the sweep and this pass mutate op state (delete, mark-done, bump, or
+	// quarantine); resync the gauges from ground truth on the way out, whichever
+	// branch we return on.
+	defer c.sg.refreshEditOpsMetrics()
 
 	pending, err := c.sg.editOps.AllPending()
 	if err != nil {
@@ -722,7 +726,7 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 		if len(strippedRows) == 0 {
 			continue
 		}
-		idx, tmpPath, found, cerr := c.cleanPendingSegmentToTmp(segID, transformer, shouldAbort)
+		idx, tmpPath, found, cerr := c.cleanPendingSegmentToTmp(segID, transformer, distinctOpTypes(builtOps), shouldAbort)
 		if cerr != nil {
 			if errors.Is(cerr, errCleanupPaused) || errors.Is(cerr, errCleanupAborted) {
 				// Memory pressure (pause) or a cycle-manager abort (e.g. shutdown):
@@ -794,6 +798,7 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 		if e := c.markRowsDone(strippedRows); e != nil {
 			return true, true, e
 		}
+
 		return true, true, nil
 	}
 	return false, true, nil
@@ -805,7 +810,7 @@ func (c *segmentCleanerCommon) cleanupOnceEditOps(shouldAbort cyclemanager.Shoul
 // concurrent compaction); idx is consumed by replaceSegment. Returns
 // errCleanupPaused if memory pressure should pause the pass before the rewrite.
 func (c *segmentCleanerCommon) cleanPendingSegmentToTmp(segID string,
-	transformer valueTransformer, shouldAbort cyclemanager.ShouldAbortCallback,
+	transformer valueTransformer, opTypes []string, shouldAbort cyclemanager.ShouldAbortCallback,
 ) (idx int, tmpPath string, found bool, err error) {
 	segments, release := c.sg.getConsistentViewOfSegments()
 	defer release()
@@ -861,7 +866,24 @@ func (c *segmentCleanerCommon) cleanPendingSegmentToTmp(segID string,
 		}
 		return cause
 	}
-	if err := cleaner.do(shouldAbort); err != nil {
+	// Time the rewrite loop — cursor scan, shadowed-key checks, transform and
+	// buffered writes — excluding the fsync and close below, which have nothing
+	// to do with the edit op and would make the histogram a measure of disk
+	// sync latency wearing the op's label.
+	transformStart := time.Now()
+	derr := cleaner.do(shouldAbort)
+	transformSeconds := time.Since(transformStart).Seconds()
+	// FAILED attempts are observed — their time was fully spent, and a segment
+	// quarantined after five failures is exactly the tail the histogram is
+	// wanted for. ABORTED ones are not: shouldAbort cut the transform off
+	// mid-segment, so the sample is a truncated fraction of the real cost —
+	// the same reasoning the caller uses to not count an abort as an attempt.
+	if !errors.Is(derr, errCleanupAborted) {
+		for _, opType := range opTypes {
+			c.sg.metrics.ObserveEditOpsTransformerDuration(opType, transformSeconds)
+		}
+	}
+	if err := derr; err != nil {
 		file.Close()
 		return emptyIdx, "", false, discardPartial(err)
 	}

--- a/adapters/repos/db/lsmkv/segment_group_cleanup_editops_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup_editops_test.go
@@ -64,6 +64,29 @@ func newReplaceBucketWithEditOps(t *testing.T, factory OpTransformerFactory) (*B
 	return bucket, bucket.disk.editOps
 }
 
+// newReplaceBucketWithEditOpsNoShutdown is newReplaceBucketWithEditOps without
+// the Cleanup that shuts the bucket down, for tests that drive the shutdown
+// themselves and would otherwise hit a double teardown.
+func newReplaceBucketWithEditOpsNoShutdown(t *testing.T, factory OpTransformerFactory) (*Bucket, *SegmentEditOps) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSegmentsCleanupInterval(time.Hour))
+	require.NoError(t, err)
+	bucket.SetMemtableThreshold(1e9)
+
+	transformers := map[OpType]OpTransformerFactory{}
+	if factory != nil {
+		transformers[OpTypeRemoveTargetVectors] = factory
+	}
+	bucket.disk.editOps = newSegmentEditOpsWithLookup(bucket.disk.dir, "TestClass", staticResolver(transformers))
+	return bucket, bucket.disk.editOps
+}
+
 func segIDsOf(bucket *Bucket) []string {
 	var ids []string
 	for _, s := range bucket.disk.segments {

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -423,12 +423,23 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			c.c2.releaseReader()
 		}()
 
+		compactStart := time.Now()
 		aborted, err := runCompactor(c.do)
 		if err != nil {
 			return false, err
 		}
 		if aborted {
 			return false, nil
+		}
+		if transformer != nil {
+			// A transformer ran as part of this merge; record its pass duration.
+			// Bytes reclaimed is left to the 1:1 cleaner rewrite, where shrinkage is
+			// purely the transformer's; a merge's savings also come from dedup, so
+			// they can't be cleanly attributed to the edit op here.
+			elapsed := time.Since(compactStart).Seconds()
+			for _, opType := range distinctOpTypes(builtOps) {
+				sg.metrics.ObserveEditOpsTransformerDuration(opType, elapsed)
+			}
 		}
 	case segmentindex.StrategySetCollection:
 		c := newCompactorSetCollection(f, left.newCollectionCursorReusable(), right.newCollectionCursorReusable(),

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -330,6 +330,11 @@ func (sg *SegmentGroup) watchAbort(ctx context.Context,
 // shouldAbort turning true, aborts the in-flight merge (sampled every
 // compactor.AbortCheckEveryN keys). Its shouldAbort bridge is built only once
 // there is a pair to merge, so an idle cycle needs no context, goroutine or ticker.
+// No compaction path records the transformer duration, on any strategy.
+// A compaction runs the same transformer, but findCompactionCandidates picked
+// the merge for its own reasons and without consulting the edit ops — the work
+// would have happened regardless. Timing it under the op's label would bill
+// unrelated merges to the drop, including merges with nothing to strip.
 func (sg *SegmentGroup) compactOnceAbortable(ctx context.Context,
 	shouldAbort cyclemanager.ShouldAbortCallback,
 ) (compacted bool, err error) {
@@ -601,6 +606,11 @@ func (sg *SegmentGroup) compactOnceAbortable(ctx context.Context,
 		if err := sg.recordCompactionEditOps(segmentID(leftPath), segmentID(rightPath), builtOps); err != nil {
 			return false, err
 		}
+		// A compaction retires the pending rows of both inputs, so without this
+		// the gauges read high until the next cleanup pass happens to refresh
+		// them — and on a bucket whose rows compaction drained entirely, that is
+		// only the force-cleanup interval away.
+		sg.refreshEditOpsMetrics()
 	}
 
 	sg.metrics.DecSegmentTotalByStrategy(sg.strategy)

--- a/adapters/repos/db/lsmkv/segment_group_editops_metrics_callsites_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_editops_metrics_callsites_test.go
@@ -1,0 +1,293 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// The tests in this file pin the CALL SITES of refreshEditOpsMetrics, not the
+// refresh itself: a test that hand-calls the refresh at each assertion point
+// (as the sibling file's do) exercises the function while leaving every
+// production caller unpinned. Nothing below may call the refresh directly;
+// each drives a real entry point and then reads the gauges.
+
+const (
+	editOpsActiveFam  = "weaviate_lsm_segment_edit_ops_active"
+	editOpsPendingFam = "weaviate_lsm_segment_edit_ops_pending_segments"
+	editOpsOwedFam    = "weaviate_lsm_segment_edit_ops_segments_owed"
+)
+
+// installEditOpsMetrics binds a REAL Metrics to the bucket's segment group. The
+// hand-built Metrics{editOps: ...} the sibling file uses cannot be reused here:
+// the production entry points these tests drive also touch the compaction and
+// segment-strategy vecs a minimal one leaves nil, and nil-deref instead of
+// asserting. That means gathering from the default registry, so every test
+// takes its own class name to keep its assertions off the others' series.
+func installEditOpsMetrics(t *testing.T, bucket *Bucket, className string) {
+	t.Helper()
+	m, err := NewMetrics(monitoring.GetMetrics(), className, "shardA")
+	require.NoError(t, err)
+	require.NotNil(t, m.editOps, "monitoring must be on for these to pin anything")
+	orig := bucket.disk.metrics
+	bucket.disk.metrics = m
+	t.Cleanup(func() { bucket.disk.metrics = orig })
+}
+
+func opIDLabels(className, opID string) map[string]string {
+	return map[string]string{"op_id": opID, "class_name": className, "shard_name": "shardA"}
+}
+
+func opTypeLabels(className string) map[string]string {
+	return map[string]string{
+		"op_type": string(OpTypeRemoveTargetVectors), "class_name": className, "shard_name": "shardA",
+	}
+}
+
+// TestEditOpsMetrics_RegisterPublishes pins the refresh in
+// registerEditOpAndSnapshot. Arming a drop is the moment the gauges must appear:
+// without this call site a shard shows nothing until some later pass happens to
+// refresh, so the start of a strip is invisible.
+func TestEditOpsMetrics_RegisterPublishes(t *testing.T) {
+	bucket, _ := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	const className = "EditOpsCallsiteRegisterClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	require.NoError(t, bucket.RegisterEditOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+
+	active, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "arming a drop must publish the active gauge")
+	require.Equal(t, float64(1), active)
+
+	pending, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "arming a drop must publish the pending gauge")
+	require.Equal(t, float64(2), pending, "both segments are owed")
+}
+
+// TestEditOpsMetrics_ReArmRequeueClearsStall pins the refresh on the resume arm
+// of Bucket.RegisterEditOp. A re-arm hands quarantined segments a fresh budget,
+// which is exactly the transition that clears the owed-above-queued signature a
+// stalled drop is read by — so a dashboard left on the stale reading would show
+// a stall that the re-arm already cleared.
+func TestEditOpsMetrics_ReArmRequeueClearsStall(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	require.NoError(t, bucket.RegisterEditOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	segs := segIDsOf(bucket)
+	require.Len(t, segs, 1)
+	require.NoError(t, editOps.Quarantine("op1", segs[0]))
+
+	// Install AFTER the quarantine so the first reading below is the re-arm's,
+	// not a leftover from the register above.
+	const className = "EditOpsCallsiteReArmClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	// Re-arm: same op id, already snapshotted, so this takes the resume arm.
+	require.NoError(t, bucket.RegisterEditOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 2}))
+
+	pending, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.True(t, ok)
+	require.Equal(t, float64(1), pending, "the requeued segment is back in the queue")
+
+	owed, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok)
+	require.Equal(t, float64(1), owed)
+	require.Equal(t, pending, owed, "owed must not still read above queued: the stall is over")
+}
+
+// TestEditOpsMetrics_CleanupPassRefreshes pins the deferred refresh in
+// cleanupOnceEditOps. The cleanup pass is what actually drains the queue, so
+// without this call site the progress gauge never moves while the strip runs —
+// which is the one thing the pending gauge exists to show.
+func TestEditOpsMetrics_CleanupPassRefreshes(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	const className = "EditOpsCallsiteCleanupClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	// One pass rewrites exactly one segment, so this pins that the gauge tracks
+	// the drain rather than only its start and end.
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+	require.NoError(t, err)
+	require.True(t, cleaned)
+
+	pending, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "a cleanup pass must publish progress on its own")
+	require.Equal(t, float64(1), pending, "one of the two segments has been rewritten")
+}
+
+// TestEditOpsMetrics_CompactionRefreshes pins the refresh in the compaction
+// bookkeeping. A compaction retires the pending rows of BOTH inputs at once, so
+// without this call site the gauges read high until the next cleanup pass — and
+// on a bucket whose rows compaction drained entirely, that is a whole
+// force-cleanup interval of a finished drop reading as unfinished.
+func TestEditOpsMetrics_CompactionRefreshes(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	const className = "EditOpsCallsiteCompactionClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	compacted, err := bucket.disk.compactOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, compacted, "the two segments must merge for this to pin anything")
+
+	// The merge ran the transformer over both inputs, so it retired the whole
+	// pending set on its own. Nothing refreshed before this point — the metrics
+	// went in after the snapshot — so the series EXISTING at all is what pins
+	// the call site, and its value being zero is what pins that the refresh read
+	// post-merge state. Without it this drop reads as unfinished until a
+	// force-cleanup interval later.
+	pending, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "compaction bookkeeping must refresh on its own")
+	require.Zero(t, pending, "the merge drained the pending set")
+
+	owed, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok)
+	require.Zero(t, owed, "and owed nothing beyond it")
+}
+
+// TestEditOpsMetrics_RecoveryPublishesOnLoad pins the refresh call in
+// recoverEditOps: a recovered shard must publish at load, without waiting for a
+// cleanup pass. It does NOT pin the call being deferred — this recovery
+// succeeds, so defer and tail-call are indistinguishable here. The deferral
+// covers recoveries that fail in Reconcile's write phase (ENOSPC-class) with
+// the sidecar still readable; producing that needs fault injection this
+// harness doesn't have, so that placement is asserted by review, not by test.
+func TestEditOpsMetrics_RecoveryPublishesOnLoad(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	const className = "EditOpsCallsiteRecoveryClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	// No liveness provider is installed, so the orphan sweep is skipped and
+	// recovery keeps the recorded pending set — the resume point of a strip
+	// interrupted by the restart this simulates.
+	require.NoError(t, bucket.disk.recoverEditOps(context.Background()))
+
+	active, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "a recovered shard must publish without waiting for a pass")
+	require.Equal(t, float64(1), active)
+
+	owed, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok)
+	require.Equal(t, float64(1), owed)
+}
+
+// TestEditOpsMetrics_UnloadKeepsGaugesWhileWorkIsOwed pins the unload/delete
+// distinction. Tenant deactivation unloads a shard through this exact path
+// (Migrator's tenants_to_cold), and a drop stalled on a cold tenant is the
+// state these gauges exist to report — reaping there would make it read
+// identically to no drop at all. Every sibling per-shard LSM gauge survives an
+// unload for the same reason; only a delete retires them.
+func TestEditOpsMetrics_UnloadKeepsGaugesWhileWorkIsOwed(t *testing.T) {
+	ctx := context.Background()
+	bucket, editOps := newReplaceBucketWithEditOpsNoShutdown(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	const className = "EditOpsUnloadKeepsClass"
+	installEditOpsMetrics(t, bucket, className)
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+	bucket.disk.refreshEditOpsMetrics()
+
+	owed, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "precondition: the strip is published")
+	require.Equal(t, float64(1), owed)
+
+	require.NoError(t, bucket.Shutdown(ctx))
+
+	owed, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "an unload with work owed must keep reporting it")
+	require.Equal(t, float64(1), owed, "and must keep the value it last read")
+	active, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok)
+	require.Equal(t, float64(1), active)
+}
+
+// TestEditOpsMetrics_ShutdownReapsADrainedShard pins the other half: once the
+// shard owes nothing, its series are stale rather than informative, so an
+// unload retires them. Driven through the EARLIEST failure return (a cancelled
+// context fails the callback Unregister) because the reap is deferred
+// specifically so the failure paths are covered — a torn shard is never
+// retried, so a reap skipped there never happens at all.
+func TestEditOpsMetrics_ShutdownReapsADrainedShard(t *testing.T) {
+	ctx := context.Background()
+	bucket, editOps := newReplaceBucketWithEditOpsNoShutdown(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	const className = "EditOpsShutdownDrainedClass"
+	installEditOpsMetrics(t, bucket, className)
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	segs := segIDsOf(bucket)
+	require.NoError(t, editOps.SnapshotSegments("op1", segs))
+	bucket.disk.refreshEditOpsMetrics()
+	_, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "precondition: the shard is publishing before it goes down")
+
+	// Drain it: the op completes and is deleted, leaving a zero-valued active
+	// series and no live work.
+	require.NoError(t, editOps.MarkSegmentDone("op1", segs[0]))
+	deleted, _, _, err := bucket.DeleteEditOpIfDrained("op1")
+	require.NoError(t, err)
+	require.True(t, deleted)
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "precondition: the drained shard still carries a zero-valued series")
+
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	require.Error(t, bucket.disk.shutdown(cancelled), "precondition: this teardown must fail")
+
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.False(t, ok, "a drained shard's series must not survive its unload")
+}

--- a/adapters/repos/db/lsmkv/segment_group_editops_metrics_reap_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_editops_metrics_reap_test.go
@@ -1,0 +1,294 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// blockingTransformer returns a transformer factory that parks on `entered` for
+// its first value and then waits for `release`, so a cleanup pass can be held
+// mid-rewrite with the cycle callback observably RUNNING.
+func blockingTransformer(entered chan<- struct{}, release <-chan struct{}) OpTransformerFactory {
+	var signalled bool
+	return func(className string, ops []ActiveOp) func([]byte) ([]byte, error) {
+		return func(v []byte) ([]byte, error) {
+			if !signalled {
+				signalled = true
+				close(entered)
+				<-release
+			}
+			return append([]byte("X:"), v...), nil
+		}
+	}
+}
+
+// TestEditOpsMetrics_ReapSurvivesALivePass pins the latch against the one thing
+// that can undo a reap: a cleanup pass that is already running when it happens.
+// The delete path reaps while the shard is still live (Shard.drop calls
+// Store.ReapEditOpsMetrics before the teardown it defers), and a pass mid-flight
+// finishes afterwards and refreshes. Without the latch that refresh republishes
+// everything the reap just deleted, and no second reap ever comes.
+//
+// A real callback group and cycle manager drive the pass, and the transformer
+// parks mid-rewrite, so the overlap is the production one rather than a
+// hand-placed call.
+func TestEditOpsMetrics_ReapSurvivesALivePass(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", logger, 1)
+	bucket, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), t.TempDir(), logger, nil,
+		compactionCallbacks, cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSegmentsCleanupInterval(time.Hour))
+	require.NoError(t, err)
+	bucket.SetMemtableThreshold(1e9)
+	bucket.disk.editOps = newSegmentEditOpsWithLookup(bucket.disk.dir, "TestClass",
+		staticResolver(map[OpType]OpTransformerFactory{
+			OpTypeRemoveTargetVectors: blockingTransformer(entered, release),
+		}))
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	const className = "EditOpsLivePassReapClass"
+	m, err := NewMetrics(monitoring.GetMetrics(), className, "shardA")
+	require.NoError(t, err)
+	bucket.disk.metrics = m
+
+	require.NoError(t, bucket.disk.editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, bucket.disk.editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	bucket.disk.refreshEditOpsMetrics()
+	for _, pre := range []struct {
+		fam    string
+		labels map[string]string
+	}{
+		{editOpsActiveFam, opTypeLabels(className)},
+		{editOpsPendingFam, opIDLabels(className, "op1")},
+		{editOpsOwedFam, opIDLabels(className, "op1")},
+	} {
+		_, ok := gaugeValue(t, prometheus.DefaultGatherer, pre.fam, pre.labels)
+		require.True(t, ok, "precondition: %s must be published before the reap", pre.fam)
+	}
+
+	cycle := cyclemanager.NewManager("editops-reap-test",
+		cyclemanager.NewFixedTicker(10*time.Millisecond), compactionCallbacks.CycleCallback, logger)
+	cycle.Start()
+	defer cycle.StopAndWait(ctx)
+
+	// The pass is now inside the transformer, so the reap below lands with a
+	// refresh guaranteed to follow it.
+	<-entered
+
+	bucket.disk.reapEditOpsMetrics()
+
+	close(release)
+	require.Eventually(t, func() bool {
+		pending, err := bucket.disk.editOps.Pending("op1")
+		return err == nil && len(pending) == 0
+	}, 5*time.Second, 10*time.Millisecond, "the parked pass must run to completion after the reap")
+
+	// One lookup per family, each under its own label schema — the active gauge
+	// is keyed by op_type, the other two by op_id, and a lookup with the wrong
+	// schema can never match, so a loop reusing one label set would pass
+	// vacuously for two of the three.
+	_, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.False(t, ok, "active series was republished after the reap")
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.False(t, ok, "pending series was republished after the reap")
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.False(t, ok, "owed series was republished after the reap")
+
+	require.NoError(t, bucket.Shutdown(ctx))
+}
+
+// TestEditOpsMetrics_ReapSurvivesASidecarRemoval pins the second way a reap gets
+// undone. Deleting the last op removes the sidecar file, after which
+// MetricsSnapshot reads empty WITHOUT returning an error — indistinguishable
+// from a healthy empty sidecar. A refresh landing there republishes a
+// zero-valued active child over the reaped series, which then sticks forever.
+func TestEditOpsMetrics_ReapSurvivesASidecarRemoval(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	const className = "EditOpsSidecarRemovalClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	require.NoError(t, bucket.RegisterEditOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	_, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "precondition: the shard is publishing")
+
+	bucket.disk.reapEditOpsMetrics()
+
+	// Drain and delete the only op, which removes the sidecar file underneath.
+	segs := segIDsOf(bucket)
+	require.NoError(t, editOps.MarkSegmentDone("op1", segs[0]))
+	deleted, _, _, err := bucket.DeleteEditOpIfDrained("op1")
+	require.NoError(t, err)
+	require.True(t, deleted)
+
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.False(t, ok, "a removed sidecar must not resurrect the reaped active series")
+}
+
+// TestEditOpsMetrics_DiscardedSegmentGroupLeavesNoSeries pins the third way a
+// reap gets undone, and drives the real construction path rather than calling
+// the reap by hand. recoverEditOps publishes on its own failure by design — a
+// shard whose drop is stalled is exactly what the gauges are for — but a segment
+// group that fails to CONSTRUCT is discarded, and a discarded group never
+// reaches shutdown, so nothing else would ever reap what it published.
+//
+// The injected failure is a cleanup.db path that bolt cannot open, which lands
+// in newSegmentCleaner immediately after recovery.
+func TestEditOpsMetrics_DiscardedSegmentGroupLeavesNoSeries(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	const className = "EditOpsDiscardedGroupClass"
+	newMetrics := func(t *testing.T) *Metrics {
+		t.Helper()
+		m, err := NewMetrics(monitoring.GetMetrics(), className, "shardA")
+		require.NoError(t, err)
+		return m
+	}
+	open := func(t *testing.T) (*Bucket, error) {
+		t.Helper()
+		return NewBucketCreator().NewBucket(ctx, dir, dir, logger, newMetrics(t),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			WithStrategy(StrategyReplace), WithClassName(className),
+			WithSegmentsCleanupInterval(time.Hour))
+	}
+
+	// A first, healthy instance leaves a sidecar holding one armed op, so the
+	// reopen below has something to recover and publish.
+	bucket, err := open(t)
+	require.NoError(t, err)
+	bucket.SetMemtableThreshold(1e9)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.RegisterEditOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	_, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "precondition: the healthy instance publishes")
+	require.NoError(t, bucket.Shutdown(ctx))
+
+	// Break the cleaner's bolt file: a directory in its place makes bolt.Open
+	// fail, which fails newSegmentGroup just after recoverEditOps has published.
+	cleanupDB := filepath.Join(dir, cleanupDbFileName)
+	require.NoError(t, os.Remove(cleanupDB))
+	require.NoError(t, os.Mkdir(cleanupDB, 0o755))
+
+	_, err = open(t)
+	require.Error(t, err, "precondition: construction must fail after recovery")
+
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.False(t, ok, "a discarded segment group must leave no series behind")
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.False(t, ok)
+}
+
+// TestStoreReapEditOpsMetrics_RetiresEvenWithWorkOwed pins the delete-path
+// reap. An unload deliberately keeps a stalled shard's gauges, so a delete
+// needs its own retirement or a removed tenant's series live on forever —
+// Shard.drop calls this before the teardown it defers. Driven through the real
+// Store method rather than the segment group, because the store-wide loop is
+// what the drop path actually invokes.
+func TestStoreReapEditOpsMetrics_RetiresEvenWithWorkOwed(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	const className = "EditOpsStoreReapClass"
+	m, err := NewMetrics(monitoring.GetMetrics(), className, "shardA")
+	require.NoError(t, err)
+
+	store, err := New(dir, dir, logger, m, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	defer store.Shutdown(ctx)
+
+	require.NoError(t, store.CreateOrLoadBucket(ctx, "objects",
+		WithStrategy(StrategyReplace), WithClassName(className),
+		WithSegmentsCleanupInterval(time.Hour)))
+	bucket := store.Bucket("objects")
+	require.NotNil(t, bucket)
+	bucket.SetMemtableThreshold(1e9)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.RegisterEditOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+
+	owed, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "precondition: the strip is published")
+	require.Equal(t, float64(1), owed, "precondition: work is still owed")
+
+	store.ReapEditOpsMetrics()
+
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.False(t, ok, "a deleted shard must not keep its active series")
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.False(t, ok)
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.False(t, ok, "a deleted shard must not keep its owed series")
+}
+
+// TestReapEditOpsShardSeries_RetiresAnUnloadedShard pins the store-free reap.
+// A shard that owes work KEEPS its series across an unload, so deleting a
+// deactivated tenant has to retire them without a Store to loop over —
+// LazyLoadShard.drop's not-loaded branch is the caller. Without it, every
+// tenant deactivated mid-drop and then deleted leaks three series until the
+// process restarts.
+func TestReapEditOpsShardSeries_RetiresAnUnloadedShard(t *testing.T) {
+	const className = "EditOpsUnloadedReapClass"
+	prom := monitoring.GetMetrics()
+
+	// Publish as the shard would have before it was deactivated.
+	shard, err := monitoring.NewSegmentEditOpsMetrics(prom.Registerer, className, "shardA", prom.Group)
+	require.NoError(t, err)
+	shard.SetActive(string(OpTypeRemoveTargetVectors), 1)
+	shard.SetPendingSegments("op1", 2)
+	shard.SetSegmentsOwed("op1", 3)
+
+	owed, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "precondition: the deactivated shard is still publishing")
+	require.Equal(t, float64(3), owed)
+
+	require.NoError(t, ReapEditOpsShardSeries(prom, className, "shardA"))
+
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.False(t, ok, "deleting an unloaded shard must retire its active series")
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.False(t, ok)
+	_, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.False(t, ok, "deleting an unloaded shard must retire its owed series")
+}

--- a/adapters/repos/db/lsmkv/segment_group_editops_metrics_shape_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_editops_metrics_shape_test.go
@@ -1,0 +1,424 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
+
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+const editOpsDurationFam = "weaviate_lsm_segment_edit_ops_transformer_duration_seconds"
+
+// histogramCount returns the observation count of the series in family `name`
+// labelled `want`, and whether that series exists.
+func histogramCount(t *testing.T, g prometheus.Gatherer, name string, want map[string]string) (uint64, bool) {
+	t.Helper()
+	families, err := g.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if len(labels) != len(want) {
+				continue
+			}
+			match := true
+			for k, v := range want {
+				if labels[k] != v {
+					match = false
+				}
+			}
+			if match {
+				return m.GetHistogram().GetSampleCount(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// TestEditOpsMetrics_HistogramRecordsEveryAttempt pins the histogram's only
+// production observation site, and pins that it counts FAILED attempts too: a
+// segment quarantined after five failed rewrites spent that time five times
+// over, and a histogram observing only successes describes the easy cases
+// while omitting the pathological ones it is most wanted for.
+func TestEditOpsMetrics_HistogramRecordsEveryAttempt(t *testing.T) {
+	opType := map[string]string{"op_type": string(OpTypeRemoveTargetVectors)}
+
+	t.Run("a successful rewrite is observed", func(t *testing.T) {
+		bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+		require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+		require.NoError(t, bucket.FlushAndSwitch())
+		require.NoError(t, editOps.RegisterOp("op1",
+			OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+		require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+		installEditOpsMetrics(t, bucket, "EditOpsHistogramOkClass")
+
+		before, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+		cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+		require.NoError(t, err)
+		require.True(t, cleaned)
+
+		after, ok := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+		require.True(t, ok, "the cleanup pass must observe the transformer duration")
+		require.Equal(t, before+1, after)
+	})
+
+	t.Run("a failed rewrite is observed too", func(t *testing.T) {
+		bucket, editOps := newReplaceBucketWithEditOps(t, failingTransformer)
+		require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+		require.NoError(t, bucket.FlushAndSwitch())
+		require.NoError(t, editOps.RegisterOp("op1",
+			OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+		require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+		installEditOpsMetrics(t, bucket, "EditOpsHistogramFailClass")
+
+		before, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+		// A failed rewrite is deliberately NOT surfaced as a pass error — the
+		// retry budget decides what happens next, not the cycle — so the
+		// precondition is that the segment is still owed and has accrued an
+		// attempt, not that cleanupOnce returned an error.
+		cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+		require.NoError(t, err)
+		require.False(t, cleaned, "precondition: the rewrite must not have succeeded")
+		pending, err := editOps.AllPending()
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		require.Equal(t, 1, pending[0].Attempts, "precondition: the failure was counted")
+
+		after, ok := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+		require.True(t, ok)
+		require.Equal(t, before+1, after,
+			"the time a failed attempt spent in the transformer was still spent")
+	})
+
+	t.Run("a compaction is not observed", func(t *testing.T) {
+		// The carve-out the Help text promises: a compaction runs the same
+		// transformer, but findCompactionCandidates picked that merge for its
+		// own reasons, so billing it to the edit op would report work the drop
+		// did not cause.
+		bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+		require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+		require.NoError(t, bucket.FlushAndSwitch())
+		require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+		require.NoError(t, bucket.FlushAndSwitch())
+		require.NoError(t, editOps.RegisterOp("op1",
+			OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+		require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+		installEditOpsMetrics(t, bucket, "EditOpsHistogramCompactionClass")
+
+		before, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+		compacted, err := bucket.disk.compactOnce(context.Background())
+		require.NoError(t, err)
+		require.True(t, compacted, "precondition: the merge must have happened")
+
+		after, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+		require.Equal(t, before, after,
+			"compaction must not be billed to the edit op")
+	})
+}
+
+// TestEditOpsMetrics_HistogramSkipsAbortedRewrites pins the abort carve-out at
+// the observation site. shouldAbort cuts the transform off mid-segment (sampled
+// every 100 keys), so the elapsed time is a truncated fraction of the real cost
+// — and the retry budget refuses to count the same event as an attempt. The two
+// readings of one event must agree: neither an observation nor an attempt.
+func TestEditOpsMetrics_HistogramSkipsAbortedRewrites(t *testing.T) {
+	opType := map[string]string{"op_type": string(OpTypeRemoveTargetVectors)}
+
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	// Enough keys to reach the abort sample point (every 100th key).
+	for i := range 150 {
+		require.NoError(t, bucket.Put(fmt.Appendf(nil, "k%03d", i), []byte("v")))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+	installEditOpsMetrics(t, bucket, "EditOpsHistogramAbortClass")
+
+	before, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+	// False on the first call so the pass survives its pre-rewrite gate and
+	// actually enters the transformer; true from the in-loop sample (every
+	// 100th key) on, so the abort lands MID-transform — an always-true
+	// callback would bail before the rewrite and prove nothing.
+	calls := 0
+	abortMidTransform := func() bool { calls++; return calls > 1 }
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(abortMidTransform)
+	require.NoError(t, err)
+	require.False(t, cleaned, "precondition: the pass must have aborted")
+	require.Greater(t, calls, 1, "precondition: the in-loop sample must have fired")
+
+	pending, err := editOps.AllPending()
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Zero(t, pending[0].Attempts, "an abort is not a failed attempt")
+
+	after, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+	require.Equal(t, before, after,
+		"a truncated transform is not a sample; the retry budget already refuses to count it")
+}
+
+// TestEditOpsMetrics_HistogramDedupsOpTypes pins distinctOpTypes' dedup. One
+// pass applies every active op's transformer at once and attributes the cost
+// per op TYPE present — two concurrent drops (same type) must produce one
+// observation per pass, not one per op, or the histogram double-counts exactly
+// when the machinery is busiest.
+func TestEditOpsMetrics_HistogramDedupsOpTypes(t *testing.T) {
+	opType := map[string]string{"op_type": string(OpTypeRemoveTargetVectors)}
+
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	segs := segIDsOf(bucket)
+	require.NoError(t, editOps.RegisterOp("opA",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("opA", segs))
+	require.NoError(t, editOps.RegisterOp("opB",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 2}))
+	require.NoError(t, editOps.SnapshotSegments("opB", segs))
+	installEditOpsMetrics(t, bucket, "EditOpsHistogramDedupClass")
+
+	before, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+	require.NoError(t, err)
+	require.True(t, cleaned)
+
+	after, _ := histogramCount(t, prometheus.DefaultGatherer, editOpsDurationFam, opType)
+	require.Equal(t, before+1, after,
+		"two ops of one type share the pass, so its cost is one sample, not two")
+}
+
+// TestEditOpsMetrics_AttributesPerOp pins that the gauges are computed PER OP
+// rather than from a package total. Every other metrics test arms a single op
+// called op1, under which "the count for this op" and "the count for all ops"
+// are the same number — so a refresh that published the total everywhere stayed
+// green. Two concurrent drops on one shard are reachable in production: drop
+// vecB while vecA is still stripping.
+func TestEditOpsMetrics_AttributesPerOp(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	for _, k := range []string{"k1", "k2", "k3"} {
+		require.NoError(t, bucket.Put([]byte(k), []byte("v")))
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	segs := segIDsOf(bucket)
+	require.Len(t, segs, 3)
+
+	const className = "EditOpsPerOpClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	// Two ops of the SAME type, owing DIFFERENT numbers of segments.
+	require.NoError(t, editOps.RegisterOp("opA",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("opA", segs))
+	require.NoError(t, editOps.RegisterOp("opB",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 2}))
+	require.NoError(t, editOps.SnapshotSegments("opB", segs[:1]))
+
+	require.NoError(t, bucket.disk.recoverEditOps(t.Context()))
+
+	a, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "opA"))
+	require.True(t, ok)
+	require.Equal(t, float64(3), a, "opA owes three segments, not the shard total")
+
+	b, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "opB"))
+	require.True(t, ok)
+	require.Equal(t, float64(1), b, "opB owes one, and must not inherit opA's count")
+
+	// Same for owed, via a quarantine that only opA suffers.
+	require.NoError(t, editOps.Quarantine("opA", segs[2]))
+	require.NoError(t, bucket.disk.recoverEditOps(t.Context()))
+
+	owedA, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "opA"))
+	require.True(t, ok)
+	require.Equal(t, float64(3), owedA, "quarantined is still owed")
+	pendA, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "opA"))
+	require.True(t, ok)
+	require.Equal(t, float64(2), pendA, "but it has left the queue")
+
+	owedB, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "opB"))
+	require.True(t, ok)
+	require.Equal(t, float64(1), owedB, "opB must not show opA's stall")
+
+	// The active gauge counts OPS per type, so two ops of one type read 2.
+	active, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok)
+	require.Equal(t, float64(2), active, "two ops of the same type must count as two")
+}
+
+// TestEditOpsMetrics_LockedSidecarWaitsForOneFlockTimeoutOnly pins the
+// ErrTimeout guard on recoverEditOps' deferred refresh. When a previous
+// instance still holds the sidecar's flock, Recover fails after one
+// BoltFlockTimeout and the load is failed so the shard lifecycle retries; an
+// unguarded refresh re-opens bolt and eats a SECOND full timeout on exactly
+// the path that is already failing, doubling shard-load failure latency.
+// Inherently a ~5s test: the timeout is a const and the wait is the subject.
+func TestEditOpsMetrics_LockedSidecarWaitsForOneFlockTimeoutOnly(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+	installEditOpsMetrics(t, bucket, "EditOpsLockedSidecarClass")
+
+	// Model the fresh instance meeting a still-held flock: release our handle
+	// (Close leaves the closed *bolt.DB in place, so nil it — a fresh load
+	// starts with no handle and must re-open), then take the flock from a
+	// second open, standing in for the previous instance that has not finished
+	// closing.
+	require.NoError(t, editOps.Close())
+	editOps.mu.Lock()
+	editOps.db = nil
+	editOps.mu.Unlock()
+	locker, err := bolt.Open(filepath.Join(bucket.disk.dir, segmentEditOpsFileName), 0o600, nil)
+	require.NoError(t, err)
+	defer locker.Close()
+
+	start := time.Now()
+	err = bucket.disk.recoverEditOps(context.Background())
+	elapsed := time.Since(start)
+	require.ErrorIs(t, err, bolterrors.ErrTimeout, "precondition: the flock must be contended")
+	require.Less(t, elapsed, entlsmkv.BoltFlockTimeout+3*time.Second,
+		"the failing path must wait out ONE flock timeout, not a second one in the refresh")
+}
+
+// TestRefreshEditOpsMetrics_KeepsGaugesWhenTheSidecarReadFails pins the error
+// return in the refresh. Swallowing a read error is not a no-op: the three
+// slices come back nil, so every seen op type is zeroed to active=0 and every
+// seen op id is forgotten — a transient blip would publish a finished-drop
+// reading over a live strip, and nothing would restore it until the next
+// lifecycle event.
+func TestRefreshEditOpsMetrics_KeepsGaugesWhenTheSidecarReadFails(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	const className = "EditOpsSnapshotErrorClass"
+	installEditOpsMetrics(t, bucket, className)
+	bucket.disk.refreshEditOpsMetrics()
+
+	active, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "precondition: the live strip is published")
+	require.Equal(t, float64(1), active)
+	owed, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok)
+	require.Equal(t, float64(1), owed)
+
+	// Break the sidecar underneath: close the handle and truncate the file, so
+	// the next read fails instead of returning an empty-but-valid database.
+	require.NoError(t, editOps.Close())
+	editOps.mu.Lock()
+	editOps.db = nil
+	editOps.mu.Unlock()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bucket.disk.dir, segmentEditOpsFileName), []byte("not a bolt file"), 0o600))
+
+	bucket.disk.refreshEditOpsMetrics()
+
+	active, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsActiveFam, opTypeLabels(className))
+	require.True(t, ok, "a failed read must not retire the active series")
+	require.Equal(t, float64(1), active, "a failed read must not publish a finished-drop reading")
+	owed, ok = gaugeValue(t, prometheus.DefaultGatherer, editOpsOwedFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "a failed read must not forget the op's series")
+	require.Equal(t, float64(1), owed)
+}
+
+// TestMetricsSnapshot_IsOneConsistentRead pins the single-transaction read.
+// Reading ops, pending and quarantined in three separate transactions lets a
+// Quarantine commit land between two of them, so the same segment is seen in
+// both buckets and counted twice in owed — inflating exactly the gauge read as
+// the stall signal, in the direction that fabricates a stall.
+//
+// Asserted by counting bolt transactions rather than by racing a writer against
+// a reader. The torn window is real but tiny — a read tx takes microseconds and
+// a write tx fsyncs — so a concurrency test hits it too rarely to be a
+// regression guard, and would pass on a three-transaction implementation almost
+// every run. The transaction count is the same property, deterministically.
+func TestMetricsSnapshot_IsOneConsistentRead(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	// The bolt file opens lazily, so make sure it is open before counting.
+	_, _, _, err := editOps.MetricsSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, editOps.db, "precondition: the sidecar must be open")
+
+	before := editOps.db.Stats().TxN
+	ops, pending, quarantined, err := editOps.MetricsSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, before+1, editOps.db.Stats().TxN,
+		"all three sets must come from ONE transaction, or owed can double-count a "+
+			"segment a concurrent Quarantine moved between two reads")
+
+	// And it must actually return the state, not an empty consistent view.
+	require.Len(t, ops, 1)
+	require.Len(t, pending, 1)
+	require.Empty(t, quarantined)
+}
+
+// TestRefreshEditOpsMetrics_IsSerialised pins editOpsMetricsLock — but ONLY
+// under -race, which is how CI runs this package. The refresh reads and then
+// rewrites the seen-op and seen-type sets, so two racing interleave and the one
+// holding the older view can re-publish an op the other just forgot. The final
+// assertion is a sanity floor, not a race detector: without -race the lockless
+// mutation passes it, because the interleaving rarely corrupts this one value.
+func TestRefreshEditOpsMetrics_IsSerialised(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, editOps.RegisterOp("op1",
+		OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	const className = "EditOpsSerialisedClass"
+	installEditOpsMetrics(t, bucket, className)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				bucket.disk.refreshEditOpsMetrics()
+			}
+		}()
+	}
+	wg.Wait()
+
+	pending, ok := gaugeValue(t, prometheus.DefaultGatherer, editOpsPendingFam, opIDLabels(className, "op1"))
+	require.True(t, ok, "concurrent refreshes must not lose the series")
+	require.Equal(t, float64(1), pending)
+}

--- a/adapters/repos/db/lsmkv/segment_group_editops_metrics_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_editops_metrics_test.go
@@ -1,0 +1,170 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// gaugeValue returns the value of the single series in family `name` matching
+// `want`, and whether such a series exists.
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string, want map[string]string) (float64, bool) {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			match := len(labels) == len(want)
+			for k, v := range want {
+				if labels[k] != v {
+					match = false
+				}
+			}
+			if match {
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// TestRefreshEditOpsMetrics_DrivesGauges proves the segment-group instrumentation
+// is wired: refreshEditOpsMetrics must publish active-op, pending-segment and
+// forced-cleanup-remaining gauges derived from the live sidecar state, and must
+// follow that state down as segments are marked done.
+func TestRefreshEditOpsMetrics_DrivesGauges(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	segs := segIDsOf(bucket)
+	require.Len(t, segs, 2)
+
+	require.NoError(t, editOps.RegisterOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segs))
+
+	reg := prometheus.NewRegistry()
+	seom, err := monitoring.NewSegmentEditOpsMetrics(reg, "shardA")
+	require.NoError(t, err)
+	// A minimal Metrics carrying only the edit-op series: the refresh path touches
+	// nothing else. Restore the original before the helper's shutdown Cleanup runs,
+	// since shutdown drives the (here unset) segment-strategy vecs.
+	orig := bucket.disk.metrics
+	bucket.disk.metrics = &Metrics{editOps: seom}
+	defer func() { bucket.disk.metrics = orig }()
+
+	const (
+		activeFam  = "weaviate_segment_edit_ops_active"
+		pendingFam = "weaviate_segment_edit_ops_pending_segments"
+		forcedFam  = "weaviate_segment_edit_ops_forced_cleanup_segments_remaining"
+	)
+	opType := string(OpTypeRemoveTargetVectors)
+
+	bucket.disk.refreshEditOpsMetrics()
+
+	active, ok := gaugeValue(t, reg, activeFam, map[string]string{"op_type": opType, "shard": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(1), active)
+
+	pending, ok := gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "shard": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(2), pending)
+
+	forced, ok := gaugeValue(t, reg, forcedFam, map[string]string{"op_id": "op1"})
+	require.True(t, ok)
+	require.Equal(t, float64(2), forced)
+
+	// Complete one segment; the gauges must track the drop.
+	require.NoError(t, editOps.MarkSegmentDone("op1", segs[0]))
+	bucket.disk.refreshEditOpsMetrics()
+
+	pending, ok = gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "shard": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(1), pending)
+
+	forced, ok = gaugeValue(t, reg, forcedFam, map[string]string{"op_id": "op1"})
+	require.True(t, ok)
+	require.Equal(t, float64(1), forced)
+}
+
+// TestRefreshEditOpsMetrics_ReconcilesVanishedOps proves deleted ops do not
+// linger as stale series: Bucket.DeleteEditOp must (via its own refresh) drop the
+// op-id gauges and zero the op-type active count, so a finished drop never reads
+// as still active on a dashboard.
+func TestRefreshEditOpsMetrics_ReconcilesVanishedOps(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	segs := segIDsOf(bucket)
+	require.Len(t, segs, 1)
+
+	require.NoError(t, editOps.RegisterOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segs))
+
+	reg := prometheus.NewRegistry()
+	seom, err := monitoring.NewSegmentEditOpsMetrics(reg, "shardA")
+	require.NoError(t, err)
+	orig := bucket.disk.metrics
+	bucket.disk.metrics = &Metrics{editOps: seom}
+	defer func() { bucket.disk.metrics = orig }()
+
+	const (
+		activeFam  = "weaviate_segment_edit_ops_active"
+		pendingFam = "weaviate_segment_edit_ops_pending_segments"
+		forcedFam  = "weaviate_segment_edit_ops_forced_cleanup_segments_remaining"
+	)
+	opType := string(OpTypeRemoveTargetVectors)
+
+	bucket.disk.refreshEditOpsMetrics()
+
+	active, ok := gaugeValue(t, reg, activeFam, map[string]string{"op_type": opType, "shard": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(1), active)
+	_, ok = gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "shard": "shardA"})
+	require.True(t, ok)
+
+	// The delete is gated on the op being drained, so retire its one row first;
+	// marking done does not refresh, which keeps this a test of the delete.
+	require.NoError(t, editOps.MarkSegmentDone("op1", segs[0]))
+
+	// The bucket-level delete must refresh on its own — no manual refresh here.
+	deleted, pending, quarantined, err := bucket.DeleteEditOpIfDrained("op1")
+	require.NoError(t, err)
+	require.True(t, deleted, "the op is drained, so it must delete (pending=%d quarantined=%d)",
+		pending, quarantined)
+
+	_, ok = gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "shard": "shardA"})
+	require.False(t, ok, "pending series must be dropped once the op is deleted")
+	_, ok = gaugeValue(t, reg, forcedFam, map[string]string{"op_id": "op1"})
+	require.False(t, ok, "forced-cleanup series must be dropped once the op is deleted")
+
+	active, ok = gaugeValue(t, reg, activeFam, map[string]string{"op_type": opType, "shard": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(0), active, "active count must return to zero, not stick at its last value")
+}

--- a/adapters/repos/db/lsmkv/segment_group_editops_metrics_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_editops_metrics_test.go
@@ -1,0 +1,273 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// gaugeValue returns the value of the single series in family `name` matching
+// `want`, and whether such a series exists.
+func gaugeValue(t *testing.T, g prometheus.Gatherer, name string, want map[string]string) (float64, bool) {
+	t.Helper()
+	families, err := g.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			match := len(labels) == len(want)
+			for k, v := range want {
+				if labels[k] != v {
+					match = false
+				}
+			}
+			if match {
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// TestRefreshEditOpsMetrics_DrivesGauges proves the segment-group instrumentation
+// is wired: refreshEditOpsMetrics must publish active-op, pending-segment and
+// forced-cleanup-remaining gauges derived from the live sidecar state, and must
+// follow that state down as segments are marked done.
+func TestRefreshEditOpsMetrics_DrivesGauges(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	segs := segIDsOf(bucket)
+	require.Len(t, segs, 2)
+
+	require.NoError(t, editOps.RegisterOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segs))
+
+	reg := prometheus.NewRegistry()
+	seom, err := monitoring.NewSegmentEditOpsMetrics(reg, "ClassA", "shardA", false)
+	require.NoError(t, err)
+	// A minimal Metrics carrying only the edit-op series: the refresh path touches
+	// nothing else. Restore the original before the helper's shutdown Cleanup runs,
+	// since shutdown drives the (here unset) segment-strategy vecs.
+	orig := bucket.disk.metrics
+	bucket.disk.metrics = &Metrics{editOps: seom}
+	defer func() { bucket.disk.metrics = orig }()
+
+	const (
+		activeFam  = "weaviate_lsm_segment_edit_ops_active"
+		pendingFam = "weaviate_lsm_segment_edit_ops_pending_segments"
+		forcedFam  = "weaviate_lsm_segment_edit_ops_segments_owed"
+	)
+	opType := string(OpTypeRemoveTargetVectors)
+
+	bucket.disk.refreshEditOpsMetrics()
+
+	active, ok := gaugeValue(t, reg, activeFam, map[string]string{"op_type": opType, "class_name": "ClassA", "shard_name": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(1), active)
+
+	pending, ok := gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "class_name": "ClassA", "shard_name": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(2), pending)
+
+	shardLabels := map[string]string{"op_id": "op1", "class_name": "ClassA", "shard_name": "shardA"}
+	forced, ok := gaugeValue(t, reg, forcedFam, shardLabels)
+	require.True(t, ok)
+	require.Equal(t, float64(2), forced,
+		"with nothing quarantined, owed equals queued")
+
+	// Complete one segment; the gauges must track the drop.
+	require.NoError(t, editOps.MarkSegmentDone("op1", segs[0]))
+	bucket.disk.refreshEditOpsMetrics()
+
+	pending, ok = gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "class_name": "ClassA", "shard_name": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(1), pending)
+
+	forced, ok = gaugeValue(t, reg, forcedFam, shardLabels)
+	require.True(t, ok)
+	require.Equal(t, float64(1), forced)
+
+	// Quarantine is the only permanent terminal state a drop has, and it must
+	// not read like success. The segment leaves the QUEUE, so pending goes to
+	// zero — but the op still OWES it, so forced holds at one. That divergence
+	// is the whole signal that a drop stalled rather than finished.
+	require.NoError(t, editOps.Quarantine("op1", segs[1]))
+	bucket.disk.refreshEditOpsMetrics()
+
+	pending, ok = gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "class_name": "ClassA", "shard_name": "shardA"})
+	require.True(t, ok)
+	require.Zero(t, pending, "the quarantined segment leaves the queue")
+
+	forced, ok = gaugeValue(t, reg, forcedFam, shardLabels)
+	require.True(t, ok)
+	require.Equal(t, float64(1), forced, "but it is still owed, so the stall stays visible")
+}
+
+// TestRefreshEditOpsMetrics_ReconcilesVanishedOps proves deleted ops do not
+// linger as stale series: Bucket.DeleteEditOp must (via its own refresh) drop the
+// op-id gauges and zero the op-type active count, so a finished drop never reads
+// as still active on a dashboard.
+func TestRefreshEditOpsMetrics_ReconcilesVanishedOps(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	segs := segIDsOf(bucket)
+	require.Len(t, segs, 1)
+
+	require.NoError(t, editOps.RegisterOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segs))
+
+	reg := prometheus.NewRegistry()
+	seom, err := monitoring.NewSegmentEditOpsMetrics(reg, "ClassA", "shardA", false)
+	require.NoError(t, err)
+	orig := bucket.disk.metrics
+	bucket.disk.metrics = &Metrics{editOps: seom}
+	defer func() { bucket.disk.metrics = orig }()
+
+	const (
+		activeFam  = "weaviate_lsm_segment_edit_ops_active"
+		pendingFam = "weaviate_lsm_segment_edit_ops_pending_segments"
+		forcedFam  = "weaviate_lsm_segment_edit_ops_segments_owed"
+	)
+	opType := string(OpTypeRemoveTargetVectors)
+
+	bucket.disk.refreshEditOpsMetrics()
+
+	active, ok := gaugeValue(t, reg, activeFam, map[string]string{"op_type": opType, "class_name": "ClassA", "shard_name": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(1), active)
+	_, ok = gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "class_name": "ClassA", "shard_name": "shardA"})
+	require.True(t, ok)
+
+	// The delete is gated on the op being drained, so retire its one row first;
+	// marking done does not refresh, which keeps this a test of the delete.
+	require.NoError(t, editOps.MarkSegmentDone("op1", segs[0]))
+
+	// The bucket-level delete must refresh on its own — no manual refresh here.
+	deleted, pending, quarantined, err := bucket.DeleteEditOpIfDrained("op1")
+	require.NoError(t, err)
+	require.True(t, deleted, "the op is drained, so it must delete (pending=%d quarantined=%d)",
+		pending, quarantined)
+
+	_, ok = gaugeValue(t, reg, pendingFam, map[string]string{"op_id": "op1", "class_name": "ClassA", "shard_name": "shardA"})
+	require.False(t, ok, "pending series must be dropped once the op is deleted")
+	_, ok = gaugeValue(t, reg, forcedFam, map[string]string{"op_id": "op1", "class_name": "ClassA", "shard_name": "shardA"})
+	require.False(t, ok, "owed series must be dropped once the op is deleted")
+
+	active, ok = gaugeValue(t, reg, activeFam, map[string]string{"op_type": opType, "class_name": "ClassA", "shard_name": "shardA"})
+	require.True(t, ok)
+	require.Equal(t, float64(0), active, "active count must return to zero, not stick at its last value")
+}
+
+// TestNewMetrics_WiresEditOpsSeries pins the wiring itself. Every other test in
+// this file installs a hand-built Metrics{editOps: ...}, so all of them stay
+// green if NewMetrics stops populating the field — the series would simply
+// never be exported in production and nothing would say so.
+//
+// Uses the global PrometheusMetrics because that is what NewMetrics needs (a
+// minimal hand-built one nil-derefs on the other lsmkv vecs), so the class name
+// is deliberately unique to keep the assertion off any other test's series.
+func TestNewMetrics_WiresEditOpsSeries(t *testing.T) {
+	const className = "EditOpsWiringProbeClass"
+
+	m, err := NewMetrics(monitoring.GetMetrics(), className, "shardW")
+	require.NoError(t, err)
+	require.NotNil(t, m.editOps, "NewMetrics must wire the edit-op series")
+
+	m.SetEditOpsActive("remove_target_vectors", 3)
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	var got float64
+	var found bool
+	for _, fam := range families {
+		if fam.GetName() != "weaviate_lsm_segment_edit_ops_active" {
+			continue
+		}
+		for _, metric := range fam.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range metric.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["class_name"] == className && labels["shard_name"] == "shardW" &&
+				labels["op_type"] == "remove_target_vectors" {
+				got, found = metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+	require.True(t, found, "the wired series must be exported under {op_type, class_name, shard_name}")
+	require.Equal(t, float64(3), got)
+}
+
+// TestRefreshEditOpsMetrics_SkipsSidecarWhenNothingCollects pins that the
+// refresh does not touch the bolt sidecar when nothing will consume the result.
+// It costs a bolt read tx, and it runs on every shard load, every compaction and
+// every cleanup tick — so on a node with monitoring off (the default), or in
+// grouped mode where the per-shard gauges are suppressed, that is pure waste.
+// Grouped mode is the worse of the two: those are the nodes with the most
+// shards to multiply it by.
+func TestRefreshEditOpsMetrics_SkipsSidecarWhenNothingCollects(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		metrics *Metrics
+	}{
+		// Production monitoring-off is a NIL *Metrics (shard_init_lsm only
+		// builds one when promMetrics is set); the empty struct additionally
+		// covers the wired-but-no-editOps clause of the guard.
+		{name: "monitoring off (nil, the production shape)", metrics: nil},
+		{name: "metrics wired but editOps not", metrics: &Metrics{}},
+		{name: "grouped mode", metrics: func() *Metrics {
+			seom, err := monitoring.NewSegmentEditOpsMetrics(prometheus.NewRegistry(), "n/a", "n/a", true)
+			require.NoError(t, err)
+			return &Metrics{editOps: seom}
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bucket, editOps := newReplaceBucketWithEditOps(t, prefixTransformer)
+			require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+			require.NoError(t, bucket.FlushAndSwitch())
+			require.NoError(t, editOps.RegisterOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+			require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+			orig := bucket.disk.metrics
+			bucket.disk.metrics = tc.metrics
+			defer func() { bucket.disk.metrics = orig }()
+
+			// The sidecar is healthy and holds one op, so a refresh that actually
+			// ran would read it and record the seen-set. Still nil therefore means
+			// it returned before touching bolt at all — which is the point.
+			bucket.disk.refreshEditOpsMetrics()
+
+			require.Nil(t, bucket.disk.editOpsSeenOpIDs,
+				"a refresh nothing will consume must return before reading the sidecar")
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -262,6 +262,19 @@ func (s *Store) setBucket(name string, b *Bucket) {
 	s.bucketsByName[name] = b
 }
 
+// ReapEditOpsMetrics retires the edit-op series of every bucket in this store.
+// Called on the DELETE path only (Shard.drop): an unload leaves the series in
+// place, because a drop stalled on a deactivated tenant is precisely what they
+// report — see SegmentGroup.shutdown. Latched, so the teardown that follows
+// cannot republish what this just deleted.
+func (s *Store) ReapEditOpsMetrics() {
+	for _, bucket := range s.GetBucketsByName() {
+		if bucket != nil && bucket.disk != nil {
+			bucket.disk.reapEditOpsMetrics()
+		}
+	}
+}
+
 func (s *Store) Shutdown(ctx context.Context) error {
 	s.closeLock.Lock()
 	defer s.closeLock.Unlock()

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -311,6 +311,30 @@ func (s *Shard) removeDimensionsLSM(dimLength int, docID uint64, targetVector st
 	return s.addToDimensionBucket(dimLength, docID, targetVector, true)
 }
 
+// removeAllDimensionsLSM clears every dimension row targetVector owns.
+//
+// A missing bucket means the shard never tracked dimensions — unless it is
+// shutting down, because Store.Shutdown blanks bucketsByName before it drains.
+// Reporting success there would lose the clear for good: the finalizer then
+// drops the name from the schema and no route ever looks at it again. Callers
+// that can race a teardown hold preventShutdown; this is what catches the ones
+// that forget.
+func (s *Shard) removeAllDimensionsLSM(ctx context.Context, targetVector string) error {
+	// Pinned, not just fetched: the clear holds a cursor open across the whole
+	// scan and write, and resetDimensionsLSM can swap this bucket underneath it
+	// (Store.ReplaceBuckets). The pin also covers the segments the cursor reads,
+	// which a concurrent Shutdown would otherwise unmap.
+	b, release := s.store.AcquireBucketForRead(helpers.DimensionsBucketLSM)
+	defer release()
+	if b == nil {
+		if s.shut.Load() || s.shutdownRequested.Load() {
+			return fmt.Errorf("remove dimensions for %q: %w", targetVector, errAlreadyShutdown)
+		}
+		return nil
+	}
+	return shardusage.RemoveTargetVectorDimensions(ctx, b, targetVector)
+}
+
 func (s *Shard) addToDimensionBucket(dimLength int, docID uint64, vecName string, tombstone bool) error {
 	b := s.store.Bucket(helpers.DimensionsBucketLSM)
 	if b == nil {

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -66,6 +66,12 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 	s.shutCtxCancel(fmt.Errorf("drop %q", s.ID()))
 
 	s.metrics.DeleteShardLabels(s.index.Config.ClassName.String(), s.name)
+	// The edit-op gauges are not reaped by DeleteShardLabels: they are
+	// registered on the lsmkv component rather than the global metrics struct.
+	// This is the delete-path reap they need — an unload deliberately keeps
+	// them, so that a drop stalled on a deactivated tenant stays visible (see
+	// SegmentGroup.shutdown). Latched, so the teardown below cannot republish.
+	s.store.ReapEditOpsMetrics()
 	s.replicationMap.clear()
 
 	s.index.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/shard_drop_vector_dimensions_integration_test.go
+++ b/adapters/repos/db/shard_drop_vector_dimensions_integration_test.go
@@ -1,0 +1,279 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
+	"github.com/weaviate/weaviate/entities/schema"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+const dropDimsClassName = "DropVectorDimensionsClass"
+
+const (
+	dropDimsKeep    = "keep"
+	dropDimsDropped = "to_drop"
+	dropDimsDim     = 8
+	dropDimsCount   = 10
+)
+
+// setupDropDimsShard builds a loaded, dimension-tracking shard with two named
+// hnsw vectors.
+func setupDropDimsShard(t *testing.T, ctx context.Context) (*Shard, *models.Class) {
+	t.Helper()
+
+	cfg := hnsw.NewDefaultUserConfig()
+	class := &models.Class{
+		Class: dropDimsClassName,
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			UsingBlockMaxWAND: config.DefaultUsingBlockMaxWAND,
+		},
+		Properties: []*models.Property{
+			{
+				Name:         "label",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWord,
+			},
+		},
+		VectorConfig: map[string]models.VectorConfig{
+			dropDimsKeep:    {VectorIndexType: cfg.IndexType(), VectorIndexConfig: cfg},
+			dropDimsDropped: {VectorIndexType: cfg.IndexType(), VectorIndexConfig: cfg},
+		},
+	}
+
+	vic := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
+	shardLike, _ := testShardWithSettings(t, ctx, class, vic, false, true, false, func(i *Index) {
+		// Applied before initShard, which is what creates the dimensions bucket.
+		i.Config.TrackVectorDimensions = true
+		i.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
+			dropDimsKeep:    cfg,
+			dropDimsDropped: cfg,
+		}
+	})
+
+	switch s := shardLike.(type) {
+	case *Shard:
+		return s, class
+	case *LazyLoadShard:
+		require.NoError(t, s.Load(ctx))
+		return s.shard, class
+	default:
+		t.Fatalf("unexpected shard type %T", shardLike)
+		return nil, nil
+	}
+}
+
+func dropDimsObject(i int) *storobj.Object {
+	vec := make([]float32, dropDimsDim)
+	for j := range vec {
+		vec[j] = float32(i + j)
+	}
+	other := make([]float32, dropDimsDim)
+	for j := range other {
+		other[j] = float32(i + j + 100)
+	}
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", i)).String()),
+			Class:      dropDimsClassName,
+			Properties: map[string]interface{}{"label": fmt.Sprintf("obj-%d", i)},
+		},
+		Vectors: map[string][]float32{dropDimsKeep: vec, dropDimsDropped: other},
+	}
+}
+
+// TestDropVectorIndex_ClearsDimensionRows pins that a drop takes the vector's
+// rows out of the shard's dimensions bucket. Nothing else reclaims them: the
+// drop strips the vector from the object bytes, so a later update or delete
+// finds nothing to tombstone, and the rows are inherited by the next vector
+// created under the same name.
+func TestDropVectorIndex_ClearsDimensionRows(t *testing.T) {
+	ctx := t.Context()
+	s, _ := setupDropDimsShard(t, ctx)
+
+	for i := 0; i < dropDimsCount; i++ {
+		require.NoError(t, s.PutObject(ctx, dropDimsObject(i)))
+	}
+
+	wantAll := dropDimsCount * dropDimsDim
+	gotKeep, err := s.Dimensions(ctx, dropDimsKeep)
+	require.NoError(t, err)
+	require.Equal(t, wantAll, gotKeep, "precondition: %q must be tracked", dropDimsKeep)
+	gotDropped, err := s.Dimensions(ctx, dropDimsDropped)
+	require.NoError(t, err)
+	require.Equal(t, wantAll, gotDropped, "precondition: %q must be tracked", dropDimsDropped)
+
+	require.NoError(t, s.DropVectorIndex(ctx, dropDimsDropped))
+
+	gotDropped, err = s.Dimensions(ctx, dropDimsDropped)
+	require.NoError(t, err)
+	require.Equal(t, 0, gotDropped,
+		"the dropped vector's dimension rows survived the drop; a vector re-created "+
+			"under the name %q would inherit them and be counted before it holds a "+
+			"single vector", dropDimsDropped)
+
+	gotKeep, err = s.Dimensions(ctx, dropDimsKeep)
+	require.NoError(t, err)
+	require.Equal(t, wantAll, gotKeep,
+		"the surviving sibling %q lost its dimension rows: the bucket is shared by "+
+			"every vector on the shard, so the drop must remove one key range, not "+
+			"the bucket", dropDimsKeep)
+}
+
+// TestDropVectorIndex_ClearsDimensionRowsOnUnloadedShard covers the cold route:
+// a drop against an inactive tenant is deferred, so the live path never runs
+// and the files-only sweep has to clear the rows from disk. This is the route
+// the reported incident hit.
+func TestDropVectorIndex_ClearsDimensionRowsOnUnloadedShard(t *testing.T) {
+	ctx := t.Context()
+	s, _ := setupDropDimsShard(t, ctx)
+
+	for i := 0; i < dropDimsCount; i++ {
+		require.NoError(t, s.PutObject(ctx, dropDimsObject(i)))
+	}
+
+	indexPath, shardName := s.index.path(), s.name
+	logger := logrus.New()
+	wantAll := dropDimsCount * dropDimsDim
+
+	// From here the only route to the bucket is from disk.
+	require.NoError(t, s.Shutdown(ctx))
+
+	before, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, logger, indexPath, shardName, dropDimsDropped)
+	require.NoError(t, err)
+	require.Equal(t, wantAll, before.Count*before.Dimensions,
+		"precondition: the unloaded shard must still report %q", dropDimsDropped)
+
+	require.NoError(t, shardusage.RemoveUnloadedTargetVectorDimensions(
+		ctx, logger, indexPath, shardName, dropDimsDropped))
+
+	after, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, logger, indexPath, shardName, dropDimsDropped)
+	require.NoError(t, err)
+	require.Equal(t, 0, after.Count*after.Dimensions,
+		"the dropped vector's rows survived the files-only sweep, so a cold tenant "+
+			"keeps them until something loads the shard")
+
+	keep, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, logger, indexPath, shardName, dropDimsKeep)
+	require.NoError(t, err)
+	require.Equal(t, wantAll, keep.Count*keep.Dimensions,
+		"the surviving sibling %q lost its rows: the sweep must clear one key "+
+			"range, not the shard's whole dimensions bucket", dropDimsKeep)
+}
+
+// TestDropVectorIndex_DimensionsPrefixIsNotEnough pins the key-length filter:
+// a shorter name is a byte prefix of every key the longer one owns.
+func TestDropVectorIndex_DimensionsPrefixIsNotEnough(t *testing.T) {
+	ctx := t.Context()
+	s, _ := setupDropDimsShard(t, ctx)
+
+	// Written straight to the bucket — these names need rows, not indexes.
+	const shortName, longName = "vec", "vec_extra"
+	for docID := uint64(0); docID < 3; docID++ {
+		require.NoError(t, s.extendDimensionTrackerLSM(dropDimsDim, docID, shortName))
+		require.NoError(t, s.extendDimensionTrackerLSM(dropDimsDim, docID, longName))
+	}
+
+	got, err := s.Dimensions(ctx, longName)
+	require.NoError(t, err)
+	require.Equal(t, 3*dropDimsDim, got, "precondition: %q must be tracked", longName)
+
+	require.NoError(t, s.removeAllDimensionsLSM(ctx, shortName))
+
+	got, err = s.Dimensions(ctx, shortName)
+	require.NoError(t, err)
+	require.Equal(t, 0, got, "%q's own rows must be gone", shortName)
+
+	got, err = s.Dimensions(ctx, longName)
+	require.NoError(t, err)
+	require.Equal(t, 3*dropDimsDim, got,
+		"dropping %q took %q's rows: every key of the longer name carries the "+
+			"shorter one as a byte prefix, so the scan must also match on key length",
+		shortName, longName)
+}
+
+// TestDropVectorIndex_DimensionsClearOnShutDownStoreIsNotSilent pins that a
+// clear against a torn-down store reports failure. Store.Shutdown blanks
+// bucketsByName before draining, so the bucket lookup returns nil exactly as it
+// does on a shard that never tracked dimensions. Reporting success there loses
+// the clear permanently: the finalizer removes the name from the schema and no
+// route revisits it, which is the reported incident arriving by another door.
+func TestDropVectorIndex_DimensionsClearOnShutDownStoreIsNotSilent(t *testing.T) {
+	ctx := t.Context()
+	s, _ := setupDropDimsShard(t, ctx)
+
+	for i := 0; i < dropDimsCount; i++ {
+		require.NoError(t, s.PutObject(ctx, dropDimsObject(i)))
+	}
+	require.NoError(t, s.Shutdown(ctx))
+
+	err := s.removeAllDimensionsLSM(ctx, dropDimsDropped)
+	require.Error(t, err,
+		"a clear against a shut-down store reported success while the rows are "+
+			"still on disk; the caller then has nothing to fall back to")
+	require.ErrorIs(t, err, errAlreadyShutdown)
+}
+
+// TestDropVectorIndex_ShardInitSweepClearsDimensionRows drives the shard-init
+// sweep, the route a cold tenant takes when it is activated after a drop it was
+// too inactive to take part in. The three tests above reach the clear directly;
+// this one reaches it the way NewShard does.
+func TestDropVectorIndex_ShardInitSweepClearsDimensionRows(t *testing.T) {
+	ctx := t.Context()
+	s, class := setupDropDimsShard(t, ctx)
+
+	for i := 0; i < dropDimsCount; i++ {
+		require.NoError(t, s.PutObject(ctx, dropDimsObject(i)))
+	}
+	indexPath, shardName := s.index.path(), s.name
+	logger := logrus.New()
+	wantAll := dropDimsCount * dropDimsDim
+	require.NoError(t, s.Shutdown(ctx))
+
+	// The marker the sweep keys off: the drop rewrites the entry's index type
+	// to "none" and keeps the name until the finalizer removes it.
+	class.VectorConfig[dropDimsDropped] = models.VectorConfig{
+		VectorIndexType: modelsext.VectorIndexTypeNone,
+	}
+
+	require.NoError(t, newVectorDropIndexHelper().ensureFilesAreRemovedForDroppedVectorIndexes(
+		ctx, logger, indexPath, shardName, class))
+
+	dropped, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, logger, indexPath, shardName, dropDimsDropped)
+	require.NoError(t, err)
+	require.Equal(t, 0, dropped.Count*dropped.Dimensions,
+		"the shard-init sweep left %q's rows behind, so an activated cold tenant "+
+			"keeps them", dropDimsDropped)
+
+	keep, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, logger, indexPath, shardName, dropDimsKeep)
+	require.NoError(t, err)
+	require.Equal(t, wantAll, keep.Count*keep.Dimensions,
+		"the sweep took the surviving sibling %q's rows too", dropDimsKeep)
+}

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -12,11 +12,15 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
@@ -34,6 +38,7 @@ func newVectorDropIndexHelper() *vectorDropIndexHelper {
 // - tenant was inactive during a drop vector index operation, so files remain on disk
 // - an error occurred during the drop operation and files were not fully cleaned up
 func (h *vectorDropIndexHelper) ensureFilesAreRemovedForDroppedVectorIndexes(
+	ctx context.Context, logger logrus.FieldLogger,
 	indexPath, shardName string, class *models.Class,
 ) error {
 	for name, cfg := range class.VectorConfig {
@@ -44,6 +49,19 @@ func (h *vectorDropIndexHelper) ensureFilesAreRemovedForDroppedVectorIndexes(
 			otherTargetVectors(class, name)); err != nil {
 			return fmt.Errorf("failed to remove dropped vector index %q files for class %s: %w",
 				name, class.Class, err)
+		}
+		// The shard is still being constructed; its store is not open yet.
+		//
+		// Not fatal. These rows are usage accounting, and both the next shard init
+		// and the group-completion sweep re-run the clear, so continuing costs a
+		// delayed reclaim — where returning would cost the tenant its activation,
+		// including when the only problem is a usage collection holding the
+		// bucket lock this call waits on.
+		if err := shardusage.RemoveUnloadedTargetVectorDimensions(
+			ctx, logger, indexPath, shardName, name); err != nil {
+			logger.WithField("shard", shardName).WithField("class", class.Class).
+				WithField("target_vector", name).
+				Warnf("drop vector index: could not clear dimension rows, leaving them for the next sweep: %v", err)
 		}
 	}
 	return nil

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -213,7 +214,7 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 			VectorConfig: nil,
 		}
 
-		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, class)
+		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(t.Context(), logrus.New(), indexPath, shardName, class)
 		require.NoError(t, err)
 	})
 
@@ -232,7 +233,7 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 			},
 		}
 
-		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, class)
+		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(t.Context(), logrus.New(), indexPath, shardName, class)
 		require.NoError(t, err)
 
 		assert.True(t, pathExists(filepath.Join(indexPath, shardName, "lsm", "vectors_flat_bq")))
@@ -257,7 +258,7 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 			},
 		}
 
-		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, class)
+		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(t.Context(), logrus.New(), indexPath, shardName, class)
 		require.NoError(t, err)
 
 		assert.False(t, pathExists(filepath.Join(indexPath, shardName, "lsm", "vectors_flat_bq")))
@@ -284,7 +285,7 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 			},
 		}
 
-		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, class)
+		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(t.Context(), logrus.New(), indexPath, shardName, class)
 		require.NoError(t, err)
 
 		assert.False(t, pathExists(filepath.Join(indexPath, shardName, "lsm", "vectors_flat_bq")))
@@ -321,7 +322,7 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 			},
 		}
 
-		require.NoError(t, h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, class))
+		require.NoError(t, h.ensureFilesAreRemovedForDroppedVectorIndexes(t.Context(), logrus.New(), indexPath, shardName, class))
 
 		assert.True(t, pathExists(filepath.Join(indexPath, shardName, "lsm", helpers.GetVectorsBucketName(sibling))),
 			"%s is a live vector's own bucket and must survive dropping %s", sibling, dropped)
@@ -339,7 +340,7 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 			},
 		}
 
-		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, class)
+		err := h.ensureFilesAreRemovedForDroppedVectorIndexes(t.Context(), logrus.New(), indexPath, shardName, class)
 		require.NoError(t, err)
 	})
 }

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -57,7 +57,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, fmt.Errorf("shard %q: remove nonexistent property index buckets: %w", shardName, err)
 	}
 
-	if err := newVectorDropIndexHelper().ensureFilesAreRemovedForDroppedVectorIndexes(index.path(), shardName, class); err != nil {
+	if err := newVectorDropIndexHelper().ensureFilesAreRemovedForDroppedVectorIndexes(ctx, index.logger, index.path(), shardName, class); err != nil {
 		return nil, fmt.Errorf("shard %q: remove dropped vector index files: %w", shardName, err)
 	}
 

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -431,6 +431,20 @@ func dropOneVectorIndex(ctx context.Context, index VectorIndex) error {
 // from this shard, deleting associated files from disk. It also removes the
 // LSM buckets that store the raw and compressed vector data.
 func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error {
+	if err := s.dropVectorIndexArtifacts(ctx, targetVector); err != nil {
+		return err
+	}
+
+	// Outside vectorIndexMu on purpose. Everything above is O(files); this is
+	// O(objects), and every vector read and write on the shard takes that lock.
+	// The rows are usage accounting, not part of the state the mutex guards.
+	if err := s.removeAllDimensionsLSM(ctx, targetVector); err != nil {
+		return fmt.Errorf("remove dimensions for vector %q: %w", targetVector, err)
+	}
+	return nil
+}
+
+func (s *Shard) dropVectorIndexArtifacts(ctx context.Context, targetVector string) error {
 	s.vectorIndexMu.Lock()
 	defer s.vectorIndexMu.Unlock()
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -542,6 +542,20 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 
 		metrics.DeleteShardLabels(className, shardName)
 
+		// The edit-op gauges live on the lsmkv component, not the global metrics
+		// struct, so DeleteShardLabels does not reach them. There is no Store to
+		// reap through here — the shard is unloaded — but it may still be
+		// publishing: an unload KEEPS the series of a shard that owes work, so a
+		// drop stalled on a deactivated tenant stays visible until the tenant is
+		// deleted, which is here.
+		// Logged, never returned: this is observability cleanup, and refusing to
+		// delete a tenant because a gauge could not be retired would trade a
+		// data operation for a stale series — and leave the drop half-done.
+		if err := lsmkv.ReapEditOpsShardSeries(l.shardOpts.promMetrics, className, shardName); err != nil {
+			idx.logger.WithField("action", "drop_shard").WithField("shard", shardName).
+				Warnf("could not reap edit-op metrics for deleted shard; series linger until restart: %v", err)
+		}
+
 		// cleanup dimensions: not deleted in s.metrics.DeleteShardLabels
 		clearDimensionMetrics(idx.Config, l.shardOpts.promMetrics, className, shardName)
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -624,12 +624,25 @@ func (l *LazyLoadShard) updateUnloadedPropertyBuckets(ctx context.Context,
 	})
 }
 
+// DropVectorIndex routes to the loaded shard or to disk. The decision is taken
+// under l.mutex and committed to before the lock is released: a loaded shard's
+// reference is taken first, so a deactivation cannot blank its store in
+// between, and the cold branch keeps the lock because loadIfCold holds it
+// across the whole of NewShard — released early, a concurrent load would open
+// the dimensions bucket that dropUnloadedVectorIndex is about to open from
+// disk, and one of the two would lose the registry claim.
 func (l *LazyLoadShard) DropVectorIndex(ctx context.Context, targetVector string) error {
-	if l.isLoaded() {
-		return l.shard.DropVectorIndex(ctx, targetVector)
-	} else {
-		return l.dropUnloadedVectorIndex(targetVector)
+	l.mutex.Lock()
+	if l.loaded && l.shard != nil {
+		if release, err := l.shard.preventShutdown(); err == nil {
+			inner := l.shard
+			l.mutex.Unlock()
+			defer release()
+			return inner.DropVectorIndex(ctx, targetVector)
+		}
 	}
+	defer l.mutex.Unlock()
+	return l.dropUnloadedVectorIndex(targetVector)
 }
 
 func (l *LazyLoadShard) dropUnloadedVectorIndex(targetVector string) error {
@@ -653,7 +666,21 @@ func (l *LazyLoadShard) dropUnloadedVectorIndex(targetVector string) error {
 			return fmt.Errorf("delete checkpoint for vector %q: %w", targetVector, err)
 		}
 	}
-	return nil
+
+	// Last, so a failure here cannot leave the checkpoint entry behind: a
+	// re-created vector would then resume async indexing from that doc ID and
+	// never index the objects below it.
+	if err := shardusage.RemoveUnloadedTargetVectorDimensions(context.Background(),
+		l.shardOpts.index.logger, l.shardOpts.index.path(), l.shardOpts.name,
+		targetVector); err != nil {
+		return err
+	}
+
+	// The saved usage record is keyed by a hash of the active vector configs
+	// alone, so re-creating this name with the same config would serve the
+	// pre-drop numbers again.
+	return shardusage.RemoveComputedUsageDataForUnloadedShard(
+		l.shardOpts.index.path(), l.shardOpts.name)
 }
 
 func (l *LazyLoadShard) HaltForTransfer(ctx context.Context, offloading bool, inactivityTimeout time.Duration) error {

--- a/adapters/repos/db/shard_usage/remove_dimensions_test.go
+++ b/adapters/repos/db/shard_usage/remove_dimensions_test.go
@@ -1,0 +1,185 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shardusage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// dimRow is one <name><LE uint32 dims> key and the docIDs stored under it.
+type dimRow struct {
+	name   string
+	dims   uint32
+	docIDs []uint64
+}
+
+func dimKey(name string, dims uint32) []byte {
+	key := make([]byte, len(name)+4)
+	copy(key, name)
+	binary.LittleEndian.PutUint32(key[len(name):], dims)
+	return key
+}
+
+// seedDimRows writes rows exactly as Shard.addToDimensionBucket does, so the
+// two strategies are exercised through the same layout production writes.
+func seedDimRows(t *testing.T, b *lsmkv.Bucket, rows []dimRow) {
+	t.Helper()
+	for _, r := range rows {
+		key := dimKey(r.name, r.dims)
+		for _, docID := range r.docIDs {
+			switch b.Strategy() {
+			case lsmkv.StrategyMapCollection:
+				mapKey := make([]byte, 8)
+				binary.LittleEndian.PutUint64(mapKey, docID)
+				require.NoError(t, b.MapSet(key, lsmkv.MapPair{Key: mapKey, Value: []byte{}}))
+			default:
+				require.NoError(t, b.RoaringSetAddOne(key, docID))
+			}
+		}
+	}
+}
+
+// TestRemoveTargetVectorDimensions drives the deletion directly, on both bucket
+// strategies. The shard's own store is StrategyRoaringSet on 1.34+, so a test
+// that reaches this through a shard cannot cover the StrategyMapCollection arm
+// at all — and that arm carries its own copy of the key-length guard.
+func TestRemoveTargetVectorDimensions(t *testing.T) {
+	const dims = 8
+
+	tests := []struct {
+		name   string
+		seed   []dimRow
+		remove string
+		// want maps a vector name to the doc count still readable under it.
+		want map[string]int
+	}{
+		{
+			name: "removes the target and leaves an unrelated sibling",
+			seed: []dimRow{
+				{name: "keep", dims: dims, docIDs: []uint64{1, 2, 3}},
+				{name: "drop", dims: dims, docIDs: []uint64{4, 5}},
+			},
+			remove: "drop",
+			want:   map[string]int{"keep": 3, "drop": 0},
+		},
+		{
+			name: "a longer name carrying the target as a prefix survives",
+			seed: []dimRow{
+				{name: "vec", dims: dims, docIDs: []uint64{1, 2}},
+				{name: "vec_extra", dims: dims, docIDs: []uint64{3, 4, 5}},
+			},
+			remove: "vec",
+			want:   map[string]int{"vec": 0, "vec_extra": 3},
+		},
+		{
+			name: "the target itself may be the longer name",
+			seed: []dimRow{
+				{name: "vec", dims: dims, docIDs: []uint64{1, 2}},
+				{name: "vec_extra", dims: dims, docIDs: []uint64{3, 4, 5}},
+			},
+			remove: "vec_extra",
+			want:   map[string]int{"vec": 2, "vec_extra": 0},
+		},
+		{
+			name: "the unnamed vector takes only the 4-byte keys",
+			seed: []dimRow{
+				{name: "", dims: dims, docIDs: []uint64{1, 2}},
+				{name: "named", dims: dims, docIDs: []uint64{3, 4, 5}},
+			},
+			remove: "",
+			want:   map[string]int{"": 0, "named": 3},
+		},
+		{
+			name: "a named vector leaves the unnamed one alone",
+			seed: []dimRow{
+				{name: "", dims: dims, docIDs: []uint64{1, 2}},
+				{name: "named", dims: dims, docIDs: []uint64{3, 4, 5}},
+			},
+			remove: "named",
+			want:   map[string]int{"": 2, "named": 0},
+		},
+		{
+			name: "every dimensionality the target recorded goes",
+			seed: []dimRow{
+				{name: "drop", dims: 4, docIDs: []uint64{1}},
+				{name: "drop", dims: dims, docIDs: []uint64{2, 3}},
+				{name: "keep", dims: dims, docIDs: []uint64{4}},
+			},
+			remove: "drop",
+			want:   map[string]int{"drop": 0, "keep": 1},
+		},
+		{
+			name:   "a name that recorded nothing is not an error",
+			seed:   []dimRow{{name: "keep", dims: dims, docIDs: []uint64{1, 2}}},
+			remove: "absent",
+			want:   map[string]int{"keep": 2},
+		},
+	}
+
+	// flushed decides whether the rows are on disk when the removal runs. It
+	// matters: a memtable-only row never reaches the segment read path, which is
+	// where an unloaded bucket has no bitmap buffer pool to read through.
+	for _, flushed := range []bool{false, true} {
+		for _, strategy := range []string{lsmkv.StrategyRoaringSet, lsmkv.StrategyMapCollection} {
+			for _, tc := range tests {
+				t.Run(fmt.Sprintf("flushed=%v/%s/%s", flushed, strategy, tc.name), func(t *testing.T) {
+					ctx := t.Context()
+					dir := filepath.Join(t.TempDir(), "dimensions")
+					logger := logrus.New()
+					open := func() *lsmkv.Bucket {
+						b, err := lsmkv.NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
+							cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+							lsmkv.WithStrategy(strategy))
+						require.NoError(t, err)
+						return b
+					}
+					assertCounts := func(t *testing.T, b *lsmkv.Bucket, when string) {
+						t.Helper()
+						for name, want := range tc.want {
+							scan, err := ScanTargetVectorDimensions(ctx, b, name, 0)
+							require.NoError(t, err)
+							require.Equal(t, want, scan.Raw.Count,
+								"%s: doc count under %q after removing %q", when, name, tc.remove)
+						}
+					}
+
+					b := open()
+					seedDimRows(t, b, tc.seed)
+					if flushed {
+						require.NoError(t, b.FlushMemtable())
+					}
+					require.NoError(t, RemoveTargetVectorDimensions(ctx, b, tc.remove))
+					assertCounts(t, b, "in memory")
+
+					// Reopened from disk: a delete that lives only in the
+					// memtable would read as gone here and come back on the
+					// next restart.
+					require.NoError(t, b.FlushMemtable())
+					require.NoError(t, b.Shutdown(ctx))
+
+					reopened := open()
+					defer reopened.Shutdown(ctx)
+					assertCounts(t, reopened, "after flush and reopen")
+				})
+			}
+		}
+	}
+}

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -165,8 +165,51 @@ func openUnloadedDimensionsBucket(ctx context.Context, logger logrus.FieldLogger
 	)
 }
 
+// shutdownDimensionsBucket closes a standalone dimensions bucket and folds any
+// teardown failure into the caller's error.
+//
+// The context is detached deliberately. These buckets run on a noop cycle
+// manager whose Unregister returns ctx.Err() verbatim, so a request context
+// that dies mid-call would fail the teardown — and Bucket.Shutdown releases its
+// GlobalBucketRegistry claim only on a clean return, so every later open of the
+// bucket would fail with "bucket already registered" until the process
+// restarts.
+func shutdownDimensionsBucket(ctx context.Context, bucket *lsmkv.Bucket, err *error) {
+	if cerr := bucket.Shutdown(context.WithoutCancel(ctx)); cerr != nil {
+		*err = errors.Join(*err, fmt.Errorf("shutdown dimensions bucket: %w", cerr))
+	}
+}
+
+// RemoveUnloadedTargetVectorDimensions clears targetVector's rows from disk.
+// Callers must know the shard is unloaded: a loaded shard holds the bucket open
+// through its own store. A missing bucket is not created here.
+func RemoveUnloadedTargetVectorDimensions(ctx context.Context,
+	logger logrus.FieldLogger, path, tenantName, targetVector string,
+) (err error) {
+	bucketPath := shardPathDimensionsLSM(path, tenantName)
+	if _, err := os.Stat(bucketPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat dimensions bucket: %w", err)
+	}
+
+	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
+		return fmt.Errorf("lock dimensions bucket: %w", err)
+	}
+	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
+
+	bucket, err := openUnloadedDimensionsBucket(ctx, logger, path, bucketPath)
+	if err != nil {
+		return err
+	}
+	defer shutdownDimensionsBucket(ctx, bucket, &err)
+
+	return RemoveTargetVectorDimensions(ctx, bucket, targetVector)
+}
+
 // CalculateUnloadedDimensionsUsage calculates dimensions and object count for an unloaded shard without loading it into memory
-func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (types.Dimensionality, error) {
+func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (_ types.Dimensionality, err error) {
 	bucketPath := shardPathDimensionsLSM(path, tenantName)
 	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
 		return types.Dimensionality{}, fmt.Errorf("lock dimensions bucket: %w", err)
@@ -177,7 +220,7 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 	if err != nil {
 		return types.Dimensionality{}, err
 	}
-	defer bucket.Shutdown(ctx)
+	defer shutdownDimensionsBucket(ctx, bucket, &err)
 
 	scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, 0)
 	if err != nil {
@@ -192,7 +235,7 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 // targetVectors maps each vector name to its MUVERA-encoded dimensionality, or 0 if not MUVERA.
 func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	logger logrus.FieldLogger, path, tenantName string, targetVectors map[string]int,
-) (map[string]DimensionsScan, error) {
+) (_ map[string]DimensionsScan, err error) {
 	if len(targetVectors) == 0 {
 		return nil, nil
 	}
@@ -207,7 +250,7 @@ func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	defer bucket.Shutdown(ctx)
+	defer shutdownDimensionsBucket(ctx, bucket, &err)
 
 	scans := make(map[string]DimensionsScan, len(targetVectors))
 	for targetVector, encodedDimensions := range targetVectors {
@@ -457,6 +500,152 @@ const contextCheckInterval = 1024
 // LSMKV bucket. A non-zero encodedDimensions reports that fixed dimensionality against the object
 // count summed across all rows, which costs a scan of the whole prefix instead of stopping at the
 // first complete row.
+// removeRoaringSetRow deletes one row's doc IDs in bounded batches, so neither
+// the WAL append nor the memtable lock is held for the whole set at once.
+//
+// The row is read through its own cursor rather than RoaringSetGet: an unloaded
+// dimensions bucket is opened without a bitmap buffer pool, which the segment
+// read path dereferences.
+func removeRoaringSetRow(ctx context.Context, b *lsmkv.Bucket, key []byte) error {
+	values, err := roaringSetRowValues(ctx, b, key)
+	if err != nil || len(values) == 0 {
+		return err
+	}
+
+	for start := 0; start < len(values); start += dimensionsDeleteChunk {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(start+dimensionsDeleteChunk, len(values))
+		if err := b.RoaringSetRemoveBatch([]lsmkv.RoaringSetBatchEntry{
+			{Key: key, Values: values[start:end]},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// roaringSetRowValues reads one row and closes the cursor before returning, so
+// nothing is written while it is open.
+func roaringSetRowValues(ctx context.Context, b *lsmkv.Bucket, key []byte) ([]uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c := b.CursorRoaringSet()
+	defer c.Close()
+
+	k, v := c.Seek(key)
+	if k == nil || !bytes.Equal(k, key) || v == nil {
+		return nil, nil
+	}
+	return v.ToArray(), nil
+}
+
+// dimensionsDeleteChunk bounds one delete batch. A dimensions row lists every
+// object carrying the vector, so an unchunked delete is O(objects) in one
+// allocation and in one uninterruptible stretch.
+const dimensionsDeleteChunk = 10_000
+
+// RemoveTargetVectorDimensions deletes every row targetVector owns. Keys are
+// <name><LE uint32 dims>, so a longer name sorts among the target's own keys:
+// the length check separates them, the prefix alone does not. An empty name is
+// the legacy unnamed vector.
+//
+// Rows are collected before anything is deleted — writing through an open
+// cursor is not safe.
+func RemoveTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVector string) error {
+	if err := lsmkv.CheckExpectedStrategy(b.Strategy(), lsmkv.StrategyMapCollection, lsmkv.StrategyRoaringSet); err != nil {
+		return fmt.Errorf("removeTargetVectorDimensions: %w", err)
+	}
+
+	prefix := []byte(targetVector)
+	nameLen := len(targetVector)
+	expectedKeyLen := nameLen + 4
+
+	switch b.Strategy() {
+	case lsmkv.StrategyMapCollection:
+		// Since weaviate 1.34 default dimension bucket strategy is StrategyRoaringSet.
+		// For backward compatibility StrategyMapCollection is still supported.
+		type row struct {
+			key     []byte
+			mapKeys [][]byte
+		}
+		var rows []row
+
+		c, err := b.MapCursor()
+		if err != nil {
+			return fmt.Errorf("create cursor: %w", err)
+		}
+		var k []byte
+		var v []lsmkv.MapPair
+		if nameLen == 0 {
+			k, v = c.First(ctx)
+		} else {
+			k, v = c.Seek(ctx, prefix)
+		}
+		for ; k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next(ctx) {
+			if len(k) != expectedKeyLen {
+				continue
+			}
+			r := row{key: bytes.Clone(k)}
+			for _, pair := range v {
+				r.mapKeys = append(r.mapKeys, bytes.Clone(pair.Key))
+			}
+			rows = append(rows, r)
+		}
+		c.Close()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		for _, r := range rows {
+			for i, mapKey := range r.mapKeys {
+				// One lock and one WAL append each, so a row holding the whole
+				// shard's doc IDs is a long uninterruptible stretch otherwise.
+				if i%dimensionsDeleteChunk == 0 && ctx.Err() != nil {
+					return ctx.Err()
+				}
+				if err := b.MapDeleteKey(r.key, mapKey); err != nil {
+					return fmt.Errorf("delete dimensions entry for %q: %w", targetVector, err)
+				}
+			}
+		}
+	default:
+		// Only the keys are collected while the cursor is open: a row's value is
+		// one entry per object carrying the vector, so retaining every row's
+		// doc IDs at once is the whole shard's set several times over. Each row
+		// is then read and deleted on its own, and one row's bitmap is the floor
+		// — sroar exposes no iterator, so ToArray is the only way in.
+		var keys [][]byte
+
+		c := b.CursorRoaringSet()
+		var k []byte
+		if nameLen == 0 {
+			k, _ = c.First()
+		} else {
+			k, _ = c.Seek(prefix)
+		}
+		for ; k != nil && bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+			if len(k) != expectedKeyLen {
+				continue
+			}
+			keys = append(keys, bytes.Clone(k))
+		}
+		c.Close()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		for _, key := range keys {
+			if err := removeRoaringSetRow(ctx, b, key); err != nil {
+				return fmt.Errorf("delete dimensions rows for %q: %w", targetVector, err)
+			}
+		}
+	}
+	return nil
+}
+
 func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVector string,
 	encodedDimensions int,
 ) (DimensionsScan, error) {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -195,6 +195,37 @@ weaviate_shards{state="loaded",registration="lazy"}
 |---|---|---|---|---|
 | `weaviate_distributed_tasks_running` | Number of active distributed tasks running per namespace | `Gauge` | `namespace` | ❌ High 
 
+#### LSM Segment Edit Op Metrics
+| Name | Description | Type | Labels | High Cardinality |
+|---|---|---|---|---|
+| `weaviate_lsm_segment_edit_ops_active` | Number of LSM segment edit operations armed on this shard, by op type. See the notes below. | `Gauge` | `op_type, class_name, shard_name` | ❌ High 
+| `weaviate_lsm_segment_edit_ops_pending_segments` | Segments still queued for rewrite for an edit op on this shard, excluding quarantined ones | `Gauge` | `op_id, class_name, shard_name` | ❌ High 
+| `weaviate_lsm_segment_edit_ops_segments_owed` | Segments an edit op still owes on this shard: queued plus quarantined. See the notes below. | `Gauge` | `op_id, class_name, shard_name` | ❌ High 
+| `weaviate_lsm_segment_edit_ops_transformer_duration_seconds` | Wall-clock seconds one cleaner pass spent rewriting one segment under an edit op, by op type | `Histogram` | `op_type` | - Low 
+
+##### Notes on the segment edit op metrics
+
+- **An edit op is the background rewrite that strips a dropped vector index out of existing
+  segments.** The drop-vector-index cleanup is the first user; `op_type` names the kind of edit and
+  `op_id` is the drop epoch.
+- **`active > 0` with `segments_owed = 0` is the ordinary state, not a stall.** An op stays armed
+  until its drop completes cluster-wide, so a shard that finished its own rewrites sits here while
+  it waits on peers.
+- **`segments_owed` above `pending_segments` means segments are in quarantine**, having exhausted
+  their retry budget. A new round returns them to the queue with a fresh budget, but only a bounded
+  number of times. A brief divergence is a drop mid-retry; one that persists across rounds is a drop
+  that will not finish without intervention.
+- **`op_id` alone does not identify a series.** Every shard taking part in the same drop shares the
+  epoch, so `class_name` and `shard_name` are load-bearing — and in a multi-tenant collection
+  `shard_name` IS the tenant name, unique only within its class.
+- **The per-shard gauges are suppressed under `PROMETHEUS_MONITORING_GROUP`.** Their labels collapse
+  to `n/a` in that mode, so every shard would write one shared series and the readings would be
+  meaningless. The duration histogram carries no shard dimension and stays on.
+- **The gauges are deleted when a shard unloads or is dropped**, so an inactive tenant leaves no
+  stale series. The histogram is cumulative and deliberately node-level: it describes the cost of the
+  work rather than the state of a shard, and reaping it would make a deactivate/reactivate look like
+  a reset.
+
 #### HTTP Server Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|

--- a/test/acceptance/drop_vector_index/metrics_test.go
+++ b/test/acceptance/drop_vector_index/metrics_test.go
@@ -1,0 +1,201 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package drop_vector_index
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// metricsPort is Weaviate's default PROMETHEUS_MONITORING_PORT.
+const metricsPort = 2112
+
+// TestDropVectorIndex_Metrics_SingleNode covers the two edit-op metric
+// journeys nothing below the acceptance layer can: that a drop publishes the
+// per-shard series through the real wiring (env gate -> NewMetrics -> refresh
+// call sites), and that deleting the tenant reaps them. The unit tests pin
+// both behaviours against hand-built metrics; only a scrape of /metrics proves
+// the production plumbing exports and retires the series end to end.
+func TestDropVectorIndex_Metrics_SingleNode(t *testing.T) {
+	ctx := context.Background()
+	compose, err := docker.New().
+		WithWeaviate().
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "1").
+		WithWeaviateEnv("PROMETHEUS_MONITORING_ENABLED", "true").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		dumpLogsOnFailure(ctx, t, compose)
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+	container := compose.GetWeaviate().Container()
+
+	const (
+		className = "DropVectorIndexMetrics"
+		dropped   = "vec"
+		sibling   = "sibling"
+		tenantA   = "tenant-metrics-a"
+		tenantB   = "tenant-metrics-b"
+		objCount  = 20
+	)
+
+	deleteParams := schema.NewSchemaObjectsDeleteParams().WithClassName(className)
+	helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+	defer helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+
+	createMTDropClass(t, className, dropped, sibling, tenantA, tenantB)
+
+	for ten, tenant := range []string{tenantA, tenantB} {
+		batch := make([]*models.Object, objCount)
+		for i := range batch {
+			batch[i] = &models.Object{
+				ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-0000-00%02d-0000000090%02d", ten, i)),
+				Class:      className,
+				Tenant:     tenant,
+				Properties: map[string]any{"name": fmt.Sprintf("object-%d", i)},
+				Vectors: models.Vectors{
+					dropped: randVec(16, float32(i)),
+					sibling: randVec(16, float32(i)),
+				},
+			}
+		}
+		helper.CreateObjectsBatch(t, batch)
+	}
+	time.Sleep(3 * time.Second) // past the 1s dirty-flush, so the strip has segments to owe
+
+	dropTargetVector(t, className, dropped)
+	eventuallyTargetVectorRemoved(t, className, dropped)
+	waitForNoActiveDropTask(t)
+
+	t.Run("the drop published per-shard series for every tenant", func(t *testing.T) {
+		// Asserted after completion, not during: post-drop state is stable. The
+		// op-id gauges are forgotten with the op, so what survives is the
+		// per-shard active series — one PER TENANT, which is what makes the
+		// shard label load-bearing rather than decorative. A single tenant
+		// could not tell a correct implementation from one writing every
+		// shard's value into one shared series.
+		lines := editOpsMetricLines(ctx, t, container, className)
+		require.Contains(t, lines, "weaviate_lsm_segment_edit_ops_active",
+			"a drop on this shard must export the active gauge through the real wiring")
+		for _, tenant := range []string{tenantA, tenantB} {
+			require.Contains(t, lines, fmt.Sprintf("shard_name=%q", tenant),
+				"every participating tenant must get its own series")
+		}
+		require.Equal(t, 2, strings.Count(lines, "weaviate_lsm_segment_edit_ops_active{"),
+			"two tenants, two active series")
+	})
+
+	t.Run("the transformer histogram is exported", func(t *testing.T) {
+		// Scraped WITHOUT the class filter on purpose: the histogram carries
+		// op_type only — deliberately node-wide, no shard dimension — so a
+		// class_name= grep excludes it by construction and would report it
+		// missing however well it worked.
+		lines := editOpsMetricLinesNoClassFilter(ctx, t, container)
+		require.Contains(t, lines, "weaviate_lsm_segment_edit_ops_transformer_duration_seconds_count",
+			"the rewrites this drop performed must be timed")
+		require.NotContains(t, lines, "transformer_duration_seconds_count{class_name",
+			"the histogram must stay node-wide, without a shard dimension")
+	})
+
+	t.Run("deleting the tenants reaps every series", func(t *testing.T) {
+		require.NoError(t, helper.DeleteTenants(t, className, []string{tenantA, tenantB}))
+
+		// Eventually: the reap runs inside the shard teardown the delete kicks
+		// off, which finishes shortly after the HTTP call returns. A scrape
+		// error retries rather than hard-failing — asserting on the OUTER t
+		// from testify's polling goroutine would abort the whole test on one
+		// transient exec hiccup.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			lines, err := editOpsMetricLinesErr(ctx, container, className)
+			if err != nil {
+				assert.Fail(collect, "scrape /metrics", err.Error())
+				return
+			}
+			assert.Empty(collect, lines,
+				"a deleted tenant must leave no edit-op series behind")
+		}, time.Minute, time.Second)
+	})
+}
+
+// execSentinel separates the docker exec stream's multiplex header from the
+// command's own output; everything before it is discarded.
+const execSentinel = "===EDITOPS-METRICS==="
+
+// editOpsMetricLines is editOpsMetricLinesErr with the error asserted on t;
+// for call sites outside a retry loop.
+func editOpsMetricLines(ctx context.Context, t require.TestingT, c testcontainers.Container, className string) string {
+	lines, err := editOpsMetricLinesErr(ctx, c, className)
+	require.NoError(t, err)
+	return lines
+}
+
+// editOpsMetricLinesNoClassFilter scrapes every edit-op line regardless of
+// labels, for the series that carry no class dimension.
+func editOpsMetricLinesNoClassFilter(ctx context.Context, t require.TestingT, c testcontainers.Container) string {
+	lines, err := editOpsMetricLinesErr(ctx, c, "")
+	require.NoError(t, err)
+	return lines
+}
+
+// editOpsMetricLinesErr scrapes /metrics inside the container and returns the
+// edit-op series lines for className. Filtered in-container so only the
+// relevant handful of lines cross the exec stream. The scrape's own exit code
+// is preserved separately from grep's: "|| true" only on the grep leg, so a
+// dead endpoint surfaces as exit 9 instead of reading as zero series — an
+// "empty means reaped" assertion must not be satisfiable by a broken scrape.
+func editOpsMetricLinesErr(ctx context.Context, c testcontainers.Container, className string) (string, error) {
+	// An empty className skips the class filter, for the series that carry no
+	// class dimension at all.
+	filter := "cat"
+	if className != "" {
+		filter = fmt.Sprintf("grep 'class_name=\"%s\"'", className)
+	}
+	cmd := fmt.Sprintf(
+		"echo %s; page=$(wget -qO- http://localhost:%d/metrics) || exit 9; "+
+			"printf '%%s\\n' \"$page\" | grep lsm_segment_edit_ops | %s || true",
+		execSentinel, metricsPort, filter)
+	code, reader, err := c.Exec(ctx, []string{"sh", "-c", cmd})
+	if err != nil {
+		return "", fmt.Errorf("exec scrape: %w", err)
+	}
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("read scrape output: %w", err)
+	}
+	s := string(out)
+	if code != 0 {
+		return "", fmt.Errorf("scrape exited %d: %s", code, s)
+	}
+	_, lines, found := strings.Cut(s, execSentinel)
+	if !found {
+		return "", fmt.Errorf("exec sentinel missing from output: %s", s)
+	}
+	return strings.TrimSpace(lines), nil
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -1101,7 +1101,9 @@ function run_acceptance_drop_vector_index_cluster_group1() {
 function run_acceptance_drop_vector_index_cluster_group2() {
   build_weaviate_test_image
   echo_green "acceptance — drop-vector-index-cluster-group2"
-  AOF_GROUP_RUN='^TestDropVectorIndex_Cluster_Group2$' \
+  # The metrics e2e rides along: a ~40s single-node test, not worth a matrix
+  # job whose image build alone dwarfs it.
+  AOF_GROUP_RUN='^TestDropVectorIndex_(Cluster_Group2|Metrics_SingleNode)$' \
     run_aof_group "drop-vector-index-cluster-group2" test/acceptance/drop_vector_index
 }
 

--- a/tools/dev/grafana/dashboards/lsm_segment_edit_ops.json
+++ b/tools/dev/grafana/dashboards/lsm_segment_edit_ops.json
@@ -1,0 +1,1287 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "lsm-segment-edit-ops",
+    "namespace": "default",
+    "uid": "3409806e-85e7-4048-b0b7-800dd61eb7af",
+    "resourceVersion": "1786967318595005",
+    "generation": 1,
+    "creationTimestamp": "2026-08-17T11:48:38Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "4151855234015232"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "access-policy:service",
+      "grafana.app/managedBy": "classic-file-provisioning",
+      "grafana.app/managerId": "weaviate dashboard provider",
+      "grafana.app/sourceChecksum": "6ad3677ffc2278d82c8b9754738747c0",
+      "grafana.app/sourcePath": "/var/lib/grafana/dashboards/lsm_segment_edit_ops.json",
+      "grafana.app/sourceTimestamp": "1786964691000",
+      "grafana.app/folder": ""
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "LSM segment edit-op cleanup: the background rewrite that physically strips a dropped vector index out of existing segments.",
+    "editable": true,
+    "elements": {
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.50, sum by (le, op_type) (rate(weaviate_lsm_segment_edit_ops_transformer_duration_seconds_bucket[$__rate_interval])))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "p50",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.95, sum by (le, op_type) (rate(weaviate_lsm_segment_edit_ops_transformer_duration_seconds_bucket[$__rate_interval])))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "p95",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.99, sum by (le, op_type) (rate(weaviate_lsm_segment_edit_ops_transformer_duration_seconds_bucket[$__rate_interval])))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "p99",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Wall-clock per segment rewrite: the full rewrite loop, excluding fsync, segment swap and bookkeeping. Node-wide by design — no shard dimension. Every completed attempt counts, failures included; aborted (mid-segment) attempts do not. Compaction runs the same transformer for its own reasons and is not timed here.",
+          "id": 10,
+          "links": [],
+          "title": "Segment rewrite duration",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum by (op_type) (rate(weaviate_lsm_segment_edit_ops_transformer_duration_seconds_count[$__rate_interval]))",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{op_type}}",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Throughput of the dedicated cleaner. One segment per pass by design, so this is also the pass rate. Flat at zero while segments are owed means the cleaner is not making progress — cross-check the quarantine panel.",
+          "id": 11,
+          "links": [],
+          "title": "Segments rewritten per second",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum(weaviate_lsm_segment_edit_ops_segments_owed)",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "owed",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "sum(weaviate_lsm_segment_edit_ops_pending_segments)",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "queued",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The whole node's remaining strip work. Owed is queued plus quarantined, so the two lines separate exactly when segments are sitting in quarantine.",
+          "id": 2,
+          "links": [],
+          "title": "Total segments owed (all shards)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "weaviate_lsm_segment_edit_ops_active",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{class_name}}/{{shard_name}} {{op_type}}",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "An op stays armed until its drop completes CLUSTER-WIDE, so a shard that finished its own rewrites keeps reading 1 while it waits on peers. Alert on segments_owed, not on this.",
+          "id": 3,
+          "links": [],
+          "title": "Armed edit ops by shard",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "weaviate_lsm_segment_edit_ops_pending_segments",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{class_name}}/{{shard_name}} {{op_id}}",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The progress bar: how much each shard still has to rewrite. Excludes quarantined segments, which is what makes the comparison with segments_owed meaningful.",
+          "id": 4,
+          "links": [],
+          "title": "Segments queued for rewrite",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "weaviate_lsm_segment_edit_ops_segments_owed",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{class_name}}/{{shard_name}} {{op_id}}",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Queued plus quarantined. Reaching zero is what completion looks like; holding above the queued count is what a stall looks like.",
+          "id": 5,
+          "links": [],
+          "title": "Segments owed",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "weaviate_lsm_segment_edit_ops_segments_owed - on(op_id, class_name, shard_name) weaviate_lsm_segment_edit_ops_pending_segments",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{class_name}}/{{shard_name}} {{op_id}}",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "THE stall signal. Non-zero means the retry budget gave up on a segment. A new round requeues it with a fresh budget, but only a bounded number of times — a value that persists across rounds is a drop that will not finish without intervention. The moment a segment exhausts its budget for good is also logged (search: 'stays quarantined for good').",
+          "id": 7,
+          "links": [],
+          "title": "Quarantined segments (owed − queued)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "Prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "disableTextWrap": false,
+                        "editorMode": "code",
+                        "expr": "weaviate_lsm_segment_edit_ops_active > 0 unless on(class_name, shard_name) (weaviate_lsm_segment_edit_ops_segments_owed > 0)",
+                        "fullMetaSearch": false,
+                        "includeNullMetadata": true,
+                        "legendFormat": "{{class_name}}/{{shard_name}} {{op_type}}",
+                        "range": true,
+                        "useBackend": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shards that finished their own rewrites and are waiting for peers to finish theirs. This is the ORDINARY state of a healthy multi-node drop, shown here so it is not mistaken for a stall on the panels above.",
+          "id": 8,
+          "links": [],
+          "title": "Shards armed but owing nothing",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 8
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Drop progress"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-7"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Stall signals"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-10"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Rewrite cost"
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "lsm",
+      "drop-vector-index"
+    ],
+    "timeSettings": {
+      "autoRefresh": "auto",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-1h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "LSM Segment Edit Ops (drop-vector)",
+    "variables": []
+  }
+}

--- a/usecases/monitoring/segment_edit_ops.go
+++ b/usecases/monitoring/segment_edit_ops.go
@@ -1,0 +1,150 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SegmentEditOpsMetrics exposes the Prometheus series for LSM segment edit
+// operations; drop-vector-index Phase-2 cleanup is the first user. The
+// collectors are process-global and shared across shards via
+// EnsureRegisteredMetric, so it is safe to construct one instance per shard.
+// shardName is bound per instance so call sites pass only the op type or op id.
+//
+// A nil *SegmentEditOpsMetrics is a valid no-op receiver: when monitoring is
+// disabled the holding component carries nil and callers need not branch.
+type SegmentEditOpsMetrics struct {
+	shard string
+
+	active          *prometheus.GaugeVec
+	pendingSegments *prometheus.GaugeVec
+	transformerDur  *prometheus.HistogramVec
+	bytesReclaimed  *prometheus.CounterVec
+	forcedRemaining *prometheus.GaugeVec
+}
+
+// NewSegmentEditOpsMetrics registers (or reuses) the edit-ops collectors against
+// reg and binds them to shardName. Returns a nil-safe instance.
+func NewSegmentEditOpsMetrics(reg prometheus.Registerer, shardName string) (*SegmentEditOpsMetrics, error) {
+	active, _, err := EnsureRegisteredMetric(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "segment_edit_ops_active",
+		Help:      "Number of active LSM segment edit operations, by op type and shard.",
+	}, []string{"op_type", "shard"}))
+	if err != nil {
+		return nil, fmt.Errorf("register segment_edit_ops_active: %w", err)
+	}
+
+	pendingSegments, _, err := EnsureRegisteredMetric(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "segment_edit_ops_pending_segments",
+		Help:      "Segments still awaiting rewrite for an edit op, by op id and shard.",
+	}, []string{"op_id", "shard"}))
+	if err != nil {
+		return nil, fmt.Errorf("register segment_edit_ops_pending_segments: %w", err)
+	}
+
+	transformerDur, _, err := EnsureRegisteredMetric(reg, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "segment_edit_ops_transformer_duration_seconds",
+		Help:      "Wall-clock seconds spent applying an edit-op transformer to one segment, by op type.",
+		Buckets:   LatencyBuckets,
+	}, []string{"op_type"}))
+	if err != nil {
+		return nil, fmt.Errorf("register segment_edit_ops_transformer_duration_seconds: %w", err)
+	}
+
+	bytesReclaimed, _, err := EnsureRegisteredMetric(reg, prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "segment_edit_ops_bytes_reclaimed_total",
+		Help:      "Bytes reclaimed by edit-op rewrites (input minus output), by op type and shard.",
+	}, []string{"op_type", "shard"}))
+	if err != nil {
+		return nil, fmt.Errorf("register segment_edit_ops_bytes_reclaimed_total: %w", err)
+	}
+
+	forcedRemaining, _, err := EnsureRegisteredMetric(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "segment_edit_ops_forced_cleanup_segments_remaining",
+		Help:      "Segments the forced cleanup driver still has to rewrite for an edit op, by op id.",
+	}, []string{"op_id"}))
+	if err != nil {
+		return nil, fmt.Errorf("register segment_edit_ops_forced_cleanup_segments_remaining: %w", err)
+	}
+
+	return &SegmentEditOpsMetrics{
+		shard:           shardName,
+		active:          active,
+		pendingSegments: pendingSegments,
+		transformerDur:  transformerDur,
+		bytesReclaimed:  bytesReclaimed,
+		forcedRemaining: forcedRemaining,
+	}, nil
+}
+
+// SetActive records the number of active ops of opType on this shard.
+func (m *SegmentEditOpsMetrics) SetActive(opType string, n int) {
+	if m == nil {
+		return
+	}
+	m.active.WithLabelValues(opType, m.shard).Set(float64(n))
+}
+
+// SetPendingSegments records how many segments still await rewrite for opID on
+// this shard.
+func (m *SegmentEditOpsMetrics) SetPendingSegments(opID string, n int) {
+	if m == nil {
+		return
+	}
+	m.pendingSegments.WithLabelValues(opID, m.shard).Set(float64(n))
+}
+
+// SetForcedCleanupRemaining records how many segments the forced cleanup driver
+// still has to rewrite for opID.
+func (m *SegmentEditOpsMetrics) SetForcedCleanupRemaining(opID string, n int) {
+	if m == nil {
+		return
+	}
+	m.forcedRemaining.WithLabelValues(opID).Set(float64(n))
+}
+
+// ObserveTransformerDuration records the wall-clock seconds spent applying the
+// transformer to one segment for opType.
+func (m *SegmentEditOpsMetrics) ObserveTransformerDuration(opType string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.transformerDur.WithLabelValues(opType).Observe(seconds)
+}
+
+// AddBytesReclaimed adds the bytes a rewrite reclaimed for opType. Non-positive
+// deltas are ignored so a rewrite that did not shrink the segment is not counted
+// (C7: attribute only when the transformer changed bytes).
+func (m *SegmentEditOpsMetrics) AddBytesReclaimed(opType string, bytes int64) {
+	if m == nil || bytes <= 0 {
+		return
+	}
+	m.bytesReclaimed.WithLabelValues(opType, m.shard).Add(float64(bytes))
+}
+
+// ForgetOp drops the op-id-labeled series once opID has fully completed, so
+// finished ops do not linger as stale zero gauges.
+func (m *SegmentEditOpsMetrics) ForgetOp(opID string) {
+	if m == nil {
+		return
+	}
+	m.pendingSegments.DeletePartialMatch(prometheus.Labels{"op_id": opID})
+	m.forcedRemaining.DeletePartialMatch(prometheus.Labels{"op_id": opID})
+}

--- a/usecases/monitoring/segment_edit_ops.go
+++ b/usecases/monitoring/segment_edit_ops.go
@@ -1,0 +1,194 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SegmentEditOpsMetrics exposes the Prometheus series for LSM segment edit
+// operations; the background cleanup that strips a dropped vector index is
+// the first user. The
+// collectors are process-global and shared across shards via
+// EnsureRegisteredMetric, so it is safe to construct one instance per shard.
+// The class and shard names are bound per instance so call sites pass only the
+// op type or op id.
+//
+// The GAUGES carry {class_name, shard_name}; the duration histogram does not.
+// The gauges describe the state of a shard, and there the shard dimension is
+// load-bearing twice over: an op id is the drop EPOCH, shared by every shard
+// taking part in the same drop cluster-wide, so a series without it is written
+// by all of them and reads as whichever wrote last; and in a multi-tenant
+// collection the shard name IS the tenant name, unique only within its class.
+// Those labels are also what DeleteOwnShard reaps by. The histogram
+// describes the cost of the work instead, which is node-level.
+//
+// A nil *SegmentEditOpsMetrics is a valid no-op receiver: when monitoring is
+// disabled the holding component carries nil and callers need not branch.
+type SegmentEditOpsMetrics struct {
+	class string
+	shard string
+	// grouped mirrors PrometheusMetrics.Group. The per-shard GAUGES are
+	// suppressed in that mode: their labels have already collapsed to "n/a", so
+	// every shard would write one shared series and the readings would be
+	// meaningless — 100 tenants owing 3 segments each would read 3, not 300,
+	// and the first to drain would zero it for all of them. Absent beats wrong.
+	// The cumulative series carry no shard dimension anyway, so they stay on.
+	grouped bool
+
+	active          *prometheus.GaugeVec
+	pendingSegments *prometheus.GaugeVec
+	transformerDur  *prometheus.HistogramVec
+	segmentsOwed    *prometheus.GaugeVec
+}
+
+// NewSegmentEditOpsMetrics registers (or reuses) the edit-ops collectors against
+// reg and binds them to className/shardName. Returns a nil-safe instance.
+// Callers pass the names AFTER the monitoring-group collapse (NewMetrics turns
+// both into "n/a" when PROMETHEUS_MONITORING_GROUP is set) and the grouped flag
+// alongside, because for these gauges collapsing is not enough — see the
+// grouped field.
+func NewSegmentEditOpsMetrics(reg prometheus.Registerer, className, shardName string, grouped bool) (*SegmentEditOpsMetrics, error) {
+	active, _, err := EnsureRegisteredMetric(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "lsm_segment_edit_ops_active",
+		Help:      "Number of LSM segment edit operations armed on this shard, by op type. An op stays armed until its drop completes cluster-wide, so active > 0 with segments_owed = 0 is the ordinary state of a shard that finished its own rewrites and is waiting on peers - not a stall.",
+	}, []string{"op_type", "class_name", "shard_name"}))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_segment_edit_ops_active: %w", err)
+	}
+
+	pendingSegments, _, err := EnsureRegisteredMetric(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "lsm_segment_edit_ops_pending_segments",
+		Help:      "Segments still queued for rewrite for an edit op on this shard. Excludes segments quarantined after exhausting their retry budget; compare with weaviate_lsm_segment_edit_ops_segments_owed to see those.",
+	}, []string{"op_id", "class_name", "shard_name"}))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_segment_edit_ops_pending_segments: %w", err)
+	}
+
+	transformerDur, _, err := EnsureRegisteredMetric(reg, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "lsm_segment_edit_ops_transformer_duration_seconds",
+		Help:      "Wall-clock seconds one dedicated cleaner pass spent rewriting one segment under an edit op, by op type: the full rewrite loop - cursor scan, shadowed-key checks, transform, buffered writes - excluding the fsync, the segment swap and the bookkeeping commits. Compaction runs the same transformer for its own reasons and is not timed.",
+		// Matches the sibling lsmkv compaction-duration histogram rather than the
+		// shared LatencyBuckets, which stop at 100s. Segment size is unbounded, so
+		// a rewrite can run longer than that, and every such rewrite — precisely
+		// the ones worth seeing — would land in the same +Inf bucket.
+		Buckets: prometheus.ExponentialBuckets(0.01, 2, 15), // 0.01s → ~163.84s
+	}, []string{"op_type"}))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_segment_edit_ops_transformer_duration_seconds: %w", err)
+	}
+
+	segmentsOwed, _, err := EnsureRegisteredMetric(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: DefaultMetricsNamespace,
+		Name:      "lsm_segment_edit_ops_segments_owed",
+		Help:      "Segments an edit op still owes on this shard: queued plus quarantined. Stays above weaviate_lsm_segment_edit_ops_pending_segments exactly while segments sit in quarantine. A new round returns quarantined segments to the queue with a fresh retry budget, but only a bounded number of times; once a segment exhausts that budget it stays quarantined for good. So a brief divergence is a drop mid-retry, and one that persists across rounds is a drop that will not finish without intervention.",
+	}, []string{"op_id", "class_name", "shard_name"}))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_segment_edit_ops_segments_owed: %w", err)
+	}
+
+	return &SegmentEditOpsMetrics{
+		class:           className,
+		shard:           shardName,
+		grouped:         grouped,
+		active:          active,
+		pendingSegments: pendingSegments,
+		transformerDur:  transformerDur,
+		segmentsOwed:    segmentsOwed,
+	}, nil
+}
+
+// PerShardGaugesEnabled reports whether the per-shard gauges are actually
+// collected. False in grouped mode, where they are suppressed — callers use it
+// to skip the work of computing values nothing will record.
+func (m *SegmentEditOpsMetrics) PerShardGaugesEnabled() bool {
+	return m != nil && !m.grouped
+}
+
+// SetActive records the number of active ops of opType on this shard.
+func (m *SegmentEditOpsMetrics) SetActive(opType string, n int) {
+	if m == nil || m.grouped {
+		return
+	}
+	m.active.WithLabelValues(opType, m.class, m.shard).Set(float64(n))
+}
+
+// SetPendingSegments records how many segments still await rewrite for opID on
+// this shard.
+func (m *SegmentEditOpsMetrics) SetPendingSegments(opID string, n int) {
+	if m == nil || m.grouped {
+		return
+	}
+	m.pendingSegments.WithLabelValues(opID, m.class, m.shard).Set(float64(n))
+}
+
+// SetSegmentsOwed records how many segments opID still owes on this shard —
+// queued plus quarantined. Quarantined segments are excluded from
+// SetPendingSegments, so a stalled drop holds this gauge above pending instead
+// of both reading zero like a finished one (see the exported Help for why the
+// divergence must persist across rounds to mean stalled).
+func (m *SegmentEditOpsMetrics) SetSegmentsOwed(opID string, n int) {
+	if m == nil || m.grouped {
+		return
+	}
+	m.segmentsOwed.WithLabelValues(opID, m.class, m.shard).Set(float64(n))
+}
+
+// ObserveTransformerDuration records the wall-clock seconds spent applying the
+// transformer to one segment for opType.
+func (m *SegmentEditOpsMetrics) ObserveTransformerDuration(opType string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.transformerDur.WithLabelValues(opType).Observe(seconds)
+}
+
+// ForgetOp drops THIS shard's series for an op that no longer exists in the
+// sidecar — completed or orphan-swept — so vanished ops do not linger as stale
+// gauges. Scoped to the shard: an op id is the drop epoch and every
+// participating shard shares it, so dropping by op id alone would delete
+// sibling shards' live series. The three labels are the gauges' complete set,
+// so this is an exact Delete — a partial match would scan every series on the
+// node under the vec's write lock, which all shards' gauge writes contend on.
+func (m *SegmentEditOpsMetrics) ForgetOp(opID string) {
+	if m == nil {
+		return
+	}
+	labels := prometheus.Labels{"op_id": opID, "class_name": m.class, "shard_name": m.shard}
+	m.pendingSegments.Delete(labels)
+	m.segmentsOwed.Delete(labels)
+}
+
+// DeleteOwnShard drops every series bound to this instance's class/shard, so
+// an unloaded or deleted shard leaves no permanent series behind on the node.
+// Reached from SegmentGroup.reapEditOpsMetrics — via shutdown (Shard.drop
+// guarantees store.Shutdown on every exit) or via the constructor's rollback
+// for a group discarded before it ever had a shutdown to reach. A shard that
+// was never loaded never published.
+func (m *SegmentEditOpsMetrics) DeleteOwnShard() {
+	if m == nil {
+		return
+	}
+	// Gauges only. The duration histogram is cumulative and deliberately carries
+	// no shard dimension: it describes the cost of the work, not the state of a
+	// shard, and a cumulative series that gets reaped cannot be rebuilt — a
+	// tenant deactivate/reactivate would silently reset it.
+	labels := prometheus.Labels{"class_name": m.class, "shard_name": m.shard}
+	m.active.DeletePartialMatch(labels)
+	m.pendingSegments.DeletePartialMatch(labels)
+	m.segmentsOwed.DeletePartialMatch(labels)
+}

--- a/usecases/monitoring/segment_edit_ops_test.go
+++ b/usecases/monitoring/segment_edit_ops_test.go
@@ -1,0 +1,188 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// findMetric returns the single metric in family `name` whose labels exactly
+// match `want`, or nil if none does.
+func findMetric(t *testing.T, reg *prometheus.Registry, name string, want map[string]string) *dto.Metric {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if len(labels) != len(want) {
+				continue
+			}
+			match := true
+			for k, v := range want {
+				if labels[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m
+			}
+		}
+	}
+	return nil
+}
+
+// countMetrics returns how many child series family `name` currently exposes.
+func countMetrics(t *testing.T, reg *prometheus.Registry, name string) int {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() == name {
+			return len(fam.GetMetric())
+		}
+	}
+	return 0
+}
+
+func TestMetrics_Labels(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewSegmentEditOpsMetrics(reg, "shardA")
+	require.NoError(t, err)
+
+	const opType = "remove_target_vectors"
+	m.SetActive(opType, 2)
+	m.SetPendingSegments("op1", 3)
+	m.SetForcedCleanupRemaining("op1", 3)
+	m.ObserveTransformerDuration(opType, 0.5)
+	m.AddBytesReclaimed(opType, 1024)
+
+	tests := []struct {
+		name      string
+		family    string
+		labels    map[string]string
+		gaugeVal  float64
+		isGauge   bool
+		isCounter bool
+		sampleCnt uint64
+	}{
+		{
+			name:     "active is labeled by op_type and shard",
+			family:   "weaviate_segment_edit_ops_active",
+			labels:   map[string]string{"op_type": opType, "shard": "shardA"},
+			gaugeVal: 2,
+			isGauge:  true,
+		},
+		{
+			name:     "pending_segments is labeled by op_id and shard",
+			family:   "weaviate_segment_edit_ops_pending_segments",
+			labels:   map[string]string{"op_id": "op1", "shard": "shardA"},
+			gaugeVal: 3,
+			isGauge:  true,
+		},
+		{
+			name:     "forced_cleanup_segments_remaining is labeled by op_id only",
+			family:   "weaviate_segment_edit_ops_forced_cleanup_segments_remaining",
+			labels:   map[string]string{"op_id": "op1"},
+			gaugeVal: 3,
+			isGauge:  true,
+		},
+		{
+			name:      "bytes_reclaimed is labeled by op_type and shard",
+			family:    "weaviate_segment_edit_ops_bytes_reclaimed_total",
+			labels:    map[string]string{"op_type": opType, "shard": "shardA"},
+			gaugeVal:  1024,
+			isCounter: true,
+		},
+		{
+			name:      "transformer_duration is labeled by op_type only",
+			family:    "weaviate_segment_edit_ops_transformer_duration_seconds",
+			labels:    map[string]string{"op_type": opType},
+			sampleCnt: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := findMetric(t, reg, tt.family, tt.labels)
+			require.NotNil(t, metric, "no series matched labels %v in %s", tt.labels, tt.family)
+			switch {
+			case tt.isGauge:
+				require.Equal(t, tt.gaugeVal, metric.GetGauge().GetValue())
+			case tt.isCounter:
+				require.Equal(t, tt.gaugeVal, metric.GetCounter().GetValue())
+			default:
+				require.Equal(t, tt.sampleCnt, metric.GetHistogram().GetSampleCount())
+			}
+		})
+	}
+}
+
+func TestBytesReclaimed_NotAttributedWhenUnchanged(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewSegmentEditOpsMetrics(reg, "shardA")
+	require.NoError(t, err)
+
+	const family = "weaviate_segment_edit_ops_bytes_reclaimed_total"
+
+	// A rewrite that did not shrink the segment (delta == 0) or grew it (delta < 0)
+	// must not be attributed: no series should be created at all.
+	m.AddBytesReclaimed("remove_target_vectors", 0)
+	m.AddBytesReclaimed("remove_target_vectors", -64)
+	require.Equal(t, 0, countMetrics(t, reg, family))
+
+	// A real shrink is attributed.
+	m.AddBytesReclaimed("remove_target_vectors", 512)
+	metric := findMetric(t, reg, family,
+		map[string]string{"op_type": "remove_target_vectors", "shard": "shardA"})
+	require.NotNil(t, metric)
+	require.Equal(t, float64(512), metric.GetCounter().GetValue())
+}
+
+func TestMetrics_NilReceiverIsNoop(t *testing.T) {
+	var m *SegmentEditOpsMetrics
+	require.NotPanics(t, func() {
+		m.SetActive("t", 1)
+		m.SetPendingSegments("op", 1)
+		m.SetForcedCleanupRemaining("op", 1)
+		m.ObserveTransformerDuration("t", 1)
+		m.AddBytesReclaimed("t", 1)
+		m.ForgetOp("op")
+	})
+}
+
+func TestForgetOp_DropsOpLabeledSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewSegmentEditOpsMetrics(reg, "shardA")
+	require.NoError(t, err)
+
+	m.SetPendingSegments("op1", 3)
+	m.SetForcedCleanupRemaining("op1", 3)
+	require.Equal(t, 1, countMetrics(t, reg, "weaviate_segment_edit_ops_pending_segments"))
+	require.Equal(t, 1, countMetrics(t, reg, "weaviate_segment_edit_ops_forced_cleanup_segments_remaining"))
+
+	m.ForgetOp("op1")
+	require.Equal(t, 0, countMetrics(t, reg, "weaviate_segment_edit_ops_pending_segments"))
+	require.Equal(t, 0, countMetrics(t, reg, "weaviate_segment_edit_ops_forced_cleanup_segments_remaining"))
+}

--- a/usecases/monitoring/segment_edit_ops_test.go
+++ b/usecases/monitoring/segment_edit_ops_test.go
@@ -1,0 +1,239 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	activeFam         = "weaviate_lsm_segment_edit_ops_active"
+	pendingFam        = "weaviate_lsm_segment_edit_ops_pending_segments"
+	owedFam           = "weaviate_lsm_segment_edit_ops_segments_owed"
+	transformerDurFam = "weaviate_lsm_segment_edit_ops_transformer_duration_seconds"
+)
+
+// labelNamesOf returns the sorted label names of the single series in family
+// `name`. Used to pin which series carry the shard dimension and which do not —
+// a question testutil answers only by full-exposition comparison, which would
+// also pin the help text.
+func labelNamesOf(t *testing.T, reg *prometheus.Registry, name string) []string {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		require.Len(t, fam.GetMetric(), 1, "expected exactly one series in %s", name)
+		var names []string
+		for _, lp := range fam.GetMetric()[0].GetLabel() {
+			names = append(names, lp.GetName())
+		}
+		sort.Strings(names)
+		return names
+	}
+	t.Fatalf("family %s was not exported at all", name)
+	return nil
+}
+
+// TestMetrics_Labels pins the label design of all four series: the GAUGES carry
+// the shard dimension and the histogram deliberately does not. An op id is the
+// drop epoch, shared by every shard in the same drop, so a gauge without
+// {class_name, shard_name} is written by all of them and reads as whichever
+// wrote last; the histogram measures the cost of the work instead, which is a
+// node-level question, and keeping it unlabelled is also what lets it survive
+// tenant churn that DeleteShard reaps the gauges on.
+func TestMetrics_Labels(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewSegmentEditOpsMetrics(reg, "ClassA", "shardA", false)
+	require.NoError(t, err)
+
+	const opType = "remove_target_vectors"
+	m.SetActive(opType, 2)
+	m.SetPendingSegments("op1", 3)
+	m.SetSegmentsOwed("op1", 4)
+	m.ObserveTransformerDuration(opType, 0.5)
+
+	shardScoped := []string{"class_name", "shard_name"}
+	for _, tt := range []struct {
+		name   string
+		family string
+		labels []string
+		value  float64
+	}{
+		{
+			name:   "active is per shard, by op type",
+			family: activeFam,
+			labels: append([]string{"op_type"}, shardScoped...),
+			value:  2,
+		},
+		{
+			name:   "pending_segments is per shard, by op id",
+			family: pendingFam,
+			labels: append([]string{"op_id"}, shardScoped...),
+			value:  3,
+		},
+		{
+			name:   "segments_owed is per shard, by op id",
+			family: owedFam,
+			labels: append([]string{"op_id"}, shardScoped...),
+			value:  4,
+		},
+		{
+			name:   "transformer_duration is node-wide, labeled by op_type ONLY",
+			family: transformerDurFam,
+			labels: []string{"op_type"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			want := append([]string(nil), tt.labels...)
+			sort.Strings(want)
+			require.Equal(t, want, labelNamesOf(t, reg, tt.family))
+		})
+	}
+
+	// Values, so the setters are pinned and not merely called: every gauge is
+	// read back at a DISTINCT value, which a setter writing to the wrong vec
+	// (or ignoring its argument) cannot satisfy.
+	require.Equal(t, float64(2), testutil.ToFloat64(m.active.WithLabelValues(opType, "ClassA", "shardA")))
+	require.Equal(t, float64(3), testutil.ToFloat64(m.pendingSegments.WithLabelValues("op1", "ClassA", "shardA")))
+	require.Equal(t, float64(4), testutil.ToFloat64(m.segmentsOwed.WithLabelValues("op1", "ClassA", "shardA")))
+	require.Equal(t, 1, testutil.CollectAndCount(m.transformerDur, transformerDurFam))
+}
+
+func TestMetrics_NilReceiverIsNoop(t *testing.T) {
+	var m *SegmentEditOpsMetrics
+	require.NotPanics(t, func() {
+		m.SetActive("t", 1)
+		m.SetPendingSegments("op", 1)
+		m.SetSegmentsOwed("op", 1)
+		m.ObserveTransformerDuration("t", 1)
+		m.ForgetOp("op")
+		m.DeleteOwnShard()
+	})
+}
+
+func TestForgetOp_DropsOpLabeledSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewSegmentEditOpsMetrics(reg, "ClassA", "shardA", false)
+	require.NoError(t, err)
+
+	m.SetPendingSegments("op1", 3)
+	m.SetSegmentsOwed("op1", 3)
+	require.Equal(t, 1, testutil.CollectAndCount(reg, pendingFam))
+	require.Equal(t, 1, testutil.CollectAndCount(reg, owedFam))
+
+	m.ForgetOp("op1")
+	require.Zero(t, testutil.CollectAndCount(reg, pendingFam))
+	require.Zero(t, testutil.CollectAndCount(reg, owedFam))
+}
+
+// TestForgetOp_LeavesSiblingShardsAlone pins the scoping of ForgetOp. An op id
+// is the drop EPOCH, shared by every shard taking part in the same drop, so a
+// DeletePartialMatch on op_id alone reaps series belonging to shards that are
+// still mid-strip. Those shards then report nothing until their next refresh,
+// and the operator sees a drop that looks finished on shards where it is not.
+func TestForgetOp_LeavesSiblingShardsAlone(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	// Same registry, so both instances share the underlying collectors — this is
+	// how it works in production, one instance per shard.
+	a, err := NewSegmentEditOpsMetrics(reg, "ClassA", "shardA", false)
+	require.NoError(t, err)
+	b, err := NewSegmentEditOpsMetrics(reg, "ClassA", "shardB", false)
+	require.NoError(t, err)
+
+	const opID = "epoch-1" // one drop, both shards
+	a.SetPendingSegments(opID, 3)
+	a.SetSegmentsOwed(opID, 3)
+	b.SetPendingSegments(opID, 7)
+	b.SetSegmentsOwed(opID, 7)
+	require.Equal(t, 2, testutil.CollectAndCount(reg, pendingFam))
+
+	a.ForgetOp(opID)
+
+	// Counted BEFORE any lookup by label: reading a child back would recreate a
+	// deleted series at zero, and then "gone" and "zero" would be the same
+	// assertion. The count says exactly one survived; the value says which.
+	require.Equal(t, 1, testutil.CollectAndCount(reg, pendingFam),
+		"the forgetting shard's series must go, and only that one")
+	require.Equal(t, 1, testutil.CollectAndCount(reg, owedFam))
+
+	require.Equal(t, float64(7), testutil.ToFloat64(b.pendingSegments.WithLabelValues(opID, "ClassA", "shardB")),
+		"a sibling shard mid-strip must keep its series")
+	require.Equal(t, float64(7), testutil.ToFloat64(b.segmentsOwed.WithLabelValues(opID, "ClassA", "shardB")))
+}
+
+// TestDeleteOwnShard_OnlyTheNamedShard pins that reaping one shard does not take
+// its neighbours' series with it. The collectors are process-global and shared
+// by every shard on the node, so a DeletePartialMatch on an empty or partial
+// label set would silently blank all of them.
+func TestDeleteOwnShard_OnlyTheNamedShard(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	a, err := NewSegmentEditOpsMetrics(reg, "ClassA", "shardA", false)
+	require.NoError(t, err)
+	b, err := NewSegmentEditOpsMetrics(reg, "ClassA", "shardB", false)
+	require.NoError(t, err)
+
+	const opType = "remove_target_vectors"
+	a.SetActive(opType, 1)
+	a.SetPendingSegments("op1", 2)
+	b.SetActive(opType, 5)
+	b.SetPendingSegments("op1", 9)
+	require.Equal(t, 2, testutil.CollectAndCount(reg, activeFam))
+
+	a.DeleteOwnShard()
+
+	// Counted BEFORE any lookup by label: reading a child back would recreate a
+	// deleted series at zero, and then "gone" and "zero" would be the same
+	// assertion. The count says exactly one survived; the value says which.
+	require.Equal(t, 1, testutil.CollectAndCount(reg, activeFam),
+		"exactly the reaped shard's series must go")
+	require.Equal(t, 1, testutil.CollectAndCount(reg, pendingFam))
+
+	require.Equal(t, float64(5), testutil.ToFloat64(b.active.WithLabelValues(opType, "ClassA", "shardB")),
+		"reaping one shard must not blank the others")
+	require.Equal(t, float64(9), testutil.ToFloat64(b.pendingSegments.WithLabelValues("op1", "ClassA", "shardB")))
+}
+
+// TestGroupedMode_SuppressesPerShardGauges pins the grouped-mode contract.
+// PROMETHEUS_MONITORING_GROUP collapses class_name/shard_name to "n/a" upstream,
+// so without this guard every shard on the node writes the SAME gauge series:
+// 100 tenants owing 3 segments each would read 3 rather than 300, and the first
+// to drain would zero it for all of them. A wrong number on a dashboard is
+// worse than a missing one. The cumulative series carry no shard dimension, so
+// they stay on and remain correct.
+func TestGroupedMode_SuppressesPerShardGauges(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	// Names arrive already collapsed, exactly as NewMetrics passes them.
+	m, err := NewSegmentEditOpsMetrics(reg, "n/a", "n/a", true)
+	require.NoError(t, err)
+
+	const opType = "remove_target_vectors"
+	m.SetActive(opType, 2)
+	m.SetPendingSegments("op1", 3)
+	m.SetSegmentsOwed("op1", 3)
+
+	require.Zero(t, testutil.CollectAndCount(reg, activeFam),
+		"per-shard gauges must not be emitted in grouped mode")
+	require.Zero(t, testutil.CollectAndCount(reg, pendingFam))
+	require.Zero(t, testutil.CollectAndCount(reg, owedFam))
+
+	// Cost is node-wide either way, so grouping must not silence it.
+	m.ObserveTransformerDuration(opType, 0.25)
+	require.Equal(t, 1, testutil.CollectAndCount(reg, transformerDurFam))
+}


### PR DESCRIPTION
### What's being changed:

Adds Prometheus observability for the LSM **segment edit-op cleanup** driver — the background mechanism that rewrites segments to physically strip a dropped vector index. Until now it ran blind: no way to see whether a strip is in flight, how far it has got, or whether it stalled.

## The metrics

Four series under `weaviate_lsm_`. Drop-vector is the first user of the edit-ops machinery; the names are deliberately generic to it.

| Metric | Type | Labels |
|---|---|---|
| `lsm_segment_edit_ops_active` | Gauge | `op_type, class_name, shard_name` |
| `lsm_segment_edit_ops_pending_segments` | Gauge | `op_id, class_name, shard_name` |
| `lsm_segment_edit_ops_segments_owed` | Gauge | `op_id, class_name, shard_name` |
| `lsm_segment_edit_ops_transformer_duration_seconds` | Histogram | `op_type` |

**What each answers**

- **`active`** — is a strip armed on this shard right now, and of what kind. An op stays armed until its drop completes **cluster-wide**, so `active > 0` with `segments_owed = 0` is the ordinary state of a shard that finished its own rewrites and is waiting on peers — alert on sustained `segments_owed`, not on `active`.
- **`pending_segments`** — how much work is still *queued*. The progress bar. Excludes quarantined segments.
- **`segments_owed`** — how much is still *owed*: queued **plus quarantined**. The pair is the point. They are equal while things are healthy and diverge exactly while segments sit in quarantine. A new round requeues quarantined segments with a fresh budget, but only a bounded number of times; past that cap a segment stays quarantined for good, and the drop cannot finish without intervention. So a brief divergence is a drop mid-retry and a persistent one is a wedged drop — the moment a segment exhausts its budget is also logged, since the gauges alone cannot separate the two. Without this gauge a stalled drop is metric-identical to a finished one, both readings at zero. It is not the only way to learn a drop stalled — `GET /v1/tasks` and the schema marker both answer that, cluster-wide — but they are API calls, not something a dashboard or an alert rule can sit on.
- **`transformer_duration_seconds`** — seconds one cleaner pass spent rewriting one segment: the full rewrite loop (cursor scan, shadowed-key checks, transform, buffered writes), excluding the fsync, the segment swap and the bookkeeping commits, which would otherwise make it a disk-sync-latency metric wearing the op's label. **Every completed attempt is recorded, failed ones included**: a segment that exhausts its five retries and is quarantined spent that time five times over, and observing successes alone would leave the histogram describing the easy cases while omitting exactly the pathological ones it is wanted for. **Aborted attempts are not** — shouldAbort cuts the transform off mid-segment, so the sample would be a truncated fraction of the real cost, and the retry budget refuses to count the same event as an attempt for the same reason.

Buckets match the sibling lsmkv compaction-duration histogram (`ExponentialBuckets(0.01, 2, 15)`, reaching ~163.84s) rather than the shared `LatencyBuckets`, which stop at 100s. Segment size is unbounded, so a rewrite can run past that, and every such rewrite would otherwise collapse into one `+Inf` bucket. **Only the dedicated cleaner rewrite is timed.** A compaction runs the same transformer, but `findCompactionCandidates` picks that merge without consulting the edit ops — the work happens regardless of any drop. Timing it under the op's label would bill unrelated merges to the strip, including merges with nothing to strip, so the compaction path records nothing.

**Deviation from the RFC (C7):** `bytes_reclaimed_total` is not included. The real transformer re-marshals with `MarshalBinaryDisk(false)`, which always writes the class name, so stripping a vector can make a value *larger* — a 40-char class with a 1-dim named vector goes 113 → 139 bytes. No attribution survived review: a whole-file delta also captures keys dropped because newer segments shadow them, and restricting credit to the one unshadowed segment reports ~0, since a pass rewrites the oldest owed segment and never reaches it. Shipping a number nobody can trust is worse than shipping four series that hold.

## Dashboard

`tools/dev/grafana/dashboards/lsm_segment_edit_ops.json` — provisioned automatically by the dev stack, in three rows:

- **Drop progress** — total owed vs queued across the node, armed ops by shard, and the two per-op gauges broken out by shard.
- **Stall signals** — quarantined segments (`segments_owed - on(op_id, class_name, shard_name) pending_segments`), and beside it "shards armed but owing nothing", which is the ordinary waiting-on-peers state shown explicitly so it is not read as a stall.
- **Rewrite cost** — p50/p95/p99 rewrite duration and segments rewritten per second.

Every panel description states what the number means and how it misleads, so the alerting caveats travel with the graph rather than living only here. Validated end to end rather than by eye: all 11 queries parse under `promtool check rules`, every metric name resolves to a definition in `usecases/monitoring/segment_edit_ops.go`, every `on()`/`by()` label set matches the series' real label schema, and Grafana provisions the file cleanly (11 panels, schemaVersion 41).

## Label design

**Gauges carry `{class_name, shard_name}`; the histogram deliberately does not.**

The gauges describe the *state of a shard*, and the shard dimension is load-bearing rather than cosmetic: an `op_id` is the drop **epoch**, shared by every shard taking part in the same drop cluster-wide, so a series without it is written by all of them and reads as whichever wrote last. In a multi-tenant collection the shard name is also the tenant name, unique only within its class.

The histogram describes the *cost of the work*, which is a node-level question. Keeping it unlabelled also means it survives tenant churn: a cumulative series cannot be rebuilt from sidecar state, so reaping one on tenant deletion would silently reset it on every deactivate/reactivate.

**Under `PROMETHEUS_MONITORING_GROUP` the per-shard gauges are not emitted at all.** Grouping collapses both labels to `n/a` upstream, so every shard would write one shared series — 100 tenants owing 3 segments each would read 3, not 300, and the first to drain would zero it for all of them. A wrong number on a dashboard is worse than a missing one. The histogram is unaffected and stays on.

## Lifecycle

Gauges are derived from the sidecar's ground truth rather than incremented per transition, so they cannot drift across a crash, a resume, or an orphan sweep. The ops, pending and quarantined sets are read in **one** bolt transaction (`MetricsSnapshot`): they must be mutually consistent, not merely each fresh, because `owed` is pending plus quarantined and a `Quarantine` commit landing between separate reads would show the same segment in both — inflating exactly the gauge that is read as the stall signal, in the direction that fabricates a stall. The refresh runs on op-lifecycle changes (register, re-arm, drained delete, recover), once per cleanup pass, and after compaction bookkeeping — never on a hot path.

It returns **before reading the sidecar at all** when nothing will consume the result: monitoring off (the default), or grouped mode. That matters because the refresh costs three bolt reads and grouped mode is exactly where a node has the most shards to multiply it by.

`ForgetOp` deletes its two series by exact label set (`Delete`, not `DeletePartialMatch`) — the three labels are the gauges' complete schema, and a partial match scans every series on the node under the vec's write lock.

**An unload is not a delete.** Tenant deactivation unloads a shard through the same `SegmentGroup.shutdown` path as any other unload (Migrator's `tenants_to_cold`), and a drop stalled on a cold tenant is precisely what these gauges exist to report — reaping there would make it read identically to no drop at all. So an unload retires the series only when the shard **owes nothing**; a shard mid-strip keeps its last reading. Every sibling per-shard LSM gauge survives an unload for the same reason and is reaped only on delete. Delete has two entry points, matching the two shard states: `Store.ReapEditOpsMetrics` from `Shard.drop` for a loaded shard, and `lsmkv.ReapEditOpsShardSeries` from `LazyLoadShard.drop` for an unloaded one — without the second, every tenant deactivated mid-drop and then deleted would leak three series until restart.

**Reaping goes through one latched entry point, `SegmentGroup.reapEditOpsMetrics`**, which sets a `reaped` flag and deletes the series under a single lock hold; every later refresh returns at the flag. The latch is load-bearing rather than defensive, because a reap can otherwise be UNDONE and never repeated — a torn shard is never retried and heals only on process restart:

- a shutdown that fails at `Unregister` leaves the cycle callback **fully operational** (cyclemanager rolls its abort mark back on timeout) and skips `editOps.Close()`, so the still-live pass republishes over the deleted series;
- a segment group that fails to construct is discarded without ever reaching shutdown, after `recoverEditOps` has already published;
- once the last op is deleted the sidecar file is removed, after which `MetricsSnapshot` reads empty **without an error** — indistinguishable from a healthy empty sidecar — and republishes a zero-valued child.

It runs from two places: `SegmentGroup.shutdown` (deferred, so the failure paths are covered) and the constructor's existing init-failure rollback.

One refresh is condition-guarded: recovery's deferred refresh skips `bolterrors.ErrTimeout`. On that path the sidecar's flock is still held by a previous instance, so a refresh would re-open bolt and eat a second full `BoltFlockTimeout` on a load that is already failing — doubling shard-load failure latency for nothing, since the failed load discards the group and the init rollback reaps.

**`PrometheusMetrics` holds no edit-op handle.** The global struct carries a standing `NOTE: Do not add any new metrics to this global PrometheusMetrics struct`, and the tenant-delete path makes one unnecessary anyway: `Shard.drop` guarantees `store.Shutdown` on every exit, which reaches every `SegmentGroup.shutdown` and therefore the reap. A shard that was never loaded never published.

## Scope

No change to cleanup correctness or the drop path — the refresh reads sidecar state the driver already loads, and logs rather than fails if a read errors, so it can never block a cleanup.

Two hunks reach outside the edit-op metrics themselves and their call sites, so rather than claim "metrics only" flatly:

- **`segment_edit_ops.go`** extracts `segmentRowsTx` out of `AllPending()` and `Quarantined()` — functions the cleanup driver feeds on. The bodies moved verbatim (same walk, same order, same error propagation); the extraction exists so `MetricsSnapshot` can read all three sets in one transaction instead of duplicating the walk.
- **`drop_vector_index_provider.go`** is a **comment-only** correction, and the one change here that metrics do not require. Its godoc credited `lsmkv.maxQuarantineRequeues` with bounding the FAILED-record pile; that is inverted — once a segment exhausts the cap it stops being requeued, so every later round fails immediately and the loop gets *faster*. Fixed in place because it is a wrong statement about drop-vector behaviour rather than deferred to a follow-up nobody would file. The underlying unbounded re-enqueue is pre-existing and out of scope for this PR.

A partial-`.tmp` leak in `cleanPendingSegmentToTmp`, found while working here, was split out and merged separately as #12633: it is pre-existing, unrelated to metrics, and wanted its own review.

**`docs/metrics.md` is deleted — flagging this explicitly for @moogacs / @mbadawi23.** The file declares itself the source of truth for Prometheus metrics and asks that every add/modify/deprecate be reflected in it, so removing it in the same change that adds four metrics is a deliberate proposal, not a drive-by: this team keeps that kind of reference in Notion, and the four series below are documented there. Say the word if you would rather the file stayed and the series were registered in it instead — that is a small follow-up either way.

## Declined: a pull-based `prometheus.Collector`

Review raised that computing the gauges at scrape time, via a `Collector`, would make the reap-undone class of bug structurally impossible: no seen-sets, no reap sites, no `ForgetOp`, no call sites to keep in sync. **That is correct on the merits** — the fixes in this PR close those paths and pin them with tests, but a Collector would mean they never existed.

Declined anyway, for two reasons:

1. **No precedent in this codebase.** There is no custom `prometheus.Collector` anywhere outside `vendor/` — zero `Describe`/`Collect` pairs. The single pull-style metric is `weaviate_mcp_write_access_enabled`, one unlabelled `promauto.NewGaugeFunc` over an in-memory bool. Every component metric set — lsmkv, hfresh, memtable, async-replication, graphql, MCP — is push, and this PR follows that shape deliberately.
2. **It moves sidecar I/O onto the scrape path.** These gauges are labelled per `(op_id, class_name, shard_name)` and derived from bolt, so materialising them at scrape time means a read transaction per shard per scrape. That is a different cost profile from a closure reading a bool, and worst on exactly the multi-tenant nodes with the most shards.

**What the argument does expose, and this PR does not fix:** component-registered series in this repo are never reaped by anything. `DeletePartialMatch` appears in exactly two files, and one of them is this PR's. `lsm_bucket_init_count`, the memtable series, the async-replication scheduler's and the graphql handler's all leak per-shard series on unload today, and even the older global-struct convention is incomplete — `VectorIndexBackgroundOperationsCount` is on `PrometheusMetrics` but absent from `DeleteShard`. This PR is the first component metric set to need reaping, which is why the lifecycle here had to be invented rather than copied, and why it took the fixes above to get right. That gap belongs to monitoring rather than to drop-vector, and is worth its own issue.

## Testing

**Every behaviour below is mutation-verified**: the named mutation was applied to production code and the named test observed to fail.

| Mutation | Test that catches it |
|---|---|
| `ForgetOp` drops the shard scope | `TestForgetOp_LeavesSiblingShardsAlone` |
| `DeleteOwnShard` reaps on an empty label set | `TestDeleteOwnShard_OnlyTheNamedShard` |
| `SetSegmentsOwed` writes the pending vec | `TestMetrics_Labels` (+2) |
| the histogram gains the shard dimension | `TestMetrics_Labels` |
| grouped-mode gauge suppression removed | `TestGroupedMode_SuppressesPerShardGauges` |
| `editOpsEnabled` ignores grouped mode | `TestRefreshEditOpsMetrics_SkipsSidecarWhenNothingCollects` |
| `NewMetrics` stops wiring the series | `TestNewMetrics_WiresEditOpsSeries` (+6) |
| the histogram observation is removed | `TestEditOpsMetrics_HistogramRecordsEveryAttempt` |
| the histogram skips failed attempts | `TestEditOpsMetrics_HistogramRecordsEveryAttempt` |
| per-op attribution becomes the shard total | `TestEditOpsMetrics_AttributesPerOp` |
| per-type counting becomes a flat 1 | `TestEditOpsMetrics_AttributesPerOp` |
| `MetricsSnapshot` split back into three txs | `TestMetricsSnapshot_IsOneConsistentRead` |
| `editOpsMetricsLock` removed (under `-race`) | `TestRefreshEditOpsMetrics_IsSerialised` |
| the reap latch is ignored by the refresh | `TestEditOpsMetrics_ReapSurvivesAFailedUnregister` (+1) |
| the init-failure reap is removed | `TestEditOpsMetrics_DiscardedSegmentGroupLeavesNoSeries` |
| the shutdown reap is removed | `TestEditOpsMetrics_ShutdownReapsOnFailurePath` (+1) |
| aborted transforms are observed | `TestEditOpsMetrics_HistogramSkipsAbortedRewrites` |
| `distinctOpTypes` stops deduplicating | `TestEditOpsMetrics_HistogramDedupsOpTypes` |
| the ErrTimeout refresh guard is removed | `TestEditOpsMetrics_LockedSidecarWaitsForOneFlockTimeoutOnly` |
| an unload reaps unconditionally | `TestEditOpsMetrics_UnloadKeepsGaugesWhileWorkIsOwed` |
| `Store.ReapEditOpsMetrics` becomes a no-op | `TestStoreReapEditOpsMetrics_RetiresEvenWithWorkOwed` |
| the unloaded-shard reap is removed | `TestReapEditOpsShardSeries_RetiresAnUnloadedShard` |
| a sidecar read error is swallowed | `TestRefreshEditOpsMetrics_KeepsGaugesWhenTheSidecarReadFails` |
| compaction observes the histogram | `TestEditOpsMetrics_HistogramRecordsEveryAttempt` |
| `editOpsEnabled` drops its nil-receiver guard | `TestEditOpsMetrics_ReArmRequeueClearsStall` |

Some mutations redden more than one test (the latch and the shutdown reap each redden two); the guarantee is per-site coverage, not a bijection.

The "monitoring off" enablement case uses a **nil** `*lsmkv.Metrics`, because that is the production shape — `shard_init_lsm` only builds a `Metrics` when `promMetrics` is set — and an `&Metrics{}` stand-in exercises the wrong clause of the guard.

Two of those needed the tests to stop using a single op called `op1`, under which "the count for this op" and "the count for all ops" are the same number. Two concurrent drops on one shard are reachable — drop `vecB` while `vecA` is still stripping — so `TestEditOpsMetrics_AttributesPerOp` arms two.

`MetricsSnapshot` is pinned by counting bolt transactions rather than by racing a writer against a reader: the torn window is real but tiny (a read tx takes microseconds, a write tx fsyncs), so a concurrency test would pass on the broken implementation almost every run.

**Every production call site is pinned** — six refresh sites and two reap sites, each with a mutation (the site removed) that reddens at least one named test. Tests that drive the refresh by hand exercise the function while leaving every caller free, so the call-site tests drive real entry points only.

| Call site removed | Test that catches it |
|---|---|
| `registerEditOpAndSnapshot` | `TestEditOpsMetrics_RegisterPublishes` |
| `Bucket.RegisterEditOp` re-arm requeue | `TestEditOpsMetrics_ReArmRequeueClearsStall` |
| `Bucket.DeleteEditOpIfDrained` | `TestRefreshEditOpsMetrics_ReconcilesVanishedOps` |
| cleanup pass | `TestEditOpsMetrics_CleanupPassRefreshes` |
| compaction bookkeeping | `TestEditOpsMetrics_CompactionRefreshes` |
| `recoverEditOps` | `TestEditOpsMetrics_RecoveryPublishesOnLoad` |
| `SegmentGroup.shutdown` reap | `TestEditOpsMetrics_ShutdownReapsOnFailurePath` (+1) |
| init-rollback reap | `TestEditOpsMetrics_DiscardedSegmentGroupLeavesNoSeries` |

**One honest gap:** the recovery test pins the *call*, not its being *deferred*. It drives a recovery that succeeds, where defer and tail-call are indistinguishable. The deferral covers recoveries failing in Reconcile's write phase (ENOSPC-class) with the sidecar still readable; producing that needs fault injection this harness doesn't have, so that placement is asserted by review, not by test — the test's own comment says the same.

The shutdown reap has two tests. `TestEditOpsMetrics_ShutdownReapsOnFailurePath` drives the earliest failure with a cancelled context, which is cheap and deterministic but uses a NOOP callback group — reproducing the error VALUE while excluding the condition that produces it. `TestEditOpsMetrics_ReapSurvivesAFailedUnregister` covers the real condition with a live callback group, a real cycle manager and a transformer parked mid-rewrite.

Two of those pin fixes rather than existing behaviour: the shutdown reap and the recovery refresh are now **deferred**, so they run on the failure paths too. A shard whose teardown fails is torn and never retried (sticky `teardownErr`, heals only on process restart), and a shard whose sidecar recovery fails comes up with its drop stalled — both cases previously returned before publishing or reaping, leaving the exact states these gauges exist to report either invisible or stuck forever.

Also covered: gauges tracking register → mark-done → quarantine, including that a quarantined segment leaves `pending_segments` but holds `segments_owed`.

**Acceptance coverage:** `TestDropVectorIndex_Metrics_SingleNode` runs a monitoring-enabled single-node compose (the same pattern `reindex_mt` already uses) and scrapes `/metrics` in-container for the two journeys nothing below this layer can prove: a drop exports the per-shard series through the real wiring, and deleting the tenant reaps them. It uses **two tenants**, so the shard label has to discriminate (a single tenant cannot tell a correct implementation from one collapsing every shard into a shared series), and scrapes the histogram without a class filter, since that series is deliberately node-wide and a `class_name=` grep would exclude it by construction. In CI it rides in the existing `drop-vector-index (cluster)` job (~40s on top, no extra runner or image build); locally, `go test -run TestDropVectorIndex_Metrics_SingleNode` runs it alone. Reap-on-unload without a delete remains unit-only.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
