### PR TITLE
Update dynamic tests for hnsw-compact-v2 API (#11892)

### DIFF
--- a/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
@@ -77,7 +77,7 @@ func TestRestoreUpgradedLegacyDynamic(t *testing.T) {
 			Logger:           logger,
 			DistanceProvider: dp,
 			MakeCommitLoggerThunk: func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
-				return hnsw.NewCommitLogger(root, indexID, logger, noopCallback)
+				return hnsw.NewCommitLogger(root, indexID, logger, noopCallback, opts...)
 			},
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 				vec := vectors[int(id)]


### PR DESCRIPTION
Fixes #11892

Updates dynamic tests for hnsw-compact-v2 API changes. Specifically updates MakeCommitLoggerThunk signature to properly forward CommitlogOption variadic arguments.