### PR TITLE
perf(lsmkv): wire inverted compaction through the reusable encode pipeline

### DIFF
--- a/adapters/repos/db/lsmkv/compaction_bench_test.go
+++ b/adapters/repos/db/lsmkv/compaction_bench_test.go
@@ -106,3 +106,48 @@ func getFiles(t testing.TB, dirName string) map[string]int {
 	}
 	return fileTypes
 }
+
+// BenchmarkInvertedCompaction compacts two inverted segments whose terms
+// overlap (so postings are merged and re-encoded through the reusable pipeline),
+// with >BLOCK_SIZE docs per term to exercise the block-encode path. Run with
+// -benchmem to see the per-key/per-block allocation profile.
+func BenchmarkInvertedCompaction(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	const (
+		numTerms = 100
+		docsPer  = 200 // > BLOCK_SIZE (128) -> multi-block postings
+	)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tmpDir := b.TempDir()
+		bu, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			WithStrategy(StrategyInverted), WithKeepTombstones(true))
+		require.NoError(b, err)
+		bu.SetMemtableThreshold(1 << 30) // never auto-flush mid-segment
+
+		for seg := 0; seg < 2; seg++ {
+			for term := 0; term < numTerms; term++ {
+				key := []byte(fmt.Sprintf("term%d", term))
+				for d := 0; d < docsPer; d++ {
+					docID := uint64(seg*numTerms*docsPer + term*docsPer + d)
+					require.NoError(b, bu.MapSet(key, NewMapPairFromDocIdAndTf(docID, float32(d%10+1), float32(d%5+1), false)))
+				}
+			}
+			require.NoError(b, bu.FlushAndSwitch())
+		}
+		b.StartTimer()
+
+		ok, err := bu.disk.compactOnce(ctx)
+		require.NoError(b, err)
+		require.True(b, ok)
+
+		b.StopTimer()
+		require.NoError(b, bu.Shutdown(ctx))
+		b.StartTimer()
+	}
+}

--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -74,6 +74,11 @@ type compactorInverted struct {
 
 	segmentFile    *segmentindex.SegmentFile
 	maxNewFileSize int64
+
+	// reusable buffers so per-key/per-block compaction encoding allocates nothing
+	writeBuf   [8]byte
+	arena      keyArena
+	encodeBufs compactorInvertedBuffers
 }
 
 func newCompactorInverted(w io.WriteSeeker,
@@ -108,6 +113,7 @@ func newCompactorInverted(w io.WriteSeeker,
 		enableChecksumValidation: enableChecksumValidation,
 		maxNewFileSize:           maxNewFileSize,
 		allocChecker:             allocChecker,
+		encodeBufs:               newCompactorInvertedBuffers(),
 	}
 }
 
@@ -167,7 +173,7 @@ func (c *compactorInverted) do(ctx context.Context) error {
 		return errors.Wrap(err, "write property lengths")
 	}
 	treeOffset := uint64(c.offset)
