### PR TITLE
review(usage): guard semaphore capacity, drop FIFO claim, shorten test timeout

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -40,7 +40,7 @@ import (
 
 // UsageForIndex computes usage for a single collection. shardReadSem bounds the number of
 // concurrent shard readers within a single usage report — parallel UsageForIndex calls share
-// the same semaphore. Acquisition is FIFO.
+// the same semaphore.
 func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, shardReadSem *semaphore.Weighted, exactObjectCount bool, vectorsConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
 	var (
 		index  *Index

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -89,7 +89,7 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 	// The semaphore is shared by all collections of this report, bounding concurrent shard
 	// readers at shardConcurrency. Up to shardConcurrency collections are in flight at once,
 	// so spare capacity left by one collection is used by the shards of the next.
-	shardConcurrency := int(s.shardConcurrency.Load())
+	shardConcurrency := max(int(s.shardConcurrency.Load()), 1)
 	shardReadSem := semaphore.NewWeighted(int64(shardConcurrency))
 
 	s.logger.Infof("Creating usage report with %d collections", len(collections))

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -642,7 +642,7 @@ func TestService_Usage_MultipleCollectionsConcurrent(t *testing.T) {
 				}
 				select {
 				case <-barrier:
-				case <-time.After(30 * time.Second):
+				case <-time.After(5 * time.Second):
 					return fmt.Errorf("collections are not processed concurrently: %d/%d in flight",
 						entered.Load(), len(classes))
 				}


### PR DESCRIPTION
### What's being changed:

Follow-up fixes for review comments on the usage shard-concurrency change (#12071 / #12081):

- Guard the shard-read semaphore capacity with `max(…, 1)` at its construction site — a capacity ≤ 0 semaphore would block collection forever
- Drop the undocumented "FIFO" acquisition claim from the `UsageForIndex` godoc (`x/sync/semaphore` gives no such guarantee)
- Shorten the concurrency-test barrier timeout 30s → 5s so a regression fails CI fast

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
