### PR TITLE
perf(usage): open dimensions bucket once per shard with sequential-access hint

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -407,6 +407,16 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	}
 
 	// Get named vector data for cold shards from schema configuration
+	targetVectors := make([]string, 0, len(vectorConfigs))
+	for targetVector := range vectorConfigs {
+		targetVectors = append(targetVectors, targetVector)
+	}
+	// open the dimensions bucket once for all target vectors
+	dimensionalitiesAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, targetVectors)
+	if err != nil {
+		return nil, err
+	}
+
 	var namedVectors types.VectorsUsage
 	uncompressedVectorSize := uint64(0) // calculate total uncompressed vector size for all vectors
 	for targetVector, vectorConfig := range vectorConfigs {
@@ -428,10 +438,7 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 			vectorUsage.VectorIndexType = vectorIndexConfig.IndexType()
 		}
 
-		dimensionalities, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, i.logger, i.path(), shardName, targetVector)
-		if err != nil {
-			return nil, err
-		}
+		dimensionalities := dimensionalitiesAll[targetVector]
 		uncompressedVectorSize += uint64(dimensionalities.Count) * uint64(dimensionalities.Dimensions) * 4
 		vectorUsage.Dimensionalities = append(vectorUsage.Dimensionalities, &dimensionalities)
 		vectorUsage.MultiVectorConfig = multiVectorConfigFromConfig(vectorIndexConfig)

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -105,20 +105,18 @@ func usageDisk(shardUsage *types.ShardUsage) *types.UsageDisk {
 // which lsmkv's GlobalBucketRegistry rejects with "bucket already registered".
 var unloadedDimensionsBucketLocks = entsync.NewKeyLockerContext()
 
-// CalculateUnloadedDimensionsUsage calculates dimensions and object count for an unloaded shard without loading it into memory
-func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (types.Dimensionality, error) {
-	bucketPath := shardPathDimensionsLSM(path, tenantName)
+// openUnloadedDimensionsBucket opens the dimensions bucket of an unloaded shard without
+// loading the shard into memory. The bucket is opened with a sequential-access hint, as the
+// dimension calculations scan it with cursors.
+// Callers must hold the unloadedDimensionsBucketLocks lock for bucketPath until the returned
+// bucket is shut down.
+func openUnloadedDimensionsBucket(ctx context.Context, logger logrus.FieldLogger, path, bucketPath string) (*lsmkv.Bucket, error) {
 	strategy, err := lsmkv.DetermineUnloadedBucketStrategyAmong(bucketPath, lsmkv.DimensionsBucketPrioritizedStrategies)
 	if err != nil {
-		return types.Dimensionality{}, fmt.Errorf("determine dimensions bucket strategy: %w", err)
+		return nil, fmt.Errorf("determine dimensions bucket strategy: %w", err)
 	}
 
-	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
-		return types.Dimensionality{}, fmt.Errorf("lock dimensions bucket: %w", err)
-	}
-	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
-
-	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx,
+	return lsmkv.NewBucketCreator().NewBucket(ctx,
 		bucketPath,
 		path,
 		logger,
@@ -126,13 +124,58 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
 		lsmkv.WithStrategy(strategy),
+		lsmkv.WithSequentialAccess(true),
 	)
+}
+
+// CalculateUnloadedDimensionsUsage calculates dimensions and object count for an unloaded shard without loading it into memory
+func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (types.Dimensionality, error) {
+	bucketPath := shardPathDimensionsLSM(path, tenantName)
+	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
+		return types.Dimensionality{}, fmt.Errorf("lock dimensions bucket: %w", err)
+	}
+	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
+
+	bucket, err := openUnloadedDimensionsBucket(ctx, logger, path, bucketPath)
 	if err != nil {
 		return types.Dimensionality{}, err
 	}
 	defer bucket.Shutdown(ctx)
 
 	return CalculateTargetVectorDimensionsFromBucket(ctx, bucket, targetVector)
+}
+
+// CalculateUnloadedDimensionsUsageAll calculates dimensions and object count for all target
+// vectors of an unloaded shard without loading it into memory. The dimensions bucket is opened
+// once and shared by all target vector calculations, instead of once per target vector.
+func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
+	logger logrus.FieldLogger, path, tenantName string, targetVectors []string,
+) (map[string]types.Dimensionality, error) {
+	if len(targetVectors) == 0 {
+		return nil, nil
+	}
+
+	bucketPath := shardPathDimensionsLSM(path, tenantName)
+	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
+		return nil, fmt.Errorf("lock dimensions bucket: %w", err)
+	}
+	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
+
+	bucket, err := openUnloadedDimensionsBucket(ctx, logger, path, bucketPath)
+	if err != nil {
+		return nil, err
+	}
+	defer bucket.Shutdown(ctx)
+
+	dimensionalities := make(map[string]types.Dimensionality, len(targetVectors))
+	for _, targetVector := range targetVectors {
+		dimensionality, err := CalculateTargetVectorDimensionsFromBucket(ctx, bucket, targetVector)
+		if err != nil {
+			return nil, err
+		}
+		dimensionalities[targetVector] = dimensionality
+	}
+	return dimensionalities, nil
 }
 
 // CalculateUnloadedVectorsMetrics calculates vector storage size from disk

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
@@ -458,13 +459,22 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	errs := make(chan error, 80)
-	for range 8 {
-		wg.Add(1)
+	for range 4 {
+		wg.Add(2)
 		go func() {
 			defer wg.Done()
 			<-start
 			for range 10 {
 				if _, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, "text"); err != nil {
+					errs <- err
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 10 {
+				if _, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, []string{"text"}); err != nil {
 					errs <- err
 				}
 			}
@@ -476,4 +486,51 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 	for err := range errs {
 		require.NoError(t, err)
 	}
+}
+
+func TestCalculateUnloadedDimensionsUsageAll(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	tenantName := "tenant"
+
+	writeDims := func(t *testing.T, b *lsmkv.Bucket, targetVector string, dims uint32, docIDs []uint64) {
+		key := make([]byte, len(targetVector)+4)
+		copy(key, targetVector)
+		binary.LittleEndian.PutUint32(key[len(targetVector):], dims)
+		for _, docID := range docIDs {
+			require.NoError(t, b.RoaringSetAddOne(key, docID))
+		}
+	}
+
+	dirName := t.TempDir()
+	bucketFolder := shardPathDimensionsLSM(dirName, tenantName)
+	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, bucketFolder, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
+	require.NoError(t, err)
+
+	writeDims(t, b, "text", 128, []uint64{1, 2, 3, 4, 5})
+	writeDims(t, b, "image", 512, []uint64{1, 2, 3})
+	require.NoError(t, b.FlushMemtable())
+	require.NoError(t, b.Shutdown(ctx))
+
+	targetVectors := []string{"text", "image", "missing"}
+	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors)
+	require.NoError(t, err)
+	require.Len(t, all, len(targetVectors))
+	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, all["text"])
+	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, all["image"])
+	assert.Equal(t, types.Dimensionality{}, all["missing"])
+
+	// parity with the single-vector variant
+	for _, targetVector := range targetVectors {
+		single, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, targetVector)
+		require.NoError(t, err)
+		assert.Equal(t, all[targetVector], single, targetVector)
+	}
+
+	// no target vectors → nothing to calculate, no bucket open
+	none, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, nil)
+	require.NoError(t, err)
+	assert.Nil(t, none)
 }


### PR DESCRIPTION
### What's being changed:

open dimensions bucket once per shard with sequential-access hint

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
