### PR TITLE
fix(async-repl): fold ≤cutoff changes into the async-checkpoint bounded hashtree

### DIFF
--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -312,6 +312,8 @@ func asyncCheckpointErrorToGRPC(err error) error {
 		return status.Errorf(codes.AlreadyExists, "%v", err)
 	case errors.Is(err, replica.ErrAsyncReplicationNotActive):
 		return status.Errorf(codes.FailedPrecondition, "%v", err)
+	case errors.Is(err, replica.ErrAsyncCheckpointCutoffInPast):
+		return status.Errorf(codes.FailedPrecondition, "%v", err)
 	}
 	return status.Errorf(codes.Internal, "%v", err)
 }

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -1244,6 +1244,8 @@ func asyncCheckpointHTTPStatus(err error) int {
 		return http.StatusConflict
 	case errors.Is(err, replica.ErrAsyncReplicationNotActive):
 		return http.StatusPreconditionFailed
+	case errors.Is(err, replica.ErrAsyncCheckpointCutoffInPast):
+		return http.StatusPreconditionFailed
 	}
 	return http.StatusInternalServerError
 }

--- a/adapters/repos/db/shard_async_checkpoint_integration_test.go
+++ b/adapters/repos/db/shard_async_checkpoint_integration_test.go
@@ -1,0 +1,269 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+const (
+	ckCutoff = 1_000_000
+	ckSeedTS = 800_000
+	ckPreTS  = 900_000
+	ckPostTS = 1_100_000
+)
+
+func ckID(n int) strfmt.UUID {
+	return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+}
+
+func ckCheckpointRoot(t *testing.T, ctx context.Context, sl ShardLike) hashtree.Digest {
+	t.Helper()
+	root, _, _, ok := sl.AsyncCheckpointRoot(ctx)
+	require.True(t, ok)
+	return root
+}
+
+func ckLiveRoot(t *testing.T, s *Shard) hashtree.Digest {
+	t.Helper()
+	root, ok := s.HashTreeRoot()
+	require.True(t, ok)
+	return root
+}
+
+// ckSetup enables async replication, seeds objects, and creates a checkpoint at ckCutoff; returns the checkpoint root.
+func ckSetup(t *testing.T, ctx context.Context, sl ShardLike, s *Shard, seed []*storobj.Object) hashtree.Digest {
+	t.Helper()
+	require.NoError(t, s.enableAsyncReplication(ctx, minAsyncReplicationConfig()))
+	awaitHashtreeInitialized(t, s)
+	for _, o := range seed {
+		require.NoError(t, sl.PutObject(ctx, o))
+	}
+	require.NoError(t, sl.CreateAsyncCheckpoint(ctx, ckCutoff, time.UnixMilli(ckCutoff)))
+	return ckCheckpointRoot(t, ctx, sl)
+}
+
+// freshCkShard builds a property-less async-replicated shard seeded and checkpointed at ckCutoff.
+func freshCkShard(t *testing.T, ctx context.Context, class string, seed []*storobj.Object) (ShardLike, *Index, *Shard, hashtree.Digest) {
+	t.Helper()
+	sl, idx := testShard(t, ctx, class, withAsyncScheduler(t))
+	s := concreteShard(t, sl)
+	return sl, idx, s, ckSetup(t, ctx, sl, s, seed)
+}
+
+func ckAssertAbsorbed(t *testing.T, ctx context.Context, sl ShardLike, s *Shard, r0 hashtree.Digest) {
+	t.Helper()
+	cp := ckCheckpointRoot(t, ctx, sl)
+	assert.NotEqual(t, r0, cp, "≤cutoff op must move the checkpoint root")
+	assert.Equal(t, ckLiveRoot(t, s), cp, "with only ≤cutoff ops the checkpoint must equal the live hashtree")
+}
+
+func ckAssertFrozen(t *testing.T, ctx context.Context, sl ShardLike, s *Shard, r0 hashtree.Digest) {
+	t.Helper()
+	cp := ckCheckpointRoot(t, ctx, sl)
+	assert.Equal(t, r0, cp, ">cutoff op must not move the checkpoint root")
+	assert.NotEqual(t, ckLiveRoot(t, s), cp, ">cutoff op must move the live hashtree away from the frozen checkpoint")
+}
+
+func ckOverwrite(t *testing.T, ctx context.Context, idx *Index, shard string, vo *objects.VObject) {
+	t.Helper()
+	res, err := idx.OverwriteObjects(ctx, shard, []*objects.VObject{vo})
+	require.NoError(t, err)
+	for _, r := range res {
+		require.Empty(t, r.Err, "overwrite reported a conflict")
+	}
+}
+
+func TestAsyncCheckpoint_LocalCreateJourney(t *testing.T) {
+	ctx := context.Background()
+	seed := []*storobj.Object{testObjWithTime("CkCreate", ckID(1), ckSeedTS)}
+
+	t.Run("single pre-cutoff absorbed", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkCreate", seed)
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime("CkCreate", ckID(2), ckPreTS)))
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("single post-cutoff frozen", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkCreate", seed)
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime("CkCreate", ckID(2), ckPostTS)))
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+	t.Run("batch pre-cutoff absorbed", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkCreate", seed)
+		errs := sl.PutObjectBatch(ctx, []*storobj.Object{
+			testObjWithTime("CkCreate", ckID(2), ckPreTS),
+			testObjWithTime("CkCreate", ckID(3), ckPreTS),
+		})
+		for _, e := range errs {
+			require.NoError(t, e)
+		}
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("batch post-cutoff frozen", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkCreate", seed)
+		errs := sl.PutObjectBatch(ctx, []*storobj.Object{
+			testObjWithTime("CkCreate", ckID(2), ckPostTS),
+			testObjWithTime("CkCreate", ckID(3), ckPostTS),
+		})
+		for _, e := range errs {
+			require.NoError(t, e)
+		}
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+}
+
+func TestAsyncCheckpoint_LocalDeleteJourney(t *testing.T) {
+	ctx := context.Background()
+	seed := []*storobj.Object{
+		testObjWithTime("CkDelete", ckID(1), ckSeedTS),
+		testObjWithTime("CkDelete", ckID(2), ckSeedTS),
+	}
+
+	t.Run("single pre-cutoff absorbed", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkDelete", seed)
+		require.NoError(t, sl.DeleteObject(ctx, ckID(2), time.UnixMilli(ckPreTS)))
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("single post-cutoff frozen", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkDelete", seed)
+		require.NoError(t, sl.DeleteObject(ctx, ckID(2), time.UnixMilli(ckPostTS)))
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+	t.Run("batch pre-cutoff absorbed", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkDelete", seed)
+		res := sl.DeleteObjectBatch(ctx, []strfmt.UUID{ckID(2)}, time.UnixMilli(ckPreTS), false)
+		for _, r := range res {
+			require.NoError(t, r.Err)
+		}
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("batch post-cutoff frozen", func(t *testing.T) {
+		sl, _, s, r0 := freshCkShard(t, ctx, "CkDelete", seed)
+		res := sl.DeleteObjectBatch(ctx, []strfmt.UUID{ckID(2)}, time.UnixMilli(ckPostTS), false)
+		for _, r := range res {
+			require.NoError(t, r.Err)
+		}
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+}
+
+func TestAsyncCheckpoint_ReceiveFromReplicaJourney(t *testing.T) {
+	ctx := context.Background()
+
+	receiveObj := func(id strfmt.UUID, ts, stale int64) *objects.VObject {
+		return &objects.VObject{
+			ID:                      id,
+			LatestObject:            &models.Object{ID: id, Class: "CkReceive", LastUpdateTimeUnix: ts},
+			LastUpdateTimeUnixMilli: ts,
+			StaleUpdateTime:         stale,
+		}
+	}
+	receiveDelete := func(id strfmt.UUID, deletionTs, stale int64) *objects.VObject {
+		return &objects.VObject{ID: id, Deleted: true, LastUpdateTimeUnixMilli: deletionTs, StaleUpdateTime: stale}
+	}
+
+	t.Run("create pre-cutoff absorbed", func(t *testing.T) {
+		sl, idx, s, r0 := freshCkShard(t, ctx, "CkReceive", []*storobj.Object{testObjWithTime("CkReceive", ckID(1), ckSeedTS)})
+		ckOverwrite(t, ctx, idx, s.Name(), receiveObj(ckID(2), ckPreTS, 0))
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("create post-cutoff frozen", func(t *testing.T) {
+		sl, idx, s, r0 := freshCkShard(t, ctx, "CkReceive", []*storobj.Object{testObjWithTime("CkReceive", ckID(1), ckSeedTS)})
+		ckOverwrite(t, ctx, idx, s.Name(), receiveObj(ckID(2), ckPostTS, 0))
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+	t.Run("update pre-cutoff absorbed", func(t *testing.T) {
+		sl, idx, s, r0 := freshCkShard(t, ctx, "CkReceive", []*storobj.Object{testObjWithTime("CkReceive", ckID(1), ckSeedTS)})
+		ckOverwrite(t, ctx, idx, s.Name(), receiveObj(ckID(1), ckPreTS, ckSeedTS))
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("update post-cutoff frozen", func(t *testing.T) {
+		sl, idx, s, r0 := freshCkShard(t, ctx, "CkReceive", []*storobj.Object{testObjWithTime("CkReceive", ckID(1), ckSeedTS)})
+		ckOverwrite(t, ctx, idx, s.Name(), receiveObj(ckID(1), ckPostTS, ckSeedTS))
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+	t.Run("delete pre-cutoff absorbed", func(t *testing.T) {
+		seed := []*storobj.Object{testObjWithTime("CkReceive", ckID(1), ckSeedTS), testObjWithTime("CkReceive", ckID(2), ckSeedTS)}
+		sl, idx, s, r0 := freshCkShard(t, ctx, "CkReceive", seed)
+		ckOverwrite(t, ctx, idx, s.Name(), receiveDelete(ckID(2), ckPreTS, ckSeedTS))
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("delete post-cutoff frozen", func(t *testing.T) {
+		seed := []*storobj.Object{testObjWithTime("CkReceive", ckID(1), ckSeedTS), testObjWithTime("CkReceive", ckID(2), ckSeedTS)}
+		sl, idx, s, r0 := freshCkShard(t, ctx, "CkReceive", seed)
+		ckOverwrite(t, ctx, idx, s.Name(), receiveDelete(ckID(2), ckPostTS, ckSeedTS))
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+}
+
+func TestAsyncCheckpoint_MergeJourney(t *testing.T) {
+	ctx := context.Background()
+	class := &models.Class{
+		Class: "CkMerge",
+		Properties: []*models.Property{{
+			Name:         "name",
+			DataType:     schema.DataTypeText.PropString(),
+			Tokenization: models.PropertyTokenizationWhitespace,
+		}},
+		InvertedIndexConfig: &models.InvertedIndexConfig{UsingBlockMaxWAND: true},
+	}
+	seedObj := func() *storobj.Object {
+		return &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:                 ckID(1),
+				Class:              "CkMerge",
+				Properties:         map[string]interface{}{"name": "word1"},
+				LastUpdateTimeUnix: ckSeedTS,
+			},
+		}
+	}
+	setup := func(t *testing.T) (ShardLike, *Shard, hashtree.Digest) {
+		sl, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true}, true, false, false, withAsyncScheduler(t))
+		s := concreteShard(t, sl)
+		return sl, s, ckSetup(t, ctx, sl, s, []*storobj.Object{seedObj()})
+	}
+
+	t.Run("pre-cutoff absorbed", func(t *testing.T) {
+		sl, s, r0 := setup(t)
+		require.NoError(t, sl.MergeObject(ctx, objects.MergeDocument{
+			ID: ckID(1), Class: "CkMerge",
+			PrimitiveSchema: map[string]interface{}{"name": "word2"},
+			UpdateTime:      ckPreTS,
+		}))
+		ckAssertAbsorbed(t, ctx, sl, s, r0)
+	})
+	t.Run("post-cutoff frozen", func(t *testing.T) {
+		sl, s, r0 := setup(t)
+		require.NoError(t, sl.MergeObject(ctx, objects.MergeDocument{
+			ID: ckID(1), Class: "CkMerge",
+			PrimitiveSchema: map[string]interface{}{"name": "word2"},
+			UpdateTime:      ckPostTS,
+		}))
+		ckAssertFrozen(t, ctx, sl, s, r0)
+	})
+}

--- a/adapters/repos/db/shard_async_checkpoint_integration_test.go
+++ b/adapters/repos/db/shard_async_checkpoint_integration_test.go
@@ -30,11 +30,13 @@ import (
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
-const (
-	ckCutoff = 1_000_000
-	ckSeedTS = 800_000
-	ckPreTS  = 900_000
-	ckPostTS = 1_100_000
+// Shifted into the future so the cutoff-in-past guard passes; seed<pre<cutoff<post is what matters.
+var (
+	ckIntgBase = time.Now().Add(time.Hour).UnixMilli()
+	ckCutoff   = ckIntgBase + 1_000_000
+	ckSeedTS   = ckIntgBase + 800_000
+	ckPreTS    = ckIntgBase + 900_000
+	ckPostTS   = ckIntgBase + 1_100_000
 )
 
 func ckID(n int) strfmt.UUID {

--- a/adapters/repos/db/shard_async_checkpoint_test.go
+++ b/adapters/repos/db/shard_async_checkpoint_test.go
@@ -14,12 +14,17 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -247,4 +252,146 @@ func TestShard_CreateAsyncCheckpoint_ConcurrentRaceIsSerialised(t *testing.T) {
 	// one is at or after the earliest proposal.
 	assert.GreaterOrEqual(t, ca.UnixMilli(), base.UnixMilli())
 	assert.Greater(t, cutoff, int64(0))
+}
+
+const (
+	ckA = strfmt.UUID("00000000-0000-0000-0000-0000000000a1")
+	ckB = strfmt.UUID("00000000-0000-0000-0000-0000000000b2")
+	ckC = strfmt.UUID("00000000-0000-0000-0000-0000000000c3")
+)
+
+type ckOp struct {
+	del      bool
+	id       strfmt.UUID
+	ts       int64
+	old      int64
+	delEvent int64
+}
+
+func ckApply(t *testing.T, s *Shard, op ckOp) {
+	t.Helper()
+	idBytes, err := uuid.MustParse(op.id.String()).MarshalBinary()
+	require.NoError(t, err)
+	if op.del {
+		require.NoError(t, s.deleteObjectHashTree(idBytes, op.ts, op.delEvent))
+		return
+	}
+	obj := &storobj.Object{Object: models.Object{ID: op.id, LastUpdateTimeUnix: op.ts}}
+	require.NoError(t, s.upsertObjectHashTree(obj, idBytes, objectInsertStatus{oldUpdateTime: op.old}))
+}
+
+// ckRoot builds a fresh shard, applies before-ops, creates a checkpoint at cutoff, applies after-ops, returns the checkpoint root.
+func ckRoot(t *testing.T, cutoff int64, before, after []ckOp) hashtree.Digest {
+	t.Helper()
+	s := shardWithHashtree(t)
+	for _, op := range before {
+		ckApply(t, s, op)
+	}
+	require.NoError(t, s.CreateAsyncCheckpoint(context.Background(), cutoff, time.UnixMilli(cutoff)))
+	for _, op := range after {
+		ckApply(t, s, op)
+	}
+	root, _, _, ok := s.AsyncCheckpointRoot(context.Background())
+	require.True(t, ok)
+	return root
+}
+
+func TestShard_AsyncCheckpoint_AbsorbsLatePreCutoffObjects(t *testing.T) {
+	const cutoff = 200
+	full := ckRoot(t, cutoff, []ckOp{{id: ckA, ts: 100}, {id: ckB, ts: 110}, {id: ckC, ts: 120}}, nil)
+	behind := ckRoot(t, cutoff, []ckOp{{id: ckA, ts: 100}, {id: ckB, ts: 110}}, nil)
+	require.NotEqual(t, full, behind, "a shard missing a pre-cutoff object must not already match")
+
+	caughtUp := ckRoot(t, cutoff,
+		[]ckOp{{id: ckA, ts: 100}, {id: ckB, ts: 110}},
+		[]ckOp{{id: ckC, ts: 120}})
+	require.Equal(t, full, caughtUp, "a pre-cutoff object arriving after creation must converge the root")
+}
+
+func TestShard_AsyncCheckpoint_FoldGating(t *testing.T) {
+	const cutoff = 200
+	tests := []struct {
+		name                             string
+		beforeA, afterA, beforeB, afterB []ckOp
+	}{
+		{
+			name:    "pre-cutoff create absorbed",
+			beforeA: []ckOp{{id: ckA, ts: 100}, {id: ckB, ts: 120}},
+			beforeB: []ckOp{{id: ckA, ts: 100}}, afterB: []ckOp{{id: ckB, ts: 120}},
+		},
+		{
+			name:    "post-cutoff create excluded",
+			beforeA: []ckOp{{id: ckA, ts: 100}},
+			beforeB: []ckOp{{id: ckA, ts: 100}}, afterB: []ckOp{{id: ckB, ts: 250}},
+		},
+		{
+			name:    "pre-cutoff update absorbed",
+			beforeA: []ckOp{{id: ckA, ts: 150}},
+			beforeB: []ckOp{{id: ckA, ts: 100}}, afterB: []ckOp{{id: ckA, ts: 150, old: 100}},
+		},
+		{
+			name:    "post-cutoff update keeps pre-cutoff version",
+			beforeA: []ckOp{{id: ckA, ts: 100}},
+			beforeB: []ckOp{{id: ckA, ts: 100}}, afterB: []ckOp{{id: ckA, ts: 250, old: 100}},
+		},
+		{
+			name:    "pre-cutoff delete absorbed",
+			beforeA: []ckOp{{id: ckB, ts: 110}},
+			beforeB: []ckOp{{id: ckA, ts: 100}, {id: ckB, ts: 110}}, afterB: []ckOp{{del: true, id: ckA, ts: 100, delEvent: 150}},
+		},
+		{
+			name:    "post-cutoff delete keeps object",
+			beforeA: []ckOp{{id: ckA, ts: 100}},
+			beforeB: []ckOp{{id: ckA, ts: 100}}, afterB: []ckOp{{del: true, id: ckA, ts: 100, delEvent: 250}},
+		},
+		{
+			name:    "resurrection converges to recreated state",
+			beforeA: []ckOp{{id: ckA, ts: 150}},
+			beforeB: []ckOp{{id: ckA, ts: 100}}, afterB: []ckOp{{del: true, id: ckA, ts: 100, delEvent: 120}, {id: ckA, ts: 150}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reference := ckRoot(t, cutoff, tt.beforeA, tt.afterA)
+			journey := ckRoot(t, cutoff, tt.beforeB, tt.afterB)
+			require.Equal(t, reference, journey)
+		})
+	}
+}
+
+func TestShard_AsyncCheckpoint_ConcurrentFoldIsRaceFree(t *testing.T) {
+	ctx := context.Background()
+	s := shardWithHashtree(t)
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 1_000_000, time.UnixMilli(1_000_000)))
+
+	const writers = 8
+	var wg sync.WaitGroup
+	wg.Add(writers + 1)
+	for w := 0; w < writers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				id := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", w*1000+i))
+				idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
+				if err != nil {
+					continue
+				}
+				obj := &storobj.Object{Object: models.Object{ID: id, LastUpdateTimeUnix: 500_000}}
+				s.asyncReplicationRWMux.RLock()
+				_ = s.upsertObjectHashTree(obj, idBytes, objectInsertStatus{})
+				s.asyncReplicationRWMux.RUnlock()
+			}
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = s.DeleteAsyncCheckpoint(ctx)
+			_ = s.CreateAsyncCheckpoint(ctx, 1_000_000, time.UnixMilli(int64(1_000_001+i)))
+		}
+	}()
+	wg.Wait()
+
+	require.NotPanics(t, func() { s.AsyncCheckpointRoot(ctx) })
 }

--- a/adapters/repos/db/shard_async_checkpoint_test.go
+++ b/adapters/repos/db/shard_async_checkpoint_test.go
@@ -48,11 +48,11 @@ func TestShard_CreateAsyncCheckpoint_Basic(t *testing.T) {
 	s := shardWithHashtree(t)
 	createdAt := time.Now().UTC()
 
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 1_000, createdAt))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(1_000), createdAt))
 
 	root, cutoff, ca, ok := s.AsyncCheckpointRoot(ctx)
 	assert.True(t, ok, "expected active checkpoint")
-	assert.Equal(t, int64(1_000), cutoff)
+	assert.Equal(t, ckAbs(1_000), cutoff)
 	assert.Equal(t, createdAt, ca)
 	// Root mirrors the unbounded hashtree at clone time.
 	assert.Equal(t, s.hashtree.Root(), root)
@@ -64,16 +64,16 @@ func TestShard_CreateAsyncCheckpoint_StaleCreatedAtIsRejected(t *testing.T) {
 	older := time.Now().UTC()
 	newer := older.Add(time.Second)
 
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 2_000, newer))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(2_000), newer))
 
 	// An older createdAt loses the tie-breaker; the active checkpoint stays.
-	err := s.CreateAsyncCheckpoint(ctx, 3_000, older)
+	err := s.CreateAsyncCheckpoint(ctx, ckAbs(3_000), older)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errAsyncCheckpointStale), "expected stale error, got %v", err)
 
 	_, cutoff, ca, ok := s.AsyncCheckpointRoot(ctx)
 	assert.True(t, ok)
-	assert.Equal(t, int64(2_000), cutoff, "active checkpoint must not be overwritten by stale createdAt")
+	assert.Equal(t, ckAbs(2_000), cutoff, "active checkpoint must not be overwritten by stale createdAt")
 	assert.Equal(t, newer, ca)
 }
 
@@ -83,12 +83,12 @@ func TestShard_CreateAsyncCheckpoint_NewerCreatedAtReplaces(t *testing.T) {
 	first := time.Now().UTC()
 	second := first.Add(time.Second)
 
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 2_000, first))
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 3_000, second))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(2_000), first))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(3_000), second))
 
 	_, cutoff, ca, ok := s.AsyncCheckpointRoot(ctx)
 	assert.True(t, ok)
