### PR TITLE
Fix batch vectorization deadlocks

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1130,8 +1130,19 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.ReplGRPCConnManager.Close()
 		appState.GRPCConnManager.Close()
 
-		// gracefully stop gRPC server
-		grpcServer.GracefulStop()
+		// stop the gRPC server gracefully, but cap the wait so a stuck
+		// request can't block shutdown.
+		grpcStopped := make(chan struct{})
+		enterrors.GoWrapper(func() {
+			grpcServer.GracefulStop()
+			close(grpcStopped)
+		}, appState.Logger)
+		select {
+		case <-grpcStopped:
+		case <-time.After(20 * time.Second):
+			appState.Logger.Warn("grpc graceful stop timed out, forcing stop")
+			grpcServer.Stop()
+		}
 
 		if appState.ServerConfig.Config.Sentry.Enabled {
 			sentry.Flush(2 * time.Second)

--- a/modules/text2vec-openai/vectorizer/batch_test.go
+++ b/modules/text2vec-openai/vectorizer/batch_test.go
@@ -80,12 +80,19 @@ func TestBatch(t *testing.T) {
 		}, skip: []bool{false, false, true}},
 		{name: "deadline", deadline: 400 * time.Millisecond, objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "tokens 15"}}, // set limit so next two items are in a batch
-			{Class: "Car", Properties: map[string]interface{}{"test": "wait 500"}},  // needs to be higher than deadline, so all remaining objects time out
+			{Class: "Car", Properties: map[string]interface{}{"test": "wait 500"}},  // higher than the deadline, so the job is still in flight when the request context expires
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "next batch, will be aborted due to context deadline"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "skipped"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "has error again"}},
-		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{3: fmt.Errorf("context deadline exceeded"), 5: fmt.Errorf("context deadline exceeded")}},
+			// The expired request context abandons the whole job, so every non-skipped object errors.
+		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{
+			0: fmt.Errorf("context deadline exceeded"),
+			1: fmt.Errorf("context deadline exceeded"),
+			2: fmt.Errorf("context deadline exceeded"),
+			3: fmt.Errorf("context deadline exceeded"),
+			5: fmt.Errorf("context deadline exceeded"),
+		}},
 		{name: "azure limit without total Limit", objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "azure_tokens 20"}}, // set azure limit without total Limit
 			{Class: "Car", Properties: map[string]interface{}{"test": "long long long long"}},