-	if err := c.writeIndices(kis); err != nil {
+	if err := c.writeIndices(kis, uint64(keysOffset)); err != nil {
 		return errors.Wrap(err, "write index")
 	}
 
@@ -302,13 +308,13 @@ func (c *compactorInverted) writePropertyLengths() (int, error) {
 	return len(encoded) + 8 + 8 + 8, nil
 }
 
-func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.Key, error) {
+func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.KeyRedux, error) {
 	key1, value1, _ := c.c1.first()
 	key2, value2, _ := c.c2.first()
 
 	// the (dummy) header was already written, this is our initial offset
 
-	var kis []segmentindex.Key
+	kis := make([]segmentindex.KeyRedux, 0, c.c1.segment.index.KeyCount()+c.c2.segment.index.KeyCount())
 	sim := newSortedMapMerger()
 
 	for i := 0; ; i++ {
@@ -384,21 +390,13 @@ func (c *compactorInverted) writeKeys(ctx context.Context) ([]segmentindex.Key, 
 
 func (c *compactorInverted) writeIndividualNode(offset int, key []byte,
 	values []MapPair,
-) (segmentindex.Key, error) {
-	// NOTE: There are no guarantees in the cursor logic that any memory is valid
-	// for more than a single iteration. Every time you call next() to advance
-	// the cursor, any memory might be reused.
-	//
-	// This includes the key buffer which was the cause of
-	// https://github.com/weaviate/weaviate/issues/3517
-	//
-	// A previous logic created a new assignment in each iteration, but thatwas
-	// not an explicit guarantee. A change in v1.21 (for pread/mmap) added a
-	// reusable buffer for the key which surfaced this bug.
-	keyCopy := make([]byte, len(key))
-	copy(keyCopy, key)
+) (segmentindex.KeyRedux, error) {
+	// Copy the key: the cursor reuses its key buffer across iterations, so
+	// keeping the slice would let a later next() overwrite it
+	// (https://github.com/weaviate/weaviate/issues/3517).
+	keyCopy := c.arena.CopyKey(key)
 
-	// fresh cursor per term: its docIDs ascend, so lookups stay amortized O(1)
+	// fresh view per term: its docIDs ascend, so lookups stay amortized O(1)
 	view := propLengthsView{ids: c.propLengthIds, lens: c.propLengthLens}
 
 	return segmentInvertedNode{
@@ -406,17 +404,18 @@ func (c *compactorInverted) writeIndividualNode(offset int, key []byte,
 		primaryKey:  keyCopy,
 		offset:      offset,
 		propLengths: &view,
-	}.KeyIndexAndWriteTo(c.segmentFile.BodyWriter(), c.docIdEncoder, c.tfEncoder, c.k1, c.b, c.avgPropLen)
+	}.KeyIndexAndWriteToCompaction(c.segmentFile.BodyWriter(), c.writeBuf[:], &c.encodeBufs,
+		c.docIdEncoder, c.tfEncoder, c.k1, c.b, c.avgPropLen)
 }
 
-func (c *compactorInverted) writeIndices(keys []segmentindex.Key) error {
-	indices := segmentindex.Indexes{
-		Keys:                keys,
-		SecondaryIndexCount: c.secondaryIndexCount,
-		AllocChecker:        c.allocChecker,
+func (c *compactorInverted) writeIndices(keys []segmentindex.KeyRedux, dataStartOffset uint64) error {
+	// KeyIndexAndWriteToCompaction emits no secondary keys and MarshalSortedKeys
+	// serializes none, so this path is only valid without secondary indexes —
+	// which inverted (BM25 postings) never has.
+	if c.secondaryIndexCount > 0 {
+		return fmt.Errorf("inverted compaction does not support secondary indexes")
 	}
-
-	_, err := indices.WriteTo(c.segmentFile.BodyWriter())
+	_, err := segmentindex.MarshalSortedKeys(c.segmentFile.BodyWriter(), keys, dataStartOffset)
 	return err
 }
 


### PR DESCRIPTION
### What's being changed:

Wires `compactorInverted` through the reusable encode pipeline (PR5c), removing the per-key/per-block allocation storm from inverted compaction:

- `writeIndividualNode` copies the key via a `keyArena` and encodes through `KeyIndexAndWriteToCompaction` (reusable block-entry/data storage + shared varint arena + reusable output buffer).
- `writeKeys` collects `[]segmentindex.KeyRedux` preallocated to both input segments' key counts.
- `writeIndices` serializes the index directly with `MarshalSortedKeys` at the inverted header's data-start offset (PR3), instead of `Indexes.WriteTo`.

**Output is unchanged.** `KeyIndexAndWriteToCompaction` is byte-identical to `KeyIndexAndWriteTo` (unit-tested in PR5c), and `MarshalSortedKeys` produces the same index the old path already used (`Indexes.WriteTo` → `MarshalSortedKeysFromKeys` for the no-secondary case). Inverted has no secondary indexes, which `writeIndices` now asserts.

Final step of porting the inverted-compaction allocation work from #11450 onto `stable/v1.37`. Adds `BenchmarkInvertedCompaction` (`-benchmem`) as an allocation-profile harness — a baseline that the read-side reusable cursor (PR5b) will further reduce.

> **Stacking:** builds on the reusable encode helpers (#12160) → `EncodeAppend`/`EncodeInto` (#12149, #12150), `MarshalSortedKeys` offset (#12151), and the #274 reclaim (#12147). Opened against the encode-helpers branch. **Base will be retargeted to `stable/v1.37` as the foundations merge.** Review `compactor_inverted.go` + the benchmark here.

### Tests

Existing inverted compaction integration suite passes unchanged — `TestCompaction/compactionInvertedStrategy*` (segment bytes, BlockMax + WAND search, cursor read-back), `TestInvertedCompaction*`, `TestTombstonesInverted_Compaction`, `TestInvertedNaNPropLength`. The exact-size assertions were updated in #12147 (the #274 reclaim shrinks the segment); this PR's wiring is byte-neutral on top of that.

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
