### PR TITLE
fix(hfresh): never hold version-map locks across LSM operations

### DIFF
--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -60,136 +60,136 @@ var v1 = VectorVersion(0).Increment()
 // VersionMap keeps track of the version of each vector.
 // It uses a combination of an LSMKV store for persistence and an in-memory
 // cache for fast access.
+//
+// Locking is two-tier so that readers never wait on disk:
+//   - locks guards the in-memory pages only; every hold is nanoseconds.
+//     Search scans take it read-side for every candidate, so no LSM
+//     operation is ever performed while holding it.
+//   - persistLocks serializes store writes per vector among writers. Each
+//     persist re-reads the current memory value under the read lock, so the
+//     last persist among racing writers always lands the newest value and
+//     memory and store converge.
 type VersionMap struct {
-	data  *common.GroupedPagedArray[VectorVersion]
-	locks *common.ShardedRWLocks
-	store *VersionStore
+	data         *common.GroupedPagedArray[VectorVersion]
+	locks        *common.ShardedRWLocks
+	persistLocks *common.ShardedLocks
+	store        *VersionStore
 }
 
 func NewVersionMap(bucket *lsmkv.Bucket) *VersionMap {
 	return &VersionMap{
-		data:  common.NewGroupedPagedArray[VectorVersion](16*1024, 64*1024), // 1 billion entries with 64k per page
-		locks: common.NewShardedRWLocks(512),
-		store: NewVersionStore(bucket),
+		data:         common.NewGroupedPagedArray[VectorVersion](16*1024, 64*1024), // 1 billion entries with 64k per page
+		locks:        common.NewShardedRWLocks(512),
+		persistLocks: common.NewShardedLocks(512),
+		store:        NewVersionStore(bucket),
 	}
 }
 