--- a/modules/text2vec-openai/vectorizer/batch_test.go
+++ b/modules/text2vec-openai/vectorizer/batch_test.go
@@ -127,7 +127,7 @@ func TestBatch(t *testing.T) {
 
 			for i := range tt.objects {
 				if tt.wantErrors[i] != nil {
-					require.Equal(t, tt.wantErrors[i], errs[i])
+					require.ErrorContains(t, errs[i], tt.wantErrors[i].Error())
 				} else if tt.skip[i] {
 					require.Nil(t, vecs[i])
 				} else {

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -281,12 +281,36 @@ timeLoop:
 }
 
 func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulecomponents.RateLimits, timePerToken float64, reservedReqs int, concurrentBatch bool) {
+	// Release the waiting submitter even on panic, so its handler cannot hang.
 	defer job.wg.Done()
+
 	maxTokensPerBatch := b.settings.MaxTokensPerBatch(job.cfg)
 	estimatedTokensInCurrentBatch := 0
 	numRequests := 0
 	numSendObjects := 0
 	actualTokensUsed := 0
+
+	// Release the concurrency slot and reserved budget even on panic; leaking either
+	// wedges the worker.
+	defer func() {
+		objectsPerRequest := 0
+		if numRequests > 0 {
+			objectsPerRequest = numSendObjects / numRequests
+		}
+		monitoring.GetMetrics().T2VRequestsPerBatch.WithLabelValues(b.Label).Observe(float64(numRequests))
+		b.endOfBatchChannel <- endOfBatchJob{
+			timePerToken:      timePerToken,
+			objectsPerRequest: objectsPerRequest,
+			reservedTokens:    job.tokenSum,
+			reservedReqs:      reservedReqs,
+			actualTokens:      actualTokensUsed,
+			actualReqs:        numRequests,
+			apiKeyHash:        job.apiKeyHash,
+			concurrentBatch:   concurrentBatch,
+		}
+		b.concurrentBatches.Add(-1)
+		monitoring.GetMetrics().T2VBatches.WithLabelValues(b.Label).Dec()
+	}()
 
 	texts := make([]string, 0, 100)
 	origIndex := make([]int, 0, 100)
@@ -409,23 +433,6 @@ func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulec
 		actualTokensUsedInReq, _ := b.makeRequest(job, texts, job.cfg, origIndex, rateLimit, estimatedTokensInCurrentBatch)
 		actualTokensUsed += actualTokensUsedInReq
 	}
-	objectsPerRequest := 0
-	if numRequests > 0 {
-		objectsPerRequest = numSendObjects / numRequests
-	}
-	monitoring.GetMetrics().T2VRequestsPerBatch.WithLabelValues(b.Label).Observe(float64(numRequests))
-	b.endOfBatchChannel <- endOfBatchJob{
-		timePerToken:      timePerToken,
-		objectsPerRequest: objectsPerRequest,
-		reservedTokens:    job.tokenSum,
-		reservedReqs:      reservedReqs,
-		actualTokens:      actualTokensUsed,
-		actualReqs:        numRequests,
-		apiKeyHash:        job.apiKeyHash,
-		concurrentBatch:   concurrentBatch,
-	}
-	b.concurrentBatches.Add(-1)
-	monitoring.GetMetrics().T2VBatches.WithLabelValues(b.Label).Dec()
 }
 
 func (b *Batch[T]) makeRequest(job BatchJob[T], texts []string, cfg moduletools.ClassConfig, origIndex []int, rateLimit *modulecomponents.RateLimits, tokensInCurrentBatch int) (int, error) {

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -448,10 +448,12 @@ func (b *Batch[T]) makeRequest(job BatchJob[T], texts []string, cfg moduletools.
 		}
 	} else {
 		for j := 0; j < len(texts); j++ {
-			if res.Errors != nil && res.Errors[j] != nil {
+			if res.Errors != nil && j < len(res.Errors) && res.Errors[j] != nil {
 				job.errs[origIndex[j]] = res.Errors[j]
-			} else {
+			} else if j < len(res.Vector) {
 				job.vecs[origIndex[j]] = res.Vector[j]
+			} else {
+				job.errs[origIndex[j]] = errors.New("vectorizer returned fewer vectors than requested")
 			}
 		}
 	}

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -459,7 +459,15 @@ func (b *Batch[T]) makeRequest(job BatchJob[T], texts []string, cfg moduletools.
 	}
 	if rateLimitNew != nil {
 		rateLimit.UpdateWithRateLimit(rateLimitNew)
-		b.rateLimitChannel <- rateLimitJob{rateLimit: rateLimitNew, apiKeyHash: job.apiKeyHash}
+		// Non-blocking: during a sequential batch the worker is inside sendBatch and
+		// not draining this channel, so a blocking send would deadlock once the buffer
+		// fills. Dropping is safe: the sequential path (the only one that fills the
+		// buffer) already applied the update in place above, and updateState keeps only
+		// the freshest update anyway.
+		select {
+		case b.rateLimitChannel <- rateLimitJob{rateLimit: rateLimitNew, apiKeyHash: job.apiKeyHash}:
+		default:
+		}
 	} else if b.settings.HasTokenLimit {
 		if tokensUsed > -1 {
 			tokensInCurrentBatch = tokensUsed

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -135,103 +135,110 @@ func (b *Batch[T]) batchWorker() {
 
 	// the total batch should not take longer than 60s to avoid timeouts. We will only use 40s here to be safe
 	for job := range b.jobQueueCh {
-		// observe how long the batch was in the queue waiting for processing
-		durWaiting := time.Since(job.startTime).Seconds()
-		monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "waiting_for_processing").
-			Observe(durWaiting)
-
-		startProcessingTime := time.Now()
-
-		// check if we already have rate limits for the current api key and reuse them if possible
-		// Note that the rateLimit is a pointer and should only be updated in place and not replaced with a new object
-		//  as otherwise any changes are lost
-		rateLimit, ok := rateLimitPerApiKey[job.apiKeyHash]
-		if !ok {
-			rateLimit = b.client.GetVectorizerRateLimit(job.ctx, job.cfg)
-			rateLimitPerApiKey[job.apiKeyHash] = rateLimit
-		}
-		rateLimit.CheckForReset()
-
-		objCounter := 0
-
-		// If the user does not supply rate limits, and we do not have defaults for the provider we don't know the
-		// rate limits without a request => send a small one. This currently only affects OpenAI.
-		for objCounter < len(job.texts) && rateLimit.IsInitialized() {
-			var err error
-			if !job.skipObject[objCounter] {
-				_, err = b.makeRequest(job, job.texts[objCounter:objCounter+1], job.cfg, []int{objCounter}, rateLimit, job.tokens[objCounter])
-				if err != nil {
-					job.errs[objCounter] = err
-					objCounter++
-					continue
-				}
-			}
-			objCounter++
-		}
-
-		// if we have a high rate limit we can send multiple batches in parallel.
-		//
-		// If the rate limit is high enough to "fit" the current batch, we send it concurrently. If not, we wait for
-		// either
-		//   - the rate limit to refresh, so we can schedule another concurrent batch
-		//   - the current batch to finish, so the next batch can be sent sequentially
-		//
-		// While using the same code both modes are working slightly different:
-		// 	- For concurrent batching, the amount of used tokens/requests is reserved as long as the batch is running
-		//	  and is cleared when it finishes. This ensures that we never exceed the rate limit and don't need to check
-		//	  the rate limit in the sendBatch function (we use a dummy that never fails a check). All updates happen
-		//	  in the main loop.
-		//  - For sequential batching, the rate limit  will be passed into the sendBatch function and is observed and
-		//    updated there. This allows to use the rate-limit in an optimal way, but also requires more checks. No
-		//    concurrent batch can be started while a sequential batch is running.
-		repeats := 0
-		for {
-			timePerToken, objectsPerBatch = b.updateState(rateLimitPerApiKey, timePerToken, objectsPerBatch)
-			expectedNumRequests := 1 + int(1.25*float32(len(job.texts)))/objectsPerBatch // round up to be on the safe side
-
-			stats := monitoring.GetMetrics().T2VRateLimitStats
-			stats.WithLabelValues(b.Label, "token_limit").Set(float64(rateLimit.LimitTokens))
-			stats.WithLabelValues(b.Label, "token_remaining").Set(float64(rateLimit.RemainingTokens))
-			stats.WithLabelValues(b.Label, "token_reserved").Set(float64(rateLimit.ReservedTokens))
-			stats.WithLabelValues(b.Label, "request_limit").Set(float64(rateLimit.LimitRequests))
-			stats.WithLabelValues(b.Label, "request_remaining").Set(float64(rateLimit.RemainingRequests))
-			stats.WithLabelValues(b.Label, "request_reserved").Set(float64(rateLimit.ReservedRequests))
-			stats.WithLabelValues(b.Label, "estimated_requests_needed").Set(float64(expectedNumRequests))
-			stats.WithLabelValues(b.Label, "tokens_needed").Set(float64(job.tokenSum))
-			stats.WithLabelValues(b.Label, "concurrent_batches").Set(float64(b.concurrentBatches.Load()))
-			stats.WithLabelValues(b.Label, "repeats_for_scheduling").Set(float64(repeats))
-
-			if rateLimit.CanSendFullBatch(expectedNumRequests, job.tokenSum, repeats > 0, b.Label) {
-				b.concurrentBatches.Add(1)
-				monitoring.GetMetrics().T2VBatches.WithLabelValues(b.Label).Inc()
-				jobCopy := job.copy()
-				rateLimit.ReservedRequests += expectedNumRequests
-				rateLimit.ReservedTokens += job.tokenSum
-
-				// necessary, because the outer loop can modify these values through b.updateState while the goroutine
-				// is accessing them => race
-				timePerToken := timePerToken
-				expectedNumRequests := expectedNumRequests
-				enterrors.GoWrapper(func() {
-					b.sendBatch(jobCopy, objCounter, dummyRateLimit(), timePerToken, expectedNumRequests, true)
-					monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "processing_async").
-						Observe(time.Since(startProcessingTime).Seconds())
-				}, b.logger)
-				break
-			} else if b.concurrentBatches.Load() < 1 {
-				b.concurrentBatches.Add(1)
-
-				monitoring.GetMetrics().T2VBatches.WithLabelValues(b.Label).Inc()
-				// block so no concurrent batch can be sent
-				b.sendBatch(job, objCounter, rateLimit, timePerToken, 0, false)
-				monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "processing_sync").
-					Observe(time.Since(startProcessingTime).Seconds())
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-			repeats++
-		}
+		timePerToken, objectsPerBatch = b.processJob(job, timePerToken, objectsPerBatch, rateLimitPerApiKey)
 	}
+}
+
+// processJob schedules and sends a single batch job, returning the updated pacing
+// state (time-per-token and objects-per-batch) for the next job.
+func (b *Batch[T]) processJob(job BatchJob[T], timePerToken float64, objectsPerBatch int, rateLimitPerApiKey map[[32]byte]*modulecomponents.RateLimits) (float64, int) {
+	// observe how long the batch was in the queue waiting for processing
+	durWaiting := time.Since(job.startTime).Seconds()
+	monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "waiting_for_processing").
+		Observe(durWaiting)
+
+	startProcessingTime := time.Now()
+
+	// check if we already have rate limits for the current api key and reuse them if possible
+	// Note that the rateLimit is a pointer and should only be updated in place and not replaced with a new object
+	//  as otherwise any changes are lost
+	rateLimit, ok := rateLimitPerApiKey[job.apiKeyHash]
+	if !ok {
+		rateLimit = b.client.GetVectorizerRateLimit(job.ctx, job.cfg)
+		rateLimitPerApiKey[job.apiKeyHash] = rateLimit
+	}
+	rateLimit.CheckForReset()
+
+	objCounter := 0
+
+	// If the user does not supply rate limits, and we do not have defaults for the provider we don't know the
+	// rate limits without a request => send a small one. This currently only affects OpenAI.
+	for objCounter < len(job.texts) && rateLimit.IsInitialized() {
+		var err error
+		if !job.skipObject[objCounter] {
+			_, err = b.makeRequest(job, job.texts[objCounter:objCounter+1], job.cfg, []int{objCounter}, rateLimit, job.tokens[objCounter])
+			if err != nil {
+				job.errs[objCounter] = err
+				objCounter++
+				continue
+			}
+		}
+		objCounter++
+	}
+
+	// if we have a high rate limit we can send multiple batches in parallel.
+	//
+	// If the rate limit is high enough to "fit" the current batch, we send it concurrently. If not, we wait for
+	// either
+	//   - the rate limit to refresh, so we can schedule another concurrent batch
+	//   - the current batch to finish, so the next batch can be sent sequentially
+	//
+	// While using the same code both modes are working slightly different:
+	// 	- For concurrent batching, the amount of used tokens/requests is reserved as long as the batch is running
+	//	  and is cleared when it finishes. This ensures that we never exceed the rate limit and don't need to check
+	//	  the rate limit in the sendBatch function (we use a dummy that never fails a check). All updates happen
+	//	  in the main loop.
+	//  - For sequential batching, the rate limit  will be passed into the sendBatch function and is observed and
+	//    updated there. This allows to use the rate-limit in an optimal way, but also requires more checks. No
+	//    concurrent batch can be started while a sequential batch is running.
+	repeats := 0
+	for {
+		timePerToken, objectsPerBatch = b.updateState(rateLimitPerApiKey, timePerToken, objectsPerBatch)
+		expectedNumRequests := 1 + int(1.25*float32(len(job.texts)))/objectsPerBatch // round up to be on the safe side
+
+		stats := monitoring.GetMetrics().T2VRateLimitStats
+		stats.WithLabelValues(b.Label, "token_limit").Set(float64(rateLimit.LimitTokens))
+		stats.WithLabelValues(b.Label, "token_remaining").Set(float64(rateLimit.RemainingTokens))
+		stats.WithLabelValues(b.Label, "token_reserved").Set(float64(rateLimit.ReservedTokens))
+		stats.WithLabelValues(b.Label, "request_limit").Set(float64(rateLimit.LimitRequests))
+		stats.WithLabelValues(b.Label, "request_remaining").Set(float64(rateLimit.RemainingRequests))
+		stats.WithLabelValues(b.Label, "request_reserved").Set(float64(rateLimit.ReservedRequests))
+		stats.WithLabelValues(b.Label, "estimated_requests_needed").Set(float64(expectedNumRequests))
+		stats.WithLabelValues(b.Label, "tokens_needed").Set(float64(job.tokenSum))
+		stats.WithLabelValues(b.Label, "concurrent_batches").Set(float64(b.concurrentBatches.Load()))
+		stats.WithLabelValues(b.Label, "repeats_for_scheduling").Set(float64(repeats))
+
+		if rateLimit.CanSendFullBatch(expectedNumRequests, job.tokenSum, repeats > 0, b.Label) {
+			b.concurrentBatches.Add(1)
+			monitoring.GetMetrics().T2VBatches.WithLabelValues(b.Label).Inc()
+			jobCopy := job.copy()
+			rateLimit.ReservedRequests += expectedNumRequests
+			rateLimit.ReservedTokens += job.tokenSum
+
+			// necessary, because the outer loop can modify these values through b.updateState while the goroutine
+			// is accessing them => race
+			timePerToken := timePerToken
+			expectedNumRequests := expectedNumRequests
+			enterrors.GoWrapper(func() {
+				b.sendBatch(jobCopy, objCounter, dummyRateLimit(), timePerToken, expectedNumRequests, true)
+				monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "processing_async").
+					Observe(time.Since(startProcessingTime).Seconds())
+			}, b.logger)
+			break
+		} else if b.concurrentBatches.Load() < 1 {
+			b.concurrentBatches.Add(1)
+
+			monitoring.GetMetrics().T2VBatches.WithLabelValues(b.Label).Inc()
+			// block so no concurrent batch can be sent
+			b.sendBatch(job, objCounter, rateLimit, timePerToken, 0, false)
+			monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "processing_sync").
+				Observe(time.Since(startProcessingTime).Seconds())
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+		repeats++
+	}
+	return timePerToken, objectsPerBatch
 }
 
 // updateState collects the latest updates from finished batches

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -139,9 +139,18 @@ func (b *Batch[T]) batchWorker() {
 	}
 }
 
