### PR TITLE
flat: fix vectors invisible to flat cached search after restart with unflushed data

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -84,13 +84,13 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 	seedCount := cpi.parallel - 1
 	seeds := cpi.bucket.QuantileKeys(seedCount)
 	if len(seeds) == 0 {
-		// no seeds likely means an empty index. If we exit early, we also need to
-		// stop the progress tracking.
+		// quantile keys are derived from flushed segments only, so an absence
+		// of seeds means no segments — not necessarily no data: the bucket may
+		// still hold entries in the memtable (e.g. recovered from the WAL
+		// after a restart). Fall back to a single sequential cursor, which
+		// also covers the memtable.
 		stopTracking()
-		aborted <- false
-		close(aborted)
-		close(out)
-		return out, aborted
+		return cpi.iterateAllNoConcurrency(ctx)
 	}
 
 	wg := sync.WaitGroup{}

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -75,8 +75,6 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 		return cpi.iterateAllNoConcurrency(ctx)
 	}
 
-	stopTracking := cpi.startTracking()
-
 	// We need one fewer seed than our desired parallel factor, that is because
 	// we will add one routine that starts with cursor.First() and reads to the
 	// first checkpoint, therefore we will have len(checkpoints) + 1 routines in
@@ -89,9 +87,12 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 		// still hold entries in the memtable (e.g. recovered from the WAL
 		// after a restart). Fall back to a single sequential cursor, which
 		// also covers the memtable.
-		stopTracking()
 		return cpi.iterateAllNoConcurrency(ctx)
 	}
