### PR TITLE
fix(async-repl): init-scan hashtree double-count and tombstone resurrection

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -494,8 +494,11 @@ func (b *Bucket) resumeCompaction(ctx context.Context) error {
 	return nil
 }
 
-// ApplyToObjectDigests applies f to every object in the bucket (memtable and disk),
-// stopping on the first error. afterInMemCallback fires once the in-memory scan is done.
+// ApplyToObjectDigests applies f to every live object (memtable and disk) once per
+// UUID, stopping on the first error. Dedup is keyed by UUID, not docID (a
+// vector-changed update reuses the UUID under a new docID); memtable-only tombstones
+// suppress their stale on-disk value. afterInMemCallback fires once the in-memory
+// scan is done.
 //
 // The on-disk cursor is created while the in-mem cursor holds the flush lock, so both
 // snapshots are taken at a single consistent point with no flush in between. Compaction
@@ -505,13 +508,13 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 ) error {
 	var onDiskCursor *CursorReplace
 
-	inmemProcessedDocIDs := make(map[uint64]struct{})
+	inmemProcessedUUIDs := make(map[[16]byte]struct{})
 
 	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
 	err := func() error {
 		defer afterInMemCallback()
 
-		inMemCursor := b.CursorInMem()
+		inMemCursor := b.CursorInMemWithTombstones()
 		defer inMemCursor.Close()
 
 		// created under the in-mem cursor's flush lock, so it is consistent with the
@@ -524,15 +527,25 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				docID, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
-				if err != nil {
-					return fmt.Errorf("cannot unmarshal object: %w", err)
-				}
-				if err := f(k, updateTime); err != nil {
-					return fmt.Errorf("callback on object '%d' failed: %w", docID, err)
-				}
+			}
 
-				inmemProcessedDocIDs[docID] = struct{}{}
+			// record every UUID (live or tombstone) so the disk pass skips its stale value
+			if len(k) == 16 {
+				var uuid [16]byte
+				copy(uuid[:], k)
+				inmemProcessedUUIDs[uuid] = struct{}{}
+			}
+
+			if v == nil {
+				continue // tombstone: recorded, not folded
+			}
+
+			_, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
+			if err != nil {
+				return fmt.Errorf("cannot unmarshal object: %w", err)
+			}
+			if err := f(k, updateTime); err != nil {
+				return fmt.Errorf("callback on object failed: %w", err)
 			}
 		}
 
@@ -550,18 +563,22 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			docID, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
-			if err != nil {
-				return fmt.Errorf("cannot unmarshal object: %w", err)
-			}
+		}
 
