### PR TITLE
cyclemanager: replace per-tick due-scan with a due-heap scheduler

### DIFF
--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -45,7 +45,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		defer cycle.StopAndWait(ctx)
 
 		err := combinedCtrl.Unregister(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		assert.False(t, combinedCtrl.IsActive())
 		assert.False(t, ctrl1.IsActive())
@@ -143,7 +143,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		defer cycle.StopAndWait(ctx)
 
 		err := combinedCtrl.Deactivate(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		assert.False(t, combinedCtrl.IsActive())
 		assert.False(t, ctrl1.IsActive())
@@ -245,7 +245,7 @@ func TestCycleCombineCallbackCtrl_Activate(t *testing.T) {
 		assert.False(t, ctrl2.IsActive())
 
 		err := combinedCtrl.Activate()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		assert.True(t, combinedCtrl.IsActive())
 		assert.True(t, ctrl1.IsActive())

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -12,11 +12,13 @@
 package cyclemanager
 
 import (
+	"container/heap"
 	"context"
 	"fmt"
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -42,7 +44,7 @@ type cycleCallbackGroup struct {
 	customId      string
 	routinesLimit int
 	nextId        uint32
-	callbackIds   []uint32
+	dueHeap       dueHeap
 	callbacks     map[uint32]*cycleCallbackMeta
 }
 
@@ -52,7 +54,7 @@ func NewCallbackGroup(id string, logger logrus.FieldLogger, routinesLimit int) C
 		customId:      id,
 		routinesLimit: routinesLimit,
 		nextId:        0,
-		callbackIds:   []uint32{},
+		dueHeap:       dueHeap{},
 		callbacks:     map[uint32]*cycleCallbackMeta{},
 	}
 }
@@ -68,6 +70,7 @@ func (c *cycleCallbackGroup) Register(id string, cycleCallback CycleCallback, op
 		runningCtx:    nil,
 		started:       time.Now(),
 		intervals:     nil,
+		heapIndex:     -1,
 	}
 	for _, option := range options {
 		if option != nil {
@@ -76,9 +79,10 @@ func (c *cycleCallbackGroup) Register(id string, cycleCallback CycleCallback, op
 	}
 
 	callbackId := c.nextId
-	c.callbackIds = append(c.callbackIds, callbackId)
+	meta.callbackId = callbackId
 	c.callbacks[callbackId] = meta
 	c.nextId++
+	c.pushDue(meta)
 
 	return &cycleCallbackCtrl{
 		callbackId:       callbackId,
@@ -99,144 +103,52 @@ func (c *cycleCallbackGroup) CycleCallback(shouldAbort ShouldAbortCallback) bool
 }
 
 func (c *cycleCallbackGroup) cycleCallbackSequential(shouldAbort ShouldAbortCallback) bool {
+	due := c.drainDue(time.Now())
 	anyExecuted := false
-	i := 0
-	for {
+	for _, meta := range due {
 		if shouldAbort() {
-			break
-		}
-
-		c.Lock()
-		// no more callbacks left, exit the loop
-		if i >= len(c.callbackIds) {
-			c.Unlock()
-			break
-		}
-
-		callbackId := c.callbackIds[i]
-		meta, ok := c.callbacks[callbackId]
-		// callback deleted in the meantime, remove its id
-		// and proceed to the next one (no "i" increment required)
-		if !ok {
-			c.callbackIds = append(c.callbackIds[:i], c.callbackIds[i+1:]...)
-			c.Unlock()
+			// restore the un-run remainder so it is retried next tick
+			c.repushDue(meta)
 			continue
 		}
-		i++
-		// callback deactivated, proceed to the next one
-		if !meta.active {
-			c.Unlock()
-			continue
+		if c.execute(meta, shouldAbort) {
+			anyExecuted = true
 		}
-		now := time.Now()
-		// not enough time passed since previous execution
-		if meta.intervals != nil && now.Sub(meta.started) < meta.intervals.Get() {
-			c.Unlock()
-			continue
-		}
-		// callback active, mark as running
-		runningCtx, cancel := context.WithCancel(context.Background())
-		meta.runningCtx = runningCtx
-		meta.started = now
-		c.Unlock()
-
-		func() {
-			// cancel called in recover, regardless of panic occurred or not
-			defer c.recover(meta.customId, cancel)
-			executed := meta.cycleCallback(func() bool {
-				if shouldAbort() {
-					return true
-				}
-
-				c.Lock()
-				defer c.Unlock()
-
-				return meta.shouldAbort
-			})
-			anyExecuted = executed || anyExecuted
-
-			if meta.intervals != nil {
-				if executed {
-					meta.intervals.Reset()
-				} else {
-					meta.intervals.Advance()
-				}
-			}
-		}()
+		c.repushDue(meta)
 	}
-
 	return anyExecuted
 }
 
 func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallback, routinesLimit int) bool {
-	// snapshot the due callbacks under a single lock, then dispatch without it,
-	// so the scan does not serialize Register/execution
-	dueIds := c.collectDueCallbacks()
+	due := c.drainDue(time.Now())
 	// spawn no workers when nothing is due; callbacks becoming due right after
-	// the snapshot are picked up on the next tick
-	if len(dueIds) == 0 {
+	// the drain are picked up on the next tick
+	if len(due) == 0 {
 		return false
 	}
 
-	anyExecuted := false
-	lock := new(sync.Mutex)
+	var anyExecuted atomic.Bool
 	wg := new(sync.WaitGroup)
-	ch := make(chan uint32)
+	ch := make(chan *cycleCallbackMeta)
 
 	worker := func() {
 		defer wg.Done()
-		for callbackId := range ch {
+		for meta := range ch {
 			if shouldAbort() {
-				// keep reading from channel until it is closed
+				// restore the un-run entry so it is retried next tick
+				c.repushDue(meta)
 				continue
 			}
-
-			c.Lock()
-			meta, ok := c.callbacks[callbackId]
-			// callback missing or deactivated, proceed to the next one
-			if !ok || !meta.active {
-				c.Unlock()
-				continue
+			if c.execute(meta, shouldAbort) {
+				anyExecuted.Store(true)
 			}
-			// callback active, mark as running
-			runningCtx, cancel := context.WithCancel(context.Background())
-			meta.runningCtx = runningCtx
-			meta.started = time.Now()
-			c.Unlock()
-
-			func() {
-				// cancel called in recover, regardless of panic occurred or not
-				defer c.recover(meta.customId, cancel)
-				executed := meta.cycleCallback(func() bool {
-					if shouldAbort() {
-						return true
-					}
-
-					c.Lock()
-					defer c.Unlock()
-
-					return meta.shouldAbort
-				})
-
-				if executed {
-					lock.Lock()
-					anyExecuted = true
-					lock.Unlock()
-				}
-				if meta.intervals != nil {
-					if executed {
-						meta.intervals.Reset()
-					} else {
-						meta.intervals.Advance()
-					}
-				}
-			}()
+			c.repushDue(meta)
 		}
 	}
 
 	// no need for more workers than callbacks due
-	if routinesLimit > len(dueIds) {
-		routinesLimit = len(dueIds)
+	if routinesLimit > len(due) {
+		routinesLimit = len(due)
 	}
 
 	wg.Add(routinesLimit)
@@ -244,51 +156,100 @@ func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallba
 		enterrors.GoWrapper(worker, c.logger)
 	}
 
-	// dispatch only due ids, so workers re-lock per due id rather than per
-	// registered callback
-	for _, callbackId := range dueIds {
-		if shouldAbort() {
-			break
-		}
-		ch <- callbackId
+	// every drained meta must be handed to a worker so it is executed or
+	// restored; an early break would orphan the remainder outside the heap
+	for _, meta := range due {
+		ch <- meta
 	}
 	close(ch)
 	wg.Wait()
-	return anyExecuted
+	return anyExecuted.Load()
 }
 
-// collectDueCallbacks prunes ids of deleted callbacks and returns a snapshot of
-// the ids that are active and whose interval has elapsed. Workers re-verify each
-// under lock before executing, so ids deactivated or unregistered after the
-// snapshot are skipped. Callbacks registered after the snapshot run on the next
-// tick rather than the current one.
-func (c *cycleCallbackGroup) collectDueCallbacks() []uint32 {
+// pushDue caches meta's next-due time and inserts it into the heap. Caller holds
+// the lock.
+func (c *cycleCallbackGroup) pushDue(meta *cycleCallbackMeta) {
+	meta.nextDue = computeNextDue(meta)
+	heap.Push(&c.dueHeap, meta)
+}
+
+// drainDue pops every callback whose next-due time has arrived and returns those
+// still registered and active. Popped entries are removed from the heap, so each
+// caller must execute or repush them (see execute / repushDue). Draining the whole
+// due set up front runs each entry at most once per tick, which is what keeps a
+// nil-interval "always due" entry from being re-popped within the same tick.
+func (c *cycleCallbackGroup) drainDue(now time.Time) []*cycleCallbackMeta {
 	c.Lock()
 	defer c.Unlock()
 
-	var dueIds []uint32
-	now := time.Now()
-	i := 0
-	for _, callbackId := range c.callbackIds {
-		meta, ok := c.callbacks[callbackId]
-		// callback deleted in the meantime, drop its id
-		if !ok {
+	var due []*cycleCallbackMeta
+	for c.dueHeap.Len() > 0 {
+		if c.dueHeap[0].nextDue.After(now) {
+			break
+		}
+		meta := heap.Pop(&c.dueHeap).(*cycleCallbackMeta)
+		// drop callbacks unregistered or deactivated since they were queued
+		if _, ok := c.callbacks[meta.callbackId]; !ok || !meta.active {
 			continue
 		}
-		c.callbackIds[i] = callbackId
-		i++
-		// callback deactivated
-		if !meta.active {
-			continue
-		}
-		// not enough time passed since previous execution
-		if meta.intervals != nil && now.Sub(meta.started) < meta.intervals.Get() {
-			continue
-		}
-		dueIds = append(dueIds, callbackId)
+		due = append(due, meta)
 	}
-	c.callbackIds = c.callbackIds[:i]
-	return dueIds
+	return due
+}
+
+// execute runs a single drained callback and returns whether it did work. It
+// rechecks registration and active state under the lock, since the entry can be
+// unregistered or deactivated between drainDue and here (it is no longer in the
+// heap, so those paths cannot remove it).
+func (c *cycleCallbackGroup) execute(meta *cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
+	c.Lock()
+	if _, ok := c.callbacks[meta.callbackId]; !ok || !meta.active {
+		c.Unlock()
+		return false
+	}
+	// callback active, mark as running
+	runningCtx, cancel := context.WithCancel(context.Background())
+	meta.runningCtx = runningCtx
+	meta.started = time.Now()
+	c.Unlock()
+
+	executed := false
+	func() {
+		// cancel called in recover, regardless of panic occurred or not
+		defer c.recover(meta.customId, cancel)
+		executed = meta.cycleCallback(func() bool {
+			if shouldAbort() {
+				return true
+			}
+
+			c.Lock()
+			defer c.Unlock()
+
+			return meta.shouldAbort
+		})
+
+		if meta.intervals != nil {
+			if executed {
+				meta.intervals.Reset()
+			} else {
+				meta.intervals.Advance()
+			}
+		}
+	}()
+	return executed
+}
+
+// repushDue returns a drained callback to the heap. It drops the callback if it
+// was unregistered or deactivated in the meantime, and skips a re-push if a
+// concurrent activate already re-queued it (heapIndex tracks a single membership).
+func (c *cycleCallbackGroup) repushDue(meta *cycleCallbackMeta) {
+	c.Lock()
+	defer c.Unlock()
+
+	if _, ok := c.callbacks[meta.callbackId]; !ok || !meta.active || meta.heapIndex != -1 {
+		return
+	}
+	c.pushDue(meta)
 }
 
 func (c *cycleCallbackGroup) recover(callbackCustomId string, cancel context.CancelFunc) {
@@ -363,6 +324,9 @@ func (c *cycleCallbackGroup) unregister(ctx context.Context, callbackId uint32, 
 		func(callbackId uint32, meta *cycleCallbackMeta, running bool) error {
 			meta.shouldAbort = true
 			if !running {
+				if meta.heapIndex >= 0 {
+					heap.Remove(&c.dueHeap, meta.heapIndex)
+				}
 				meta.active = false
 				delete(c.callbacks, callbackId)
 			}
@@ -380,6 +344,9 @@ func (c *cycleCallbackGroup) deactivate(ctx context.Context, callbackId uint32, 
 		func(callbackId uint32, meta *cycleCallbackMeta, running bool) error {
 			meta.shouldAbort = true
 			if !running {
+				if meta.heapIndex >= 0 {
+					heap.Remove(&c.dueHeap, meta.heapIndex)
+				}
 				meta.active = false
 			}
 			return nil
@@ -399,6 +366,10 @@ func (c *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string
 
 	meta.shouldAbort = false
 	meta.active = true
+	// push only if not already queued, keeping each callback in the heap at most once
+	if meta.heapIndex == -1 {
+		c.pushDue(meta)
+	}
 	return nil
 }
 

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -413,6 +413,7 @@ func (c *cycleCallbackGroup) isActive(callbackId uint32, callbackCustomId string
 }
 
 type cycleCallbackMeta struct {
+	callbackId    uint32
 	customId      string
 	cycleCallback CycleCallback
 	active        bool
@@ -424,6 +425,50 @@ type cycleCallbackMeta struct {
 	intervals  CycleIntervals
 	// true if deactivate or unregister were requested to abort callback when running
 	shouldAbort bool
+	// next-due time ordering the heap, cached from started (+ intervals.Get()) and
+	// recomputed on every state change
+	nextDue time.Time
+	// position in the group's dueHeap, or -1 when not queued
+	heapIndex int
+}
+
+// computeNextDue returns the time the callback is next eligible to run. A nil
+// interval means "always due", so its next-due time is simply started.
+func computeNextDue(meta *cycleCallbackMeta) time.Time {
+	if meta.intervals == nil {
+		return meta.started
+	}
+	return meta.started.Add(meta.intervals.Get())
+}
+
+// dueHeap is a min-heap of callbacks ordered by nextDue (earliest first). Each
+// meta appears at most once; heapIndex tracks its slot for O(log n) heap.Remove.
+type dueHeap []*cycleCallbackMeta
+
+func (h dueHeap) Len() int { return len(h) }
+
+func (h dueHeap) Less(i, j int) bool { return h[i].nextDue.Before(h[j].nextDue) }
+
+func (h dueHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].heapIndex = i
+	h[j].heapIndex = j
+}
+
+func (h *dueHeap) Push(x any) {
+	meta := x.(*cycleCallbackMeta)
+	meta.heapIndex = len(*h)
+	*h = append(*h, meta)
+}
+
+func (h *dueHeap) Pop() any {
+	old := *h
+	n := len(old)
+	meta := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	meta.heapIndex = -1
+	return meta
 }
 
 type cycleCallbackGroupNoop struct{}

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -77,8 +77,13 @@ type cycleCallbackGroup struct {
 	logger        logrus.FieldLogger
 	name          string
 	routinesLimit int
-	// nextCallbackId is monotone and IDs are never reused; reuse could cause a
-	// stale dueEntry to match a new meta's schedGen.
+	// epoch is a fixed reference captured at construction. Due-times are stored as
+	// nanoseconds relative to it, so scheduling and draining compare via the
+	// monotonic clock and stay correct across wall-clock jumps.
+	epoch time.Time
+	// nextCallbackId is monotone and IDs are never reused; reuse could make a stale
+	// dueEntry match a new meta's schedGen. uint32 suffices: wrapping needs 2^32
+	// registrations in one process, far beyond any real lifetime.
 	nextCallbackId uint32
 	heap           dueHeap
 	metas          map[uint32]*cycleCallbackMeta
@@ -89,16 +94,26 @@ func NewCallbackGroup(id string, logger logrus.FieldLogger, routinesLimit int) C
 		logger:        logger,
 		name:          id,
 		routinesLimit: routinesLimit,
+		epoch:         time.Now(),
 		heap:          dueHeap{},
 		metas:         map[uint32]*cycleCallbackMeta{},
 	}
+}
+
+// computeNextDue returns when m is next eligible to run, as nanoseconds relative
+// to the group epoch.
+func (g *cycleCallbackGroup) computeNextDue(m *cycleCallbackMeta) int64 {
+	if m.intervals == nil {
+		return m.started.Sub(g.epoch).Nanoseconds()
+	}
+	return m.started.Add(m.intervals.Get()).Sub(g.epoch).Nanoseconds()
 }
 
 // schedule pushes a new heap entry for meta, bumping schedGen so any prior
 // entry becomes stale. Caller holds the lock.
 func (g *cycleCallbackGroup) schedule(m *cycleCallbackMeta) {
 	m.schedGen++
-	due := computeNextDue(m)
+	due := g.computeNextDue(m)
 	g.heap.push(dueEntry{callbackId: m.callbackId, due: due, schedGen: m.schedGen})
 }
 
@@ -120,7 +135,7 @@ func (g *cycleCallbackGroup) drainDue(now time.Time) []*cycleCallbackMeta {
 	g.Lock()
 	defer g.Unlock()
 
-	nowNanos := now.UnixNano()
+	nowNanos := now.Sub(g.epoch).Nanoseconds()
 	var due []*cycleCallbackMeta
 	for len(g.heap) > 0 {
 		if g.heap[0].due > nowNanos {
@@ -323,8 +338,11 @@ func (g *cycleCallbackGroup) isActive(callbackId uint32, _ string) bool {
 	return false
 }
 
-// activate sets the callback active and pushes a new heap entry under the lock.
-// defer ensures the lock is released even if schedule panics.
+// activate clears any pending abort and, if the callback was inactive, marks it
+// active and schedules it. An already-active callback is left as-is: it is either
+// running (teardown reschedules it) or already holds a live entry, so re-scheduling
+// would race computeNextDue's interval read against the running callback's unlocked
+// Reset/Advance and leave a stale entry behind.
 func (g *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string) error {
 	g.Lock()
 	defer g.Unlock()
@@ -333,9 +351,11 @@ func (g *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string
 	if !ok {
 		return errorActivateCallback(callbackCustomId, g.name, ErrorCallbackNotFound)
 	}
-	meta.active = true
 	meta.abort = false
-	g.schedule(meta)
+	if !meta.active {
+		g.schedule(meta)
+		meta.active = true
+	}
 	return nil
 }
 
@@ -343,56 +363,53 @@ func (g *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string
 // Returns the captured done channel and whether the caller must wait for it.
 // On needWait==false the callback has already been committed as inactive, or
 // was not found (immediateErr carries the result in that case).
-func (g *cycleCallbackGroup) deactivatePrepare(callbackId uint32) (meta *cycleCallbackMeta, done chan struct{}, needWait bool, immediateErr error) {
+func (g *cycleCallbackGroup) deactivatePrepare(callbackId uint32) (done chan struct{}, needWait bool, immediateErr error) {
 	g.Lock()
 	defer g.Unlock()
 
 	m, ok := g.metas[callbackId]
 	if !ok {
-		return nil, nil, false, ErrorCallbackNotFound
+		return nil, false, ErrorCallbackNotFound
 	}
 	m.abort = true
 	if !m.running {
 		m.active = false
-		return m, nil, false, nil
+		return nil, false, nil
 	}
 	if m.done == nil {
 		m.done = make(chan struct{})
 	}
-	return m, m.done, true, nil
-}
-
-// commitDeactivated sets active=false on a meta that just finished running,
-// under the group lock. Called after a successful wait on the done channel.
-func (g *cycleCallbackGroup) commitDeactivated(meta *cycleCallbackMeta) {
-	g.Lock()
-	defer g.Unlock()
-	meta.active = false
+	return m.done, true, nil
 }
 
 func (g *cycleCallbackGroup) deactivate(ctx context.Context, callbackId uint32, callbackCustomId string) error {
 	if ctx.Err() != nil {
 		return errorDeactivateCallback(callbackCustomId, g.name, ctx.Err())
 	}
-	meta, done, needWait, immediateErr := g.deactivatePrepare(callbackId)
-	if !needWait {
-		return errorDeactivateCallback(callbackCustomId, g.name, immediateErr)
-	}
 
-	select {
-	case <-done:
-		g.commitDeactivated(meta)
-		return errorDeactivateCallback(callbackCustomId, g.name, nil)
-	case <-ctx.Done():
+	// One run's done channel is not enough: teardown reschedules a still-active
+	// callback, so a fresh tick can start another run while we wait. Loop back
+	// through deactivatePrepare after each finished run; it commits active=false
+	// only once it observes the callback not running.
+	for {
+		done, needWait, immediateErr := g.deactivatePrepare(callbackId)
+		if !needWait {
+			return errorDeactivateCallback(callbackCustomId, g.name, immediateErr)
+		}
+
 		select {
 		case <-done:
-			g.commitDeactivated(meta)
-			return errorDeactivateCallback(callbackCustomId, g.name, nil)
-		default:
-			// Timeout: leave active=true, abort=true. The running callback will
-			// eventually finish; teardown reschedules it and abort is reset on next
-			// Activate call.
-			return errorDeactivateCallback(callbackCustomId, g.name, ctx.Err())
+			// re-check under the lock on the next iteration
+		case <-ctx.Done():
+			select {
+			case <-done:
+				// re-check under the lock on the next iteration
+			default:
+				// Timeout: leave active=true, abort=true. The running callback will
+				// eventually finish; teardown reschedules it and abort is reset on next
+				// Activate call.
+				return errorDeactivateCallback(callbackCustomId, g.name, ctx.Err())
+			}
 		}
 	}
 }
@@ -419,36 +436,32 @@ func (g *cycleCallbackGroup) unregisterPrepare(callbackId uint32) (done chan str
 	return meta.done, true
 }
 
-// commitUnregistered deletes the meta from the metas map under the group lock.
-// Idempotent: deleting an absent key is safe in Go.
-func (g *cycleCallbackGroup) commitUnregistered(callbackId uint32) {
-	g.Lock()
-	defer g.Unlock()
-	delete(g.metas, callbackId)
-}
-
 func (g *cycleCallbackGroup) unregister(ctx context.Context, callbackId uint32, callbackCustomId string) error {
 	if ctx.Err() != nil {
 		return errorUnregisterCallback(callbackCustomId, g.name, ctx.Err())
 	}
-	done, needWait := g.unregisterPrepare(callbackId)
-	if !needWait {
-		return nil
-	}
 
-	select {
-	case <-done:
-		g.commitUnregistered(callbackId)
-		return nil
-	case <-ctx.Done():
+	// Same one-run race as deactivate: loop back through unregisterPrepare after
+	// each finished run; it deletes the meta only once it observes the callback
+	// not running.
+	for {
+		done, needWait := g.unregisterPrepare(callbackId)
+		if !needWait {
+			return nil
+		}
+
 		select {
 		case <-done:
-			g.commitUnregistered(callbackId)
-			return nil
-		default:
-			// Timeout: leave meta in map with active=true, abort=true. The callback
-			// finishes eventually; teardown reschedules it. Caller can retry later.
-			return errorUnregisterCallback(callbackCustomId, g.name, ctx.Err())
+			// re-check under the lock on the next iteration
+		case <-ctx.Done():
+			select {
+			case <-done:
+				// re-check under the lock on the next iteration
+			default:
+				// Timeout: leave meta in map with active=true, abort=true. The callback
+				// finishes eventually; teardown reschedules it. Caller can retry later.
+				return errorUnregisterCallback(callbackCustomId, g.name, ctx.Err())
+			}
 		}
 	}
 }

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -115,6 +115,24 @@ func (g *cycleCallbackGroup) schedule(m *cycleCallbackMeta) {
 	m.schedGen++
 	due := g.computeNextDue(m)
 	g.heap.push(dueEntry{callbackId: m.callbackId, due: due, schedGen: m.schedGen})
+
+	// Stale entries are otherwise reclaimed only lazily on pop, so churn on a
+	// far-future callback can pile them up. Compact past ~2x the live-entry ceiling
+	// to keep heap size, and pop cost, bounded by the registered-callback count.
+	if len(g.heap) > 2*len(g.metas)+8 {
+		g.compactHeap()
+	}
+}
+
+// compactHeap drops every stale entry — callback gone, or schedGen superseded —
+// keeping the single current entry per registered callback. It removes only
+// provably-dead entries, so every survivor is one drainDue would still act on.
+// Caller holds the lock.
+func (g *cycleCallbackGroup) compactHeap() {
+	g.heap.compact(func(e dueEntry) bool {
+		meta, ok := g.metas[e.callbackId]
+		return ok && e.schedGen == meta.schedGen
+	})
 }
 
 // reschedule re-queues meta after a tick in which it was not run (abort path).
@@ -176,9 +194,8 @@ func (g *cycleCallbackGroup) Register(id string, cycleCallback CycleCallback, op
 		return meta.abort
 	}
 
-	// Publish the meta and push the first heap entry under the lock. defer ensures
-	// the lock is released even if schedule (which calls computeNextDue → Get())
-	// panics, so a panic here cannot leave the group locked.
+	// Publish the meta before scheduling so compaction (which schedule may trigger)
+	// keeps the entry it just pushed.
 	var callbackId uint32
 	func() {
 		g.Lock()

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -12,7 +12,6 @@
 package cyclemanager
 
 import (
-	"container/heap"
 	"context"
 	"fmt"
 	"runtime"
@@ -22,10 +21,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
-
-	"github.com/sirupsen/logrus"
 )
 
 // Container for multiple callbacks exposing CycleCallback method acting as single callback.
@@ -37,40 +35,113 @@ type CycleCallbackGroup interface {
 	CycleCallback(shouldAbort ShouldAbortCallback) bool
 }
 
+type cycleCallbackMeta struct {
+	// callbackId is the heap and metas-map key; name is the public id string.
+	callbackId    uint32
+	name          string
+	cycleCallback CycleCallback
+	// active means the callback is enabled and will be scheduled for future ticks.
+	// abort is the cooperative-abort signal set by deactivate/unregister while running.
+	active bool
+	abort  bool
+	// running is true while the callback body is executing. Set and read only under
+	// the group lock. Deactivate/Unregister use this to decide whether to wait.
+	running bool
+	// done is the on-demand wait handle. It is nil unless a Deactivate or Unregister
+	// caller needs to wait for an in-flight run; the first such caller creates it,
+	// subsequent concurrent callers reuse the same channel. Teardown closes and nils
+	// it after setting running=false. All accesses are under the group lock.
+	done      chan struct{}
+	started   time.Time
+	intervals CycleIntervals
+	schedGen  uint64
+	// cycleShouldAbort holds the current cycle's abort signal, refreshed in runOne
+	// before each invocation and read by abortCheck. Written and read by the single
+	// goroutine handling this meta, so no lock is needed.
+	cycleShouldAbort ShouldAbortCallback
+	// abortCheck is the ShouldAbortCallback handed to cycleCallback. Built once in
+	// Register and reused every cycle to avoid a per-invocation closure allocation.
+	abortCheck ShouldAbortCallback
+}
+
+func (m *cycleCallbackMeta) setInactive() { m.active = false; m.abort = false }
+
+func (m *cycleCallbackMeta) setIntervals(intervals CycleIntervals) {
+	m.intervals = intervals
+	m.started = time.Now().Add(-intervals.Get())
+}
+
 type cycleCallbackGroup struct {
 	sync.Mutex
 
 	logger        logrus.FieldLogger
-	customId      string
+	name          string
 	routinesLimit int
-	nextId        uint32
-	dueHeap       dueHeap
-	callbacks     map[uint32]*cycleCallbackMeta
+	// nextCallbackId is monotone and IDs are never reused; reuse could cause a
+	// stale dueEntry to match a new meta's schedGen.
+	nextCallbackId uint32
+	heap           dueHeap
+	metas          map[uint32]*cycleCallbackMeta
 }
 
 func NewCallbackGroup(id string, logger logrus.FieldLogger, routinesLimit int) CycleCallbackGroup {
 	return &cycleCallbackGroup{
 		logger:        logger,
-		customId:      id,
+		name:          id,
 		routinesLimit: routinesLimit,
-		nextId:        0,
-		dueHeap:       dueHeap{},
-		callbacks:     map[uint32]*cycleCallbackMeta{},
+		heap:          dueHeap{},
+		metas:         map[uint32]*cycleCallbackMeta{},
 	}
 }
 
-func (c *cycleCallbackGroup) Register(id string, cycleCallback CycleCallback, options ...RegisterOption) CycleCallbackCtrl {
-	c.Lock()
-	defer c.Unlock()
+// schedule pushes a new heap entry for meta, bumping schedGen so any prior
+// entry becomes stale. Caller holds the lock.
+func (g *cycleCallbackGroup) schedule(m *cycleCallbackMeta) {
+	m.schedGen++
+	due := computeNextDue(m)
+	g.heap.push(dueEntry{callbackId: m.callbackId, due: due, schedGen: m.schedGen})
+}
 
+// reschedule re-queues meta after a tick in which it was not run (abort path).
+// Acquires the lock.
+func (g *cycleCallbackGroup) reschedule(meta *cycleCallbackMeta) {
+	g.Lock()
+	defer g.Unlock()
+
+	if g.metas[meta.callbackId] == nil || !meta.active {
+		return
+	}
+	g.schedule(meta)
+}
+
+// drainDue pops every entry due by now, discards stale/inactive ones, and
+// returns the live metas. Acquires and releases the lock.
+func (g *cycleCallbackGroup) drainDue(now time.Time) []*cycleCallbackMeta {
+	g.Lock()
+	defer g.Unlock()
+
+	nowNanos := now.UnixNano()
+	var due []*cycleCallbackMeta
+	for len(g.heap) > 0 {
+		if g.heap[0].due > nowNanos {
+			break
+		}
+		e := g.heap.pop()
+		meta, ok := g.metas[e.callbackId]
+		if !ok || e.schedGen != meta.schedGen || !meta.active {
+			continue
+		}
+		due = append(due, meta)
+	}
+	return due
+}
+
+func (g *cycleCallbackGroup) Register(id string, cycleCallback CycleCallback, options ...RegisterOption) CycleCallbackCtrl {
 	meta := &cycleCallbackMeta{
-		customId:      id,
+		name:          id,
 		cycleCallback: cycleCallback,
 		active:        true,
-		runningCtx:    nil,
 		started:       time.Now(),
-		intervals:     nil,
-		heapIndex:     -1,
 	}
 	for _, option := range options {
 		if option != nil {
@@ -78,86 +149,89 @@ func (c *cycleCallbackGroup) Register(id string, cycleCallback CycleCallback, op
 		}
 	}
 
-	callbackId := c.nextId
-	meta.callbackId = callbackId
-	c.callbacks[callbackId] = meta
-	c.nextId++
-	c.pushDue(meta)
+	// Build the abort-check closure once here. g and meta are stable for the
+	// lifetime of this registration; capturing them now avoids allocating a new
+	// closure on every cycleCallback invocation.
+	meta.abortCheck = func() bool {
+		if meta.cycleShouldAbort() {
+			return true
+		}
+		g.Lock()
+		defer g.Unlock()
+		return meta.abort
+	}
+
+	// Publish the meta and push the first heap entry under the lock. defer ensures
+	// the lock is released even if schedule (which calls computeNextDue → Get())
+	// panics, so a panic here cannot leave the group locked.
+	var callbackId uint32
+	func() {
+		g.Lock()
+		defer g.Unlock()
+		callbackId = g.nextCallbackId
+		meta.callbackId = callbackId
+		g.metas[callbackId] = meta
+		g.nextCallbackId++
+		g.schedule(meta)
+	}()
 
 	return &cycleCallbackCtrl{
 		callbackId:       callbackId,
 		callbackCustomId: id,
-
-		isActive:   c.isActive,
-		activate:   c.activate,
-		deactivate: c.deactivate,
-		unregister: c.unregister,
+		isActive:         g.isActive,
+		activate:         g.activate,
+		deactivate:       g.deactivate,
+		unregister:       g.unregister,
 	}
 }
 
-func (c *cycleCallbackGroup) CycleCallback(shouldAbort ShouldAbortCallback) bool {
-	if c.routinesLimit <= 1 {
-		return c.cycleCallbackSequential(shouldAbort)
+func (g *cycleCallbackGroup) CycleCallback(shouldAbort ShouldAbortCallback) bool {
+	due := g.drainDue(time.Now())
+	if len(due) == 0 {
+		return false
 	}
-	return c.cycleCallbackParallel(shouldAbort, c.routinesLimit)
+	if g.routinesLimit <= 1 || len(due) == 1 {
+		return g.runSequential(due, shouldAbort)
+	}
+	return g.runParallel(due, shouldAbort)
 }
 
-func (c *cycleCallbackGroup) cycleCallbackSequential(shouldAbort ShouldAbortCallback) bool {
-	due := c.drainDue(time.Now())
+func (g *cycleCallbackGroup) runSequential(due []*cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
 	anyExecuted := false
 	for _, meta := range due {
 		if shouldAbort() {
-			// restore the un-run remainder so it is retried next tick
-			c.repushDue(meta)
+			g.reschedule(meta)
 			continue
 		}
-		if c.execute(meta, shouldAbort) {
+		if g.runOne(meta, shouldAbort) {
 			anyExecuted = true
 		}
-		c.repushDue(meta)
 	}
 	return anyExecuted
 }
 
-func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallback, routinesLimit int) bool {
-	due := c.drainDue(time.Now())
-	// spawn no workers when nothing is due; callbacks becoming due right after
-	// the drain are picked up on the next tick
-	if len(due) == 0 {
-		return false
-	}
-
+func (g *cycleCallbackGroup) runParallel(due []*cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
 	var anyExecuted atomic.Bool
 	wg := new(sync.WaitGroup)
 	ch := make(chan *cycleCallbackMeta)
 
-	worker := func() {
-		defer wg.Done()
-		for meta := range ch {
-			if shouldAbort() {
-				// restore the un-run entry so it is retried next tick
-				c.repushDue(meta)
-				continue
+	limit := min(len(due), g.routinesLimit)
+	wg.Add(limit)
+	for range limit {
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			for meta := range ch {
+				if shouldAbort() {
+					g.reschedule(meta)
+					continue
+				}
+				if g.runOne(meta, shouldAbort) {
+					anyExecuted.Store(true)
+				}
 			}
-			if c.execute(meta, shouldAbort) {
-				anyExecuted.Store(true)
-			}
-			c.repushDue(meta)
-		}
+		}, g.logger)
 	}
 
-	// no need for more workers than callbacks due
-	if routinesLimit > len(due) {
-		routinesLimit = len(due)
-	}
-
-	wg.Add(routinesLimit)
-	for r := 0; r < routinesLimit; r++ {
-		enterrors.GoWrapper(worker, c.logger)
-	}
-
-	// every drained meta must be handed to a worker so it is executed or
-	// restored; an early break would orphan the remainder outside the heap
 	for _, meta := range due {
 		ch <- meta
 	}
@@ -166,68 +240,53 @@ func (c *cycleCallbackGroup) cycleCallbackParallel(shouldAbort ShouldAbortCallba
 	return anyExecuted.Load()
 }
 
-// pushDue caches meta's next-due time and inserts it into the heap. Caller holds
-// the lock.
-func (c *cycleCallbackGroup) pushDue(meta *cycleCallbackMeta) {
-	meta.nextDue = computeNextDue(meta)
-	heap.Push(&c.dueHeap, meta)
-}
+// beginRun performs the entry check and marks the callback as running, under
+// the group lock. Returns false if the callback was deactivated or unregistered
+// since drainDue returned it. Kept as a method rather than a closure so the
+// entry check stays allocation-free on the dispatch path.
+func (g *cycleCallbackGroup) beginRun(meta *cycleCallbackMeta) bool {
+	g.Lock()
+	defer g.Unlock()
 
-// drainDue pops every callback whose next-due time has arrived and returns those
-// still registered and active. Popped entries are removed from the heap, so each
-// caller must execute or repush them (see execute / repushDue). Draining the whole
-// due set up front runs each entry at most once per tick, which is what keeps a
-// nil-interval "always due" entry from being re-popped within the same tick.
-func (c *cycleCallbackGroup) drainDue(now time.Time) []*cycleCallbackMeta {
-	c.Lock()
-	defer c.Unlock()
-
-	var due []*cycleCallbackMeta
-	for c.dueHeap.Len() > 0 {
-		if c.dueHeap[0].nextDue.After(now) {
-			break
-		}
-		meta := heap.Pop(&c.dueHeap).(*cycleCallbackMeta)
-		// drop callbacks unregistered or deactivated since they were queued
-		if _, ok := c.callbacks[meta.callbackId]; !ok || !meta.active {
-			continue
-		}
-		due = append(due, meta)
-	}
-	return due
-}
-
-// execute runs a single drained callback and returns whether it did work. It
-// rechecks registration and active state under the lock, since the entry can be
-// unregistered or deactivated between drainDue and here (it is no longer in the
-// heap, so those paths cannot remove it).
-func (c *cycleCallbackGroup) execute(meta *cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
-	c.Lock()
-	if _, ok := c.callbacks[meta.callbackId]; !ok || !meta.active {
-		c.Unlock()
+	if g.metas[meta.callbackId] == nil || !meta.active {
 		return false
 	}
-	// callback active, mark as running
-	runningCtx, cancel := context.WithCancel(context.Background())
-	meta.runningCtx = runningCtx
+	meta.running = true
 	meta.started = time.Now()
-	c.Unlock()
+	return true
+}
+
+// endRun performs teardown under the group lock: clears running, wakes any
+// Deactivate/Unregister waiters, and reschedules the callback if still active.
+// Kept as a method rather than a closure so teardown stays allocation-free on
+// the dispatch path.
+func (g *cycleCallbackGroup) endRun(meta *cycleCallbackMeta) {
+	g.Lock()
+	defer g.Unlock()
+
+	meta.running = false
+	if meta.done != nil {
+		close(meta.done)
+		meta.done = nil
+	}
+	if g.metas[meta.callbackId] != nil && meta.active {
+		g.schedule(meta)
+	}
+}
+
+// runOne executes meta under the entry-check / run / teardown protocol.
+func (g *cycleCallbackGroup) runOne(meta *cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
+	if !g.beginRun(meta) {
+		return false
+	}
 
 	executed := false
 	func() {
-		// cancel called in recover, regardless of panic occurred or not
-		defer c.recover(meta.customId, cancel)
-		executed = meta.cycleCallback(func() bool {
-			if shouldAbort() {
-				return true
-			}
-
-			c.Lock()
-			defer c.Unlock()
-
-			return meta.shouldAbort
-		})
-
+		defer g.recover(meta)
+		meta.cycleShouldAbort = shouldAbort
+		executed = meta.cycleCallback(meta.abortCheck)
+		// Interval update is inside the closure so a panic unwinds past it,
+		// leaving the interval unchanged (panic is not "no work done").
 		if meta.intervals != nil {
 			if executed {
 				meta.intervals.Reset()
@@ -236,210 +295,162 @@ func (c *cycleCallbackGroup) execute(meta *cycleCallbackMeta, shouldAbort Should
 			}
 		}
 	}()
+
+	g.endRun(meta)
 	return executed
 }
 
-// repushDue returns a drained callback to the heap. It drops the callback if it
-// was unregistered or deactivated in the meantime, and skips a re-push if a
-// concurrent activate already re-queued it (heapIndex tracks a single membership).
-func (c *cycleCallbackGroup) repushDue(meta *cycleCallbackMeta) {
-	c.Lock()
-	defer c.Unlock()
-
-	if _, ok := c.callbacks[meta.callbackId]; !ok || !meta.active || meta.heapIndex != -1 {
-		return
-	}
-	c.pushDue(meta)
-}
-
-func (c *cycleCallbackGroup) recover(callbackCustomId string, cancel context.CancelFunc) {
+func (g *cycleCallbackGroup) recover(meta *cycleCallbackMeta) {
 	if r := recover(); r != nil {
 		entsentry.Recover(r)
-		enterrors.PrintStack(c.logger)
-		c.logger.WithFields(logrus.Fields{
+		enterrors.PrintStack(g.logger)
+		g.logger.WithFields(logrus.Fields{
 			"action":       "cyclemanager",
-			"callback_id":  callbackCustomId,
-			"callbacks_id": c.customId,
+			"callback_id":  meta.name,
+			"callbacks_id": g.name,
 			"trace":        trace(),
 		}).Errorf("callback panic: %v", r)
 	}
-	cancel()
 }
 
-func (c *cycleCallbackGroup) mutateCallback(ctx context.Context, callbackId uint32,
-	onMetaNotFound func(callbackId uint32) error,
-	onMetaFound func(callbackId uint32, meta *cycleCallbackMeta, running bool) error,
-) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
+func (g *cycleCallbackGroup) isActive(callbackId uint32, _ string) bool {
+	g.Lock()
+	defer g.Unlock()
 
-	for {
-		// mutate callback in collection only if not running (not yet started of finished)
-		c.Lock()
-		meta, ok := c.callbacks[callbackId]
-		if !ok {
-			err := onMetaNotFound(callbackId)
-			c.Unlock()
-			return err
-		}
-		runningCtx := meta.runningCtx
-		running := runningCtx != nil && runningCtx.Err() == nil
-
-		if err := onMetaFound(callbackId, meta, running); err != nil {
-			c.Unlock()
-			return err
-		}
-		if !running {
-			c.Unlock()
-			return nil
-		}
-		c.Unlock()
-
-		// wait for callback to finish
-		select {
-		case <-runningCtx.Done():
-			// get back to the beginning of the loop to make sure state.runningCtx
-			// was not changed. If not, loop will finish on runningCtx.Err() != nil check
-			continue
-		case <-ctx.Done():
-			// in case both contexts are ready, but input ctx was selected
-			// check again running ctx as priority one
-			if runningCtx.Err() != nil {
-				// get back to the beginning of the loop to make sure state.runningCtx
-				// was not changed. If not, loop will finish on runningCtx.Err() != nil check
-				continue
-			}
-			// input ctx expired
-			return ctx.Err()
-		}
-	}
-}
-
-func (c *cycleCallbackGroup) unregister(ctx context.Context, callbackId uint32, callbackCustomId string) error {
-	err := c.mutateCallback(ctx, callbackId,
-		func(callbackId uint32) error {
-			return nil
-		},
-		func(callbackId uint32, meta *cycleCallbackMeta, running bool) error {
-			meta.shouldAbort = true
-			if !running {
-				if meta.heapIndex >= 0 {
-					heap.Remove(&c.dueHeap, meta.heapIndex)
-				}
-				meta.active = false
-				delete(c.callbacks, callbackId)
-			}
-			return nil
-		},
-	)
-	return errorUnregisterCallback(callbackCustomId, c.customId, err)
-}
-
-func (c *cycleCallbackGroup) deactivate(ctx context.Context, callbackId uint32, callbackCustomId string) error {
-	err := c.mutateCallback(ctx, callbackId,
-		func(callbackId uint32) error {
-			return ErrorCallbackNotFound
-		},
-		func(callbackId uint32, meta *cycleCallbackMeta, running bool) error {
-			meta.shouldAbort = true
-			if !running {
-				if meta.heapIndex >= 0 {
-					heap.Remove(&c.dueHeap, meta.heapIndex)
-				}
-				meta.active = false
-			}
-			return nil
-		},
-	)
-	return errorDeactivateCallback(callbackCustomId, c.customId, err)
-}
-
-func (c *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string) error {
-	c.Lock()
-	defer c.Unlock()
-
-	meta, ok := c.callbacks[callbackId]
-	if !ok {
-		return errorActivateCallback(callbackCustomId, c.customId, ErrorCallbackNotFound)
-	}
-
-	meta.shouldAbort = false
-	meta.active = true
-	// push only if not already queued, keeping each callback in the heap at most once
-	if meta.heapIndex == -1 {
-		c.pushDue(meta)
-	}
-	return nil
-}
-
-func (c *cycleCallbackGroup) isActive(callbackId uint32, callbackCustomId string) bool {
-	c.Lock()
-	defer c.Unlock()
-
-	if meta, ok := c.callbacks[callbackId]; ok {
+	if meta, ok := g.metas[callbackId]; ok {
 		return meta.active
 	}
 	return false
 }
 
-type cycleCallbackMeta struct {
-	callbackId    uint32
-	customId      string
-	cycleCallback CycleCallback
-	active        bool
-	// indicates whether callback is already running - context active
-	// or not running (already finished) - context expired
-	// or not running (not yet started) - context nil
-	runningCtx context.Context
-	started    time.Time
-	intervals  CycleIntervals
-	// true if deactivate or unregister were requested to abort callback when running
-	shouldAbort bool
-	// next-due time ordering the heap, cached from started (+ intervals.Get()) and
-	// recomputed on every state change
-	nextDue time.Time
-	// position in the group's dueHeap, or -1 when not queued
-	heapIndex int
-}
+// activate sets the callback active and pushes a new heap entry under the lock.
+// defer ensures the lock is released even if schedule panics.
+func (g *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string) error {
+	g.Lock()
+	defer g.Unlock()
 
-// computeNextDue returns the time the callback is next eligible to run. A nil
-// interval means "always due", so its next-due time is simply started.
-func computeNextDue(meta *cycleCallbackMeta) time.Time {
-	if meta.intervals == nil {
-		return meta.started
+	meta, ok := g.metas[callbackId]
+	if !ok {
+		return errorActivateCallback(callbackCustomId, g.name, ErrorCallbackNotFound)
 	}
-	return meta.started.Add(meta.intervals.Get())
+	meta.active = true
+	meta.abort = false
+	g.schedule(meta)
+	return nil
 }
 
-// dueHeap is a min-heap of callbacks ordered by nextDue (earliest first). Each
-// meta appears at most once; heapIndex tracks its slot for O(log n) heap.Remove.
-type dueHeap []*cycleCallbackMeta
+// deactivatePrepare performs the decision block for deactivate under the lock.
+// Returns the captured done channel and whether the caller must wait for it.
+// On needWait==false the callback has already been committed as inactive, or
+// was not found (immediateErr carries the result in that case).
+func (g *cycleCallbackGroup) deactivatePrepare(callbackId uint32) (meta *cycleCallbackMeta, done chan struct{}, needWait bool, immediateErr error) {
+	g.Lock()
+	defer g.Unlock()
 
-func (h dueHeap) Len() int { return len(h) }
-
-func (h dueHeap) Less(i, j int) bool { return h[i].nextDue.Before(h[j].nextDue) }
-
-func (h dueHeap) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-	h[i].heapIndex = i
-	h[j].heapIndex = j
+	m, ok := g.metas[callbackId]
+	if !ok {
+		return nil, nil, false, ErrorCallbackNotFound
+	}
+	m.abort = true
+	if !m.running {
+		m.active = false
+		return m, nil, false, nil
+	}
+	if m.done == nil {
+		m.done = make(chan struct{})
+	}
+	return m, m.done, true, nil
 }
 
-func (h *dueHeap) Push(x any) {
-	meta := x.(*cycleCallbackMeta)
-	meta.heapIndex = len(*h)
-	*h = append(*h, meta)
+// commitDeactivated sets active=false on a meta that just finished running,
+// under the group lock. Called after a successful wait on the done channel.
+func (g *cycleCallbackGroup) commitDeactivated(meta *cycleCallbackMeta) {
+	g.Lock()
+	defer g.Unlock()
+	meta.active = false
 }
 
-func (h *dueHeap) Pop() any {
-	old := *h
-	n := len(old)
-	meta := old[n-1]
-	old[n-1] = nil
-	*h = old[:n-1]
-	meta.heapIndex = -1
-	return meta
+func (g *cycleCallbackGroup) deactivate(ctx context.Context, callbackId uint32, callbackCustomId string) error {
+	if ctx.Err() != nil {
+		return errorDeactivateCallback(callbackCustomId, g.name, ctx.Err())
+	}
+	meta, done, needWait, immediateErr := g.deactivatePrepare(callbackId)
+	if !needWait {
+		return errorDeactivateCallback(callbackCustomId, g.name, immediateErr)
+	}
+
+	select {
+	case <-done:
+		g.commitDeactivated(meta)
+		return errorDeactivateCallback(callbackCustomId, g.name, nil)
+	case <-ctx.Done():
+		select {
+		case <-done:
+			g.commitDeactivated(meta)
+			return errorDeactivateCallback(callbackCustomId, g.name, nil)
+		default:
+			// Timeout: leave active=true, abort=true. The running callback will
+			// eventually finish; teardown reschedules it and abort is reset on next
+			// Activate call.
+			return errorDeactivateCallback(callbackCustomId, g.name, ctx.Err())
+		}
+	}
+}
+
+// unregisterPrepare performs the decision block for unregister under the lock.
+// Returns the captured done channel and whether the caller must wait.
+// On needWait==false, the meta has already been deleted (or was absent: nil return).
+func (g *cycleCallbackGroup) unregisterPrepare(callbackId uint32) (done chan struct{}, needWait bool) {
+	g.Lock()
+	defer g.Unlock()
+
+	meta, ok := g.metas[callbackId]
+	if !ok {
+		return nil, false
+	}
+	meta.abort = true
+	if !meta.running {
+		delete(g.metas, callbackId)
+		return nil, false
+	}
+	if meta.done == nil {
+		meta.done = make(chan struct{})
+	}
+	return meta.done, true
+}
+
+// commitUnregistered deletes the meta from the metas map under the group lock.
+// Idempotent: deleting an absent key is safe in Go.
+func (g *cycleCallbackGroup) commitUnregistered(callbackId uint32) {
+	g.Lock()
+	defer g.Unlock()
+	delete(g.metas, callbackId)
+}
+
+func (g *cycleCallbackGroup) unregister(ctx context.Context, callbackId uint32, callbackCustomId string) error {
+	if ctx.Err() != nil {
+		return errorUnregisterCallback(callbackCustomId, g.name, ctx.Err())
+	}
+	done, needWait := g.unregisterPrepare(callbackId)
+	if !needWait {
+		return nil
+	}
+
+	select {
+	case <-done:
+		g.commitUnregistered(callbackId)
+		return nil
+	case <-ctx.Done():
+		select {
+		case <-done:
+			g.commitUnregistered(callbackId)
+			return nil
+		default:
+			// Timeout: leave meta in map with active=true, abort=true. The callback
+			// finishes eventually; teardown reschedules it. Caller can retry later.
+			return errorUnregisterCallback(callbackCustomId, g.name, ctx.Err())
+		}
+	}
 }
 
 type cycleCallbackGroupNoop struct{}
@@ -454,26 +465,6 @@ func (c *cycleCallbackGroupNoop) Register(id string, cycleCallback CycleCallback
 
 func (c *cycleCallbackGroupNoop) CycleCallback(shouldAbort ShouldAbortCallback) bool {
 	return false
-}
-
-type RegisterOption func(meta *cycleCallbackMeta)
-
-func AsInactive() RegisterOption {
-	return func(meta *cycleCallbackMeta) {
-		meta.active = false
-	}
-}
-
-func WithIntervals(intervals CycleIntervals) RegisterOption {
-	if intervals == nil {
-		return nil
-	}
-	return func(meta *cycleCallbackMeta) {
-		meta.intervals = intervals
-		// adjusts start time to allow for immediate callback execution without
-		// having to wait for interval duration to pass
-		meta.started = time.Now().Add(-intervals.Get())
-	}
 }
 
 func trace() string {

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -26,12 +26,22 @@ import (
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 )
 
-// Container for multiple callbacks exposing CycleCallback method acting as single callback.
-// Can be provided to CycleManager.
+// CycleCallbackGroup holds multiple callbacks and exposes them as one combined
+// CycleCallback that a CycleManager drives. Registered callbacks can be
+// individually activated, deactivated, and unregistered while the group runs.
+//
+// CycleCallback must be driven by a single consumer — one CycleManager, one tick
+// at a time. Scheduling reserves each due callback by popping it from an internal
+// heap, so two concurrent CycleCallback calls could otherwise reserve and run the
+// same callback twice. Every group has exactly one CycleManager, so this holds; it
+// is a required precondition, not something the group synchronizes against.
 type CycleCallbackGroup interface {
-	// Adds CycleCallback method to container
+	// Register adds a CycleCallback to the container, returning a controller to
+	// activate, deactivate, or unregister it.
 	Register(id string, cycleCallback CycleCallback, options ...RegisterOption) CycleCallbackCtrl
-	// Method of CycleCallback acting as single callback for all callbacks added to the container
+	// CycleCallback runs every callback due this tick, acting as a single callback
+	// for the whole container. It must be called by a single consumer (see the
+	// type doc); concurrent calls are not supported.
 	CycleCallback(shouldAbort ShouldAbortCallback) bool
 }
 
@@ -49,22 +59,24 @@ type cycleCallbackMeta struct {
 	running bool
 	// done is the on-demand wait handle. It is nil unless a Deactivate or Unregister
 	// caller needs to wait for an in-flight run; the first such caller creates it,
-	// subsequent concurrent callers reuse the same channel. Teardown closes and nils
+	// subsequent concurrent callers reuse the same channel. endRun closes and nils
 	// it after setting running=false. All accesses are under the group lock.
 	done      chan struct{}
 	started   time.Time
 	intervals CycleIntervals
 	schedGen  uint64
-	// cycleShouldAbort holds the current cycle's abort signal, refreshed in runOne
-	// before each invocation and read by abortCheck. Written and read by the single
-	// goroutine handling this meta, so no lock is needed.
+	// cycleShouldAbort holds the current run's manager-stop signal. Written in
+	// beginRun, cleared in endRun, and read by abortCheck — all under the group
+	// lock, so a retained abortCheck (e.g. an abort-watcher goroutine still in
+	// flight after the callback returns) reads it safely across ticks.
 	cycleShouldAbort ShouldAbortCallback
-	// abortCheck is the ShouldAbortCallback handed to cycleCallback. Built once in
-	// Register and reused every cycle to avoid a per-invocation closure allocation.
+	// abortCheck is the ShouldAbortCallback handed to the callback. Built once in
+	// Register and reused every run, so the dispatch path allocates no per-run
+	// closure. It reads cycleShouldAbort and abort under the lock.
 	abortCheck ShouldAbortCallback
 }
 
-func (m *cycleCallbackMeta) setInactive() { m.active = false; m.abort = false }
+func (m *cycleCallbackMeta) setInactive() { m.active = false }
 
 func (m *cycleCallbackMeta) setIntervals(intervals CycleIntervals) {
 	m.intervals = intervals
@@ -117,11 +129,24 @@ func (g *cycleCallbackGroup) schedule(m *cycleCallbackMeta) {
 	g.heap.push(dueEntry{callbackId: m.callbackId, due: due, schedGen: m.schedGen})
 
 	// Stale entries are otherwise reclaimed only lazily on pop, so churn on a
-	// far-future callback can pile them up. Compact past ~2x the live-entry ceiling
-	// to keep heap size, and pop cost, bounded by the registered-callback count.
-	if len(g.heap) > 2*len(g.metas)+8 {
+	// far-future callback can pile them up. Compact once the heap grows past the
+	// live-entry ceiling to keep heap size, and pop cost, bounded by the
+	// registered-callback count.
+	if len(g.heap) > heapCompactThreshold(len(g.metas)) {
 		g.compactHeap()
 	}
+}
+
+// heapCompactThreshold is the heap size schedule tolerates before compacting,
+// given the live-callback count. The factor bounds stale-entry growth relative to
+// the live count; the slack keeps small groups from compacting on nearly every
+// schedule.
+func heapCompactThreshold(liveCount int) int {
+	const (
+		factor = 2
+		slack  = 8
+	)
+	return factor*liveCount + slack
 }
 
 // compactHeap drops every stale entry — callback gone, or schedGen superseded —
@@ -182,30 +207,34 @@ func (g *cycleCallbackGroup) Register(id string, cycleCallback CycleCallback, op
 		}
 	}
 
-	// Build the abort-check closure once here. g and meta are stable for the
-	// lifetime of this registration; capturing them now avoids allocating a new
-	// closure on every cycleCallback invocation.
+	// Built once and reused every run to avoid a per-run closure allocation. g and
+	// meta are stable for this registration's lifetime. Reads cycleShouldAbort and
+	// abort under the lock; safe to call even after the run returns.
 	meta.abortCheck = func() bool {
-		if meta.cycleShouldAbort() {
-			return true
-		}
 		g.Lock()
-		defer g.Unlock()
-		return meta.abort
+		shouldAbort, abort := meta.cycleShouldAbort, meta.abort
+		g.Unlock()
+		return abort || (shouldAbort != nil && shouldAbort())
 	}
 
-	// Publish the meta before scheduling so compaction (which schedule may trigger)
-	// keeps the entry it just pushed.
-	var callbackId uint32
-	func() {
-		g.Lock()
-		defer g.Unlock()
-		callbackId = g.nextCallbackId
-		meta.callbackId = callbackId
-		g.metas[callbackId] = meta
-		g.nextCallbackId++
+	g.Lock()
+	defer g.Unlock()
+
+	callbackId := g.nextCallbackId
+	meta.callbackId = callbackId
+	g.metas[callbackId] = meta
+	g.nextCallbackId++
+	// Publish the meta before scheduling so compaction (which schedule may
+	// trigger) keeps the entry it just pushed. An inactive callback gets no entry
+	// — Activate schedules it if and when it is enabled.
+	//
+	// schedule reaches intervals.Get via computeNextDue. Get must not panic (see
+	// CycleIntervals); a misbehaving implementation that did would unwind Register
+	// with the meta already in g.metas but no controller returned — orphaned and
+	// un-unregisterable. The in-tree intervals are index-bounded and cannot panic.
+	if meta.active {
 		g.schedule(meta)
-	}()
+	}
 
 	return &cycleCallbackCtrl{
 		callbackId:       callbackId,
@@ -245,7 +274,10 @@ func (g *cycleCallbackGroup) runSequential(due []*cycleCallbackMeta, shouldAbort
 func (g *cycleCallbackGroup) runParallel(due []*cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
 	var anyExecuted atomic.Bool
 	wg := new(sync.WaitGroup)
-	ch := make(chan *cycleCallbackMeta)
+	// Buffered to len(due) so the dispatch loop never blocks on a send: if every
+	// worker exits early (a panic outside runOne's recover), the sends still land
+	// in the buffer and this goroutine finishes instead of hanging forever.
+	ch := make(chan *cycleCallbackMeta, len(due))
 
 	limit := min(len(due), g.routinesLimit)
 	wg.Add(limit)
@@ -269,34 +301,44 @@ func (g *cycleCallbackGroup) runParallel(due []*cycleCallbackMeta, shouldAbort S
 	}
 	close(ch)
 	wg.Wait()
+
+	// A worker that exits abnormally (e.g. runtime.Goexit in a callback) stops
+	// draining ch; if every worker exits, metas remain buffered. They were popped
+	// from the heap by drainDue, so reschedule any left over to avoid losing them.
+	for meta := range ch {
+		g.reschedule(meta)
+	}
 	return anyExecuted.Load()
 }
 
 // beginRun performs the entry check and marks the callback as running, under
 // the group lock. Returns false if the callback was deactivated or unregistered
-// since drainDue returned it. Kept as a method rather than a closure so the
-// entry check stays allocation-free on the dispatch path.
-func (g *cycleCallbackGroup) beginRun(meta *cycleCallbackMeta) bool {
+// since drainDue returned it, or is already running. The running check guards the
+// single-consumer contract (see CycleCallbackGroup): a concurrent CycleCallback
+// plus a Deactivate+Activate could otherwise re-queue and reserve the same meta
+// twice.
+func (g *cycleCallbackGroup) beginRun(meta *cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
 	g.Lock()
 	defer g.Unlock()
 
-	if g.metas[meta.callbackId] == nil || !meta.active {
+	if g.metas[meta.callbackId] == nil || !meta.active || meta.running {
 		return false
 	}
 	meta.running = true
 	meta.started = time.Now()
+	meta.cycleShouldAbort = shouldAbort
 	return true
 }
 
-// endRun performs teardown under the group lock: clears running, wakes any
-// Deactivate/Unregister waiters, and reschedules the callback if still active.
-// Kept as a method rather than a closure so teardown stays allocation-free on
-// the dispatch path.
+// endRun runs under the group lock after a callback returns: it clears running,
+// wakes any Deactivate/Unregister waiters, and reschedules the callback if it is
+// still active.
 func (g *cycleCallbackGroup) endRun(meta *cycleCallbackMeta) {
 	g.Lock()
 	defer g.Unlock()
 
 	meta.running = false
+	meta.cycleShouldAbort = nil
 	if meta.done != nil {
 		close(meta.done)
 		meta.done = nil
@@ -306,16 +348,26 @@ func (g *cycleCallbackGroup) endRun(meta *cycleCallbackMeta) {
 	}
 }
 
-// runOne executes meta under the entry-check / run / teardown protocol.
+// runOne executes meta under the entry-check / run / endRun protocol.
 func (g *cycleCallbackGroup) runOne(meta *cycleCallbackMeta, shouldAbort ShouldAbortCallback) bool {
-	if !g.beginRun(meta) {
+	if !g.beginRun(meta, shouldAbort) {
 		return false
 	}
+	// endRun must run on every unwind path: if a panic escapes g.recover or the
+	// callback calls runtime.Goexit, meta.running stays set (never rescheduled) and
+	// meta.done stays unclosed (Deactivate/Unregister wait out their full deadline).
+	// The interval update completes inside the inner closure before this defer fires.
+	//
+	// This keeps meta bookkeeping consistent, but only the parallel path contains a
+	// Goexit: it kills a disposable worker, and runParallel reschedules any metas
+	// left buffered. In sequential mode runOne runs on the CycleManager's driving
+	// goroutine, so a Goexit there ends that manager's tick loop — as it did before
+	// this rewrite. A panic, unlike Goexit, is caught by g.recover on both paths.
+	defer g.endRun(meta)
 
 	executed := false
 	func() {
 		defer g.recover(meta)
-		meta.cycleShouldAbort = shouldAbort
 		executed = meta.cycleCallback(meta.abortCheck)
 		// Interval update is inside the closure so a panic unwinds past it,
 		// leaving the interval unchanged (panic is not "no work done").
@@ -328,7 +380,6 @@ func (g *cycleCallbackGroup) runOne(meta *cycleCallbackMeta, shouldAbort ShouldA
 		}
 	}()
 
-	g.endRun(meta)
 	return executed
 }
 
@@ -357,7 +408,7 @@ func (g *cycleCallbackGroup) isActive(callbackId uint32, _ string) bool {
 
 // activate clears any pending abort and, if the callback was inactive, marks it
 // active and schedules it. An already-active callback is left as-is: it is either
-// running (teardown reschedules it) or already holds a live entry, so re-scheduling
+// running (endRun reschedules it) or already holds a live entry, so re-scheduling
 // would race computeNextDue's interval read against the running callback's unlocked
 // Reset/Advance and leave a stale entry behind.
 func (g *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string) error {
@@ -376,95 +427,50 @@ func (g *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string
 	return nil
 }
 
-// deactivatePrepare performs the decision block for deactivate under the lock.
-// Returns the captured done channel and whether the caller must wait for it.
-// On needWait==false the callback has already been committed as inactive, or
-// was not found (immediateErr carries the result in that case).
-func (g *cycleCallbackGroup) deactivatePrepare(callbackId uint32) (done chan struct{}, needWait bool, immediateErr error) {
-	g.Lock()
-	defer g.Unlock()
-
-	m, ok := g.metas[callbackId]
-	if !ok {
-		return nil, false, ErrorCallbackNotFound
-	}
-	m.abort = true
-	if !m.running {
-		m.active = false
-		return nil, false, nil
-	}
-	if m.done == nil {
-		m.done = make(chan struct{})
-	}
-	return m.done, true, nil
-}
-
-func (g *cycleCallbackGroup) deactivate(ctx context.Context, callbackId uint32, callbackCustomId string) error {
-	if ctx.Err() != nil {
-		return errorDeactivateCallback(callbackCustomId, g.name, ctx.Err())
-	}
-
-	// One run's done channel is not enough: teardown reschedules a still-active
-	// callback, so a fresh tick can start another run while we wait. Loop back
-	// through deactivatePrepare after each finished run; it commits active=false
-	// only once it observes the callback not running.
-	for {
-		done, needWait, immediateErr := g.deactivatePrepare(callbackId)
-		if !needWait {
-			return errorDeactivateCallback(callbackCustomId, g.name, immediateErr)
-		}
-
-		select {
-		case <-done:
-			// re-check under the lock on the next iteration
-		case <-ctx.Done():
-			select {
-			case <-done:
-				// re-check under the lock on the next iteration
-			default:
-				// Timeout: leave active=true, abort=true. The running callback will
-				// eventually finish; teardown reschedules it and abort is reset on next
-				// Activate call.
-				return errorDeactivateCallback(callbackCustomId, g.name, ctx.Err())
-			}
-		}
-	}
-}
-
-// unregisterPrepare performs the decision block for unregister under the lock.
-// Returns the captured done channel and whether the caller must wait.
-// On needWait==false, the meta has already been deleted (or was absent: nil return).
-func (g *cycleCallbackGroup) unregisterPrepare(callbackId uint32) (done chan struct{}, needWait bool) {
+// tryCommitIdle is one under-lock attempt of the commitIdle protocol. It sets
+// abort, then reports one of three outcomes: the callback is absent
+// (needWait=false, err=notFound); it is not running, so commit is applied and the
+// operation is complete (needWait=false, err=nil); or it is running, so the
+// lazily-created done channel is returned to wait on (needWait=true).
+func (g *cycleCallbackGroup) tryCommitIdle(callbackId uint32, commit func(*cycleCallbackMeta), notFound error,
+) (done chan struct{}, needWait bool, err error) {
 	g.Lock()
 	defer g.Unlock()
 
 	meta, ok := g.metas[callbackId]
 	if !ok {
-		return nil, false
+		return nil, false, notFound
 	}
 	meta.abort = true
 	if !meta.running {
-		delete(g.metas, callbackId)
-		return nil, false
+		commit(meta)
+		return nil, false, nil
 	}
 	if meta.done == nil {
 		meta.done = make(chan struct{})
 	}
-	return meta.done, true
+	return meta.done, true, nil
 }
 
-func (g *cycleCallbackGroup) unregister(ctx context.Context, callbackId uint32, callbackCustomId string) error {
+// commitIdle drives the try/wait/re-check protocol shared by deactivate and
+// unregister. One run's done channel is not enough: endRun reschedules a
+// still-active callback, so a fresh tick can start another run while we wait. It
+// retries tryCommitIdle after each finished run; commit is applied only once
+// tryCommitIdle observes the callback not running. A ctx deadline hit while
+// waiting returns ctx.Err(), but an already-finished run takes priority so a
+// completed operation is never reported as a timeout. Every result passes through
+// wrap (which maps nil to nil).
+func (g *cycleCallbackGroup) commitIdle(ctx context.Context, callbackId uint32,
+	commit func(*cycleCallbackMeta), notFound error, wrap func(error) error,
+) error {
 	if ctx.Err() != nil {
-		return errorUnregisterCallback(callbackCustomId, g.name, ctx.Err())
+		return wrap(ctx.Err())
 	}
 
-	// Same one-run race as deactivate: loop back through unregisterPrepare after
-	// each finished run; it deletes the meta only once it observes the callback
-	// not running.
 	for {
-		done, needWait := g.unregisterPrepare(callbackId)
+		done, needWait, err := g.tryCommitIdle(callbackId, commit, notFound)
 		if !needWait {
-			return nil
+			return wrap(err)
 		}
 
 		select {
@@ -475,12 +481,37 @@ func (g *cycleCallbackGroup) unregister(ctx context.Context, callbackId uint32, 
 			case <-done:
 				// re-check under the lock on the next iteration
 			default:
-				// Timeout: leave meta in map with active=true, abort=true. The callback
-				// finishes eventually; teardown reschedules it. Caller can retry later.
-				return errorUnregisterCallback(callbackCustomId, g.name, ctx.Err())
+				// Timeout: leave the callback in place (abort stays set). The running
+				// callback finishes eventually and endRun reschedules it; the caller
+				// can retry, and Activate resets abort.
+				return wrap(ctx.Err())
 			}
 		}
 	}
+}
+
+func (g *cycleCallbackGroup) deactivate(ctx context.Context, callbackId uint32, callbackCustomId string) error {
+	return g.commitIdle(ctx, callbackId,
+		func(m *cycleCallbackMeta) { m.active = false },
+		ErrorCallbackNotFound,
+		func(err error) error { return errorDeactivateCallback(callbackCustomId, g.name, err) },
+	)
+}
+
+func (g *cycleCallbackGroup) unregister(ctx context.Context, callbackId uint32, callbackCustomId string) error {
+	return g.commitIdle(ctx, callbackId,
+		func(m *cycleCallbackMeta) {
+			delete(g.metas, callbackId)
+			// With no live metas, schedule never runs again, so its size-based
+			// compaction can't reclaim the entries left behind. Drop the heap now,
+			// releasing every stale entry and the backing array.
+			if len(g.metas) == 0 {
+				g.heap = dueHeap{}
+			}
+		},
+		nil, // an absent callback is a no-op success for unregister
+		func(err error) error { return errorUnregisterCallback(callbackCustomId, g.name, err) },
+	)
 }
 
 type cycleCallbackGroupNoop struct{}

--- a/entities/cyclemanager/cyclecallbackgroup_options.go
+++ b/entities/cyclemanager/cyclecallbackgroup_options.go
@@ -1,0 +1,35 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cyclemanager
+
+// RegisterOption is applied to a callback at registration time.
+type RegisterOption func(*cycleCallbackMeta)
+
+// AsInactive returns a RegisterOption that marks the callback inactive on
+// registration; it will not run until explicitly activated.
+func AsInactive() RegisterOption {
+	return func(m *cycleCallbackMeta) {
+		m.setInactive()
+	}
+}
+
+// WithIntervals returns a RegisterOption that assigns the given intervals to the
+// callback and adjusts the start time so the first run is immediate. Returns nil
+// when intervals is nil, which Register treats as a no-op option.
+func WithIntervals(intervals CycleIntervals) RegisterOption {
+	if intervals == nil {
+		return nil
+	}
+	return func(m *cycleCallbackMeta) {
+		m.setIntervals(intervals)
+	}
+}

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -117,14 +117,12 @@ func TestCycleCallback_Parallel(t *testing.T) {
 			executedCounter3++
 			return true
 		}
-		// due to async calls of shouldAbort callback by main for loop
-		// and goroutines reading from shared channel it is hard to
-		// establish order of calls.
-		// with 3 callbacks and shouldAbort returning true on 6th call
-		// 1 or 2 callbacks should be executed, but not all 3.
+		// each due callback triggers one shouldAbort check in its worker before
+		// running; with 3 due callbacks and abort tripping after the 2nd check,
+		// the callback picked up third is skipped, so some run but not all 3.
 		shouldAbortCounter := uint32(0)
 		shouldAbort := func() bool {
-			return atomic.AddUint32(&shouldAbortCounter, 1) > 5
+			return atomic.AddUint32(&shouldAbortCounter, 1) > 2
 		}
 		var executed bool
 		var d time.Duration
@@ -250,7 +248,7 @@ func TestCycleCallback_Parallel(t *testing.T) {
 		executed := callbacks.CycleCallback(shouldNotAbort)
 
 		assert.False(t, executed)
-		assert.Empty(t, callbacks.(*cycleCallbackGroup).callbackIds)
+		assert.Empty(t, callbacks.(*cycleCallbackGroup).dueHeap)
 	})
 
 	t.Run("run with intervals", func(T *testing.T) {
@@ -1209,7 +1207,7 @@ func TestCycleCallback_Sequential(t *testing.T) {
 		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
 	})
 
-	t.Run("register new while executing", func(t *testing.T) {
+	t.Run("register new while executing runs it on the next tick", func(t *testing.T) {
 		executedCounter1 := 0
 		callback1 := func(shouldAbort ShouldAbortCallback) bool {
 			time.Sleep(50 * time.Millisecond)
@@ -1230,6 +1228,8 @@ func TestCycleCallback_Sequential(t *testing.T) {
 		callbacks := NewCallbackGroup("id", logger, 1)
 		callbacks.Register("c1", callback1)
 
+		// register 2nd callback while the 1st is executing. The tick dispatches
+		// the callbacks due when it started (c1), so the 2nd is not part of it.
 		go func() {
 			chStarted <- struct{}{}
 			start := time.Now()
@@ -1244,8 +1244,12 @@ func TestCycleCallback_Sequential(t *testing.T) {
 
 		assert.True(t, executed)
 		assert.Equal(t, 1, executedCounter1)
+		assert.Equal(t, 0, executedCounter2)
+		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+
+		// the next tick picks up the 2nd callback
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 100*time.Millisecond)
 	})
 
 	t.Run("run with intervals", func(T *testing.T) {
@@ -1736,7 +1740,7 @@ func TestCycleCallback_Parallel_DueDispatch(t *testing.T) {
 		group.Lock()
 		defer group.Unlock()
 		assert.Len(t, group.callbacks, stable)
-		assert.Len(t, group.callbackIds, stable)
+		assert.Len(t, group.dueHeap, stable)
 	})
 }
 
@@ -2158,5 +2162,224 @@ func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
 			assert.Greater(t, counter, max)
 			assert.GreaterOrEqual(t, d, 100*time.Millisecond)
 		})
+	})
+}
+
+// TestCycleCallback_DueHeap covers the due-heap scheduling behaviors in both
+// dispatch modes: nil-interval "always due" entries, running only the due
+// subset, the single-membership invariant across deactivate/activate, panic
+// containment, and restoring drained-but-un-run entries on abort.
+func TestCycleCallback_DueHeap(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	modes := []struct {
+		name     string
+		routines int
+	}{
+		{"sequential", 1},
+		{"parallel", 4},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			t.Run("always-due entry runs every tick", func(t *testing.T) {
+				var counter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				callbacks.Register("always", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&counter, 1)
+					return true
+				})
+
+				// nil interval means always due; each tick runs it exactly once,
+				// never re-popped within the same tick
+				for tick := int64(1); tick <= 3; tick++ {
+					assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+					assert.Equal(t, tick, atomic.LoadInt64(&counter))
+				}
+			})
+
+			t.Run("only due entries run", func(t *testing.T) {
+				var alwaysCounter, longCounter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				callbacks.Register("always", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&alwaysCounter, 1)
+					return true
+				})
+				callbacks.Register("long", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&longCounter, 1)
+					return true
+				}, WithIntervals(NewFixedIntervals(time.Hour)))
+
+				// 1st tick: both due (registration allows immediate execution)
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&alwaysCounter))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&longCounter))
+
+				// 2nd tick: only the always-due entry runs, long interval not elapsed
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(2), atomic.LoadInt64(&alwaysCounter))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&longCounter))
+			})
+
+			t.Run("activate after deactivate runs once", func(t *testing.T) {
+				var counter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&counter, 1)
+					return true
+				})
+				require.NoError(t, ctrl.Deactivate(context.Background()))
+				require.NoError(t, ctrl.Activate())
+
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+
+				// exactly one heap entry afterwards - the activate push did not
+				// duplicate it
+				group := callbacks.(*cycleCallbackGroup)
+				group.Lock()
+				heapLen := group.dueHeap.Len()
+				group.Unlock()
+				assert.Equal(t, 1, heapLen)
+			})
+
+			t.Run("panicking callback is contained and rescheduled", func(t *testing.T) {
+				const siblings = 4
+				var okCounter, panicCounter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				for i := 0; i < siblings; i++ {
+					callbacks.Register(fmt.Sprintf("ok%d", i), func(shouldAbort ShouldAbortCallback) bool {
+						atomic.AddInt64(&okCounter, 1)
+						return true
+					})
+				}
+				callbacks.Register("panic", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&panicCounter, 1)
+					panic("boom")
+				})
+
+				// 1st tick: siblings all run, the panic is contained
+				callbacks.CycleCallback(shouldNotAbort)
+				assert.Equal(t, int64(siblings), atomic.LoadInt64(&okCounter))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&panicCounter))
+
+				// 2nd tick: the panicking entry was rescheduled, so it runs again
+				callbacks.CycleCallback(shouldNotAbort)
+				assert.Equal(t, int64(2), atomic.LoadInt64(&panicCounter))
+			})
+
+			t.Run("abort restores un-run drained entries", func(t *testing.T) {
+				const total = 5
+				var counter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				for i := 0; i < total; i++ {
+					callbacks.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+						atomic.AddInt64(&counter, 1)
+						return true
+					})
+				}
+
+				// abort the whole tick: every drained entry is restored, none run
+				assert.False(t, callbacks.CycleCallback(func() bool { return true }))
+				assert.Equal(t, int64(0), atomic.LoadInt64(&counter))
+
+				group := callbacks.(*cycleCallbackGroup)
+				group.Lock()
+				heapLen := group.dueHeap.Len()
+				group.Unlock()
+				assert.Equal(t, total, heapLen) // nothing orphaned outside the heap
+
+				// next tick runs exactly the restored entries
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(total), atomic.LoadInt64(&counter))
+			})
+
+			t.Run("abort then deactivate does not resurrect", func(t *testing.T) {
+				const total = 4
+				counters := make([]int64, total)
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				ctrls := make([]CycleCallbackCtrl, total)
+				for i := 0; i < total; i++ {
+					idx := i
+					ctrls[i] = callbacks.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+						atomic.AddInt64(&counters[idx], 1)
+						return true
+					})
+				}
+
+				// abort tick: all entries restored to the heap, none run
+				assert.False(t, callbacks.CycleCallback(func() bool { return true }))
+
+				// deactivate one restored entry
+				require.NoError(t, ctrls[0].Deactivate(context.Background()))
+
+				// next tick runs every entry but the deactivated one
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(0), atomic.LoadInt64(&counters[0]))
+				for i := 1; i < total; i++ {
+					assert.Equal(t, int64(1), atomic.LoadInt64(&counters[i]))
+				}
+			})
+		})
+	}
+
+	t.Run("activate during execution does not duplicate the heap entry", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		callbacks := NewCallbackGroup("id", logger, 2)
+		ctrl := callbacks.Register("blocking", func(shouldAbort ShouldAbortCallback) bool {
+			started <- struct{}{}
+			<-release
+			return true
+		})
+
+		// run a tick concurrently: it drains the entry (heapIndex -1) and blocks
+		// inside the callback, holding it in flight
+		done := make(chan bool, 1)
+		go func() {
+			done <- callbacks.CycleCallback(shouldNotAbort)
+		}()
+		<-started
+
+		// activate the in-flight entry: activate re-queues it (its heapIndex -1
+		// guard passes), so the tick's repushDue must not push it a second time
+		require.NoError(t, ctrl.Activate())
+		close(release)
+		<-done
+
+		group := callbacks.(*cycleCallbackGroup)
+		group.Lock()
+		heapLen := group.dueHeap.Len()
+		group.Unlock()
+		assert.Equal(t, 1, heapLen)
+	})
+
+	t.Run("sequential abort after first execution restores the remainder", func(t *testing.T) {
+		const total = 4
+		var counter int64
+		callbacks := NewCallbackGroup("id", logger, 1)
+		for i := 0; i < total; i++ {
+			callbacks.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&counter, 1)
+				return true
+			})
+		}
+
+		// abort once the first callback has run; the sequential loop stops
+		// executing but restores every remaining drained entry
+		shouldAbort := func() bool { return atomic.LoadInt64(&counter) >= 1 }
+		assert.True(t, callbacks.CycleCallback(shouldAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+
+		group := callbacks.(*cycleCallbackGroup)
+		group.Lock()
+		heapLen := group.dueHeap.Len()
+		group.Unlock()
+		assert.Equal(t, total, heapLen) // executed one re-pushed, remainder restored
+
+		// next tick runs all four again
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1+total), atomic.LoadInt64(&counter))
 	})
 }

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -1398,12 +1398,12 @@ func TestCycleCallback_StaleEntryBoundedGrowth(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
 
-	const N = 10
+	// Far-future interval so nothing ever drains: without compaction each cycle
+	// would orphan a stale entry and the heap would grow linearly with N.
+	const N = 1000
 	ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true },
 		WithIntervals(NewFixedIntervals(time.Hour)))
 
-	// N Deactivate/Activate cycles without draining; each cycle may leave one
-	// stale entry in the heap.
 	for i := 0; i < N; i++ {
 		require.NoError(t, ctrl.Deactivate(context.Background()))
 		require.NoError(t, ctrl.Activate())
@@ -1418,19 +1418,133 @@ func TestCycleCallback_StaleEntryBoundedGrowth(t *testing.T) {
 	}
 	meta := g.metas[callbackId]
 
-	staleEntries := 0
 	liveEntries := 0
 	for _, e := range g.heap {
-		if e.callbackId == callbackId {
-			if e.schedGen == meta.schedGen {
-				liveEntries++
-			} else {
-				staleEntries++
-			}
+		if e.callbackId == callbackId && e.schedGen == meta.schedGen {
+			liveEntries++
 		}
 	}
 	assert.Equal(t, 1, liveEntries, "exactly one live entry")
-	assert.LessOrEqual(t, staleEntries, N)
+	// Compaction keeps the heap bounded by the registered-callback count, no matter
+	// how many Deactivate/Activate cycles churn through it.
+	assert.LessOrEqual(t, len(g.heap), 2*len(g.metas)+8,
+		"heap stays bounded regardless of churn")
+}
+
+// TestCycleCallback_CompactHeapKeepsInvariant churns several callbacks with
+// distinct due times to trigger compaction, then verifies the rebuilt heap is
+// still a valid min-heap holding exactly the one current entry per callback.
+func TestCycleCallback_CompactHeapKeepsInvariant(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	const callbacks = 6
+	ctrls := make([]CycleCallbackCtrl, callbacks)
+	for i := 0; i < callbacks; i++ {
+		// Distinct intervals give distinct due times, so compaction's re-heapify
+		// has a real multi-level heap to rebuild.
+		ctrls[i] = g.Register(fmt.Sprintf("c%d", i),
+			func(shouldAbort ShouldAbortCallback) bool { return true },
+			WithIntervals(NewFixedIntervals(time.Duration(i+1)*time.Hour)))
+	}
+
+	// Churn every callback well past the compaction threshold.
+	for round := 0; round < 200; round++ {
+		ctrl := ctrls[round%callbacks]
+		require.NoError(t, ctrl.Deactivate(context.Background()))
+		require.NoError(t, ctrl.Activate())
+	}
+
+	g.Lock()
+	defer g.Unlock()
+
+	// Compaction bounds the total entry count (some bounded stale entries may
+	// remain between compactions; only the count is capped, not stale presence).
+	assert.LessOrEqual(t, len(g.heap), 2*len(g.metas)+8, "heap bounded after churn")
+
+	// Every callback still has exactly one live (current-schedGen) entry, so it
+	// will still fire; stragglers, if any, are stale duplicates.
+	live := map[uint32]int{}
+	for _, e := range g.heap {
+		meta, ok := g.metas[e.callbackId]
+		require.True(t, ok, "no entry may reference an unregistered callback")
+		if e.schedGen == meta.schedGen {
+			live[e.callbackId]++
+		}
+	}
+	for id, n := range live {
+		assert.Equal(t, 1, n, "callback %d has exactly one live entry", id)
+	}
+	assert.Len(t, live, callbacks, "every callback still scheduled")
+
+	// Min-heap invariant: each parent is due no later than its children — this is
+	// what compactHeap's Floyd re-heapify must restore.
+	for i := range g.heap {
+		if l := 2*i + 1; l < len(g.heap) {
+			assert.LessOrEqual(t, g.heap[i].due, g.heap[l].due, "heap property at %d/left", i)
+		}
+		if r := 2*i + 2; r < len(g.heap) {
+			assert.LessOrEqual(t, g.heap[i].due, g.heap[r].due, "heap property at %d/right", i)
+		}
+	}
+}
+
+// TestCycleCallback_RegisterDuringCompaction guards the interaction between
+// Register and heap compaction: when schedule (called during Register) triggers
+// compaction, it must recognize the callback being registered and keep its
+// freshly-pushed entry rather than dropping it as stale.
+func TestCycleCallback_RegisterDuringCompaction(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	// Bloat the heap so the next Register actually compacts. Churn can't: every
+	// schedule self-compacts, and registering a callback raises the threshold faster
+	// than it adds entries. Unregister is the lever — it leaves entries behind and
+	// never compacts. Register a batch, then unregister most of it.
+	const fillers = 20
+	ctrls := make([]CycleCallbackCtrl, fillers)
+	for i := 0; i < fillers; i++ {
+		ctrls[i] = g.Register(fmt.Sprintf("filler%d", i),
+			func(shouldAbort ShouldAbortCallback) bool { return true },
+			WithIntervals(NewFixedIntervals(time.Hour)))
+	}
+	for i := 1; i < fillers; i++ { // keep filler0 so metas stays > 0
+		require.NoError(t, ctrls[i].Unregister(context.Background()))
+	}
+
+	g.Lock()
+	heapBefore := len(g.heap)
+	metasBefore := len(g.metas)
+	g.Unlock()
+	// Registering "fresh" raises metas to metasBefore+1; the heap must exceed that
+	// post-register threshold so schedule actually compacts mid-registration.
+	require.Greater(t, heapBefore, 2*(metasBefore+1)+8,
+		"setup must leave the heap over the post-register compaction threshold")
+
+	g.Register("fresh", func(shouldAbort ShouldAbortCallback) bool { return true })
+
+	g.Lock()
+	defer g.Unlock()
+
+	// Compaction actually ran during Register: the stale filler entries were reclaimed.
+	require.Less(t, len(g.heap), heapBefore, "compaction should have run during Register")
+
+	var freshID uint32
+	found := false
+	for id, m := range g.metas {
+		if m.name == "fresh" {
+			freshID, found = id, true
+		}
+	}
+	require.True(t, found, "fresh callback is registered")
+
+	live := 0
+	for _, e := range g.heap {
+		if e.callbackId == freshID && e.schedGen == g.metas[freshID].schedGen {
+			live++
+		}
+	}
+	assert.Equal(t, 1, live, "fresh callback must stay scheduled through compaction")
 }
 
 func TestCycleCallback_DeactivatePriorityClaimedButNotStarted(t *testing.T) {

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -17,313 +17,185 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// ----------------------------------------------------------------------------
+// Black-box behavioral tests
+// ----------------------------------------------------------------------------
 
 func TestCycleCallback_Parallel(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
 	t.Run("no callbacks", func(t *testing.T) {
-		var executed bool
-
 		callbacks := NewCallbackGroup("id", logger, 2)
-
-		executed = callbacks.CycleCallback(shouldNotAbort)
-
-		assert.False(t, executed)
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 	})
 
 	t.Run("2 executable callbacks", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
+		var c1, c2 int64
 
-		callbacks := NewCallbackGroup("id", logger, 2)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
+		synctest.Test(t, func(t *testing.T) {
+			callbacks := NewCallbackGroup("id", logger, 2)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				time.Sleep(50 * time.Millisecond)
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+			callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				time.Sleep(25 * time.Millisecond)
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
 
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
+			start := time.Now()
+			executed := callbacks.CycleCallback(shouldNotAbort)
+			d := time.Since(start)
 
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+			assert.True(t, executed)
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+			assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+		})
 	})
 
 	t.Run("2 non-executable callbacks", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(10 * time.Millisecond)
-			executedCounter1++
-			return false
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(10 * time.Millisecond)
-			executedCounter2++
-			return false
-		}
-		var executed bool
-		var d time.Duration
+		var c1, c2 int64
 
-		callbacks := NewCallbackGroup("id", logger, 2)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
+		synctest.Test(t, func(t *testing.T) {
+			callbacks := NewCallbackGroup("id", logger, 2)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				time.Sleep(10 * time.Millisecond)
+				atomic.AddInt64(&c1, 1)
+				return false
+			})
+			callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				time.Sleep(10 * time.Millisecond)
+				atomic.AddInt64(&c2, 1)
+				return false
+			})
 
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 10*time.Millisecond)
-	})
-
-	t.Run("3 executable callbacks, not all executed due to should abort", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		// each due callback triggers one shouldAbort check in its worker before
-		// running; with 3 due callbacks and abort tripping after the 2nd check,
-		// the callback picked up third is skipped, so some run but not all 3.
-		shouldAbortCounter := uint32(0)
-		shouldAbort := func() bool {
-			return atomic.AddUint32(&shouldAbortCounter, 1) > 2
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-		callbacks.Register("c3", callback3)
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldAbort)
-		d = time.Since(start)
-
-		assert.True(t, executed)
-		totalExecuted := executedCounter1 + executedCounter2 + executedCounter3
-		assert.Greater(t, totalExecuted, 0)
-		assert.Less(t, totalExecuted, 3)
-		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
-	})
-
-	t.Run("register new while executing runs it on the next tick", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		executedCounter4 := 0
-		callback4 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter4++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-		callbacks.Register("c3", callback3)
-
-		// register 4th callback while the others are executing:
-		// 1st and 2nd are processed first (50ms), 3rd waits for a free routine.
-		// The tick dispatches the callbacks due when it started (c1, c2, c3), so
-		// the 4th, registered afterwards, is not part of this tick.
-		go func() {
-			chStarted <- struct{}{}
 			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(25 * time.Millisecond)
-		callbacks.Register("c4", callback4)
-		<-chFinished
+			executed := callbacks.CycleCallback(shouldNotAbort)
+			d := time.Since(start)
+
+			assert.False(t, executed)
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+			assert.GreaterOrEqual(t, d, 10*time.Millisecond)
+		})
+	})
+
+	t.Run("abort skips some callbacks", func(t *testing.T) {
+		var c1, c2, c3 int64
+		shouldAbortCtr := uint32(0)
+		shouldAbort := func() bool {
+			return atomic.AddUint32(&shouldAbortCtr, 1) > 2
+		}
+		callbacks := NewCallbackGroup("id", logger, 2)
+		callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
+		callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c3, 1)
+			return true
+		})
+
+		executed := callbacks.CycleCallback(shouldAbort)
 
 		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.Equal(t, 1, executedCounter3)
-		assert.Equal(t, 0, executedCounter4)
-		assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+		total := atomic.LoadInt64(&c1) + atomic.LoadInt64(&c2) + atomic.LoadInt64(&c3)
+		assert.Greater(t, total, int64(0))
+		assert.Less(t, total, int64(3))
+	})
 
-		// the next tick picks up the 4th callback
-		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-		assert.Equal(t, 1, executedCounter4)
+	t.Run("register new while executing runs it on next tick", func(t *testing.T) {
+		var c1, c2, c3, c4 int64
+		chFinished := make(chan struct{}, 1)
+
+		synctest.Test(t, func(t *testing.T) {
+			// tickRunning is closed by c1 when it starts executing.
+			// release is closed by the test to let c1 proceed. This
+			// channel rendezvous is a true happens-before guarantee that
+			// Register("c4") is called while the tick is in-progress.
+			tickRunning := make(chan struct{})
+			release := make(chan struct{})
+
+			callbacks := NewCallbackGroup("id", logger, 2)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				close(tickRunning)
+				<-release
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+			callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
+			callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c3, 1)
+				return true
+			})
+
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-tickRunning
+			// c1 is confirmed mid-execution (blocked on release). Register
+			// c4 now: it arrives after drainDue snapshotted the due set for
+			// this tick, so it will not be included in the current tick.
+			callbacks.Register("c4", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c4, 1)
+				return true
+			})
+			close(release)
+			<-chFinished
+
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c3))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c4))
+
+			assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c4))
+		})
 	})
 
 	t.Run("idle tick executes nothing", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			executedCounter2++
-			return true
-		}
-
+		var c1, c2 int64
 		callbacks := NewCallbackGroup("id", logger, 2)
-		callbacks.Register("c1", callback1, WithIntervals(NewFixedIntervals(time.Hour)))
-		callbacks.Register("c2", callback2, WithIntervals(NewFixedIntervals(time.Hour)))
-
-		// 1st tick: both callbacks due (registration allows immediate execution)
-		executed := callbacks.CycleCallback(shouldNotAbort)
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-
-		// 2nd tick: intervals not elapsed, nothing due
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		assert.False(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-	})
-
-	t.Run("idle tick prunes ids of unregistered callbacks", func(t *testing.T) {
-		callback := func(shouldAbort ShouldAbortCallback) bool { return true }
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback)
-		ctrl2 := callbacks.Register("c2", callback)
-
-		require.NoError(t, ctrl1.Unregister(context.Background()))
-		require.NoError(t, ctrl2.Unregister(context.Background()))
-
-		executed := callbacks.CycleCallback(shouldNotAbort)
-
-		assert.False(t, executed)
-		assert.Empty(t, callbacks.(*cycleCallbackGroup).dueHeap)
-	})
-
-	t.Run("run with intervals", func(T *testing.T) {
-		ticker := NewFixedTicker(10 * time.Millisecond)
-		intervals2 := NewSeriesIntervals([]time.Duration{
-			10 * time.Millisecond, 30 * time.Millisecond, 50 * time.Millisecond,
-		})
-		intervals3 := NewFixedIntervals(60 * time.Millisecond)
-		now := time.Now()
-
-		executionTimes1 := []time.Duration{}
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			executionTimes1 = append(executionTimes1, time.Since(now))
+		callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			atomic.AddInt64(&c1, 1)
 			return true
-		}
-		executionCounter2 := 0
-		executionTimes2 := []time.Duration{}
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			executionCounter2++
-			executionTimes2 = append(executionTimes2, time.Since(now))
-			// reports executed every 3 calls, should result in 10, 30, 50, 50, 10, 30, 50, 50, ... intervals
-			return executionCounter2%4 == 0
-		}
-		executionTimes3 := []time.Duration{}
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			executionTimes3 = append(executionTimes3, time.Since(now))
+		}, WithIntervals(NewFixedIntervals(time.Hour)))
+		callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			atomic.AddInt64(&c2, 1)
 			return true
