### PR TITLE
fix(validation): reject strings containing lone UTF-16 surrogates

### DIFF
--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -396,7 +397,12 @@ func stringVal(val interface{}) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("not a string, but %T", val)
 	}
-
+	// Go's encoding/json silently replaces lone UTF-16 surrogate escapes
+	// (e.g. \ud800) with U+FFFD. Reject such strings so callers receive a
+	// 422 rather than silently storing corrupt data (see GitHub #11744).
+	if strings.ContainsRune(typed, '�') {
+		return "", fmt.Errorf("not a valid UTF-8 string (contains replacement character U+FFFD, likely from a lone UTF-16 surrogate in the input)")
+	}
 	return typed, nil
 }
 

--- a/usecases/objects/validation/properties_validation_test.go
+++ b/usecases/objects/validation/properties_validation_test.go
@@ -516,6 +516,25 @@ func TestValidator_ValuesCasting(t *testing.T) {
 				expectedValue: "",
 				expectedErr:   true,
 			},
+			// Go's encoding/json replaces lone UTF-16 surrogates with U+FFFD.
+			// stringVal must reject such strings to return 422 instead of
+			// silently storing corrupt data (GitHub #11744).
+			{
+				value:         "�",
+				expectedValue: "",
+				expectedErr:   true,
+			},
+			{
+				value:         "hello�world",
+				expectedValue: "",
+				expectedErr:   true,
+			},
+			// Legitimate Unicode outside the BMP must still be accepted.
+			{
+				value:         "valid unicode ★",
+				expectedValue: "valid unicode ★",
+				expectedErr:   false,
+			},
 		}
 
 		for i, tc := range testCases {


### PR DESCRIPTION
## What

`stringVal` in `usecases/objects/validation/properties_validation.go` performed only a type assertion, with no Unicode validation. Go's `encoding/json` decoder silently replaces lone UTF-16 surrogate escapes (e.g. `\ud800`) with U+FFFD (the replacement character) before the decoded string reaches `stringVal`. Weaviate was storing the replacement character without error, giving callers no 422 and no way to detect the silent data loss.

Fixes #11744.

## How

Add a `strings.ContainsRune(typed, '\\uFFFD')` check inside `stringVal`. Both `DataTypeText` and `DataTypeTextArray` are covered by this single change because `stringArrayVal` already delegates to `stringVal` per element.

## Tests

Extended the existing `TestValidator_ValuesCasting/string(s)` table with three cases:

- `"�"` alone → error ✓
- `"hello�world"` (mid-string) → error ✓
- `"valid unicode ★"` → accepted ✓

All 10 string sub-tests pass (`go test ./usecases/objects/validation/...`).

## Notes

- This check rejects any string containing U+FFFD, not only those that originated from a lone surrogate. U+FFFD in a legitimate UTF-8 payload is rare and itself signals encoding corruption, so the tradeoff was deemed acceptable (see issue discussion).
- `stringArrayVal` requires no changes; it calls `stringVal` per element.