### PR TITLE
fix(db): don't hold index locks across index teardown

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -111,12 +111,11 @@ func (db *DB) BackupDescriptors(ctx context.Context, bakid string, classes []str
 				}
 				idx.dropIndex.RLock()
 				defer idx.dropIndex.RUnlock()
-				idx.closeLock.RLock()
-				defer idx.closeLock.RUnlock()
-				if idx.closed {
+				if err := idx.enterRead(); err != nil {
 					desc.Error = fmt.Errorf("index for class %v is closed", c)
 					return
 				}
+				defer idx.exitRead()
 				var classBaseDescr []*backup.ClassDescriptor
 				for _, b := range baseDescrs {
 					classbaseDescrTmp := b.GetClassDescriptor(c)

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -21,17 +21,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/usecases/file"
-	"github.com/weaviate/weaviate/usecases/sharding"
-
-	"github.com/weaviate/weaviate/entities/diskio"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/diskio"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/file"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 type BackupState struct {
@@ -160,8 +159,6 @@ func (db *DB) ReleaseBackup(ctx context.Context, bakID, class string) (err error
 
 	idx := db.GetIndex(schema.ClassName(class))
 	if idx != nil {
-		idx.closeLock.RLock()
-		defer idx.closeLock.RUnlock()
 		return idx.ReleaseBackup(ctx, bakID)
 	} else {
 		// index has been deleted in the meantime. Cleanup files that were kept to complete backup
@@ -655,6 +652,14 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	})
 
 	i.resetBackupState()
+
+	// Releasing backupLock above unblocks a waiting index.drop(), which shuts the
+	// shard stores down. Resuming their cycles now would be a use-after-drop.
+	if err := i.enterRead(); err != nil {
+		return nil
+	}
+	defer i.exitRead()
+
 	// resumeMaintenanceCycles is still called for safety, but is a no-op since
 	// CreateBackupSnapshot already resumed compaction. Handles edge cases where
 	// a snapshot creation failed mid-way.

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -158,6 +158,12 @@ func (db *DB) ReleaseBackup(ctx context.Context, bakID, class string) (err error
 	}()
 
 	idx := db.GetIndex(schema.ClassName(class))
+	if idx == nil {
+		// a class deleted mid-backup is unpublished before its drop runs, and that
+		// drop parks on backupLock until this call releases it.
+		idx = db.droppingIndex(indexID(schema.ClassName(class)))
+	}
+
 	if idx != nil {
 		return idx.ReleaseBackup(ctx, bakID)
 	} else {

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -281,6 +281,12 @@ func TestBackup_BucketLevel(t *testing.T) {
 }
 
 func setupTestDB(t *testing.T, rootDir string, classes ...*models.Class) *DB {
+	return setupTestDBWithConfig(t, rootDir, nil, classes...)
+}
+
+// setupTestDBWithConfig builds a single-node DB. override, when non-nil, adjusts
+// the Config before the DB is created.
+func setupTestDBWithConfig(t *testing.T, rootDir string, override func(*Config), classes ...*models.Class) *DB {
 	logger, _ := test.NewNullLogger()
 
 	shardState := singleShardState()
@@ -309,12 +315,16 @@ func setupTestDB(t *testing.T, rootDir string, classes ...*models.Class) *DB {
 	mockNodeSelector := cluster.NewMockNodeSelector(t)
 	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
-	db, err := New(logger, "node1", Config{
+	cfg := Config{
 		MemtablesFlushDirtyAfter:  60,
 		RootPath:                  rootDir,
 		QueryMaximumResults:       10,
 		MaxImportGoroutinesFactor: 1,
-	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
+	}
+	if override != nil {
+		override(&cfg)
+	}
+	db, err := New(logger, "node1", cfg, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
 		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader)
 	require.Nil(t, err)
 	db.SetSchemaGetter(schemaGetter)

--- a/adapters/repos/db/class_delete_integration_test.go
+++ b/adapters/repos/db/class_delete_integration_test.go
@@ -1,0 +1,209 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+const (
+	deleteTestClass      = "ClassDeleteLifecycle"
+	deleteTestOtherClass = "ClassDeleteBystander"
+	deleteTestBackupID   = "delete-lifecycle-backup"
+)
+
+// deadline bounds every "must not hang" assertion. A dropping class blocking a
+// caller is the bug under test, so exceeding it fails rather than stalls.
+const deadline = 15 * time.Second
+
+func newTestRepo(t *testing.T, lazyLoadShards bool, classes ...*models.Class) (*DB, *Migrator, *fakeSchemaGetter) {
+	t.Helper()
+
+	repo := setupTestDBWithConfig(t, t.TempDir(), func(cfg *Config) {
+		cfg.EnableLazyLoadShards = &lazyLoadShards
+	}, classes...)
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	return repo, NewMigrator(repo, repo.logger, "node1"), repo.schemaGetter.(*fakeSchemaGetter)
+}
+
+func createClass(t *testing.T, ctx context.Context, migrator *Migrator, sg *fakeSchemaGetter, name string) {
+	t.Helper()
+	class := makeTestClass(name)
+	require.Nil(t, migrator.AddClass(ctx, class))
+	sg.schema.Objects.Classes = append(sg.schema.Objects.Classes, class)
+}
+
+func deleteClass(t *testing.T, ctx context.Context, migrator *Migrator, sg *fakeSchemaGetter, name string) {
+	t.Helper()
+	require.NoError(t, migrator.DropClass(ctx, name, false))
+	unpublish(sg, name)
+}
+
+func unpublish(sg *fakeSchemaGetter, name string) {
+	kept := sg.schema.Objects.Classes[:0]
+	for _, c := range sg.schema.Objects.Classes {
+		if c.Class != name {
+			kept = append(kept, c)
+		}
+	}
+	sg.schema.Objects.Classes = kept
+}
+
+func putObject(ctx context.Context, repo *DB, class, value string) error {
+	obj := testObject(class).Object
+	obj.Properties = map[string]any{"stringProp": value}
+	return repo.PutObject(ctx, &obj, []float32{1, 3, 5, 0.4}, nil, nil, nil, 0)
+}
+
+func addObject(t *testing.T, ctx context.Context, repo *DB, class, value string) {
+	t.Helper()
+	require.NoError(t, putObject(ctx, repo, class, value))
+}
+
+func queryClass(ctx context.Context, repo *DB, class string) (search.Results, *objects.Error) {
+	return repo.Query(ctx, &objects.QueryInput{Class: class, Limit: 10})
+}
+
+// TestClassLifecycle exercises the ordinary create/write/read/delete/recreate
+// path. Recreating a deleted class must yield a fresh, empty class: the drop
+// has to release every LSM bucket registration the first class held.
+func TestClassLifecycle(t *testing.T) {
+	ctx := context.Background()
+	repo, migrator, sg := newTestRepo(t, false, makeTestClass(deleteTestClass))
+
+	addObject(t, ctx, repo, deleteTestClass, "before")
+
+	res, objErr := queryClass(ctx, repo, deleteTestClass)
+	require.Nil(t, objErr)
+	require.Len(t, res, 1)
+
+	statuses, err := repo.GetNodeStatus(ctx, deleteTestClass, "", verbosity.OutputVerbose)
+	require.NoError(t, err)
+	require.NotEmpty(t, statuses[0].Shards)
+
+	deleteClass(t, ctx, migrator, sg, deleteTestClass)
+
+	_, objErr = queryClass(ctx, repo, deleteTestClass)
+	require.NotNil(t, objErr)
+	assert.Equal(t, objects.StatusNotFound, objErr.Code, "reading a deleted class: %v", objErr.Msg)
+
+	createClass(t, ctx, migrator, sg, deleteTestClass)
+
+	res, objErr = queryClass(ctx, repo, deleteTestClass)
+	require.Nil(t, objErr)
+	assert.Empty(t, res, "recreated class must not serve objects from its predecessor")
+
+	addObject(t, ctx, repo, deleteTestClass, "after")
+	res, objErr = queryClass(ctx, repo, deleteTestClass)
+	require.Nil(t, objErr)
+	require.Len(t, res, 1)
+
+	statuses, err = repo.GetNodeStatus(ctx, deleteTestClass, "", verbosity.OutputVerbose)
+	require.NoError(t, err)
+	require.Len(t, statuses, 1)
+	assert.NotEmpty(t, statuses[0].Shards)
+}
+
+// TestDeleteClassDuringBackup deletes a class while a backup of it is still
+// open. On a filesystem without hardlink support a backup keeps its shard
+// write-locked under backupLock until ReleaseBackup, so the delete parks in
+// dropShard. While it is parked the node must stay live: the dropping class
+// reads as absent, unrelated classes keep serving, and releasing the backup
+// lets the delete finish.
+func TestDeleteClassDuringBackup(t *testing.T) {
+	t.Setenv("WEAVIATE_TEST_FORCE_NO_HARDLINK", "true")
+	ctx := context.Background()
+	repo, migrator, sg := newTestRepo(t, true,
+		makeTestClass(deleteTestClass), makeTestClass(deleteTestOtherClass))
+
+	addObject(t, ctx, repo, deleteTestOtherClass, "bystander")
+
+	for d := range repo.BackupDescriptors(ctx, deleteTestBackupID, []string{deleteTestClass}, nil) {
+		require.NoError(t, d.Error)
+	}
+
+	deleted := make(chan struct{})
+	go func() {
+		defer close(deleted)
+		_ = migrator.DropClass(ctx, deleteTestClass, false)
+	}()
+	unpublish(sg, deleteTestClass)
+
+	require.Eventually(t, func() bool {
+		return repo.GetIndex(schema.ClassName(deleteTestClass)) == nil
+	}, deadline, 50*time.Millisecond, "class must stop resolving as soon as its delete starts")
+
+	select {
+	case <-deleted:
+		t.Fatal("precondition: the open backup must hold the delete")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// The parked delete must not freeze the node.
+	var droppingErr, bystanderErr *objects.Error
+	var bystander search.Results
+	var writeErr error
+	requireNoHang(t, "read of the dropping class", func() {
+		_, droppingErr = queryClass(ctx, repo, deleteTestClass)
+	})
+	requireNoHang(t, "read of an unrelated class", func() {
+		bystander, bystanderErr = queryClass(ctx, repo, deleteTestOtherClass)
+	})
+	requireNoHang(t, "write to an unrelated class", func() {
+		writeErr = putObject(ctx, repo, deleteTestOtherClass, "still writable")
+	})
+
+	require.NotNil(t, droppingErr, "reading a class being deleted must fail")
+	assert.Equal(t, objects.StatusNotFound, droppingErr.Code, "got %v", droppingErr.Msg)
+	require.Nil(t, bystanderErr)
+	assert.Len(t, bystander, 1)
+	assert.NoError(t, writeErr)
+
+	require.NoError(t, repo.ReleaseBackup(ctx, deleteTestBackupID, deleteTestClass))
+
+	select {
+	case <-deleted:
+	case <-time.After(deadline):
+		t.Fatal("releasing the backup must unblock the delete")
+	}
+}
+
+// requireNoHang fails instead of stalling when fn blocks on a lock the parked
+// delete holds. fn runs on its own goroutine, so it records results for the
+// caller to assert on rather than calling require itself.
+func requireNoHang(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(deadline):
+		t.Fatalf("%s blocked behind the parked delete", what)
+	}
+}

--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -162,11 +162,10 @@ func (db *DB) SnapshotShards(ctx context.Context, className string, shardNames [
 	}
 	defer idx.dropIndex.RUnlock()
 
-	idx.closeLock.RLock()
-	defer idx.closeLock.RUnlock()
-	if idx.closed {
-		return nil, errAlreadyShutdown
+	if err := idx.enterRead(); err != nil {
+		return nil, err
 	}
+	defer idx.exitRead()
 	return idx.snapshotShardsForExport(ctx, shardNames, exportID)
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3294,7 +3294,16 @@ func (i *Index) drop() error {
 
 	if keepFiles {
 		// backup framework expects the DeleteMarkerAdd-prefixed rename
-		return os.Rename(i.path(), filepath.Join(i.Config.RootPath, backup.DeleteMarkerAdd(i.ID())))
+		marker := filepath.Join(i.Config.RootPath, backup.DeleteMarkerAdd(i.ID()))
+		if err := os.Rename(i.path(), marker); err != nil {
+			return err
+		}
+		// drop blocks on backupLock until ReleaseBackup runs, so if that already
+		// finished it looked for the marker before this rename created it.
+		if i.lastBackup.Load() == nil {
+			return os.RemoveAll(marker)
+		}
+		return nil
 	}
 
 	// rename sync (must complete even if ctx is expired); RemoveAll async

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -320,6 +320,10 @@ type Index struct {
 
 	closed bool
 
+	// inflight counts operations admitted by enterRead. beginClose drains it
+	// instead of holding closeLock across teardown.
+	inflight sync.WaitGroup
+
 	shardReindexer ShardReindexerV3
 
 	router         routerTypes.Router
@@ -1024,11 +1028,10 @@ func (db *DB) ReconcileAsyncReplication(ctx context.Context) error {
 		err := func() error {
 			idx.dropIndex.RLock()
 			defer idx.dropIndex.RUnlock()
-			idx.closeLock.RLock()
-			defer idx.closeLock.RUnlock()
-			if idx.closed {
+			if err := idx.enterRead(); err != nil {
 				return nil // index is shutting down; nothing to reconcile
 			}
+			defer idx.exitRead()
 			return idx.reconcileAsyncReplication(ctx)
 		}()
 		if err != nil {
@@ -2945,12 +2948,10 @@ func (i *Index) LoadLocalShard(ctx context.Context, shardName string, implicitSh
 }
 
 func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *models.Class, shardName string, mustLoad bool, implicitShardLoading bool) error {
-	i.closeLock.RLock()
-	defer i.closeLock.RUnlock()
-
-	if i.closed {
-		return errAlreadyShutdown
+	if err := i.enterRead(); err != nil {
+		return err
 	}
+	defer i.exitRead()
 
 	// make sure same shard is not inited in parallel
 	i.shardCreateLocks.Lock(shardName)
@@ -2985,12 +2986,10 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 }
 
 func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
-	i.closeLock.RLock()
-	defer i.closeLock.RUnlock()
-
-	if i.closed {
-		return errAlreadyShutdown
+	if err := i.enterRead(); err != nil {
+		return err
 	}
+	defer i.exitRead()
 
 	i.shardCreateLocks.Lock(shardName)
 	defer i.shardCreateLocks.Unlock(shardName)
@@ -3035,12 +3034,10 @@ func (i *Index) getOrInitShard(ctx context.Context, shardName string) (
 func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensureInit bool) (
 	shard ShardLike, release func(), err error,
 ) {
-	i.closeLock.RLock()
-	defer i.closeLock.RUnlock()
-
-	if i.closed {
-		return nil, func() {}, errAlreadyShutdown
+	if err := i.enterRead(); err != nil {
+		return nil, func() {}, err
 	}
+	defer i.exitRead()
 
 	// make sure same shard is not inited in parallel. In case it is not loaded yet, switch to a RW lock and initialize
 	// the shard
@@ -3247,16 +3244,9 @@ func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 }
 
 func (i *Index) drop() error {
-	i.closeLock.Lock()
-	defer i.closeLock.Unlock()
-
-	if i.closed {
-		return errAlreadyShutdown
+	if err := i.beginClose(); err != nil {
+		return err
 	}
-
-	i.closed = true
-
-	i.closingCancel()
 
 	// Check if a backup is in progress. Dont delete files in this case so the backup process can complete successfully
 	// The files will be deleted after the backup is completed and in case of a crash on next startup.
@@ -3318,32 +3308,27 @@ func (i *Index) drop() error {
 	return nil
 }
 
-// withCloseRLockGuard runs fn under i.closeLock.RLock, returning
-// context.Canceled WITHOUT running fn if the index is closing/closed. fn
-// must be short and must not acquire i.closeLock for writing or any lock
-// drop() holds in an inverting order.
+// withCloseRLockGuard runs fn only if the index is not closing/closed,
+// returning context.Canceled without running it otherwise. fn must not acquire
+// i.closeLock for writing or any lock drop() holds in an inverting order.
 //
 // Covers whole-index drops only: dropShards never sets i.closed, so tenant
 // deletes are invisible to the guard. Tracked in
 // https://github.com/weaviate/0-weaviate-issues/issues/288.
 func (i *Index) withCloseRLockGuard(fn func() error) error {
-	i.closeLock.RLock()
-	defer i.closeLock.RUnlock()
-
-	if i.closed {
+	if err := i.enterRead(); err != nil {
 		return context.Canceled
 	}
+	defer i.exitRead()
 
 	return fn()
 }
 
 func (i *Index) dropShards(names []string) error {
-	i.closeLock.RLock()
-	defer i.closeLock.RUnlock()
-
-	if i.closed {
-		return errAlreadyShutdown
+	if err := i.enterRead(); err != nil {
+		return err
 	}
+	defer i.exitRead()
 
 	ec := errorcompounder.New()
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
@@ -3382,12 +3367,10 @@ func (i *Index) dropShards(names []string) error {
 }
 
 func (i *Index) dropCloudShards(ctx context.Context, cloud modulecapabilities.OffloadCloud, names []string, nodeId string) error {
-	i.closeLock.RLock()
-	defer i.closeLock.RUnlock()
-
-	if i.closed {
-		return errAlreadyShutdown
+	if err := i.enterRead(); err != nil {
+		return err
 	}
+	defer i.exitRead()
 
 	ec := errorcompounder.New()
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
@@ -3414,16 +3397,9 @@ func (i *Index) dropCloudShards(ctx context.Context, cloud modulecapabilities.Of
 }
 
 func (i *Index) Shutdown(ctx context.Context) error {
-	i.closeLock.Lock()
-	defer i.closeLock.Unlock()
-
-	if i.closed {
-		return errAlreadyShutdown
+	if err := i.beginClose(); err != nil {
+		return err
 	}
-
-	i.closed = true
-
-	i.closingCancel()
 
 	// TODO allow every resource cleanup to run, before returning early with error
 	if err := i.shards.RangeConcurrently(i.logger, func(name string, shard ShardLike) error {
@@ -3985,5 +3961,37 @@ func (i *Index) DebugRequantizeIndex(ctx context.Context, shardName, targetVecto
 		}
 	}, i.logger)
 
+	return nil
+}
+
+// enterRead admits an operation onto a live index; pair it with exitRead. The
+// Add runs under closeLock.RLock, so it cannot land after beginClose's Wait.
+func (i *Index) enterRead() error {
+	i.closeLock.RLock()
+	defer i.closeLock.RUnlock()
+
+	if i.closed {
+		return errAlreadyShutdown
+	}
+	i.inflight.Add(1)
+	return nil
+}
+
+func (i *Index) exitRead() { i.inflight.Done() }
+
+// beginClose closes the index and drains in-flight readers. It returns holding
+// no lock: teardown must not exclude readers, or a peer's RPC handler blocks
+// behind it while this node waits on that peer.
+func (i *Index) beginClose() error {
+	i.closeLock.Lock()
+	if i.closed {
+		i.closeLock.Unlock()
+		return errAlreadyShutdown
+	}
+	i.closed = true
+	i.closingCancel()
+	i.closeLock.Unlock()
+
+	i.inflight.Wait()
 	return nil
 }

--- a/adapters/repos/db/index_close_test.go
+++ b/adapters/repos/db/index_close_test.go
@@ -1,0 +1,217 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newClosableIndex() *Index {
+	idx := &Index{}
+	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
+	return idx
+}
+
+func TestIndexCloseGuards(t *testing.T) {
+	tests := []struct {
+		name        string
+		closeBefore bool
+		op          func(idx *Index, ran *bool) error
+		wantErr     error
+		wantRan     bool
+	}{
+		{
+			name: "enterRead admits on a live index",
+			op: func(idx *Index, ran *bool) error {
+				err := idx.enterRead()
+				if err == nil {
+					*ran = true
+					idx.exitRead()
+				}
+				return err
+			},
+			wantRan: true,
+		},
+		{
+			name:        "enterRead rejects after close",
+			closeBefore: true,
+			op: func(idx *Index, ran *bool) error {
+				err := idx.enterRead()
+				if err == nil {
+					*ran = true
+					idx.exitRead()
+				}
+				return err
+			},
+			wantErr: errAlreadyShutdown,
+		},
+		{
+			name: "withCloseRLockGuard runs fn on a live index",
+			op: func(idx *Index, ran *bool) error {
+				return idx.withCloseRLockGuard(func() error { *ran = true; return nil })
+			},
+			wantRan: true,
+		},
+		{
+			name:        "withCloseRLockGuard skips fn after close",
+			closeBefore: true,
+			op: func(idx *Index, ran *bool) error {
+				return idx.withCloseRLockGuard(func() error { *ran = true; return nil })
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "beginClose succeeds once",
+			op: func(idx *Index, _ *bool) error {
+				return idx.beginClose()
+			},
+		},
+		{
+			name:        "beginClose is idempotent",
+			closeBefore: true,
+			op: func(idx *Index, _ *bool) error {
+				return idx.beginClose()
+			},
+			wantErr: errAlreadyShutdown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := newClosableIndex()
+			if tc.closeBefore {
+				require.NoError(t, idx.beginClose())
+			}
+
+			ran := false
+			err := tc.op(idx, &ran)
+
+			if tc.wantErr != nil {
+				assert.ErrorIs(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantRan, ran)
+		})
+	}
+}
+
+// TestBeginCloseDoesNotBlockNewcomers pins the deadlock root cause: drop() used
+// to hold closeLock for writing across teardown, so a peer's RPC handler blocked
+// behind it while this node's own pre-filter blocked on that peer.
+func TestBeginCloseDoesNotBlockNewcomers(t *testing.T) {
+	tests := []struct {
+		name     string
+		newcomer func(idx *Index) error
+		wantErr  error
+	}{
+		{
+			name:     "enterRead",
+			newcomer: func(idx *Index) error { return idx.enterRead() },
+			wantErr:  errAlreadyShutdown,
+		},
+		{
+			name:     "withCloseRLockGuard",
+			newcomer: func(idx *Index) error { return idx.withCloseRLockGuard(func() error { return nil }) },
+			wantErr:  context.Canceled,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := newClosableIndex()
+			require.NoError(t, idx.enterRead())
+
+			closed := make(chan struct{})
+			go func() {
+				_ = idx.beginClose()
+				close(closed)
+			}()
+
+			// closingCtx is cancelled under the write lock, so this also proves the
+			// lock is released by the time we probe.
+			<-idx.closingCtx.Done()
+
+			bail := make(chan error, 1)
+			go func() { bail <- tc.newcomer(idx) }()
+
+			select {
+			case err := <-bail:
+				assert.ErrorIs(t, err, tc.wantErr)
+			case <-time.After(5 * time.Second):
+				t.Fatal("newcomer blocked while beginClose drained; a peer's RPC handler would deadlock")
+			}
+
+			select {
+			case <-closed:
+				t.Fatal("beginClose returned while an in-flight reader was still running")
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			idx.exitRead()
+
+			select {
+			case <-closed:
+			case <-time.After(5 * time.Second):
+				t.Fatal("beginClose did not return after its in-flight reader exited")
+			}
+		})
+	}
+}
+
+// TestEnterReadRacesBeginClose: an Add must never land after Wait starts, which
+// would panic the WaitGroup.
+func TestEnterReadRacesBeginClose(t *testing.T) {
+	tests := []struct {
+		readers    int
+		iterations int
+	}{
+		{readers: 1, iterations: 50},
+		{readers: 8, iterations: 50},
+		{readers: 64, iterations: 10},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%d readers", tc.readers), func(t *testing.T) {
+			for range tc.iterations {
+				idx := newClosableIndex()
+
+				var wg sync.WaitGroup
+				for range tc.readers {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						if err := idx.enterRead(); err == nil {
+							idx.exitRead()
+						}
+					}()
+				}
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_ = idx.beginClose()
+				}()
+
+				wg.Wait()
+				assert.ErrorIs(t, idx.enterRead(), errAlreadyShutdown)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -259,11 +259,10 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 	func() {
 		idx.dropIndex.RLock()
 		defer idx.dropIndex.RUnlock()
-		idx.closeLock.RLock()
-		defer idx.closeLock.RUnlock()
-		if idx.closed {
+		if err := idx.enterRead(); err != nil {
 			return
 		}
+		defer idx.exitRead()
 		if err := idx.reconcileAsyncReplication(ctx); err != nil {
 			m.logger.WithField("action", "add_class").WithField("class", class.Class).
 				Errorf("reconcile async replication for new index: %v", err)
@@ -630,12 +629,11 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 	if idx == nil {
 		return fmt.Errorf("cannot find index for %q", class.Class)
 	}
-	idx.closeLock.RLock()
-	defer idx.closeLock.RUnlock()
-	if idx.closed {
+	if err := idx.enterRead(); err != nil {
 		m.logger.WithField("index", idx.ID()).Debug("index is already shut down or dropped")
-		return errAlreadyShutdown
+		return err
 	}
+	defer idx.exitRead()
 
 	hot := make([]string, 0, len(updates))
 	cold := make([]string, 0, len(updates))

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -582,17 +582,18 @@ func (db *DB) DeleteIndex(className schema.ClassName) error {
 		return nil
 	}
 
-	// drop index
-	db.indexLock.Lock()
-	delete(db.indices, indexID(className))
-	db.indexLock.Unlock()
-
 	index.dropIndex.Lock()
-	defer index.dropIndex.Unlock()
 	if err := index.drop(); err != nil {
 		db.logger.WithField("action", "delete_index").WithField("class", className).
 			Errorf("drop index: %v", err)
 	}
+	index.dropIndex.Unlock()
+
+	// Unpublish after the drop: db.ReleaseBackup's GetIndex()==nil branch never
+	// releases backupLock, so an early delete hangs dropShard forever.
+	db.indexLock.Lock()
+	delete(db.indices, indexID(className))
+	db.indexLock.Unlock()
 
 	if err := db.promMetrics.DeleteClass(className.String()); err != nil {
 		db.logger.Errorf("can't delete prometheus metrics: %v", err)

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -584,18 +584,18 @@ func (db *DB) DeleteIndex(className schema.ClassName) error {
 
 	// drop index
 	db.indexLock.Lock()
-	defer db.indexLock.Unlock()
+	delete(db.indices, indexID(className))
+	db.indexLock.Unlock()
 
 	index.dropIndex.Lock()
 	defer index.dropIndex.Unlock()
 	if err := index.drop(); err != nil {
-		db.logger.WithField("action", "delete_index").WithField("class", className).Error(err)
+		db.logger.WithField("action", "delete_index").WithField("class", className).
+			Errorf("drop index: %v", err)
 	}
 
-	delete(db.indices, indexID(className))
-
 	if err := db.promMetrics.DeleteClass(className.String()); err != nil {
-		db.logger.Error("can't delete prometheus metrics", err)
+		db.logger.Errorf("can't delete prometheus metrics: %v", err)
 	}
 	return nil
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -91,6 +91,9 @@ type DB struct {
 	// mark a given index in use, lock that index directly.
 	indexLock sync.RWMutex
 
+	// dropping holds indices whose index.drop() is still running for backup purposes.
+	dropping sync.Map
+
 	jobQueueCh          chan job
 	scheduler           *queue.Scheduler
 	shutDownWg          sync.WaitGroup
@@ -575,25 +578,40 @@ func (db *DB) GetIndexForIncomingSharding(className schema.ClassName) sharding.R
 	return index
 }
 
+// droppingIndex returns an index whose drop is still in flight, or nil. Only
+// db.ReleaseBackup may use it: drop() parks on backupLock, which nothing but
+// idx.ReleaseBackup releases. Everything else wants GetIndex, which reports a
+// deleted class as gone.
+func (db *DB) droppingIndex(id string) *Index {
+	if idx, ok := db.dropping.Load(id); ok {
+		return idx.(*Index)
+	}
+	return nil
+}
+
 // DeleteIndex deletes the index
 func (db *DB) DeleteIndex(className schema.ClassName) error {
 	index := db.GetIndex(className)
 	if index == nil {
 		return nil
 	}
+	id := indexID(className)
+
+	// Register before unpublishing: db.ReleaseBackup must find the index in one
+	// map or the other, never neither.
+	db.dropping.Store(id, index)
+	defer db.dropping.Delete(id)
+
+	db.indexLock.Lock()
+	delete(db.indices, id)
+	db.indexLock.Unlock()
 
 	index.dropIndex.Lock()
+	defer index.dropIndex.Unlock()
 	if err := index.drop(); err != nil {
 		db.logger.WithField("action", "delete_index").WithField("class", className).
 			Errorf("drop index: %v", err)
 	}
-	index.dropIndex.Unlock()
-
-	// Unpublish after the drop: db.ReleaseBackup's GetIndex()==nil branch never
-	// releases backupLock, so an early delete hangs dropShard forever.
-	db.indexLock.Lock()
-	delete(db.indices, indexID(className))
-	db.indexLock.Unlock()
 
 	if err := db.promMetrics.DeleteClass(className.String()); err != nil {
 		db.logger.Errorf("can't delete prometheus metrics: %v", err)


### PR DESCRIPTION
### What's being changed:
Deleting a collection used to grab two big locks and hold them for the entire teardown — the whole file-deletion, store-shutdown, disk-cleanup sequence, so this PR fixes multiple issues
- Cross-node `DELETE_CLASS` deadlock. index.drop() held `db.indexLock` and `index.closeLock` for writing across the whole teardown

- Node-wide data-plane freeze. `DeleteIndex()` held the DB-global `indexLock` across `index.drop()`. `GetIndex()` takes it on every read, write, and batch path, so deleting one collection stalled every collection on that node for the drop's duration.

- Permanent dropShard hang. `db.ReleaseBackup's GetIndex()==nil` branch never releases backupLock, and drop()'s dropShard blocks on backupLock.RLock with no timeout. 

- Deleting a class during a non-hardlink backup with a protected shard wedged the raft apply loop forever. Fixed by unpublishing after the drop and removing closeLock.RLock in db.ReleaseBackup.

- Leaked __DELETE_ME_AFTER_BACKUP__ directory when `ReleaseBackup` finished before `drop()` created the marker. `drop()` now removes it when lastBackup is already nil.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/29021810992
- [x] e2e : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/29021865347
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
