### PR TITLE
perf(internode): exact-size single-alloc marshalling for fan-out payloads (slice 1/3)

### DIFF
--- a/adapters/clients/client.go
+++ b/adapters/clients/client.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+
+	clusterapi "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared"
 )
 
 type retryClient struct {
@@ -68,7 +70,7 @@ func (c *retryClient) doWithCustomMarshaller(timeout time.Duration,
 		}
 		defer res.Body.Close()
 
-		respBody, err := io.ReadAll(res.Body)
+		respBody, err := clusterapi.ReadBody(res.Body, res.ContentLength)
 		if err != nil {
 			return shouldRetry(res.StatusCode), fmt.Errorf("read response: %w", err)
 		}
@@ -101,7 +103,7 @@ func (c *retryClient) do(timeout time.Duration, req *http.Request, body []byte, 
 		defer res.Body.Close()
 
 		if code = res.StatusCode; !success(code) {
-			b, _ := io.ReadAll(res.Body)
+			b, _ := clusterapi.ReadBody(res.Body, res.ContentLength)
 			return shouldRetry(code), &HTTPError{Code: code, Body: b}
 		}
 		if resp != nil {

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -420,7 +420,7 @@ func (i *indices) postObject() http.Handler {
 func (i *indices) postObjectSingle(w http.ResponseWriter, r *http.Request,
 	index, shard string,
 ) {
-	bodyBytes, err := io.ReadAll(r.Body)
+	bodyBytes, err := shared.ReadBody(r.Body, r.ContentLength)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -453,7 +453,7 @@ func (i *indices) postObjectSingle(w http.ResponseWriter, r *http.Request,
 func (i *indices) postObjectBatch(w http.ResponseWriter, r *http.Request,
 	index, shard string,
 ) {
-	bodyBytes, err := io.ReadAll(r.Body)
+	bodyBytes, err := shared.ReadBody(r.Body, r.ContentLength)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -652,7 +652,7 @@ func (i *indices) mergeObject() http.Handler {
 			return
 		}
 
-		bodyBytes, err := io.ReadAll(r.Body)
+		bodyBytes, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -746,7 +746,7 @@ func (i *indices) postSearchObjects() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -813,7 +813,7 @@ func (i *indices) postReferences() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(),
 				http.StatusInternalServerError)
@@ -863,7 +863,7 @@ func (i *indices) postAggregateObjects() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(),
 				http.StatusInternalServerError)
@@ -922,7 +922,7 @@ func (i *indices) postFindUUIDs() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -981,7 +981,7 @@ func (i *indices) putOverwriteObjects() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1029,7 +1029,7 @@ func (i *indices) getObjectsDigest() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1079,7 +1079,7 @@ func (i *indices) getObjectsDigestsInRange() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1121,7 +1121,7 @@ func (i *indices) getHashTreeLevel() http.Handler {
 		}
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1162,7 +1162,7 @@ func (i *indices) deleteObjects() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1290,7 +1290,7 @@ func (i *indices) postUpdateShardStatus() http.Handler {
 		index, shard := args[1], args[2]
 
 		defer r.Body.Close()
-		reqPayload, err := io.ReadAll(r.Body)
+		reqPayload, err := shared.ReadBody(r.Body, r.ContentLength)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/byteops"

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads.go
@@ -362,12 +362,9 @@ var objectListAllProps = additional.Properties{
 	IncludeAllTargetVectors: true,
 }
 
-// prepare runs the storobj sizing pass for every non-nil object and returns
-// the prepared per-object marshals plus the total framed payload size
-// (8-byte length prefix per object + object bytes). marshalTo writes the
-// corresponding bytes; splitting the two passes lets callers that wrap the
-// object list in a larger payload (searchResultsPayload) allocate one
-// exactly-sized buffer for the whole thing.
+// prepare runs the storobj sizing pass per object, returning prepared
+// marshals plus total framed size (8-byte length prefix + object bytes) so
+// callers wrapping the list in a larger payload can allocate one exact buffer.
 func (p objectListPayload) prepare(in []*storobj.Object, method string, addProps additional.Properties) ([]storobj.PreparedMarshal, int, error) {
 	prepared := make([]storobj.PreparedMarshal, 0, len(in))
 	totalSize := 0
@@ -430,10 +427,8 @@ func (p objectListPayload) Marshal(in []*storobj.Object, method string) ([]byte,
 	return out, nil
 }
 
-// MarshalWithAdditional is like Marshal but uses the optional-marshal
-// semantics of storobj.MarshalBinaryOptional to conditionally include vectors
-// and properties based on the additional.Properties parameter. This reduces
-// network bandwidth by not transmitting vectors when they are not requested.
+// MarshalWithAdditional is like Marshal but conditionally includes vectors
+// and properties per addProps, reducing bandwidth when they aren't requested.
 func (p objectListPayload) MarshalWithAdditional(in []*storobj.Object, addProps additional.Properties) ([]byte, error) {
 	prepared, size, err := p.prepare(in, MethodGet, addProps)
 	if err != nil {
@@ -447,10 +442,8 @@ func (p objectListPayload) MarshalWithAdditional(in []*storobj.Object, addProps 
 	return out, nil
 }
 
-// Unmarshal decodes a framed object list. Each object is decoded from a
-// sub-slice of in rather than a per-object copy: the storobj decoder copies
-// everything it retains (vectors into fresh []float32, strings/props via
-// string conversion and json.Unmarshal), so no decoded object holds a
+// Unmarshal decodes a framed object list from sub-slices of in; the storobj
+// decoder copies everything it retains, so decoded objects hold no
 // reference into in once Unmarshal returns.
 func (p objectListPayload) Unmarshal(in []byte, method string) ([]*storobj.Object, error) {
 	var out []*storobj.Object
@@ -911,7 +904,6 @@ func (p searchResultsPayload) MarshalWithAdditional(objs []*storobj.Object,
 		return nil, err
 	}
 
-	// Optional profile data appended after dists.
 	var profilesBytes []byte
 	if len(queryProfiles) > 0 {
 		profilesBytes, err = json.Marshal(queryProfiles)

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads.go
@@ -235,7 +235,14 @@ func rowToError(v map[string]interface{}) error {
 // This is because all replication POST/PUT methods mistakenly double send the vector in both storobj and models.Object
 // This function ensures that the models.Object vectors are nil and that only the storobj vectors are sent
 func marshallStorObj(in *storobj.Object) ([]byte, error) {
-	obj := storobj.Object{
+	obj := networkStorObj(in)
+	return obj.MarshalBinary()
+}
+
+// networkStorObj builds the shallow copy of in that the PUT-path network
+// encoding serializes (see marshallStorObj for why the copy exists).
+func networkStorObj(in *storobj.Object) storobj.Object {
+	return storobj.Object{
 		MarshallerVersion: in.MarshallerVersion,
 		Object: models.Object{
 			Additional:         in.Object.Additional,
@@ -259,7 +266,6 @@ func marshallStorObj(in *storobj.Object) ([]byte, error) {
 		Vectors:        in.Vectors,
 		MultiVectors:   in.MultiVectors,
 	}
-	return obj.MarshalBinary()
 }
 
 // unmarshallStorObj converts a byte slice received over the network into a *storobj.Object
@@ -348,90 +354,122 @@ func (p objectListPayload) SetContentTypeHeaderReq(r *http.Request) {
 	r.Header.Set("content-type", p.MIME())
 }
 
+// objectListAllProps mirrors what storobj.(*Object).MarshalBinary includes:
+// everything. It is the addProps set of the non-optional Marshal path.
+var objectListAllProps = additional.Properties{
+	Vector:                  true,
+	IncludeAllTargetVectors: true,
+}
+
+// prepare runs the storobj sizing pass for every non-nil object and returns
+// the prepared per-object marshals plus the total framed payload size
+// (8-byte length prefix per object + object bytes). marshalTo writes the
+// corresponding bytes; splitting the two passes lets callers that wrap the
+// object list in a larger payload (searchResultsPayload) allocate one
+// exactly-sized buffer for the whole thing.
+func (p objectListPayload) prepare(in []*storobj.Object, method string, addProps additional.Properties) ([]storobj.PreparedMarshal, int, error) {
+	prepared := make([]storobj.PreparedMarshal, 0, len(in))
+	totalSize := 0
+
+	for _, ind := range in {
+		if ind == nil {
+			continue
+		}
+
+		var pm storobj.PreparedMarshal
+		var err error
+		switch method {
+		case MethodPut:
+			// Need to take vectors out of models.Object into storobj
+			obj := networkStorObj(ind)
+			pm, err = obj.PrepareMarshalOptional(addProps)
+		case MethodGet:
+			// Don't need to modify anything since GET requests don't double send
+			pm, err = ind.PrepareMarshalOptional(addProps)
+		default:
+			return nil, 0, fmt.Errorf("unsupported operation type: %s", method)
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+
+		prepared = append(prepared, pm)
+		totalSize += 8 + pm.Len()
+	}
+
+	return prepared, totalSize, nil
+}
+
+// marshalTo writes the framed object list into buf, which must be exactly
+// the total size returned by prepare.
+func (p objectListPayload) marshalTo(buf []byte, prepared []storobj.PreparedMarshal) error {
+	offset := 0
+	for i := range prepared {
+		objLen := prepared[i].Len()
+		binary.LittleEndian.PutUint64(buf[offset:offset+8], uint64(objLen))
+		offset += 8
+		if err := prepared[i].MarshalTo(buf[offset : offset+objLen]); err != nil {
+			return err
+		}
+		offset += objLen
+	}
+	return nil
+}
+
 func (p objectListPayload) Marshal(in []*storobj.Object, method string) ([]byte, error) {
-	// NOTE: This implementation is not optimized for allocation efficiency,
-	// reserve 1024 byte per object which is rather arbitrary
-	out := make([]byte, 0, 1024*len(in))
-
-	reusableLengthBuf := make([]byte, 8)
-	for _, ind := range in {
-		if ind != nil {
-			var bytes []byte
-			var err error
-			switch method {
-			case MethodPut:
-				// Need to take vectors out of models.Object into storobj
-				bytes, err = marshallStorObj(ind)
-			case MethodGet:
-				// Don't need to modify anything since GET requests don't double send
-				bytes, err = ind.MarshalBinary()
-			default:
-				return nil, fmt.Errorf("unsupported operation type: %s", method)
-			}
-			if err != nil {
-				return nil, err
-			}
-
-			length := uint64(len(bytes))
-			binary.LittleEndian.PutUint64(reusableLengthBuf, length)
-
-			out = append(out, reusableLengthBuf...)
-			out = append(out, bytes...)
-		}
+	prepared, size, err := p.prepare(in, method, objectListAllProps)
+	if err != nil {
+		return nil, err
 	}
 
+	out := make([]byte, size)
+	if err := p.marshalTo(out, prepared); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 
-// MarshalWithAdditional is like Marshal but uses MarshalBinaryOptional to conditionally
-// include vectors and properties based on the additional.Properties parameter.
-// This reduces network bandwidth by not transmitting vectors when they are not requested.
+// MarshalWithAdditional is like Marshal but uses the optional-marshal
+// semantics of storobj.MarshalBinaryOptional to conditionally include vectors
+// and properties based on the additional.Properties parameter. This reduces
+// network bandwidth by not transmitting vectors when they are not requested.
 func (p objectListPayload) MarshalWithAdditional(in []*storobj.Object, addProps additional.Properties) ([]byte, error) {
-	// NOTE: This implementation is not optimized for allocation efficiency,
-	// reserve 1024 byte per object which is rather arbitrary
-	out := make([]byte, 0, 1024*len(in))
-
-	reusableLengthBuf := make([]byte, 8)
-	for _, ind := range in {
-		if ind != nil {
-			bytes, err := ind.MarshalBinaryOptional(addProps)
-			if err != nil {
-				return nil, err
-			}
-
-			length := uint64(len(bytes))
-			binary.LittleEndian.PutUint64(reusableLengthBuf, length)
-
-			out = append(out, reusableLengthBuf...)
-			out = append(out, bytes...)
-		}
+	prepared, size, err := p.prepare(in, MethodGet, addProps)
+	if err != nil {
+		return nil, err
 	}
 
+	out := make([]byte, size)
+	if err := p.marshalTo(out, prepared); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 
+// Unmarshal decodes a framed object list. Each object is decoded from a
+// sub-slice of in rather than a per-object copy: the storobj decoder copies
+// everything it retains (vectors into fresh []float32, strings/props via
+// string conversion and json.Unmarshal), so no decoded object holds a
+// reference into in once Unmarshal returns.
 func (p objectListPayload) Unmarshal(in []byte, method string) ([]*storobj.Object, error) {
 	var out []*storobj.Object
 
-	reusableLengthBuf := make([]byte, 8)
-	r := bytes.NewReader(in)
+	offset := 0
+	for offset < len(in) {
+		if len(in)-offset < 8 {
+			return nil, fmt.Errorf("object list: truncated length prefix: %d bytes remaining", len(in)-offset)
+		}
+		payloadLen := binary.LittleEndian.Uint64(in[offset : offset+8])
+		offset += 8
 
-	for {
-		_, err := r.Read(reusableLengthBuf)
-		if errors.Is(err, io.EOF) {
-			break
+		if payloadLen > uint64(len(in)-offset) {
+			return nil, fmt.Errorf("payload read: object payload length %d exceeds remaining %d bytes", payloadLen, len(in)-offset)
 		}
-		if err != nil {
-			return nil, err
-		}
-
-		payloadBytes := make([]byte, binary.LittleEndian.Uint64(reusableLengthBuf))
-		_, err = r.Read(payloadBytes)
-		if err != nil {
-			return nil, fmt.Errorf("payload read: %w", err)
-		}
+		payloadBytes := in[offset : offset+int(payloadLen)]
+		offset += int(payloadLen)
 
 		var obj *storobj.Object
+		var err error
 		switch method {
 		case MethodPut:
 			// Need to add vectors back to models.Object from storobj
@@ -838,26 +876,25 @@ func (p searchResultsPayload) Unmarshal(in []byte) ([]*storobj.Object, []float32
 func (p searchResultsPayload) Marshal(objs []*storobj.Object,
 	dists []float32,
 ) ([]byte, error) {
-	reusableLengthBuf := make([]byte, 8)
-	var out []byte
-	objsBytes, err := IndicesPayloads.ObjectList.Marshal(objs, MethodGet)
+	prepared, objsLength, err := IndicesPayloads.ObjectList.prepare(objs, MethodGet, objectListAllProps)
 	if err != nil {
 		return nil, err
 	}
 
-	objsLength := uint64(len(objsBytes))
-	binary.LittleEndian.PutUint64(reusableLengthBuf, objsLength)
+	out := make([]byte, 8+objsLength+8+len(dists)*4)
 
-	out = append(out, reusableLengthBuf...)
-	out = append(out, objsBytes...)
+	binary.LittleEndian.PutUint64(out[:8], uint64(objsLength))
+	offset := 8
 
-	distsLength := uint64(len(dists))
-	binary.LittleEndian.PutUint64(reusableLengthBuf, distsLength)
-	out = append(out, reusableLengthBuf...)
+	if err := IndicesPayloads.ObjectList.marshalTo(out[offset:offset+objsLength], prepared); err != nil {
+		return nil, err
+	}
+	offset += objsLength
 
-	distsBuf := make([]byte, distsLength*4)
-	byteops.CopySliceToBytes(distsBuf, dists)
-	out = append(out, distsBuf...)
+	binary.LittleEndian.PutUint64(out[offset:offset+8], uint64(len(dists)))
+	offset += 8
+
+	byteops.CopySliceToBytes(out[offset:offset+len(dists)*4], dists)
 
 	return out, nil
 }
@@ -868,28 +905,12 @@ func (p searchResultsPayload) Marshal(objs []*storobj.Object,
 func (p searchResultsPayload) MarshalWithAdditional(objs []*storobj.Object,
 	dists []float32, addProps additional.Properties, queryProfiles []helpers.ShardQueryProfile,
 ) ([]byte, error) {
-	reusableLengthBuf := make([]byte, 8)
-	var out []byte
-	objsBytes, err := IndicesPayloads.ObjectList.MarshalWithAdditional(objs, addProps)
+	prepared, objsLength, err := IndicesPayloads.ObjectList.prepare(objs, MethodGet, addProps)
 	if err != nil {
 		return nil, err
 	}
 
-	objsLength := uint64(len(objsBytes))
-	binary.LittleEndian.PutUint64(reusableLengthBuf, objsLength)
-
-	out = append(out, reusableLengthBuf...)
-	out = append(out, objsBytes...)
-
-	distsLength := uint64(len(dists))
-	binary.LittleEndian.PutUint64(reusableLengthBuf, distsLength)
-	out = append(out, reusableLengthBuf...)
-
-	distsBuf := make([]byte, distsLength*4)
-	byteops.CopySliceToBytes(distsBuf, dists)
-	out = append(out, distsBuf...)
-
-	// Append optional profile data.
+	// Optional profile data appended after dists.
 	var profilesBytes []byte
 	if len(queryProfiles) > 0 {
 		profilesBytes, err = json.Marshal(queryProfiles)
@@ -897,9 +918,26 @@ func (p searchResultsPayload) MarshalWithAdditional(objs []*storobj.Object,
 			return nil, fmt.Errorf("marshal query profiles: %w", err)
 		}
 	}
-	binary.LittleEndian.PutUint64(reusableLengthBuf, uint64(len(profilesBytes)))
-	out = append(out, reusableLengthBuf...)
-	out = append(out, profilesBytes...)
+
+	out := make([]byte, 8+objsLength+8+len(dists)*4+8+len(profilesBytes))
+
+	binary.LittleEndian.PutUint64(out[:8], uint64(objsLength))
+	offset := 8
+
+	if err := IndicesPayloads.ObjectList.marshalTo(out[offset:offset+objsLength], prepared); err != nil {
+		return nil, err
+	}
+	offset += objsLength
+
+	binary.LittleEndian.PutUint64(out[offset:offset+8], uint64(len(dists)))
+	offset += 8
+
+	byteops.CopySliceToBytes(out[offset:offset+len(dists)*4], dists)
+	offset += len(dists) * 4
+
+	binary.LittleEndian.PutUint64(out[offset:offset+8], uint64(len(profilesBytes)))
+	offset += 8
+	copy(out[offset:], profilesBytes)
 
 	return out, nil
 }

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_bench_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_bench_test.go
@@ -11,13 +11,8 @@
 
 package shared
 
-// Baseline microbenchmarks for the internode fan-out marshal/unmarshal hot
-// paths (search results, object lists, and the per-object storobj codec).
-// These pin the allocs/op and B/op numbers on main so that each optimization
-// slice (buffer pooling / streaming decode, binary props encoding, gRPC
-// migration) has a before-number to compare against.
-//
-// Run with:
+// Baseline microbenchmarks for internode marshal/unmarshal hot paths, to
+// diff against later optimization slices.
 //
 //	go test -run '^$' -bench 'BenchmarkInternode' -benchmem \
 //	  ./adapters/handlers/rest/clusterapi/shared/
@@ -115,8 +110,7 @@ var benchAddPropsVariants = []struct {
 }
 
 // BenchmarkInternodeSearchResultsMarshal measures the server-side encode of a
-// shard search response (searchResultsPayload.MarshalWithAdditional), the top
-// allocation source in the 12-node load-test profile.
+// shard search response (searchResultsPayload.MarshalWithAdditional).
 func BenchmarkInternodeSearchResultsMarshal(b *testing.B) {
 	for _, size := range []int{10, 100} {
 		objs, dists := makeBenchObjects(size)
@@ -184,8 +178,7 @@ func BenchmarkInternodeObjectListMarshal(b *testing.B) {
 	}
 }
 
-// BenchmarkInternodeObjectListUnmarshal measures objectListPayload.Unmarshal
-// (MethodGet), the second-largest allocation source in the profile.
+// BenchmarkInternodeObjectListUnmarshal measures objectListPayload.Unmarshal (MethodGet).
 func BenchmarkInternodeObjectListUnmarshal(b *testing.B) {
 	for _, size := range []int{10, 100} {
 		objs, _ := makeBenchObjects(size)

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_bench_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_bench_test.go
@@ -1,0 +1,316 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shared
+
+// Baseline microbenchmarks for the internode fan-out marshal/unmarshal hot
+// paths (search results, object lists, and the per-object storobj codec).
+// These pin the allocs/op and B/op numbers on main so that each optimization
+// slice (buffer pooling / streaming decode, binary props encoding, gRPC
+// migration) has a before-number to compare against.
+//
+// Run with:
+//
+//	go test -run '^$' -bench 'BenchmarkInternode' -benchmem \
+//	  ./adapters/handlers/rest/clusterapi/shared/
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+const benchVectorDims = 768
+
+// makeBenchObject builds a storobj.Object that resembles a typical production
+// object: ~10 properties including a longer text field, plus a 768-dim vector.
+func makeBenchObject(rnd *rand.Rand, i int) *storobj.Object {
+	vec := make([]float32, benchVectorDims)
+	for j := range vec {
+		vec[j] = rnd.Float32()
+	}
+
+	longText := make([]byte, 512)
+	for j := range longText {
+		longText[j] = byte('a' + rnd.Intn(26))
+	}
+
+	props := map[string]interface{}{
+		"title":       fmt.Sprintf("object-%d-title-with-some-length", i),
+		"description": string(longText),
+		"category":    "category-" + fmt.Sprint(i%7),
+		"count":       float64(i * 3),
+		"score":       rnd.Float64(),
+		"active":      i%2 == 0,
+		"tags":        []interface{}{"alpha", "beta", "gamma"},
+		"nested": map[string]interface{}{
+			"fieldA": "valueA",
+			"fieldB": float64(42),
+		},
+		"url":        "https://example.com/objects/" + fmt.Sprint(i),
+		"identifier": uuid.NewString(),
+	}
+
+	obj := storobj.New(uint64(i))
+	obj.MarshallerVersion = 1
+	obj.Object = models.Object{
+		ID:                 strfmt.UUID(uuid.NewString()),
+		Class:              "BenchClass",
+		CreationTimeUnix:   1700000000000,
+		LastUpdateTimeUnix: 1700000001000,
+		Properties:         props,
+	}
+	obj.Vector = vec
+	obj.VectorLen = benchVectorDims
+	return obj
+}
+
+func makeBenchObjects(n int) ([]*storobj.Object, []float32) {
+	rnd := rand.New(rand.NewSource(42))
+	objs := make([]*storobj.Object, n)
+	dists := make([]float32, n)
+	for i := range objs {
+		objs[i] = makeBenchObject(rnd, i)
+		dists[i] = rnd.Float32()
+	}
+	return objs, dists
+}
+
+var benchAddPropsVariants = []struct {
+	name     string
+	addProps additional.Properties
+}{
+	{
+		// props + vector: worst case, everything on the wire
+		name:     "props_and_vector",
+		addProps: additional.Properties{Vector: true},
+	},
+	{
+		// props only: the common search fan-out case (vectors not requested)
+		name:     "props_only",
+		addProps: additional.Properties{},
+	},
+	{
+		// no props + vector: isolates the JSON props blob share
+		name:     "noprops_and_vector",
+		addProps: additional.Properties{Vector: true, NoProps: true},
+	},
+}
+
+// BenchmarkInternodeSearchResultsMarshal measures the server-side encode of a
+// shard search response (searchResultsPayload.MarshalWithAdditional), the top
+// allocation source in the 12-node load-test profile.
+func BenchmarkInternodeSearchResultsMarshal(b *testing.B) {
+	for _, size := range []int{10, 100} {
+		objs, dists := makeBenchObjects(size)
+		for _, v := range benchAddPropsVariants {
+			b.Run(fmt.Sprintf("objs_%d/%s", size, v.name), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					out, err := IndicesPayloads.SearchResults.MarshalWithAdditional(objs, dists, v.addProps, nil)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(out) == 0 {
+						b.Fatal("empty payload")
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkInternodeSearchResultsUnmarshal measures the coordinator-side decode
+// of a shard search response (searchResultsPayload.Unmarshal), including the
+// per-object FromBinaryNetwork + JSON props decode.
+func BenchmarkInternodeSearchResultsUnmarshal(b *testing.B) {
+	for _, size := range []int{10, 100} {
+		objs, dists := makeBenchObjects(size)
+		for _, v := range benchAddPropsVariants {
+			payload, err := IndicesPayloads.SearchResults.MarshalWithAdditional(objs, dists, v.addProps, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Run(fmt.Sprintf("objs_%d/%s", size, v.name), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					outObjs, outDists, _, err := IndicesPayloads.SearchResults.Unmarshal(payload)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(outObjs) != size || len(outDists) != size {
+						b.Fatal("unexpected result size")
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkInternodeObjectListMarshal measures objectListPayload.Marshal
+// (MethodGet), used by MultiGetObjects responses and inside search results.
+func BenchmarkInternodeObjectListMarshal(b *testing.B) {
+	for _, size := range []int{10, 100} {
+		objs, _ := makeBenchObjects(size)
+		b.Run(fmt.Sprintf("objs_%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out, err := IndicesPayloads.ObjectList.Marshal(objs, MethodGet)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(out) == 0 {
+					b.Fatal("empty payload")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkInternodeObjectListUnmarshal measures objectListPayload.Unmarshal
+// (MethodGet), the second-largest allocation source in the profile.
+func BenchmarkInternodeObjectListUnmarshal(b *testing.B) {
+	for _, size := range []int{10, 100} {
+		objs, _ := makeBenchObjects(size)
+		payload, err := IndicesPayloads.ObjectList.Marshal(objs, MethodGet)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("objs_%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out, err := IndicesPayloads.ObjectList.Unmarshal(payload, MethodGet)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(out) != size {
+					b.Fatal("unexpected result size")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkInternodeStorobjMarshal measures the per-object binary encode
+// (storobj MarshalBinaryOptional). The noprops variants isolate the cost of
+// the JSON-encoded props blob inside the otherwise-binary format.
+func BenchmarkInternodeStorobjMarshal(b *testing.B) {
+	objs, _ := makeBenchObjects(1)
+	obj := objs[0]
+	for _, v := range benchAddPropsVariants {
+		b.Run(v.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out, err := obj.MarshalBinaryOptional(v.addProps)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(out) == 0 {
+					b.Fatal("empty payload")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkInternodeStorobjUnmarshal measures the per-object binary decode
+// (storobj.FromBinaryNetwork), including json.Unmarshal of the props blob and
+// enrichSchemaTypes.
+func BenchmarkInternodeStorobjUnmarshal(b *testing.B) {
+	objs, _ := makeBenchObjects(1)
+	obj := objs[0]
+	for _, v := range benchAddPropsVariants {
+		payload, err := obj.MarshalBinaryOptional(v.addProps)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(v.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out, err := storobj.FromBinaryNetwork(payload)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if out.DocID != obj.DocID {
+					b.Fatal("docID mismatch")
+				}
+			}
+		})
+	}
+}
+
+// chunkedReader yields data in fixed-size chunks without exposing a length,
+// mimicking an HTTP response body so io.ReadAll must grow its buffer.
+type chunkedReader struct {
+	data []byte
+	pos  int
+	step int
+}
+
+func (c *chunkedReader) Read(p []byte) (int, error) {
+	if c.pos >= len(c.data) {
+		return 0, io.EOF
+	}
+	n := c.step
+	if n > len(p) {
+		n = len(p)
+	}
+	if c.pos+n > len(c.data) {
+		n = len(c.data) - c.pos
+	}
+	copy(p, c.data[c.pos:c.pos+n])
+	c.pos += n
+	return n, nil
+}
+
+// BenchmarkInternodeReadAllBody measures the io.ReadAll full-body buffering
+// pattern used across the remote_index client sites, on a payload the size of
+// a typical 100-object search response.
+func BenchmarkInternodeReadAllBody(b *testing.B) {
+	objs, dists := makeBenchObjects(100)
+	payload, err := IndicesPayloads.SearchResults.MarshalWithAdditional(objs, dists, additional.Properties{Vector: true}, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Run(fmt.Sprintf("payload_%dKB", len(payload)/1024), func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			body, err := io.ReadAll(&chunkedReader{data: payload, step: 32 * 1024})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(body) != len(payload) {
+				b.Fatal("short read")
+			}
+		}
+	})
+	// contrast: the same read when the length is known upfront (what a
+	// content-length-aware or pooled-buffer implementation could do)
+	b.Run("preallocated_readfull", func(b *testing.B) {
+		b.ReportAllocs()
+		buf := make([]byte, len(payload))
+		for i := 0; i < b.N; i++ {
+			r := bytes.NewReader(payload)
+			if _, err := io.ReadFull(r, buf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema/crossref"
 	"github.com/weaviate/weaviate/entities/storobj"

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_test.go
@@ -827,7 +827,7 @@ func TestObjectListUnmarshalFramingErrors(t *testing.T) {
 
 	t.Run("crafted overflow length", func(t *testing.T) {
 		crafted := make([]byte, 8)
-		binary.LittleEndian.PutUint64(crafted, ^uint64(0)) // max uint64
+		binary.LittleEndian.PutUint64(crafted, ^uint64(0))
 		_, err := IndicesPayloads.ObjectList.Unmarshal(crafted, MethodGet)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "exceeds remaining")
@@ -846,10 +846,7 @@ func TestObjectListUnmarshalFramingErrors(t *testing.T) {
 	})
 }
 
-// TestObjectListUnmarshalDoesNotAliasInput pins the lifetime contract that
-// makes the sub-slicing decode safe: the storobj decoder copies everything it
-// retains, so clobbering the input buffer after Unmarshal must not affect the
-// decoded objects.
+// Clobbering the input buffer after Unmarshal must not affect decoded objects.
 func TestObjectListUnmarshalDoesNotAliasInput(t *testing.T) {
 	obj := objectListFramingTestObject()
 	obj.Vectors = map[string][]float32{"named": {4, 5}}
@@ -864,7 +861,6 @@ func TestObjectListUnmarshalDoesNotAliasInput(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, decoded, 1)
 
-			// clobber the input buffer
 			for i := range payload {
 				payload[i] = 0xFF
 			}

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_test.go
@@ -783,3 +783,99 @@ func TestErrorListPayload_MixedShape(t *testing.T) {
 	assert.Equal(t, int64(5), le.Value)
 	assert.Equal(t, "third error", got[2].Error())
 }
+
+func objectListFramingTestObject() *storobj.Object {
+	obj := storobj.New(11)
+	obj.MarshallerVersion = 1
+	obj.Object = models.Object{
+		ID:                 strfmt.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+		Class:              "FramingClass",
+		CreationTimeUnix:   1700000000000,
+		LastUpdateTimeUnix: 1700000001000,
+		Properties: map[string]interface{}{
+			"prop": "value",
+		},
+	}
+	obj.Vector = []float32{1, 2, 3}
+	obj.VectorLen = 3
+	return obj
+}
+
+func TestObjectListUnmarshalFramingErrors(t *testing.T) {
+	obj := objectListFramingTestObject()
+	payload, err := IndicesPayloads.ObjectList.Marshal([]*storobj.Object{obj}, MethodGet)
+	require.NoError(t, err)
+
+	t.Run("empty input", func(t *testing.T) {
+		out, err := IndicesPayloads.ObjectList.Unmarshal(nil, MethodGet)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("truncated length prefix", func(t *testing.T) {
+		_, err := IndicesPayloads.ObjectList.Unmarshal(payload[:5], MethodGet)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "truncated length prefix")
+	})
+
+	t.Run("truncated object payload", func(t *testing.T) {
+		_, err := IndicesPayloads.ObjectList.Unmarshal(payload[:len(payload)-3], MethodGet)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds remaining")
+	})
+
+	t.Run("crafted overflow length", func(t *testing.T) {
+		crafted := make([]byte, 8)
+		binary.LittleEndian.PutUint64(crafted, ^uint64(0)) // max uint64
+		_, err := IndicesPayloads.ObjectList.Unmarshal(crafted, MethodGet)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds remaining")
+	})
+
+	t.Run("trailing garbage after valid object", func(t *testing.T) {
+		withTrailing := append(append([]byte{}, payload...), 0x01, 0x02)
+		_, err := IndicesPayloads.ObjectList.Unmarshal(withTrailing, MethodGet)
+		require.Error(t, err)
+	})
+
+	t.Run("unsupported method", func(t *testing.T) {
+		_, err := IndicesPayloads.ObjectList.Unmarshal(payload, "POST")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported operation type")
+	})
+}
+
+// TestObjectListUnmarshalDoesNotAliasInput pins the lifetime contract that
+// makes the sub-slicing decode safe: the storobj decoder copies everything it
+// retains, so clobbering the input buffer after Unmarshal must not affect the
+// decoded objects.
+func TestObjectListUnmarshalDoesNotAliasInput(t *testing.T) {
+	obj := objectListFramingTestObject()
+	obj.Vectors = map[string][]float32{"named": {4, 5}}
+	obj.MultiVectors = map[string][][]float32{"multi": {{6, 7}, {8}}}
+
+	for _, method := range []string{MethodGet, MethodPut} {
+		t.Run(method, func(t *testing.T) {
+			payload, err := IndicesPayloads.ObjectList.Marshal([]*storobj.Object{obj}, method)
+			require.NoError(t, err)
+
+			decoded, err := IndicesPayloads.ObjectList.Unmarshal(payload, method)
+			require.NoError(t, err)
+			require.Len(t, decoded, 1)
+
+			// clobber the input buffer
+			for i := range payload {
+				payload[i] = 0xFF
+			}
+
+			got := decoded[0]
+			assert.Equal(t, obj.DocID, got.DocID)
+			assert.Equal(t, obj.ID(), got.ID())
+			assert.Equal(t, obj.Object.Class, got.Object.Class)
+			assert.Equal(t, obj.Vector, got.Vector)
+			assert.Equal(t, obj.Vectors, got.Vectors)
+			assert.Equal(t, obj.MultiVectors, got.MultiVectors)
+			assert.Equal(t, obj.Object.Properties, got.Object.Properties)
+		})
+	}
+}

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_wire_identity_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_wire_identity_test.go
@@ -338,14 +338,14 @@ func legacyObjectListMarshalWithAdditional(in []*storobj.Object, addProps additi
 	return out, nil
 }
 
-// legacySearchResultsMarshal replicates searchResultsPayload.Marshal pre-optimization.
-func legacySearchResultsMarshal(objs []*storobj.Object, dists []float32) ([]byte, error) {
+// legacyAppendObjsAndDists appends the length-prefixed object-list bytes
+// followed by the length-prefixed distances block. The pre-optimization
+// searchResultsPayload.Marshal and MarshalWithAdditional both contained this
+// framing verbatim; it is consolidated to a single copy here. The byte-identity
+// assertions against the current implementation pin its output.
+func legacyAppendObjsAndDists(objsBytes []byte, dists []float32) []byte {
 	reusableLengthBuf := make([]byte, 8)
 	var out []byte
-	objsBytes, err := legacyObjectListMarshal(objs, MethodGet)
-	if err != nil {
-		return nil, err
-	}
 
 	objsLength := uint64(len(objsBytes))
 	binary.LittleEndian.PutUint64(reusableLengthBuf, objsLength)
@@ -361,7 +361,16 @@ func legacySearchResultsMarshal(objs []*storobj.Object, dists []float32) ([]byte
 	byteops.CopySliceToBytes(distsBuf, dists)
 	out = append(out, distsBuf...)
 
-	return out, nil
+	return out
+}
+
+// legacySearchResultsMarshal replicates searchResultsPayload.Marshal pre-optimization.
+func legacySearchResultsMarshal(objs []*storobj.Object, dists []float32) ([]byte, error) {
+	objsBytes, err := legacyObjectListMarshal(objs, MethodGet)
+	if err != nil {
+		return nil, err
+	}
+	return legacyAppendObjsAndDists(objsBytes, dists), nil
 }
 
 // legacySearchResultsMarshalWithAdditional replicates
@@ -369,26 +378,11 @@ func legacySearchResultsMarshal(objs []*storobj.Object, dists []float32) ([]byte
 func legacySearchResultsMarshalWithAdditional(objs []*storobj.Object,
 	dists []float32, addProps additional.Properties, queryProfiles []helpers.ShardQueryProfile,
 ) ([]byte, error) {
-	reusableLengthBuf := make([]byte, 8)
-	var out []byte
 	objsBytes, err := legacyObjectListMarshalWithAdditional(objs, addProps)
 	if err != nil {
 		return nil, err
 	}
-
-	objsLength := uint64(len(objsBytes))
-	binary.LittleEndian.PutUint64(reusableLengthBuf, objsLength)
-
-	out = append(out, reusableLengthBuf...)
-	out = append(out, objsBytes...)
-
-	distsLength := uint64(len(dists))
-	binary.LittleEndian.PutUint64(reusableLengthBuf, distsLength)
-	out = append(out, reusableLengthBuf...)
-
-	distsBuf := make([]byte, distsLength*4)
-	byteops.CopySliceToBytes(distsBuf, dists)
-	out = append(out, distsBuf...)
+	out := legacyAppendObjsAndDists(objsBytes, dists)
 
 	var profilesBytes []byte
 	if len(queryProfiles) > 0 {
@@ -397,8 +391,9 @@ func legacySearchResultsMarshalWithAdditional(objs []*storobj.Object,
 			return nil, err
 		}
 	}
-	binary.LittleEndian.PutUint64(reusableLengthBuf, uint64(len(profilesBytes)))
-	out = append(out, reusableLengthBuf...)
+	lengthBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(lengthBuf, uint64(len(profilesBytes)))
+	out = append(out, lengthBuf...)
 	out = append(out, profilesBytes...)
 
 	return out, nil

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_wire_identity_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_wire_identity_test.go
@@ -1,0 +1,671 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shared
+
+// Wire-identity tests for the internode marshalling optimizations. The
+// legacy* functions below are a verbatim replica of the marshal
+// implementations as of commit 61a1c99276 (per-object intermediate buffers,
+// append-based framing). The tests assert that the optimized implementations
+// produce byte-identical output, i.e. that no wire-format change sneaks in.
+//
+// Objects with more than one entry in Vectors/MultiVectors are excluded from
+// the byte-identity assertions because the offsets header is a
+// msgpack-encoded map whose key order depends on Go map iteration order:
+// even two consecutive calls of the SAME implementation can produce
+// different (equivalent) bytes. Those cases are covered by the semantic
+// round-trip test instead.
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+// legacyMarshalBinaryOptional replicates storobj.(*Object).marshalBinaryInternal
+// (skipClassName=false) as of commit 61a1c99276.
+func legacyMarshalBinaryOptional(ko *storobj.Object, addProps additional.Properties) ([]byte, error) {
+	if ko.MarshallerVersion != 1 {
+		return nil, fmt.Errorf("unsupported marshaller version %d", ko.MarshallerVersion)
+	}
+
+	kindByte := uint8(1)
+
+	idParsed, err := uuid.Parse(ko.ID().String())
+	if err != nil {
+		return nil, err
+	}
+	idBytes, err := idParsed.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	var vectorLength uint32
+	if addProps.Vector {
+		vectorLength = uint32(len(ko.Vector))
+	}
+
+	className := []byte(ko.Class())
+	classNameLength := uint32(len(className))
+
+	var schema []byte
+	var schemaLength uint32
+	if !addProps.NoProps {
+		schema, err = json.Marshal(ko.Properties())
+		if err != nil {
+			return nil, err
+		}
+		schemaLength = uint32(len(schema))
+	} else {
+		schema = []byte("{}")
+		schemaLength = uint32(len(schema))
+	}
+
+	meta, err := json.Marshal(ko.AdditionalProperties())
+	if err != nil {
+		return nil, err
+	}
+	metaLength := uint32(len(meta))
+
+	vectorWeights, err := json.Marshal(ko.VectorWeights())
+	if err != nil {
+		return nil, err
+	}
+	vectorWeightsLength := uint32(len(vectorWeights))
+
+	includeAllTargetVectors := addProps.IncludeAllTargetVectors
+	includeSpecificTargetVectors := len(addProps.Vectors) > 0
+
+	var requestedVectors map[string]struct{}
+	if includeSpecificTargetVectors {
+		requestedVectors = make(map[string]struct{}, len(addProps.Vectors))
+		for _, v := range addProps.Vectors {
+			requestedVectors[v] = struct{}{}
+		}
+	}
+
+	var targetVectorsOffsets []byte
+	var targetVectorsOffsetsLength uint32
+	var targetVectorsSegmentLength int
+
+	targetVectorsOffsetOrder := make([]string, 0, len(ko.Vectors))
+	if (includeAllTargetVectors || includeSpecificTargetVectors) && len(ko.Vectors) > 0 {
+		offsetsMap := map[string]uint32{}
+		for name, vec := range ko.Vectors {
+			if includeSpecificTargetVectors {
+				if _, ok := requestedVectors[name]; !ok {
+					continue
+				}
+			}
+			offsetsMap[name] = uint32(targetVectorsSegmentLength)
+			targetVectorsSegmentLength += 2 + 4*len(vec)
+			targetVectorsOffsetOrder = append(targetVectorsOffsetOrder, name)
+		}
+
+		if len(offsetsMap) > 0 {
+			targetVectorsOffsets, err = msgpack.Marshal(offsetsMap)
+			if err != nil {
+				return nil, err
+			}
+			targetVectorsOffsetsLength = uint32(len(targetVectorsOffsets))
+		}
+	}
+
+	var multiVectorsOffsets []byte
+	var multiVectorsOffsetsLength uint32
+	var multiVectorsSegmentLength int
+
+	multiVectorsOffsetOrder := make([]string, 0, len(ko.MultiVectors))
+	if (includeAllTargetVectors || includeSpecificTargetVectors) && len(ko.MultiVectors) > 0 {
+		offsetsMap := map[string]uint32{}
+		for name, vecs := range ko.MultiVectors {
+			if includeSpecificTargetVectors {
+				if _, ok := requestedVectors[name]; !ok {
+					continue
+				}
+			}
+			offsetsMap[name] = uint32(multiVectorsSegmentLength)
+			multiVectorsSegmentLength += 4
+			for _, vec := range vecs {
+				multiVectorsSegmentLength += 2 + 4*len(vec)
+			}
+			multiVectorsOffsetOrder = append(multiVectorsOffsetOrder, name)
+		}
+
+		if len(offsetsMap) > 0 {
+			multiVectorsOffsets, err = msgpack.Marshal(offsetsMap)
+			if err != nil {
+				return nil, err
+			}
+			multiVectorsOffsetsLength = uint32(len(multiVectorsOffsets))
+		}
+	}
+
+	totalBufferLength := 1 + 8 + 1 + 16 + 8 + 8 +
+		2 + vectorLength*4 +
+		2 + classNameLength +
+		4 + schemaLength +
+		4 + metaLength +
+		4 + vectorWeightsLength +
+		4 + targetVectorsOffsetsLength +
+		4 + uint32(targetVectorsSegmentLength) +
+		4 + multiVectorsOffsetsLength +
+		4 + uint32(multiVectorsSegmentLength)
+
+	byteBuffer := make([]byte, totalBufferLength)
+	rw := byteops.NewReadWriter(byteBuffer)
+	rw.WriteByte(ko.MarshallerVersion)
+	rw.WriteUint64(ko.DocID)
+	rw.WriteByte(kindByte)
+
+	if err := rw.CopyBytesToBuffer(idBytes); err != nil {
+		return nil, err
+	}
+
+	rw.WriteUint64(uint64(ko.CreationTimeUnix()))
+	rw.WriteUint64(uint64(ko.LastUpdateTimeUnix()))
+	rw.WriteUint16(uint16(vectorLength))
+
+	if addProps.Vector {
+		byteops.CopySliceToBytes(rw.Buffer[rw.Position:rw.Position+uint64(vectorLength)*byteops.Uint32Len], ko.Vector)
+		rw.MoveBufferPositionForward(uint64(vectorLength) * byteops.Uint32Len)
+	}
+
+	rw.WriteUint16(uint16(classNameLength))
+	if classNameLength > 0 {
+		if err := rw.CopyBytesToBuffer(className); err != nil {
+			return nil, err
+		}
+	}
+
+	rw.WriteUint32(schemaLength)
+	if schemaLength > 0 {
+		if err := rw.CopyBytesToBuffer(schema); err != nil {
+			return nil, err
+		}
+	}
+
+	rw.WriteUint32(metaLength)
+	if err := rw.CopyBytesToBuffer(meta); err != nil {
+		return nil, err
+	}
+
+	rw.WriteUint32(vectorWeightsLength)
+	if err := rw.CopyBytesToBuffer(vectorWeights); err != nil {
+		return nil, err
+	}
+
+	rw.WriteUint32(targetVectorsOffsetsLength)
+	if targetVectorsOffsetsLength > 0 {
+		if err := rw.CopyBytesToBuffer(targetVectorsOffsets); err != nil {
+			return nil, err
+		}
+	}
+
+	rw.WriteUint32(uint32(targetVectorsSegmentLength))
+	for _, name := range targetVectorsOffsetOrder {
+		vec := ko.Vectors[name]
+		vecLen := len(vec)
+
+		rw.WriteUint16(uint16(vecLen))
+		byteops.CopySliceToBytes(rw.Buffer[rw.Position:rw.Position+uint64(vecLen)*byteops.Uint32Len], vec)
+		rw.MoveBufferPositionForward(uint64(vecLen) * byteops.Uint32Len)
+	}
+
+	rw.WriteUint32(multiVectorsOffsetsLength)
+	if multiVectorsOffsetsLength > 0 {
+		if err := rw.CopyBytesToBuffer(multiVectorsOffsets); err != nil {
+			return nil, err
+		}
+	}
+
+	rw.WriteUint32(uint32(multiVectorsSegmentLength))
+	for _, name := range multiVectorsOffsetOrder {
+		vecs := ko.MultiVectors[name]
+		rw.WriteUint32(uint32(len(vecs)))
+		for _, vec := range vecs {
+			vecLen := len(vec)
+			rw.WriteUint16(uint16(vecLen))
+			byteops.CopySliceToBytes(rw.Buffer[rw.Position:rw.Position+uint64(vecLen)*byteops.Uint32Len], vec)
+			rw.MoveBufferPositionForward(uint64(vecLen) * byteops.Uint32Len)
+		}
+	}
+
+	return byteBuffer, nil
+}
+
+// legacyMarshalBinary replicates storobj.(*Object).MarshalBinary as of
+// commit 61a1c99276.
+func legacyMarshalBinary(ko *storobj.Object) ([]byte, error) {
+	return legacyMarshalBinaryOptional(ko, additional.Properties{
+		Vector:                  true,
+		IncludeAllTargetVectors: true,
+	})
+}
+
+// legacyMarshallStorObj replicates the marshallStorObj PUT-path wrapper as of
+// commit 61a1c99276.
+func legacyMarshallStorObj(in *storobj.Object) ([]byte, error) {
+	obj := storobj.Object{
+		MarshallerVersion: in.MarshallerVersion,
+		Object: models.Object{
+			Additional:         in.Object.Additional,
+			Class:              in.Object.Class,
+			CreationTimeUnix:   in.Object.CreationTimeUnix,
+			ID:                 in.Object.ID,
+			LastUpdateTimeUnix: in.Object.LastUpdateTimeUnix,
+			Properties:         in.Object.Properties,
+			Tenant:             in.Object.Tenant,
+			Vector:             in.Object.Vector,
+			Vectors:            in.Object.Vectors,
+		},
+		Vector:         in.Vector,
+		VectorLen:      in.VectorLen,
+		BelongsToNode:  in.BelongsToNode,
+		BelongsToShard: in.BelongsToShard,
+		IsConsistent:   in.IsConsistent,
+		DocID:          in.DocID,
+		Vectors:        in.Vectors,
+		MultiVectors:   in.MultiVectors,
+	}
+	return legacyMarshalBinary(&obj)
+}
+
+// legacyObjectListMarshal replicates objectListPayload.Marshal as of commit
+// 61a1c99276.
+func legacyObjectListMarshal(in []*storobj.Object, method string) ([]byte, error) {
+	out := make([]byte, 0, 1024*len(in))
+
+	reusableLengthBuf := make([]byte, 8)
+	for _, ind := range in {
+		if ind != nil {
+			var bytes []byte
+			var err error
+			switch method {
+			case MethodPut:
+				bytes, err = legacyMarshallStorObj(ind)
+			case MethodGet:
+				bytes, err = legacyMarshalBinary(ind)
+			default:
+				return nil, fmt.Errorf("unsupported operation type: %s", method)
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			length := uint64(len(bytes))
+			binary.LittleEndian.PutUint64(reusableLengthBuf, length)
+
+			out = append(out, reusableLengthBuf...)
+			out = append(out, bytes...)
+		}
+	}
+
+	return out, nil
+}
+
+// legacyObjectListMarshalWithAdditional replicates
+// objectListPayload.MarshalWithAdditional as of commit 61a1c99276.
+func legacyObjectListMarshalWithAdditional(in []*storobj.Object, addProps additional.Properties) ([]byte, error) {
+	out := make([]byte, 0, 1024*len(in))
+
+	reusableLengthBuf := make([]byte, 8)
+	for _, ind := range in {
+		if ind != nil {
+			bytes, err := legacyMarshalBinaryOptional(ind, addProps)
+			if err != nil {
+				return nil, err
+			}
+
+			length := uint64(len(bytes))
+			binary.LittleEndian.PutUint64(reusableLengthBuf, length)
+
+			out = append(out, reusableLengthBuf...)
+			out = append(out, bytes...)
+		}
+	}
+
+	return out, nil
+}
+
+// legacySearchResultsMarshal replicates searchResultsPayload.Marshal as of
+// commit 61a1c99276.
+func legacySearchResultsMarshal(objs []*storobj.Object, dists []float32) ([]byte, error) {
+	reusableLengthBuf := make([]byte, 8)
+	var out []byte
+	objsBytes, err := legacyObjectListMarshal(objs, MethodGet)
+	if err != nil {
+		return nil, err
+	}
+
+	objsLength := uint64(len(objsBytes))
+	binary.LittleEndian.PutUint64(reusableLengthBuf, objsLength)
+
+	out = append(out, reusableLengthBuf...)
+	out = append(out, objsBytes...)
+
+	distsLength := uint64(len(dists))
+	binary.LittleEndian.PutUint64(reusableLengthBuf, distsLength)
+	out = append(out, reusableLengthBuf...)
+
+	distsBuf := make([]byte, distsLength*4)
+	byteops.CopySliceToBytes(distsBuf, dists)
+	out = append(out, distsBuf...)
+
+	return out, nil
+}
+
+// legacySearchResultsMarshalWithAdditional replicates
+// searchResultsPayload.MarshalWithAdditional as of commit 61a1c99276.
+func legacySearchResultsMarshalWithAdditional(objs []*storobj.Object,
+	dists []float32, addProps additional.Properties, queryProfiles []helpers.ShardQueryProfile,
+) ([]byte, error) {
+	reusableLengthBuf := make([]byte, 8)
+	var out []byte
+	objsBytes, err := legacyObjectListMarshalWithAdditional(objs, addProps)
+	if err != nil {
+		return nil, err
+	}
+
+	objsLength := uint64(len(objsBytes))
+	binary.LittleEndian.PutUint64(reusableLengthBuf, objsLength)
+
+	out = append(out, reusableLengthBuf...)
+	out = append(out, objsBytes...)
+
+	distsLength := uint64(len(dists))
+	binary.LittleEndian.PutUint64(reusableLengthBuf, distsLength)
+	out = append(out, reusableLengthBuf...)
+
+	distsBuf := make([]byte, distsLength*4)
+	byteops.CopySliceToBytes(distsBuf, dists)
+	out = append(out, distsBuf...)
+
+	var profilesBytes []byte
+	if len(queryProfiles) > 0 {
+		profilesBytes, err = json.Marshal(queryProfiles)
+		if err != nil {
+			return nil, err
+		}
+	}
+	binary.LittleEndian.PutUint64(reusableLengthBuf, uint64(len(profilesBytes)))
+	out = append(out, reusableLengthBuf...)
+	out = append(out, profilesBytes...)
+
+	return out, nil
+}
+
+// wireIdentityObject builds a deterministic object for the given variant.
+// All variants keep Vectors/MultiVectors at <=1 entry so that the msgpack
+// offsets header is deterministic (see file comment).
+func wireIdentityObject(variant string) *storobj.Object {
+	obj := storobj.New(42)
+	obj.MarshallerVersion = 1
+	obj.Object = models.Object{
+		ID:                 strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168247"),
+		Class:              "WireIdentityClass",
+		CreationTimeUnix:   1700000000000,
+		LastUpdateTimeUnix: 1700000001000,
+		Properties: map[string]interface{}{
+			"title":  "hello world",
+			"count":  float64(7),
+			"active": true,
+			"tags":   []interface{}{"a", "b"},
+			"nested": map[string]interface{}{"x": "y"},
+		},
+	}
+
+	switch variant {
+	case "props_and_vector":
+		obj.Vector = []float32{0.1, 0.2, 0.3, -1.5}
+		obj.VectorLen = 4
+	case "props_only":
+		obj.Vector = []float32{0.1, 0.2, 0.3, -1.5}
+		obj.VectorLen = 4
+	case "nil_vector":
+		obj.Vector = nil
+		obj.VectorLen = 0
+	case "with_additional":
+		obj.Vector = []float32{1, 2}
+		obj.VectorLen = 2
+		obj.Object.Additional = models.AdditionalProperties{
+			"distance": float64(0.25),
+		}
+	case "single_named_vector":
+		obj.Vector = []float32{1, 2}
+		obj.VectorLen = 2
+		obj.Vectors = map[string][]float32{
+			"named1": {0.5, 0.6, 0.7},
+		}
+	case "single_multi_vector":
+		obj.Vector = []float32{1, 2}
+		obj.VectorLen = 2
+		obj.MultiVectors = map[string][][]float32{
+			"colbert": {{0.1, 0.2}, {0.3, 0.4}, {0.5, 0.6}},
+		}
+	case "empty_props":
+		obj.Object.Properties = map[string]interface{}{}
+		obj.Vector = []float32{1}
+		obj.VectorLen = 1
+	}
+
+	return obj
+}
+
+var wireIdentityVariants = []string{
+	"props_and_vector",
+	"props_only",
+	"nil_vector",
+	"with_additional",
+	"single_named_vector",
+	"single_multi_vector",
+	"empty_props",
+}
+
+func wireIdentityAddProps(variant string) additional.Properties {
+	switch variant {
+	case "props_only":
+		return additional.Properties{}
+	case "nil_vector":
+		return additional.Properties{Vector: true}
+	case "single_named_vector", "single_multi_vector":
+		return additional.Properties{Vector: true, IncludeAllTargetVectors: true}
+	default:
+		return additional.Properties{Vector: true}
+	}
+}
+
+func TestWireIdentityStorobjMarshal(t *testing.T) {
+	for _, variant := range wireIdentityVariants {
+		t.Run(variant, func(t *testing.T) {
+			obj := wireIdentityObject(variant)
+			addProps := wireIdentityAddProps(variant)
+
+			legacy, err := legacyMarshalBinaryOptional(obj, addProps)
+			require.NoError(t, err)
+
+			current, err := obj.MarshalBinaryOptional(addProps)
+			require.NoError(t, err)
+
+			require.Equal(t, legacy, current, "MarshalBinaryOptional output must be byte-identical to the legacy implementation")
+
+			legacyFull, err := legacyMarshalBinary(obj)
+			require.NoError(t, err)
+
+			currentFull, err := obj.MarshalBinary()
+			require.NoError(t, err)
+
+			require.Equal(t, legacyFull, currentFull, "MarshalBinary output must be byte-identical to the legacy implementation")
+		})
+	}
+
+	t.Run("noprops_and_vector", func(t *testing.T) {
+		obj := wireIdentityObject("props_and_vector")
+		addProps := additional.Properties{Vector: true, NoProps: true}
+
+		legacy, err := legacyMarshalBinaryOptional(obj, addProps)
+		require.NoError(t, err)
+
+		current, err := obj.MarshalBinaryOptional(addProps)
+		require.NoError(t, err)
+
+		require.Equal(t, legacy, current)
+	})
+}
+
+func TestWireIdentityObjectListMarshal(t *testing.T) {
+	objs := make([]*storobj.Object, 0, len(wireIdentityVariants)+2)
+	for _, variant := range wireIdentityVariants {
+		objs = append(objs, wireIdentityObject(variant))
+	}
+	// nil entries must be skipped identically
+	objs = append(objs, nil)
+	objs = append(objs, wireIdentityObject("props_and_vector"))
+
+	for _, method := range []string{MethodGet, MethodPut} {
+		t.Run(method, func(t *testing.T) {
+			legacy, err := legacyObjectListMarshal(objs, method)
+			require.NoError(t, err)
+
+			current, err := IndicesPayloads.ObjectList.Marshal(objs, method)
+			require.NoError(t, err)
+
+			require.Equal(t, legacy, current, "ObjectList.Marshal output must be byte-identical to the legacy implementation")
+		})
+	}
+
+	t.Run("empty_list", func(t *testing.T) {
+		legacy, err := legacyObjectListMarshal(nil, MethodGet)
+		require.NoError(t, err)
+
+		current, err := IndicesPayloads.ObjectList.Marshal(nil, MethodGet)
+		require.NoError(t, err)
+
+		require.Equal(t, len(legacy), len(current))
+		require.Empty(t, current)
+	})
+
+	t.Run("with_additional", func(t *testing.T) {
+		for _, addProps := range []additional.Properties{
+			{Vector: true, IncludeAllTargetVectors: true},
+			{Vector: true},
+			{},
+			{Vector: true, NoProps: true},
+			{Vector: true, Vectors: []string{"named1"}},
+		} {
+			legacy, err := legacyObjectListMarshalWithAdditional(objs, addProps)
+			require.NoError(t, err)
+
+			current, err := IndicesPayloads.ObjectList.MarshalWithAdditional(objs, addProps)
+			require.NoError(t, err)
+
+			require.Equal(t, legacy, current, "ObjectList.MarshalWithAdditional output must be byte-identical to the legacy implementation (addProps=%+v)", addProps)
+		}
+	})
+}
+
+func TestWireIdentitySearchResultsMarshal(t *testing.T) {
+	objs := make([]*storobj.Object, 0, len(wireIdentityVariants))
+	for _, variant := range wireIdentityVariants {
+		objs = append(objs, wireIdentityObject(variant))
+	}
+	dists := []float32{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7}
+
+	t.Run("marshal", func(t *testing.T) {
+		legacy, err := legacySearchResultsMarshal(objs, dists)
+		require.NoError(t, err)
+
+		current, err := IndicesPayloads.SearchResults.Marshal(objs, dists)
+		require.NoError(t, err)
+
+		require.Equal(t, legacy, current, "SearchResults.Marshal output must be byte-identical to the legacy implementation")
+	})
+
+	t.Run("marshal_empty", func(t *testing.T) {
+		legacy, err := legacySearchResultsMarshal(nil, nil)
+		require.NoError(t, err)
+
+		current, err := IndicesPayloads.SearchResults.Marshal(nil, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, legacy, current)
+	})
+
+	profileVariants := map[string][]helpers.ShardQueryProfile{
+		"no_profiles": nil,
+		"with_profiles": {
+			{Name: "shard-1", Node: "node-1"},
+		},
+	}
+
+	for name, profiles := range profileVariants {
+		for _, addProps := range []additional.Properties{
+			{Vector: true},
+			{},
+			{Vector: true, NoProps: true},
+		} {
+			t.Run(fmt.Sprintf("marshal_with_additional/%s", name), func(t *testing.T) {
+				legacy, err := legacySearchResultsMarshalWithAdditional(objs, dists, addProps, profiles)
+				require.NoError(t, err)
+
+				current, err := IndicesPayloads.SearchResults.MarshalWithAdditional(objs, dists, addProps, profiles)
+				require.NoError(t, err)
+
+				require.Equal(t, legacy, current, "SearchResults.MarshalWithAdditional output must be byte-identical to the legacy implementation")
+			})
+		}
+	}
+}
+
+// TestWireIdentityMultiEntryVectorsRoundTrip covers objects with multiple
+// named vectors / multivectors, where byte-identity cannot be asserted
+// (msgpack map key order is nondeterministic in both implementations).
+// Instead it asserts that the optimized marshal round-trips to a
+// semantically identical object.
+func TestWireIdentityMultiEntryVectorsRoundTrip(t *testing.T) {
+	obj := wireIdentityObject("props_and_vector")
+	obj.Vectors = map[string][]float32{
+		"named1": {0.5, 0.6, 0.7},
+		"named2": {1.5, 2.5},
+		"named3": {9},
+	}
+	obj.MultiVectors = map[string][][]float32{
+		"colbertA": {{0.1, 0.2}, {0.3, 0.4}},
+		"colbertB": {{5, 6, 7}},
+	}
+
+	payload, err := IndicesPayloads.ObjectList.Marshal([]*storobj.Object{obj}, MethodGet)
+	require.NoError(t, err)
+
+	decodedList, err := IndicesPayloads.ObjectList.Unmarshal(payload, MethodGet)
+	require.NoError(t, err)
+	require.Len(t, decodedList, 1)
+
+	decoded := decodedList[0]
+	require.Equal(t, obj.DocID, decoded.DocID)
+	require.Equal(t, obj.ID(), decoded.ID())
+	require.Equal(t, obj.Vector, decoded.Vector)
+	require.Equal(t, obj.Vectors, decoded.Vectors)
+	require.Equal(t, obj.MultiVectors, decoded.MultiVectors)
+	require.Equal(t, obj.Object.Class, decoded.Object.Class)
+}

--- a/adapters/handlers/rest/clusterapi/shared/indices_payloads_wire_identity_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/indices_payloads_wire_identity_test.go
@@ -11,18 +11,11 @@
 
 package shared
 
-// Wire-identity tests for the internode marshalling optimizations. The
-// legacy* functions below are a verbatim replica of the marshal
-// implementations as of commit 61a1c99276 (per-object intermediate buffers,
-// append-based framing). The tests assert that the optimized implementations
-// produce byte-identical output, i.e. that no wire-format change sneaks in.
-//
-// Objects with more than one entry in Vectors/MultiVectors are excluded from
-// the byte-identity assertions because the offsets header is a
-// msgpack-encoded map whose key order depends on Go map iteration order:
-// even two consecutive calls of the SAME implementation can produce
-// different (equivalent) bytes. Those cases are covered by the semantic
-// round-trip test instead.
+// Wire-identity tests: legacy* functions freeze the pre-optimization marshal
+// implementations so the optimized path can be asserted byte-identical to
+// them. Objects with >1 Vectors/MultiVectors entry are excluded from
+// byte-identity checks (msgpack map key order is nondeterministic) and
+// covered by the semantic round-trip test instead.
 
 import (
 	"encoding/binary"
@@ -43,7 +36,7 @@ import (
 )
 
 // legacyMarshalBinaryOptional replicates storobj.(*Object).marshalBinaryInternal
-// (skipClassName=false) as of commit 61a1c99276.
+// (skipClassName=false) pre-optimization.
 func legacyMarshalBinaryOptional(ko *storobj.Object, addProps additional.Properties) ([]byte, error) {
 	if ko.MarshallerVersion != 1 {
 		return nil, fmt.Errorf("unsupported marshaller version %d", ko.MarshallerVersion)
@@ -254,8 +247,7 @@ func legacyMarshalBinaryOptional(ko *storobj.Object, addProps additional.Propert
 	return byteBuffer, nil
 }
 
-// legacyMarshalBinary replicates storobj.(*Object).MarshalBinary as of
-// commit 61a1c99276.
+// legacyMarshalBinary replicates storobj.(*Object).MarshalBinary pre-optimization.
 func legacyMarshalBinary(ko *storobj.Object) ([]byte, error) {
 	return legacyMarshalBinaryOptional(ko, additional.Properties{
 		Vector:                  true,
@@ -263,8 +255,7 @@ func legacyMarshalBinary(ko *storobj.Object) ([]byte, error) {
 	})
 }
 
-// legacyMarshallStorObj replicates the marshallStorObj PUT-path wrapper as of
-// commit 61a1c99276.
+// legacyMarshallStorObj replicates the marshallStorObj PUT-path wrapper pre-optimization.
 func legacyMarshallStorObj(in *storobj.Object) ([]byte, error) {
 	obj := storobj.Object{
 		MarshallerVersion: in.MarshallerVersion,
@@ -291,8 +282,7 @@ func legacyMarshallStorObj(in *storobj.Object) ([]byte, error) {
 	return legacyMarshalBinary(&obj)
 }
 
-// legacyObjectListMarshal replicates objectListPayload.Marshal as of commit
-// 61a1c99276.
+// legacyObjectListMarshal replicates objectListPayload.Marshal pre-optimization.
 func legacyObjectListMarshal(in []*storobj.Object, method string) ([]byte, error) {
 	out := make([]byte, 0, 1024*len(in))
 
@@ -325,7 +315,7 @@ func legacyObjectListMarshal(in []*storobj.Object, method string) ([]byte, error
 }
 
 // legacyObjectListMarshalWithAdditional replicates
-// objectListPayload.MarshalWithAdditional as of commit 61a1c99276.
+// objectListPayload.MarshalWithAdditional pre-optimization.
 func legacyObjectListMarshalWithAdditional(in []*storobj.Object, addProps additional.Properties) ([]byte, error) {
 	out := make([]byte, 0, 1024*len(in))
 
@@ -348,8 +338,7 @@ func legacyObjectListMarshalWithAdditional(in []*storobj.Object, addProps additi
 	return out, nil
 }
 
-// legacySearchResultsMarshal replicates searchResultsPayload.Marshal as of
-// commit 61a1c99276.
+// legacySearchResultsMarshal replicates searchResultsPayload.Marshal pre-optimization.
 func legacySearchResultsMarshal(objs []*storobj.Object, dists []float32) ([]byte, error) {
 	reusableLengthBuf := make([]byte, 8)
 	var out []byte
@@ -376,7 +365,7 @@ func legacySearchResultsMarshal(objs []*storobj.Object, dists []float32) ([]byte
 }
 
 // legacySearchResultsMarshalWithAdditional replicates
-// searchResultsPayload.MarshalWithAdditional as of commit 61a1c99276.
+// searchResultsPayload.MarshalWithAdditional pre-optimization.
 func legacySearchResultsMarshalWithAdditional(objs []*storobj.Object,
 	dists []float32, addProps additional.Properties, queryProfiles []helpers.ShardQueryProfile,
 ) ([]byte, error) {
@@ -637,11 +626,8 @@ func TestWireIdentitySearchResultsMarshal(t *testing.T) {
 	}
 }
 
-// TestWireIdentityMultiEntryVectorsRoundTrip covers objects with multiple
-// named vectors / multivectors, where byte-identity cannot be asserted
-// (msgpack map key order is nondeterministic in both implementations).
-// Instead it asserts that the optimized marshal round-trips to a
-// semantically identical object.
+// Multi-entry Vectors/MultiVectors can't be asserted byte-identical (map
+// iteration order); this checks semantic round-trip equality instead.
 func TestWireIdentityMultiEntryVectorsRoundTrip(t *testing.T) {
 	obj := wireIdentityObject("props_and_vector")
 	obj.Vectors = map[string][]float32{

--- a/adapters/handlers/rest/clusterapi/shared/read_body.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body.go
@@ -16,28 +16,16 @@ import (
 	"io"
 )
 
-// MaxUpfrontBodyAlloc caps how many bytes ReadBody allocates purely on the
-// peer-supplied Content-Length claim. Bodies that declare more start from a
-// buffer of this capacity and grow as data actually arrives, so a lying or
-// buggy peer cannot force a large allocation without sending real bytes
-// (io.ReadAll semantics). 64 MiB comfortably covers realistic internode
-// payloads (a 100-object search response with 768-dim vectors is well under
-// 1 MiB); larger legitimate bodies still work, they just pay the incremental
-// growth above the cap.
+// MaxUpfrontBodyAlloc caps how many bytes ReadBody preallocates from a
+// peer-supplied Content-Length; larger bodies grow incrementally instead
+// (io.ReadAll semantics), so a lying or buggy peer can't force a large
+// allocation without sending real bytes.
 const MaxUpfrontBodyAlloc = 64 << 20 // 64 MiB
 
-// ReadBody reads an HTTP request or response body to EOF. When contentLength
-// is positive (the Content-Length header was set) and within
-// MaxUpfrontBodyAlloc, the result buffer is allocated at exactly that size
-// upfront, avoiding the repeated grow-and-copy of io.ReadAll on large
-// internode payloads. A non-positive contentLength (unknown length / chunked
-// transfer encoding) falls back to io.ReadAll.
-//
-// net/http limits request and response body readers to the declared
-// Content-Length, so a matching read is guaranteed to end at EOF. On the
-// exact-size path, a body shorter than the declared length returns
-// io.ErrUnexpectedEOF; above the cap, truncation surfaces in the payload
-// decode instead (same as io.ReadAll).
+// ReadBody reads a body to EOF, preallocating an exact-size buffer when
+// contentLength is positive and within MaxUpfrontBodyAlloc (net/http caps
+// reads to the declared Content-Length, so short bodies surface as
+// io.ErrUnexpectedEOF instead of hanging). Otherwise falls back to io.ReadAll.
 func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
 	if contentLength <= 0 {
 		return io.ReadAll(r)
@@ -51,8 +39,7 @@ func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
 		return buf, nil
 	}
 
-	// The declared length exceeds what we are willing to allocate on the
-	// peer's word alone: pre-size to the cap and grow only as data arrives.
+	// don't trust the declared length past the cap; grow incrementally instead
 	buf := bytes.NewBuffer(make([]byte, 0, MaxUpfrontBodyAlloc))
 	if _, err := buf.ReadFrom(r); err != nil {
 		return nil, err

--- a/adapters/handlers/rest/clusterapi/shared/read_body.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body.go
@@ -12,31 +12,50 @@
 package shared
 
 import (
-	"fmt"
+	"bytes"
 	"io"
-	"math"
 )
 
+// MaxUpfrontBodyAlloc caps how many bytes ReadBody allocates purely on the
+// peer-supplied Content-Length claim. Bodies that declare more start from a
+// buffer of this capacity and grow as data actually arrives, so a lying or
+// buggy peer cannot force a large allocation without sending real bytes
+// (io.ReadAll semantics). 64 MiB comfortably covers realistic internode
+// payloads (a 100-object search response with 768-dim vectors is well under
+// 1 MiB); larger legitimate bodies still work, they just pay the incremental
+// growth above the cap.
+const MaxUpfrontBodyAlloc = 64 << 20 // 64 MiB
+
 // ReadBody reads an HTTP request or response body to EOF. When contentLength
-// is positive (the Content-Length header was set), the result buffer is
-// allocated at exactly that size upfront, avoiding the repeated grow-and-copy
-// of io.ReadAll on large internode payloads. A non-positive contentLength
-// (unknown length / chunked transfer encoding) falls back to io.ReadAll.
+// is positive (the Content-Length header was set) and within
+// MaxUpfrontBodyAlloc, the result buffer is allocated at exactly that size
+// upfront, avoiding the repeated grow-and-copy of io.ReadAll on large
+// internode payloads. A non-positive contentLength (unknown length / chunked
+// transfer encoding) falls back to io.ReadAll.
 //
 // net/http limits request and response body readers to the declared
-// Content-Length, so a matching read is guaranteed to end at EOF. A body
-// shorter than the declared length returns io.ErrUnexpectedEOF.
+// Content-Length, so a matching read is guaranteed to end at EOF. On the
+// exact-size path, a body shorter than the declared length returns
+// io.ErrUnexpectedEOF; above the cap, truncation surfaces in the payload
+// decode instead (same as io.ReadAll).
 func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
 	if contentLength <= 0 {
 		return io.ReadAll(r)
 	}
-	if contentLength > int64(math.MaxInt) {
-		return nil, fmt.Errorf("content length %d overflows int", contentLength)
+
+	if contentLength <= MaxUpfrontBodyAlloc {
+		buf := make([]byte, contentLength)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		return buf, nil
 	}
 
-	buf := make([]byte, contentLength)
-	if _, err := io.ReadFull(r, buf); err != nil {
+	// The declared length exceeds what we are willing to allocate on the
+	// peer's word alone: pre-size to the cap and grow only as data arrives.
+	buf := bytes.NewBuffer(make([]byte, 0, MaxUpfrontBodyAlloc))
+	if _, err := buf.ReadFrom(r); err != nil {
 		return nil, err
 	}
-	return buf, nil
+	return buf.Bytes(), nil
 }

--- a/adapters/handlers/rest/clusterapi/shared/read_body.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body.go
@@ -1,0 +1,42 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shared
+
+import (
+	"fmt"
+	"io"
+	"math"
+)
+
+// ReadBody reads an HTTP request or response body to EOF. When contentLength
+// is positive (the Content-Length header was set), the result buffer is
+// allocated at exactly that size upfront, avoiding the repeated grow-and-copy
+// of io.ReadAll on large internode payloads. A non-positive contentLength
+// (unknown length / chunked transfer encoding) falls back to io.ReadAll.
+//
+// net/http limits request and response body readers to the declared
+// Content-Length, so a matching read is guaranteed to end at EOF. A body
+// shorter than the declared length returns io.ErrUnexpectedEOF.
+func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
+	if contentLength <= 0 {
+		return io.ReadAll(r)
+	}
+	if contentLength > int64(math.MaxInt) {
+		return nil, fmt.Errorf("content length %d overflows int", contentLength)
+	}
+
+	buf := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/adapters/handlers/rest/clusterapi/shared/read_body.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body.go
@@ -12,33 +12,27 @@
 package shared
 
 import (
-	"bytes"
+	"errors"
 	"io"
 )
 
-const (
-	// MaxOnArrivalBodyAlloc caps how many bytes ReadBody allocates based on
-	// the peer-supplied Content-Length once the peer has proven itself by
-	// delivering UnverifiedBodyAlloc real bytes; claims beyond the cap grow
-	// incrementally (io.ReadAll semantics) as data arrives.
-	MaxOnArrivalBodyAlloc = 64 << 20 // 64 MiB
+// UnverifiedBodyAlloc is the only allocation ReadBody makes on an
+// unverified Content-Length claim. Keeping it small bounds the memory a
+// peer can pin with stalled connections (clusterapi auth can be a noop,
+// so claims alone must stay cheap) while still giving the common small
+// internode body a single exact-size allocation.
+const UnverifiedBodyAlloc = 1 << 20 // 1 MiB
 
-	// UnverifiedBodyAlloc is the only allocation ReadBody makes on an
-	// unverified Content-Length claim. Keeping it small bounds the memory a
-	// peer can pin with stalled connections (clusterapi auth can be a noop,
-	// so claims alone must stay cheap) while still giving the common small
-	// internode body a single exact-size allocation.
-	UnverifiedBodyAlloc = 1 << 20 // 1 MiB
-)
-
-// ReadBody reads a body to EOF with allocations proportional to trust: at
-// most UnverifiedBodyAlloc is allocated on the Content-Length claim alone;
-// only after those bytes actually arrive does the claim buy an exact-size
-// buffer (up to MaxOnArrivalBodyAlloc), so forcing a multi-MiB allocation
-// costs the peer real bandwidth. Bodies within UnverifiedBodyAlloc get a
-// single exact-size allocation. A non-positive contentLength falls back to
-// io.ReadAll. net/http caps reads at the declared Content-Length, so bodies
-// shorter than declared surface as io.ErrUnexpectedEOF instead of hanging.
+// ReadBody reads a body to EOF with allocations proportional to the bytes
+// actually delivered, not to the peer-supplied Content-Length. Bodies within
+// UnverifiedBodyAlloc get a single exact-size allocation. Larger claims buy
+// only an UnverifiedBodyAlloc head; from there the buffer doubles (capped at
+// the claim) as bytes arrive, so live memory never exceeds 2x what the peer
+// has actually sent. Honest large bodies pay O(log n) grow-and-copy steps
+// and still end in an exact-size buffer. A non-positive contentLength falls
+// back to io.ReadAll. net/http caps reads at the declared Content-Length, so
+// bodies shorter than declared surface as io.ErrUnexpectedEOF instead of
+// hanging.
 func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
 	if contentLength <= 0 {
 		return io.ReadAll(r)
@@ -52,27 +46,24 @@ func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
 		return buf, nil
 	}
 
-	// the claim exceeds what we allocate on trust: require the first
-	// UnverifiedBodyAlloc bytes to arrive before allocating any further
-	head := make([]byte, UnverifiedBodyAlloc)
-	if _, err := io.ReadFull(r, head); err != nil {
+	// the claim exceeds what we allocate on trust: start with an
+	// UnverifiedBodyAlloc head and grow only as bytes actually arrive
+	buf := make([]byte, UnverifiedBodyAlloc)
+	if _, err := io.ReadFull(r, buf); err != nil {
 		return nil, err
 	}
-
-	if contentLength <= MaxOnArrivalBodyAlloc {
-		buf := make([]byte, contentLength)
-		copy(buf, head)
-		if _, err := io.ReadFull(r, buf[len(head):]); err != nil {
+	for int64(len(buf)) < contentLength {
+		grown := make([]byte, min(2*int64(len(buf)), contentLength))
+		filled := copy(grown, buf)
+		buf = grown // drop the old buffer before blocking on the next read
+		if _, err := io.ReadFull(r, buf[filled:]); err != nil {
+			if errors.Is(err, io.EOF) {
+				// ReadFull reports a bare EOF when zero bytes arrive, but
+				// mid-body (the head already arrived) that is a truncation
+				err = io.ErrUnexpectedEOF
+			}
 			return nil, err
 		}
-		return buf, nil
 	}
-
-	// don't trust the declared length past the cap; grow incrementally instead
-	buf := bytes.NewBuffer(make([]byte, 0, MaxOnArrivalBodyAlloc))
-	buf.Write(head)
-	if _, err := buf.ReadFrom(r); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return buf, nil
 }

--- a/adapters/handlers/rest/clusterapi/shared/read_body.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body.go
@@ -16,22 +16,35 @@ import (
 	"io"
 )
 
-// MaxUpfrontBodyAlloc caps how many bytes ReadBody preallocates from a
-// peer-supplied Content-Length; larger bodies grow incrementally instead
-// (io.ReadAll semantics), so a lying or buggy peer can't force a large
-// allocation without sending real bytes.
-const MaxUpfrontBodyAlloc = 64 << 20 // 64 MiB
+const (
+	// MaxOnArrivalBodyAlloc caps how many bytes ReadBody allocates based on
+	// the peer-supplied Content-Length once the peer has proven itself by
+	// delivering UnverifiedBodyAlloc real bytes; claims beyond the cap grow
+	// incrementally (io.ReadAll semantics) as data arrives.
+	MaxOnArrivalBodyAlloc = 64 << 20 // 64 MiB
 
-// ReadBody reads a body to EOF, preallocating an exact-size buffer when
-// contentLength is positive and within MaxUpfrontBodyAlloc (net/http caps
-// reads to the declared Content-Length, so short bodies surface as
-// io.ErrUnexpectedEOF instead of hanging). Otherwise falls back to io.ReadAll.
+	// UnverifiedBodyAlloc is the only allocation ReadBody makes on an
+	// unverified Content-Length claim. Keeping it small bounds the memory a
+	// peer can pin with stalled connections (clusterapi auth can be a noop,
+	// so claims alone must stay cheap) while still giving the common small
+	// internode body a single exact-size allocation.
+	UnverifiedBodyAlloc = 1 << 20 // 1 MiB
+)
+
+// ReadBody reads a body to EOF with allocations proportional to trust: at
+// most UnverifiedBodyAlloc is allocated on the Content-Length claim alone;
+// only after those bytes actually arrive does the claim buy an exact-size
+// buffer (up to MaxOnArrivalBodyAlloc), so forcing a multi-MiB allocation
+// costs the peer real bandwidth. Bodies within UnverifiedBodyAlloc get a
+// single exact-size allocation. A non-positive contentLength falls back to
+// io.ReadAll. net/http caps reads at the declared Content-Length, so bodies
+// shorter than declared surface as io.ErrUnexpectedEOF instead of hanging.
 func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
 	if contentLength <= 0 {
 		return io.ReadAll(r)
 	}
 
-	if contentLength <= MaxUpfrontBodyAlloc {
+	if contentLength <= UnverifiedBodyAlloc {
 		buf := make([]byte, contentLength)
 		if _, err := io.ReadFull(r, buf); err != nil {
 			return nil, err
@@ -39,8 +52,25 @@ func ReadBody(r io.Reader, contentLength int64) ([]byte, error) {
 		return buf, nil
 	}
 
+	// the claim exceeds what we allocate on trust: require the first
+	// UnverifiedBodyAlloc bytes to arrive before allocating any further
+	head := make([]byte, UnverifiedBodyAlloc)
+	if _, err := io.ReadFull(r, head); err != nil {
+		return nil, err
+	}
+
+	if contentLength <= MaxOnArrivalBodyAlloc {
+		buf := make([]byte, contentLength)
+		copy(buf, head)
+		if _, err := io.ReadFull(r, buf[len(head):]); err != nil {
+			return nil, err
+		}
+		return buf, nil
+	}
+
 	// don't trust the declared length past the cap; grow incrementally instead
-	buf := bytes.NewBuffer(make([]byte, 0, MaxUpfrontBodyAlloc))
+	buf := bytes.NewBuffer(make([]byte, 0, MaxOnArrivalBodyAlloc))
+	buf.Write(head)
 	if _, err := buf.ReadFrom(r); err != nil {
 		return nil, err
 	}

--- a/adapters/handlers/rest/clusterapi/shared/read_body_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body_test.go
@@ -1,0 +1,62 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shared
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadBody(t *testing.T) {
+	payload := []byte("internode payload bytes")
+
+	t.Run("known content length", func(t *testing.T) {
+		out, err := ReadBody(bytes.NewReader(payload), int64(len(payload)))
+		require.NoError(t, err)
+		assert.Equal(t, payload, out)
+		// exact-size allocation: no spare capacity from growth
+		assert.Equal(t, len(payload), cap(out))
+	})
+
+	t.Run("unknown content length falls back to ReadAll", func(t *testing.T) {
+		for _, cl := range []int64{-1, 0} {
+			out, err := ReadBody(bytes.NewReader(payload), cl)
+			require.NoError(t, err)
+			assert.Equal(t, payload, out)
+		}
+	})
+
+	t.Run("empty body with zero content length", func(t *testing.T) {
+		out, err := ReadBody(bytes.NewReader(nil), 0)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("body shorter than declared length", func(t *testing.T) {
+		_, err := ReadBody(bytes.NewReader(payload), int64(len(payload))+10)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, io.ErrUnexpectedEOF), "got %v", err)
+	})
+
+	t.Run("declared length shorter than body reads only declared bytes", func(t *testing.T) {
+		// net/http bounds body readers at Content-Length, so this cannot
+		// happen with real HTTP bodies; the helper still behaves sanely.
+		out, err := ReadBody(bytes.NewReader(payload), 4)
+		require.NoError(t, err)
+		assert.Equal(t, payload[:4], out)
+	})
+}

--- a/adapters/handlers/rest/clusterapi/shared/read_body_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body_test.go
@@ -59,4 +59,29 @@ func TestReadBody(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, payload[:4], out)
 	})
+
+	t.Run("spoofed huge content length does not preallocate", func(t *testing.T) {
+		// a lying peer claims 2 GiB but sends a few bytes: the returned
+		// buffer must be bounded by the actual data (grown from the cap),
+		// not by the claim
+		out, err := ReadBody(bytes.NewReader(payload), 2<<30)
+		require.NoError(t, err)
+		assert.Equal(t, payload, out)
+		assert.LessOrEqual(t, cap(out), MaxUpfrontBodyAlloc)
+	})
+
+	t.Run("body larger than upfront cap is read fully", func(t *testing.T) {
+		big := bytes.Repeat([]byte{0xAB}, MaxUpfrontBodyAlloc+512)
+		out, err := ReadBody(bytes.NewReader(big), int64(len(big)))
+		require.NoError(t, err)
+		assert.Equal(t, big, out)
+	})
+
+	t.Run("content length exactly at cap uses exact-size path", func(t *testing.T) {
+		big := bytes.Repeat([]byte{0xCD}, MaxUpfrontBodyAlloc)
+		out, err := ReadBody(bytes.NewReader(big), int64(len(big)))
+		require.NoError(t, err)
+		assert.Equal(t, big, out)
+		assert.Equal(t, MaxUpfrontBodyAlloc, cap(out))
+	})
 }

--- a/adapters/handlers/rest/clusterapi/shared/read_body_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body_test.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,17 @@ func TestReadBody(t *testing.T) {
 		assert.Equal(t, payload, out)
 		// exact-size allocation: no spare capacity from growth
 		assert.Equal(t, len(payload), cap(out))
+	})
+
+	t.Run("small body allocates only its exact buffer", func(t *testing.T) {
+		rd := bytes.NewReader(nil)
+		allocs := testing.AllocsPerRun(100, func() {
+			rd.Reset(payload)
+			if _, err := ReadBody(rd, int64(len(payload))); err != nil {
+				t.Error(err)
+			}
+		})
+		assert.LessOrEqual(t, allocs, 1.0)
 	})
 
 	t.Run("unknown content length falls back to ReadAll", func(t *testing.T) {
@@ -60,26 +72,58 @@ func TestReadBody(t *testing.T) {
 		assert.Equal(t, payload[:4], out)
 	})
 
-	t.Run("spoofed huge content length does not preallocate", func(t *testing.T) {
-		// buffer must be bounded by actual data, not by the peer's claim
+	t.Run("spoofed huge content length with tiny body errors after small allocation", func(t *testing.T) {
+		// a claim alone must not buy more than UnverifiedBodyAlloc: the tiny
+		// body fails the head read before any claim-sized buffer exists
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
 		out, err := ReadBody(bytes.NewReader(payload), 2<<30)
-		require.NoError(t, err)
-		assert.Equal(t, payload, out)
-		assert.LessOrEqual(t, cap(out), MaxUpfrontBodyAlloc)
+		runtime.ReadMemStats(&after)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, io.ErrUnexpectedEOF), "got %v", err)
+		assert.Nil(t, out)
+		allocated := after.TotalAlloc - before.TotalAlloc
+		assert.Less(t, allocated, uint64(2*UnverifiedBodyAlloc),
+			"claim of 2GiB must not allocate beyond the unverified budget, got %d bytes", allocated)
 	})
 
-	t.Run("body larger than upfront cap is read fully", func(t *testing.T) {
-		big := bytes.Repeat([]byte{0xAB}, MaxUpfrontBodyAlloc+512)
+	t.Run("spoofed huge content length with real bytes past head still errors on truncation", func(t *testing.T) {
+		// enough real bytes to pass the head read, then truncated mid-body
+		partial := bytes.Repeat([]byte{0xEE}, 2*UnverifiedBodyAlloc)
+		_, err := ReadBody(bytes.NewReader(partial), 8<<20)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, io.ErrUnexpectedEOF), "got %v", err)
+	})
+
+	t.Run("content length above unverified budget with full body is read exactly", func(t *testing.T) {
+		body := bytes.Repeat([]byte{0x42}, 2*UnverifiedBodyAlloc+512)
+		out, err := ReadBody(bytes.NewReader(body), int64(len(body)))
+		require.NoError(t, err)
+		assert.Equal(t, body, out)
+		assert.Equal(t, len(body), cap(out))
+	})
+
+	t.Run("body larger than on-arrival cap is read fully", func(t *testing.T) {
+		big := bytes.Repeat([]byte{0xAB}, MaxOnArrivalBodyAlloc+512)
 		out, err := ReadBody(bytes.NewReader(big), int64(len(big)))
 		require.NoError(t, err)
 		assert.Equal(t, big, out)
 	})
 
 	t.Run("content length exactly at cap uses exact-size path", func(t *testing.T) {
-		big := bytes.Repeat([]byte{0xCD}, MaxUpfrontBodyAlloc)
+		big := bytes.Repeat([]byte{0xCD}, MaxOnArrivalBodyAlloc)
 		out, err := ReadBody(bytes.NewReader(big), int64(len(big)))
 		require.NoError(t, err)
 		assert.Equal(t, big, out)
-		assert.Equal(t, MaxUpfrontBodyAlloc, cap(out))
+		assert.Equal(t, MaxOnArrivalBodyAlloc, cap(out))
+	})
+
+	t.Run("content length exactly at unverified budget uses exact-size path", func(t *testing.T) {
+		body := bytes.Repeat([]byte{0x11}, UnverifiedBodyAlloc)
+		out, err := ReadBody(bytes.NewReader(body), int64(len(body)))
+		require.NoError(t, err)
+		assert.Equal(t, body, out)
+		assert.Equal(t, UnverifiedBodyAlloc, cap(out))
 	})
 }

--- a/adapters/handlers/rest/clusterapi/shared/read_body_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body_test.go
@@ -96,6 +96,25 @@ func TestReadBody(t *testing.T) {
 		assert.True(t, errors.Is(err, io.ErrUnexpectedEOF), "got %v", err)
 	})
 
+	t.Run("huge claim with partial delivery allocates proportional to delivered bytes", func(t *testing.T) {
+		// 2GiB claim, 3MiB delivered: the buffer doubles from the 1MiB head
+		// only as bytes arrive, so live memory stays within 2x delivered and
+		// cumulative allocation within 4x delivered (geometric series), no
+		// matter what the peer declares
+		partial := bytes.Repeat([]byte{0xEE}, 3*UnverifiedBodyAlloc)
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		out, err := ReadBody(bytes.NewReader(partial), 2<<30)
+		runtime.ReadMemStats(&after)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, io.ErrUnexpectedEOF), "got %v", err)
+		assert.Nil(t, out)
+		allocated := after.TotalAlloc - before.TotalAlloc
+		assert.Less(t, allocated, uint64(4*len(partial)),
+			"claim of 2GiB with %d bytes delivered must allocate proportional to delivery, got %d bytes", len(partial), allocated)
+	})
+
 	t.Run("content length above unverified budget with full body is read exactly", func(t *testing.T) {
 		body := bytes.Repeat([]byte{0x42}, 2*UnverifiedBodyAlloc+512)
 		out, err := ReadBody(bytes.NewReader(body), int64(len(body)))
@@ -104,19 +123,22 @@ func TestReadBody(t *testing.T) {
 		assert.Equal(t, len(body), cap(out))
 	})
 
-	t.Run("body larger than on-arrival cap is read fully", func(t *testing.T) {
-		big := bytes.Repeat([]byte{0xAB}, MaxOnArrivalBodyAlloc+512)
+	t.Run("large body needing several doublings is read fully into an exact buffer", func(t *testing.T) {
+		// 9MiB+3 forces four grow steps past the 1MiB head (2, 4, 8, 9MiB+3);
+		// the final grow caps at the claim, so honest bodies end exact-size
+		big := bytes.Repeat([]byte{0xAB}, 9*UnverifiedBodyAlloc+3)
 		out, err := ReadBody(bytes.NewReader(big), int64(len(big)))
 		require.NoError(t, err)
 		assert.Equal(t, big, out)
+		assert.Equal(t, len(big), cap(out))
 	})
 
-	t.Run("content length exactly at cap uses exact-size path", func(t *testing.T) {
-		big := bytes.Repeat([]byte{0xCD}, MaxOnArrivalBodyAlloc)
-		out, err := ReadBody(bytes.NewReader(big), int64(len(big)))
+	t.Run("content length one past unverified budget grows once to exact size", func(t *testing.T) {
+		body := bytes.Repeat([]byte{0xCD}, UnverifiedBodyAlloc+1)
+		out, err := ReadBody(bytes.NewReader(body), int64(len(body)))
 		require.NoError(t, err)
-		assert.Equal(t, big, out)
-		assert.Equal(t, MaxOnArrivalBodyAlloc, cap(out))
+		assert.Equal(t, body, out)
+		assert.Equal(t, len(body), cap(out))
 	})
 
 	t.Run("content length exactly at unverified budget uses exact-size path", func(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/shared/read_body_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/read_body_test.go
@@ -61,9 +61,7 @@ func TestReadBody(t *testing.T) {
 	})
 
 	t.Run("spoofed huge content length does not preallocate", func(t *testing.T) {
-		// a lying peer claims 2 GiB but sends a few bytes: the returned
-		// buffer must be bounded by the actual data (grown from the cap),
-		// not by the claim
+		// buffer must be bounded by actual data, not by the peer's claim
 		out, err := ReadBody(bytes.NewReader(payload), 2<<30)
 		require.NoError(t, err)
 		assert.Equal(t, payload, out)

--- a/adapters/handlers/rest/clusterapi/shared/util.go
+++ b/adapters/handlers/rest/clusterapi/shared/util.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 
 	"github.com/go-openapi/strfmt"
+
 	"github.com/weaviate/weaviate/usecases/replica"
 	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )

--- a/entities/storobj/prepared_marshal_test.go
+++ b/entities/storobj/prepared_marshal_test.go
@@ -96,10 +96,7 @@ func TestPreparedMarshalUnsupportedVersion(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported marshaller version")
 }
 
-// TestPreparedMarshalSurvivesSourceMutation pins the documented contract that
-// a PreparedMarshal is self-contained with respect to the source object's
-// *structure*: replacing the object's fields (maps, slices, props) after the
-// prepare pass must not change what MarshalTo writes.
+// PreparedMarshal must be unaffected by later mutation of the source Object.
 func TestPreparedMarshalSurvivesSourceMutation(t *testing.T) {
 	obj := preparedMarshalTestObject()
 	addProps := additional.Properties{Vector: true, IncludeAllTargetVectors: true}
@@ -110,7 +107,7 @@ func TestPreparedMarshalSurvivesSourceMutation(t *testing.T) {
 	pm, err := obj.PrepareMarshalOptional(addProps)
 	require.NoError(t, err)
 
-	// replace (not mutate in place) everything on the source object
+	// replace, don't mutate in place, so aliasing wouldn't mask this test
 	obj.Object.Properties = map[string]interface{}{"other": "value"}
 	obj.Vector = []float32{9, 9, 9, 9}
 	obj.Vectors = map[string][]float32{"different": {8}}

--- a/entities/storobj/prepared_marshal_test.go
+++ b/entities/storobj/prepared_marshal_test.go
@@ -1,0 +1,123 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func preparedMarshalTestObject() *Object {
+	obj := New(7)
+	obj.MarshallerVersion = 1
+	obj.Object = models.Object{
+		ID:                 strfmt.UUID("11111111-2222-3333-4444-555555555555"),
+		Class:              "PreparedMarshalClass",
+		CreationTimeUnix:   1700000000000,
+		LastUpdateTimeUnix: 1700000001000,
+		Properties: map[string]interface{}{
+			"name":  "prepared",
+			"count": float64(3),
+		},
+	}
+	obj.Vector = []float32{0.5, -0.5, 1.5}
+	obj.VectorLen = 3
+	obj.Vectors = map[string][]float32{"named": {1, 2}}
+	obj.MultiVectors = map[string][][]float32{"multi": {{3, 4}, {5}}}
+	return obj
+}
+
+func TestPreparedMarshalMatchesMarshalBinaryOptional(t *testing.T) {
+	obj := preparedMarshalTestObject()
+
+	tests := []struct {
+		name     string
+		addProps additional.Properties
+	}{
+		{name: "everything", addProps: additional.Properties{Vector: true, IncludeAllTargetVectors: true}},
+		{name: "no_vector", addProps: additional.Properties{}},
+		{name: "no_props", addProps: additional.Properties{Vector: true, NoProps: true}},
+		{name: "specific_target_vector", addProps: additional.Properties{Vector: true, Vectors: []string{"named"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected, err := obj.MarshalBinaryOptional(tt.addProps)
+			require.NoError(t, err)
+
+			pm, err := obj.PrepareMarshalOptional(tt.addProps)
+			require.NoError(t, err)
+			require.Equal(t, len(expected), pm.Len())
+
+			buf := make([]byte, pm.Len())
+			require.NoError(t, pm.MarshalTo(buf))
+			assert.Equal(t, expected, buf)
+		})
+	}
+}
+
+func TestPreparedMarshalToBufferSizeMismatch(t *testing.T) {
+	obj := preparedMarshalTestObject()
+
+	pm, err := obj.PrepareMarshalOptional(additional.Properties{Vector: true, IncludeAllTargetVectors: true})
+	require.NoError(t, err)
+
+	tooSmall := make([]byte, pm.Len()-1)
+	err = pm.MarshalTo(tooSmall)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a buffer of exactly")
+
+	tooLarge := make([]byte, pm.Len()+1)
+	err = pm.MarshalTo(tooLarge)
+	require.Error(t, err)
+}
+
+func TestPreparedMarshalUnsupportedVersion(t *testing.T) {
+	obj := preparedMarshalTestObject()
+	obj.MarshallerVersion = 2
+
+	_, err := obj.PrepareMarshalOptional(additional.Properties{Vector: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported marshaller version")
+}
+
+// TestPreparedMarshalSurvivesSourceMutation pins the documented contract that
+// a PreparedMarshal is self-contained with respect to the source object's
+// *structure*: replacing the object's fields (maps, slices, props) after the
+// prepare pass must not change what MarshalTo writes.
+func TestPreparedMarshalSurvivesSourceMutation(t *testing.T) {
+	obj := preparedMarshalTestObject()
+	addProps := additional.Properties{Vector: true, IncludeAllTargetVectors: true}
+
+	expected, err := obj.MarshalBinaryOptional(addProps)
+	require.NoError(t, err)
+
+	pm, err := obj.PrepareMarshalOptional(addProps)
+	require.NoError(t, err)
+
+	// replace (not mutate in place) everything on the source object
+	obj.Object.Properties = map[string]interface{}{"other": "value"}
+	obj.Vector = []float32{9, 9, 9, 9}
+	obj.Vectors = map[string][]float32{"different": {8}}
+	obj.MultiVectors = nil
+	obj.DocID = 999
+
+	buf := make([]byte, pm.Len())
+	require.NoError(t, pm.MarshalTo(buf))
+	assert.Equal(t, expected, buf)
+}

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -962,27 +962,18 @@ func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClas
 	return byteBuffer, nil
 }
 
-// emptySchemaJSON is the props payload sent when addProps.NoProps is set. An
-// empty object rather than nothing so that we don't break unmarshalling
-// during upgrades where some nodes don't have the empty check on the
-// unmarshal side yet. Shared and read-only: MarshalTo only ever copies it.
+// emptySchemaJSON keeps older nodes' pre-upgrade unmarshal path (which lacks
+// an empty-schema check) from breaking. Shared across objects; read-only.
 var emptySchemaJSON = []byte("{}")
 
-// PreparedMarshal is the output of the sizing pass of the two-pass binary
-// marshal. PrepareMarshalOptional computes the exact serialized size and all
-// variable-length parts (JSON-encoded props, msgpack offset headers, the
-// vector slices in their serialization order); MarshalTo then writes the
-// bytes into a caller-provided buffer of exactly Len() bytes.
+// PreparedMarshal is the sizing-pass output of the two-pass binary marshal
+// (see PrepareMarshalOptional, MarshalTo), letting callers that batch many
+// objects into one payload allocate a single exactly-sized buffer instead of
+// one per object.
 //
-// This lets callers that frame many objects into one payload (e.g. the
-// clusterapi object-list encoding) allocate a single exactly-sized output
-// buffer instead of one intermediate buffer per object.
-//
-// A PreparedMarshal is self-contained: mutating or discarding the source
-// Object after the prepare pass does not affect MarshalTo. It does, however,
-// alias the source object's vector slices (it does not deep-copy them), so
-// concurrent mutation of the vector *contents* is as unsafe as it is for
-// MarshalBinary itself.
+// It aliases rather than copies the source Object's vector slices, so
+// concurrent mutation of vector contents is as unsafe as for MarshalBinary;
+// otherwise it is self-contained once the source Object is discarded.
 type PreparedMarshal struct {
 	version      uint8
 	docID        uint64
@@ -1014,18 +1005,16 @@ func (pm *PreparedMarshal) Len() int {
 	return pm.size
 }
 
-// PrepareMarshalOptional runs the sizing pass of the two-pass binary marshal
-// with the same vector/props filtering semantics as MarshalBinaryOptional.
-// The result's MarshalTo produces bytes identical to MarshalBinaryOptional
-// with the same addProps.
+// PrepareMarshalOptional runs the sizing pass of the two-pass marshal with
+// the same addProps filtering as MarshalBinaryOptional; MarshalTo produces
+// identical bytes.
 func (ko *Object) PrepareMarshalOptional(addProps additional.Properties) (PreparedMarshal, error) {
 	return ko.prepareMarshal(addProps, false)
 }
 
-// prepareMarshal computes everything marshalBinaryInternal needs to write the
-// serialized form: the exact buffer size plus all variable-length parts. The
-// filtering semantics (addProps, skipClassName) match marshalBinaryInternal,
-// whose write phase now lives in PreparedMarshal.MarshalTo.
+// prepareMarshal is the sizing pass shared by marshalBinaryInternal and
+// PrepareMarshalOptional; filtering semantics (addProps, skipClassName)
+// match marshalBinaryInternal.
 func (ko *Object) prepareMarshal(addProps additional.Properties, skipClassName bool) (PreparedMarshal, error) {
 	var pm PreparedMarshal
 
@@ -1208,9 +1197,8 @@ func (ko *Object) prepareMarshal(addProps additional.Properties, skipClassName b
 }
 
 // MarshalTo writes the serialized object into buf, which must be exactly
-// Len() bytes long. The bytes written are identical to what
-// MarshalBinaryOptional returns for the addProps the PreparedMarshal was
-// prepared with.
+// Len() bytes long, producing the same bytes as MarshalBinaryOptional for
+// the addProps the PreparedMarshal was prepared with.
 func (pm *PreparedMarshal) MarshalTo(buf []byte) error {
 	if len(buf) != pm.size {
 		return errors.Errorf("prepared marshal requires a buffer of exactly %d bytes, got %d", pm.size, len(buf))

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmihailenco/msgpack/v5"
+
 	"github.com/weaviate/weaviate/entities/additional"
 	errwrap "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
@@ -961,6 +962,12 @@ func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClas
 	return byteBuffer, nil
 }
 
+// emptySchemaJSON is the props payload sent when addProps.NoProps is set. An
+// empty object rather than nothing so that we don't break unmarshalling
+// during upgrades where some nodes don't have the empty check on the
+// unmarshal side yet. Shared and read-only: MarshalTo only ever copies it.
+var emptySchemaJSON = []byte("{}")
+
 // PreparedMarshal is the output of the sizing pass of the two-pass binary
 // marshal. PrepareMarshalOptional computes the exact serialized size and all
 // variable-length parts (JSON-encoded props, msgpack offset headers, the
@@ -986,7 +993,7 @@ type PreparedMarshal struct {
 
 	vector []float32 // nil when the vector is excluded
 
-	className     []byte // nil when skipped (on-disk format without class name)
+	className     string // empty when skipped (on-disk format without class name)
 	schema        []byte
 	meta          []byte
 	vectorWeights []byte
@@ -1049,7 +1056,7 @@ func (ko *Object) prepareMarshal(addProps additional.Properties, skipClassName b
 		pm.vector = ko.Vector
 	}
 
-	className := []byte(ko.Class())
+	className := string(ko.Class())
 	if len(className) > maxClassNameLength {
 		return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "className", len(className), maxClassNameLength)
 	}
@@ -1069,7 +1076,7 @@ func (ko *Object) prepareMarshal(addProps additional.Properties, skipClassName b
 	} else {
 		// send empty object so that we don't break unmarshalling during upgrades
 		// where some nodes don't have the empty check on the unmarshal side yet
-		pm.schema = []byte("{}")
+		pm.schema = emptySchemaJSON
 	}
 
 	pm.meta, err = json.Marshal(ko.AdditionalProperties())
@@ -1228,9 +1235,10 @@ func (pm *PreparedMarshal) MarshalTo(buf []byte) error {
 
 	rw.WriteUint16(uint16(len(pm.className)))
 	if len(pm.className) > 0 {
-		if err := rw.CopyBytesToBuffer(pm.className); err != nil {
-			return errors.Wrap(err, "Could not copy className")
-		}
+		// copy the string directly instead of going through a []byte
+		// conversion, which would allocate
+		copy(rw.Buffer[rw.Position:rw.Position+uint64(len(pm.className))], pm.className)
+		rw.MoveBufferPositionForward(uint64(len(pm.className)))
 	}
 
 	rw.WriteUint32(uint32(len(pm.schema)))

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -949,77 +949,144 @@ func (ko *Object) MarshalBinaryOptional(addProps additional.Properties) ([]byte,
 }
 
 func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClassName bool) ([]byte, error) {
-	if ko.MarshallerVersion != 1 {
-		return nil, errors.Errorf("unsupported marshaller version %d", ko.MarshallerVersion)
+	pm, err := ko.prepareMarshal(addProps, skipClassName)
+	if err != nil {
+		return nil, err
 	}
 
-	kindByte := uint8(0)
+	byteBuffer := make([]byte, pm.Len())
+	if err := pm.MarshalTo(byteBuffer); err != nil {
+		return byteBuffer, err
+	}
+	return byteBuffer, nil
+}
+
+// PreparedMarshal is the output of the sizing pass of the two-pass binary
+// marshal. PrepareMarshalOptional computes the exact serialized size and all
+// variable-length parts (JSON-encoded props, msgpack offset headers, the
+// vector slices in their serialization order); MarshalTo then writes the
+// bytes into a caller-provided buffer of exactly Len() bytes.
+//
+// This lets callers that frame many objects into one payload (e.g. the
+// clusterapi object-list encoding) allocate a single exactly-sized output
+// buffer instead of one intermediate buffer per object.
+//
+// A PreparedMarshal is self-contained: mutating or discarding the source
+// Object after the prepare pass does not affect MarshalTo. It does, however,
+// alias the source object's vector slices (it does not deep-copy them), so
+// concurrent mutation of the vector *contents* is as unsafe as it is for
+// MarshalBinary itself.
+type PreparedMarshal struct {
+	version      uint8
+	docID        uint64
+	kind         uint8
+	id           uuid.UUID
+	creationTime uint64
+	updateTime   uint64
+
+	vector []float32 // nil when the vector is excluded
+
+	className     []byte // nil when skipped (on-disk format without class name)
+	schema        []byte
+	meta          []byte
+	vectorWeights []byte
+
+	targetVectorsOffsets       []byte
+	targetVectorsSegmentLength uint32
+	targetVectors              [][]float32 // in targetVectorsOffsets order
+
+	multiVectorsOffsets       []byte
+	multiVectorsSegmentLength uint32
+	multiVectors              [][][]float32 // in multiVectorsOffsets order
+
+	size int
+}
+
+// Len returns the exact number of bytes MarshalTo will write.
+func (pm *PreparedMarshal) Len() int {
+	return pm.size
+}
+
+// PrepareMarshalOptional runs the sizing pass of the two-pass binary marshal
+// with the same vector/props filtering semantics as MarshalBinaryOptional.
+// The result's MarshalTo produces bytes identical to MarshalBinaryOptional
+// with the same addProps.
+func (ko *Object) PrepareMarshalOptional(addProps additional.Properties) (PreparedMarshal, error) {
+	return ko.prepareMarshal(addProps, false)
+}
+
+// prepareMarshal computes everything marshalBinaryInternal needs to write the
+// serialized form: the exact buffer size plus all variable-length parts. The
+// filtering semantics (addProps, skipClassName) match marshalBinaryInternal,
+// whose write phase now lives in PreparedMarshal.MarshalTo.
+func (ko *Object) prepareMarshal(addProps additional.Properties, skipClassName bool) (PreparedMarshal, error) {
+	var pm PreparedMarshal
+
+	if ko.MarshallerVersion != 1 {
+		return pm, errors.Errorf("unsupported marshaller version %d", ko.MarshallerVersion)
+	}
+
+	pm.version = ko.MarshallerVersion
+	pm.docID = ko.DocID
 	// Deprecated Kind field
-	kindByte = 1
+	pm.kind = 1
+	pm.creationTime = uint64(ko.CreationTimeUnix())
+	pm.updateTime = uint64(ko.LastUpdateTimeUnix())
 
 	idParsed, err := uuid.Parse(ko.ID().String())
 	if err != nil {
-		return nil, err
+		return pm, err
 	}
-	idBytes, err := idParsed.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
+	pm.id = idParsed
 
 	// Conditionally include vector based on addProps.Vector
 	var vectorLength uint32
 	if addProps.Vector {
 		if len(ko.Vector) > maxVectorLength {
-			return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vector", len(ko.Vector), maxVectorLength)
+			return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vector", len(ko.Vector), maxVectorLength)
 		}
 		vectorLength = uint32(len(ko.Vector))
+		pm.vector = ko.Vector
 	}
 
 	className := []byte(ko.Class())
 	if len(className) > maxClassNameLength {
-		return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "className", len(className), maxClassNameLength)
+		return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "className", len(className), maxClassNameLength)
 	}
-	classNameLength := uint32(len(className))
-	if skipClassName {
-		classNameLength = 0
+	if !skipClassName {
+		pm.className = className
 	}
 
 	// Conditionally include properties based on addProps.NoProps
-	var schema []byte
-	var schemaLength uint32
 	if !addProps.NoProps {
-		schema, err = json.Marshal(ko.Properties())
+		pm.schema, err = json.Marshal(ko.Properties())
 		if err != nil {
-			return nil, err
+			return pm, err
 		}
-		if len(schema) > maxSchemaLength {
-			return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "schema", len(schema), maxSchemaLength)
+		if len(pm.schema) > maxSchemaLength {
+			return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "schema", len(pm.schema), maxSchemaLength)
 		}
-		schemaLength = uint32(len(schema))
 	} else {
 		// send empty object so that we don't break unmarshalling during upgrades
 		// where some nodes don't have the empty check on the unmarshal side yet
-		schema = []byte("{}")
-		schemaLength = uint32(len(schema))
+		pm.schema = []byte("{}")
 	}
 
-	meta, err := json.Marshal(ko.AdditionalProperties())
+	pm.meta, err = json.Marshal(ko.AdditionalProperties())
 	if err != nil {
-		return nil, err
+		return pm, err
 	}
-	if len(meta) > maxMetaLength {
-		return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "meta", len(meta), maxMetaLength)
+	if len(pm.meta) > maxMetaLength {
+		return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "meta", len(pm.meta), maxMetaLength)
 	}
-	metaLength := uint32(len(meta))
 
-	vectorWeights, err := json.Marshal(ko.VectorWeights())
+	pm.vectorWeights, err = json.Marshal(ko.VectorWeights())
 	if err != nil {
-		return nil, err
+		return pm, err
 	}
-	if len(vectorWeights) > maxVectorWeightsLength {
-		return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vectorWeights", len(vectorWeights), maxVectorWeightsLength)
+	if len(pm.vectorWeights) > maxVectorWeightsLength {
+		return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vectorWeights", len(pm.vectorWeights), maxVectorWeightsLength)
 	}
-	vectorWeightsLength := uint32(len(vectorWeights))
 
 	// Determine which target vectors to include:
 	// - IncludeAllTargetVectors: true means include ALL vectors (used by MarshalBinary)
@@ -1037,13 +1104,10 @@ func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClas
 		}
 	}
 
-	var targetVectorsOffsets []byte
-	var targetVectorsOffsetsLength uint32
 	var targetVectorsSegmentLength int
-
-	targetVectorsOffsetOrder := make([]string, 0, len(ko.Vectors))
 	if (includeAllTargetVectors || includeSpecificTargetVectors) && len(ko.Vectors) > 0 {
 		offsetsMap := map[string]uint32{}
+		pm.targetVectors = make([][]float32, 0, len(ko.Vectors))
 		for name, vec := range ko.Vectors {
 			// Skip if we're filtering and this vector wasn't requested
 			if includeSpecificTargetVectors {
@@ -1052,40 +1116,37 @@ func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClas
 				}
 			}
 			if len(vec) > maxVectorLength {
-				return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vector", len(vec), maxVectorLength)
+				return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vector", len(vec), maxVectorLength)
 			}
 
 			offsetsMap[name] = uint32(targetVectorsSegmentLength)
 			targetVectorsSegmentLength += 2 + 4*len(vec) // 2 for vec length + vec bytes
 
 			if targetVectorsSegmentLength > maxTargetVectorsSegmentLength {
-				return nil,
+				return pm,
 					fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)",
 						"targetVectorsSegmentLength", targetVectorsSegmentLength, maxTargetVectorsSegmentLength)
 			}
 
-			targetVectorsOffsetOrder = append(targetVectorsOffsetOrder, name)
+			pm.targetVectors = append(pm.targetVectors, vec)
 		}
 
 		if len(offsetsMap) > 0 {
-			targetVectorsOffsets, err = msgpack.Marshal(offsetsMap)
+			pm.targetVectorsOffsets, err = msgpack.Marshal(offsetsMap)
 			if err != nil {
-				return nil, fmt.Errorf("could not marshal target vectors offsets: %w", err)
+				return pm, fmt.Errorf("could not marshal target vectors offsets: %w", err)
 			}
-			if len(targetVectorsOffsets) > maxTargetVectorsOffsetsLength {
-				return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "targetVectorsOffsets", len(targetVectorsOffsets), maxTargetVectorsOffsetsLength)
+			if len(pm.targetVectorsOffsets) > maxTargetVectorsOffsetsLength {
+				return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "targetVectorsOffsets", len(pm.targetVectorsOffsets), maxTargetVectorsOffsetsLength)
 			}
-			targetVectorsOffsetsLength = uint32(len(targetVectorsOffsets))
 		}
 	}
+	pm.targetVectorsSegmentLength = uint32(targetVectorsSegmentLength)
 
-	var multiVectorsOffsets []byte
-	var multiVectorsOffsetsLength uint32
 	var multiVectorsSegmentLength int
-
-	multiVectorsOffsetOrder := make([]string, 0, len(ko.MultiVectors))
 	if (includeAllTargetVectors || includeSpecificTargetVectors) && len(ko.MultiVectors) > 0 {
 		offsetsMap := map[string]uint32{}
+		pm.multiVectors = make([][][]float32, 0, len(ko.MultiVectors))
 		for name, vecs := range ko.MultiVectors {
 			// Skip if we're filtering and this vector wasn't requested
 			if includeSpecificTargetVectors {
@@ -1098,99 +1159,106 @@ func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClas
 			multiVectorsSegmentLength += 4
 			for _, vec := range vecs {
 				if len(vec) > maxVectorLength {
-					return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vector", len(vec), maxVectorLength)
+					return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "vector", len(vec), maxVectorLength)
 				}
 				// 2 bytes for vec length and 4 bytes per float32
 				multiVectorsSegmentLength += 2 + 4*len(vec)
 
 				if multiVectorsSegmentLength > maxMultiVectorsSegmentLength {
-					return nil,
+					return pm,
 						fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)",
 							"multiVectorsSegmentLength", multiVectorsSegmentLength, maxMultiVectorsSegmentLength)
 				}
 			}
-			multiVectorsOffsetOrder = append(multiVectorsOffsetOrder, name)
+			pm.multiVectors = append(pm.multiVectors, vecs)
 		}
 
 		if len(offsetsMap) > 0 {
-			multiVectorsOffsets, err = msgpack.Marshal(offsetsMap)
+			pm.multiVectorsOffsets, err = msgpack.Marshal(offsetsMap)
 			if err != nil {
-				return nil, fmt.Errorf("could not marshal multi vectors offsets: %w", err)
+				return pm, fmt.Errorf("could not marshal multi vectors offsets: %w", err)
 			}
-			if len(multiVectorsOffsets) > maxMultiVectorsOffsetsLength {
-				return nil, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "multiVectorsOffsets", len(multiVectorsOffsets), maxMultiVectorsOffsetsLength)
+			if len(pm.multiVectorsOffsets) > maxMultiVectorsOffsetsLength {
+				return pm, fmt.Errorf("could not marshal '%s' max length exceeded (%d/%d)", "multiVectorsOffsets", len(pm.multiVectorsOffsets), maxMultiVectorsOffsetsLength)
 			}
-			multiVectorsOffsetsLength = uint32(len(multiVectorsOffsets))
 		}
 	}
+	pm.multiVectorsSegmentLength = uint32(multiVectorsSegmentLength)
 
 	totalBufferLength := 1 + 8 + 1 + 16 + 8 + 8 +
 		2 + vectorLength*4 +
-		2 + classNameLength +
-		4 + schemaLength +
-		4 + metaLength +
-		4 + vectorWeightsLength +
-		4 + targetVectorsOffsetsLength +
-		4 + uint32(targetVectorsSegmentLength) +
-		4 + multiVectorsOffsetsLength +
-		4 + uint32(multiVectorsSegmentLength)
+		2 + uint32(len(pm.className)) +
+		4 + uint32(len(pm.schema)) +
+		4 + uint32(len(pm.meta)) +
+		4 + uint32(len(pm.vectorWeights)) +
+		4 + uint32(len(pm.targetVectorsOffsets)) +
+		4 + pm.targetVectorsSegmentLength +
+		4 + uint32(len(pm.multiVectorsOffsets)) +
+		4 + pm.multiVectorsSegmentLength
+	pm.size = int(totalBufferLength)
 
-	byteBuffer := make([]byte, totalBufferLength)
-	rw := byteops.NewReadWriter(byteBuffer)
-	rw.WriteByte(ko.MarshallerVersion)
-	rw.WriteUint64(ko.DocID)
-	rw.WriteByte(kindByte)
+	return pm, nil
+}
 
-	rw.CopyBytesToBuffer(idBytes)
+// MarshalTo writes the serialized object into buf, which must be exactly
+// Len() bytes long. The bytes written are identical to what
+// MarshalBinaryOptional returns for the addProps the PreparedMarshal was
+// prepared with.
+func (pm *PreparedMarshal) MarshalTo(buf []byte) error {
+	if len(buf) != pm.size {
+		return errors.Errorf("prepared marshal requires a buffer of exactly %d bytes, got %d", pm.size, len(buf))
+	}
 
-	rw.WriteUint64(uint64(ko.CreationTimeUnix()))
-	rw.WriteUint64(uint64(ko.LastUpdateTimeUnix()))
+	rw := byteops.NewReadWriter(buf)
+	rw.WriteByte(pm.version)
+	rw.WriteUint64(pm.docID)
+	rw.WriteByte(pm.kind)
+
+	rw.CopyBytesToBuffer(pm.id[:])
+
+	rw.WriteUint64(pm.creationTime)
+	rw.WriteUint64(pm.updateTime)
+
+	vectorLength := len(pm.vector)
 	rw.WriteUint16(uint16(vectorLength))
-
-	if addProps.Vector {
-		byteops.CopySliceToBytes(rw.Buffer[rw.Position:rw.Position+uint64(vectorLength)*byteops.Uint32Len], ko.Vector)
+	if vectorLength > 0 {
+		byteops.CopySliceToBytes(rw.Buffer[rw.Position:rw.Position+uint64(vectorLength)*byteops.Uint32Len], pm.vector)
 		rw.MoveBufferPositionForward(uint64(vectorLength) * byteops.Uint32Len)
 	}
 
-	rw.WriteUint16(uint16(classNameLength))
-	if classNameLength > 0 {
-		err = rw.CopyBytesToBuffer(className)
-		if err != nil {
-			return byteBuffer, errors.Wrap(err, "Could not copy className")
+	rw.WriteUint16(uint16(len(pm.className)))
+	if len(pm.className) > 0 {
+		if err := rw.CopyBytesToBuffer(pm.className); err != nil {
+			return errors.Wrap(err, "Could not copy className")
 		}
 	}
 
-	rw.WriteUint32(schemaLength)
-	if schemaLength > 0 {
-		err = rw.CopyBytesToBuffer(schema)
-		if err != nil {
-			return byteBuffer, errors.Wrap(err, "Could not copy schema")
+	rw.WriteUint32(uint32(len(pm.schema)))
+	if len(pm.schema) > 0 {
+		if err := rw.CopyBytesToBuffer(pm.schema); err != nil {
+			return errors.Wrap(err, "Could not copy schema")
 		}
 	}
 
-	rw.WriteUint32(metaLength)
-	err = rw.CopyBytesToBuffer(meta)
-	if err != nil {
-		return byteBuffer, errors.Wrap(err, "Could not copy meta")
+	rw.WriteUint32(uint32(len(pm.meta)))
+	if err := rw.CopyBytesToBuffer(pm.meta); err != nil {
+		return errors.Wrap(err, "Could not copy meta")
 	}
 
-	rw.WriteUint32(vectorWeightsLength)
-	err = rw.CopyBytesToBuffer(vectorWeights)
-	if err != nil {
-		return byteBuffer, errors.Wrap(err, "Could not copy vectorWeights")
+	rw.WriteUint32(uint32(len(pm.vectorWeights)))
+	if err := rw.CopyBytesToBuffer(pm.vectorWeights); err != nil {
+		return errors.Wrap(err, "Could not copy vectorWeights")
 	}
 
-	rw.WriteUint32(targetVectorsOffsetsLength)
-	if targetVectorsOffsetsLength > 0 {
-		err = rw.CopyBytesToBuffer(targetVectorsOffsets)
-		if err != nil {
-			return byteBuffer, errors.Wrap(err, "Could not copy targetVectorsOffsets")
+	rw.WriteUint32(uint32(len(pm.targetVectorsOffsets)))
+	if len(pm.targetVectorsOffsets) > 0 {
+		if err := rw.CopyBytesToBuffer(pm.targetVectorsOffsets); err != nil {
+			return errors.Wrap(err, "Could not copy targetVectorsOffsets")
 		}
 	}
 
-	rw.WriteUint32(uint32(targetVectorsSegmentLength))
-	for _, name := range targetVectorsOffsetOrder {
-		vec := ko.Vectors[name]
+	rw.WriteUint32(pm.targetVectorsSegmentLength)
+	for _, vec := range pm.targetVectors {
 		vecLen := len(vec)
 
 		rw.WriteUint16(uint16(vecLen))
@@ -1198,17 +1266,15 @@ func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClas
 		rw.MoveBufferPositionForward(uint64(vecLen) * byteops.Uint32Len)
 	}
 
-	rw.WriteUint32(multiVectorsOffsetsLength)
-	if multiVectorsOffsetsLength > 0 {
-		err = rw.CopyBytesToBuffer(multiVectorsOffsets)
-		if err != nil {
-			return byteBuffer, errors.Wrap(err, "Could not copy multiVectorsOffsets")
+	rw.WriteUint32(uint32(len(pm.multiVectorsOffsets)))
+	if len(pm.multiVectorsOffsets) > 0 {
+		if err := rw.CopyBytesToBuffer(pm.multiVectorsOffsets); err != nil {
+			return errors.Wrap(err, "Could not copy multiVectorsOffsets")
 		}
 	}
 
-	rw.WriteUint32(uint32(multiVectorsSegmentLength))
-	for _, name := range multiVectorsOffsetOrder {
-		vecs := ko.MultiVectors[name]
+	rw.WriteUint32(pm.multiVectorsSegmentLength)
+	for _, vecs := range pm.multiVectors {
 		rw.WriteUint32(uint32(len(vecs)))
 		for _, vec := range vecs {
 			vecLen := len(vec)
@@ -1218,7 +1284,7 @@ func (ko *Object) marshalBinaryInternal(addProps additional.Properties, skipClas
 		}
 	}
 
-	return byteBuffer, nil
+	return nil
 }
 
 func (ko *Object) MarshalBinary() ([]byte, error) {


### PR DESCRIPTION
## Motivation

Internode marshalling is the top allocation domain in a recent production load-test profile. The fan-out paths (replica reads/writes, distributed search) paid for it several times over per request: every storobj was marshalled into its own intermediate buffer, the list payload preallocated an arbitrary 1024 B/object and re-grew from there, the finished object list was copied once more into the final payload, unmarshalling copied every object out of the already-buffered body, and HTTP bodies were read via `io.ReadAll` grow-and-copy even when Content-Length was known.

This is **slice 1 of 3** of the internode marshalling workstream (slice 2 = binary props codec, slice 3 = gRPC fan-out). There is **no wire-format change**: bytes on the wire are identical to `main`, pinned by golden tests.

## Approach

- **Two-pass storobj marshal**: `marshalBinaryInternal` split into a sizing pass (`Object.PrepareMarshalOptional` → `PreparedMarshal`) and a write pass (`PreparedMarshal.MarshalTo` into a caller-provided, exactly-sized buffer).
- **Single-alloc payload framing**: `objectListPayload` and `searchResultsPayload` `Marshal`/`MarshalWithAdditional` write all objects, length prefixes, distances, and profiles into one exactly-sized buffer. Kills the per-object buffers, the 1024 B/object guess, and the `objsBytes`→`out` copy.
- **Sub-slice unmarshal**: `objectListPayload.Unmarshal` decodes each object from a sub-slice of the input instead of a per-object copy. Safe because the storobj decoder copies everything it retains (pinned by `TestObjectListUnmarshalDoesNotAliasInput`). Truncated/overflowing frames now error loudly instead of decoding zero-padded garbage.
- **Content-Length-sized body reads**: clusterapi client + handlers read bodies via `shared.ReadBody` into an exactly-sized buffer, trusting the peer's Content-Length only up to 64 MiB (`MaxUpfrontBodyAlloc`); larger claims grow only as data actually arrives. Unknown length falls back to `io.ReadAll`.
- **Deliberately no `sync.Pool` in this slice**: most of the win is killing re-growth and double copies; pooling adds buffer-lifetime risk and is deferred.

## Benchmarks

Apple M1 Max, n=6, baseline (`61a1c99276`) vs this branch. Geomean across the suite: **sec/op −24.2%, B/op −42.2%, allocs/op −5.9%**. The single-object storobj codec (also the lsmkv disk-write path) is byte- and alloc-identical to baseline.

| benchmark (objs_100) | sec/op | B/op | allocs/op |
|---|---|---|---|
| SearchResultsMarshal props_and_vector | −42.5% | −77.2% | −3.7% |
| SearchResultsMarshal noprops_and_vector | −72.9% | −81.4% | −34.9% |
| SearchResultsMarshal props_only | −11.5% | −36.3% | −3.4% |
| ObjectListMarshal | −39.2% | −73.3% | −3.6% |
| ObjectListUnmarshal | −10.3% | −38.6% | −1.4% |
| SearchResultsUnmarshal props_and_vector | −9.4% | −38.6% | −1.4% |

<details>
<summary>Full benchstat output</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared
cpu: Apple M1 Max
                                                               │ old-bench.log │            new-bench2.log            │
                                                               │    sec/op     │    sec/op      vs base               │
InternodeSearchResultsMarshal/objs_10/props_and_vector-10         66.72µ ±  1%   37.56µ ±   1%  -43.71% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_10/props_only-10               36.04µ ±  1%   31.76µ ±   3%  -11.89% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_10/noprops_and_vector-10      27.026µ ±  4%   6.244µ ±   1%  -76.90% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/props_and_vector-10        638.0µ ±  3%   366.8µ ±   1%  -42.51% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/props_only-10              358.3µ ±  6%   317.1µ ±   4%  -11.50% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/noprops_and_vector-10     208.74µ ± 19%   56.58µ ±   7%  -72.90% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/props_and_vector-10       88.90µ ±  1%   79.62µ ±   6%  -10.43% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/props_only-10             75.28µ ±  9%   72.26µ ±   0%   -4.01% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/noprops_and_vector-10     16.07µ ±  1%   10.58µ ±   1%  -34.16% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/props_and_vector-10      873.7µ ±  1%   791.8µ ±   9%   -9.38% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/props_only-10            744.7µ ±  5%   721.6µ ±  11%        ~ (p=0.065 n=6)
InternodeSearchResultsUnmarshal/objs_100/noprops_and_vector-10    148.7µ ±  2%   102.1µ ±   1%  -31.38% (p=0.002 n=6)
InternodeObjectListMarshal/objs_10-10                             62.50µ ±  5%   37.71µ ±   0%  -39.67% (p=0.002 n=6)
InternodeObjectListMarshal/objs_100-10                            606.3µ ±  1%   368.7µ ±   5%  -39.19% (p=0.002 n=6)
InternodeObjectListUnmarshal/objs_10-10                           88.93µ ±  2%   79.68µ ±   1%  -10.40% (p=0.002 n=6)
InternodeObjectListUnmarshal/objs_100-10                          881.4µ ±  1%   791.0µ ±   5%  -10.25% (p=0.002 n=6)
InternodeStorobjMarshal/props_and_vector-10                       3.661µ ±  1%   3.642µ ±   0%        ~ (p=0.132 n=6)
InternodeStorobjMarshal/props_only-10                             3.008µ ±  2%   3.014µ ±   0%        ~ (p=0.273 n=6)
InternodeStorobjMarshal/noprops_and_vector-10                     759.8n ± 18%   606.5n ±   1%  -20.18% (p=0.002 n=6)
InternodeStorobjUnmarshal/props_and_vector-10                     7.823µ ±  5%   7.832µ ±   5%        ~ (p=0.818 n=6)
InternodeStorobjUnmarshal/props_only-10                           7.071µ ±  1%   7.148µ ±   0%   +1.09% (p=0.015 n=6)
InternodeStorobjUnmarshal/noprops_and_vector-10                   1.062µ ±  9%   1.122µ ±  47%        ~ (p=0.699 n=6)
InternodeReadAllBody/payload_389KB-10                             114.8µ ±  1%   109.2µ ± 128%        ~ (p=0.368 n=6)
InternodeReadAllBody/preallocated_readfull-10                     5.882µ ± 11%   5.965µ ±   9%        ~ (p=0.937 n=6)
geomean                                                           48.71µ         36.93µ         -24.17%

                                                               │ old-bench.log │            new-bench2.log             │
                                                               │     B/op      │     B/op      vs base                 │
InternodeSearchResultsMarshal/objs_10/props_and_vector-10        242.98Ki ± 0%   60.54Ki ± 0%  -75.09% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_10/props_only-10               46.83Ki ± 0%   29.77Ki ± 0%  -36.44% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_10/noprops_and_vector-10      160.77Ki ± 0%   35.17Ki ± 0%  -78.13% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/props_and_vector-10       2632.8Ki ± 0%   599.4Ki ± 0%  -77.24% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/props_only-10              475.7Ki ± 0%   303.2Ki ± 0%  -36.27% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/noprops_and_vector-10     1858.9Ki ± 0%   345.7Ki ± 0%  -81.40% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/props_and_vector-10      103.63Ki ± 0%   63.63Ki ± 0%  -38.60% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/props_only-10             43.63Ki ± 0%   33.63Ki ± 0%  -22.92% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/noprops_and_vector-10     69.55Ki ± 0%   38.30Ki ± 0%  -44.93% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/props_and_vector-10     1036.8Ki ± 0%   636.8Ki ± 0%  -38.58% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/props_only-10            436.8Ki ± 0%   336.8Ki ± 0%  -22.89% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/noprops_and_vector-10    695.5Ki ± 0%   383.0Ki ± 0%  -44.93% (p=0.002 n=6)
InternodeObjectListMarshal/objs_10-10                            202.89Ki ± 0%   60.54Ki ± 0%  -70.16% (p=0.002 n=6)
InternodeObjectListMarshal/objs_100-10                           2240.3Ki ± 0%   599.3Ki ± 0%  -73.25% (p=0.002 n=6)
InternodeObjectListUnmarshal/objs_10-10                          103.56Ki ± 0%   63.56Ki ± 0%  -38.62% (p=0.002 n=6)
InternodeObjectListUnmarshal/objs_100-10                         1036.4Ki ± 0%   636.4Ki ± 0%  -38.60% (p=0.002 n=6)
InternodeStorobjMarshal/props_and_vector-10                       5.753Ki ± 0%   5.753Ki ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjMarshal/props_only-10                             2.751Ki ± 0%   2.751Ki ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjMarshal/noprops_and_vector-10                     3.142Ki ± 0%   3.142Ki ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjUnmarshal/props_and_vector-10                     6.328Ki ± 0%   6.328Ki ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjUnmarshal/props_only-10                           3.328Ki ± 0%   3.328Ki ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjUnmarshal/noprops_and_vector-10                   3.805Ki ± 0%   3.805Ki ± 0%        ~ (p=1.000 n=6) ¹
InternodeReadAllBody/payload_389KB-10                             919.8Ki ± 0%   919.8Ki ± 0%        ~ (p=0.513 n=6)
InternodeReadAllBody/preallocated_readfull-10                       50.00 ± 2%     50.00 ± 0%        ~ (p=0.455 n=6)
geomean                                                           79.18Ki        45.74Ki       -42.23%
¹ all samples are equal

                                                               │ old-bench.log │            new-bench2.log            │
                                                               │   allocs/op   │  allocs/op   vs base                 │
InternodeSearchResultsMarshal/objs_10/props_and_vector-10           309.0 ± 0%    292.0 ± 0%   -5.50% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_10/props_only-10                 304.0 ± 0%    292.0 ± 0%   -3.95% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_10/noprops_and_vector-10         38.00 ± 0%    22.00 ± 0%  -42.11% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/props_and_vector-10         3.013k ± 0%   2.902k ± 0%   -3.68% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/props_only-10               3.004k ± 0%   2.902k ± 0%   -3.40% (p=0.002 n=6)
InternodeSearchResultsMarshal/objs_100/noprops_and_vector-10        310.5 ± 0%    202.0 ± 0%  -34.94% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/props_and_vector-10         729.0 ± 0%    719.0 ± 0%   -1.37% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/props_only-10               719.0 ± 0%    709.0 ± 0%   -1.39% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_10/noprops_and_vector-10       134.0 ± 0%    124.0 ± 0%   -7.46% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/props_and_vector-10       7.302k ± 0%   7.202k ± 0%   -1.37% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/props_only-10             7.202k ± 0%   7.102k ± 0%   -1.39% (p=0.002 n=6)
InternodeSearchResultsUnmarshal/objs_100/noprops_and_vector-10     1.307k ± 0%   1.207k ± 0%   -7.65% (p=0.002 n=6)
InternodeObjectListMarshal/objs_10-10                               306.0 ± 0%    292.0 ± 0%   -4.58% (p=0.002 n=6)
InternodeObjectListMarshal/objs_100-10                             3.009k ± 0%   2.902k ± 0%   -3.56% (p=0.002 n=6)
InternodeObjectListUnmarshal/objs_10-10                             727.0 ± 0%    717.0 ± 0%   -1.38% (p=0.002 n=6)
InternodeObjectListUnmarshal/objs_100-10                           7.300k ± 0%   7.200k ± 0%   -1.37% (p=0.002 n=6)
InternodeStorobjMarshal/props_and_vector-10                         30.00 ± 0%    30.00 ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjMarshal/props_only-10                               30.00 ± 0%    30.00 ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjMarshal/noprops_and_vector-10                       3.000 ± 0%    3.000 ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjUnmarshal/props_and_vector-10                       70.00 ± 0%    70.00 ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjUnmarshal/props_only-10                             69.00 ± 0%    69.00 ± 0%        ~ (p=1.000 n=6) ¹
InternodeStorobjUnmarshal/noprops_and_vector-10                     12.00 ± 0%    12.00 ± 0%        ~ (p=1.000 n=6) ¹
InternodeReadAllBody/payload_389KB-10                               23.00 ± 0%    23.00 ± 0%        ~ (p=1.000 n=6) ¹
InternodeReadAllBody/preallocated_readfull-10                       1.000 ± 0%    1.000 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                             235.6         221.6        -5.94%
¹ all samples are equal
```

</details>

## Testing

- **Wire-identity golden tests** (`indices_payloads_wire_identity_test.go`): a verbatim replica of the pre-change marshal implementations lives in the test file; the live code must produce byte-identical output. The replica was committed and run green against the unmodified implementation first, proving it faithful. These tests must stay green for every future slice.
- Anti-aliasing, framing-error, and `ReadBody` (exact-size / short-body / above-cap growth) unit tests.
- All touched packages green with `-race`: `entities/storobj`, `adapters/handlers/rest/clusterapi/...`, `adapters/clients`.
- `golangci-lint`, gofumpt/goimports, goroutine linter clean.

Baseline microbenchmarks are committed first (`indices_payloads_bench_test.go`) so slices 2 and 3 have a pinned before-number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM
