### PR TITLE
fix(async-repl): overwrite read-repair must not resurrect unloaded shards; drop redundant REST retry

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -549,9 +549,23 @@ func (c *replicationClient) OverwriteObjects(ctx context.Context,
 		req.Header.Set("X-Request-Encoding", "binary")
 	}
 
+	// No per-RPC retry: the async replication scheduler retries the full cycle on the next tick (matches CompareDigests/DigestObjectsInRange and the gRPC client).
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("status code: %v, error: %s", res.StatusCode, b)
+	}
+
 	var resp []types.RepairResponse
-	err = c.doRetry(req, bodyCompressed, &resp, MAX_RETRIES)
-	return resp, err
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return resp, nil
 }
 
 func (c *replicationClient) FetchObjects(ctx context.Context, host,

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -912,6 +913,45 @@ func TestReplicationOverwriteObjectsConcurrent(t *testing.T) {
 
 	for i, err := range errs {
 		require.NoErrorf(t, err, "goroutine %d failed", i)
+	}
+}
+
+func TestReplicationOverwriteObjectsNoRetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	input := []*objects.VObject{
+		{
+			LatestObject:    &models.Object{ID: UUID1, Class: "C1", LastUpdateTimeUnix: now.UnixMilli()},
+			StaleUpdateTime: now.UnixMilli(),
+		},
+	}
+
+	cases := []struct {
+		name string
+		code int
+	}{
+		{name: "service unavailable", code: http.StatusServiceUnavailable},
+		{name: "internal server error", code: http.StatusInternalServerError},
+		{name: "too many requests", code: http.StatusTooManyRequests},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				http.Error(w, "boom", tc.code)
+			}))
+			defer server.Close()
+
+			c := newReplicationClient(t, server.Client())
+			_, err := c.OverwriteObjects(context.Background(), server.URL[7:], "C1", "S1", input)
+			require.Error(t, err)
+			assert.Equal(t, int32(1), calls.Load(), "OverwriteObjects must not retry on %d", tc.code)
+		})
 	}
 }
 

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -2616,6 +2616,28 @@ func TestOverwriteObjects(t *testing.T) {
 		require.Nil(t, err)
 		assert.EqualValues(t, freshRaw, found.Object())
 	})
