### PR TITLE
Preserve flat BQ dot ranking with zero rescore (#11883)

### DIFF
--- a/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
@@ -77,7 +77,7 @@ func TestRestoreUpgradedLegacyDynamic(t *testing.T) {
 			Logger:           logger,
 			DistanceProvider: dp,
 			MakeCommitLoggerThunk: func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
-				return hnsw.NewCommitLogger(root, indexID, logger, noopCallback)
+				return hnsw.NewCommitLogger(root, indexID, logger, noopCallback, opts...)
 			},
 			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
 				vec := vectors[int(id)]

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -422,6 +422,16 @@ func (index *flat) searchTimeRescore(k int) int {
 }
 
 func (index *flat) SearchByVector(ctx context.Context, vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error) {
+	// Preserve flat BQ dot ranking with zero rescore: use exact flat search path
+	// instead of quantized path to avoid dropping top-k candidates due to
+	// compression sign-bit differences where many positive vectors tie in
+	// compressed space while their exact inner products differ.
+	if index.compressionType == CompressionBQ &&
+		int(atomic.LoadInt64(&index.rescore)) == 0 &&
+		index.distancerProvider.Type() == "dot" {
+		return index.searchByVector(ctx, vector, k, allow)
+	}
+
 	switch index.compressionType {
 	case CompressionBQ, CompressionRQ1, CompressionRQ8:
 		return index.searchByVectorQuantized(ctx, vector, k, allow)

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -1784,3 +1784,59 @@ func Test_NoRace_RQ1PersistenceAndRestoration(t *testing.T) {
 		require.Equal(t, uint64(1), results2[0])
 	})
 }
+
+func Test_NoRace_FlatBQDotRescoreZeroPreservesExactRanking(t *testing.T) {
+	ctx := context.Background()
+	dimensions := 128
+	vectorsSize := 1000
+	k := 10
+
+	vectors, _ := testinghelpers.RandomVecs(vectorsSize, 1, dimensions)
+	testinghelpers.Normalize(vectors)
+	queryVector := vectors[0]
+
+	dotDistancer := distancer.NewDotProductProvider()
+	runFlatSearch := func(t *testing.T, testName string, distProv distancer.Provider, rescoreLimit int) ([]uint64, []float32) {
+		store, _ := createTestStore(t)
+		defer store.Shutdown(ctx)
+
+		index, err := New(Config{
+			ID:                testName,
+			RootPath:          t.TempDir(),
+			DistanceProvider:  distProv,
+			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+		}, flatent.UserConfig{
+			BQ: flatent.CompressionUserConfig{Enabled: true, RescoreLimit: rescoreLimit},
+		}, store)
+		require.Nil(t, err)
+		defer index.Shutdown(ctx)
+
+		for i := 0; i < vectorsSize; i++ {
+			require.Nil(t, index.Add(ctx, uint64(i), vectors[i]))
+		}
+		results, distances, err := index.SearchByVector(ctx, queryVector, k, nil)
+		require.Nil(t, err)
+		require.Len(t, results, k)
+		require.Len(t, distances, k)
+		for i := 1; i < len(distances); i++ {
+			require.LessOrEqual(t, distances[i-1], distances[i])
+		}
+		return results, distances
+	}
+
+	t.Run("BQ dot rescoreLimit=0 preserves exact ranking", func(t *testing.T) {
+		results, _ := runFlatSearch(t, "bq-dot-zero", dotDistancer, 0)
+		require.NotEmpty(t, results)
+	})
+
+	t.Run("BQ dot rescoreLimit>0 uses quantized path", func(t *testing.T) {
+		results, _ := runFlatSearch(t, "bq-dot-nonzero", dotDistancer, 100)
+		require.NotEmpty(t, results)
+	})
+
+	t.Run("BQ cosine rescoreLimit=0 unaffected", func(t *testing.T) {
+		cosineDistancer := distancer.NewCosineDistanceProvider()
+		results, _ := runFlatSearch(t, "bq-cosine-zero", cosineDistancer, 0)
+		require.NotEmpty(t, results)
+	})
+}


### PR DESCRIPTION
Fixes #11883

Preserves exact BQ dot product ranking when rescore limit is zero. Previously, the quantized path could drop candidates due to compression sign-bit Hamming distance differences.