### PR TITLE
fix(usage): skip collection tick while previous report is still running

### DIFF
--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -57,9 +57,9 @@ type BaseModule struct {
 	// mu mutex to protect shared fields to run concurrently the collection and upload
 	// to avoid interval overlap for the tickers
 	mu sync.RWMutex
-	// collectionsInFlight counts running collection cycles to detect ticks
-	// overlapping a report that takes longer than the collection interval
-	collectionsInFlight atomic.Int32
+	// collectionInFlight guards against overlapping collection cycles when a
+	// report takes longer than the collection interval
+	collectionInFlight atomic.Bool
 }
 
 // NewBaseModule creates a new base module instance
@@ -215,12 +215,10 @@ func (b *BaseModule) collectAndUploadPeriodically(ctx context.Context) {
 				"interval":     b.interval.String(),
 			}).Debug("collection ticker fired - starting collection cycle")
 
-			enterrors.GoWrapper(func() {
-				b.runCollectAndUpload(ctx)
-			}, b.logger)
-
-			// save last push date
-			b.storeLastPushDate()
+			if b.tryCollectAndUpload(ctx) {
+				// save last push date
+				b.storeLastPushDate()
+			}
 			// ticker is used to reset the interval
 			b.reloadConfig(ticker)
 
@@ -242,22 +240,26 @@ func (b *BaseModule) collectAndUploadPeriodically(ctx context.Context) {
 	}
 }
 
-// runCollectAndUpload runs one collection cycle. Overlapping cycles are
-// allowed but logged, as they indicate reports taking longer than the
-// collection interval.
-func (b *BaseModule) runCollectAndUpload(ctx context.Context) {
-	if inFlight := b.collectionsInFlight.Add(1); inFlight > 1 {
-		b.logger.Warnf("starting a usage collection cycle while %d previous cycle(s) are still running: usage report generation takes longer than the collection interval", inFlight-1)
+// tryCollectAndUpload starts a collection cycle in the background unless the
+// previous one is still running, in which case the tick is skipped.
+func (b *BaseModule) tryCollectAndUpload(ctx context.Context) bool {
+	if !b.collectionInFlight.CompareAndSwap(false, true) {
+		b.logger.Warn("previous usage collection still in progress - skipping this cycle")
+		b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "skipped").Inc()
+		return false
 	}
-	defer b.collectionsInFlight.Add(-1)
 
-	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessUsageCollection)()
-	if err := b.collectAndUploadUsage(ctx); err != nil {
-		b.logger.Errorf("Failed to collect and upload usage data: %v", err)
-		b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "error").Inc()
-	} else {
-		b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "success").Inc()
-	}
+	enterrors.GoWrapper(func() {
+		defer b.collectionInFlight.Store(false)
+		defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessUsageCollection)()
+		if err := b.collectAndUploadUsage(ctx); err != nil {
+			b.logger.Errorf("Failed to collect and upload usage data: %v", err)
+			b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "error").Inc()
+		} else {
+			b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "success").Inc()
+		}
+	}, b.logger)
+	return true
 }
 
 func (b *BaseModule) collectAndUploadUsage(ctx context.Context) error {

--- a/usecases/modulecomponents/usage/base_module_test.go
+++ b/usecases/modulecomponents/usage/base_module_test.go
@@ -15,21 +15,18 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	clusterusage "github.com/weaviate/weaviate/cluster/usage"
 	"github.com/weaviate/weaviate/cluster/usage/types"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 	configruntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
@@ -110,61 +107,44 @@ func TestBaseModule_RuntimeOverridesConcurrencyReachesService(t *testing.T) {
 	}
 }
 
