### PR TITLE
perf(inverted): add EncodeInto for BlockEntry and BlockData

### DIFF
--- a/adapters/repos/db/inverted/terms/terms_block.go
+++ b/adapters/repos/db/inverted/terms/terms_block.go
@@ -35,11 +35,16 @@ func (b BlockEntry) Size() int {
 
 func (b *BlockEntry) Encode() []byte {
 	out := make([]byte, 20)
-	binary.LittleEndian.PutUint64(out, b.MaxId)
-	binary.LittleEndian.PutUint32(out[8:], b.Offset)
-	binary.LittleEndian.PutUint32(out[12:], b.MaxImpactTf)
-	binary.LittleEndian.PutUint32(out[16:], b.MaxImpactPropLength)
+	b.EncodeInto(out)
 	return out
+}
+
+// EncodeInto writes the BlockEntry into buf (must be >= 20 bytes), without allocating.
+func (b *BlockEntry) EncodeInto(buf []byte) {
+	binary.LittleEndian.PutUint64(buf, b.MaxId)
+	binary.LittleEndian.PutUint32(buf[8:], b.Offset)
+	binary.LittleEndian.PutUint32(buf[12:], b.MaxImpactTf)
+	binary.LittleEndian.PutUint32(buf[16:], b.MaxImpactPropLength)
 }
 
 func DecodeBlockEntry(data []byte) *BlockEntry {
@@ -73,17 +78,18 @@ func (b *BlockData) Size() int {
 }
 
 func (b *BlockData) Encode() []byte {
-	out := make([]byte, len(b.DocIds)+len(b.Tfs)+4)
-	offset := 0
-	// write the lengths of the slices
-	binary.LittleEndian.PutUint16(out[offset:], uint16(len(b.DocIds)))
-	offset += 2
-	binary.LittleEndian.PutUint16(out[offset:], uint16(len(b.Tfs)))
-	offset += 2
-
-	offset += copy(out[offset:], b.DocIds)
-	copy(out[offset:], b.Tfs)
+	out := make([]byte, b.Size())
+	b.EncodeInto(out)
 	return out
+}
+
+// EncodeInto writes the BlockData into buf (must be >= b.Size() bytes), without allocating.
+func (b *BlockData) EncodeInto(buf []byte) {
+	binary.LittleEndian.PutUint16(buf, uint16(len(b.DocIds)))
+	binary.LittleEndian.PutUint16(buf[2:], uint16(len(b.Tfs)))
+	offset := 4
+	offset += copy(buf[offset:], b.DocIds)
+	copy(buf[offset:], b.Tfs)
 }
 
 func DecodeBlockData(data []byte) *BlockData {

--- a/adapters/repos/db/inverted/terms/terms_block.go
+++ b/adapters/repos/db/inverted/terms/terms_block.go
@@ -34,12 +34,12 @@ func (b BlockEntry) Size() int {
 }
 
 func (b *BlockEntry) Encode() []byte {
-	out := make([]byte, 20)
+	out := make([]byte, b.Size())
 	b.EncodeInto(out)
 	return out
 }
 
-// EncodeInto writes the BlockEntry into buf (must be >= 20 bytes), without allocating.
+// EncodeInto writes the BlockEntry into buf (must be >= b.Size() bytes), without allocating.
 func (b *BlockEntry) EncodeInto(buf []byte) {
 	binary.LittleEndian.PutUint64(buf, b.MaxId)
 	binary.LittleEndian.PutUint32(buf[8:], b.Offset)

--- a/adapters/repos/db/inverted/terms/terms_block_test.go
+++ b/adapters/repos/db/inverted/terms/terms_block_test.go
@@ -33,13 +33,34 @@ func TestBlockEntryEncodeInto(t *testing.T) {
 		}
 	})
 
+	// pin the exact on-disk layout independently of Encode/Decode
+	t.Run("golden bytes", func(t *testing.T) {
+		e := BlockEntry{MaxId: 1, Offset: 2, MaxImpactTf: 3, MaxImpactPropLength: 4}
+		buf := make([]byte, e.Size())
+		e.EncodeInto(buf)
+		assert.Equal(t, []byte{
+			1, 0, 0, 0, 0, 0, 0, 0, // MaxId (uint64)
+			2, 0, 0, 0, // Offset (uint32)
+			3, 0, 0, 0, // MaxImpactTf (uint32)
+			4, 0, 0, 0, // MaxImpactPropLength (uint32)
+		}, buf)
+	})
+
 	t.Run("packs contiguously and round-trips", func(t *testing.T) {
-		buf := make([]byte, len(entries)*20)
+		total := 0
 		for i := range entries {
-			entries[i].EncodeInto(buf[i*20:])
+			total += entries[i].Size()
+		}
+		buf := make([]byte, total)
+		offsets := make([]int, len(entries))
+		off := 0
+		for i := range entries {
+			offsets[i] = off
+			entries[i].EncodeInto(buf[off:])
+			off += entries[i].Size()
 		}
 		for i := range entries {
-			got := DecodeBlockEntry(buf[i*20 : (i+1)*20])
+			got := DecodeBlockEntry(buf[offsets[i]:])
 			assert.Equal(t, entries[i], *got, "entry %d survived neighbouring writes", i)
 		}
 	})
@@ -58,6 +79,19 @@ func TestBlockDataEncodeInto(t *testing.T) {
 			datas[i].EncodeInto(buf)
 			assert.Equal(t, datas[i].Encode(), buf)
 		}
+	})
+
+	// pin the exact on-disk layout: two uint16 lengths then the raw slices
+	t.Run("golden bytes", func(t *testing.T) {
+		d := BlockData{DocIds: []byte{1, 2, 3}, Tfs: []byte{4, 5}}
+		buf := make([]byte, d.Size())
+		d.EncodeInto(buf)
+		assert.Equal(t, []byte{
+			3, 0, // len(DocIds) (uint16)
+			2, 0, // len(Tfs) (uint16)
+			1, 2, 3, // DocIds
+			4, 5, // Tfs
+		}, buf)
 	})
 
 	t.Run("packs contiguously and round-trips", func(t *testing.T) {

--- a/adapters/repos/db/inverted/terms/terms_block_test.go
+++ b/adapters/repos/db/inverted/terms/terms_block_test.go
@@ -1,0 +1,82 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package terms
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockEntryEncodeInto(t *testing.T) {
+	entries := []BlockEntry{
+		{MaxId: 0, Offset: 0, MaxImpactTf: 0, MaxImpactPropLength: 0},
+		{MaxId: 1, Offset: 2, MaxImpactTf: 3, MaxImpactPropLength: 4},
+		{MaxId: 1 << 40, Offset: 1 << 20, MaxImpactTf: 1<<31 + 7, MaxImpactPropLength: 9999},
+	}
+
+	t.Run("matches Encode", func(t *testing.T) {
+		for i := range entries {
+			buf := make([]byte, entries[i].Size())
+			entries[i].EncodeInto(buf)
+			assert.Equal(t, entries[i].Encode(), buf)
+		}
+	})
+
+	t.Run("packs contiguously and round-trips", func(t *testing.T) {
+		buf := make([]byte, len(entries)*20)
+		for i := range entries {
+			entries[i].EncodeInto(buf[i*20:])
+		}
+		for i := range entries {
+			got := DecodeBlockEntry(buf[i*20 : (i+1)*20])
+			assert.Equal(t, entries[i], *got, "entry %d survived neighbouring writes", i)
+		}
+	})
+}
+
+func TestBlockDataEncodeInto(t *testing.T) {
+	datas := []BlockData{
+		{DocIds: nil, Tfs: nil},
+		{DocIds: []byte{1, 2, 3}, Tfs: []byte{4, 5}},
+		{DocIds: []byte{9, 8, 7, 6, 5}, Tfs: []byte{1}},
+	}
+
+	t.Run("matches Encode", func(t *testing.T) {
+		for i := range datas {
+			buf := make([]byte, datas[i].Size())
+			datas[i].EncodeInto(buf)
+			assert.Equal(t, datas[i].Encode(), buf)
+		}
+	})
+
+	t.Run("packs contiguously and round-trips", func(t *testing.T) {
+		total := 0
+		for i := range datas {
+			total += datas[i].Size()
+		}
+		buf := make([]byte, total)
+		offsets := make([]int, len(datas))
+		off := 0
+		for i := range datas {
+			offsets[i] = off
+			datas[i].EncodeInto(buf[off:])
+			off += datas[i].Size()
+		}
+		for i := range datas {
+			got := DecodeBlockData(buf[offsets[i]:])
+			assert.True(t, bytes.Equal(datas[i].DocIds, got.DocIds), "data %d docids", i)
+			assert.True(t, bytes.Equal(datas[i].Tfs, got.Tfs), "data %d tfs", i)
+		}
+	})
+}


### PR DESCRIPTION
### What's being changed:

Adds `EncodeInto(buf []byte)` to `terms.BlockEntry` and `terms.BlockData`, and reworks `Encode()` to delegate to it.

`EncodeInto` writes the block into a caller-supplied buffer instead of allocating a fresh one, so a caller can pack every block for a key into one pre-sized arena rather than allocating per block. `Encode()` keeps its existing signature and produces the **exact same bytes** (it now just allocates and calls `EncodeInto`).

This is the encode-side counterpart to the reusable *decode* helpers already in the tree (`DecodeBlockEntryInto`, `DecodeBlockDataReusable`), and the second self-contained step of porting the inverted-compaction allocation work from #11450 onto `stable/v1.37`. No production caller uses `EncodeInto` yet — the reusable compaction pipeline that consumes it lands in a follow-up — so there is no behavior change to existing paths.

### Tests

`terms_block_test.go`:
- **matches Encode** — `EncodeInto` produces the same bytes as `Encode` for both types (incl. empty `BlockData`).
- **packs contiguously and round-trips** — several blocks written into one buffer at successive offsets each decode back correctly, proving neighbouring writes don't clobber.

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
