### PR TITLE
fix(lsmkv): reclaim deleted docs' property lengths at compaction

### DIFF
--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -428,11 +428,12 @@ func TestCompaction(t *testing.T) {
 				WithStrategy(StrategyRoaringSetRange),
 			},
 		},
-		// Inverted
+		// Inverted. Sizes shrank (was 8627 / 8931) because compaction now drops
+		// deleted docs' per-doc property lengths instead of carrying them forever.
 		{
 			name: "compactionInvertedStrategy",
 			f: func(ctx context.Context, t *testing.T, opts []BucketOption) {
-				compactionInvertedStrategy(ctx, t, opts, 8627, 8627)
+				compactionInvertedStrategy(ctx, t, opts, 8447, 8447)
 			},
 			opts: []BucketOption{
 				WithStrategy(StrategyInverted),
@@ -441,7 +442,7 @@ func TestCompaction(t *testing.T) {
 		{
 			name: "compactionInvertedStrategy_KeepTombstones",
 			f: func(ctx context.Context, t *testing.T, opts []BucketOption) {
-				compactionInvertedStrategy(ctx, t, opts, 8931, 8931)
+				compactionInvertedStrategy(ctx, t, opts, 8751, 8751)
 			},
 			opts: []BucketOption{
 				WithStrategy(StrategyInverted),

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -428,8 +428,7 @@ func TestCompaction(t *testing.T) {
 				WithStrategy(StrategyRoaringSetRange),
 			},
 		},
-		// Inverted. Sizes shrank (was 8627 / 8931) because compaction now drops
-		// deleted docs' per-doc property lengths instead of carrying them forever.
+		// Inverted
 		{
 			name: "compactionInvertedStrategy",
 			f: func(ctx context.Context, t *testing.T, opts []BucketOption) {

--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -143,7 +143,8 @@ func (c *compactorInverted) do(ctx context.Context) error {
 		return errors.Wrap(err, "get property lengths")
 	}
 
-	c.propLengthIds, c.propLengthLens = mergePropLenPairs(ids1, lens1, ids2, lens2)
+	// drop the property lengths of docs cleanupValues removes from the older segment
+	c.propLengthIds, c.propLengthLens = mergePropLenPairs(ids1, lens1, ids2, lens2, c.tombstonesToClean)
 
 	tombstones := c.computeTombstones()
 

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -364,23 +364,28 @@ func (s *segment) getPropertyLengthsPairs() ([]uint64, []uint32, error) {
 }
 
 // mergePropLenPairs merges two docID-sorted pair arrays into one, deduping
-// docIDs. On a tie the second array wins (c2 is the newer segment) — the
-// precedence the compactor's prior map overwrite relied on.
-func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uint32) ([]uint64, []uint32) {
+// docIDs (newer array wins on a tie). docIDs in deletedFromOlder are dropped
+// only from the first (older) array — the newer array is never filtered, since
+// a tombstone suppresses only older segments and a docID re-inserted in the
+// newer segment stays live. deletedFromOlder may be nil.
+func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uint32, deletedFromOlder *sroar.Bitmap) ([]uint64, []uint32) {
 	outIDs := make([]uint64, 0, len(ids1)+len(ids2))
 	outLens := make([]uint32, 0, len(ids1)+len(ids2))
+	keepOlder := func(id uint64) bool { return deletedFromOlder == nil || !deletedFromOlder.Contains(id) }
 	i, j := 0, 0
 	for i < len(ids1) && j < len(ids2) {
 		switch {
 		case ids1[i] < ids2[j]:
-			outIDs = append(outIDs, ids1[i])
-			outLens = append(outLens, lens1[i])
+			if keepOlder(ids1[i]) {
+				outIDs = append(outIDs, ids1[i])
+				outLens = append(outLens, lens1[i])
+			}
 			i++
 		case ids1[i] > ids2[j]:
 			outIDs = append(outIDs, ids2[j])
 			outLens = append(outLens, lens2[j])
 			j++
-		default: // equal docID: second (newer) wins
+		default: // equal docID: newer wins
 			outIDs = append(outIDs, ids2[j])
 			outLens = append(outLens, lens2[j])
 			i++
@@ -388,8 +393,10 @@ func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uin
 		}
 	}
 	for ; i < len(ids1); i++ {
-		outIDs = append(outIDs, ids1[i])
-		outLens = append(outLens, lens1[i])
+		if keepOlder(ids1[i]) {
+			outIDs = append(outIDs, ids1[i])
+			outLens = append(outLens, lens1[i])
+		}
 	}
 	for ; j < len(ids2); j++ {
 		outIDs = append(outIDs, ids2[j])

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -371,7 +371,9 @@ func (s *segment) getPropertyLengthsPairs() ([]uint64, []uint32, error) {
 func mergePropLenPairs(ids1 []uint64, lens1 []uint32, ids2 []uint64, lens2 []uint32, deletedFromOlder *sroar.Bitmap) ([]uint64, []uint32) {
 	outIDs := make([]uint64, 0, len(ids1)+len(ids2))
 	outLens := make([]uint32, 0, len(ids1)+len(ids2))
-	keepOlder := func(id uint64) bool { return deletedFromOlder == nil || !deletedFromOlder.Contains(id) }
+	// skip the per-docID bitmap lookup entirely when there is nothing to drop
+	hasDeleted := deletedFromOlder != nil && !deletedFromOlder.IsEmpty()
+	keepOlder := func(id uint64) bool { return !hasDeleted || !deletedFromOlder.Contains(id) }
 	i, j := 0, 0
 	for i < len(ids1) && j < len(ids2) {
 		switch {

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -337,3 +337,79 @@ func TestInvertedCompactionPropertyLengthsSparsePairs(t *testing.T) {
 		require.Equal(t, l, plView.get(id), "view docID %d", id)
 	}
 }
+
+// TestInvertedCompactionReclaimsDeletedPropertyLengths verifies that a delete
+// drops its per-doc property length at compaction, not just its posting. The
+// control (live postings and consumed tombstones) rules out a false pass from a
+// compaction that never ran.
+func TestInvertedCompactionReclaimsDeletedPropertyLengths(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9) // never auto-flush mid-segment
+
+	const (
+		total   = 100
+		deleted = 60 // docIDs [0,deleted) are tombstoned; [deleted,total) survive
+	)
+	term := []byte("shared")
+
+	// segment 1 (older, c1): every doc under one shared term, each with a propLen
+	for id := 0; id < total; id++ {
+		require.NoError(t, bucket.MapSet(term, NewMapPairFromDocIdAndTf(uint64(id), 1, float32(id+1), false)))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// segment 2 (newer, c2): tombstone the first `deleted` docs
+	for id := 0; id < deleted; id++ {
+		pair := NewMapPairFromDocIdAndTf(uint64(id), 1, 1, true)
+		require.NoError(t, bucket.MapDeleteKey(term, pair.Key))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// force the root compaction that physically drops the tombstoned docs
+	for {
+		compacted, err := bucket.disk.compactOnce(ctx)
+		require.NoError(t, err)
+		if !compacted {
+			break
+		}
+	}
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1, "expected a single segment after compaction")
+	seg := view.Disk[0]
+
+	// control: postings and tombstones prove a real cleanup compaction ran, so a
+	// retained property length can only be the leak, not "hasn't compacted yet"
+	live, err := bucket.MapList(ctx, term)
+	require.NoError(t, err)
+	liveCount := 0
+	for _, mp := range live {
+		if !mp.Tombstone {
+			liveCount++
+		}
+	}
+	require.Equal(t, total-deleted, liveCount, "postings physically reclaimed the deleted docs")
+
+	tomb, err := seg.ReadOnlyTombstones()
+	require.NoError(t, err)
+	require.True(t, tomb == nil || tomb.IsEmpty(), "root compaction consumed the tombstones")
+
+	// property lengths track the live set, not every doc ever ingested
+	pls, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	assert.Len(t, pls, total-deleted, "deleted docs' property lengths must be reclaimed")
+	for id := 0; id < deleted; id++ {
+		_, ok := pls[uint64(id)]
+		assert.False(t, ok, "tombstoned docID %d still carries a property length", id)
+	}
+	for id := deleted; id < total; id++ {
+		assert.Equal(t, uint32(id+1), pls[uint64(id)], "surviving docID %d property length", id)
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_integration_test.go
@@ -16,6 +16,7 @@ package lsmkv
 
 import (
 	"context"
+	"encoding/binary"
 	"math"
 	"testing"
 
@@ -412,4 +413,62 @@ func TestInvertedCompactionReclaimsDeletedPropertyLengths(t *testing.T) {
 	for id := deleted; id < total; id++ {
 		assert.Equal(t, uint32(id+1), pls[uint64(id)], "surviving docID %d property length", id)
 	}
+}
+
+// TestInvertedCompactionReinsertKeepsPropertyLength guards the delete-then-
+// reinsert case raised in review: a docID deleted and re-added with a new
+// length in a newer segment must keep its NEW property length through
+// compaction, not be reclaimed as a delete. The reclaim only drops the older
+// segment's entries, so the newer (live) length always survives.
+func TestInvertedCompactionReinsertKeepsPropertyLength(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9) // never auto-flush mid-segment
+
+	term := []byte("shared")
+	const docID = uint64(7)
+
+	// older segment: docID with an initial property length
+	require.NoError(t, bucket.MapSet(term, NewMapPairFromDocIdAndTf(docID, 1, 10, false)))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// newer segment: delete then re-add the same docID with a new property length
+	del := NewMapPairFromDocIdAndTf(docID, 1, 1, true)
+	require.NoError(t, bucket.MapDeleteKey(term, del.Key))
+	require.NoError(t, bucket.MapSet(term, NewMapPairFromDocIdAndTf(docID, 2, 20, false)))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	for {
+		compacted, err := bucket.disk.compactOnce(ctx)
+		require.NoError(t, err)
+		if !compacted {
+			break
+		}
+	}
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	require.Len(t, view.Disk, 1)
+	seg := view.Disk[0]
+
+	// the reinserted doc stays live...
+	live, err := bucket.MapList(ctx, term)
+	require.NoError(t, err)
+	liveIDs := map[uint64]bool{}
+	for _, mp := range live {
+		if !mp.Tombstone {
+			liveIDs[binary.BigEndian.Uint64(mp.Key)] = true
+		}
+	}
+	require.True(t, liveIDs[docID], "reinserted docID must survive compaction")
+
+	// ...with its NEW property length, not dropped or zeroed
+	pls, err := seg.getPropertyLengths()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(20), pls[docID], "reinserted doc keeps its new property length")
 }

--- a/adapters/repos/db/lsmkv/segment_inverted_proplen_test.go
+++ b/adapters/repos/db/lsmkv/segment_inverted_proplen_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
 )
 
 func TestSortPropLenPairs(t *testing.T) {
@@ -224,16 +225,18 @@ func TestMergePropLenPairs(t *testing.T) {
 		ids1, ids2 []uint64
 		lens1      []uint32
 		lens2      []uint32
+		deleted    []uint64 // deleted from the older (first) input
 		wantIDs    []uint64
 		wantLens   []uint32
 	}{
-		{"both_empty", nil, nil, nil, nil, nil, nil},
+		{"both_empty", nil, nil, nil, nil, nil, nil, nil},
 		{
 			"left_empty",
 			nil,
 			[]uint64{2, 5},
 			nil,
 			[]uint32{20, 50},
+			nil,
 			[]uint64{2, 5},
 			[]uint32{20, 50},
 		},
@@ -242,6 +245,7 @@ func TestMergePropLenPairs(t *testing.T) {
 			[]uint64{1, 3},
 			nil,
 			[]uint32{10, 30},
+			nil,
 			nil,
 			[]uint64{1, 3},
 			[]uint32{10, 30},
@@ -252,6 +256,7 @@ func TestMergePropLenPairs(t *testing.T) {
 			[]uint64{2, 3, 7},
 			[]uint32{10, 40, 60},
 			[]uint32{20, 30, 70},
+			nil,
 			[]uint64{1, 2, 3, 4, 6, 7},
 			[]uint32{10, 20, 30, 40, 60, 70},
 		},
@@ -263,6 +268,7 @@ func TestMergePropLenPairs(t *testing.T) {
 			[]uint64{5, 9, 12},
 			[]uint32{10, 50, 90},
 			[]uint32{555, 999, 120},
+			nil,
 			[]uint64{1, 5, 9, 12},
 			[]uint32{10, 555, 999, 120},
 		},
@@ -272,15 +278,63 @@ func TestMergePropLenPairs(t *testing.T) {
 			[]uint64{1, 2},
 			[]uint32{10, 20},
 			[]uint32{11, 22},
+			nil,
 			[]uint64{1, 2},
 			[]uint32{11, 22},
+		},
+		{
+			"drops_deleted_older",
+			[]uint64{1, 4, 6},
+			[]uint64{2, 7},
+			[]uint32{10, 40, 60},
+			[]uint32{20, 70},
+			[]uint64{4, 6},
+			[]uint64{1, 2, 7},
+			[]uint32{10, 20, 70},
+		},
+		{
+			"newer_survives_delete",
+			[]uint64{1},
+			[]uint64{5, 8},
+			[]uint32{10},
+			[]uint32{50, 80},
+			[]uint64{5},
+			[]uint64{1, 5, 8},
+			[]uint32{10, 50, 80},
+		},
+		{
+			"duplicate_deleted_newer_wins",
+			[]uint64{5},
+			[]uint64{5},
+			[]uint32{10},
+			[]uint32{999},
+			[]uint64{5},
+			[]uint64{5},
+			[]uint32{999},
+		},
+		{
+			"all_older_deleted",
+			[]uint64{1, 2},
+			nil,
+			[]uint32{10, 20},
+			nil,
+			[]uint64{1, 2},
+			nil,
+			nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			ids, lens := mergePropLenPairs(tc.ids1, tc.lens1, tc.ids2, tc.lens2)
+			var deleted *sroar.Bitmap
+			if len(tc.deleted) > 0 {
+				deleted = sroar.NewBitmap()
+				for _, id := range tc.deleted {
+					deleted.Set(id)
+				}
+			}
+			ids, lens := mergePropLenPairs(tc.ids1, tc.lens1, tc.ids2, tc.lens2, deleted)
 			assert.Equal(t, tc.wantIDs, nilIfEmpty(ids))
 			assert.Equal(t, tc.wantLens, nilIfEmptyU32(lens))
 			require.True(t, sort.SliceIsSorted(ids, func(i, j int) bool { return ids[i] < ids[j] }))


### PR DESCRIPTION
### What's being changed:

Fixes [`0-weaviate-issues#274`](https://github.com/weaviate/0-weaviate-issues/issues/274): BM25 per-document property lengths were never reclaimed on delete — a resident-memory leak that grows without bound under churn (ingest + delete).

Deleting an object never removed its per-doc property-length entry from the inverted segment. Compaction merged **every** docID from both input segments into the property-length array (`mergePropLenPairs`), while tombstones were tracked in a separate bitmap used only to (a) filter queries and (b) clean the postings — the property-length array was **never** filtered by tombstones. Resident propLength therefore tracked every document ever ingested into a shard, not the live set (~8–12 B/deleted doc), reclaimable only by a manual inverted reindex.

Correctness was unaffected (deleted docs are filtered at query time via the tombstone bitmap, so their orphaned length entries are never *read*), which is exactly why it went unnoticed.

### Fix

Reclaim inside `mergePropLenPairs`: drop a docID's property length when the compaction removes it from the postings — but **only from the older segment**, mirroring the posting cleanup:

- A delete never writes a property length (a tombstoned value is skipped at flush, [`memtable_flush_inverted.go`](https://github.com/weaviate/weaviate/blob/stable/v1.37/adapters/repos/db/lsmkv/memtable_flush_inverted.go)), so a deleted doc's length always lives in the **older** segment where it was ingested.
- Compaction cleans only the older segment's postings, for docs tombstoned in the newer one (`cleanupValues`, by `tombstonesToClean`). We drop exactly those entries from the older array.
- The **newer** segment's entries are never filtered — a tombstone only suppresses *older* segments, so a docID re-inserted in the newer segment is live and must keep its length.

`avgdl` (BM25 scoring) is unaffected — it reads the stored avg/count scalars, which are independent of the property-length array length (the existing `TestInvertedNaNPropLength` still passes).

### Tests

- **Unit** — `TestMergePropLenPairs` gains cases for the asymmetry: `drops_deleted_older`, `newer_survives_delete`, `duplicate_deleted_newer_wins`, `all_older_deleted`.
- **Integration** — `TestInvertedCompactionReclaimsDeletedPropertyLengths`: the issue's reproducer (100 ingested under a shared term, 60 tombstoned, forced root compaction) with a control (live postings == 40, tombstones consumed) that rules out "hasn't compacted yet". Verified red→green.

Front-port target: lands on `stable/v1.37` and forward-ports to `stable/v1.38` / `main` (same pairs-based code shape). `stable/v1.36` is map-based and would need a separate backport if desired.

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.