### PR TITLE
perf(lsmkv): pass data start offset to MarshalSortedKeys

### DIFF
--- a/adapters/repos/db/lsmkv/compactor_set.go
+++ b/adapters/repos/db/lsmkv/compactor_set.go
@@ -264,7 +264,7 @@ func (c *compactorSet) writeIndexes(f *segmentindex.SegmentFile,
 		return fmt.Errorf("unsupported secondary indexes in compactorSet")
 	}
 
-	_, err := segmentindex.MarshalSortedKeys(f.BodyWriter(), keys)
+	_, err := segmentindex.MarshalSortedKeys(f.BodyWriter(), keys, segmentindex.HeaderSize)
 	return err
 }
 

--- a/adapters/repos/db/lsmkv/compactor_set.go
+++ b/adapters/repos/db/lsmkv/compactor_set.go
@@ -264,7 +264,7 @@ func (c *compactorSet) writeIndexes(f *segmentindex.SegmentFile,
 		return fmt.Errorf("unsupported secondary indexes in compactorSet")
 	}
 
-	_, err := segmentindex.MarshalSortedKeys(f.BodyWriter(), keys, segmentindex.HeaderSize)
+	_, err := segmentindex.MarshalSortedKeys(f.BodyWriter(), keys, uint64(segmentindex.HeaderSize))
 	return err
 }
 

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -341,9 +341,11 @@ func (t *Tree) Size() int {
 
 // MarshalSortedKeys serializes a balanced BST index directly from sorted
 // KeyRedux entries, without constructing intermediate Tree or Node structures.
-// Keys must be in sorted order. Each key's ValueEnd is the absolute byte
-// offset where that key's data ends in the segment file.
-func MarshalSortedKeys(w io.Writer, keys []KeyRedux) (int64, error) {
+// Keys must be in sorted order. Each key's ValueEnd is the absolute byte offset
+// where that key's data ends in the segment file. dataStartOffset is where the
+// first key's data begins — HeaderSize for most strategies, larger for inverted
+// segments with an extended header.
+func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (int64, error) {
 	n := len(keys)
 	if n == 0 {
 		return 0, nil
@@ -387,7 +389,7 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux) (int64, error) {
 		// Derive Start from the previous key's ValueEnd.
 		var start uint64
 		if si == 0 {
-			start = uint64(HeaderSize)
+			start = dataStartOffset
 		} else {
 			start = uint64(keys[si-1].ValueEnd)
 		}

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -351,6 +351,13 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (in
 		return 0, nil
 	}
 
+	// The first key's data spans [dataStartOffset, keys[0].ValueEnd]; a start past
+	// the end would silently serialize a corrupt node, so reject it explicitly.
+	if dataStartOffset > uint64(keys[0].ValueEnd) {
+		return 0, fmt.Errorf("dataStartOffset %d exceeds first key's ValueEnd %d",
+			dataStartOffset, keys[0].ValueEnd)
+	}
+
 	capacity := balancedTreeCapacity(n)
 
 	// Build BFS-position → sorted-index mapping.

--- a/adapters/repos/db/lsmkv/segmentindex/tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree_test.go
@@ -301,3 +301,48 @@ func TestMarshalSortedKeysFromKeys(t *testing.T) {
 		assert.ElementsMatch(t, expected, keys)
 	})
 }
+
+// MarshalSortedKeys must place the first key's data at the caller-provided
+// dataStartOffset (not a hard-coded HeaderSize), while later keys chain from the
+// previous key's ValueEnd. This is what lets inverted segments, whose data
+// begins after an extended header, use the direct KeyRedux marshaller.
+func TestMarshalSortedKeysDataStartOffset(t *testing.T) {
+	keys := []KeyRedux{
+		{Key: []byte("aaa"), ValueEnd: 40},
+		{Key: []byte("bbb"), ValueEnd: 55},
+		{Key: []byte("ccc"), ValueEnd: 70},
+	}
+	const dataStart = 27 // not HeaderSize — e.g. an inverted extended header
+
+	var buf bytes.Buffer
+	_, err := MarshalSortedKeys(&buf, keys, dataStart)
+	require.NoError(t, err)
+
+	dTree := NewDiskTree(buf.Bytes())
+
+	// first key starts at the provided offset, ends at its ValueEnd
+	n, err := dTree.Get([]byte("aaa"))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(dataStart), n.Start)
+	assert.Equal(t, uint64(40), n.End)
+
+	// later keys chain from the previous ValueEnd
+	n, err = dTree.Get([]byte("bbb"))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(40), n.Start)
+	assert.Equal(t, uint64(55), n.End)
+
+	n, err = dTree.Get([]byte("ccc"))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(55), n.Start)
+	assert.Equal(t, uint64(70), n.End)
+}
+
+// A dataStartOffset past the first key's ValueEnd would serialize start > end;
+// MarshalSortedKeys must reject it rather than emit a corrupt index.
+func TestMarshalSortedKeysRejectsOffsetPastFirstValueEnd(t *testing.T) {
+	keys := []KeyRedux{{Key: []byte("aaa"), ValueEnd: 10}}
+	var buf bytes.Buffer
+	_, err := MarshalSortedKeys(&buf, keys, 20)
+	require.Error(t, err)
+}


### PR DESCRIPTION
### What's being changed:

`segmentindex.MarshalSortedKeys` hard-coded the first key's data start at `HeaderSize` (16 bytes). Inverted segments place an extended header (`HeaderInverted` + data-field bytes) between the standard 16-byte header and the first key's data, so that assumption doesn't hold for them.

This takes `dataStartOffset uint64` as a parameter instead. The one existing caller — `compactorSet` — passes `segmentindex.HeaderSize`, so **its output is byte-for-byte unchanged**. The change lets the inverted compactor use this direct `KeyRedux` marshaller (instead of the scratch-space `Indexes.WriteTo` path) once it's wired up in a follow-up.

Third self-contained step of porting the inverted-compaction allocation work from #11450 onto `stable/v1.37`. Behavior-preserving for every current strategy.

### Tests

Covered by the existing `segmentindex` tree/index tests and the set/collection compaction integration tests (both pass unchanged) — the set compactor is the sole current caller and its serialized index is identical.

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
