### PR TITLE
fix(MT): don't auto-activate tenants from internal routing lookups

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -298,7 +298,7 @@ func (f *fakeSchemaManager) TenantsShards(_ context.Context, class string, tenan
 	return res, nil
 }
 
-func (f *fakeSchemaManager) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaManager) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/adapters/repos/db/fakes_for_tests.go
+++ b/adapters/repos/db/fakes_for_tests.go
@@ -93,7 +93,7 @@ func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenant
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/adapters/repos/db/file_structure_migration_test.go
+++ b/adapters/repos/db/file_structure_migration_test.go
@@ -326,7 +326,7 @@ func (sg *fakeMigrationSchemaGetter) TenantsShards(_ context.Context, class stri
 	return nil, nil
 }
 
-func (f *fakeMigrationSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeMigrationSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3954,10 +3954,6 @@ func (i *Index) tenantDirExists(tenantName string) (bool, error) {
 	return true, nil
 }
 
-// buildReadRoutingPlan builds the read plan for search, aggregate and findUUIDs. These serve
-// an external request, so auto tenant activation applies: querying a COLD tenant activates it.
-// Peer-to-peer reads never get here; they land on the Incoming* methods, which resolve the
-// shard directly without the router.
 func (i *Index) buildReadRoutingPlan(cl routerTypes.ConsistencyLevel, tenantName string) (routerTypes.ReadRoutingPlan, error) {
 	planOptions := routerTypes.RoutingPlanBuildOptions{
 		Tenant:                tenantName,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3954,10 +3954,15 @@ func (i *Index) tenantDirExists(tenantName string) (bool, error) {
 	return true, nil
 }
 
+// buildReadRoutingPlan builds the read plan for search, aggregate and findUUIDs. These serve
+// an external request, so auto tenant activation applies: querying a COLD tenant activates it.
+// Peer-to-peer reads never get here; they land on the Incoming* methods, which resolve the
+// shard directly without the router.
 func (i *Index) buildReadRoutingPlan(cl routerTypes.ConsistencyLevel, tenantName string) (routerTypes.ReadRoutingPlan, error) {
 	planOptions := routerTypes.RoutingPlanBuildOptions{
-		Tenant:           tenantName,
-		ConsistencyLevel: cl,
+		Tenant:                tenantName,
+		ConsistencyLevel:      cl,
+		AllowTenantActivation: true,
 	}
 	readPlan, err := i.router.BuildReadRoutingPlan(planOptions)
 	if err != nil {

--- a/cluster/router/router.go
+++ b/cluster/router/router.go
@@ -437,7 +437,9 @@ func (r *multiTenantRouter) GetReadWriteReplicasLocation(collection string, tena
 		return types.ReadReplicaSet{}, types.WriteReplicaSet{}, err
 	}
 
-	readReplicas, err := r.getReadReplicasLocation(collection, tenant, shard)
+	// Combined read+write lookup, only used to serve an external request, so auto tenant
+	// activation applies.
+	readReplicas, err := r.getReadReplicasLocation(collection, tenant, shard, true)
 	if err != nil {
 		return types.ReadReplicaSet{}, types.WriteReplicaSet{}, err
 	}
@@ -469,12 +471,17 @@ func (r *multiTenantRouter) GetReadReplicasLocation(collection string, tenant st
 	if err := r.validateTenantShard(tenant, shard); err != nil {
 		return types.ReadReplicaSet{}, err
 	}
-	return r.getReadReplicasLocation(collection, tenant, shard)
+	// Serves an external request, so auto tenant activation applies.
+	return r.getReadReplicasLocation(collection, tenant, shard, true)
 }
 
 // getReadReplicasLocation returns only read replicas for multi-tenant collections.
-func (r *multiTenantRouter) getReadReplicasLocation(collection string, tenant, shard string) (types.ReadReplicaSet, error) {
-	tenantStatus, err := r.schemaGetter.OptimisticTenantStatus(context.TODO(), collection, tenant)
+//
+// allowTenantActivation lets the tenant status lookup activate a COLD tenant under auto
+// tenant activation. Only callers acting for an external request pass true; internal ones
+// must not revive a tenant just by asking where its shard lives.
+func (r *multiTenantRouter) getReadReplicasLocation(collection string, tenant, shard string, allowTenantActivation bool) (types.ReadReplicaSet, error) {
+	tenantStatus, err := r.schemaGetter.OptimisticTenantStatus(context.TODO(), collection, tenant, allowTenantActivation)
 	if err != nil {
 		return types.ReadReplicaSet{}, objects.NewErrMultiTenancy(err)
 	}
@@ -495,8 +502,12 @@ func (r *multiTenantRouter) getReadReplicasLocation(collection string, tenant, s
 }
 
 // getWriteReplicasLocation returns only write replicas for multi-tenant collections.
+//
+// Writes only reach the router on the node serving an external request; replicated writes
+// from a peer land on the Incoming* path, which never consults the router. So auto tenant
+// activation always applies here.
 func (r *multiTenantRouter) getWriteReplicasLocation(collection string, tenant, shard string) (types.WriteReplicaSet, error) {
-	tenantStatus, err := r.schemaGetter.OptimisticTenantStatus(context.TODO(), collection, tenant)
+	tenantStatus, err := r.schemaGetter.OptimisticTenantStatus(context.TODO(), collection, tenant, true)
 	if err != nil {
 		return types.WriteReplicaSet{}, objects.NewErrMultiTenancy(err)
 	}
@@ -578,8 +589,12 @@ func (r *multiTenantRouter) BuildReadRoutingPlan(params types.RoutingPlanBuildOp
 }
 
 // buildReadRoutingPlan constructs a read routing plan for multi-tenant collections.
+//
+// Whether an inactive tenant may be activated as a side effect is the caller's call, declared
+// via params.AllowTenantActivation. It defaults to false, so internal callers (async
+// replication) never activate unless they explicitly ask to.
 func (r *multiTenantRouter) buildReadRoutingPlan(params types.RoutingPlanBuildOptions) (types.ReadRoutingPlan, error) {
-	readReplicas, err := r.getReadReplicasLocation(r.collection, params.Tenant, params.Shard)
+	readReplicas, err := r.getReadReplicasLocation(r.collection, params.Tenant, params.Shard, params.AllowTenantActivation)
 	if err != nil {
 		return types.ReadRoutingPlan{}, err
 	}

--- a/cluster/router/router.go
+++ b/cluster/router/router.go
@@ -437,8 +437,7 @@ func (r *multiTenantRouter) GetReadWriteReplicasLocation(collection string, tena
 		return types.ReadReplicaSet{}, types.WriteReplicaSet{}, err
 	}
 
-	// Combined read+write lookup, only used to serve an external request, so auto tenant
-	// activation applies.
+	// Serves an external request, so auto tenant activation applies.
 	readReplicas, err := r.getReadReplicasLocation(collection, tenant, shard, true)
 	if err != nil {
 		return types.ReadReplicaSet{}, types.WriteReplicaSet{}, err
@@ -477,9 +476,9 @@ func (r *multiTenantRouter) GetReadReplicasLocation(collection string, tenant st
 
 // getReadReplicasLocation returns only read replicas for multi-tenant collections.
 //
-// allowTenantActivation lets the tenant status lookup activate a COLD tenant under auto
-// tenant activation. Only callers acting for an external request pass true; internal ones
-// must not revive a tenant just by asking where its shard lives.
+// allowTenantActivation lets the status lookup activate a COLD tenant under auto tenant
+// activation. Only callers acting for an external request pass true; internal ones must not
+// revive a tenant just by asking where its shard lives.
 func (r *multiTenantRouter) getReadReplicasLocation(collection string, tenant, shard string, allowTenantActivation bool) (types.ReadReplicaSet, error) {
 	tenantStatus, err := r.schemaGetter.OptimisticTenantStatus(context.TODO(), collection, tenant, allowTenantActivation)
 	if err != nil {
@@ -503,9 +502,9 @@ func (r *multiTenantRouter) getReadReplicasLocation(collection string, tenant, s
 
 // getWriteReplicasLocation returns only write replicas for multi-tenant collections.
 //
-// Writes only reach the router on the node serving an external request; replicated writes
-// from a peer land on the Incoming* path, which never consults the router. So auto tenant
-// activation always applies here.
+// Writes only reach the router on the node serving an external request — replicated writes
+// from a peer land on the Incoming* path, which never consults the router — so auto tenant
+// activation always applies.
 func (r *multiTenantRouter) getWriteReplicasLocation(collection string, tenant, shard string) (types.WriteReplicaSet, error) {
 	tenantStatus, err := r.schemaGetter.OptimisticTenantStatus(context.TODO(), collection, tenant, true)
 	if err != nil {
@@ -589,10 +588,6 @@ func (r *multiTenantRouter) BuildReadRoutingPlan(params types.RoutingPlanBuildOp
 }
 
 // buildReadRoutingPlan constructs a read routing plan for multi-tenant collections.
-//
-// Whether an inactive tenant may be activated as a side effect is the caller's call, declared
-// via params.AllowTenantActivation. It defaults to false, so internal callers (async
-// replication) never activate unless they explicitly ask to.
 func (r *multiTenantRouter) buildReadRoutingPlan(params types.RoutingPlanBuildOptions) (types.ReadRoutingPlan, error) {
 	readReplicas, err := r.getReadReplicasLocation(r.collection, params.Tenant, params.Shard, params.AllowTenantActivation)
 	if err != nil {

--- a/cluster/router/router_fsm_test.go
+++ b/cluster/router/router_fsm_test.go
@@ -130,7 +130,7 @@ func TestReadRoutingWithFSM(t *testing.T) {
 			clusterState := clusterMocks.NewMockNodeSelector(testCase.allShardNodes...)
 			schemaReaderMock := schema.NewMockSchemaReader(t)
 			schemaGetterMock := schema.NewMockSchemaGetter(t)
-			schemaGetterMock.EXPECT().OptimisticTenantStatus(mock.Anything, "collection1", "shard1").Return(
+			schemaGetterMock.EXPECT().OptimisticTenantStatus(mock.Anything, "collection1", "shard1", mock.Anything).Return(
 				map[string]string{
 					"shard1": models.TenantActivityStatusHOT,
 				}, nil).Maybe()
@@ -195,8 +195,9 @@ func TestReadRoutingWithFSM(t *testing.T) {
 			}
 			// Build the routing plan
 			readPlan, err := myRouter.BuildReadRoutingPlan(types.RoutingPlanBuildOptions{
-				Shard:  "shard1",
-				Tenant: tenant,
+				AllowTenantActivation: true,
+				Shard:                 "shard1",
+				Tenant:                tenant,
 			})
 			if testCase.expectedErrorStr != "" {
 				require.Error(t, err)
@@ -307,7 +308,7 @@ func TestWriteRoutingWithFSM(t *testing.T) {
 			clusterState := clusterMocks.NewMockNodeSelector(testCase.allShardNodes...)
 			schemaReaderMock := schema.NewMockSchemaReader(t)
 			schemaGetterMock := schema.NewMockSchemaGetter(t)
-			schemaGetterMock.EXPECT().OptimisticTenantStatus(mock.Anything, "collection1", "shard1").Return(
+			schemaGetterMock.EXPECT().OptimisticTenantStatus(mock.Anything, "collection1", "shard1", mock.Anything).Return(
 				map[string]string{
 					"shard1": models.TenantActivityStatusHOT,
 				}, nil).Maybe()

--- a/cluster/router/router_test.go
+++ b/cluster/router/router_test.go
@@ -2063,9 +2063,9 @@ func TestSingleTenantRouter_BuildReadRoutingPlan_AllShards(t *testing.T) {
 // as a side effect of asking where its shard lives.
 //
 // Resolving replicas requires a tenant status check, which under auto tenant activation turns
-// a COLD tenant HOT via a RAFT write. That is right for an external request and wrong for
-// internal work: async replication must not revive a tenant an operator deactivated. The
-// router must forward the caller's AllowTenantActivation to the lookup, unchanged.
+// a COLD tenant HOT via a RAFT write. Right for an external request, wrong for internal work:
+// async replication must not revive a tenant an operator deactivated. So the router must
+// forward the caller's AllowTenantActivation to the lookup, unchanged.
 func TestMultiTenantRouter_BuildReadRoutingPlan_TenantActivation(t *testing.T) {
 	const (
 		collection = "TestClass"
@@ -2077,18 +2077,14 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_TenantActivation(t *testing.T) {
 		// allowTenantActivation is what the caller declares: true for external request paths,
 		// false (the zero value) for internal ones such as async replication.
 		allowTenantActivation bool
-		// wantActivatingLookup is the status lookup the router must use as a result.
-		wantActivatingLookup bool
 	}{
 		{
 			name:                  "external request may activate the tenant",
 			allowTenantActivation: true,
-			wantActivatingLookup:  true,
 		},
 		{
 			name:                  "internal caller must not activate the tenant",
 			allowTenantActivation: false,
-			wantActivatingLookup:  false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2097,11 +2093,10 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_TenantActivation(t *testing.T) {
 			mockReplicationFSM := replicationTypes.NewMockReplicationFSMReader(t)
 			mockNodeSelector := mocks.NewMockNodeSelector("node1")
 
-			// The router must forward the caller.s intent verbatim: registering the expectation
-			// on the exact bool means the wrong one fails the test.
+			// Expecting the exact bool is the assertion: forwarding the wrong one fails here.
 			status := map[string]string{tenant: models.TenantActivityStatusHOT}
 			mockSchemaGetter.EXPECT().
-				OptimisticTenantStatus(mock.Anything, collection, tenant, tt.wantActivatingLookup).
+				OptimisticTenantStatus(mock.Anything, collection, tenant, tt.allowTenantActivation).
 				Return(status, nil).Once()
 
 			mockSchemaReader.EXPECT().ShardReplicas(collection, tenant).Return([]string{"node1"}, nil)
@@ -2145,8 +2140,7 @@ func TestMultiTenantRouter_RoutingPlanOptions_DoNotActivateByDefault(t *testing.
 	mockReplicationFSM := replicationTypes.NewMockReplicationFSMReader(t)
 	mockNodeSelector := mocks.NewMockNodeSelector("node1")
 
-	// Expect the lookup to be told NOT to activate. If the router activates on options that
-	// never opted in, the mock fails the test.
+	// The lookup must be told not to activate; activating on options that never opted in fails.
 	mockSchemaGetter.EXPECT().
 		OptimisticTenantStatus(mock.Anything, collection, tenant, false).
 		Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil).Once()
@@ -2159,7 +2153,7 @@ func TestMultiTenantRouter_RoutingPlanOptions_DoNotActivateByDefault(t *testing.
 		collection, true, mockNodeSelector, mockSchemaGetter, mockSchemaReader, mockReplicationFSM,
 	).Build()
 
-	// Options built the way the async-replication paths build them: no activation opt-in.
+	// Options built the way the async-replication paths build them: no opt-in.
 	options := r.BuildRoutingPlanOptions(tenant, tenant, types.ConsistencyLevelOne, "")
 	require.False(t, options.AllowTenantActivation,
 		"BuildRoutingPlanOptions must not opt into tenant activation on the caller's behalf")

--- a/cluster/router/router_test.go
+++ b/cluster/router/router_test.go
@@ -325,7 +325,7 @@ func TestMultiTenantRouter_GetReadWriteReplicasLocation_Success(t *testing.T) {
 		"luke": models.TenantActivityStatusHOT,
 	}
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+		OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatus, nil)
 
 	mockReplicationFSM.EXPECT().
@@ -367,7 +367,7 @@ func TestMultiTenantRouter_GetReadWriteReplicasLocation_TenantNotFound(t *testin
 	mockSchemaReader := schema.NewMockSchemaReader(t)
 
 	tenantStatus := map[string]string{}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatus, errors.New("tenant not found: \"luke\""))
 
 	r := router.NewBuilder(
@@ -396,7 +396,7 @@ func TestMultiTenantRouter_GetReadWriteReplicasLocation_TenantNotActive(t *testi
 	tenantStatus := map[string]string{
 		"luke": models.TenantActivityStatusCOLD,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatus, nil)
 
 	r := router.NewBuilder(
@@ -451,7 +451,7 @@ func TestMultiTenantRouter_GetWriteReplicasLocation(t *testing.T) {
 		"luke": models.TenantActivityStatusHOT,
 	}
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+		OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().
 		FilterOneShardReplicasWrite("TestClass", "luke", []string{"node1"}).
@@ -487,7 +487,7 @@ func TestMultiTenantRouter_GetReadReplicasLocation(t *testing.T) {
 		"luke": models.TenantActivityStatusHOT,
 	}
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+		OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().
 		FilterOneShardReplicasRead("TestClass", "luke", []string{"node1"}).
@@ -526,13 +526,13 @@ func TestMultiTenantRouter_TenantStatusChangeDuringOperation(t *testing.T) {
 	}
 
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+		OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatusFirst, nil).Once() // first tenant read replicas
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+		OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatusFirst, nil).Once() // first tenant write replicas
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+		OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatusSecond, nil).Once() // second tenant read replica (error)
 
 	mockReplicationFSM.EXPECT().
@@ -590,7 +590,7 @@ func TestMultiTenantRouter_VariousTenantStatuses(t *testing.T) {
 			tenantStatus := map[string]string{
 				"luke": test.status,
 			}
-			mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+			mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 				Return(tenantStatus, nil)
 
 			var expectedReplicas []types.Replica
@@ -673,7 +673,7 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_NoReplicas(t *testing.T) {
 		"luke": models.TenantActivityStatusHOT,
 	}
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+		OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().
 		FilterOneShardReplicasRead("TestClass", "luke", []string{}).
@@ -702,7 +702,7 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_Success(t *testing.T) {
 	tenantStatus := map[string]string{
 		"luke": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke", mock.Anything).
 		Return(tenantStatus, nil)
 
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasRead("TestClass", "luke", []string{"node1"}).
@@ -732,7 +732,7 @@ func TestMultiTenantRouter_BuildRoutingPlan_TenantNotFoundDuringBuild(t *testing
 	metadataReader := schema.NewMockSchemaReader(t)
 
 	tenantStatus := map[string]string{}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "nonexistent").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "nonexistent", mock.Anything).
 		Return(tenantStatus, nil)
 
 	r := router.NewBuilder(
@@ -843,7 +843,7 @@ func TestMultiTenantRouter_MultipleTenantsSameCollection(t *testing.T) {
 
 	for tenant, replicas := range tenants {
 		tenantStatus := map[string]string{tenant: models.TenantActivityStatusHOT}
-		mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", tenant).
+		mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", tenant, mock.Anything).
 			Return(tenantStatus, nil)
 		mockSchemaReader.EXPECT().ShardReplicas("TestClass", tenant).Return(replicas, nil)
 		mockReplicationFSM.EXPECT().FilterOneShardReplicasRead("TestClass", tenant, replicas).
@@ -892,7 +892,7 @@ func TestMultiTenantRouter_MixedTenantStates(t *testing.T) {
 
 	for tenantName, tenantsStatus := range tenants {
 		tenantStatus := map[string]string{tenantName: tenantsStatus.status}
-		mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", tenantName).
+		mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", tenantName, mock.Anything).
 			Return(tenantStatus, nil)
 
 		if tenantsStatus.shouldWork {
@@ -947,7 +947,7 @@ func TestMultiTenantRouter_SameTenantDifferentCollections(t *testing.T) {
 			}
 
 			tenantStatus := map[string]string{tenantName: models.TenantActivityStatusHOT}
-			mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, collection, tenantName).
+			mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, collection, tenantName, mock.Anything).
 				Return(tenantStatus, nil)
 			mockSchemaReader.EXPECT().ShardReplicas(collection, tenantName).Return(expectedReplicas, nil)
 			mockReplicationFSM.EXPECT().FilterOneShardReplicasRead(collection, tenantName, expectedReplicas).
@@ -1195,7 +1195,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_Success(t *testing.T) {
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasWrite("TestClass", "alice", []string{"node1", "node2"}).
 		Return([]string{"node1"})
@@ -1227,7 +1227,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_NoWriteReplicas(t *testing.T) {
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasWrite("TestClass", "alice", []string{}).
 		Return([]string{})
@@ -1274,7 +1274,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_TenantNotActive(t *testing.T) {
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusCOLD,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 
 	r := router.NewBuilder(
@@ -1339,7 +1339,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_DefaultShard(t *testing.T) {
 	tenant := "luke"
 
 	mockSchemaGetter.EXPECT().
-		OptimisticTenantStatus(mock.Anything, "TestClass", tenant).
+		OptimisticTenantStatus(mock.Anything, "TestClass", tenant, mock.Anything).
 		Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil)
 
 	mockSchemaReader.EXPECT().ShardReplicas("TestClass", tenant).
@@ -1516,7 +1516,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_NoReplicas(t *testing.T) {
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasWrite("TestClass", "alice", []string{"node1"}).
 		Return([]string{}) // No write replicas
@@ -1552,7 +1552,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_ConsistencyLevelValidation(t *t
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasWrite("TestClass", "alice", []string{"node1", "node2"}).
 		Return([]string{"node1"})
@@ -1587,7 +1587,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_ReplicaOrdering(t *testing.T) {
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasWrite("TestClass", "alice", []string{"node1", "node2", "node3"}).
 		Return([]string{"node1", "node3"})
@@ -1620,7 +1620,7 @@ func TestMultiTenantRouter_BuildWriteRoutingPlan_TenantNotFound(t *testing.T) {
 	mockSchemaReader := schema.NewMockSchemaReader(t)
 
 	tenantStatus := map[string]string{}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "nonexistent").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "nonexistent", mock.Anything).
 		Return(tenantStatus, errors.New("tenant not found: \"nonexistent\""))
 
 	r := router.NewBuilder(
@@ -1681,7 +1681,7 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_ConsistencyLevelValidation(t *te
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasRead("TestClass", "alice", []string{"node1", "node2"}).
 		Return([]string{"node1", "node2"})
@@ -1696,9 +1696,10 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_ConsistencyLevelValidation(t *te
 	).Build()
 
 	opts := types.RoutingPlanBuildOptions{
-		Tenant:           "alice",
-		Shard:            "",
-		ConsistencyLevel: "INVALID_LEVEL",
+		AllowTenantActivation: true,
+		Tenant:                "alice",
+		Shard:                 "",
+		ConsistencyLevel:      "INVALID_LEVEL",
 	}
 
 	plan, err := r.BuildReadRoutingPlan(opts)
@@ -1716,7 +1717,7 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_NoReplicasError(t *testing.T) {
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasRead("TestClass", "alice", []string{}).
 		Return([]string{}) // No read replicas
@@ -1731,9 +1732,10 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_NoReplicasError(t *testing.T) {
 	).Build()
 
 	opts := types.RoutingPlanBuildOptions{
-		Tenant:           "alice",
-		Shard:            "",
-		ConsistencyLevel: types.ConsistencyLevelOne,
+		AllowTenantActivation: true,
+		Tenant:                "alice",
+		Shard:                 "",
+		ConsistencyLevel:      types.ConsistencyLevelOne,
 	}
 
 	plan, err := r.BuildReadRoutingPlan(opts)
@@ -1825,7 +1827,7 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_ReplicaOrdering(t *testing.T) {
 	tenantStatus := map[string]string{
 		"alice": models.TenantActivityStatusHOT,
 	}
-	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice").
+	mockSchemaGetter.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "alice", mock.Anything).
 		Return(tenantStatus, nil)
 	mockReplicationFSM.EXPECT().FilterOneShardReplicasRead("TestClass", "alice", []string{"node1", "node2", "node3"}).
 		Return([]string{"node1", "node2", "node3"})
@@ -1840,10 +1842,11 @@ func TestMultiTenantRouter_BuildReadRoutingPlan_ReplicaOrdering(t *testing.T) {
 	).Build()
 
 	opts := types.RoutingPlanBuildOptions{
-		Tenant:              "alice",
-		Shard:               "",
-		ConsistencyLevel:    types.ConsistencyLevelOne,
-		DirectCandidateNode: "node2",
+		AllowTenantActivation: true,
+		Tenant:                "alice",
+		Shard:                 "",
+		ConsistencyLevel:      types.ConsistencyLevelOne,
+		DirectCandidateNode:   "node2",
 	}
 
 	plan, err := r.BuildReadRoutingPlan(opts)
@@ -2054,4 +2057,113 @@ func TestSingleTenantRouter_BuildReadRoutingPlan_AllShards(t *testing.T) {
 	}
 	require.True(t, shardNames["shard1"], "should have replica from shard1")
 	require.True(t, shardNames["shard2"], "should have replica from shard2")
+}
+
+// TestMultiTenantRouter_BuildReadRoutingPlan_TenantActivation pins who may activate a tenant
+// as a side effect of asking where its shard lives.
+//
+// Resolving replicas requires a tenant status check, which under auto tenant activation turns
+// a COLD tenant HOT via a RAFT write. That is right for an external request and wrong for
+// internal work: async replication must not revive a tenant an operator deactivated. The
+// router must forward the caller's AllowTenantActivation to the lookup, unchanged.
+func TestMultiTenantRouter_BuildReadRoutingPlan_TenantActivation(t *testing.T) {
+	const (
+		collection = "TestClass"
+		tenant     = "luke"
+	)
+
+	for _, tt := range []struct {
+		name string
+		// allowTenantActivation is what the caller declares: true for external request paths,
+		// false (the zero value) for internal ones such as async replication.
+		allowTenantActivation bool
+		// wantActivatingLookup is the status lookup the router must use as a result.
+		wantActivatingLookup bool
+	}{
+		{
+			name:                  "external request may activate the tenant",
+			allowTenantActivation: true,
+			wantActivatingLookup:  true,
+		},
+		{
+			name:                  "internal caller must not activate the tenant",
+			allowTenantActivation: false,
+			wantActivatingLookup:  false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSchemaGetter := schema.NewMockSchemaGetter(t)
+			mockSchemaReader := schema.NewMockSchemaReader(t)
+			mockReplicationFSM := replicationTypes.NewMockReplicationFSMReader(t)
+			mockNodeSelector := mocks.NewMockNodeSelector("node1")
+
+			// The router must forward the caller.s intent verbatim: registering the expectation
+			// on the exact bool means the wrong one fails the test.
+			status := map[string]string{tenant: models.TenantActivityStatusHOT}
+			mockSchemaGetter.EXPECT().
+				OptimisticTenantStatus(mock.Anything, collection, tenant, tt.wantActivatingLookup).
+				Return(status, nil).Once()
+
+			mockSchemaReader.EXPECT().ShardReplicas(collection, tenant).Return([]string{"node1"}, nil)
+			mockReplicationFSM.EXPECT().
+				FilterOneShardReplicasRead(collection, tenant, []string{"node1"}).
+				Return([]string{"node1"})
+
+			r := router.NewBuilder(
+				collection,
+				true,
+				mockNodeSelector,
+				mockSchemaGetter,
+				mockSchemaReader,
+				mockReplicationFSM,
+			).Build()
+
+			plan, err := r.BuildReadRoutingPlan(types.RoutingPlanBuildOptions{
+				Tenant:                tenant,
+				ConsistencyLevel:      types.ConsistencyLevelOne,
+				AllowTenantActivation: tt.allowTenantActivation,
+			})
+			require.NoError(t, err)
+			require.Equal(t, []types.Replica{
+				{NodeName: "node1", ShardName: tenant, HostAddr: "node1"},
+			}, plan.ReplicaSet.Replicas)
+		})
+	}
+}
+
+// TestMultiTenantRouter_RoutingPlanOptions_DoNotActivateByDefault pins the safe default:
+// AllowTenantActivation is opt-in, so a caller who says nothing does not activate. A forgotten
+// flag then merely fails to route an inactive tenant instead of silently reviving one.
+func TestMultiTenantRouter_RoutingPlanOptions_DoNotActivateByDefault(t *testing.T) {
+	const (
+		collection = "TestClass"
+		tenant     = "luke"
+	)
+
+	mockSchemaGetter := schema.NewMockSchemaGetter(t)
+	mockSchemaReader := schema.NewMockSchemaReader(t)
+	mockReplicationFSM := replicationTypes.NewMockReplicationFSMReader(t)
+	mockNodeSelector := mocks.NewMockNodeSelector("node1")
+
+	// Expect the lookup to be told NOT to activate. If the router activates on options that
+	// never opted in, the mock fails the test.
+	mockSchemaGetter.EXPECT().
+		OptimisticTenantStatus(mock.Anything, collection, tenant, false).
+		Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil).Once()
+	mockSchemaReader.EXPECT().ShardReplicas(collection, tenant).Return([]string{"node1"}, nil)
+	mockReplicationFSM.EXPECT().
+		FilterOneShardReplicasRead(collection, tenant, []string{"node1"}).
+		Return([]string{"node1"})
+
+	r := router.NewBuilder(
+		collection, true, mockNodeSelector, mockSchemaGetter, mockSchemaReader, mockReplicationFSM,
+	).Build()
+
+	// Options built the way the async-replication paths build them: no activation opt-in.
+	options := r.BuildRoutingPlanOptions(tenant, tenant, types.ConsistencyLevelOne, "")
+	require.False(t, options.AllowTenantActivation,
+		"BuildRoutingPlanOptions must not opt into tenant activation on the caller's behalf")
+
+	_, err := r.BuildReadRoutingPlan(options)
+	require.NoError(t, err)
 }

--- a/cluster/router/types/router_plan.go
+++ b/cluster/router/types/router_plan.go
@@ -33,6 +33,12 @@ type RoutingPlanBuildOptions struct {
 	Tenant              string
 	ConsistencyLevel    ConsistencyLevel
 	DirectCandidateNode string
+
+	// AllowTenantActivation states that this plan serves an external request, and so may
+	// activate a COLD tenant under auto tenant activation. Internal callers must leave it off:
+	// async replication would otherwise revive a tenant an operator deactivated. The zero value
+	// does not activate, so a caller who forgets it fails to route rather than reviving one.
+	AllowTenantActivation bool
 }
 
 // String returns a human-readable representation of the RoutingPlanBuildOptions.

--- a/cluster/router/types/router_plan.go
+++ b/cluster/router/types/router_plan.go
@@ -34,7 +34,7 @@ type RoutingPlanBuildOptions struct {
 	ConsistencyLevel    ConsistencyLevel
 	DirectCandidateNode string
 
-	//AllowTenantActivation if set to true, it will activate a COLD tenant under auto tenant activation.
+	// AllowTenantActivation if set to true, it will activate a COLD tenant under auto tenant activation.
 	// Rule of thumb: only set to true if the plan serves an external request.
 	AllowTenantActivation bool
 }

--- a/cluster/router/types/router_plan.go
+++ b/cluster/router/types/router_plan.go
@@ -34,10 +34,8 @@ type RoutingPlanBuildOptions struct {
 	ConsistencyLevel    ConsistencyLevel
 	DirectCandidateNode string
 
-	// AllowTenantActivation states that this plan serves an external request, and so may
-	// activate a COLD tenant under auto tenant activation. Internal callers must leave it off:
-	// async replication would otherwise revive a tenant an operator deactivated. The zero value
-	// does not activate, so a caller who forgets it fails to route rather than reviving one.
+	//AllowTenantActivation if set to true, it will activate a COLD tenant under auto tenant activation.
+	// Rule of thumb: only set to true if the plan serves an external request.
 	AllowTenantActivation bool
 }
 

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -206,7 +206,7 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 	mockSchema.EXPECT().ReadOnlyClass(class.Class).Return(class).Maybe()
 	mockSchema.EXPECT().TenantsShards(mock.Anything, className, hotTenant).
 		Return(map[string]string{hotTenant: models.TenantActivityStatusHOT}, nil).Maybe()
-	mockSchema.EXPECT().OptimisticTenantStatus(mock.Anything, className, hotTenant).
+	mockSchema.EXPECT().OptimisticTenantStatus(mock.Anything, className, hotTenant, mock.Anything).
 		Return(map[string]string{hotTenant: models.TenantActivityStatusHOT}, nil).Maybe()
 	mockSchema.EXPECT().ShardOwner(className, hotTenant).Return(nodeName, nil).Maybe()
 

--- a/modules/text2vec-contextionary/classification/fakes_for_test.go
+++ b/modules/text2vec-contextionary/classification/fakes_for_test.go
@@ -66,7 +66,7 @@ func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenant
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -72,7 +72,7 @@ func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenant
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -100,7 +100,7 @@ func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenant
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -333,6 +333,8 @@ func (c *coordinator[T, any]) Pull(ctx context.Context,
 	timeout time.Duration,
 ) (<-chan Result[T], int, error) {
 	options := c.Router.BuildRoutingPlanOptions(c.Shard, c.Shard, cl, directCandidate)
+	// Only runs on the node serving an external request, so auto tenant activation applies.
+	options.AllowTenantActivation = true
 	readRoutingPlan, err := c.Router.BuildReadRoutingPlan(options)
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w : class %q shard %q", err, c.Class, c.Shard)

--- a/usecases/replica/coordinator_test.go
+++ b/usecases/replica/coordinator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/clients"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
@@ -314,7 +315,7 @@ func Test_coordinatorPull(t *testing.T) {
 	setupRouter := func(cl types.ConsistencyLevel, replicas []types.Replica) *types.MockRouter {
 		mockRouter := types.NewMockRouter(t)
 
-		routingPlanOptions := types.RoutingPlanBuildOptions{Shard: shard, Tenant: "", ConsistencyLevel: cl, DirectCandidateNode: ""}
+		routingPlanOptions := types.RoutingPlanBuildOptions{Shard: shard, Tenant: "", ConsistencyLevel: cl, DirectCandidateNode: "", AllowTenantActivation: true}
 		mockRouter.EXPECT().BuildRoutingPlanOptions(shard, shard, cl, "").Return(routingPlanOptions).Once()
 		readRoutingPlan := types.ReadRoutingPlan{
 			Shard:               shard,

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -348,6 +348,8 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 	shardName string, ht hashtree.AggregatedHashTree, diffTimeoutPerNode time.Duration,
 	targetNodeOverrides []additional.AsyncReplicationTargetNodeOverride,
 ) (diffReader *ShardDifferenceReader, err error) {
+	// Async repl. is internal work: AllowTenantActivation stays off, so routing a multi-tenant shard never
+	// revives a deactivated tenant. Routing fails for one instead, and the cycle skips it.
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
 	if err != nil {
@@ -495,6 +497,7 @@ func (f *Finder) CompareDigests(ctx context.Context,
 // targetHostAddrsForShard resolves a shard's remote replica host addresses
 // (excluding the local node), mirroring CollectShardDifferences.
 func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
+	// Internal: never activates a tenant (see CollectShardDifferences).
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
 	if err != nil {
@@ -699,6 +702,7 @@ type AsyncCheckpointShardStatus struct {
 }
 
 func (f *Finder) remoteReplicaHosts(shardName string) (names []string, addrs []string) {
+	// Internal: never activates a tenant (see CollectShardDifferences).
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
 	if err != nil {

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -348,8 +348,6 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 	shardName string, ht hashtree.AggregatedHashTree, diffTimeoutPerNode time.Duration,
 	targetNodeOverrides []additional.AsyncReplicationTargetNodeOverride,
 ) (diffReader *ShardDifferenceReader, err error) {
-	// Async repl. is internal work: AllowTenantActivation stays off, so routing a multi-tenant shard never
-	// revives a deactivated tenant. Routing fails for one instead, and the cycle skips it.
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
 	if err != nil {
@@ -497,7 +495,6 @@ func (f *Finder) CompareDigests(ctx context.Context,
 // targetHostAddrsForShard resolves a shard's remote replica host addresses
 // (excluding the local node), mirroring CollectShardDifferences.
 func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
-	// Internal: never activates a tenant (see CollectShardDifferences).
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
 	if err != nil {
@@ -702,7 +699,6 @@ type AsyncCheckpointShardStatus struct {
 }
 
 func (f *Finder) remoteReplicaHosts(shardName string) (names []string, addrs []string) {
-	// Internal: never activates a tenant (see CollectShardDifferences).
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
 	if err != nil {

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -901,8 +901,8 @@ func (f *fakeFactory) newRouter(thisNode string) types.Router {
 	}
 	clusterState := clusterMocks.NewMockNodeSelector(nodes...)
 	schemaGetterMock := schema.NewMockSchemaGetter(f.t)
-	schemaGetterMock.EXPECT().OptimisticTenantStatus(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-		func(ctx context.Context, class string, tenant string) (map[string]string, error) {
+	schemaGetterMock.EXPECT().OptimisticTenantStatus(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 			return map[string]string{
 				tenant: models.TenantActivityStatusHOT,
 			}, nil

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -313,11 +313,13 @@ func (m *Manager) TenantsShardsWithVersion(ctx context.Context, class string, te
 // leader-lookups and only fall back to the leader if the local result implies
 // an unhappy path.
 //
-// allowImplicitActivation decides whether the leader fallback may also activate a COLD
-// tenant (a RAFT write) when the collection has auto tenant activation enabled. Only pass
-// true when acting for an external user request: activation encodes the user's intent to
-// use the tenant. Internal, cluster-driven callers pass false, so that background work
-// cannot revive a tenant an operator deactivated.
+// All of the above applies to external user requests, which is what allowImplicitActivation
+// selects: only they need the leader fallback, which is also what activates a COLD tenant
+// under auto tenant activation.
+//
+// Internal callers pass false and stay local. They must not revive a tenant an operator
+// deactivated, and they need no leader lookup either: async replication runs on a loop, so a
+// stale local read just skips the tenant this cycle and the next one picks it up.
 func (m *Manager) OptimisticTenantStatus(ctx context.Context, class string, tenant string,
 	allowImplicitActivation bool,
 ) (map[string]string, error) {
@@ -337,19 +339,20 @@ func (m *Manager) OptimisticTenantStatus(ctx context.Context, class string, tena
 		return nil, err
 	}
 
-	if !foundTenant || status != models.TenantActivityStatusHOT {
-		// either no state at all or state does not imply happy path -> delegate to
-		// leader
-		if !allowImplicitActivation {
-			// TenantsStatus asks the leader without the activation side effect.
-			return m.TenantsStatus(class, tenant)
-		}
-		return m.TenantsShards(ctx, class, tenant)
+	if foundTenant && status == models.TenantActivityStatusHOT {
+		return map[string]string{tenant: status}, nil
 	}
 
-	return map[string]string{
-		tenant: status,
-	}, nil
+	// No state at all, or state does not imply the happy path.
+	if !allowImplicitActivation {
+		if !foundTenant {
+			// An empty map reads as "tenant not found" to the caller.
+			return map[string]string{}, nil
+		}
+		return map[string]string{tenant: status}, nil
+	}
+
+	return m.TenantsShards(ctx, class, tenant)
 }
 
 func (m *Manager) activateTenantIfInactive(ctx context.Context, class string,

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -68,7 +68,9 @@ type SchemaGetter interface {
 
 	ShardOwner(class, shard string) (string, error)
 	TenantsShards(ctx context.Context, class string, tenants ...string) (map[string]string, error)
-	OptimisticTenantStatus(ctx context.Context, class string, tenants string) (map[string]string, error)
+	// allowImplicitActivation may only be set by callers acting for an external user request;
+	// it lets the lookup activate a COLD tenant under auto tenant activation.
+	OptimisticTenantStatus(ctx context.Context, class string, tenants string, allowImplicitActivation bool) (map[string]string, error)
 	ShardFromUUID(class string, uuid []byte) string
 	ShardReplicas(class, shard string) ([]string, error)
 }
@@ -310,7 +312,15 @@ func (m *Manager) TenantsShardsWithVersion(ctx context.Context, class string, te
 // Overall, we keep the (very common) happy path, free from expensive
 // leader-lookups and only fall back to the leader if the local result implies
 // an unhappy path.
-func (m *Manager) OptimisticTenantStatus(ctx context.Context, class string, tenant string) (map[string]string, error) {
+//
+// allowImplicitActivation decides whether the leader fallback may also activate a COLD
+// tenant (a RAFT write) when the collection has auto tenant activation enabled. Only pass
+// true when acting for an external user request: activation encodes the user's intent to
+// use the tenant. Internal, cluster-driven callers pass false, so that background work
+// cannot revive a tenant an operator deactivated.
+func (m *Manager) OptimisticTenantStatus(ctx context.Context, class string, tenant string,
+	allowImplicitActivation bool,
+) (map[string]string, error) {
 	var foundTenant bool
 	var status string
 	err := m.schemaReader.Read(class, true, func(_ *models.Class, ss *sharding.State) error {
@@ -330,6 +340,10 @@ func (m *Manager) OptimisticTenantStatus(ctx context.Context, class string, tena
 	if !foundTenant || status != models.TenantActivityStatusHOT {
 		// either no state at all or state does not imply happy path -> delegate to
 		// leader
+		if !allowImplicitActivation {
+			// TenantsStatus asks the leader without the activation side effect.
+			return m.TenantsStatus(class, tenant)
+		}
 		return m.TenantsShards(ctx, class, tenant)
 	}
 

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -289,10 +289,9 @@ func (m *Manager) TenantsShardsWithVersion(ctx context.Context, class string, te
 	return m.activateTenantIfInactive(ctx, class, status)
 }
 
-// OptimisticTenantStatus tries to query the local state first. It is
-// optimistic that the state has already propagated correctly. If the state is
-// unexpected, i.e. either the tenant is not found at all or the status is
-// COLD, it will double-check with the leader.
+// OptimisticTenantStatus tries to query the local state first
+// allowImplicitActivation may only be set by callers acting for an external user request;
+// because it lets the lookup activate a COLD tenant under auto tenant activation and leader lookup.
 //
 // This way we accept false positives (for HOT tenants), but guarantee that there will never be
 // false negatives (i.e. tenants labelled as COLD that the leader thinks should

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -68,8 +68,9 @@ type SchemaGetter interface {
 
 	ShardOwner(class, shard string) (string, error)
 	TenantsShards(ctx context.Context, class string, tenants ...string) (map[string]string, error)
+	// OptimisticTenantStatus tries to query the local state first
 	// allowImplicitActivation may only be set by callers acting for an external user request;
-	// it lets the lookup activate a COLD tenant under auto tenant activation.
+	// because it lets the lookup activate a COLD tenant under auto tenant activation and leader lookup.
 	OptimisticTenantStatus(ctx context.Context, class string, tenants string, allowImplicitActivation bool) (map[string]string, error)
 	ShardFromUUID(class string, uuid []byte) string
 	ShardReplicas(class, shard string) ([]string, error)
@@ -312,14 +313,6 @@ func (m *Manager) TenantsShardsWithVersion(ctx context.Context, class string, te
 // Overall, we keep the (very common) happy path, free from expensive
 // leader-lookups and only fall back to the leader if the local result implies
 // an unhappy path.
-//
-// All of the above applies to external user requests, which is what allowImplicitActivation
-// selects: only they need the leader fallback, which is also what activates a COLD tenant
-// under auto tenant activation.
-//
-// Internal callers pass false and stay local. They must not revive a tenant an operator
-// deactivated, and they need no leader lookup either: async replication runs on a loop, so a
-// stale local read just skips the tenant this cycle and the next one picks it up.
 func (m *Manager) OptimisticTenantStatus(ctx context.Context, class string, tenant string,
 	allowImplicitActivation bool,
 ) (map[string]string, error) {

--- a/usecases/schema/mock_schema_getter.go
+++ b/usecases/schema/mock_schema_getter.go
@@ -265,9 +265,9 @@ func (_c *MockSchemaGetter_Nodes_Call) RunAndReturn(run func() []string) *MockSc
 	return _c
 }
 
-// OptimisticTenantStatus provides a mock function with given fields: ctx, class, tenants
-func (_m *MockSchemaGetter) OptimisticTenantStatus(ctx context.Context, class string, tenants string) (map[string]string, error) {
-	ret := _m.Called(ctx, class, tenants)
+// OptimisticTenantStatus provides a mock function with given fields: ctx, class, tenants, allowImplicitActivation
+func (_m *MockSchemaGetter) OptimisticTenantStatus(ctx context.Context, class string, tenants string, allowImplicitActivation bool) (map[string]string, error) {
+	ret := _m.Called(ctx, class, tenants, allowImplicitActivation)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OptimisticTenantStatus")
@@ -275,19 +275,19 @@ func (_m *MockSchemaGetter) OptimisticTenantStatus(ctx context.Context, class st
 
 	var r0 map[string]string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (map[string]string, error)); ok {
-		return rf(ctx, class, tenants)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) (map[string]string, error)); ok {
+		return rf(ctx, class, tenants, allowImplicitActivation)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) map[string]string); ok {
-		r0 = rf(ctx, class, tenants)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) map[string]string); ok {
+		r0 = rf(ctx, class, tenants, allowImplicitActivation)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, class, tenants)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, bool) error); ok {
+		r1 = rf(ctx, class, tenants, allowImplicitActivation)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -304,13 +304,14 @@ type MockSchemaGetter_OptimisticTenantStatus_Call struct {
 //   - ctx context.Context
 //   - class string
 //   - tenants string
-func (_e *MockSchemaGetter_Expecter) OptimisticTenantStatus(ctx interface{}, class interface{}, tenants interface{}) *MockSchemaGetter_OptimisticTenantStatus_Call {
-	return &MockSchemaGetter_OptimisticTenantStatus_Call{Call: _e.mock.On("OptimisticTenantStatus", ctx, class, tenants)}
+//   - allowImplicitActivation bool
+func (_e *MockSchemaGetter_Expecter) OptimisticTenantStatus(ctx interface{}, class interface{}, tenants interface{}, allowImplicitActivation interface{}) *MockSchemaGetter_OptimisticTenantStatus_Call {
+	return &MockSchemaGetter_OptimisticTenantStatus_Call{Call: _e.mock.On("OptimisticTenantStatus", ctx, class, tenants, allowImplicitActivation)}
 }
 
-func (_c *MockSchemaGetter_OptimisticTenantStatus_Call) Run(run func(ctx context.Context, class string, tenants string)) *MockSchemaGetter_OptimisticTenantStatus_Call {
+func (_c *MockSchemaGetter_OptimisticTenantStatus_Call) Run(run func(ctx context.Context, class string, tenants string, allowImplicitActivation bool)) *MockSchemaGetter_OptimisticTenantStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(bool))
 	})
 	return _c
 }
@@ -320,7 +321,7 @@ func (_c *MockSchemaGetter_OptimisticTenantStatus_Call) Return(_a0 map[string]st
 	return _c
 }
 
-func (_c *MockSchemaGetter_OptimisticTenantStatus_Call) RunAndReturn(run func(context.Context, string, string) (map[string]string, error)) *MockSchemaGetter_OptimisticTenantStatus_Call {
+func (_c *MockSchemaGetter_OptimisticTenantStatus_Call) RunAndReturn(run func(context.Context, string, string, bool) (map[string]string, error)) *MockSchemaGetter_OptimisticTenantStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/schema/optimistic_tenant_status_test.go
+++ b/usecases/schema/optimistic_tenant_status_test.go
@@ -1,0 +1,193 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// activationSpySM records whether the leader was queried and whether an implicit activation
+// (a RAFT UpdateTenants write) was issued.
+type activationSpySM struct {
+	*fakeSchemaManager
+	leaderStatus map[string]string
+
+	queryCount  int
+	updateCount int
+}
+
+func (a *activationSpySM) QueryTenantsShards(class string, tenants ...string) (map[string]string, uint64, error) {
+	a.queryCount++
+	res := make(map[string]string, len(tenants))
+	for _, t := range tenants {
+		if s, ok := a.leaderStatus[t]; ok {
+			res[t] = s
+		}
+	}
+	return res, 0, nil
+}
+
+func (a *activationSpySM) UpdateTenants(_ context.Context, _ string, _ *command.UpdateTenantsRequest) (uint64, error) {
+	a.updateCount++
+	return 0, nil
+}
+
+// TestOptimisticTenantStatus_ImplicitActivation pins who may activate a tenant.
+//
+// Auto tenant activation encodes a user's intent: a request arrived for this tenant, so make
+// it HOT. The leader fallback therefore activates a COLD tenant, which is right for external
+// requests — reads as well as writes. Internal work carries no such intent, and must not
+// revive a tenant an operator deactivated; with allowImplicitActivation=false it gets the same
+// leader-checked status (so still no false negatives) without the RAFT write.
+func TestOptimisticTenantStatus_ImplicitActivation(t *testing.T) {
+	const (
+		className  = "TestClass"
+		tenantName = "tenant1"
+	)
+
+	for _, tt := range []struct {
+		name string
+
+		// allowActivation is what the caller passes: true for external request paths.
+		allowActivation bool
+
+		localStatus    string // tenant's status in the local schema; "" means absent
+		autoActivation bool   // is auto tenant activation enabled on the collection
+		leaderStatus   string // status the leader reports
+
+		wantStatus      string
+		wantLeaderQuery bool
+		wantActivation  bool
+	}{
+		{
+			// Happy path: local state is trusted, nothing is consulted or written.
+			name:            "external request: HOT locally, no leader lookup, no activation",
+			allowActivation: true,
+			localStatus:     models.TenantActivityStatusHOT,
+			autoActivation:  true,
+			leaderStatus:    models.TenantActivityStatusHOT,
+			wantStatus:      models.TenantActivityStatusHOT,
+			wantLeaderQuery: false,
+			wantActivation:  false,
+		},
+		{
+			// External request semantics: a COLD tenant is activated on access.
+			name:            "external request: COLD tenant is activated",
+			allowActivation: true,
+			localStatus:     models.TenantActivityStatusCOLD,
+			autoActivation:  true,
+			leaderStatus:    models.TenantActivityStatusCOLD,
+			wantStatus:      models.TenantActivityStatusHOT,
+			wantLeaderQuery: true,
+			wantActivation:  true,
+		},
+		{
+			// Without auto tenant activation nothing is activated, even externally.
+			name:            "external request: COLD tenant stays COLD without auto activation",
+			allowActivation: true,
+			localStatus:     models.TenantActivityStatusCOLD,
+			autoActivation:  false,
+			leaderStatus:    models.TenantActivityStatusCOLD,
+			wantStatus:      models.TenantActivityStatusCOLD,
+			wantLeaderQuery: true,
+			wantActivation:  false,
+		},
+		{
+			// The bug this prevents: a background async-replication cycle reaching a COLD
+			// tenant must NOT turn it back on, even with auto activation set.
+			name:            "internal caller: COLD tenant is never activated",
+			localStatus:     models.TenantActivityStatusCOLD,
+			autoActivation:  true,
+			leaderStatus:    models.TenantActivityStatusCOLD,
+			wantStatus:      models.TenantActivityStatusCOLD,
+			wantLeaderQuery: true,
+			wantActivation:  false,
+		},
+		{
+			// ...while still double-checking with the leader, so a tenant that is really HOT is
+			// never reported COLD off a stale local read (no false negatives).
+			name:            "internal caller: still consults the leader, no false negative",
+			localStatus:     models.TenantActivityStatusCOLD,
+			autoActivation:  true,
+			leaderStatus:    models.TenantActivityStatusHOT,
+			wantStatus:      models.TenantActivityStatusHOT,
+			wantLeaderQuery: true,
+			wantActivation:  false,
+		},
+		{
+			name:            "internal caller: HOT locally short-circuits the same way",
+			localStatus:     models.TenantActivityStatusHOT,
+			autoActivation:  true,
+			leaderStatus:    models.TenantActivityStatusHOT,
+			wantStatus:      models.TenantActivityStatusHOT,
+			wantLeaderQuery: false,
+			wantActivation:  false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			class := &models.Class{
+				Class: className,
+				MultiTenancyConfig: &models.MultiTenancyConfig{
+					Enabled:              true,
+					AutoTenantActivation: tt.autoActivation,
+				},
+			}
+
+			state := &sharding.State{Physical: map[string]sharding.Physical{}}
+			if tt.localStatus != "" {
+				state.Physical[tenantName] = sharding.Physical{Name: tenantName, Status: tt.localStatus}
+			}
+
+			// Read serves both the local tenant probe (sharding state) and
+			// AllowImplicitTenantActivation (class config).
+			sr := &fakeSchemaManager{}
+			sr.On("Read", className, mock.Anything).
+				Run(func(args mock.Arguments) {
+					reader := args.Get(1).(func(*models.Class, *sharding.State) error)
+					_ = reader(class, state)
+				}).
+				Return(nil)
+
+			sm := &activationSpySM{
+				fakeSchemaManager: sr,
+				leaderStatus:      map[string]string{tenantName: tt.leaderStatus},
+			}
+
+			m := &Manager{Handler: Handler{schemaManager: sm, schemaReader: sr}}
+
+			status, err := m.OptimisticTenantStatus(context.Background(), className, tenantName, tt.allowActivation)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, status[tenantName], "reported tenant status")
+
+			if tt.wantLeaderQuery {
+				require.Equal(t, 1, sm.queryCount, "leader should have been consulted")
+			} else {
+				require.Zero(t, sm.queryCount, "happy path must not pay for a leader lookup")
+			}
+
+			if tt.wantActivation {
+				require.Equal(t, 1, sm.updateCount, "tenant should have been implicitly activated")
+			} else {
+				require.Zero(t, sm.updateCount,
+					"no implicit activation (RAFT UpdateTenants) may be issued here")
+			}
+		})
+	}
+}

--- a/usecases/schema/optimistic_tenant_status_test.go
+++ b/usecases/schema/optimistic_tenant_status_test.go
@@ -53,9 +53,9 @@ func (a *activationSpySM) UpdateTenants(_ context.Context, _ string, _ *command.
 //
 // Auto tenant activation encodes a user's intent: a request arrived for this tenant, so make
 // it HOT. The leader fallback therefore activates a COLD tenant, which is right for external
-// requests — reads as well as writes. Internal work carries no such intent, and must not
-// revive a tenant an operator deactivated; with allowImplicitActivation=false it gets the same
-// leader-checked status (so still no false negatives) without the RAFT write.
+// requests — reads as well as writes. Internal work carries no such intent: with
+// allowImplicitActivation=false the lookup stays local, so it can neither revive a tenant an
+// operator deactivated nor pay for a leader query on every background cycle.
 func TestOptimisticTenantStatus_ImplicitActivation(t *testing.T) {
 	const (
 		className  = "TestClass"
@@ -111,24 +111,36 @@ func TestOptimisticTenantStatus_ImplicitActivation(t *testing.T) {
 		},
 		{
 			// The bug this prevents: a background async-replication cycle reaching a COLD
-			// tenant must NOT turn it back on, even with auto activation set.
+			// tenant must NOT turn it back on, even with auto activation set. It stays local:
+			// no leader query, and above all no activating RAFT write.
 			name:            "internal caller: COLD tenant is never activated",
 			localStatus:     models.TenantActivityStatusCOLD,
 			autoActivation:  true,
 			leaderStatus:    models.TenantActivityStatusCOLD,
 			wantStatus:      models.TenantActivityStatusCOLD,
-			wantLeaderQuery: true,
+			wantLeaderQuery: false,
 			wantActivation:  false,
 		},
 		{
-			// ...while still double-checking with the leader, so a tenant that is really HOT is
-			// never reported COLD off a stale local read (no false negatives).
-			name:            "internal caller: still consults the leader, no false negative",
+			// A stale local read is fine here even though the leader would say otherwise:
+			// internal work runs on a loop, so it just skips the tenant and the next cycle
+			// picks it up. Cheaper than a leader query per shard per cycle.
+			name:            "internal caller: stale local state is used as-is, no leader query",
 			localStatus:     models.TenantActivityStatusCOLD,
 			autoActivation:  true,
 			leaderStatus:    models.TenantActivityStatusHOT,
-			wantStatus:      models.TenantActivityStatusHOT,
-			wantLeaderQuery: true,
+			wantStatus:      models.TenantActivityStatusCOLD,
+			wantLeaderQuery: false,
+			wantActivation:  false,
+		},
+		{
+			// Tenant not in the local schema at all: reported as absent, still no leader query.
+			name:            "internal caller: unknown tenant is absent, no leader query",
+			localStatus:     "",
+			autoActivation:  true,
+			leaderStatus:    models.TenantActivityStatusHOT,
+			wantStatus:      "",
+			wantLeaderQuery: false,
 			wantActivation:  false,
 		},
 		{

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -224,7 +224,7 @@ func (f *fakeSchemaGetter) TenantsShards(_ context.Context, class string, tenant
 	return res, nil
 }
 
-func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaGetter) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil

--- a/usecases/traverser/hybrid/fakes_for_test.go
+++ b/usecases/traverser/hybrid/fakes_for_test.go
@@ -92,7 +92,7 @@ func (f *fakeSchemaManager) TenantsShards(_ context.Context, class string, tenan
 	return nil, nil
 }
 
-func (f *fakeSchemaManager) OptimisticTenantStatus(_ context.Context, class string, tenant string) (map[string]string, error) {
+func (f *fakeSchemaManager) OptimisticTenantStatus(_ context.Context, class string, tenant string, _ bool) (map[string]string, error) {
 	res := map[string]string{}
 	res[tenant] = models.TenantActivityStatusHOT
 	return res, nil


### PR DESCRIPTION
### What's being changed:
Resolving a multi-tenant collection's replicas requires a tenant status check, and under `autoTenantActivation` that check activates a `COLD` tenant via a RAFT write. Doing it in the router means anyone asking where a tenant's shard lives activates it including async replication. A background hashtree diff on a deactivated tenant would silently turn it back `HOT`, undoing an operator's deactivation and re-consuming its memory and disk.


the fix is only external paths opt in  `index.buildReadRoutingPlan` and the read coordinator's Pull. Writes always activate. they only reach the router on the node serving the request, since replicated writes land on Incoming*, which never consults the `router. finder.go` needs no change: the async replication paths get the safe behaviour from the default.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/29250843757
- [x] e2e : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/29250832959
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
