### PR TITLE
fix(generative-google): make class settings optional to avoid sending defaults to Gemini

### DIFF
--- a/modules/generative-google/clients/google.go
+++ b/modules/generative-google/clients/google.go
@@ -281,20 +281,16 @@ func (v *google) getParameters(cfg moduletools.ClassConfig, options interface{},
 		params.Model = model
 	}
 	if params.Temperature == nil {
-		temperature := settings.Temperature()
-		params.Temperature = &temperature
+		params.Temperature = settings.Temperature()
 	}
 	if params.TopP == nil {
-		topP := settings.TopP()
-		params.TopP = &topP
+		params.TopP = settings.TopP()
 	}
 	if params.TopK == nil {
-		topK := settings.TopK()
-		params.TopK = &topK
+		params.TopK = settings.TopK()
 	}
 	if params.MaxTokens == nil {
-		maxTokens := settings.TokenLimit()
-		params.MaxTokens = &maxTokens
+		params.MaxTokens = settings.TokenLimit()
 	}
 
 	params.Images = generative.ParseImageProperties(params.Images, params.ImageProperties, imagePropertiesArray)

--- a/modules/generative-google/clients/google_test.go
+++ b/modules/generative-google/clients/google_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/schema"
 	googleparams "github.com/weaviate/weaviate/modules/generative-google/parameters"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/apikey"
 )
 
@@ -104,6 +106,84 @@ func TestGetAnswer(t *testing.T) {
 		require.NotNil(t, err)
 		assert.EqualError(t, err, "connection to Google failed with status: 500 error: some error from the server")
 	})