-		}
+		}, WithIntervals(NewFixedIntervals(time.Hour)))
 
-		callbacks := NewCallbackGroup("id", logger, 2)
-		// should be called on every tick, with 10 intervals
-		callbacks.Register("c1", callback1)
-		// should be called with 10, 30, 50, 50, 10, 30, 50, 50, ... intervals
-		callbacks.Register("c2", callback2, WithIntervals(intervals2))
-		// should be called with 60, 60, ... intervals
-		callbacks.Register("c3", callback3, WithIntervals(intervals3))
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
 
-		cm := NewManager("test", ticker, callbacks.CycleCallback, logger)
-		cm.Start()
-		time.Sleep(400 * time.Millisecond)
-		cm.StopAndWait(context.Background())
-
-		// within 400 ms c1 should be called at least 30x
-		require.GreaterOrEqual(t, len(executionTimes1), 30)
-		// 1st call on 1st tick after 10ms
-		sumDuration := time.Duration(10)
-		for i := 0; i < 30; i++ {
-			assert.GreaterOrEqual(t, executionTimes1[i], sumDuration)
-			sumDuration += 10 * time.Millisecond
-		}
-
-		// within 400 ms c2 should be called at least 8x
-		require.GreaterOrEqual(t, len(executionTimes2), 8)
-		// 1st call on 1st tick after 10ms
-		sumDuration = time.Duration(0)
-		for i := 0; i < 8; i++ {
-			assert.GreaterOrEqual(t, executionTimes2[i], sumDuration)
-			switch (i + 1) % 4 {
-			case 0:
-				sumDuration += 10 * time.Millisecond
-			case 1:
-				sumDuration += 30 * time.Millisecond
-			case 2, 3:
-				sumDuration += 50 * time.Millisecond
-			}
-		}
-
-		// within 400 ms c3 should be called at least 6x
-		require.GreaterOrEqual(t, len(executionTimes3), 6)
-		// 1st call on 1st tick after 10ms
-		sumDuration = time.Duration(0)
-		for i := 0; i < 6; i++ {
-			assert.GreaterOrEqual(t, executionTimes3[i], sumDuration)
-			sumDuration += 60 * time.Millisecond
-		}
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
 	})
 }
 
