### PR TITLE
fix(hfresh): normalize vectors during reassign

### DIFF
--- a/adapters/repos/db/vector/hfresh/reassign.go
+++ b/adapters/repos/db/vector/hfresh/reassign.go
@@ -46,6 +46,7 @@ func (h *HFresh) doReassign(ctx context.Context, op reassignOperation) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get vector by index ID")
 	}
+	q = h.normalizeVec(q)
 
 	replicas, needsReassign, err := h.RNGSelect(q, op.PostingID)
 	if err != nil {

--- a/adapters/repos/db/vector/hfresh/reassign_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
 // Reassign a vector that has been deleted
@@ -154,6 +155,45 @@ func TestReassignConcurrentVersionChange(t *testing.T) {
 
 	err := tf.Index.doReassign(t.Context(), op)
 	require.NoError(t, err)
+}
+
+func TestReassignNormalizesFetchedVectorForCosineDistance(t *testing.T) {
+	tf := createHFreshIndex(t)
+	tf.Index.config.DistanceProvider = distancer.NewCosineDistanceProvider()
+
+	rawVector := []float32{3.0, 4.0, 0.0, 0.0}
+	normalizedVector := distancer.Normalize(rawVector)
+	vectorID := uint64(700)
+	targetPostingID := uint64(1)
+	previousPostingID := uint64(2)
+
+	initializeDimensions(t, &tf, rawVector)
+
+	compressedCentroid := tf.Index.quantizer.CompressedBytes(tf.Index.quantizer.Encode(normalizedVector))
+	err := tf.Index.Centroids.Insert(targetPostingID, &Centroid{
+		Uncompressed: normalizedVector,
+		Compressed:   compressedCentroid,
+		Deleted:      false,
+	})
+	require.NoError(t, err)
+
+	tf.Index.config.VectorForIDThunk = func(ctx context.Context, id uint64) ([]float32, error) {
+		require.Equal(t, vectorID, id)
+		return rawVector, nil
+	}
+
+	err = tf.Index.doReassign(t.Context(), reassignOperation{
+		PostingID: previousPostingID,
+		VectorID:  vectorID,
+	})
+	require.NoError(t, err)
+
+	posting, err := tf.Index.PostingStore.Get(t.Context(), targetPostingID)
+	require.NoError(t, err)
+	require.Len(t, posting, 1)
+
+	expected := tf.Index.quantizer.CompressedBytes(tf.Index.quantizer.Encode(normalizedVector))
+	require.Equal(t, expected, posting[0].Data())
 }
 
 // Reassign properly manages task queue


### PR DESCRIPTION
### What's being changed:

HFresh now normalizes vectors fetched from `VectorForIDThunk` inside `doReassign` before RNG selection and before encoding the reassigned copy. This matches the insert and search paths for cosine-dot indexes where the object store returns the original raw vector.

Adds a regression test that uses an unnormalized original vector with cosine distance and verifies the reassigned posting stores the normalized encoding.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: not necessary, internal bug fix.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary, one normalization call on reassign path.

Tested with:

`go test ./adapters/repos/db/vector/hfresh`

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
