### PR TITLE
perf(inverted): reuse read buffer in objectsByDocID

### DIFF
--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -155,6 +155,11 @@ func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator,
 	out := make([]*storobj.Object, outlen)
 	docIDBytes := make([]byte, 8)
 
+	// Reused across iterations and grown to fit the largest object seen. Safe to
+	// reuse because FromBinary*Disk copies every value out of the returned bytes
+	// before the next lookup overwrites the buffer.
+	var objBuf []byte
+
 	propertyPaths := make([][]string, len(properties))
 	for j := range properties {
 		propertyPaths[j] = []string{properties[j]}
@@ -190,10 +195,11 @@ func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator,
 		loop++
 
 		binary.LittleEndian.PutUint64(docIDBytes, docID)
-		res, err := bucket.GetBySecondary(ctx, 0, docIDBytes)
+		res, newBuf, err := bucket.GetBySecondaryWithBuffer(ctx, 0, docIDBytes, objBuf)
 		if err != nil {
 			return nil, err
 		}
+		objBuf = newBuf
 
 		if res == nil {
 			handleDeletedId(docID)


### PR DESCRIPTION
## What

Thread a single, reused read buffer through the result-resolution loop in `Searcher.objectsByDocID`, replacing the per-object `GetBySecondary` call (which passes a `nil` buffer) with `GetBySecondaryWithBuffer`.

## Why

`objectsByDocID` is the object-resolution loop for **filter-only queries** (a `where` filter with no vector and no BM25/keyword ranking). For every result docID it called `bucket.GetBySecondary(ctx, 0, docIDBytes)`, which forwards a `nil` buffer to `GetBySecondaryWithBuffer` — so `segment.getBySecondary` allocates a fresh, object-sized `[]byte` on **every** read.

In a production CPU/heap profile this was the dominant allocation site: **`segment.getBySecondary` accounted for ~71% of all heap allocation** in the process, and the resulting GC churn (`gcDrain`/`scanObject`) was consuming ~11% of CPU that would otherwise serve queries.

This mirrors the pattern the vector-read path (`readVectorByIndexIDIntoSlice`) already uses: keep one buffer, grow it to the largest object seen, and reuse it for every subsequent read.

## Safety

Reuse is safe because the returned bytes are fully copied out before the next lookup overwrites the buffer:
- `FromBinaryOptionalDisk` → `UnmarshalProperties` copies every scalar via `jsonparser.ParseString`/`ParseFloat` (the `string([]byte)` conversion allocates), and nested objects/refs via `json.Unmarshal`/`GetString`. `props`, `meta`, and `vectorWeights` are all consumed by copying parsers and none are retained on the `Object`.
- `FromBinaryUUIDOnlyDisk` (the `ReferenceQuery` branch) only reads the header and copies the UUID string.
- On not-found/deleted, `GetBySecondaryWithBuffer` returns the caller's buffer unchanged, so threading it forward is correct.

## Testing

- `go test ./adapters/repos/db/inverted/...` — pass
- `go test -tags integrationTest -run 'TestFilters'` — pass (real LSM object retrieval through this loop)
- `go test -tags integrationTest -run 'TestSort|TestFiltersLimits|Null'` — pass (slice-iterator / sorted and limit paths through the same loop)
- `golangci-lint run ./...` + goroutine linter — clean