### PR TITLE
Allocate per-tenant vector cache memory lazily and proportionally to tenant size

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -13,6 +13,7 @@ package cache
 
 import (
 	"context"
+	"math/bits"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -29,7 +30,7 @@ import (
 )
 
 type shardedLockCache[T float32 | byte | uint64] struct {
-	shardedLocks           *common.ShardedRWLocks
+	shardedLocks           *common.LazyShardedRWLocks
 	cache                  [][]T
 	vectorForID            common.VectorForID[T]
 	multipleVectorForDocID common.VectorForID[[]float32]
@@ -53,7 +54,43 @@ const (
 	MinimumRelativeGrowthDelta = 20
 	indexGrowthRate            = 1.25
 	defaultCacheMaxSize        = 1e12
+
+	// initialShardedLocksCount is the stripe count of a small cache; growing
+	// scales it with the cache size at one stripe per slotsPerLockStripe
+	// slots, up to the full common.DefaultShardedLocksCount.
+	initialShardedLocksCount = 8
+	slotsPerLockStripe       = 64
 )
+
+// growTargetFor returns the backing-slice length needed to fit node. Small
+// caches grow relative to the requested id so that barely used caches stay
+// proportional to their tenant's size; large caches keep the fixed headroom.
+func growTargetFor(node uint64) uint64 {
+	relative := uint64(float64(node) * indexGrowthRate)
+	if minRelative := node + MinimumRelativeGrowthDelta; relative < minRelative {
+		relative = minRelative
+	}
+	if absolute := node + MinimumIndexGrowthDelta; absolute < relative {
+		return absolute
+	}
+	return relative + 1
+}
+
+// stripeCountFor returns the lock stripe count appropriate for a backing
+// slice of the given length, keeping the lock memory proportional to the
+// cache itself.
+func stripeCountFor(cacheLen uint64) uint64 {
+	stripes := cacheLen / slotsPerLockStripe
+	if stripes <= initialShardedLocksCount {
+		return initialShardedLocksCount
+	}
+	if stripes >= common.DefaultShardedLocksCount {
+		return common.DefaultShardedLocksCount
+	}
+	// quantize to powers of two so a growing cache re-stripes a bounded
+	// number of times (each upgrade drains the previous lock set)
+	return 1 << bits.Len64(stripes-1)
+}
 
 func NewShardedFloat32LockCache(vecForID common.VectorForID[float32], multiVecForID common.VectorForID[[]float32], maxSize int, pageSize uint64,
 	logger logrus.FieldLogger, normalizeOnRead bool, deletionInterval time.Duration,
@@ -71,13 +108,12 @@ func NewShardedFloat32LockCache(vecForID common.VectorForID[float32], multiVecFo
 			return vec, nil
 		},
 		multipleVectorForDocID: multiVecForID,
-		cache:                  make([][]float32, InitialSize),
 		normalizeOnRead:        normalizeOnRead,
 		count:                  0,
 		maxSize:                int64(maxSize),
 		cancel:                 make(chan bool),
 		logger:                 logger,
-		shardedLocks:           common.NewShardedRWLocksWithPageSize(pageSize),
+		shardedLocks:           common.NewLazyShardedRWLocks(initialShardedLocksCount, pageSize),
 		maintenanceLock:        sync.RWMutex{},
 		deletionInterval:       deletionInterval,
 		allocChecker:           allocChecker,
@@ -93,13 +129,12 @@ func NewShardedByteLockCache(vecForID common.VectorForID[byte], maxSize int, pag
 ) Cache[byte] {
 	vc := &shardedLockCache[byte]{
 		vectorForID:      vecForID,
-		cache:            make([][]byte, InitialSize),
 		normalizeOnRead:  false,
 		count:            0,
 		maxSize:          int64(maxSize),
 		cancel:           make(chan bool),
 		logger:           logger,
-		shardedLocks:     common.NewShardedRWLocksWithPageSize(pageSize),
+		shardedLocks:     common.NewLazyShardedRWLocks(initialShardedLocksCount, pageSize),
 		maintenanceLock:  sync.RWMutex{},
 		deletionInterval: deletionInterval,
 		allocChecker:     allocChecker,
@@ -115,13 +150,12 @@ func NewShardedUInt64LockCache(vecForID common.VectorForID[uint64], maxSize int,
 ) Cache[uint64] {
 	vc := &shardedLockCache[uint64]{
 		vectorForID:      vecForID,
-		cache:            make([][]uint64, InitialSize),
 		normalizeOnRead:  false,
 		count:            0,
 		maxSize:          int64(maxSize),
 		cancel:           make(chan bool),
 		logger:           logger,
-		shardedLocks:     common.NewShardedRWLocksWithPageSize(pageSize),
+		shardedLocks:     common.NewLazyShardedRWLocks(initialShardedLocksCount, pageSize),
 		maintenanceLock:  sync.RWMutex{},
 		deletionInterval: deletionInterval,
 		allocChecker:     allocChecker,
@@ -206,11 +240,17 @@ func (s *shardedLockCache[T]) MultiGet(ctx context.Context, ids []uint64) ([][]T
 	var errs []error // Only allocate if we encounter an error
 
 	for i, id := range ids {
+		var vec []T
 		s.shardedLocks.RLock(id)
-		vec := s.cache[id]
+		if int(id) < len(s.cache) {
+			vec = s.cache[id]
+		}
 		s.shardedLocks.RUnlock(id)
 
 		if vec == nil {
+			// make sure the cache covers id before handleCacheMiss stores
+			// into it; a no-op once the cache is large enough
+			s.Grow(id)
 			vecFromDisk, err := s.handleCacheMiss(ctx, id)
 			if err != nil {
 				// Allocate errors slice only on first error
@@ -284,10 +324,19 @@ func (s *shardedLockCache[T]) Prefetch(id uint64) {
 	s.shardedLocks.RLock(id)
 	defer s.shardedLocks.RUnlock(id)
 
+	// the cache is allocated lazily, it may not cover id yet
+	if int(id) >= len(s.cache) {
+		return
+	}
+
 	prefetchFunc(uintptr(unsafe.Pointer(&s.cache[id])))
 }
 
 func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
+	// make sure the cache covers id: preloaders (e.g. the HNSW insert path)
+	// don't grow the cache themselves; a no-op once the cache is large enough
+	s.Grow(id)
+
 	s.shardedLocks.Lock(id)
 	defer s.shardedLocks.Unlock(id)
 
@@ -305,7 +354,7 @@ func (s *shardedLockCache[T]) SetSizeAndGrowNoLock(size uint64) {
 	if size < uint64(len(s.cache)) {
 		return
 	}
-	newSize := size + MinimumIndexGrowthDelta
+	newSize := growTargetFor(size)
 	newCache := make([][]T, newSize)
 	copy(newCache, s.cache)
 	s.cache = newCache
@@ -328,10 +377,14 @@ func (s *shardedLockCache[T]) Grow(node uint64) {
 		return
 	}
 
+	newSize := growTargetFor(node)
+
+	// scale the stripe count with the cache size
+	s.shardedLocks.EnsureCount(stripeCountFor(newSize))
+
 	s.shardedLocks.LockAll()
 	defer s.shardedLocks.UnlockAll()
 
-	newSize := node + MinimumIndexGrowthDelta
 	newCache := make([][]T, newSize)
 	copy(newCache, s.cache)
 	s.cache = newCache

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -333,15 +333,25 @@ func (s *shardedLockCache[T]) Prefetch(id uint64) {
 }
 
 func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
-	// make sure the cache covers id: preloaders (e.g. the HNSW insert path)
-	// don't grow the cache themselves; a no-op once the cache is large enough
-	s.Grow(id)
+	for {
+		s.shardedLocks.Lock(id)
+		// reading len(s.cache) under a stripe lock is safe: the slice is
+		// only ever swapped while all stripes are held (see Grow). Checking
+		// it here keeps the common case as cheap as before the cache became
+		// lazy: one stripe lock, no maintenanceLock traffic.
+		if int(id) < len(s.cache) {
+			s.cache[id] = vec
+			atomic.AddInt64(&s.count, 1)
+			s.shardedLocks.Unlock(id)
+			return
+		}
+		s.shardedLocks.Unlock(id)
 
-	s.shardedLocks.Lock(id)
-	defer s.shardedLocks.Unlock(id)
-
-	atomic.AddInt64(&s.count, 1)
-	s.cache[id] = vec
+		// slow path: the cache doesn't cover id yet — preloaders (e.g. the
+		// HNSW insert path) don't grow the cache themselves. Grow guarantees
+		// coverage of id, so the next iteration stores.
+		s.Grow(id)
+	}
 }
 
 func (s *shardedLockCache[T]) PreloadNoLock(id uint64, vec []T) {

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -16,11 +16,13 @@ import (
 	"errors"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -447,4 +449,318 @@ func countMultiCached(c *shardedMultipleLockCache[float32]) int {
 		}
 	}
 	return count
+}
+
+// countingFetcher returns a deterministic vector for any id ([]T{T(id)}) and
+// counts how often the cache had to fall back to it.
+func countingFetcher[T float32 | byte | uint64]() (common.VectorForID[T], *int64) {
+	var calls int64
+	return func(_ context.Context, id uint64) ([]T, error) {
+		atomic.AddInt64(&calls, 1)
+		return []T{T(id)}, nil
+	}, &calls
+}
+
+// stripeCountOf gives white-box access to the lock stripe count of a
+// shardedLockCache so tests can assert on lazy allocation and re-striping.
+// It is 0 until the stripes are allocated on first use.
+func stripeCountOf[T float32 | byte | uint64](t *testing.T, c Cache[T]) uint64 {
+	t.Helper()
+	s, ok := c.(*shardedLockCache[T])
+	require.True(t, ok, "expected *shardedLockCache")
+	return s.shardedLocks.Count()
+}
+
+func newLazyTestCache[T float32 | byte | uint64](t *testing.T, fetch common.VectorForID[T]) Cache[T] {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	switch any(*new(T)).(type) {
+	case float32:
+		f := any(fetch).(common.VectorForID[float32])
+		return any(NewShardedFloat32LockCache(f, nil, 1_000_000, 1, logger, false, 0, nil)).(Cache[T])
+	case byte:
+		f := any(fetch).(common.VectorForID[byte])
+		return any(NewShardedByteLockCache(f, 1_000_000, 1, logger, 0, nil)).(Cache[T])
+	case uint64:
+		f := any(fetch).(common.VectorForID[uint64])
+		return any(NewShardedUInt64LockCache(f, 1_000_000, 1, logger, 0, nil)).(Cache[T])
+	}
+	t.Fatal("unsupported type")
+	return nil
+}
+
+func testLazyAllocation[T float32 | byte | uint64](t *testing.T) {
+	fetch, calls := countingFetcher[T]()
+	c := newLazyTestCache[T](t, fetch)
+
+	// a fresh cache must not allocate its backing slice or its lock stripes
+	assert.EqualValues(t, 0, c.Len(), "fresh cache must have length 0")
+	assert.EqualValues(t, 0, c.CountVectors())
+	assert.Nil(t, c.All(), "fresh cache must not allocate the backing slice")
+	assert.EqualValues(t, 0, stripeCountOf(t, c), "fresh cache must not allocate lock stripes")
+
+	// first Get initializes on demand and serves the vector
+	vec, err := c.Get(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, []T{T(42)}, vec)
+	assert.EqualValues(t, 1, atomic.LoadInt64(calls))
+
+	// the cache grew relative to the requested id, not by a fixed 2000 jump
+	assert.Greater(t, c.Len(), int32(42))
+	assert.LessOrEqual(t, c.Len(), int32(100), "small first use must not allocate a large slice")
+
+	assert.EqualValues(t, 8, stripeCountOf(t, c), "small cache must use a small stripe count")
+
+	// second Get is served from cache
+	vec, err = c.Get(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, []T{T(42)}, vec)
+	assert.EqualValues(t, 1, atomic.LoadInt64(calls), "second Get must hit the cache")
+}
+
+func TestShardedLockCache_LazyAllocation(t *testing.T) {
+	t.Run("float32", testLazyAllocation[float32])
+	t.Run("byte", testLazyAllocation[byte])
+	t.Run("uint64", testLazyAllocation[uint64])
+}
+
+func TestShardedLockCache_GrowSizing(t *testing.T) {
+	fetch, _ := countingFetcher[float32]()
+	c := newLazyTestCache[float32](t, fetch)
+
+	c.Grow(10)
+	assert.Greater(t, c.Len(), int32(10))
+	assert.LessOrEqual(t, c.Len(), int32(50), "growing to a small id must stay small")
+	small := c.Len()
+
+	// mid-size caches get a stripe count proportional to their size:
+	// Grow(2000) yields ~2500 slots, one stripe per 64 slots → 64 stripes
+	c.Grow(2000)
+	assert.EqualValues(t, 64, stripeCountOf(t, c),
+		"mid-size cache must use a proportional stripe count")
+
+	// large caches keep the fixed growth headroom and the full stripe count
+	c.Grow(100_000)
+	assert.Greater(t, c.Len(), int32(100_000))
+	assert.LessOrEqual(t, c.Len(), int32(100_000+MinimumIndexGrowthDelta))
+	assert.EqualValues(t, common.DefaultShardedLocksCount, stripeCountOf(t, c),
+		"large cache must use the full stripe count")
+
+	// growing never shrinks
+	c.Grow(10)
+	assert.Greater(t, c.Len(), small)
+}
+
+func TestShardedLockCache_OpsOnFreshCache(t *testing.T) {
+	fetch, calls := countingFetcher[float32]()
+	c := newLazyTestCache[float32](t, fetch)
+
+	// none of these must panic on an untouched cache, and they must allocate
+	// at most the minimal stripe set (never the backing slice)
+	c.Delete(context.Background(), 7)
+	c.Prefetch(7)
+	assert.EqualValues(t, 0, c.CountVectors())
+	assert.EqualValues(t, 0, c.Len(), "read-only ops must not allocate the backing slice")
+	assert.LessOrEqual(t, stripeCountOf(t, c), uint64(initialShardedLocksCount),
+		"read-only ops must allocate at most the minimal stripe set")
+
+	// MultiGet on a fresh cache must fetch and cache the vectors
+	vecs, errs := c.MultiGet(context.Background(), []uint64{5, 10})
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+	require.Len(t, vecs, 2)
+	assert.Equal(t, []float32{5}, vecs[0])
+	assert.Equal(t, []float32{10}, vecs[1])
+	assert.EqualValues(t, 2, atomic.LoadInt64(calls))
+
+	c.Drop()
+}
+
+func TestShardedLockCache_GetAllInCurrentLockOnFreshCache(t *testing.T) {
+	t.Run("default max size does not fetch through", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		fetch, calls := countingFetcher[uint64]()
+		c := NewShardedUInt64LockCache(fetch, int(defaultCacheMaxSize), 1, logger, 0, nil)
+
+		out := make([][]uint64, 1)
+		errs := make([]error, 1)
+		_, _, _, end := c.GetAllInCurrentLock(context.Background(), 3, out, errs)
+		assert.EqualValues(t, 0, end, "fresh cache has nothing in range")
+		assert.EqualValues(t, 0, atomic.LoadInt64(calls))
+	})
+
+	t.Run("altered max size does not fetch through either", func(t *testing.T) {
+		// fetch-through only applies to pages within the current window;
+		// iterating never grows the cache as a side effect
+		fetch, calls := countingFetcher[uint64]()
+		c := newLazyTestCache[uint64](t, fetch)
+
+		out := make([][]uint64, 1)
+		errs := make([]error, 1)
+		_, _, _, end := c.GetAllInCurrentLock(context.Background(), 3, out, errs)
+		assert.EqualValues(t, 0, end, "fresh cache has nothing in range")
+		assert.EqualValues(t, 0, atomic.LoadInt64(calls))
+	})
+}
+
+func TestShardedLockCache_PreloadGrowsCache(t *testing.T) {
+	fetch, calls := countingFetcher[float32]()
+	c := newLazyTestCache[float32](t, fetch)
+
+	// Preload without a prior Grow must work for any id: HNSW's insert path
+	// preloads freshly assigned node ids without growing the cache first.
+	c.Preload(500, []float32{500})
+	c.Preload(5000, []float32{5000})
+
+	vec, err := c.Get(context.Background(), 500)
+	require.NoError(t, err)
+	assert.Equal(t, []float32{500}, vec)
+	vec, err = c.Get(context.Background(), 5000)
+	require.NoError(t, err)
+	assert.Equal(t, []float32{5000}, vec)
+	assert.EqualValues(t, 0, atomic.LoadInt64(calls), "preloaded vectors must not hit the fetcher")
+	assert.EqualValues(t, 2, c.CountVectors())
+}
+
+func TestShardedLockCache_LockAllPreloadFlow(t *testing.T) {
+	// mirrors the flat index PostStartup preload sequence
+	fetch, calls := countingFetcher[uint64]()
+	c := newLazyTestCache[uint64](t, fetch)
+
+	const maxID = 300
+	c.Grow(maxID)
+	c.LockAll()
+	c.SetSizeAndGrowNoLock(maxID)
+	for i := uint64(0); i <= maxID; i++ {
+		c.PreloadNoLock(i, []uint64{i})
+	}
+	c.UnlockAll()
+
+	for _, id := range []uint64{0, 150, maxID} {
+		vec, err := c.Get(context.Background(), id)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{id}, vec)
+	}
+	assert.EqualValues(t, 0, atomic.LoadInt64(calls), "preloaded vectors must not hit the fetcher")
+}
+
+func TestShardedLockCache_LockAllOnFreshCache(t *testing.T) {
+	// LockAll on an untouched cache must initialize the locks so the
+	// LockAll/PreloadNoLock/UnlockAll contract holds even without a prior Grow
+	fetch, _ := countingFetcher[byte]()
+	c := newLazyTestCache[byte](t, fetch)
+
+	c.LockAll()
+	c.SetSizeAndGrowNoLock(50)
+	c.PreloadNoLock(50, []byte{50})
+	c.UnlockAll()
+
+	vec, err := c.Get(context.Background(), 50)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{50}, vec)
+}
+
+func TestShardedLockCache_ConcurrentLazyInit(t *testing.T) {
+	// hammer a fresh cache from many goroutines so the nil→initialized
+	// transition and the stripe upgrade both happen under contention
+	fetch, _ := countingFetcher[float32]()
+	c := newLazyTestCache[float32](t, fetch)
+
+	const (
+		goroutines = 16
+		maxID      = 5000 // crosses the stripe upgrade threshold
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(seed uint64) {
+			defer wg.Done()
+			for i := uint64(0); i < 500; i++ {
+				id := (seed*131 + i*7) % maxID
+				switch i % 5 {
+				case 0:
+					c.Grow(id)
+				case 1:
+					c.Preload(id, []float32{float32(id)})
+				case 2:
+					vec, err := c.Get(context.Background(), id)
+					if err == nil && len(vec) == 1 && vec[0] != float32(id) {
+						t.Errorf("id %d: got %v", id, vec[0])
+					}
+				case 3:
+					c.Delete(context.Background(), id)
+				case 4:
+					c.Len()
+					c.CountVectors()
+				}
+			}
+		}(uint64(g))
+	}
+	wg.Wait()
+
+	// after the dust settles every id must resolve correctly
+	for _, id := range []uint64{0, 1, 2500, maxID - 1} {
+		vec, err := c.Get(context.Background(), id)
+		require.NoError(t, err)
+		assert.Equal(t, []float32{float32(id)}, vec)
+	}
+	// the cache grew to cover ids up to ~5000 (5000..6250 slots depending on
+	// interleaving), which at one stripe per 64 slots quantizes to 128
+	assert.EqualValues(t, 128, stripeCountOf(t, c),
+		"cache must have re-striped proportionally to its size")
+}
+
+func TestShardedLockCache_ReadersDuringReStripe(t *testing.T) {
+	// readers on low ids while a grower pushes the cache past the stripe
+	// upgrade threshold: reads must stay correct through the lock swap
+	fetch, _ := countingFetcher[float32]()
+	c := newLazyTestCache[float32](t, fetch)
+
+	for i := uint64(0); i < 100; i++ {
+		c.Preload(i, []float32{float32(i)})
+	}
+	require.EqualValues(t, 8, stripeCountOf(t, c))
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(seed uint64) {
+			defer wg.Done()
+			for i := uint64(0); ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				id := (seed + i) % 100
+				vec, err := c.Get(context.Background(), id)
+				if err != nil {
+					t.Errorf("get %d: %v", id, err)
+					return
+				}
+				if len(vec) != 1 || vec[0] != float32(id) {
+					t.Errorf("get %d: wrong vector %v", id, vec)
+					return
+				}
+			}
+		}(uint64(g))
+	}
+
+	// force re-striping while readers are active
+	for step := uint64(1000); step <= 20_000; step += 1000 {
+		c.Grow(step)
+	}
+	close(stop)
+	wg.Wait()
+
+	assert.EqualValues(t, common.DefaultShardedLocksCount, stripeCountOf(t, c))
+}
+
+func TestShardedLockCache_PageSizeOnFreshCache(t *testing.T) {
+	fetch, _ := countingFetcher[uint64]()
+	c := newLazyTestCache[uint64](t, fetch)
+	assert.EqualValues(t, 1, c.PageSize(), "PageSize must work before the locks are allocated")
 }

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -123,8 +123,8 @@ func TestCacheCleanup(t *testing.T) {
 }
 
 func countCached(c *shardedLockCache[float32]) int {
-	c.shardedLocks.LockAll()
-	defer c.shardedLocks.UnlockAll()
+	c.LockAll()
+	defer c.UnlockAll()
 
 	count := 0
 	for _, vec := range c.cache {
@@ -235,6 +235,10 @@ func TestGetAllInCurrentLock(t *testing.T) {
 
 		vectorCache := NewShardedFloat32LockCache(vecForID, nil, maxSize, pageSize, logger, false, 0, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
+
+		// make the page part of the cache window; fetch-through only applies
+		// to pages within it
+		cache.Grow(pageSize - 1)
 
 		out := make([][]float32, pageSize)
 		errs := make([]error, pageSize)

--- a/adapters/repos/db/vector/common/sharded_locks.go
+++ b/adapters/repos/db/vector/common/sharded_locks.go
@@ -253,6 +253,12 @@ func (l *LazyShardedRWLocks) EnsureCount(count uint64) {
 		count = 2
 	}
 
+	// fast path: the count of an allocated set is immutable, so a single
+	// atomic load suffices to detect the common no-op case without the mutex
+	if locks := l.locks.Load(); locks != nil && count <= locks.Count() {
+		return
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/adapters/repos/db/vector/common/sharded_locks.go
+++ b/adapters/repos/db/vector/common/sharded_locks.go
@@ -247,10 +247,12 @@ func (l *LazyShardedRWLocks) Count() uint64 {
 }
 
 // EnsureCount grows the stripe count to at least count, allocating the
-// stripes if this is the first use. It never shrinks.
+// stripes if this is the first use. It never shrinks, and never allocates
+// fewer stripes than the constructor's initial count: the initial layout
+// must not depend on which operation touches the instance first.
 func (l *LazyShardedRWLocks) EnsureCount(count uint64) {
-	if count < 2 {
-		count = 2
+	if count < l.initialCount {
+		count = l.initialCount
 	}
 
 	// fast path: the count of an allocated set is immutable, so a single

--- a/adapters/repos/db/vector/common/sharded_locks.go
+++ b/adapters/repos/db/vector/common/sharded_locks.go
@@ -13,6 +13,7 @@ package common
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
 const (
@@ -122,6 +123,11 @@ func NewShardedRWLocksWithPageSize(pageSize uint64) *ShardedRWLocks {
 	return NewShardedRWLocksWith(DefaultShardedLocksCount, pageSize)
 }
 
+// Count returns the number of lock stripes.
+func (sl *ShardedRWLocks) Count() uint64 {
+	return sl.count
+}
+
 func (sl *ShardedRWLocks) LockAll() {
 	for i := uint64(0); i < sl.count; i++ {
 		sl.shards[i].Lock()
@@ -194,6 +200,195 @@ func (sl *ShardedRWLocks) RUnlock(id uint64) {
 func (sl *ShardedRWLocks) RLocked(id uint64, callback func()) {
 	sl.RLock(id)
 	defer sl.RUnlock(id)
+
+	callback()
+}
+
+// LazyShardedRWLocks provides the same locking API as ShardedRWLocks, but
+// allocates its stripes on first use and can grow the stripe count later via
+// EnsureCount. This lets components that exist in large numbers but are
+// mostly idle (e.g. per-tenant vector caches) avoid paying for a full stripe
+// array up front.
+//
+// Correctness of the stripe swap relies on one invariant: the stripe set is
+// only ever replaced while every stripe of the previous set is held
+// exclusively. Consequently no stripe of the old set can be held during a
+// swap, so unlock operations may always resolve the current set, and only
+// acquire operations need to re-check the set after acquiring (a goroutine
+// that was blocked on an old stripe retries on the new set).
+type LazyShardedRWLocks struct {
+	locks atomic.Pointer[ShardedRWLocks]
+	// mu serializes allocation and re-striping
+	mu           sync.Mutex
+	initialCount uint64
+
+	PageSize uint64
+}
+
+// NewLazyShardedRWLocks creates sharded RW locks whose stripes are allocated
+// on first use, starting with initialCount stripes.
+func NewLazyShardedRWLocks(initialCount, pageSize uint64) *LazyShardedRWLocks {
+	if initialCount < 2 {
+		initialCount = 2
+	}
+
+	return &LazyShardedRWLocks{
+		initialCount: initialCount,
+		PageSize:     pageSize,
+	}
+}
+
+// Count returns the number of allocated stripes: 0 before first use.
+func (l *LazyShardedRWLocks) Count() uint64 {
+	if locks := l.locks.Load(); locks != nil {
+		return locks.Count()
+	}
+	return 0
+}
+
+// EnsureCount grows the stripe count to at least count, allocating the
+// stripes if this is the first use. It never shrinks.
+func (l *LazyShardedRWLocks) EnsureCount(count uint64) {
+	if count < 2 {
+		count = 2
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	locks := l.locks.Load()
+	if locks == nil {
+		l.locks.Store(NewShardedRWLocksWith(count, l.PageSize))
+		return
+	}
+	if count <= locks.Count() {
+		return
+	}
+
+	upgraded := NewShardedRWLocksWith(count, l.PageSize)
+	// drain every holder of the current set before publishing the new one,
+	// upholding the swap invariant documented on the type
+	locks.LockAll()
+	l.locks.Store(upgraded)
+	// wake goroutines still blocked on the old set; they re-check the set
+	// after acquiring and retry on the new one
+	locks.UnlockAll()
+}
+
+// current returns the stripe set, allocating it on first use.
+func (l *LazyShardedRWLocks) current() *ShardedRWLocks {
+	if locks := l.locks.Load(); locks != nil {
+		return locks
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if locks := l.locks.Load(); locks != nil {
+		return locks
+	}
+	locks := NewShardedRWLocksWith(l.initialCount, l.PageSize)
+	l.locks.Store(locks)
+	return locks
+}
+
+func (l *LazyShardedRWLocks) Lock(id uint64) {
+	for {
+		locks := l.current()
+		locks.Lock(id)
+		if l.locks.Load() == locks {
+			return
+		}
+		locks.Unlock(id)
+	}
+}
+
+func (l *LazyShardedRWLocks) TryLock(id uint64) bool {
+	for {
+		locks := l.current()
+		if !locks.TryLock(id) {
+			return false
+		}
+		if l.locks.Load() == locks {
+			return true
+		}
+		locks.Unlock(id)
+	}
+}
+
+func (l *LazyShardedRWLocks) Unlock(id uint64) {
+	l.locks.Load().Unlock(id)
+}
+
+func (l *LazyShardedRWLocks) RLock(id uint64) {
+	for {
+		locks := l.current()
+		locks.RLock(id)
+		if l.locks.Load() == locks {
+			return
+		}
+		locks.RUnlock(id)
+	}
+}
+
+func (l *LazyShardedRWLocks) RUnlock(id uint64) {
+	l.locks.Load().RUnlock(id)
+}
+
+func (l *LazyShardedRWLocks) LockAll() {
+	for {
+		locks := l.current()
+		locks.LockAll()
+		if l.locks.Load() == locks {
+			return
+		}
+		locks.UnlockAll()
+	}
+}
+
+func (l *LazyShardedRWLocks) UnlockAll() {
+	l.locks.Load().UnlockAll()
+}
+
+func (l *LazyShardedRWLocks) RLockAll() {
+	for {
+		locks := l.current()
+		locks.RLockAll()
+		if l.locks.Load() == locks {
+			return
+		}
+		locks.RUnlockAll()
+	}
+}
+
+func (l *LazyShardedRWLocks) RUnlockAll() {
+	l.locks.Load().RUnlockAll()
+}
+
+func (l *LazyShardedRWLocks) Locked(id uint64, callback func()) {
+	l.Lock(id)
+	defer l.Unlock(id)
+
+	callback()
+}
+
+func (l *LazyShardedRWLocks) RLocked(id uint64, callback func()) {
+	l.RLock(id)
+	defer l.RUnlock(id)
+
+	callback()
+}
+
+func (l *LazyShardedRWLocks) LockedAll(callback func()) {
+	l.LockAll()
+	defer l.UnlockAll()
+
+	callback()
+}
+
+func (l *LazyShardedRWLocks) RLockedAll(callback func()) {
+	l.RLockAll()
+	defer l.RUnlockAll()
 
 	callback()
 }

--- a/adapters/repos/db/vector/common/sharded_locks_test.go
+++ b/adapters/repos/db/vector/common/sharded_locks_test.go
@@ -674,3 +674,141 @@ func BenchmarkLocksHighContention(b *testing.B) {
 		run(b, NewShardedRWLocks(512))
 	})
 }
+
+func TestLazyShardedRWLocks_LazyAllocation(t *testing.T) {
+	l := NewLazyShardedRWLocks(8, 4)
+
+	require.EqualValues(t, 0, l.Count(), "no stripes must be allocated before first use")
+	require.EqualValues(t, 4, l.PageSize)
+
+	l.Lock(1)
+	l.Unlock(1)
+	require.EqualValues(t, 8, l.Count(), "first use must allocate the initial stripe count")
+
+	l.RLock(2)
+	l.RUnlock(2)
+	l.LockAll()
+	l.UnlockAll()
+	require.EqualValues(t, 8, l.Count(), "regular use must not change the stripe count")
+}
+
+func TestLazyShardedRWLocks_EnsureCount(t *testing.T) {
+	t.Run("on a fresh instance", func(t *testing.T) {
+		l := NewLazyShardedRWLocks(8, 1)
+		l.EnsureCount(512)
+		require.EqualValues(t, 512, l.Count())
+	})
+
+	t.Run("grows but never shrinks", func(t *testing.T) {
+		l := NewLazyShardedRWLocks(8, 1)
+		l.Lock(1)
+		l.Unlock(1)
+		require.EqualValues(t, 8, l.Count())
+
+		l.EnsureCount(64)
+		require.EqualValues(t, 64, l.Count())
+
+		l.EnsureCount(16)
+		require.EqualValues(t, 64, l.Count(), "EnsureCount must never shrink")
+	})
+}
+
+func TestLazyShardedRWLocks_MutualExclusionAcrossRestripe(t *testing.T) {
+	// counters guarded by per-id locks while another goroutine keeps growing
+	// the stripe count: no increment may be lost across the stripe swaps
+	const (
+		goroutines = 8
+		increments = 2_000
+		ids        = 16
+	)
+
+	l := NewLazyShardedRWLocks(2, 1)
+	counters := make([]int, ids)
+
+	wg := new(sync.WaitGroup)
+	wg.Add(goroutines + 1)
+
+	go func() {
+		defer wg.Done()
+		for c := uint64(4); c <= 512; c *= 2 {
+			l.EnsureCount(c)
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < increments; i++ {
+				id := uint64((g + i) % ids)
+				l.Lock(id)
+				counters[id]++
+				l.Unlock(id)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	total := 0
+	for _, c := range counters {
+		total += c
+	}
+	require.Equal(t, goroutines*increments, total, "increments were lost across re-striping")
+	require.EqualValues(t, 512, l.Count())
+}
+
+func TestLazyShardedRWLocks_MixedLocks(t *testing.T) {
+	// no asserts
+	// ensures parallel LockAll + Lock + RLock + EnsureCount does not deadlock
+	count := 1000
+	l := NewLazyShardedRWLocks(2, 1)
+
+	wg := new(sync.WaitGroup)
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := uint64(i)
+			switch i % 7 {
+			case 0:
+				l.LockAll()
+				l.UnlockAll()
+			case 1:
+				l.EnsureCount(uint64(i))
+			default:
+				if i%2 == 0 {
+					l.Lock(id)
+					l.Unlock(id)
+				} else {
+					l.RLock(id)
+					l.RUnlock(id)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestLazyShardedRWLocks_LockBlocks(t *testing.T) {
+	l := NewLazyShardedRWLocks(4, 1)
+
+	l.Lock(1)
+
+	ch := make(chan struct{})
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		l.Unlock(1)
+
+		close(ch)
+	}()
+
+	l.Lock(1)
+
+	select {
+	case <-ch:
+	case <-time.After(1 * time.Second):
+		require.Fail(t, "should be unlocked")
+	}
+
+	l.Unlock(1)
+}

--- a/adapters/repos/db/vector/common/sharded_locks_test.go
+++ b/adapters/repos/db/vector/common/sharded_locks_test.go
@@ -711,6 +711,14 @@ func TestLazyShardedRWLocks_EnsureCount(t *testing.T) {
 		l.EnsureCount(16)
 		require.EqualValues(t, 64, l.Count(), "EnsureCount must never shrink")
 	})
+
+	t.Run("never allocates below the initial count", func(t *testing.T) {
+		// the initial layout must not depend on whether EnsureCount or a
+		// lock operation touches the instance first
+		l := NewLazyShardedRWLocks(8, 1)
+		l.EnsureCount(2)
+		require.EqualValues(t, 8, l.Count())
+	})
 }
 
 func TestLazyShardedRWLocks_MutualExclusionAcrossRestripe(t *testing.T) {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -63,12 +63,13 @@ type flat struct {
 	compressionType CompressionType
 	quantizer       Quantizer
 	cache           *Cache
-	// cacheComplete reports whether the cache is known to hold every vector
-	// of the index, which is what allows searches to iterate the cache
-	// instead of the store. It is set once the startup preload has run over
-	// an index whose data is fully visible to it (or trivially, for an index
-	// that starts empty: insert-time preloading keeps it complete).
-	cacheComplete atomic.Bool
+	// cachePrefilled reports whether the cache is known to hold every vector
+	// of the index, allowing searches to iterate the cache instead of the
+	// store. It is set when the startup prefill loaded the full index, and
+	// for an index that starts empty (insert-time preloading then keeps the
+	// cache complete). It stays false when the prefill could not see the
+	// data, e.g. vectors that only live in the memtable.
+	cachePrefilled atomic.Bool
 
 	pqResults *common.PqMaxPool
 	pool      *pools
@@ -493,7 +494,7 @@ func (index *flat) searchByVectorQuantized(ctx context.Context, vector []float32
 	// the cached search iterates the cache window, which silently skips
 	// anything not cached; it is only correct once the cache is known to be
 	// complete, otherwise the store is the source of truth
-	if index.Compressed() && index.Cached() && index.cacheComplete.Load() {
+	if index.Compressed() && index.Cached() && index.cachePrefilled.Load() {
 		if err := index.findTopVectorsQuantizedCached(heap, allow, rescore, vector); err != nil {
 			return nil, nil, err
 		}
@@ -921,7 +922,7 @@ func (index *flat) PostStartup(ctx context.Context) {
 	if index.quantizer == nil {
 		// no quantizer means nothing was restored from disk: the index
 		// starts empty and insert-time preloading keeps the cache complete
-		index.cacheComplete.Store(true)
+		index.cachePrefilled.Store(true)
 		return
 	}
 
@@ -1036,7 +1037,7 @@ func (index *flat) PostStartup(ctx context.Context) {
 		k, _ := c.First()
 		c.Close()
 		if k == nil {
-			index.cacheComplete.Store(true)
+			index.cachePrefilled.Store(true)
 		}
 		return
 	}
@@ -1096,7 +1097,7 @@ func (index *flat) PostStartup(ctx context.Context) {
 		}
 	}
 
-	index.cacheComplete.Store(true)
+	index.cachePrefilled.Store(true)
 
 	took := time.Since(before)
 	index.logger.WithFields(logrus.Fields{
@@ -1261,7 +1262,7 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 					// the window guard only makes sense on a complete cache,
 					// where an id beyond it cannot exist; on an incomplete
 					// cache, Get below falls back to disk
-					if cacheLen := index.cache.Len(); index.cacheComplete.Load() && int32(nodeID) > cacheLen {
+					if cacheLen := index.cache.Len(); index.cachePrefilled.Load() && int32(nodeID) > cacheLen {
 						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, cacheLen)
 					}
 					vec, err := index.cache.uint64Cache.Get(context.Background(), nodeID)
@@ -1288,7 +1289,7 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 					// the window guard only makes sense on a complete cache,
 					// where an id beyond it cannot exist; on an incomplete
 					// cache, Get below falls back to disk
-					if cacheLen := index.cache.Len(); index.cacheComplete.Load() && int32(nodeID) > cacheLen {
+					if cacheLen := index.cache.Len(); index.cachePrefilled.Load() && int32(nodeID) > cacheLen {
 						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, cacheLen)
 					}
 					if index.quantizer.Type() == Uint64Quantizer {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -1258,14 +1258,18 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 				// Create a distancer that uses 5-bit query quantization
 				distancer := index.quantizer.(*BinaryRotationalQuantizerWrapper).NewDistancer(queryVector)
 				distFunc = func(nodeID uint64) (float32, error) {
-					// a cache of size 0 hasn't been preloaded yet (it is
-					// allocated lazily); Get below falls back to disk then
-					if cacheLen := index.cache.Len(); cacheLen > 0 && int32(nodeID) > cacheLen {
+					// the window guard only makes sense on a complete cache,
+					// where an id beyond it cannot exist; on an incomplete
+					// cache, Get below falls back to disk
+					if cacheLen := index.cache.Len(); index.cacheComplete.Load() && int32(nodeID) > cacheLen {
 						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, cacheLen)
 					}
 					vec, err := index.cache.uint64Cache.Get(context.Background(), nodeID)
 					if err != nil {
 						return 0, err
+					}
+					if len(vec) == 0 {
+						return -1, fmt.Errorf("node %v not found", nodeID)
 					}
 					return distancer.Distance(vec)
 				}
@@ -1281,9 +1285,10 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 				}
 
 				distFunc = func(nodeID uint64) (float32, error) {
-					// a cache of size 0 hasn't been preloaded yet (it is
-					// allocated lazily); Get below falls back to disk then
-					if cacheLen := index.cache.Len(); cacheLen > 0 && int32(nodeID) > cacheLen {
+					// the window guard only makes sense on a complete cache,
+					// where an id beyond it cannot exist; on an incomplete
+					// cache, Get below falls back to disk
+					if cacheLen := index.cache.Len(); index.cacheComplete.Load() && int32(nodeID) > cacheLen {
 						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, cacheLen)
 					}
 					if index.quantizer.Type() == Uint64Quantizer {
@@ -1291,11 +1296,17 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 						if err != nil {
 							return 0, err
 						}
+						if len(vec) == 0 {
+							return -1, fmt.Errorf("node %v not found", nodeID)
+						}
 						return index.quantizer.DistanceBetweenUint64Vectors(vec, queryVecEncodeUint64)
 					} else if index.quantizer.Type() == ByteQuantizer {
 						vec, err := index.cache.byteCache.Get(context.Background(), nodeID)
 						if err != nil {
 							return 0, err
+						}
+						if len(vec) == 0 {
+							return -1, fmt.Errorf("node %v not found", nodeID)
 						}
 						return index.quantizer.DistanceBetweenByteVectors(vec, queryVecEncodeBytes)
 					}

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -63,6 +63,12 @@ type flat struct {
 	compressionType CompressionType
 	quantizer       Quantizer
 	cache           *Cache
+	// cacheComplete reports whether the cache is known to hold every vector
+	// of the index, which is what allows searches to iterate the cache
+	// instead of the store. It is set once the startup preload has run over
+	// an index whose data is fully visible to it (or trivially, for an index
+	// that starts empty: insert-time preloading keeps it complete).
+	cacheComplete atomic.Bool
 
 	pqResults *common.PqMaxPool
 	pool      *pools
@@ -484,10 +490,10 @@ func (index *flat) searchByVectorQuantized(ctx context.Context, vector []float32
 
 	vector = index.normalized(vector)
 
-	// the cached search iterates the cache window, which is complete only
-	// once the startup preload (or insert-time preloading) populated it; a
-	// cold cache (length 0, allocated lazily) must search the store instead
-	if index.Compressed() && index.Cached() && index.cache.Len() > 0 {
+	// the cached search iterates the cache window, which silently skips
+	// anything not cached; it is only correct once the cache is known to be
+	// complete, otherwise the store is the source of truth
+	if index.Compressed() && index.Cached() && index.cacheComplete.Load() {
 		if err := index.findTopVectorsQuantizedCached(heap, allow, rescore, vector); err != nil {
 			return nil, nil, err
 		}
@@ -909,7 +915,13 @@ func (index *flat) Preload(id uint64, vector []float32) {
 }
 
 func (index *flat) PostStartup(ctx context.Context) {
-	if !index.Cached() || index.quantizer == nil {
+	if !index.Cached() {
+		return
+	}
+	if index.quantizer == nil {
+		// no quantizer means nothing was restored from disk: the index
+		// starts empty and insert-time preloading keeps the cache complete
+		index.cacheComplete.Store(true)
 		return
 	}
 
@@ -1015,7 +1027,17 @@ func (index *flat) PostStartup(ctx context.Context) {
 	}
 
 	if count == 0 {
-		// nothing on disk: don't allocate the cache for an empty tenant
+		// nothing to preload: don't allocate the cache for an empty tenant.
+		// The parallel iterator only sees flushed segments, so distinguish a
+		// truly empty index (the cache is trivially complete and stays
+		// complete via insert-time preloading) from data that only lives in
+		// the memtable (the cache must not be trusted for searches).
+		c := bucket.Cursor()
+		k, _ := c.First()
+		c.Close()
+		if k == nil {
+			index.cacheComplete.Store(true)
+		}
 		return
 	}
 
@@ -1073,6 +1095,8 @@ func (index *flat) PostStartup(ctx context.Context) {
 			return
 		}
 	}
+
+	index.cacheComplete.Store(true)
 
 	took := time.Since(before)
 	index.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -484,7 +484,10 @@ func (index *flat) searchByVectorQuantized(ctx context.Context, vector []float32
 
 	vector = index.normalized(vector)
 
-	if index.Compressed() && index.Cached() {
+	// the cached search iterates the cache window, which is complete only
+	// once the startup preload (or insert-time preloading) populated it; a
+	// cold cache (length 0, allocated lazily) must search the store instead
+	if index.Compressed() && index.Cached() && index.cache.Len() > 0 {
 		if err := index.findTopVectorsQuantizedCached(heap, allow, rescore, vector); err != nil {
 			return nil, nil, err
 		}
@@ -1011,7 +1014,15 @@ func (index *flat) PostStartup(ctx context.Context) {
 		}
 	}
 
-	// Grow cache just once
+	if count == 0 {
+		// nothing on disk: don't allocate the cache for an empty tenant
+		return
+	}
+
+	// Grow cache just once. Growing before LockAll also sizes the cache's
+	// lock stripes to the actual tenant size; SetSizeAndGrowNoLock below then
+	// only records the count.
+	index.cache.Grow(maxID)
 	index.cache.LockAll()
 	defer index.cache.UnlockAll()
 
@@ -1223,8 +1234,10 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 				// Create a distancer that uses 5-bit query quantization
 				distancer := index.quantizer.(*BinaryRotationalQuantizerWrapper).NewDistancer(queryVector)
 				distFunc = func(nodeID uint64) (float32, error) {
-					if int32(nodeID) > index.cache.Len() {
-						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, index.cache.Len())
+					// a cache of size 0 hasn't been preloaded yet (it is
+					// allocated lazily); Get below falls back to disk then
+					if cacheLen := index.cache.Len(); cacheLen > 0 && int32(nodeID) > cacheLen {
+						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, cacheLen)
 					}
 					vec, err := index.cache.uint64Cache.Get(context.Background(), nodeID)
 					if err != nil {
@@ -1244,8 +1257,10 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 				}
 
 				distFunc = func(nodeID uint64) (float32, error) {
-					if int32(nodeID) > index.cache.Len() {
-						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, index.cache.Len())
+					// a cache of size 0 hasn't been preloaded yet (it is
+					// allocated lazily); Get below falls back to disk then
+					if cacheLen := index.cache.Len(); cacheLen > 0 && int32(nodeID) > cacheLen {
+						return -1, fmt.Errorf("node %v is larger than the cache size %v", nodeID, cacheLen)
 					}
 					if index.quantizer.Type() == Uint64Quantizer {
 						vec, err := index.cache.uint64Cache.Get(context.Background(), nodeID)

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -1948,6 +1948,11 @@ func Test_NoRace_Flat_SearchAfterPartialCacheWarmup(t *testing.T) {
 	require.Greater(t, window, int32(0), "the distancer call must have warmed the cache")
 	require.Less(t, window, int32(100), "vector 100 must lie beyond the warmed window")
 
+	// a valid id beyond the partially warmed window must be fetched from
+	// disk, not rejected by the cache window guard
+	_, err = qvd.DistanceToNode(100)
+	require.NoError(t, err, "valid ids beyond an incomplete cache window must fall back to disk")
+
 	// a search must not trust the partially warmed cache window: it must
 	// return the complete result set from the store
 	ids, _, err := index.SearchByVector(ctx, []float32{1, 0, 0}, len(vectors), nil)
@@ -1962,4 +1967,48 @@ func Test_NoRace_Flat_SearchAfterPartialCacheWarmup(t *testing.T) {
 	ids, _, err = index.SearchByVector(ctx, []float32{1, 0, 0}, len(vectors), nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint64{0, 1, 2, 100}, ids)
+}
+
+func Test_NoRace_Flat_RQ1DistancerOnPartialCacheWarmup(t *testing.T) {
+	// same scenario as the BQ variant above, for the RQ-1 distancer branch
+	// which has its own cache window guard
+	dirName := t.TempDir()
+	ctx := context.Background()
+
+	store := loadTestStore(t, dirName)
+	index, err := New(Config{
+		ID:                "lazy-cache-rq1-test",
+		RootPath:          dirName,
+		DistanceProvider:  distancer.NewCosineDistanceProvider(),
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, flatent.UserConfig{
+		RQ: flatent.RQUserConfig{Enabled: true, Cache: true, RescoreLimit: 10},
+	}, store)
+	require.NoError(t, err)
+	require.NoError(t, index.Add(ctx, 2, []float32{0.5, 0.5, 0.5}))
+	require.NoError(t, index.Add(ctx, 100, []float32{1, 0.5, 0}))
+	require.NoError(t, index.Shutdown(ctx))
+	require.NoError(t, store.Shutdown(ctx))
+
+	store = loadTestStore(t, dirName)
+	defer store.Shutdown(ctx)
+	index, err = New(Config{
+		ID:                "lazy-cache-rq1-test",
+		RootPath:          dirName,
+		DistanceProvider:  distancer.NewCosineDistanceProvider(),
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, flatent.UserConfig{
+		RQ: flatent.RQUserConfig{Enabled: true, Cache: true, RescoreLimit: 10},
+	}, store)
+	require.NoError(t, err)
+	defer index.Shutdown(ctx)
+	require.EqualValues(t, 0, index.cache.Len())
+
+	// warm a partial window, then request a valid id beyond it
+	qvd := index.QueryVectorDistancer([]float32{1, 0, 0})
+	_, err = qvd.DistanceToNode(2)
+	require.NoError(t, err)
+	require.Less(t, index.cache.Len(), int32(100), "vector 100 must lie beyond the warmed window")
+	_, err = qvd.DistanceToNode(100)
+	require.NoError(t, err, "valid ids beyond an incomplete cache window must fall back to disk")
 }

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -1911,3 +1911,55 @@ func Test_NoRace_Flat_QueryVectorDistancerBeforePreload(t *testing.T) {
 		assert.NoError(t, err, "query on a not-yet-preloaded cache must fall back to disk, not error")
 	}
 }
+
+func Test_NoRace_Flat_SearchAfterPartialCacheWarmup(t *testing.T) {
+	dirName := t.TempDir()
+	ctx := context.Background()
+
+	// populate an index, then shut it down so the data is only on disk; the
+	// gap between ids 2 and 100 matters: a partial cache warmup below creates
+	// a window covering the low ids only
+	store := loadTestStore(t, dirName)
+	index := newBQCachedIndex(t, dirName, store)
+	vectors := map[uint64][]float32{
+		0:   {4, -1, 4},
+		1:   {-2, 3, 1},
+		2:   {0.5, 0.5, 0.5},
+		100: {1, 0.5, 0},
+	}
+	for id, vec := range vectors {
+		require.NoError(t, index.Add(ctx, id, vec))
+	}
+	require.NoError(t, index.Shutdown(ctx))
+	require.NoError(t, store.Shutdown(ctx))
+
+	// reopen without running PostStartup, then warm a single cache entry via
+	// the distancer: the cache window is now non-empty but incomplete, and
+	// vector 100 lies beyond it
+	store = loadTestStore(t, dirName)
+	defer store.Shutdown(ctx)
+	index = newBQCachedIndex(t, dirName, store)
+	defer index.Shutdown(ctx)
+
+	qvd := index.QueryVectorDistancer([]float32{1, 0, 0})
+	_, err := qvd.DistanceToNode(2)
+	require.NoError(t, err)
+	window := index.cache.Len()
+	require.Greater(t, window, int32(0), "the distancer call must have warmed the cache")
+	require.Less(t, window, int32(100), "vector 100 must lie beyond the warmed window")
+
+	// a search must not trust the partially warmed cache window: it must
+	// return the complete result set from the store
+	ids, _, err := index.SearchByVector(ctx, []float32{1, 0, 0}, len(vectors), nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint64{0, 1, 2, 100}, ids)
+
+	// searches stay complete after PostStartup as well. Note that in this
+	// test the data lives only in the memtable (never flushed to a segment),
+	// which the preload's parallel iterator cannot see: the index must keep
+	// serving searches from the store rather than trust the cache.
+	index.PostStartup(ctx)
+	ids, _, err = index.SearchByVector(ctx, []float32{1, 0, 0}, len(vectors), nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint64{0, 1, 2, 100}, ids)
+}

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -1838,3 +1838,76 @@ func Test_NoRace_Flat_SearchAfterRestartWithUnflushedData(t *testing.T) {
 	assert.ElementsMatch(t, []uint64{0, 1, 2, 3}, ids,
 		"vectors recovered from the WAL must be visible to the cached search")
 }
+
+func bqCachedConfig() flatent.UserConfig {
+	return flatent.UserConfig{
+		BQ: flatent.CompressionUserConfig{
+			Enabled: true, Cache: true, RescoreLimit: 10,
+		},
+	}
+}
+
+func newBQCachedIndex(t *testing.T, dirName string, store *lsmkv.Store) *flat {
+	t.Helper()
+	index, err := New(Config{
+		ID:                "lazy-cache-test",
+		RootPath:          dirName,
+		DistanceProvider:  distancer.NewCosineDistanceProvider(),
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, bqCachedConfig(), store)
+	require.NoError(t, err)
+	return index
+}
+
+func Test_NoRace_Flat_EmptyTenantPostStartupAllocatesNothing(t *testing.T) {
+	dirName := t.TempDir()
+	store := loadTestStore(t, dirName)
+	defer store.Shutdown(context.Background())
+
+	index := newBQCachedIndex(t, dirName, store)
+	defer index.Shutdown(context.Background())
+
+	index.PostStartup(context.Background())
+
+	// an empty tenant must not pay for a cache it doesn't use
+	assert.EqualValues(t, 0, index.cache.Len(),
+		"PostStartup on an empty index must not allocate the vector cache")
+}
+
+func Test_NoRace_Flat_QueryVectorDistancerBeforePreload(t *testing.T) {
+	dirName := t.TempDir()
+	ctx := context.Background()
+
+	// populate an index, then shut it down so the data is only on disk
+	store := loadTestStore(t, dirName)
+	index := newBQCachedIndex(t, dirName, store)
+	vectors := [][]float32{{4, -1, 4}, {-2, 3, 1}, {0.5, 0.5, 0.5}}
+	for i, vec := range vectors {
+		require.NoError(t, index.Add(ctx, uint64(i), vec))
+	}
+	require.NoError(t, index.Shutdown(ctx))
+	require.NoError(t, store.Shutdown(ctx))
+
+	// reopen without running PostStartup: the cache exists but is empty,
+	// exactly the state a lazily loaded shard is in before (or while) the
+	// startup preload runs
+	store = loadTestStore(t, dirName)
+	defer store.Shutdown(ctx)
+	index = newBQCachedIndex(t, dirName, store)
+	defer index.Shutdown(ctx)
+	require.EqualValues(t, 0, index.cache.Len())
+
+	// a search on the cold cache must fall back to the store and return
+	// complete results, not iterate an empty (or partial) cache window
+	ids, _, err := index.SearchByVector(ctx, []float32{1, 0, 0}, len(vectors), nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint64{0, 1, 2}, ids)
+
+	distancer := index.QueryVectorDistancer([]float32{1, 0, 0})
+	// query the highest id first: on an empty cache the first Get grows the
+	// cache, which would mask the guard against ids beyond the cache window
+	for i := len(vectors) - 1; i >= 0; i-- {
+		_, err := distancer.DistanceToNode(uint64(i))
+		assert.NoError(t, err, "query on a not-yet-preloaded cache must fall back to disk, not error")
+	}
+}

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -105,7 +105,9 @@ func TestHnswIndexGrow(t *testing.T) {
 		require.Nil(t, err)
 		// index should grow to 5001
 		assert.Equal(t, int(id)+cache.MinimumIndexGrowthDelta, len(index.nodes))
-		assert.Equal(t, int32(id+2*cache.MinimumIndexGrowthDelta), index.cache.Len())
+		// the exact cache size depends on the growth strategy (small caches
+		// grow relative to the requested id); it must cover the nodes slice
+		assert.GreaterOrEqual(t, index.cache.Len(), int32(len(index.nodes)))
 		// try to add a vector with id: 8001
 		id = uint64(6*cache.InitialSize + cache.MinimumIndexGrowthDelta + 1)
 		err = index.Add(ctx, id, vector)

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -93,21 +93,14 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 	}
 	targetVector := h.getTargetVector()
 
-	h.RLock()
-	preGrown := uint64(len(h.nodes))
-	h.RUnlock()
-
 	var loaded atomic.Int64
 	onVector := func(id uint64, vec []float32) {
 		// cosine-dot keeps normalized vectors in the cache; the serial path gets this
 		// from the cache's normalizeOnRead wrapper, which Preload bypasses. vec is a
 		// fresh per-vector allocation, so normalizing in place is safe.
 		h.normalizeVecInPlace(vec)
-		if id >= preGrown {
-			// Cache is pre-grown to len(h.nodes) at restore, so live ids are in-bounds;
-			// grow only for an id from a write that landed after we snapshotted the count.
-			h.cache.Grow(id)
-		}
+		// Preload grows the cache on demand, covering ids from writes that
+		// land while the prefill is running
 		h.cache.Preload(id, vec)
 		loaded.Add(1)
 	}


### PR DESCRIPTION
### What's being changed:

Every `shardedLockCache` (one per flat/HNSW vector index, i.e. per tenant in multi-tenant setups) eagerly allocates a 1000-slot backing slice (24 KiB) and 512 lock stripes (12 KiB) at construction, regardless of whether the tenant holds any vectors. On a multi-tenant cluster with ~10k flat+BQ tenants per node, heap profiles attribute ~340 MB (~14% of retained heap) per node to these two allocations, mostly for caches that sit empty.

This PR makes both allocations lazy and proportional to actual tenant size:

- **`LazyShardedRWLocks`** (new, in `common`): same locking API as `ShardedRWLocks`, but stripes are allocated on first use and the stripe count can grow later via `EnsureCount`. The stripe set is only ever replaced while all stripes of the previous set are held exclusively, so unlock operations always resolve the current set and only acquires re-check after acquiring.
- **`shardedLockCache`** starts with a nil backing slice and 0 stripes. Growth is relative for small caches (`max(node+20, node*1.25)`, capped by the previous fixed `node+2000` step), and the stripe count scales at one stripe per 64 slots, quantized to powers of two, from 8 up to the previous fixed 512.
- **Flat index**: `PostStartup` skips the cache preload entirely for empty tenants and sizes the cache (and its stripes) via `Grow(maxID)` before locking; quantized search falls back to the store cursor while the cache is cold, and the `QueryVectorDistancer` guard tolerates a not-yet-preloaded cache. `Preload` on the cache now grows on demand, which also removes a latent panic for preloads beyond the cache window that was previously masked by the eager 1000-slot allocation.

Cost per tenant drops from ~36.7 KiB (fixed) to ~0 for idle tenants and ~2 KiB for a preloaded 50-vector tenant; large tenants converge to the exact previous behavior (same growth arithmetic, full 512 stripes from ~32k slots).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.