### PR TITLE
Fix HNSW global entrypoint repair (#11910)

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -709,6 +709,48 @@ func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error 
 	return nil
 }
 
+// repairGlobalEntrypoint attempts to repair the global entrypoint when it becomes
+// unusable. It builds a denial list and finds a new valid entrypoint using
+// compare-and-swap semantics to prevent race conditions. Returns true if a repair
+// was performed, false otherwise.
+func (h *hnsw) repairGlobalEntrypoint(denyList helpers.AllowList) bool {
+	currentEP := h.getEntrypoint()
+
+	// Get the current maximum layer without holding the write lock
+	h.RLock()
+	currentMaxLayer := h.currentMaximumLayer
+	h.RUnlock()
+
+	// Try to find a new entrypoint (this doesn't require holding the main lock)
+	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, currentMaxLayer, currentEP)
+	if !ok {
+		// No better entrypoint found
+		return false
+	}
+
+	// Now acquire the write lock to update the entrypoint atomically
+	h.Lock()
+	defer h.Unlock()
+
+	// Double-check that the entrypoint hasn't changed since we started
+	if h.entryPointID != currentEP {
+		return false
+	}
+
+	// Update the entrypoint atomically
+	h.entryPointID = newEntrypoint
+	h.currentMaximumLayer = level
+
+	// Persist the change to commit log
+	if err := h.commitLog.SetEntryPointWithMaxLayer(newEntrypoint, level); err != nil {
+		h.logger.WithField("action", "repair_global_entrypoint").
+			Warnf("failed to persist entrypoint repair: %v", err)
+		// Even if persistence fails, we've updated in-memory state
+	}
+
+	return true
+}
+
 // returns entryPointID, level and whether a change occurred
 func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel int,
 	oldEntrypoint uint64,

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -469,7 +469,26 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 	}
 
 	// The global candidate is not usable, we need to find a new one.
+	// First, attempt to repair the global entrypoint proactively
 	localDeny := n.denyList.WrapOnWrite()
+	localDeny.Insert(candidate)
+
+	if ok := n.graph.repairGlobalEntrypoint(localDeny); ok {
+		// Repair succeeded, try the new global entrypoint
+		newCandidate := n.graph.getEntrypoint()
+		success, err := n.tryEpCandidate(newCandidate)
+		if err != nil {
+			var e storobj.ErrNotFound
+			if !errors.As(err, &e) {
+				return err
+			}
+		}
+		if success {
+			return nil
+		}
+		// Repair didn't produce a usable candidate, add it to deny list
+		localDeny.Insert(newCandidate)
+	}
 
 	// make sure the loop cannot block forever. In most cases, results should be
 	// found within micro to milliseconds, this is just a last resort to handle
@@ -482,6 +501,7 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 		"duration": 60 * time.Second,
 	}).Debug("context.WithTimeout")
 
+	lastCandidate := candidate
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -511,11 +531,21 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 		if err != nil {
 			return err
 		}
+
+		// Check for no progress: if we get the same candidate back, we've exhausted options
+		if alternative == lastCandidate {
+			return fmt.Errorf("unable to find a usable entrypoint after exhausting candidates")
+		}
+
+		lastCandidate = candidate
 		candidate = alternative
 	}
 }
 
-func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error) {
+// tryEpCandidateIgnoreDeleted checks if a candidate is usable as an entrypoint,
+// ignoring ErrNotFound errors (treating deleted nodes as non-viable). Returns
+// (success, error) where success indicates the candidate is usable.
+func (n *neighborFinderConnector) tryEpCandidateIgnoreDeleted(candidate uint64) (bool, error) {
 	node := n.graph.nodeByID(candidate)
 	if node == nil {
 		return false, nil
@@ -535,7 +565,7 @@ func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error)
 	if err != nil {
 		var e storobj.ErrNotFound
 		if errors.As(err, &e) {
-			n.graph.handleDeletedNode(e.DocID, "tryEpCandidate")
+			n.graph.handleDeletedNode(e.DocID, "tryEpCandidateIgnoreDeleted")
 			return false, nil
 		}
 		return false, fmt.Errorf("calculate distance between insert node and entrypoint: %w", err)
@@ -545,4 +575,8 @@ func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error)
 	n.entryPointDist = dist
 	n.entryPointID = candidate
 	return true, nil
+}
+
+func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error) {
+	return n.tryEpCandidateIgnoreDeleted(candidate)
 }


### PR DESCRIPTION
Fixes #11910

Fixes the infinite loop when HNSW global entrypoint becomes unusable. Added proactive repair function with compare-and-swap semantics and proper locking to prevent race conditions.