-// processJob schedules and sends a single batch job, returning the updated pacing
-// state (time-per-token and objects-per-batch) for the next job.
+// processJob schedules and sends one batch job and returns the updated pacing state
+// for the next job. It recovers a panic so one bad job cannot kill the worker: the
+// job's objects are errored and its submitter released.
 func (b *Batch[T]) processJob(job BatchJob[T], timePerToken float64, objectsPerBatch int, rateLimitPerApiKey map[[32]byte]*modulecomponents.RateLimits) (float64, int) {
+	defer func() {
+		if r := recover(); r != nil {
+			b.logger.Errorf("batch vectorizer worker recovered from panic: %v", r)
+			b.failUnresolved(job)
+			job.wg.Done() //nolint:SA2000
+		}
+	}()
+
 	// observe how long the batch was in the queue waiting for processing
 	durWaiting := time.Since(job.startTime).Seconds()
 	monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "waiting_for_processing").
@@ -287,6 +296,19 @@ timeLoop:
 	return timePerToken, objectsPerBatch
 }
 
+// failUnresolved errors every object left without a vector, so a recovered panic
+// cannot leave one silently un-vectorized.
+func (b *Batch[T]) failUnresolved(job BatchJob[T]) {
+	for i := range job.texts {
+		if job.skipObject[i] {
+			continue
+		}
+		if job.errs[i] == nil && len(job.vecs[i]) == 0 {
+			job.errs[i] = errors.New("vectorization aborted after an internal error")
+		}
+	}
+}
+
 func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulecomponents.RateLimits, timePerToken float64, reservedReqs int, concurrentBatch bool) {
 	// Release the waiting submitter even on panic, so its handler cannot hang.
 	defer job.wg.Done()
@@ -298,7 +320,7 @@ func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulec
 	actualTokensUsed := 0
 
 	// Release the concurrency slot and reserved budget even on panic; leaking either
-	// wedges the worker.
+	// stops the worker from scheduling further batches.
 	defer func() {
 		objectsPerRequest := 0
 		if numRequests > 0 {
@@ -317,6 +339,15 @@ func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulec
 		}
 		b.concurrentBatches.Add(-1)
 		monitoring.GetMetrics().T2VBatches.WithLabelValues(b.Label).Dec()
+	}()
+
+	// Recover a panic so it cannot kill the worker or escape the goroutine; runs
+	// before the cleanup above, erroring any unfinished object.
+	defer func() {
+		if r := recover(); r != nil {
+			b.logger.Errorf("batch vectorizer recovered from panic while sending batch: %v", r)
+			b.failUnresolved(job)
+		}
 	}()
 
 	texts := make([]string, 0, 100)

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -35,6 +35,19 @@ var _NUMCPU = runtime.GOMAXPROCS(0)
 
 const BatchChannelSize = 100
 
+// contextError maps a cancelled context to the per-object error reported for
+// objects that could not be vectorized because of it.
+func contextError(ctx context.Context) error {
+	switch ctx.Err() {
+	case context.Canceled:
+		return fmt.Errorf("context cancelled")
+	case context.DeadlineExceeded:
+		return fmt.Errorf("context deadline exceeded")
+	default:
+		return fmt.Errorf("context error: %w", ctx.Err())
+	}
+}
+
 type BatchJob[T dto.Embedding] struct {
 	texts      []string
 	tokens     []int
@@ -357,15 +370,7 @@ func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulec
 		if job.ctx.Err() != nil {
 			for j := objCounter; j < len(job.texts); j++ {
 				if !job.skipObject[j] {
-					switch job.ctx.Err() {
-					case context.Canceled:
-						job.errs[j] = fmt.Errorf("context cancelled")
-					case context.DeadlineExceeded:
-						job.errs[j] = fmt.Errorf("context deadline exceeded")
-					default:
-						// this should not happen but we need to handle it
-						job.errs[j] = fmt.Errorf("context error: %w", job.ctx.Err())
-					}
+					job.errs[j] = contextError(job.ctx)
 				}
 			}
 			break
@@ -555,7 +560,27 @@ func (b *Batch[T]) SubmitBatchAndWait(ctx context.Context, cfg moduletools.Class
 	monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "enqueue").
 		Observe(time.Since(beforeEnqueue).Seconds())
 
-	wg.Wait()
+	done := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		wg.Wait()
+		close(done)
+	}, b.logger)
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		// Abandon the job once the request is gone so a stuck worker cannot hang the
+		// caller forever. The worker keeps running and still owns the job's errs and
+		// vecs, so return neither: a fresh error map for every unresolved object, and
+		// a fresh vector slice it cannot mutate.
+		ctxErrs := make(map[int]error)
+		for i := range skipObject {
+			if !skipObject[i] {
+				ctxErrs[i] = contextError(ctx)
+			}
+		}
+		return make([]T, len(skipObject)), ctxErrs
+	}
 
 	// observe total duration
 	monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "total").

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -355,7 +355,8 @@ func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulec
 	}()
 
 	// Recover a panic so it cannot kill the worker or escape the goroutine; runs
-	// before the cleanup above, erroring any unfinished object.
+	// before the cleanup above, erroring any unfinished object. Must not re-panic:
+	// processJob's recover would then fire a second job.wg.Done.
 	defer func() {
 		if r := recover(); r != nil {
 			b.logger.Errorf("batch vectorizer recovered from panic while sending batch: %v", r)
@@ -511,9 +512,9 @@ func (b *Batch[T]) makeRequest(job BatchJob[T], texts []string, cfg moduletools.
 		rateLimit.UpdateWithRateLimit(rateLimitNew)
 		// Non-blocking: during a sequential batch the worker is inside sendBatch and
 		// not draining this channel, so a blocking send would deadlock once the buffer
-		// fills. Dropping is safe: the sequential path (the only one that fills the
-		// buffer) already applied the update in place above, and updateState keeps only
-		// the freshest update anyway.
+		// fills. Dropping is safe: the sequential path applied the update in place above,
+		// and a dropped concurrent update only costs a slightly staler rate-limit
+		// estimate, corrected on the next drained update.
 		select {
 		case b.rateLimitChannel <- rateLimitJob{rateLimit: rateLimitNew, apiKeyHash: job.apiKeyHash}:
 		default:

--- a/usecases/modulecomponents/batch/batch.go
+++ b/usecases/modulecomponents/batch/batch.go
@@ -35,18 +35,7 @@ var _NUMCPU = runtime.GOMAXPROCS(0)
 
 const BatchChannelSize = 100
 
-// contextError maps a cancelled context to the per-object error reported for
-// objects that could not be vectorized because of it.
-func contextError(ctx context.Context) error {
-	switch ctx.Err() {
-	case context.Canceled:
-		return fmt.Errorf("context cancelled")
-	case context.DeadlineExceeded:
-		return fmt.Errorf("context deadline exceeded")
-	default:
-		return fmt.Errorf("context error: %w", ctx.Err())
-	}
-}
+var errVectorizationAborted = errors.New("vectorization aborted after an internal error")
 
 type BatchJob[T dto.Embedding] struct {
 	texts      []string
@@ -317,7 +306,7 @@ func (b *Batch[T]) failUnresolved(job BatchJob[T]) {
 			continue
 		}
 		if job.errs[i] == nil && len(job.vecs[i]) == 0 {
-			job.errs[i] = errors.New("vectorization aborted after an internal error")
+			job.errs[i] = errVectorizationAborted
 		}
 	}
 }
@@ -340,6 +329,10 @@ func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulec
 			objectsPerRequest = numSendObjects / numRequests
 		}
 		monitoring.GetMetrics().T2VRequestsPerBatch.WithLabelValues(b.Label).Observe(float64(numRequests))
+		// Blocking, not dropping: this entry releases the concurrent-batch reservation
+		// in updateState. The worker is the sole consumer and drains on every scheduling
+		// iteration; the buffer only backs up while the job queue is idle, cleared by
+		// the next scheduled job.
 		b.endOfBatchChannel <- endOfBatchJob{
 			timePerToken:      timePerToken,
 			objectsPerRequest: objectsPerRequest,
@@ -371,7 +364,7 @@ func (b *Batch[T]) sendBatch(job BatchJob[T], objCounter int, rateLimit *modulec
 		if job.ctx.Err() != nil {
 			for j := objCounter; j < len(job.texts); j++ {
 				if !job.skipObject[j] {
-					job.errs[j] = contextError(job.ctx)
+					job.errs[j] = fmt.Errorf("context deadline exceeded or cancelled: %w", job.ctx.Err())
 				}
 			}
 			break
@@ -561,6 +554,8 @@ func (b *Batch[T]) SubmitBatchAndWait(ctx context.Context, cfg moduletools.Class
 	monitoring.GetMetrics().T2VBatchQueueDuration.WithLabelValues(b.Label, "enqueue").
 		Observe(time.Since(beforeEnqueue).Seconds())
 
+	// On the ctx escape below this goroutine lives until the worker finishes the job.
+	// Safe because the worker always completes (panics recovered, slots released).
 	done := make(chan struct{})
 	enterrors.GoWrapper(func() {
 		wg.Wait()
@@ -572,12 +567,13 @@ func (b *Batch[T]) SubmitBatchAndWait(ctx context.Context, cfg moduletools.Class
 	case <-ctx.Done():
 		// Abandon the job once the request is gone so a stuck worker cannot hang the
 		// caller forever. The worker keeps running and still owns the job's errs and
-		// vecs, so return neither: a fresh error map for every unresolved object, and
-		// a fresh vector slice it cannot mutate.
+		// vecs, so return neither: a fresh error map for every unresolved object, and a
+		// fresh vector slice it cannot mutate. Any already-vectorized objects are
+		// dropped - the request is gone, so partial results have nowhere to go.
 		ctxErrs := make(map[int]error)
 		for i := range skipObject {
 			if !skipObject[i] {
-				ctxErrs[i] = contextError(ctx)
+				ctxErrs[i] = fmt.Errorf("context deadline exceeded or cancelled: %w", ctx.Err())
 			}
 		}
 		return make([]T, len(skipObject)), ctxErrs

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -437,6 +437,111 @@ func TestMakeRequestFewerVectorsThanTexts(t *testing.T) {
 	require.Error(t, job.errs[1])
 }
 
+// fakePanicClient panics for the text "panic" and vectorizes everything else. Its
+// rate limit selects which scheduling path the panic happens on.
+type fakePanicClient struct {
+	rateLimit *modulecomponents.RateLimits
+}
+
+func (c *fakePanicClient) Vectorize(ctx context.Context, text []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
+	for i := range text {
+		if text[i] == "panic" {
+			panic("boom from vectorizer")
+		}
+	}
+	vectors := make([][]float32, len(text))
+	for i := range vectors {
+		vectors[i] = []float32{0, 1, 2, 3}
+	}
+	return &modulecomponents.VectorizationResult[[]float32]{Vector: vectors, Errors: make([]error, len(text))}, nil, 0, nil
+}
+
+func (c *fakePanicClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
+	return c.rateLimit
+}
+
+func (c *fakePanicClient) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	return [32]byte{}
+}
+
+func submitWithTimeout(t *testing.T, v *Batch[[]float32], cfg moduletools.ClassConfig, skip []bool, tokens []int, texts []string) ([][]float32, map[int]error) {
+	t.Helper()
+	type result struct {
+		vecs [][]float32
+		errs map[int]error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		vecs, errs := v.SubmitBatchAndWait(context.Background(), cfg, skip, tokens, texts)
+		ch <- result{vecs, errs}
+	}()
+	select {
+	case r := <-ch:
+		return r.vecs, r.errs
+	case <-time.After(5 * time.Second):
+		t.Fatal("SubmitBatchAndWait did not return in time")
+		return nil, nil
+	}
+}
+
+// A panic while vectorizing one batch must not kill the worker: the panicking batch
+// must return an error for its objects (not a silent nil vector), and subsequent
+// batches must still be processed instead of blocking forever in SubmitBatchAndWait.
+func TestBatchWorkerSurvivesPanic(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	cfg := &fakeClassConfig{classConfig: map[string]interface{}{"vectorizeClassName": false}}
+
+	cases := []struct {
+		name      string
+		rateLimit *modulecomponents.RateLimits
+	}{
+		{
+			// RemainingRequests != 0 skips the probe path; a request limit of 1 keeps
+			// every batch above CanSendFullBatch's threshold, forcing the sequential
+			// path where a panic runs inside the worker goroutine.
+			name: "sequential path",
+			rateLimit: &modulecomponents.RateLimits{
+				RemainingRequests: 100, RemainingTokens: 100,
+				LimitRequests: 1, LimitTokens: 1000,
+				ResetRequests: time.Now().Add(time.Minute), ResetTokens: time.Now().Add(time.Minute),
+			},
+		},
+		{
+			// zero remaining requests/tokens make the rate limit look uninitialized, so
+			// the worker takes the probe path and panics there, outside sendBatch.
+			name:      "probe path",
+			rateLimit: &modulecomponents.RateLimits{},
+		},
+		{
+			// ample headroom lets CanSendFullBatch pass, so the batch is sent
+			// concurrently and panics inside the GoWrapper goroutine.
+			name: "concurrent path",
+			rateLimit: &modulecomponents.RateLimits{
+				RemainingRequests: 1000, RemainingTokens: 1000,
+				LimitRequests: 1000, LimitTokens: 1000,
+				ResetRequests: time.Now().Add(time.Minute), ResetTokens: time.Now().Add(time.Minute),
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewBatchVectorizer[[]float32](&fakePanicClient{rateLimit: tt.rateLimit}, 200*time.Millisecond,
+				Settings{MaxObjectsPerBatch: 2000, MaxTokensPerBatch: maxTokensPerBatch, MaxTimePerBatch: 10}, logger, "test")
+
+			texts, tokenCounts := generateTokens([]*models.Object{{Class: "Car", Properties: map[string]interface{}{"test": "panic"}}})
+			_, errs := submitWithTimeout(t, v, cfg, []bool{false}, tokenCounts, texts)
+			require.Error(t, errs[0])
+
+			// the worker must have survived, so a normal batch still gets vectorized
+			texts, tokenCounts = generateTokens([]*models.Object{{Class: "Car", Properties: map[string]interface{}{"test": "normal"}}})
+			vecs, errs := submitWithTimeout(t, v, cfg, []bool{false}, tokenCounts, texts)
+			require.Len(t, errs, 0)
+			require.NotNil(t, vecs[0])
+		})
+	}
+}
+
 func TestEncoderCache(t *testing.T) {
 	cache := NewEncoderCache()
 

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -361,6 +361,41 @@ func TestBatchRequestMissingRLValues(t *testing.T) {
 	require.Less(t, time.Since(start), time.Millisecond*900)
 }
 
+// A batch that needs more vectorizer sub-requests than the rate-limit channel can
+// buffer must not deadlock: the worker is blocked inside sendBatch and cannot drain
+// the channel, so the send has to be non-blocking.
+func TestMakeRequestDoesNotBlockWhenRateLimitChannelFull(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	cfg := &fakeClassConfig{classConfig: map[string]interface{}{"vectorizeClassName": false}}
+	b := &Batch[[]float32]{
+		client:            &fakeBatchClientWithRL[[]float32]{},
+		rateLimitChannel:  make(chan rateLimitJob, BatchChannelSize),
+		endOfBatchChannel: make(chan endOfBatchJob, BatchChannelSize),
+		logger:            logger,
+		settings:          Settings{MaxObjectsPerBatch: 2000, MaxTokensPerBatch: maxTokensPerBatch, MaxTimePerBatch: 10, HasTokenLimit: true, ReturnsRateLimit: true},
+		Label:             "test",
+	}
+
+	// fill the channel to capacity so a blocking send would hang forever
+	for i := 0; i < BatchChannelSize; i++ {
+		b.rateLimitChannel <- rateLimitJob{}
+	}
+
+	job := BatchJob[[]float32]{ctx: context.Background(), cfg: cfg, errs: map[int]error{}, vecs: make([][]float32, 1)}
+
+	done := make(chan struct{})
+	go func() {
+		b.makeRequest(job, []string{"text"}, cfg, []int{0}, &modulecomponents.RateLimits{}, 4)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("makeRequest blocked on a full rateLimitChannel")
+	}
+}
+
 // fakeShortVectorClient returns fewer vectors than requested, mimicking a provider
 // that responds with a truncated result.
 type fakeShortVectorClient struct{}

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -361,6 +361,47 @@ func TestBatchRequestMissingRLValues(t *testing.T) {
 	require.Less(t, time.Since(start), time.Millisecond*900)
 }
 
+// fakeShortVectorClient returns fewer vectors than requested, mimicking a provider
+// that responds with a truncated result.
+type fakeShortVectorClient struct{}
+
+func (c *fakeShortVectorClient) Vectorize(ctx context.Context, text []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
+	return &modulecomponents.VectorizationResult[[]float32]{
+		Vector: make([][]float32, 0),
+		Errors: make([]error, len(text)),
+	}, nil, 0, nil
+}
+
+func (c *fakeShortVectorClient) GetVectorizerRateLimit(ctx context.Context, cfg moduletools.ClassConfig) *modulecomponents.RateLimits {
+	return &modulecomponents.RateLimits{}
+}
+
+func (c *fakeShortVectorClient) GetApiKeyHash(ctx context.Context, cfg moduletools.ClassConfig) [32]byte {
+	return [32]byte{}
+}
+
+// A provider returning fewer vectors than inputs must produce an error for the
+// missing objects instead of panicking on an out-of-range index.
+func TestMakeRequestFewerVectorsThanTexts(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	cfg := &fakeClassConfig{classConfig: map[string]interface{}{"vectorizeClassName": false}}
+	b := &Batch[[]float32]{
+		client:            &fakeShortVectorClient{},
+		rateLimitChannel:  make(chan rateLimitJob, BatchChannelSize),
+		endOfBatchChannel: make(chan endOfBatchJob, BatchChannelSize),
+		logger:            logger,
+		Label:             "test",
+	}
+	job := BatchJob[[]float32]{ctx: context.Background(), cfg: cfg, errs: map[int]error{}, vecs: make([][]float32, 2)}
+
+	require.NotPanics(t, func() {
+		b.makeRequest(job, []string{"a", "b"}, cfg, []int{0, 1}, &modulecomponents.RateLimits{}, 2)
+	})
+	require.Error(t, job.errs[0])
+	require.Error(t, job.errs[1])
+}
+
 func TestEncoderCache(t *testing.T) {
 	cache := NewEncoderCache()
 

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -84,6 +84,9 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "1. obj 1. batch"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "2. obj 1. batch"}},
 		}, skip: []bool{false, false, true}},
+		// The deadline expires while the first batch is still in flight, so the call
+		// is abandoned before any object is resolved: every non-skipped object gets
+		// the deadline error and no vectors are returned.
 		{name: "deadline", deadline: 200 * time.Millisecond, objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "tokens 40"}}, // set limit so next two items are in a batch
 			{Class: "Car", Properties: map[string]interface{}{"test": "wait 400"}},
@@ -91,7 +94,13 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "next batch, will be aborted due to context deadline"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "skipped"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "has error again"}},
-		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{3: fmt.Errorf("context deadline exceeded"), 5: fmt.Errorf("context deadline exceeded")}},
+		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{
+			0: fmt.Errorf("context deadline exceeded"),
+			1: fmt.Errorf("context deadline exceeded"),
+			2: fmt.Errorf("context deadline exceeded"),
+			3: fmt.Errorf("context deadline exceeded"),
+			5: fmt.Errorf("context deadline exceeded"),
+		}},
 		{name: "request error", objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "ReqError something"}},
 		}, skip: []bool{false}, wantErrors: map[int]error{0: fmt.Errorf("something")}},
@@ -538,6 +547,72 @@ func TestBatchWorkerSurvivesPanic(t *testing.T) {
 			vecs, errs := submitWithTimeout(t, v, cfg, []bool{false}, tokenCounts, texts)
 			require.Len(t, errs, 0)
 			require.NotNil(t, vecs[0])
+		})
+	}
+}
+
+// SubmitBatchAndWait must not hang forever when a job never signals completion:
+// once the request context is cancelled it returns, giving only unresolved
+// (non-skipped) objects the context error and no vectors.
+func TestSubmitBatchAndWaitRespectsContext(t *testing.T) {
+	cases := []struct {
+		name    string
+		newCtx  func() (context.Context, context.CancelFunc)
+		wantErr string
+	}{
+		{
+			name: "cancel",
+			newCtx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel() // already cancelled so the escape must fire on ctx.Done
+				return ctx, cancel
+			},
+			wantErr: "context cancelled",
+		},
+		{
+			name: "deadline",
+			newCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 50*time.Millisecond)
+			},
+			wantErr: "context deadline exceeded",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			cfg := &fakeClassConfig{classConfig: map[string]interface{}{"vectorizeClassName": false}}
+			// No worker drains jobQueueCh, so the enqueued job never completes and
+			// wg.Done never fires - only the context escape can unblock the call.
+			b := &Batch[[]float32]{
+				client:            &fakeBatchClientWithRL[[]float32]{},
+				jobQueueCh:        make(chan BatchJob[[]float32], BatchChannelSize),
+				rateLimitChannel:  make(chan rateLimitJob, BatchChannelSize),
+				endOfBatchChannel: make(chan endOfBatchJob, BatchChannelSize),
+				logger:            logger,
+				Label:             "test",
+			}
+
+			ctx, cancel := tt.newCtx()
+			defer cancel()
+
+			done := make(chan struct{})
+			var vecs [][]float32
+			var errs map[int]error
+			go func() {
+				vecs, errs = b.SubmitBatchAndWait(ctx, cfg, []bool{false, true}, []int{1, 1}, []string{"a", "b"})
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("SubmitBatchAndWait did not return after context cancellation")
+			}
+			require.Len(t, vecs, 2)
+			require.Nil(t, vecs[0])
+			require.EqualError(t, errs[0], tt.wantErr)
+			_, skipped := errs[1]
+			require.False(t, skipped, "skipped object must not get an error")
 		})
 	}
 }

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -13,6 +13,7 @@ package batch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -84,9 +85,9 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "1. obj 1. batch"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "2. obj 1. batch"}},
 		}, skip: []bool{false, false, true}},
-		// The deadline expires while the first batch is still in flight, so the call
-		// is abandoned before any object is resolved: every non-skipped object gets
-		// the deadline error and no vectors are returned.
+		// The first batch waits 400ms, longer than the 200ms deadline, so the call is
+		// abandoned before any object resolves: every non-skipped object gets an error
+		// wrapping context.DeadlineExceeded and no vectors are returned.
 		{name: "deadline", deadline: 200 * time.Millisecond, objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "tokens 40"}}, // set limit so next two items are in a batch
 			{Class: "Car", Properties: map[string]interface{}{"test": "wait 400"}},
@@ -95,11 +96,11 @@ func TestBatch(t *testing.T) {
 			{Class: "Car", Properties: map[string]interface{}{"test": "skipped"}},
 			{Class: "Car", Properties: map[string]interface{}{"test": "has error again"}},
 		}, skip: []bool{false, false, false, false, true, false}, wantErrors: map[int]error{
-			0: fmt.Errorf("context deadline exceeded"),
-			1: fmt.Errorf("context deadline exceeded"),
-			2: fmt.Errorf("context deadline exceeded"),
-			3: fmt.Errorf("context deadline exceeded"),
-			5: fmt.Errorf("context deadline exceeded"),
+			0: context.DeadlineExceeded,
+			1: context.DeadlineExceeded,
+			2: context.DeadlineExceeded,
+			3: context.DeadlineExceeded,
+			5: context.DeadlineExceeded,
 		}},
 		{name: "request error", objects: []*models.Object{
 			{Class: "Car", Properties: map[string]interface{}{"test": "ReqError something"}},
@@ -126,12 +127,16 @@ func TestBatch(t *testing.T) {
 			require.Len(t, vecs, len(tt.objects))
 
 			for i := range tt.objects {
-				if tt.wantErrors[i] != nil {
-					require.Equal(t, tt.wantErrors[i], errs[i])
-				} else if tt.skip[i] {
+				want := tt.wantErrors[i]
+				switch {
+				case want == nil && tt.skip[i]:
 					require.Nil(t, vecs[i])
-				} else {
+				case want == nil:
 					require.NotNil(t, vecs[i])
+				case errors.Is(want, context.DeadlineExceeded) || errors.Is(want, context.Canceled):
+					require.ErrorIs(t, errs[i], want)
+				default:
+					require.Equal(t, want, errs[i])
 				}
 			}
 			cancl()
@@ -174,12 +179,16 @@ func TestBatchNoRLreturn(t *testing.T) {
 			require.Len(t, vecs, len(tt.objects))
 
 			for i := range tt.objects {
-				if tt.wantErrors[i] != nil {
-					require.Equal(t, tt.wantErrors[i], errs[i])
-				} else if tt.skip[i] {
+				want := tt.wantErrors[i]
+				switch {
+				case want == nil && tt.skip[i]:
 					require.Nil(t, vecs[i])
-				} else {
+				case want == nil:
 					require.NotNil(t, vecs[i])
+				case errors.Is(want, context.DeadlineExceeded) || errors.Is(want, context.Canceled):
+					require.ErrorIs(t, errs[i], want)
+				default:
+					require.Equal(t, want, errs[i])
 				}
 			}
 			cancl()
@@ -608,7 +617,7 @@ func TestSubmitBatchAndWaitRespectsContext(t *testing.T) {
 	cases := []struct {
 		name    string
 		newCtx  func() (context.Context, context.CancelFunc)
-		wantErr string
+		wantErr error
 	}{
 		{
 			name: "cancel",
@@ -617,14 +626,14 @@ func TestSubmitBatchAndWaitRespectsContext(t *testing.T) {
 				cancel() // already cancelled so the escape must fire on ctx.Done
 				return ctx, cancel
 			},
-			wantErr: "context cancelled",
+			wantErr: context.Canceled,
 		},
 		{
 			name: "deadline",
 			newCtx: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 50*time.Millisecond)
 			},
-			wantErr: "context deadline exceeded",
+			wantErr: context.DeadlineExceeded,
 		},
 	}
 	for _, tt := range cases {
@@ -660,7 +669,7 @@ func TestSubmitBatchAndWaitRespectsContext(t *testing.T) {
 			}
 			require.Len(t, vecs, 2)
 			require.Nil(t, vecs[0])
-			require.EqualError(t, errs[0], tt.wantErr)
+			require.ErrorIs(t, errs[0], tt.wantErr)
 			_, skipped := errs[1]
 			require.False(t, skipped, "skipped object must not get an error")
 		})

--- a/usecases/modulecomponents/batch/batch_test.go
+++ b/usecases/modulecomponents/batch/batch_test.go
@@ -405,14 +405,20 @@ func TestMakeRequestDoesNotBlockWhenRateLimitChannelFull(t *testing.T) {
 	}
 }
 
-// fakeShortVectorClient returns fewer vectors than requested, mimicking a provider
-// that responds with a truncated result.
-type fakeShortVectorClient struct{}
+// fakeShortVectorClient returns a fixed number of vectors regardless of how many
+// texts it was given, mimicking a provider that responds with a truncated result.
+type fakeShortVectorClient struct {
+	vectorsToReturn int
+}
 
 func (c *fakeShortVectorClient) Vectorize(ctx context.Context, text []string, cfg moduletools.ClassConfig,
 ) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
+	vectors := make([][]float32, c.vectorsToReturn)
+	for i := range vectors {
+		vectors[i] = []float32{0, 1, 2, 3}
+	}
 	return &modulecomponents.VectorizationResult[[]float32]{
-		Vector: make([][]float32, 0),
+		Vector: vectors,
 		Errors: make([]error, len(text)),
 	}, nil, 0, nil
 }
@@ -426,24 +432,44 @@ func (c *fakeShortVectorClient) GetApiKeyHash(ctx context.Context, cfg moduletoo
 }
 
 // A provider returning fewer vectors than inputs must produce an error for the
-// missing objects instead of panicking on an out-of-range index.
+// missing objects instead of panicking on an out-of-range index. The objects that
+// did come back must still keep their vectors.
 func TestMakeRequestFewerVectorsThanTexts(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	cfg := &fakeClassConfig{classConfig: map[string]interface{}{"vectorizeClassName": false}}
-	b := &Batch[[]float32]{
-		client:            &fakeShortVectorClient{},
-		rateLimitChannel:  make(chan rateLimitJob, BatchChannelSize),
-		endOfBatchChannel: make(chan endOfBatchJob, BatchChannelSize),
-		logger:            logger,
-		Label:             "test",
-	}
-	job := BatchJob[[]float32]{ctx: context.Background(), cfg: cfg, errs: map[int]error{}, vecs: make([][]float32, 2)}
 
-	require.NotPanics(t, func() {
-		b.makeRequest(job, []string{"a", "b"}, cfg, []int{0, 1}, &modulecomponents.RateLimits{}, 2)
-	})
-	require.Error(t, job.errs[0])
-	require.Error(t, job.errs[1])
+	cases := []struct {
+		name            string
+		vectorsToReturn int
+		wantErr         []bool // per object: expect an error rather than a vector
+	}{
+		{name: "none of two", vectorsToReturn: 0, wantErr: []bool{true, true}},
+		{name: "one of two", vectorsToReturn: 1, wantErr: []bool{false, true}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Batch[[]float32]{
+				client:            &fakeShortVectorClient{vectorsToReturn: tt.vectorsToReturn},
+				rateLimitChannel:  make(chan rateLimitJob, BatchChannelSize),
+				endOfBatchChannel: make(chan endOfBatchJob, BatchChannelSize),
+				logger:            logger,
+				Label:             "test",
+			}
+			job := BatchJob[[]float32]{ctx: context.Background(), cfg: cfg, errs: map[int]error{}, vecs: make([][]float32, 2)}
+
+			require.NotPanics(t, func() {
+				b.makeRequest(job, []string{"a", "b"}, cfg, []int{0, 1}, &modulecomponents.RateLimits{}, 2)
+			})
+			for i, wantErr := range tt.wantErr {
+				if wantErr {
+					require.Error(t, job.errs[i])
+				} else {
+					require.NoError(t, job.errs[i])
+					require.NotNil(t, job.vecs[i])
+				}
+			}
+		})
+	}
 }
 
 // fakePanicClient panics for the text "panic" and vectorizes everything else. Its
@@ -549,6 +575,30 @@ func TestBatchWorkerSurvivesPanic(t *testing.T) {
 			require.NotNil(t, vecs[0])
 		})
 	}