+
+	t.Run("does not resurrect an unloaded shard", func(t *testing.T) {
+		idx := repo.GetIndex(schema.ClassName(class.Class))
+		shd, err := idx.shardResolver.ResolveShardByObjectID(context.Background(), fresh.ID, "")
+		require.Nil(t, err)
+
+		require.Nil(t, idx.UnloadLocalShard(context.Background(), shd))
+		require.Nil(t, idx.shards.Load(shd))
+
+		input := []*objects.VObject{
+			{
+				LatestObject:    fresh,
+				Vector:          fresh.Vector,
+				StaleUpdateTime: stale.LastUpdateTimeUnix,
+			},
+		}
+
+		_, err = idx.OverwriteObjects(context.Background(), shd, input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found locally")
+		assert.Nil(t, idx.shards.Load(shd), "shard must not be reloaded by OverwriteObjects")
+	})
 }
 
 func TestIndexDigestObjects(t *testing.T) {

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -659,7 +659,7 @@ func (s *Shard) filePutter(ctx context.Context,
 func (idx *Index) OverwriteObjects(ctx context.Context,
 	shard string, updates []*objects.VObject,
 ) ([]types.RepairResponse, error) {
-	s, release, err := idx.getOrInitShard(ctx, shard)
+	s, release, err := idx.GetShard(ctx, shard)
 	if err != nil {
 		return nil, fmt.Errorf("shard %q not found locally", shard)
 	}


### PR DESCRIPTION
## Motivation

Two related hardening fixes on the async-replication / read-repair `OverwriteObjects` RPC, both concerning the same operation on the client and server sides.

**1. Shard resurrection.** `Index.OverwriteObjects` (the server side of an incoming read-repair overwrite) resolved its shard with `getOrInitShard`, whose own godoc forbids exactly this: *"Don't use this function on read requests. Instead, use GetShard() to avoid creating an empty shard"* ([index.go:3025](https://github.com/weaviate/weaviate/blob/cd28cdc699/adapters/repos/db/index.go#L3025)). Because an async-replication overwrite is an unsolicited background message, a repair aimed at a shard that had been intentionally unloaded — a COLD multi-tenant tenant, an offloaded shard, or one mid-drop — would silently **re-create** it on disk. This is the A4 "drop-resurrection" family: a lifecycle operation removes a shard and a stray repair RPC brings it back.

**2. Redundant per-RPC retry.** The REST client's `OverwriteObjects` retried up to `MAX_RETRIES = 9` with exponential backoff on 500/429/503, while the gRPC client and the sibling digest RPCs (`CompareDigests`, `DigestObjectsInRange`) do not retry at all — the async-replication scheduler already re-runs the whole compare/repair cycle on the next tick. The REST retry only stretched the per-shard deadline without reducing repair latency, and made REST and gRPC replicas behave differently for the same logical operation in a mixed cluster.

## Approach

**Server** (`adapters/repos/db/replication.go`): swap `getOrInitShard` → `GetShard` in `Index.OverwriteObjects`. `GetShard` returns `(nil, no-op release, nil)` when the shard isn't loaded, which the existing nil-guard already turns into `shard %q not found locally`. No new branch needed.

The two nearby paths that keep `getOrInitShard` are intentional, not oversights:
- the write-replication path (`writableShard` → `ReplicateObject/Objects/...`), where init is correct because the coordinator is committing an actual write;
- `OverwriteObjectsFromChangeLog`, the coordinated CDC replay used during replica movement, where the target shard is *supposed* to be materialized by the copy op.

Only the unsolicited read-repair overwrite must not init.

**Client** (`adapters/clients/replication.go`): the REST `OverwriteObjects` now issues a single `client.Do`, checks the status code, and decodes — mirroring `DigestObjectsInRange` / `CompareDigests` and the gRPC client. Errors propagate verbatim to the scheduler.

## Key areas for review

- `adapters/repos/db/replication.go:659` `Index.OverwriteObjects` — the `GetShard` swap. Verify the nil-shard case returns "not found locally" and that `defer release()` on the no-op release is safe.
- `adapters/repos/db/replication.go:849` `OverwriteObjectsFromChangeLog` — **deliberately unchanged**; confirm CDC replay should still materialize the target shard (if not, it shares the resurrection risk and needs the same treatment).
- `adapters/clients/replication.go:519` client `OverwriteObjects` — single-shot request; confirm parity with the digest/gRPC paths and that read-repair idempotency makes the dropped retries safe.

## Risks and mitigations

- **Lost transient-error resilience on repair overwrite (500/429/503).** Mitigated: read-repair is idempotent and best-effort; the async-replication scheduler re-runs the full cycle next tick, and gRPC replicas already behaved this way — this only aligns the legacy REST path, it doesn't introduce new fragility.
- **Accidentally skipping a legitimate shard init.** Mitigated: only the unsolicited read-repair path changed. The coordinated write and CDC-replay paths still use `getOrInitShard`, and the new integration test pins that the read-repair path leaves an unloaded shard unloaded.

## Testing

- **Unit** — `TestReplicationOverwriteObjectsNoRetry` (table-driven over 503 / 500 / 429): asserts the client makes exactly one HTTP call and returns the error, i.e. no retry.
- **Integration** — `TestOverwriteObjects/"does not resurrect an unloaded shard"`: unloads a live shard, calls `Index.OverwriteObjects`, asserts it fails with `not found locally` and that `idx.shards.Load(shard)` is still nil afterward (the shard was not reloaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)