### PR TITLE
perf(sorter,group-by): reuse read buffer in docID resolution loops

### DIFF
--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -102,13 +102,18 @@ func (g *grouper) Do(ctx context.Context) ([]*storobj.Object, []float32, error) 
 		return nil, nil, fmt.Errorf("getting bucket class name: %w", err)
 	}
 
+	// Reused across iterations and grown to fit the largest object. Safe to reuse
+	// because ParseAndExtractProperty and FromBinaryOptionalDisk copy every value
+	// out before the next lookup overwrites the buffer.
+	var lsmBuf []byte
 DOCS_LOOP:
 	for i, docID := range g.ids {
 		binary.LittleEndian.PutUint64(docIDBytes, docID)
-		objData, err := g.objBucket.GetBySecondary(ctx, 0, docIDBytes)
+		objData, newBuf, err := g.objBucket.GetBySecondaryWithBuffer(ctx, 0, docIDBytes, lsmBuf)
 		if err != nil {
 			return nil, nil, fmt.Errorf("%w: could not get obj by doc id %d", err, docID)
 		}
+		lsmBuf = newBuf
 		if objData == nil {
 			continue
 		}

--- a/adapters/repos/db/sorter/lsm_sorter.go
+++ b/adapters/repos/db/sorter/lsm_sorter.go
@@ -173,12 +173,17 @@ func (h *lsmSorterHelper) getSortedDocIDs(ctx context.Context, docIDs helpers.Al
 	it := docIDs.Iterator()
 	defer it.Stop()
 
+	// Reused across iterations and grown to fit the largest object. Safe to reuse
+	// because createFromBytes copies every sort-key value out (string(...)) before
+	// the next lookup overwrites the buffer; it retains no slice into objData.
+	var lsmBuf []byte
 	for docID, ok := it.Next(); ok; docID, ok = it.Next() {
 		binary.LittleEndian.PutUint64(docIDBytes, docID)
-		objData, err := h.bucket.GetBySecondary(ctx, 0, docIDBytes)
+		objData, newBuf, err := h.bucket.GetBySecondaryWithBuffer(ctx, 0, docIDBytes, lsmBuf)
 		if err != nil {
 			return nil, errors.Wrapf(err, "lsm sorter - could not get obj by doc id %d", docID)
 		}
+		lsmBuf = newBuf
 		if objData == nil {
 			continue
 		}
@@ -196,12 +201,16 @@ func (h *lsmSorterHelper) getSortedDocIDsAndDistances(ctx context.Context, docID
 	sorter := newInsertSorter(h.comparator, h.limit)
 	docIDBytes := make([]byte, 8)
 
+	// See getSortedDocIDs: reuse is safe because createFromBytesWithPayload copies
+	// the sort-key values out and retains no slice into objData.
+	var lsmBuf []byte
 	for i, docID := range docIDs {
 		binary.LittleEndian.PutUint64(docIDBytes, docID)
-		objData, err := h.bucket.GetBySecondary(ctx, 0, docIDBytes)
+		objData, newBuf, err := h.bucket.GetBySecondaryWithBuffer(ctx, 0, docIDBytes, lsmBuf)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "lsm sorter - could not get obj by doc id %d", docID)
 		}
+		lsmBuf = newBuf
 		if objData == nil {
 			continue
 		}


### PR DESCRIPTION
## What

Follow-up to #12142. Thread a single reused read buffer through the two remaining **query-path** object-resolution loops that still resolved each result docID with a `nil` buffer:

- `lsmSorterHelper.getSortedDocIDs` and `getSortedDocIDsAndDistances` (the LSM sorter)
- `grouper.Do` (group-by result resolution)

Both replace per-object `GetBySecondary(ctx, 0, docIDBytes)` with `GetBySecondaryWithBuffer`, growing one buffer to the largest object seen — the same pattern as #12142 and the vector-read path.

## Why

`segment.getBySecondary` was the single largest allocation site in a production heap profile (~71% of all allocations), because a `nil` buffer forces a fresh object-sized `[]byte` on every read. On a **sorted** query the sorter reads *every* object in the filtered set to extract its sort key (not just the page limit), and group-by reads every candidate — so these loops are high-volume allocators whose GC churn steals CPU from queries.

## Safety

Reuse is safe only because each consumer copies every value out of the returned bytes before the next lookup overwrites the buffer — none retain a slice into it:
- **Sorter**: `comparableValueExtractor.extractFromBytes` → `ParseAndExtractProperty` → `ParseAndExtractTextProp`, which appends `string(value)` (a copy); numeric/bool/date keys parse to value types; id via `uuid.String()`. The `comparable` holds only these copies.
- **Group-by**: `ParseAndExtractProperty` (copies, as above) plus `FromBinaryOptionalDisk` (copies all properties out via `UnmarshalProperties`/`json.Unmarshal`; see #12142). The result maps store decoded `*storobj.Object`s and docIDs, never `objData`.

The third sorter path (`getSorted`) uses a `Cursor`, not `GetBySecondary`, so it is unaffected.

Note: `storobj.ObjectsByDocID` (used by vector-search / group-by result fetch in `shard_read.go`) already reuses a pooled buffer + shared view, so it needs no change.

## Testing

- `go test ./adapters/repos/db/sorter/...` — pass (real LSM buckets across all property/sort types)
- `go test -tags integrationTest -run 'Test_SortBy'` — pass (exercises `getSortedDocIDsAndDistances`)
- `go test -tags integrationTest -run 'TestSort|TestFilters'` — pass
- `golangci-lint run ./...` + goroutine linter — clean