### PR TITLE
chore(test): raise tenant-delete budget in offload-s3 tests to mitigate busy CPU

### DIFF
--- a/test/modules/offload-s3/misocnfigured_test.go
+++ b/test/modules/offload-s3/misocnfigured_test.go
@@ -77,7 +77,7 @@ func Test_DeleteTenantsWhileMisconfigured(t *testing.T) {
 		})
 
 		t.Run("delete tenant 1 in time manner", func(t *testing.T) {
-			customCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			customCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
 
 			errChan := make(chan error, 1)
@@ -164,7 +164,7 @@ func Test_DeleteTenantsWhileProviderIsDown(t *testing.T) {
 		})
 
 		t.Run("delete tenant 1 in time manner", func(t *testing.T) {
-			customCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			customCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
 
 			errChan := make(chan error, 1)


### PR DESCRIPTION
### What's being changed:
given the runners resources this could take in some cases bit longer, to avoid flakiness extending the budget

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
