### PR TITLE
perf(lsmkv): add EncodeAppend arena-append primitive to varenc

### DIFF
--- a/adapters/repos/db/lsmkv/varenc/simple.go
+++ b/adapters/repos/db/lsmkv/varenc/simple.go
@@ -98,6 +98,14 @@ func (e *SimpleEncoder[T]) Encode(values []T) []byte {
 	return e.buf
 }
 
+func (e *SimpleEncoder[T]) EncodeAppend(values []T, arena []byte) ([]byte, []byte) {
+	e.EncodeReusable(values, e.buf)
+	n := 8 + len(values)*e.elementSize
+	start := len(arena)
+	arena = append(arena, e.buf[:n]...)
+	return arena[start:], arena
+}
+
 func (e *SimpleEncoder[T]) Decode(data []byte) []T {
 	e.DecodeReusable(data, e.values)
 	return e.values

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding.go
@@ -29,6 +29,12 @@ const (
 type VarEncEncoder[T any] interface {
 	Init(expectedCount int)
 	Encode(values []T) []byte
+	// EncodeAppend encodes values into the encoder's internal buffer, then
+	// appends the encoded bytes to arena. It returns the encoded sub-slice and
+	// the updated arena, avoiding a per-call allocation when several blocks whose
+	// data must coexist are encoded into one arena. A later append that grows the
+	// arena invalidates earlier sub-slices, so pre-size the arena to keep them.
+	EncodeAppend(values []T, arena []byte) (encoded []byte, updatedArena []byte)
 	Decode(data []byte) []T
 	EncodeReusable(values []T, buf []byte)
 	DecodeReusable(data []byte, values []T)

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding.go
@@ -29,13 +29,9 @@ const (
 type VarEncEncoder[T any] interface {
 	Init(expectedCount int)
 	Encode(values []T) []byte
-	// EncodeAppend encodes values into the encoder's internal buffer, then
-	// appends the encoded bytes to arena. It returns the encoded sub-slice and
-	// the updated arena, avoiding a per-call allocation when several blocks whose
-	// data must coexist are encoded into one arena. A later append that grows the
-	// arena reallocates it: earlier sub-slices keep their bytes (they retain the
-	// old backing array) but are no longer contiguous with the returned arena, so
-	// pre-size the arena when all sub-slices must share one backing array.
+	// EncodeAppend appends the encoding to arena and returns the encoded sub-slice
+	// plus the (possibly reallocated) arena. A growth realloc leaves earlier
+	// sub-slices valid but detached, so pre-size arena if they must stay contiguous.
 	EncodeAppend(values []T, arena []byte) (encoded []byte, updatedArena []byte)
 	Decode(data []byte) []T
 	EncodeReusable(values []T, buf []byte)

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding.go
@@ -33,7 +33,9 @@ type VarEncEncoder[T any] interface {
 	// appends the encoded bytes to arena. It returns the encoded sub-slice and
 	// the updated arena, avoiding a per-call allocation when several blocks whose
 	// data must coexist are encoded into one arena. A later append that grows the
-	// arena invalidates earlier sub-slices, so pre-size the arena to keep them.
+	// arena reallocates it: earlier sub-slices keep their bytes (they retain the
+	// old backing array) but are no longer contiguous with the returned arena, so
+	// pre-size the arena when all sub-slices must share one backing array.
 	EncodeAppend(values []T, arena []byte) (encoded []byte, updatedArena []byte)
 	Decode(data []byte) []T
 	EncodeReusable(values []T, buf []byte)

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding_test.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding_test.go
@@ -142,6 +142,64 @@ func TestCompareDeltaEncoders(t *testing.T) {
 	}
 }
 
+func TestEncodeAppend(t *testing.T) {
+	valueCount := terms.BLOCK_SIZE
+
+	values := make([]uint64, valueCount)
+	values[0] = 100
+	for i := 1; i < valueCount; i++ {
+		values[i] = values[i-1] + rand.Uint64N(10)
+	}
+
+	newEncoders := func() []VarEncEncoder[uint64] {
+		return []VarEncEncoder[uint64]{
+			&SimpleEncoder[uint64]{},
+			&VarIntEncoder{},
+			&VarIntDeltaEncoder{},
+		}
+	}
+
+	t.Run("matches Encode and round-trips", func(t *testing.T) {
+		for _, enc := range newEncoders() {
+			enc.Init(valueCount)
+
+			encoded, arena := enc.EncodeAppend(values, nil)
+			assert.Equal(t, len(arena), len(encoded), "%T: a single append fills the arena", enc)
+			assert.Equal(t, enc.Encode(values)[:len(encoded)], encoded, "%T: same bytes as Encode", enc)
+
+			decoded := append([]uint64(nil), enc.Decode(encoded)...)
+			assert.Equal(t, values, decoded, "%T: round-trip", enc)
+		}
+	})
+
+	t.Run("blocks coexist in one arena", func(t *testing.T) {
+		const blocks = 4
+		for _, enc := range newEncoders() {
+			enc.Init(valueCount)
+
+			// pre-size the arena so no append reallocates and invalidates an
+			// earlier sub-slice
+			arena := make([]byte, 0, blocks*(8+8*valueCount))
+			subs := make([][]byte, blocks)
+			want := make([][]uint64, blocks)
+			for b := 0; b < blocks; b++ {
+				block := make([]uint64, valueCount)
+				block[0] = uint64(b + 1)
+				for i := 1; i < valueCount; i++ {
+					block[i] = block[i-1] + uint64(b) + 1
+				}
+				want[b] = block
+				subs[b], arena = enc.EncodeAppend(block, arena)
+			}
+
+			for b := 0; b < blocks; b++ {
+				decoded := append([]uint64(nil), enc.Decode(subs[b])...)
+				assert.Equal(t, want[b], decoded, "%T: block %d survived later appends", enc, b)
+			}
+		}
+	})
+}
+
 func BenchmarkDeltaEncoders(b *testing.B) {
 	encs := []VarEncEncoder[uint64]{
 		&SimpleEncoder[uint64]{},

--- a/adapters/repos/db/lsmkv/varenc/variable_encoding_test.go
+++ b/adapters/repos/db/lsmkv/varenc/variable_encoding_test.go
@@ -177,9 +177,10 @@ func TestEncodeAppend(t *testing.T) {
 		for _, enc := range newEncoders() {
 			enc.Init(valueCount)
 
-			// pre-size the arena so no append reallocates and invalidates an
-			// earlier sub-slice
-			arena := make([]byte, 0, blocks*(8+8*valueCount))
+			// pre-size the arena past any encoder's worst case (a uint64 varint is
+			// at most 10 bytes/value) so no append reallocates and moves an
+			// earlier sub-slice off the shared backing array
+			arena := make([]byte, 0, blocks*(16+16*valueCount))
 			subs := make([][]byte, blocks)
 			want := make([][]uint64, blocks)
 			for b := 0; b < blocks; b++ {

--- a/adapters/repos/db/lsmkv/varenc/varint.go
+++ b/adapters/repos/db/lsmkv/varenc/varint.go
@@ -317,6 +317,13 @@ func (e *VarIntEncoder) Encode(values []uint64) []byte {
 	return output
 }
 
+func (e *VarIntEncoder) EncodeAppend(values []uint64, arena []byte) ([]byte, []byte) {
+	n := encodeReusable(values, e.buf, false)
+	start := len(arena)
+	arena = append(arena, e.buf[:n]...)
+	return arena[start:], arena
+}
+
 func (e *VarIntEncoder) Decode(data []byte) []uint64 {
 	decodeReusable(e.values, data, false)
 	return e.values
@@ -349,6 +356,13 @@ func (e *VarIntDeltaEncoder) Encode(values []uint64) []byte {
 	output := make([]byte, n)
 	copy(output, e.buf[:n])
 	return output
+}
+
+func (e *VarIntDeltaEncoder) EncodeAppend(values []uint64, arena []byte) ([]byte, []byte) {
+	n := encodeReusable(values, e.buf, true)
+	start := len(arena)
+	arena = append(arena, e.buf[:n]...)
+	return arena[start:], arena
 }
 
 func (e *VarIntDeltaEncoder) Decode(data []byte) []uint64 {


### PR DESCRIPTION
### What's being changed:

Adds `EncodeAppend` to the `varenc.VarEncEncoder` interface and its three implementations (`SimpleEncoder`, `VarIntEncoder`, `VarIntDeltaEncoder`).

`EncodeAppend(values, arena)` encodes into the encoder's internal buffer and appends the encoded bytes to a caller-owned `arena`, returning the encoded sub-slice and the grown arena. Unlike `Encode` (which returns the encoder's own buffer) it lets a caller pack several encoded blocks into **one contiguous allocation** instead of one allocation per block. The produced bytes are identical to `Encode`.

This is the first, self-contained step of porting the inverted-compaction allocation-reduction work from #11450 onto `stable/v1.37`. There is no production caller yet — the reusable compaction encode pipeline that consumes it lands in a follow-up PR — so this change only adds the primitive and its tests, with no behavior change to existing paths.

### Tests

`TestEncodeAppend` (over all three encoders):
- **matches Encode and round-trips** — a single `EncodeAppend` into a nil arena yields the same bytes as `Encode` and decodes back to the input.
- **blocks coexist in one arena** — four different blocks appended into one pre-sized arena each decode back correctly, proving the sub-slices don't clobber each other.

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
