### PR TITLE
chore(async-repl): fix async replication tests expectations because of lazy load empty shards

### DIFF
--- a/test/acceptance/replication/async_replication/async_repair_root_prefilter_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_root_prefilter_test.go
@@ -39,8 +39,10 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairRootPrefilterManyTenants(
 	var (
 		clusterSize      = 3
 		tenantCount      = 12
+		seedPerTenant    = 2
 		objectsPerTenant = 20
 	)
+	objectsAfterRepair := seedPerTenant + objectsPerTenant
 
 	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
 	defer cancel()
@@ -86,6 +88,21 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairRootPrefilterManyTenants(
 		helper.CreateTenants(t, paragraphClass.Class, tenants)
 	})
 
+	// A tenant shard with a zero index counter stays unloaded on restart, leaving
+	// its hashtree cold and the restarted replica absent from the root compare.
+	t.Run("seed every tenant on all nodes", func(t *testing.T) {
+		for _, tenant := range tenantNames {
+			batch := make([]*models.Object, seedPerTenant)
+			for i := range batch {
+				batch[i] = articles.NewParagraph().
+					WithContents(fmt.Sprintf("%s#seed-%d", tenant, i)).
+					WithTenant(tenant).
+					Object()
+			}
+			common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelAll)
+		}
+	})
+
 	node := 3
 
 	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
@@ -129,7 +146,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairRootPrefilterManyTenants(
 			for _, tenant := range tenantNames {
 				resp := common.GQLTenantGet(t, compose.GetWeaviateNode(node).URI(),
 					paragraphClass.Class, types.ConsistencyLevelOne, tenant)
-				require.Len(ct, resp, objectsPerTenant, "tenant %s not fully reconciled", tenant)
+				require.Len(ct, resp, objectsAfterRepair, "tenant %s not fully reconciled", tenant)
 			}
 		}, 180*time.Second, 5*time.Second, "not all tenants were asynchronously reconciled")
 	})


### PR DESCRIPTION
### What's being changed:
adter changing behaviour and lazy load empty shards, some tests would need adjustment like async replication `TestAsyncRepairRootPrefilterManyTenants`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
