### PR TITLE
perf(db): skip cross-ref resolution when no ref properties are selected

### DIFF
--- a/adapters/repos/db/crud.go
+++ b/adapters/repos/db/crud.go
@@ -225,6 +225,11 @@ func (db *DB) Object(ctx context.Context, class string, id strfmt.UUID,
 func (db *DB) enrichRefsForSingle(ctx context.Context, obj *search.Result,
 	props search.SelectProperties, additional additional.Properties, tenant string,
 ) (*search.Result, error) {
+	if !props.HasRefs() {
+		// No ref select-properties: nothing for the resolver to do.
+		return obj, nil
+	}
+
 	res, err := refcache.NewResolver(refcache.NewCacher(db, db.logger, tenant)).
 		Do(ctx, []search.Result{*obj}, props, additional)
 	if err != nil {

--- a/adapters/repos/db/refcache/cacher.go
+++ b/adapters/repos/db/refcache/cacher.go
@@ -25,6 +25,13 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 )
 
+// Log-action values asserted by tests (adapters/repos/db/resolve_references_skip_test.go)
+// to detect whether the cacher ran; do not change the string values.
+const (
+	ActionDedupJoblistStart = "request_cacher_dedup_joblist_start"
+	ActionFetchJobsSkip     = "request_cacher_fetch_jobs_skip"
+)
+
 type repo interface {
 	MultiGet(ctx context.Context, query []multi.Identifier,
 		additional additional.Properties, tenant string) ([]search.Result, error)
@@ -284,7 +291,7 @@ func (c *Cacher) dedupJobList() {
 
 	c.logger.
 		WithFields(logrus.Fields{
-			"action": "request_cacher_dedup_joblist_start",
+			"action": ActionDedupJoblistStart,
 			"jobs":   before,
 		}).
 		Debug("starting job list deduplication")
@@ -338,7 +345,7 @@ func (c *Cacher) logSkipFetchJobs() {
 	c.logger.
 		WithFields(
 			logrus.Fields{
-				"action": "request_cacher_fetch_jobs_skip",
+				"action": ActionFetchJobsSkip,
 			}).
 		Trace("skip fetch jobs, have no incomplete jobs")
 }

--- a/adapters/repos/db/resolve_references_skip_test.go
+++ b/adapters/repos/db/resolve_references_skip_test.go
@@ -159,12 +159,10 @@ func TestResolveReferencesSkipsWithoutRefSelectProps(t *testing.T) {
 				refLessResults(), tt.props, tt.groupBy, additional.Properties{}, "")
 			require.NoError(t, err)
 
-			// no cacher log activity: early exit must skip construction entirely
 			assert.Equal(t, 0, countLogAction(hook, actionFetchSkip),
 				"cacher ran despite ref-less select props")
 			assert.Equal(t, 0, countLogAction(hook, actionDedupStart))
 
-			// baseline: full resolver path, for comparison against gated above
 			var ungated search.Results
 			if tt.groupBy != nil {
 				ungated, err = refcache.NewResolverWithGroup(

--- a/adapters/repos/db/resolve_references_skip_test.go
+++ b/adapters/repos/db/resolve_references_skip_test.go
@@ -1,0 +1,261 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/refcache"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/entities/searchparams"
+)
+
+const (
+	// logged only when the resolver machinery actually ran
+	actionDedupStart = "request_cacher_dedup_joblist_start"
+	// logged when Build ran but found no jobs; never fires if skipped entirely
+	actionFetchSkip = "request_cacher_fetch_jobs_skip"
+)
+
+// refLessResults returns a fresh copy each call, so tests can compare two
+// independent runs without shared mutation.
+func refLessResults() search.Results {
+	return search.Results{
+		{
+			ID:        "91b1a2ce-0000-0000-0000-000000000001",
+			ClassName: "Book",
+			Schema: map[string]interface{}{
+				"title": "some title",
+				"pages": float64(342),
+				"meta": map[string]interface{}{
+					"isbn": "978-3-16-148410-0",
+				},
+				// ref data present but never selected in these tests
+				"ofAuthor": models.MultipleRef{
+					&models.SingleRef{Beacon: "weaviate://localhost/Author/91b1a2ce-0000-0000-0000-000000000002"},
+				},
+			},
+		},
+		{
+			ID:        "91b1a2ce-0000-0000-0000-000000000003",
+			ClassName: "Book",
+			Schema: map[string]interface{}{
+				"title": "another title",
+			},
+		},
+	}
+}
+
+func groupedResults(hitProps map[string]interface{}) search.Results {
+	res := refLessResults()
+	res[0].AdditionalProperties = models.AdditionalProperties{
+		"group": &additional.Group{
+			Hits: []map[string]interface{}{hitProps},
+		},
+	}
+	return res
+}
+
+func refSelectProps() search.SelectProperties {
+	return search.SelectProperties{
+		{Name: "title", IsPrimitive: true},
+		{
+			Name: "ofAuthor",
+			Refs: []search.SelectClass{
+				{
+					ClassName: "Author",
+					RefProperties: search.SelectProperties{
+						{Name: "name", IsPrimitive: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTestDBWithHook() (*DB, *test.Hook) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+	return &DB{logger: logger}, hook
+}
+
+func countLogAction(hook *test.Hook, action string) int {
+	count := 0
+	for _, entry := range hook.AllEntries() {
+		if entry.Data["action"] == action {
+			count++
+		}
+	}
+	return count
+}
+
+func TestResolveReferencesSkipsWithoutRefSelectProps(t *testing.T) {
+	tests := []struct {
+		name    string
+		props   search.SelectProperties
+		groupBy *searchparams.GroupBy
+	}{
+		{
+			name:  "nil select props",
+			props: nil,
+		},
+		{
+			name: "primitive select props only",
+			props: search.SelectProperties{
+				{Name: "title", IsPrimitive: true},
+				{Name: "pages", IsPrimitive: true},
+			},
+		},
+		{
+			name: "nested object select props without refs",
+			props: search.SelectProperties{
+				{Name: "meta", IsObject: true, Props: search.SelectProperties{
+					{Name: "isbn", IsPrimitive: true},
+				}},
+			},
+		},
+		{
+			name: "ref-shaped prop selected without target classes",
+			props: search.SelectProperties{
+				{Name: "ofAuthor"},
+			},
+		},
+		{
+			name: "groupBy without refs anywhere",
+			props: search.SelectProperties{
+				{Name: "title", IsPrimitive: true},
+			},
+			groupBy: &searchparams.GroupBy{
+				Property: "title",
+				Properties: search.SelectProperties{
+					{Name: "title", IsPrimitive: true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, hook := newTestDBWithHook()
+
+			gated, err := db.ResolveReferences(context.Background(),
+				refLessResults(), tt.props, tt.groupBy, additional.Properties{}, "")
+			require.NoError(t, err)
+
+			// no cacher log activity: early exit must skip construction entirely
+			assert.Equal(t, 0, countLogAction(hook, actionFetchSkip),
+				"cacher ran despite ref-less select props")
+			assert.Equal(t, 0, countLogAction(hook, actionDedupStart))
+
+			// baseline: full resolver path, for comparison against gated above
+			var ungated search.Results
+			if tt.groupBy != nil {
+				ungated, err = refcache.NewResolverWithGroup(
+					refcache.NewCacher(db, db.logger, ""), tt.groupBy.Properties).
+					Do(context.Background(), refLessResults(), tt.props, additional.Properties{})
+			} else {
+				ungated, err = refcache.NewResolver(refcache.NewCacher(db, db.logger, "")).
+					Do(context.Background(), refLessResults(), tt.props, additional.Properties{})
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, ungated, gated,
+				"early-exited result differs from full resolver result")
+			assert.Equal(t, refLessResults(), gated,
+				"ref-less resolution must not alter the input")
+
+			// guard: fail loudly if the full path itself never ran
+			assert.Equal(t, 1, countLogAction(hook, actionFetchSkip))
+		})
+	}
+}
+
+func TestResolveReferencesRunsWithRefSelectProps(t *testing.T) {
+	db, hook := newTestDBWithHook()
+
+	res, err := db.ResolveReferences(context.Background(),
+		refLessResults(), refSelectProps(), nil, additional.Properties{}, "")
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	assert.Equal(t, 1, countLogAction(hook, actionDedupStart),
+		"resolver machinery did not run despite ref select props")
+}
+
+func TestResolveReferencesRunsWithGroupByRefProps(t *testing.T) {
+	db, hook := newTestDBWithHook()
+
+	// refs live only in groupBy properties, not top-level select props
+	props := search.SelectProperties{{Name: "title", IsPrimitive: true}}
+	groupBy := &searchparams.GroupBy{
+		Property:   "title",
+		Properties: refSelectProps(),
+	}
+	objs := groupedResults(map[string]interface{}{
+		"ofAuthor": models.MultipleRef{
+			&models.SingleRef{Beacon: "weaviate://localhost/Author/91b1a2ce-0000-0000-0000-000000000004"},
+		},
+	})
+
+	res, err := db.ResolveReferences(context.Background(),
+		objs, props, groupBy, additional.Properties{}, "")
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	assert.Equal(t, 1, countLogAction(hook, actionDedupStart),
+		"resolver machinery did not run despite refs in groupBy props")
+}
+
+func TestEnrichRefsForSingleSkipsWithoutRefSelectProps(t *testing.T) {
+	db, hook := newTestDBWithHook()
+
+	obj := refLessResults()[0]
+	props := search.SelectProperties{{Name: "title", IsPrimitive: true}}
+
+	gated, err := db.enrichRefsForSingle(context.Background(), &obj, props,
+		additional.Properties{}, "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, countLogAction(hook, actionFetchSkip),
+		"cacher ran despite ref-less select props")
+
+	ungatedIn := refLessResults()[0]
+	ungated, err := refcache.NewResolver(refcache.NewCacher(db, db.logger, "")).
+		Do(context.Background(), []search.Result{ungatedIn}, props, additional.Properties{})
+	require.NoError(t, err)
+
+	assert.Equal(t, ungated[0], *gated,
+		"early-exited result differs from full resolver result")
+	assert.Equal(t, refLessResults()[0], *gated,
+		"ref-less resolution must not alter the input")
+	assert.Equal(t, 1, countLogAction(hook, actionFetchSkip))
+}
+
+func TestEnrichRefsForSingleRunsWithRefSelectProps(t *testing.T) {
+	db, hook := newTestDBWithHook()
+
+	obj := refLessResults()[0]
+	res, err := db.enrichRefsForSingle(context.Background(), &obj,
+		refSelectProps(), additional.Properties{}, "")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.Equal(t, 1, countLogAction(hook, actionDedupStart),
+		"resolver machinery did not run despite ref select props")
+}

--- a/adapters/repos/db/resolve_references_skip_test.go
+++ b/adapters/repos/db/resolve_references_skip_test.go
@@ -29,9 +29,9 @@ import (
 
 const (
 	// logged only when the resolver machinery actually ran
-	actionDedupStart = "request_cacher_dedup_joblist_start"
+	actionDedupStart = refcache.ActionDedupJoblistStart
 	// logged when Build ran but found no jobs; never fires if skipped entirely
-	actionFetchSkip = "request_cacher_fetch_jobs_skip"
+	actionFetchSkip = refcache.ActionFetchJobsSkip
 )
 
 // refLessResults returns a fresh copy each call, so tests can compare two

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -442,6 +442,11 @@ func (db *DB) ResolveReferences(ctx context.Context, objs search.Results,
 		return objs, nil
 	}
 
+	if !props.HasRefs() && (groupBy == nil || !groupBy.Properties.HasRefs()) {
+		// No ref select-properties anywhere: nothing for the resolver to do.
+		return objs, nil
+	}
+
 	if groupBy != nil {
 		res, err := refcache.NewResolverWithGroup(refcache.NewCacher(db, db.logger, tenant), groupBy.Properties).
 			Do(ctx, objs, props, addl)


### PR DESCRIPTION
## Motivation

`DB.ResolveReferences` (search responses) and `enrichRefsForSingle` (single-object GETs) run the refcache resolver on every request, even when the requested select properties contain no cross-references. In a recent production load-test alloc profile, this no-op machinery ran **341.6M times on a single node**, accounting for **131 GB of allocations just for the "skip fetch jobs, have no incomplete jobs" trace-log fields** — plus walking every result object's property map and constructing a cacher per request, all to change nothing.

## Mechanism

Gate both entry points on `SelectProperties.HasRefs()` (pre-existing, O(props), zero-alloc):

- `ResolveReferences` (`adapters/repos/db/search.go`): early return when neither the select properties nor the groupBy properties (which flow into the resolver for grouped searches and can independently carry refs) contain refs. Sits after the existing `NoProps` exit.
- `enrichRefsForSingle` (`adapters/repos/db/crud.go`): early return when the select properties contain no refs.

## Why this is safe

Without ref select-properties the resolver provably cannot do anything:

- `Cacher.Build` only creates lookup jobs inside `for _, selectPropRef := range selectProp.Refs` (and the equivalent loop over groupBy hit props) — with no `Refs` anywhere, zero jobs, `MultiGet` never called.
- `Resolver.parseSchema` only rewrites a schema entry when the matched select property has `Refs` — otherwise every value passes through untouched.
- Nested/transitive refs are only reachable through a top-level `Refs` entry (`SelectClass.RefProperties`), so top-level `HasRefs() == false` covers them.

The unit tests enforce this by comparing the early-exited result against the full resolver path on identical inputs (byte-identical), and by asserting via log-hook that the machinery still runs whenever refs are present in select props or groupBy props.

This composes with (and does not depend on) the `FindProperty` allocation fix in #12134; the two PRs touch disjoint files.

## Testing

- New unit tests in `adapters/repos/db/resolve_references_skip_test.go` (skip equivalence incl. groupBy, gate-stays-open with refs in props and in groupBy props, single-object path). Red without the fix, green with it.
- `-race` runs: full `adapters/repos/db` unit suite, `refcache`, `usecases/traverser/...`, and the ref integration tests (`TestNestedReferences`, `TestRefFilters*`, `TestMultipleCrossRefTypes`, `Test_AddingReference*`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM
