### PR TITLE
perf(usage): make shard concurrency a usage node wide constraint

### DIFF
--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -489,7 +489,7 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	}))
 	newIndex.shards.LoadAndDelete(tenantNamePopulated)
 
-	usage, err := newIndex.usageForCollection(ctx, 4, true, class.VectorConfig)
+	usage, err := newIndex.usageForCollection(ctx, NewShardReadLimiter(4), true, class.VectorConfig)
 	require.NoError(t, err)
 
 	for _, shardUsage := range usage.Shards {

--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -489,7 +490,7 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	}))
 	newIndex.shards.LoadAndDelete(tenantNamePopulated)
 
-	usage, err := newIndex.usageForCollection(ctx, NewShardReadLimiter(4), true, class.VectorConfig)
+	usage, err := newIndex.usageForCollection(ctx, semaphore.NewWeighted(4), true, class.VectorConfig)
 	require.NoError(t, err)
 
 	for _, shardUsage := range usage.Shards {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -38,8 +38,8 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-// ShardReadLimiter bounds the number of concurrent shard readers node-wide — parallel
-// UsageForIndex calls share the same limiter. Acquisition is FIFO.
+// ShardReadLimiter bounds the number of concurrent shard readers within a single usage
+// report — parallel UsageForIndex calls share the same limiter. Acquisition is FIFO.
 type ShardReadLimiter struct {
 	sem   *semaphore.Weighted
 	limit int

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -38,34 +38,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-// ShardReadLimiter bounds the number of concurrent shard readers within a single usage
-// report — parallel UsageForIndex calls share the same limiter. Acquisition is FIFO.
-type ShardReadLimiter struct {
-	sem   *semaphore.Weighted
-	limit int
-}
-
-func NewShardReadLimiter(limit int) *ShardReadLimiter {
-	if limit < 1 {
-		limit = 1
-	}
-	return &ShardReadLimiter{sem: semaphore.NewWeighted(int64(limit)), limit: limit}
-}
-
-func (l *ShardReadLimiter) Acquire(ctx context.Context) error {
-	return l.sem.Acquire(ctx, 1)
-}
-
-func (l *ShardReadLimiter) Release() {
-	l.sem.Release(1)
-}
-
-func (l *ShardReadLimiter) Limit() int {
-	return l.limit
-}
-
-// UsageForIndex computes usage for a single collection.
-func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, shardReadLimiter *ShardReadLimiter, exactObjectCount bool, vectorsConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
+// UsageForIndex computes usage for a single collection. shardReadSem bounds the number of
+// concurrent shard readers within a single usage report — parallel UsageForIndex calls share
+// the same semaphore. Acquisition is FIFO.
+func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, shardReadSem *semaphore.Weighted, exactObjectCount bool, vectorsConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
 	var (
 		index  *Index
 		exists bool
@@ -88,19 +64,18 @@ func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, sha
 		index.dropIndex.RUnlock()
 	}()
 
-	return index.usageForCollection(ctx, shardReadLimiter, exactObjectCount, vectorsConfig)
+	return index.usageForCollection(ctx, shardReadSem, exactObjectCount, vectorsConfig)
 }
 
-func (i *Index) usageForCollection(ctx context.Context, shardReadLimiter *ShardReadLimiter, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
+func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.Weighted, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
 	collectionUsage := &types.CollectionUsage{
 		Name:              i.Config.ClassName.String(),
 		ReplicationFactor: int(i.Config.ReplicationFactor),
 	}
 
-	if shardReadLimiter == nil {
-		shardReadLimiter = NewShardReadLimiter(1)
+	if shardReadSem == nil {
+		shardReadSem = semaphore.NewWeighted(1)
 	}
-	shardConcurrency := shardReadLimiter.Limit()
 
 	localShards := map[string]struct{}{}
 
@@ -123,18 +98,16 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadLimiter *ShardR
 		return nil, fmt.Errorf("schemareader: %w", err)
 	}
 
-	i.logger.WithFields(
-		logrus.Fields{
-			"class":             i.Config.ClassName.String(),
-			"shard_concurrency": shardConcurrency,
-		}).Infof("creating usage report with %d shards", len(localShards))
+	i.logger.WithField("class", i.Config.ClassName.String()).
+		Infof("creating usage report with %d shards", len(localShards))
 
 	shardNames := make([]string, 0, len(localShards))
 	for shardName := range localShards {
 		shardNames = append(shardNames, shardName)
 	}
 
-	// process the local shards with a bounded number of concurrent readers
+	// Acquiring the semaphore before spawning bounds both the concurrent shard readers and the
+	// number of goroutines: a goroutine only exists while it holds a permit.
 	var (
 		mu        sync.Mutex
 		processed atomic.Int64
@@ -142,13 +115,12 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadLimiter *ShardR
 	start := time.Now()
 
 	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
-	eg.SetLimit(shardConcurrency)
 	for _, shardName := range shardNames {
+		if err := shardReadSem.Acquire(egCtx, 1); err != nil {
+			break
+		}
 		eg.Go(func() error {
-			if err := shardReadLimiter.Acquire(egCtx); err != nil {
-				return err
-			}
-			defer shardReadLimiter.Release()
+			defer shardReadSem.Release(1)
 
 			shardUsage, err := i.usageForShard(egCtx, shardName, exactObjectCount, vectorConfig)
 			if err != nil {
@@ -167,10 +139,9 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadLimiter *ShardR
 			if count%1000 == 0 {
 				i.logger.WithFields(
 					logrus.Fields{
-						"class":             i.Config.ClassName.String(),
-						"shard_concurrency": shardConcurrency,
-						"processed_shards":  count,
-						"took":              time.Since(start).Seconds(),
+						"class":            i.Config.ClassName.String(),
+						"processed_shards": count,
+						"took":             time.Since(start).Seconds(),
 					}).Debugf("processed %d/%d shards for usage report", count, len(shardNames))
 			}
 			return nil
@@ -179,14 +150,17 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadLimiter *ShardR
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
+	// the loop may have stopped early on a cancelled parent context without any shard error
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	uniqueShardCount := int(processed.Load())
 	i.logger.WithFields(
 		logrus.Fields{
-			"class":             i.Config.ClassName.String(),
-			"shard_concurrency": shardConcurrency,
-			"processed_shards":  uniqueShardCount,
-			"took":              time.Since(start).Seconds(),
+			"class":            i.Config.ClassName.String(),
+			"processed_shards": uniqueShardCount,
+			"took":             time.Since(start).Seconds(),
 		}).Infof("finished processing %d/%d shards for usage report", uniqueShardCount, len(shardNames))
 
 	collectionUsage.UniqueShardCount = uniqueShardCount

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+
 	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
@@ -36,7 +38,34 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, shardConcurrency int, exactObjectCount bool, vectorsConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
+// ShardReadLimiter bounds the number of concurrent shard readers node-wide — parallel
+// UsageForIndex calls share the same limiter. Acquisition is FIFO.
+type ShardReadLimiter struct {
+	sem   *semaphore.Weighted
+	limit int
+}
+
+func NewShardReadLimiter(limit int) *ShardReadLimiter {
+	if limit < 1 {
+		limit = 1
+	}
+	return &ShardReadLimiter{sem: semaphore.NewWeighted(int64(limit)), limit: limit}
+}
+
+func (l *ShardReadLimiter) Acquire(ctx context.Context) error {
+	return l.sem.Acquire(ctx, 1)
+}
+
+func (l *ShardReadLimiter) Release() {
+	l.sem.Release(1)
+}
+
+func (l *ShardReadLimiter) Limit() int {
+	return l.limit
+}
+
+// UsageForIndex computes usage for a single collection.
+func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, shardReadLimiter *ShardReadLimiter, exactObjectCount bool, vectorsConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
 	var (
 		index  *Index
 		exists bool
@@ -59,18 +88,19 @@ func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, sha
 		index.dropIndex.RUnlock()
 	}()
 
-	return index.usageForCollection(ctx, shardConcurrency, exactObjectCount, vectorsConfig)
+	return index.usageForCollection(ctx, shardReadLimiter, exactObjectCount, vectorsConfig)
 }
 
-func (i *Index) usageForCollection(ctx context.Context, shardConcurrency int, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
+func (i *Index) usageForCollection(ctx context.Context, shardReadLimiter *ShardReadLimiter, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
 	collectionUsage := &types.CollectionUsage{
 		Name:              i.Config.ClassName.String(),
 		ReplicationFactor: int(i.Config.ReplicationFactor),
 	}
 
-	if shardConcurrency < 1 {
-		shardConcurrency = 1
+	if shardReadLimiter == nil {
+		shardReadLimiter = NewShardReadLimiter(1)
 	}
+	shardConcurrency := shardReadLimiter.Limit()
 
 	localShards := map[string]struct{}{}
 
@@ -115,9 +145,10 @@ func (i *Index) usageForCollection(ctx context.Context, shardConcurrency int, ex
 	eg.SetLimit(shardConcurrency)
 	for _, shardName := range shardNames {
 		eg.Go(func() error {
-			if err := egCtx.Err(); err != nil {
+			if err := shardReadLimiter.Acquire(egCtx); err != nil {
 				return err
 			}
+			defer shardReadLimiter.Release()
 
 			shardUsage, err := i.usageForShard(egCtx, shardName, exactObjectCount, vectorConfig)
 			if err != nil {

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -105,7 +106,7 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 			require.DirExists(t, shardDir, "precondition: shard dir must exist")
 			require.NoError(t, os.RemoveAll(filepath.Join(shardDir, tt.removeRelPath)))
 
-			usage, err := index.usageForCollection(ctx, NewShardReadLimiter(4), true, nil)
+			usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, nil)
 			require.NoError(t, err, "one disappearing shard must not fail the whole report")
 			require.NotNil(t, usage)
 

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -105,7 +105,7 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 			require.DirExists(t, shardDir, "precondition: shard dir must exist")
 			require.NoError(t, os.RemoveAll(filepath.Join(shardDir, tt.removeRelPath)))
 
-			usage, err := index.usageForCollection(ctx, 4, true, nil)
+			usage, err := index.usageForCollection(ctx, NewShardReadLimiter(4), true, nil)
 			require.NoError(t, err, "one disappearing shard must not fail the whole report")
 			require.NotNil(t, usage)
 

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -884,7 +884,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	newIndex.shards.LoadAndDelete(tenantNamePopulated)
 
 	// Compare active and inactive metrics
-	collectionUsage, err := newIndex.usageForCollection(ctx, 4, true, class.VectorConfig)
+	collectionUsage, err := newIndex.usageForCollection(ctx, NewShardReadLimiter(4), true, class.VectorConfig)
 	require.NoError(t, err)
 	for _, tenant := range collectionUsage.Shards {
 		if tenant.Name == tenantNamePopulated {

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
@@ -884,7 +885,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	newIndex.shards.LoadAndDelete(tenantNamePopulated)
 
 	// Compare active and inactive metrics
-	collectionUsage, err := newIndex.usageForCollection(ctx, NewShardReadLimiter(4), true, class.VectorConfig)
+	collectionUsage, err := newIndex.usageForCollection(ctx, semaphore.NewWeighted(4), true, class.VectorConfig)
 	require.NoError(t, err)
 	for _, tenant := range collectionUsage.Shards {
 		if tenant.Name == tenantNamePopulated {

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -85,14 +85,11 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 		Backups:     make([]*types.BackupUsage, 0),
 	}
 
-	shardConcurrency := int(s.shardConcurrency.Load())
-	if shardConcurrency < 1 {
-		shardConcurrency = 1
-	}
-	// The limiter is shared by all collections, bounding concurrent shard readers node-wide at
-	// shardConcurrency. Up to shardConcurrency collections are in flight at once, so spare
+	// The limiter is shared by all collections of this report, bounding concurrent shard readers
+	// at shardConcurrency. Up to shardConcurrency collections are in flight at once, so spare
 	// capacity left by one collection is used by the shards of the next.
-	shardReadLimiter := db.NewShardReadLimiter(shardConcurrency)
+	shardReadLimiter := db.NewShardReadLimiter(int(s.shardConcurrency.Load()))
+	shardConcurrency := shardReadLimiter.Limit()
 
 	s.logger.Infof("Creating usage report with %d collections", len(collections))
 	var mu sync.Mutex

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/schema"
+	"golang.org/x/sync/semaphore"
 )
 
 // DefaultShardConcurrency is the default number of shards processed concurrently while collecting usage.
@@ -85,11 +86,11 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 		Backups:     make([]*types.BackupUsage, 0),
 	}
 
-	// The limiter is shared by all collections of this report, bounding concurrent shard readers
-	// at shardConcurrency. Up to shardConcurrency collections are in flight at once, so spare
-	// capacity left by one collection is used by the shards of the next.
-	shardReadLimiter := db.NewShardReadLimiter(int(s.shardConcurrency.Load()))
-	shardConcurrency := shardReadLimiter.Limit()
+	// The semaphore is shared by all collections of this report, bounding concurrent shard
+	// readers at shardConcurrency. Up to shardConcurrency collections are in flight at once,
+	// so spare capacity left by one collection is used by the shards of the next.
+	shardConcurrency := int(s.shardConcurrency.Load())
+	shardReadSem := semaphore.NewWeighted(int64(shardConcurrency))
 
 	s.logger.Infof("Creating usage report with %d collections", len(collections))
 	var mu sync.Mutex
@@ -101,7 +102,7 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 			if err != nil {
 				return fmt.Errorf("collection %s: %w", collection.Class, err)
 			}
-			collectionUsage, err := s.db.UsageForIndex(egCtx, entschema.ClassName(collection.Class), shardReadLimiter, exactObjectCount, vectorConfig)
+			collectionUsage, err := s.db.UsageForIndex(egCtx, entschema.ClassName(collection.Class), shardReadSem, exactObjectCount, vectorConfig)
 			// we lock the local index against being deleted while we collect usage, however we cannot lock the RAFT schema
 			// against being changed. If the class was deleted in the RAFT schema, we simply skip it here
 			// as it is no longer relevant for the current node usage

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	backupent "github.com/weaviate/weaviate/entities/backup"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	entschema "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/usecases/backup"
@@ -83,28 +85,47 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 		Backups:     make([]*types.BackupUsage, 0),
 	}
 
-	s.logger.Infof("Creating usage report with %d collections", len(collections))
-	// Collect usage for each collection
-	for _, collection := range collections {
-		vectorConfig, err := config.ExtractVectorConfigs(collection)
-		if err != nil {
-			return nil, fmt.Errorf("collection %s: %w", collection.Class, err)
-		}
-		collectionUsage, err := s.db.UsageForIndex(ctx, entschema.ClassName(collection.Class), int(s.shardConcurrency.Load()), exactObjectCount, vectorConfig)
-		// we lock the local index against being deleted while we collect usage, however we cannot lock the RAFT schema
-		// against being changed. If the class was deleted in the RAFT schema, we simply skip it here
-		// as it is no longer relevant for the current node usage
-		if errors.Is(err, clusterSchema.ErrClassNotFound) {
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("collection %s: %w", collection.Class, err)
-		}
-		if collectionUsage == nil {
-			continue
-		}
+	shardConcurrency := int(s.shardConcurrency.Load())
+	if shardConcurrency < 1 {
+		shardConcurrency = 1
+	}
+	// The limiter is shared by all collections, bounding concurrent shard readers node-wide at
+	// shardConcurrency. Up to shardConcurrency collections are in flight at once, so spare
+	// capacity left by one collection is used by the shards of the next.
+	shardReadLimiter := db.NewShardReadLimiter(shardConcurrency)
 
-		usage.Collections = append(usage.Collections, collectionUsage)
+	s.logger.Infof("Creating usage report with %d collections", len(collections))
+	var mu sync.Mutex
+	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(s.logger, ctx)
+	eg.SetLimit(shardConcurrency)
+	for _, collection := range collections {
+		eg.Go(func() error {
+			vectorConfig, err := config.ExtractVectorConfigs(collection)
+			if err != nil {
+				return fmt.Errorf("collection %s: %w", collection.Class, err)
+			}
+			collectionUsage, err := s.db.UsageForIndex(egCtx, entschema.ClassName(collection.Class), shardReadLimiter, exactObjectCount, vectorConfig)
+			// we lock the local index against being deleted while we collect usage, however we cannot lock the RAFT schema
+			// against being changed. If the class was deleted in the RAFT schema, we simply skip it here
+			// as it is no longer relevant for the current node usage
+			if errors.Is(err, clusterSchema.ErrClassNotFound) {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("collection %s: %w", collection.Class, err)
+			}
+			if collectionUsage == nil {
+				return nil
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			usage.Collections = append(usage.Collections, collectionUsage)
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	sort.Sort(usage.Collections)
 

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -698,6 +698,82 @@ func TestService_Usage_MultipleCollectionsConcurrent(t *testing.T) {
 	mockBackupProvider.AssertExpectations(t)
 }
 
+// TestService_Usage_MultipleCollectionsError verifies that a failing collection fails the whole
+// report with a wrapped error, also when collections are processed concurrently.
+func TestService_Usage_MultipleCollectionsError(t *testing.T) {
+	ctx := context.Background()
+
+	nodeName := "test-node"
+	shardName := "shard1"
+	vectorName := "vec"
+
+	classNames := []string{"ColA", "ColB", "ColC"}
+	classes := make([]*models.Class, len(classNames))
+	for i, name := range classNames {
+		classes[i] = &models.Class{
+			Class:             name,
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+			VectorConfig:      map[string]models.VectorConfig{vectorName: {VectorIndexConfig: hnsw.UserConfig{}}},
+		}
+	}
+
+	shardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			shardName: {
+				Name:           shardName,
+				BelongsToNodes: []string{nodeName},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+	}
+	shardingState.SetLocalName(nodeName)
+
+	var usageStarted atomic.Bool
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(className string, _ bool, fn func(*models.Class, *sharding.State) error) error {
+			if usageStarted.Load() && className == "ColB" {
+				return fmt.Errorf("schema read exploded")
+			}
+			return fn(nil, shardingState)
+		},
+	)
+
+	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
+	mockSchemaGetter.EXPECT().GetSchemaSkipAuth().Return(entschema.Schema{
+		Objects: &models.Schema{Classes: classes},
+	})
+	for _, class := range classes {
+		mockSchemaGetter.EXPECT().ReadOnlyClass(class.Class).Return(class)
+	}
+	mockSchemaGetter.EXPECT().ShardFromUUID(mock.Anything, mock.Anything).Return(shardName)
+	mockSchemaGetter.EXPECT().NodeName().Return(nodeName)
+
+	mockBackupProvider := backupusecase.NewMockBackupBackendProvider(t)
+
+	repo := createTestDb(t, mockSchemaGetter, shardingState, nil, nodeName)
+	logger, _ := logrus.NewNullLogger()
+	migrator := db.NewMigrator(repo, logger, nodeName)
+	for _, class := range classes {
+		require.NoError(t, migrator.LoadShard(ctx, class.Class, shardName))
+		putObjectAndFlush(t, repo, class.Class, "", map[string][]float32{vectorName: {0.1, 0.2, 0.3}})
+	}
+	repo.Shutdown(ctx)
+	repo.SetSchemaReader(mockSchemaReader)
+	require.Nil(t, repo.WaitForStartup(context.Background()))
+
+	service := NewService(mockSchemaGetter, repo, mockBackupProvider, logger)
+	service.SetShardConcurrency(len(classes))
+
+	usageStarted.Store(true)
+	result, err := service.Usage(ctx, true)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "collection ColB")
+	assert.ErrorContains(t, err, "schema read exploded")
+	assert.Nil(t, result)
+}
+
 func createTestDb(t *testing.T, sg schemaUC.SchemaGetter, shardingState *sharding.State, class *models.Class, nodeName string) *db.DB {
 	mockNodeSelector := cluster.NewMockNodeSelector(t)
 	mockNodeSelector.EXPECT().LocalName().Return(nodeName).Maybe()

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -13,9 +13,11 @@ package usage
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -590,6 +592,109 @@ func TestService_Usage_NilVectorIndexConfig(t *testing.T) {
 	assert.Nil(t, shard.NamedVectors)
 
 	mockSchema.AssertExpectations(t)
+	mockBackupProvider.AssertExpectations(t)
+}
+
+// TestService_Usage_MultipleCollectionsConcurrent verifies that with shard concurrency >=
+// collection count, all collections are processed at the same time: every per-collection
+// schemaReader.Read blocks on a barrier that only opens once all collections have entered it.
+// Serial processing would never open the barrier and fail the test via the Read timeout.
+func TestService_Usage_MultipleCollectionsConcurrent(t *testing.T) {
+	ctx := context.Background()
+
+	nodeName := "test-node"
+	shardName := "shard1"
+	vectorName := "vec"
+
+	classNames := []string{"ColA", "ColB", "ColC", "ColD", "ColE", "ColF"}
+	classes := make([]*models.Class, len(classNames))
+	for i, name := range classNames {
+		classes[i] = &models.Class{
+			Class:             name,
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+			VectorConfig:      map[string]models.VectorConfig{vectorName: {VectorIndexConfig: hnsw.UserConfig{}}},
+		}
+	}
+
+	shardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			shardName: {
+				Name:           shardName,
+				BelongsToNodes: []string{nodeName},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+	}
+	shardingState.SetLocalName(nodeName)
+
+	// the barrier only applies to Reads issued by service.Usage — startup paths also call Read
+	var (
+		usageStarted atomic.Bool
+		entered      atomic.Int64
+		barrier      = make(chan struct{})
+	)
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ string, _ bool, fn func(*models.Class, *sharding.State) error) error {
+			if usageStarted.Load() {
+				if entered.Add(1) == int64(len(classes)) {
+					close(barrier)
+				}
+				select {
+				case <-barrier:
+				case <-time.After(30 * time.Second):
+					return fmt.Errorf("collections are not processed concurrently: %d/%d in flight",
+						entered.Load(), len(classes))
+				}
+			}
+			return fn(nil, shardingState)
+		},
+	)
+
+	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
+	mockSchemaGetter.EXPECT().GetSchemaSkipAuth().Return(entschema.Schema{
+		Objects: &models.Schema{Classes: classes},
+	})
+	for _, class := range classes {
+		mockSchemaGetter.EXPECT().ReadOnlyClass(class.Class).Return(class)
+	}
+	mockSchemaGetter.EXPECT().ShardFromUUID(mock.Anything, mock.Anything).Return(shardName)
+	mockSchemaGetter.EXPECT().NodeName().Return(nodeName)
+
+	mockBackupProvider := backupusecase.NewMockBackupBackendProvider(t)
+	mockBackupProvider.EXPECT().EnabledBackupBackends().Return([]modulecapabilities.BackupBackend{})
+
+	// createTestDb's startup already created an index per schema class
+	repo := createTestDb(t, mockSchemaGetter, shardingState, nil, nodeName)
+	logger, _ := logrus.NewNullLogger()
+	migrator := db.NewMigrator(repo, logger, nodeName)
+	for _, class := range classes {
+		require.NoError(t, migrator.LoadShard(ctx, class.Class, shardName))
+		putObjectAndFlush(t, repo, class.Class, "", map[string][]float32{vectorName: {0.1, 0.2, 0.3}})
+	}
+	repo.Shutdown(ctx)
+	repo.SetSchemaReader(mockSchemaReader)
+	require.Nil(t, repo.WaitForStartup(context.Background()))
+
+	service := NewService(mockSchemaGetter, repo, mockBackupProvider, logger)
+	service.SetShardConcurrency(len(classes))
+
+	usageStarted.Store(true)
+	result, err := service.Usage(ctx, true)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Collections, len(classes))
+	for i, name := range classNames {
+		collection := result.Collections[i]
+		assert.Equal(t, name, collection.Name)
+		assert.Equal(t, 1, collection.UniqueShardCount)
+		require.Len(t, collection.Shards, 1)
+		assert.Equal(t, shardName, collection.Shards[0].Name)
+		assert.Equal(t, int64(1), collection.Shards[0].ObjectsCount)
+	}
+
+	mockSchemaGetter.AssertExpectations(t)
 	mockBackupProvider.AssertExpectations(t)
 }
 

--- a/usecases/modulecomponents/usage/base_module_test.go
+++ b/usecases/modulecomponents/usage/base_module_test.go
@@ -29,9 +29,9 @@ import (
 	configruntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
-// TestBaseModule_EnvShardConcurrencyReachesService verifies USAGE_SHARD_CONCURRENCY reaches
+// TestBaseModule_EnvConcurrencyReachesService verifies USAGE_SHARD_CONCURRENCY reaches
 // the usage service regardless of whether the service is wired before or after module Init.
-func TestBaseModule_EnvShardConcurrencyReachesService(t *testing.T) {
+func TestBaseModule_EnvConcurrencyReachesService(t *testing.T) {
 	t.Setenv("USAGE_SHARD_CONCURRENCY", "3")
 
 	mockStorage := NewMockStorageBackend(t)
@@ -54,10 +54,10 @@ func TestBaseModule_EnvShardConcurrencyReachesService(t *testing.T) {
 	assert.Equal(t, 3, module.shardConcurrency)
 }
 
-// TestBaseModule_RuntimeOverridesShardConcurrencyReachesService exercises the full runtime
+// TestBaseModule_RuntimeOverridesConcurrencyReachesService exercises the full runtime
 // overrides chain: overrides file → ConfigManager → shared DynamicValue → module reloadConfig
 // → usage service.
-func TestBaseModule_RuntimeOverridesShardConcurrencyReachesService(t *testing.T) {
+func TestBaseModule_RuntimeOverridesConcurrencyReachesService(t *testing.T) {
 	overridesPath := filepath.Join(t.TempDir(), "overrides.yaml")
 	require.NoError(t, os.WriteFile(overridesPath, []byte(""), 0o644))
 


### PR DESCRIPTION
### What's being changed:

Added possibility of collecting shards concurrently node-wide when generating usage metrics.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
