### PR TITLE
perf(lsmkv): add reusable decode helpers for inverted node data

### DIFF
--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -359,6 +359,8 @@ func convertFromBlocksReusable(blockEntries []*terms.BlockEntry, encodedBlocks [
 	neededArena := int(objectCount) * 16
 	if cap(kvArena) < neededArena {
 		kvArena = make([]byte, neededArena)
+	} else {
+		kvArena = kvArena[:neededArena] // reslice so len tracks content, like out above
 	}
 	arenaOff := 0
 
@@ -403,6 +405,8 @@ func decodeAndConvertFromBlocksReusable(data []byte, mapPairBuf []MapPair, kvAre
 		neededArena := int(collectionSize) * 16
 		if cap(kvArena) < neededArena {
 			kvArena = make([]byte, neededArena)
+		} else {
+			kvArena = kvArena[:neededArena] // reslice so len tracks content, like mapPairBuf below
 		}
 		if cap(mapPairBuf) < int(collectionSize) {
 			mapPairBuf = make([]MapPair, 0, collectionSize)

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -345,6 +345,93 @@ func convertFromBlocks(blockEntries []*terms.BlockEntry, encodedBlocks []*terms.
 	return out
 }
 
+// convertFromBlocksReusable is convertFromBlocks with the output MapPair slice
+// and the key/value arena passed in and grown as needed, so a caller decoding
+// many nodes reuses one allocation instead of a make([]byte, 8) per docID.
+// Returns the (possibly regrown) slices for the caller to store back.
+func convertFromBlocksReusable(blockEntries []*terms.BlockEntry, encodedBlocks []*terms.BlockData, objectCount uint64, out []MapPair, kvArena []byte, deltaEnc, tfEnc varenc.VarEncEncoder[uint64]) ([]MapPair, []byte) {
+	if cap(out) < int(objectCount) {
+		out = make([]MapPair, 0, objectCount)
+	} else {
+		out = out[:0]
+	}
+
+	neededArena := int(objectCount) * 16
+	if cap(kvArena) < neededArena {
+		kvArena = make([]byte, neededArena)
+	}
+	arenaOff := 0
+
+	for i := range blockEntries {
+		blockSize := uint64(terms.BLOCK_SIZE)
+		if i == len(blockEntries)-1 {
+			blockSize = objectCount - uint64(terms.BLOCK_SIZE)*uint64(i)
+		}
+		blockSizeInt := int(blockSize)
+
+		docIds, tfs := packedDecode(encodedBlocks[i], blockSizeInt, deltaEnc, tfEnc)
+
+		for j := 0; j < blockSizeInt; j++ {
+			key := kvArena[arenaOff : arenaOff+8]
+			binary.BigEndian.PutUint64(key, docIds[j])
+			arenaOff += 8
+
+			value := kvArena[arenaOff : arenaOff+8]
+			// PutUint64 (not PutUint32) writes the TF into value[0:4] and zeroes
+			// value[4:8] — the propLength slot, which a plain copy would leave as
+			// stale bytes from a prior node in the reused arena.
+			binary.LittleEndian.PutUint64(value, uint64(math.Float32bits(float32(tfs[j]))))
+			arenaOff += 8
+
+			out = append(out, MapPair{
+				Key:   key,
+				Value: value,
+			})
+		}
+	}
+	return out, kvArena
+}
+
+// decodeAndConvertFromBlocksReusable is decodeAndConvertFromBlocks with the
+// output slice and arena passed in and grown as needed. It returns the updated
+// mapPairBuf and kvArena for the caller to store back, plus the byte offset
+// where the node's data ends.
+func decodeAndConvertFromBlocksReusable(data []byte, mapPairBuf []MapPair, kvArena []byte, deltaEnc, tfEnc varenc.VarEncEncoder[uint64]) ([]MapPair, []byte, int) {
+	collectionSize := binary.LittleEndian.Uint64(data)
+
+	if collectionSize <= uint64(terms.ENCODE_AS_FULL_BYTES) {
+		neededArena := int(collectionSize) * 16
+		if cap(kvArena) < neededArena {
+			kvArena = make([]byte, neededArena)
+		}
+		if cap(mapPairBuf) < int(collectionSize) {
+			mapPairBuf = make([]MapPair, 0, collectionSize)
+		} else {
+			mapPairBuf = mapPairBuf[:0]
+		}
+		arenaOff := 0
+		offset := 8
+		for i := 0; i < int(collectionSize*16); i += 16 {
+			key := kvArena[arenaOff : arenaOff+8]
+			copy(key, data[offset:offset+8])
+			arenaOff += 8
+			value := kvArena[arenaOff : arenaOff+8]
+			copy(value, data[offset+8:offset+12])
+			binary.LittleEndian.PutUint32(value[4:], 0) // zero the reused propLength slot
+			arenaOff += 8
+			mapPairBuf = append(mapPairBuf, MapPair{
+				Key:   key,
+				Value: value,
+			})
+			offset += 16
+		}
+		return mapPairBuf, kvArena, offset
+	}
+	blockEntries, blockDatas, offset := decodeBlocks(data)
+	mapPairBuf, kvArena = convertFromBlocksReusable(blockEntries, blockDatas, collectionSize, mapPairBuf, kvArena, deltaEnc, tfEnc)
+	return mapPairBuf, kvArena, offset
+}
+
 func convertFixedLengthFromMemory(data []byte, blockSize int) *terms.BlockDataDecoded {
 	out := &terms.BlockDataDecoded{
 		DocIds: make([]uint64, blockSize),

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted_reusable_test.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted_reusable_test.go
@@ -1,0 +1,86 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
+)
+
+func encodeInvertedNode(t *testing.T, count, base int) []byte {
+	t.Helper()
+	nodes := make([]MapPair, count)
+	for i := 0; i < count; i++ {
+		nodes[i] = NewMapPairFromDocIdAndTf(uint64(base+i*3+1), float32(i%7+1), 1, false)
+	}
+	data, _ := createAndEncodeBlocksWithLengths(nodes,
+		&varenc.VarIntDeltaEncoder{}, &varenc.VarIntEncoder{}, 1.2, 0.75, 1.0)
+	return data
+}
+
+func copyMapPairs(in []MapPair) []MapPair {
+	out := make([]MapPair, len(in))
+	for i, mp := range in {
+		out[i] = MapPair{
+			Key:       append([]byte(nil), mp.Key...),
+			Value:     append([]byte(nil), mp.Value...),
+			Tombstone: mp.Tombstone,
+		}
+	}
+	return out
+}
+
+// decodeAndConvertFromBlocksReusable must decode byte-for-byte identically to
+// the allocating decodeAndConvertFromBlocks, across the full-bytes path
+// (count <= ENCODE_AS_FULL_BYTES), a single block, and multiple blocks.
+func TestDecodeAndConvertFromBlocksReusable(t *testing.T) {
+	// ENCODE_AS_FULL_BYTES=1, BLOCK_SIZE=128
+	for _, count := range []int{1, 5, 200} {
+		t.Run(fmt.Sprintf("count=%d", count), func(t *testing.T) {
+			data := encodeInvertedNode(t, count, 0)
+
+			want, wantOff := decodeAndConvertFromBlocks(data)
+
+			got, _, gotOff := decodeAndConvertFromBlocksReusable(data, nil, nil,
+				&varenc.VarIntDeltaEncoder{}, &varenc.VarIntEncoder{})
+
+			assert.Equal(t, wantOff, gotOff, "data-end offset")
+			assert.Equal(t, want, got, "decoded MapPairs")
+		})
+	}
+}
+
+// Decoding a second node into the same buffers must produce the right result
+// and must not corrupt the first node's data once the caller has copied it out.
+func TestDecodeAndConvertFromBlocksReusable_BufferReuse(t *testing.T) {
+	dataA := encodeInvertedNode(t, 200, 0)     // multi-block
+	dataB := encodeInvertedNode(t, 50, 100000) // smaller, fits A's buffers
+
+	wantA, _ := decodeAndConvertFromBlocks(dataA)
+	wantB, _ := decodeAndConvertFromBlocks(dataB)
+
+	delta := &varenc.VarIntDeltaEncoder{}
+	tf := &varenc.VarIntEncoder{}
+
+	gotA, arena, _ := decodeAndConvertFromBlocksReusable(dataA, nil, nil, delta, tf)
+	copyA := copyMapPairs(gotA) // caller consumes/copies before reusing
+
+	gotB, _, _ := decodeAndConvertFromBlocksReusable(dataB, gotA, arena, delta, tf)
+	copyB := copyMapPairs(gotB)
+
+	require.Equal(t, wantA, copyA, "first node intact after copy-out")
+	require.Equal(t, wantB, copyB, "second node correct after buffer reuse")
+}

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted_reusable_test.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted_reusable_test.go
@@ -84,3 +84,19 @@ func TestDecodeAndConvertFromBlocksReusable_BufferReuse(t *testing.T) {
 	require.Equal(t, wantA, copyA, "first node intact after copy-out")
 	require.Equal(t, wantB, copyB, "second node correct after buffer reuse")
 }
+
+// A caller may pass a pre-sized but zero-length buffer, e.g. make([]byte, 0, N);
+// the reusable decoders must reslice it rather than index past len. Covers both
+// the full-bytes and multi-block arena paths.
+func TestReusableDecodeAcceptsZeroLenPresizedBuffers(t *testing.T) {
+	for _, count := range []int{1, 200} { // full-bytes path, then multi-block path
+		t.Run(fmt.Sprintf("count=%d", count), func(t *testing.T) {
+			data := encodeInvertedNode(t, count, 0)
+			want, _ := decodeAndConvertFromBlocks(data)
+			got, _, _ := decodeAndConvertFromBlocksReusable(data,
+				make([]MapPair, 0, count), make([]byte, 0, count*16),
+				&varenc.VarIntDeltaEncoder{}, &varenc.VarIntEncoder{})
+			assert.Equal(t, want, got)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Adds two read-side helpers to `segment_serialization_inverted.go`:

- `convertFromBlocksReusable` — like `convertFromBlocks`, but the output `[]MapPair` and the key/value arena are passed in and grown as needed.
- `decodeAndConvertFromBlocksReusable` — like `decodeAndConvertFromBlocks`, but reuses those buffers and returns them for the caller to store back.

Instead of a fresh `MapPair` and `make([]byte, 8)` per docID, a caller decoding many inverted nodes reuses one allocation across iterations. Output is **byte-for-byte identical** to the allocating versions (the `PutUint64`/explicit-zero on the value handles the reused-arena stale-bytes case that a fresh `make` gets for free).

First of the read-path steps of porting the inverted-compaction allocation work from #11450 onto `stable/v1.37`. No production caller yet — the reusable inverted cursor that consumes these lands in a follow-up — so no behavior change to existing paths.

### Tests

`segment_serialization_inverted_reusable_test.go`:
- **equivalence** — for the full-bytes path (count ≤ `ENCODE_AS_FULL_BYTES`), a single block, and multiple blocks, the reusable decoder returns MapPairs and a data-end offset identical to `decodeAndConvertFromBlocks`.
- **buffer reuse** — decoding a second node into the first node's buffers is correct and doesn't corrupt the first node once it's been copied out (the documented contract).

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
