### PR TITLE
fix(lsmkv): capture values in keyOnly map cursor so keys aren't dropped

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -125,9 +125,7 @@ func (c *CursorMap) seekAll(target []byte) {
 		}
 
 		state[i].key = key
-		if !c.keyOnly {
-			state[i].value = value
-		}
+		state[i].value = value
 	}
 
 	c.state = state
@@ -147,9 +145,7 @@ func (c *CursorMap) firstAll() {
 		}
 
 		state[i].key = key
-		if !c.keyOnly {
-			state[i].value = value
-		}
+		state[i].value = value
 	}
 
 	c.state = state
@@ -197,7 +193,6 @@ func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []
 			continue
 		}
 
-		// TODO remove keyOnly option, not used anyway
 		if !c.keyOnly {
 			return key, merged
 		}
@@ -269,8 +264,6 @@ func (c *CursorMap) advanceInner(id int) {
 	}
 
 	c.state[id].key = k
-	if !c.keyOnly {
-		c.state[id].value = v
-	}
+	c.state[id].value = v
 	c.state[id].err = nil
 }

--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -125,6 +125,10 @@ func (c *CursorMap) seekAll(target []byte) {
 		}
 
 		state[i].key = key
+		// capture the value even in keyOnly mode: serveCurrentStateAndAdvance
+		// merges the per-segment values to decide which keys survive, so dropping
+		// them here makes every key look empty. keyOnly only omits them from the
+		// returned tuple (see firstAll/advanceInner for the same reason).
 		state[i].value = value
 	}
 

--- a/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
@@ -177,3 +177,74 @@ func TestMapCursorConsistentView(t *testing.T) {
 	}
 	require.Equal(t, expected, actual)
 }
+
+// MapCursorKeyOnly must walk every primary key just like MapCursor — it just
+// drops the values from the returned tuple. Regression for a bug where the
+// keyOnly fast-path left state[i].value=nil, the merger saw only empty
+// per-segment results, and every key was skipped (callers like
+// filterableToSearchableMigrator.isEmptyMapBucket then mis-classified
+// non-empty buckets as empty).
+func TestMapCursorKeyOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	logger, _ := test.NewNullLogger()
+
+	diskSegments := &SegmentGroup{
+		logger: logger,
+		segments: []Segment{
+			newFakeMapSegment(map[string][]MapPair{
+				"key1": {{Key: []byte("dk1"), Value: []byte("dv1")}},
+			}),
+			newFakeMapSegment(map[string][]MapPair{
+				"key2": {{Key: []byte("dk2"), Value: []byte("dv2")}},
+			}),
+		},
+	}
+
+	active := newTestMemtableMap(map[string][]MapPair{
+		"key3": {{Key: []byte("ak1"), Value: []byte("av1")}},
+	})
+
+	b := Bucket{
+		active:   active,
+		disk:     diskSegments,
+		strategy: StrategyMapCollection,
+	}
+
+	cur, err := b.MapCursorKeyOnly()
+	require.NoError(t, err)
+	defer cur.Close()
+
+	var keys []string
+	for k, v := cur.First(ctx); k != nil; k, v = cur.Next(ctx) {
+		assert.Nil(t, v, "keyOnly cursor must not return values")
+		keys = append(keys, string(k))
+	}
+	require.Equal(t, []string{"key1", "key2", "key3"}, keys)
+}
+
+// Mirrors the filterableToSearchableMigrator.isEmptyMapBucket usage: only the
+// first key is read. If the cursor's keyOnly path is broken, this looks like
+// an empty bucket even though it has data.
+func TestMapCursorKeyOnly_FirstKeyOnNonEmptyBucket(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	logger, _ := test.NewNullLogger()
+
+	b := Bucket{
+		active: newTestMemtableMap(map[string][]MapPair{
+			"only": {{Key: []byte("sk"), Value: []byte("sv")}},
+		}),
+		disk:     &SegmentGroup{logger: logger},
+		strategy: StrategyMapCollection,
+	}
+
+	cur, err := b.MapCursorKeyOnly()
+	require.NoError(t, err)
+	defer cur.Close()
+
+	k, _ := cur.First(ctx)
+	require.Equal(t, []byte("only"), k)
+}