@@ -332,189 +204,35 @@ func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
-	t.Run("1 executable callback, 1 unregistered", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
+	t.Run("1 executable callback 1 unregistered", func(t *testing.T) {
+		var counter int64
 		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl := callbacks.Register("c1", callback)
+		ctrl := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&counter, 1)
+			return true
+		})
 		require.Nil(t, ctrl.Unregister(ctx))
 
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&counter))
 	})
 
-	t.Run("2 executable callbacks, 2 unregistered", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		require.Nil(t, ctrl1.Unregister(ctx))
-		require.Nil(t, ctrl2.Unregister(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
-	})
-
-	t.Run("2 executable callbacks, 1 unregistered", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-		require.Nil(t, ctrl1.Unregister(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.True(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
-	})
-
-	t.Run("4 executable callbacks, all unregistered at different time", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		executedCounter4 := 0
-		callback4 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter4++
-			return true
-		}
-		var executed1 bool
-		var executed2 bool
-		var executed3 bool
-		var executed4 bool
-		var d1 time.Duration
-		var d2 time.Duration
-		var d3 time.Duration
-		var d4 time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-		ctrl4 := callbacks.Register("c4", callback4)
-		require.Nil(t, ctrl3.Unregister(ctx))
-
-		start := time.Now()
-		executed1 = callbacks.CycleCallback(shouldNotAbort)
-		d1 = time.Since(start)
-
-		require.Nil(t, ctrl1.Unregister(ctx))
-
-		start = time.Now()
-		executed2 = callbacks.CycleCallback(shouldNotAbort)
-		d2 = time.Since(start)
-
-		require.Nil(t, ctrl4.Unregister(ctx))
-
-		start = time.Now()
-		executed3 = callbacks.CycleCallback(shouldNotAbort)
-		d3 = time.Since(start)
-
-		require.Nil(t, ctrl2.Unregister(ctx))
-
-		start = time.Now()
-		executed4 = callbacks.CycleCallback(shouldNotAbort)
-		d4 = time.Since(start)
-
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.True(t, executed3)
-		assert.False(t, executed4)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 3, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.Equal(t, 2, executedCounter4)
-		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 25*time.Millisecond)
-		assert.GreaterOrEqual(t, d3, 25*time.Millisecond)
-		assert.GreaterOrEqual(t, d4, 0*time.Millisecond)
-	})
-
-	t.Run("unregister is waiting till the end of execution", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
+	t.Run("unregister is waiting till end of execution", func(t *testing.T) {
+		var counter int64
 		chStarted := make(chan struct{}, 1)
 		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
 
 		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl := callbacks.Register("c", callback)
+		ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&counter, 1)
+			return true
+		})
 
 		go func() {
 			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
+			callbacks.CycleCallback(shouldNotAbort)
 			chFinished <- struct{}{}
 		}()
 		<-chStarted
@@ -524,180 +242,175 @@ func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 		du := time.Since(start)
 		<-chFinished
 
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
+		assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
 		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
 	})
 
 	t.Run("unregister fails due to context timeout", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
+		var counter int64
 		chStarted := make(chan struct{}, 1)
 		chFinished := make(chan struct{}, 1)
-		var executed1 bool
-		var executed2 bool
-		var d1 time.Duration
-		var d2 time.Duration
 
 		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl := callbacks.Register("c", callback)
+		ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&counter, 1)
+			return true
+		})
 
 		go func() {
 			chStarted <- struct{}{}
-			start := time.Now()
-			executed1 = callbacks.CycleCallback(shouldNotAbort)
-			d1 = time.Since(start)
+			callbacks.CycleCallback(shouldNotAbort)
 			chFinished <- struct{}{}
 		}()
 		<-chStarted
-		start := time.Now()
 		time.Sleep(25 * time.Millisecond)
 		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
 		defer cancel()
 		require.NotNil(t, ctrl.Unregister(ctxTimeout))
-		du := time.Since(start)
 		<-chFinished
 
+		assert.True(t, ctrl.IsActive())
 		go func() {
-			start := time.Now()
-			executed2 = callbacks.CycleCallback(shouldNotAbort)
-			d2 = time.Since(start)
+			callbacks.CycleCallback(shouldNotAbort)
 			chFinished <- struct{}{}
 		}()
 		<-chFinished
 
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.Equal(t, 2, executedCounter)
-		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
+		assert.Equal(t, int64(2), atomic.LoadInt64(&counter))
 	})
 
-	t.Run("unregister 3rd and 4th while executing", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		executedCounter4 := 0
-		callback4 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter4++
-			return true
-		}
+	t.Run("unregister while running cooperative abort", func(t *testing.T) {
+		var counter int64
+		max := int64(25)
 		chStarted := make(chan struct{}, 1)
 		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
 
 		callbacks := NewCallbackGroup("id", logger, 2)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-		ctrl4 := callbacks.Register("c4", callback4)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl3.Unregister(ctx))
-		require.Nil(t, ctrl4.Unregister(ctx))
-		<-chFinished
-
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.Equal(t, 0, executedCounter3)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-	})
-
-	t.Run("unregister while running", func(t *testing.T) {
-		counter1 := 0
-		counter2 := 0
-		max := 25
-
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+		ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
 			for {
 				if shouldAbort() {
 					return false
 				}
-
 				time.Sleep(10 * time.Millisecond)
-				counter1++
-
-				// 10ms * 25 = 250ms
-				if counter1 > max {
+				atomic.AddInt64(&counter, 1)
+				if atomic.LoadInt64(&counter) > max {
 					return true
 				}
 			}
-		}
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			for {
-				if shouldAbort() {
-					return false
-				}
-
-				time.Sleep(10 * time.Millisecond)
-				counter2++
-
-				// 10ms * 25 = 250ms
-				if counter2 > max {
-					return true
-				}
-			}
-		}
-
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
+		})
 
 		go func() {
 			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
+			callbacks.CycleCallback(shouldNotAbort)
 			chFinished <- struct{}{}
 		}()
 		<-chStarted
 		time.Sleep(50 * time.Millisecond)
-		require.NoError(t, ctrl1.Unregister(ctx))
-		require.NoError(t, ctrl2.Unregister(ctx))
+		require.NoError(t, ctrl.Unregister(ctx))
 		<-chFinished
 
-		assert.False(t, executed)
-		assert.LessOrEqual(t, counter1, max)
-		assert.LessOrEqual(t, counter2, max)
-		assert.LessOrEqual(t, d, 200*time.Millisecond)
+		assert.LessOrEqual(t, atomic.LoadInt64(&counter), max)
+	})
+
+	t.Run("2 all unregistered 0 executed", func(t *testing.T) {
+		var c1, c2 int64
+		callbacks := NewCallbackGroup("id", logger, 2)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
+		require.Nil(t, ctrl1.Unregister(ctx))
+		require.Nil(t, ctrl2.Unregister(ctx))
+
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
+	})
+
+	t.Run("1 of 2 unregistered 1 executed", func(t *testing.T) {
+		var c1, c2 int64
+		callbacks := NewCallbackGroup("id", logger, 2)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
+		require.Nil(t, ctrl1.Unregister(ctx))
+
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+	})
+
+	t.Run("unregister 3rd and 4th while executing", func(t *testing.T) {
+		var c1, c2, c3, c4 int64
+
+		synctest.Test(t, func(t *testing.T) {
+			// tickRunning is closed by c1 on its first execution, confirming
+			// drainDue has already snapshotted the due set for that tick. c3
+			// and c4 are registered only after that signal, so they are absent
+			// from the first tick's due slice. Unregister removes them before
+			// any future tick can dispatch them.
+			tickRunning := make(chan struct{})
+			var once sync.Once
+			release := make(chan struct{})
+			chFinished := make(chan struct{}, 1)
+
+			callbacks := NewCallbackGroup("id", logger, 2)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				once.Do(func() { close(tickRunning) })
+				<-release
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+			callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				<-release
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
+
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-tickRunning
+
+			// c1 is confirmed executing; drainDue already returned [c1, c2].
+			// c3 and c4 registered now are not in this tick's dispatch set.
+			ctrl3 := callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c3, 1)
+				return true
+			})
+			ctrl4 := callbacks.Register("c4", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c4, 1)
+				return true
+			})
+			require.Nil(t, ctrl3.Unregister(ctx))
+			require.Nil(t, ctrl4.Unregister(ctx))
+
+			// release lets c1 and c2 finish tick 1; closed channel unblocks
+			// c1 and c2 again in tick 2 without stalling.
+			close(release)
+			<-chFinished
+
+			assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, int64(2), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(2), atomic.LoadInt64(&c2))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c4))
+		})
 	})
 }
 
@@ -706,393 +419,220 @@ func TestCycleCallback_Parallel_Deactivate(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
-	t.Run("1 executable callback, 1 deactivated", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
+	t.Run("1 executable callback 1 deactivated", func(t *testing.T) {
+		var counter int64
 		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl := callbacks.Register("c1", callback)
+		ctrl := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&counter, 1)
+			return true
+		})
 		require.Nil(t, ctrl.Deactivate(ctx))
 
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&counter))
 	})
 
-	t.Run("2 executable callbacks, 2 deactivated", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		require.Nil(t, ctrl1.Deactivate(ctx))
-		require.Nil(t, ctrl2.Deactivate(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
-	})
-
-	t.Run("2 executable callbacks, 1 deactivated", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-		require.Nil(t, ctrl1.Deactivate(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.True(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
-	})
-
-	t.Run("4 executable callbacks, all deactivated at different time", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		executedCounter4 := 0
-		callback4 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter4++
-			return true
-		}
-		var executed1 bool
-		var executed2 bool
-		var executed3 bool
-		var executed4 bool
-		var d1 time.Duration
-		var d2 time.Duration
-		var d3 time.Duration
-		var d4 time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-		ctrl4 := callbacks.Register("c4", callback4)
-		require.Nil(t, ctrl3.Deactivate(ctx))
-
-		start := time.Now()
-		executed1 = callbacks.CycleCallback(shouldNotAbort)
-		d1 = time.Since(start)
-
-		require.Nil(t, ctrl1.Deactivate(ctx))
-
-		start = time.Now()
-		executed2 = callbacks.CycleCallback(shouldNotAbort)
-		d2 = time.Since(start)
-
-		require.Nil(t, ctrl4.Deactivate(ctx))
-
-		start = time.Now()
-		executed3 = callbacks.CycleCallback(shouldNotAbort)
-		d3 = time.Since(start)
-
-		require.Nil(t, ctrl2.Deactivate(ctx))
-
-		start = time.Now()
-		executed4 = callbacks.CycleCallback(shouldNotAbort)
-		d4 = time.Since(start)
-
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.True(t, executed3)
-		assert.False(t, executed4)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 3, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.Equal(t, 2, executedCounter4)
-		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 25*time.Millisecond)
-		assert.GreaterOrEqual(t, d3, 25*time.Millisecond)
-		assert.GreaterOrEqual(t, d4, 0*time.Millisecond)
-	})
-
-	t.Run("deactivate is waiting till the end of execution", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
+	t.Run("deactivate is waiting till end of execution", func(t *testing.T) {
+		var counter int64
 		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
 
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl := callbacks.Register("c", callback)
+		synctest.Test(t, func(t *testing.T) {
+			started := make(chan struct{}, 1)
+			release := make(chan struct{})
 
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		start := time.Now()
-		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl.Deactivate(ctx))
-		du := time.Since(start)
-		<-chFinished
+			callbacks := NewCallbackGroup("id", logger, 2)
+			ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+				started <- struct{}{}
+				<-release
+				atomic.AddInt64(&counter, 1)
+				return true
+			})
 
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-started
+			// Callback is mid-execution. Deactivate blocks on the done
+			// channel until the callback finishes. Releasing it in a
+			// goroutine lets both the callback and Deactivate complete.
+			// When Deactivate returns, counter==1 proves it waited for the
+			// callback to run to completion (its last act before returning).
+			go func() { close(release) }()
+			require.Nil(t, ctrl.Deactivate(ctx))
+			<-chFinished
+
+			assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+		})
 	})
 
 	t.Run("deactivate fails due to context timeout", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
+		var counter int64
 		chFinished := make(chan struct{}, 1)
-		var executed1 bool
-		var executed2 bool
-		var d1 time.Duration
-		var d2 time.Duration
 
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl := callbacks.Register("c", callback)
+		synctest.Test(t, func(t *testing.T) {
+			started := make(chan struct{}, 1)
+			release := make(chan struct{})
 
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed1 = callbacks.CycleCallback(shouldNotAbort)
-			d1 = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		start := time.Now()
-		time.Sleep(25 * time.Millisecond)
-		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cancel()
-		require.NotNil(t, ctrl.Deactivate(ctxTimeout))
-		du := time.Since(start)
-		<-chFinished
-
-		go func() {
-			start := time.Now()
-			executed2 = callbacks.CycleCallback(shouldNotAbort)
-			d2 = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chFinished
-
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.Equal(t, 2, executedCounter)
-		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
-	})
-
-	t.Run("deactivate 3rd and 4th while executing", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		executedCounter4 := 0
-		callback4 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter4++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-		ctrl4 := callbacks.Register("c4", callback4)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl3.Deactivate(ctx))
-		require.Nil(t, ctrl4.Deactivate(ctx))
-		<-chFinished
-
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.Equal(t, 0, executedCounter3)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-	})
-
-	t.Run("deactivate while running", func(t *testing.T) {
-		counter1 := 0
-		counter2 := 0
-		max := 25
-
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			for {
-				if shouldAbort() {
-					return false
-				}
-
-				time.Sleep(10 * time.Millisecond)
-				counter1++
-
-				// 10ms * 25 = 250ms
-				if counter1 > max {
-					return true
-				}
-			}
-		}
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			for {
-				if shouldAbort() {
-					return false
-				}
-
-				time.Sleep(10 * time.Millisecond)
-				counter2++
-
-				// 10ms * 25 = 250ms
-				if counter2 > max {
-					return true
-				}
-			}
-		}
-
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(50 * time.Millisecond)
-		require.NoError(t, ctrl1.Deactivate(ctx))
-		require.NoError(t, ctrl2.Deactivate(ctx))
-		<-chFinished
-
-		assert.False(t, executed)
-		assert.LessOrEqual(t, counter1, max)
-		assert.LessOrEqual(t, counter2, max)
-		assert.LessOrEqual(t, d, 200*time.Millisecond)
-
-		t.Run("does not abort after activated back again", func(t *testing.T) {
-			require.NoError(t, ctrl1.Activate())
-			require.NoError(t, ctrl2.Activate())
-
-			counter1 = 0
-			counter2 = 0
-			max = 10
+			callbacks := NewCallbackGroup("id", logger, 2)
+			ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+				started <- struct{}{}
+				<-release
+				atomic.AddInt64(&counter, 1)
+				return true
+			})
 
 			go func() {
-				start := time.Now()
-				executed = callbacks.CycleCallback(shouldNotAbort)
-				d = time.Since(start)
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-started
+			// Callback is mid-execution. The 5ms timeout expires before
+			// release is closed, so Deactivate returns non-nil.
+			ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+			defer cancel()
+			require.NotNil(t, ctrl.Deactivate(ctxTimeout))
+			close(release)
+			<-chFinished
+
+			assert.True(t, ctrl.IsActive())
+			chFinished2 := make(chan struct{}, 1)
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished2 <- struct{}{}
+			}()
+			<-chFinished2
+
+			assert.Equal(t, int64(2), atomic.LoadInt64(&counter))
+		})
+	})
+
+	t.Run("deactivate while running cooperative abort", func(t *testing.T) {
+		var counter int64
+		max := int64(25)
+		chFinished := make(chan struct{}, 1)
+
+		synctest.Test(t, func(t *testing.T) {
+			started := make(chan struct{}, 1)
+
+			callbacks := NewCallbackGroup("id", logger, 2)
+			ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+				started <- struct{}{}
+				for {
+					if shouldAbort() {
+						return false
+					}
+					time.Sleep(10 * time.Millisecond)
+					atomic.AddInt64(&counter, 1)
+					if atomic.LoadInt64(&counter) > max {
+						return true
+					}
+				}
+			})
+
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-started
+			// Callback is running and looping with 10ms fake sleeps.
+			// Deactivate sets abort=true; callback sees it on next check.
+			require.NoError(t, ctrl.Deactivate(ctx))
+			<-chFinished
+
+			assert.LessOrEqual(t, atomic.LoadInt64(&counter), max)
+		})
+	})
+
+	// t.Run cannot be nested inside a synctest bubble. This sub-test
+	// verifies the same callback (registered fresh here) does not abort
+	// after being activated, exercising the activate/run sequence
+	// independently of the deactivate scenario above.
+	t.Run("deactivate while running cooperative abort/does not abort after being reactivated", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			var counter int64
+			chFinished := make(chan struct{}, 1)
+
+			callbacks := NewCallbackGroup("id", logger, 2)
+			ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+				for {
+					if shouldAbort() {
+						return false
+					}
+					time.Sleep(10 * time.Millisecond)
+					atomic.AddInt64(&counter, 1)
+					if atomic.LoadInt64(&counter) > 10 {
+						return true
+					}
+				}
+			})
+			// Deactivate immediately so we can test re-activation.
+			require.NoError(t, ctrl.Deactivate(ctx))
+			require.NoError(t, ctrl.Activate())
+
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
 				chFinished <- struct{}{}
 			}()
 			<-chFinished
 
-			assert.True(t, executed)
-			assert.Greater(t, counter1, max)
-			assert.Greater(t, counter2, max)
-			assert.GreaterOrEqual(t, d, 100*time.Millisecond)
+			assert.Greater(t, atomic.LoadInt64(&counter), int64(10))
+		})
+	})
+
+	t.Run("deactivate 3rd and 4th while 1st and 2nd are executing", func(t *testing.T) {
+		var c1, c2, c3, c4 int64
+
+		synctest.Test(t, func(t *testing.T) {
+			// tickRunning is closed by c1 when it begins, confirming drainDue
+			// has already snapshotted the due set for this tick. c3 and c4 are
+			// registered only after that signal, so they are absent from the
+			// current tick's due slice. Deactivate sets active=false immediately
+			// (they are not running), preventing any future tick from running them.
+			tickRunning := make(chan struct{})
+			release := make(chan struct{})
+			chFinished := make(chan struct{}, 1)
+
+			callbacks := NewCallbackGroup("id", logger, 2)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				close(tickRunning)
+				<-release
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+			callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				<-release
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
+
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-tickRunning
+
+			// c1 is confirmed executing; drainDue already returned [c1, c2].
+			// c3 and c4 registered now are not in this tick's dispatch set.
+			ctrl3 := callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c3, 1)
+				return true
+			})
+			ctrl4 := callbacks.Register("c4", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c4, 1)
+				return true
+			})
+			require.Nil(t, ctrl3.Deactivate(ctx))
+			require.Nil(t, ctrl4.Deactivate(ctx))
+
+			close(release)
+			<-chFinished
+
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c4))
 		})
 	})
 }
@@ -1102,229 +642,61 @@ func TestCycleCallback_Sequential(t *testing.T) {
 	shouldNotAbort := func() bool { return false }
 
 	t.Run("no callbacks", func(t *testing.T) {
-		var executed bool
-
 		callbacks := NewCallbackGroup("id", logger, 1)
-
-		executed = callbacks.CycleCallback(shouldNotAbort)
-
-		assert.False(t, executed)
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 	})
 
 	t.Run("2 executable callbacks", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
+		var c1, c2 int64
 
-		callbacks := NewCallbackGroup("id", logger, 1)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
+		synctest.Test(t, func(t *testing.T) {
+			callbacks := NewCallbackGroup("id", logger, 1)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				time.Sleep(50 * time.Millisecond)
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+			callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				time.Sleep(25 * time.Millisecond)
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
 
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 75*time.Millisecond)
-	})
-
-	t.Run("2 non-executable callbacks", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(10 * time.Millisecond)
-			executedCounter1++
-			return false
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(10 * time.Millisecond)
-			executedCounter2++
-			return false
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 10*time.Millisecond)
-	})
-
-	t.Run("2 executable callbacks, not executed due to should abort", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		shouldAbortCounter := 0
-		shouldAbort := func() bool {
-			shouldAbortCounter++
-			return shouldAbortCounter > 1
-		}
-
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldAbort)
-		d = time.Since(start)
-
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
-	})
-
-	t.Run("register new while executing runs it on the next tick", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		callbacks.Register("c1", callback1)
-
-		// register 2nd callback while the 1st is executing. The tick dispatches
-		// the callbacks due when it started (c1), so the 2nd is not part of it.
-		go func() {
-			chStarted <- struct{}{}
 			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(25 * time.Millisecond)
-		callbacks.Register("c2", callback2)
-		<-chFinished
+			executed := callbacks.CycleCallback(shouldNotAbort)
+			d := time.Since(start)
 
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-
-		// the next tick picks up the 2nd callback
-		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-		assert.Equal(t, 1, executedCounter2)
+			assert.True(t, executed)
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+			assert.GreaterOrEqual(t, d, 75*time.Millisecond)
+		})
 	})
 
-	t.Run("run with intervals", func(T *testing.T) {
-		ticker := NewFixedTicker(10 * time.Millisecond)
-		intervals2 := NewSeriesIntervals([]time.Duration{
-			10 * time.Millisecond, 30 * time.Millisecond, 50 * time.Millisecond,
-		})
-		intervals3 := NewFixedIntervals(60 * time.Millisecond)
-		now := time.Now()
-
-		executionTimes1 := []time.Duration{}
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			executionTimes1 = append(executionTimes1, time.Since(now))
-			return true
+	t.Run("2 executable callbacks not executed due to abort", func(t *testing.T) {
+		var c1, c2 int64
+		abortCtr := 0
+		shouldAbort := func() bool {
+			abortCtr++
+			return abortCtr > 1
 		}
-		executionCounter2 := 0
-		executionTimes2 := []time.Duration{}
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			executionCounter2++
-			executionTimes2 = append(executionTimes2, time.Since(now))
-			// reports executed every 3 calls, should result in 10, 30, 50, 50, 10, 30, 50, 50, ... intervals
-			return executionCounter2%4 == 0
-		}
-		executionTimes3 := []time.Duration{}
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			executionTimes3 = append(executionTimes3, time.Since(now))
-			return true
-		}
-
 		callbacks := NewCallbackGroup("id", logger, 1)
-		// should be called on every tick, with 10 intervals
-		callbacks.Register("c1", callback1)
-		// should be called with 10, 30, 50, 50, 10, 30, 50, 50, ... intervals
-		callbacks.Register("c2", callback2, WithIntervals(intervals2))
-		// should be called with 60, 60, ... intervals
-		callbacks.Register("c3", callback3, WithIntervals(intervals3))
+		callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
 
-		cm := NewManager("test", ticker, callbacks.CycleCallback, logger)
-		cm.Start()
-		time.Sleep(400 * time.Millisecond)
-		cm.StopAndWait(context.Background())
+		executed := callbacks.CycleCallback(shouldAbort)
 
-		// within 400 ms c1 should be called at least 30x
-		require.GreaterOrEqual(t, len(executionTimes1), 30)
-		// 1st call on 1st tick after 10ms
-		sumDuration := time.Duration(10)
-		for i := 0; i < 30; i++ {
-			assert.GreaterOrEqual(t, executionTimes1[i], sumDuration)
-			sumDuration += 10 * time.Millisecond
-		}
-
-		// within 400 ms c2 should be called at least 8x
-		require.GreaterOrEqual(t, len(executionTimes2), 8)
-		// 1st call on 1st tick after 10ms
-		sumDuration = time.Duration(0)
-		for i := 0; i < 8; i++ {
-			assert.GreaterOrEqual(t, executionTimes2[i], sumDuration)
-			switch (i + 1) % 4 {
-			case 0:
-				sumDuration += 10 * time.Millisecond
-			case 1:
-				sumDuration += 30 * time.Millisecond
-			case 2, 3:
-				sumDuration += 50 * time.Millisecond
-			}
-		}
-
-		// within 400 ms c3 should be called at least 6x
-		require.GreaterOrEqual(t, len(executionTimes3), 6)
-		// 1st call on 1st tick after 10ms
-		sumDuration = time.Duration(0)
-		for i := 0; i < 6; i++ {
-			assert.GreaterOrEqual(t, executionTimes3[i], sumDuration)
-			sumDuration += 60 * time.Millisecond
-		}
+		assert.True(t, executed)
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
 	})
 }
 
@@ -1333,347 +705,412 @@ func TestCycleCallback_Sequential_Unregister(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
-	t.Run("1 executable callback, 1 unregistered", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
+	t.Run("2 all unregistered 0 executed", func(t *testing.T) {
+		var c1, c2 int64
 		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c1", callback)
-		require.Nil(t, ctrl.Unregister(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
-	})
-
-	t.Run("2 executable callbacks, 2 unregistered", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
 			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
+			atomic.AddInt64(&c1, 1)
 			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
+		})
+		ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
 			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
+			atomic.AddInt64(&c2, 1)
 			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
+		})
 		require.Nil(t, ctrl1.Unregister(ctx))
 		require.Nil(t, ctrl2.Unregister(ctx))
 
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
 	})
 
-	t.Run("2 executable callbacks, 1 unregistered", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
+	t.Run("1 of 2 unregistered 1 executed", func(t *testing.T) {
+		var c1, c2 int64
 		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl1 := callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
 		require.Nil(t, ctrl1.Unregister(ctx))
 
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.True(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
 	})
 
-	t.Run("4 executable callbacks, all unregistered at different time", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		executedCounter4 := 0
-		callback4 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter4++
-			return true
-		}
-		var executed1 bool
-		var executed2 bool
-		var executed3 bool
-		var executed4 bool
-		var d1 time.Duration
-		var d2 time.Duration
-		var d3 time.Duration
-		var d4 time.Duration
-
+	t.Run("4 unregistered at different ticks", func(t *testing.T) {
+		var c1, c2, c3, c4 int64
 		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-		ctrl4 := callbacks.Register("c4", callback4)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
+		ctrl3 := callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c3, 1)
+			return true
+		})
+		ctrl4 := callbacks.Register("c4", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c4, 1)
+			return true
+		})
 		require.Nil(t, ctrl3.Unregister(ctx))
 
-		start := time.Now()
-		executed1 = callbacks.CycleCallback(shouldNotAbort)
-		d1 = time.Since(start)
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c4))
 
 		require.Nil(t, ctrl1.Unregister(ctx))
 
-		start = time.Now()
-		executed2 = callbacks.CycleCallback(shouldNotAbort)
-		d2 = time.Since(start)
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(2), atomic.LoadInt64(&c2))
+		assert.Equal(t, int64(2), atomic.LoadInt64(&c4))
 
 		require.Nil(t, ctrl4.Unregister(ctx))
 
-		start = time.Now()
-		executed3 = callbacks.CycleCallback(shouldNotAbort)
-		d3 = time.Since(start)
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(3), atomic.LoadInt64(&c2))
 
 		require.Nil(t, ctrl2.Unregister(ctx))
 
-		start = time.Now()
-		executed4 = callbacks.CycleCallback(shouldNotAbort)
-		d4 = time.Since(start)
-
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.True(t, executed3)
-		assert.False(t, executed4)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 3, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.Equal(t, 2, executedCounter4)
-		assert.GreaterOrEqual(t, d1, 75*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d3, 25*time.Millisecond)
-		assert.GreaterOrEqual(t, d4, 0*time.Millisecond)
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 	})
 