-	assert.Equal(t, int64(3_000), cutoff)
+	assert.Equal(t, ckAbs(3_000), cutoff)
 	assert.Equal(t, second, ca)
 }
 
@@ -99,8 +99,8 @@ func TestShard_CreateAsyncCheckpoint_EqualCreatedAtIsStale(t *testing.T) {
 	s := shardWithHashtree(t)
 	at := time.Now().UTC()
 
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 2_000, at))
-	err := s.CreateAsyncCheckpoint(ctx, 3_000, at)
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(2_000), at))
+	err := s.CreateAsyncCheckpoint(ctx, ckAbs(3_000), at)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errAsyncCheckpointStale))
 }
@@ -138,7 +138,7 @@ func TestShard_CreateAsyncCheckpoint_HonoursContextCancel(t *testing.T) {
 func TestShard_DeleteAsyncCheckpoint(t *testing.T) {
 	ctx := context.Background()
 	s := shardWithHashtree(t)
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 1_000, time.Now().UTC()))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(1_000), time.Now().UTC()))
 
 	require.NoError(t, s.DeleteAsyncCheckpoint(ctx))
 
@@ -160,7 +160,7 @@ func TestShard_DeleteAsyncCheckpoint_IdempotentWhenInactive(t *testing.T) {
 func TestShard_DeleteAsyncCheckpoint_HonoursContextCancel(t *testing.T) {
 	ctx := context.Background()
 	s := shardWithHashtree(t)
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 1_000, time.Now().UTC()))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(1_000), time.Now().UTC()))
 
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -187,7 +187,7 @@ func TestShard_AsyncCheckpoint_ClearedOnStateReset(t *testing.T) {
 	// state but forgets to wire it in.
 	ctx := context.Background()
 	s := shardWithHashtree(t)
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 1_000, time.Now().UTC()))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(1_000), time.Now().UTC()))
 
 	s.asyncReplicationRWMux.Lock()
 	s.clearAsyncCheckpointLocked()
