### PR TITLE
fix(acceptance-test): handle http client conccurency

### DIFF
--- a/test/acceptance/replication/replica_replication/fast/endpoints_test.go
+++ b/test/acceptance/replication/replica_replication/fast/endpoints_test.go
@@ -46,9 +46,8 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 	mainCtx := context.Background()
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 
-	expectedMembers := 3
 	compose, err := docker.New().
-		WithWeaviateCluster(expectedMembers).
+		WithWeaviateCluster(3).
 		WithWeaviateEnv("REPLICATION_ENGINE_MAX_WORKERS", "100").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		Start(ctx)
@@ -64,15 +63,6 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 			t.Fatalf("failed to terminate test containers: %+v", err)
 		}
 	}
-
-	client := helper.NewClient(t, compose.GetWeaviate().URI())
-	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-		nodesResp, err := client.Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
-		if !assert.NoError(ct, err, "failed to get nodes") {
-			return
-		}
-		assert.Len(ct, nodesResp.Payload.Nodes, expectedMembers)
-	}, 60*time.Second, 1*time.Second, "expected %d cluster nodes", expectedMembers)
 }
 
 func (suite *ReplicationTestSuite) TearDownSuite() {

--- a/test/acceptance/replication/replica_replication/fast/endpoints_test.go
+++ b/test/acceptance/replication/replica_replication/fast/endpoints_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
 	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/client/replication"
 	"github.com/weaviate/weaviate/entities/models"
@@ -45,8 +46,9 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 	mainCtx := context.Background()
 	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
 
+	expectedMembers := 3
 	compose, err := docker.New().
-		WithWeaviateCluster(3).
+		WithWeaviateCluster(expectedMembers).
 		WithWeaviateEnv("REPLICATION_ENGINE_MAX_WORKERS", "100").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		Start(ctx)
@@ -62,6 +64,12 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 			t.Fatalf("failed to terminate test containers: %+v", err)
 		}
 	}
+
+	assert.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
+		nodesResp, err := helper.Client(suite.T()).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		require.NoError(ct, err, "failed to get nodes")
+		require.Len(ct, nodesResp.Payload.Nodes, expectedMembers)
+	}, 60*time.Second, 1*time.Second, "expected %d cluster nodes", expectedMembers)
 }
 
 func (suite *ReplicationTestSuite) TearDownSuite() {

--- a/test/acceptance/replication/replica_replication/fast/endpoints_test.go
+++ b/test/acceptance/replication/replica_replication/fast/endpoints_test.go
@@ -65,10 +65,13 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 		}
 	}
 
-	assert.EventuallyWithT(suite.T(), func(ct *assert.CollectT) {
-		nodesResp, err := helper.Client(suite.T()).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
-		require.NoError(ct, err, "failed to get nodes")
-		require.Len(ct, nodesResp.Payload.Nodes, expectedMembers)
+	client := helper.NewClient(t, compose.GetWeaviate().URI())
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		nodesResp, err := client.Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		if !assert.NoError(ct, err, "failed to get nodes") {
+			return
+		}
+		assert.Len(ct, nodesResp.Payload.Nodes, expectedMembers)
 	}, 60*time.Second, 1*time.Second, "expected %d cluster nodes", expectedMembers)
 }
 

--- a/test/acceptance/replication/replica_replication/fast/mutating_data_test.go
+++ b/test/acceptance/replication/replica_replication/fast/mutating_data_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/client"
 	"github.com/weaviate/weaviate/client/batch"
 	"github.com/weaviate/weaviate/client/graphql"
@@ -118,11 +119,12 @@ func test(suite *ReplicationTestSuite, strategy string) {
 		if shard.Shard != tenantName {
 			continue
 		}
+		require.NotEmpty(t, shard.Replicas, "tenant %s has no replicas (nodes=%v)", tenantName, nodeNames)
 		others := symmetricDifference(nodeNames, shard.Replicas)
 		require.NotEmpty(t, others, "no node outside the replica set of tenant %s (nodes=%v, replicas=%v)",
 			tenantName, nodeNames, shard.Replicas)
-		sourceNode = shard.Replicas[0]
-		targetNode = others[0]
+		sourceNode = shard.Replicas[0] // Take the first (of two) replica as the source node
+		targetNode = others[0]         // Choose the other node as the target
 	}
 
 	// Start replication