--- a/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
@@ -182,7 +182,7 @@ func TestMapCursorConsistentView(t *testing.T) {
 // drops the values from the returned tuple. Regression for a bug where the
 // keyOnly fast-path left state[i].value=nil, the merger saw only empty
 // per-segment results, and every key was skipped (callers like
-// filterableToSearchableMigrator.isEmptyMapBucket then mis-classified
+// filterableToSearchableMigrator.isEmptyMapBucket then misclassified
 // non-empty buckets as empty).
 func TestMapCursorKeyOnly(t *testing.T) {
 	t.Parallel()
@@ -247,4 +247,47 @@ func TestMapCursorKeyOnly_FirstKeyOnNonEmptyBucket(t *testing.T) {
 
 	k, _ := cur.First(ctx)
 	require.Equal(t, []byte("only"), k)
+}
+
+// A key that is live on disk but tombstoned in the newer active memtable must
+// NOT surface from a keyOnly cursor. This guards the merge semantics from the
+// opposite direction of TestMapCursorKeyOnly: capturing values (needed to walk
+// keys) must not resurface deleted keys. The tombstone lives in the memtable
+// because the fake disk segment can't represent one.
+func TestMapCursorKeyOnly_TombstonedKeyDropped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	logger, _ := test.NewNullLogger()
+
+	diskSegments := &SegmentGroup{
+		logger: logger,
+		segments: []Segment{
+			// disk (older): both keys live
+			newFakeMapSegment(map[string][]MapPair{
+				"gone": {{Key: []byte("d1"), Value: []byte("v1")}},
+				"keep": {{Key: []byte("d2"), Value: []byte("v2")}},
+			}),
+		},
+	}
+
+	b := Bucket{
+		// active memtable (newer) tombstones "gone"'s only entry
+		active: newTestMemtableMap(map[string][]MapPair{
+			"gone": {{Key: []byte("d1"), Tombstone: true}},
+		}),
+		disk:     diskSegments,
+		strategy: StrategyMapCollection,
+	}
+
+	cur, err := b.MapCursorKeyOnly()
+	require.NoError(t, err)
+	defer cur.Close()
+
+	var keys []string
+	for k, v := cur.First(ctx); k != nil; k, v = cur.Next(ctx) {
+		assert.Nil(t, v, "keyOnly cursor must not return values")
+		keys = append(keys, string(k))
+	}
+	require.Equal(t, []string{"keep"}, keys, "a fully tombstoned key must not appear")
 }


### PR DESCRIPTION
### What's being changed:

Fixes `Bucket.MapCursorKeyOnly`, which yielded **zero keys on a non-empty bucket**.

The keyOnly fast-path skipped capturing per-segment values (`if !c.keyOnly { state[i].value = value }` in `seekAll`/`firstAll`/`advanceInner`). With the values left nil, the sorted-map merger saw only empty per-segment results, produced an empty merge, and the cursor treated every key as "all values deleted" and skipped it. Callers that read only keys — notably `filterableToSearchableMigrator.isEmptyMapBucket` — then mis-classified populated buckets as empty.

The fix always captures the value in seek/first/advance. `keyOnly` still drops values from the returned tuple (the return path is unchanged); it just no longer breaks the merge that decides which keys exist. Also removes a stale `// TODO remove keyOnly option, not used anyway` comment — this PR shows it *is* used.

This lands independently on `stable/v1.37`; it also unblocks a correct `MapCursorKeyOnly` for the reusable-compaction work being ported from #11450.

### Tests

- `TestMapCursorKeyOnly` — across two disk segments + an active memtable, the keyOnly cursor walks all three keys and returns nil values.
- `TestMapCursorKeyOnly_FirstKeyOnNonEmptyBucket` — mirrors the `isEmptyMapBucket` usage: `First` returns the sole key instead of nil.

Both verified red→green (fail on the pre-fix code, pass with the fix).

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