-			if _, ok := inmemProcessedDocIDs[docID]; ok {
+		if len(k) == 16 {
+			var uuid [16]byte
+			copy(uuid[:], k)
+			if _, ok := inmemProcessedUUIDs[uuid]; ok {
 				continue
 			}
+		}
 
-			if err := f(k, updateTime); err != nil {
-				return fmt.Errorf("callback on object '%d' failed: %w", docID, err)
-			}
+		_, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
+		if err != nil {
+			return fmt.Errorf("cannot unmarshal object: %w", err)
+		}
+		if err := f(k, updateTime); err != nil {
+			return fmt.Errorf("callback on object failed: %w", err)
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -529,12 +529,12 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 			default:
 			}
 
-			// record every UUID (live or tombstone) so the disk pass skips its stale value
-			if len(k) == 16 {
-				var uuid [16]byte
-				copy(uuid[:], k)
-				inmemProcessedUUIDs[uuid] = struct{}{}
+			if len(k) != 16 {
+				return fmt.Errorf("invalid object uuid '%x': expected 16 bytes, got %d", k, len(k))
 			}
+
+			// record every UUID (live or tombstone) so the disk pass skips its stale value
+			inmemProcessedUUIDs[[16]byte(k)] = struct{}{}
 
 			if v == nil {
 				continue // tombstone: recorded, not folded
@@ -542,10 +542,10 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 
 			_, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
 			if err != nil {
-				return fmt.Errorf("cannot unmarshal object: %w", err)
+				return fmt.Errorf("cannot unmarshal object '%x': %w", k, err)
 			}
 			if err := f(k, updateTime); err != nil {
-				return fmt.Errorf("callback on object failed: %w", err)
+				return fmt.Errorf("callback on object '%x' failed: %w", k, err)
 			}
 		}
 
@@ -565,20 +565,20 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 		default:
 		}
 
-		if len(k) == 16 {
-			var uuid [16]byte
-			copy(uuid[:], k)
-			if _, ok := inmemProcessedUUIDs[uuid]; ok {
-				continue
-			}
+		if len(k) != 16 {
+			return fmt.Errorf("invalid object uuid '%x': expected 16 bytes, got %d", k, len(k))
+		}
+
+		if _, ok := inmemProcessedUUIDs[[16]byte(k)]; ok {
+			continue
 		}
 
 		_, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
 		if err != nil {
-			return fmt.Errorf("cannot unmarshal object: %w", err)
+			return fmt.Errorf("cannot unmarshal object '%x': %w", k, err)
 		}
 		if err := f(k, updateTime); err != nil {
-			return fmt.Errorf("callback on object failed: %w", err)
+			return fmt.Errorf("callback on object '%x' failed: %w", k, err)
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -3010,3 +3010,30 @@ func TestPutRequiresSecondaryKeys(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestApplyToObjectDigestsRejectsNonUUIDKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "shorterThanUUID", key: "not-a-uuid"},
+		{name: "longerThanUUID", key: "0123456789abcdef0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			active := newTestMemtableReplace(map[string][]byte{test.key: []byte("value")})
+			b := Bucket{active: active, disk: &SegmentGroup{}, strategy: StrategyReplace}
+
+			folded := 0
+			err := b.ApplyToObjectDigests(context.Background(), func() {}, func([]byte, int64) error {
+				folded++
+				return nil
+			})
+			require.ErrorContains(t, err, "invalid object uuid")
+			require.Zero(t, folded)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -21,9 +22,12 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +40,9 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/lsmkv"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 type bucketTest struct {
@@ -3036,4 +3042,82 @@ func TestApplyToObjectDigestsRejectsNonUUIDKey(t *testing.T) {
 			require.Zero(t, folded)
 		})
 	}
+}
+
+func TestApplyToObjectDigestsWithFlushingMemtable(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	const updateTime = int64(1700000000000)
+
+	key := func(b byte) []byte { return bytes.Repeat([]byte{b}, 16) }
+	keyA, keyB, keyC, keyD := key(0x0a), key(0x0b), key(0x0c), key(0x0d)
+
+	objValue := func(t *testing.T, k []byte, docID uint64, updateTime int64) []byte {
+		t.Helper()
+		obj := storobj.FromObject(&models.Object{
+			Class:              "Digest",
+			ID:                 strfmt.UUID(uuid.UUID(k).String()),
+			LastUpdateTimeUnix: updateTime,
+		}, nil, nil, nil)
+		obj.DocID = docID
+		v, err := obj.MarshalBinary()
+		require.NoError(t, err)
+		return v
+	}
+
+	scan := func(t *testing.T, b *Bucket) map[string]int64 {
+		t.Helper()
+		folds := map[string]int64{}
+		folded := 0
+		require.NoError(t, b.ApplyToObjectDigests(ctx, func() {}, func(uuidBytes []byte, updateTime int64) error {
+			folds[fmt.Sprintf("%x", uuidBytes)] = updateTime
+			folded++
+			return nil
+		}))
+		require.Len(t, folds, folded, "every live UUID must be folded exactly once")
+		return folds
+	}
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put(keyA, objValue(t, keyA, 1, updateTime)))
+	require.NoError(t, b.Put(keyB, objValue(t, keyB, 2, updateTime)))
+	require.NoError(t, b.FlushAndSwitch())
+
+	require.NoError(t, b.Put(keyA, objValue(t, keyA, 3, updateTime+1)))
+	require.NoError(t, b.Put(keyC, objValue(t, keyC, 4, updateTime)))
+
+	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	require.NoError(t, err)
+	require.True(t, switched)
+	require.NotNil(t, b.flushing, "the scan must run against a live flushing memtable")
+
+	// Shutdown blocks until b.flushing clears, so land it even if an assertion below fails.
+	landFlushing := sync.OnceFunc(func() {
+		segmentPath, err := b.flushing.flush()
+		require.NoError(t, err)
+		segment, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
+		require.NoError(t, err)
+		require.NoError(t, b.atomicallyAddDiskSegmentAndRemoveFlushing(segment))
+	})
+	t.Cleanup(landFlushing)
+
+	require.NoError(t, b.Delete(keyB))
+	require.NoError(t, b.Put(keyD, objValue(t, keyD, 5, updateTime)))
+
+	want := map[string]int64{
+		fmt.Sprintf("%x", keyA): updateTime + 1,
+		fmt.Sprintf("%x", keyC): updateTime,
+		fmt.Sprintf("%x", keyD): updateTime,
+	}
+	require.Equal(t, want, scan(t, b))
+
+	landFlushing()
+
+	require.Equal(t, want, scan(t, b), "root must not depend on whether the flushing memtable had landed")
 }

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -26,6 +26,9 @@ type CursorReplace struct {
 	serveCache   cursorStateReplace
 
 	reusableIDList []int
+
+	// surface deleted keys (nil value) instead of skipping; set by CursorInMemWithTombstones
+	emitTombstones bool
 }
 
 type innerCursorReplace interface {
@@ -155,10 +158,20 @@ func (b *Bucket) CursorReplaceDigestReusable(valuePrefixLen int) *CursorReplace 
 	}
 }
 