-	t.Run("unregister is waiting till the end of execution", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
+	t.Run("unregister 2nd and 3rd while 1st is executing", func(t *testing.T) {
+		var c1, c2, c3 int64
 		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
 
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c", callback)
+		synctest.Test(t, func(t *testing.T) {
+			started := make(chan struct{}, 1)
+			release := make(chan struct{})
 
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		start := time.Now()
-		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl.Unregister(ctx))
-		du := time.Since(start)
-		<-chFinished
+			callbacks := NewCallbackGroup("id", logger, 1)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				started <- struct{}{}
+				<-release
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+			ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
+			ctrl3 := callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c3, 1)
+				return true
+			})
 
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
-	})
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-started
+			// c1 is running (sequential mode); c2 and c3 are not yet
+			// dispatched. Unregister sees running=false for both and
+			// deletes them immediately under the lock.
+			require.Nil(t, ctrl2.Unregister(ctx))
+			require.Nil(t, ctrl3.Unregister(ctx))
+			close(release)
+			<-chFinished
 
-	t.Run("unregister fails due to context timeout", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed1 bool
-		var executed2 bool
-		var d1 time.Duration
-		var d2 time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c", callback)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed1 = callbacks.CycleCallback(shouldNotAbort)
-			d1 = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		start := time.Now()
-		time.Sleep(25 * time.Millisecond)
-		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cancel()
-		require.NotNil(t, ctrl.Unregister(ctxTimeout))
-		du := time.Since(start)
-		<-chFinished
-
-		go func() {
-			start := time.Now()
-			executed2 = callbacks.CycleCallback(shouldNotAbort)
-			d2 = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chFinished
-
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.Equal(t, 2, executedCounter)
-		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
-	})
-
-	t.Run("unregister 2nd and 3rd while executing", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl2.Unregister(ctx))
-		require.Nil(t, ctrl3.Unregister(ctx))
-		<-chFinished
-
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-	})
-
-	t.Run("unregister while running", func(t *testing.T) {
-		counter := 0
-		max := 25
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			for {
-				if shouldAbort() {
-					return false
-				}
-
-				time.Sleep(10 * time.Millisecond)
-				counter++
-
-				// 10ms * 25 = 250ms
-				if counter > max {
-					return true
-				}
-			}
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c", callback)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(50 * time.Millisecond)
-		require.NoError(t, ctrl.Unregister(ctx))
-		<-chFinished
-
-		assert.False(t, executed)
-		assert.LessOrEqual(t, counter, max)
-		assert.LessOrEqual(t, d, 200*time.Millisecond)
+			assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, int64(2), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
+		})
 	})
 }
 
-func TestCycleCallback_Parallel_DueDispatch(t *testing.T) {
+func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	t.Run("2 all deactivated 0 executed", func(t *testing.T) {
+		var c1, c2 int64
+		callbacks := NewCallbackGroup("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
+		require.Nil(t, ctrl1.Deactivate(ctx))
+		require.Nil(t, ctrl2.Deactivate(ctx))
+
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
+	})
+
+	t.Run("1 of 2 deactivated 1 executed", func(t *testing.T) {
+		var c1, c2 int64
+		callbacks := NewCallbackGroup("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
+		require.Nil(t, ctrl1.Deactivate(ctx))
+
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+	})
+
+	t.Run("4 deactivated at different ticks", func(t *testing.T) {
+		var c1, c2, c3, c4 int64
+		callbacks := NewCallbackGroup("id", logger, 1)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c1, 1)
+			return true
+		})
+		ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c2, 1)
+			return true
+		})
+		ctrl3 := callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c3, 1)
+			return true
+		})
+		ctrl4 := callbacks.Register("c4", func(shouldAbort ShouldAbortCallback) bool {
+			time.Sleep(25 * time.Millisecond)
+			atomic.AddInt64(&c4, 1)
+			return true
+		})
+		require.Nil(t, ctrl3.Deactivate(ctx))
+
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c4))
+
+		require.Nil(t, ctrl1.Deactivate(ctx))
+
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+		assert.Equal(t, int64(2), atomic.LoadInt64(&c2))
+		assert.Equal(t, int64(2), atomic.LoadInt64(&c4))
+
+		require.Nil(t, ctrl4.Deactivate(ctx))
+
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(3), atomic.LoadInt64(&c2))
+
+		require.Nil(t, ctrl2.Deactivate(ctx))
+
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+	})
+
+	t.Run("deactivate 2nd and 3rd while 1st is executing", func(t *testing.T) {
+		var c1, c2, c3 int64
+		chFinished := make(chan struct{}, 1)
+
+		synctest.Test(t, func(t *testing.T) {
+			started := make(chan struct{}, 1)
+			release := make(chan struct{})
+
+			callbacks := NewCallbackGroup("id", logger, 1)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				started <- struct{}{}
+				<-release
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+			ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
+			ctrl3 := callbacks.Register("c3", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c3, 1)
+				return true
+			})
+
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-started
+			// c1 is running (sequential mode); c2 and c3 are queued but
+			// not dispatched. Deactivate sees running=false for both and
+			// commits active=false immediately under the lock.
+			require.Nil(t, ctrl2.Deactivate(ctx))
+			require.Nil(t, ctrl3.Deactivate(ctx))
+			close(release)
+			<-chFinished
+
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
+		})
+	})
+}
+
+func TestCycleCallback_DueHeap(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	modes := []struct {
+		name     string
+		routines int
+	}{
+		{"sequential", 1},
+		{"parallel", 4},
+	}
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			t.Run("always-due entry runs every tick", func(t *testing.T) {
+				var counter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				callbacks.Register("always", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&counter, 1)
+					return true
+				})
+
+				for tick := int64(1); tick <= 3; tick++ {
+					assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+					assert.Equal(t, tick, atomic.LoadInt64(&counter))
+				}
+			})
+
+			t.Run("only due entries run", func(t *testing.T) {
+				var alwaysCounter, longCounter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				callbacks.Register("always", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&alwaysCounter, 1)
+					return true
+				})
+				callbacks.Register("long", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&longCounter, 1)
+					return true
+				}, WithIntervals(NewFixedIntervals(time.Hour)))
+
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&alwaysCounter))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&longCounter))
+
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(2), atomic.LoadInt64(&alwaysCounter))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&longCounter))
+			})
+
+			t.Run("activate after deactivate runs once", func(t *testing.T) {
+				var counter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&counter, 1)
+					return true
+				})
+				require.NoError(t, ctrl.Deactivate(context.Background()))
+				require.NoError(t, ctrl.Activate())
+
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+
+				// second tick: entry was rescheduled, runs again
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(2), atomic.LoadInt64(&counter))
+			})
+
+			t.Run("panicking callback is contained and rescheduled", func(t *testing.T) {
+				const siblings = 4
+				var okCounter, panicCounter int64
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				for i := 0; i < siblings; i++ {
+					callbacks.Register(fmt.Sprintf("ok%d", i), func(shouldAbort ShouldAbortCallback) bool {
+						atomic.AddInt64(&okCounter, 1)
+						return true
+					})
+				}
+				callbacks.Register("panic", func(shouldAbort ShouldAbortCallback) bool {
+					atomic.AddInt64(&panicCounter, 1)
+					panic("boom")
+				})
+
+				callbacks.CycleCallback(shouldNotAbort)
+				assert.Equal(t, int64(siblings), atomic.LoadInt64(&okCounter))
+				assert.Equal(t, int64(1), atomic.LoadInt64(&panicCounter))
+
+				callbacks.CycleCallback(shouldNotAbort)
+				assert.Equal(t, int64(2), atomic.LoadInt64(&panicCounter))
+			})
+
+			t.Run("panic does not advance intervals", func(t *testing.T) {
+				// Use a two-step series so Advance() is observable via Get().
+				intervals := NewSeriesIntervals([]time.Duration{
+					10 * time.Millisecond, 20 * time.Millisecond,
+				})
+				intervalBefore := intervals.Get()
+
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				callbacks.Register("panic", func(shouldAbort ShouldAbortCallback) bool {
+					panic("boom")
+				}, WithIntervals(intervals))
+
+				callbacks.CycleCallback(shouldNotAbort)
+
+				// Advance must NOT have been called: Get() returns the same value.
+				assert.Equal(t, intervalBefore, intervals.Get())
+			})
+
+			t.Run("abort then deactivate does not resurrect", func(t *testing.T) {
+				const total = 4
+				counters := make([]int64, total)
+				callbacks := NewCallbackGroup("id", logger, mode.routines)
+				ctrls := make([]CycleCallbackCtrl, total)
+				for i := 0; i < total; i++ {
+					idx := i
+					ctrls[i] = callbacks.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+						atomic.AddInt64(&counters[idx], 1)
+						return true
+					})
+				}
+
+				assert.False(t, callbacks.CycleCallback(func() bool { return true }))
+				require.NoError(t, ctrls[0].Deactivate(context.Background()))
+
+				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+				assert.Equal(t, int64(0), atomic.LoadInt64(&counters[0]))
+				for i := 1; i < total; i++ {
+					assert.Equal(t, int64(1), atomic.LoadInt64(&counters[i]))
+				}
+			})
+		})
+	}
+}
+
+func TestCycleCallback_DueDispatch(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
 
@@ -1682,8 +1119,6 @@ func TestCycleCallback_Parallel_DueDispatch(t *testing.T) {
 		var executed int64
 
 		callbacks := NewCallbackGroup("id", logger, 4)
-		// long interval: due on the first tick (registration allows immediate
-		// execution), not due afterwards
 		for i := 0; i < total; i++ {
 			callbacks.Register(fmt.Sprintf("c%d", i),
 				func(shouldAbort ShouldAbortCallback) bool {
@@ -1692,13 +1127,51 @@ func TestCycleCallback_Parallel_DueDispatch(t *testing.T) {
 				}, WithIntervals(NewFixedIntervals(time.Hour)))
 		}
 
-		// 1st tick: all due
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(total), atomic.LoadInt64(&executed))
 
-		// 2nd tick: none due, nothing runs
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(total), atomic.LoadInt64(&executed))
+	})
+
+	t.Run("WithIntervals callback runs immediately on the first tick", func(t *testing.T) {
+		var counter int64
+
+		callbacks := NewCallbackGroup("id", logger, 4)
+		callbacks.Register("c1",
+			func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&counter, 1)
+				return true
+			}, WithIntervals(NewFixedIntervals(time.Hour)))
+
+		// Despite the hour-long interval, WithIntervals back-dates the start time
+		// so the first run is due immediately.
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+
+		// The next tick is well within the interval, so it must not run again.
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+	})
+
+	t.Run("AsInactive callback is suppressed until activated", func(t *testing.T) {
+		var counter int64
+
+		callbacks := NewCallbackGroup("id", logger, 4)
+		ctrl := callbacks.Register("c1",
+			func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&counter, 1)
+				return true
+			}, AsInactive())
+
+		// Registered inactive: a tick finds nothing due to run.
+		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(0), atomic.LoadInt64(&counter))
+
+		// Once activated, the callback (nil intervals, always due) runs.
+		ctrl.Activate()
+		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
 	})
 
 	t.Run("concurrent register and unregister during cycles is race free", func(t *testing.T) {
@@ -1712,7 +1185,6 @@ func TestCycleCallback_Parallel_DueDispatch(t *testing.T) {
 
 		stop := make(chan struct{})
 		wg := new(sync.WaitGroup)
-		// churn: continuously register then unregister while cycles run
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -1733,23 +1205,755 @@ func TestCycleCallback_Parallel_DueDispatch(t *testing.T) {
 		close(stop)
 		wg.Wait()
 
-		// final tick prunes ids of the churned callbacks
 		callbacks.CycleCallback(shouldNotAbort)
-
-		group := callbacks.(*cycleCallbackGroup)
-		group.Lock()
-		defer group.Unlock()
-		assert.Len(t, group.callbacks, stable)
-		assert.Len(t, group.dueHeap, stable)
 	})
 }
 
-// BenchmarkCycleCallback_Parallel measures per-tick scheduling overhead of an
-// index-level group. The two regimes mirror the backoff decision in
-// index_cyclecallbacks.go: MT registers each shard entry with its own interval
-// (WithIntervals) and on a steady-state tick only a few shards are due; ST
-// registers entries with no interval (the ticker backs off instead), so every
-// entry is due whenever the group fires.
+// ----------------------------------------------------------------------------
+// White-box tests
+// ----------------------------------------------------------------------------
+
+// liveEntryCount counts dueHeap entries for callbackId whose schedGen
+// matches the current meta's schedGen. Caller holds g's lock.
+func liveEntryCount(g *cycleCallbackGroup, callbackId uint32) int {
+	meta, ok := g.metas[callbackId]
+	if !ok {
+		return 0
+	}
+	count := 0
+	for _, e := range g.heap {
+		if e.callbackId == callbackId && e.schedGen == meta.schedGen {
+			count++
+		}
+	}
+	return count
+}
+
+func TestCycleCallback_SingleLiveEntry_AfterRegister(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
+
+	g.Lock()
+	defer g.Unlock()
+
+	require.Len(t, g.metas, 1)
+	var callbackId uint32
+	for id := range g.metas {
+		callbackId = id
+	}
+	assert.Equal(t, 1, liveEntryCount(g, callbackId))
+}
+
+func TestCycleCallback_SingleLiveEntry_DeactivateThenActivate(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
+	require.NoError(t, ctrl.Deactivate(context.Background()))
+	require.NoError(t, ctrl.Activate())
+
+	g.Lock()
+	defer g.Unlock()
+
+	var callbackId uint32
+	for id := range g.metas {
+		callbackId = id
+	}
+	assert.Equal(t, 1, liveEntryCount(g, callbackId))
+}
+
+func TestCycleCallback_SingleLiveEntry_ActivateDuringDrain(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 2).(*cycleCallbackGroup)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	ctrl := g.Register("blocking", func(shouldAbort ShouldAbortCallback) bool {
+		close(started)
+		<-release
+		return true
+	})
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- g.CycleCallback(func() bool { return false })
+	}()
+	<-started
+
+	// Activate while the entry is in-flight (drained from heap, executing).
+	require.NoError(t, ctrl.Activate())
+	close(release)
+	<-done
+
+	// After the tick completes (teardown reschedules), exactly one live entry.
+	g.Lock()
+	defer g.Unlock()
+
+	var callbackId uint32
+	for id := range g.metas {
+		callbackId = id
+	}
+	assert.Equal(t, 1, liveEntryCount(g, callbackId))
+}
+
+func TestCycleCallback_AbortRestoresEntries(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 4).(*cycleCallbackGroup)
+
+	const total = 5
+	for i := 0; i < total; i++ {
+		g.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+			return true
+		})
+	}
+
+	// Abort the entire tick; every drained entry must be restored.
+	g.CycleCallback(func() bool { return true })
+
+	g.Lock()
+	defer g.Unlock()
+
+	assert.Len(t, g.metas, total)
+	liveTotal := 0
+	for callbackId := range g.metas {
+		liveTotal += liveEntryCount(g, callbackId)
+	}
+	assert.Equal(t, total, liveTotal)
+}
+
+func TestCycleCallback_SequentialAbortRestoresRemainder(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	const total = 4
+	var counter int64
+	for i := 0; i < total; i++ {
+		g.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+			atomic.AddInt64(&counter, 1)
+			return true
+		})
+	}
+
+	// Abort once the first callback has run.
+	g.CycleCallback(func() bool { return atomic.LoadInt64(&counter) >= 1 })
+	assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+
+	g.Lock()
+	defer g.Unlock()
+
+	// Every registered callback must have exactly one live entry.
+	for callbackId := range g.metas {
+		assert.Equal(t, 1, liveEntryCount(g, callbackId),
+			"callbackId %d has wrong live-entry count", callbackId)
+	}
+}
+
+func TestCycleCallback_StaleEntryBoundedGrowth(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	const N = 10
+	ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true },
+		WithIntervals(NewFixedIntervals(time.Hour)))
+
+	// N Deactivate/Activate cycles without draining; each cycle may leave one
+	// stale entry in the heap.
+	for i := 0; i < N; i++ {
+		require.NoError(t, ctrl.Deactivate(context.Background()))
+		require.NoError(t, ctrl.Activate())
+	}
+
+	g.Lock()
+	defer g.Unlock()
+
+	var callbackId uint32
+	for id := range g.metas {
+		callbackId = id
+	}
+	meta := g.metas[callbackId]
+
+	staleEntries := 0
+	liveEntries := 0
+	for _, e := range g.heap {
+		if e.callbackId == callbackId {
+			if e.schedGen == meta.schedGen {
+				liveEntries++
+			} else {
+				staleEntries++
+			}
+		}
+	}
+	assert.Equal(t, 1, liveEntries, "exactly one live entry")
+	assert.LessOrEqual(t, staleEntries, N)
+}
+
+func TestCycleCallback_DeactivatePriorityClaimedButNotStarted(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	var bodyEntered int64
+	g.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+		atomic.AddInt64(&bodyEntered, 1)
+		return true
+	})
+
+	// Manually drain the meta from the heap (simulates what drainDue does).
+	g.Lock()
+	var drained *cycleCallbackMeta
+	for len(g.heap) > 0 {
+		e := g.heap.pop()
+		meta, ok := g.metas[e.callbackId]
+		if ok && e.schedGen == meta.schedGen && meta.active {
+			drained = meta
+			break
+		}
+	}
+	g.Unlock()
+
+	require.NotNil(t, drained)
+
+	// Deactivate before runOne takes the lock: sets active=false.
+	g.Lock()
+	drained.active = false
+	g.Unlock()
+
+	// runOne should skip execution because active=false.
+	executed := g.runOne(drained, func() bool { return false })
+
+	assert.False(t, executed)
+	assert.Equal(t, int64(0), atomic.LoadInt64(&bodyEntered))
+}
+
+func TestCycleCallback_UnregisterNilOnAbsentID(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	// unregister is called via a ctrl that holds the ID, but we can test via a
+	// freshly created ctrl pointing to a non-existent callbackId.
+	ctrl := &cycleCallbackCtrl{
+		callbackId:       99,
+		callbackCustomId: "ghost",
+		unregister:       g.unregister,
+	}
+	assert.Nil(t, ctrl.Unregister(context.Background()))
+}
+
+func TestCycleCallback_ConcurrentRegisterUnregisterLeakCheck(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 4).(*cycleCallbackGroup)
+	callback := func(shouldAbort ShouldAbortCallback) bool { return true }
+	shouldNotAbort := func() bool { return false }
+
+	const stable = 8
+	for i := 0; i < stable; i++ {
+		g.Register(fmt.Sprintf("stable%d", i), callback)
+	}
+
+	stop := make(chan struct{})
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			ctrl := g.Register("churn", callback)
+			assert.NoError(t, ctrl.Unregister(context.Background()))
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		g.CycleCallback(shouldNotAbort)
+	}
+	close(stop)
+	wg.Wait()
+
+	// one final tick to flush any in-flight churn
+	g.CycleCallback(shouldNotAbort)
+
+	g.Lock()
+	defer g.Unlock()
+	assert.Len(t, g.metas, stable)
+}
+
+// ----------------------------------------------------------------------------
+// Stress / race test
+// ----------------------------------------------------------------------------
+
+func TestCycleCallback_StressRace(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	callbacks := NewCallbackGroup("id", logger, 4)
+
+	const stable = 4
+	ctrls := make([]CycleCallbackCtrl, stable)
+	for i := 0; i < stable; i++ {
+		ctrls[i] = callbacks.Register(fmt.Sprintf("stable%d", i),
+			func(shouldAbort ShouldAbortCallback) bool { return true })
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var wg sync.WaitGroup
+
+	// tight CycleCallback loop
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(deadline) {
+			callbacks.CycleCallback(func() bool { return false })
+		}
+	}()
+
+	// 8 goroutines hammering Activate/Deactivate/Register/Unregister
+	for i := 0; i < 8; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := context.Background()
+			for time.Now().Before(deadline) {
+				switch i % 4 {
+				case 0:
+					ctrls[i%stable].Deactivate(ctx) //nolint:errcheck
+				case 1:
+					ctrls[i%stable].Activate() //nolint:errcheck
+				case 2:
+					ctrl := callbacks.Register(fmt.Sprintf("churn%d", i),
+						func(shouldAbort ShouldAbortCallback) bool { return true })
+					ctrl.Unregister(ctx) //nolint:errcheck
+				case 3:
+					ctrls[i%stable].Deactivate(ctx) //nolint:errcheck
+					ctrls[i%stable].Activate()      //nolint:errcheck
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestCycleCallback_RunWithIntervals exercises computeNextDue and interval Reset/Advance
+// over many real ticks driven by a live NewManager, for both parallel and
+// sequential routinesLimit values.
+func TestCycleCallback_RunWithIntervals(t *testing.T) {
+	modes := []struct {
+		name     string
+		routines int
+	}{
+		{"parallel", 2},
+		{"sequential", 1},
+	}
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			var times1, times2, times3 []time.Duration
+
+			synctest.Test(t, func(t *testing.T) {
+				ticker := NewFixedTicker(10 * time.Millisecond)
+				intervals2 := NewSeriesIntervals([]time.Duration{
+					10 * time.Millisecond, 30 * time.Millisecond, 50 * time.Millisecond,
+				})
+				intervals3 := NewFixedIntervals(60 * time.Millisecond)
+				now := time.Now()
+
+				var mu sync.Mutex
+				executionTimes1 := []time.Duration{}
+				callback1 := func(shouldAbort ShouldAbortCallback) bool {
+					mu.Lock()
+					executionTimes1 = append(executionTimes1, time.Since(now))
+					mu.Unlock()
+					return true
+				}
+				executionCounter2 := 0
+				executionTimes2 := []time.Duration{}
+				callback2 := func(shouldAbort ShouldAbortCallback) bool {
+					mu.Lock()
+					executionCounter2++
+					executionTimes2 = append(executionTimes2, time.Since(now))
+					executed := executionCounter2%4 == 0
+					mu.Unlock()
+					return executed
+				}
+				executionTimes3 := []time.Duration{}
+				callback3 := func(shouldAbort ShouldAbortCallback) bool {
+					mu.Lock()
+					executionTimes3 = append(executionTimes3, time.Since(now))
+					mu.Unlock()
+					return true
+				}
+
+				callbacks := NewCallbackGroup("id", logrus.New(), mode.routines)
+				// called on every tick (nil interval = always due)
+				callbacks.Register("c1", callback1)
+				// called with 10, 30, 50, 50, 10, 30, 50, 50, ... intervals
+				callbacks.Register("c2", callback2, WithIntervals(intervals2))
+				// called with 60 ms fixed intervals
+				callbacks.Register("c3", callback3, WithIntervals(intervals3))
+
+				logger, _ := test.NewNullLogger()
+				cm := NewManager("test", ticker, callbacks.CycleCallback, logger)
+				cm.Start()
+				// Under the fake clock, 400ms of simulated time is instant.
+				// synctest.Wait() after the sleep ensures the manager has
+				// processed all ticks before we call StopAndWait.
+				time.Sleep(400 * time.Millisecond)
+				synctest.Wait()
+				cm.StopAndWait(context.Background()) //nolint:errcheck
+
+				mu.Lock()
+				times1 = make([]time.Duration, len(executionTimes1))
+				copy(times1, executionTimes1)
+				times2 = make([]time.Duration, len(executionTimes2))
+				copy(times2, executionTimes2)
+				times3 = make([]time.Duration, len(executionTimes3))
+				copy(times3, executionTimes3)
+				mu.Unlock()
+			})
+
+			// within 400 ms c1 should be called at least 30x
+			require.GreaterOrEqual(t, len(times1), 30)
+			sumDuration := time.Duration(10)
+			for i := 0; i < 30; i++ {
+				assert.GreaterOrEqual(t, times1[i], sumDuration)
+				sumDuration += 10 * time.Millisecond
+			}
+
+			// within 400 ms c2 should be called at least 8x
+			require.GreaterOrEqual(t, len(times2), 8)
+			sumDuration = time.Duration(0)
+			for i := 0; i < 8; i++ {
+				assert.GreaterOrEqual(t, times2[i], sumDuration)
+				switch (i + 1) % 4 {
+				case 0:
+					sumDuration += 10 * time.Millisecond
+				case 1:
+					sumDuration += 30 * time.Millisecond
+				case 2, 3:
+					sumDuration += 50 * time.Millisecond
+				}
+			}
+
+			// within 400 ms c3 should be called at least 6x
+			require.GreaterOrEqual(t, len(times3), 6)
+			sumDuration = time.Duration(0)
+			for i := 0; i < 6; i++ {
+				assert.GreaterOrEqual(t, times3[i], sumDuration)
+				sumDuration += 60 * time.Millisecond
+			}
+		})
+	}
+}
+
+// TestCycleCallback_IdleTickPrunesUnregistered asserts that after unregistering callbacks
+// and running a tick, no live due-heap entries remain for those callbacks and
+// g.metas contains only the still-registered ones.
+func TestCycleCallback_IdleTickPrunesUnregistered(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	callback := func(shouldAbort ShouldAbortCallback) bool { return true }
+
+	g := NewCallbackGroup("id", logger, 2).(*cycleCallbackGroup)
+	ctrl1 := g.Register("c1", callback)
+	ctrl2 := g.Register("c2", callback)
+	g.Register("c3", callback)
+
+	require.NoError(t, ctrl1.Unregister(context.Background()))
+	require.NoError(t, ctrl2.Unregister(context.Background()))
+
+	// A tick drains and discards entries for unregistered callbacks on pop.
+	g.CycleCallback(func() bool { return false })
+
+	g.Lock()
+	defer g.Unlock()
+
+	// Only c3 remains in metas.
+	assert.Len(t, g.metas, 1)
+
+	// No live due-heap entries for the unregistered callbacks (id 0 and 1).
+	for _, e := range g.heap {
+		_, registered := g.metas[e.callbackId]
+		assert.True(t, registered, "heap entry for unregistered callbackId %d must not survive a tick", e.callbackId)
+	}
+
+	// c3 was not unregistered, its live entry must be present.
+	liveCount := 0
+	for id := range g.metas {
+		liveCount += liveEntryCount(g, id)
+	}
+	assert.Equal(t, 1, liveCount)
+}
+
+// TestCycleCallback_CombinedCtrl_DeactivateTimeoutRollback verifies that when a combined
+// controller's Deactivate times out on one callback, the rollback (re-activate
+// only the ones that succeeded) does not leave the timed-out callback stuck
+// in an inactive state.
+func TestCycleCallback_CombinedCtrl_DeactivateTimeoutRollback(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	// blocking holds the first callback's run hostage until we release it.
+	blocking := make(chan struct{})
+	chStarted := make(chan struct{}, 1)
+	chFinished := make(chan struct{}, 1)
+
+	callbacks := NewCallbackGroup("id", logger, 2)
+
+	ctrl1 := callbacks.Register("slow", func(shouldAbort ShouldAbortCallback) bool {
+		chStarted <- struct{}{}
+		<-blocking
+		return true
+	})
+	ctrl2 := callbacks.Register("fast", func(shouldAbort ShouldAbortCallback) bool {
+		return true
+	})
+
+	// Start a tick so the slow callback runs.
+	go func() {
+		callbacks.CycleCallback(shouldNotAbort)
+		chFinished <- struct{}{}
+	}()
+	<-chStarted
+
+	// Deactivate via combined ctrl with a very short context so it times out
+	// on ctrl1 (still running) but ctrl2 has already finished.
+	combined := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	err := combined.Deactivate(ctxTimeout)
+	require.Error(t, err)
+
+	// ctrl1 timed out: it must remain ACTIVE (rollback only re-activates
+	// those that succeeded, so it must NOT have deactivated ctrl1).
+	assert.True(t, ctrl1.IsActive())
+
+	// Release the slow callback and wait for the tick to finish.
+	close(blocking)
+	<-chFinished
+
+	// After the tick finishes, ctrl1 is still active and runs again.
+	assert.True(t, ctrl1.IsActive())
+	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+}
+
+// TestCycleCallback_DeactivateTimeoutState is a white-box test that verifies the
+// documented post-timeout state (active=true, abort=true) and confirms that a
+// subsequent Deactivate with a valid ctx succeeds and commits active=false.
+func TestCycleCallback_DeactivateTimeoutState(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+	ctrl := g.Register("slow", func(shouldAbort ShouldAbortCallback) bool {
+		started <- struct{}{}
+		<-release
+		return true
+	})
+
+	tickDone := make(chan struct{})
+	go func() {
+		g.CycleCallback(func() bool { return false })
+		close(tickDone)
+	}()
+	<-started
+
+	// Deactivate with a context that expires while the callback is still blocked.
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	err := ctrl.Deactivate(ctxTimeout)
+	require.Error(t, err, "Deactivate must return an error on ctx timeout")
+
+	// Under the lock: the callback is still running; state must be active=true, abort=true.
+	g.Lock()
+	var meta *cycleCallbackMeta
+	for _, m := range g.metas {
+		meta = m
+	}
+	require.NotNil(t, meta)
+	assert.True(t, meta.active, "active must remain true after Deactivate timeout")
+	assert.True(t, meta.abort, "abort must remain true after Deactivate timeout")
+	g.Unlock()
+
+	// Release the callback so the tick can finish.
+	close(release)
+	<-tickDone
+
+	// A second Deactivate with a generous ctx must succeed.
+	err = ctrl.Deactivate(context.Background())
+	require.NoError(t, err, "second Deactivate must succeed after the run completes")
+
+	// active is now false; abort remains true (only Activate clears it).
+	g.Lock()
+	assert.False(t, meta.active, "active must be false after successful Deactivate")
+	assert.True(t, meta.abort, "abort remains true after Deactivate; only Activate clears it")
+	g.Unlock()
+}
+
+// TestCycleCallback_ConcurrentWaiters verifies that two concurrent callers waiting on the
+// same in-flight callback both wake when the run finishes — exercising the
+// shared lazy-channel broadcast path.
+func TestCycleCallback_ConcurrentWaiters(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		started := make(chan struct{}, 1)
+
+		callbacks := NewCallbackGroup("id", logger, 1)
+		ctrl := callbacks.Register("slow", func(shouldAbort ShouldAbortCallback) bool {
+			started <- struct{}{}
+			<-release
+			return true
+		})
+
+		tickDone := make(chan struct{})
+		go func() {
+			callbacks.CycleCallback(func() bool { return false })
+			close(tickDone)
+		}()
+		<-started
+
+		// Two concurrent Unregister callers on the same ctrl land while the
+		// callback runs. They share the lazily-created done channel and must
+		// both wake after the run completes (the second delete is a no-op in Go).
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		unregisterErr := make(chan error, 1)
+		go func() {
+			defer wg.Done()
+			unregisterErr <- ctrl.Unregister(context.Background())
+		}()
+
+		unregisterErr2 := make(chan error, 1)
+		go func() {
+			defer wg.Done()
+			// Second concurrent Unregister on the same ctrl exercises the shared-waiter path.
+			unregisterErr2 <- ctrl.Unregister(context.Background())
+		}()
+
+		// synctest.Wait ensures both Unregister goroutines are durably parked
+		// as waiters on the lazily-created done channel before release is
+		// closed, deterministically exercising the shared-waiter broadcast path.
+		synctest.Wait()
+		close(release)
+		wg.Wait()
+		<-tickDone
+
+		assert.NoError(t, <-unregisterErr)
+		assert.NoError(t, <-unregisterErr2)
+	})
+}
+
+// TestCycleCallback_PanicUnderLockDoesNotDeadlock guards against a lock leak caused by a
+// panic while the group lock is held. schedule calls computeNextDue, which
+// calls CycleIntervals.Get(); if Get() panics (e.g. due to a nil dereference or
+// user error), the group lock must still be released so subsequent operations
+// can proceed. This test exercises that path via activate, which calls schedule
+// under the lock.
+func TestCycleCallback_PanicUnderLockDoesNotDeadlock(t *testing.T) {
+	intervals := &panicCycleIntervals{}
+
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	// Register with Get() returning normally (flag not yet set), so the initial
+	// schedule in Register succeeds.
+	ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true },
+		WithIntervals(intervals))
+
+	// Deactivate so the next Activate will call schedule → Get() under the lock.
+	require.NoError(t, ctrl.Deactivate(context.Background()))
+
+	// Arm the panic, then call Activate. activate holds the group lock when it
+	// calls schedule → computeNextDue → Get(), which now panics. The defer in
+	// activate must release the lock before the panic unwinds.
+	intervals.armed.Store(true)
+	require.Panics(t, func() { ctrl.Activate() }) //nolint:errcheck
+
+	// If the lock leaked, any operation that acquires it would block forever.
+	// Prove the lock was released by running a follow-up operation with a timeout.
+	done := make(chan struct{})
+	go func() {
+		// isActive acquires the group lock; it must not block.
+		g.isActive(0, "c")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// lock was released: group is healthy
+	case <-time.After(2 * time.Second):
+		t.Fatal("group lock leaked after panic in activate: follow-up isActive blocked")
+	}
+}
+
+// panicCycleIntervals is a CycleIntervals whose Get panics when armed.
+type panicCycleIntervals struct {
+	armed atomic.Bool
+}
+
+func (p *panicCycleIntervals) Get() time.Duration {
+	if p.armed.Load() {
+		panic("injected panic in Get()")
+	}
+	return 10 * time.Millisecond
+}
+
+func (p *panicCycleIntervals) Reset()   {}
+func (p *panicCycleIntervals) Advance() {}
+
+// BenchmarkCycleCallback measures the hot-path allocation profile with a single
+// always-due no-op callback on a sequential (routinesLimit=1) group, so no
+// worker-goroutine allocations contaminate the measurement.
+func BenchmarkCycleCallback(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("bench", logger, 1)
+	g.Register("noop", func(shouldAbort ShouldAbortCallback) bool { return true })
+	shouldNotAbort := func() bool { return false }
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.CycleCallback(shouldNotAbort)
+	}
+}
+
+// TestCycleCallback_AllocRegression asserts that the per-CycleCallback allocation count
+// stays within a tight bound. Because the done channel is now allocated lazily
+// (only when a Deactivate/Unregister waiter needs it), the no-waiter hot path
+// has no make(chan struct{}) at all. If someone (a) reintroduces a
+// per-invocation abort closure OR (b) reverts to eager done-channel allocation,
+// the count rises by at least 1 and the test fails.
+func TestCycleCallback_AllocRegression(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("alloc", logger, 1)
+	g.Register("noop", func(shouldAbort ShouldAbortCallback) bool { return true })
+	shouldNotAbort := func() bool { return false }
+
+	allocs := testing.AllocsPerRun(100, func() {
+		g.CycleCallback(shouldNotAbort)
+	})
+
+	// Alloc breakdown per CycleCallback call (1 total):
+	//   1. drainDue: append([]*cycleCallbackMeta, meta) — fresh result slice per tick
+	// The concrete dueHeap pushes/pops dueEntry by value (no container/heap
+	// any-boxing), the abort closure is built once in Register, and the done
+	// channel is lazy — none of those allocate on the no-waiter hot path. A
+	// reintroduced per-invocation abort closure, eager done-channel allocation,
+	// or a return to container/heap's any-boxing would raise the count.
+	const maxAllocs = 1
+	assert.LessOrEqual(t, allocs, float64(maxAllocs),
+		"CycleCallback allocs per run: got %.1f, want <= %d",
+		allocs, maxAllocs)
+}
+
+// BenchmarkCycleCallback_Parallel reports allocs and drives multi-tenant and
+// single-tenant large-collection cases to measure per-tick scheduling overhead.
 func BenchmarkCycleCallback_Parallel(b *testing.B) {
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
@@ -1785,601 +1989,19 @@ func BenchmarkCycleCallback_Parallel(b *testing.B) {
 					callbacks.Register(fmt.Sprintf("due%d", i), noop,
 						WithIntervals(NewFixedIntervals(time.Nanosecond)))
 				default:
-					// MT backed-off entry: long interval; priming below records
-					// started=now so it stays not-due for the rest of the benchmark
+					// MT backed-off entry: long interval; the prime call below
+					// records started=now so it stays not-due for the rest of the run
 					callbacks.Register(fmt.Sprintf("idle%d", i), noop,
 						WithIntervals(NewFixedIntervals(time.Hour)))
 				}
 			}
 			callbacks.CycleCallback(shouldNotAbort)
 
