### PR TITLE
fix(drop-vector-index): reject writes targeting a dropped vector on the receiving node

### DIFF
--- a/usecases/objects/validation/vector_validation.go
+++ b/usecases/objects/validation/vector_validation.go
@@ -55,9 +55,17 @@ func (v *Validator) vector(ctx context.Context, class *models.Class,
 
 	var incomingTargetVectors []string
 	for name := range incomingObject.Vectors {
-		_, ok := class.VectorConfig[name]
+		cfg, ok := class.VectorConfig[name]
 		if !ok {
 			return fmt.Errorf("collection %v does not have configuration for vector %s", class.Class, name)
+		}
+		// Reject dropped ("none"-marked) targets here, on the node receiving the
+		// request: the shard-level reject runs on the owner node, whose schema
+		// view can trail this node's during the drop's finalize propagation —
+		// without this check a write can slip through that window and persist
+		// vector bytes no cleanup will ever remove.
+		if modelsext.IsVectorIndexDropped(cfg) {
+			return fmt.Errorf("vector index for %s was dropped; writes targeting it are rejected", name)
 		}
 
 		incomingTargetVectors = append(incomingTargetVectors, name)

--- a/usecases/objects/validation/vector_validation_test.go
+++ b/usecases/objects/validation/vector_validation_test.go
@@ -64,6 +64,33 @@ func TestVectors(t *testing.T) {
 			},
 			expErr: true,
 		},
+		"dropped named vector target is rejected": {
+			// The receiving node must reject dropped targets itself: the
+			// shard-level reject runs on the owner, whose schema view can trail
+			// during finalize propagation.
+			class: &models.Class{
+				VectorConfig: map[string]models.VectorConfig{
+					"first":   {VectorIndexType: "hnsw"},
+					"dropped": {VectorIndexType: "none"},
+				},
+			},
+			obj: &models.Object{
+				Vectors: models.Vectors{"dropped": []float32{1, 2, 3}},
+			},
+			expErr: true,
+		},
+		"live sibling of a dropped vector is accepted": {
+			class: &models.Class{
+				VectorConfig: map[string]models.VectorConfig{
+					"first":   {VectorIndexType: "hnsw"},
+					"dropped": {VectorIndexType: "none"},
+				},
+			},
+			obj: &models.Object{
+				Vectors: models.Vectors{"first": []float32{1, 2, 3}},
+			},
+			expErr: false,
+		},
 		"non existent named vectors": {
 			class: &models.Class{
 				VectorConfig: map[string]models.VectorConfig{"first": {}, "second": {}},


### PR DESCRIPTION
### What's being changed

Writes carrying a named vector whose `VectorConfig` entry is marked dropped (`vectorIndexType: "none"`) are now rejected by validation on the node receiving the request, not only by the shard-level check on the owner node.

### Why

The owner's schema view can trail the receiving node's during a drop's finalize propagation (per-node RAFT apply skew). In that sub-second window a write carrying the vector could be accepted end to end: the receiving node's validation only checked entry *presence* (a "none"-marked entry passed), and post-removal the owner-side vector-index inserts silently skip missing queues — persisting vector bytes for a vector that no longer exists in the schema, which no cleanup ever removes. Found by the drop-vector e2e suite (sustained-load test, `drop-vector-s20` branch), which reproduced ~1 accepted write per drop under continuous traffic and now serves as the regression pin.

With this check, both states of the receiving node reject: marker present → dropped-vector reject; entry removed → existing unknown-vector reject. The message keeps the "vector index" wording existing tests assert on.

### Follow-ups noted (not in this PR)

- The `IgnoreDelete` vector-insert paths silently skip unknown targets while the strict update path errors — worth unifying.
- The shard-level reject surfaces as HTTP 500; should be a 4xx.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.