### PR TITLE
When resetting the HNSW graph, ensure tombstone metric is cleared

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -199,6 +199,7 @@ func (h *hnsw) resetUnlocked() error {
 	h.initialInsertOnce = &sync.Once{}
 	h.nodes = make([]*vertex, cache.InitialSize)
 	h.tombstones = make(map[uint64]struct{})
+	h.metrics.SetTombstone(0)
 
 	return h.commitLog.Reset()
 }

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -491,9 +491,13 @@ func (n *neighborFinderConnector) pickEntrypoint() error {
 		if err != nil {
 			return err
 		}
-		if localDeny.Contains(alternative) {
+		if localDeny.Contains(alternative) && alternative != n.graph.getEntrypoint() {
 			return fmt.Errorf("no usable entrypoint: local fallback exhausted")
 		}
+		// an alternative on the deny list is retried when it is the current
+		// global entrypoint: a concurrent insert may have promoted a node we
+		// denied earlier for a transient reason (it was under maintenance
+		// while being inserted), so it can be perfectly usable by now
 		candidate = alternative
 	}
 }


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
