### PR TITLE
fix(async-repl): restore shard after a failed tenant freeze

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1675,6 +1675,29 @@ func (i *Index) ReconcileAsyncReplicationForShard(ctx context.Context, shardName
 	return ctrl.disableAsyncReplication(ctx)
 }
 
+// resumeAfterAbortedOffload reverses an aborted offloading HaltForTransfer: resume maintenance and rebuild async replication from a full scan so the shard cannot silently diverge. No-op when not loaded.
+func (i *Index) resumeAfterAbortedOffload(ctx context.Context, shardName string) error {
+	shard := i.shards.Loaded(shardName)
+	if shard == nil {
+		return nil
+	}
+
+	ctrl, ok := shard.(asyncReplicationController)
+	if !ok {
+		return fmt.Errorf("shard %q does not implement asyncReplicationController", shardName)
+	}
+
+	// Idempotent when not halted (e.g. HaltForTransfer failed and self-resumed).
+	if err := shard.resumeMaintenanceCycles(ctx); err != nil {
+		return fmt.Errorf("resume maintenance cycles on shard %q: %w", shardName, err)
+	}
+
+	i.replicationConfigLock.Lock()
+	defer i.replicationConfigLock.Unlock()
+
+	return ctrl.rebuildAsyncReplicationFromScratch(ctx, i.asyncReplicationEnabledForShard(shardName), i.Config.AsyncReplicationConfig)
+}
+
 // parseDateFieldsInProps checks the schema for the current class for which
 // fields are date fields, then - if they are set - parses them accordingly.
 // Works for both date and date[].

--- a/adapters/repos/db/migrator_shard_status_ops.go
+++ b/adapters/repos/db/migrator_shard_status_ops.go
@@ -121,6 +121,21 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 			idx.shardCreateLocks.Lock(name)
 			defer idx.shardCreateLocks.Unlock(name)
 
+			// restoreAfterAbort reverses an already-run offloading HaltForTransfer.
+			restoreAfterAbort := func() {
+				if shard == nil {
+					return // COLD/inactive: no local shard was halted
+				}
+				if err := idx.resumeAfterAbortedOffload(ctx, name); err != nil {
+					m.logger.WithFields(logrus.Fields{
+						"action": "resume_after_aborted_offload",
+						"name":   class,
+						"tenant": name,
+					}).Errorf("resume after aborted offload: %v", err)
+					ec.Add(fmt.Errorf("resume after aborted offload: %w", err))
+				}
+			}
+
 			if shard != nil {
 				if err := shard.HaltForTransfer(ctx, true, 0); err != nil {
 					m.logger.WithFields(logrus.Fields{
@@ -137,6 +152,7 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 						Op: command.TenantsProcess_OP_ABORT,
 					}
 					ec.Add(err)
+					restoreAfterAbort()
 					return fmt.Errorf("attempt to mark begin offloading: %w", err)
 				}
 			}
@@ -157,6 +173,7 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 					},
 					Op: command.TenantsProcess_OP_ABORT,
 				}
