### PR TITLE
fix(memberlist): retry on join with deadline

### DIFF
--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -204,6 +204,19 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 		}).Errorf("memberlist not created: %v", err)
 		return nil, errors.Wrap(err, "create memberlist")
 	}
+
+	// memberlist.Create has bound the gossip sockets. Any error from here on
+	// returns a nil State, so no caller is left with a handle to close them
+	defer func() {
+		if err == nil {
+			return
+		}
+		if shutdownErr := state.list.Shutdown(); shutdownErr != nil {
+			logger.WithField("action", "memberlist_init").
+				Warnf("memberlist shutdown after failed init: %v", shutdownErr)
+		}
+	}()
+
 	var joinAddr []string
 	if userConfig.Join != "" {
 		joinAddr = strings.Split(userConfig.Join, ",")

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -20,11 +20,18 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/memberlist"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/cluster/utils"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+var (
+	joinInitialInterval = time.Second
+	joinTimeout         = 60 * time.Second
 )
 
 // NodeResolver provides read-only access to cluster nodes and their addresses.
@@ -204,23 +211,31 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 
 	if len(joinAddr) > 0 {
 		joinHost := extractHost(joinAddr[0])
-		_, err := net.LookupIP(joinHost)
-		if err != nil {
+		if _, err := net.LookupIP(joinHost); err != nil {
 			logger.WithFields(logrus.Fields{
 				"action":          "cluster_attempt_join",
 				"remote_hostname": joinAddr[0],
-			}).WithError(err).Warn(
-				"specified hostname to join cluster cannot be resolved. This is fine" +
-					"if this is the first node of a new cluster, but problematic otherwise.")
-		} else {
+			}).Warnf("specified hostname to join cluster cannot be resolved. This is fine "+
+				"if this is the first node of a new cluster, but problematic otherwise: %v", err)
+		} else if err := backoff.Retry(func() error {
 			_, err := state.list.Join(joinAddr)
-			if err != nil {
-				logger.WithFields(logrus.Fields{
-					"action":          "memberlist_init",
-					"remote_hostname": joinAddr,
-				}).WithError(err).Error("memberlist join not successful")
+			if err != nil && userConfig.RaftBootstrapExpect <= 1 {
+				// A sole seed has no peer coming up behind it, so a failed join is
+				// a misconfiguration rather than a race. Waiting cannot fix it.
+				return backoff.Permanent(err)
+			}
+			return err
+		}, utils.NewExponentialBackoff(joinInitialInterval, joinTimeout)); err != nil {
+			entry := logger.WithFields(logrus.Fields{
+				"action":          "memberlist_init",
+				"remote_hostname": joinAddr,
+			})
+			if userConfig.RaftBootstrapExpect <= 1 {
+				entry.Errorf("memberlist join not successful: %v", err)
 				return nil, errors.Wrap(err, "join cluster")
 			}
+			// The periodic rejoin below still converges the cluster.
+			entry.Warnf("memberlist join not successful, periodic rejoin will retry: %v", err)
 		}
 	}
 

--- a/usecases/cluster/state_join_test.go
+++ b/usecases/cluster/state_join_test.go
@@ -1,0 +1,111 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadJoinAddr resolves, so Init gets past the net.LookupIP guard, but refuses
+// the gossip dial — which is exactly what a peer whose port has not bound yet
+// looks like.
+const deadJoinAddr = "127.0.0.1:1"
+
+// shrinkJoinBudget makes the retry window small enough to sleep through in a
+// unit test, and restores it afterwards.
+func shrinkJoinBudget(t *testing.T, initial, total time.Duration) {
+	t.Helper()
+
+	origInitial, origTotal := joinInitialInterval, joinTimeout
+	joinInitialInterval, joinTimeout = initial, total
+	t.Cleanup(func() { joinInitialInterval, joinTimeout = origInitial, origTotal })
+}
+
+// TestInitJoinRetryPolicy pins who is allowed to wait for a peer.
+func TestInitJoinRetryPolicy(t *testing.T) {
+	// Long enough that a single retry is unmistakable, short enough to wait out.
+	const (
+		testInitialInterval = 200 * time.Millisecond
+		testJoinTimeout     = 2 * time.Second
+	)
+
+	tests := []struct {
+		name            string
+		bootstrapExpect int
+		wantErr         bool
+		wantRetry       bool
+	}{
+		{
+			name:            "sole seed: unreachable join address is fatal, and immediately so",
+			bootstrapExpect: 1,
+			wantErr:         true,
+			wantRetry:       false,
+		},
+		{
+			name:            "unset bootstrap expect is treated as a sole seed",
+			bootstrapExpect: 0,
+			wantErr:         true,
+			wantRetry:       false,
+		},
+		{
+			name:            "peers expected: retry the window, then start and let rejoin converge",
+			bootstrapExpect: 3,
+			wantErr:         false,
+			wantRetry:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			shrinkJoinBudget(t, testInitialInterval, testJoinTimeout)
+			logger, hook := logrustest.NewNullLogger()
+
+			cfg := Config{
+				Hostname:            "node1",
+				Localhost:           true,
+				Join:                deadJoinAddr,
+				RaftBootstrapExpect: test.bootstrapExpect,
+			}
+
+			start := time.Now()
+			state, err := Init(cfg, 1, t.TempDir(), nil, logger)
+			elapsed := time.Since(start)
+
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, state)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, state)
+				t.Cleanup(func() { _ = state.list.Shutdown() })
+			}
+
+			// The only signal that separates "retried" from "gave up at once" is
+			// time: one backoff sleep is the smallest observable retry.
+			if test.wantRetry {
+				assert.GreaterOrEqual(t, elapsed, testInitialInterval,
+					"returned before it could have slept even once; the join was not retried")
+			} else {
+				assert.Less(t, elapsed, testInitialInterval,
+					"slept at least one backoff interval; the sole seed retried instead of failing fast")
+			}
+
+			// Neither giving up nor carrying on may happen quietly.
+			assert.NotEmpty(t, hook.AllEntries(), "an unreachable join must be logged")
+		})
+	}
+}

--- a/usecases/cluster/state_join_test.go
+++ b/usecases/cluster/state_join_test.go
@@ -12,6 +12,7 @@
 package cluster
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -24,6 +25,19 @@ import (
 // the gossip dial — which is exactly what a peer whose port has not bound yet
 // looks like.
 const deadJoinAddr = "127.0.0.1:1"
+
+// freeGossipPort returns a port nothing is listening on, so the test does not
+// collide with memberlist's default 7946
+func freeGossipPort(t *testing.T) int {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+
+	return port
+}
 
 // shrinkJoinBudget makes the retry window small enough to sleep through in a
 // unit test, and restores it afterwards.
@@ -69,6 +83,8 @@ func TestInitJoinRetryPolicy(t *testing.T) {
 		},
 	}
 
+	gossipPort := freeGossipPort(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			shrinkJoinBudget(t, testInitialInterval, testJoinTimeout)
@@ -78,6 +94,7 @@ func TestInitJoinRetryPolicy(t *testing.T) {
 				Hostname:            "node1",
 				Localhost:           true,
 				Join:                deadJoinAddr,
+				GossipBindPort:      gossipPort,
 				RaftBootstrapExpect: test.bootstrapExpect,
 			}
 


### PR DESCRIPTION
### What's being changed:
in some cases especially on tests, startup faces networking issues, this PR makes sure that the node will retry to join for 60s at least, instead of failing directly 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
