### PR TITLE
perf(shard): lazy load empty multi-tenant shards at startup

### DIFF
--- a/adapters/repos/db/defer_empty_shard_integration_test.go
+++ b/adapters/repos/db/defer_empty_shard_integration_test.go
@@ -153,8 +153,10 @@ func TestDeferEmptyMultiTenantShardOnInit(t *testing.T) {
 
 				require.NoError(t, lazy.Load(ctx))
 				require.True(t, lazy.isLoaded(), "deferred tenant should materialize on access")
-			} else if lazy, isLazy := stored.(*LazyLoadShard); isLazy {
-				require.True(t, lazy.isLoaded(), "non-deferred tenant should be loaded after init")
+			} else {
+				// Loaded eagerly, so it is stored as the raw shard, not a wrapper.
+				_, stillLazy := stored.(*LazyLoadShard)
+				require.False(t, stillLazy, "loaded tenant should be stored as a raw *Shard, got %T", stored)
 			}
 		})
 	}

--- a/adapters/repos/db/defer_empty_shard_integration_test.go
+++ b/adapters/repos/db/defer_empty_shard_integration_test.go
@@ -1,0 +1,161 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/replication"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestDeferEmptyMultiTenantShardOnInit checks that startup leaves an empty MT
+// tenant unloaded (and materializes it on first access), while loading a tenant it
+// cannot prove empty. It runs in eager mode, the path that would otherwise load
+// every HOT shard on init.
+func TestDeferEmptyMultiTenantShardOnInit(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	const (
+		className = "TestDeferClass"
+		nodeName  = "test-node"
+	)
+
+	tests := []struct {
+		name string
+		// emptyShardOnDisk pre-creates the tenant's empty objects LSM directory.
+		emptyShardOnDisk bool
+		wantDeferred     bool
+	}{
+		{
+			name:             "empty tenant with existing dir is deferred",
+			emptyShardOnDisk: true,
+			wantDeferred:     true,
+		},
+		{
+			name:             "tenant without on-disk dir is not deferred (safe fallback)",
+			emptyShardOnDisk: false,
+			wantDeferred:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+			tenant := "empty-tenant"
+
+			class := &models.Class{
+				Class:               className,
+				InvertedIndexConfig: &models.InvertedIndexConfig{},
+				MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+				ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+			}
+			fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+			shardState := &sharding.State{
+				Physical: map[string]sharding.Physical{
+					tenant: {
+						Name:           tenant,
+						BelongsToNodes: []string{nodeName},
+						Status:         models.TenantActivityStatusHOT,
+					},
+				},
+				PartitioningEnabled: true,
+			}
+			shardState.SetLocalName(nodeName)
+
+			if tt.emptyShardOnDisk {
+				objectsDir := filepath.Join(dirName, indexID(schema.ClassName(className)), tenant, "lsm", helpers.ObjectsBucketLSM)
+				require.NoError(t, os.MkdirAll(objectsDir, os.ModePerm))
+			}
+
+			scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+			mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+			mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+				func(_ string, _ bool, readerFunc func(*models.Class, *sharding.State) error) error {
+					return readerFunc(class, shardState)
+				}).Maybe()
+			mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
+
+			mockSchema := schemaUC.NewMockSchemaGetter(t)
+			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+			mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
+			mockSchema.EXPECT().NodeName().Maybe().Return(nodeName)
+			mockSchema.EXPECT().TenantsShards(ctx, className, tenant).Maybe().
+				Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil)
+
+			mockRouter := types.NewMockRouter(t)
+			mockRouter.EXPECT().GetWriteReplicasLocation(className, mock.Anything, tenant).
+				Return(types.WriteReplicaSet{
+					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
+				}, nil).Maybe()
+			mockRouter.EXPECT().GetReadReplicasLocation(className, tenant, tenant).
+				Return(types.ReadReplicaSet{
+					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
+				}, nil).Maybe()
+
+			schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
+			shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
+
+			index, err := NewIndex(ctx, IndexConfig{
+				RootPath:             dirName,
+				ClassName:            schema.ClassName(className),
+				ReplicationFactor:    1,
+				ShardLoadLimiter:     loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+				EnableLazyLoadShards: false, // eager mode: without the fix every HOT shard loads at init
+			}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+				enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
+				mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
+				class, nil, scheduler, nil, nil,
+				NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+			require.NoError(t, err)
+			defer index.Shutdown(ctx)
+
+			stored := index.shards.Load(tenant)
+			require.NotNil(t, stored, "shard must be registered after init")
+
+			if tt.wantDeferred {
+				lazy, isLazy := stored.(*LazyLoadShard)
+				require.True(t, isLazy, "empty tenant should be a deferred lazy wrapper, got %T", stored)
+				require.False(t, lazy.isLoaded(), "empty tenant should be unloaded after init")
+
+				require.NoError(t, lazy.Load(ctx))
+				require.True(t, lazy.isLoaded(), "deferred tenant should materialize on access")
+			} else if lazy, isLazy := stored.(*LazyLoadShard); isLazy {
+				require.True(t, lazy.isLoaded(), "non-deferred tenant should be loaded after init")
+			}
+		})
+	}
+}