@@ -210,7 +210,7 @@ func TestShard_CreateAsyncCheckpoint_ActivatedAtUsesLocalClock(t *testing.T) {
 
 	before := time.Now()
 	futureCreatedAt := before.Add(2 * time.Minute).UTC()
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 1_000, futureCreatedAt))
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, ckAbs(1_000), futureCreatedAt))
 	after := time.Now()
 
 	s.asyncReplicationRWMux.RLock()
@@ -236,11 +236,12 @@ func TestShard_CreateAsyncCheckpoint_ConcurrentRaceIsSerialised(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(N)
 	base := time.Now().UTC()
+	futureCutoff := base.Add(time.Hour).UnixMilli()
 	for i := 0; i < N; i++ {
 		i := i
 		go func() {
 			defer wg.Done()
-			_ = s.CreateAsyncCheckpoint(ctx, int64(i+1), base.Add(time.Duration(i)*time.Millisecond))
+			_ = s.CreateAsyncCheckpoint(ctx, futureCutoff+int64(i+1), base.Add(time.Duration(i)*time.Millisecond))
 		}()
 	}
 	wg.Wait()
@@ -252,6 +253,21 @@ func TestShard_CreateAsyncCheckpoint_ConcurrentRaceIsSerialised(t *testing.T) {
 	// one is at or after the earliest proposal.
 	assert.GreaterOrEqual(t, ca.UnixMilli(), base.UnixMilli())
 	assert.Greater(t, cutoff, int64(0))
+}
+
+func TestShard_CreateAsyncCheckpoint_RejectsPastCutoff(t *testing.T) {
+	ctx := context.Background()
+	s := shardWithHashtree(t)
+
+	require.ErrorIs(t, s.CreateAsyncCheckpoint(ctx, time.Now().Add(-time.Hour).UnixMilli(), time.Now()), errAsyncCheckpointCutoffInPast)
+	if _, _, _, ok := s.AsyncCheckpointRoot(ctx); ok {
+		t.Fatal("a rejected create must leave no active checkpoint")
+	}
+
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, time.Now().Add(time.Hour).UnixMilli(), time.Now()))
+	if _, _, _, ok := s.AsyncCheckpointRoot(ctx); !ok {
+		t.Fatal("a future cutoff must create the checkpoint")
+	}
 }
 
 const (
@@ -268,16 +284,26 @@ type ckOp struct {
 	delEvent int64
 }
 
+// ckBase shifts test timestamps into the future so the cutoff-in-past guard passes; 0 stays 0 (no-version sentinel).
+var ckBase = time.Now().Add(time.Hour).UnixMilli()
+
+func ckAbs(v int64) int64 {
+	if v == 0 {
+		return 0
+	}
+	return ckBase + v
+}
+
 func ckApply(t *testing.T, s *Shard, op ckOp) {
 	t.Helper()
 	idBytes, err := uuid.MustParse(op.id.String()).MarshalBinary()
 	require.NoError(t, err)
 	if op.del {
-		require.NoError(t, s.deleteObjectHashTree(idBytes, op.ts, op.delEvent))
+		require.NoError(t, s.deleteObjectHashTree(idBytes, ckAbs(op.ts), ckAbs(op.delEvent)))
 		return
 	}
-	obj := &storobj.Object{Object: models.Object{ID: op.id, LastUpdateTimeUnix: op.ts}}
-	require.NoError(t, s.upsertObjectHashTree(obj, idBytes, objectInsertStatus{oldUpdateTime: op.old}))
+	obj := &storobj.Object{Object: models.Object{ID: op.id, LastUpdateTimeUnix: ckAbs(op.ts)}}
+	require.NoError(t, s.upsertObjectHashTree(obj, idBytes, objectInsertStatus{oldUpdateTime: ckAbs(op.old)}))
 }
 
 // ckRoot builds a fresh shard, applies before-ops, creates a checkpoint at cutoff, applies after-ops, returns the checkpoint root.
@@ -287,7 +313,7 @@ func ckRoot(t *testing.T, cutoff int64, before, after []ckOp) hashtree.Digest {
 	for _, op := range before {
 		ckApply(t, s, op)
 	}
-	require.NoError(t, s.CreateAsyncCheckpoint(context.Background(), cutoff, time.UnixMilli(cutoff)))
+	require.NoError(t, s.CreateAsyncCheckpoint(context.Background(), ckAbs(cutoff), time.UnixMilli(ckAbs(cutoff))))
 	for _, op := range after {
 		ckApply(t, s, op)
 	}
@@ -349,6 +375,16 @@ func TestShard_AsyncCheckpoint_FoldGating(t *testing.T) {
 			beforeA: []ckOp{{id: ckA, ts: 150}},
 			beforeB: []ckOp{{id: ckA, ts: 100}}, afterB: []ckOp{{del: true, id: ckA, ts: 100, delEvent: 120}, {id: ckA, ts: 150}},
 		},
+		{
+			name:    "post-cutoff-then-pre-cutoff update injects no phantom",
+			beforeA: []ckOp{{id: ckB, ts: 100}}, afterA: []ckOp{{id: ckA, ts: 150}},
+			beforeB: []ckOp{{id: ckB, ts: 100}}, afterB: []ckOp{{id: ckA, ts: 300}, {id: ckA, ts: 150, old: 300}},
+		},
+		{
+			name:    "post-cutoff object with pre-cutoff deletion event stays absent",
+			beforeA: []ckOp{{id: ckB, ts: 100}},
+			beforeB: []ckOp{{id: ckB, ts: 100}}, afterB: []ckOp{{id: ckA, ts: 300}, {del: true, id: ckA, ts: 300, delEvent: 150}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -362,7 +398,8 @@ func TestShard_AsyncCheckpoint_FoldGating(t *testing.T) {
 func TestShard_AsyncCheckpoint_ConcurrentFoldIsRaceFree(t *testing.T) {
 	ctx := context.Background()
 	s := shardWithHashtree(t)
-	require.NoError(t, s.CreateAsyncCheckpoint(ctx, 1_000_000, time.UnixMilli(1_000_000)))
+	cutoff := time.Now().Add(time.Hour).UnixMilli()
+	require.NoError(t, s.CreateAsyncCheckpoint(ctx, cutoff, time.UnixMilli(cutoff)))
 
 	const writers = 8
 	var wg sync.WaitGroup
@@ -388,7 +425,7 @@ func TestShard_AsyncCheckpoint_ConcurrentFoldIsRaceFree(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 50; i++ {
 			_ = s.DeleteAsyncCheckpoint(ctx)
-			_ = s.CreateAsyncCheckpoint(ctx, 1_000_000, time.UnixMilli(int64(1_000_001+i)))
+			_ = s.CreateAsyncCheckpoint(ctx, cutoff+int64(i+1), time.UnixMilli(cutoff+int64(i+1)))
 		}
 	}()
 	wg.Wait()

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1320,8 +1320,9 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 }
 
 var (
-	errAsyncReplicationNotActive = replica.ErrAsyncReplicationNotActive
-	errAsyncCheckpointStale      = replica.ErrAsyncCheckpointStale
+	errAsyncReplicationNotActive   = replica.ErrAsyncReplicationNotActive
+	errAsyncCheckpointStale        = replica.ErrAsyncCheckpointStale
+	errAsyncCheckpointCutoffInPast = replica.ErrAsyncCheckpointCutoffInPast
 )
 
 func (s *Shard) CreateAsyncCheckpoint(ctx context.Context, cutoffMs int64, createdAt time.Time) error {
@@ -1342,6 +1343,13 @@ func (s *Shard) CreateAsyncCheckpoint(ctx context.Context, cutoffMs int64, creat
 	if s.asyncCheckpointHashtree != nil && !createdAt.After(s.asyncCheckpointCreatedAt) {
 		s.metrics.IncAsyncCheckpointCreateFailureCount()
 		return errAsyncCheckpointStale
+	}
+
+	// Checked under the clone lock so it can't go stale: if this node's clock already reached
+	// the cutoff, applied >cutoff writes would be baked into the clone and diverge the root.
+	if cutoffMs <= time.Now().UnixMilli() {
+		s.metrics.IncAsyncCheckpointCreateFailureCount()
+		return errAsyncCheckpointCutoffInPast
 	}
 
 	// Lifetime measured from local activation, never initiator createdAt, to avoid skew.

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -1041,7 +1041,7 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 	}
 	s.AppendChangeLogDelete(idBytes, logTime)
 
-	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {
+	if err = s.mayDeleteObjectHashTree(idBytes, updateTime, logTime); err != nil {
 		return errors.Wrap(err, "object deletion in hashtree")
 	}
 

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -100,7 +100,7 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 	}
 	s.AppendChangeLogDelete(idBytes, logTime)
 
-	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {
+	if err = s.mayDeleteObjectHashTree(idBytes, updateTime, logTime); err != nil {
 		return false, fmt.Errorf("object deletion in hashtree: %w", err)
 	}
 
@@ -206,15 +206,15 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 	return nil
 }
 
-func (s *Shard) mayDeleteObjectHashTree(uuidBytes []byte, updateTime int64) error {
+func (s *Shard) mayDeleteObjectHashTree(uuidBytes []byte, updateTime, deletionEventMs int64) error {
 	if s.hashtree == nil {
 		return nil
 	}
 
-	return s.deleteObjectHashTree(uuidBytes, updateTime)
+	return s.deleteObjectHashTree(uuidBytes, updateTime, deletionEventMs)
 }
 
-func (s *Shard) deleteObjectHashTree(uuidBytes []byte, updateTime int64) error {
+func (s *Shard) deleteObjectHashTree(uuidBytes []byte, updateTime, deletionEventMs int64) error {
 	if len(uuidBytes) != 16 {
 		return fmt.Errorf("invalid object uuid")
 	}
@@ -233,6 +233,14 @@ func (s *Shard) deleteObjectHashTree(uuidBytes []byte, updateTime int64) error {
 	// object deletion is treated as non-existent because the deletion time or
 	// tombstone may not be available
 	s.hashtree.AggregateLeafWith(leaf, objectDigest[:])
+
+	// Fold ≤cutoff deletions out of the active checkpoint; a post-cutoff delete keeps the pre-cutoff object.
+	// The clone shares the live tree's leaf layout (any height-changing rebuild clears the checkpoint first).
+	if cpht := s.asyncCheckpointHashtree; cpht != nil && deletionEventMs <= s.asyncCheckpointCutoff {
+		if err := cpht.AggregateLeafWith(leaf, objectDigest[:]); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -234,9 +234,9 @@ func (s *Shard) deleteObjectHashTree(uuidBytes []byte, updateTime, deletionEvent
 	// tombstone may not be available
 	s.hashtree.AggregateLeafWith(leaf, objectDigest[:])
 
-	// Fold ≤cutoff deletions out of the active checkpoint; a post-cutoff delete keeps the pre-cutoff object.
-	// The clone shares the live tree's leaf layout (any height-changing rebuild clears the checkpoint first).
-	if cpht := s.asyncCheckpointHashtree; cpht != nil && deletionEventMs <= s.asyncCheckpointCutoff {
+	// Fold a ≤cutoff delete out of the checkpoint. Require BOTH the event and the stored version
+	// ≤cutoff: erasing a >cutoff version the clone never held would inject a phantom term.
+	if cpht := s.asyncCheckpointHashtree; cpht != nil && deletionEventMs <= s.asyncCheckpointCutoff && updateTime <= s.asyncCheckpointCutoff {
 		if err := cpht.AggregateLeafWith(leaf, objectDigest[:]); err != nil {
 			return err
 		}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -344,31 +344,29 @@ func (s *Shard) upsertObjectHashTree(object *storobj.Object, uuidBytes []byte, s
 	var objectDigest [16 + 8]byte
 	copy(objectDigest[:], uuidBytes)
 
-	// Fold ≤cutoff changes into the active checkpoint so it converges post-creation; post-cutoff writes are excluded.
-	// The clone shares the live tree's leaf layout (any height-changing rebuild clears the checkpoint first).
-	cpht := s.asyncCheckpointHashtree
-	foldCheckpoint := cpht != nil && object.Object.LastUpdateTimeUnix <= s.asyncCheckpointCutoff
-
+	// Update the live tree first so a checkpoint-fold error can never leave a torn leaf.
 	if status.oldUpdateTime > 0 {
 		// Given only latest object version is maintained, previous registration is erased
 		binary.BigEndian.PutUint64(objectDigest[16:], uint64(status.oldUpdateTime))
 		s.hashtree.AggregateLeafWith(leaf, objectDigest[:])
-		if foldCheckpoint {
-			if err := cpht.AggregateLeafWith(leaf, objectDigest[:]); err != nil {
-				return err
-			}
-		}
 	}
-
 	binary.BigEndian.PutUint64(objectDigest[16:], uint64(object.Object.LastUpdateTimeUnix))
 	s.hashtree.AggregateLeafWith(leaf, objectDigest[:])
-	if foldCheckpoint {
+
+	// Fold ≤cutoff changes into the checkpoint so it converges; >cutoff writes leave it frozen.
+	cpht := s.asyncCheckpointHashtree
+	if cpht == nil || object.Object.LastUpdateTimeUnix > s.asyncCheckpointCutoff {
+		return nil
+	}
+	// Erase old only if the clone holds it (old ≤ cutoff); erasing a >cutoff version injects a phantom.
+	if status.oldUpdateTime > 0 && status.oldUpdateTime <= s.asyncCheckpointCutoff {
+		binary.BigEndian.PutUint64(objectDigest[16:], uint64(status.oldUpdateTime))
 		if err := cpht.AggregateLeafWith(leaf, objectDigest[:]); err != nil {
 			return err
 		}
+		binary.BigEndian.PutUint64(objectDigest[16:], uint64(object.Object.LastUpdateTimeUnix))
 	}
-
-	return nil
+	return cpht.AggregateLeafWith(leaf, objectDigest[:])
 }
 
 func (s *Shard) hashtreeLeafFor(uuidBytes []byte) uint64 {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -344,14 +344,29 @@ func (s *Shard) upsertObjectHashTree(object *storobj.Object, uuidBytes []byte, s
 	var objectDigest [16 + 8]byte
 	copy(objectDigest[:], uuidBytes)
 
+	// Fold ≤cutoff changes into the active checkpoint so it converges post-creation; post-cutoff writes are excluded.
+	// The clone shares the live tree's leaf layout (any height-changing rebuild clears the checkpoint first).
+	cpht := s.asyncCheckpointHashtree
+	foldCheckpoint := cpht != nil && object.Object.LastUpdateTimeUnix <= s.asyncCheckpointCutoff
+
 	if status.oldUpdateTime > 0 {
 		// Given only latest object version is maintained, previous registration is erased
 		binary.BigEndian.PutUint64(objectDigest[16:], uint64(status.oldUpdateTime))
 		s.hashtree.AggregateLeafWith(leaf, objectDigest[:])
+		if foldCheckpoint {
+			if err := cpht.AggregateLeafWith(leaf, objectDigest[:]); err != nil {
+				return err
+			}
+		}
 	}
 
 	binary.BigEndian.PutUint64(objectDigest[16:], uint64(object.Object.LastUpdateTimeUnix))
 	s.hashtree.AggregateLeafWith(leaf, objectDigest[:])
+	if foldCheckpoint {
+		if err := cpht.AggregateLeafWith(leaf, objectDigest[:]); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
+++ b/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
@@ -225,7 +225,9 @@ func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_Convergenc
 
 	// Single createdAt, propagated unchanged: replicas reject one another via the strict-greater-than guard.
 	createdAt := time.Now().UTC()
-	cutoffMs := createdAt.UnixMilli()
+	// Cutoff must be in every node's future at create (past-cutoff guard); short so the frozen subtest can outwait it.
+	cutoff := createdAt.Add(20 * time.Second)
+	cutoffMs := cutoff.UnixMilli()
 
 	t.Run("create checkpoint on every node with the same createdAt", func(t *testing.T) {
 		for i, cluster := range nodeClusters {
@@ -289,6 +291,10 @@ func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_Convergenc
 	})
 
 	t.Run("post-cutoff writes do NOT change the checkpoint root", func(t *testing.T) {
+		// Wait until wall-clock passes the cutoff so these writes are genuinely post-cutoff.
+		if d := time.Until(cutoff); d > 0 {
+			time.Sleep(d + time.Second)
+		}
 		batch := make([]*models.Object, 10)
 		for i := 0; i < 10; i++ {
 			batch[i] = articles.NewParagraph().
@@ -374,8 +380,9 @@ func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_RestartDro
 	shards := discoverShards(t, node1REST, paragraphClass.Class)
 
 	createdAt := time.Now().UTC()
+	cutoffMs := createdAt.Add(time.Hour).UnixMilli()
 	for _, c := range []string{node1Cluster, node2Cluster, node3Cluster} {
-		asyncCheckpointCreate(t, c, paragraphClass.Class, shards, createdAt.UnixMilli(), createdAt.UnixMilli())
+		asyncCheckpointCreate(t, c, paragraphClass.Class, shards, cutoffMs, createdAt.UnixMilli())
 	}
 
 	// Pre-restart: every node has an active checkpoint.

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -43,6 +43,8 @@ var (
 	ErrAsyncCheckpointStale = errors.New("checkpoint createdAt is not newer than the active one")
 	// ErrAsyncReplicationNotActive maps to HTTP 412 / FailedPrecondition.
 	ErrAsyncReplicationNotActive = errors.New("async replication is not active on this shard")
+	// ErrAsyncCheckpointCutoffInPast maps to HTTP 412 / FailedPrecondition.
+	ErrAsyncCheckpointCutoffInPast = errors.New("checkpoint cutoff is not in this node's future")
 	// MsgCLevel consistency level cannot be achieved
 	MsgCLevel = "cannot achieve consistency level"
 


### PR DESCRIPTION
## Motivation

The async-checkpoint feature pins a *bounded* hashtree root at a cutoff timestamp so the backup orchestrator can assert that every replica of a shard has converged on the same pre-cutoff state before a single-node backup is taken. `CreateAsyncCheckpoint` implements this by deep-cloning the live shard hashtree at create time (`shard_async_replication.go` `CreateAsyncCheckpoint`).

The other half of the design — "keep absorbing pre-cutoff objects that are still trickling in from other replicas" — was never wired into the apply path. The clone was frozen at create time and never updated again. So a replica that was still catching up when the checkpoint was created could **never** converge its bounded root: it stayed pinned to a partial snapshot, and the cross-replica bit-identical-root contract was unsatisfiable for it.

This is exactly why `TestAsyncCheckpoint_ConvergenceAcrossReplicas` flaked — any run where a seed object hadn't finished replicating to all three nodes by checkpoint-create time left one replica's bounded root permanently divergent.

## Approach

Fold every applied leaf change into the active checkpoint clone **iff ≤ cutoff**, on the shared apply path (`upsertObjectHashTree` / `deleteObjectHashTree`), so a late-arriving pre-cutoff object moves the bounded root toward the converged state while post-cutoff writes — including post-cutoff *updates and deletes of pre-cutoff objects* — leave it frozen.

A fold is an XOR of a per-version digest (the object's UUID concatenated with its `LastUpdateTimeUnix`). The subtlety the second commit fixes is that the gate must key on **which versions the clone actually holds**, not merely on the incoming event's timestamp. Three consequences:

- **Erase-old is gated on the stored version, not the new one.** An upsert XORs the old digest *out* of the clone and the new digest *in*. The clone only ever absorbed the old digest if the old version was ≤cutoff. When the old version is >cutoff — e.g. a post-cutoff write followed by a non-monotonic pre-cutoff update landing from another replica — XORing out a digest the clone never held injects a phantom term and silently diverges the bounded root. So the erase-old fold now requires `oldUpdateTime ≤ cutoff`, independent of the new version's own gate.
- **A delete is gated on both the stored version and the deletion event.** `deleteObjectHashTree` takes the deletion **event** time (`logTime`), distinct from the object's stored `updateTime`, and folds the erase only when *both* are ≤cutoff. A past-dated delete event of a >cutoff object must not erase a version the clone never held.
- **The cutoff must be in this node's future.** The clone is a snapshot of the live tree at create time; if this node's clock has already passed the cutoff, the live tree can already contain >cutoff versions that get baked into the clone at birth — unremovable, permanently divergent. `CreateAsyncCheckpoint` now rejects with `ErrAsyncCheckpointCutoffInPast` (HTTP 412 / gRPC `FailedPrecondition`), checked under the *same write lock that clones the tree* so the guard can't race the clone. A skewed peer whose clock is still behind the cutoff creates normally; the initiator handles the per-node rejection.

The live tree is also updated **before** any clone fold, so a fold error can never leave a torn leaf on the source-of-truth tree.

**Why the two shared helpers are the right (and only) place**: every hashtree-mutating journey funnels through them — single/batch put, merge, single/batch delete, and the async-rep receive (`OverwriteObjects`) and changelog-replay (`OverwriteObjectsFromChangeLog`) paths. The only tree mutations that *don't* go through them are the init-scan build and `Reset`, which run before `hashtreeFullyInitialized` when no checkpoint can be active; and the runtime height-change rebuild, which clears the checkpoint via `disableAsyncReplication` first. So the clone always shares the live tree's leaf layout — a load-bearing precondition for `AggregateLeafWith` on the clone to target the right leaf.

## Key areas for review

- `shard_write_put.go:upsertObjectHashTree` — live-tree-first ordering, then the two clone folds: erase-old gated on `oldUpdateTime ≤ cutoff`, write-new gated on the new version ≤ cutoff. Verify a phantom can't be XORed out when the stored version was >cutoff.
- `shard_write_delete.go:deleteObjectHashTree` — the dual gate `deletionEventMs ≤ cutoff && updateTime ≤ cutoff`; confirm both the event-time-vs-update-time distinction and the stored-version guard are correct.
- `shard_async_replication.go:CreateAsyncCheckpoint` — the cutoff-in-future reject; verify it sits after the stale check and before the clone, is evaluated under the write lock, and that failure increments the create-failure metric.
- Error plumbing for the new precondition: `ErrAsyncCheckpointCutoffInPast` (`finder.go`) → HTTP 412 (`indices_replicas.go`) / gRPC `FailedPrecondition` (`replication_service.go`).
- The claim that these two helpers are the sole mutation funnel while a checkpoint is active — if any journey mutates `s.hashtree` without going through them, the bounded root silently diverges.

## Risks and mitigations

- **Phantom XOR diverging the bounded root** (the second-commit bug): erasing an old/stored version the clone never absorbed silently corrupts the root the backup convergence contract depends on. Mitigated by gating *every* erase on the stored version's own ≤cutoff check, and by rejecting cutoffs already in the past so a >cutoff version can't be cloned in at birth. Pinned by the two new `FoldGating` cases and `TestShard_CreateAsyncCheckpoint_RejectsPastCutoff`, both red against the first commit.
- **Torn state / lost fold during a concurrent create-swap**: the live tree is fully updated before any clone fold, so a fold error leaves the source-of-truth tree intact; folds read and mutate `s.asyncCheckpointHashtree` under `asyncReplicationRWMux.RLock` (the same lock every write path already holds when calling these helpers), while `Create`/`Delete`/`clear` swap the pointer under the write `Lock`. Covered by `TestShard_AsyncCheckpoint_ConcurrentFoldIsRaceFree` under `-race`.
- **Clock skew across replicas**: the future-cutoff guard is per-node — a node whose clock already passed the cutoff rejects (412/FailedPrecondition) rather than baking in >cutoff data, and laggier peers create normally, so the orchestrator sees an explicit precondition failure instead of a silently-wrong root.
- **Leaf-layout mismatch corrupting the bounded root**: a height-changing rebuild would make the clone's leaves disagree with the live tree. Mitigated because that rebuild goes through `disableAsyncReplication` → `clearAsyncCheckpointLocked` first, so no stale clone survives a layout change. `AggregateLeafWith` is also bounds-checked (returns an error rather than corrupting) as defense in depth.
- **Per-write overhead**: at most two `AggregateLeafWith` on the clone per upsert (erase-old + write-new) and one per delete, only while a checkpoint is active and only for ≤cutoff versions; a nil-pointer check otherwise. Negligible and scoped to the checkpoint's (short) lifetime.

## Testing

Two tiers, both of which go **red** without the fold *and* without the second-commit gating fix:

- **Unit** (`shard_async_checkpoint_test.go`) — deterministic XOR-algorithm tests over the two helpers directly. `TestShard_AsyncCheckpoint_FoldGating` is table-driven and now includes the two phantom-injection regressions — *post-cutoff-then-pre-cutoff update injects no phantom* and *post-cutoff object with pre-cutoff deletion event stays absent* — both of which fail against the first commit's event-only gate. Plus late-pre-cutoff absorption, create/update/delete gating, the post-cutoff-update-keeps-pre-cutoff-version case, resurrection (delete-then-recreate), the new `TestShard_CreateAsyncCheckpoint_RejectsPastCutoff`, and an 8-writer `-race` concurrency test. All checkpoint tests were shifted onto future cutoffs (via the `ckAbs`/`ckBase` helpers) so the new guard is satisfied while preserving the seed<pre<cutoff<post ordering the assertions rely on.
- **Integration** (`shard_async_checkpoint_integration_test.go`) — journey tests driving the *real public methods* for every mutating path (single/batch put, single/batch delete, merge, and `OverwriteObjects` receive), each asserting both the absorbed (≤cutoff moves the bounded root to equal the live root) and frozen (>cutoff leaves it pinned) outcomes; timestamps are shifted an hour into the future so the cutoff-in-past guard passes.

Verified locally: both tiers pass under `-race`; existing async-rep/checkpoint/delete unit + integration tests pass; `golangci-lint` and the goroutine linter are clean; and the acceptance suite `TestAsyncCheckpointConvergenceTestSuite` passes on a fresh 3-node testcontainer cluster (27s vs. the failing run's 104s that burned the full convergence timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
