### PR TITLE
feat(lsmkv): make in-place segment cleanup switch crash-atomic

### DIFF
--- a/adapters/repos/db/lsmkv/cleanup_replace_crash_recovery_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_crash_recovery_integration_test.go
@@ -17,7 +17,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +109,173 @@ func TestCleanupReplace_InPlaceSwitch_CrashRecovery(t *testing.T) {
 				require.NoError(t, err)
 				defer rec.Shutdown(context.Background())
 				assertState(t, rec)
+			})
+		})
+	}
+}
+
+// TestCleanupReplace_InPlaceSwitch_MidSwitchCrashRecovery covers crashes in the
+// middle of the switch (between the individual os.Rename calls), hand-crafting
+// the on-disk state rather than snapshotting after the switch completes.
+func TestCleanupReplace_InPlaceSwitch_MidSwitchCrashRecovery(t *testing.T) {
+	ctx := testCtx()
+
+	tests := []struct {
+		name                string
+		writeInfoInFileName bool
+	}{
+		{name: "segment info not in filename", writeInfoInFileName: false},
+		{name: "segment info in filename", writeInfoInFileName: true},
+	}
+
+	// correct end state of both segments; a safely aborted cleanup, and a
+	// completed one, must both leave exactly this.
+	assertFullState := func(t *testing.T, b *Bucket) {
+		v, err := b.Get([]byte("keyKeep"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("v1"), v)
+		v, err = b.Get([]byte("keyUpdated"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("v2"), v)
+		v, err = b.Get([]byte("keyGone"))
+		require.NoError(t, err)
+		assert.Nil(t, v)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithSegmentsCleanupInterval(time.Second),
+				WithCalcCountNetAdditions(true),
+			}
+			if tt.writeInfoInFileName {
+				opts = append(opts, WithWriteSegmentInfoIntoFileName(true))
+			}
+
+			// writeTwoSegments creates a bucket with a bottom segment (keyKeep,
+			// keyUpdated, keyGone) and an upper segment that updates keyUpdated and
+			// deletes keyGone, then shuts it down so the state can be manipulated.
+			writeTwoSegments := func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+
+				b, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				require.NoError(t, err)
+				b.SetMemtableThreshold(1e9)
+
+				require.NoError(t, b.Put([]byte("keyKeep"), []byte("v1")))
+				require.NoError(t, b.Put([]byte("keyUpdated"), []byte("v1")))
+				require.NoError(t, b.Put([]byte("keyGone"), []byte("v1")))
+				require.NoError(t, b.FlushAndSwitch())
+
+				require.NoError(t, b.Put([]byte("keyUpdated"), []byte("v2")))
+				require.NoError(t, b.Delete([]byte("keyGone")))
+				require.NoError(t, b.FlushAndSwitch())
+
+				require.NoError(t, b.Shutdown(context.Background()))
+				return dir
+			}
+
+			// oldestSegmentDB returns the basename of the oldest on-disk .db segment
+			// (ids are fixed-width unix-nano, so the smallest name is oldest).
+			oldestSegmentDB := func(t *testing.T, dir string) string {
+				t.Helper()
+				entries, err := os.ReadDir(dir)
+				require.NoError(t, err)
+
+				oldest := ""
+				for _, e := range entries {
+					name := e.Name()
+					if strings.HasPrefix(name, "segment-") && strings.HasSuffix(name, ".db") {
+						if oldest == "" || name < oldest {
+							oldest = name
+						}
+					}
+				}
+				require.NotEmpty(t, oldest, "no on-disk .db segment found")
+				return oldest
+			}
+
+			// markSegmentSidecarsDeleted renames the sidecars (bloom/CNA/metadata) of
+			// the segment owning dbFile to ".deleteme" markers, as
+			// markForDeletionExceptSegment does, leaving the .db (and .db.tmp) alone.
+			markSegmentSidecarsDeleted := func(t *testing.T, dir, dbFile string) {
+				t.Helper()
+				prefix := "segment-" + segmentID(dbFile) + "."
+
+				entries, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				for _, e := range entries {
+					name := e.Name()
+					if name == dbFile || !strings.HasPrefix(name, prefix) ||
+						strings.HasSuffix(name, ".tmp") || strings.HasSuffix(name, DeleteMarkerSuffix) {
+						continue
+					}
+					marker := fmt.Sprintf("%s.%013d%s", name, 0, DeleteMarkerSuffix)
+					require.NoError(t, os.Rename(filepath.Join(dir, name), filepath.Join(dir, marker)))
+				}
+			}
+
+			// assertNoTempFiles asserts recovery removed all segment .tmp leftovers.
+			assertNoTempFiles := func(t *testing.T, dir string) {
+				t.Helper()
+				entries, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				for _, e := range entries {
+					if strings.HasPrefix(e.Name(), "segment-") && strings.HasSuffix(e.Name(), ".tmp") {
+						t.Errorf("leftover temp file after recovery: %s", e.Name())
+					}
+				}
+			}
+
+			// crash after the sidecars were marked but before the new .db.tmp was
+			// renamed onto the old .db: the old .db is still live, the .db.tmp is a
+			// leftover. Recovery deletes the .db.tmp and keeps the old data.
+			t.Run("leftover .db.tmp with live old .db", func(t *testing.T) {
+				dir := writeTwoSegments(t)
+				bottomDB := oldestSegmentDB(t, dir)
+				copyFile(t, filepath.Join(dir, bottomDB), filepath.Join(dir, bottomDB+".tmp"))
+				// a stray precomputed sidecar .tmp must also be swept on recovery
+				sidecarTmp := fmt.Sprintf("segment-%s.bloom.tmp", segmentID(bottomDB))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, sidecarTmp), []byte("x"), 0o644))
+				markSegmentSidecarsDeleted(t, dir, bottomDB)
+
+				b, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				require.NoError(t, err)
+				defer b.Shutdown(context.Background())
+				assertFullState(t, b)
+
+				assertNoTempFiles(t, dir)
+			})
+
+			// crash after the .db was overwritten but before the new sidecars were
+			// renamed into place: the new .db is live, its canonical sidecars are
+			// absent and must be recomputed on load.
+			t.Run("new db live, canonical sidecars absent", func(t *testing.T) {
+				dir := writeTwoSegments(t)
+
+				b, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				require.NoError(t, err)
+				b.SetMemtableThreshold(1e9)
+				cleaned, err := b.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+				require.NoError(t, err)
+				require.True(t, cleaned)
+
+				recoveryDir := t.TempDir()
+				copyDir(t, dir, recoveryDir)
+				require.NoError(t, b.Shutdown(context.Background()))
+
+				markSegmentSidecarsDeleted(t, recoveryDir, oldestSegmentDB(t, recoveryDir))
+
+				rec, err := NewBucketCreator().NewBucket(ctx, recoveryDir, recoveryDir, nullLogger(), nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				require.NoError(t, err)
+				defer rec.Shutdown(context.Background())
+				assertFullState(t, rec)
 			})
 		})
 	}

