### PR TITLE
fix(async-repl): stop worker-pool grow path leaking goroutines

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -186,6 +186,8 @@ type asyncReplicationSchedulerMetrics struct {
 	queueDepth prometheus.Gauge
 	// workerPoolSize is the current target worker pool size.
 	workerPoolSize prometheus.Gauge
+	// workersLive tracks live worker goroutines (spawned, not yet exited).
+	workersLive prometheus.Gauge
 	// reconcileFailures counts indices that failed to reconcile their async
 	// replication state with the global flag (see DB.ReconcileAsyncReplication).
 	// A non-zero rate means a cluster may be stuck partially reconciled until
@@ -248,6 +250,18 @@ func newAsyncReplicationSchedulerMetrics(prom *monitoring.PrometheusMetrics) (as
 			Namespace: "weaviate",
 			Name:      "async_replication_scheduler_worker_pool_size",
 			Help:      "Current target size of the scheduler worker pool.",
+		}),
+	)
+	if err != nil {
+		return m, err
+	}
+
+	m.workersLive, _, err = monitoring.EnsureRegisteredMetric(
+		prom.Registerer,
+		prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "weaviate",
+			Name:      "async_replication_scheduler_workers_live",
+			Help:      "Number of live scheduler worker goroutines (spawned but not yet exited).",
 		}),
 	)
 	if err != nil {
@@ -348,6 +362,18 @@ func (m *asyncReplicationSchedulerMetrics) setWorkerPoolSize(n int) {
 	}
 }
 