-// TestBaseModule_WarnsOnOverlappingCollection verifies overlapping collection
-// cycles are allowed to run concurrently but emit a warning log.
-func TestBaseModule_WarnsOnOverlappingCollection(t *testing.T) {
-	logger, hook := logrustest.NewNullLogger()
-
+// TestBaseModule_SkipsOverlappingCollection verifies a collection tick is skipped
+// while the previous cycle is still running, and allowed again once it finishes.
+func TestBaseModule_SkipsOverlappingCollection(t *testing.T) {
 	mockStorage := NewMockStorageBackend(t)
-	mockStorage.EXPECT().UploadUsageData(mock.Anything, mock.Anything).Return(nil).Times(2)
+	mockStorage.EXPECT().UploadUsageData(mock.Anything, mock.Anything).Return(nil).Once()
 
-	entered := make(chan struct{}, 2)
+	started := make(chan struct{})
 	release := make(chan struct{})
 	mockService := clusterusage.NewMockService(t)
 	mockService.EXPECT().Usage(mock.Anything, false).RunAndReturn(
 		func(context.Context, bool) (*types.Report, error) {
-			entered <- struct{}{}
+			close(started)
 			<-release
 			return &types.Report{}, nil
-		}).Times(2)
+		}).Once()
 
 	module := NewBaseModule("test-module", mockStorage)
+	metrics := NewMetrics(prometheus.NewRegistry(), "test-module")
 
 	cfg := &config.Config{}
 	cfg.Cluster.Hostname = "test-node"
 	cfg.Persistence.DataPath = t.TempDir()
 	require.NoError(t, ParseCommonUsageConfig(cfg))
-	require.NoError(t, module.InitializeCommon(context.Background(), cfg, logger,
-		NewMetrics(prometheus.NewRegistry(), "test-module")))
+	require.NoError(t, module.InitializeCommon(context.Background(), cfg, logrus.New(), metrics))
 	// set the service directly to avoid starting the periodic collector
 	module.usageService = mockService
 
-	var wg sync.WaitGroup
-	for range 2 {
-		wg.Add(1)
-		enterrors.GoWrapper(func() {
-			defer wg.Done()
-			module.runCollectAndUpload(context.Background())
-		}, logger)
-	}
+	require.True(t, module.tryCollectAndUpload(context.Background()))
+	<-started
 
-	// both cycles are inside Usage at the same time
-	for range 2 {
-		select {
-		case <-entered:
-		case <-time.After(5 * time.Second):
-			t.Fatal("collection cycles did not run concurrently")
-		}
-	}
+	assert.False(t, module.tryCollectAndUpload(context.Background()))
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(metrics.OperationTotal.WithLabelValues("collect_and_upload", "skipped")))
+
 	close(release)
-	wg.Wait()
-
-	var warned bool
-	for _, entry := range hook.AllEntries() {
-		if entry.Level == logrus.WarnLevel && strings.Contains(entry.Message, "still running") {
-			warned = true
-		}
-	}
-	assert.True(t, warned, "expected a warning about overlapping collection cycles")
-	assert.Equal(t, int32(0), module.collectionsInFlight.Load())
+	assert.Eventually(t, func() bool {
+		return !module.collectionInFlight.Load()
+	}, 5*time.Second, 10*time.Millisecond, "in-flight flag was not cleared after the cycle finished")
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(metrics.OperationTotal.WithLabelValues("collect_and_upload", "success")))
 }

--- a/usecases/modulecomponents/usage/metrics.go
+++ b/usecases/modulecomponents/usage/metrics.go
@@ -37,7 +37,7 @@ func NewMetrics(reg prometheus.Registerer, moduleName string) *Metrics {
 				Name: moduleName + "_operations_total",
 				Help: "Total number of " + moduleName + " operations",
 			},
-			[]string{"operation", "status"}, // operation: collect/upload, status: success/error
+			[]string{"operation", "status"}, // operation: collect/upload, status: success/error/skipped
 		),
 		OperationLatency: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{


### PR DESCRIPTION
### What's being changed:

The usage module ticker spawned a new collection goroutine on every tick with no in-flight guard, so when a report takes longer than the collection interval, overlapping reports run concurrently — wasting I/O and racing on cold-shard reads.

- Add an `atomic.Bool` in-flight guard: a tick is skipped (warn log + `collect_and_upload/skipped` metric) while the previous cycle is still running.
- A skipped tick no longer updates the last-push date; config reload still runs every tick.
- Test: `TestBaseModule_SkipsOverlappingCollection`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
