### PR TITLE
fix(lsmkv): sort WALs before recovery so the newest stays the active memtable

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -136,7 +136,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 			if errRecovery != nil {
 				b.logger.WithField("action", "lsm_recover_from_active_wal_corruption").
 					WithField("path", filepath.Join(b.dir, fname)).
-					Error(errors.Wrap(err, "write-ahead-log ended abruptly, some elements may not have been recovered"))
+					Error(errors.Wrap(errRecovery, "write-ahead-log ended abruptly, some elements may not have been recovered"))
 			}
 
 			if mt.strategy == StrategyInverted {

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -65,6 +65,11 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 		return nil
 	}
 
+	// Names are segment-<unix-nano>.wal (fixed-width, so lexicographic == chronological).
+	// Recovery relies on order: only the last WAL is kept as the active memtable, the
+	// rest are flushed to segments. The source is a map, whose iteration order is random.
+	sort.Strings(walFileNames)
+
 	logOnceWhenRecoveringFromWAL.Do(func() {
 		b.logger.WithField("action", "lsm_recover_from_active_wal").
 			WithField("path", b.dir).

--- a/adapters/repos/db/lsmkv/recover_from_wal_order_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_order_integration_test.go
@@ -1,0 +1,123 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// Reproduces the crash-during-flush state: two non-empty WALs on disk, an older
+// one (memtable being flushed) and a newer one (active memtable). Recovery must
+// keep the newest as the active memtable, else the older stale values shadow the
+// newer flushed data. The iteration loop defeats the random map order that the
+// pre-fix code depended on (which WAL is iterated last became the active memtable).
+func TestReplaceStrategy_RecoverFromMultipleWALs_NewestWins(t *testing.T) {
+	key := []byte("key-1")
+
+	tests := []struct {
+		name         string
+		newerWAL     []byte // written under the larger (newer) timestamp
+		expectedGet  []byte
+		expectNilGet bool
+	}{
+		{
+			name:        "newer WAL updates the key",
+			newerWAL:    makeReplaceWAL(t, key, []byte("fresh-v2"), false),
+			expectedGet: []byte("fresh-v2"),
+		},
+		{
+			name:         "newer WAL deletes the key",
+			newerWAL:     makeReplaceWAL(t, key, nil, true),
+			expectNilGet: true,
+		},
+	}
+
+	// stale value lives in the older WAL (the memtable being flushed at crash)
+	olderWAL := makeReplaceWAL(t, key, []byte("stale-v1"), false)
+
+	const iterations = 30
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := 0; i < iterations; i++ {
+				dir := t.TempDir()
+				// Fixed-width (19-digit) unix-nano timestamps; lexicographic order
+				// equals chronological order.
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "segment-1000000000000000000.wal"), olderWAL, 0o644))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "segment-2000000000000000000.wal"), tt.newerWAL, 0o644))
+
+				b, err := NewBucketCreator().NewBucket(testCtx(), dir, "", nullLogger(), nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+					WithStrategy(StrategyReplace), WithMinWalThreshold(0))
+				require.NoError(t, err)
+
+				res, err := b.Get(key)
+				require.NoError(t, err)
+				if tt.expectNilGet {
+					assert.Nilf(t, res, "iteration %d: newer WAL's delete must win", i)
+				} else {
+					assert.Equalf(t, tt.expectedGet, res,
+						"iteration %d: newer WAL's value must win over the older WAL", i)
+				}
+
+				require.NoError(t, b.Shutdown(context.Background()))
+			}
+		})
+	}
+}
+
+// makeReplaceWAL writes a single Put (or Delete when del is true) to a throwaway
+// bucket and returns the resulting WAL's raw bytes for staging in a recovery dir.
+func makeReplaceWAL(t *testing.T, key, value []byte, del bool) []byte {
+	t.Helper()
+
+	dir := t.TempDir()
+	b, err := NewBucketCreator().NewBucket(testCtx(), dir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithMinWalThreshold(0))
+	require.NoError(t, err)
+
+	if del {
+		require.NoError(t, b.Delete(key))
+	} else {
+		require.NoError(t, b.Put(key, value))
+	}
+	require.NoError(t, b.WriteWAL())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var walName string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".wal" {
+			walName = e.Name()
+		}
+	}
+	require.NotEmpty(t, walName, "expected exactly one .wal file")
+
+	data, err := os.ReadFile(filepath.Join(dir, walName))
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	require.NoError(t, b.Shutdown(context.Background()))
+	return data
+}

--- a/adapters/repos/db/lsmkv/recover_from_wal_order_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_order_integration_test.go
@@ -27,8 +27,8 @@ import (
 // Reproduces the crash-during-flush state: two non-empty WALs on disk, an older
 // one (memtable being flushed) and a newer one (active memtable). Recovery must
 // keep the newest as the active memtable, else the older stale values shadow the
-// newer flushed data. The iteration loop defeats the random map order that the
-// pre-fix code depended on (which WAL is iterated last became the active memtable).
+// newer flushed data. The iteration loop defeats the random WAL-file map order,
+// so a recovery that keeps the wrong WAL active is caught deterministically.
 func TestReplaceStrategy_RecoverFromMultipleWALs_NewestWins(t *testing.T) {
 	key := []byte("key-1")
 


### PR DESCRIPTION
### What's being changed:

Fixes a critical crash-recovery bug in the LSM store where WAL replay could keep an **older** WAL as the active memtable and shadow newer, already-flushed data.

**Problem.** `mayRecoverFromCommitLogs` builds the list of WAL files by ranging over a `map`, whose iteration order is random, and never sorts it. Recovery relies on ordering: every WAL except the last is flushed into a disk segment, while the last one is retained as the live active memtable (which shadows all disk segments on reads). With two or more non-empty WALs on disk — the normal state after a crash while a flush was in progress (old memtable's WAL + new active WAL) — there was a ~50% chance the **older** WAL was picked as the active memtable. Its stale values then win over the newer WAL's data that was just flushed to a segment: a deleted object is resurrected, or an update is silently rolled back, for the lifetime of the process (and can be baked in permanently if a compaction runs in that window).

**Fix.** `sort.Strings(walFileNames)` before the recovery loop. WAL names are `segment-<unix-nano>.wal` with fixed-width timestamps, so lexicographic order equals chronological order — WALs now always replay oldest-to-newest and only the newest WAL is retained as the active memtable.

**Test.** Adds an integration test that stages two WALs on disk (older with a stale value, newer with either an update or a delete of the same key) and asserts the newest wins. It loops 30× over fresh directories to defeat the random map order; it reliably fails without the fix (stale value / resurrected delete) and passes with it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