--- a/adapters/repos/db/lsmkv/cleanup_replace_crash_recovery_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_crash_recovery_integration_test.go
@@ -1,0 +1,123 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestCleanupReplace_InPlaceSwitch_CrashRecovery checks that (1) dropping the
+// superseded segment does not delete the live .db that now holds the cleaned
+// data, and (2) a crash after the switch but before the drop recovers cleanly.
+func TestCleanupReplace_InPlaceSwitch_CrashRecovery(t *testing.T) {
+	ctx := testCtx()
+
+	tests := []struct {
+		name                string
+		writeInfoInFileName bool
+	}{
+		{name: "segment info not in filename", writeInfoInFileName: false},
+		{name: "segment info in filename", writeInfoInFileName: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			opts := []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithSegmentsCleanupInterval(time.Second),
+				WithCalcCountNetAdditions(true),
+			}
+			if tt.writeInfoInFileName {
+				opts = append(opts, WithWriteSegmentInfoIntoFileName(true))
+			}
+
+			bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			require.NoError(t, err)
+			defer bucket.Shutdown(context.Background())
+			bucket.SetMemtableThreshold(1e9)
+
+			// bottom segment: three keys, two of which get superseded above.
+			require.NoError(t, bucket.Put([]byte("keyKeep"), []byte("v1")))
+			require.NoError(t, bucket.Put([]byte("keyUpdated"), []byte("v1")))
+			require.NoError(t, bucket.Put([]byte("keyGone"), []byte("v1")))
+			require.NoError(t, bucket.FlushAndSwitch())
+
+			// upper segment: update one key, delete another.
+			require.NoError(t, bucket.Put([]byte("keyUpdated"), []byte("v2")))
+			require.NoError(t, bucket.Delete([]byte("keyGone")))
+			require.NoError(t, bucket.FlushAndSwitch())
+
+			// cleaning the bottom segment removes keyUpdated (superseded) and
+			// keyGone (superseded by the tombstone above), keeping keyKeep.
+			cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+			require.NoError(t, err)
+			require.True(t, cleaned, "expected the bottom segment to be cleaned in place")
+
+			// Capture the on-disk state right after the switch, before the async
+			// drop of the superseded segment runs — this is the crash state.
+			recoveryDir := t.TempDir()
+			copyDir(t, dir, recoveryDir)
+
+			assertState := func(t *testing.T, b *Bucket) {
+				v, err := b.Get([]byte("keyKeep"))
+				require.NoError(t, err)
+				assert.Equal(t, []byte("v1"), v)
+
+				v, err = b.Get([]byte("keyUpdated"))
+				require.NoError(t, err)
+				assert.Equal(t, []byte("v2"), v)
+
+				v, err = b.Get([]byte("keyGone"))
+				require.NoError(t, err)
+				assert.Nil(t, v)
+			}
+
+			t.Run("drop of superseded segment keeps the live db", func(t *testing.T) {
+				_, err := bucket.disk.dropSegmentsAwaiting()
+				require.NoError(t, err)
+				assertState(t, bucket)
+			})
+
+			t.Run("crash-before-drop recovers to the cleaned state", func(t *testing.T) {
+				rec, err := NewBucketCreator().NewBucket(ctx, recoveryDir, recoveryDir, nullLogger(), nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				require.NoError(t, err)
+				defer rec.Shutdown(context.Background())
+				assertState(t, rec)
+			})
+		})
+	}
+}
+
+// copyDir recursively copies the contents of src into dst (which already exists).
+func copyDir(t *testing.T, src, dst string) {
+	t.Helper()
+	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("cp -a %s/. %s/", src, dst))
+	var out bytes.Buffer
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("copy dir: %v: %s", err, out.String())
+	}
+}