+			b.ReportAllocs()
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
 				callbacks.CycleCallback(shouldNotAbort)
 			}
 		})
 	}
-}
-
-func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
-	ctx := context.Background()
-	logger, _ := test.NewNullLogger()
-	shouldNotAbort := func() bool { return false }
-
-	t.Run("1 executable callback, 1 deactivated", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c1", callback)
-		require.Nil(t, ctrl.Deactivate(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
-	})
-
-	t.Run("2 executable callbacks, 2 deactivated", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		require.Nil(t, ctrl1.Deactivate(ctx))
-		require.Nil(t, ctrl2.Deactivate(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.False(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.GreaterOrEqual(t, d, 0*time.Millisecond)
-	})
-
-	t.Run("2 executable callbacks, 1 deactivated", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl1 := callbacks.Register("c1", callback1)
-		callbacks.Register("c2", callback2)
-		require.Nil(t, ctrl1.Deactivate(ctx))
-
-		start := time.Now()
-		executed = callbacks.CycleCallback(shouldNotAbort)
-		d = time.Since(start)
-
-		assert.True(t, executed)
-		assert.Equal(t, 0, executedCounter1)
-		assert.Equal(t, 1, executedCounter2)
-		assert.GreaterOrEqual(t, d, 25*time.Millisecond)
-	})
-
-	t.Run("4 executable callbacks, all deactivated at different time", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		executedCounter4 := 0
-		callback4 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(25 * time.Millisecond)
-			executedCounter4++
-			return true
-		}
-		var executed1 bool
-		var executed2 bool
-		var executed3 bool
-		var executed4 bool
-		var d1 time.Duration
-		var d2 time.Duration
-		var d3 time.Duration
-		var d4 time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-		ctrl4 := callbacks.Register("c4", callback4)
-		require.Nil(t, ctrl3.Deactivate(ctx))
-
-		start := time.Now()
-		executed1 = callbacks.CycleCallback(shouldNotAbort)
-		d1 = time.Since(start)
-
-		require.Nil(t, ctrl1.Deactivate(ctx))
-
-		start = time.Now()
-		executed2 = callbacks.CycleCallback(shouldNotAbort)
-		d2 = time.Since(start)
-
-		require.Nil(t, ctrl4.Deactivate(ctx))
-
-		start = time.Now()
-		executed3 = callbacks.CycleCallback(shouldNotAbort)
-		d3 = time.Since(start)
-
-		require.Nil(t, ctrl2.Deactivate(ctx))
-
-		start = time.Now()
-		executed4 = callbacks.CycleCallback(shouldNotAbort)
-		d4 = time.Since(start)
-
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.True(t, executed3)
-		assert.False(t, executed4)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 3, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.Equal(t, 2, executedCounter4)
-		assert.GreaterOrEqual(t, d1, 75*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d3, 25*time.Millisecond)
-		assert.GreaterOrEqual(t, d4, 0*time.Millisecond)
-	})
-
-	t.Run("deactivate is waiting till the end of execution", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c", callback)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		start := time.Now()
-		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl.Deactivate(ctx))
-		du := time.Since(start)
-		<-chFinished
-
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 40*time.Millisecond)
-	})
-
-	t.Run("deactivate fails due to context timeout", func(t *testing.T) {
-		executedCounter := 0
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed1 bool
-		var executed2 bool
-		var d1 time.Duration
-		var d2 time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c", callback)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed1 = callbacks.CycleCallback(shouldNotAbort)
-			d1 = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		start := time.Now()
-		time.Sleep(25 * time.Millisecond)
-		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cancel()
-		require.NotNil(t, ctrl.Deactivate(ctxTimeout))
-		du := time.Since(start)
-		<-chFinished
-
-		go func() {
-			start := time.Now()
-			executed2 = callbacks.CycleCallback(shouldNotAbort)
-			d2 = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chFinished
-
-		assert.True(t, executed1)
-		assert.True(t, executed2)
-		assert.Equal(t, 2, executedCounter)
-		assert.GreaterOrEqual(t, d1, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, d2, 50*time.Millisecond)
-		assert.GreaterOrEqual(t, du, 30*time.Millisecond)
-	})
-
-	t.Run("deactivate 2nd and 3rd while executing", func(t *testing.T) {
-		executedCounter1 := 0
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter1++
-			return true
-		}
-		executedCounter2 := 0
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter2++
-			return true
-		}
-		executedCounter3 := 0
-		callback3 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(50 * time.Millisecond)
-			executedCounter3++
-			return true
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
-		ctrl3 := callbacks.Register("c3", callback3)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl2.Deactivate(ctx))
-		require.Nil(t, ctrl3.Deactivate(ctx))
-		<-chFinished
-
-		assert.True(t, executed)
-		assert.Equal(t, 1, executedCounter1)
-		assert.Equal(t, 0, executedCounter2)
-		assert.Equal(t, 0, executedCounter3)
-		assert.GreaterOrEqual(t, d, 50*time.Millisecond)
-	})
-
-	t.Run("deactivate while running", func(t *testing.T) {
-		counter := 0
-		max := 25
-		callback := func(shouldAbort ShouldAbortCallback) bool {
-			for {
-				if shouldAbort() {
-					return false
-				}
-
-				time.Sleep(10 * time.Millisecond)
-				counter++
-
-				// 10ms * 25 = 250ms
-				if counter > max {
-					return true
-				}
-			}
-		}
-		chStarted := make(chan struct{}, 1)
-		chFinished := make(chan struct{}, 1)
-		var executed bool
-		var d time.Duration
-
-		callbacks := NewCallbackGroup("id", logger, 1)
-		ctrl := callbacks.Register("c", callback)
-
-		go func() {
-			chStarted <- struct{}{}
-			start := time.Now()
-			executed = callbacks.CycleCallback(shouldNotAbort)
-			d = time.Since(start)
-			chFinished <- struct{}{}
-		}()
-		<-chStarted
-		time.Sleep(50 * time.Millisecond)
-		require.NoError(t, ctrl.Deactivate(ctx))
-		<-chFinished
-
-		assert.False(t, executed)
-		assert.LessOrEqual(t, counter, max)
-		assert.LessOrEqual(t, d, 200*time.Millisecond)
-
-		t.Run("does not abort after activated back again", func(t *testing.T) {
-			require.NoError(t, ctrl.Activate())
-
-			counter = 0
-			max = 10
-
-			go func() {
-				start := time.Now()
-				executed = callbacks.CycleCallback(shouldNotAbort)
-				d = time.Since(start)
-				chFinished <- struct{}{}
-			}()
-			<-chFinished
-
-			assert.True(t, executed)
-			assert.Greater(t, counter, max)
-			assert.GreaterOrEqual(t, d, 100*time.Millisecond)
-		})
-	})
-}
-
-// TestCycleCallback_DueHeap covers the due-heap scheduling behaviors in both
-// dispatch modes: nil-interval "always due" entries, running only the due
-// subset, the single-membership invariant across deactivate/activate, panic
-// containment, and restoring drained-but-un-run entries on abort.
-func TestCycleCallback_DueHeap(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	shouldNotAbort := func() bool { return false }
-
-	modes := []struct {
-		name     string
-		routines int
-	}{
-		{"sequential", 1},
-		{"parallel", 4},
-	}
-
-	for _, mode := range modes {
-		t.Run(mode.name, func(t *testing.T) {
-			t.Run("always-due entry runs every tick", func(t *testing.T) {
-				var counter int64
-				callbacks := NewCallbackGroup("id", logger, mode.routines)
-				callbacks.Register("always", func(shouldAbort ShouldAbortCallback) bool {
-					atomic.AddInt64(&counter, 1)
-					return true
-				})
-
-				// nil interval means always due; each tick runs it exactly once,
-				// never re-popped within the same tick
-				for tick := int64(1); tick <= 3; tick++ {
-					assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-					assert.Equal(t, tick, atomic.LoadInt64(&counter))
-				}
-			})
-
-			t.Run("only due entries run", func(t *testing.T) {
-				var alwaysCounter, longCounter int64
-				callbacks := NewCallbackGroup("id", logger, mode.routines)
-				callbacks.Register("always", func(shouldAbort ShouldAbortCallback) bool {
-					atomic.AddInt64(&alwaysCounter, 1)
-					return true
-				})
-				callbacks.Register("long", func(shouldAbort ShouldAbortCallback) bool {
-					atomic.AddInt64(&longCounter, 1)
-					return true
-				}, WithIntervals(NewFixedIntervals(time.Hour)))
-
-				// 1st tick: both due (registration allows immediate execution)
-				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-				assert.Equal(t, int64(1), atomic.LoadInt64(&alwaysCounter))
-				assert.Equal(t, int64(1), atomic.LoadInt64(&longCounter))
-
-				// 2nd tick: only the always-due entry runs, long interval not elapsed
-				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-				assert.Equal(t, int64(2), atomic.LoadInt64(&alwaysCounter))
-				assert.Equal(t, int64(1), atomic.LoadInt64(&longCounter))
-			})
-
-			t.Run("activate after deactivate runs once", func(t *testing.T) {
-				var counter int64
-				callbacks := NewCallbackGroup("id", logger, mode.routines)
-				ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
-					atomic.AddInt64(&counter, 1)
-					return true
-				})
-				require.NoError(t, ctrl.Deactivate(context.Background()))
-				require.NoError(t, ctrl.Activate())
-
-				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-				assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
-
-				// exactly one heap entry afterwards - the activate push did not
-				// duplicate it
-				group := callbacks.(*cycleCallbackGroup)
-				group.Lock()
-				heapLen := group.dueHeap.Len()
-				group.Unlock()
-				assert.Equal(t, 1, heapLen)
-			})
-
-			t.Run("panicking callback is contained and rescheduled", func(t *testing.T) {
-				const siblings = 4
-				var okCounter, panicCounter int64
-				callbacks := NewCallbackGroup("id", logger, mode.routines)
-				for i := 0; i < siblings; i++ {
-					callbacks.Register(fmt.Sprintf("ok%d", i), func(shouldAbort ShouldAbortCallback) bool {
-						atomic.AddInt64(&okCounter, 1)
-						return true
-					})
-				}
-				callbacks.Register("panic", func(shouldAbort ShouldAbortCallback) bool {
-					atomic.AddInt64(&panicCounter, 1)
-					panic("boom")
-				})
-
-				// 1st tick: siblings all run, the panic is contained
-				callbacks.CycleCallback(shouldNotAbort)
-				assert.Equal(t, int64(siblings), atomic.LoadInt64(&okCounter))
-				assert.Equal(t, int64(1), atomic.LoadInt64(&panicCounter))
-
-				// 2nd tick: the panicking entry was rescheduled, so it runs again
-				callbacks.CycleCallback(shouldNotAbort)
-				assert.Equal(t, int64(2), atomic.LoadInt64(&panicCounter))
-			})
-
-			t.Run("abort restores un-run drained entries", func(t *testing.T) {
-				const total = 5
-				var counter int64
-				callbacks := NewCallbackGroup("id", logger, mode.routines)
-				for i := 0; i < total; i++ {
-					callbacks.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
-						atomic.AddInt64(&counter, 1)
-						return true
-					})
-				}
-
-				// abort the whole tick: every drained entry is restored, none run
-				assert.False(t, callbacks.CycleCallback(func() bool { return true }))
-				assert.Equal(t, int64(0), atomic.LoadInt64(&counter))
-
-				group := callbacks.(*cycleCallbackGroup)
-				group.Lock()
-				heapLen := group.dueHeap.Len()
-				group.Unlock()
-				assert.Equal(t, total, heapLen) // nothing orphaned outside the heap
-
-				// next tick runs exactly the restored entries
-				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-				assert.Equal(t, int64(total), atomic.LoadInt64(&counter))
-			})
-
-			t.Run("abort then deactivate does not resurrect", func(t *testing.T) {
-				const total = 4
-				counters := make([]int64, total)
-				callbacks := NewCallbackGroup("id", logger, mode.routines)
-				ctrls := make([]CycleCallbackCtrl, total)
-				for i := 0; i < total; i++ {
-					idx := i
-					ctrls[i] = callbacks.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
-						atomic.AddInt64(&counters[idx], 1)
-						return true
-					})
-				}
-
-				// abort tick: all entries restored to the heap, none run
-				assert.False(t, callbacks.CycleCallback(func() bool { return true }))
-
-				// deactivate one restored entry
-				require.NoError(t, ctrls[0].Deactivate(context.Background()))
-
-				// next tick runs every entry but the deactivated one
-				assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-				assert.Equal(t, int64(0), atomic.LoadInt64(&counters[0]))
-				for i := 1; i < total; i++ {
-					assert.Equal(t, int64(1), atomic.LoadInt64(&counters[i]))
-				}
-			})
-		})
-	}
-
-	t.Run("activate during execution does not duplicate the heap entry", func(t *testing.T) {
-		started := make(chan struct{})
-		release := make(chan struct{})
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl := callbacks.Register("blocking", func(shouldAbort ShouldAbortCallback) bool {
-			started <- struct{}{}
-			<-release
-			return true
-		})
-
-		// run a tick concurrently: it drains the entry (heapIndex -1) and blocks
-		// inside the callback, holding it in flight
-		done := make(chan bool, 1)
-		go func() {
-			done <- callbacks.CycleCallback(shouldNotAbort)
-		}()
-		<-started
-
-		// activate the in-flight entry: activate re-queues it (its heapIndex -1
-		// guard passes), so the tick's repushDue must not push it a second time
-		require.NoError(t, ctrl.Activate())
-		close(release)
-		<-done
-
-		group := callbacks.(*cycleCallbackGroup)
-		group.Lock()
-		heapLen := group.dueHeap.Len()
-		group.Unlock()
-		assert.Equal(t, 1, heapLen)
-	})
-
-	t.Run("sequential abort after first execution restores the remainder", func(t *testing.T) {
-		const total = 4
-		var counter int64
-		callbacks := NewCallbackGroup("id", logger, 1)
-		for i := 0; i < total; i++ {
-			callbacks.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
-				atomic.AddInt64(&counter, 1)
-				return true
-			})
-		}
-
-		// abort once the first callback has run; the sequential loop stops
-		// executing but restores every remaining drained entry
-		shouldAbort := func() bool { return atomic.LoadInt64(&counter) >= 1 }
-		assert.True(t, callbacks.CycleCallback(shouldAbort))
-		assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
-
-		group := callbacks.(*cycleCallbackGroup)
-		group.Lock()
-		heapLen := group.dueHeap.Len()
-		group.Unlock()
-		assert.Equal(t, total, heapLen) // executed one re-pushed, remainder restored
-
-		// next tick runs all four again
-		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-		assert.Equal(t, int64(1+total), atomic.LoadInt64(&counter))
-	})
 }

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -14,6 +14,7 @@ package cyclemanager
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -212,7 +213,7 @@ func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 			atomic.AddInt64(&counter, 1)
 			return true
 		})
-		require.Nil(t, ctrl.Unregister(ctx))
+		require.NoError(t, ctrl.Unregister(ctx))
 
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&counter))
@@ -238,7 +239,7 @@ func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 		<-chStarted
 		start := time.Now()
 		time.Sleep(25 * time.Millisecond)
-		require.Nil(t, ctrl.Unregister(ctx))
+		require.NoError(t, ctrl.Unregister(ctx))
 		du := time.Since(start)
 		<-chFinished
 
@@ -326,8 +327,8 @@ func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 			atomic.AddInt64(&c2, 1)
 			return true
 		})
-		require.Nil(t, ctrl1.Unregister(ctx))
-		require.Nil(t, ctrl2.Unregister(ctx))
+		require.NoError(t, ctrl1.Unregister(ctx))
+		require.NoError(t, ctrl2.Unregister(ctx))
 
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
@@ -347,7 +348,7 @@ func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 			atomic.AddInt64(&c2, 1)
 			return true
 		})
-		require.Nil(t, ctrl1.Unregister(ctx))
+		require.NoError(t, ctrl1.Unregister(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
@@ -397,8 +398,8 @@ func TestCycleCallback_Parallel_Unregister(t *testing.T) {
 				atomic.AddInt64(&c4, 1)
 				return true
 			})
-			require.Nil(t, ctrl3.Unregister(ctx))
-			require.Nil(t, ctrl4.Unregister(ctx))
+			require.NoError(t, ctrl3.Unregister(ctx))
+			require.NoError(t, ctrl4.Unregister(ctx))
 
 			// release lets c1 and c2 finish tick 1; closed channel unblocks
 			// c1 and c2 again in tick 2 without stalling.
@@ -427,7 +428,7 @@ func TestCycleCallback_Parallel_Deactivate(t *testing.T) {
 			atomic.AddInt64(&counter, 1)
 			return true
 		})
-		require.Nil(t, ctrl.Deactivate(ctx))
+		require.NoError(t, ctrl.Deactivate(ctx))
 
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&counter))
@@ -460,7 +461,7 @@ func TestCycleCallback_Parallel_Deactivate(t *testing.T) {
 			// When Deactivate returns, counter==1 proves it waited for the
 			// callback to run to completion (its last act before returning).
 			go func() { close(release) }()
-			require.Nil(t, ctrl.Deactivate(ctx))
+			require.NoError(t, ctrl.Deactivate(ctx))
 			<-chFinished
 
 			assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
@@ -623,8 +624,8 @@ func TestCycleCallback_Parallel_Deactivate(t *testing.T) {
 				atomic.AddInt64(&c4, 1)
 				return true
 			})
-			require.Nil(t, ctrl3.Deactivate(ctx))
-			require.Nil(t, ctrl4.Deactivate(ctx))
+			require.NoError(t, ctrl3.Deactivate(ctx))
+			require.NoError(t, ctrl4.Deactivate(ctx))
 
 			close(release)
 			<-chFinished
@@ -761,8 +762,8 @@ func TestCycleCallback_Sequential_Unregister(t *testing.T) {
 			atomic.AddInt64(&c2, 1)
 			return true
 		})
-		require.Nil(t, ctrl1.Unregister(ctx))
-		require.Nil(t, ctrl2.Unregister(ctx))
+		require.NoError(t, ctrl1.Unregister(ctx))
+		require.NoError(t, ctrl2.Unregister(ctx))
 
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
@@ -782,7 +783,7 @@ func TestCycleCallback_Sequential_Unregister(t *testing.T) {
 			atomic.AddInt64(&c2, 1)
 			return true
 		})
-		require.Nil(t, ctrl1.Unregister(ctx))
+		require.NoError(t, ctrl1.Unregister(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
@@ -812,7 +813,7 @@ func TestCycleCallback_Sequential_Unregister(t *testing.T) {
 			atomic.AddInt64(&c4, 1)
 			return true
 		})
-		require.Nil(t, ctrl3.Unregister(ctx))
+		require.NoError(t, ctrl3.Unregister(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
@@ -820,19 +821,19 @@ func TestCycleCallback_Sequential_Unregister(t *testing.T) {
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
 		assert.Equal(t, int64(1), atomic.LoadInt64(&c4))
 
-		require.Nil(t, ctrl1.Unregister(ctx))
+		require.NoError(t, ctrl1.Unregister(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
 		assert.Equal(t, int64(2), atomic.LoadInt64(&c2))
 		assert.Equal(t, int64(2), atomic.LoadInt64(&c4))
 
-		require.Nil(t, ctrl4.Unregister(ctx))
+		require.NoError(t, ctrl4.Unregister(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(3), atomic.LoadInt64(&c2))
 
-		require.Nil(t, ctrl2.Unregister(ctx))
+		require.NoError(t, ctrl2.Unregister(ctx))
 
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 	})
@@ -869,8 +870,8 @@ func TestCycleCallback_Sequential_Unregister(t *testing.T) {
 			// c1 is running (sequential mode); c2 and c3 are not yet
 			// dispatched. Unregister sees running=false for both and
 			// deletes them immediately under the lock.
-			require.Nil(t, ctrl2.Unregister(ctx))
-			require.Nil(t, ctrl3.Unregister(ctx))
+			require.NoError(t, ctrl2.Unregister(ctx))
+			require.NoError(t, ctrl3.Unregister(ctx))
 			close(release)
 			<-chFinished
 
@@ -900,8 +901,8 @@ func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
 			atomic.AddInt64(&c2, 1)
 			return true
 		})
-		require.Nil(t, ctrl1.Deactivate(ctx))
-		require.Nil(t, ctrl2.Deactivate(ctx))
+		require.NoError(t, ctrl1.Deactivate(ctx))
+		require.NoError(t, ctrl2.Deactivate(ctx))
 
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
@@ -921,7 +922,7 @@ func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
 			atomic.AddInt64(&c2, 1)
 			return true
 		})
-		require.Nil(t, ctrl1.Deactivate(ctx))
+		require.NoError(t, ctrl1.Deactivate(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c1))
@@ -951,7 +952,7 @@ func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
 			atomic.AddInt64(&c4, 1)
 			return true
 		})
-		require.Nil(t, ctrl3.Deactivate(ctx))
+		require.NoError(t, ctrl3.Deactivate(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
@@ -959,19 +960,19 @@ func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c3))
 		assert.Equal(t, int64(1), atomic.LoadInt64(&c4))
 
-		require.Nil(t, ctrl1.Deactivate(ctx))
+		require.NoError(t, ctrl1.Deactivate(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
 		assert.Equal(t, int64(2), atomic.LoadInt64(&c2))
 		assert.Equal(t, int64(2), atomic.LoadInt64(&c4))
 
-		require.Nil(t, ctrl4.Deactivate(ctx))
+		require.NoError(t, ctrl4.Deactivate(ctx))
 
 		assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 		assert.Equal(t, int64(3), atomic.LoadInt64(&c2))
 
-		require.Nil(t, ctrl2.Deactivate(ctx))
+		require.NoError(t, ctrl2.Deactivate(ctx))
 
 		assert.False(t, callbacks.CycleCallback(shouldNotAbort))
 	})
@@ -1008,8 +1009,8 @@ func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
 			// c1 is running (sequential mode); c2 and c3 are queued but
 			// not dispatched. Deactivate sees running=false for both and
 			// commits active=false immediately under the lock.
-			require.Nil(t, ctrl2.Deactivate(ctx))
-			require.Nil(t, ctrl3.Deactivate(ctx))
+			require.NoError(t, ctrl2.Deactivate(ctx))
+			require.NoError(t, ctrl3.Deactivate(ctx))
 			close(release)
 			<-chFinished
 
@@ -1272,126 +1273,102 @@ func liveEntryCount(g *cycleCallbackGroup, callbackId uint32) int {
 	return count
 }
 
-func TestCycleCallback_SingleLiveEntry_AfterRegister(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
-
-	g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
-
+// assertLiveEntries locks g and asserts it holds exactly wantMetas registered
+// callbacks, each with exactly one live (current-schedGen) heap entry — the
+// scheduling invariant the group must hold after any register/activate/abort/
+// teardown sequence.
+func assertLiveEntries(t *testing.T, g *cycleCallbackGroup, wantMetas int) {
+	t.Helper()
 	g.Lock()
 	defer g.Unlock()
 
-	require.Len(t, g.metas, 1)
-	var callbackId uint32
-	for id := range g.metas {
-		callbackId = id
-	}
-	assert.Equal(t, 1, liveEntryCount(g, callbackId))
-}
-
-func TestCycleCallback_SingleLiveEntry_DeactivateThenActivate(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
-
-	ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
-	require.NoError(t, ctrl.Deactivate(context.Background()))
-	require.NoError(t, ctrl.Activate())
-
-	g.Lock()
-	defer g.Unlock()
-
-	var callbackId uint32
-	for id := range g.metas {
-		callbackId = id
-	}
-	assert.Equal(t, 1, liveEntryCount(g, callbackId))
-}
-
-func TestCycleCallback_SingleLiveEntry_ActivateDuringDrain(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	g := NewCallbackGroup("id", logger, 2).(*cycleCallbackGroup)
-
-	started := make(chan struct{})
-	release := make(chan struct{})
-
-	ctrl := g.Register("blocking", func(shouldAbort ShouldAbortCallback) bool {
-		close(started)
-		<-release
-		return true
-	})
-
-	done := make(chan bool, 1)
-	go func() {
-		done <- g.CycleCallback(func() bool { return false })
-	}()
-	<-started
-
-	// Activate while the entry is in-flight (drained from heap, executing).
-	require.NoError(t, ctrl.Activate())
-	close(release)
-	<-done
-
-	// After the tick completes (teardown reschedules), exactly one live entry.
-	g.Lock()
-	defer g.Unlock()
-
-	var callbackId uint32
-	for id := range g.metas {
-		callbackId = id
-	}
-	assert.Equal(t, 1, liveEntryCount(g, callbackId))
-}
-
-func TestCycleCallback_AbortRestoresEntries(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	g := NewCallbackGroup("id", logger, 4).(*cycleCallbackGroup)
-
-	const total = 5
-	for i := 0; i < total; i++ {
-		g.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
-			return true
-		})
-	}
-
-	// Abort the entire tick; every drained entry must be restored.
-	g.CycleCallback(func() bool { return true })
-
-	g.Lock()
-	defer g.Unlock()
-
-	assert.Len(t, g.metas, total)
-	liveTotal := 0
-	for callbackId := range g.metas {
-		liveTotal += liveEntryCount(g, callbackId)
-	}
-	assert.Equal(t, total, liveTotal)
-}
-
-func TestCycleCallback_SequentialAbortRestoresRemainder(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
-
-	const total = 4
-	var counter int64
-	for i := 0; i < total; i++ {
-		g.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
-			atomic.AddInt64(&counter, 1)
-			return true
-		})
-	}
-
-	// Abort once the first callback has run.
-	g.CycleCallback(func() bool { return atomic.LoadInt64(&counter) >= 1 })
-	assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
-
-	g.Lock()
-	defer g.Unlock()
-
-	// Every registered callback must have exactly one live entry.
+	assert.Len(t, g.metas, wantMetas)
 	for callbackId := range g.metas {
 		assert.Equal(t, 1, liveEntryCount(g, callbackId),
-			"callbackId %d has wrong live-entry count", callbackId)
+			"callbackId %d must have exactly one live entry", callbackId)
 	}
