### PR TITLE
Fix flaky GQL accptance test with EC issues

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
@@ -356,6 +356,11 @@ func getVectorsWithNearArgs(t *testing.T, client *wvt.Client,
 		resp, err = get.Do(context.Background())
 		require.NoError(ct, err)
 		require.NotNil(ct, resp)
+		// Transient errors (e.g. a replica whose local index isn't ready yet
+		// during async indexing) surface here; retry instead of aborting on t.
+		if !assert.Empty(ct, resp.Errors) {
+			return
+		}
 		if len(resp.Data) == 0 {
 			return
 		}


### PR DESCRIPTION
### What's being changed:

Test would fail sometimes if the node did not have the collection created yet due to EC

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