--- a/adapters/repos/db/defer_empty_shard_integration_test.go
+++ b/adapters/repos/db/defer_empty_shard_integration_test.go
@@ -15,6 +15,7 @@ package db
 
 import (
 	"context"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,7 +24,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -40,9 +40,10 @@ import (
 )
 
 // TestDeferEmptyMultiTenantShardOnInit checks that startup leaves an empty MT
-// tenant unloaded (and materializes it on first access), while loading a tenant it
-// cannot prove empty. It runs in eager mode, the path that would otherwise load
-// every HOT shard on init.
+// tenant (index counter 0) unloaded and materializes it on first access, while a
+// tenant that has written objects (counter > 0, including data that would only be
+// in an unflushed WAL) is loaded eagerly as a raw shard. It runs in eager mode,
+// the path that would otherwise load every HOT shard on init.
 func TestDeferEmptyMultiTenantShardOnInit(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
@@ -54,19 +55,21 @@ func TestDeferEmptyMultiTenantShardOnInit(t *testing.T) {
 
 	tests := []struct {
 		name string
-		// emptyShardOnDisk pre-creates the tenant's empty objects LSM directory.
-		emptyShardOnDisk bool
-		wantDeferred     bool
+		// objectCount is the persisted index counter; 0 means the tenant has never
+		// held objects. It is written directly so the "loaded" branch is exercised
+		// even without flushed segments (mirrors the reused-WAL case).
+		objectCount  uint64
+		wantDeferred bool
 	}{
 		{
-			name:             "empty tenant with existing dir is deferred",
-			emptyShardOnDisk: true,
-			wantDeferred:     true,
+			name:         "empty tenant (counter 0) is deferred",
+			objectCount:  0,
+			wantDeferred: true,
 		},
 		{
-			name:             "tenant without on-disk dir is not deferred (safe fallback)",
-			emptyShardOnDisk: false,
-			wantDeferred:     false,
+			name:         "tenant with objects is loaded, not deferred",
+			objectCount:  10,
+			wantDeferred: false,
 		},
 	}
 
@@ -95,9 +98,14 @@ func TestDeferEmptyMultiTenantShardOnInit(t *testing.T) {
 			}
 			shardState.SetLocalName(nodeName)
 
-			if tt.emptyShardOnDisk {
-				objectsDir := filepath.Join(dirName, indexID(schema.ClassName(className)), tenant, "lsm", helpers.ObjectsBucketLSM)
-				require.NoError(t, os.MkdirAll(objectsDir, os.ModePerm))
+			if tt.objectCount > 0 {
+				// Persist an index counter as a real shard would, so the tenant reads
+				// as non-empty without needing flushed segments.
+				shardDir := filepath.Join(dirName, indexID(schema.ClassName(className)), tenant)
+				require.NoError(t, os.MkdirAll(shardDir, os.ModePerm))
+				var buf [8]byte
+				binary.LittleEndian.PutUint64(buf[:], tt.objectCount)
+				require.NoError(t, os.WriteFile(filepath.Join(shardDir, "indexcount"), buf[:], 0o644))
 			}
 
 			scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -13,8 +13,11 @@ package db
 
 import (
 	"context"
+	"encoding/binary"
 	"log"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -45,6 +48,19 @@ import (
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
+
+// seedShardObjectCounter writes a non-zero index counter to disk for a shard so
+// that at startup it reads as non-empty and is loaded as a raw *Shard rather than
+// deferred as a *LazyLoadShard. Use it in multi-tenant tests that populate a tenant
+// and then need the underlying *Shard, mirroring a tenant that already holds data.
+func seedShardObjectCounter(t *testing.T, rootPath, className, shardName string) {
+	t.Helper()
+	dir := filepath.Join(rootPath, indexID(schema.ClassName(className)), shardName)
+	require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], 1)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "indexcount"), buf[:], 0o644))
+}
 
 func parkingGaragesSchema() schema.Schema {
 	return schema.Schema{

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -471,38 +471,18 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return fmt.Errorf("failed to read sharding state: %w", err)
 	}
 
-	// Collect HOT shards up front so each has a stable index. toLoad[idx] then
-	// gives each goroutine its own slot to record whether its shard must be
-	// loaded, avoiding a lock on a shared slice.
-	hotShards := make([]string, 0, len(localShards))
-	for _, shard := range localShards {
-		if shard.activityStatus == models.TenantActivityStatusHOT {
-			hotShards = append(hotShards, shard.name)
-		}
-	}
+	hotShardNames := make([]string, 0, len(localShards))
 
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU)
 
-	// toLoad[idx] holds the shard name to load, or "" for a deferred empty tenant.
-	toLoad := make([]string, len(hotShards))
-	for idx, shardName := range hotShards {
+	for _, shard := range localShards {
+		if shard.activityStatus != models.TenantActivityStatusHOT {
+			continue
+		}
+		hotShardNames = append(hotShardNames, shard.name)
+		shardName := shard.name
 		eg.Go(func() error {
-			// Multi-tenant collections defer empty (e.g. pre-provisioned) tenants:
-			// read the on-disk object count without materializing the shard and, if
-			// empty, leave it as an unloaded wrapper until first accessed. Non-empty
-			// tenants (and non-MT collections) fall through to the normal load path.
-			if i.partitioningEnabled {
-				usage, err := shardusage.CalculateUnloadedObjectsMetrics(i.logger, i.path(), shardName, true)
-				if err == nil && usage.Count == 0 {
-					i.shards.Store(shardName, NewLazyLoadShard(ctx, promMetrics, shardName, i, class,
-						i.centralJobQueue, i.indexCheckpoints, i.allocChecker, i.shardLoadLimiter,
-						i.shardReindexer, i.Config.EnableLazyLoadShards, i.bitmapBufPool))
-					return nil
-				}
-			}
-
-			toLoad[idx] = shardName
 			switch {
 			case i.Config.EnableLazyLoadShards:
 				lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
@@ -510,6 +490,16 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				i.shards.Store(shardName, lazyShard)
 				return nil
 			default:
+				// Defer empty (e.g. pre-provisioned) multi-tenant tenants: keep them
+				// unloaded until first accessed instead of paying the fixed per-shard
+				// footprint. Lazy mode defers in the background loader instead, so the
+				// check lives here to avoid probing the same shard twice.
+				if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
+					i.shards.Store(shardName, NewLazyLoadShard(ctx, promMetrics, shardName, i, class,
+						i.centralJobQueue, i.indexCheckpoints, i.allocChecker, i.shardLoadLimiter,
+						i.shardReindexer, false, i.bitmapBufPool))
+					return nil
+				}
 				// default behavior is to load all shards immediately
 				if err := i.shardLoadLimiter.Acquire(ctx); err != nil {
 					return fmt.Errorf("acquiring permit to load shard: %w", err)
@@ -534,14 +524,6 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return err
 	}
 
-	// Compact out the deferred (empty) shards; the rest must be loaded.
-	shardsToLoad := make([]string, 0, len(toLoad))
-	for _, name := range toLoad {
-		if name != "" {
-			shardsToLoad = append(shardsToLoad, name)
-		}
-	}
-
 	if !i.Config.EnableLazyLoadShards {
 		i.allShardsReady.Store(true)
 		return nil
@@ -558,7 +540,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 
 		now := time.Now()
 
-		for _, shardName := range shardsToLoad {
+		for _, shardName := range hotShardNames {
 			select {
 			case <-i.closingCtx.Done():
 				i.logger.
@@ -596,6 +578,13 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 	return nil
 }
 
+// unloadedShardIsEmpty reports whether a not-yet-loaded tenant shard has no
+// objects on disk. On any error it returns false so the shard is loaded normally.
+func (i *Index) unloadedShardIsEmpty(shardName string) bool {
+	hasObjects, err := shardusage.UnloadedShardHasObjects(i.logger, i.path(), shardName)
+	return err == nil && !hasObjects
+}
+
 func (i *Index) loadLocalShardIfActive(shardName string) error {
 	i.shardCreateLocks.Lock(shardName)
 	defer i.shardCreateLocks.Unlock(shardName)
@@ -608,6 +597,11 @@ func (i *Index) loadLocalShardIfActive(shardName string) error {
 
 	lazyShard, ok := shard.(*LazyLoadShard)
 	if ok {
+		// Leave empty (e.g. pre-provisioned) multi-tenant tenants unloaded until
+		// first accessed instead of force-loading them here.
+		if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
+			return nil
+		}
 		return lazyShard.Load(context.Background())
 	}
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
@@ -488,25 +489,17 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 	for idx, shardName := range hotShards {
 		eg.Go(func() error {
 			// Multi-tenant collections defer empty (e.g. pre-provisioned) tenants:
-			// ObjectCountAsync reads the on-disk count without materializing the
-			// shard, so empty ones stay unloaded until first accessed instead of
-			// paying the fixed per-shard footprint.
+			// read the on-disk object count without materializing the shard and, if
+			// empty, leave it as an unloaded wrapper until first accessed. Non-empty
+			// tenants (and non-MT collections) fall through to the normal load path.
 			if i.partitioningEnabled {
-				// lazyLoadSegments mirrors EnableLazyLoadShards to keep prior
-				// segment-loading behavior once materialized.
-				lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
-					i.allocChecker, i.shardLoadLimiter, i.shardReindexer, i.Config.EnableLazyLoadShards, i.bitmapBufPool)
-				i.shards.Store(shardName, lazyShard)
-
-				if count, err := lazyShard.ObjectCountAsync(ctx); err == nil && count == 0 {
-					return nil // deferred: leave toLoad[idx] empty
+				usage, err := shardusage.CalculateUnloadedObjectsMetrics(i.logger, i.path(), shardName, true)
+				if err == nil && usage.Count == 0 {
+					i.shards.Store(shardName, NewLazyLoadShard(ctx, promMetrics, shardName, i, class,
+						i.centralJobQueue, i.indexCheckpoints, i.allocChecker, i.shardLoadLimiter,
+						i.shardReindexer, i.Config.EnableLazyLoadShards, i.bitmapBufPool))
+					return nil
 				}
-
-				toLoad[idx] = shardName
-				if i.Config.EnableLazyLoadShards {
-					return nil // background loader materializes it (staggered)
-				}
-				return lazyShard.Load(ctx)
 			}
 
 			toLoad[idx] = shardName

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -490,10 +490,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				i.shards.Store(shardName, lazyShard)
 				return nil
 			default:
-				// Defer empty (e.g. pre-provisioned) multi-tenant tenants: keep them
-				// unloaded until first accessed instead of paying the fixed per-shard
-				// footprint. Lazy mode defers in the background loader instead, so the
-				// check lives here to avoid probing the same shard twice.
+				// avoid footprint of empty shards
 				if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
 					i.shards.Store(shardName, NewLazyLoadShard(ctx, promMetrics, shardName, i, class,
 						i.centralJobQueue, i.indexCheckpoints, i.allocChecker, i.shardLoadLimiter,
@@ -600,8 +597,7 @@ func (i *Index) loadLocalShardIfActive(shardName string) error {
 
 	lazyShard, ok := shard.(*LazyLoadShard)
 	if ok {
-		// Leave empty (e.g. pre-provisioned) multi-tenant tenants unloaded until
-		// first accessed instead of force-loading them here.
+		// avoid footprint of empty shards
 		if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
 			return nil
 		}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -470,17 +470,46 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return fmt.Errorf("failed to read sharding state: %w", err)
 	}
 
-	hotShardNames := make([]string, 0, len(localShards))
+	// Collect HOT shards up front so each has a stable index. toLoad[idx] then
+	// gives each goroutine its own slot to record whether its shard must be
+	// loaded, avoiding a lock on a shared slice.
+	hotShards := make([]string, 0, len(localShards))
+	for _, shard := range localShards {
+		if shard.activityStatus == models.TenantActivityStatusHOT {
+			hotShards = append(hotShards, shard.name)
+		}
+	}
+
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU)
 
-	for _, shard := range localShards {
-		if shard.activityStatus != models.TenantActivityStatusHOT {
-			continue
-		}
-		hotShardNames = append(hotShardNames, shard.name)
-		shardName := shard.name
+	// toLoad[idx] holds the shard name to load, or "" for a deferred empty tenant.
+	toLoad := make([]string, len(hotShards))
+	for idx, shardName := range hotShards {
 		eg.Go(func() error {
+			// Multi-tenant collections defer empty (e.g. pre-provisioned) tenants:
+			// ObjectCountAsync reads the on-disk count without materializing the
+			// shard, so empty ones stay unloaded until first accessed instead of
+			// paying the fixed per-shard footprint.
+			if i.partitioningEnabled {
+				// lazyLoadSegments mirrors EnableLazyLoadShards to keep prior
+				// segment-loading behavior once materialized.
+				lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
+					i.allocChecker, i.shardLoadLimiter, i.shardReindexer, i.Config.EnableLazyLoadShards, i.bitmapBufPool)
+				i.shards.Store(shardName, lazyShard)
+
+				if count, err := lazyShard.ObjectCountAsync(ctx); err == nil && count == 0 {
+					return nil // deferred: leave toLoad[idx] empty
+				}
+
+				toLoad[idx] = shardName
+				if i.Config.EnableLazyLoadShards {
+					return nil // background loader materializes it (staggered)
+				}
+				return lazyShard.Load(ctx)
+			}
+
+			toLoad[idx] = shardName
 			switch {
 			case i.Config.EnableLazyLoadShards:
 				lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
@@ -506,11 +535,18 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				return nil
 			}
 		}, shardName)
-
 	}
 
 	if err := eg.Wait(); err != nil {
 		return err
+	}
+
+	// Compact out the deferred (empty) shards; the rest must be loaded.
+	shardsToLoad := make([]string, 0, len(toLoad))
+	for _, name := range toLoad {
+		if name != "" {
+			shardsToLoad = append(shardsToLoad, name)
+		}
 	}
 
 	if !i.Config.EnableLazyLoadShards {
@@ -529,7 +565,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 
 		now := time.Now()
 
-		for _, shardName := range hotShardNames {
+		for _, shardName := range shardsToLoad {
 			select {
 			case <-i.closingCtx.Done():
 				i.logger.

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -33,12 +33,12 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/aggregator"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
+	"github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
-	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
@@ -578,11 +578,14 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 	return nil
 }
 
-// unloadedShardIsEmpty reports whether a not-yet-loaded tenant shard has no
-// objects on disk. On any error it returns false so the shard is loaded normally.
+// unloadedShardIsEmpty reports whether a not-yet-loaded tenant shard has never
+// held any objects, read from the persisted index counter without materializing
+// the shard. The counter is incremented on every write, so it also accounts for
+// data still in an unflushed/reused WAL (unlike segment metadata). On any error it
+// returns false so the shard is loaded normally.
 func (i *Index) unloadedShardIsEmpty(shardName string) bool {
-	hasObjects, err := shardusage.UnloadedShardHasObjects(i.logger, i.path(), shardName)
-	return err == nil && !hasObjects
+	count, err := indexcounter.ReadOnDisk(shardPath(i.path(), shardName))
+	return err == nil && count == 0
 }
 
 func (i *Index) loadLocalShardIfActive(shardName string) error {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -581,7 +581,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 // data still in an unflushed/reused WAL (unlike segment metadata). On any error it
 // returns false so the shard is loaded normally.
 func (i *Index) unloadedShardIsEmpty(shardName string) bool {
-	count, err := indexcounter.ReadOnDisk(shardPath(i.path(), shardName))
+	count, err := indexcounter.Read(shardPath(i.path(), shardName))
 	return err == nil && count == 0
 }
 

--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -341,6 +341,9 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 			Replicas: []types.Replica{{NodeName: "test-node", ShardName: tenantName, HostAddr: "110.12.15.23"}},
 		}, nil).Maybe()
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
+	// Seed a non-zero counter so the populated tenant reads as non-empty and is
+	// loaded as a raw *Shard (not deferred as an empty tenant).
+	seedShardObjectCounter(t, dirName, className, tenantNamePopulated)
 	// Create index with lazy loading disabled to test active calculation methods
 	index, err := NewIndex(ctx, IndexConfig{
 		RootPath:              dirName,

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -747,6 +747,9 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 			AdditionalReplicas: nil,
 		}, nil).Maybe()
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
+	// Seed a non-zero counter so the populated tenant reads as non-empty and is
+	// loaded as a raw *Shard (not deferred as an empty tenant).
+	seedShardObjectCounter(t, dirName, className, tenantNamePopulated)
 	// Create index with lazy loading disabled to test active calculation methods
 	index, err := NewIndex(ctx, IndexConfig{
 		RootPath:              dirName,

--- a/adapters/repos/db/indexcounter/counter.go
+++ b/adapters/repos/db/indexcounter/counter.go
@@ -63,6 +63,40 @@ func New(shardPath string) (cr *Counter, rerr error) {
 	}, nil
 }
 
+// ReadOnDisk returns the persisted counter value for the shard at shardPath
+// without opening/creating the counter for use. It returns 0 when the counter
+// file is missing or empty.
+//
+// Because the counter is incremented and persisted on every write (see
+// GetAndInc), a zero value reliably means the shard has never held any objects —
+// including data still sitting in an unflushed/reused WAL, which segment metadata
+// would not yet reflect. This makes it a safe, cheap probe for deciding whether a
+// not-yet-loaded shard is empty.
+func ReadOnDisk(shardPath string) (uint64, error) {
+	f, err := os.Open(fmt.Sprintf("%s/indexcount", shardPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if stat.Size() == 0 {
+		return 0, nil
+	}
+
+	var count uint64
+	if err := binary.Read(f, binary.LittleEndian, &count); err != nil {
+		return 0, errors.Wrap(err, "read counter from file")
+	}
+	return count, nil
+}
+
 func (c *Counter) Get() uint64 {
 	c.Lock()
 	defer c.Unlock()

--- a/adapters/repos/db/indexcounter/counter.go
+++ b/adapters/repos/db/indexcounter/counter.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -63,7 +64,7 @@ func New(shardPath string) (cr *Counter, rerr error) {
 	}, nil
 }
 
-// ReadOnDisk returns the persisted counter value for the shard at shardPath
+// Read returns the persisted counter value for the shard at shardPath
 // without opening/creating the counter for use. It returns 0 when the counter
 // file is missing or empty.
 //
@@ -72,8 +73,8 @@ func New(shardPath string) (cr *Counter, rerr error) {
 // including data still sitting in an unflushed/reused WAL, which segment metadata
 // would not yet reflect. This makes it a safe, cheap probe for deciding whether a
 // not-yet-loaded shard is empty.
-func ReadOnDisk(shardPath string) (uint64, error) {
-	f, err := os.Open(fmt.Sprintf("%s/indexcount", shardPath))
+func Read(shardPath string) (uint64, error) {
+	f, err := os.Open(filepath.Join(shardPath, "indexcount"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, nil

--- a/adapters/repos/db/indexcounter/counter_test.go
+++ b/adapters/repos/db/indexcounter/counter_test.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package indexcounter
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOnDisk(t *testing.T) {
+	t.Run("missing counter file reads as 0", func(t *testing.T) {
+		count, err := ReadOnDisk(t.TempDir())
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), count)
+	})
+
+	t.Run("does not create the counter file", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := ReadOnDisk(dir)
+		require.NoError(t, err)
+		_, statErr := os.Stat(filepath.Join(dir, "indexcount"))
+		require.True(t, os.IsNotExist(statErr), "ReadOnDisk must not create the counter file")
+	})
+
+	t.Run("empty counter file reads as 0", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "indexcount"), nil, 0o644))
+		count, err := ReadOnDisk(dir)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), count)
+	})
+
+	t.Run("returns the persisted value", func(t *testing.T) {
+		dir := t.TempDir()
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], 42)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "indexcount"), buf[:], 0o644))
+		count, err := ReadOnDisk(dir)
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), count)
+	})
+
+	t.Run("agrees with the counter after increments", func(t *testing.T) {
+		dir := t.TempDir()
+		c, err := New(dir)
+		require.NoError(t, err)
+		for range 3 {
+			_, err := c.GetAndInc()
+			require.NoError(t, err)
+		}
+		count, err := ReadOnDisk(dir)
+		require.NoError(t, err)
+		require.Equal(t, c.Get(), count)
+		require.Equal(t, uint64(3), count)
+	})
+}

--- a/adapters/repos/db/indexcounter/counter_test.go
+++ b/adapters/repos/db/indexcounter/counter_test.go
@@ -22,14 +22,14 @@ import (
 
 func TestReadOnDisk(t *testing.T) {
 	t.Run("missing counter file reads as 0", func(t *testing.T) {
-		count, err := ReadOnDisk(t.TempDir())
+		count, err := Read(t.TempDir())
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), count)
 	})
 
 	t.Run("does not create the counter file", func(t *testing.T) {
 		dir := t.TempDir()
-		_, err := ReadOnDisk(dir)
+		_, err := Read(dir)
 		require.NoError(t, err)
 		_, statErr := os.Stat(filepath.Join(dir, "indexcount"))
 		require.True(t, os.IsNotExist(statErr), "ReadOnDisk must not create the counter file")
@@ -38,7 +38,7 @@ func TestReadOnDisk(t *testing.T) {
 	t.Run("empty counter file reads as 0", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "indexcount"), nil, 0o644))
-		count, err := ReadOnDisk(dir)
+		count, err := Read(dir)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), count)
 	})
@@ -48,7 +48,7 @@ func TestReadOnDisk(t *testing.T) {
 		var buf [8]byte
 		binary.LittleEndian.PutUint64(buf[:], 42)
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "indexcount"), buf[:], 0o644))
-		count, err := ReadOnDisk(dir)
+		count, err := Read(dir)
 		require.NoError(t, err)
 		require.Equal(t, uint64(42), count)
 	})
