### PR TITLE
Gate drop-vector-index phase-2 cleanup on cluster min version (#11901)

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -726,7 +726,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	// Created here (not in the DTM wiring) so it can be injected into the schema
 	// manager at construction, and so the edit-op liveness provider is installed
 	// before ClusterService.Open drives restore-time shard loads.
-	dropVectorEnqueuer := newDropVectorIndexEnqueuer(appState.ClusterService, appState.ClusterService.Raft, appState.Logger)
+	dropVectorEnqueuer := newDropVectorIndexEnqueuer(appState.ClusterService, appState.ClusterService.Raft, appState.DB, appState.Logger)
 	editops.SetLivenessProvider(dropVectorEnqueuer.LiveOpIDs)
 
 	schemaManager, err := schema.NewManager(migrator,

--- a/adapters/handlers/rest/drop_vector_index_enqueuer.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,14 +31,19 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
+// dropVectorMinClusterVersion is the minimum Weaviate version required across
+// all cluster nodes before Phase-2 cleanup tasks are enqueued.
+const dropVectorMinClusterVersion = "1.39.0"
+
 // dropVectorIndexEnqueuer implements schema.DropVectorIndexEnqueuer. It submits
 // the background cleanup distributed task and reports whether one is in flight,
 // using the cluster DTM client + sharding state. Lives in the REST wiring layer
 // so it can reuse buildUnitMaps/buildUnitSpecs.
 type dropVectorIndexEnqueuer struct {
-	clusterService clusterDropTaskClient
-	schemaState    schemaStateQuerier
-	logger         logrus.FieldLogger // nil-safe: only used for skip warnings
+	clusterService   clusterDropTaskClient
+	schemaState      schemaStateQuerier
+	clusterVersioner clusterVersionLister
+	logger           logrus.FieldLogger // nil-safe: only used for skip warnings
 }
 
 // clusterDropTaskClient is the slice of the cluster service the enqueuer uses.
@@ -58,8 +64,20 @@ type schemaStateQuerier interface {
 	QueryReadOnlyClasses(classes ...string) (map[string]versioned.Class, error)
 }
 
-func newDropVectorIndexEnqueuer(clusterService clusterDropTaskClient, schemaState schemaStateQuerier, logger logrus.FieldLogger) *dropVectorIndexEnqueuer {
-	return &dropVectorIndexEnqueuer{clusterService: clusterService, schemaState: schemaState, logger: logger}
+// clusterVersionLister provides version information about all nodes in the cluster.
+// Used to gate operations until the entire cluster is upgraded to a minimum version.
+type clusterVersionLister interface {
+	GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error)
+}
+
+func newDropVectorIndexEnqueuer(clusterService clusterDropTaskClient, schemaState schemaStateQuerier,
+	clusterVersioner clusterVersionLister, logger logrus.FieldLogger) *dropVectorIndexEnqueuer {
+	return &dropVectorIndexEnqueuer{
+		clusterService:   clusterService,
+		schemaState:      schemaState,
+		clusterVersioner: clusterVersioner,
+		logger:           logger,
+	}
 }
 
 // warnSkippedPayload surfaces an undecodable active-task payload instead of
@@ -69,6 +87,72 @@ func (e *dropVectorIndexEnqueuer) warnSkippedPayload(where, taskID string, err e
 		e.logger.WithField("task", taskID).
 			Warnf("drop-vector %s: skipping active task with unparseable payload: %v", where, err)
 	}
+}
+
+// parseSemverPrefix extracts the major.minor version from a semantic version string.
+// For "1.39.0" returns (1, 39, nil); for invalid input returns (0, 0, error).
+func parseSemverPrefix(version string) (int, int, error) {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("invalid semver: %q", version)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid major version in %q: %w", version, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minor version in %q: %w", version, err)
+	}
+	return major, minor, nil
+}
+
+// versionAtLeast reports whether version >= minVersion.
+func versionAtLeast(version, minVersion string) (bool, error) {
+	major, minor, err := parseSemverPrefix(version)
+	if err != nil {
+		return false, err
+	}
+	minMajor, minMinor, err := parseSemverPrefix(minVersion)
+	if err != nil {
+		return false, err
+	}
+	if major > minMajor {
+		return true, nil
+	}
+	if major < minMajor {
+		return false, nil
+	}
+	return minor >= minMinor, nil
+}
+
+// clusterFullyUpgraded reports whether all nodes in the cluster are upgraded
+// to at least minVersion.
+func (e *dropVectorIndexEnqueuer) clusterFullyUpgraded(ctx context.Context, minVersion string) (bool, error) {
+	statuses, err := e.clusterVersioner.GetNodeStatus(ctx, "", "", "minimal")
+	if err != nil {
+		return false, fmt.Errorf("checking cluster versions: %w", err)
+	}
+	for _, status := range statuses {
+		if status == nil || status.Version == "" {
+			// Missing version = node not ready or incompatible
+			return false, nil
+		}
+		ok, err := versionAtLeast(status.Version, minVersion)
+		if err != nil {
+			// Parse error = incompatible version format, treat as not upgraded
+			if e.logger != nil {
+				e.logger.WithField("node", status.Name).
+					Debugf("drop-vector cluster version check: could not parse version %q: %v", status.Version, err)
+			}
+			return false, nil
+		}
+		if !ok {
+			// This node is below the minimum
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // HasActiveDrop reports whether a non-terminal drop task already covers
@@ -104,6 +188,28 @@ func (e *dropVectorIndexEnqueuer) HasActiveDrop(ctx context.Context, collection,
 // one unit per (shard, replica) grouped by shard, so each replica node strips
 // its own objects bucket.
 func (e *dropVectorIndexEnqueuer) EnqueueDropVectorIndex(ctx context.Context, collection string, targets []string) error {
+	// Gate on cluster upgrade: Phase-2 cleanup is only safe once all nodes are
+	// at the minimum version. If the cluster is mixed-version, defer the enqueue
+	// and let reconciliation retry later.
+	upgraded, err := e.clusterFullyUpgraded(ctx, dropVectorMinClusterVersion)
+	if err != nil {
+		// Errors checking cluster version are transient (network, unavailable nodes);
+		// treat as not-upgraded so we defer and retry on the next reconciliation pass.
+		if e.logger != nil {
+			e.logger.WithField("collection", collection).
+				Debugf("drop-vector enqueue: deferring due to cluster version check error: %v", err)
+		}
+		return nil
+	}
+	if !upgraded {
+		// Cluster not fully upgraded; defer the cleanup task.
+		if e.logger != nil {
+			e.logger.WithField("collection", collection).
+				Infof("drop-vector enqueue: deferring cleanup for %q until cluster is at version %s", collection, dropVectorMinClusterVersion)
+		}
+		return nil
+	}
+
 	// Re-validate against the leader-consistent class: the marker commit and this
 	// enqueue are not atomic, and reconciliation may run off a stale local schema
 	// snapshot. A target that is no longer marked dropped (class deleted and

--- a/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
@@ -14,6 +14,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -336,4 +337,170 @@ func TestEnqueueDropVectorIndex_PayloadSurvivesClusterMarshal(t *testing.T) {
 	require.NotEmpty(t, p.OpID)
 	require.Equal(t, "node1", p.UnitToNode["shard1__node1"])
 	require.Equal(t, "shard1", p.UnitToShard["shard1__node1"])
+}
+
+// TestParseSemverPrefix tests parsing major.minor from semantic version strings.
+func TestParseSemverPrefix(t *testing.T) {
+	tests := []struct {
+		version string
+		major   int
+		minor   int
+		errOK   bool
+	}{
+		{"1.39.0", 1, 39, false},
+		{"1.39.0-alpha", 1, 39, false},
+		{"2.0.0", 2, 0, false},
+		{"0.1.0", 0, 1, false},
+		{"1.39", 1, 39, false},
+		{"invalid", 0, 0, true},
+		{"1.x.0", 0, 0, true},
+		{"", 0, 0, true},
+		{"1", 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			major, minor, err := parseSemverPrefix(tt.version)
+			if tt.errOK {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.major, major)
+				require.Equal(t, tt.minor, minor)
+			}
+		})
+	}
+}
+
+// TestVersionAtLeast tests semantic version comparison.
+func TestVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		version    string
+		minVersion string
+		expected   bool
+		errOK      bool
+	}{
+		{"1.39.0", "1.39.0", true, false},
+		{"1.40.0", "1.39.0", true, false},
+		{"2.0.0", "1.39.0", true, false},
+		{"1.39.5", "1.39.0", true, false},
+		{"1.38.0", "1.39.0", false, false},
+		{"1.0.0", "1.39.0", false, false},
+		{"0.39.0", "1.39.0", false, false},
+		{"1.39.0-alpha", "1.39.0", true, false},  // -alpha doesn't affect major.minor
+		{"invalid", "1.39.0", false, true},
+		{"1.39.0", "invalid", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version+"-vs-"+tt.minVersion, func(t *testing.T) {
+			ok, err := versionAtLeast(tt.version, tt.minVersion)
+			if tt.errOK {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, ok)
+			}
+		})
+	}
+}
+
+// fakeClusterVersioner provides fake node statuses for version checking tests.
+type fakeClusterVersioner struct {
+	statuses []*models.NodeStatus
+	err      error
+}
+
+func (f *fakeClusterVersioner) GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error) {
+	return f.statuses, f.err
+}
+
+// TestEnqueueDropVectorIndex_DeferIfClusterNotUpgraded gates enqueue on cluster version.
+func TestEnqueueDropVectorIndex_DeferIfClusterNotUpgraded(t *testing.T) {
+	t.Run("fully upgraded cluster enqueues normally", func(t *testing.T) {
+		cluster := &fakeClusterDropClient{}
+		state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+			"s1": {BelongsToNodes: []string{"n1"}},
+		})}
+		versioner := &fakeClusterVersioner{statuses: []*models.NodeStatus{
+			{Name: "n1", Version: "1.39.0"},
+		}}
+		enq := &dropVectorIndexEnqueuer{
+			clusterService:   cluster,
+			schemaState:      state,
+			clusterVersioner: versioner,
+		}
+
+		require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
+		require.NotEmpty(t, cluster.gotTaskID, "task should be enqueued on a fully upgraded cluster")
+	})
+
+	t.Run("mixed-version cluster defers enqueue", func(t *testing.T) {
+		cluster := &fakeClusterDropClient{}
+		state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+			"s1": {BelongsToNodes: []string{"n1", "n2"}},
+		})}
+		versioner := &fakeClusterVersioner{statuses: []*models.NodeStatus{
+			{Name: "n1", Version: "1.39.0"},
+			{Name: "n2", Version: "1.38.0"}, // Below minimum
+		}}
+		enq := &dropVectorIndexEnqueuer{
+			clusterService:   cluster,
+			schemaState:      state,
+			clusterVersioner: versioner,
+		}
+
+		require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
+		require.Empty(t, cluster.gotTaskID, "task should not be enqueued on a mixed-version cluster")
+	})
+
+	t.Run("node missing version defers enqueue", func(t *testing.T) {
+		cluster := &fakeClusterDropClient{}
+		state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+			"s1": {BelongsToNodes: []string{"n1"}},
+		})}
+		versioner := &fakeClusterVersioner{statuses: []*models.NodeStatus{
+			{Name: "n1", Version: ""}, // Missing version
+		}}
+		enq := &dropVectorIndexEnqueuer{
+			clusterService:   cluster,
+			schemaState:      state,
+			clusterVersioner: versioner,
+		}
+
+		require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
+		require.Empty(t, cluster.gotTaskID, "task should not be enqueued if a node has no version")
+	})
+
+	t.Run("version check error defers enqueue", func(t *testing.T) {
+		cluster := &fakeClusterDropClient{}
+		state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+			"s1": {BelongsToNodes: []string{"n1"}},
+		})}
+		versioner := &fakeClusterVersioner{err: fmt.Errorf("network error")}
+		enq := &dropVectorIndexEnqueuer{
+			clusterService:   cluster,
+			schemaState:      state,
+			clusterVersioner: versioner,
+		}
+
+		require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
+		require.Empty(t, cluster.gotTaskID, "task should not be enqueued if version check fails")
+	})
+
+	t.Run("newer cluster version enqueues normally", func(t *testing.T) {
+		cluster := &fakeClusterDropClient{}
+		state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
+			"s1": {BelongsToNodes: []string{"n1"}},
+		})}
+		versioner := &fakeClusterVersioner{statuses: []*models.NodeStatus{
+			{Name: "n1", Version: "1.40.0"}, // Newer than minimum
+		}}
+		enq := &dropVectorIndexEnqueuer{
+			clusterService:   cluster,
+			schemaState:      state,
+			clusterVersioner: versioner,
+		}
+
+		require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
+		require.NotEmpty(t, cluster.gotTaskID, "task should be enqueued when all nodes are at or above minimum version")
+	})
 }


### PR DESCRIPTION
Fixes #11901

Gates the phase-2 cleanup enqueue on cluster minimum version (1.39.0). Ensures drop-vector-index operations only proceed on fully upgraded clusters.