-// CursorInMemWith returns a cursor which scan over the primary key of entries
+// CursorInMem returns a cursor which scans over the primary key of entries
 // not yet persisted on disk.
-// Segment creation and compaction will be blocked until the cursor is closed
+// Segment creation and compaction will be blocked until the cursor is closed.
 func (b *Bucket) CursorInMem() *CursorReplace {
+	return b.cursorInMem(false)
+}
+
+// CursorInMemWithTombstones behaves like CursorInMem but surfaces deleted keys with
+// a nil value (used by the hashtree init scan to record memtable-only tombstones).
+func (b *Bucket) CursorInMemWithTombstones() *CursorReplace {
+	return b.cursorInMem(true)
+}
+
+func (b *Bucket) cursorInMem(emitTombstones bool) *CursorReplace {
 	MustBeExpectedStrategy(b.strategy, StrategyReplace)
 	b.flushLock.RLock()
 
@@ -167,10 +180,11 @@ func (b *Bucket) CursorInMem() *CursorReplace {
 	// we have a flush-RLock, so we have the guarantee that the flushing state
 	// will not change for the lifetime of the cursor, thus there can only be two
 	// states: either a flushing memtable currently exists - or it doesn't
-	var flushingMemtableCursor innerCursorReplace
 	var releaseFlushingMemtable func()
+	hadFlushing := b.flushing != nil
 
-	if b.flushing != nil {
+	if hadFlushing {
+		var flushingMemtableCursor innerCursorReplace
 		flushingMemtableCursor, releaseFlushingMemtable = b.flushing.newBlockingCursor()
 		innerCursors = append(innerCursors, flushingMemtableCursor)
 	}
@@ -181,9 +195,11 @@ func (b *Bucket) CursorInMem() *CursorReplace {
 	return &CursorReplace{
 		// cursor are in order from oldest to newest, with the memtable cursor
 		// being at the very top
-		innerCursors: innerCursors,
+		innerCursors:   innerCursors,
+		emitTombstones: emitTombstones,
+		// capture hadFlushing so unlock releases exactly what it acquired
 		unlock: func() {
-			if b.flushing != nil {
+			if hadFlushing {
 				releaseFlushingMemtable()
 			}
 			releaseActiveMemtable()
@@ -310,6 +326,10 @@ func (c *CursorReplace) serveCurrentStateAndAdvance() ([]byte, []byte) {
 		}
 
 		if errors.Is(c.serveCache.err, lsmkv.Deleted) {
+			if c.emitTombstones {
+				// literal nil, not the reused serveCache.value, so callers can detect the tombstone
+				return c.serveCache.key, nil
+			}
 			// element was deleted, proceed with next round
 			continue
 		}

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_test.go
@@ -170,3 +170,39 @@ func TestReplaceCursorConsistentView(t *testing.T) {
 	}
 	require.Equal(t, expected, actual)
 }
+
+// TestCursorInMemWithTombstones checks CursorInMemWithTombstones yields deleted keys with a literal nil value ("ccc" sorts after live keys to pin nil vs the reused buffer); plain CursorInMem skips them.
+func TestCursorInMemWithTombstones(t *testing.T) {
+	t.Parallel()
+
+	active := newTestMemtableReplace(map[string][]byte{
+		"aaa": []byte("va"),
+		"bbb": []byte("vb"),
+	})
+	active.key.setTombstone([]byte("ccc"), nil, nil)
+
+	b := Bucket{active: active, disk: &SegmentGroup{}, strategy: StrategyReplace}
+
+	// plain in-mem cursor skips the tombstone
+	plain := map[string]string{}
+	c := b.CursorInMem()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		plain[string(k)] = string(v)
+	}
+	c.Close()
+	require.Equal(t, map[string]string{"aaa": "va", "bbb": "vb"}, plain)
+
+	// tombstone-emitting cursor surfaces "ccc" with a literal nil value
+	seen := map[string]bool{}
+	ct := b.CursorInMemWithTombstones()
+	for k, v := ct.First(); k != nil; k, v = ct.Next() {
+		seen[string(k)] = true
+		if string(k) == "ccc" {
+			require.Nil(t, v, "tombstone must yield a literal nil value, not a zero-length slice")
+		} else {
+			require.NotNil(t, v, "live entry must retain its value")
+		}
+	}
+	ct.Close()
+	require.Equal(t, map[string]bool{"aaa": true, "bbb": true, "ccc": true}, seen)
+}

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -770,8 +770,7 @@ func TestInitScanPopulatesHashtree(t *testing.T) {
 	sl, _ := testShard(t, ctx, class, withAsyncScheduler(t))
 	s := concreteShard(t, sl)
 
-	// Objects must be flushed to disk before enabling async replication:
-	// initHashtree only scans on-disk segments (no memtables).
+	// Flush to disk so this exercises the on-disk pass of the init scan.
 	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
 	}
@@ -790,6 +789,187 @@ func TestInitScanPopulatesHashtree(t *testing.T) {
 		"hashtree root must be non-zero: on-disk objects must have been registered by init scan")
 
 	require.NoError(t, s.disableAsyncReplication(context.Background()))
+}
+
+// buildInitScanRoot applies layout to a fresh shard, enables async replication, and returns the init-scan root.
+func buildInitScanRoot(t *testing.T, ctx context.Context, class string, layout func(sl ShardLike, s *Shard)) hashtree.Digest {
+	t.Helper()
+	sl, _ := testShard(t, ctx, class, withAsyncScheduler(t))
+	s := concreteShard(t, sl)
+	layout(sl, s)
+	require.NoError(t, s.enableAsyncReplication(ctx, minAsyncReplicationConfig()))
+	awaitHashtreeInitialized(t, s)
+	s.asyncReplicationRWMux.RLock()
+	root := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.NoError(t, s.disableAsyncReplication(ctx))
+	return root
+}
+
+// TestInitScanHashtreeConsistency asserts the init scan folds each live UUID once regardless of physical layout (identical logical state ⇒ identical root).
+func TestInitScanHashtreeConsistency(t *testing.T) {
+	ctx := context.Background()
+
+	// empty tree has a non-zero Merkle root, so this is the "no live objects" oracle, not Digest{}
+	emptyRoot := buildInitScanRoot(t, ctx, "InitScanEmpty", func(sl ShardLike, s *Shard) {})
+
+	// testObjWithTime has nil Properties, so every re-put allocates a new docID (docID-changed straddle)
+	t.Run("docIDChangedUpdateStraddlingMemtableAndDisk", func(t *testing.T) {
+		got := buildInitScanRoot(t, ctx, "InitScanDocIDChange", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDocIDChange", uuidMid, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDocIDChange", uuidMid, tsFarPast+1)))
+		})
+		want := buildInitScanRoot(t, ctx, "InitScanDocIDChangeRef", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDocIDChangeRef", uuidMid, tsFarPast+1)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		})
+		require.Equal(t, want, got)
+	})
+
+	t.Run("memtableOnlyTombstoneOverDiskValue", func(t *testing.T) {
+		got := buildInitScanRoot(t, ctx, "InitScanTombstone", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanTombstone", uuidMid, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.DeleteObject(ctx, uuidMid, time.Now()))
+		})
+		require.Equal(t, emptyRoot, got, "deleted object must not be resurrected by the init scan")
+	})
+
+	t.Run("multiUpdateChainAcrossLayers", func(t *testing.T) {
+		got := buildInitScanRoot(t, ctx, "InitScanChain", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanChain", uuidMid, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanChain", uuidMid, tsFarPast+1)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanChain", uuidMid, tsFarPast+2)))
+		})
+		want := buildInitScanRoot(t, ctx, "InitScanChainRef", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanChainRef", uuidMid, tsFarPast+2)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		})
+		require.Equal(t, want, got)
+	})
+
+	t.Run("updateThenDeleteStraddling", func(t *testing.T) {
+		got := buildInitScanRoot(t, ctx, "InitScanUpdDel", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanUpdDel", uuidMid, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanUpdDel", uuidMid, tsFarPast+1)))
+			require.NoError(t, sl.DeleteObject(ctx, uuidMid, time.Now()))
+		})
+		require.Equal(t, emptyRoot, got)
+	})
+
+	t.Run("deleteThenReinsertStraddling", func(t *testing.T) {
+		got := buildInitScanRoot(t, ctx, "InitScanDelReins", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDelReins", uuidMid, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.DeleteObject(ctx, uuidMid, time.Now()))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDelReins", uuidMid, tsFarPast+2)))
+		})
+		want := buildInitScanRoot(t, ctx, "InitScanDelReinsRef", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDelReinsRef", uuidMid, tsFarPast+2)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		})
+		require.Equal(t, want, got)
+	})
+
+	t.Run("memtableOnlyObjectNeverFlushed", func(t *testing.T) {
+		got := buildInitScanRoot(t, ctx, "InitScanMemOnly", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanMemOnly", uuidMid, tsFarPast)))
+		})
+		want := buildInitScanRoot(t, ctx, "InitScanMemOnlyRef", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanMemOnlyRef", uuidMid, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		})
+		require.Equal(t, want, got)
+		require.NotEqual(t, emptyRoot, got, "memtable object must be folded")
+	})
+
+	t.Run("multipleUUIDsCollidingToOneLeaf", func(t *testing.T) {
+		// uuidLow and uuidMid share leaf 0 at height 1 (top bit 0); mix layouts.
+		got := buildInitScanRoot(t, ctx, "InitScanCollide", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanCollide", uuidLow, tsFarPast)))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanCollide", uuidMid, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanCollide", uuidLow, tsFarPast+1)))
+			require.NoError(t, sl.DeleteObject(ctx, uuidMid, time.Now()))
+		})
+		want := buildInitScanRoot(t, ctx, "InitScanCollideRef", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanCollideRef", uuidLow, tsFarPast+1)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		})
+		require.Equal(t, want, got)
+	})
+}
+
+// TestInitScanHashtreeConcurrentWrites (-race) checks a concurrently-built root matches a serial rebuild; writers start after enable() to avoid the out-of-scope enable-transition race.
+func TestInitScanHashtreeConcurrentWrites(t *testing.T) {
+	ctx := context.Background()
+	const class = "InitScanConcurrent"
+	const n = 240
+	const writers = 4
+
+	uuids := make([]strfmt.UUID, n)
+	for i := range uuids {
+		prefix := "0"
+		if i%2 == 1 {
+			prefix = "f" // spread across both leaves at height 1
+		}
+		uuids[i] = strfmt.UUID(fmt.Sprintf("%s0000000-0000-0000-0000-%012d", prefix, i+1))
+	}
+
+	sl, _ := testShard(t, ctx, class, withAsyncScheduler(t))
+	s := concreteShard(t, sl)
+
+	// seed: half on disk, half in memtable so the scan straddles layers
+	for i := 0; i < n; i++ {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuids[i], tsFarPast)))
+		if i == n/2 {
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		}
+	}
+
+	// enable before writers so none observes hashtree==nil at the barrier
+	require.NoError(t, s.enableAsyncReplication(ctx, minAsyncReplicationConfig()))
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := w; i < n; i += writers {
+				switch i % 4 {
+				case 0:
+					assert.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuids[i], tsFarPast+5)))
+				case 1:
+					assert.NoError(t, sl.DeleteObject(ctx, uuids[i], time.Now()))
+				case 2:
+					assert.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuids[i], tsFarPast+5)))
+					assert.NoError(t, s.store.FlushMemtables(ctx)) // force flushes concurrent with the scan
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	concurrentRoot := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+
+	// clean serial rebuild over the frozen final state
+	require.NoError(t, s.disableAsyncReplication(ctx))
+	require.NoError(t, s.enableAsyncReplication(ctx, minAsyncReplicationConfig()))
+	awaitHashtreeInitialized(t, s)
+	s.asyncReplicationRWMux.RLock()
+	rebuiltRoot := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.NoError(t, s.disableAsyncReplication(ctx))
+
+	require.Equal(t, rebuiltRoot, concurrentRoot,
+		"root built concurrently with writes must match a clean serial rebuild of the final state")
 }
 
 // ─── propagateObjects ─────────────────────────────────────────────────────────

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -836,6 +836,22 @@ func TestInitScanHashtreeConsistency(t *testing.T) {
 		require.Equal(t, emptyRoot, got, "deleted object must not be resurrected by the init scan")
 	})
 