+				restoreAfterAbort()
 			} else {
 				cmd.TenantsProcesses[uidx] = &command.TenantsProcess{
 					Tenant: &command.Tenant{

--- a/adapters/repos/db/migrator_shard_status_ops_offload_test.go
+++ b/adapters/repos/db/migrator_shard_status_ops_offload_test.go
@@ -1,0 +1,97 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// failingOffloadCloud is an OffloadCloud whose Upload always fails.
+type failingOffloadCloud struct{ uploadErr error }
+
+func (f *failingOffloadCloud) VerifyBucket(context.Context) error { return nil }
+
+func (f *failingOffloadCloud) Upload(context.Context, string, string, string) error {
+	return f.uploadErr
+}
+
+func (f *failingOffloadCloud) Download(context.Context, string, string, string) error { return nil }
+
+func (f *failingOffloadCloud) Delete(context.Context, string, string, string) error { return nil }
+
+// recordingProcessor captures the RAFT command freeze produces.
+type recordingProcessor struct {
+	mu  sync.Mutex
+	req *command.TenantProcessRequest
+}
+
+func (p *recordingProcessor) UpdateTenantsProcess(_ context.Context, _ string, req *command.TenantProcessRequest) (uint64, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.req = req
+	return 0, nil
+}
+
+// TestFreezeAbortRestoresShardOnUploadFailure: a freeze whose Upload fails must fully restore the shard.
+func TestFreezeAbortRestoresShardOnUploadFailure(t *testing.T) {
+	ctx := context.Background()
+	const class = "FreezeAbortRestoresShard"
+
+	sl, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+	setShardReplicas(t, idx, "node1", "node2")
+
+	cfg := minAsyncReplicationConfig()
+	require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+	require.NoError(t, s.store.FlushMemtables(ctx))
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+
+	logger, _ := test.NewNullLogger()
+	m := NewMigrator(nil, logger, "node1")
+	m.SetNode("node1")
+	proc := &recordingProcessor{}
+	m.SetCluster(proc)
+	m.cloud = &failingOffloadCloud{uploadErr: fmt.Errorf("simulated upload failure")}
+
+	ec := errorcompounder.New()
+	m.freeze(ctx, idx, class, []string{s.name}, ec)
+
+	require.Equal(t, 0, s.haltForTransferCount, "freeze abort must resume maintenance")
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()), "freeze abort must discard the stale snapshot")
+	awaitHashtreeInitialized(t, s)
+	require.Error(t, ec.ToError(), "the upload error must be recorded")
+
+	require.Eventually(t, func() bool {
+		proc.mu.Lock()
+		defer proc.mu.Unlock()
+		if proc.req == nil || len(proc.req.TenantsProcesses) != 1 {
+			return false
+		}
+		tp := proc.req.TenantsProcesses[0]
+		return tp.Op == command.TenantsProcess_OP_ABORT && tp.Tenant.Status == models.TenantActivityStatusHOT
+	}, 5*time.Second, 20*time.Millisecond, "freeze must record OP_ABORT back to HOT")
+}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -240,6 +240,10 @@ type asyncReplicationController interface {
 	// hasActiveAsyncReplicationTargetOverrides reports whether the shard holds
 	// target-node overrides that force async replication on.
 	hasActiveAsyncReplicationTargetOverrides() bool
+	// removePersistedHashtree deletes any persisted hashtree (.ht) snapshot.
+	removePersistedHashtree() error
+	// rebuildAsyncReplicationFromScratch drops any snapshot and rebuilds from a full scan.
+	rebuildAsyncReplicationFromScratch(ctx context.Context, enabled bool, config AsyncReplicationConfig) error
 }
 
 type onAddToPropertyValueIndex func(shard *Shard, docID uint64, property *inverted.Property) error

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1068,6 +1068,47 @@ func (s *Shard) disableAsyncReplication(_ context.Context) error {
 	return nil
 }
 
+// rebuildAsyncReplicationFromScratch drops any tree, deletes the snapshot, and rebuilds from a full scan when enabled — atomically, so no racing enable can trust the stale snapshot.
+func (s *Shard) rebuildAsyncReplicationFromScratch(ctx context.Context, enabled bool, config AsyncReplicationConfig) error {
+	var clearStats bool
+	err := func() error {
+		s.asyncReplicationRWMux.Lock()
+		defer s.asyncReplicationRWMux.Unlock()
+
+		if s.hashtree != nil { // drop any tree a racing enable may have installed
+			s.asyncReplicationCancelFunc()
+			s.hashtree = nil
+			s.hashtreeFullyInitialized = false
+			s.clearAsyncCheckpointLocked()
+
+			// Deadlock-free: removeCh takes only sched.mu, never asyncReplicationRWMux.
+			if s.index.asyncReplicationScheduler != nil {
+				if err := s.index.asyncReplicationScheduler.Deregister(s); err != nil {
+					s.index.logger.WithField("action", "async_replication").Error(err)
+				}
+			}
+			clearStats = true
+		}
+
+		if err := s.removePersistedHashtree(); err != nil { // no snapshot may survive to be cached
+			return err
+		}
+
+		if enabled {
+			return s.initAsyncReplication(config, nil) // cached=nil forces a full scan
+		}
+		return nil
+	}()
+
+	// Clear stats outside the mux, matching disableAsyncReplication.
+	if clearStats {
+		s.asyncReplicationStatsMux.Lock()
+		s.asyncReplicationStatsByTargetNode = nil
+		s.asyncReplicationStatsMux.Unlock()
+	}
+	return err
+}
+
 func (s *Shard) addTargetNodeOverride(ctx context.Context, targetNodeOverride additional.AsyncReplicationTargetNodeOverride) error {
 	func() {
 		s.asyncReplicationRWMux.Lock()

--- a/adapters/repos/db/shard_async_replication_offload_test.go
+++ b/adapters/repos/db/shard_async_replication_offload_test.go
@@ -1,0 +1,195 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+// uuidPostDump is written after the snapshot dump; a correct rebuild differs from the dump-time root.
+const uuidPostDump = strfmt.UUID("77777777-7777-7777-7777-777777777777")
+
+// haltAndDumpForOffload puts s into the post-offloading-halt state (maintenance paused, async off, stale .ht).
+func haltAndDumpForOffload(t *testing.T, ctx context.Context, s *Shard) {
+	t.Helper()
+	require.NoError(t, s.HaltForTransfer(ctx, true, 0))
+	require.Len(t, htFilesInDir(t, s.pathHashTree()), 1, "offloading halt must dump a .ht")
+	s.asyncReplicationRWMux.RLock()
+	require.Nil(t, s.hashtree, "offloading halt must nil the hashtree")
+	s.asyncReplicationRWMux.RUnlock()
+	require.Equal(t, 1, s.haltForTransferCount, "offloading halt must pause maintenance")
+}
+
+// TestResumeAfterAbortedOffload_RebuildsFromScratch: a post-dump write must appear in the rebuilt tree.
+func TestResumeAfterAbortedOffload_RebuildsFromScratch(t *testing.T) {
+	ctx := context.Background()
+	const class = "ResumeAfterAbortedOffloadRebuild"
+
+	sl, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+	setShardReplicas(t, idx, "node1", "node2")
+
+	cfg := minAsyncReplicationConfig()
+
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+	require.NoError(t, s.store.FlushMemtables(ctx))
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	rootAtDump := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.NotEqual(t, hashtree.Digest{}, rootAtDump, "sanity: seeded hashtree must have a non-zero root")
+
+	haltAndDumpForOffload(t, ctx, s)
+
+	require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidPostDump, tsFarPast)))
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	require.NoError(t, idx.resumeAfterAbortedOffload(ctx, s.name))
+
+	require.Equal(t, 0, s.haltForTransferCount, "maintenance must be resumed")
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()), "stale .ht must be discarded")
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	rootAfterResume := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.NotEqual(t, rootAtDump, rootAfterResume,
+		"rebuilt hashtree must reflect the post-dump write; equal roots mean the stale snapshot was trusted and divergence is invisible to repair")
+}
+
+// TestResumeAfterAbortedOffload_AsyncDisabledRemovesStaleHashtree: recovery drops the snapshot, leaves async off.
+func TestResumeAfterAbortedOffload_AsyncDisabledRemovesStaleHashtree(t *testing.T) {
+	ctx := context.Background()
+	const class = "ResumeAfterAbortedOffloadAsyncDisabled"
+
+	sl, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+	setShardReplicas(t, idx, "node1") // single replica → not enabled
+
+	cfg := minAsyncReplicationConfig()
+
+	require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+	require.NoError(t, s.store.FlushMemtables(ctx))
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+
+	haltAndDumpForOffload(t, ctx, s)
+
+	require.NoError(t, idx.resumeAfterAbortedOffload(ctx, s.name))
+
+	require.Equal(t, 0, s.haltForTransferCount, "maintenance must be resumed")
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()), "stale .ht must be discarded even when async is disabled")
+	s.asyncReplicationRWMux.RLock()
+	require.Nil(t, s.hashtree, "async replication must stay off when not enabled for the shard")
+	s.asyncReplicationRWMux.RUnlock()
+}
+
+// TestResumeAfterAbortedOffload_NotHalted: the HaltForTransfer-failed shape; recovery still drops the snapshot and rebuilds.
+func TestResumeAfterAbortedOffload_NotHalted(t *testing.T) {
+	ctx := context.Background()
+	const class = "ResumeAfterAbortedOffloadNotHalted"
+
+	sl, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+	setShardReplicas(t, idx, "node1", "node2")
+
+	cfg := minAsyncReplicationConfig()
+
+	require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+	require.NoError(t, s.store.FlushMemtables(ctx))
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+
+	// snapshot + disable without halting
+	s.mayStopAsyncReplication()
+	require.Len(t, htFilesInDir(t, s.pathHashTree()), 1, "pre-condition: a snapshot exists")
+	require.Equal(t, 0, s.haltForTransferCount, "pre-condition: maintenance not halted")
+
+	require.NoError(t, idx.resumeAfterAbortedOffload(ctx, s.name))
+	require.Equal(t, 0, s.haltForTransferCount)
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()), "stale .ht must be discarded")
+	awaitHashtreeInitialized(t, s)
+
+	// second recovery is idempotent
+	require.NoError(t, idx.resumeAfterAbortedOffload(ctx, s.name))
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()))
+	awaitHashtreeInitialized(t, s)
+}
+
+// TestResumeAfterAbortedOffload_ConcurrentReconcileNoStaleTree: reconcile racing recovery, -race.
+func TestResumeAfterAbortedOffload_ConcurrentReconcileNoStaleTree(t *testing.T) {
+	ctx := context.Background()
+	const class = "ResumeAfterAbortedOffloadConcurrentReconcile"
+
+	sl, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+	setShardReplicas(t, idx, "node1", "node2")
+
+	cfg := minAsyncReplicationConfig()
+
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+	require.NoError(t, s.store.FlushMemtables(ctx))
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	rootAtDump := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+
+	haltAndDumpForOffload(t, ctx, s)
+
+	require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidPostDump, tsFarPast)))
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = idx.reconcileAsyncReplication(ctx)
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, idx.resumeAfterAbortedOffload(ctx, s.name))
+	}()
+	wg.Wait()
+
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()), "no stale .ht may survive the race")
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	rootAfterResume := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.NotEqual(t, rootAtDump, rootAfterResume,
+		"final hashtree must reflect the post-dump write even under a concurrent reconcile")
+}

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -346,6 +346,23 @@ func (l *LazyLoadShard) hasActiveAsyncReplicationTargetOverrides() bool {
 	return l.shard.hasActiveAsyncReplicationTargetOverrides()
 }
 
