### PR TITLE
feat(raft): warn when a schema apply stalls the FSM loop

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -921,14 +922,47 @@ func (op applyOp) validate() error {
 	return nil
 }
 
+const slowApplyThreshold = 5 * time.Second
+
+func humanizeDuration(d time.Duration) string {
+	switch {
+	case d < time.Second:
+		return d.Round(time.Millisecond).String()
+	case d < time.Minute:
+		return d.Round(10 * time.Millisecond).String()
+	default:
+		return d.Round(time.Second).String()
+	}
+}
+
 // apply does apply commands from RAFT to schema 1st and then db
 func (s *SchemaManager) apply(op applyOp) error {
 	if err := op.validate(); err != nil {
 		return fmt.Errorf("could not validate raft apply op: %w", err)
 	}
 
+	begin := time.Now()
+	var schemaTook, callbackTook, storeTook time.Duration
+	defer func() {
+		total := time.Since(begin)
+		if total < slowApplyThreshold || s.log == nil {
+			return
+		}
+		s.log.WithFields(logrus.Fields{
+			"action":        "raft_apply_time",
+			"op":            op.op,
+			"took":          humanizeDuration(total),
+			"schema_took":   humanizeDuration(schemaTook),
+			"callback_took": humanizeDuration(callbackTook),
+			"store_took":    humanizeDuration(storeTook),
+		}).Warnf("raft apply held the apply loop for %s; commands queued behind it are delayed",
+			humanizeDuration(total))
+	}()
+
 	// schema applied 1st to make sure any validation happen before applying it to db
+	schemaBegin := time.Now()
 	schemaErr := op.updateSchema()
+	schemaTook = time.Since(schemaBegin)
 	if schemaErr != nil {
 		var partialErr *PartialUpdateError
 		if !op.allowPartialSchemaErr || !errors.As(schemaErr, &partialErr) {
@@ -939,11 +973,16 @@ func (s *SchemaManager) apply(op applyOp) error {
 	if op.enableSchemaCallback && s.db != nil {
 		// TriggerSchemaUpdateCallbacks is concurrent and at
 		// this point of time schema shall be up to date.
+		callbackBegin := time.Now()
 		s.db.TriggerSchemaUpdateCallbacks()
+		callbackTook = time.Since(callbackBegin)
 	}
 
 	if !op.schemaOnly {
-		if err := op.updateStore(); err != nil {
+		storeBegin := time.Now()
+		err := op.updateStore()
+		storeTook = time.Since(storeBegin)
+		if err != nil {
 			if schemaErr != nil {
 				// Both the schema update (partial) and the DB update failed.
 				// Return both so the caller is informed of what was skipped

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -922,7 +922,7 @@ func (op applyOp) validate() error {
 	return nil
 }
 
-const slowApplyThreshold = 5 * time.Second
+const slowApplyThreshold = 10 * time.Second
 
 func humanizeDuration(d time.Duration) string {
 	switch {


### PR DESCRIPTION
### What's being changed:
Schema applies run on RAFT's single FSM goroutine, so one slow command (due lock contentions) delays every command behind it and every request waiting to observe schema version.

this PR adds warn log as trace to catch those cases 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
