### PR TITLE
fix(hnsw): drain commit-log maintenance before locking in Drop()

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -579,10 +579,15 @@ func (l *hnswCommitLogger) switchCommitLogs(force bool) (bool, error) {
 }
 
 func (l *hnswCommitLogger) Drop(ctx context.Context, keepFiles bool) error {
+	// Drain before locking: Shutdown waits for an in-flight switchCommitLogs,
+	// which starts by taking l.Mutex. Holding it here deadlocks both until ctx
+	// expires. Report the drain error only after the fd is closed, or a timed-out
+	// drain leaks it.
+	shutdownErr := l.Shutdown(ctx)
+
 	l.Lock()
 	defer l.Unlock()
 
-	// Flush and close the file
 	if err := l.currentWriter.Flush(); err != nil {
 		return errors.Wrap(err, "flush hnsw commit logger prior to delete")
 	}
@@ -590,9 +595,8 @@ func (l *hnswCommitLogger) Drop(ctx context.Context, keepFiles bool) error {
 		return errors.Wrap(err, "close hnsw commit logger prior to delete")
 	}
 
-	// stop all goroutines
-	if err := l.Shutdown(ctx); err != nil {
-		return errors.Wrap(err, "drop commitlog")
+	if shutdownErr != nil {
+		return errors.Wrap(shutdownErr, "drop commitlog")
 	}
 
 	if keepFiles {

--- a/adapters/repos/db/vector/hnsw/commit_logger_drop_deadlock_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_drop_deadlock_test.go
@@ -1,0 +1,101 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestCommitLoggerDropDoesNotDeadlockWithMaintenanceCycle pins a deadlock: Drop
+// held l.Mutex while Shutdown -> Unregister waited for an in-flight
+// switchCommitLogs, whose first statement is l.Lock(). It unwound only when ctx
+// expired — Shard.drop's 20s, on the RAFT apply goroutine.
+//
+// gatedFile forces the interleaving rather than racing for it: it parks Drop
+// inside its critical section, so switchCommitLogs blocks on the mutex before
+// Drop starts draining.
+func TestCommitLoggerDropDoesNotDeadlockWithMaintenanceCycle(t *testing.T) {
+	// Shard.drop allows 20s; shortened so a deadlock fails fast.
+	const dropCtxBudget = 5 * time.Second
+
+	logger, _ := test.NewNullLogger()
+	ctx, cancel := context.WithTimeout(context.Background(), dropCtxBudget)
+	defer cancel()
+
+	callbacks := cyclemanager.NewCallbackGroup("maintenance", logger, 1)
+	cycle := cyclemanager.NewManager("maintenance",
+		cyclemanager.NewFixedTicker(time.Millisecond), callbacks.CycleCallback, logger)
+	cycle.Start()
+	defer cycle.StopAndWait(context.Background())
+
+	gate := &gatedFile{parked: make(chan struct{}), released: make(chan struct{})}
+	fs := common.NewTestFS()
+	fs.OnOpenFile = func(f common.File) common.File { gate.File = f; return gate }
+
+	cl, err := NewCommitLogger(t.TempDir(), "deadlock", logger, callbacks, WithFS(fs))
+	require.NoError(t, err)
+
+	// Without this there is no callback to drain and the test passes vacuously.
+	cl.InitMaintenance()
+
+	dropped := make(chan error, 1)
+	begin := time.Now()
+	go func() { dropped <- cl.Drop(ctx, false) }()
+
+	select {
+	case <-gate.parked:
+	case err := <-dropped:
+		t.Fatalf("Drop returned without reaching its critical section: %v", err)
+	}
+
+	// switchCommitLogs cannot pass l.Lock() while Drop holds it, so it parks there
+	// and the group marks it running — what Unregister waits on.
+	time.Sleep(200 * time.Millisecond)
+	close(gate.released)
+
+	select {
+	case err := <-dropped:
+		require.NoError(t, err, "Drop drained switchCommitLogs while holding l.Mutex, "+
+			"so Unregister timed out after %s", time.Since(begin))
+	case <-time.After(dropCtxBudget + time.Second):
+		t.Fatal("Drop never returned: it waits for switchCommitLogs, blocked on the " +
+			"l.Mutex that Drop holds")
+	}
+
+	require.True(t, cl.TryLock(), "Drop returned while still holding l.Mutex")
+	cl.Unlock()
+}
+
+// gatedFile parks Close() until released, holding Drop inside its critical
+// section. Drop's is the only Close here: switchCommitLogs rotates (and closes)
+// only past maxSizeIndividual, and this commit log stays empty.
+type gatedFile struct {
+	common.File
+	once     sync.Once
+	parked   chan struct{}
+	released chan struct{}
+}
+
+func (f *gatedFile) Close() error {
+	f.once.Do(func() { close(f.parked) })
+	<-f.released
+	return f.File.Close()
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -734,35 +734,15 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 	return h.nodes[id]
 }
 
+// Drop stops the index exactly as Shutdown does, then removes the commit log's
+// files. Dropping before stopping would leave the maintenance cycles and the
+// tombstone cleanup running against state being torn down underneath them.
 func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
-	// Stop background work before tearing anything down
-	h.shutdownCtxCancel()
-
-	// Drain the commit-log maintenance cycles. commitLog.Drop drains them too,
-	// but not until the compressor and cache are already gone.
-	if err := h.commitLog.Shutdown(ctx); err != nil {
+	if err := h.Shutdown(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")
 	}
 
-	// cancel tombstone cleanup goroutine
-	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
-		return errors.Wrap(err, "hnsw drop")
-	}
-
-	if h.compressed.Load() {
-		err := h.compressor.Drop()
-		if err != nil {
-			return fmt.Errorf("failed to shutdown compressed store")
-		}
-	} else {
-		// cancel vector cache goroutine
-		h.cache.Drop()
-	}
-
-	// cancel commit logger last, as the tombstone cleanup cycle might still
-	// write while it's still running
-	err := h.commitLog.Drop(ctx, keepFiles)
-	if err != nil {
+	if err := h.commitLog.Drop(ctx, keepFiles); err != nil {
 		return errors.Wrap(err, "commit log drop")
 	}
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -735,6 +735,15 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 }
 
 func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
+	// Stop background work before tearing anything down
+	h.shutdownCtxCancel()
+
+	// Drain the commit-log maintenance cycles. commitLog.Drop drains them too,
+	// but not until the compressor and cache are already gone.
+	if err := h.commitLog.Shutdown(ctx); err != nil {
+		return errors.Wrap(err, "hnsw drop")
+	}
+
 	// cancel tombstone cleanup goroutine
 	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")

--- a/adapters/repos/db/vector/hnsw/index_drop_teardown_test.go
+++ b/adapters/repos/db/vector/hnsw/index_drop_teardown_test.go
@@ -13,6 +13,7 @@ package hnsw
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,39 +21,114 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
-// TestDropCancelsBackgroundWorkBeforeTeardown holds hnsw.Drop to Shutdown's
-// teardown order. Drop used to leave shutdownCtx live, so tombstone cleanup kept
-// walking the graph (delete.go: reassignNeighborsOf) while the index it walks was
-// being torn down.
+// TestDropTeardown holds hnsw.Drop to Shutdown's teardown order.
 //
-// Drop runs under Shard.drop's 20s ctx on the RAFT apply goroutine, so a wait here
+// Drop used to leave shutdownCtx live, so tombstone cleanup kept walking the graph
+// (delete.go: reassignNeighborsOf) while the index it walks was being torn down. It
+// runs under Shard.drop's 20s ctx on the RAFT apply goroutine, so a wait here
 // freezes the node's schema applies.
-func TestDropCancelsBackgroundWorkBeforeTeardown(t *testing.T) {
+//
+// Both compression branches are covered: collapsing Drop into Shutdown must keep
+// each arm. A double stands in for the compressor, whose Compress() needs an
+// lsmkv.Store.
+func TestDropTeardown(t *testing.T) {
+	// Shard.drop allows 20s; shortened so a stalled Drop fails fast.
 	const dropMustFinishWithin = 5 * time.Second
+
+	tests := []struct {
+		name           string
+		compressed     bool
+		wantCompressor int32
+	}{
+		{name: "compressed index drops the compressor", compressed: true, wantCompressor: 1},
+		{name: "uncompressed index drops the cache", compressed: false, wantCompressor: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			idx := newDropTeardownIndex(t)
+
+			for i := 0; i < 10; i++ {
+				inc := float32(i)
+				require.Nil(t, idx.Add(ctx, uint64(i), []float32{inc, inc + 1, inc + 2}))
+			}
+
+			// Only the teardown path is under test, and it reaches nothing but
+			// VectorCompressor.Drop. Flip the flag after inserting: the insert path
+			// would call Preload on the embedded nil interface.
+			compressor := &countingCompressor{}
+			idx.compressor = compressor
+			idx.compressed.Store(tt.compressed)
+
+			// Let the cycles pick the callbacks up, so Drop competes with live
+			// maintenance rather than an idle index.
+			time.Sleep(50 * time.Millisecond)
+			require.NoError(t, idx.shutdownCtx.Err(), "precondition: shutdownCtx live before Drop")
+
+			dropCtx, cancel := context.WithTimeout(ctx, dropMustFinishWithin)
+			defer cancel()
+
+			dropped := make(chan error, 1)
+			begin := time.Now()
+			go func() { dropped <- idx.Drop(dropCtx, false) }()
+
+			select {
+			case err := <-dropped:
+				require.NoError(t, err, "Drop failed after %s", time.Since(begin))
+				require.Less(t, time.Since(begin), dropMustFinishWithin,
+					"Drop waited on background work it should have cancelled first")
+			case <-time.After(dropMustFinishWithin + time.Second):
+				t.Fatal("Drop never returned: it waits on a background cycle it never cancelled")
+			}
+
+			require.Error(t, idx.shutdownCtx.Err(), "Drop must cancel shutdownCtx")
+			require.Equal(t, tt.wantCompressor, compressor.drops.Load(),
+				"Drop must take the compressed=%v arm of Shutdown", tt.compressed)
+		})
+	}
+}
+
+// countingCompressor embeds the interface: Drop is the only method the teardown
+// path reaches.
+type countingCompressor struct {
+	compressionhelpers.VectorCompressor
+	drops atomic.Int32
+}
+
+func (c *countingCompressor) Drop() error {
+	c.drops.Add(1)
+	return nil
+}
+
+// newDropTeardownIndex builds an index whose maintenance cycles fire throughout,
+// as on a shard that was restored and is immediately deleted.
+func newDropTeardownIndex(t *testing.T) *hnsw {
+	t.Helper()
 
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 	dirName := t.TempDir()
 	const indexID = "drop-teardown"
 
-	// Cycles fire throughout, as on a shard restored and immediately deleted.
 	commitLoggerCallbacks := cyclemanager.NewCallbackGroup("commitLogger", logger, 1)
 	commitLoggerCycle := cyclemanager.NewManager("commitLogger",
 		cyclemanager.NewFixedTicker(time.Millisecond), commitLoggerCallbacks.CycleCallback, logger)
 	commitLoggerCycle.Start()
-	defer commitLoggerCycle.StopAndWait(ctx)
+	t.Cleanup(func() { commitLoggerCycle.StopAndWait(ctx) })
 
 	tombstoneCallbacks := cyclemanager.NewCallbackGroup("tombstoneCleanup", logger, 1)
 	tombstoneCycle := cyclemanager.NewManager("tombstoneCleanup",
 		cyclemanager.NewFixedTicker(time.Millisecond), tombstoneCallbacks.CycleCallback, logger)
 	tombstoneCycle.Start()
-	defer tombstoneCycle.StopAndWait(ctx)
+	t.Cleanup(func() { tombstoneCycle.StopAndWait(ctx) })
 
 	idx, err := New(Config{
 		AllocChecker:     memwatch.NewDummyMonitor(),
@@ -67,36 +143,9 @@ func TestDropCancelsBackgroundWorkBeforeTeardown(t *testing.T) {
 		},
 	}, enthnsw.NewDefaultUserConfig(), tombstoneCallbacks, nil)
 	require.Nil(t, err)
-	idx.PostStartup(context.Background())
+	idx.PostStartup(ctx)
 
-	for i := 0; i < 10; i++ {
-		inc := float32(i)
-		require.Nil(t, idx.Add(ctx, uint64(i), []float32{inc, inc + 1, inc + 2}))
-	}
-
-	// Let the cycles pick the callbacks up, so Drop competes with live maintenance.
-	time.Sleep(50 * time.Millisecond)
-
-	require.NoError(t, idx.shutdownCtx.Err(), "precondition: shutdownCtx live before Drop")
-
-	dropCtx, cancel := context.WithTimeout(ctx, dropMustFinishWithin)
-	defer cancel()
-
-	dropped := make(chan error, 1)
-	begin := time.Now()
-	go func() { dropped <- idx.Drop(dropCtx, false) }()
-
-	select {
-	case err := <-dropped:
-		require.NoError(t, err, "Drop failed after %s", time.Since(begin))
-		require.Less(t, time.Since(begin), dropMustFinishWithin,
-			"Drop waited on background work it should have cancelled first")
-	case <-time.After(dropMustFinishWithin + time.Second):
-		t.Fatal("Drop never returned: it is waiting on a background cycle it never cancelled")
-	}
-
-	require.Error(t, idx.shutdownCtx.Err(),
-		"Drop must cancel shutdownCtx; tombstone cleanup threads it into reassignNeighborsOf")
+	return idx
 }
 
 type dropTeardownNoopBucketView struct{}

--- a/adapters/repos/db/vector/hnsw/index_drop_teardown_test.go
+++ b/adapters/repos/db/vector/hnsw/index_drop_teardown_test.go
@@ -1,0 +1,104 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// TestDropCancelsBackgroundWorkBeforeTeardown holds hnsw.Drop to Shutdown's
+// teardown order. Drop used to leave shutdownCtx live, so tombstone cleanup kept
+// walking the graph (delete.go: reassignNeighborsOf) while the index it walks was
+// being torn down.
+//
+// Drop runs under Shard.drop's 20s ctx on the RAFT apply goroutine, so a wait here
+// freezes the node's schema applies.
+func TestDropCancelsBackgroundWorkBeforeTeardown(t *testing.T) {
+	const dropMustFinishWithin = 5 * time.Second
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+	const indexID = "drop-teardown"
+
+	// Cycles fire throughout, as on a shard restored and immediately deleted.
+	commitLoggerCallbacks := cyclemanager.NewCallbackGroup("commitLogger", logger, 1)
+	commitLoggerCycle := cyclemanager.NewManager("commitLogger",
+		cyclemanager.NewFixedTicker(time.Millisecond), commitLoggerCallbacks.CycleCallback, logger)
+	commitLoggerCycle.Start()
+	defer commitLoggerCycle.StopAndWait(ctx)
+
+	tombstoneCallbacks := cyclemanager.NewCallbackGroup("tombstoneCleanup", logger, 1)
+	tombstoneCycle := cyclemanager.NewManager("tombstoneCleanup",
+		cyclemanager.NewFixedTicker(time.Millisecond), tombstoneCallbacks.CycleCallback, logger)
+	tombstoneCycle.Start()
+	defer tombstoneCycle.StopAndWait(ctx)
+
+	idx, err := New(Config{
+		AllocChecker:     memwatch.NewDummyMonitor(),
+		RootPath:         dirName,
+		ID:               indexID,
+		Logger:           logger,
+		DistanceProvider: distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: testVectorForID,
+		GetViewThunk:     func() common.BucketView { return &dropTeardownNoopBucketView{} },
+		MakeCommitLoggerThunk: func(opts ...CommitlogOption) (CommitLogger, error) {
+			return NewCommitLogger(dirName, indexID, logger, commitLoggerCallbacks, opts...)
+		},
+	}, enthnsw.NewDefaultUserConfig(), tombstoneCallbacks, nil)
+	require.Nil(t, err)
+	idx.PostStartup(context.Background())
+
+	for i := 0; i < 10; i++ {
+		inc := float32(i)
+		require.Nil(t, idx.Add(ctx, uint64(i), []float32{inc, inc + 1, inc + 2}))
+	}
+
+	// Let the cycles pick the callbacks up, so Drop competes with live maintenance.
+	time.Sleep(50 * time.Millisecond)
+
+	require.NoError(t, idx.shutdownCtx.Err(), "precondition: shutdownCtx live before Drop")
+
+	dropCtx, cancel := context.WithTimeout(ctx, dropMustFinishWithin)
+	defer cancel()
+
+	dropped := make(chan error, 1)
+	begin := time.Now()
+	go func() { dropped <- idx.Drop(dropCtx, false) }()
+
+	select {
+	case err := <-dropped:
+		require.NoError(t, err, "Drop failed after %s", time.Since(begin))
+		require.Less(t, time.Since(begin), dropMustFinishWithin,
+			"Drop waited on background work it should have cancelled first")
+	case <-time.After(dropMustFinishWithin + time.Second):
+		t.Fatal("Drop never returned: it is waiting on a background cycle it never cancelled")
+	}
+
+	require.Error(t, idx.shutdownCtx.Err(),
+		"Drop must cancel shutdownCtx; tombstone cleanup threads it into reassignNeighborsOf")
+}
+
+type dropTeardownNoopBucketView struct{}
+
+func (v *dropTeardownNoopBucketView) ReleaseView() {}


### PR DESCRIPTION
### What's being changed:
this PR fix 2 bugs 

-  deadlock (bug 1)

1. A class is deleted. RAFT applies DELETE_CLASS, on the apply goroutine.
2. That reaches `Shard.drop()`, which creates a 20-second context and calls `hnsw.Drop()` → `commitLog.Drop(ctx, keepFiles)`.
3. commitLog.Drop takes `l.Mutex`.
4. Still holding it, Drop calls Shutdown → Unregister, which blocks until any running callback finishes.
5. The running callback is [switchCommitLogs](https://github.com/weaviate/weaviate/blob/moogacs-44162f21/adapters/repos/db/vector/hnsw/commit_logger.go#L502). Its first statement is l.Lock(), the mutex Drop is holding.
6. Neither can move. They unwind only when the 20s context expires.
7. Drop returns; its defer `l.Unlock()` fires; the callback finally gets the lock and stats the file Drop closed at step 3 → hnsw commit log switch failed: … file already closed. That log line is the deadlock ending, not starting.

- teardown ordering (bug 2)

1. `hnsw.Drop()` never called `h.shutdownCtxCancel()` only Shutdown did. So shutdownCtx stayed live through the whole drop, and tombstone cleanup's reassignNeighborsOf(h.shutdownCtx, …) kept running. Unregister had to wait out a full cleanup pass rather than abort it.
2. Drop also left the commit-log maintenance cycle registered while compressor.Drop() tore down the compressed store cycling over the directory about to be removed. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