+}
+
+// TestCycleCallback_SingleLiveEntry checks the group keeps exactly one live heap
+// entry per callback across sequences that each risk leaving a duplicate or
+// dropping the entry: a plain register, a deactivate+activate cycle, and an
+// activate while the callback is mid-run.
+func TestCycleCallback_SingleLiveEntry(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("after register", func(t *testing.T) {
+		g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+		g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
+		assertLiveEntries(t, g, 1)
+	})
+
+	t.Run("deactivate then activate", func(t *testing.T) {
+		g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+		ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
+		require.NoError(t, ctrl.Deactivate(context.Background()))
+		require.NoError(t, ctrl.Activate())
+		assertLiveEntries(t, g, 1)
+	})
+
+	t.Run("activate during drain", func(t *testing.T) {
+		g := NewCallbackGroup("id", logger, 2).(*cycleCallbackGroup)
+		started := make(chan struct{})
+		release := make(chan struct{})
+		ctrl := g.Register("blocking", func(shouldAbort ShouldAbortCallback) bool {
+			close(started)
+			<-release
+			return true
+		})
+
+		done := make(chan bool, 1)
+		go func() { done <- g.CycleCallback(func() bool { return false }) }()
+		<-started
+
+		// Activate while the entry is in-flight (drained from heap, executing).
+		require.NoError(t, ctrl.Activate())
+		close(release)
+		<-done
+
+		// After the tick completes (teardown reschedules), exactly one live entry.
+		assertLiveEntries(t, g, 1)
+	})
+}
+
+// TestCycleCallback_AbortRestoresEntries checks that entries drained for a tick
+// that is then aborted are restored, so every callback keeps its live entry —
+// both when the whole parallel tick aborts and when a sequential tick aborts
+// partway through.
+func TestCycleCallback_AbortRestoresEntries(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("parallel full abort", func(t *testing.T) {
+		g := NewCallbackGroup("id", logger, 4).(*cycleCallbackGroup)
+		const total = 5
+		for i := 0; i < total; i++ {
+			g.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool { return true })
+		}
+
+		// Abort the entire tick; every drained entry must be restored.
+		g.CycleCallback(func() bool { return true })
+		assertLiveEntries(t, g, total)
+	})
+
+	t.Run("sequential partial abort", func(t *testing.T) {
+		g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+		const total = 4
+		var counter int64
+		for i := 0; i < total; i++ {
+			g.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&counter, 1)
+				return true
+			})
+		}
+
+		// Abort once the first callback has run; the remainder must be restored.
+		g.CycleCallback(func() bool { return atomic.LoadInt64(&counter) >= 1 })
+		assert.Equal(t, int64(1), atomic.LoadInt64(&counter))
+		assertLiveEntries(t, g, total)
+	})
 }
 
 func TestCycleCallback_StaleEntryBoundedGrowth(t *testing.T) {
@@ -1427,7 +1404,7 @@ func TestCycleCallback_StaleEntryBoundedGrowth(t *testing.T) {
 	assert.Equal(t, 1, liveEntries, "exactly one live entry")
 	// Compaction keeps the heap bounded by the registered-callback count, no matter
 	// how many Deactivate/Activate cycles churn through it.
-	assert.LessOrEqual(t, len(g.heap), 2*len(g.metas)+8,
+	assert.LessOrEqual(t, len(g.heap), heapCompactThreshold(len(g.metas)),
 		"heap stays bounded regardless of churn")
 }
 
@@ -1460,7 +1437,7 @@ func TestCycleCallback_CompactHeapKeepsInvariant(t *testing.T) {
 
 	// Compaction bounds the total entry count (some bounded stale entries may
 	// remain between compactions; only the count is capped, not stale presence).
-	assert.LessOrEqual(t, len(g.heap), 2*len(g.metas)+8, "heap bounded after churn")
+	assert.LessOrEqual(t, len(g.heap), heapCompactThreshold(len(g.metas)), "heap bounded after churn")
 
 	// Every callback still has exactly one live (current-schedGen) entry, so it
 	// will still fire; stragglers, if any, are stale duplicates.
@@ -1518,7 +1495,7 @@ func TestCycleCallback_RegisterDuringCompaction(t *testing.T) {
 	g.Unlock()
 	// Registering "fresh" raises metas to metasBefore+1; the heap must exceed that
 	// post-register threshold so schedule actually compacts mid-registration.
-	require.Greater(t, heapBefore, 2*(metasBefore+1)+8,
+	require.Greater(t, heapBefore, heapCompactThreshold(metasBefore+1),
 		"setup must leave the heap over the post-register compaction threshold")
 
 	g.Register("fresh", func(shouldAbort ShouldAbortCallback) bool { return true })
@@ -1584,20 +1561,6 @@ func TestCycleCallback_DeactivatePriorityClaimedButNotStarted(t *testing.T) {
 	assert.Equal(t, int64(0), atomic.LoadInt64(&bodyEntered))
 }
 
-func TestCycleCallback_UnregisterNilOnAbsentID(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
-
-	// unregister is called via a ctrl that holds the ID, but we can test via a
-	// freshly created ctrl pointing to a non-existent callbackId.
-	ctrl := &cycleCallbackCtrl{
-		callbackId:       99,
-		callbackCustomId: "ghost",
-		unregister:       g.unregister,
-	}
-	assert.Nil(t, ctrl.Unregister(context.Background()))
-}
-
 // TestCycleCallback_ControlErrorBranches covers the early-return error paths of
 // the control operations: acting on an absent callback id, and acting with an
 // already-cancelled context.
@@ -1617,6 +1580,8 @@ func TestCycleCallback_ControlErrorBranches(t *testing.T) {
 
 		assert.ErrorIs(t, ghost.Activate(), ErrorCallbackNotFound)
 		assert.ErrorIs(t, ghost.Deactivate(context.Background()), ErrorCallbackNotFound)
+		// Unregister of an absent id is a no-op success, not an error.
+		assert.NoError(t, ghost.Unregister(context.Background()))
 	})
 
 	t.Run("pre-cancelled context", func(t *testing.T) {
@@ -2112,6 +2077,167 @@ func TestCycleCallback_ConcurrentWaiters(t *testing.T) {
 	})
 }
 
+// TestCycleCallback_NilIntervalsRunsEveryTick covers a callback with no intervals:
+// WithIntervals(nil) is a no-op option, so intervals stays nil and computeNextDue
+// takes its nil branch, leaving the due-time at the group epoch — due on every tick.
+func TestCycleCallback_NilIntervalsRunsEveryTick(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	var counter int64
+	g := NewCallbackGroup("id", logger, 1)
+	g.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+		atomic.AddInt64(&counter, 1)
+		return true
+	}, WithIntervals(nil))
+
+	for i := 0; i < 3; i++ {
+		require.True(t, g.CycleCallback(shouldNotAbort))
+	}
+	assert.Equal(t, int64(3), atomic.LoadInt64(&counter),
+		"nil-interval callback must run on every tick")
+}
+
+// TestCycleCallback_CompactionThresholdBoundary pins the strict-greater-than
+// comparison in schedule: with one live meta heapCompactThreshold(1) is 10, so a
+// schedule that lands the heap at exactly 10 must not compact, while one that
+// lands it at 11 must. A >= mutation would compact in the at-threshold case.
+func TestCycleCallback_CompactionThresholdBoundary(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	cases := []struct {
+		name        string
+		stale       int // stale entries present before the boundary schedule
+		wantCompact bool
+	}{
+		{name: "at threshold keeps entries", stale: 8, wantCompact: false}, // 8 stale +1 live, +1 pushed = 10
+		{name: "over threshold compacts", stale: 9, wantCompact: true},     // 9 stale +1 live, +1 pushed = 11
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+			g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true },
+				WithIntervals(NewFixedIntervals(time.Hour)))
+
+			g.Lock()
+			defer g.Unlock()
+
+			var meta *cycleCallbackMeta
+			for _, m := range g.metas {
+				meta = m
+			}
+
+			// Rebuild a known heap: one live entry plus `stale` entries whose
+			// callbackIds are absent from metas, so compaction (if it runs) drops them.
+			g.heap = dueHeap{}
+			g.heap.push(dueEntry{callbackId: meta.callbackId, due: 0, schedGen: meta.schedGen})
+			for i := 0; i < tc.stale; i++ {
+				g.heap.push(dueEntry{callbackId: 1000 + uint32(i), due: int64(i + 1), schedGen: 1})
+			}
+			require.Len(t, g.heap, tc.stale+1)
+
+			g.schedule(meta) // pushes one more, crossing (or not) the boundary
+
+			if tc.wantCompact {
+				assert.Len(t, g.heap, 1, "compaction drops the stale entries, keeping the live one")
+			} else {
+				assert.Len(t, g.heap, tc.stale+2, "no compaction at exactly the threshold")
+			}
+		})
+	}
+}
+
+// TestCycleCallback_UnregisterAllDropsHeap covers reclaiming the heap once the
+// last meta is gone: schedule's size-based compaction can never run again with no
+// live metas, so unregistering the last callback must drop the heap outright.
+func TestCycleCallback_UnregisterAllDropsHeap(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+
+	const n = 100
+	ctrls := make([]CycleCallbackCtrl, n)
+	for i := 0; i < n; i++ {
+		ctrls[i] = g.Register(fmt.Sprintf("c%d", i),
+			func(shouldAbort ShouldAbortCallback) bool { return true },
+			WithIntervals(NewFixedIntervals(time.Hour)))
+	}
+	for i := 0; i < n; i++ {
+		require.NoError(t, ctrls[i].Unregister(context.Background()))
+	}
+
+	g.Lock()
+	defer g.Unlock()
+	assert.Empty(t, g.metas, "every callback unregistered")
+	assert.Empty(t, g.heap, "heap dropped once the last meta is unregistered")
+}
+
+// TestCycleCallback_ParallelWorkerGoexitReschedules covers the parallel dispatch
+// path when every worker exits abnormally: each callback calls runtime.Goexit,
+// which kills its worker. Metas a worker picked up are rescheduled by endRun;
+// metas left buffered in the (closed) channel are rescheduled by the post-Wait
+// drain. Either way no meta — all popped from the heap by drainDue — is lost.
+func TestCycleCallback_ParallelWorkerGoexitReschedules(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	g := NewCallbackGroup("id", logger, 4).(*cycleCallbackGroup)
+
+	const n = 8 // more than routinesLimit, so some metas stay buffered
+	for i := 0; i < n; i++ {
+		g.Register(fmt.Sprintf("c%d", i), func(shouldAbort ShouldAbortCallback) bool {
+			runtime.Goexit()
+			return true
+		})
+	}
+
+	g.CycleCallback(func() bool { return false })
+
+	// Every callback must still hold exactly one live heap entry, so the next tick
+	// will run it.
+	assertLiveEntries(t, g, n)
+}
+
+// TestCycleCallback_DeactivateWhileRunningPreventsRerun covers the interaction the
+// deactivate retry loop exists for: endRun reschedules a still-active callback
+// mid-teardown, so deactivate must observe the finished run, commit active=false,
+// and — together with drainDue's active check — keep it from running on later ticks.
+func TestCycleCallback_DeactivateWhileRunningPreventsRerun(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	synctest.Test(t, func(t *testing.T) {
+		var counter int64
+		started := make(chan struct{})
+		release := make(chan struct{})
+
+		callbacks := NewCallbackGroup("id", logger, 1)
+		ctrl := callbacks.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+			atomic.AddInt64(&counter, 1)
+			close(started)
+			<-release
+			return true
+		})
+
+		tickDone := make(chan struct{})
+		go func() {
+			callbacks.CycleCallback(func() bool { return false })
+			close(tickDone)
+		}()
+		<-started
+
+		deactivated := make(chan error, 1)
+		go func() { deactivated <- ctrl.Deactivate(context.Background()) }()
+		synctest.Wait() // deactivate is parked waiting on the in-flight run
+
+		close(release)
+		require.NoError(t, <-deactivated)
+		<-tickDone
+
+		// A later tick must not run the now-deactivated callback.
+		assert.False(t, callbacks.CycleCallback(func() bool { return false }))
+		assert.Equal(t, int64(1), atomic.LoadInt64(&counter),
+			"deactivated callback must not run on a later tick")
+	})
+}
+
 // BenchmarkCycleCallback measures the hot-path allocation profile with a single
 // always-due no-op callback on a sequential (routinesLimit=1) group, so no
 // worker-goroutine allocations contaminate the measurement.
@@ -2128,12 +2254,10 @@ func BenchmarkCycleCallback(b *testing.B) {
 	}
 }
 
-// TestCycleCallback_AllocRegression asserts that the per-CycleCallback allocation count
-// stays within a tight bound. Because the done channel is now allocated lazily
-// (only when a Deactivate/Unregister waiter needs it), the no-waiter hot path
-// has no make(chan struct{}) at all. If someone (a) reintroduces a
-// per-invocation abort closure OR (b) reverts to eager done-channel allocation,
-// the count rises by at least 1 and the test fails.
+// TestCycleCallback_AllocRegression bounds the per-CycleCallback allocation count.
+// The done channel is lazy (allocated only when a Deactivate/Unregister waiter
+// needs it) and dueHeap pushes/pops by value (no container/heap any-boxing);
+// reverting either raises the count and fails the test.
 func TestCycleCallback_AllocRegression(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	g := NewCallbackGroup("alloc", logger, 1)
@@ -2144,13 +2268,9 @@ func TestCycleCallback_AllocRegression(t *testing.T) {
 		g.CycleCallback(shouldNotAbort)
 	})
 
-	// Alloc breakdown per CycleCallback call (1 total):
-	//   1. drainDue: append([]*cycleCallbackMeta, meta) — fresh result slice per tick
-	// The concrete dueHeap pushes/pops dueEntry by value (no container/heap
-	// any-boxing), the abort closure is built once in Register, and the done
-	// channel is lazy — none of those allocate on the no-waiter hot path. A
-	// reintroduced per-invocation abort closure, eager done-channel allocation,
-	// or a return to container/heap's any-boxing would raise the count.
+	// Allocs per call that runs one callback (1): drainDue's result slice, fresh
+	// per tick. The abort closure is built once in Register (not per run) and the
+	// done channel is lazy, so neither adds to the run path.
 	const maxAllocs = 1
 	assert.LessOrEqual(t, allocs, float64(maxAllocs),
 		"CycleCallback allocs per run: got %.1f, want <= %d",

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -698,6 +698,49 @@ func TestCycleCallback_Sequential(t *testing.T) {
 		assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
 		assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
 	})
+
+	// drainDue snapshots the due set at the start of a tick, so a callback
+	// registered while an earlier one is running is deferred to the next tick.
+	// This matches the parallel path; both dispatch paths share one contract.
+	t.Run("register new while executing runs it on next tick", func(t *testing.T) {
+		var c1, c2 int64
+		chFinished := make(chan struct{}, 1)
+
+		synctest.Test(t, func(t *testing.T) {
+			// tickRunning is closed by c1 when it starts executing; release is
+			// closed by the test to let c1 proceed. This rendezvous is a true
+			// happens-before guarantee that Register("c2") is called while the
+			// tick is in-progress, after drainDue snapshotted the due set.
+			tickRunning := make(chan struct{})
+			release := make(chan struct{})
+
+			callbacks := NewCallbackGroup("id", logger, 1)
+			callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool {
+				close(tickRunning)
+				<-release
+				atomic.AddInt64(&c1, 1)
+				return true
+			})
+
+			go func() {
+				callbacks.CycleCallback(shouldNotAbort)
+				chFinished <- struct{}{}
+			}()
+			<-tickRunning
+			callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool {
+				atomic.AddInt64(&c2, 1)
+				return true
+			})
+			close(release)
+			<-chFinished
+
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c1))
+			assert.Equal(t, int64(0), atomic.LoadInt64(&c2))
+
+			assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, int64(1), atomic.LoadInt64(&c2))
+		})
+	})
 }
 
 func TestCycleCallback_Sequential_Unregister(t *testing.T) {
@@ -1441,6 +1484,39 @@ func TestCycleCallback_UnregisterNilOnAbsentID(t *testing.T) {
 	assert.Nil(t, ctrl.Unregister(context.Background()))
 }
 
+// TestCycleCallback_ControlErrorBranches covers the early-return error paths of
+// the control operations: acting on an absent callback id, and acting with an
+// already-cancelled context.
+func TestCycleCallback_ControlErrorBranches(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("absent id", func(t *testing.T) {
+		g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+		ghost := &cycleCallbackCtrl{
+			callbackId:       99,
+			callbackCustomId: "ghost",
+			isActive:         g.isActive,
+			activate:         g.activate,
+			deactivate:       g.deactivate,
+			unregister:       g.unregister,
+		}
+
+		assert.ErrorIs(t, ghost.Activate(), ErrorCallbackNotFound)
+		assert.ErrorIs(t, ghost.Deactivate(context.Background()), ErrorCallbackNotFound)
+	})
+
+	t.Run("pre-cancelled context", func(t *testing.T) {
+		g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+		ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		assert.ErrorIs(t, ctrl.Deactivate(ctx), context.Canceled)
+		assert.ErrorIs(t, ctrl.Unregister(ctx), context.Canceled)
+	})
+}
+
 func TestCycleCallback_ConcurrentRegisterUnregisterLeakCheck(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	g := NewCallbackGroup("id", logger, 4).(*cycleCallbackGroup)
@@ -1493,8 +1569,12 @@ func TestCycleCallback_StressRace(t *testing.T) {
 	const stable = 4
 	ctrls := make([]CycleCallbackCtrl, stable)
 	for i := 0; i < stable; i++ {
+		// Interval-bearing callbacks so the Activate path drives computeNextDue's
+		// interval Get() concurrently with the running callback's Reset/Advance,
+		// exercising the interval state under -race.
 		ctrls[i] = callbacks.Register(fmt.Sprintf("stable%d", i),
-			func(shouldAbort ShouldAbortCallback) bool { return true })
+			func(shouldAbort ShouldAbortCallback) bool { return true },
+			WithIntervals(NewExpIntervals(time.Millisecond, 10*time.Millisecond, 2, 4)))
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -1535,6 +1615,75 @@ func TestCycleCallback_StressRace(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestCycleCallback_StopWaitsForInFlightRun asserts the Deactivate/Unregister
+// contract: the call must not return while a callback body is executing. Because
+// teardown reschedules a still-active callback, a run that finishes mid-wait can
+// start a fresh run before the stopper commits — the stopper must wait for that
+// one too.
+//
+// The body sleeps briefly so an overlapping run is observable via inFlight, and
+// the attempt is repeated because hitting the reschedule-then-rerun window
+// depends on scheduling.
+func TestCycleCallback_StopWaitsForInFlightRun(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	modes := []struct {
+		name string
+		stop func(ctrl CycleCallbackCtrl) error
+	}{
+		{"deactivate", func(ctrl CycleCallbackCtrl) error { return ctrl.Deactivate(context.Background()) }},
+		{"unregister", func(ctrl CycleCallbackCtrl) error { return ctrl.Unregister(context.Background()) }},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			for attempt := 0; attempt < 50; attempt++ {
+				g := NewCallbackGroup("id", logger, 4)
+
+				var inFlight atomic.Int32
+				firstRun := make(chan struct{})
+				var once sync.Once
+				ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool {
+					inFlight.Add(1)
+					defer inFlight.Add(-1)
+					once.Do(func() { close(firstRun) })
+					time.Sleep(10 * time.Microsecond)
+					return true
+				})
+
+				stopTicking := make(chan struct{})
+				ticking := runTicks(g, stopTicking)
+
+				<-firstRun
+				require.NoError(t, mode.stop(ctrl))
+				require.Zero(t, inFlight.Load(),
+					"%s returned while a callback body was in flight (attempt %d)", mode.name, attempt)
+
+				close(stopTicking)
+				<-ticking
+			}
+		})
+	}
+}
+
+// runTicks drives CycleCallback in a loop until stop is closed, returning a channel
+// that closes once the loop has exited.
+func runTicks(g CycleCallbackGroup, stop <-chan struct{}) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				g.CycleCallback(func() bool { return false })
+			}
+		}
+	}()
+	return done
 }
 
 // TestCycleCallback_RunWithIntervals exercises computeNextDue and interval Reset/Advance
@@ -1848,64 +1997,6 @@ func TestCycleCallback_ConcurrentWaiters(t *testing.T) {
 		assert.NoError(t, <-unregisterErr2)
 	})
 }
-
-// TestCycleCallback_PanicUnderLockDoesNotDeadlock guards against a lock leak caused by a
-// panic while the group lock is held. schedule calls computeNextDue, which
-// calls CycleIntervals.Get(); if Get() panics (e.g. due to a nil dereference or
-// user error), the group lock must still be released so subsequent operations
-// can proceed. This test exercises that path via activate, which calls schedule
-// under the lock.
-func TestCycleCallback_PanicUnderLockDoesNotDeadlock(t *testing.T) {
-	intervals := &panicCycleIntervals{}
-
-	logger, _ := test.NewNullLogger()
-	g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
-
-	// Register with Get() returning normally (flag not yet set), so the initial
-	// schedule in Register succeeds.
-	ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true },
-		WithIntervals(intervals))
-
-	// Deactivate so the next Activate will call schedule → Get() under the lock.
-	require.NoError(t, ctrl.Deactivate(context.Background()))
-
-	// Arm the panic, then call Activate. activate holds the group lock when it
-	// calls schedule → computeNextDue → Get(), which now panics. The defer in
-	// activate must release the lock before the panic unwinds.
-	intervals.armed.Store(true)
-	require.Panics(t, func() { ctrl.Activate() }) //nolint:errcheck
-
-	// If the lock leaked, any operation that acquires it would block forever.
-	// Prove the lock was released by running a follow-up operation with a timeout.
-	done := make(chan struct{})
-	go func() {
-		// isActive acquires the group lock; it must not block.
-		g.isActive(0, "c")
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// lock was released: group is healthy
-	case <-time.After(2 * time.Second):
-		t.Fatal("group lock leaked after panic in activate: follow-up isActive blocked")
-	}
-}
-
-// panicCycleIntervals is a CycleIntervals whose Get panics when armed.
-type panicCycleIntervals struct {
-	armed atomic.Bool
-}
-
-func (p *panicCycleIntervals) Get() time.Duration {
-	if p.armed.Load() {
-		panic("injected panic in Get()")
-	}
-	return 10 * time.Millisecond
-}
-
-func (p *panicCycleIntervals) Reset()   {}
-func (p *panicCycleIntervals) Advance() {}
 
 // BenchmarkCycleCallback measures the hot-path allocation profile with a single
 // always-due no-op callback on a sequential (routinesLimit=1) group, so no

--- a/entities/cyclemanager/cyclemanager_test.go
+++ b/entities/cyclemanager/cyclemanager_test.go
@@ -130,7 +130,7 @@ func TestCycleManager_beforeTimeoutWithWait(t *testing.T) {
 
 		err := cm.StopAndWait(timeoutCtx)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, cm.Running())
 		assert.Equal(t, "something wonderful...", <-p.results)
 	})
@@ -244,7 +244,7 @@ func TestCycleManager_doesNotStartMultipleTimesWithWait(t *testing.T) {
 
 		err := cm.StopAndWait(context.Background())
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, cm.Running())
 		// just one result produced
 		assert.Equal(t, 1, len(p.results))
@@ -365,7 +365,7 @@ func TestCycleManager_cycleCallbackStoppedDueToFrequentStopChecks(t *testing.T) 
 
 		err := cm.StopAndWait(timeoutCtx)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.False(t, cm.Running())
 		assert.Equal(t, 0, len(p.results))
 	})

--- a/entities/cyclemanager/dueheap.go
+++ b/entities/cyclemanager/dueheap.go
@@ -78,3 +78,21 @@ func (h dueHeap) down(i int) {
 		i = smallest
 	}
 }
+
+// compact drops every entry for which keep returns false, then rebuilds the
+// min-heap invariant in O(n) via Floyd's build-heap. It filters in place into the
+// existing backing array, allocating nothing. Runs off the hot push/pop path
+// (only when the heap has grown too large), so keep may be a closure.
+func (h *dueHeap) compact(keep func(dueEntry) bool) {
+	a := *h
+	kept := a[:0]
+	for _, e := range a {
+		if keep(e) {
+			kept = append(kept, e)
+		}
+	}
+	*h = kept
+	for i := len(kept)/2 - 1; i >= 0; i-- {
+		kept.down(i)
+	}
+}

--- a/entities/cyclemanager/dueheap.go
+++ b/entities/cyclemanager/dueheap.go
@@ -25,10 +25,9 @@ type dueEntry struct {
 	schedGen   uint64
 }
 
-// dueHeap is a min-heap of dueEntry ordered by due (earliest first). The
-// heap operations are implemented directly on the concrete slice, rather than
-// through container/heap, so push/pop pass dueEntry by value and never box it
-// into an any — container/heap's any-based Push/Pop allocate on every call.
+// dueHeap is a min-heap of dueEntry ordered by due (earliest first). Operations
+// are implemented directly on the slice rather than via container/heap, whose
+// any-typed Push/Pop would box each dueEntry and allocate on every call.
 type dueHeap []dueEntry
 
 // push adds e and sifts it up to restore the min-heap invariant.
@@ -46,7 +45,7 @@ func (h *dueHeap) push(e dueEntry) {
 	}
 }
 
-// pop removes and returns the earliest-due entry. Caller must check Len() > 0.
+// pop removes and returns the earliest-due entry. Caller must ensure len(*h) > 0.
 func (h *dueHeap) pop() dueEntry {
 	a := *h
 	n := len(a) - 1

--- a/entities/cyclemanager/dueheap.go
+++ b/entities/cyclemanager/dueheap.go
@@ -14,11 +14,11 @@ package cyclemanager
 // dueEntry is a single heap slot. The schedGen field lets drainDue discard
 // stale entries without an explicit remove.
 //
-// due is stored as Unix-nanoseconds (int64) rather than time.Time on purpose:
-// time.Time embeds a *Location pointer, which turns every heap swap into a GC
-// write barrier — a large cost when a tick sifts many entries. An int64 key
-// makes dueEntry pointer-free, so swaps are plain memory moves and comparisons
-// are integer compares.
+// due is stored as nanoseconds relative to the group epoch (int64) rather than
+// time.Time on purpose: time.Time embeds a *Location pointer, which turns every
+// heap swap into a GC write barrier — a large cost when a tick sifts many
+// entries. An int64 key makes dueEntry pointer-free, so swaps are plain memory
+// moves and comparisons are integer compares.
 type dueEntry struct {
 	callbackId uint32
 	due        int64
@@ -77,12 +77,4 @@ func (h dueHeap) down(i int) {
 		h[i], h[smallest] = h[smallest], h[i]
 		i = smallest
 	}
-}
-
-// computeNextDue returns when meta is next eligible to run, as Unix-nanoseconds.
-func computeNextDue(m *cycleCallbackMeta) int64 {
-	if m.intervals == nil {
-		return m.started.UnixNano()
-	}
-	return m.started.Add(m.intervals.Get()).UnixNano()
 }

--- a/entities/cyclemanager/dueheap.go
+++ b/entities/cyclemanager/dueheap.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cyclemanager
+
+// dueEntry is a single heap slot. The schedGen field lets drainDue discard
+// stale entries without an explicit remove.
+//
+// due is stored as Unix-nanoseconds (int64) rather than time.Time on purpose:
+// time.Time embeds a *Location pointer, which turns every heap swap into a GC
+// write barrier — a large cost when a tick sifts many entries. An int64 key
+// makes dueEntry pointer-free, so swaps are plain memory moves and comparisons
+// are integer compares.
+type dueEntry struct {
+	callbackId uint32
+	due        int64
+	schedGen   uint64
+}
+
+// dueHeap is a min-heap of dueEntry ordered by due (earliest first). The
+// heap operations are implemented directly on the concrete slice, rather than
+// through container/heap, so push/pop pass dueEntry by value and never box it
+// into an any — container/heap's any-based Push/Pop allocate on every call.
+type dueHeap []dueEntry
+
+// push adds e and sifts it up to restore the min-heap invariant.
+func (h *dueHeap) push(e dueEntry) {
+	*h = append(*h, e)
+	a := *h
+	i := len(a) - 1
+	for i > 0 {
+		parent := (i - 1) / 2
+		if a[i].due >= a[parent].due {
+			break
+		}
+		a[i], a[parent] = a[parent], a[i]
+		i = parent
+	}
+}
+
+// pop removes and returns the earliest-due entry. Caller must check Len() > 0.
+func (h *dueHeap) pop() dueEntry {
+	a := *h
+	n := len(a) - 1
+	a[0], a[n] = a[n], a[0]
+	e := a[n]
+	*h = a[:n]
+	if n > 0 {
+		h.down(0)
+	}
+	return e
+}
+
+// down sifts the element at index i down to restore the min-heap invariant.
+func (h dueHeap) down(i int) {
+	n := len(h)
+	for {
+		left := 2*i + 1
+		if left >= n {
+			break
+		}
+		smallest := left
+		if right := left + 1; right < n && h[right].due < h[left].due {
+			smallest = right
+		}
+		if h[smallest].due >= h[i].due {
+			break
+		}
+		h[i], h[smallest] = h[smallest], h[i]
+		i = smallest
+	}
+}
+
+// computeNextDue returns when meta is next eligible to run, as Unix-nanoseconds.
+func computeNextDue(m *cycleCallbackMeta) int64 {
+	if m.intervals == nil {
+		return m.started.UnixNano()
+	}
+	return m.started.Add(m.intervals.Get()).UnixNano()
+}

--- a/entities/cyclemanager/dueheap_test.go
+++ b/entities/cyclemanager/dueheap_test.go
@@ -1,0 +1,185 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cyclemanager
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDueHeap_PopOrder(t *testing.T) {
+	base := time.Now()
+
+	type entry struct {
+		name    string
+		nextDue time.Time
+	}
+
+	tests := []struct {
+		name    string
+		entries []entry
+		want    []string // names in exact pop order, when order is fully determined
+		// names that must occupy the first len(wantPrefix) pops, in any order
+		// (used when some entries share a due time)
+		wantPrefix []string
+	}{
+		{
+			name:    "empty",
+			entries: nil,
+			want:    nil,
+		},
+		{
+			name:    "single",
+			entries: []entry{{"a", base}},
+			want:    []string{"a"},
+		},
+		{
+			name: "ascending input",
+			entries: []entry{
+				{"a", base},
+				{"b", base.Add(time.Second)},
+				{"c", base.Add(2 * time.Second)},
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "descending input",
+			entries: []entry{
+				{"c", base.Add(2 * time.Second)},
+				{"b", base.Add(time.Second)},
+				{"a", base},
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "shuffled with equal due times",
+			entries: []entry{
+				{"late", base.Add(3 * time.Second)},
+				{"early1", base},
+				{"mid", base.Add(time.Second)},
+				{"early2", base},
+			},
+			// two entries share base; they must pop before mid/late, but their
+			// relative order within the tie is unspecified.
+			wantPrefix: []string{"early1", "early2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &dueHeap{}
+			heap.Init(h)
+			for _, e := range tt.entries {
+				heap.Push(h, &cycleCallbackMeta{customId: e.name, nextDue: e.nextDue})
+			}
+
+			var popped []time.Time
+			var names []string
+			for h.Len() > 0 {
+				meta := heap.Pop(h).(*cycleCallbackMeta)
+				popped = append(popped, meta.nextDue)
+				names = append(names, meta.customId)
+			}
+
+			// pop order is always non-decreasing in nextDue
+			for i := 1; i < len(popped); i++ {
+				assert.False(t, popped[i].Before(popped[i-1]),
+					"pop %d (%v) before pop %d (%v)", i, popped[i], i-1, popped[i-1])
+			}
+			if tt.want != nil {
+				assert.Equal(t, tt.want, names)
+			}
+			if tt.wantPrefix != nil {
+				require.GreaterOrEqual(t, len(names), len(tt.wantPrefix))
+				assert.ElementsMatch(t, tt.wantPrefix, names[:len(tt.wantPrefix)])
+			}
+		})
+	}
+}
+
+func TestDueHeap_HeapIndexConsistency(t *testing.T) {
+	base := time.Now()
+	h := &dueHeap{}
+	heap.Init(h)
+
+	metas := []*cycleCallbackMeta{
+		{callbackId: 3, customId: "d", nextDue: base.Add(3 * time.Second)},
+		{callbackId: 0, customId: "a", nextDue: base},
+		{callbackId: 2, customId: "c", nextDue: base.Add(2 * time.Second)},
+		{callbackId: 1, customId: "b", nextDue: base.Add(time.Second)},
+	}
+	for _, m := range metas {
+		heap.Push(h, m)
+	}
+
+	// every queued meta's heapIndex points back at its slot
+	for i, m := range *h {
+		assert.Equal(t, i, m.heapIndex, "heapIndex mismatch for %s", m.customId)
+	}
+
+	// the top of the heap is the earliest-due entry, carrying its callbackId
+	// intact for the lazy map lookup on pop
+	assert.Equal(t, uint32(0), (*h)[0].callbackId)
+
+	// remove the middle element by its tracked index; remaining indices stay valid
+	victim := metas[2] // "c"
+	require.GreaterOrEqual(t, victim.heapIndex, 0)
+	heap.Remove(h, victim.heapIndex)
+	assert.Equal(t, -1, victim.heapIndex, "removed meta keeps heapIndex -1")
+	for i, m := range *h {
+		assert.Equal(t, i, m.heapIndex, "heapIndex mismatch after remove for %s", m.customId)
+	}
+
+	// draining sets heapIndex -1 on every popped meta and preserves due order
+	var prev time.Time
+	first := true
+	for h.Len() > 0 {
+		meta := heap.Pop(h).(*cycleCallbackMeta)
+		assert.Equal(t, -1, meta.heapIndex)
+		if !first {
+			assert.False(t, meta.nextDue.Before(prev))
+		}
+		prev, first = meta.nextDue, false
+	}
+}
+
+func TestComputeNextDue(t *testing.T) {
+	started := time.Now()
+	interval := 5 * time.Second
+
+	tests := []struct {
+		name string
+		meta *cycleCallbackMeta
+		want time.Time
+	}{
+		{
+			name: "nil interval is always due at started",
+			meta: &cycleCallbackMeta{started: started, intervals: nil},
+			want: started,
+		},
+		{
+			name: "interval adds Get() to started",
+			meta: &cycleCallbackMeta{started: started, intervals: NewFixedIntervals(interval)},
+			want: started.Add(interval),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, computeNextDue(tt.meta))
+		})
+	}
+}

--- a/entities/cyclemanager/dueheap_test.go
+++ b/entities/cyclemanager/dueheap_test.go
@@ -118,6 +118,7 @@ func TestDueHeap_PopOrder(t *testing.T) {
 }
 
 func TestComputeNextDue(t *testing.T) {
+	g := &cycleCallbackGroup{epoch: time.Now()}
 	started := time.Now()
 	interval := 5 * time.Second
 
@@ -129,18 +130,18 @@ func TestComputeNextDue(t *testing.T) {
 		{
 			name: "nil interval is always due at started",
 			meta: &cycleCallbackMeta{started: started, intervals: nil},
-			want: started.UnixNano(),
+			want: started.Sub(g.epoch).Nanoseconds(),
 		},
 		{
 			name: "interval adds Get() to started",
 			meta: &cycleCallbackMeta{started: started, intervals: NewFixedIntervals(interval)},
-			want: started.Add(interval).UnixNano(),
+			want: started.Add(interval).Sub(g.epoch).Nanoseconds(),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, computeNextDue(tt.meta))
+			assert.Equal(t, tt.want, g.computeNextDue(tt.meta))
 		})
 	}
 }

--- a/entities/cyclemanager/dueheap_test.go
+++ b/entities/cyclemanager/dueheap_test.go
@@ -12,6 +12,7 @@
 package cyclemanager
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -19,8 +20,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// checkHeapInvariant asserts the min-heap property on the backing array: every
+// parent is due no later than either child.
+func checkHeapInvariant(t *testing.T, h dueHeap) {
+	t.Helper()
+	for i := range h {
+		if left := 2*i + 1; left < len(h) {
+			assert.LessOrEqualf(t, h[i].due, h[left].due,
+				"heap invariant violated: parent %d (due=%d) > left child %d (due=%d)",
+				i, h[i].due, left, h[left].due)
+		}
+		if right := 2*i + 2; right < len(h) {
+			assert.LessOrEqualf(t, h[i].due, h[right].due,
+				"heap invariant violated: parent %d (due=%d) > right child %d (due=%d)",
+				i, h[i].due, right, h[right].due)
+		}
+	}
+}
+
 func TestDueHeap_PopOrder(t *testing.T) {
 	base := time.Now().UnixNano()
+
+	// deepEntries builds n entries with due times scrambled by a fixed LCG, so
+	// push and pop sift through every level of a tall heap.
+	deepEntries := func(n int) []dueEntry {
+		es := make([]dueEntry, n)
+		x := uint64(1)
+		for i := 0; i < n; i++ {
+			x = x*6364136223846793005 + 1442695040888963407
+			es[i] = dueEntry{
+				callbackId: uint32(i),
+				due:        base + int64(x%uint64(n)),
+				schedGen:   uint64(i) + 1,
+			}
+		}
+		return es
+	}
 
 	tests := []struct {
 		name       string
@@ -68,6 +103,10 @@ func TestDueHeap_PopOrder(t *testing.T) {
 			// but their relative order within the tie is unspecified.
 			wantPrefix: []uint32{1, 2},
 		},
+		{
+			name:    "deep sift, 200 entries",
+			entries: deepEntries(200),
+		},
 	}
 
 	for _, tt := range tests {
@@ -75,6 +114,7 @@ func TestDueHeap_PopOrder(t *testing.T) {
 			h := &dueHeap{}
 			for _, e := range tt.entries {
 				h.push(e)
+				checkHeapInvariant(t, *h)
 			}
 
 			var poppedDue []int64
@@ -87,6 +127,7 @@ func TestDueHeap_PopOrder(t *testing.T) {
 
 			for len(*h) > 0 {
 				e := h.pop()
+				checkHeapInvariant(t, *h)
 				poppedDue = append(poppedDue, e.due)
 				poppedIds = append(poppedIds, e.callbackId)
 				poppedSched = append(poppedSched, e.schedGen)
@@ -175,6 +216,7 @@ func TestDueHeap_Compact(t *testing.T) {
 			}
 
 			h.compact(tt.keep)
+			checkHeapInvariant(t, *h)
 
 			gotIds := make([]uint32, 0, len(*h))
 			for _, e := range *h {
@@ -182,7 +224,6 @@ func TestDueHeap_Compact(t *testing.T) {
 			}
 			assert.ElementsMatch(t, tt.wantIds, gotIds, "survivors")
 
-			// The invariant is restored: pops come out in non-decreasing due order.
 			var prev int64 = -1
 			for len(*h) > 0 {
 				e := h.pop()
@@ -191,6 +232,105 @@ func TestDueHeap_Compact(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDueHeap_PushAfterCompact checks that a push onto a just-compacted heap
+// sifts correctly, since compact rebuilds the heap and push assumes a valid one.
+func TestDueHeap_PushAfterCompact(t *testing.T) {
+	base := time.Now().UnixNano()
+	h := &dueHeap{}
+	for i := 0; i < 12; i++ {
+		h.push(dueEntry{callbackId: uint32(i), due: base + int64(i%5)*int64(time.Second), schedGen: 1})
+	}
+
+	h.compact(func(e dueEntry) bool { return e.callbackId%3 == 0 })
+	checkHeapInvariant(t, *h)
+
+	h.push(dueEntry{callbackId: 100, due: base - int64(time.Second), schedGen: 1}) // new minimum
+	checkHeapInvariant(t, *h)
+	h.push(dueEntry{callbackId: 101, due: base + int64(10*time.Second), schedGen: 1}) // new maximum
+	checkHeapInvariant(t, *h)
+
+	require.Equal(t, uint32(100), (*h)[0].callbackId, "new minimum must sift to the root")
+
+	var prev int64 = -1
+	for len(*h) > 0 {
+		e := h.pop()
+		assert.GreaterOrEqual(t, e.due, prev, "pop out of order after compact+push")
+		prev = e.due
+	}
+}
+
+// FuzzDueHeap drives random push/pop/compact sequences, checking after every
+// operation that the heap invariant holds and that the live set matches an
+// independent reference model.
+func FuzzDueHeap(f *testing.F) {
+	f.Add([]byte{0, 5, 1, 3, 2, 0, 0, 7, 1, 9})
+	f.Add([]byte{0, 0, 0, 0, 0, 2, 1, 1, 2, 3, 3, 3})
+
+	f.Fuzz(func(t *testing.T, ops []byte) {
+		h := &dueHeap{}
+		var model []dueEntry // reference multiset of live entries
+		var nextId uint32
+
+		for i := 0; i+1 < len(ops); i += 2 {
+			switch ops[i] % 3 {
+			case 0: // push
+				e := dueEntry{callbackId: nextId, due: int64(ops[i+1]), schedGen: 1}
+				nextId++
+				h.push(e)
+				model = append(model, e)
+			case 1: // pop (min due)
+				if len(model) == 0 {
+					continue
+				}
+				got := h.pop()
+				// Ties may resolve to any entry sharing the min due, so match on
+				// due rather than identity.
+				minDue := model[0].due
+				for _, e := range model {
+					if e.due < minDue {
+						minDue = e.due
+					}
+				}
+				require.Equal(t, minDue, got.due, "pop did not return the minimum due")
+				removed := false
+				for j, e := range model {
+					if e == got {
+						model = append(model[:j], model[j+1:]...)
+						removed = true
+						break
+					}
+				}
+				require.True(t, removed, "popped an entry not in the model")
+			case 2: // compact: keep entries with even due
+				keep := func(e dueEntry) bool { return e.due%2 == 0 }
+				h.compact(keep)
+				kept := model[:0]
+				for _, e := range model {
+					if keep(e) {
+						kept = append(kept, e)
+					}
+				}
+				model = kept
+			}
+
+			checkHeapInvariant(t, *h)
+			require.Equal(t, len(model), len(*h), "heap size diverged from model")
+		}
+
+		// Final drain must equal the model sorted by due.
+		wantDue := make([]int64, len(model))
+		for i, e := range model {
+			wantDue[i] = e.due
+		}
+		sort.Slice(wantDue, func(i, j int) bool { return wantDue[i] < wantDue[j] })
+		gotDue := make([]int64, 0, len(*h))
+		for len(*h) > 0 {
+			gotDue = append(gotDue, h.pop().due)
+		}
+		require.Equal(t, wantDue, gotDue, "final drain order")
+	})
 }
 
 func TestComputeNextDue(t *testing.T) {

--- a/entities/cyclemanager/dueheap_test.go
+++ b/entities/cyclemanager/dueheap_test.go
@@ -119,28 +119,77 @@ func TestDueHeap_PopOrder(t *testing.T) {
 
 func TestDueHeap_Compact(t *testing.T) {
 	base := time.Now().UnixNano()
-
-	h := &dueHeap{}
-	for i := 0; i < 20; i++ {
-		// Interleave "keep" (even) and "drop" (odd) ids across a range of due
-		// times so compaction has a multi-level heap to rebuild.
-		h.push(dueEntry{callbackId: uint32(i), due: base + int64(i%7)*int64(time.Second), schedGen: 1})
+	// entries builds n entries across a range of due times so a surviving subset
+	// forms a multi-level heap for compaction to rebuild.
+	entries := func(n int) []dueEntry {
+		es := make([]dueEntry, n)
+		for i := 0; i < n; i++ {
+			es[i] = dueEntry{callbackId: uint32(i), due: base + int64(i%7)*int64(time.Second), schedGen: 1}
+		}
+		return es
 	}
 
-	h.compact(func(e dueEntry) bool { return e.callbackId%2 == 0 })
-
-	// Only even ids survive.
-	require.Len(t, *h, 10)
-	for _, e := range *h {
-		assert.Zero(t, e.callbackId%2, "odd id %d should have been dropped", e.callbackId)
+	tests := []struct {
+		name    string
+		entries []dueEntry
+		keep    func(dueEntry) bool
+		wantIds []uint32 // surviving callbackIds, in any order (nil = none)
+	}{
+		{
+			name:    "empty heap",
+			entries: nil,
+			keep:    func(dueEntry) bool { return true },
+			wantIds: nil,
+		},
+		{
+			name:    "keep none",
+			entries: entries(10),
+			keep:    func(dueEntry) bool { return false },
+			wantIds: nil,
+		},
+		{
+			name:    "keep all",
+			entries: entries(5),
+			keep:    func(dueEntry) bool { return true },
+			wantIds: []uint32{0, 1, 2, 3, 4},
+		},
+		{
+			name:    "keep one",
+			entries: entries(6),
+			keep:    func(e dueEntry) bool { return e.callbackId == 3 },
+			wantIds: []uint32{3},
+		},
+		{
+			name:    "keep even across multi-level heap",
+			entries: entries(20),
+			keep:    func(e dueEntry) bool { return e.callbackId%2 == 0 },
+			wantIds: []uint32{0, 2, 4, 6, 8, 10, 12, 14, 16, 18},
+		},
 	}
 
-	// The invariant is restored: pops come out in non-decreasing due order.
-	var prev int64 = -1
-	for len(*h) > 0 {
-		e := h.pop()
-		assert.GreaterOrEqual(t, e.due, prev, "pop out of order")
-		prev = e.due
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &dueHeap{}
+			for _, e := range tt.entries {
+				h.push(e)
+			}
+
+			h.compact(tt.keep)
+
+			gotIds := make([]uint32, 0, len(*h))
+			for _, e := range *h {
+				gotIds = append(gotIds, e.callbackId)
+			}
+			assert.ElementsMatch(t, tt.wantIds, gotIds, "survivors")
+
+			// The invariant is restored: pops come out in non-decreasing due order.
+			var prev int64 = -1
+			for len(*h) > 0 {
+				e := h.pop()
+				assert.GreaterOrEqual(t, e.due, prev, "pop out of order")
+				prev = e.due
+			}
+		})
 	}
 }
 

--- a/entities/cyclemanager/dueheap_test.go
+++ b/entities/cyclemanager/dueheap_test.go
@@ -117,6 +117,33 @@ func TestDueHeap_PopOrder(t *testing.T) {
 	}
 }
 
+func TestDueHeap_Compact(t *testing.T) {
+	base := time.Now().UnixNano()
+
+	h := &dueHeap{}
+	for i := 0; i < 20; i++ {
+		// Interleave "keep" (even) and "drop" (odd) ids across a range of due
+		// times so compaction has a multi-level heap to rebuild.
+		h.push(dueEntry{callbackId: uint32(i), due: base + int64(i%7)*int64(time.Second), schedGen: 1})
+	}
+
+	h.compact(func(e dueEntry) bool { return e.callbackId%2 == 0 })
+
+	// Only even ids survive.
+	require.Len(t, *h, 10)
+	for _, e := range *h {
+		assert.Zero(t, e.callbackId%2, "odd id %d should have been dropped", e.callbackId)
+	}
+
+	// The invariant is restored: pops come out in non-decreasing due order.
+	var prev int64 = -1
+	for len(*h) > 0 {
+		e := h.pop()
+		assert.GreaterOrEqual(t, e.due, prev, "pop out of order")
+		prev = e.due
+	}
+}
+
 func TestComputeNextDue(t *testing.T) {
 	g := &cycleCallbackGroup{epoch: time.Now()}
 	started := time.Now()

--- a/entities/cyclemanager/dueheap_test.go
+++ b/entities/cyclemanager/dueheap_test.go
@@ -12,7 +12,6 @@
 package cyclemanager
 
 import (
-	"container/heap"
 	"testing"
 	"time"
 
@@ -21,20 +20,13 @@ import (
 )
 
 func TestDueHeap_PopOrder(t *testing.T) {
-	base := time.Now()
-
-	type entry struct {
-		name    string
-		nextDue time.Time
-	}
+	base := time.Now().UnixNano()
 
 	tests := []struct {
-		name    string
-		entries []entry
-		want    []string // names in exact pop order, when order is fully determined
-		// names that must occupy the first len(wantPrefix) pops, in any order
-		// (used when some entries share a due time)
-		wantPrefix []string
+		name       string
+		entries    []dueEntry
+		want       []uint32 // callbackIds in exact pop order
+		wantPrefix []uint32 // callbackIds that must occupy the first len(wantPrefix) pops, in any order
 	}{
 		{
 			name:    "empty",
@@ -43,116 +35,85 @@ func TestDueHeap_PopOrder(t *testing.T) {
 		},
 		{
 			name:    "single",
-			entries: []entry{{"a", base}},
-			want:    []string{"a"},
+			entries: []dueEntry{{callbackId: 1, due: base, schedGen: 10}},
+			want:    []uint32{1},
 		},
 		{
 			name: "ascending input",
-			entries: []entry{
-				{"a", base},
-				{"b", base.Add(time.Second)},
-				{"c", base.Add(2 * time.Second)},
+			entries: []dueEntry{
+				{callbackId: 1, due: base, schedGen: 1},
+				{callbackId: 2, due: base + int64(time.Second), schedGen: 2},
+				{callbackId: 3, due: base + int64(2*time.Second), schedGen: 3},
 			},
-			want: []string{"a", "b", "c"},
+			want: []uint32{1, 2, 3},
 		},
 		{
 			name: "descending input",
-			entries: []entry{
-				{"c", base.Add(2 * time.Second)},
-				{"b", base.Add(time.Second)},
-				{"a", base},
+			entries: []dueEntry{
+				{callbackId: 3, due: base + int64(2*time.Second), schedGen: 3},
+				{callbackId: 2, due: base + int64(time.Second), schedGen: 2},
+				{callbackId: 1, due: base, schedGen: 1},
 			},
-			want: []string{"a", "b", "c"},
+			want: []uint32{1, 2, 3},
 		},
 		{
 			name: "shuffled with equal due times",
-			entries: []entry{
-				{"late", base.Add(3 * time.Second)},
-				{"early1", base},
-				{"mid", base.Add(time.Second)},
-				{"early2", base},
+			entries: []dueEntry{
+				{callbackId: 4, due: base + int64(3*time.Second), schedGen: 4},
+				{callbackId: 1, due: base, schedGen: 1},
+				{callbackId: 3, due: base + int64(time.Second), schedGen: 3},
+				{callbackId: 2, due: base, schedGen: 2},
 			},
-			// two entries share base; they must pop before mid/late, but their
-			// relative order within the tie is unspecified.
-			wantPrefix: []string{"early1", "early2"},
+			// callbackId 1 and 2 share base due; they must pop before 3 and 4,
+			// but their relative order within the tie is unspecified.
+			wantPrefix: []uint32{1, 2},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &dueHeap{}
-			heap.Init(h)
 			for _, e := range tt.entries {
-				heap.Push(h, &cycleCallbackMeta{customId: e.name, nextDue: e.nextDue})
+				h.push(e)
 			}
 
-			var popped []time.Time
-			var names []string
-			for h.Len() > 0 {
-				meta := heap.Pop(h).(*cycleCallbackMeta)
-				popped = append(popped, meta.nextDue)
-				names = append(names, meta.customId)
+			var poppedDue []int64
+			var poppedIds []uint32
+			var poppedSched []uint64
+			origSched := make(map[uint32]uint64, len(tt.entries))
+			for _, e := range tt.entries {
+				origSched[e.callbackId] = e.schedGen
 			}
 
-			// pop order is always non-decreasing in nextDue
-			for i := 1; i < len(popped); i++ {
-				assert.False(t, popped[i].Before(popped[i-1]),
-					"pop %d (%v) before pop %d (%v)", i, popped[i], i-1, popped[i-1])
+			for len(*h) > 0 {
+				e := h.pop()
+				poppedDue = append(poppedDue, e.due)
+				poppedIds = append(poppedIds, e.callbackId)
+				poppedSched = append(poppedSched, e.schedGen)
 			}
+
+			// pop order is always non-decreasing in due
+			for i := 1; i < len(poppedDue); i++ {
+				assert.False(t, poppedDue[i] < poppedDue[i-1],
+					"pop %d (%v) before pop %d (%v)", i, poppedDue[i], i-1, poppedDue[i-1])
+			}
+
+			// value integrity: each popped entry retains its original callbackId and schedGen
+			for i, id := range poppedIds {
+				expected, ok := origSched[id]
+				require.True(t, ok, "popped unknown callbackId %d", id)
+				assert.Equal(t, expected, poppedSched[i],
+					"schedGen mismatch for callbackId %d at pop %d", id, i)
+			}
+
 			if tt.want != nil {
-				assert.Equal(t, tt.want, names)
+				assert.Equal(t, tt.want, poppedIds)
 			}
 			if tt.wantPrefix != nil {
-				require.GreaterOrEqual(t, len(names), len(tt.wantPrefix))
-				assert.ElementsMatch(t, tt.wantPrefix, names[:len(tt.wantPrefix)])
+				require.GreaterOrEqual(t, len(poppedIds), len(tt.wantPrefix))
+				assert.ElementsMatch(t, tt.wantPrefix, poppedIds[:len(tt.wantPrefix)])
 			}
 		})
-	}
-}
-
-func TestDueHeap_HeapIndexConsistency(t *testing.T) {
-	base := time.Now()
-	h := &dueHeap{}
-	heap.Init(h)
-
-	metas := []*cycleCallbackMeta{
-		{callbackId: 3, customId: "d", nextDue: base.Add(3 * time.Second)},
-		{callbackId: 0, customId: "a", nextDue: base},
-		{callbackId: 2, customId: "c", nextDue: base.Add(2 * time.Second)},
-		{callbackId: 1, customId: "b", nextDue: base.Add(time.Second)},
-	}
-	for _, m := range metas {
-		heap.Push(h, m)
-	}
-
-	// every queued meta's heapIndex points back at its slot
-	for i, m := range *h {
-		assert.Equal(t, i, m.heapIndex, "heapIndex mismatch for %s", m.customId)
-	}
-
-	// the top of the heap is the earliest-due entry, carrying its callbackId
-	// intact for the lazy map lookup on pop
-	assert.Equal(t, uint32(0), (*h)[0].callbackId)
-
-	// remove the middle element by its tracked index; remaining indices stay valid
-	victim := metas[2] // "c"
-	require.GreaterOrEqual(t, victim.heapIndex, 0)
-	heap.Remove(h, victim.heapIndex)
-	assert.Equal(t, -1, victim.heapIndex, "removed meta keeps heapIndex -1")
-	for i, m := range *h {
-		assert.Equal(t, i, m.heapIndex, "heapIndex mismatch after remove for %s", m.customId)
-	}
-
-	// draining sets heapIndex -1 on every popped meta and preserves due order
-	var prev time.Time
-	first := true
-	for h.Len() > 0 {
-		meta := heap.Pop(h).(*cycleCallbackMeta)
-		assert.Equal(t, -1, meta.heapIndex)
-		if !first {
-			assert.False(t, meta.nextDue.Before(prev))
-		}
-		prev, first = meta.nextDue, false
 	}
 }
 
@@ -163,17 +124,17 @@ func TestComputeNextDue(t *testing.T) {
 	tests := []struct {
 		name string
 		meta *cycleCallbackMeta
-		want time.Time
+		want int64
 	}{
 		{
 			name: "nil interval is always due at started",
 			meta: &cycleCallbackMeta{started: started, intervals: nil},
-			want: started,
+			want: started.UnixNano(),
 		},
 		{
 			name: "interval adds Get() to started",
 			meta: &cycleCallbackMeta{started: started, intervals: NewFixedIntervals(interval)},
-			want: started.Add(interval),
+			want: started.Add(interval).UnixNano(),
 		},
 	}
 

--- a/entities/cyclemanager/ticker.go
+++ b/entities/cyclemanager/ticker.go
@@ -131,6 +131,9 @@ func (t *noopTicker) CycleExecuted(executed bool) {
 
 // ===== Intervals =====
 
+// CycleIntervals yields the delay before a callback's next run. Get is called by
+// the scheduler while the group lock is held, so implementations must be total:
+// Get, Reset, and Advance must return normally and never panic.
 type CycleIntervals interface {
 	Get() time.Duration
 	Reset()

--- a/entities/cyclemanager/ticker.go
+++ b/entities/cyclemanager/ticker.go
@@ -131,9 +131,12 @@ func (t *noopTicker) CycleExecuted(executed bool) {
 
 // ===== Intervals =====
 
-// CycleIntervals yields the delay before a callback's next run. Get is called by
-// the scheduler while the group lock is held, so implementations must be total:
-// Get, Reset, and Advance must return normally and never panic.
+// CycleIntervals yields the delay before a callback's next run: Get reports it,
+// Reset and Advance update it after a run (Reset on work done, Advance on an idle
+// run). None may panic — the scheduler calls Get while rescheduling on the ticker
+// goroutine, outside the callback's recover scope, so a panic there kills the
+// scheduler goroutine. Each instance serves one registration and must not be
+// shared across registrations.
 type CycleIntervals interface {
 	Get() time.Duration
 	Reset()


### PR DESCRIPTION
### What's being changed

On every tick, `CycleCallbackGroup` decides which registered callbacks are due. Today that's a linear pass over **all** registered callbacks — **O(registered)** per tick (already snapshot-optimized in #11958). For large multi-tenant clusters (~25k tenants) the group burns CPU on this pass even when almost nothing is due.

This PR replaces the scan with a **due-heap** (min-heap ordered by next-due time). A tick pops only the entries that are actually due, dropping per-tick cost to **O(due · log n)**; an idle tick is a single heap peek. The `CycleCallbackGroup` / `CycleCallbackCtrl` contract is unchanged — drop-in replacement, no call sites change.

### How it works

- Callbacks are scheduled as sequence-stamped heap entries `{callbackId, due, schedGen}`. Register/Activate/reschedule bump `schedGen` and push a fresh entry; at pop an entry is live iff its `schedGen` still matches and the callback is active. Stale entries are dropped on pop (lazy deletion) — so Deactivate/Unregister never touch the heap, and there's no back-pointer bookkeeping.
- The due key is `int64` nanos and the heap is hand-rolled, so heap ops allocate nothing and fire no GC write barriers (no `container/heap` boxing, no `time.Time` pointer on swaps).
- In-flight coordination uses a lazy done channel + abort flag (replacing the runningCtx tri-state + retry loop), preserving Deactivate priority and the exact ctx-timeout state. Sequential and parallel dispatch share one run path.

### Benchmark

Re-run back-to-back on one idle machine (Apple M4 Pro, Go 1.26.2), `-benchmem -count=6`, via `benchstat` (n=6). **Before** = `stable/v1.37` (optimized scan, incl. #11958); **After** = this branch. MT = multi-tenant (only `due` of `registered` elapsed each tick); ST = single-tenant (all due).

| Scenario | Before (sec/op) | After (sec/op) | Δ (n=6) |
|---|--:|--:|--:|
| **MT** 5000, `due=0` (idle) | 43.29µ | 34.68n | **−99.92%** |
| **MT** 5000, `due=5` | 50.84µ | 2.601µ | **−94.88%** |
| **MT** 5000, `due=200` | 122.8µ | 71.89µ | **−41.48%** |
| **MT** 5000, `due=1000` | 427.5µ | 352.9µ | **−17.45%** |
| **MT** 5000, `due=5000` (all) | 1.908m | 1.738m | **−8.91%** |
| **MT** 1000, `due=5` | 11.93µ | 2.506µ | **−78.99%** |
| **MT** 10000, `due=5` | 99.38µ | 2.642µ | **−97.34%** |
| **ST** 1000 (all due) | 372.2µ | 334.2µ | **−10.21%** |
| **ST** 5000 (all due) | 1.945m | 1.724m | **−11.40%** |
| **geomean** | 179.1µ | 29.14µ | **−83.72%** |

Allocation (geomean): **−63.64% B/op**, **−95.70% allocs/op**. The idle case drops ~43µs→~35ns/tick (~1250×), allocation-free. Every scenario improves — including all-due (`due=5000`), now −8.91% rather than a wash: the parallel dispatch channel is buffered, so it no longer stalls the dispatcher when everything runs at once. Idle ticks stay 0-alloc; run-path allocation is O(1) per tick (the callback's abort check is built once per registration, not per run).

### Compatibility & tests

Behavioral parity with the previous impl was reviewed across the full contract (Deactivate priority, ctx-expiry-mid-run state, abort semantics, always-due-once-per-tick, `WithIntervals` immediate first run, combined-ctrl rollback) — no divergence. Coverage 89.5%: existing black-box tests preserved, plus new white-box invariant tests (single live entry per callback, bounded stale-entry growth, ctx-timeout state, panic isolation) and a `-race` stress test hammering Activate/Deactivate/Register/Unregister against a running tick.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.


chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/29832403431
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/29832426078