+	t.Run("diskOnlyTombstoneWithLiveSibling", func(t *testing.T) {
+		got := buildInitScanRoot(t, ctx, "InitScanDiskTombstone", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDiskTombstone", uuidMid, tsFarPast)))
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDiskTombstone", uuidHigh, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+			require.NoError(t, sl.DeleteObject(ctx, uuidMid, time.Now()))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		})
+		want := buildInitScanRoot(t, ctx, "InitScanDiskTombstoneRef", func(sl ShardLike, s *Shard) {
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanDiskTombstoneRef", uuidHigh, tsFarPast)))
+			require.NoError(t, s.store.FlushMemtables(ctx))
+		})
+		require.Equal(t, want, got, "flushed tombstone must not resurrect the deleted object")
+		require.NotEqual(t, emptyRoot, got, "the live sibling must still be folded")
+	})
+
 	t.Run("multiUpdateChainAcrossLayers", func(t *testing.T) {
 		got := buildInitScanRoot(t, ctx, "InitScanChain", func(sl ShardLike, s *Shard) {
 			require.NoError(t, sl.PutObject(ctx, testObjWithTime("InitScanChain", uuidMid, tsFarPast)))


### PR DESCRIPTION
## Motivation

Async replication now identifies objects by UUID everywhere (`acee6141b3` "async replication just relying on uuid"), but the hashtree init scan was left deduping memtable-vs-disk entries by **docID**. `ApplyToObjectDigests` scans the memtable and the on-disk segments as two consecutive passes and must fold each live object exactly once. Keying that dedup by docID is wrong for the object bucket and produces a hashtree root that does not reflect the shard's true logical state — which surfaces as persistent digest divergence between replicas and needless (or incorrect) read-repair. Two concrete failure modes:

- **docID-changed update straddling memtable and disk.** A re-put reuses the UUID under a *new* docID (any object with no user-set properties allocates a fresh docID on every put; a vector-only change does the same). The stale on-disk entry and the fresh memtable entry then have different docIDs, so the docID dedup treats them as two distinct objects and folds **both** into the tree. The same UUID gets counted twice with two different update times.

- **memtable-only tombstone over a live on-disk value.** A delete that hasn't been flushed/compacted is a memtable tombstone while the old value still sits on disk. `CursorInMem` silently skips deleted keys, so the tombstone was never recorded; the disk pass then folded the stale value and **resurrected the deleted object** into the hashtree.

Both make an identical logical state hash differently depending purely on physical layout (what's flushed vs. still in the memtable), so replicas that took different flush timing disagree forever.

## Approach

- **Dedup by UUID, not docID.** The in-mem pass records every 16-byte key it sees (live or tombstone) in a `map[[16]byte]struct{}`; the disk pass skips any UUID already seen in memory. Memtable always wins over disk for the same UUID, which is correct — the memtable is strictly newer.

- **Surface memtable tombstones.** New `CursorInMemWithTombstones` emits deleted keys with a **literal nil value** (plain `CursorInMem` still skips them). The in-mem pass records the tombstoned UUID so the disk pass suppresses its stale value, but does **not** fold the tombstone itself (a deleted object contributes nothing to the tree). This is what makes the delete-straddling-layers cases collapse to the empty-tree root.

- **Incidental hardening in `cursorInMem`:** capture `hadFlushing := b.flushing != nil` once and use it both when adding the flushing cursor and in the `unlock` closure, so unlock releases exactly what it acquired instead of re-reading `b.flushing` at close time.

## Key areas for review

- `adapters/repos/db/lsmkv/bucket.go` — `ApplyToObjectDigests`: the two-pass UUID dedup and the `v == nil` tombstone branch (recorded, not folded). Confirm the `len(k) == 16` guards are the right defensive check for the object bucket.
- `adapters/repos/db/lsmkv/cursor_bucket_replace.go` — `serveCurrentStateAndAdvance` returns literal `nil` (not the reused `serveCache.value`) on `emitTombstones`; verify the `hadFlushing` capture matches acquire/release.
- `adapters/repos/db/shard_async_replication.go:768` — the only caller; folds via `aggregateHashTreeLeaf` keyed on the UUID bytes.

## Risks and mitigations

- **nil vs. zero-length value confusion.** Callers distinguish tombstone from live entry only by `v == nil`, so the cursor must return a true nil, not the reused buffer. `TestCursorInMemWithTombstones` pins this with a tombstone key (`"ccc"`) that sorts *after* the live keys, so a leaked reused buffer would be non-nil and fail the assertion.
- **Non-UUID keys.** Guarded by `len(k) == 16` before treating a key as a UUID; the object bucket keys are always 16-byte UUIDs, so this is defensive only.
- **Memory.** The processed-set is keyed by `[16]byte` instead of `uint64` and holds only UUIDs observed in the in-memory memtables (not the whole shard), so its footprint stays on the same order as before.

## Testing

- `TestCursorInMemWithTombstones` — plain `CursorInMem` skips the tombstone; `CursorInMemWithTombstones` surfaces it with a literal nil value.
- `TestInitScanHashtreeConsistency` — table of layouts that must all yield the same Merkle root as a single clean-flushed reference (or the empty-tree root for full deletes): docID-changed straddle, memtable-only tombstone over disk, multi-update chain across layers, update-then-delete, delete-then-reinsert, memtable-only never flushed, and multiple UUIDs colliding into one leaf. `emptyRoot` is used as the "no live objects" oracle (an empty tree has a non-zero root, so `Digest{}` would be the wrong oracle).
- `TestInitScanHashtreeConcurrentWrites` (`-race`) — 4 writers doing puts/deletes/forced flushes concurrent with the init scan; the concurrently-built root must equal a clean serial rebuild over the frozen final state. Writers start after `enable()` to avoid the unrelated enable-transition race.

Each consistency case fails on the pre-fix docID dedup: the straddle cases fold the same UUID twice, and the tombstone cases resurrect the deleted object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
