### PR TITLE
fix(clusterapi): wrap the composed handler with Sentry, not the bare mux

### DIFF
--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -88,36 +88,7 @@ func NewServer(appState *state.State) *Server {
 
 	grpcServer := grpc.NewServer(appState)
 
-	var handler http.Handler
-	// Multiplexing handler: Routes gRPC vs. REST (HTTP)
-	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("content-type"), "application/grpc") {
-			grpcServer.ServeHTTP(w, r) // Route to gRPC
-			return
-		}
-		mux.ServeHTTP(w, r) // Route to REST mux (handles HTTP/1.1 or plain HTTP/2)
-	})
-
-	handler = addClusterHandlerMiddleware(handler, appState, auth)
-	if appState.ServerConfig.Config.Sentry.Enabled {
-		// Wrap the default mux with Sentry to capture panics, report errors and
-		// measure performance.
-		//
-		// Alternatively, you can also wrap individual handlers if you need to
-		// use different options for different parts of your app.
-		handler = sentryhttp.New(sentryhttp.Options{}).Handle(mux)
-	}
-
-	if appState.ServerConfig.Config.Monitoring.Enabled {
-		handler = monitoring.InstrumentHTTP(
-			handler,
-			staticRoute(mux),
-			appState.HTTPServerMetrics.InflightRequests,
-			appState.HTTPServerMetrics.RequestDuration,
-			appState.HTTPServerMetrics.RequestBodySize,
-			appState.HTTPServerMetrics.ResponseBodySize,
-		)
-	}
+	handler := composeClusterHandler(mux, grpcServer, appState, auth)
 
 	protocols := http.Protocols{}
 	protocols.SetHTTP1(true)
@@ -132,6 +103,52 @@ func NewServer(appState *state.State) *Server {
 		appState: appState,
 		grpc:     grpcServer,
 	}
+}
+
+// composeClusterHandler builds the internal cluster-API handler chain and
+// applies the optional observability wraps in order:
+//  1. a gRPC-vs-REST multiplexer (application/grpc HTTP/2 requests go to the
+//     internal gRPC server, everything else to the REST mux),
+//  2. the /v1/cluster/* RAFT join/remove middleware,
+//  3. an optional Sentry wrap, and
+//  4. an optional monitoring wrap.
+//
+// Each optional wrap must be applied to the fully composed `handler`, never to
+// the bare `mux`. Wrapping `mux` would silently drop the gRPC multiplexer and
+// the cluster middleware, breaking replica-movement file copies and raft
+// join/remove whenever that layer is enabled.
+func composeClusterHandler(mux *http.ServeMux, grpcServer http.Handler,
+	appState *state.State, auth auth,
+) http.Handler {
+	var handler http.Handler
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("content-type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r) // Route to gRPC
+			return
+		}
+		mux.ServeHTTP(w, r) // Route to REST mux (handles HTTP/1.1 or plain HTTP/2)
+	})
+
+	handler = addClusterHandlerMiddleware(handler, appState, auth)
+
+	if appState.ServerConfig.Config.Sentry.Enabled {
+		// Wrap with Sentry to capture panics, report errors and measure
+		// performance.
+		handler = sentryhttp.New(sentryhttp.Options{}).Handle(handler)
+	}
+
+	if appState.ServerConfig.Config.Monitoring.Enabled {
+		handler = monitoring.InstrumentHTTP(
+			handler,
+			staticRoute(mux),
+			appState.HTTPServerMetrics.InflightRequests,
+			appState.HTTPServerMetrics.RequestDuration,
+			appState.HTTPServerMetrics.RequestBodySize,
+			appState.HTTPServerMetrics.ResponseBodySize,
+		)
+	}
+
+	return handler
 }
 
 // Serve starts the server and blocks until an error occurs

--- a/adapters/handlers/rest/clusterapi/serve_compose_test.go
+++ b/adapters/handlers/rest/clusterapi/serve_compose_test.go
@@ -1,0 +1,103 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clusterapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	entsentry "github.com/weaviate/weaviate/entities/sentry"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/schema"
+)
+
+// Test_composeClusterHandler_PreservesRouting guards against regressing the
+// observability wraps onto the bare mux (dropping the gRPC multiplexer and the
+// /v1/cluster/* RAFT middleware). It asserts that, with Sentry enabled or
+// disabled, gRPC requests still reach the gRPC server and /v1/cluster/* still
+// reaches the RAFT router rather than falling through to the REST mux.
+func Test_composeClusterHandler_PreservesRouting(t *testing.T) {
+	for _, sentryEnabled := range []bool{false, true} {
+		name := "sentry disabled"
+		if sentryEnabled {
+			name = "sentry enabled"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			appState := &state.State{
+				SchemaManager: &schema.Manager{},
+				ServerConfig: &config.WeaviateConfig{
+					Config: config.Config{
+						Sentry: &entsentry.ConfigOpts{Enabled: sentryEnabled},
+						// Monitoring left disabled (zero value).
+					},
+				},
+			}
+			auth := NewBasicAuthHandler(cluster.AuthConfig{})
+
+			var grpcCalled bool
+			grpcProbe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				grpcCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			mux := http.NewServeMux()
+			mux.Handle("/", index())
+
+			handler := composeClusterHandler(mux, grpcProbe, appState, auth)
+
+			t.Run("gRPC request reaches the gRPC server", func(t *testing.T) {
+				grpcCalled = false
+				req := httptest.NewRequest(http.MethodPost, "/grpc.health.v1.Health/Check", nil)
+				req.ProtoMajor = 2
+				req.Header.Set("content-type", "application/grpc")
+				rec := httptest.NewRecorder()
+
+				handler.ServeHTTP(rec, req)
+
+				assert.True(t, grpcCalled, "gRPC request must be routed to the gRPC server, not the REST mux")
+			})
+
+			t.Run("/v1/cluster/join reaches the RAFT router", func(t *testing.T) {
+				grpcCalled = false
+				req := httptest.NewRequest(http.MethodPost, "/v1/cluster/join", strings.NewReader(""))
+				rec := httptest.NewRecorder()
+
+				handler.ServeHTTP(rec, req)
+
+				// empty body -> 400 from the raft handler; a 404 would mean the
+				// request fell through to the mux's index() (middleware dropped).
+				assert.Equal(t, http.StatusBadRequest, rec.Code,
+					"/v1/cluster/join must reach the RAFT router, not the REST mux")
+				assert.False(t, grpcCalled)
+			})
+
+			t.Run("plain REST request reaches the mux", func(t *testing.T) {
+				grpcCalled = false
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				rec := httptest.NewRecorder()
+
+				handler.ServeHTTP(rec, req)
+
+				require.False(t, grpcCalled)
+				assert.Equal(t, http.StatusOK, rec.Code)
+			})
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Fixes the internal cluster-API server dropping its gRPC multiplexer and cluster middleware when Sentry is enabled.

The handler is composed in layers — a gRPC-vs-REST multiplexer, then the `/v1/cluster/*` RAFT join/remove middleware. The Sentry wrap was applied to the bare `mux` (`Handle(mux)`) instead of the composed `handler`, silently discarding both layers. With `SENTRY_ENABLED=true`, internal gRPC file-replication calls (replica movement) and operator `/v1/cluster/join`|`remove` requests fell through to the REST mux and 404'd — breaking those paths cluster-wide.

The composition is extracted into a `composeClusterHandler` helper (so the optional Sentry/monitoring wraps always apply to the full chain), and the Sentry wrap now targets `handler`. Adds a regression test asserting gRPC and `/v1/cluster/*` routing survive with Sentry enabled/disabled; it fails without the fix.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
