### PR TITLE
Revert "Merge pull request #12010 from weaviate/reuse_view"

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -780,23 +780,6 @@ func (b *Bucket) GetBySecondaryWithBufferAndView(ctx context.Context, pos int, s
 	return v, allocBuf, err
 }
 
-// SecondaryViewLookup acquires a single consistent view and returns a lookup
-// function bound to it, together with a release function. Reusing one view
-// across many secondary-key lookups avoids acquiring a fresh view (flush lock,
-// segment snapshot, and per-segment refcount churn) for every lookup. The
-// returned lookup is safe for concurrent use; call release exactly once, after
-// all lookups are done.
-func (b *Bucket) SecondaryViewLookup() (
-	func(ctx context.Context, pos int, seckey, buffer []byte) ([]byte, []byte, error),
-	func(),
-) {
-	view := b.GetConsistentView()
-	lookup := func(ctx context.Context, pos int, seckey, buffer []byte) ([]byte, []byte, error) {
-		return b.GetBySecondaryWithBufferAndView(ctx, pos, seckey, buffer, view)
-	}
-	return lookup, view.ReleaseView
-}
-
 func (b *Bucket) getBySecondary(ctx context.Context, pos int, seckey []byte, buffer []byte) ([]byte, []byte, error) {
 	beforeAll := time.Now()
 	view := b.GetConsistentView()

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -387,10 +387,6 @@ func AllPropertiesExtraction(class *models.Class) *PropertyExtraction {
 	return pe
 }
 
-// secondaryLookup fetches a value by secondary key into the given buffer,
-// returning the value and the (possibly regrown) buffer.
-type secondaryLookup = func(ctx context.Context, pos int, seckey, buffer []byte) ([]byte, []byte, error)
-
 // bucket is the objects LSM bucket needed to fetch objects by their doc-id
 // secondary key.
 type bucket interface {
@@ -403,20 +399,6 @@ type bucket interface {
 	// non-objects buckets); the helpers propagate that error rather than fall
 	// back to the on-disk class name.
 	ClassName() (string, error)
-	// SecondaryViewLookup returns a doc-id lookup bound to a single consistent
-	// view for the whole batch, plus a release func to call when done.
-	SecondaryViewLookup() (lookup secondaryLookup, release func())
-}
-
-// withBatchLookup runs fn with a doc-id lookup that shares one consistent view
-// for the whole batch, releasing the view once fn returns.
-func withBatchLookup(bucket bucket, fn func(secondaryLookup) ([]*Object, error)) ([]*Object, error) {
-	if bucket == nil {
-		return nil, fmt.Errorf("objects bucket not found")
-	}
-	lookup, release := bucket.SecondaryViewLookup()
-	defer release()
-	return fn(lookup)
 }
 
 // ObjectsByDocID resolves a batch of doc IDs against the given bucket and
@@ -427,7 +409,11 @@ func withBatchLookup(bucket bucket, fn func(secondaryLookup) ([]*Object, error))
 func ObjectsByDocID(bucket bucket, ids []uint64,
 	additional additional.Properties, properties []string, logger logrus.FieldLogger,
 ) ([]*Object, error) {
-	return objectsByDocID(bucket, ids, additional, properties, logger, false)
+	if len(ids) == 1 { // no need to try to run concurrently if there is just one result anyway
+		return objectsByDocIDSequentialInner(bucket, ids, additional, properties, false)
+	}
+
+	return objectsByDocIDParallelInner(bucket, ids, additional, properties, logger, false)
 }
 
 // ObjectsByDocIDWithEmpty is like ObjectsByDocID but preserves nil entries at
@@ -437,33 +423,20 @@ func ObjectsByDocID(bucket bucket, ids []uint64,
 func ObjectsByDocIDWithEmpty(bucket bucket, ids []uint64,
 	additional additional.Properties, properties []string, logger logrus.FieldLogger,
 ) ([]*Object, error) {
-	return objectsByDocID(bucket, ids, additional, properties, logger, true)
-}
-
-func objectsByDocID(bucket bucket, ids []uint64,
-	additional additional.Properties, properties []string, logger logrus.FieldLogger,
-	includeEmpty bool,
-) ([]*Object, error) {
-	if len(ids) == 0 { // avoid acquiring a consistent view for an empty batch
-		return []*Object{}, nil
+	if len(ids) == 1 { // no need to try to run concurrently if there is just one result anyway
+		return objectsByDocIDSequentialInner(bucket, ids, additional, properties, true)
 	}
-	return withBatchLookup(bucket, func(lookup secondaryLookup) ([]*Object, error) {
-		if len(ids) == 1 { // no need to try to run concurrently if there is just one result anyway
-			return objectsByDocIDSequentialInner(bucket, lookup, ids, additional, properties, includeEmpty)
-		}
-		return objectsByDocIDParallelInner(bucket, lookup, ids, additional, properties, logger, includeEmpty)
-	})
+
+	return objectsByDocIDParallelInner(bucket, ids, additional, properties, logger, true)
 }
 
 func objectsByDocIDParallel(bucket bucket, ids []uint64,
 	addProp additional.Properties, properties []string, logger logrus.FieldLogger,
 ) ([]*Object, error) {
-	return withBatchLookup(bucket, func(lookup secondaryLookup) ([]*Object, error) {
-		return objectsByDocIDParallelInner(bucket, lookup, ids, addProp, properties, logger, false)
-	})
+	return objectsByDocIDParallelInner(bucket, ids, addProp, properties, logger, false)
 }
 
-func objectsByDocIDParallelInner(bucket bucket, lookup secondaryLookup, ids []uint64,
+func objectsByDocIDParallelInner(bucket bucket, ids []uint64,
 	addProp additional.Properties, properties []string, logger logrus.FieldLogger,
 	includeEmpty bool,
 ) ([]*Object, error) {
@@ -491,7 +464,7 @@ func objectsByDocIDParallelInner(bucket bucket, lookup secondaryLookup, ids []ui
 		}
 
 		eg.Go(func() error {
-			objs, err := objectsByDocIDSequentialInner(bucket, lookup, ids[start:end], addProp, properties, includeEmpty)
+			objs, err := objectsByDocIDSequentialInner(bucket, ids[start:end], addProp, properties, includeEmpty)
 			if err != nil {
 				return err
 			}
@@ -524,12 +497,10 @@ func objectsByDocIDParallelInner(bucket bucket, lookup secondaryLookup, ids []ui
 func objectsByDocIDSequential(bucket bucket, ids []uint64,
 	additional additional.Properties, properties []string,
 ) ([]*Object, error) {
-	return withBatchLookup(bucket, func(lookup secondaryLookup) ([]*Object, error) {
-		return objectsByDocIDSequentialInner(bucket, lookup, ids, additional, properties, false)
-	})
+	return objectsByDocIDSequentialInner(bucket, ids, additional, properties, false)
 }
 
-func objectsByDocIDSequentialInner(bucket bucket, lookup secondaryLookup, ids []uint64,
+func objectsByDocIDSequentialInner(bucket bucket, ids []uint64,
 	additional additional.Properties, properties []string,
 	includeEmpty bool,
 ) ([]*Object, error) {
@@ -568,7 +539,7 @@ func objectsByDocIDSequentialInner(bucket bucket, lookup secondaryLookup, ids []
 
 	for _, id := range ids {
 		binary.LittleEndian.PutUint64(docIDBuf, id)
-		res, newBuf, err := lookup(context.TODO(), 0, docIDBuf, lsmBuf) // TODO: pass through context instead of spawning new one
+		res, newBuf, err := bucket.GetBySecondaryWithBuffer(context.TODO(), 0, docIDBuf, lsmBuf) // TODO: pass through context instead of spawning new one
 		if err != nil {
 			return nil, err
 		}

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -1707,81 +1707,6 @@ func TestObjectsByDocID(t *testing.T) {
 	}
 }
 
-func TestObjectsByDocIDSharedView(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-
-	tests := []struct {
-		name     string
-		inputIDs []uint64
-	}{
-		{name: "1 object - sequential code path", inputIDs: []uint64{0}},
-		{name: "2 objects - concurrent code path", inputIDs: []uint64{0, 1}},
-		{name: "100 objects - concurrent code path", inputIDs: pickRandomIDsBetween(0, 1000, 100)},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bucket := genFakeBucket(t, 1000)
-
-			res, err := ObjectsByDocID(bucket, tt.inputIDs, additional.Properties{}, nil, logger)
-			require.NoError(t, err)
-			require.Len(t, res, len(tt.inputIDs))
-
-			// a single consistent view is acquired and released for the whole
-			// batch, regardless of the number of objects or parallel chunks
-			assert.Equal(t, 1, bucket.views)
-			assert.Equal(t, 1, bucket.released)
-
-			for i, obj := range res {
-				expectedDocID := tt.inputIDs[i]
-				assert.Equal(t, expectedDocID, uint64(obj.Properties().(map[string]any)["i"].(float64)))
-			}
-		})
-	}
-}
-
-func TestObjectsByDocIDSharedViewReleasedOnError(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-
-	for _, name := range []string{"sequential code path", "concurrent code path"} {
-		t.Run(name, func(t *testing.T) {
-			ids := []uint64{0}
-			if name == "concurrent code path" {
-				ids = pickRandomIDsBetween(0, 1000, 100)
-			}
-
-			bucket := genFakeBucket(t, 1000)
-			bucket.lookupErr = fmt.Errorf("boom")
-
-			_, err := ObjectsByDocID(bucket, ids, additional.Properties{}, nil, logger)
-			require.Error(t, err)
-
-			// the view is still released exactly once when a lookup fails mid-batch
-			assert.Equal(t, 1, bucket.views)
-			assert.Equal(t, 1, bucket.released)
-		})
-	}
-}
-
-func TestObjectsByDocIDEmptyBatch(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	bucket := genFakeBucket(t, 1000)
-
-	res, err := ObjectsByDocID(bucket, nil, additional.Properties{}, nil, logger)
-	require.NoError(t, err)
-	require.Empty(t, res)
-
-	// an empty batch acquires no consistent view
-	assert.Equal(t, 0, bucket.views)
-	assert.Equal(t, 0, bucket.released)
-}
-
-func TestObjectsByDocIDNilBucket(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	_, err := ObjectsByDocID(nil, []uint64{0}, additional.Properties{}, nil, logger)
-	require.Error(t, err)
-}
-
 func TestSkipMissingObjects(t *testing.T) {
 	bucket := genFakeBucket(t, 1000)
 	logger, _ := test.NewNullLogger()
@@ -1972,18 +1897,6 @@ func FuzzObjectGet(f *testing.F) {
 
 type fakeBucket struct {
 	objects map[uint64][]byte
-	// views and released count how often a consistent view is acquired and
-	// released for a batch.
-	views    int
-	released int
-	// lookupErr, when set, makes every lookup fail, simulating an error
-	// mid-batch.
-	lookupErr error
-}
-
-func (f *fakeBucket) SecondaryViewLookup() (secondaryLookup, func()) {
-	f.views++
-	return f.GetBySecondaryWithBuffer, func() { f.released++ }
 }
 
 func (f *fakeBucket) GetBySecondary(ctx context.Context, indexID int, docIDBytes []byte) ([]byte, error) {
@@ -1992,9 +1905,6 @@ func (f *fakeBucket) GetBySecondary(ctx context.Context, indexID int, docIDBytes
 }
 
 func (f *fakeBucket) GetBySecondaryWithBuffer(ctx context.Context, indexID int, docIDBytes []byte, lsmBuf []byte) ([]byte, []byte, error) {
-	if f.lookupErr != nil {
-		return nil, nil, f.lookupErr
-	}
 	docID := binary.LittleEndian.Uint64(docIDBytes)
 	objBytes, ok := f.objects[docID]
 	if !ok {


### PR DESCRIPTION
This reverts commit a0c549ad35d65dd5bad2c2728e6055cab6a1a16f, reversing changes made to aa96e5050656a3464c700fe968e81f40c50e7e1b.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
