### PR TITLE
fix(usage): serialize unloaded dimensions bucket access across concurrent reports

### DIFF
--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/diskio"
+	entsync "github.com/weaviate/weaviate/entities/sync"
 )
 
 func shardPathLSM(indexPath, shardName string) string {
@@ -98,6 +99,12 @@ func usageDisk(shardUsage *types.ShardUsage) *types.UsageDisk {
 	return &types.UsageDisk{Version: types.UsageDiskVersion, ShardUsage: shardUsage}
 }
 
+// unloadedDimensionsBucketLocks serializes access to the same unloaded dimensions bucket.
+// Concurrent usage reports (overlapping periodic collections, /debug/usage, both usage modules
+// enabled) and the node-wide metrics observer may otherwise open the same bucket at once,
+// which lsmkv's GlobalBucketRegistry rejects with "bucket already registered".
+var unloadedDimensionsBucketLocks = entsync.NewKeyLocker()
+
 // CalculateUnloadedDimensionsUsage calculates dimensions and object count for an unloaded shard without loading it into memory
 func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (types.Dimensionality, error) {
 	bucketPath := shardPathDimensionsLSM(path, tenantName)
@@ -105,6 +112,9 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 	if err != nil {
 		return types.Dimensionality{}, fmt.Errorf("determine dimensions bucket strategy: %w", err)
 	}
+
+	unloadedDimensionsBucketLocks.Lock(bucketPath)
+	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
 
 	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx,
 		bucketPath,

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -103,7 +103,7 @@ func usageDisk(shardUsage *types.ShardUsage) *types.UsageDisk {
 // Concurrent usage reports (overlapping periodic collections, /debug/usage, both usage modules
 // enabled) and the node-wide metrics observer may otherwise open the same bucket at once,
 // which lsmkv's GlobalBucketRegistry rejects with "bucket already registered".
-var unloadedDimensionsBucketLocks = entsync.NewKeyLocker()
+var unloadedDimensionsBucketLocks = entsync.NewKeyLockerContext()
 
 // CalculateUnloadedDimensionsUsage calculates dimensions and object count for an unloaded shard without loading it into memory
 func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (types.Dimensionality, error) {
@@ -113,7 +113,9 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 		return types.Dimensionality{}, fmt.Errorf("determine dimensions bucket strategy: %w", err)
 	}
 
-	unloadedDimensionsBucketLocks.Lock(bucketPath)
+	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
+		return types.Dimensionality{}, fmt.Errorf("lock dimensions bucket: %w", err)
+	}
 	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
 
 	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx,

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -13,10 +13,12 @@ package shardusage
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -429,4 +431,46 @@ func TestCalculateNonLSMStorage_HFreshOneLevelDeep(t *testing.T) {
 	expectedCommitLogSize := uint64(1000 + 2000 + 3000)
 	assert.Equal(t, expectedCommitLogSize, vectorCommitLogsStorageSize, "nested commitlog/snapshot/queue.d should be counted")
 	assert.Equal(t, uint64(0), otherNonLSMFoldersStorageSize, "no other storage expected")
+}
+
+// TestCalculateUnloadedDimensionsUsage_Concurrent pins the "bucket already registered" error:
+// concurrent usage reports (overlapping periodic collections, /debug/usage) used to open the
+// same unloaded dimensions bucket at once, which lsmkv's GlobalBucketRegistry rejects.
+func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	tenantName := "tenant"
+
+	dirName := t.TempDir()
+	bucketFolder := shardPathDimensionsLSM(dirName, tenantName)
+	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, bucketFolder, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
+	require.NoError(t, err)
+
+	key := make([]byte, 4+4)
+	copy(key, "text")
+	binary.LittleEndian.PutUint32(key[4:], 128)
+	require.NoError(t, b.RoaringSetAddOne(key, 1))
+	require.NoError(t, b.FlushMemtable())
+	require.NoError(t, b.Shutdown(ctx))
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 80)
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 10 {
+				if _, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, "text"); err != nil {
+					errs <- err
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 }

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -456,11 +456,13 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 	require.NoError(t, b.Shutdown(ctx))
 
 	var wg sync.WaitGroup
+	start := make(chan struct{})
 	errs := make(chan error, 80)
 	for range 8 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			<-start
 			for range 10 {
 				if _, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, "text"); err != nil {
 					errs <- err
@@ -468,6 +470,7 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 			}
 		}()
 	}
+	close(start)
 	wg.Wait()
 	close(errs)
 	for err := range errs {


### PR DESCRIPTION
### What's being changed:

Fixes usage reports failing with:

```
failed to get usage data: collection Email: inactive shard <shard>: bucket ".../lsm/dimensions": bucket already registered
```

Concurrent usage reports (overlapping periodic collections, `/debug/usage`, or both usage modules enabled) could open the same cold shard's dimensions bucket at once, which lsmkv's `GlobalBucketRegistry` rejects — failing the whole report. Access to the unloaded dimensions bucket is now serialized per bucket path with a keyed lock. Regression test reproduces the error without the fix.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