--- a/test/acceptance/replication/replica_replication/fast/mutating_data_test.go
+++ b/test/acceptance/replication/replica_replication/fast/mutating_data_test.go
@@ -118,8 +118,11 @@ func test(suite *ReplicationTestSuite, strategy string) {
 		if shard.Shard != tenantName {
 			continue
 		}
-		sourceNode = shard.Replicas[0]                                 // Take the first (of two) replica as the source node
-		targetNode = symmetricDifference(nodeNames, shard.Replicas)[0] // Choose the other node as the target
+		others := symmetricDifference(nodeNames, shard.Replicas)
+		require.NotEmpty(t, others, "no node outside the replica set of tenant %s (nodes=%v, replicas=%v)",
+			tenantName, nodeNames, shard.Replicas)
+		sourceNode = shard.Replicas[0]
+		targetNode = others[0]
 	}
 
 	// Start replication

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -32,7 +32,6 @@ import (
 
 	apiclient "github.com/weaviate/weaviate/client"
 	"github.com/weaviate/weaviate/client/nodes"
-
 	modstgazure "github.com/weaviate/weaviate/modules/backup-azure"
 	modstgfilesystem "github.com/weaviate/weaviate/modules/backup-filesystem"
 	modstggcs "github.com/weaviate/weaviate/modules/backup-gcs"
@@ -1276,13 +1275,18 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 }
 
 // waitForMembership blocks until every node's /v1/nodes lists all `size` peers.