+}
+
+func TestGetParameters(t *testing.T) {
+	c := &google{logger: nullLogger()}
+
+	t.Run("leaves generation params nil when class config does not set them", func(t *testing.T) {
+		cfg := fakeClassConfig{classConfig: map[string]interface{}{
+			"projectId": "cloud-project",
+		}}
+
+		params := c.getParameters(cfg, nil, nil)
+
+		assert.Nil(t, params.Temperature)
+		assert.Nil(t, params.TopP)
+		assert.Nil(t, params.TopK)
+		assert.Nil(t, params.MaxTokens)
+
+		// the nil params must be omitted from the request body sent to Google
+		body, err := json.Marshal(c.getPayload(false, "prompt", params))
+		require.NoError(t, err)
+		assert.NotContains(t, string(body), "temperature")
+		assert.NotContains(t, string(body), "topP")
+		assert.NotContains(t, string(body), "topK")
+		assert.NotContains(t, string(body), "maxOutputTokens")
+	})
+
+	t.Run("uses generation params from class config when set", func(t *testing.T) {
+		cfg := fakeClassConfig{classConfig: map[string]interface{}{
+			"projectId":   "cloud-project",
+			"temperature": 0.25,
+			"topP":        0.97,
+			"topK":        30,
+			"tokenLimit":  254,
+		}}
+
+		params := c.getParameters(cfg, nil, nil)
+
+		require.NotNil(t, params.Temperature)
+		require.NotNil(t, params.TopP)
+		require.NotNil(t, params.TopK)
+		require.NotNil(t, params.MaxTokens)
+		assert.Equal(t, 0.25, *params.Temperature)
+		assert.Equal(t, 0.97, *params.TopP)
+		assert.Equal(t, 30, *params.TopK)
+		assert.Equal(t, 254, *params.MaxTokens)
+	})
+}
+
+type fakeClassConfig struct {
+	classConfig map[string]interface{}
+}
+
+func (f fakeClassConfig) Class() map[string]interface{} {
+	return f.classConfig
+}
+
+func (f fakeClassConfig) Tenant() string {
+	return ""
+}
+
+func (f fakeClassConfig) ClassByModuleName(moduleName string) map[string]interface{} {
+	return f.classConfig
+}
+
+func (f fakeClassConfig) Property(propName string) map[string]interface{} {
+	return nil
+}
+
+func (f fakeClassConfig) TargetVector() string {
+	return ""
+}
+
+func (f fakeClassConfig) PropertiesDataTypes() map[string]schema.DataType {
+	return nil
+}
+
+func (f fakeClassConfig) Config() *config.Config {
+	return nil
 }
 
 type testAnswerHandler struct {

--- a/modules/generative-google/config/class_settings.go
+++ b/modules/generative-google/config/class_settings.go
@@ -40,13 +40,10 @@ var (
 	DefaultGoogleModel                = "chat-bison"
 	DefaultGoogleRegion               = "us-central1"
 	DefaultGoogleLocation             = "us-central1"
-	DefaultGoogleTemperature          = 1.0
 	DefaultTokenLimit                 = 1024
 	DefaultTokenLimitGemini1_0        = 2048
 	DefaultTokenLimitGemini1_0_Vision = 2048
 	DefaultTokenLimitGemini1_5        = 8192
-	DefaultGoogleTopP                 = 0.95
-	DefaultGoogleTopK                 = 40
 	DefaulGenerativeAIApiEndpoint     = "generativelanguage.googleapis.com"
 	DefaulGenerativeAIModelID         = "chat-bison-001"
 )
@@ -64,13 +61,13 @@ type ClassSettings interface {
 	Model() string
 	// parameters
 	// 0.0 - 1.0
-	Temperature() float64
+	Temperature() *float64
 	// 1 - 1024 / 2048 Gemini 1.0 / 8192 Gemini 1.5
-	TokenLimit() int
+	TokenLimit() *int
 	// 1 -
-	TopK() int
+	TopK() *int
 	// 0.0 - 1.0
-	TopP() float64
+	TopP() *float64
 }
 
 type classSettings struct {
@@ -98,20 +95,16 @@ func (ic *classSettings) Validate(class *models.Class) error {
 	if apiEndpoint != DefaulGenerativeAIApiEndpoint && projectID == "" {
 		errorMessages = append(errorMessages, fmt.Sprintf("%s cannot be empty", projectIDProperty))
 	}
-	temperature := ic.Temperature()
-	if temperature < 0 || temperature > 1 {
+	if temperature := ic.Temperature(); temperature != nil && (*temperature < 0 || *temperature > 1) {
 		errorMessages = append(errorMessages, fmt.Sprintf("%s has to be float value between 0 and 1", temperatureProperty))
 	}
-	tokenLimit := ic.TokenLimit()
-	if tokenLimit < 1 || tokenLimit > ic.getDefaultTokenLimit(ic.ModelID()) {
-		errorMessages = append(errorMessages, fmt.Sprintf("%s has to be an integer value between 1 and %v", tokenLimitProperty, ic.getDefaultTokenLimit(ic.ModelID())))
+	if tokenLimit := ic.TokenLimit(); tokenLimit != nil && (*tokenLimit < 1 || *tokenLimit > ic.getDefaultTokenLimit(ic.getModel())) {
+		errorMessages = append(errorMessages, fmt.Sprintf("%s has to be an integer value between 1 and %v", tokenLimitProperty, ic.getDefaultTokenLimit(ic.getModel())))
 	}
-	topK := ic.TopK()
-	if topK < 1 {
+	if topK := ic.TopK(); topK != nil && *topK < 1 {
 		errorMessages = append(errorMessages, fmt.Sprintf("%s has to be an integer value above or equal 1", topKProperty))
 	}
-	topP := ic.TopP()
-	if topP < 0 || topP > 1 {
+	if topP := ic.TopP(); topP != nil && (*topP < 0 || *topP > 1) {
 		errorMessages = append(errorMessages, fmt.Sprintf("%s has to be float value between 0 and 1", topPProperty))
 	}
 	if len(errorMessages) > 0 {
@@ -125,14 +118,17 @@ func (ic *classSettings) getStringProperty(name, defaultValue string) string {
 	return ic.propertyValuesHelper.GetPropertyAsString(ic.cfg, name, defaultValue)
 }
 
-func (ic *classSettings) getFloatProperty(name string, defaultValue float64) float64 {
-	asFloat64 := ic.propertyValuesHelper.GetPropertyAsFloat64(ic.cfg, name, &defaultValue)
-	return *asFloat64
+// getOptionalFloatProperty returns nil when the property is not set, so that no
+// default is sent to the provider. wrongVal is an out-of-range sentinel returned
+// when the property is present but has an invalid (non-numeric) type, so that
+// Validate rejects it instead of silently skipping validation.
+func (ic *classSettings) getOptionalFloatProperty(name string, wrongVal float64) *float64 {
+	return ic.propertyValuesHelper.GetPropertyAsFloat64WithNotExists(ic.cfg, name, &wrongVal, nil)
 }
 
-func (ic *classSettings) getIntProperty(name string, defaultValue int) int {
-	asInt := ic.propertyValuesHelper.GetPropertyAsInt(ic.cfg, name, &defaultValue)
-	return *asInt
+// getOptionalIntProperty behaves like getOptionalFloatProperty for integer properties.
+func (ic *classSettings) getOptionalIntProperty(name string, wrongVal int) *int {
+	return ic.propertyValuesHelper.GetPropertyAsIntWithNotExists(ic.cfg, name, &wrongVal, nil)
 }
 
 func (ic *classSettings) getApiEndpoint(projectID string) string {
@@ -183,6 +179,15 @@ func (ic *classSettings) Model() string {
 	return ic.getStringProperty(modelProperty, "")
 }
 
+// getModel returns the model that will actually be used for a request: Model()
+// takes precedence over ModelID(), matching the client's request-building logic.
+func (ic *classSettings) getModel() string {
+	if model := ic.Model(); model != "" {
+		return model
+	}
+	return ic.ModelID()
+}
+
 func (ic *classSettings) Region() string {
 	return ic.getStringProperty(regionProperty, DefaultGoogleRegion)
 }
@@ -194,21 +199,21 @@ func (ic *classSettings) Location() string {
 // parameters
 
 // 0.0 - 1.0
-func (ic *classSettings) Temperature() float64 {
-	return ic.getFloatProperty(temperatureProperty, DefaultGoogleTemperature)
+func (ic *classSettings) Temperature() *float64 {
+	return ic.getOptionalFloatProperty(temperatureProperty, -1.0)
 }
 
 // 1 - 1024
-func (ic *classSettings) TokenLimit() int {
-	return ic.getIntProperty(tokenLimitProperty, ic.getDefaultTokenLimit(ic.ModelID()))
+func (ic *classSettings) TokenLimit() *int {
+	return ic.getOptionalIntProperty(tokenLimitProperty, 0)
 }
 
 // 1 - 40
-func (ic *classSettings) TopK() int {
-	return ic.getIntProperty(topKProperty, DefaultGoogleTopK)
+func (ic *classSettings) TopK() *int {
+	return ic.getOptionalIntProperty(topKProperty, 0)
 }
 
 // 0.0 - 1.0
-func (ic *classSettings) TopP() float64 {
-	return ic.getFloatProperty(topPProperty, DefaultGoogleTopP)
+func (ic *classSettings) TopP() *float64 {
+	return ic.getOptionalFloatProperty(topPProperty, -1.0)
 }

--- a/modules/generative-google/config/class_settings_test.go
+++ b/modules/generative-google/config/class_settings_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func Test_classSettings_Validate(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -30,10 +34,10 @@ func Test_classSettings_Validate(t *testing.T) {
 		wantProjectID   string
 		wantModelID     string
 		wantModel       string
-		wantTemperature float64
-		wantTokenLimit  int
-		wantTopK        int
-		wantTopP        float64
+		wantTemperature *float64
+		wantTokenLimit  *int
+		wantTopK        *int
+		wantTopP        *float64
 		wantErr         error
 	}{
 		{
@@ -45,10 +49,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantProjectID:   "",
 			wantModelID:     "chat-bison-001",
 			wantModel:       "",
-			wantTemperature: 1.0,
-			wantTokenLimit:  1024,
-			wantTopK:        40,
-			wantTopP:        0.95,
 			wantErr:         nil,
 		},
 		{
@@ -61,10 +61,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "us-central1-aiplatform.googleapis.com",
 			wantProjectID:   "projectId",
 			wantModelID:     "chat-bison",
-			wantTemperature: 1.0,
-			wantTokenLimit:  1024,
-			wantTopK:        40,
-			wantTopP:        0.95,
 			wantErr:         nil,
 		},
 		{
@@ -83,10 +79,10 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "google.com",
 			wantProjectID:   "cloud-project",
 			wantModelID:     "model-id",
-			wantTemperature: 0.25,
-			wantTokenLimit:  254,
-			wantTopK:        30,
-			wantTopP:        0.97,
+			wantTemperature: ptr(0.25),
+			wantTokenLimit:  ptr(254),
+			wantTopK:        ptr(30),
+			wantTopP:        ptr(0.97),
 			wantErr:         nil,
 		},
 		{
@@ -120,6 +116,42 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantErr: errors.Errorf("topP has to be float value between 0 and 1"),
 		},
 		{
+			name: "wrong temperature type",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"projectId":   "cloud-project",
+					"temperature": true,
+				},
+			},
+			wantErr: errors.Errorf("temperature has to be float value between 0 and 1"),
+		},
+		{
+			name: "wrong tokenLimit type",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"projectId":  "cloud-project",
+					"tokenLimit": true,
+				},
+			},
+			wantErr: errors.Errorf("tokenLimit has to be an integer value between 1 and 1024"),
+		},
+		{
+			name: "tokenLimit validated against effective model",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"projectId":  "cloud-project",
+					"model":      "gemini-1.5-pro",
+					"tokenLimit": 5000,
+				},
+			},
+			wantApiEndpoint: "us-central1-aiplatform.googleapis.com",
+			wantProjectID:   "cloud-project",
+			wantModelID:     "chat-bison",
+			wantModel:       "gemini-1.5-pro",
+			wantTokenLimit:  ptr(5000),
+			wantErr:         nil,
+		},
+		{
 			name: "wrong all",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
@@ -143,10 +175,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "generativelanguage.googleapis.com",
 			wantProjectID:   "",
 			wantModelID:     "chat-bison-001",
-			wantTemperature: 1.0,
-			wantTokenLimit:  1024,
-			wantTopK:        40,
-			wantTopP:        0.95,
 			wantErr:         nil,
 		},
 		{
@@ -160,10 +188,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "generativelanguage.googleapis.com",
 			wantProjectID:   "",
 			wantModelID:     "chat-bison-001",
-			wantTemperature: 1.0,
-			wantTokenLimit:  1024,
-			wantTopK:        40,
-			wantTopP:        0.95,
 			wantErr:         nil,
 		},
 		{
@@ -177,10 +201,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantApiEndpoint: "generativelanguage.googleapis.com",
 			wantProjectID:   "",
 			wantModelID:     "gemini-ultra",
-			wantTemperature: 1.0,
-			wantTokenLimit:  1024,
-			wantTopK:        40,
-			wantTopP:        0.95,
 			wantErr:         nil,
 		},
 	}


### PR DESCRIPTION
### What's being changed:

This PR makes generative-google module settings optional

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
