### PR TITLE
fix(async-repl): goroutine leak on tenant shutdown — settle Done()s owed by queued scheduler batches

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -83,6 +83,21 @@ type asyncSchedulerEntry struct {
 	// is pushed onto the heap. Entries with the same nextRunAt are served in
 	// the order they were enqueued (FIFO within a tie).
 	seq uint64
+	// true while a dispatch's asyncRepWg.Add(1) awaits its Done(); the CAS winner
+	// owns it. Assumes at most one outstanding dispatch per entry.
+	pendingDone atomic.Bool
+}
+
+// tryOwnDone takes ownership of the pending Done(); false when already owned.
+func (e *asyncSchedulerEntry) tryOwnDone() bool {
+	return e.pendingDone.CompareAndSwap(true, false)
+}
+
+// settleDone settles the pending Done() unless a worker already owns the cycle.
+func (e *asyncSchedulerEntry) settleDone() {
+	if e.tryOwnDone() {
+		e.shard.asyncRepWg.Done()
+	}
 }
 
 // asyncSchedulerHeap is a min-heap ordered by nextRunAt with FIFO tie-breaking
@@ -772,7 +787,7 @@ func (sched *AsyncReplicationScheduler) dispatcher() {
 	defer timer.Stop()
 	// Sole drain mechanism for workCh. Workers exit promptly on ctx.Done()
 	// without competing for items; the dispatcher is the only producer so
-	// anything left here on exit gets its Add(1) balanced by Done().
+	// anything left here on exit gets its still-pending Add(1) settled by Done().
 	defer sched.drainWorkChOnExit()
 
 	resetTimer := func() {
@@ -876,7 +891,7 @@ func (sched *AsyncReplicationScheduler) effectiveBatchSize() int {
 // could not be dispatched, re-queuing it with a fresh seq. mu must be held.
 func (sched *AsyncReplicationScheduler) rollbackReservedLocked(entry *asyncSchedulerEntry) {
 	entry.inFlight = false
-	entry.shard.asyncRepWg.Done()
+	entry.settleDone()
 	entry.seq = sched.nextSeq
 	sched.nextSeq++
 	heap.Push(&sched.h, entry)
@@ -935,6 +950,7 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 			// Diverging shard: ship as a standalone singleton so its descent runs on
 			// any free worker. Clear descendDirect only on a successful send.
 			entry.shard.asyncRepWg.Add(1)
+			entry.pendingDone.Store(true)
 			entry.inFlight = true
 			heap.Pop(&sched.h)
 			if sched.trySendBatchLocked([]*asyncSchedulerEntry{entry}) {
@@ -950,6 +966,7 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 
 		// Add(1) before send so Deregister+asyncRepWg.Wait() catches the cycle; pop to advance.
 		entry.shard.asyncRepWg.Add(1)
+		entry.pendingDone.Store(true)
 		entry.inFlight = true
 		heap.Pop(&sched.h)
 
@@ -1067,9 +1084,9 @@ func (sched *AsyncReplicationScheduler) onAddLocked(s *Shard) {
 	sched.metrics.setQueueDepth(len(sched.h))
 }
 
-// onRemoveLocked removes a shard from the registry (and heap if not in-flight).
-// If in-flight, the worker's eventual result will be discarded by onResultLocked
-// (entry no longer in sched.entries). mu must be held.
+// onRemoveLocked removes a shard from the registry/heap and settles Done()s
+// still pending on queued batches so asyncRepWg.Wait() can't be pinned by them;
+// a worker that already owns the cycle keeps its Done(). mu must be held.
 func (sched *AsyncReplicationScheduler) onRemoveLocked(s *Shard) {
 	entry, ok := sched.entries[s]
 	if !ok {
@@ -1077,14 +1094,16 @@ func (sched *AsyncReplicationScheduler) onRemoveLocked(s *Shard) {
 	}
 	delete(sched.entries, s)
 	sched.metrics.decShardsRegistered()
-	if !entry.inFlight {
+	if entry.heapIdx >= 0 {
 		heap.Remove(&sched.h, entry.heapIdx)
 	}
+	entry.settleDone()
+	entry.inFlight = false
 	sched.metrics.setQueueDepth(len(sched.h))
 }
 
-// drainWorkChOnExit empties workCh after the dispatcher returned, balancing each
-// reserved entry's Add(1). Single non-blocking pass suffices (sole producer).
+// drainWorkChOnExit empties workCh after the dispatcher returned, settling each
+// still-unowned Done. Single non-blocking pass suffices (sole producer).
 func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 	for {
 		select {
@@ -1094,7 +1113,7 @@ func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 			}
 			for _, entry := range *bp {
 				entry.inFlight = false
-				entry.shard.asyncRepWg.Done()
+				entry.settleDone()
 			}
 		default:
 			return
@@ -1259,6 +1278,16 @@ func (sched *AsyncReplicationScheduler) runBatch(bp *[]*asyncSchedulerEntry, scr
 		*bp = (*bp)[:0]
 		sched.batchPool.Put(bp)
 	}()
+
+	// Own each entry's Done before touching any shard; already-settled
+	// (deregistered) entries are dropped without a run, Done, or result.
+	kept := batch[:0]
+	for _, entry := range batch {
+		if entry.tryOwnDone() {
+			kept = append(kept, entry)
+		}
+	}
+	batch = kept
 
 	if len(batch) <= 1 {
 		if len(batch) == 1 {

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1694,6 +1694,7 @@ func TestRunBatchEmitsOneResultPerEntry(t *testing.T) {
 		s := &Shard{class: &models.Class{Class: "C"}}
 		s.asyncRepWg.Add(1)
 		entries[i] = &asyncSchedulerEntry{shard: s}
+		entries[i].pendingDone.Store(true)
 	}
 
 	sched.runBatch(&entries, newBatchScratch())
@@ -2117,4 +2118,159 @@ func TestDescendDirectSurvivesFullChannel(t *testing.T) {
 	sched.dispatchDueLocked()
 	assert.ElementsMatch(t, []int{1, 1}, drainBatchSizes(sched.workCh),
 		"remaining divergers keep dispatching as singletons")
+}
+
+func awaitAsyncRepWg(t *testing.T, s *Shard, msg string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { s.asyncRepWg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal(msg)
+	}
+}
+
+// TestDeregisterSettlesQueuedDone: deregistration settles a queued batch's pending Done instead of pinning asyncRepWg until Close.
+func TestDeregisterSettlesQueuedDone(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		descendDirect bool
+	}{
+		{name: "bucket dispatch"},
+		{name: "descendDirect dispatch", descendDirect: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newBareScheduler(512, 4)
+			sched.ctx = context.Background()
+			sched.resultCh = make(chan asyncSchedulerResult, 8)
+
+			s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+			sched.onAddLocked(s)
+			sched.entries[s].descendDirect = tc.descendDirect
+
+			sched.dispatchDueLocked()
+			batches := drainBatches(sched.workCh)
+			require.Len(t, batches, 1)
+
+			sched.onRemoveLocked(s)
+			awaitAsyncRepWg(t, s, "asyncRepWg must drain once deregistration settles the queued Done")
+
+			sched.runBatch(batches[0], newBatchScratch())
+			assert.Empty(t, drainResults(sched.resultCh), "released entry must not produce a result")
+			s.asyncRepWg.Wait()
+		})
+	}
+}
+
+// TestDrainSkipsSettledDones: Close's drain must not settle a Done that deregistration already settled.
+func TestDrainSkipsSettledDones(t *testing.T) {
+	sched := newBareScheduler(512, 4)
+	sched.ctx = context.Background()
+
+	s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+	sched.onAddLocked(s)
+	sched.dispatchDueLocked()
+
+	sched.onRemoveLocked(s)
+	awaitAsyncRepWg(t, s, "asyncRepWg must drain on deregistration")
+
+	sched.drainWorkChOnExit()
+	s.asyncRepWg.Wait()
+	assert.Empty(t, drainBatches(sched.workCh))
+}
+
+// TestStaleBatchDroppedAfterReRegister: a previous registration's stranded batch is dropped; the new one runs once.
+func TestStaleBatchDroppedAfterReRegister(t *testing.T) {
+	sched := newBareScheduler(512, 4)
+	sched.ctx = context.Background()
+	sched.resultCh = make(chan asyncSchedulerResult, 8)
+
+	s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+	sched.onAddLocked(s)
+	e1 := sched.entries[s]
+	sched.dispatchDueLocked()
+	b1 := drainBatches(sched.workCh)
+	require.Len(t, b1, 1)
+
+	sched.onRemoveLocked(s)
+	awaitAsyncRepWg(t, s, "asyncRepWg must drain on deregistration")
+
+	sched.onAddLocked(s)
+	e2 := sched.entries[s]
+	require.NotSame(t, e1, e2)
+	sched.dispatchDueLocked()
+	b2 := drainBatches(sched.workCh)
+	require.Len(t, b2, 1)
+
+	sched.runBatch(b1[0], newBatchScratch())
+	assert.Empty(t, drainResults(sched.resultCh), "stale batch must be dropped without a result")
+
+	sched.runBatch(b2[0], newBatchScratch())
+	results := drainResults(sched.resultCh)
+	require.Len(t, results, 1)
+	assert.Same(t, e2, results[0].entry)
+	s.asyncRepWg.Wait()
+}
+
+// TestRollbackSettlesPendingDone: full-workCh rollback re-queues the entry with asyncRepWg balanced and no pending Done.
+func TestRollbackSettlesPendingDone(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		descendDirect bool
+	}{
+		{name: "bucket dispatch"},
+		{name: "descendDirect dispatch", descendDirect: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newBareScheduler(512, 0)
+			sched.ctx = context.Background()
+
+			s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+			sched.onAddLocked(s)
+			e := sched.entries[s]
+			e.descendDirect = tc.descendDirect
+
+			sched.dispatchDueLocked()
+
+			assert.False(t, e.inFlight)
+			assert.GreaterOrEqual(t, e.heapIdx, 0, "entry must be re-queued")
+			assert.False(t, e.pendingDone.Load())
+			s.asyncRepWg.Wait()
+		})
+	}
+}
+
+// TestDeregisterDrainsWithSingleWorker: every deregistered shard's asyncRepWg drains before Close despite batches queued behind one worker.
+func TestDeregisterDrainsWithSingleWorker(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	sched, err := NewAsyncReplicationScheduler(context.Background(), replication.GlobalConfig{
+		AsyncReplicationSchedulerWorkers:       configRuntime.NewDynamicValue(1),
+		AsyncReplicationDisabled:               configRuntime.NewDynamicValue(false),
+		AsyncReplicationRootPrefilterBatchSize: configRuntime.NewDynamicValue(3),
+	}, nil, logger)
+	require.NoError(t, err)
+
+	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}
+	shards := make([]*Shard, 30)
+	for i := range shards {
+		shards[i] = &Shard{index: idx, class: &models.Class{Class: "MT"}, name: fmt.Sprintf("t%02d", i)}
+	}
+
+	var wg sync.WaitGroup
+	for _, s := range shards {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = sched.Register(s)
+			time.Sleep(2 * time.Millisecond)
+			_ = sched.Deregister(s)
+		}()
+	}
+	wg.Wait()
+
+	for _, s := range shards {
+		awaitAsyncRepWg(t, s, "asyncRepWg must drain after Deregister without Close")
+	}
+	sched.Close()
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -309,7 +309,8 @@ type Shard struct {
 	// Done() for hashbeat cycles is called before the result is sent back to
 	// the dispatcher, so the scheduler cannot re-dispatch until Done() fires.
 	// Callers that need a strict happens-before guarantee call asyncRepWg.Wait()
-	// after Deregister to ensure all goroutines have fully exited.
+	// after Deregister; Deregister settles Done()s for batches still queued, so
+	// Wait() only covers cycles that actually started.
 	asyncRepWg sync.WaitGroup
 
 	// asyncRepNeedsRebuild is set by runEntry when the effective hashtree height

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -930,10 +930,19 @@ func (s *Shard) mayStopAsyncReplication() {
 			s.index.logger.WithField("action", "async_replication").Error(err)
 		}
 	}
+	drainStart := time.Now()
 	workersDone := make(chan struct{})
 	enterrors.GoWrapper(func() {
 		defer close(workersDone)
 		s.asyncRepWg.Wait()
+		// Distinguish a late drain from a permanently leaked waiter in goroutine dumps.
+		if elapsed := time.Since(drainStart); elapsed > asyncReplicationWorkerDrainTimeout {
+			s.index.logger.
+				WithField("action", "async_replication").
+				WithField("class_name", s.class.Class).
+				WithField("shard_name", s.name).
+				Warnf("async replication drain completed after deadline (took %s)", elapsed)
+		}
 	}, s.index.logger)
 	select {
 	case <-workersDone:

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -154,6 +154,10 @@ func (s *Shard) MultiObjectRawByID(ctx context.Context, ids []strfmt.UUID) ([][]
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	for i, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 		if err != nil {
 			return nil, err
@@ -181,6 +185,10 @@ func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	for i, q := range query {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		idBytes, err := uuid.MustParse(q.ID).MarshalBinary()
 		if err != nil {
 			return nil, err

--- a/adapters/repos/db/shard_read_integration_test.go
+++ b/adapters/repos/db/shard_read_integration_test.go
@@ -1,0 +1,59 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/entities/multi"
+)
+
+// TestShardReadsHonorCtxCancellation: batch read loops must abort on a cancelled ctx.
+func TestShardReadsHonorCtxCancellation(t *testing.T) {
+	ctx := context.Background()
+	_, idx := testShard(t, ctx, "ShardReadCtxCancel")
+	s := firstShard(t, idx)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for _, tc := range []struct {
+		name string
+		call func(context.Context) error
+	}{
+		{
+			name: "MultiObjectRawByID",
+			call: func(ctx context.Context) error {
+				_, err := s.MultiObjectRawByID(ctx, []strfmt.UUID{strfmt.UUID(uuid.NewString())})
+				return err
+			},
+		},
+		{
+			name: "ObjectDigests",
+			call: func(ctx context.Context) error {
+				_, err := s.ObjectDigests(ctx, []multi.Identifier{{ID: uuid.NewString()}})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ErrorIs(t, tc.call(cancelledCtx), context.Canceled)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A production goroutine dump showed 22 goroutines parked forever in `mayStopAsyncReplication` on `asyncRepWg.Wait()` — one per tenant deactivation. The 10s drain timeout only unblocks shard shutdown itself; the waiter goroutine stays blocked until the shard's `asyncRepWg` reaches zero, and it never did.

The scheduler calls `asyncRepWg.Add(1)` for every dispatched cycle **before** queuing the batch in `workCh`. The matching `Done()` could only come from a worker running the batch, a full-channel rollback, or the queue drain at scheduler `Close()`. So if a tenant was shut down or dropped while its batch was still sitting in the queue (e.g. the sole default worker was wedged on a long cycle), nobody ever called `Done()`: the WaitGroup stayed >0 forever and one waiter goroutine leaked per deactivation.

## Fix

The work queue holds **pointers** to per-shard scheduler entries, and the same entry objects are also reachable from the scheduler's registry map. So when a tenant is shut down or removed, its pending work is **not removed from the queue** (a Go channel can't be scanned) — instead its owed `Done()` is settled immediately and the entry is **marked as settled**, via an atomic per-entry flag (`doneOwed`) with a CAS take-ownership helper (`tryOwnDone`) — effectively a `sync.Once` per owed `Done()`:

- **Deregister** settles the `Done()`s of batches still queued → the shard's `Wait()` unblocks immediately and shutdown proceeds leak-free.
- When a **worker** later pops that batch, ownership is already taken → it skips the entry entirely: the cycle doesn't run and `Done()` is not called again. It never touches the shut-down shard.
- When the **database shuts down entirely** and `Close()` drains the queue, already-settled entries are skipped the same way — no double `Done()` (which would panic the WaitGroup).
- If the worker got there **first** (cycle already running), Deregister's take fails and shutdown correctly waits for the in-flight cycle — the existing happens-before guarantee is preserved, and strengthened: previously a post-timeout worker would still run the cycle against the shut shard.

Exactly one of {worker, rollback, deregister, Close drain} ever owns each `Done()`.

Also:
- `MultiObjectRawByID` / `ObjectDigests` now check ctx per iteration, so propagation batches abort promptly once the shard's async-replication ctx is cancelled.
- The drain waiter logs a Warn when it completes after the deadline, so a slow drain is distinguishable from a leaked one in future dumps.

## Why not something simpler

- **Bounding/deduping the waiter**: the WG stays >0 forever, silently hanging every other `Wait()` site — `rebuildHashtree` parks with `asyncRepRebuildInFlight=true` (permanently disabling rebuilds) and scheduler `Close()` hangs.
- **Unconditional `Done()` in Deregister**: double-settles when a worker is mid-cycle → negative-WaitGroup panic. The queued-vs-running race is exactly what the CAS arbitrates.
- **`Add(1)` at worker pickup instead of dispatch**: queued cycles become invisible to `rebuildHashtree`'s `Wait()`, letting a stale cycle run concurrently with a re-registered shard's new cycle.
- **Per-entry, not per-shard**: re-registration creates a new entry; a shared flag would let a stale batch steal the new registration's `Done()`. The flag relies on the existing invariant that an entry has at most one outstanding dispatch (it re-enters the heap only after its previous result settles).

Residual (accepted): a worker stuck in a genuinely non-returning op (e.g. hung fsync on failed disk) still pins its own shard's waiter until the op returns — inherent to `sync.WaitGroup` — but that is now 1:1 with hung ops instead of N leaked waiters behind one wedged worker, and it's logged.

## Review focus

- `onRemoveLocked`: settles the owed `Done()` and the heap guard changed from `!inFlight` to `heapIdx >= 0`.
- `runBatch`: ownership filter runs before any shard access (including `classifyBatch` and the singleton fast path).

## Tests

- `TestDeregisterSettlesQueuedDone` **fails without the fix** (Wait pins forever) — pins the production bug; variants for both dispatch paths.
- `TestDrainSkipsSettledDones` (no double-Done at Close), `TestStaleBatchDroppedAfterReRegister`, `TestRollbackSettlesOwedDone`, `TestDeregisterDrainsWithSingleWorker` (30 tenants against a 1-worker pool: every WG must drain before Close), `TestShardReadsHonorCtxCancellation` (integrationTest).
- Full `./adapters/repos/db` unit sweep and async-replication integration tests under `-race`: pass. `golangci-lint` and the goroutine linter: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