--- a/adapters/repos/db/lsmkv/lazy_segment.go
+++ b/adapters/repos/db/lsmkv/lazy_segment.go
@@ -244,6 +244,11 @@ func (s *lazySegment) markForDeletion() error {
 	return s.segment.markForDeletion()
 }
 
+func (s *lazySegment) markForDeletionExceptSegment() error {
+	s.mustLoad()
+	return s.segment.markForDeletionExceptSegment()
+}
+
 func (s *lazySegment) MergeTombstones(other *sroar.Bitmap) (*sroar.Bitmap, error) {
 	s.mustLoad()
 	return s.segment.MergeTombstones(other)

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -65,6 +65,7 @@ type Segment interface {
 	getInvertedData() *segmentInvertedData
 	isLoaded() bool
 	markForDeletion() error
+	markForDeletionExceptSegment() error
 	stripTmpExtensions(leftSegmentID, rightSegmentID string) error
 	MergeTombstones(other *sroar.Bitmap) (*sroar.Bitmap, error)
 	newCollectionCursor() innerCursorCollection
@@ -131,6 +132,10 @@ type segment struct {
 	refCount         int
 
 	deleteMarkerSuffix string
+
+	// set when the .db was overwritten in place by a newer segment, so drop must
+	// not look for a ".deleteme" copy of it. See markForDeletionExceptSegment.
+	segmentFileSuperseded bool
 }
 
 type diskIndex interface {
@@ -488,6 +493,12 @@ func (s *segment) dropMarked() error {
 		return fmt.Errorf("drop previously marked metadata file: %w", err)
 	}
 
+	if s.segmentFileSuperseded {
+		// .db was overwritten in place; no ".deleteme" copy to remove, the old
+		// inode is freed by the preceding close().
+		return nil
+	}
+
 	// for the segment itself, we're not using RemoveAll, but Remove. If there
 	// was a NotExists error here, something would be seriously wrong, and we
 	// don't want to ignore it.
@@ -513,6 +524,34 @@ func (s *segment) removeMarked(path string) error {
 }
 
 func (s *segment) markForDeletion() error {
+	if err := s.markSidecarsForDeletion(); err != nil {
+		return err
+	}
+
+	// for the segment itself, we're not accepting a NotExists error. If there
+	// was a NotExists error here, something would be seriously wrong, and we
+	// don't want to ignore it.
+	if err := s.markDeleted(s.path); err != nil {
+		return fmt.Errorf("mark segment deleted: %w", err)
+	}
+
+	return nil
+}
+
+// markForDeletionExceptSegment marks the sidecars for deletion but leaves the
+// .db in place, for the in-place cleanup switch where the new segment overwrites
+// the old .db at the same path (see segment_group_replacer.go switchOnDisk).
+func (s *segment) markForDeletionExceptSegment() error {
+	if err := s.markSidecarsForDeletion(); err != nil {
+		return err
+	}
+	s.segmentFileSuperseded = true
+	return nil
+}
+
+// markSidecarsForDeletion renames the derived files (bloom filters, CNA,
+// metadata) to their ".deleteme" markers.
+func (s *segment) markSidecarsForDeletion() error {
 	// support for persisting bloom filters and cnas was added in v1.17,
 	// therefore the files may not be present on segments created with previous
 	// versions. If we get a not exist error, we ignore it.
@@ -540,13 +579,6 @@ func (s *segment) markForDeletion() error {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("mark metadata file deleted: %w", err)
 		}
-	}
-
-	// for the segment itself, we're not accepting a NotExists error. If there
-	// was a NotExists error here, something would be seriously wrong, and we
-	// don't want to ignore it.
-	if err := s.markDeleted(s.path); err != nil {
-		return fmt.Errorf("mark segment deleted: %w", err)
 	}
 
 	return nil

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -243,6 +243,11 @@ func (f *fakeSegment) markForDeletion() error {
 	return nil
 }
 
+func (f *fakeSegment) markForDeletionExceptSegment() error {
+	f.isMarkedForDeletion = true
+	return nil
+}
+
 func (f *fakeSegment) MergeTombstones(other *sroar.Bitmap) (*sroar.Bitmap, error) {
 	panic("not implemented")
 }

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -196,7 +196,15 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		potentialCompactedSegmentFileName := strings.TrimSuffix(entry, ".tmp")
 
 		if filepath.Ext(potentialCompactedSegmentFileName) != ".db" {
-			// another kind of temporal file, ignore at this point but it may need to be deleted...
+			// A non-.db segment .tmp (e.g. a precomputed segment-X.bloom.tmp) is a
+			// leftover from a crash during a compaction/cleanup switch — no such
+			// work runs during init — so remove it. The derived files are
+			// recomputed on load.
+			if strings.HasPrefix(entry, "segment-") {
+				if err := os.Remove(filepath.Join(sg.dir, entry)); err != nil {
+					return nil, fmt.Errorf("delete leftover segment temp file %q: %w", entry, err)
+				}
+			}
 			continue
 		}
 

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -178,6 +178,48 @@ func TestCompactionCleanupBothSegmentsPresentUpgrade(t *testing.T) {
 	}
 }
 
+// TestSegmentGroupInit_RemovesStrayTempFiles pins the recovery-loop behavior
+// that a segment sidecar .tmp left behind by a crash during a compaction/cleanup
+// switch (e.g. a precomputed segment-X.bloom.tmp) is removed on init, while a
+// .tmp not belonging to a segment is left untouched.
+func TestSegmentGroupInit_RemovesStrayTempFiles(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		file    string
+		removed bool
+	}{
+		{name: "stray bloom tmp", file: "segment-1700000000000000000.bloom.tmp", removed: true},
+		{name: "stray cna tmp", file: "segment-1700000000000000000.cna.tmp", removed: true},
+		{name: "stray metadata tmp", file: "segment-1700000000000000000.metadata.tmp", removed: true},
+		{name: "stray secondary bloom tmp", file: "segment-1700000000000000000.secondary.0.bloom.tmp", removed: true},
+		{name: "non-segment tmp preserved", file: "something-else.tmp", removed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, tt.file)
+			require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
+
+			b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithUseBloomFilter(false), WithStrategy(StrategyReplace))
+			require.NoError(t, err)
+			defer b.Shutdown(ctx)
+
+			_, statErr := os.Stat(path)
+			if tt.removed {
+				require.True(t, os.IsNotExist(statErr), "expected %q to be removed on init", tt.file)
+			} else {
+				require.NoError(t, statErr, "expected %q to be preserved", tt.file)
+			}
+		})
+	}
+}
+
 func copyFile(t *testing.T, src, dest string) {
 	t.Helper()
 	target, err := os.Create(dest)

--- a/adapters/repos/db/lsmkv/segment_group_replacer.go
+++ b/adapters/repos/db/lsmkv/segment_group_replacer.go
@@ -13,10 +13,13 @@ package lsmkv
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/entities/diskio"
 )
 
 func newSegmentReplacer(sg *SegmentGroup, oldLeftPos, oldRightPos int, newSeg Segment) *segmentReplacer {
@@ -53,13 +56,37 @@ func (sr *segmentReplacer) switchOnDisk() (Segment, Segment, error) {
 	rightSegment = sr.sg.segments[sr.oldRightPos]
 	sr.sg.maintenanceLock.RUnlock()
 
-	if !sr.replaceSingleSegment {
-		if err := leftSegment.markForDeletion(); err != nil {
-			return nil, nil, errors.Wrap(err, "drop disk segment")
+	if sr.replaceSingleSegment {
+		// In-place cleanup switch: the rewritten segment has the same canonical
+		// name as the old one, so stripTmpExtensions renames the new .db.tmp
+		// atomically onto the old .db — the canonical .db always names a complete
+		// segment, so a crash can never leave it missing. Only the old sidecars
+		// are marked for deletion (they no longer match the cleaned data); the
+		// fsync makes those marks durable before the overwrite so a stale bloom
+		// filter can't survive paired with the new .db. The old inode stays alive
+		// for active readers via mmap/fd and is freed on close().
+		if err := rightSegment.markForDeletionExceptSegment(); err != nil {
+			return nil, nil, errors.Wrap(err, "mark old sidecars for deletion")
 		}
-		sr.oldLeftPath = leftSegment.getPath()
-		leftSegID = segmentID(sr.oldLeftPath)
+		sr.oldRightPath = rightSegment.getPath()
+		rightSegID = segmentID(sr.oldRightPath)
+
+		if err := diskio.Fsync(filepath.Dir(sr.oldRightPath)); err != nil {
+			return nil, nil, fmt.Errorf("fsync segment dir before in-place swap: %w", err)
+		}
+
+		if err := sr.newSeg.stripTmpExtensions(leftSegID, rightSegID); err != nil {
+			return nil, nil, fmt.Errorf("strip .tmp extensions of new segment: %w", err)
+		}
+
+		return leftSegment, rightSegment, nil
 	}
+
+	if err := leftSegment.markForDeletion(); err != nil {
+		return nil, nil, errors.Wrap(err, "drop disk segment")
+	}
+	sr.oldLeftPath = leftSegment.getPath()
+	leftSegID = segmentID(sr.oldLeftPath)
 
 	if err := rightSegment.markForDeletion(); err != nil {
 		return nil, nil, errors.Wrap(err, "drop disk segment")

--- a/adapters/repos/db/lsmkv/segment_group_replacer_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_replacer_test.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -21,24 +22,26 @@ import (
 
 func TestSegmentReplacer_OnDisk(t *testing.T) {
 	logger, _ := test.NewNullLogger()
+	// real directory so the in-place cleanup switch can fsync it
+	dir := t.TempDir()
 
 	createDiskOf4 := func() (*SegmentGroup, *fakeSegment, *fakeSegment, *fakeSegment, *fakeSegment) {
 		segA := newFakeReplaceSegment(map[string][]byte{
 			"keyA": []byte("valueA"),
 		})
-		segA.setPath("directory/segment-0001.db")
+		segA.setPath(filepath.Join(dir, "segment-0001.db"))
 		segB := newFakeReplaceSegment(map[string][]byte{
 			"keyB": []byte("valueB"),
 		})
-		segB.setPath("directory/segment-0002.db")
+		segB.setPath(filepath.Join(dir, "segment-0002.db"))
 		segC := newFakeReplaceSegment(map[string][]byte{
 			"keyC": []byte("valueC"),
 		})
-		segC.setPath("directory/segment-0003.db")
+		segC.setPath(filepath.Join(dir, "segment-0003.db"))
 		segD := newFakeReplaceSegment(map[string][]byte{
 			"keyD": []byte("valueD"),
 		})
-		segD.setPath("directory/segment-0004.db")
+		segD.setPath(filepath.Join(dir, "segment-0004.db"))
 
 		diskSegments := &SegmentGroup{
 			logger:   logger,


### PR DESCRIPTION
### What's being changed:

Makes the LSM segment-cleaner's on-disk switch crash-atomic, so a crash can never leave a cleaned segment in an unrecoverable state.

The cleanup rewrite reuses the old segment's exact canonical name, so `stripTmpExtensions` renames the new `.db.tmp` atomically onto the old `.db` — the canonical `.db` always names a complete segment. Previously the switch first renamed the old `.db` to a `.deleteme` marker and only then promoted the `.tmp`; a crash in that window left only `.deleteme` + `.db.tmp` on disk, which startup then deleted (silent data loss).

For the single-segment (cleanup) path, `switchOnDisk` now:
- marks only the **old sidecars** (bloom/CNA/metadata) for deletion — they no longer match the cleaned data,
- fsyncs the dir so those marks are durable before the overwrite (otherwise a stale bloom filter could survive paired with the new `.db`),
- lets `stripTmpExtensions` overwrite the `.db` in place.

The old inode stays alive for active readers via their mmap/fd and is freed on `close()`; `dropMarked` skips removing the (non-existent) `.deleteme` copy of the `.db` (`segmentFileSuperseded`). The two-segment compaction path is unchanged. Adds a crash-recovery integration test (both filename modes) covering that the drop keeps the live db and a crash-before-drop recovers cleanly.

This is complementary to #12141 (startup promotion guard): that recovers disks already corrupted by the old code, this prevents new occurrences.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
