### PR TITLE
Optimize shard gauge allocations

### DIFF
--- a/adapters/repos/db/vector/common/shared_gauge.go
+++ b/adapters/repos/db/vector/common/shared_gauge.go
@@ -21,14 +21,11 @@ import (
 type SharedGauge struct {
 	mu    sync.Mutex
 	count int64
-	done  chan struct{} // closed when count reaches 0; replaced when count rises from 0
+	done  chan struct{} // lazily created by Wait while count>0; closed and cleared when count returns to 0
 }
 
 func NewSharedGauge() *SharedGauge {
-	// Start at zero: done channel is already closed.
-	done := make(chan struct{})
-	close(done)
-	return &SharedGauge{done: done}
+	return &SharedGauge{}
 }
 
 // Incr increments the gauge and returns the new count.
@@ -36,10 +33,6 @@ func (sc *SharedGauge) Incr() int64 {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
-	if sc.count == 0 {
-		// Open a fresh channel; waiters will block on it until count drops to 0 again.
-		sc.done = make(chan struct{})
-	}
 	sc.count++
 
 	return sc.count
@@ -56,8 +49,10 @@ func (sc *SharedGauge) Decr() int64 {
 
 	sc.count--
 
-	if sc.count == 0 {
+	if sc.count == 0 && sc.done != nil {
+		// Wake any waiters and drop the channel so the next waiter creates a fresh one.
 		close(sc.done)
+		sc.done = nil
 	}
 
 	return sc.count
@@ -78,6 +73,9 @@ func (sc *SharedGauge) Wait(ctx context.Context) error {
 		if sc.count == 0 {
 			sc.mu.Unlock()
 			return nil
+		}
+		if sc.done == nil {
+			sc.done = make(chan struct{})
 		}
 		done := sc.done
 		sc.mu.Unlock()

--- a/adapters/repos/db/vector/common/shared_gauge.go
+++ b/adapters/repos/db/vector/common/shared_gauge.go
@@ -74,6 +74,10 @@ func (sc *SharedGauge) Wait(ctx context.Context) error {
 			sc.mu.Unlock()
 			return nil
 		}
+		if err := ctx.Err(); err != nil {
+			sc.mu.Unlock()
+			return err
+		}
 		if sc.done == nil {
 			sc.done = make(chan struct{})
 		}

--- a/adapters/repos/db/vector/common/shared_gauge_test.go
+++ b/adapters/repos/db/vector/common/shared_gauge_test.go
@@ -1,0 +1,110 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedGauge_WaitReturnsImmediatelyAtZero(t *testing.T) {
+	g := NewSharedGauge()
+	require.NoError(t, g.Wait(context.Background()))
+}
+
+func TestSharedGauge_WaitBlocksUntilZero(t *testing.T) {
+	g := NewSharedGauge()
+	require.EqualValues(t, 1, g.Incr())
+	require.EqualValues(t, 2, g.Incr())
+
+	waited := make(chan error, 1)
+	go func() { waited <- g.Wait(context.Background()) }()
+
+	// Still running: Wait must not have returned yet.
+	select {
+	case <-waited:
+		t.Fatal("Wait returned while count > 0")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.EqualValues(t, 1, g.Decr())
+	require.EqualValues(t, 0, g.Decr())
+
+	select {
+	case err := <-waited:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Wait did not return after count reached 0")
+	}
+}
+
+func TestSharedGauge_WaitHonoursContextCancellation(t *testing.T) {
+	g := NewSharedGauge()
+	g.Incr()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, g.Wait(ctx), context.Canceled)
+}
+
+func TestSharedGauge_ReusableAcrossCycles(t *testing.T) {
+	g := NewSharedGauge()
+	for i := 0; i < 3; i++ {
+		g.Incr()
+		require.EqualValues(t, 0, g.Decr())
+		require.NoError(t, g.Wait(context.Background()))
+	}
+}
+
+func TestSharedGauge_MultipleWaitersAllWake(t *testing.T) {
+	g := NewSharedGauge()
+	g.Incr()
+
+	const waiters = 5
+	errs := make(chan error, waiters)
+	for i := 0; i < waiters; i++ {
+		go func() { errs <- g.Wait(context.Background()) }()
+	}
+
+	// Give the waiters a moment to block, then release them.
+	time.Sleep(50 * time.Millisecond)
+	require.EqualValues(t, 0, g.Decr())
+
+	for i := 0; i < waiters; i++ {
+		select {
+		case err := <-errs:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("not all waiters woke after count reached 0")
+		}
+	}
+}
+
+func TestSharedGauge_DecrBelowZeroPanics(t *testing.T) {
+	g := NewSharedGauge()
+	require.Panics(t, func() { g.Decr() })
+}
+
+// Incr/Decr are on a hot path that oscillates 0->1->0 constantly; with no
+// waiter present they must not allocate a channel per transition.
+func TestSharedGauge_IncrDecrDoNotAllocateWithoutWaiter(t *testing.T) {
+	g := NewSharedGauge()
+	allocs := testing.AllocsPerRun(1000, func() {
+		g.Incr()
+		g.Decr()
+	})
+	require.Zero(t, allocs)
+}


### PR DESCRIPTION
### What's being changed:

Only create channel when there is an actual waiter. Currently we create it with ever 0->1 transition. Wait is rarely called and usually we do not need the channel.

Was part of the profile of a big MT cluster:
```
  2. shared_gauge.go:41 — lazy channel — 2.5% (~112 GB).
  if sc.count == 0 { sc.done = make(chan struct{}) }  // on every 0→1 transition
  The gauge oscillates 0→1→0 constantly, allocating a channel each time even when nobody waits. Only create
  done when a Wait() caller actually needs it (or hand out a shared closed-channel sentinel when
  count==0). Small, self-contained change.
```


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
