### PR TITLE
Remove noisy HNSW compactor no-op debug log

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/compactor.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor.go
@@ -440,9 +440,6 @@ func (c *Compactor) decideAction(state *DirectoryState) Action {
 		return ActionMergeSorted
 	}
 
-	log.WithField("reason", "sorted ratio below threshold and only one sorted file").
-		Debugf("decision: no action (ratio %.1f%% <= threshold %.1f%%, only %d sorted file)",
-			sortedRatio*100, c.config.SnapshotThreshold*100, sortedCount)
 	return ActionNone
 }
 


### PR DESCRIPTION
### What's being changed:

Removes a repetitive debug log emitted when the HNSW compactor decides there is no action to take because the sorted ratio is below the snapshot threshold and there is only one sorted file.

The compaction decision remains unchanged: this path still returns `ActionNone`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: not necessary
- [ ] Chaos pipeline run or not necessary. Link to pipeline: not necessary
- [ ] All new code is covered by tests where it is reasonable. Existing focused compactor tests cover the decision behavior; no new behavior added.
- [ ] Performance tests have been run or not necessary. Not necessary for log-only change.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->