+
+	// only start tracking once we know this path does the iteration itself
+	// (the fallbacks above track their own progress)
+	stopTracking := cpi.startTracking()
 
 	wg := sync.WaitGroup{}
 	abort := &atomic.Bool{}

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator_test.go
@@ -88,7 +88,7 @@ func TestCompressedParallelIterator(t *testing.T) {
 
 	for _, test := range testsWithQuantization {
 		t.Run(fmt.Sprintf("%s: %s", test.quantization, test.name), func(t *testing.T) {
-			bucket := buildCompressedBucketForTest(t, test.totalVecs)
+			bucket := buildCompressedBucketForTest(t, test.totalVecs, true)
 			defer bucket.Shutdown(context.Background())
 
 			logger, _ := logrustest.NewNullLogger()
@@ -138,7 +138,7 @@ func TestCompressedParallelIterator(t *testing.T) {
 		t.Run("context already cancelled", func(t *testing.T) {
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
-					bucket := buildCompressedBucketForTest(t, test.totalVecs)
+					bucket := buildCompressedBucketForTest(t, test.totalVecs, true)
 					defer bucket.Shutdown(context.Background())
 
 					cpi := NewParallelIterator(bucket, test.parallel, loadId, fromCompressed, logger)
@@ -157,7 +157,7 @@ func TestCompressedParallelIterator(t *testing.T) {
 		t.Run("context cancelled in the meantime", func(t *testing.T) {
 			for _, test := range testsCancellable {
 				t.Run(test.name, func(t *testing.T) {
-					bucket := buildCompressedBucketForTest(t, test.totalVecs)
+					bucket := buildCompressedBucketForTest(t, test.totalVecs, true)
 					defer bucket.Shutdown(context.Background())
 
 					cpi := NewParallelIterator(bucket, test.parallel, loadId, fromCompressed, logger)
@@ -222,7 +222,7 @@ func testIterator[T uint64 | byte](t *testing.T, cpi *parallelIterator[T], test 
 	require.False(t, <-abortedCh)
 }
 
-func buildCompressedBucketForTest(t *testing.T, totalVecs int) *lsmkv.Bucket {
+func buildCompressedBucketForTest(t *testing.T, totalVecs int, flush bool) *lsmkv.Bucket {
 	ctx := context.Background()
 	logger, _ := logrustest.NewNullLogger()
 	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
@@ -243,7 +243,33 @@ func buildCompressedBucketForTest(t *testing.T, totalVecs int) *lsmkv.Bucket {
 		require.Nil(t, err)
 	}
 
-	require.Nil(t, bucket.FlushAndSwitch())
+	if flush {
+		require.Nil(t, bucket.FlushAndSwitch())
+	}
 
 	return bucket
+}
+
+func TestCompressedParallelIteratorMemtableOnly(t *testing.T) {
+	// data that only lives in the memtable (e.g. recovered from the WAL after
+	// a restart, never flushed to a segment) yields no quantile-key seeds;
+	// the iterator must fall back to a sequential cursor instead of reporting
+	// an empty bucket
+	logger, _ := logrustest.NewNullLogger()
+	loadId := binary.BigEndian.Uint64
+	q := NewBinaryQuantizer(nil)
+
+	for _, totalVecs := range []int{1, 100, 3000} {
+		t.Run(fmt.Sprintf("%d unflushed vectors", totalVecs), func(t *testing.T) {
+			bucket := buildCompressedBucketForTest(t, totalVecs, false)
+			defer bucket.Shutdown(context.Background())
+
+			cpi := NewParallelIterator(bucket, 16, loadId,
+				q.FromCompressedBytesWithSubsliceBuffer, logger)
+			testIterator(t, cpi, iteratorTestCase{totalVecs: totalVecs, parallel: 16},
+				func(t *testing.T, vec VecAndID[uint64]) {
+					assert.Equal(t, vec.Id, vec.Vec[0])
+				})
+		})
+	}
 }

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -1820,9 +1820,17 @@ func Test_NoRace_Flat_SearchAfterRestartWithUnflushedData(t *testing.T) {
 	// reopen: the data comes back via WAL recovery into the memtable, no
 	// segments exist. PostStartup must still preload the cache from it.
 	store = loadTestStore(t, dirName)
-	defer store.Shutdown(ctx)
+	defer func() { require.NoError(t, store.Shutdown(ctx)) }()
 	index = newIndex(store)
-	defer index.Shutdown(ctx)
+	defer func() { require.NoError(t, index.Shutdown(ctx)) }()
+
+	// precondition: the data must be memtable-only. If this ever fails (e.g.
+	// because lsmkv starts flushing this bucket on shutdown), the scenario
+	// below no longer exercises the no-seeds fallback and needs a new setup.
+	bucket := store.Bucket(index.getCompressedBucketName())
+	require.NotNil(t, bucket)
+	require.Empty(t, bucket.QuantileKeys(16), "expected no segments, data must live in the memtable only")
+
 	index.PostStartup(ctx)
 
 	ids, _, err := index.SearchByVector(ctx, []float32{1, 0, 0}, len(vectors), nil)

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -1784,3 +1784,49 @@ func Test_NoRace_RQ1PersistenceAndRestoration(t *testing.T) {
 		require.Equal(t, uint64(1), results2[0])
 	})
 }
+
+func Test_NoRace_Flat_SearchAfterRestartWithUnflushedData(t *testing.T) {
+	// vectors that only live in the WAL/memtable at restart (no segment
+	// flush) must remain visible to the quantized cached search: the startup
+	// preload has to iterate the memtable, not just flushed segments
+	dirName := t.TempDir()
+	ctx := context.Background()
+
+	newIndex := func(store *lsmkv.Store) *flat {
+		index, err := New(Config{
+			ID:                "unflushed-search-test",
+			RootPath:          dirName,
+			DistanceProvider:  distancer.NewCosineDistanceProvider(),
+			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+		}, flatent.UserConfig{
+			BQ: flatent.CompressionUserConfig{Enabled: true, Cache: true, RescoreLimit: 10},
+			// the production default: with it, cache misses during search are
+			// NOT fetched from disk, so the preload must be complete
+			VectorCacheMaxObjects: flatent.DefaultVectorCacheMaxObjects,
+		}, store)
+		require.NoError(t, err)
+		return index
+	}
+
+	store := loadTestStore(t, dirName)
+	index := newIndex(store)
+	vectors := [][]float32{{4, -1, 4}, {-2, 3, 1}, {0.5, 0.5, 0.5}, {1, 0.5, 0}}
+	for i, vec := range vectors {
+		require.NoError(t, index.Add(ctx, uint64(i), vec))
+	}
+	require.NoError(t, index.Shutdown(ctx))
+	require.NoError(t, store.Shutdown(ctx))
+
+	// reopen: the data comes back via WAL recovery into the memtable, no
+	// segments exist. PostStartup must still preload the cache from it.
+	store = loadTestStore(t, dirName)
+	defer store.Shutdown(ctx)
+	index = newIndex(store)
+	defer index.Shutdown(ctx)
+	index.PostStartup(ctx)
+
+	ids, _, err := index.SearchByVector(ctx, []float32{1, 0, 0}, len(vectors), nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint64{0, 1, 2, 3}, ids,
+		"vectors recovered from the WAL must be visible to the cached search")
+}


### PR DESCRIPTION
### What's being changed:

Fixes weaviate/0-weaviate-issues#306.

**When this happens:** a node restarts while some recently written vectors have not yet been flushed from the memtable to an LSM segment — e.g. after a crash, or any shutdown/restart cycle that lands between memtable flushes. On startup the data is recovered from the WAL into the memtable, but no segment exists for it yet. Small, recently written tenants are the most likely to be in this state.

**The symptom:** for flat indexes with BQ/RQ compression and the vector cache enabled, those vectors become **invisible to vector search** — queries silently return incomplete or empty results, while point reads (fetch by id) still work. The tenant stays broken until its data is flushed *and* the shard is loaded again. In a 5,000-tenant reproduction (see weaviate/weaviate#12116 verification), 839 tenants returned zero search results after a restart.

**The cause:** the startup cache preload reads the compressed-vectors bucket through `compressionhelpers.ParallelIterator`, which partitions the key space using `Bucket.QuantileKeys`. Quantile keys are derived from flushed segments only, so a bucket whose data lives solely in the memtable yields zero seeds — and `IterateAll` treated "no seeds" as "empty bucket" and returned without creating a single cursor. The cache preload then loaded nothing, and the quantized search (which iterates the cache, with no disk fallback at the default `vectorCacheMaxObjects`) found nothing.

**The fix:** when no seeds are available, fall back to the existing sequential iteration path (`iterateAllNoConcurrency`), whose bucket cursor merges segments *and* memtables. Parallelism is irrelevant in this state anyway — there are no segments to partition. This also restores cache prefill for HNSW compressed-vector caches in the same state (there it was a performance gap, not a correctness one, since HNSW's cache falls back to disk on misses).

Note: buckets with at least one segment were never affected — the worker cursors already merge memtables; only the zero-segment state hit the early exit.

Tests: a unit test for the iterator over an unflushed bucket (previously reported 0 of 3,000 vectors), and an end-to-end flat test pinning the user-visible symptom (restart with WAL-only data → search must find all vectors), both verified to fail without the fix.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.