### PR TITLE
perf(async-repl): cut digest-scan allocations & IO, reduce default scheduler workers

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	defaultAsyncReplicationSchedulerWorkers        = 10
+	defaultAsyncReplicationSchedulerWorkers        = 1
 	defaultAsyncReplicationHashtreeInitConcurrency = 100
 	maxMaxWorkers                                  = 100
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_digest_pool_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_digest_pool_test.go
@@ -1,0 +1,114 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// pread + fully flushed is the only path that pools a per-segment reader.
+func preadDigestBucket(t *testing.T, ctx context.Context) *Bucket {
+	t.Helper()
+	b := newReusableTestBucket(t, ctx, WithPread(true), WithMinMMapSize(0))
+	seedDigestBucket(t, b, true)
+	return b
+}
+
+// Recycled readers must never bleed stale bytes: every reopen returns the same sequence.
+func TestDigestCursorReaderPoolReuseAcrossOpens(t *testing.T) {
+	ctx := context.Background()
+	const prefix = 8
+	b := preadDigestBucket(t, ctx)
+	defer b.Shutdown(ctx)
+
+	baseline := drainCursor(b.CursorReplaceDigestReusable(prefix))
+	require.NotEmpty(t, baseline)
+
+	for i := 0; i < 200; i++ {
+		require.Equal(t, baseline, drainCursor(b.CursorReplaceDigestReusable(prefix)), "First/Next iteration %d", i)
+	}
+
+	for _, target := range []string{"", "key-000", "key-045", "key-089", "key-999"} {
+		want := drainSeek(b.CursorReplaceDigestReusable(prefix), []byte(target))
+		for i := 0; i < 50; i++ {
+			require.Equal(t, want, drainSeek(b.CursorReplaceDigestReusable(prefix), []byte(target)), "Seek(%q) iteration %d", target, i)
+		}
+	}
+}
+
+// Concurrent cursors sharing the pool must each get an isolated reader.
+func TestDigestCursorReaderPoolConcurrentCursors(t *testing.T) {
+	ctx := context.Background()
+	const prefix = 8
+	b := preadDigestBucket(t, ctx)
+	defer b.Shutdown(ctx)
+
+	baseline := drainCursor(b.CursorReplaceDigestReusable(prefix))
+	require.NotEmpty(t, baseline)
+
+	const workers = 16
+	const iters = 30
+	var wg sync.WaitGroup
+	mismatches := make(chan []string, workers*iters)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if got := drainCursor(b.CursorReplaceDigestReusable(prefix)); !digestSeqEqual(got, baseline) {
+					mismatches <- got
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(mismatches)
+
+	for got := range mismatches {
+		require.Equal(t, baseline, got, "concurrent cursor returned a corrupted/mismatched sequence")
+	}
+}
+
+// Mirrors the async-rep RPC pattern (open→short scan→close); -benchmem shows the pooled-reader saving.
+func BenchmarkDigestCursorOpenScan(b *testing.B) {
+	ctx := context.Background()
+	bkt := newReusableTestBucket(b, ctx, WithPread(true), WithMinMMapSize(0))
+	defer bkt.Shutdown(ctx)
+	seedDigestBucket(b, bkt, true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := bkt.CursorReplaceDigestReusable(8)
+		for k, _ := c.Seek([]byte("key-020")); k != nil && string(k) <= "key-060"; k, _ = c.Next() {
+		}
+		c.Close()
+	}
+}
+
+func digestSeqEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_digest_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_digest_test.go
@@ -87,7 +87,7 @@ func digestCursorModes() []struct {
 }
 
 // seedDigestBucket writes multi-segment data with overlaps and tombstones; flushLast drains the last batch so nothing is served from the live memtable.
-func seedDigestBucket(t *testing.T, b *Bucket, flushLast bool) {
+func seedDigestBucket(t testing.TB, b *Bucket, flushLast bool) {
 	t.Helper()
 	val := func(tag string, i int) []byte {
 		return []byte(fmt.Sprintf("%s-value-%03d-paddingpadding", tag, i))

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_reusable_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_reusable_test.go
@@ -107,7 +107,7 @@ func drainSeek(c *CursorReplace, target []byte) []string {
 	return out
 }
 
-func newReusableTestBucket(t *testing.T, ctx context.Context, opts ...BucketOption) *Bucket {
+func newReusableTestBucket(t testing.TB, ctx context.Context, opts ...BucketOption) *Bucket {
 	t.Helper()
 	dir := t.TempDir()
 	o := append([]BucketOption{WithStrategy(StrategyReplace)}, opts...)

--- a/adapters/repos/db/lsmkv/cursor_segment_reader_pool_test.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_reader_pool_test.go
@@ -1,0 +1,34 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Reuse is non-deterministic (sync.Pool); assert only the release contract here.
+func TestSegmentCursorReaderReleaseContract(t *testing.T) {
+	c := &segmentCursorReplaceReusable{
+		preadReader: acquireSegmentCursorReader(bytes.NewReader(nil)),
+		preadOffset: &offsetReader{},
+	}
+	require.NotNil(t, c.preadReader)
+
+	c.releaseReader()
+	require.Nil(t, c.preadReader, "releaseReader must clear the reader")
+	require.Nil(t, c.preadOffset)
+
+	require.NotPanics(t, c.releaseReader, "releaseReader must be idempotent (no double-Put)")
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -14,10 +14,28 @@ package lsmkv
 import (
 	"bufio"
 	"errors"
+	"io"
+	"sync"
 
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/usecases/byteops"
 )
+
+// segmentCursorReaderBufSize matches bufio.NewReader's default so pooled readers
+// behave byte-for-byte like the previous bufio.NewReader(or) call.
+const segmentCursorReaderBufSize = 4096
+
+// segmentCursorReaderPool recycles reusable-cursor read buffers (one per segment
+// per digest RPC), previously the largest allocation source in async-rep scans.
+var segmentCursorReaderPool = sync.Pool{
+	New: func() any { return bufio.NewReaderSize(nil, segmentCursorReaderBufSize) },
+}
+
+func acquireSegmentCursorReader(r io.Reader) *bufio.Reader {
+	br := segmentCursorReaderPool.Get().(*bufio.Reader)
+	br.Reset(r)
+	return br
+}
 
 // offsetReader adapts an io.ReaderAt into a sequential io.Reader by tracking
 // the current read position. Used by segmentCursorReplaceReusable to avoid
@@ -326,9 +344,21 @@ func (s *segment) newReplaceCursorReusableWithPrefix(valuePrefixLen int) *segmen
 	if !s.readFromMemory && s.contentFile != nil {
 		or := &offsetReader{ra: s.contentFile}
 		c.preadOffset = or
-		c.preadReader = bufio.NewReader(or)
+		c.preadReader = acquireSegmentCursorReader(or)
 	}
 	return c
+}
+
+// releaseReader pools the read buffer (no-op for mmap cursors, idempotent). Call
+// only once the cursor is done (at Close), never mid-scan — it's reused at once.
+func (s *segmentCursorReplaceReusable) releaseReader() {
+	if s.preadReader == nil {
+		return
+	}
+	s.preadReader.Reset(nil) // drop the segment reference before the buffer is reused
+	segmentCursorReaderPool.Put(s.preadReader)
+	s.preadReader = nil
+	s.preadOffset = nil
 }
 
 func (s *segmentCursorReplaceReusable) keyCount() int {
@@ -441,13 +471,22 @@ func (sg *SegmentGroup) newReusableCursorsWithPrefix(valuePrefixLen int) ([]inne
 	segments, release := sg.getConsistentViewOfSegments()
 
 	out := make([]innerCursorReplace, len(segments))
+	reusables := make([]*segmentCursorReplaceReusable, len(segments))
 	for i, segment := range segments {
+		var c *segmentCursorReplaceReusable
 		if valuePrefixLen > 0 {
-			out[i] = &reusableInnerCursorReplace{c: segment.newReplaceCursorDigestReusable(valuePrefixLen)}
+			c = segment.newReplaceCursorDigestReusable(valuePrefixLen)
 		} else {
-			out[i] = &reusableInnerCursorReplace{c: segment.newReplaceCursorReusable()}
+			c = segment.newReplaceCursorReusable()
 		}
+		out[i] = &reusableInnerCursorReplace{c: c}
+		reusables[i] = c
 	}
 
-	return out, release
+	return out, func() {
+		for _, c := range reusables {
+			c.releaseReader()
+		}
+		release()
+	}
 }

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -382,6 +382,11 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 		c := newCompactorReplace(f, left.newReplaceCursorReusable(), right.newReplaceCursorReusable(),
 			level, secondaryIndices, cleanupTombstones,
 			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
+		// recycle the cursor read buffers on every exit, including a panic in do()
+		defer func() {
+			c.c1.releaseReader()
+			c.c2.releaseReader()
+		}()
 
 		aborted, err := runCompactor(c.do)
 		if err != nil {

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -37,6 +37,7 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	entreplication "github.com/weaviate/weaviate/entities/replication"
+	"github.com/weaviate/weaviate/entities/storobj"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -1851,7 +1852,8 @@ func (s *Shard) collectObjectsToPropagate(
 	localUpdateTimeByUUID = make(map[strfmt.UUID]int64, config.propagationLimit)
 	remoteStaleUpdateTimeByUUID = make(map[strfmt.UUID]int64, config.propagationLimit)
 
-	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceReusable()
+	// Digest mode: this scan reads only headers; full objects are fetched later.
+	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceDigestReusable(storobj.MarshallerV1HeaderLen)
 	defer cursor.Close()
 
 	scratch := newPropagationScratch(config.diffBatchSize)

--- a/test/acceptance/replication/async_replication/async_replication_runtime_toggle_test.go
+++ b/test/acceptance/replication/async_replication/async_replication_runtime_toggle_test.go
@@ -245,12 +245,28 @@ func TestAsyncReplicationRuntimeToggle_EnableDisableEnable(t *testing.T) {
 	})
 
 	t.Run("async replication is registered on every shard at boot", func(t *testing.T) {
+		// Gate on a healthy cluster and allow >1 hashbeat frequency (30s): a first cycle before peers are reachable errors and only repopulates asyncReplicationStatus a full frequency later.
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().
+				WithClassName(paragraphClass.Class).WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			shards := 0
+			for _, node := range body.Payload.Nodes {
+				require.NotNil(ct, node.Status)
+				require.Equal(ct, "HEALTHY", *node.Status)
+				shards += len(node.Shards)
+			}
+			require.Greater(ct, shards, 0, "class shards not reported yet")
+
 			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
 			require.NoError(ct, err)
 			require.Greater(ct, n, 0,
 				"asyncReplicationStatus must be populated on at least one shard at boot")
-		}, 30*time.Second, 500*time.Millisecond)
+		}, 90*time.Second, 1*time.Second)
 	})
 
 	t.Run("admin disables async replication via the runtime-overrides file", func(t *testing.T) {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1877,7 +1877,7 @@ const (
 	DefaultGRPCIdleConnTimeout                 = 5 * time.Minute
 	DefaultMinimumReplicationFactor            = 1
 	DefaultMaximumReplicationFactor            = 0 // 0 / negative = no cap
-	DefaultAsyncReplicationSchedulerWorkers    = 3
+	DefaultAsyncReplicationSchedulerWorkers    = 1
 	// MaxAsyncReplicationSchedulerWorkers is the hard ceiling on the worker
 	// pool size. The scheduler's internal channel buffers (workCh, resultCh,
 	// scaleDownCh) are all sized relative to this value; exceeding it requires


### PR DESCRIPTION
## Motivation

Async replication's hashbeat scans (both the source-side scan and the RPC-serving digest handlers) dominate allocation and disk I/O in multi-tenant deployments. Profiling a multi-tenant simulator showed `bufio.NewReaderSize` as the single largest byte-allocation source (~52% of all bytes allocated). This PR reduces async-replication resource usage in three independent, low-risk steps.

## Changes

### 1. Pool reusable replace-cursor read buffers

Digest scans open a **fresh replace cursor per RPC** (`ObjectDigestsInRange`, `CompareDigests`, root pre-filter batches). Each open allocates one 4 KB `bufio.Reader` **per on-disk segment** on the pread path — pure churn, discarded the moment the short scan finishes.

Recycle those readers through a package-level `sync.Pool`. Reusable/digest cursors acquire a reader from the pool when built on the pread path and return it when the cursor is done — on `Close` (via the existing `unlock`/release func) and after compaction (`defer`, so a panic in `do()` still returns them). `sync.Pool` matches the transient, concurrent, per-RPC lifecycle better than a persisted per-segment reader.

**Why it's safe:** parsed keys/values never alias the pooled buffer — the pread parsers `ReadFull` node bytes into the reusable node's own buffers, so nothing the caller sees points back into the `bufio.Reader`. On release, `Reset(nil)` drops the segment reference so an idle pooled reader pins no segment memory. mmap cursors are untouched (they read from mapped memory and never allocated a reader).

### 2. Scan hashbeat digests with the digest cursor

The source-side hashbeat scan (`objectsToPropagateWithinRange`) opened the **full** `CursorReplaceReusable`, but only reads each object's 42-byte header via `collectObjectDigests` — full objects are fetched separately later in `buildPropagationBatch`. Switch it to `CursorReplaceDigestReusable(storobj.MarshallerV1HeaderLen)` so this scan stops copying full (vector-sized) values off disk, matching the RPC-serving digest sites. Behavior-preserving: only headers were ever read.

### 3. Reduce the default async-replication scheduler workers to 1

The effective default worker-pool size was 3 (set in `usecases/config` when `ASYNC_REPLICATION_SCHEDULER_WORKERS` is unset). Lower it to 1, and align the scheduler's nil-config fallback (was a separate value) to match so the default is unambiguous. Configurable via the env var as before.

## Risks and mitigations

- **Stale-buffer bleed-through / cross-cursor aliasing** (would silently corrupt digests → false async-rep divergence): parsers `ReadFull` into the reusable node's buffers, never retaining the pooled buffer; `Reset(nil)` on release. Covered by `TestDigestCursorReaderPoolReuseAcrossOpens` (200 reopens must return the identical sequence) and `TestDigestCursorReaderPoolConcurrentCursors` (16 concurrent cursors, each isolated).
- **Use-after-return-to-pool**: `releaseReader` runs only at Close / end-of-compaction, never mid-scan.
- **Idle pooled reader pinning a segment**: `Reset(nil)` before `Put`.
- **Reader never returned if a caller forgets `Close`**: no new leak surface — the cursor already required `Close` to unlock the segment group; a lost pooled entry is benign (GC reclaims it).
- **Digest-cursor switch (change 2)**: only headers were ever consumed, so results are identical; covered by the existing `TestObjectsToPropagateWithinRange` / `TestPropagateObjects` / `TestShardCompareDigests` suite.
- **Fewer default workers (change 3)**: reduces default hashbeat concurrency; unchanged for anyone setting `ASYNC_REPLICATION_SCHEDULER_WORKERS` explicitly. No test pinned the old default.

## Testing

- `TestSegmentCursorReaderReleaseContract` (unit) — the release contract: fields cleared, idempotent (no double-`Put`). Reader **reuse** itself is a `sync.Pool` performance property (no deterministic same-object guarantee), proven by the benchmark rather than asserted in a unit test.
- `TestDigestCursorReaderPoolReuseAcrossOpens` / `...ConcurrentCursors` (integration, pread) — correctness under repeated reuse and concurrency.
- `BenchmarkDigestCursorOpenScan` (3-segment pread bucket, mirrors the RPC open→short-scan→close): **17138 → 4478 B/op (~74% fewer)** per open+scan.
- Async-rep scan/propagation suite (`-race`) green for the digest-cursor switch.

No on-disk format or API changes.