+}
+
+// failUnresolved must error only the objects still missing a vector: a vectorized
+// object keeps its vector, a skipped object stays untouched, and an object that
+// already carries an error is not overwritten.
+func TestFailUnresolved(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	b := &Batch[[]float32]{logger: logger, Label: "test"}
+
+	preExisting := fmt.Errorf("provider rejected object")
+	job := BatchJob[[]float32]{
+		texts:      []string{"vectorized", "skipped", "missing", "already errored"},
+		skipObject: []bool{false, true, false, false},
+		vecs:       [][]float32{{0, 1, 2, 3}, nil, nil, nil},
+		errs:       map[int]error{3: preExisting},
+	}
+
+	b.failUnresolved(job)
+
+	require.NotNil(t, job.vecs[0])
+	require.NoError(t, job.errs[0])
+	require.NoError(t, job.errs[1]) // skipped object untouched
+	require.Error(t, job.errs[2])   // only the missing object gets a fresh error
+	require.Equal(t, preExisting, job.errs[3])
 }
 
 // SubmitBatchAndWait must not hang forever when a job never signals completion:


### PR DESCRIPTION
### What's being changed:

This fixes four separate bugs in the batch vectorization, each commit contains one fix:
1. Vectorizer returns less vectors than expected
2. No self-deadlock if the request is divided into more than 100 separate requests. This is currently filling up a channel and then hanging on send. The drain happens in the same function later. Now we skip sending if the channel is full
3. Clear out all reservations in case of a panic
4. Refactor moving a block of code into an extra function
5. Adds recover for ⬆️  so the worker goroutine does not die on a panic which would block vectorization until the next restart
6. Add timeout to shutdown
7. Respect context in SubmitBatchAndWait. This should not matter anymore as we should have taken care of all panics but defense in depth

Fixes https://github.com/weaviate/weaviate/issues/12043

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
