### PR TITLE
fix(lsmkv): guard nil logger in GetConsistentView slow-lock warning

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -548,7 +548,10 @@ func (b *Bucket) GetConsistentView() BucketConsistentView {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
 
-	if duration := time.Since(beforeFlushLock); duration > 100*time.Millisecond {
+	// logger nil-guard: test buckets are built as bare literals without one, and
+	// under load this slow-lock branch can fire (RLock timed >100ms) where it never
+	// would in production; a nil FieldLogger would then panic on WithFields.
+	if duration := time.Since(beforeFlushLock); duration > 100*time.Millisecond && b.logger != nil {
 		b.logger.WithFields(logrus.Fields{
 			"duration": duration,
 			"action":   "lsm_bucket_get_acquire_flush_lock",


### PR DESCRIPTION
## What

`GetConsistentView` dereferences `b.logger` in its `>100ms` slow-lock warning branch. Several lsmkv tests build bare `Bucket{}` literals **without a logger** (the #9104 convention) and call `GetConsistentView` under `t.Parallel()`. On a loaded CI runner the `RLock` can time >100ms from scheduler starvation (not real contention) even though it never would in production, so the branch fires and panics on `b.logger.WithFields` — a nil `FieldLogger`.

This guards the diagnostic log on a non-nil logger. Production always has one, so behavior there is unchanged; every bare-`Bucket{}` test is now safe.

## Symptom (flaky CI panic)

```
--- FAIL: TestBucketRoaringSetStrategyWriteVsFlush
panic: runtime error: invalid memory address or nil pointer dereference
  ...(*Bucket).GetConsistentView(...) bucket.go:552
```

## Why it's safe / verified

- The zero-value `logrus.FieldLogger` is a nil interface (`b.logger == nil` is true), so the `!= nil` guard is the correct fix.
- Forcing the branch always-on **without** the guard reproduces the exact `GetConsistentView` nil-deref; **with** the guard the test passes — definitive.
- `-race -count 20 -parallel 16` over the failing test + sibling consistent-view tests: green.
- `go vet`, `golangci-lint`, goroutine linter: clean.

## Notes

Latent since the #9104 LSM sync rework. The two identical patterns in `getFromMemtable`/`getBySecondaryFromMemtable` sit behind `b.metrics` usage, so bare-`Bucket{}` tests can't reach them — out of scope for this flake, left as-is.