-// No 3-node compose enables authentication, so the calls go out unauthenticated.
+//
+// The calls go out unauthenticated. The one 3-node compose that enables auth is
+// cluster_api_auth, whose WithWeaviateBasicAuth guards the internal cluster port
+// rather than the public API. A 3-node compose that turned on RBAC, API keys, or
+// OIDC would have /v1/nodes reject these calls, and this wait would time out
+// rather than report the real cause.
 func waitForMembership(ctx context.Context, cs []*DockerContainer, size int) error {
 	if size < 2 {
 		return nil
 	}
 	const (
-		membershipTimeout = 60 * time.Second
+		membershipTimeout = 120 * time.Second
 		pollInterval      = time.Second
 	)
 

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -22,16 +22,12 @@ import (
 
 	dockernetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
-	httptransport "github.com/go-openapi/runtime/client"
-	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
 	tescontainersnetwork "github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"golang.org/x/sync/errgroup"
 
-	apiclient "github.com/weaviate/weaviate/client"
-	"github.com/weaviate/weaviate/client/nodes"
 	modstgazure "github.com/weaviate/weaviate/modules/backup-azure"
 	modstgfilesystem "github.com/weaviate/weaviate/modules/backup-filesystem"
 	modstggcs "github.com/weaviate/weaviate/modules/backup-gcs"
@@ -1264,63 +1260,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		return cs, fmt.Errorf("startCluster phase 2 (readiness): %w", err)
 	}
 
-	// Phase 3: Readiness only means Raft quorum, which three nodes reach with two.
-	// A class created before the third node joins is sized against the smaller
-	// membership, so wait until every node sees all its peers.
-	if err := waitForMembership(ctx, cs, size); err != nil {
-		return cs, fmt.Errorf("startCluster phase 3 (membership): %w", err)
-	}
-
 	return cs, nil
-}
-
-// waitForMembership blocks until every node's /v1/nodes lists all `size` peers.
-//
-// The calls go out unauthenticated. The one 3-node compose that enables auth is
-// cluster_api_auth, whose WithWeaviateBasicAuth guards the internal cluster port
-// rather than the public API. A 3-node compose that turned on RBAC, API keys, or
-// OIDC would have /v1/nodes reject these calls, and this wait would time out
-// rather than report the real cause.
-func waitForMembership(ctx context.Context, cs []*DockerContainer, size int) error {
-	if size < 2 {
-		return nil
-	}
-	const (
-		membershipTimeout = 120 * time.Second
-		pollInterval      = time.Second
-	)
-
-	eg := errgroup.Group{}
-	for i := 0; i < size; i++ {
-		c := cs[i]
-		if c == nil {
-			continue
-		}
-		hostname := []string{Weaviate0, Weaviate1, Weaviate2}[i]
-		eg.Go(func() error {
-			client := apiclient.New(httptransport.New(c.URI(), "/v1", []string{"http"}), strfmt.Default)
-			params := nodes.NewNodesGetParams().WithContext(ctx)
-
-			var last string
-			for deadline := time.Now().Add(membershipTimeout); time.Now().Before(deadline); {
-				resp, err := client.Nodes.NodesGet(params, nil)
-				switch {
-				case ctx.Err() != nil:
-					return ctx.Err()
-				case err != nil:
-					last = fmt.Sprintf("list cluster nodes: %v", err)
-				case len(resp.Payload.Nodes) == size:
-					return nil
-				default:
-					last = fmt.Sprintf("memberlist has %d of %d nodes", len(resp.Payload.Nodes), size)
-				}
-				time.Sleep(pollInterval)
-			}
-			return fmt.Errorf("startCluster[%s]: cluster did not form within %s: %s",
-				hostname, membershipTimeout, last)
-		})
-	}
-	return eg.Wait()
 }
 
 func copySettings(s map[string]string) map[string]string {

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -22,11 +22,16 @@ import (
 
 	dockernetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go"
 	tescontainersnetwork "github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"golang.org/x/sync/errgroup"
+
+	apiclient "github.com/weaviate/weaviate/client"
+	"github.com/weaviate/weaviate/client/nodes"
 
 	modstgazure "github.com/weaviate/weaviate/modules/backup-azure"
 	modstgfilesystem "github.com/weaviate/weaviate/modules/backup-filesystem"
@@ -1260,7 +1265,58 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		return cs, fmt.Errorf("startCluster phase 2 (readiness): %w", err)
 	}
 
+	// Phase 3: Readiness only means Raft quorum, which three nodes reach with two.
+	// A class created before the third node joins is sized against the smaller
+	// membership, so wait until every node sees all its peers.
+	if err := waitForMembership(ctx, cs, size); err != nil {
+		return cs, fmt.Errorf("startCluster phase 3 (membership): %w", err)
+	}
+
 	return cs, nil
+}
+
+// waitForMembership blocks until every node's /v1/nodes lists all `size` peers.
+// No 3-node compose enables authentication, so the calls go out unauthenticated.
+func waitForMembership(ctx context.Context, cs []*DockerContainer, size int) error {
+	if size < 2 {
+		return nil
+	}
+	const (
+		membershipTimeout = 60 * time.Second
+		pollInterval      = time.Second
+	)
+
+	eg := errgroup.Group{}
+	for i := 0; i < size; i++ {
+		c := cs[i]
+		if c == nil {
+			continue
+		}
+		hostname := []string{Weaviate0, Weaviate1, Weaviate2}[i]
+		eg.Go(func() error {
+			client := apiclient.New(httptransport.New(c.URI(), "/v1", []string{"http"}), strfmt.Default)
+			params := nodes.NewNodesGetParams().WithContext(ctx)
+
+			var last string
+			for deadline := time.Now().Add(membershipTimeout); time.Now().Before(deadline); {
+				resp, err := client.Nodes.NodesGet(params, nil)
+				switch {
+				case ctx.Err() != nil:
+					return ctx.Err()
+				case err != nil:
+					last = fmt.Sprintf("list cluster nodes: %v", err)
+				case len(resp.Payload.Nodes) == size:
+					return nil
+				default:
+					last = fmt.Sprintf("memberlist has %d of %d nodes", len(resp.Payload.Nodes), size)
+				}
+				time.Sleep(pollInterval)
+			}
+			return fmt.Errorf("startCluster[%s]: cluster did not form within %s: %s",
+				hostname, membershipTimeout, last)
+		})
+	}
+	return eg.Wait()
 }
 
 func copySettings(s map[string]string) map[string]string {

--- a/test/helper/client.go
+++ b/test/helper/client.go
@@ -44,7 +44,8 @@ import (
 // Create a client that logs with t.Logf, if a *testing.T is provided.
 // If there is no test case at hand, pass in nil to disable logging.
 func Client(t *testing.T) *apiclient.Weaviate {
-	transport := httptransport.New(fmt.Sprintf("%s:%s", ServerHost, ServerPort), "/v1", []string{ServerScheme})
+	target, scheme := serverTarget()
+	transport := httptransport.New(target, "/v1", []string{scheme})
 
 	// If a test case is provided, and we want to dump HTTP traffic,
 	// create a simple logger that logs HTTP traffic to the test case.
@@ -65,7 +66,7 @@ func CreateAuth(apiKey string) runtime.ClientAuthInfoWriterFunc {
 }
 
 func ClientGRPC(t *testing.T) pb.WeaviateClient {
-	conn, err := CreateGrpcConnectionClient(fmt.Sprintf("%s:%s", ServerGRPCHost, ServerGRPCPort))
+	conn, err := CreateGrpcConnectionClient(GetWeaviateGRPCURL())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	grpcClient := CreateGrpcWeaviateClient(conn)

--- a/test/helper/init.go
+++ b/test/helper/init.go
@@ -20,6 +20,7 @@ package helper
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/go-openapi/runtime"
 )
@@ -33,6 +34,11 @@ var (
 	ServerScheme   string
 	DebugHTTP      bool
 )
+
+// serverMu guards the server address globals above. Suites call SetupClient or
+// ResetClient between tests while EventuallyWithT tick goroutines from the
+// previous test may still be reading them through Client() or ClientGRPC().
+var serverMu sync.RWMutex
 
 // Credentials for the root key
 var RootAuth runtime.ClientAuthInfoWriterFunc
@@ -50,16 +56,30 @@ func init() {
 }
 
 func ResetClient() {
+	serverMu.Lock()
 	ServerScheme = "http"
 	ServerPort = "8080"
 	ServerGRPCPort = ""
+	serverMu.Unlock()
+
 	RootAuth = nil
 }
 
+// serverTarget reads the HTTP server address under serverMu.
+func serverTarget() (target, scheme string) {
+	serverMu.RLock()
+	defer serverMu.RUnlock()
+	return fmt.Sprintf("%s:%s", ServerHost, ServerPort), ServerScheme
+}
+
 func GetWeaviateURL() string {
+	serverMu.RLock()
+	defer serverMu.RUnlock()
 	return fmt.Sprintf("%s://%s:%s", ServerScheme, ServerHost, ServerPort)
 }
 
 func GetWeaviateGRPCURL() string {
+	serverMu.RLock()
+	defer serverMu.RUnlock()
 	return fmt.Sprintf("%s:%s", ServerGRPCHost, ServerGRPCPort)
 }

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -43,6 +43,8 @@ func SetupClient(uri string) {
 	if len(res) == 2 {
 		host, port = res[0], res[1]
 	}
+	serverMu.Lock()
+	defer serverMu.Unlock()
 	ServerHost = host
 	ServerPort = port
 }
@@ -117,6 +119,8 @@ func SetupGRPCClient(t *testing.T, uri string) {
 	if len(res) == 2 {
 		host, port = res[0], res[1]
 	}
+	serverMu.Lock()
+	defer serverMu.Unlock()
 	ServerGRPCHost = host
 	ServerGRPCPort = port
 }

--- a/test/helper/operations_client.go
+++ b/test/helper/operations_client.go
@@ -30,7 +30,6 @@
 package helper
 
 import (
-	"fmt"
 	"testing"
 
 	httptransport "github.com/go-openapi/runtime/client"
@@ -42,7 +41,8 @@ import (
 // Create a client that logs with t.Logf, if a *testing.T is provided.
 // If there is no test case at hand, pass in nil to disable logging.
 func OperationsClient(t *testing.T) operations_apiclient.ClientService {
-	transport := httptransport.New(fmt.Sprintf("%s:%s", ServerHost, ServerPort), "/v1", []string{ServerScheme})
+	target, scheme := serverTarget()
+	transport := httptransport.New(target, "/v1", []string{scheme})
 
 	// If a test case is provided, and we want to dump HTTP traffic,
 	// create a simple logger that logs HTTP traffic to the test case.
@@ -58,7 +58,8 @@ func OperationsClient(t *testing.T) operations_apiclient.ClientService {
 // Create a client that logs with t.Logf, if a *testing.T is provided.
 // If there is no test case at hand, pass in nil to disable logging.
 func BatchClient(t *testing.T) batch.ClientService {
-	transport := httptransport.New(fmt.Sprintf("%s:%s", ServerHost, ServerPort), "/v1", []string{ServerScheme})
+	target, scheme := serverTarget()
+	transport := httptransport.New(target, "/v1", []string{scheme})
 
 	// If a test case is provided, and we want to dump HTTP traffic,
 	// create a simple logger that logs HTTP traffic to the test case.


### PR DESCRIPTION
### What's being changed:
some tests failes because the htto client is used under Eventually which causes data race in the test and other fail because of netowrking issues where cluster of 3 nodes is not formed . 

This PR makes sure the http client synced and when expected 3 nodes cluster veifies there is no netowrk issue 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
