### PR TITLE
fix(lsmkv): promote surviving .db.tmp after an interrupted cleanup switch instead of deleting it

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -204,10 +204,38 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		jointSegmentsIDs := strings.Split(jointSegments, "_")
 
 		if len(jointSegmentsIDs) == 1 {
-			// cleanup leftover, to be removed
-			if err := os.Remove(filepath.Join(sg.dir, entry)); err != nil {
-				return nil, fmt.Errorf("delete partially cleaned segment %q: %w", entry, err)
+			// A single-ID .db.tmp has two possible producers:
+			//   - a memtable flush that never finished (its .wal still exists), or
+			//   - a segment cleanup rewrite whose on-disk switch was interrupted.
+			// During a cleanup switch the live segment is renamed to a ".deleteme"
+			// marker BEFORE the .tmp is promoted, so if the crash lands in that
+			// window the .tmp is the ONLY complete copy of the segment. Deleting it
+			// (and the ".deleteme" later) would silently lose data. Only delete the
+			// .tmp when the original is still recoverable: its live "segment-X*.db"
+			// is present, or a matching .wal exists (the flush case). Otherwise the
+			// .tmp is a fully-written, fsynced survivor and must be promoted.
+			liveSegmentFound, _ := segmentExistsWithID(jointSegments, files)
+			walFileName, _, _ := strings.Cut(entry, ".")
+			walFileName += ".wal"
+			_, walFound := files[walFileName]
+
+			if liveSegmentFound || walFound {
+				if err := os.Remove(filepath.Join(sg.dir, entry)); err != nil {
+					return nil, fmt.Errorf("delete partially cleaned segment %q: %w", entry, err)
+				}
+				continue
 			}
+
+			// Promote the surviving .tmp; it is initialized by the file loop below.
+			if err := os.Rename(filepath.Join(sg.dir, entry),
+				filepath.Join(sg.dir, potentialCompactedSegmentFileName)); err != nil {
+				return nil, fmt.Errorf("promote surviving cleaned segment %q: %w", entry, err)
+			}
+			logger.WithField("action", "lsm_segment_init").
+				WithField("path", filepath.Join(sg.dir, potentialCompactedSegmentFileName)).
+				Info("promoted surviving .db.tmp to segment after an interrupted cleanup switch")
+			files[potentialCompactedSegmentFileName] = files[entry]
+			delete(files, entry)
 			continue
 		}
 

--- a/adapters/repos/db/lsmkv/segment_group_cleanup_crash_recovery_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup_crash_recovery_integration_test.go
@@ -1,0 +1,120 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestSegmentGroupInit_PromotesSurvivingCleanupTmp reproduces a crash inside the
+// segment-cleanup on-disk switch. During that switch the live segment (and its
+// sidecars) are renamed to ".deleteme" markers via markForDeletion BEFORE the
+// rewritten copy is promoted from ".db.tmp" to ".db". If the process dies in
+// that window, the only complete copy of the segment is the ".db.tmp".
+//
+// Startup used to delete every single-ID ".db.tmp" unconditionally and every
+// ".deleteme" afterwards, destroying both copies and silently losing all data
+// whose newest version lived in that segment. The fix promotes the surviving
+// ".db.tmp" when neither a live "segment-X*.db" nor a "segment-X.wal" exists.
+func TestSegmentGroupInit_PromotesSurvivingCleanupTmp(t *testing.T) {
+	ctx := testCtx()
+
+	tests := []struct {
+		name                string
+		writeInfoInFileName bool
+	}{
+		{name: "segment info not in filename", writeInfoInFileName: false},
+		{name: "segment info in filename", writeInfoInFileName: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			opts := []BucketOption{WithStrategy(StrategyReplace)}
+			if tt.writeInfoInFileName {
+				opts = append(opts, WithWriteSegmentInfoIntoFileName(true))
+			}
+
+			b, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			require.NoError(t, err)
+
+			require.NoError(t, b.Put([]byte("key-1"), []byte("value-1")))
+			require.NoError(t, b.Put([]byte("key-2"), []byte("value-2")))
+			// flush to a real, fsynced on-disk segment; its WAL is removed here
+			require.NoError(t, b.FlushAndSwitch())
+			require.NoError(t, b.Shutdown(ctx))
+
+			simulateCleanupSwitchCrash(t, dir)
+
+			b2, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			require.NoError(t, err)
+			defer b2.Shutdown(ctx)
+
+			v1, err := b2.Get([]byte("key-1"))
+			require.NoError(t, err)
+			assert.Equal(t, []byte("value-1"), v1)
+
+			v2, err := b2.Get([]byte("key-2"))
+			require.NoError(t, err)
+			assert.Equal(t, []byte("value-2"), v2)
+		})
+	}
+}
+
+// simulateCleanupSwitchCrash mutates the on-disk state to match a crash between
+// markForDeletion and the .tmp promotion of a cleanup switch: the rewritten copy
+// survives as "segment-X....db.tmp" while the live segment and its sidecars are
+// renamed to ".deleteme" markers.
+func simulateCleanupSwitchCrash(t *testing.T, dir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var dbFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "segment-") && strings.HasSuffix(e.Name(), ".db") {
+			dbFile = e.Name()
+			break
+		}
+	}
+	require.NotEmpty(t, dbFile, "expected exactly one on-disk .db segment")
+
+	// the rewritten cleanup copy: a byte-identical, fully-written .db.tmp
+	data, err := os.ReadFile(filepath.Join(dir, dbFile))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, dbFile+".tmp"), data, 0o644))
+
+	// markForDeletion renames the segment and all its sidecars to a
+	// ".<counter>.deleteme" marker; reproduce that for every segment-X.* file.
+	segPrefix := "segment-" + segmentID(dbFile) + "."
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, segPrefix) || strings.HasSuffix(name, ".tmp") {
+			continue
+		}
+		marker := fmt.Sprintf("%s.%013d%s", name, 0, DeleteMarkerSuffix)
+		require.NoError(t, os.Rename(filepath.Join(dir, name), filepath.Join(dir, marker)))
+	}
+}


### PR DESCRIPTION
### What's being changed:

Fixes silent data loss on startup after a crash during a segment-cleanup on-disk switch.

The switch renames the live segment to a `.deleteme` marker *before* promoting its rewritten copy from `.db.tmp` to `.db`. A crash in that window leaves only the `.deleteme` marker plus the fully-fsynced `.db.tmp` — but startup deleted the single-ID `.db.tmp` unconditionally (and the `.deleteme` afterwards), destroying both copies and losing every key whose newest version lived in that segment (opt-in `PERSISTENCE_LSM_SEGMENTS_CLEANUP_INTERVAL_HOURS` only).

Now startup only deletes such a `.db.tmp` when the original is still recoverable (a live `segment-X*.db` or a matching `segment-X.wal` — the memtable-flush case); otherwise it promotes the surviving `.db.tmp` to a full segment.

Adds an integration test reproducing the crash-window disk state; it loses data without the fix and passes with it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