+func (l *LazyLoadShard) removePersistedHashtree() error {
+	l.mutex.Lock()
+	loaded := l.loaded
+	l.mutex.Unlock()
+	if !loaded {
+		return nil // not loaded: a stale .ht is discarded on next load
+	}
+	return l.shard.removePersistedHashtree()
+}
+
+func (l *LazyLoadShard) rebuildAsyncReplicationFromScratch(ctx context.Context, enabled bool, config AsyncReplicationConfig) error {
+	if err := l.Load(ctx); err != nil {
+		return err
+	}
+	return l.shard.rebuildAsyncReplicationFromScratch(ctx, enabled, config)
+}
+
 func (l *LazyLoadShard) addTargetNodeOverride(ctx context.Context, targetNodeOverride additional.AsyncReplicationTargetNodeOverride) error {
 	if err := l.Load(ctx); err != nil {
 		return err

--- a/test/acceptance/replication/offload_abort_async/offload_abort_async_test.go
+++ b/test/acceptance/replication/offload_abort_async/offload_abort_async_test.go
@@ -1,0 +1,150 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package offload_abort_async
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+const (
+	envS3AccessKey = "AWS_ACCESS_KEY_ID"
+	envS3SecretKey = "AWS_SECRET_KEY"
+	s3AccessKey    = "aws_access_key"
+	s3SecretKey    = "aws_secret_key"
+)
+
+func i64(v int64) *int64 { return &v }
+
+// TestFreezeAbortDoesNotSilentlyDivergeReplicas: after a failed tenant freeze, a write on only some replicas must still converge everywhere.
+func TestFreezeAbortDoesNotSilentlyDivergeReplicas(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	t.Setenv(envS3AccessKey, s3AccessKey)
+	t.Setenv(envS3SecretKey, s3SecretKey)
+
+	// OFFLOAD_TIMEOUT bounds the failing upload once MinIO is down. Disable bucket
+	// auto-create (MinIO pre-creates the bucket) so a node can restart while MinIO is
+	// down — auto-create is the only thing that makes the offload module touch MinIO at init.
+	compose, err := docker.New().
+		WithOffloadS3("offloading", "us-west-1").
+		WithWeaviateEnv("OFFLOAD_TIMEOUT", "5").
+		WithoutWeaviateEnvs("OFFLOAD_S3_BUCKET_AUTO_CREATE").
+		WithText2VecContextionary().
+		With3NodeCluster().
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	className := "OffloadAbortAsyncClass"
+	tenant := "Tenant1"
+	testClass := models.Class{
+		Class:             className,
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled:              true,
+			AutoTenantActivation: true,
+		},
+		// fast async cadence so repair is observable
+		Properties: []*models.Property{{Name: "name", DataType: schema.DataTypeText.PropString()}},
+	}
+	testClass.ReplicationConfig.AsyncConfig = &models.ReplicationAsyncConfig{
+		Frequency:                 i64(1000),
+		FrequencyWhilePropagating: i64(1000),
+		PropagationDelay:          i64(1000),
+	}
+	helper.CreateClass(t, &testClass)
+	defer helper.DeleteClass(t, className)
+	helper.CreateTenants(t, className, []*models.Tenant{{Name: tenant}})
+
+	baselineIDs := []strfmt.UUID{
+		"00000000-0000-0000-0000-0000000000a1",
+		"00000000-0000-0000-0000-0000000000a2",
+		"00000000-0000-0000-0000-0000000000a3",
+	}
+	for _, id := range baselineIDs {
+		require.Nil(t, helper.CreateObject(t, &models.Object{
+			ID: id, Class: className, Tenant: tenant,
+			Properties: map[string]interface{}{"name": "baseline"},
+		}))
+	}
+
+	nodeNames := []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2}
+
+	// baseline present on every replica before we start
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		for _, node := range nodeNames {
+			for _, id := range baselineIDs {
+				_, err := common.GetTenantObjectFromNode(t, compose.GetWeaviate().URI(), className, id, node, tenant)
+				assert.NoErrorf(ct, err, "baseline object %s must be present on %s", id, node)
+			}
+		}
+	}, 120*time.Second, 3*time.Second, "baseline must converge on all replicas")
+
+	// bring the offload backend down so the freeze upload fails
+	require.Nil(t, compose.StopMinIO(ctx))
+
+	// freeze with MinIO down: the upload fails (surfaced synchronously) while the abort reverts the tenant to HOT
+	if err := helper.UpdateTenantsReturnError(t, className, []*models.Tenant{
+		{Name: tenant, ActivityStatus: models.TenantActivityStatusFROZEN},
+	}); err != nil {
+		t.Logf("FROZEN update surfaced the expected offload error: %v", err)
+	}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := helper.GetTenants(t, className)
+		require.Nil(t, err)
+		for _, tn := range resp.Payload {
+			if tn.Name == tenant {
+				assert.Equal(ct, models.TenantActivityStatusHOT, tn.ActivityStatus)
+			}
+		}
+	}, 90*time.Second, 2*time.Second, "tenant must revert to HOT after the aborted freeze")
+
+	// stop a replica (weaviate-2; StopNode is 0-based), write W while down, restart it (snapshot-reload path)
+	require.Nil(t, compose.StopNode(ctx, 2, nil))
+	const w = strfmt.UUID("77777777-7777-7777-7777-777777777777")
+	require.Nil(t, common.CreateObjectCL(t, compose.GetWeaviate().URI(), &models.Object{
+		ID: w, Class: className, Tenant: tenant,
+		Properties: map[string]interface{}{"name": "w"},
+	}, types.ConsistencyLevelOne))
+	require.Nil(t, compose.StartNode(ctx, 2))
+
+	// async restored → W and baseline converge everywhere
+	wantIDs := append(append([]strfmt.UUID{}, baselineIDs...), w)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		for _, node := range nodeNames {
+			for _, id := range wantIDs {
+				_, err := common.GetTenantObjectFromNode(t, compose.GetWeaviate().URI(), className, id, node, tenant)
+				assert.NoErrorf(ct, err, "object %s must be present on %s", id, node)
+			}
+		}
+	}, 180*time.Second, 3*time.Second, "with async replication restored, W must converge to every replica")
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -1212,8 +1212,10 @@ function run_acceptance_async_replication_tests() {
   # Build once up front and reuse via TEST_WEAVIATE_IMAGE; otherwise each package
   # below rebuilds the image through testcontainers and the second package can
   # exceed the container-start deadline in CI.
+  # offload_abort_async is an async-replication divergence test triggered via
+  # tenant offload; it reuses the same image (the offload-s3 module is compiled in).
   build_weaviate_test_image
-  for pkg in $(go list ./.../ | grep 'test/acceptance/replication/async_replication'); do
+  for pkg in $(go list ./.../ | grep -E 'test/acceptance/replication/(async_replication|offload_abort_async)'); do
     if ! go test -timeout=20m -count 1 -race "$pkg"; then
       echo "Test for $pkg failed" >&2
       return 1


### PR DESCRIPTION
## Motivation

Tenant offloading (`HOT → FROZEN`) halts each shard for transfer before uploading it to cloud storage. `Shard.HaltForTransfer(offloading=true)` calls `mayStopAsyncReplication`, which **cancels async replication, dumps the hashtree to a persisted `.ht` snapshot on disk, nils the in-memory tree, and deregisters from the scheduler** — all *before* the upload runs.

If the offload then **aborts**, the tenant reverts to `HOT` and the shard resumes serving writes, but async replication stays off and a stale `.ht` sits on disk. Two abort journeys hit this:

1. **Upload fails** (`m.cloud.Upload` errors) after a successful halt.
2. **`HaltForTransfer` itself fails** after `mayStopAsyncReplication` already ran — it runs before the `haltForTransferCount > 1` early-return and is *not* undone by `HaltForTransfer`'s own error cleanup (which only resumes maintenance cycles, never re-enables async replication).

Once the shard is live again, any write that lands is absent from the stale snapshot. When async replication is later re-enabled (via `ReconcileAsyncReplication`, a config change, or the next shard load), that snapshot is loaded as the seed for the rebuilt hashtree. Because it predates the post-abort writes, the tree **under-reports divergence** — hashbeat/read-repair believe the replicas are in sync, so they **silently diverge and never converge**.

## Approach

On every abort path *after* a halt has run, `Migrator.freeze` now invokes `restoreAfterAbort → Index.resumeAfterAbortedOffload`, which:

1. `resumeMaintenanceCycles` — idempotent, so the failed-`HaltForTransfer` case (which already self-resumed) is a safe no-op.
2. Under `Index.replicationConfigLock` (serialized against `ReconcileAsyncReplication`/`updateReplicationConfig`), calls `Shard.rebuildAsyncReplicationFromScratch(enabled, config)`.

`rebuildAsyncReplicationFromScratch` is the core: under `asyncReplicationRWMux` it drops any in-memory tree (including one a racing enable just installed from the snapshot), cancels, clears the checkpoint, and deregisters; then **removes the persisted `.ht` before any re-enable** so it can never be loaded as cache; then, if async replication is enabled for the shard, re-inits with `cached=nil` to force a **full scan** rather than trusting the snapshot. The rescan runs asynchronously (as with any enable/init), so `freeze` isn't blocked for its duration.

The alternative — reusing the snapshot and diffing forward — was rejected: the snapshot's whole problem is that it can't see the writes that happened while async rep was off, so a full rescan is the only sound recovery. It runs only on the (rare) abort path, scoped to the single aborted shard.

## Concurrency / correctness

- **Deadlock-free.** Total lock order `backupLock > shardCreateLocks > replicationConfigLock > asyncReplicationRWMux > sched.mu`. No async-replication code takes `backupLock`/`shardCreateLocks`; the `replicationConfigLock → asyncReplicationRWMux` order matches `updateReplicationConfig`/`addTargetNodeOverride`. `Deregister` is deliberately called under the mux — its `removeCh` path takes only `sched.mu`, never `asyncReplicationRWMux` — so it is deadlock-free on this branch. Calling this synchronously from `freeze` mirrors the existing `HaltForTransfer → mayStopAsyncReplication → Deregister` path.
- **No stale-`.ht` reload.** The drop → `removePersistedHashtree` → `initAsyncReplication(cfg, nil)` sequence is atomic under `asyncReplicationRWMux`; the snapshot is deleted before any re-enable; and the whole rebuild is serialized against reconcile via `replicationConfigLock`. The race guard keys on `hashtree != nil` (set synchronously), so a late racing enable discards its cached tree.

## Key areas for review

- `shard_async_replication.go:rebuildAsyncReplicationFromScratch` — the critical section (drop → delete snapshot → re-init `cached=nil`, all inside the mux).
- `index.go:resumeAfterAbortedOffload` — `replicationConfigLock` scope and the not-loaded (`shard == nil`) no-op.
- `migrator_shard_status_ops.go:freeze` — `restoreAfterAbort` wired into **both** abort paths, skipped for COLD/inactive tenants, and errors both logged and added to the collector.
- `shard_lazyloader.go` — `removePersistedHashtree` no-op when unloaded (stale `.ht` discarded on next load in `shard_init_lsm`); `rebuildAsyncReplicationFromScratch` forces a `Load` first.

## Testing

Integration (`integrationTest`, `-race`):
- `TestResumeAfterAbortedOffload_RebuildsFromScratch` — a write made *after* the snapshot dump is reflected in the rebuilt tree (root differs from the dump-time root); the snapshot is not trusted.
- `TestResumeAfterAbortedOffload_AsyncDisabledRemovesStaleHashtree` — single-replica shard: stale `.ht` removed, no tree rebuilt when async rep isn't enabled for the shard.
- `TestResumeAfterAbortedOffload_NotHalted` — models the failed-`HaltForTransfer` shape (snapshot present, disabled, maintenance not halted); asserts idempotency of a second recovery.
- `TestResumeAfterAbortedOffload_ConcurrentReconcileNoStaleTree` — recovery racing 4 reconciles under `-race`; no stale `.ht` survives and the tree reflects the post-dump write.
- `TestFreezeAbortRestoresShardOnUploadFailure` — migrator-level upload-failure abort restores the shard (verified red without the fix, green with it).

Acceptance (3-node, RF=3, async, MinIO offload): `TestFreezeAbortDoesNotSilentlyDivergeReplicas` — MinIO down → freeze aborts → tenant reverts to `HOT` → stop one replica, write `W` at `CL=ONE`, restart it (exercises the snapshot-reload path) → assert `W` + baseline converge on all three replicas. **Validated locally red→green**: passes with the fix (~42s); with the fix reverted the restarted replica returns `404` for `W` ("object must be present on weaviate-2") and the convergence assertion times out — i.e. the permanent divergence the fix prevents. Wired into CI via `run_acceptance_async_replication_tests` (`-aoar`), reusing that job's single image build. Timing knobs may need tuning on CI hardware.

## Notes / open items

- **Target branch**: opened against `stable/v1.38` (this branch's base, matching the sibling worker-pool fix #12107). Repoint if `main` is preferred.
- The same silent-divergence path very likely exists on `main`/`stable/v1.37` and would want a forward-port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