-// Get returns the size of the vector with the given ID.
+// Get returns the version of the vector with the given ID.
 func (v *VersionMap) Get(ctx context.Context, vectorID uint64) (VectorVersion, error) {
 	page, slot := v.data.GetPageFor(vectorID)
-	if page == nil {
-		// not in cache, check store
-		version, err := v.store.Get(ctx, vectorID)
-		if err != nil && !errors.Is(err, ErrVectorNotFound) {
-			return 0, errors.Wrapf(err, "failed to get version for vector %d", vectorID)
-		}
-		if errors.Is(err, ErrVectorNotFound) {
-			version = v1
-		}
-
-		// update cache
-		page, slot := v.data.EnsurePageFor(vectorID)
-		v.locks.Lock(vectorID)
-		page[slot] = version
-		v.locks.Unlock(vectorID)
-
-		return version, nil
-	}
-
-	v.locks.RLock(vectorID)
-	version := page[slot]
-	v.locks.RUnlock(vectorID)
-
-	if version == 0 {
-		v.locks.Lock(vectorID)
-		defer v.locks.Unlock(vectorID)
-
-		// double-check after acquiring the lock
-		version = page[slot]
+	if page != nil {
+		v.locks.RLock(vectorID)
+		version := page[slot]
+		v.locks.RUnlock(vectorID)
 		if version != 0 {
 			return version, nil
 		}
-
-		// not in cache, check store
-		var err error
-		version, err = v.store.Get(ctx, vectorID)
-		if err != nil && !errors.Is(err, ErrVectorNotFound) {
-			return 0, errors.Wrapf(err, "failed to get version for vector %d", vectorID)
-		}
-		if errors.Is(err, ErrVectorNotFound) {
-			version = v1
-		}
-
-		// update cache
-		page[slot] = version
 	}
+
+	return v.loadInto(ctx, vectorID)
+}
+
+// loadInto fetches the version from the store — without holding any lock, so
+// concurrent readers never queue behind an LSM read — and installs it into
+// memory only if no writer beat us to it. The memory value always wins: it is
+// at least as new as anything the store returned before we took the lock.
+func (v *VersionMap) loadInto(ctx context.Context, vectorID uint64) (VectorVersion, error) {
+	loaded, err := v.store.Get(ctx, vectorID)
+	if err != nil && !errors.Is(err, ErrVectorNotFound) {
+		return 0, errors.Wrapf(err, "failed to get version for vector %d", vectorID)
+	}
+	if errors.Is(err, ErrVectorNotFound) {
+		loaded = v1
+	}
+
+	page, slot := v.data.EnsurePageFor(vectorID)
+	v.locks.Lock(vectorID)
+	if page[slot] == 0 {
+		page[slot] = loaded
+	}
+	version := page[slot]
+	v.locks.Unlock(vectorID)
 
 	return version, nil
 }
 
-// Incr increments the version of the vector and returns the new version.
+// persist writes the current in-memory version of the vector to the store.
+// Persists are serialized per vector, and each re-reads memory after
+// acquiring the persist lock, so the last persist among racing writers lands
+// the newest value. The memory lock is never held across the LSM write.
+func (v *VersionMap) persist(ctx context.Context, vectorID uint64, page []VectorVersion, slot int) error {
+	v.persistLocks.Lock(vectorID)
+	defer v.persistLocks.Unlock(vectorID)
+
+	v.locks.RLock(vectorID)
+	cur := page[slot]
+	v.locks.RUnlock(vectorID)
+
+	return v.store.Set(ctx, vectorID, cur)
+}
+
+// Increment increments the version of the vector and returns the new version.
+// It fails with ErrVersionIncrementFailed if the current version does not
+// match previousVersion or the vector is deleted. On a persist error the
+// memory update has already happened; a retry (Get + Increment) re-persists
+// and heals the store.
 func (v *VersionMap) Increment(ctx context.Context, vectorID uint64, previousVersion VectorVersion) (VectorVersion, error) {
-	var err error
-
-	page, slot := v.data.EnsurePageFor(vectorID)
-	v.locks.Lock(vectorID)
-	defer v.locks.Unlock(vectorID)
-
-	old := page[slot]
-	if old == 0 {
-		// not in cache, check store
-		old, err = v.store.Get(ctx, vectorID)
-		if err != nil && !errors.Is(err, ErrVectorNotFound) {
-			return 0, errors.Wrapf(err, "failed to get version for vector %d", vectorID)
-		}
-		if errors.Is(err, ErrVectorNotFound) {
-			old = v1
-		}
+	// ensure the entry is loaded so the CAS below never touches the store
+	if _, err := v.Get(ctx, vectorID); err != nil {
+		return 0, err
 	}
 
+	page, slot := v.data.GetPageFor(vectorID)
+	v.locks.Lock(vectorID)
+	old := page[slot]
 	if old.Deleted() || old != previousVersion {
+		v.locks.Unlock(vectorID)
 		return old, ErrVersionIncrementFailed
 	}
-
 	newVersion := old.Increment()
-	err = v.store.Set(ctx, vectorID, newVersion)
-	if err != nil {
-		return old, err
-	}
 	page[slot] = newVersion
+	v.locks.Unlock(vectorID)
+
+	if err := v.persist(ctx, vectorID, page, slot); err != nil {
+		return newVersion, err
+	}
 	return newVersion, nil
 }
 
+// MarkDeleted sets the tombstone bit for the vector. It always persists, even
+// when the vector is already deleted in memory, so a retry after a failed
+// persist heals a store that missed the tombstone.
 func (v *VersionMap) MarkDeleted(ctx context.Context, vectorID uint64) (VectorVersion, error) {
-	var err error
+	// ensure the entry is loaded so the update below never touches the store
+	if _, err := v.Get(ctx, vectorID); err != nil {
+		return 0, err
+	}
 
-	page, slot := v.data.EnsurePageFor(vectorID)
+	page, slot := v.data.GetPageFor(vectorID)
 	v.locks.Lock(vectorID)
-	defer v.locks.Unlock(vectorID)
-
 	old := page[slot]
-	if old == 0 {
-		// not in cache, check store
-		old, err = v.store.Get(ctx, vectorID)
-		if err != nil && !errors.Is(err, ErrVectorNotFound) {
-			return 0, errors.Wrapf(err, "failed to get version for vector %d", vectorID)
-		}
-		if errors.Is(err, ErrVectorNotFound) {
-			old = v1
-		}
+	newVersion := old
+	if !old.Deleted() {
+		counter := uint8(old) & counterMask // 0-127
+		newVersion = VectorVersion(tombstoneMask | counter)
+		page[slot] = newVersion
 	}
+	v.locks.Unlock(vectorID)
 
-	if old.Deleted() {
-		return old, nil
+	if err := v.persist(ctx, vectorID, page, slot); err != nil {
+		return newVersion, err
 	}
-
-	counter := uint8(old) & counterMask // 0-127
-	newVersion := VectorVersion(tombstoneMask | counter)
-	err = v.store.Set(ctx, vectorID, newVersion)
-	if err != nil {
-		return old, err
-	}
-	page[slot] = newVersion
 
 	return newVersion, nil
 }

--- a/adapters/repos/db/vector/hfresh/version_map_test.go
+++ b/adapters/repos/db/vector/hfresh/version_map_test.go
@@ -12,6 +12,8 @@
 package hfresh
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,6 +28,90 @@ func makeVersionMap(t *testing.T) *VersionMap {
 	bucket, err := NewSharedBucket(store, "test", StoreConfig{MakeBucketOptions: lsmkv.MakeNoopBucketOptions})
 	require.NoError(t, err)
 	return NewVersionMap(bucket)
+}
+
+// MarkDeleted must persist the tombstone even when the vector is already
+// deleted in memory: if a previous persist failed (or was lost), a retry has
+// to heal the store, otherwise the vector resurrects on restart.
+func TestMarkDeletedRepersistsTombstone(t *testing.T) {
+	ctx := t.Context()
+	vm := makeVersionMap(t)
+
+	_, err := vm.MarkDeleted(ctx, 7)
+	require.NoError(t, err)
+
+	// simulate a store that missed the tombstone (failed/lost persist)
+	require.NoError(t, vm.store.Set(ctx, 7, VectorVersion(3)))
+
+	// memory already says deleted — the retry must still persist
+	v, err := vm.MarkDeleted(ctx, 7)
+	require.NoError(t, err)
+	require.True(t, v.Deleted())
+
+	got, err := vm.store.Get(ctx, 7)
+	require.NoError(t, err)
+	require.True(t, got.Deleted(), "tombstone was not re-persisted to the store")
+}
+
+// Concurrent writers and readers must leave memory and store converged: the
+// persist path re-reads memory under a per-id persist lock, so the last
+// persist always lands the newest value. Run with -race.
+func TestVersionMapConcurrentConvergence(t *testing.T) {
+	ctx := context.Background()
+	vm := makeVersionMap(t)
+
+	const numIDs = 32
+	const writersPerID = 4
+	const incrementsPerWriter = 20
+
+	var wg sync.WaitGroup
+	for id := range uint64(numIDs) {
+		for range writersPerID {
+			wg.Go(func() {
+				for range incrementsPerWriter {
+					cur, err := vm.Get(ctx, id)
+					if err != nil {
+						return
+					}
+					if cur.Deleted() {
+						return
+					}
+					_, _ = vm.Increment(ctx, id, cur) // CAS may fail; retried next round
+				}
+			})
+		}
+		// concurrent readers
+		wg.Go(func() {
+			for range 100 {
+				_, _ = vm.IsDeleted(ctx, id)
+			}
+		})
+	}
+	// delete a subset concurrently with the increments
+	for id := range uint64(numIDs) {
+		if id%4 != 0 {
+			continue
+		}
+		wg.Go(func() {
+			_, _ = vm.MarkDeleted(ctx, id)
+		})
+	}
+	wg.Wait()
+
+	// memory and store must agree for every id, and deletes must stick
+	for id := range uint64(numIDs) {
+		page, slot := vm.data.GetPageFor(id)
+		require.NotNil(t, page, "id %d", id)
+		mem := page[slot]
+
+		stored, err := vm.store.Get(ctx, id)
+		require.NoError(t, err, "id %d", id)
+		require.Equal(t, mem, stored, "memory and store diverged for id %d", id)
+
+		if id%4 == 0 {
+			require.True(t, mem.Deleted(), "delete lost for id %d", id)
+		}
+	}
 }
 
 func TestVectorVersion(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Fixes two problems sharing one root cause in HFresh's `VersionMap`: locks were held across LSM operations, and one lock-free window allowed lost updates.

**1. Deleted vectors could resurrect (data-integrity bug).** `Get`'s first-touch path (`page == nil`) read the version store without any lock and installed the result into memory **unconditionally**. A `MarkDeleted` completing in between had its tombstone overwritten in memory by the stale value; subsequent `Increment`s would then CAS against the resurrected version and persist it, wiping the tombstone from the store as well — the deleted vector came back to life. `TestVersionMapConcurrentConvergence` reproduces this against the previous implementation (deletes are lost within a handful of runs under `-race`) and pins the fix.

**2. Search scans stalled behind background reassign writes (lock contention).** `Increment`/`MarkDeleted` held the sharded version-map **write** lock for the duration of an LSM put, including memtable-lock waits behind other writers. Background reassign tasks increment versions constantly, and every search scan takes the same lock read-side once per scanned candidate (thousands per query). Measured on a 1B-vector index: a flat ~600 ms scan penalty per query regardless of `searchProbe`, with goroutine dumps showing scans parked on `RLock` behind `ReassignTask → Increment → Bucket.Put`. After the fix the penalty disappears (scan time dropped ~4× under concurrent background load).

**The fix — two-tier locking:**
- The sharded `RWMutex` guards the in-memory pages only; every hold is nanoseconds and no LSM operation ever happens under it.
- A new per-vector persist lock serializes store writes among writers; each persist re-reads the current memory value after acquiring it, so the last persist among racing writers always lands the newest value — memory and store converge (pinned by the `-race` convergence test).
- Lazy loads read the store unlocked and install only if the slot is still empty (fixes the resurrection window).
- `MarkDeleted` always persists, even when the vector is already deleted in memory, so a retry heals a store that missed its tombstone.

Durability semantics are unchanged: an operation still persists before returning success.

<img width="959" height="703" alt="output" src="https://github.com/user-attachments/assets/56cd0fae-1b38-4665-b0a1-b7f22de40fe6" />

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