+func (m *asyncReplicationSchedulerMetrics) incWorkersLive() {
+	if m.monitoring {
+		m.workersLive.Inc()
+	}
+}
+
+func (m *asyncReplicationSchedulerMetrics) decWorkersLive() {
+	if m.monitoring {
+		m.workersLive.Dec()
+	}
+}
+
 func (m *asyncReplicationSchedulerMetrics) incRootPrefilterSkips() {
 	if m.monitoring {
 		m.rootPrefilterSkips.Inc()
@@ -409,6 +435,9 @@ type AsyncReplicationScheduler struct {
 	// adjustWorkers. Protected by workersMu.
 	targetWorkers int
 	workersMu     sync.Mutex
+
+	// liveWorkers counts spawned-but-not-exited workers (may briefly exceed targetWorkers mid-shrink).
+	liveWorkers atomic.Int64
 
 	// scaleDownCh receives one token per worker that should exit.
 	// Sized to maxMaxWorkers: at most one token per possible worker.
@@ -575,11 +604,7 @@ func NewAsyncReplicationScheduler(
 	}, s.logger)
 
 	for range s.targetWorkers {
-		s.wg.Add(1)
-		enterrors.GoWrapper(func() {
-			defer s.wg.Done()
-			s.worker()
-		}, s.logger)
+		s.spawnWorker()
 	}
 	s.metrics.setWorkerPoolSize(s.targetWorkers)
 
@@ -1191,6 +1216,29 @@ func (sched *AsyncReplicationScheduler) workerWatcher() {
 	}
 }
 
+// tryReclaimScaleDownToken removes one pending scale-down token if present.
+func (sched *AsyncReplicationScheduler) tryReclaimScaleDownToken() bool {
+	select {
+	case <-sched.scaleDownCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// spawnWorker launches one pool worker, keeping wg, liveWorkers, and the gauge balanced.
+func (sched *AsyncReplicationScheduler) spawnWorker() {
+	sched.wg.Add(1)
+	sched.liveWorkers.Add(1)
+	sched.metrics.incWorkersLive()
+	enterrors.GoWrapper(func() {
+		defer sched.wg.Done()
+		defer sched.metrics.decWorkersLive()
+		defer sched.liveWorkers.Add(-1)
+		sched.worker()
+	}, sched.logger)
+}
+
 // adjustWorkers scales the pool to n: spawns goroutines when growing, sends
 // scale-down tokens when shrinking. n <= 0 falls back to the default. Safe
 // to call concurrently; workersMu serialises adjustments.
@@ -1220,22 +1268,13 @@ func (sched *AsyncReplicationScheduler) adjustWorkers(n int) {
 	sched.metrics.setWorkerPoolSize(n)
 
 	if delta > 0 {
-		// Drain stale scale-down tokens from a prior shrink, otherwise new
-		// workers would consume them immediately and exit. Non-blocking
-		// receives because running workers may consume concurrently.
-		for drained := false; !drained; {
-			select {
-			case <-sched.scaleDownCh:
-			default:
-				drained = true
-			}
+		// Reclaim up to delta stale tokens, then spawn only the shortfall (draining all leaks unretired workers).
+		reclaimed := 0
+		for reclaimed < delta && sched.tryReclaimScaleDownToken() {
+			reclaimed++
 		}
-		for range delta {
-			sched.wg.Add(1)
-			enterrors.GoWrapper(func() {
-				defer sched.wg.Done()
-				sched.worker()
-			}, sched.logger)
+		for range delta - reclaimed {
+			sched.spawnWorker()
 		}
 		return
 	}

--- a/adapters/repos/db/async_replication_scheduler_integration_test.go
+++ b/adapters/repos/db/async_replication_scheduler_integration_test.go
@@ -368,3 +368,55 @@ func TestAsyncSchedulerConcurrentRegisterDeregisterAndClose(t *testing.T) {
 
 	wg.Wait() // goroutines exit via ctx.Done() in Register/Deregister
 }
+
+// TestAdjustWorkersDoesNotLeakWorkersUnderConfigFlapping pins real workers busy and flaps the pool down/up: growing back must not leak workers.
+func TestAdjustWorkersDoesNotLeakWorkersUnderConfigFlapping(t *testing.T) {
+	const n = 6
+	ctx := context.Background()
+	sched := newStartedTestScheduler(t, n)
+
+	shards := make([]*Shard, 0, n)
+	for i := range n {
+		_, idx := testShard(t, ctx, fmt.Sprintf("FlapLeak%02d", i))
+		s := firstShard(t, idx)
+		prepareShardForScheduler(t, s)
+		shards = append(shards, s)
+	}
+
+	// Hold each write lock before registering so every cycle blocks in runEntry, pinning workers off the scale-down select.
+	for _, s := range shards {
+		s.asyncReplicationRWMux.Lock()
+	}
+	defer func() {
+		for _, s := range shards {
+			s.asyncReplicationRWMux.Unlock()
+		}
+	}()
+
+	for _, s := range shards {
+		require.NoError(t, sched.Register(s))
+	}
+
+	// Wait until all n cycles are dispatched and picked up: every worker is now pinned in runEntry.
+	require.Eventually(t, func() bool {
+		if len(sched.workCh) != 0 {
+			return false
+		}
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		inflight := 0
+		for _, e := range sched.entries {
+			if e.inFlight {
+				inflight++
+			}
+		}
+		return inflight == n
+	}, 5*time.Second, 5*time.Millisecond, "all %d workers must be pinned in-flight before flapping", n)
+
+	for i := range 3 {
+		sched.adjustWorkers(1)
+		sched.adjustWorkers(n)
+		require.Equal(t, int64(n), sched.liveWorkers.Load(),
+			"flap %d: growing back must reclaim pending scale-down tokens instead of leaking workers", i)
+	}
+}

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -143,6 +143,25 @@ func newSchedulerForUnitTest(t *testing.T) *AsyncReplicationScheduler {
 	return sched
 }
 
+// newWorkerPoolTestScheduler builds a scheduler at the given target with no running pool, so adjustWorkers' token/spawn accounting can be driven deterministically.
+func newWorkerPoolTestScheduler(t *testing.T, target int) *AsyncReplicationScheduler {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &AsyncReplicationScheduler{
+		ctx:           ctx,
+		cancel:        cancel,
+		targetWorkers: target,
+		scaleDownCh:   make(chan struct{}, maxMaxWorkers),
+		workCh:        make(chan *[]*asyncSchedulerEntry, maxMaxWorkers),
+		logger:        logrus.New(),
+	}
+	t.Cleanup(func() {
+		cancel()
+		s.wg.Wait()
+	})
+	return s
+}
+
 // TestAsyncSchedulerHeap verifies the min-heap invariants:
 //   - entries are popped in ascending nextRunAt order
 //   - heapIdx is correct after Push, Pop, Fix, and Remove
@@ -558,6 +577,39 @@ func TestAdjustWorkersUpdatesTargetWorkers(t *testing.T) {
 		sched.workersMu.Unlock()
 		assert.Equal(t, 8, got, "after down-then-up, targetWorkers must be 8")
 	})
+}
+
+// TestAdjustWorkersGrowReclaimsPendingTokensBeforeSpawning pins the grow-path leak: growing must reclaim at most delta stale scale-down tokens and spawn only the shortfall, never drain all tokens and spawn delta on top.
+func TestAdjustWorkersGrowReclaimsPendingTokensBeforeSpawning(t *testing.T) {
+	cases := []struct {
+		name          string
+		initialTarget int
+		pending       int
+		growTo        int
+		wantSpawned   int64
+		wantRemaining int
+	}{
+		{"full_reclaim_no_spawn", 2, 8, 10, 0, 0},
+		{"partial_reclaim", 2, 4, 10, 4, 0},
+		{"no_pending_spawns_all", 2, 0, 10, 8, 0},
+		{"reclaim_capped_at_delta", 2, 8, 6, 0, 4},
+		{"cap_then_reclaim", 2, 8, maxMaxWorkers + 50, int64(maxMaxWorkers - 2 - 8), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newWorkerPoolTestScheduler(t, tc.initialTarget)
+			for range tc.pending {
+				sched.scaleDownCh <- struct{}{}
+			}
+
+			sched.adjustWorkers(tc.growTo)
+
+			assert.Equal(t, tc.wantSpawned, sched.liveWorkers.Load(),
+				"grow must spawn only the shortfall after reclaiming pending tokens")
+			assert.Equal(t, tc.wantRemaining, len(sched.scaleDownCh),
+				"grow must reclaim at most delta tokens, not all of them")
+		})
+	}
 }
 
 // Deleted: TestAdjustWorkersScaleDownUpdatesTargetAndSendsTokens,


### PR DESCRIPTION
## Motivation

The async replication scheduler runs a worker pool whose size is adjusted at runtime (`workerWatcher` polls `AsyncReplicationSchedulerWorkers` every 30s and calls `adjustWorkers`). The grow path leaked worker goroutines: when a shrink had queued scale-down tokens that workers hadn't consumed yet, growing the pool **drained every pending token and then spawned `delta` brand-new workers on top**. The tokens it drained were the retirement signals for workers that were still alive — so those workers never exited, and `delta` new ones joined them.

Net effect: a single down→up flap overshoots the target by up to `delta` workers, and repeated oscillation compounds it with no real bound (only loosely limited by how fast busy workers get around to reading `scaleDownCh`). Left unchecked this is an unbounded goroutine leak that can push live workers past `maxMaxWorkers`, at which point the `resultCh` sizing assumption (`maxMaxWorkers*2`) no longer holds — and the scale-down send could then block the watcher against a full `scaleDownCh`.

## Approach

Instead of draining all stale tokens, **reclaim at most `delta` of them** — each reclaimed token cancels one pending retirement, keeping an existing worker alive — then spawn only the shortfall (`delta - reclaimed`). When a shrink's tokens are still in flight, an equal-sized grow now cancels the retirements and spawns nothing, landing exactly on target.

Supporting changes:
- A single `spawnWorker()` helper is the only place a pool worker is created, keeping `wg`, the new `liveWorkers` counter, and the gauge balanced across every exit path (including panic, since the decrements are deferred inside the `GoWrapper` closure).
- New `liveWorkers atomic.Int64` and a `weaviate_async_replication_scheduler_workers_live` gauge track spawned-but-not-exited goroutines. This is what makes the leak observable in prod (live goroutines vs. the *target* `worker_pool_size`) and assertable in tests.

## Key areas for review

- `adjustWorkers` grow branch — reclaim is capped at `delta` (short-circuit stops calling `tryReclaimScaleDownToken` once `reclaimed == delta`), and spawn count is exactly `delta - reclaimed`.
- `spawnWorker` / `tryReclaimScaleDownToken` — `wg.Add`/`liveWorkers`/gauge increments are matched by deferred decrements on *every* `worker()` return path.
- Concurrency: `adjustWorkers` reclaiming from `scaleDownCh` races with a live `worker()` receiving from the same channel. Both are plain receives, so exactly one side gets each token; the accounting stays consistent either way (a reclaimed token cancels a retirement; a worker-consumed token retires that worker). `workersMu` only serializes `adjustWorkers` against itself, which is sufficient because workers never *send* tokens.

## Risks and mitigations

- **Reclaim-vs-consume race**: channel receive is atomic, so the live-worker count stays correct regardless of ordering. The invariant *eventual = liveWorkers − pendingTokens = targetWorkers* is preserved for any interleaving.
- **Transient overshoot**: `liveWorkers` can briefly exceed `targetWorkers` while a shrink's tokens drain. Bounded (`liveWorkers ≤ maxMaxWorkers` by induction, since grow spawns only the shortfall); the new gauge makes any lingering gap visible.
- **Metric registration**: `workers_live` is registered via `EnsureRegisteredMetric` (idempotent) and gated on `m.monitoring` like its siblings — no duplicate-registration panic, no-op when monitoring is off. Purely additive.

## Testing

New table-driven `TestAdjustWorkersGrowReclaimsPendingTokensBeforeSpawning` drives `adjustWorkers` on a pool-less scheduler so token/spawn accounting is deterministic, asserting both the number of workers spawned (`liveWorkers`) and the tokens left in `scaleDownCh`. Cases: full reclaim (spawn 0), partial reclaim, no pending (spawn all), reclaim capped at delta (excess tokens remain), and cap-then-reclaim (grow request past `maxMaxWorkers`). Verified **red → green**: on the old drain-all-then-spawn-`delta` behavior it fails 4/5 subtests (e.g. full-reclaim spawns 8 instead of 0); with the fix it passes.

- Scheduler unit suite (`-race`): pass
- Integration tests with real shards (`-race`, incl. `Close`-with-inflight-workers): pass
- `golangci-lint` and the goroutine linter: clean

## Follow-up

This targets `stable/v1.38` only, as scoped. The same grow-path very likely leaks on `main` and `stable/v1.37` (near-identical async-rep code) and should be checked and forward-ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
