### PR TITLE
fix(concurrency): thread per-query budget into sroar merge fan-out (P1a)

### DIFF
--- a/adapters/repos/db/aggregator/unfiltered_type_specific.go
+++ b/adapters/repos/db/aggregator/unfiltered_type_specific.go
@@ -44,7 +44,7 @@ func (ua unfilteredAggregator) boolProperty(ctx context.Context,
 			return ua.parseAndAddBoolRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSetCtx(ctx)} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
@@ -160,7 +160,7 @@ func (ua unfilteredAggregator) floatProperty(ctx context.Context,
 			return ua.parseAndAddFloatRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSetCtx(ctx)} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
@@ -199,7 +199,7 @@ func (ua unfilteredAggregator) intProperty(ctx context.Context,
 			return ua.parseAndAddIntRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSetCtx(ctx)} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {
@@ -238,7 +238,7 @@ func (ua unfilteredAggregator) dateProperty(ctx context.Context,
 			return ua.parseAndAddDateRowRoaringSet(agg, k, b)
 		}
 
-		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSet()} }, extract, ua.logger); err != nil {
+		if err := iteratorConcurrently(ctx, b, func() Cursor { return RoaringCursor{b.CursorRoaringSetCtx(ctx)} }, extract, ua.logger); err != nil {
 			return nil, err
 		}
 	} else {

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -518,9 +518,10 @@ func (b *BM25Searcher) createTerm(N float64, filterDocIds helpers.AllowList, que
 	}
 
 	if filterDocIds != nil {
+		mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 		for _, docIDs := range filteredDocIDsThread {
 			if docIDs != nil {
-				filteredDocIDs.OrConc(docIDs, concurrency.SROAR_MERGE)
+				filteredDocIDs.OrConc(docIDs, mergeConc)
 			}
 		}
 	}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -100,9 +100,14 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 	resultCh := make(chan *docBitmap, 1) // merge result
 	var err error
 
+	// the merge goroutine runs concurrently with child resolution (which halves
+	// the budget per level), so cap it at the parent-level budget: a deliberate
+	// mild overshoot rather than trying to track the children's fractional split
+	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+
 	// merge subresults in separate goroutine using dbmCh (in) and resultCh (out)
 	enterrors.GoWrapper(func() {
-		processDocIDs(maxN, pv.operator, dbmCh, resultCh)
+		processDocIDs(maxN, pv.operator, dbmCh, resultCh, mergeConc)
 	}, s.logger)
 
 	outerConcurrencyLimit := concurrency.BudgetFromCtx(ctx, concurrency.GOMAXPROCS)
@@ -187,7 +192,7 @@ func (pv *propValuePair) resolveDocIDsNot(ctx context.Context, s *Searcher) (*do
 
 // processDocIDs merges received from dbmCh channel docBitmaps and sends result to resultCh channel.
 // Children are merged in batches of size [maxN]
-func processDocIDs(maxN int, operator filters.Operator, dbmCh <-chan *docBitmap, resultCh chan<- *docBitmap) {
+func processDocIDs(maxN int, operator filters.Operator, dbmCh <-chan *docBitmap, resultCh chan<- *docBitmap, maxConc int) {
 	dbms := make([]*docBitmap, 0, maxN)
 	var result *docBitmap
 	defer func() {
@@ -202,17 +207,17 @@ func processDocIDs(maxN int, operator filters.Operator, dbmCh <-chan *docBitmap,
 		dbms = append(dbms, dbm)
 		// merge if [maxN] children is received
 		if len(dbms) == maxN {
-			dbms = mergeDocIDs(operator, dbms)
+			dbms = mergeDocIDs(operator, dbms, maxConc)
 		}
 	}
 	// merge remaining children
-	if dbms = mergeDocIDs(operator, dbms); len(dbms) > 0 {
+	if dbms = mergeDocIDs(operator, dbms, maxConc); len(dbms) > 0 {
 		// merged result is first element of docBitmaps slice
 		result = dbms[0]
 	}
 }
 
-func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator) *docBitmap {
+func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator, maxConc int) *docBitmap {
 	//	- both A and B are denylists
 	//	  !A  or !B -> !(A and B) -> denylist A.And(B)
 	//	  !A and !B -> !(A  or B) -> denylist A.Or(B)
@@ -257,10 +262,10 @@ func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator) *
 		// !A  or !B -> !(A and B) -> denylist A.And(B)
 		if operator == filters.OperatorAnd {
 			swapForEfficiency(filters.OperatorOr)
-			a.docIDs.OrConc(b.docIDs, concurrency.SROAR_MERGE)
+			a.docIDs.OrConc(b.docIDs, maxConc)
 		} else {
 			swapForEfficiency(filters.OperatorAnd)
-			a.docIDs.AndConc(b.docIDs, concurrency.SROAR_MERGE)
+			a.docIDs.AndConc(b.docIDs, maxConc)
 		}
 
 	case a.IsDenyList() || b.IsDenyList():
@@ -272,19 +277,19 @@ func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator) *
 		// !A and B -> allowlist B.AndNot(A)
 		// !A  or B -> denylist  A.AndNot(B)
 		if operator == filters.OperatorAnd {
-			b.docIDs.AndNotConc(a.docIDs, concurrency.SROAR_MERGE)
+			b.docIDs.AndNotConc(a.docIDs, maxConc)
 			a, b = b, a // a=result(allowlist), b=old denylist(released by defer)
 		} else {
-			a.docIDs.AndNotConc(b.docIDs, concurrency.SROAR_MERGE)
+			a.docIDs.AndNotConc(b.docIDs, maxConc)
 		}
 
 	default:
 		// Both allowlists.
 		swapForEfficiency(operator)
 		if operator == filters.OperatorAnd {
-			a.docIDs.AndConc(b.docIDs, concurrency.SROAR_MERGE)
+			a.docIDs.AndConc(b.docIDs, maxConc)
 		} else {
-			a.docIDs.OrConc(b.docIDs, concurrency.SROAR_MERGE)
+			a.docIDs.OrConc(b.docIDs, maxConc)
 		}
 	}
 	return a
@@ -296,13 +301,13 @@ func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator) *
 // If slice of size 0 or 1 is provided, it is returned without any change.
 // Merge is performed starting from bitmap with most containers for OR operator
 // or starting from bitmap with least containers for AND operator.
-func mergeDocIDs(operator filters.Operator, dbms []*docBitmap) []*docBitmap {
+func mergeDocIDs(operator filters.Operator, dbms []*docBitmap, maxConc int) []*docBitmap {
 	if len(dbms) <= 1 {
 		return dbms
 	}
 
 	for i := 0; i < len(dbms)-1; i++ {
-		dbms[0] = mergeBitmapsAndOrWithDenyList(dbms[0], dbms[i+1], operator)
+		dbms[0] = mergeBitmapsAndOrWithDenyList(dbms[0], dbms[i+1], operator, maxConc)
 	}
 
 	return dbms[:1]

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -100,9 +100,9 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 	resultCh := make(chan *docBitmap, 1) // merge result
 	var err error
 
-	// the merge goroutine runs concurrently with child resolution (which halves
-	// the budget per level), so cap it at the parent-level budget: a deliberate
-	// mild overshoot rather than trying to track the children's fractional split
+	// merge runs alongside child resolution, which already splits the ctx
+	// budget across children: deliberate mild overshoot, as in
+	// roaringsetrange/reader.go
 	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
 	// merge subresults in separate goroutine using dbmCh (in) and resultCh (out)

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -100,9 +100,8 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 	resultCh := make(chan *docBitmap, 1) // merge result
 	var err error
 
-	// merge runs alongside child resolution, which already splits the ctx
-	// budget across children: deliberate mild overshoot, as in
-	// roaringsetrange/reader.go
+	// merge runs alongside child resolution, which already splits the budget
+	// across children: deliberate mild overshoot (mirrors roaringsetrange/reader.go).
 	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
 	// merge subresults in separate goroutine using dbmCh (in) and resultCh (out)

--- a/adapters/repos/db/inverted/row_reader_roaring_set.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set.go
@@ -26,8 +26,8 @@ import (
 type RowReaderRoaringSet struct {
 	value      []byte
 	operator   filters.Operator
-	newCursor  func() lsmkv.CursorRoaringSet
-	getter     func(key []byte) (*sroar.Bitmap, func(), error)
+	newCursor  func(context.Context) lsmkv.CursorRoaringSet
+	getter     func(ctx context.Context, key []byte) (*sroar.Bitmap, func(), error)
 	isDenyList bool
 }
 
@@ -38,9 +38,9 @@ func NewRowReaderRoaringSet(bucket *lsmkv.Bucket, value []byte, operator filters
 	keyOnly bool,
 ) *RowReaderRoaringSet {
 	getter := bucket.RoaringSetGet
-	newCursor := bucket.CursorRoaringSet
+	newCursor := bucket.CursorRoaringSetCtx
 	if keyOnly {
-		newCursor = bucket.CursorRoaringSetKeyOnly
+		newCursor = bucket.CursorRoaringSetKeyOnlyCtx
 	}
 
 	return &RowReaderRoaringSet{
@@ -116,7 +116,7 @@ func (rr *RowReaderRoaringSet) notEqual(ctx context.Context,
 func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 	readFn ReadFn, allowEqual bool,
 ) error {
-	c := rr.newCursor()
+	c := rr.newCursor(ctx)
 	defer c.Close()
 
 	for k, v := c.Seek(rr.value); k != nil; k, v = c.Next() {
@@ -144,7 +144,7 @@ func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 func (rr *RowReaderRoaringSet) lessThan(ctx context.Context,
 	readFn ReadFn, allowEqual bool,
 ) error {
-	c := rr.newCursor()
+	c := rr.newCursor(ctx)
 	defer c.Close()
 
 	for k, v := c.First(); k != nil && bytes.Compare(k, rr.value) < 1; k, v = c.Next() {
@@ -174,7 +174,7 @@ func (rr *RowReaderRoaringSet) like(ctx context.Context,
 		return fmt.Errorf("parse like value: %w", err)
 	}
 
-	c := rr.newCursor()
+	c := rr.newCursor(ctx)
 	defer c.Close()
 
 	var (
@@ -227,5 +227,5 @@ func (rr *RowReaderRoaringSet) equalHelper(ctx context.Context) (*sroar.Bitmap, 
 		return nil, noopRelease, err
 	}
 
-	return rr.getter(rr.value)
+	return rr.getter(ctx, rr.value)
 }

--- a/adapters/repos/db/inverted/row_reader_roaring_set_test.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set_test.go
@@ -285,8 +285,8 @@ func createRowReaderRoaringSet(value []byte, operator filters.Operator, data []k
 	return &RowReaderRoaringSet{
 		value:     value,
 		operator:  operator,
-		newCursor: func() lsmkv.CursorRoaringSet { return &dummyCursorRoaringSet{data: data} },
-		getter: func(key []byte) (*sroar.Bitmap, func(), error) {
+		newCursor: func(context.Context) lsmkv.CursorRoaringSet { return &dummyCursorRoaringSet{data: data} },
+		getter: func(_ context.Context, key []byte) (*sroar.Bitmap, func(), error) {
 			for i := 0; i < len(data); i++ {
 				if bytes.Equal([]byte(data[i].k), key) {
 					return roaringset.NewBitmap(data[i].v...), noopRelease, nil

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -258,7 +258,7 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	// invert once at the end if it's a deny list, to avoid multiple inversions in case of nested ORs
 	if dbm.isDenyList {
 		universe, universeRelease := s.bitmapFactory.GetBitmap()
-		universe.AndNotConc(dbm.docIDs, concurrency.SROAR_MERGE)
+		universe.AndNotConc(dbm.docIDs, concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE))
 		dbm.release()
 		return helpers.NewAllowListCloseableFromBitmap(universe, universeRelease), nil
 	}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -80,14 +80,14 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
+	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 	var readFn ReadFn = func(k []byte, docIDs *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = docIDs
 			out.release = release
 			isEmpty = false
 		} else {
-			concurrencyBudget := concurrency.BudgetFromCtx(ctx, concurrency.SROAR_MERGE)
-			out.docIDs.OrConc(docIDs, concurrencyBudget)
+			out.docIDs.OrConc(docIDs, mergeConc)
 			release()
 		}
 
@@ -135,14 +135,14 @@ func (s *Searcher) docBitmapInvertedSet(ctx context.Context, b *lsmkv.Bucket,
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
+	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = ids
 			out.release = release
 			isEmpty = false
 		} else {
-			concurrencyBudget := concurrency.BudgetFromCtx(ctx, concurrency.SROAR_MERGE)
-			out.docIDs.OrConc(ids, concurrencyBudget)
+			out.docIDs.OrConc(ids, mergeConc)
 			release()
 		}
 
@@ -169,14 +169,14 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 ) (docBitmap, error) {
 	out := newUninitializedDocBitmap()
 	isEmpty := true
+	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 	var readFn ReadFn = func(k []byte, ids *sroar.Bitmap, release func()) (bool, error) {
 		if isEmpty {
 			out.docIDs = ids
 			out.release = release
 			isEmpty = false
 		} else {
-			concurrencyBudget := concurrency.BudgetFromCtx(ctx, concurrency.SROAR_MERGE)
-			out.docIDs.OrConc(ids, concurrencyBudget)
+			out.docIDs.OrConc(ids, mergeConc)
 			release()
 		}
 

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
@@ -57,9 +57,13 @@ func TestDocBitmapInvertedRoaringSet_RowMergeBudget(t *testing.T) {
 	require.Len(t, defaultIDs, numRoaringRows*idsPerRow)
 
 	t.Run("goroutine ceiling under budget-1", func(t *testing.T) {
+		// CI implication: the kill-switch CI leg (DISABLE_SROAR_MERGE_BUDGET=true)
+		// skips this bound by design and serves as the red control instead.
 		if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 			t.Skip("budget cap disabled via kill switch")
 		}
+		// CI implication: 2-vCPU runners have SROAR_MERGE=1 and skip this entirely;
+		// the bound is only exercised on >=4-vCPU runners (SROAR_MERGE>=2).
 		if concurrency.SROAR_MERGE < 2 {
 			t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 				concurrency.SROAR_MERGE)

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
@@ -57,21 +57,28 @@ func TestDocBitmapInvertedRoaringSet_RowMergeBudget(t *testing.T) {
 	require.Len(t, defaultIDs, numRoaringRows*idsPerRow)
 
 	t.Run("goroutine ceiling under budget-1", func(t *testing.T) {
-		// CI implication: the kill-switch CI leg (DISABLE_SROAR_MERGE_BUDGET=true)
-		// skips this bound by design and serves as the red control instead.
+		// The kill switch (DISABLE_SROAR_MERGE_BUDGET=true) is this bound's red
+		// control, but it is a manual/local check: run with the env var set and
+		// this skip bypassed, and the ceiling assertion below must fail. No CI job
+		// sets the kill switch, so CI exercises only the green (budget-enforced) leg.
 		if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 			t.Skip("budget cap disabled via kill switch")
 		}
-		// CI implication: 2-vCPU runners have SROAR_MERGE=1 and skip this entirely;
-		// the bound is only exercised on >=4-vCPU runners (SROAR_MERGE>=2).
+		// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4). Skipping on a
+		// <4-vCPU runner would silently evaporate the guard, so fail loudly on CI
+		// and only skip on dev machines.
 		if concurrency.SROAR_MERGE < 2 {
+			if os.Getenv("CI") != "" {
+				t.Fatalf("bounding tests require GOMAXPROCS>=4, refusing to skip silently on CI (SROAR_MERGE=%d)",
+					concurrency.SROAR_MERGE)
+			}
 			t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 				concurrency.SROAR_MERGE)
 		}
 
 		budget1 := concurrency.CtxWithBudget(ctx, 1)
 		// budget=1 spawns no extra workers; slack absorbs sampler/GC noise
-		testinghelpers.AssertGoroutineCeiling(t, 8, 1, 8, 200*time.Millisecond, func() error {
+		testinghelpers.AssertGoroutineCeiling(t, numMergeWorkers, 1, 8, 200*time.Millisecond, func() error {
 			s := &Searcher{}
 			bm, err := s.docBitmapInvertedRoaringSet(budget1, b, 0, pv)
 			if err != nil {
@@ -84,8 +91,11 @@ func TestDocBitmapInvertedRoaringSet_RowMergeBudget(t *testing.T) {
 }
 
 const (
-	numRoaringRows = 32
-	idsPerRow      = 200
+	numRoaringRows     = 32
+	containersPerRow   = 128
+	valuesPerContainer = 128
+	idsPerRow          = containersPerRow * valuesPerContainer
+	numMergeWorkers    = 24
 )
 
 // buildMultiRowRoaringSetBucket builds a bucket with enough rows and
@@ -105,10 +115,18 @@ func buildMultiRowRoaringSetBucket(t *testing.T, ctx context.Context) *lsmkv.Buc
 
 	b.SetMemtableThreshold(1e9) // no auto-flush; keep the fixture deterministic
 
+	// Each row spans containersPerRow sroar containers (stride 2^16), each
+	// holding valuesPerContainer values. Dense containers make every OrConc
+	// merge real work, so the extra worker an ignored budget spawns lives
+	// across several 1ms sampler ticks instead of finishing between them.
+	// Low-16 bits are blocked per row (row*valuesPerContainer + j) so every
+	// value across the whole fixture is distinct: cardinality == rows*idsPerRow.
 	for row := 0; row < numRoaringRows; row++ {
-		values := make([]uint64, idsPerRow)
-		for i := range values {
-			values[i] = uint64(i)<<16 + uint64(row)
+		values := make([]uint64, 0, idsPerRow)
+		for c := 0; c < containersPerRow; c++ {
+			for j := 0; j < valuesPerContainer; j++ {
+				values = append(values, uint64(c)<<16+uint64(row*valuesPerContainer+j))
+			}
 		}
 		require.NoError(t, b.RoaringSetAddList([]byte(fmt.Sprintf("k%03d", row)), values))
 	}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
@@ -1,0 +1,123 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/concurrency/testinghelpers"
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+// TestDocBitmapInvertedRoaringSet_RowMergeBudget pins the row-merge path in
+// docBitmapInvertedRoaringSet: a >= filter that spans many rows unions each
+// row bitmap via OrConc(_, mergeConc). Two guarantees:
+//   - equivalence: a budget-1 query returns the exact same docIDs as an
+//     unconstrained one (the budget bounds merge concurrency, never the result)
+//   - ceiling: under budget-1 the per-row merge spawns no workers, so the path
+//     holds only its own goroutine
+func TestDocBitmapInvertedRoaringSet_RowMergeBudget(t *testing.T) {
+	ctx := context.Background()
+	b := buildMultiRowRoaringSetBucket(t, ctx)
+
+	// GreaterThanEqual from the lowest key walks every row, so the readFn runs
+	// numKeys-1 OrConc merges into the accumulated result
+	pv := &propValuePair{
+		operator: filters.OperatorGreaterThanEqual,
+		value:    []byte("k000"),
+	}
+
+	run := func(queryCtx context.Context) []uint64 {
+		s := &Searcher{} // RoaringSet path dereferences no Searcher fields
+		bm, err := s.docBitmapInvertedRoaringSet(queryCtx, b, 0, pv)
+		require.NoError(t, err)
+		defer bm.release()
+		return bm.docIDs.ToArray()
+	}
+
+	defaultIDs := run(ctx)
+	budget1IDs := run(concurrency.CtxWithBudget(ctx, 1))
+
+	require.Equal(t, defaultIDs, budget1IDs)
+	// guard the fixture: the merge must actually union every row
+	require.Len(t, defaultIDs, numRoaringRows*idsPerRow)
+
+	t.Run("goroutine ceiling under budget-1", func(t *testing.T) {
+		if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
+			t.Skip("budget cap disabled via kill switch")
+		}
+		if concurrency.SROAR_MERGE < 2 {
+			t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
+				concurrency.SROAR_MERGE)
+		}
+
+		budget1 := concurrency.CtxWithBudget(ctx, 1)
+		// budget=1 => each OrConc spawns no workers, so an in-flight query holds
+		// only its own goroutine; slack absorbs sampler and runtime/GC noise
+		testinghelpers.AssertGoroutineCeiling(t, 8, 1, 8, 200*time.Millisecond, func() error {
+			s := &Searcher{}
+			bm, err := s.docBitmapInvertedRoaringSet(budget1, b, 0, pv)
+			if err != nil {
+				return err
+			}
+			bm.release()
+			return nil
+		})
+	})
+}
+
+const (
+	numRoaringRows = 32
+	idsPerRow      = 200
+)
+
+// buildMultiRowRoaringSetBucket creates a real RoaringSet bucket with
+// numRoaringRows keys, each carrying idsPerRow docIDs spread across as many
+// sroar containers (stride 2^16). Distinct docIDs per row so the union grows,
+// enough containers that an unconstrained merge would want >1 worker.
+func buildMultiRowRoaringSetBucket(t *testing.T, ctx context.Context) *lsmkv.Bucket {
+	t.Helper()
+
+	logger, _ := test.NewNullLogger()
+	tmpDir := t.TempDir()
+
+	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	b.SetMemtableThreshold(1e9) // no auto-flush; keep the fixture deterministic
+
+	for row := 0; row < numRoaringRows; row++ {
+		values := make([]uint64, idsPerRow)
+		for i := range values {
+			values[i] = uint64(i)<<16 + uint64(row)
+		}
+		require.NoError(t, b.RoaringSetAddList([]byte(fmt.Sprintf("k%03d", row)), values))
+	}
+	require.NoError(t, b.FlushAndSwitch())
+
+	return b
+}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
@@ -57,16 +57,13 @@ func TestDocBitmapInvertedRoaringSet_RowMergeBudget(t *testing.T) {
 	require.Len(t, defaultIDs, numRoaringRows*idsPerRow)
 
 	t.Run("goroutine ceiling under budget-1", func(t *testing.T) {
-		// The kill switch (DISABLE_SROAR_MERGE_BUDGET=true) is this bound's red
-		// control, but it is a manual/local check: run with the env var set and
-		// this skip bypassed, and the ceiling assertion below must fail. No CI job
-		// sets the kill switch, so CI exercises only the green (budget-enforced) leg.
+		// Kill switch is this bound's red control, but no CI job sets it: CI
+		// only ever runs the green (budget-enforced) path.
 		if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 			t.Skip("budget cap disabled via kill switch")
 		}
-		// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4). Skipping on a
-		// <4-vCPU runner would silently evaporate the guard, so fail loudly on CI
-		// and only skip on dev machines.
+		// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4); skipping
+		// here silently would hide the guard, so CI fails loudly instead.
 		if concurrency.SROAR_MERGE < 2 {
 			if os.Getenv("CI") != "" {
 				t.Fatalf("bounding tests require GOMAXPROCS>=4, refusing to skip silently on CI (SROAR_MERGE=%d)",
@@ -115,12 +112,9 @@ func buildMultiRowRoaringSetBucket(t *testing.T, ctx context.Context) *lsmkv.Buc
 
 	b.SetMemtableThreshold(1e9) // no auto-flush; keep the fixture deterministic
 
-	// Each row spans containersPerRow sroar containers (stride 2^16), each
-	// holding valuesPerContainer values. Dense containers make every OrConc
-	// merge real work, so the extra worker an ignored budget spawns lives
-	// across several 1ms sampler ticks instead of finishing between them.
-	// Low-16 bits are blocked per row (row*valuesPerContainer + j) so every
-	// value across the whole fixture is distinct: cardinality == rows*idsPerRow.
+	// Values are unique across the whole fixture (cardinality ==
+	// rows*idsPerRow, checked above); dense containers keep each merge
+	// running long enough for the sampler to catch an ignored budget.
 	for row := 0; row < numRoaringRows; row++ {
 		values := make([]uint64, 0, idsPerRow)
 		for c := 0; c < containersPerRow; c++ {

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_budget_test.go
@@ -29,19 +29,13 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
-// TestDocBitmapInvertedRoaringSet_RowMergeBudget pins the row-merge path in
-// docBitmapInvertedRoaringSet: a >= filter that spans many rows unions each
-// row bitmap via OrConc(_, mergeConc). Two guarantees:
-//   - equivalence: a budget-1 query returns the exact same docIDs as an
-//     unconstrained one (the budget bounds merge concurrency, never the result)
-//   - ceiling: under budget-1 the per-row merge spawns no workers, so the path
-//     holds only its own goroutine
+// TestDocBitmapInvertedRoaringSet_RowMergeBudget pins docBitmap row-merges to
+// the per-query budget without changing results.
 func TestDocBitmapInvertedRoaringSet_RowMergeBudget(t *testing.T) {
 	ctx := context.Background()
 	b := buildMultiRowRoaringSetBucket(t, ctx)
 
-	// GreaterThanEqual from the lowest key walks every row, so the readFn runs
-	// numKeys-1 OrConc merges into the accumulated result
+	// spans every row, so readFn accumulates via numKeys-1 OrConc merges
 	pv := &propValuePair{
 		operator: filters.OperatorGreaterThanEqual,
 		value:    []byte("k000"),
@@ -72,8 +66,7 @@ func TestDocBitmapInvertedRoaringSet_RowMergeBudget(t *testing.T) {
 		}
 
 		budget1 := concurrency.CtxWithBudget(ctx, 1)
-		// budget=1 => each OrConc spawns no workers, so an in-flight query holds
-		// only its own goroutine; slack absorbs sampler and runtime/GC noise
+		// budget=1 spawns no extra workers; slack absorbs sampler/GC noise
 		testinghelpers.AssertGoroutineCeiling(t, 8, 1, 8, 200*time.Millisecond, func() error {
 			s := &Searcher{}
 			bm, err := s.docBitmapInvertedRoaringSet(budget1, b, 0, pv)
@@ -91,10 +84,8 @@ const (
 	idsPerRow      = 200
 )
 
-// buildMultiRowRoaringSetBucket creates a real RoaringSet bucket with
-// numRoaringRows keys, each carrying idsPerRow docIDs spread across as many
-// sroar containers (stride 2^16). Distinct docIDs per row so the union grows,
-// enough containers that an unconstrained merge would want >1 worker.
+// buildMultiRowRoaringSetBucket builds a bucket with enough rows and
+// containers that an unconstrained merge would want more than one worker.
 func buildMultiRowRoaringSetBucket(t *testing.T, ctx context.Context) *lsmkv.Bucket {
 	t.Helper()
 

--- a/adapters/repos/db/lsmkv/bucket_recover_test.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_test.go
@@ -251,7 +251,7 @@ func testBucketContent(t *testing.T, strategy string, b *Bucket, maxObject int) 
 			require.NoError(t, err)
 			require.Equal(t, val, get[0])
 		case StrategyRoaringSet:
-			get, release, err := b.RoaringSetGet(key)
+			get, release, err := b.RoaringSetGet(context.Background(), key)
 			require.NoError(t, err)
 			func() {
 				require.True(t, get.Contains(uint64(i)))

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -12,9 +12,11 @@
 package lsmkv
 
 import (
+	"context"
 	"errors"
 
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
@@ -62,7 +64,7 @@ func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
 	return active.roaringSetAddBitmap(key, bm)
 }
 
-func (b *Bucket) RoaringSetGet(key []byte) (bm *sroar.Bitmap, release func(), err error) {
+func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitmap, release func(), err error) {
 	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return nil, noopRelease, err
 	}
@@ -70,13 +72,17 @@ func (b *Bucket) RoaringSetGet(key []byte) (bm *sroar.Bitmap, release func(), er
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	return b.roaringSetGetFromConsistentView(view, key)
+	return b.roaringSetGetFromConsistentView(ctx, view, key)
 }
 
 func (b *Bucket) roaringSetGetFromConsistentView(
-	view BucketConsistentView, key []byte,
+	ctx context.Context, view BucketConsistentView, key []byte,
 ) (bm *sroar.Bitmap, release func(), err error) {
-	layers, release, err := b.disk.roaringSetGet(key, view.Disk)
+	// resolve the sroar merge concurrency once so every layer merge for this
+	// key shares the same per-query budget instead of the old per-site constant
+	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+
+	layers, release, err := b.disk.roaringSetGet(key, view.Disk, maxConc)
 	if err != nil {
 		return nil, noopRelease, err
 	}
@@ -106,5 +112,5 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 		layers = append(layers, activeBM)
 	}
 
-	return layers.Flatten(false), release, nil
+	return layers.Flatten(false, maxConc), release, nil
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -64,6 +64,9 @@ func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
 	return active.roaringSetAddBitmap(key, bm)
 }
 
+// RoaringSetGet returns the flattened bitmap stored under key. ctx is consulted
+// only for the per-query concurrency budget (concurrency.BudgetFromCtxCapped),
+// not for cancellation.
 func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitmap, release func(), err error) {
 	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return nil, noopRelease, err

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -79,24 +79,28 @@ func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitma
 func (b *Bucket) roaringSetGetFromConsistentView(
 	ctx context.Context, view BucketConsistentView, key []byte,
 ) (bm *sroar.Bitmap, release func(), err error) {
-	// resolve the sroar merge concurrency once so every layer merge for this
-	// key shares the same per-query budget instead of the old per-site constant
 	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
-	layers, release, err := b.disk.roaringSetGet(key, view.Disk, maxConc)
+	layers, diskRelease, err := b.disk.roaringSetGet(key, view.Disk, maxConc)
 	if err != nil {
 		return nil, noopRelease, err
 	}
+	// diskRelease frees the disk layers' pooled buffer. The defer releases it on
+	// any error path so a failed flushing/active read can't leak it back into
+	// the pool. It is a dedicated variable rather than the named release return
+	// because error paths overwrite the return with noopRelease for the caller;
+	// the defer must still see the real release.
 	defer func() {
 		if err != nil {
-			release()
+			diskRelease()
 		}
 	}()
 
 	if view.Flushing != nil {
-		flushing, err := view.Flushing.roaringSetGet(key)
-		if err != nil {
-			if !errors.Is(err, lsmkv.NotFound) {
+		flushing, flushErr := view.Flushing.roaringSetGet(key)
+		if flushErr != nil {
+			if !errors.Is(flushErr, lsmkv.NotFound) {
+				err = flushErr
 				return nil, noopRelease, err
 			}
 		} else {
@@ -104,14 +108,15 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 		}
 	}
 
-	activeBM, err := view.Active.roaringSetGet(key)
-	if err != nil {
-		if !errors.Is(err, lsmkv.NotFound) {
+	activeBM, activeErr := view.Active.roaringSetGet(key)
+	if activeErr != nil {
+		if !errors.Is(activeErr, lsmkv.NotFound) {
+			err = activeErr
 			return nil, noopRelease, err
 		}
 	} else {
 		layers = append(layers, activeBM)
 	}
 
-	return layers.Flatten(false, maxConc), release, nil
+	return layers.Flatten(false, maxConc), diskRelease, nil
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -64,9 +64,7 @@ func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
 	return active.roaringSetAddBitmap(key, bm)
 }
 
-// RoaringSetGet returns the flattened bitmap stored under key. ctx is consulted
-// only for the per-query concurrency budget (concurrency.BudgetFromCtxCapped),
-// not for cancellation.
+// RoaringSetGet consults ctx only for the concurrency budget, not for cancellation.
 func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitmap, release func(), err error) {
 	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return nil, noopRelease, err

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -85,11 +85,9 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 	if err != nil {
 		return nil, noopRelease, err
 	}
-	// diskRelease frees the disk layers' pooled buffer. The defer releases it on
-	// any error path so a failed flushing/active read can't leak it back into
-	// the pool. It is a dedicated variable rather than the named release return
-	// because error paths overwrite the return with noopRelease for the caller;
-	// the defer must still see the real release.
+	// diskRelease (not the named return, which error paths overwrite with
+	// noopRelease) is what the defer frees, so a failed flushing/active
+	// read can't leak the disk layer's pooled buffer.
 	defer func() {
 		if err != nil {
 			diskRelease()

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -13,9 +13,18 @@ package lsmkv
 
 import (
 	"context"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 // TestRoaringSetWritePathRefCount ensures that all write paths of the
@@ -63,4 +72,136 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 	defer releaseBufPol()
 	require.NoError(t, err)
 	require.Equal(t, []uint64{1, 3, 4, 5, 6, 7}, v.ToArray())
+}
+
+// TestBucket_RoaringSetGet_RespectsConcurrencyBudget proves the per-query
+// budget threaded into RoaringSetGet actually caps sroar's internal merge
+// fan-out. With a budget of 1 the *Conc merge ops run single-threaded, so
+// hammering the bucket from K callers cannot inflate the live goroutine count
+// beyond K (plus slack), no matter how many disk segments or containers are
+// involved. A regression that stopped honoring the budget would let each Get
+// fan out ~SROAR_MERGE workers per merge and blow the ceiling.
+func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
+	if concurrency.SROAR_MERGE < 2 {
+		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
+			concurrency.SROAR_MERGE)
+	}
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	tmpDir := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	// never auto-flush; we flush explicitly to control the disk segment count
+	b.SetMemtableThreshold(1e9)
+
+	// one value per sroar container (stride 2^16) => ~200 containers, enough
+	// that the *Conc ops want min(200/24, SROAR_MERGE) ~ 8 > 1 merge workers
+	const numContainers = 200
+	values := make([]uint64, numContainers)
+	for i := range values {
+		values[i] = uint64(i) << 16
+	}
+
+	key := []byte("key")
+
+	// >= 8 disk segments so each Get runs several segment merges
+	const numSegments = 8
+	for s := 0; s < numSegments; s++ {
+		require.NoError(t, b.RoaringSetAddList(key, values))
+		require.NoError(t, b.FlushAndSwitch())
+	}
+
+	budget1 := concurrency.CtxWithBudget(ctx, 1)
+
+	// correctness: a budget of 1 returns exactly the same set as an
+	// unconstrained query (merges are deterministic regardless of concurrency)
+	got1, release1, err := b.RoaringSetGet(budget1, key)
+	require.NoError(t, err)
+	arr1 := got1.ToArray()
+	release1()
+
+	gotDefault, releaseDefault, err := b.RoaringSetGet(ctx, key)
+	require.NoError(t, err)
+	arrDefault := gotDefault.ToArray()
+	releaseDefault()
+
+	require.Equal(t, values, arr1)
+	require.Equal(t, arrDefault, arr1)
+
+	// bounding leg
+	const (
+		numWorkers = 16
+		runFor     = 200 * time.Millisecond
+		// slack absorbs the sampler goroutine and transient runtime/GC workers
+		slack = 8
+	)
+
+	stop := make(chan struct{})
+	samplerDone := make(chan struct{})
+	var maxSeen int // written only by the sampler, read after samplerDone closes
+
+	go func() {
+		defer close(samplerDone)
+		ticker := time.NewTicker(1 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if n := runtime.NumGoroutine(); n > maxSeen {
+					maxSeen = n
+				}
+			}
+		}
+	}()
+
+	// let the sampler settle, then baseline (includes the sampler, excludes the
+	// workers we are about to launch)
+	time.Sleep(5 * time.Millisecond)
+	base := runtime.NumGoroutine()
+
+	firstErr := make(chan error, 1)
+	var wg sync.WaitGroup
+	deadline := time.Now().Add(runFor)
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				bm, release, err := b.RoaringSetGet(budget1, key)
+				if err != nil {
+					select {
+					case firstErr <- err:
+					default:
+					}
+					return
+				}
+				_ = bm
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	<-samplerDone
+
+	select {
+	case err := <-firstErr:
+		require.NoError(t, err)
+	default:
+	}
+
+	ceiling := base + numWorkers + slack
+	assert.LessOrEqualf(t, maxSeen, ceiling,
+		"live goroutines peaked at %d, above base(%d)+workers(%d)+slack(%d)=%d; "+
+			"a budget of 1 must not fan out sroar merge workers",
+		maxSeen, base, numWorkers, slack, ceiling)
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -13,17 +13,15 @@ package lsmkv
 
 import (
 	"context"
-	"runtime"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/concurrency/testinghelpers"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
@@ -135,73 +133,16 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, values, arr1)
 	require.Equal(t, arrDefault, arr1)
 
-	// bounding leg
-	const (
-		numWorkers = 16
-		runFor     = 200 * time.Millisecond
-		// slack absorbs the sampler goroutine and transient runtime/GC workers
-		slack = 8
-	)
-
-	stop := make(chan struct{})
-	samplerDone := make(chan struct{})
-	var maxSeen int // written only by the sampler, read after samplerDone closes
-
-	go func() {
-		defer close(samplerDone)
-		ticker := time.NewTicker(1 * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-				if n := runtime.NumGoroutine(); n > maxSeen {
-					maxSeen = n
-				}
-			}
+	// bounding leg: with a budget of 1 each in-flight Get keeps only its own
+	// worker goroutine alive (the merge ops spawn zero workers at conc=1);
+	// noise slack of 8 absorbs the sampler and transient runtime/GC workers
+	testinghelpers.AssertGoroutineCeiling(t, 16, 1, 8, 200*time.Millisecond, func() error {
+		bm, release, err := b.RoaringSetGet(budget1, key)
+		if err != nil {
+			return err
 		}
-	}()
-
-	// let the sampler settle, then baseline (includes the sampler, excludes the
-	// workers we are about to launch)
-	time.Sleep(5 * time.Millisecond)
-	base := runtime.NumGoroutine()
-
-	firstErr := make(chan error, 1)
-	var wg sync.WaitGroup
-	deadline := time.Now().Add(runFor)
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for time.Now().Before(deadline) {
-				bm, release, err := b.RoaringSetGet(budget1, key)
-				if err != nil {
-					select {
-					case firstErr <- err:
-					default:
-					}
-					return
-				}
-				_ = bm
-				release()
-			}
-		}()
-	}
-	wg.Wait()
-	close(stop)
-	<-samplerDone
-
-	select {
-	case err := <-firstErr:
-		require.NoError(t, err)
-	default:
-	}
-
-	ceiling := base + numWorkers + slack
-	assert.LessOrEqualf(t, maxSeen, ceiling,
-		"live goroutines peaked at %d, above base(%d)+workers(%d)+slack(%d)=%d; "+
-			"a budget of 1 must not fan out sroar merge workers",
-		maxSeen, base, numWorkers, slack, ceiling)
+		_ = bm
+		release()
+		return nil
+	})
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -72,13 +72,9 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 	require.Equal(t, []uint64{1, 3, 4, 5, 6, 7}, v.ToArray())
 }
 
-// TestBucket_RoaringSetGet_RespectsConcurrencyBudget proves the per-query
-// budget threaded into RoaringSetGet actually caps sroar's internal merge
-// fan-out. With a budget of 1 the *Conc merge ops run single-threaded, so
-// hammering the bucket from K callers cannot inflate the live goroutine count
-// beyond K (plus slack), no matter how many disk segments or containers are
-// involved. A regression that stopped honoring the budget would let each Get
-// fan out ~SROAR_MERGE workers per merge and blow the ceiling.
+// TestBucket_RoaringSetGet_RespectsConcurrencyBudget: a budget of 1 must
+// serialize sroar's merge fan-out, so concurrent Gets can't blow the
+// goroutine ceiling regardless of segment/container count.
 func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	if concurrency.SROAR_MERGE < 2 {
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
@@ -99,8 +95,8 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	// never auto-flush; we flush explicitly to control the disk segment count
 	b.SetMemtableThreshold(1e9)
 
-	// one value per sroar container (stride 2^16) => ~200 containers, enough
-	// that the *Conc ops want min(200/24, SROAR_MERGE) ~ 8 > 1 merge workers
+	// one value per sroar container (stride 2^16); enough that merge ops
+	// actually want >1 worker (min(200/24, SROAR_MERGE))
 	const numContainers = 200
 	values := make([]uint64, numContainers)
 	for i := range values {
@@ -118,8 +114,7 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 
 	budget1 := concurrency.CtxWithBudget(ctx, 1)
 
-	// correctness: a budget of 1 returns exactly the same set as an
-	// unconstrained query (merges are deterministic regardless of concurrency)
+	// correctness: budget=1 result must match the unconstrained query
 	got1, release1, err := b.RoaringSetGet(budget1, key)
 	require.NoError(t, err)
 	arr1 := got1.ToArray()
@@ -133,9 +128,8 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, values, arr1)
 	require.Equal(t, arrDefault, arr1)
 
-	// bounding leg: with a budget of 1 each in-flight Get keeps only its own
-	// worker goroutine alive (the merge ops spawn zero workers at conc=1);
-	// noise slack of 8 absorbs the sampler and transient runtime/GC workers
+	// budget=1 => merge ops spawn no workers, so each Get holds only its own
+	// goroutine; slack of 8 absorbs the sampler and transient runtime/GC noise
 	testinghelpers.AssertGoroutineCeiling(t, 16, 1, 8, 200*time.Millisecond, func() error {
 		bm, release, err := b.RoaringSetGet(budget1, key)
 		if err != nil {

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,7 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 	assertWriterRefs()
 
 	// sanity check, final state:
-	v, releaseBufPol, err := b.RoaringSetGet([]byte("key1"))
+	v, releaseBufPol, err := b.RoaringSetGet(context.Background(), []byte("key1"))
 	defer releaseBufPol()
 	require.NoError(t, err)
 	require.Equal(t, []uint64{1, 3, 4, 5, 6, 7}, v.ToArray())

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -76,13 +76,9 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 	require.Equal(t, []uint64{1, 3, 4, 5, 6, 7}, v.ToArray())
 }
 
-// TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError pins the
-// fix for a pooled-buffer leak in the bucket-level assembly: the disk layers are
-// acquired first (returning their real release), then the flushing and active
-// memtables are read. If one of those reads fails, the error path returns
-// noopRelease to the caller, so the deferred cleanup — not the caller — must
-// free the disk buffer. A regression that overwrites the release the defer reads
-// would leak the disk buffer on every failed flushing/active read.
+// TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError pins a
+// pooled-buffer leak when a flushing/active read fails after the disk layer's
+// buffer was already acquired.
 func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *testing.T) {
 	t.Parallel()
 
@@ -110,13 +106,9 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		require.Nil(t, bm)
 		require.NotNil(t, release)
 
-		// the disk layer's pooled buffer must have been released exactly once by
-		// the deferred cleanup, despite the error path returning noopRelease.
 		require.Equal(t, 1, diskSeg.roaringSetReleases,
 			"disk layer's release must fire when the active read errors")
 
-		// the returned release must be the caller-safe noop; calling it must not
-		// double-release the disk layer.
 		release()
 		require.Equal(t, 1, diskSeg.roaringSetReleases,
 			"returned release must be a noop; buffer already freed by defer")
@@ -158,7 +150,6 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		require.NoError(t, err)
 		require.NotNil(t, bm)
 
-		// no error => the defer must not fire; the caller still holds the buffer.
 		require.Equal(t, 0, diskSeg.roaringSetReleases,
 			"success path must not release before the caller does")
 

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/concurrency/testinghelpers"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
@@ -76,6 +78,9 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 // serialize sroar's merge fan-out, so concurrent Gets can't blow the
 // goroutine ceiling regardless of segment/container count.
 func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
+	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
+		t.Skip("budget cap disabled via kill switch")
+	}
 	if concurrency.SROAR_MERGE < 2 {
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 			concurrency.SROAR_MERGE)

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -162,14 +162,21 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 // TestBucket_RoaringSetGet_RespectsConcurrencyBudget pins RoaringSetGet's
 // merge fan-out to the per-query budget without blowing the goroutine ceiling.
 func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
-	// CI implication: the kill-switch CI leg (DISABLE_SROAR_MERGE_BUDGET=true)
-	// skips this bound by design and serves as the red control instead.
+	// The kill switch (DISABLE_SROAR_MERGE_BUDGET=true) is this bound's red
+	// control, but it is a manual/local check: run with the env var set and
+	// this skip bypassed, and the ceiling assertion below must fail. No CI job
+	// sets the kill switch, so CI exercises only the green (budget-enforced) leg.
 	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 		t.Skip("budget cap disabled via kill switch")
 	}
-	// CI implication: 2-vCPU runners have SROAR_MERGE=1 and skip this entirely;
-	// the bound is only exercised on >=4-vCPU runners (SROAR_MERGE>=2).
+	// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4). Skipping on a
+	// <4-vCPU runner would silently evaporate the guard, so fail loudly on CI
+	// and only skip on dev machines.
 	if concurrency.SROAR_MERGE < 2 {
+		if os.Getenv("CI") != "" {
+			t.Fatalf("bounding tests require GOMAXPROCS>=4, refusing to skip silently on CI (SROAR_MERGE=%d)",
+				concurrency.SROAR_MERGE)
+		}
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 			concurrency.SROAR_MERGE)
 	}
@@ -188,18 +195,27 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	// never auto-flush; we flush explicitly to control the disk segment count
 	b.SetMemtableThreshold(1e9)
 
-	// one value per sroar container (stride 2^16); enough that merge ops
-	// actually want >1 worker (min(200/24, SROAR_MERGE))
-	const numContainers = 200
-	values := make([]uint64, numContainers)
-	for i := range values {
-		values[i] = uint64(i) << 16
+	// numContainers sroar containers (stride 2^16), each holding
+	// valuesPerContainer values. Enough containers that merge ops want >1
+	// worker (min(numContainers/24, SROAR_MERGE)); dense containers make every
+	// OrConc real work, so the extra worker an ignored budget spawns lives
+	// across several 1ms sampler ticks instead of finishing between them.
+	const (
+		numContainers      = 128
+		valuesPerContainer = 128
+	)
+	values := make([]uint64, 0, numContainers*valuesPerContainer)
+	for c := 0; c < numContainers; c++ {
+		for j := 0; j < valuesPerContainer; j++ {
+			values = append(values, uint64(c)<<16+uint64(j))
+		}
 	}
 
 	key := []byte("key")
 
-	// >= 8 disk segments so each Get runs several segment merges
-	const numSegments = 8
+	// many disk segments so each Get runs several sequential segment merges,
+	// keeping each worker inside a live merge across most of the sampler window
+	const numSegments = 12
 	for s := 0; s < numSegments; s++ {
 		require.NoError(t, b.RoaringSetAddList(key, values))
 		require.NoError(t, b.FlushAndSwitch())
@@ -222,7 +238,7 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, arrDefault, arr1)
 
 	// budget=1 spawns no extra workers; slack absorbs sampler/GC noise
-	testinghelpers.AssertGoroutineCeiling(t, 16, 1, 8, 200*time.Millisecond, func() error {
+	testinghelpers.AssertGoroutineCeiling(t, 24, 1, 8, 200*time.Millisecond, func() error {
 		bm, release, err := b.RoaringSetGet(budget1, key)
 		if err != nil {
 			return err

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -162,16 +162,13 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 // TestBucket_RoaringSetGet_RespectsConcurrencyBudget pins RoaringSetGet's
 // merge fan-out to the per-query budget without blowing the goroutine ceiling.
 func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
-	// The kill switch (DISABLE_SROAR_MERGE_BUDGET=true) is this bound's red
-	// control, but it is a manual/local check: run with the env var set and
-	// this skip bypassed, and the ceiling assertion below must fail. No CI job
-	// sets the kill switch, so CI exercises only the green (budget-enforced) leg.
+	// Kill switch is this bound's red control, but no CI job sets it: CI
+	// only ever runs the green (budget-enforced) path.
 	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 		t.Skip("budget cap disabled via kill switch")
 	}
-	// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4). Skipping on a
-	// <4-vCPU runner would silently evaporate the guard, so fail loudly on CI
-	// and only skip on dev machines.
+	// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4); skipping
+	// here silently would hide the guard, so CI fails loudly instead.
 	if concurrency.SROAR_MERGE < 2 {
 		if os.Getenv("CI") != "" {
 			t.Fatalf("bounding tests require GOMAXPROCS>=4, refusing to skip silently on CI (SROAR_MERGE=%d)",
@@ -195,11 +192,9 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	// never auto-flush; we flush explicitly to control the disk segment count
 	b.SetMemtableThreshold(1e9)
 
-	// numContainers sroar containers (stride 2^16), each holding
-	// valuesPerContainer values. Enough containers that merge ops want >1
-	// worker (min(numContainers/24, SROAR_MERGE)); dense containers make every
-	// OrConc real work, so the extra worker an ignored budget spawns lives
-	// across several 1ms sampler ticks instead of finishing between them.
+	// numContainers keeps worker count (min(numContainers/24, SROAR_MERGE))
+	// above 1; dense containers keep an ignored-budget worker alive across
+	// sampler ticks.
 	const (
 		numContainers      = 128
 		valuesPerContainer = 128
@@ -213,8 +208,7 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 
 	key := []byte("key")
 
-	// many disk segments so each Get runs several sequential segment merges,
-	// keeping each worker inside a live merge across most of the sampler window
+	// many disk segments keep each Get's merges live across the sampler window
 	const numSegments = 12
 	for s := 0; s < numSegments; s++ {
 		require.NoError(t, b.RoaringSetAddList(key, values))

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -77,8 +77,7 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 }
 
 // TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError pins a
-// pooled-buffer leak when a flushing/active read fails after the disk layer's
-// buffer was already acquired.
+// disk-buffer leak on flushing/active read errors after acquisition.
 func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -13,12 +13,14 @@ package lsmkv
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
@@ -74,13 +76,108 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 	require.Equal(t, []uint64{1, 3, 4, 5, 6, 7}, v.ToArray())
 }
 
-// TestBucket_RoaringSetGet_RespectsConcurrencyBudget: a budget of 1 must
-// serialize sroar's merge fan-out, so concurrent Gets can't blow the
-// goroutine ceiling regardless of segment/container count.
+// TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError pins the
+// fix for a pooled-buffer leak in the bucket-level assembly: the disk layers are
+// acquired first (returning their real release), then the flushing and active
+// memtables are read. If one of those reads fails, the error path returns
+// noopRelease to the caller, so the deferred cleanup — not the caller — must
+// free the disk buffer. A regression that overwrites the release the defer reads
+// would leak the disk buffer on every failed flushing/active read.
+func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("simulated memtable read error")
+
+	newDiskSeg := func() *fakeSegment {
+		return newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"key1": bitmapFromSlice([]uint64{1, 2, 3}),
+		})
+	}
+
+	t.Run("active read error frees disk layer via defer, returns caller-safe noop", func(t *testing.T) {
+		diskSeg := newDiskSeg()
+		active := newTestMemtableRoaringSet(nil)
+		active.roaringSetGetErr = readErr
+
+		b := Bucket{
+			strategy: StrategyRoaringSet,
+			disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		}
+		view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}}
+
+		bm, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte("key1"))
+		require.ErrorIs(t, err, readErr)
+		require.Nil(t, bm)
+		require.NotNil(t, release)
+
+		// the disk layer's pooled buffer must have been released exactly once by
+		// the deferred cleanup, despite the error path returning noopRelease.
+		require.Equal(t, 1, diskSeg.roaringSetReleases,
+			"disk layer's release must fire when the active read errors")
+
+		// the returned release must be the caller-safe noop; calling it must not
+		// double-release the disk layer.
+		release()
+		require.Equal(t, 1, diskSeg.roaringSetReleases,
+			"returned release must be a noop; buffer already freed by defer")
+	})
+
+	t.Run("flushing read error frees disk layer via defer", func(t *testing.T) {
+		diskSeg := newDiskSeg()
+		flushing := newTestMemtableRoaringSet(nil)
+		flushing.roaringSetGetErr = readErr
+		active := newTestMemtableRoaringSet(nil)
+
+		b := Bucket{
+			strategy: StrategyRoaringSet,
+			disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		}
+		view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}}
+
+		bm, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte("key1"))
+		require.ErrorIs(t, err, readErr)
+		require.Nil(t, bm)
+		require.Equal(t, 1, diskSeg.roaringSetReleases,
+			"disk layer's release must fire when the flushing read errors")
+
+		release()
+		require.Equal(t, 1, diskSeg.roaringSetReleases)
+	})
+
+	t.Run("success path defers nothing, caller owns the release", func(t *testing.T) {
+		diskSeg := newDiskSeg()
+		active := newTestMemtableRoaringSet(nil)
+
+		b := Bucket{
+			strategy: StrategyRoaringSet,
+			disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		}
+		view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}}
+
+		bm, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte("key1"))
+		require.NoError(t, err)
+		require.NotNil(t, bm)
+
+		// no error => the defer must not fire; the caller still holds the buffer.
+		require.Equal(t, 0, diskSeg.roaringSetReleases,
+			"success path must not release before the caller does")
+
+		release()
+		require.Equal(t, 1, diskSeg.roaringSetReleases,
+			"caller's release must free the disk layer exactly once")
+	})
+}
+
+// TestBucket_RoaringSetGet_RespectsConcurrencyBudget pins RoaringSetGet's
+// merge fan-out to the per-query budget without blowing the goroutine ceiling.
 func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
+	// CI implication: the kill-switch CI leg (DISABLE_SROAR_MERGE_BUDGET=true)
+	// skips this bound by design and serves as the red control instead.
 	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 		t.Skip("budget cap disabled via kill switch")
 	}
+	// CI implication: 2-vCPU runners have SROAR_MERGE=1 and skip this entirely;
+	// the bound is only exercised on >=4-vCPU runners (SROAR_MERGE>=2).
 	if concurrency.SROAR_MERGE < 2 {
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 			concurrency.SROAR_MERGE)
@@ -133,8 +230,7 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, values, arr1)
 	require.Equal(t, arrDefault, arr1)
 
-	// budget=1 => merge ops spawn no workers, so each Get holds only its own
-	// goroutine; slack of 8 absorbs the sampler and transient runtime/GC noise
+	// budget=1 spawns no extra workers; slack absorbs sampler/GC noise
 	testinghelpers.AssertGoroutineCeiling(t, 16, 1, 8, 200*time.Millisecond, func() error {
 		bm, release, err := b.RoaringSetGet(budget1, key)
 		if err != nil {

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -987,7 +988,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 	}
 
 	// validate initial data before making any changes
-	value, releaseBuffers, err := b.RoaringSetGet([]byte("key1"))
+	value, releaseBuffers, err := b.RoaringSetGet(context.Background(), []byte("key1"))
 	require.NoError(t, err)
 	require.Equal(t, bitmapFromSlice([]uint64{1, 2}).ToArray(), value.ToArray())
 	releaseBuffers()
@@ -1003,7 +1004,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 		}
 
 		for k, expectedV := range expected {
-			v, release, err := b.roaringSetGetFromConsistentView(view, []byte(k))
+			v, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte(k))
 			require.NoError(t, err)
 			require.Equal(t, expectedV.ToArray(), v.ToArray())
 			release()
@@ -1032,7 +1033,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 		}
 
 		for k, expectedV := range expected {
-			v, release, err := b.roaringSetGetFromConsistentView(view, []byte(k))
+			v, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte(k))
 			require.NoError(t, err)
 			require.Equal(t, expectedV.ToArray(), v.ToArray())
 			release()
@@ -1052,8 +1053,8 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 	defer view3.ReleaseView()
 
 	// the original memtable was flushed to disk
-	v, release, err := b.disk.roaringSetGet([]byte("key1"), view3.Disk)
-	assert.Equal(t, []uint64{1, 2}, v.Flatten(true).ToArray())
+	v, release, err := b.disk.roaringSetGet([]byte("key1"), view3.Disk, concurrency.SROAR_MERGE)
+	assert.Equal(t, []uint64{1, 2}, v.Flatten(true, concurrency.SROAR_MERGE).ToArray())
 	require.NoError(t, err)
 	release()
 }
@@ -1120,9 +1121,9 @@ func TestBucketRoaringSetStrategyWriteVsFlush(t *testing.T) {
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	bm, release, err := b.disk.roaringSetGet([]byte("key1"), view.Disk)
+	bm, release, err := b.disk.roaringSetGet([]byte("key1"), view.Disk, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
-	assert.Equal(t, []uint64{1, 2, 3}, bm.Flatten(true).ToArray())
+	assert.Equal(t, []uint64{1, 2, 3}, bm.Flatten(true, concurrency.SROAR_MERGE).ToArray())
 	release()
 }
 

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -2091,11 +2091,21 @@ type testMemtable struct {
 	*Memtable
 	totalWriteCountIncs int
 	totalWriteCountDecs int
+	// roaringSetGetErr, when set, makes roaringSetGet fail, simulating a
+	// memtable read error mid-way through a consistent-view lookup.
+	roaringSetGetErr error
 }
 
 func (t *testMemtable) incWriterCount() {
 	t.totalWriteCountIncs++
 	t.Memtable.incWriterCount()
+}
+
+func (t *testMemtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
+	if t.roaringSetGetErr != nil {
+		return roaringset.BitmapLayer{}, t.roaringSetGetErr
+	}
+	return t.Memtable.roaringSetGet(key)
 }
 
 func (t *testMemtable) decWriterCount() {

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -90,7 +90,7 @@ func verifyBucketAgainstControl(t *testing.T, b *Bucket, control []*sroar.Bitmap
 		binary.LittleEndian.PutUint64(key, uint64(i))
 
 		func() {
-			actual, release, err := b.RoaringSetGet(key)
+			actual, release, err := b.RoaringSetGet(context.Background(), key)
 			require.NoError(t, err)
 			defer release()
 
@@ -597,7 +597,7 @@ func compactionRoaringSetStrategy_FrequentPutDeleteOperations(ctx context.Contex
 			})
 
 			t.Run("verify that objects exist before compaction", func(t *testing.T) {
-				res, release, err := bucket.RoaringSetGet(key)
+				res, release, err := bucket.RoaringSetGet(context.Background(), key)
 				require.NoError(t, err)
 				defer release()
 
@@ -620,7 +620,7 @@ func compactionRoaringSetStrategy_FrequentPutDeleteOperations(ctx context.Contex
 			})
 
 			t.Run("verify that objects exist after compaction", func(t *testing.T) {
-				res, release, err := bucket.RoaringSetGet(key)
+				res, release, err := bucket.RoaringSetGet(context.Background(), key)
 				require.NoError(t, err)
 				defer release()
 

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -276,7 +276,7 @@ func TestConcurrentWriting_RoaringSet(t *testing.T) {
 	t.Run("verify get", func(t *testing.T) {
 		for i := range keys {
 			func() {
-				value, release, err := bucket.RoaringSetGet(keys[i])
+				value, release, err := bucket.RoaringSetGet(context.Background(), keys[i])
 				require.NoError(t, err)
 				defer release()
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -12,10 +12,12 @@
 package lsmkv
 
 import (
+	"context"
 	"time"
 
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
 )
 
 type CursorRoaringSet interface {
@@ -50,17 +52,29 @@ func (c *cursorRoaringSet) Close() {
 // needs to be closed using .Close() to free references to the underlying
 // segments.
 func (b *Bucket) CursorRoaringSet() CursorRoaringSet {
-	return b.cursorRoaringSet(false)
+	return b.cursorRoaringSet(false, concurrency.SROAR_MERGE)
 }
 
 // CursorRoaringSetKey is the equivalent of [CursorRoaringSet], but only
 // returns keys. See [Cursor] for details on snapshot isolation. Needs to be
 // closed using .Close() to free references to the underlying disk segments.
 func (b *Bucket) CursorRoaringSetKeyOnly() CursorRoaringSet {
-	return b.cursorRoaringSet(true)
+	return b.cursorRoaringSet(true, concurrency.SROAR_MERGE)
 }
 
-func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
+// CursorRoaringSetCtx is like [Bucket.CursorRoaringSet] but caps the per-key
+// merge concurrency to the query's budget carried in ctx.
+func (b *Bucket) CursorRoaringSetCtx(ctx context.Context) CursorRoaringSet {
+	return b.cursorRoaringSet(false, concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE))
+}
+
+// CursorRoaringSetKeyOnlyCtx is like [Bucket.CursorRoaringSetKeyOnly] but caps
+// the per-key merge concurrency to the query's budget carried in ctx.
+func (b *Bucket) CursorRoaringSetKeyOnlyCtx(ctx context.Context) CursorRoaringSet {
+	return b.cursorRoaringSet(true, concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE))
+}
+
+func (b *Bucket) cursorRoaringSet(keyOnly bool, maxConc int) CursorRoaringSet {
 	MustBeExpectedStrategy(b.strategy, StrategyRoaringSet)
 
 	cursorOpenedAt := time.Now()
@@ -84,7 +98,7 @@ func (b *Bucket) cursorRoaringSet(keyOnly bool) CursorRoaringSet {
 	// cursors are in order from oldest to newest, with the memtable cursor
 	// being at the very top
 	return &cursorRoaringSet{
-		combinedCursor: roaringset.NewCombinedCursor(innerCursors, keyOnly),
+		combinedCursor: roaringset.NewCombinedCursor(innerCursors, keyOnly, maxConc),
 		unlock: func() {
 			unlockSegmentGroup()
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -61,8 +61,8 @@ func (b *Bucket) CursorRoaringSetCtx(ctx context.Context) CursorRoaringSet {
 	return b.cursorRoaringSet(false, concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE))
 }
 
-// CursorRoaringSetKeyOnlyCtx is like [Bucket.CursorRoaringSetKeyOnly] but caps
-// the per-key merge concurrency to the query's budget carried in ctx.
+// CursorRoaringSetKeyOnlyCtx is like [Bucket.CursorRoaringSetCtx] but only
+// returns keys.
 func (b *Bucket) CursorRoaringSetKeyOnlyCtx(ctx context.Context) CursorRoaringSet {
 	return b.cursorRoaringSet(true, concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE))
 }

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set.go
@@ -55,13 +55,6 @@ func (b *Bucket) CursorRoaringSet() CursorRoaringSet {
 	return b.cursorRoaringSet(false, concurrency.SROAR_MERGE)
 }
 
-// CursorRoaringSetKey is the equivalent of [CursorRoaringSet], but only
-// returns keys. See [Cursor] for details on snapshot isolation. Needs to be
-// closed using .Close() to free references to the underlying disk segments.
-func (b *Bucket) CursorRoaringSetKeyOnly() CursorRoaringSet {
-	return b.cursorRoaringSet(true, concurrency.SROAR_MERGE)
-}
-
 // CursorRoaringSetCtx is like [Bucket.CursorRoaringSet] but caps the per-key
 // merge concurrency to the query's budget carried in ctx.
 func (b *Bucket) CursorRoaringSetCtx(ctx context.Context) CursorRoaringSet {

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_test.go
@@ -136,8 +136,8 @@ func TestRoaringSetCursorCtxBudgetEquivalence(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	// overlapping keys across layers so the per-key Flatten merges several
-	// bitmaps: that merge is the one whose concurrency the ctx budget caps
+	// overlapping keys force a multi-layer Flatten merge, which is what the
+	// ctx budget caps
 	diskSegments := &SegmentGroup{
 		logger: logger,
 		segments: []Segment{
@@ -168,8 +168,7 @@ func TestRoaringSetCursorCtxBudgetEquivalence(t *testing.T) {
 
 	defaultRows := scan(b.CursorRoaringSet())
 
-	// a budget-1 ctx cursor bounds merge concurrency to a single worker; it must
-	// still return byte-identical rows to the unconstrained cursor
+	// budget-1 must still return byte-identical rows to the unconstrained cursor
 	budget1 := concurrency.CtxWithBudget(context.Background(), 1)
 	budget1Rows := scan(b.CursorRoaringSetCtx(budget1))
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_roaring_set_test.go
@@ -12,11 +12,13 @@
 package lsmkv
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/concurrency"
 )
 
 func TestRoaringSetCursorConsistentView(t *testing.T) {
@@ -127,4 +129,51 @@ func TestRoaringSetCursorConsistentView(t *testing.T) {
 		actual[string(k)] = bm.ToArray()
 	}
 	require.Equal(t, expected, actual)
+}
+
+func TestRoaringSetCursorCtxBudgetEquivalence(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := test.NewNullLogger()
+
+	// overlapping keys across layers so the per-key Flatten merges several
+	// bitmaps: that merge is the one whose concurrency the ctx budget caps
+	diskSegments := &SegmentGroup{
+		logger: logger,
+		segments: []Segment{
+			newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+				"key1": bitmapFromSlice([]uint64{1, 3, 5}),
+				"key2": bitmapFromSlice([]uint64{10, 20}),
+			}),
+			newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+				"key1": bitmapFromSlice([]uint64{2, 4, 6}),
+				"key3": bitmapFromSlice([]uint64{30}),
+			}),
+		},
+	}
+	active := newTestMemtableRoaringSet(map[string][]uint64{
+		"key1": {7},
+		"key2": {21},
+	})
+	b := Bucket{active: active, disk: diskSegments, strategy: StrategyRoaringSet}
+
+	scan := func(c CursorRoaringSet) map[string][]uint64 {
+		defer c.Close()
+		out := map[string][]uint64{}
+		for k, bm := c.First(); k != nil; k, bm = c.Next() {
+			out[string(k)] = bm.ToArray()
+		}
+		return out
+	}
+
+	defaultRows := scan(b.CursorRoaringSet())
+
+	// a budget-1 ctx cursor bounds merge concurrency to a single worker; it must
+	// still return byte-identical rows to the unconstrained cursor
+	budget1 := concurrency.CtxWithBudget(context.Background(), 1)
+	budget1Rows := scan(b.CursorRoaringSetCtx(budget1))
+
+	require.Equal(t, defaultRows, budget1Rows)
+	// guard the fixture: key1 must genuinely be a three-layer merge
+	require.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7}, defaultRows["key1"])
 }

--- a/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
@@ -15,7 +15,6 @@ import (
 	"io"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
-	"github.com/weaviate/weaviate/entities/concurrency"
 )
 
 func (s *segment) newRoaringSetRangeReader() roaringsetrange.InnerReader {
@@ -29,9 +28,8 @@ func (s *segment) newRoaringSetRangeReader() roaringsetrange.InnerReader {
 		segmentCursor = roaringsetrange.NewSegmentCursorPread(sectionReader, 2)
 	}
 
-	return roaringsetrange.NewSegmentReaderConcurrent(
-		roaringsetrange.NewGaplessSegmentCursor(segmentCursor),
-		concurrency.SROAR_MERGE)
+	return roaringsetrange.NewSegmentReader(
+		roaringsetrange.NewGaplessSegmentCursor(segmentCursor))
 }
 
 func (s *segment) newRoaringSetRangeCursor() roaringsetrange.SegmentCursor {

--- a/adapters/repos/db/lsmkv/lazy_segment.go
+++ b/adapters/repos/db/lsmkv/lazy_segment.go
@@ -320,10 +320,10 @@ func (s *lazySegment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapB
 	return s.segment.roaringSetGet(key, bitmapBufPool)
 }
 
-func (s *lazySegment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool,
+func (s *lazySegment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool, maxConc int,
 ) error {
 	s.mustLoad()
-	return s.segment.roaringSetMergeWith(key, input, bitmapBufPool)
+	return s.segment.roaringSetMergeWith(key, input, bitmapBufPool, maxConc)
 }
 
 func (s *lazySegment) numberFromPath(re *regexp.Regexp) (int, bool) {

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -502,17 +502,17 @@ func TestRoaringSetStrategy_RecoverFromWAL(t *testing.T) {
 			err = b.RoaringSetAddList(key3, orig3)
 			require.NoError(t, err)
 
-			bm1, release, err := b.RoaringSetGet(key1)
+			bm1, release, err := b.RoaringSetGet(context.Background(), key1)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, orig1, bm1.ToArray())
 
-			bm2, release, err := b.RoaringSetGet(key2)
+			bm2, release, err := b.RoaringSetGet(context.Background(), key2)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, orig2, bm2.ToArray())
 
-			bm3, release, err := b.RoaringSetGet(key3)
+			bm3, release, err := b.RoaringSetGet(context.Background(), key3)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, orig3, bm3.ToArray())
@@ -550,17 +550,17 @@ func TestRoaringSetStrategy_RecoverFromWAL(t *testing.T) {
 				33, // newly added
 			} // 32 deleted
 
-			bm1, release, err := b.RoaringSetGet(key1)
+			bm1, release, err := b.RoaringSetGet(context.Background(), key1)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, expected1, bm1.ToArray())
 
-			bm2, release, err := b.RoaringSetGet(key2)
+			bm2, release, err := b.RoaringSetGet(context.Background(), key2)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, expected2, bm2.ToArray())
 
-			bm3, release, err := b.RoaringSetGet(key3)
+			bm3, release, err := b.RoaringSetGet(context.Background(), key3)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, expected3, bm3.ToArray())
@@ -607,17 +607,17 @@ func TestRoaringSetStrategy_RecoverFromWAL(t *testing.T) {
 				33, // newly added
 			} // 32 deleted
 
-			bm1, release, err := bRec.RoaringSetGet(key1)
+			bm1, release, err := bRec.RoaringSetGet(context.Background(), key1)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, expected1, bm1.ToArray())
 
-			bm2, release, err := bRec.RoaringSetGet(key2)
+			bm2, release, err := bRec.RoaringSetGet(context.Background(), key2)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, expected2, bm2.ToArray())
 
-			bm3, release, err := bRec.RoaringSetGet(key3)
+			bm3, release, err := bRec.RoaringSetGet(context.Background(), key3)
 			require.NoError(t, err)
 			defer release()
 			assert.ElementsMatch(t, expected3, bm3.ToArray())

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -81,7 +81,7 @@ type Segment interface {
 	ReadOnlyTombstones() (*sroar.Bitmap, error)
 	replaceStratParseData(in []byte) ([]byte, []byte, error)
 	roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPool) (roaringset.BitmapLayer, func(), error)
-	roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool) error
+	roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool, maxConc int) error
 
 	// map/bmw specific
 	hasKey(key []byte) bool

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
-	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -351,7 +350,7 @@ func (f *fakeSegment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapB
 	return roaringset.BitmapLayer{}, nil, lsmkv.NotFound
 }
 
-func (f *fakeSegment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool) error {
+func (f *fakeSegment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool, maxConc int) error {
 	f.getCounter++
 	layer, _, err := f.roaringSetGet(key, bitmapBufPool)
 	if err != nil {
@@ -361,8 +360,8 @@ func (f *fakeSegment) roaringSetMergeWith(key []byte, input roaringset.BitmapLay
 	}
 
 	input.Additions.
-		AndNotConc(layer.Deletions, concurrency.SROAR_MERGE).
-		OrConc(layer.Additions, concurrency.SROAR_MERGE)
+		AndNotConc(layer.Deletions, maxConc).
+		OrConc(layer.Additions, maxConc)
 
 	return nil
 }

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -101,6 +101,14 @@ type fakeSegment struct {
 	path                  string
 	getCounter            int
 
+	// roaringSetReleases counts how many times the release func handed out by
+	// roaringSetGet was actually invoked, so tests can pin buffer-release
+	// behavior without a production seam.
+	roaringSetReleases int
+	// roaringSetMergeErr, when set, makes roaringSetMergeWith fail, simulating a
+	// mid-merge disk read error.
+	roaringSetMergeErr error
+
 	isMarkedForDeletion  bool
 	isStrippedExtensions bool
 	strippedLeftSegID    string
@@ -344,7 +352,7 @@ func (f *fakeSegment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapB
 	if val, ok := f.roaringStore[string(key)]; ok {
 		return roaringset.BitmapLayer{
 			Additions: val.Clone(),
-		}, func() {}, nil
+		}, func() { f.roaringSetReleases++ }, nil
 	}
 
 	return roaringset.BitmapLayer{}, nil, lsmkv.NotFound
@@ -352,6 +360,9 @@ func (f *fakeSegment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapB
 
 func (f *fakeSegment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool, maxConc int) error {
 	f.getCounter++
+	if f.roaringSetMergeErr != nil {
+		return f.roaringSetMergeErr
+	}
 	layer, _, err := f.roaringSetGet(key, bitmapBufPool)
 	if err != nil {
 		if errors.Is(err, lsmkv.NotFound) {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -803,7 +803,7 @@ func (sg *SegmentGroup) getCollectionAndSegments(ctx context.Context, key []byte
 	return out[:i], outSegments[:i], nil
 }
 
-func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment) (out roaringset.BitmapLayers, release func(), err error) {
+func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc int) (out roaringset.BitmapLayers, release func(), err error) {
 	ln := len(segments)
 	if ln == 0 {
 		return nil, noopRelease, nil
@@ -834,7 +834,7 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment) (out roari
 	}()
 
 	for ; i < ln; i++ {
-		if err := segments[i].roaringSetMergeWith(key, out[0], sg.bitmapBufPool); err != nil {
+		if err := segments[i].roaringSetMergeWith(key, out[0], sg.bitmapBufPool, maxConc); err != nil {
 			return nil, noopRelease, err
 		}
 	}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -809,37 +809,44 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc in
 		return nil, noopRelease, nil
 	}
 
-	release = noopRelease
+	// acquired frees the first layer's pooled buffer (all following segments
+	// merge into it). The defer releases it on any error after we've taken it,
+	// so a mid-merge disk read error can't leak the buffer back into the pool.
+	// It is a dedicated variable rather than the named release return because
+	// error paths overwrite the return with noopRelease for the caller; the
+	// defer must still see the real release.
+	acquired := noopRelease
 	// use bigger buffer for first layer, to make space for further merges
 	// with following layers
 	bitmapBufPool := roaringset.NewBitmapBufPoolFactorWrapper(sg.bitmapBufPool, 1.25)
 
 	i := 0
 	for ; i < ln; i++ {
-		layer, layerRelease, err := segments[i].roaringSetGet(key, bitmapBufPool)
-		if err == nil {
+		layer, layerRelease, getErr := segments[i].roaringSetGet(key, bitmapBufPool)
+		if getErr == nil {
 			out = append(out, layer)
-			release = layerRelease
+			acquired = layerRelease
 			i++
 			break
 		}
-		if !errors.Is(err, lsmkv.NotFound) {
-			return nil, noopRelease, err
+		if !errors.Is(getErr, lsmkv.NotFound) {
+			return nil, noopRelease, getErr
 		}
 	}
 	defer func() {
 		if err != nil {
-			release()
+			acquired()
 		}
 	}()
 
 	for ; i < ln; i++ {
-		if err := segments[i].roaringSetMergeWith(key, out[0], sg.bitmapBufPool, maxConc); err != nil {
+		if mergeErr := segments[i].roaringSetMergeWith(key, out[0], sg.bitmapBufPool, maxConc); mergeErr != nil {
+			err = mergeErr
 			return nil, noopRelease, err
 		}
 	}
 
-	return out, release, nil
+	return out, acquired, nil
 }
 
 func (sg *SegmentGroup) count() int {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -809,12 +809,9 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc in
 		return nil, noopRelease, nil
 	}
 
-	// acquired frees the first layer's pooled buffer (all following segments
-	// merge into it). The defer releases it on any error after we've taken it,
-	// so a mid-merge disk read error can't leak the buffer back into the pool.
-	// It is a dedicated variable rather than the named release return because
-	// error paths overwrite the return with noopRelease for the caller; the
-	// defer must still see the real release.
+	// acquired (not the named return, which error paths overwrite with
+	// noopRelease) is what the defer frees, so a mid-merge disk read error
+	// can't leak the first layer's pooled buffer.
 	acquired := noopRelease
 	// use bigger buffer for first layer, to make space for further merges
 	// with following layers

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
@@ -137,10 +138,10 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentAddition(t *testing.
 	// control before segment changes
 	segments, release := sg.getConsistentViewOfSegments()
 	defer release()
-	v, _, err := sg.roaringSetGet([]byte("key1"), segments)
+	v, _, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	expected := []uint64{1}
-	require.Equal(t, expected, v.Flatten(true).ToArray(), "k==v on initial state")
+	require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v on initial state")
 
 	// append new segment
 	segment2Data := map[string]*sroar.Bitmap{
@@ -149,18 +150,18 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentAddition(t *testing.
 	sg.addInitializedSegment(newFakeRoaringSetSegment(segment2Data))
 
 	// prove that our consistent view still shows the old value
-	v, _, err = sg.roaringSetGet([]byte("key1"), segments)
+	v, _, err = sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	expected = []uint64{1}
-	require.Equal(t, expected, v.Flatten(true).ToArray(), "k==v after segment addition on old view")
+	require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v after segment addition on old view")
 
 	// prove that new readers will see the most recent view
 	segments, release = sg.getConsistentViewOfSegments()
 	defer release()
-	v, _, err = sg.roaringSetGet([]byte("key1"), segments)
+	v, _, err = sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	expected = []uint64{1, 2}
-	require.Equal(t, expected, v.Flatten(true).ToArray(), "k==v on new view after segment addition")
+	require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v on new view after segment addition")
 }
 
 func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
@@ -185,15 +186,15 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T)
 
 	// On the original view, key1 should be {1} (from segA), key2 should be {2} (from segB)
 	validateView := func(t *testing.T, segments []Segment) {
-		v, _, err := sg.roaringSetGet([]byte("key1"), segments)
+		v, _, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 		require.NoError(t, err)
 		expected := []uint64{1}
-		require.Equal(t, expected, v.Flatten(true).ToArray(), "key1 on initial state")
+		require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "key1 on initial state")
 
-		v, _, err = sg.roaringSetGet([]byte("key2"), segments)
+		v, _, err = sg.roaringSetGet([]byte("key2"), segments, concurrency.SROAR_MERGE)
 		require.NoError(t, err)
 		expected = []uint64{2}
-		require.Equal(t, expected, v.Flatten(true).ToArray(), "key2 on initial state")
+		require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "key2 on initial state")
 	}
 	validateView(t, segments)
 

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -222,8 +222,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T)
 }
 
 // TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError pins a
-// pooled-buffer leak when a later segment's merge fails after the first
-// layer's buffer was already acquired.
+// first-layer buffer leak on a later segment's merge error.
 func TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -218,6 +219,75 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T)
 
 	validateView(t, segments)
 	require.Greater(t, segAB.getCounter, 0, "new segment should have received calls")
+}
+
+// TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError pins the fix for a
+// pooled-buffer leak: roaringSetGet acquires the first layer's buffer (returning
+// its real release), then merges every following segment into it. If a later
+// merge fails, the error path returns noopRelease to the caller, so the deferred
+// cleanup — not the caller — must free the first layer's buffer. A regression
+// that overwrites the release the defer reads would leak that buffer on every
+// mid-merge disk error.
+func TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError(t *testing.T) {
+	t.Parallel()
+
+	mergeErr := errors.New("simulated disk read error during merge")
+
+	t.Run("merge error frees first layer via defer, returns caller-safe noop", func(t *testing.T) {
+		// seg0 holds key1 and hands out a pooled buffer (its release must fire).
+		// seg1 fails mid-merge, which must not leak seg0's buffer.
+		seg0 := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"key1": bitmapFromSlice([]uint64{1, 2, 3}),
+		})
+		seg1 := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"key1": bitmapFromSlice([]uint64{4, 5, 6}),
+		})
+		seg1.roaringSetMergeErr = mergeErr
+
+		sg := &SegmentGroup{}
+		segments := []Segment{seg0, seg1}
+
+		out, release, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
+		require.ErrorIs(t, err, mergeErr)
+		require.Nil(t, out)
+		require.NotNil(t, release)
+
+		// the first layer's pooled buffer must have been released exactly once by
+		// the deferred cleanup, despite the error path returning noopRelease.
+		require.Equal(t, 1, seg0.roaringSetReleases,
+			"first layer's release must fire on merge error")
+
+		// the returned release must be the caller-safe noop; calling it must not
+		// double-release the first layer.
+		release()
+		require.Equal(t, 1, seg0.roaringSetReleases,
+			"returned release must be a noop; buffer already freed by defer")
+	})
+
+	t.Run("success path defers nothing, caller owns the release", func(t *testing.T) {
+		seg0 := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"key1": bitmapFromSlice([]uint64{1, 2, 3}),
+		})
+		seg1 := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"key1": bitmapFromSlice([]uint64{4, 5, 6}),
+		})
+
+		sg := &SegmentGroup{}
+		segments := []Segment{seg0, seg1}
+
+		out, release, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+
+		// no error => the defer must not fire; the caller still holds the buffer.
+		require.Equal(t, 0, seg0.roaringSetReleases,
+			"success path must not release before the caller does")
+
+		// the returned release frees the first layer's buffer exactly once.
+		release()
+		require.Equal(t, 1, seg0.roaringSetReleases,
+			"caller's release must free the first layer exactly once")
+	})
 }
 
 func TestSegmentGroup_RoaringSetRange_ConsistentViewAcrossSegmentAddition(t *testing.T) {

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -221,13 +221,9 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T)
 	require.Greater(t, segAB.getCounter, 0, "new segment should have received calls")
 }
 
-// TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError pins the fix for a
-// pooled-buffer leak: roaringSetGet acquires the first layer's buffer (returning
-// its real release), then merges every following segment into it. If a later
-// merge fails, the error path returns noopRelease to the caller, so the deferred
-// cleanup — not the caller — must free the first layer's buffer. A regression
-// that overwrites the release the defer reads would leak that buffer on every
-// mid-merge disk error.
+// TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError pins a
+// pooled-buffer leak when a later segment's merge fails after the first
+// layer's buffer was already acquired.
 func TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError(t *testing.T) {
 	t.Parallel()
 
@@ -252,13 +248,9 @@ func TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError(t *testing.T) {
 		require.Nil(t, out)
 		require.NotNil(t, release)
 
-		// the first layer's pooled buffer must have been released exactly once by
-		// the deferred cleanup, despite the error path returning noopRelease.
 		require.Equal(t, 1, seg0.roaringSetReleases,
 			"first layer's release must fire on merge error")
 
-		// the returned release must be the caller-safe noop; calling it must not
-		// double-release the first layer.
 		release()
 		require.Equal(t, 1, seg0.roaringSetReleases,
 			"returned release must be a noop; buffer already freed by defer")
@@ -279,11 +271,9 @@ func TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, out)
 
-		// no error => the defer must not fire; the caller still holds the buffer.
 		require.Equal(t, 0, seg0.roaringSetReleases,
 			"success path must not release before the caller does")
 
-		// the returned release frees the first layer's buffer exactly once.
 		release()
 		require.Equal(t, 1, seg0.roaringSetReleases,
 			"caller's release must free the first layer exactly once")

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
-	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
@@ -60,7 +59,7 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 	return out, func() { releaseAdd(); releaseDel() }, nil
 }
 
-func (s *segment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool,
+func (s *segment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool, maxConc int,
 ) error {
 	if err := segmentindex.CheckExpectedStrategy(s.strategy, segmentindex.StrategyRoaringSet); err != nil {
 		return err
@@ -91,8 +90,8 @@ func (s *segment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, 
 	}
 
 	input.Additions.
-		AndNotConc(sn.Deletions(), concurrency.SROAR_MERGE).
-		OrConc(sn.Additions(), concurrency.SROAR_MERGE)
+		AndNotConc(sn.Deletions(), maxConc).
+		OrConc(sn.Additions(), maxConc)
 	return nil
 }
 

--- a/adapters/repos/db/lsmkv/strategies_roaringset_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaringset_integration_test.go
@@ -67,21 +67,21 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 			err = b.RoaringSetAddList(key3, orig3)
 			require.Nil(t, err)
 
-			res, release, err := b.RoaringSetGet(key1)
+			res, release, err := b.RoaringSetGet(context.Background(), key1)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range orig1 {
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key2)
+			res, release, err = b.RoaringSetGet(context.Background(), key2)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range orig2 {
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key3)
+			res, release, err = b.RoaringSetGet(context.Background(), key3)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range orig3 {
@@ -98,21 +98,21 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 			err = b.RoaringSetRemoveOne(key3, removal3)
 			require.Nil(t, err)
 
-			res, release, err := b.RoaringSetGet(key1)
+			res, release, err := b.RoaringSetGet(context.Background(), key1)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range []uint64{1, 2} { // unchanged values
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key2)
+			res, release, err = b.RoaringSetGet(context.Background(), key2)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range []uint64{3, 4, 5} { // extended with 5
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key3)
+			res, release, err = b.RoaringSetGet(context.Background(), key3)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range []uint64{6} { // fewer remain
@@ -150,21 +150,21 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 			err = b.RoaringSetAddList(key3, orig3)
 			require.Nil(t, err)
 
-			res, release, err := b.RoaringSetGet(key1)
+			res, release, err := b.RoaringSetGet(context.Background(), key1)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range orig1 {
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key2)
+			res, release, err = b.RoaringSetGet(context.Background(), key2)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range orig2 {
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key3)
+			res, release, err = b.RoaringSetGet(context.Background(), key3)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range orig3 {
@@ -185,21 +185,21 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 			err = b.RoaringSetRemoveOne(key3, removal3)
 			require.Nil(t, err)
 
-			res, release, err := b.RoaringSetGet(key1)
+			res, release, err := b.RoaringSetGet(context.Background(), key1)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range []uint64{1, 2} { // unchanged values
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key2)
+			res, release, err = b.RoaringSetGet(context.Background(), key2)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range []uint64{3, 4, 5} { // extended with 5
 				assert.True(t, res.Contains(testVal))
 			}
 
-			res, release, err = b.RoaringSetGet(key3)
+			res, release, err = b.RoaringSetGet(context.Background(), key3)
 			require.NoError(t, err)
 			defer release()
 			for _, testVal := range []uint64{6} { // fewer remain

--- a/adapters/repos/db/roaringset/cursor.go
+++ b/adapters/repos/db/roaringset/cursor.go
@@ -24,6 +24,7 @@ type CombinedCursor struct {
 	cursors []InnerCursor
 	states  []innerCursorState
 	keyOnly bool
+	maxConc int
 }
 
 type InnerCursor interface {
@@ -41,8 +42,8 @@ type innerCursorState struct {
 // When keyOnly flag is set, only keys are returned by First/Next/Seek access methods,
 // 2nd value returned is expected to be nil
 // When keyOnly is not set, 2nd value is always bitmap. Returned bitmap can be empty (e.g. for Next call after last element was already returned)
-func NewCombinedCursor(innerCursors []InnerCursor, keyOnly bool) *CombinedCursor {
-	return &CombinedCursor{cursors: innerCursors, keyOnly: keyOnly}
+func NewCombinedCursor(innerCursors []InnerCursor, keyOnly bool, maxConc int) *CombinedCursor {
+	return &CombinedCursor{cursors: innerCursors, keyOnly: keyOnly, maxConc: maxConc}
 }
 
 func (c *CombinedCursor) First() ([]byte, *sroar.Bitmap) {
@@ -111,7 +112,7 @@ func (c *CombinedCursor) getResultFromStates(states []innerCursorState) ([]byte,
 			return nil, nil
 		}
 
-		bm := layers.Flatten(true)
+		bm := layers.Flatten(true, c.maxConc)
 		if key == nil {
 			return nil, bm
 		}

--- a/adapters/repos/db/roaringset/cursor.go
+++ b/adapters/repos/db/roaringset/cursor.go
@@ -42,9 +42,8 @@ type innerCursorState struct {
 // When keyOnly flag is set, only keys are returned by First/Next/Seek access methods,
 // 2nd value returned is expected to be nil
 // When keyOnly is not set, 2nd value is always bitmap. Returned bitmap can be empty (e.g. for Next call after last element was already returned)
-// maxConc caps the concurrency of the underlying sroar merge ops: pass the
-// per-query budget on read paths (concurrency.BudgetFromCtxCapped) or
-// concurrency.SROAR_MERGE for background work.
+// maxConc caps sroar merge concurrency; pass the per-query budget on read
+// paths, or concurrency.SROAR_MERGE for background work.
 func NewCombinedCursor(innerCursors []InnerCursor, keyOnly bool, maxConc int) *CombinedCursor {
 	return &CombinedCursor{cursors: innerCursors, keyOnly: keyOnly, maxConc: maxConc}
 }

--- a/adapters/repos/db/roaringset/cursor.go
+++ b/adapters/repos/db/roaringset/cursor.go
@@ -42,6 +42,9 @@ type innerCursorState struct {
 // When keyOnly flag is set, only keys are returned by First/Next/Seek access methods,
 // 2nd value returned is expected to be nil
 // When keyOnly is not set, 2nd value is always bitmap. Returned bitmap can be empty (e.g. for Next call after last element was already returned)
+// maxConc caps the concurrency of the underlying sroar merge ops: pass the
+// per-query budget on read paths (concurrency.BudgetFromCtxCapped) or
+// concurrency.SROAR_MERGE for background work.
 func NewCombinedCursor(innerCursors []InnerCursor, keyOnly bool, maxConc int) *CombinedCursor {
 	return &CombinedCursor{cursors: innerCursors, keyOnly: keyOnly, maxConc: maxConc}
 }

--- a/adapters/repos/db/roaringset/cursor_test.go
+++ b/adapters/repos/db/roaringset/cursor_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/concurrency"
 )
 
 func TestCombinedCursor(t *testing.T) {
@@ -400,7 +401,7 @@ func createCursor(t *testing.T, bsts ...*BinarySearchTree) *CombinedCursor {
 	for _, bst := range bsts {
 		innerCursors = append(innerCursors, NewBinarySearchTreeCursor(bst))
 	}
-	return NewCombinedCursor(innerCursors, false)
+	return NewCombinedCursor(innerCursors, false, concurrency.SROAR_MERGE)
 }
 
 func createCursorKeyOnly(t *testing.T, bsts ...*BinarySearchTree) *CombinedCursor {
@@ -412,7 +413,7 @@ func createCursorKeyOnly(t *testing.T, bsts ...*BinarySearchTree) *CombinedCurso
 // Previous implementation of cursor called recursively Next() when empty entry occurred,
 // which could lead to stack overflow. This test prevents a regression.
 func TestCombinedCursor_StackOverflow(t *testing.T) {
-	cursor := NewCombinedCursor([]InnerCursor{&emptyInnerCursor{}}, false)
+	cursor := NewCombinedCursor([]InnerCursor{&emptyInnerCursor{}}, false, concurrency.SROAR_MERGE)
 
 	k, bm := cursor.First()
 	assert.Nil(t, k)

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -83,7 +83,7 @@ type BitmapLayers []BitmapLayer
 //     should be represented in the final bitmap. If the order is reversed and
 //     layer 2 adds X, whereas layer 3 removes X, it is should not be contained
 //     in the final map.
-func (bml BitmapLayers) Flatten(clone bool) *sroar.Bitmap {
+func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 	if len(bml) == 0 {
 		return sroar.NewBitmap()
 	}
@@ -94,8 +94,8 @@ func (bml BitmapLayers) Flatten(clone bool) *sroar.Bitmap {
 	}
 
 	for i := 1; i < len(bml); i++ {
-		merged.AndNotConc(bml[i].Deletions, concurrency.SROAR_MERGE)
-		merged.OrConc(bml[i].Additions, concurrency.SROAR_MERGE)
+		merged.AndNotConc(bml[i].Deletions, maxConc)
+		merged.OrConc(bml[i].Additions, maxConc)
 	}
 
 	return merged

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -83,6 +83,10 @@ type BitmapLayers []BitmapLayer
 //     should be represented in the final bitmap. If the order is reversed and
 //     layer 2 adds X, whereas layer 3 removes X, it is should not be contained
 //     in the final map.
+//
+// maxConc caps the concurrency of the underlying sroar merge ops: pass the
+// per-query budget on read paths (concurrency.BudgetFromCtxCapped) or
+// concurrency.SROAR_MERGE for background work.
 func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 	if len(bml) == 0 {
 		return sroar.NewBitmap()

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -84,9 +84,8 @@ type BitmapLayers []BitmapLayer
 //     layer 2 adds X, whereas layer 3 removes X, it is should not be contained
 //     in the final map.
 //
-// maxConc caps the concurrency of the underlying sroar merge ops: pass the
-// per-query budget on read paths (concurrency.BudgetFromCtxCapped) or
-// concurrency.SROAR_MERGE for background work.
+// maxConc caps sroar merge concurrency; pass the per-query budget on read
+// paths, or concurrency.SROAR_MERGE for background work.
 func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 	if len(bml) == 0 {
 		return sroar.NewBitmap()

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -12,6 +12,7 @@
 package roaringset
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,21 +100,29 @@ func Test_BitmapLayers_Flatten(t *testing.T) {
 		},
 	}
 
+	// Flatten must be identical regardless of the merge concurrency: single
+	// threaded (1), the minimum fan-out (2), and the default cap (SROAR_MERGE).
+	maxConcs := []int{1, 2, concurrency.SROAR_MERGE}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			input := make(BitmapLayers, len(test.inputs))
-			for i, inp := range test.inputs {
-				input[i].Additions = NewBitmap(inp.additions...)
-				input[i].Deletions = NewBitmap(inp.deletions...)
-			}
+			for _, maxConc := range maxConcs {
+				t.Run(fmt.Sprintf("maxConc=%d", maxConc), func(t *testing.T) {
+					input := make(BitmapLayers, len(test.inputs))
+					for i, inp := range test.inputs {
+						input[i].Additions = NewBitmap(inp.additions...)
+						input[i].Deletions = NewBitmap(inp.deletions...)
+					}
 
-			res := input.Flatten(false, concurrency.SROAR_MERGE)
-			for _, x := range test.expectedContained {
-				assert.True(t, res.Contains(x))
-			}
+					res := input.Flatten(false, maxConc)
+					for _, x := range test.expectedContained {
+						assert.True(t, res.Contains(x))
+					}
 
-			for _, x := range test.expectedNotContained {
-				assert.False(t, res.Contains(x))
+					for _, x := range test.expectedNotContained {
+						assert.False(t, res.Contains(x))
+					}
+				})
 			}
 		})
 	}

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/concurrency"
 )
 
 func Test_BitmapLayers_Flatten(t *testing.T) {
@@ -106,7 +107,7 @@ func Test_BitmapLayers_Flatten(t *testing.T) {
 				input[i].Deletions = NewBitmap(inp.deletions...)
 			}
 
-			res := input.Flatten(false)
+			res := input.Flatten(false, concurrency.SROAR_MERGE)
 			for _, x := range test.expectedContained {
 				assert.True(t, res.Contains(x))
 			}

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -85,6 +85,10 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		return layer.Additions, release, nil
 	}
 
+	// resolve the per-query merge/fan-out budget once, capped at the reader's
+	// configured concurrency, so all readers for this query share it
+	conc := concurrency.BudgetFromCtxCapped(ctx, r.concurrency)
+
 	lock := new(sync.Mutex)
 	addReadTime := func(d time.Duration) {
 		lock.Lock()
@@ -101,9 +105,14 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// the readers run concurrently (up to conc inner readers plus readers[0]),
+	// so hand each a fractional slice of the budget to bound the inner fan-out
+	// instead of letting every reader spawn conc merge goroutines of its own
+	innerCtx := concurrency.ContextWithFractionalBudget(ctx, min(count-1, conc), r.concurrency)
+
 	errors.GoWrapper(func() {
-		eg, gctx := errors.NewErrorGroupWithContextWrapper(r.logger, ctx)
-		eg.SetLimit(r.concurrency)
+		eg, gctx := errors.NewErrorGroupWithContextWrapper(r.logger, innerCtx)
+		eg.SetLimit(conc)
 
 		for i := 1; i < count; i++ {
 			i := i
@@ -118,7 +127,7 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 	}, r.logger)
 
 	t := time.Now()
-	layer, release, err := r.readers[0].Read(ctx, value, operator)
+	layer, release, err := r.readers[0].Read(innerCtx, value, operator)
 	addReadTime(time.Since(t))
 
 	ec := errorcompounder.New()
@@ -130,8 +139,8 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 
 		if ec.Len() == 0 {
 			t := time.Now()
-			layer.Additions.AndNotConc(response.layer.Deletions, concurrency.SROAR_MERGE)
-			layer.Additions.OrConc(response.layer.Additions, concurrency.SROAR_MERGE)
+			layer.Additions.AndNotConc(response.layer.Deletions, conc)
+			layer.Additions.OrConc(response.layer.Additions, conc)
 			mergingSum += time.Since(t)
 		}
 		response.release()

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -85,8 +85,7 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		return layer.Additions, release, nil
 	}
 
-	// resolve the per-query merge/fan-out budget once, capped at the reader's
-	// configured concurrency, so all readers for this query share it
+	// conc is the per-query merge/fan-out budget shared by every reader below.
 	conc := concurrency.BudgetFromCtxCapped(ctx, r.concurrency)
 
 	lock := new(sync.Mutex)

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -105,10 +105,14 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// the readers run concurrently (up to conc inner readers plus readers[0]),
-	// so hand each a fractional slice of the budget to bound the inner fan-out
-	// instead of letting every reader spawn conc merge goroutines of its own
-	innerCtx := concurrency.ContextWithFractionalBudget(ctx, min(count-1, conc), r.concurrency)
+	// hand inner readers a fractional slice of the budget so the concurrent
+	// fan-out stays bounded instead of each reader spawning conc merge workers.
+	// kill switch on: leave ctx budgets untouched so BudgetFromCtx consumers
+	// below the fan-out still see the caller's original budget.
+	innerCtx := ctx
+	if !concurrency.BudgetCapDisabled() {
+		innerCtx = concurrency.ContextWithFractionalBudget(ctx, min(count-1, conc), r.concurrency)
+	}
 
 	errors.GoWrapper(func() {
 		eg, gctx := errors.NewErrorGroupWithContextWrapper(r.logger, innerCtx)
@@ -138,6 +142,9 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		ec.Add(response.err)
 
 		if ec.Len() == 0 {
+			// this outer merge runs at the full budget while inner readers may still
+			// resolve at their fractional slice: a deliberate mild overshoot, as in
+			// prop_value_pairs.go
 			t := time.Now()
 			layer.Additions.AndNotConc(response.layer.Deletions, conc)
 			layer.Additions.OrConc(response.layer.Additions, conc)

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -34,17 +34,19 @@ type CombinedReader struct {
 	logger         logrus.FieldLogger
 	readers        []InnerReader
 	releaseReaders func()
-	concurrency    int
+	// segmentConcurrency caps how many inner readers run at once; the
+	// bitmap-merge budget is a separate per-query axis carried in ctx.
+	segmentConcurrency int
 }
 
-func NewCombinedReader(readers []InnerReader, releaseReaders func(), concurrency int,
+func NewCombinedReader(readers []InnerReader, releaseReaders func(), segmentConcurrency int,
 	logger logrus.FieldLogger,
 ) *CombinedReader {
 	return &CombinedReader{
-		logger:         logger,
-		readers:        readers,
-		releaseReaders: releaseReaders,
-		concurrency:    concurrency,
+		logger:             logger,
+		readers:            readers,
+		releaseReaders:     releaseReaders,
+		segmentConcurrency: segmentConcurrency,
 	}
 }
 
@@ -85,8 +87,10 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		return layer.Additions, release, nil
 	}
 
-	// conc is the per-query merge/fan-out budget shared by every reader below.
-	conc := concurrency.BudgetFromCtxCapped(ctx, r.concurrency)
+	// Two separate axes of parallelism: r.segmentConcurrency bounds how many
+	// readers run at once (SetLimit below), outerBudget bounds bitmap-merge
+	// parallelism per query.
+	outerBudget := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
 	lock := new(sync.Mutex)
 	addReadTime := func(d time.Duration) {
@@ -104,16 +108,20 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// fractional budget bounds the inner fan-out; skipped when the kill switch
-	// is set so BudgetFromCtx consumers below still see the caller's own budget.
+	// innerCtx carries each reader's share of the merge budget: the outer
+	// budget split across the readers running at once (up to
+	// r.segmentConcurrency in the error group plus the current goroutine).
+	// Skipped when the kill switch is set so readers below fall back to the
+	// fixed constant.
 	innerCtx := ctx
 	if !concurrency.BudgetCapDisabled() {
-		innerCtx = concurrency.ContextWithFractionalBudget(ctx, min(count-1, conc), r.concurrency)
+		conc := min(count, r.segmentConcurrency+1)
+		innerCtx = concurrency.CtxWithBudget(ctx, max(1, outerBudget/conc))
 	}
 
 	errors.GoWrapper(func() {
 		eg, gctx := errors.NewErrorGroupWithContextWrapper(r.logger, innerCtx)
-		eg.SetLimit(conc)
+		eg.SetLimit(r.segmentConcurrency)
 
 		for i := 1; i < count; i++ {
 			i := i
@@ -139,11 +147,11 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		ec.Add(response.err)
 
 		if ec.Len() == 0 {
-			// deliberate mild overshoot: outer merge uses the full budget while inner
-			// readers already resolved at their fractional slice (mirrors prop_value_pairs.go)
+			// full budget rather than the inner share: remaining readers are
+			// draining while this merge runs, so a mild overshoot is acceptable
 			t := time.Now()
-			layer.Additions.AndNotConc(response.layer.Deletions, conc)
-			layer.Additions.OrConc(response.layer.Additions, conc)
+			layer.Additions.AndNotConc(response.layer.Deletions, outerBudget)
+			layer.Additions.OrConc(response.layer.Additions, outerBudget)
 			mergingSum += time.Since(t)
 		}
 		response.release()

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -105,10 +105,8 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// hand inner readers a fractional slice of the budget so the concurrent
-	// fan-out stays bounded instead of each reader spawning conc merge workers.
-	// kill switch on: leave ctx budgets untouched so BudgetFromCtx consumers
-	// below the fan-out still see the caller's original budget.
+	// fractional budget bounds the inner fan-out; skipped when the kill switch
+	// is set so BudgetFromCtx consumers below still see the caller's own budget.
 	innerCtx := ctx
 	if !concurrency.BudgetCapDisabled() {
 		innerCtx = concurrency.ContextWithFractionalBudget(ctx, min(count-1, conc), r.concurrency)
@@ -142,9 +140,8 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		ec.Add(response.err)
 
 		if ec.Len() == 0 {
-			// this outer merge runs at the full budget while inner readers may still
-			// resolve at their fractional slice: a deliberate mild overshoot, as in
-			// prop_value_pairs.go
+			// deliberate mild overshoot: outer merge uses the full budget while inner
+			// readers already resolved at their fractional slice (mirrors prop_value_pairs.go)
 			t := time.Now()
 			layer.Additions.AndNotConc(response.layer.Deletions, conc)
 			layer.Additions.OrConc(response.layer.Additions, conc)

--- a/adapters/repos/db/roaringsetrange/reader.go
+++ b/adapters/repos/db/roaringsetrange/reader.go
@@ -87,9 +87,8 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 		return layer.Additions, release, nil
 	}
 
-	// Two separate axes of parallelism: r.segmentConcurrency bounds how many
-	// readers run at once (SetLimit below), outerBudget bounds bitmap-merge
-	// parallelism per query.
+	// outerBudget bounds bitmap-merge parallelism; segmentConcurrency (below)
+	// bounds reader fan-out instead.
 	outerBudget := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
 	lock := new(sync.Mutex)
@@ -108,11 +107,8 @@ func (r *CombinedReader) Read(ctx context.Context, value uint64, operator filter
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// innerCtx carries each reader's share of the merge budget: the outer
-	// budget split across the readers running at once (up to
-	// r.segmentConcurrency in the error group plus the current goroutine).
-	// Skipped when the kill switch is set so readers below fall back to the
-	// fixed constant.
+	// innerCtx splits outerBudget across the readers running at once; skipped
+	// when the kill switch is set so readers fall back to the fixed constant.
 	innerCtx := ctx
 	if !concurrency.BudgetCapDisabled() {
 		conc := min(count, r.segmentConcurrency+1)

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -14,7 +14,10 @@ package roaringsetrange
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -22,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -339,6 +343,145 @@ func TestCombinedReaderInnerReaders(t *testing.T) {
 		assert.Equal(t, 0, innerReader2.InUseCounter())
 		assert.Equal(t, 0, innerReader3.InUseCounter())
 	})
+}
+
+// cloningInnerReader returns a fresh clone of its additions on every Read, so
+// concurrent CombinedReader.Read calls never mutate a shared bitmap.
+type cloningInnerReader struct {
+	additions *sroar.Bitmap
+}
+
+func (r *cloningInnerReader) Read(ctx context.Context, value uint64, operator filters.Operator,
+) (roaringset.BitmapLayer, func(), error) {
+	return roaringset.BitmapLayer{
+		Additions: r.additions.Clone(),
+		Deletions: sroar.NewBitmap(),
+	}, noopRelease, nil
+}
+
+// TestCombinedReader_RespectsConcurrencyBudget proves the per-query budget
+// threaded into CombinedReader.Read caps sroar's merge fan-out. With a budget
+// of 1 the outer layer merges run single-threaded, so hammering the reader
+// from many callers cannot inflate the live goroutine count. Without the
+// budget each of the (readers-1) merges would fan out ~SROAR_MERGE workers.
+func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
+	if concurrency.SROAR_MERGE < 2 {
+		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
+			concurrency.SROAR_MERGE)
+	}
+
+	logger, _ := test.NewNullLogger()
+
+	// one value per sroar container (stride 2^16). Many containers so each
+	// *Conc op spreads real work across min(n/24, SROAR_MERGE) workers that
+	// live long enough for the sampler to observe when the budget is ignored.
+	const numContainers = 8192
+	values := make([]uint64, numContainers)
+	for i := range values {
+		values[i] = uint64(i) << 16
+	}
+
+	const numReaders = 8 // several outer merges per Read
+	newReader := func() *CombinedReader {
+		readers := make([]InnerReader, numReaders)
+		for i := range readers {
+			readers[i] = &cloningInnerReader{additions: roaringset.NewBitmap(values...)}
+		}
+		return NewCombinedReader(readers, noopRelease, concurrency.SROAR_MERGE, logger)
+	}
+
+	ctx := context.Background()
+	budget1 := concurrency.CtxWithBudget(ctx, 1)
+
+	// correctness: a budget of 1 returns the same set as an unconstrained query
+	got1, release1, err := newReader().Read(budget1, 0, filters.OperatorGreaterThanEqual)
+	require.NoError(t, err)
+	arr1 := got1.ToArray()
+	release1()
+
+	gotDefault, releaseDefault, err := newReader().Read(ctx, 0, filters.OperatorGreaterThanEqual)
+	require.NoError(t, err)
+	arrDefault := gotDefault.ToArray()
+	releaseDefault()
+
+	require.Equal(t, values, arr1)
+	require.Equal(t, arrDefault, arr1)
+
+	// bounding leg
+	const (
+		numWorkers = 16
+		runFor     = 200 * time.Millisecond
+		// CombinedReader always drives its inner readers through an errgroup, so
+		// each in-flight Read keeps at most 3 goroutines alive: its own worker,
+		// the errgroup driver, and (because budget=1 forces eg.SetLimit(1)) a
+		// single limited eg.Go worker. The merge ops spawn zero workers at conc=1.
+		// Without the budget, conc=SROAR_MERGE lifts the eg limit and every Conc
+		// op fans out ~SROAR_MERGE-1 merge workers, blowing past this ceiling.
+		maxGoroutinesPerRead = 3
+		// absorbs the sampler goroutine and transient runtime/GC workers
+		noiseSlack = 12
+	)
+
+	stop := make(chan struct{})
+	samplerDone := make(chan struct{})
+	var maxSeen int // written only by the sampler, read after samplerDone closes
+
+	go func() {
+		defer close(samplerDone)
+		ticker := time.NewTicker(1 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if n := runtime.NumGoroutine(); n > maxSeen {
+					maxSeen = n
+				}
+			}
+		}
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	base := runtime.NumGoroutine()
+
+	firstErr := make(chan error, 1)
+	var wg sync.WaitGroup
+	deadline := time.Now().Add(runFor)
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := newReader()
+			for time.Now().Before(deadline) {
+				bm, release, err := r.Read(budget1, 0, filters.OperatorGreaterThanEqual)
+				if err != nil {
+					select {
+					case firstErr <- err:
+					default:
+					}
+					return
+				}
+				_ = bm
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	<-samplerDone
+
+	select {
+	case err := <-firstErr:
+		require.NoError(t, err)
+	default:
+	}
+
+	ceiling := base + numWorkers*maxGoroutinesPerRead + noiseSlack
+	assert.LessOrEqualf(t, maxSeen, ceiling,
+		"live goroutines peaked at %d, above base(%d)+workers(%d)*perRead(%d)+noise(%d)=%d; "+
+			"a budget of 1 must not fan out sroar merge workers",
+		maxSeen, base, numWorkers, maxGoroutinesPerRead, noiseSlack, ceiling)
 }
 
 func createTestMemtables(logger logrus.FieldLogger) (*Memtable, *Memtable, *Memtable) {

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -358,11 +358,9 @@ func (r *cloningInnerReader) Read(ctx context.Context, value uint64, operator fi
 	}, noopRelease, nil
 }
 
-// TestCombinedReader_RespectsConcurrencyBudget proves the per-query budget
-// threaded into CombinedReader.Read caps sroar's merge fan-out. With a budget
-// of 1 the outer layer merges run single-threaded, so hammering the reader
-// from many callers cannot inflate the live goroutine count. Without the
-// budget each of the (readers-1) merges would fan out ~SROAR_MERGE workers.
+// TestCombinedReader_RespectsConcurrencyBudget: a budget of 1 must serialize
+// the outer layer merges, so hammering the reader can't inflate the live
+// goroutine count.
 func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	if concurrency.SROAR_MERGE < 2 {
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
@@ -371,9 +369,8 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	// one value per sroar container (stride 2^16). Many containers so each
-	// *Conc op spreads real work across min(n/24, SROAR_MERGE) workers that
-	// live long enough for the sampler to observe when the budget is ignored.
+	// one value per sroar container (stride 2^16); enough real work per
+	// *Conc op that the sampler can observe an ignored budget
 	const numContainers = 8192
 	values := make([]uint64, numContainers)
 	for i := range values {
@@ -406,14 +403,10 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, values, arr1)
 	require.Equal(t, arrDefault, arr1)
 
-	// bounding leg. CombinedReader always drives its inner readers through an
-	// errgroup, so each in-flight Read keeps at most 3 goroutines alive: its
-	// own worker, the errgroup driver, and (because budget=1 forces
-	// eg.SetLimit(1)) a single limited eg.Go worker. The merge ops spawn zero
-	// workers at conc=1. Without the budget, conc=SROAR_MERGE lifts the eg
-	// limit and every Conc op fans out ~SROAR_MERGE-1 merge workers, blowing
-	// past the ceiling. Sharing one reader is safe: cloningInnerReader clones
-	// its bitmap on every Read.
+	// each in-flight Read holds <=3 goroutines: its own worker, the errgroup
+	// driver, and the one eg.Go worker budget=1 allows via eg.SetLimit(1).
+	// Sharing one reader across goroutines is safe since cloningInnerReader
+	// clones its bitmap per Read.
 	shared := newReader()
 	testinghelpers.AssertGoroutineCeiling(t, 16, 3, 12, 200*time.Millisecond, func() error {
 		bm, release, err := shared.Read(budget1, 0, filters.OperatorGreaterThanEqual)

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -14,8 +14,6 @@ package roaringsetrange
 import (
 	"context"
 	"fmt"
-	"runtime"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +24,7 @@ import (
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/concurrency/testinghelpers"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -407,81 +406,24 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, values, arr1)
 	require.Equal(t, arrDefault, arr1)
 
-	// bounding leg
-	const (
-		numWorkers = 16
-		runFor     = 200 * time.Millisecond
-		// CombinedReader always drives its inner readers through an errgroup, so
-		// each in-flight Read keeps at most 3 goroutines alive: its own worker,
-		// the errgroup driver, and (because budget=1 forces eg.SetLimit(1)) a
-		// single limited eg.Go worker. The merge ops spawn zero workers at conc=1.
-		// Without the budget, conc=SROAR_MERGE lifts the eg limit and every Conc
-		// op fans out ~SROAR_MERGE-1 merge workers, blowing past this ceiling.
-		maxGoroutinesPerRead = 3
-		// absorbs the sampler goroutine and transient runtime/GC workers
-		noiseSlack = 12
-	)
-
-	stop := make(chan struct{})
-	samplerDone := make(chan struct{})
-	var maxSeen int // written only by the sampler, read after samplerDone closes
-
-	go func() {
-		defer close(samplerDone)
-		ticker := time.NewTicker(1 * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-				if n := runtime.NumGoroutine(); n > maxSeen {
-					maxSeen = n
-				}
-			}
+	// bounding leg. CombinedReader always drives its inner readers through an
+	// errgroup, so each in-flight Read keeps at most 3 goroutines alive: its
+	// own worker, the errgroup driver, and (because budget=1 forces
+	// eg.SetLimit(1)) a single limited eg.Go worker. The merge ops spawn zero
+	// workers at conc=1. Without the budget, conc=SROAR_MERGE lifts the eg
+	// limit and every Conc op fans out ~SROAR_MERGE-1 merge workers, blowing
+	// past the ceiling. Sharing one reader is safe: cloningInnerReader clones
+	// its bitmap on every Read.
+	shared := newReader()
+	testinghelpers.AssertGoroutineCeiling(t, 16, 3, 12, 200*time.Millisecond, func() error {
+		bm, release, err := shared.Read(budget1, 0, filters.OperatorGreaterThanEqual)
+		if err != nil {
+			return err
 		}
-	}()
-
-	time.Sleep(5 * time.Millisecond)
-	base := runtime.NumGoroutine()
-
-	firstErr := make(chan error, 1)
-	var wg sync.WaitGroup
-	deadline := time.Now().Add(runFor)
-	for i := 0; i < numWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			r := newReader()
-			for time.Now().Before(deadline) {
-				bm, release, err := r.Read(budget1, 0, filters.OperatorGreaterThanEqual)
-				if err != nil {
-					select {
-					case firstErr <- err:
-					default:
-					}
-					return
-				}
-				_ = bm
-				release()
-			}
-		}()
-	}
-	wg.Wait()
-	close(stop)
-	<-samplerDone
-
-	select {
-	case err := <-firstErr:
-		require.NoError(t, err)
-	default:
-	}
-
-	ceiling := base + numWorkers*maxGoroutinesPerRead + noiseSlack
-	assert.LessOrEqualf(t, maxSeen, ceiling,
-		"live goroutines peaked at %d, above base(%d)+workers(%d)*perRead(%d)+noise(%d)=%d; "+
-			"a budget of 1 must not fan out sroar merge workers",
-		maxSeen, base, numWorkers, maxGoroutinesPerRead, noiseSlack, ceiling)
+		_ = bm
+		release()
+		return nil
+	})
 }
 
 func createTestMemtables(logger logrus.FieldLogger) (*Memtable, *Memtable, *Memtable) {

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -370,16 +370,13 @@ func (r *cloningInnerReader) Read(ctx context.Context, value uint64, operator fi
 // TestCombinedReader_RespectsConcurrencyBudget pins the outer layer merge to
 // the per-query budget without inflating the live goroutine count.
 func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
-	// The kill switch (DISABLE_SROAR_MERGE_BUDGET=true) is this bound's red
-	// control, but it is a manual/local check: run with the env var set and
-	// this skip bypassed, and the ceiling assertion below must fail. No CI job
-	// sets the kill switch, so CI exercises only the green (budget-enforced) leg.
+	// Kill switch is this bound's red control, but no CI job sets it: CI
+	// only ever runs the green (budget-enforced) path.
 	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 		t.Skip("budget cap disabled via kill switch")
 	}
-	// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4). Skipping on a
-	// <4-vCPU runner would silently evaporate the guard, so fail loudly on CI
-	// and only skip on dev machines.
+	// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4); skipping
+	// here silently would hide the guard, so CI fails loudly instead.
 	if concurrency.SROAR_MERGE < 2 {
 		if os.Getenv("CI") != "" {
 			t.Fatalf("bounding tests require GOMAXPROCS>=4, refusing to skip silently on CI (SROAR_MERGE=%d)",

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -350,23 +350,38 @@ func TestCombinedReaderInnerReaders(t *testing.T) {
 // concurrent CombinedReader.Read calls never mutate a shared bitmap.
 type cloningInnerReader struct {
 	additions *sroar.Bitmap
+	// readDelay makes each Read take a bounded, sustained amount of time. The
+	// concurrency bound is enforced by the errgroup's SetLimit(conc): at most
+	// conc inner reads run at once. Without a sustained read, those workers are
+	// too short-lived for the 1ms goroutine sampler to catch, so an ignored
+	// budget (kill switch on) produces a red-control margin that is thin at
+	// small SROAR_MERGE — the sampler simply misses the extra workers. Holding
+	// each read open for a few sampler ticks makes the live-worker count reflect
+	// conc reliably, so the red control fails decisively even at SROAR_MERGE=2.
+	readDelay time.Duration
 }
 
 func (r *cloningInnerReader) Read(ctx context.Context, value uint64, operator filters.Operator,
 ) (roaringset.BitmapLayer, func(), error) {
+	if r.readDelay > 0 {
+		time.Sleep(r.readDelay)
+	}
 	return roaringset.BitmapLayer{
 		Additions: r.additions.Clone(),
 		Deletions: sroar.NewBitmap(),
 	}, noopRelease, nil
 }
 
-// TestCombinedReader_RespectsConcurrencyBudget: a budget of 1 must serialize
-// the outer layer merges, so hammering the reader can't inflate the live
-// goroutine count.
+// TestCombinedReader_RespectsConcurrencyBudget pins the outer layer merge to
+// the per-query budget without inflating the live goroutine count.
 func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
+	// CI implication: the kill-switch CI leg (DISABLE_SROAR_MERGE_BUDGET=true)
+	// skips this bound by design and serves as the red control instead.
 	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 		t.Skip("budget cap disabled via kill switch")
 	}
+	// CI implication: 2-vCPU runners have SROAR_MERGE=1 and skip this entirely;
+	// the bound is only exercised on >=4-vCPU runners (SROAR_MERGE>=2).
 	if concurrency.SROAR_MERGE < 2 {
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 			concurrency.SROAR_MERGE)
@@ -383,10 +398,13 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	}
 
 	const numReaders = 8 // several outer merges per Read
+	// hold each inner read open for a few sampler ticks so the SetLimit(conc)
+	// fan-out is observable regardless of SROAR_MERGE (see cloningInnerReader).
+	const readDelay = 2 * time.Millisecond
 	newReader := func() *CombinedReader {
 		readers := make([]InnerReader, numReaders)
 		for i := range readers {
-			readers[i] = &cloningInnerReader{additions: roaringset.NewBitmap(values...)}
+			readers[i] = &cloningInnerReader{additions: roaringset.NewBitmap(values...), readDelay: readDelay}
 		}
 		return NewCombinedReader(readers, noopRelease, concurrency.SROAR_MERGE, logger)
 	}
@@ -411,9 +429,12 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	// each in-flight Read holds <=3 goroutines: its own worker, the errgroup
 	// driver, and the one eg.Go worker budget=1 allows via eg.SetLimit(1).
 	// Sharing one reader across goroutines is safe since cloningInnerReader
-	// clones its bitmap per Read.
+	// clones its bitmap per Read. The sustained readDelay pins the budget=1 peak
+	// deterministically at 3/worker, so a slack of 8 keeps the green margin at
+	// +8 while the kill-switch red control overshoots by >=8 even at the
+	// smallest fan-out this test runs at (SROAR_MERGE=2 => conc=2).
 	shared := newReader()
-	testinghelpers.AssertGoroutineCeiling(t, 16, 3, 12, 200*time.Millisecond, func() error {
+	testinghelpers.AssertGoroutineCeiling(t, 16, 3, 8, 200*time.Millisecond, func() error {
 		bm, release, err := shared.Read(budget1, 0, filters.OperatorGreaterThanEqual)
 		if err != nil {
 			return err

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -350,14 +350,9 @@ func TestCombinedReaderInnerReaders(t *testing.T) {
 // concurrent CombinedReader.Read calls never mutate a shared bitmap.
 type cloningInnerReader struct {
 	additions *sroar.Bitmap
-	// readDelay makes each Read take a bounded, sustained amount of time. The
-	// concurrency bound is enforced by the errgroup's SetLimit(conc): at most
-	// conc inner reads run at once. Without a sustained read, those workers are
-	// too short-lived for the 1ms goroutine sampler to catch, so an ignored
-	// budget (kill switch on) produces a red-control margin that is thin at
-	// small SROAR_MERGE — the sampler simply misses the extra workers. Holding
-	// each read open for a few sampler ticks makes the live-worker count reflect
-	// conc reliably, so the red control fails decisively even at SROAR_MERGE=2.
+	// readDelay keeps each Read alive across a few goroutine-sampler ticks, so
+	// a disabled budget (kill switch) overshoots the ceiling decisively
+	// instead of its short-lived workers being missed by the sampler.
 	readDelay time.Duration
 }
 
@@ -397,10 +392,8 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 		values[i] = uint64(i) << 16
 	}
 
-	const numReaders = 8 // several outer merges per Read
-	// hold each inner read open for a few sampler ticks so the SetLimit(conc)
-	// fan-out is observable regardless of SROAR_MERGE (see cloningInnerReader).
-	const readDelay = 2 * time.Millisecond
+	const numReaders = 8                   // several outer merges per Read
+	const readDelay = 2 * time.Millisecond // see cloningInnerReader.readDelay
 	newReader := func() *CombinedReader {
 		readers := make([]InnerReader, numReaders)
 		for i := range readers {
@@ -427,12 +420,9 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, arrDefault, arr1)
 
 	// each in-flight Read holds <=3 goroutines: its own worker, the errgroup
-	// driver, and the one eg.Go worker budget=1 allows via eg.SetLimit(1).
-	// Sharing one reader across goroutines is safe since cloningInnerReader
-	// clones its bitmap per Read. The sustained readDelay pins the budget=1 peak
-	// deterministically at 3/worker, so a slack of 8 keeps the green margin at
-	// +8 while the kill-switch red control overshoots by >=8 even at the
-	// smallest fan-out this test runs at (SROAR_MERGE=2 => conc=2).
+	// driver, and the one eg.Go worker budget=1 allows. Sharing one reader is
+	// safe since cloningInnerReader clones per Read. readDelay pins that peak
+	// so slack=8 still lets the kill-switch red control overshoot decisively.
 	shared := newReader()
 	testinghelpers.AssertGoroutineCeiling(t, 16, 3, 8, 200*time.Millisecond, func() error {
 		bm, release, err := shared.Read(budget1, 0, filters.OperatorGreaterThanEqual)

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -370,14 +370,21 @@ func (r *cloningInnerReader) Read(ctx context.Context, value uint64, operator fi
 // TestCombinedReader_RespectsConcurrencyBudget pins the outer layer merge to
 // the per-query budget without inflating the live goroutine count.
 func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
-	// CI implication: the kill-switch CI leg (DISABLE_SROAR_MERGE_BUDGET=true)
-	// skips this bound by design and serves as the red control instead.
+	// The kill switch (DISABLE_SROAR_MERGE_BUDGET=true) is this bound's red
+	// control, but it is a manual/local check: run with the env var set and
+	// this skip bypassed, and the ceiling assertion below must fail. No CI job
+	// sets the kill switch, so CI exercises only the green (budget-enforced) leg.
 	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 		t.Skip("budget cap disabled via kill switch")
 	}
-	// CI implication: 2-vCPU runners have SROAR_MERGE=1 and skip this entirely;
-	// the bound is only exercised on >=4-vCPU runners (SROAR_MERGE>=2).
+	// Merge fan-out only exists at SROAR_MERGE>=2 (GOMAXPROCS>=4). Skipping on a
+	// <4-vCPU runner would silently evaporate the guard, so fail loudly on CI
+	// and only skip on dev machines.
 	if concurrency.SROAR_MERGE < 2 {
+		if os.Getenv("CI") != "" {
+			t.Fatalf("bounding tests require GOMAXPROCS>=4, refusing to skip silently on CI (SROAR_MERGE=%d)",
+				concurrency.SROAR_MERGE)
+		}
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 			concurrency.SROAR_MERGE)
 	}

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -398,12 +399,15 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 
 	const numReaders = 8                   // several outer merges per Read
 	const readDelay = 2 * time.Millisecond // see cloningInnerReader.readDelay
+	// fixed segment parallelism keeps the goroutine ceiling machine-independent;
+	// the budget only governs merge fan-out since the two axes were split
+	const segmentParallelism = 2
 	newReader := func() *CombinedReader {
 		readers := make([]InnerReader, numReaders)
 		for i := range readers {
 			readers[i] = &cloningInnerReader{additions: roaringset.NewBitmap(values...), readDelay: readDelay}
 		}
-		return NewCombinedReader(readers, noopRelease, concurrency.SROAR_MERGE, logger)
+		return NewCombinedReader(readers, noopRelease, segmentParallelism, logger)
 	}
 
 	ctx := context.Background()
@@ -423,12 +427,13 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, values, arr1)
 	require.Equal(t, arrDefault, arr1)
 
-	// each in-flight Read holds <=3 goroutines: its own worker, the errgroup
-	// driver, and the one eg.Go worker budget=1 allows. Sharing one reader is
-	// safe since cloningInnerReader clones per Read. readDelay pins that peak
-	// so slack=8 still lets the kill-switch red control overshoot decisively.
+	// each in-flight Read holds <=4 goroutines: its own worker, the error
+	// group driver, and the segmentParallelism=2 eg.Go workers; budget=1 keeps
+	// sroar merges from adding any. Sharing one reader is safe since
+	// cloningInnerReader clones per Read. readDelay pins that peak so slack=8
+	// still lets the kill-switch red control overshoot decisively.
 	shared := newReader()
-	testinghelpers.AssertGoroutineCeiling(t, 16, 3, 8, 200*time.Millisecond, func() error {
+	testinghelpers.AssertGoroutineCeiling(t, 16, 4, 8, 200*time.Millisecond, func() error {
 		bm, release, err := shared.Read(budget1, 0, filters.OperatorGreaterThanEqual)
 		if err != nil {
 			return err
@@ -437,6 +442,162 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 		release()
 		return nil
 	})
+}
+
+// budgetRecordingReader records the merge budget its Read observed in ctx
+// (-1 when ctx carried none).
+type budgetRecordingReader struct {
+	seenBudget int
+}
+
+func (r *budgetRecordingReader) Read(ctx context.Context, value uint64, operator filters.Operator,
+) (roaringset.BitmapLayer, func(), error) {
+	r.seenBudget = concurrency.BudgetFromCtx(ctx, -1)
+	return roaringset.BitmapLayer{
+		Additions: sroar.NewBitmap(),
+		Deletions: sroar.NewBitmap(),
+	}, noopRelease, nil
+}
+
+// TestCombinedReader_SplitsBudgetAcrossReaders pins the inner budget
+// derivation: the per-query budget is divided by the number of readers that
+// can run at once (segment parallelism + the current goroutine, at most
+// count), floored at 1, and every reader sees the same share.
+func TestCombinedReader_SplitsBudgetAcrossReaders(t *testing.T) {
+	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
+		t.Skip("budget cap disabled via kill switch")
+	}
+	logger, _ := test.NewNullLogger()
+
+	// expected share per reader; outer budget via the production helper, the
+	// split formula spelled out so a regression in reader.go fails here
+	expectedInner := func(numReaders, segmentParallelism, requestedBudget int) int {
+		ctx := concurrency.CtxWithBudget(context.Background(), requestedBudget)
+		outer := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+		return max(1, outer/min(numReaders, segmentParallelism+1))
+	}
+
+	tests := []struct {
+		name               string
+		numReaders         int
+		segmentParallelism int
+		requestedBudget    int
+		expected           int
+	}{
+		{
+			name:               "budget of 1 always yields share of 1",
+			numReaders:         3,
+			segmentParallelism: 4,
+			requestedBudget:    1,
+			expected:           1,
+		},
+		{
+			name:               "share is outer budget over effective concurrency",
+			numReaders:         3,
+			segmentParallelism: 2,
+			requestedBudget:    6,
+			expected:           expectedInner(3, 2, 6),
+		},
+		{
+			name:               "effective concurrency capped by reader count",
+			numReaders:         2,
+			segmentParallelism: 8,
+			requestedBudget:    6,
+			expected:           expectedInner(2, 8, 6),
+		},
+		{
+			name:               "share floored at 1 when readers outnumber budget",
+			numReaders:         8,
+			segmentParallelism: 8,
+			requestedBudget:    2,
+			expected:           1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			readers := make([]InnerReader, tt.numReaders)
+			recorders := make([]*budgetRecordingReader, tt.numReaders)
+			for i := range readers {
+				recorders[i] = &budgetRecordingReader{}
+				readers[i] = recorders[i]
+			}
+			reader := NewCombinedReader(readers, noopRelease, tt.segmentParallelism, logger)
+
+			ctx := concurrency.CtxWithBudget(context.Background(), tt.requestedBudget)
+			_, release, err := reader.Read(ctx, 0, filters.OperatorGreaterThanEqual)
+			require.NoError(t, err)
+			release()
+
+			for i, rec := range recorders {
+				assert.Equalf(t, tt.expected, rec.seenBudget, "reader %d saw wrong budget share", i)
+			}
+		})
+	}
+
+	t.Run("single reader keeps the caller's full budget", func(t *testing.T) {
+		rec := &budgetRecordingReader{}
+		reader := NewCombinedReader([]InnerReader{rec}, noopRelease, 2, logger)
+
+		ctx := concurrency.CtxWithBudget(context.Background(), 5)
+		_, release, err := reader.Read(ctx, 0, filters.OperatorGreaterThanEqual)
+		require.NoError(t, err)
+		release()
+
+		assert.Equal(t, 5, rec.seenBudget)
+	})
+}
+
+// concurrencyTrackingReader tracks how many Reads run at once across all
+// instances sharing the same counters.
+type concurrencyTrackingReader struct {
+	current *atomic.Int32
+	peak    *atomic.Int32
+}
+
+func (r *concurrencyTrackingReader) Read(ctx context.Context, value uint64, operator filters.Operator,
+) (roaringset.BitmapLayer, func(), error) {
+	cur := r.current.Add(1)
+	for {
+		peak := r.peak.Load()
+		if cur <= peak || r.peak.CompareAndSwap(peak, cur) {
+			break
+		}
+	}
+	// keep the read alive long enough for parallel reads to overlap
+	time.Sleep(20 * time.Millisecond)
+	r.current.Add(-1)
+	return roaringset.BitmapLayer{
+		Additions: sroar.NewBitmap(),
+		Deletions: sroar.NewBitmap(),
+	}, noopRelease, nil
+}
+
+// TestCombinedReader_SegmentFanoutBoundByConcurrency pins that segment-level
+// fan-out is bound by the constructor's concurrency (not by the merge budget):
+// at most segmentParallelism readers in the error group plus the current
+// goroutine run at once, even with a merge budget of 1.
+func TestCombinedReader_SegmentFanoutBoundByConcurrency(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	const numReaders = 8
+	const segmentParallelism = 2
+
+	var current, peak atomic.Int32
+	readers := make([]InnerReader, numReaders)
+	for i := range readers {
+		readers[i] = &concurrencyTrackingReader{current: &current, peak: &peak}
+	}
+	reader := NewCombinedReader(readers, noopRelease, segmentParallelism, logger)
+
+	ctx := concurrency.CtxWithBudget(context.Background(), 1)
+	_, release, err := reader.Read(ctx, 0, filters.OperatorGreaterThanEqual)
+	require.NoError(t, err)
+	release()
+
+	assert.LessOrEqual(t, peak.Load(), int32(segmentParallelism+1),
+		"segment fan-out must be bound by constructor concurrency + current goroutine")
+	assert.GreaterOrEqual(t, peak.Load(), int32(2),
+		"a merge budget of 1 must not serialize segment reads")
 }
 
 func createTestMemtables(logger logrus.FieldLogger) (*Memtable, *Memtable, *Memtable) {

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -427,11 +427,10 @@ func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
 	require.Equal(t, values, arr1)
 	require.Equal(t, arrDefault, arr1)
 
-	// each in-flight Read holds <=4 goroutines: its own worker, the error
-	// group driver, and the segmentParallelism=2 eg.Go workers; budget=1 keeps
-	// sroar merges from adding any. Sharing one reader is safe since
-	// cloningInnerReader clones per Read. readDelay pins that peak so slack=8
-	// still lets the kill-switch red control overshoot decisively.
+	// each in-flight Read holds <=4 goroutines (own worker + error group driver
+	// + segmentParallelism=2 workers); budget=1 adds none. Reusing one reader
+	// is safe since cloningInnerReader clones per Read; slack=8 still lets the
+	// kill-switch red control overshoot decisively.
 	shared := newReader()
 	testinghelpers.AssertGoroutineCeiling(t, 16, 4, 8, 200*time.Millisecond, func() error {
 		bm, release, err := shared.Read(budget1, 0, filters.OperatorGreaterThanEqual)
@@ -459,10 +458,8 @@ func (r *budgetRecordingReader) Read(ctx context.Context, value uint64, operator
 	}, noopRelease, nil
 }
 
-// TestCombinedReader_SplitsBudgetAcrossReaders pins the inner budget
-// derivation: the per-query budget is divided by the number of readers that
-// can run at once (segment parallelism + the current goroutine, at most
-// count), floored at 1, and every reader sees the same share.
+// TestCombinedReader_SplitsBudgetAcrossReaders pins the inner budget share:
+// outer/min(count, segmentParallelism+1), floored at 1, same for every reader.
 func TestCombinedReader_SplitsBudgetAcrossReaders(t *testing.T) {
 	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
 		t.Skip("budget cap disabled via kill switch")
@@ -572,10 +569,8 @@ func (r *concurrencyTrackingReader) Read(ctx context.Context, value uint64, oper
 	}, noopRelease, nil
 }
 
-// TestCombinedReader_SegmentFanoutBoundByConcurrency pins that segment-level
-// fan-out is bound by the constructor's concurrency (not by the merge budget):
-// at most segmentParallelism readers in the error group plus the current
-// goroutine run at once, even with a merge budget of 1.
+// TestCombinedReader_SegmentFanoutBoundByConcurrency pins segment fan-out to
+// segmentParallelism+1, independent of the merge budget (here, 1).
 func TestCombinedReader_SegmentFanoutBoundByConcurrency(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 

--- a/adapters/repos/db/roaringsetrange/reader_test.go
+++ b/adapters/repos/db/roaringsetrange/reader_test.go
@@ -14,6 +14,7 @@ package roaringsetrange
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/concurrency/testinghelpers"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -362,6 +364,9 @@ func (r *cloningInnerReader) Read(ctx context.Context, value uint64, operator fi
 // the outer layer merges, so hammering the reader can't inflate the live
 // goroutine count.
 func TestCombinedReader_RespectsConcurrencyBudget(t *testing.T) {
+	if entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET")) {
+		t.Skip("budget cap disabled via kill switch")
+	}
 	if concurrency.SROAR_MERGE < 2 {
 		t.Skipf("SROAR_MERGE=%d < 2: no merge fan-out possible, nothing to bound",
 			concurrency.SROAR_MERGE)

--- a/adapters/repos/db/roaringsetrange/segment_in_memory.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory.go
@@ -162,29 +162,33 @@ func (r *segmentInMemoryReader) Read(ctx context.Context, value uint64, operator
 		return roaringset.BitmapLayer{}, noopRelease, err
 	}
 
+	// resolve the per-query merge budget once, capped at SROAR_MERGE, and thread
+	// it through the merge helpers instead of the fixed per-site constant
+	conc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+
 	switch operator {
 	case filters.OperatorEqual:
-		bm, release := r.readEqual(value)
+		bm, release := r.readEqual(value, conc)
 		return bm, release, nil
 
 	case filters.OperatorNotEqual:
-		bm, release := r.readNotEqual(value)
+		bm, release := r.readNotEqual(value, conc)
 		return bm, release, nil
 
 	case filters.OperatorLessThan:
-		bm, release := r.readLessThan(value)
+		bm, release := r.readLessThan(value, conc)
 		return bm, release, nil
 
 	case filters.OperatorLessThanEqual:
-		bm, release := r.readLessThanEqual(value)
+		bm, release := r.readLessThanEqual(value, conc)
 		return bm, release, nil
 
 	case filters.OperatorGreaterThan:
-		bm, release := r.readGreaterThan(value)
+		bm, release := r.readGreaterThan(value, conc)
 		return bm, release, nil
 
 	case filters.OperatorGreaterThanEqual:
-		bm, release := r.readGreaterThanEqual(value)
+		bm, release := r.readGreaterThanEqual(value, conc)
 		return bm, release, nil
 
 	default:
@@ -194,100 +198,100 @@ func (r *segmentInMemoryReader) Read(ctx context.Context, value uint64, operator
 	}
 }
 
-func (r *segmentInMemoryReader) readEqual(value uint64) (roaringset.BitmapLayer, func()) {
+func (r *segmentInMemoryReader) readEqual(value uint64, conc int) (roaringset.BitmapLayer, func()) {
 	if value == 0 {
-		return r.readLessThanEqual(value)
+		return r.readLessThanEqual(value, conc)
 	}
 	if value == math.MaxUint64 {
-		return r.readGreaterThanEqual(value)
+		return r.readGreaterThanEqual(value, conc)
 	}
 
-	eq, eqRelease := r.mergeBetween(value, value+1)
+	eq, eqRelease := r.mergeBetween(value, value+1, conc)
 	return roaringset.BitmapLayer{Additions: eq}, eqRelease
 }
 
-func (r *segmentInMemoryReader) readNotEqual(value uint64) (roaringset.BitmapLayer, func()) {
+func (r *segmentInMemoryReader) readNotEqual(value uint64, conc int) (roaringset.BitmapLayer, func()) {
 	if value == 0 {
-		return r.readGreaterThan(value)
+		return r.readGreaterThan(value, conc)
 	}
 	if value == math.MaxUint64 {
-		return r.readLessThan(value)
+		return r.readLessThan(value, conc)
 	}
 
-	eq, eqRelease := r.mergeBetween(value, value+1)
+	eq, eqRelease := r.mergeBetween(value, value+1, conc)
 	defer eqRelease()
 
 	neq, neqRelease := r.bufPool.CloneToBuf(r.bitmaps[0])
-	neq.AndNotConc(eq, concurrency.SROAR_MERGE)
+	neq.AndNotConc(eq, conc)
 	return roaringset.BitmapLayer{Additions: neq}, neqRelease
 }
 
-func (r *segmentInMemoryReader) readLessThan(value uint64) (roaringset.BitmapLayer, func()) {
+func (r *segmentInMemoryReader) readLessThan(value uint64, conc int) (roaringset.BitmapLayer, func()) {
 	if value == 0 {
 		// no value is < 0
 		return roaringset.BitmapLayer{Additions: sroar.NewBitmap()}, noopRelease
 	}
 
-	gte, gteRelease := r.mergeGreaterThanEqual(value)
+	gte, gteRelease := r.mergeGreaterThanEqual(value, conc)
 	defer gteRelease()
 
 	lt, ltRelease := r.bufPool.CloneToBuf(r.bitmaps[0])
-	lt.AndNotConc(gte, concurrency.SROAR_MERGE)
+	lt.AndNotConc(gte, conc)
 	return roaringset.BitmapLayer{Additions: lt}, ltRelease
 }
 
-func (r *segmentInMemoryReader) readLessThanEqual(value uint64) (roaringset.BitmapLayer, func()) {
+func (r *segmentInMemoryReader) readLessThanEqual(value uint64, conc int) (roaringset.BitmapLayer, func()) {
 	if value == math.MaxUint64 {
 		all, allRelease := r.bufPool.CloneToBuf(r.bitmaps[0])
 		// all values are <= max uint64
 		return roaringset.BitmapLayer{Additions: all}, allRelease
 	}
 
-	gte1, gte1Release := r.mergeGreaterThanEqual(value + 1)
+	gte1, gte1Release := r.mergeGreaterThanEqual(value+1, conc)
 	defer gte1Release()
 
 	lte, lteRelease := r.bufPool.CloneToBuf(r.bitmaps[0])
-	lte.AndNotConc(gte1, concurrency.SROAR_MERGE)
+	lte.AndNotConc(gte1, conc)
 	return roaringset.BitmapLayer{Additions: lte}, lteRelease
 }
 
-func (r *segmentInMemoryReader) readGreaterThan(value uint64) (roaringset.BitmapLayer, func()) {
+func (r *segmentInMemoryReader) readGreaterThan(value uint64, conc int) (roaringset.BitmapLayer, func()) {
 	if value == math.MaxUint64 {
 		// no value is > max uint64
 		return roaringset.BitmapLayer{Additions: sroar.NewBitmap()}, noopRelease
 	}
 
-	gte1, gte1Release := r.mergeGreaterThanEqual(value + 1)
+	gte1, gte1Release := r.mergeGreaterThanEqual(value+1, conc)
 	return roaringset.BitmapLayer{Additions: gte1}, gte1Release
 }
 
-func (r *segmentInMemoryReader) readGreaterThanEqual(value uint64) (roaringset.BitmapLayer, func()) {
+func (r *segmentInMemoryReader) readGreaterThanEqual(value uint64, conc int) (roaringset.BitmapLayer, func()) {
 	if value == 0 {
 		all, allRelease := r.bufPool.CloneToBuf(r.bitmaps[0])
 		// all values are >= 0
 		return roaringset.BitmapLayer{Additions: all}, allRelease
 	}
 
-	gte, gteRelease := r.mergeGreaterThanEqual(value)
+	gte, gteRelease := r.mergeGreaterThanEqual(value, conc)
 	return roaringset.BitmapLayer{Additions: gte}, gteRelease
 }
 
-func (r *segmentInMemoryReader) mergeGreaterThanEqual(value uint64) (*sroar.Bitmap, func()) {
+func (r *segmentInMemoryReader) mergeGreaterThanEqual(value uint64, conc int) (*sroar.Bitmap, func()) {
 	result, release := r.bufPool.CloneToBuf(r.bitmaps[0])
 	ANDed := false
 
 	for bit := 1; bit < len(r.bitmaps); bit++ {
 		if value&(1<<(bit-1)) != 0 {
-			result.AndConc(r.bitmaps[bit], concurrency.SROAR_MERGE)
+			result.AndConc(r.bitmaps[bit], conc)
 			ANDed = true
 		} else if ANDed {
-			result.OrConc(r.bitmaps[bit], concurrency.SROAR_MERGE)
+			result.OrConc(r.bitmaps[bit], conc)
 		}
 	}
 	return result, release
 }
 
-func (r *segmentInMemoryReader) mergeBetween(valueMinInc, valueMaxExc uint64) (*sroar.Bitmap, func()) {
+func (r *segmentInMemoryReader) mergeBetween(valueMinInc, valueMaxExc uint64, conc int) (*sroar.Bitmap, func()) {
 	resultMin, releaseMin := r.bufPool.CloneToBuf(r.bitmaps[0])
 	resultMax, releaseMax := r.bufPool.CloneToBuf(r.bitmaps[0])
 	defer releaseMax()
@@ -298,21 +302,21 @@ func (r *segmentInMemoryReader) mergeBetween(valueMinInc, valueMaxExc uint64) (*
 		var b uint64 = 1 << (bit - 1)
 
 		if valueMinInc&b != 0 {
-			resultMin.AndConc(r.bitmaps[bit], concurrency.SROAR_MERGE)
+			resultMin.AndConc(r.bitmaps[bit], conc)
 			ANDedMin = true
 		} else if ANDedMin {
-			resultMin.OrConc(r.bitmaps[bit], concurrency.SROAR_MERGE)
+			resultMin.OrConc(r.bitmaps[bit], conc)
 		}
 
 		if valueMaxExc&b != 0 {
-			resultMax.AndConc(r.bitmaps[bit], concurrency.SROAR_MERGE)
+			resultMax.AndConc(r.bitmaps[bit], conc)
 			ANDedMax = true
 		} else if ANDedMax {
-			resultMax.OrConc(r.bitmaps[bit], concurrency.SROAR_MERGE)
+			resultMax.OrConc(r.bitmaps[bit], conc)
 		}
 	}
 
-	return resultMin.AndNotConc(resultMax, concurrency.SROAR_MERGE), releaseMin
+	return resultMin.AndNotConc(resultMax, conc), releaseMin
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/roaringsetrange/segment_in_memory.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory.go
@@ -162,8 +162,7 @@ func (r *segmentInMemoryReader) Read(ctx context.Context, value uint64, operator
 		return roaringset.BitmapLayer{}, noopRelease, err
 	}
 
-	// resolve the per-query merge budget once, capped at SROAR_MERGE, and thread
-	// it through the merge helpers instead of the fixed per-site constant
+	// conc is the per-query merge budget, threaded through every read/merge helper below.
 	conc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
 	switch operator {

--- a/adapters/repos/db/roaringsetrange/segment_reader.go
+++ b/adapters/repos/db/roaringsetrange/segment_reader.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 )
@@ -45,29 +46,33 @@ func (r *SegmentReader) Read(ctx context.Context, value uint64, operator filters
 		return roaringset.BitmapLayer{}, noopRelease, err
 	}
 
+	// resolve the per-query merge budget once, capped at this reader's
+	// configured concurrency, and thread it through the merge helpers
+	conc := concurrency.BudgetFromCtxCapped(ctx, r.concurrency)
+
 	switch operator {
 	case filters.OperatorEqual:
-		bm, err := r.readEqual(ctx, value)
+		bm, err := r.readEqual(ctx, value, conc)
 		return bm, noopRelease, err
 
 	case filters.OperatorNotEqual:
-		bm, err := r.readNotEqual(ctx, value)
+		bm, err := r.readNotEqual(ctx, value, conc)
 		return bm, noopRelease, err
 
 	case filters.OperatorLessThan:
-		bm, err := r.readLessThan(ctx, value)
+		bm, err := r.readLessThan(ctx, value, conc)
 		return bm, noopRelease, err
 
 	case filters.OperatorLessThanEqual:
-		bm, err := r.readLessThanEqual(ctx, value)
+		bm, err := r.readLessThanEqual(ctx, value, conc)
 		return bm, noopRelease, err
 
 	case filters.OperatorGreaterThan:
-		bm, err := r.readGreaterThan(ctx, value)
+		bm, err := r.readGreaterThan(ctx, value, conc)
 		return bm, noopRelease, err
 
 	case filters.OperatorGreaterThanEqual:
-		bm, err := r.readGreaterThanEqual(ctx, value)
+		bm, err := r.readGreaterThanEqual(ctx, value, conc)
 		return bm, noopRelease, err
 
 	default:
@@ -108,13 +113,13 @@ func (r *SegmentReader) firstLayer() (roaringset.BitmapLayer, bool) {
 	}, true
 }
 
-func (r *SegmentReader) readEqual(ctx context.Context, value uint64,
+func (r *SegmentReader) readEqual(ctx context.Context, value uint64, conc int,
 ) (roaringset.BitmapLayer, error) {
 	if value == 0 {
-		return r.readLessThanEqual(ctx, value)
+		return r.readLessThanEqual(ctx, value, conc)
 	}
 	if value == math.MaxUint64 {
-		return r.readGreaterThanEqual(ctx, value)
+		return r.readGreaterThanEqual(ctx, value, conc)
 	}
 
 	firstLayer, ok := r.firstLayer()
@@ -122,7 +127,7 @@ func (r *SegmentReader) readEqual(ctx context.Context, value uint64,
 		return firstLayer, nil
 	}
 
-	eq, err := r.mergeBetween(ctx, value, value+1, firstLayer.Additions)
+	eq, err := r.mergeBetween(ctx, value, value+1, firstLayer.Additions, conc)
 	if err != nil {
 		return roaringset.BitmapLayer{}, err
 	}
@@ -133,13 +138,13 @@ func (r *SegmentReader) readEqual(ctx context.Context, value uint64,
 	}, nil
 }
 
-func (r *SegmentReader) readNotEqual(ctx context.Context, value uint64,
+func (r *SegmentReader) readNotEqual(ctx context.Context, value uint64, conc int,
 ) (roaringset.BitmapLayer, error) {
 	if value == 0 {
-		return r.readGreaterThan(ctx, value)
+		return r.readGreaterThan(ctx, value, conc)
 	}
 	if value == math.MaxUint64 {
-		return r.readLessThan(ctx, value)
+		return r.readLessThan(ctx, value, conc)
 	}
 
 	firstLayer, ok := r.firstLayer()
@@ -148,19 +153,19 @@ func (r *SegmentReader) readNotEqual(ctx context.Context, value uint64,
 	}
 
 	neq := firstLayer.Additions.Clone()
-	eq, err := r.mergeBetween(ctx, value, value+1, firstLayer.Additions)
+	eq, err := r.mergeBetween(ctx, value, value+1, firstLayer.Additions, conc)
 	if err != nil {
 		return roaringset.BitmapLayer{}, err
 	}
 
-	neq.AndNotConc(eq, r.concurrency)
+	neq.AndNotConc(eq, conc)
 	return roaringset.BitmapLayer{
 		Additions: neq,
 		Deletions: firstLayer.Deletions,
 	}, nil
 }
 
-func (r *SegmentReader) readLessThan(ctx context.Context, value uint64,
+func (r *SegmentReader) readLessThan(ctx context.Context, value uint64, conc int,
 ) (roaringset.BitmapLayer, error) {
 	firstLayer, ok := r.firstLayer()
 	if !ok {
@@ -176,19 +181,19 @@ func (r *SegmentReader) readLessThan(ctx context.Context, value uint64,
 	}
 
 	lt := firstLayer.Additions.Clone()
-	gte, err := r.mergeGreaterThanEqual(ctx, value, firstLayer.Additions)
+	gte, err := r.mergeGreaterThanEqual(ctx, value, firstLayer.Additions, conc)
 	if err != nil {
 		return roaringset.BitmapLayer{}, err
 	}
 
-	lt.AndNotConc(gte, r.concurrency)
+	lt.AndNotConc(gte, conc)
 	return roaringset.BitmapLayer{
 		Additions: lt,
 		Deletions: firstLayer.Deletions,
 	}, nil
 }
 
-func (r *SegmentReader) readLessThanEqual(ctx context.Context, value uint64,
+func (r *SegmentReader) readLessThanEqual(ctx context.Context, value uint64, conc int,
 ) (roaringset.BitmapLayer, error) {
 	firstLayer, ok := r.firstLayer()
 	if !ok {
@@ -201,19 +206,19 @@ func (r *SegmentReader) readLessThanEqual(ctx context.Context, value uint64,
 	}
 
 	lte := firstLayer.Additions.Clone()
-	gte1, err := r.mergeGreaterThanEqual(ctx, value+1, firstLayer.Additions)
+	gte1, err := r.mergeGreaterThanEqual(ctx, value+1, firstLayer.Additions, conc)
 	if err != nil {
 		return roaringset.BitmapLayer{}, err
 	}
 
-	lte.AndNotConc(gte1, r.concurrency)
+	lte.AndNotConc(gte1, conc)
 	return roaringset.BitmapLayer{
 		Additions: lte,
 		Deletions: firstLayer.Deletions,
 	}, nil
 }
 
-func (r *SegmentReader) readGreaterThan(ctx context.Context, value uint64,
+func (r *SegmentReader) readGreaterThan(ctx context.Context, value uint64, conc int,
 ) (roaringset.BitmapLayer, error) {
 	firstLayer, ok := r.firstLayer()
 	if !ok {
@@ -228,7 +233,7 @@ func (r *SegmentReader) readGreaterThan(ctx context.Context, value uint64,
 		}, nil
 	}
 
-	gte1, err := r.mergeGreaterThanEqual(ctx, value+1, firstLayer.Additions)
+	gte1, err := r.mergeGreaterThanEqual(ctx, value+1, firstLayer.Additions, conc)
 	if err != nil {
 		return roaringset.BitmapLayer{}, err
 	}
@@ -239,7 +244,7 @@ func (r *SegmentReader) readGreaterThan(ctx context.Context, value uint64,
 	}, nil
 }
 
-func (r *SegmentReader) readGreaterThanEqual(ctx context.Context, value uint64,
+func (r *SegmentReader) readGreaterThanEqual(ctx context.Context, value uint64, conc int,
 ) (roaringset.BitmapLayer, error) {
 	firstLayer, ok := r.firstLayer()
 	if !ok {
@@ -251,7 +256,7 @@ func (r *SegmentReader) readGreaterThanEqual(ctx context.Context, value uint64,
 		return firstLayer, nil
 	}
 
-	gte, err := r.mergeGreaterThanEqual(ctx, value, firstLayer.Additions)
+	gte, err := r.mergeGreaterThanEqual(ctx, value, firstLayer.Additions, conc)
 	if err != nil {
 		return roaringset.BitmapLayer{}, err
 	}
@@ -263,7 +268,7 @@ func (r *SegmentReader) readGreaterThanEqual(ctx context.Context, value uint64,
 }
 
 func (r *SegmentReader) mergeGreaterThanEqual(ctx context.Context, value uint64,
-	all *sroar.Bitmap,
+	all *sroar.Bitmap, conc int,
 ) (*sroar.Bitmap, error) {
 	ANDed := false
 	result := all
@@ -285,9 +290,9 @@ func (r *SegmentReader) mergeGreaterThanEqual(ctx context.Context, value uint64,
 
 		if value&(1<<(bit-1)) != 0 {
 			ANDed = true
-			result.AndConc(layer.Additions, r.concurrency)
+			result.AndConc(layer.Additions, conc)
 		} else if ANDed {
-			result.OrConc(layer.Additions, r.concurrency)
+			result.OrConc(layer.Additions, conc)
 		}
 	}
 
@@ -299,7 +304,7 @@ func (r *SegmentReader) mergeGreaterThanEqual(ctx context.Context, value uint64,
 }
 
 func (r *SegmentReader) mergeBetween(ctx context.Context, valueMinInc, valueMaxExc uint64,
-	all *sroar.Bitmap,
+	all *sroar.Bitmap, conc int,
 ) (*sroar.Bitmap, error) {
 	ANDedMin := false
 	ANDedMax := false
@@ -325,20 +330,20 @@ func (r *SegmentReader) mergeBetween(ctx context.Context, valueMinInc, valueMaxE
 
 		if valueMinInc&b != 0 {
 			ANDedMin = true
-			resultMin.AndConc(layer.Additions, r.concurrency)
+			resultMin.AndConc(layer.Additions, conc)
 		} else if ANDedMin {
-			resultMin.OrConc(layer.Additions, r.concurrency)
+			resultMin.OrConc(layer.Additions, conc)
 		}
 
 		if valueMaxExc&b != 0 {
 			ANDedMax = true
-			resultMax.AndConc(layer.Additions, r.concurrency)
+			resultMax.AndConc(layer.Additions, conc)
 		} else if ANDedMax {
-			resultMax.OrConc(layer.Additions, r.concurrency)
+			resultMax.OrConc(layer.Additions, conc)
 		}
 	}
 
-	resultMin.AndNotConc(resultMax, r.concurrency)
+	resultMin.AndNotConc(resultMax, conc)
 
 	return resultMin, nil
 }

--- a/adapters/repos/db/roaringsetrange/segment_reader.go
+++ b/adapters/repos/db/roaringsetrange/segment_reader.go
@@ -46,8 +46,7 @@ func (r *SegmentReader) Read(ctx context.Context, value uint64, operator filters
 		return roaringset.BitmapLayer{}, noopRelease, err
 	}
 
-	// resolve the per-query merge budget once, capped at this reader's
-	// configured concurrency, and thread it through the merge helpers
+	// conc is the per-query merge budget, threaded through every read/merge helper below.
 	conc := concurrency.BudgetFromCtxCapped(ctx, r.concurrency)
 
 	switch operator {

--- a/adapters/repos/db/roaringsetrange/segment_reader.go
+++ b/adapters/repos/db/roaringsetrange/segment_reader.go
@@ -24,20 +24,12 @@ import (
 )
 
 type SegmentReader struct {
-	cursor      SegmentCursor
-	concurrency int
-}
-
-func NewSegmentReader(cursor *GaplessSegmentCursor) *SegmentReader {
-	return NewSegmentReaderConcurrent(cursor, 1)
+	cursor SegmentCursor
 }
 
 // TODO aliszka:roaringrange add buf pool?
-func NewSegmentReaderConcurrent(cursor *GaplessSegmentCursor, concurrency int) *SegmentReader {
-	return &SegmentReader{
-		cursor:      cursor,
-		concurrency: concurrency,
-	}
+func NewSegmentReader(cursor *GaplessSegmentCursor) *SegmentReader {
+	return &SegmentReader{cursor: cursor}
 }
 
 func (r *SegmentReader) Read(ctx context.Context, value uint64, operator filters.Operator,
@@ -47,7 +39,7 @@ func (r *SegmentReader) Read(ctx context.Context, value uint64, operator filters
 	}
 
 	// conc is the per-query merge budget, threaded through every read/merge helper below.
-	conc := concurrency.BudgetFromCtxCapped(ctx, r.concurrency)
+	conc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
 	switch operator {
 	case filters.OperatorEqual:

--- a/adapters/repos/db/roaringsetrange/segment_reader_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_reader_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -152,13 +153,23 @@ func TestSegmentReader(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run("read", func(t *testing.T) {
-			bm, release, err := reader.Read(context.Background(), tc.value, tc.operator)
-			assert.NoError(t, err)
-			defer release()
-			assert.ElementsMatch(t, bm.Additions.ToArray(), tc.expectedAdd)
-			assert.ElementsMatch(t, bm.Deletions.ToArray(), tc.expectedDel)
-		})
+	// the merge budget comes from ctx since the constructor lost its
+	// concurrency param; results must not depend on it
+	ctxs := map[string]context.Context{
+		"no budget in ctx":     context.Background(),
+		"merge budget of 1":    concurrency.CtxWithBudget(context.Background(), 1),
+		"merge budget above 1": concurrency.CtxWithBudget(context.Background(), 4),
+	}
+
+	for ctxName, ctx := range ctxs {
+		for _, tc := range testCases {
+			t.Run("read with "+ctxName, func(t *testing.T) {
+				bm, release, err := reader.Read(ctx, tc.value, tc.operator)
+				assert.NoError(t, err)
+				defer release()
+				assert.ElementsMatch(t, bm.Additions.ToArray(), tc.expectedAdd)
+				assert.ElementsMatch(t, bm.Deletions.ToArray(), tc.expectedDel)
+			})
+		}
 	}
 }

--- a/adapters/repos/db/roaringsetrange/segment_reader_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_reader_test.go
@@ -153,8 +153,7 @@ func TestSegmentReader(t *testing.T) {
 		},
 	}
 
-	// the merge budget comes from ctx since the constructor lost its
-	// concurrency param; results must not depend on it
+	// results must not depend on the merge budget carried in ctx
 	ctxs := map[string]context.Context{
 		"no budget in ctx":     context.Background(),
 		"merge budget of 1":    concurrency.CtxWithBudget(context.Background(), 1),

--- a/adapters/repos/db/sorter/inverted_sorter.go
+++ b/adapters/repos/db/sorter/inverted_sorter.go
@@ -152,7 +152,7 @@ func (is *invertedSorter) sortRoaringSetASC(ctx context.Context, bucket *lsmkv.B
 ) ([]uint64, error) {
 	startTime := time.Now()
 	hasMoreNesting := len(sort) > 1
-	cursor := bucket.CursorRoaringSet()
+	cursor := bucket.CursorRoaringSetCtx(ctx)
 	defer cursor.Close()
 
 	foundIDs := make([]uint64, 0, limit)
@@ -278,7 +278,7 @@ func (is *invertedSorter) processDESCWindow(
 ) ([]uint64, int, error) {
 	rowsEvaluated := 0
 	idsFoundInWindow := make([]uint64, 0, limit)
-	cursor := bucket.CursorRoaringSet()
+	cursor := bucket.CursorRoaringSetCtx(ctx)
 	defer cursor.Close()
 
 	for k, v := cursor.Seek(startKey); k != nil; k, v = cursor.Next() {

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -13,7 +13,15 @@ package concurrency
 
 import (
 	"context"
+	"os"
+
+	entcfg "github.com/weaviate/weaviate/entities/config"
 )
+
+// budgetCapDisabled restores pre-P1a behavior where sroar merge concurrency
+// was a fixed constant per call site, ignoring the per-query budget.
+// Escape hatch only; to be removed once the fix has soaked.
+var budgetCapDisabled = entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET"))
 
 type budgetKey struct{}
 
@@ -39,4 +47,26 @@ func ContextWithFractionalBudget(ctx context.Context, factor, fallback int) cont
 	newBudget := FractionOf(budget, factor)
 
 	return CtxWithBudget(ctx, newBudget)
+}
+
+// BudgetFromCtxCapped returns the per-query concurrency budget from ctx,
+// clamped to [1, cap]. cap doubles as the fallback when ctx carries no
+// budget (background callers: compaction, cursors, flush), which preserves
+// pre-budget behavior exactly. The floor of 1 is load-bearing: sroar's
+// *Conc merge ops treat maxConcurrency <= 0 as "unlimited".
+func BudgetFromCtxCapped(ctx context.Context, cap int) int {
+	if budgetCapDisabled {
+		return cap
+	}
+	return clampBudget(BudgetFromCtx(ctx, cap), cap)
+}
+
+func clampBudget(b, cap int) int {
+	if b > cap {
+		b = cap
+	}
+	if b < 1 {
+		b = 1
+	}
+	return b
 }

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -59,7 +59,7 @@ func ContextWithFractionalBudget(ctx context.Context, factor, fallback int) cont
 func BudgetFromCtxCapped(ctx context.Context, limit int) int {
 	if budgetCapDisabled {
 		// even disabled, floor at 1: limit=0 means "unlimited" to sroar's *Conc
-		// ops and would hang errgroup.SetLimit(0) — a kill-switch footgun.
+		// ops and would hang an error group with SetLimit(0) — a kill-switch footgun.
 		return max(limit, 1)
 	}
 	return clampBudget(BudgetFromCtx(ctx, limit), limit)

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -23,6 +23,12 @@ import (
 // Escape hatch only; to be removed once the fix has soaked.
 var budgetCapDisabled = entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET"))
 
+// BudgetCapDisabled reports whether the sroar merge budget cap kill switch is
+// set, so read paths can leave ctx budgets untouched when the cap is disabled.
+func BudgetCapDisabled() bool {
+	return budgetCapDisabled
+}
+
 type budgetKey struct{}
 
 func (budgetKey) String() string {
@@ -50,20 +56,20 @@ func ContextWithFractionalBudget(ctx context.Context, factor, fallback int) cont
 }
 
 // BudgetFromCtxCapped returns the per-query concurrency budget from ctx,
-// clamped to [1, cap]. cap doubles as the fallback when ctx carries no
+// clamped to [1, limit]. limit doubles as the fallback when ctx carries no
 // budget (background callers: compaction, cursors, flush), which preserves
 // pre-budget behavior exactly. The floor of 1 is load-bearing: sroar's
 // *Conc merge ops treat maxConcurrency <= 0 as "unlimited".
-func BudgetFromCtxCapped(ctx context.Context, cap int) int {
+func BudgetFromCtxCapped(ctx context.Context, limit int) int {
 	if budgetCapDisabled {
-		return cap
+		return limit
 	}
-	return clampBudget(BudgetFromCtx(ctx, cap), cap)
+	return clampBudget(BudgetFromCtx(ctx, limit), limit)
 }
 
-func clampBudget(b, cap int) int {
-	if b > cap {
-		b = cap
+func clampBudget(b, limit int) int {
+	if b > limit {
+		b = limit
 	}
 	if b < 1 {
 		b = 1

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -23,8 +23,7 @@ import (
 // Escape hatch only; to be removed once the fix has soaked.
 var budgetCapDisabled = entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET"))
 
-// BudgetCapDisabled reports whether the sroar merge budget cap kill switch is
-// set, so read paths can leave ctx budgets untouched when the cap is disabled.
+// BudgetCapDisabled reports whether the sroar merge budget kill switch is set.
 func BudgetCapDisabled() bool {
 	return budgetCapDisabled
 }

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -18,9 +18,8 @@ import (
 	entcfg "github.com/weaviate/weaviate/entities/config"
 )
 
-// budgetCapDisabled restores pre-P1a behavior where sroar merge concurrency
-// was a fixed constant per call site, ignoring the per-query budget.
-// Escape hatch only; to be removed once the fix has soaked.
+// budgetCapDisabled is a temporary escape hatch: when set, sroar merge
+// concurrency ignores the per-query budget and uses the fixed constant again.
 var budgetCapDisabled = entcfg.Enabled(os.Getenv("DISABLE_SROAR_MERGE_BUDGET"))
 
 // BudgetCapDisabled reports whether the sroar merge budget kill switch is set.
@@ -54,14 +53,15 @@ func ContextWithFractionalBudget(ctx context.Context, factor, fallback int) cont
 	return CtxWithBudget(ctx, newBudget)
 }
 
-// BudgetFromCtxCapped returns the per-query concurrency budget from ctx,
-// clamped to [1, limit]. limit doubles as the fallback when ctx carries no
-// budget (background callers: compaction, cursors, flush), which preserves
-// pre-budget behavior exactly. The floor of 1 is load-bearing: sroar's
-// *Conc merge ops treat maxConcurrency <= 0 as "unlimited".
+// BudgetFromCtxCapped returns ctx's per-query budget clamped to [1, limit];
+// limit is also the fallback when ctx carries no budget. The floor of 1 is
+// load-bearing: sroar's *Conc ops treat maxConcurrency<=0 as "unlimited".
 func BudgetFromCtxCapped(ctx context.Context, limit int) int {
 	if budgetCapDisabled {
-		return limit
+		// even with the cap disabled, keep the floor of 1: a limit of 0 would
+		// otherwise mean "unlimited" to sroar's *Conc ops (and hang an
+		// errgroup.SetLimit(0)), turning the kill switch into a footgun.
+		return max(limit, 1)
 	}
 	return clampBudget(BudgetFromCtx(ctx, limit), limit)
 }

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -58,9 +58,8 @@ func ContextWithFractionalBudget(ctx context.Context, factor, fallback int) cont
 // load-bearing: sroar's *Conc ops treat maxConcurrency<=0 as "unlimited".
 func BudgetFromCtxCapped(ctx context.Context, limit int) int {
 	if budgetCapDisabled {
-		// even with the cap disabled, keep the floor of 1: a limit of 0 would
-		// otherwise mean "unlimited" to sroar's *Conc ops (and hang an
-		// errgroup.SetLimit(0)), turning the kill switch into a footgun.
+		// even disabled, floor at 1: limit=0 means "unlimited" to sroar's *Conc
+		// ops and would hang errgroup.SetLimit(0) — a kill-switch footgun.
 		return max(limit, 1)
 	}
 	return clampBudget(BudgetFromCtx(ctx, limit), limit)

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -41,3 +41,56 @@ func TestBudget(t *testing.T) {
 	budget = BudgetFromCtx(ctx, fallback)
 	assert.Equal(t, 4, budget)
 }
+
+func TestBudgetFromCtxCapped(t *testing.T) {
+	const cap = 8
+
+	tests := []struct {
+		name     string
+		budget   *int // nil => no budget in ctx
+		expected int
+	}{
+		{name: "absent budget falls back to cap", budget: nil, expected: cap},
+		{name: "budget above cap is clamped to cap", budget: ptr(cap + 5), expected: cap},
+		{name: "budget below cap is preserved", budget: ptr(3), expected: 3},
+		{name: "zero budget floored to 1", budget: ptr(0), expected: 1},
+		{name: "negative budget floored to 1", budget: ptr(-4), expected: 1},
+		{name: "budget equal to cap", budget: ptr(cap), expected: cap},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.budget != nil {
+				ctx = CtxWithBudget(ctx, *tt.budget)
+			}
+			assert.Equal(t, tt.expected, BudgetFromCtxCapped(ctx, cap))
+		})
+	}
+
+	t.Run("cap of 1 always yields 1", func(t *testing.T) {
+		assert.Equal(t, 1, BudgetFromCtxCapped(context.Background(), 1))
+		assert.Equal(t, 1, BudgetFromCtxCapped(CtxWithBudget(context.Background(), 16), 1))
+	})
+}
+
+func TestClampBudget(t *testing.T) {
+	tests := []struct {
+		name     string
+		b        int
+		cap      int
+		expected int
+	}{
+		{name: "above cap branch", b: 20, cap: 8, expected: 8},
+		{name: "below floor branch", b: 0, cap: 8, expected: 1},
+		{name: "in range unchanged", b: 5, cap: 8, expected: 5},
+		{name: "at cap", b: 8, cap: 8, expected: 8},
+		{name: "at floor", b: 1, cap: 8, expected: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, clampBudget(tt.b, tt.cap))
+		})
+	}
+}
+
+func ptr(i int) *int { return &i }

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -94,12 +94,11 @@ func TestClampBudget(t *testing.T) {
 }
 
 func TestBudgetCapDisabled_KillSwitch(t *testing.T) {
-	// flip the package var directly and restore it, so sibling tests are unaffected
 	prev := budgetCapDisabled
 	budgetCapDisabled = true
 	defer func() { budgetCapDisabled = prev }()
 
-	// kill switch on: the limit is returned verbatim; the ctx budget is ignored
+	// kill switch on: limit is returned verbatim, ctx budget is ignored
 	assert.Equal(t, 8, BudgetFromCtxCapped(CtxWithBudget(context.Background(), 1), 8))
 	assert.True(t, BudgetCapDisabled())
 }

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -98,9 +98,31 @@ func TestBudgetCapDisabled_KillSwitch(t *testing.T) {
 	budgetCapDisabled = true
 	defer func() { budgetCapDisabled = prev }()
 
-	// kill switch on: limit is returned verbatim, ctx budget is ignored
-	assert.Equal(t, 8, BudgetFromCtxCapped(CtxWithBudget(context.Background(), 1), 8))
 	assert.True(t, BudgetCapDisabled())
+
+	tests := []struct {
+		name     string
+		budget   *int // nil => no budget in ctx
+		limit    int
+		expected int
+	}{
+		// kill switch on: ctx budget is ignored, limit is used as-is...
+		{name: "positive limit returned verbatim", budget: ptr(1), limit: 8, expected: 8},
+		{name: "ctx budget above limit still ignored", budget: ptr(16), limit: 8, expected: 8},
+		// ...except the floor of 1 still holds: a limit of 0 would otherwise
+		// mean "unlimited" to sroar and hang errgroup.SetLimit(0).
+		{name: "zero limit floored to 1", budget: nil, limit: 0, expected: 1},
+		{name: "zero limit floored to 1 even with ctx budget", budget: ptr(4), limit: 0, expected: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.budget != nil {
+				ctx = CtxWithBudget(ctx, *tt.budget)
+			}
+			assert.Equal(t, tt.expected, BudgetFromCtxCapped(ctx, tt.limit))
+		})
+	}
 }
 
 func ptr(i int) *int { return &i }

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -43,6 +43,12 @@ func TestBudget(t *testing.T) {
 }
 
 func TestBudgetFromCtxCapped(t *testing.T) {
+	// pin the enabled path so the clamp behavior is tested even when the
+	// environment sets the kill switch (mirrors TestBudgetCapDisabled_KillSwitch)
+	prev := budgetCapDisabled
+	budgetCapDisabled = false
+	defer func() { budgetCapDisabled = prev }()
+
 	const cap = 8
 
 	tests := []struct {

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -93,4 +93,15 @@ func TestClampBudget(t *testing.T) {
 	}
 }
 
+func TestBudgetCapDisabled_KillSwitch(t *testing.T) {
+	// flip the package var directly and restore it, so sibling tests are unaffected
+	prev := budgetCapDisabled
+	budgetCapDisabled = true
+	defer func() { budgetCapDisabled = prev }()
+
+	// kill switch on: the limit is returned verbatim; the ctx budget is ignored
+	assert.Equal(t, 8, BudgetFromCtxCapped(CtxWithBudget(context.Background(), 1), 8))
+	assert.True(t, BudgetCapDisabled())
+}
+
 func ptr(i int) *int { return &i }

--- a/entities/concurrency/testinghelpers/goroutines.go
+++ b/entities/concurrency/testinghelpers/goroutines.go
@@ -9,9 +9,8 @@
 //  CONTACT: hello@weaviate.io
 //
 
-// Package testinghelpers provides shared assertions for tests that verify
-// concurrency-budget behavior, most notably that hot read paths do not fan
-// out more goroutines than their per-query budget allows.
+// Package testinghelpers provides shared assertions for concurrency-budget
+// tests: verifying hot read paths don't fan out more goroutines than budgeted.
 package testinghelpers
 
 import (
@@ -24,16 +23,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// AssertGoroutineCeiling hammers do from numWorkers goroutines for runFor
-// while sampling runtime.NumGoroutine every millisecond, then asserts the
-// observed peak stayed within baseline + numWorkers*maxPerWorker + noiseSlack.
-//
-// The baseline is captured after the sampler goroutine has started, so it
-// includes the sampler but excludes the workers about to launch. maxPerWorker
-// is the number of goroutines one in-flight do call may legitimately keep
-// alive (the worker itself plus any bounded helpers); noiseSlack absorbs
-// transient runtime/GC workers. do returning an error stops that worker and
-// fails the test after all workers finish.
+// AssertGoroutineCeiling runs do from numWorkers goroutines for runFor and
+// asserts peak live goroutines stay within baseline + numWorkers*maxPerWorker
+// + noiseSlack, where maxPerWorker bounds the goroutines one in-flight do
+// call may legitimately hold.
 func AssertGoroutineCeiling(t *testing.T, numWorkers, maxPerWorker, noiseSlack int,
 	runFor time.Duration, do func() error,
 ) {

--- a/entities/concurrency/testinghelpers/goroutines.go
+++ b/entities/concurrency/testinghelpers/goroutines.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package testinghelpers provides shared assertions for tests that verify
+// concurrency-budget behavior, most notably that hot read paths do not fan
+// out more goroutines than their per-query budget allows.
+package testinghelpers
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertGoroutineCeiling hammers do from numWorkers goroutines for runFor
+// while sampling runtime.NumGoroutine every millisecond, then asserts the
+// observed peak stayed within baseline + numWorkers*maxPerWorker + noiseSlack.
+//
+// The baseline is captured after the sampler goroutine has started, so it
+// includes the sampler but excludes the workers about to launch. maxPerWorker
+// is the number of goroutines one in-flight do call may legitimately keep
+// alive (the worker itself plus any bounded helpers); noiseSlack absorbs
+// transient runtime/GC workers. do returning an error stops that worker and
+// fails the test after all workers finish.
+func AssertGoroutineCeiling(t *testing.T, numWorkers, maxPerWorker, noiseSlack int,
+	runFor time.Duration, do func() error,
+) {
+	t.Helper()
+
+	stop := make(chan struct{})
+	samplerDone := make(chan struct{})
+	var maxSeen int // written only by the sampler, read after samplerDone closes
+
+	go func() {
+		defer close(samplerDone)
+		ticker := time.NewTicker(1 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if n := runtime.NumGoroutine(); n > maxSeen {
+					maxSeen = n
+				}
+			}
+		}
+	}()
+
+	// let the sampler settle before capturing the baseline
+	time.Sleep(5 * time.Millisecond)
+	base := runtime.NumGoroutine()
+
+	firstErr := make(chan error, 1)
+	var wg sync.WaitGroup
+	deadline := time.Now().Add(runFor)
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				if err := do(); err != nil {
+					select {
+					case firstErr <- err:
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	<-samplerDone
+
+	select {
+	case err := <-firstErr:
+		require.NoError(t, err)
+	default:
+	}
+
+	ceiling := base + numWorkers*maxPerWorker + noiseSlack
+	assert.LessOrEqualf(t, maxSeen, ceiling,
+		"live goroutines peaked at %d, above base(%d)+workers(%d)*perWorker(%d)+noise(%d)=%d; "+
+			"the concurrency budget must bound the fan-out",
+		maxSeen, base, numWorkers, maxPerWorker, noiseSlack, ceiling)
+}

--- a/entities/concurrency/testinghelpers/goroutines.go
+++ b/entities/concurrency/testinghelpers/goroutines.go
@@ -60,8 +60,7 @@ func AssertGoroutineCeiling(t *testing.T, numWorkers, maxPerWorker, noiseSlack i
 		mu       sync.Mutex
 		firstErr error
 	)
-	// abort lets the remaining workers stop early once one of them failed,
-	// instead of hammering do() until the deadline
+	// abort stops remaining workers early once one fails.
 	abort := make(chan struct{})
 	var wg sync.WaitGroup
 	deadline := time.Now().Add(runFor)

--- a/entities/concurrency/testinghelpers/goroutines.go
+++ b/entities/concurrency/testinghelpers/goroutines.go
@@ -56,19 +56,32 @@ func AssertGoroutineCeiling(t *testing.T, numWorkers, maxPerWorker, noiseSlack i
 	time.Sleep(5 * time.Millisecond)
 	base := runtime.NumGoroutine()
 
-	firstErr := make(chan error, 1)
+	var (
+		mu       sync.Mutex
+		firstErr error
+	)
+	// abort lets the remaining workers stop early once one of them failed,
+	// instead of hammering do() until the deadline
+	abort := make(chan struct{})
 	var wg sync.WaitGroup
 	deadline := time.Now().Add(runFor)
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for time.Now().Before(deadline) {
+				select {
+				case <-abort:
+					return
+				default:
+				}
 				if err := do(); err != nil {
-					select {
-					case firstErr <- err:
-					default:
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+						close(abort)
 					}
+					mu.Unlock()
 					return
 				}
 			}
@@ -78,11 +91,7 @@ func AssertGoroutineCeiling(t *testing.T, numWorkers, maxPerWorker, noiseSlack i
 	close(stop)
 	<-samplerDone
 
-	select {
-	case err := <-firstErr:
-		require.NoError(t, err)
-	default:
-	}
+	require.NoError(t, firstErr)
 
 	ceiling := base + numWorkers*maxPerWorker + noiseSlack
 	assert.LessOrEqualf(t, maxSeen, ceiling,

--- a/tools/linter_go_routines.sh
+++ b/tools/linter_go_routines.sh
@@ -19,6 +19,7 @@ excluded_files=(
     "usecases/auth/authorization/docs/generator.go" # docs generator
     "tools/dev/generate_release_notes/main.go" # generate release notes tool
     "test/docker/mockoidchelper/mockoidc_helper.go" # used only for OIDC tests
+    "entities/concurrency/testinghelpers/goroutines.go" # test-only helper; bare goroutines keep panics loud in tests
 )
 
 # Check if file is in excluded list


### PR DESCRIPTION
SuperClaude here.

## Motivation

Under concurrent filtered + keyword load the cluster tipped into congestion
collapse. The 2026-07-08 load-test capture showed ~56k goroutines
cluster-wide, with roughly 25% of one node's goroutines sitting in sroar
merge workers spawned from 178 concurrent parent merges. 99.8% of goroutines
were run-queue-starved while disk sat at 4% utilization: the node was pinned
on CPU scheduling merge fan-out, not on I/O.

The root cause is that the RoaringSet / roaringsetrange read path hard-coded
`concurrency.SROAR_MERGE` at every sroar `*Conc` merge site. sroar's
`OrConc`/`AndConc`/`AndNotConc` spawn `min(numContainers/24, maxConcurrency)-1`
bare goroutines per op. A per-query concurrency budget already existed in
`entities/concurrency` (seeded in the searcher, halved at filter fan-outs) but
it never reached the merge level, so every query fanned out at the full
per-site constant regardless of how many queries were already in flight.

## Design

- **Budget reaches the merge level.** A new
  `concurrency.BudgetFromCtxCapped(ctx, cap)` resolves the per-query budget
  from ctx and clamps it to `[1, cap]`, where `cap` is the old per-site
  constant (`SROAR_MERGE`, or the reader's configured concurrency). This is
  threaded down through the primary read path
  (`Bucket.RoaringSetGet` -> `SegmentGroup.roaringSetGet` ->
  `segment.roaringSetMergeWith`, `BitmapLayers.Flatten`, the roaringset
  `CombinedCursor`), the inverted filter-tree merges
  (`processDocIDs`/`mergeDocIDs`/`mergeBitmapsAndOrWithDenyList`, the
  deny-list inversion in `searcher.go`, the BM25 filtered-docID union in
  `bm25_searcher.go`), and the rangeable readers
  (`roaringsetrange.CombinedReader`, `SegmentReader`, `segmentInMemoryReader`).
- **Single idle query is unchanged.** Because `cap` is the old constant and
  doubles as the fallback when ctx carries no budget, a lone query (or any
  background caller: compaction, cursors, flush) resolves to exactly the
  pre-change concurrency. The floor of 1 is load-bearing: sroar treats
  `maxConcurrency <= 0` as unlimited.
- **Kill switch.** `DISABLE_SROAR_MERGE_BUDGET` (env, truthy) restores the
  pre-P1a fixed-constant behavior at every site, as an escape hatch until the
  fix has soaked. The clamping logic is factored into a pure
  `clampBudget(b, cap int) int` so it is unit-testable without the env seam.
- **Compaction is deliberately excluded.** `BitmapLayers.Merge`,
  `roaringset`/`roaringsetrange` compactors, and the background
  memtable/segment merges (`MergeSegmentByCursor`, `mergeMemtables`) keep the
  fixed constant. They are not per-query work and must not be throttled by a
  query's budget.
- **P1b is out of scope and composes.** Node-level admission control (P1b)
  is not in this change. It composes on top of this work through the same
  budget-seeding sites in the searcher, so it can shrink the budget cluster-
  wide without touching any of the merge sites threaded here.

### One intentional behavior change

The rangeable `CombinedReader` previously let a single query run up to
`SROAR_MERGE` inner readers, each of which then fanned out its own
`SROAR_MERGE` merge workers: an O(`SROAR_MERGE`^2) inner fan-out for one
query. It now hands each inner reader a fractional slice of the budget
(`ContextWithFractionalBudget`), so the total fan-out for one query is bounded
by the budget rather than squared. A single idle query's top-level merges
still use `SROAR_MERGE`; only the quadratic inner fan-out is removed.

## Risks

- The read path is a hot path. The budget is resolved once per key/read (a ctx
  value lookup plus two comparisons) and threaded as a plain int, so the added
  per-query cost is negligible; the seams are compile-checked function-signature
  changes, no interface indirection on the merge inner loops.
- Correctness of the merges is concurrency-independent (the same union/intersect
  regardless of worker count). The new tests assert result equality across
  budgets of 1, 2, and `SROAR_MERGE` to pin this.
- If a machine runs with `GOMAXPROCS <= 2`, `SROAR_MERGE < 2` and there is no
  fan-out to bound; the bounding tests skip in that case rather than assert on
  noise.

## Testing

- New goroutine-bounding regression guards (public APIs only, no test-only
  seams): `TestBucket_RoaringSetGet_RespectsConcurrencyBudget` (8 disk
  segments, ~200 containers) and
  `TestCombinedReader_RespectsConcurrencyBudget`. A budget of 1 returns the
  same set as an unconstrained query and keeps 16 concurrent readers within a
  goroutine ceiling; flipping `DISABLE_SROAR_MERGE_BUDGET` blows past it
  (verified: 68 vs a ceiling of 27 for the lsmkv guard under `-race`). Both run
  clean 5x under `-race` and non-race.
- `Test_BitmapLayers_Flatten` now sub-tests `maxConc` in {1, 2, `SROAR_MERGE`}.
- `BudgetFromCtxCapped` / `clampBudget` table tests cover absent/over/under
  budget, 0, negative, and `cap == 1`.
- Green locally: `go build ./...`; `go vet` (only two pre-existing warnings
  outside this diff); `golangci-lint run` (0 issues); the goroutine linter;
  unit tests for `entities/concurrency`, `roaringset`, `roaringsetrange`,
  `inverted`, `lsmkv`, `sorter`, `aggregator`; integration tests for
  `inverted`, `lsmkv` (`-timeout 20m`, 273s), and `Filters` across
  `adapters/repos/db/...`; and `-race -run RoaringSet ./adapters/repos/db/lsmkv/...`.

## Review-round updates

A follow-up review of the P1a branch surfaced a few merge sites the first pass
missed, plus a hardening of the kill switch. The design above is unchanged.

- **Three uncapped merge sites, now capped (top priority).** The per-row merges
  in `docBitmapInvertedRoaringSet` / `docBitmapInvertedSet` /
  `docBitmapInvertedMap` still resolved the budget with the raw
  `BudgetFromCtx(ctx, SROAR_MERGE)`. Seeded query budgets are `2xGOMAXPROCS`, so
  these ran at up to 4x the `SROAR_MERGE` cap and bypassed the kill switch. Each
  now hoists a single `BudgetFromCtxCapped(ctx, SROAR_MERGE)`, matching
  `bm25_searcher.go`.
- **Sorter and aggregator cursors wired to the budget.** The inverted sorter
  (ASC/DESC scans) and the unfiltered aggregators (bool/float/int/date props)
  opened roaringset cursors via the constant `CursorRoaringSet()`; they now use
  `CursorRoaringSetCtx(ctx)`. `shard_usage` stays on the constant (background
  path).
- **Kill switch now leaves ctx budgets fully untouched.** The rangeable
  `CombinedReader` wrote a fractional budget into `innerCtx` even when
  `DISABLE_SROAR_MERGE_BUDGET` was set. A new exported
  `concurrency.BudgetCapDisabled()` gates that write, restoring the invariant
  "kill switch => ctx budgets untouched" for any future `BudgetFromCtx` consumer
  below the fan-out. Added `TestBudgetCapDisabled_KillSwitch`; the two
  goroutine-bounding tests now skip under the kill switch so environments running
  with it set don't go red by design.
- **New coverage + cleanup.** A cursor budget-plumbing equivalence test
  (budget-1 ctx scan == default scan) and a docBitmap row-merge test (equivalence
  plus a kill-switch / `SROAR_MERGE>=2`-guarded goroutine-ceiling subtest over a
  real multi-row bucket). Removed the dead `Bucket.CursorRoaringSetKeyOnly`
  (zero callers repo-wide).

The one perf-relevant behavior note (already in this branch, restated for
reviewers): the rangeable `CombinedReader` no longer runs the
`SROAR_MERGE`-squared inner fan-out for budget-less callers. A single large range
filter on an otherwise idle node now bounds its inner readers to a fractional
slice of the budget instead of letting each inner reader spawn a full
`SROAR_MERGE` merge. The kill switch restores the old quadratic path.

Tracking: weaviate/0-weaviate-issues#305

— SuperClaude (P1a from the 2026-07-08 customer load-test analysis)