@@ -61,7 +61,7 @@ func TestReadOnDisk(t *testing.T) {
 			_, err := c.GetAndInc()
 			require.NoError(t, err)
 		}
-		count, err := ReadOnDisk(dir)
+		count, err := Read(dir)
 		require.NoError(t, err)
 		require.Equal(t, c.Get(), count)
 		require.Equal(t, uint64(3), count)

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -284,6 +285,29 @@ func TestUpdateIndexShards(t *testing.T) {
 			for _, shardName := range tt.initialShards {
 				err := index.initLocalShardWithForcedLoading(ctx, class, shardName, tt.mustLoad, false)
 				require.NoError(t, err)
+			}
+
+			// In eager (non-lazy) mode, empty HOT multi-tenant shards are deferred
+			// at startup as unloaded *LazyLoadShard wrappers to save memory (see
+			// Index.initAndStoreShards). These cases exercise updateIndexShards'
+			// add/remove/keep behavior against the "eager ⇒ *Shard" contract, which
+			// only holds for shards that actually hold data. Write one object into
+			// each initial shard so it is materialized (and stays) a raw *Shard
+			// rather than a deferred wrapper. Lazy-load mode is intentionally left
+			// out: it keeps every shard as an unloaded wrapper regardless of
+			// emptiness, and those cases assert exactly that below.
+			if !tt.lazyLoading {
+				for shardIdx, shardName := range tt.initialShards {
+					err := index.IncomingPutObject(ctx, shardName, &storobj.Object{
+						MarshallerVersion: 1,
+						DocID:             uint64(shardIdx),
+						Object: models.Object{
+							ID:    strfmt.UUID(uuid.New().String()),
+							Class: "TestClass",
+						},
+					}, 0)
+					require.NoError(t, err)
+				}
 			}
 
 			migrator := &Migrator{

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -13,13 +13,15 @@ package db
 
 import (
 	"context"
+	"encoding/binary"
 	"hash/crc32"
 	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -268,11 +270,30 @@ func TestUpdateIndexShards(t *testing.T) {
 			mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
 				return readFunc(class, initialState)
 			}).Maybe()
+
+			rootPath := t.TempDir()
+
+			// Seed a non-zero on-disk index counter for each initial shard BEFORE
+			// NewIndex runs. NewIndex→initAndStoreShards defers loading of empty HOT
+			// multi-tenant shards, storing them as unloaded *LazyLoadShard wrappers.
+			// "Empty" is decided via indexcounter.ReadOnDisk (a counter of 0 / missing
+			// indexcount file). Writing a counter of 1 makes each initial shard read as
+			// non-empty so the deferral does not apply, keeping this test focused on
+			// updateIndexShards' add/remove/keep behavior and the eager⇒*Shard /
+			// lazy⇒*LazyLoadShard contract rather than the empty-tenant deferral.
+			for _, shardName := range tt.initialShards {
+				shardDir := filepath.Join(rootPath, indexID(schema.ClassName("TestClass")), shardName)
+				require.NoError(t, os.MkdirAll(shardDir, 0o755))
+				var buf [8]byte
+				binary.LittleEndian.PutUint64(buf[:], 1)
+				require.NoError(t, os.WriteFile(filepath.Join(shardDir, "indexcount"), buf[:], 0o644))
+			}
+
 			shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
 			// Create index with proper configuration
 			index, err := NewIndex(ctx, IndexConfig{
 				ClassName:            schema.ClassName("TestClass"),
-				RootPath:             t.TempDir(),
+				RootPath:             rootPath,
 				ReplicationFactor:    1,
 				ShardLoadLimiter:     loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
 				EnableLazyLoadShards: tt.lazyLoading, // Enable lazy loading when lazyLoading is true
@@ -285,29 +306,6 @@ func TestUpdateIndexShards(t *testing.T) {
 			for _, shardName := range tt.initialShards {
 				err := index.initLocalShardWithForcedLoading(ctx, class, shardName, tt.mustLoad, false)
 				require.NoError(t, err)
-			}
-
-			// In eager (non-lazy) mode, empty HOT multi-tenant shards are deferred
-			// at startup as unloaded *LazyLoadShard wrappers to save memory (see
-			// Index.initAndStoreShards). These cases exercise updateIndexShards'
-			// add/remove/keep behavior against the "eager ⇒ *Shard" contract, which
-			// only holds for shards that actually hold data. Write one object into
-			// each initial shard so it is materialized (and stays) a raw *Shard
-			// rather than a deferred wrapper. Lazy-load mode is intentionally left
-			// out: it keeps every shard as an unloaded wrapper regardless of
-			// emptiness, and those cases assert exactly that below.
-			if !tt.lazyLoading {
-				for shardIdx, shardName := range tt.initialShards {
-					err := index.IncomingPutObject(ctx, shardName, &storobj.Object{
-						MarshallerVersion: 1,
-						DocID:             uint64(shardIdx),
-						Object: models.Object{
-							ID:    strfmt.UUID(uuid.New().String()),
-							Class: "TestClass",
-						},
-					}, 0)
-					require.NoError(t, err)
-				}
 			}
 
 			migrator := &Migrator{

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -13,11 +13,8 @@ package db
 
 import (
 	"context"
-	"encoding/binary"
 	"hash/crc32"
 	"io"
-	"os"
-	"path/filepath"
 	"slices"
 	"testing"
 
@@ -282,11 +279,7 @@ func TestUpdateIndexShards(t *testing.T) {
 			// updateIndexShards' add/remove/keep behavior and the eager⇒*Shard /
 			// lazy⇒*LazyLoadShard contract rather than the empty-tenant deferral.
 			for _, shardName := range tt.initialShards {
-				shardDir := filepath.Join(rootPath, indexID(schema.ClassName("TestClass")), shardName)
-				require.NoError(t, os.MkdirAll(shardDir, 0o755))
-				var buf [8]byte
-				binary.LittleEndian.PutUint64(buf[:], 1)
-				require.NoError(t, os.WriteFile(filepath.Join(shardDir, "indexcount"), buf[:], 0o644))
+				seedShardObjectCounter(t, rootPath, "TestClass", shardName)
 			}
 
 			shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -196,6 +196,40 @@ func CalculateUnloadedObjectsMetrics(logger logrus.FieldLogger, path, shardName 
 	}, nil
 }
 
+// UnloadedShardHasObjects reports whether a not-yet-loaded shard has at least one
+// object on disk, read from the objects segment metadata without materializing the
+// shard. Unlike CalculateUnloadedObjectsMetrics it short-circuits on the first
+// segment with a positive count instead of summing every segment, since callers
+// deciding whether a shard is empty only need count > 0.
+func UnloadedShardHasObjects(logger logrus.FieldLogger, indexPath, shardName string) (bool, error) {
+	objectStore := shardPathObjectsLSM(indexPath, shardName)
+	files, _, err := diskio.GetFileWithSizes(objectStore)
+	if err != nil {
+		return false, err
+	}
+	for file := range files {
+		filePath := filepath.Join(objectStore, file)
+		var count int64
+		switch {
+		case strings.HasSuffix(file, lsmkv.CountNetAdditionsFileSuffix):
+			count, err = lsmkv.ReadCountNetAdditionsFile(filePath)
+		case strings.HasSuffix(file, lsmkv.MetadataFileSuffix):
+			count, err = lsmkv.ReadObjectCountFromMetadataFile(filePath)
+		default:
+			continue
+		}
+		if err != nil {
+			logger.WithField("path", filePath).WithField("shard", shardName).
+				Warnf("failed to read object count file: %v", err)
+			return false, err
+		}
+		if count > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // CalculateUnloadedIndicesSize calculates both object count and storage size for a cold tenant without loading it into memory
 func CalculateUnloadedIndicesSize(lsmPath string, directories []string) (uint64, error) {
 	totalSize := uint64(0)

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -196,40 +196,6 @@ func CalculateUnloadedObjectsMetrics(logger logrus.FieldLogger, path, shardName 
 	}, nil
 }
 
-// UnloadedShardHasObjects reports whether a not-yet-loaded shard has at least one
-// object on disk, read from the objects segment metadata without materializing the
-// shard. Unlike CalculateUnloadedObjectsMetrics it short-circuits on the first
-// segment with a positive count instead of summing every segment, since callers
-// deciding whether a shard is empty only need count > 0.
-func UnloadedShardHasObjects(logger logrus.FieldLogger, indexPath, shardName string) (bool, error) {
-	objectStore := shardPathObjectsLSM(indexPath, shardName)
-	files, _, err := diskio.GetFileWithSizes(objectStore)
-	if err != nil {
-		return false, err
-	}
-	for file := range files {
-		filePath := filepath.Join(objectStore, file)
-		var count int64
-		switch {
-		case strings.HasSuffix(file, lsmkv.CountNetAdditionsFileSuffix):
-			count, err = lsmkv.ReadCountNetAdditionsFile(filePath)
-		case strings.HasSuffix(file, lsmkv.MetadataFileSuffix):
-			count, err = lsmkv.ReadObjectCountFromMetadataFile(filePath)
-		default:
-			continue
-		}
-		if err != nil {
-			logger.WithField("path", filePath).WithField("shard", shardName).
-				Warnf("failed to read object count file: %v", err)
-			return false, err
-		}
-		if count > 0 {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // CalculateUnloadedIndicesSize calculates both object count and storage size for a cold tenant without loading it into memory
 func CalculateUnloadedIndicesSize(lsmPath string, directories []string) (uint64, error) {
 	totalSize := uint64(0)


### PR DESCRIPTION
### What's being changed:
On startup every HOT multi-tenant shard is eagerly loaded including empty tenants, thats pay the full per-shard footprint (LSM buckets/memtables, vector index + commit logger, trackers, cycle registrations) for nothing which incurs costs 

This changes makes sure that empty tenants are lazy loaded on startup

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/29001841531
 e2e : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/29001853783
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
