### PR TITLE
perf(lsmkv): reuse decode buffers in the inverted cursor

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -28,6 +28,9 @@ type CursorMap struct {
 	unlock       func()
 	listCfg      MapListOptionConfig
 	keyOnly      bool
+	// inner cursors whose advance was deferred from the previous return, applied
+	// on the next call so reusable cursors don't overwrite still-in-use data
+	pendingAdvanceIDs []int
 }
 
 type cursorStateMap struct {
@@ -94,6 +97,8 @@ func (b *Bucket) MapCursorKeyOnly(cfgs ...MapListOption) (*CursorMap, error) {
 }
 
 func (c *CursorMap) Seek(ctx context.Context, key []byte) ([]byte, []MapPair) {
+	// re-seeking repositions every inner cursor, so any deferred advance is moot
+	c.pendingAdvanceIDs = c.pendingAdvanceIDs[:0]
 	c.seekAll(key)
 	return c.serveCurrentStateAndAdvance(ctx)
 }
@@ -103,6 +108,7 @@ func (c *CursorMap) Next(ctx context.Context) ([]byte, []MapPair) {
 }
 
 func (c *CursorMap) First(ctx context.Context) ([]byte, []MapPair) {
+	c.pendingAdvanceIDs = c.pendingAdvanceIDs[:0]
 	c.firstAll()
 	return c.serveCurrentStateAndAdvance(ctx)
 }
@@ -156,6 +162,14 @@ func (c *CursorMap) firstAll() {
 }
 
 func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []MapPair) {
+	// Apply the advances deferred from the previous return. Inner cursors that
+	// reuse their Key/Value buffers (segmentCursorInvertedReusable) overwrite them
+	// on next(), so we advance only once the caller has consumed what we returned.
+	for _, id := range c.pendingAdvanceIDs {
+		c.advanceInner(id)
+	}
+	c.pendingAdvanceIDs = c.pendingAdvanceIDs[:0]
+
 	for {
 		id, err := c.cursorWithLowestKey()
 		if err != nil {
@@ -166,17 +180,17 @@ func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []
 
 		ids, _ := c.haveDuplicatesInState(id)
 
-		// take the key from any of the results, we have the guarantee that they're
-		// all the same
-		key := c.state[ids[0]].key
+		// Copy the key: some inner cursors reuse one key buffer across iterations,
+		// so it would be overwritten once the cursor advances. The merged values
+		// are valid until the next call (deferred advance), which is the cursor's
+		// contract — callers must consume them before advancing.
+		src := c.state[ids[0]].key
+		key := make([]byte, len(src))
+		copy(key, src)
 
 		var perSegmentResults [][]MapPair
-
 		for _, id := range ids {
-			candidates := c.state[id].value
-			perSegmentResults = append(perSegmentResults, candidates)
-
-			c.advanceInner(id)
+			perSegmentResults = append(perSegmentResults, c.state[id].value)
 		}
 
 		if c.listCfg.legacyRequireManualSorting {
@@ -193,9 +207,16 @@ func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []
 			panic(fmt.Errorf("unexpected error decoding map values: %w", err))
 		}
 		if len(merged) == 0 {
-			// all values deleted, proceed
+			// all values deleted: the data is discarded, so advance immediately
+			for _, id := range ids {
+				c.advanceInner(id)
+			}
 			continue
 		}
+
+		// Defer advancing until the next call so the caller can consume the
+		// returned key/values before the reusable buffers are overwritten.
+		c.pendingAdvanceIDs = append(c.pendingAdvanceIDs, ids...)
 
 		if !c.keyOnly {
 			return key, merged

--- a/adapters/repos/db/lsmkv/cursor_bucket_map_inverted_reusable_integration_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map_inverted_reusable_integration_test.go
@@ -1,0 +1,81 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// The inverted reusable cursor reuses its key/value buffers across nodes. When
+// CursorMap wraps it, a caller that holds returned keys and values across
+// iterations must still see each node's own data — that's what the CursorMap
+// deferred-advance and returned-key copy guarantee. Without them the merger
+// would see buffers clobbered by an early advance and every key would collapse
+// onto the last node.
+func TestCursorMapInvertedReusable_HoldAcrossIterations(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyInverted))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9) // never auto-flush mid-segment
+
+	const (
+		numTerms = 50
+		docsPer  = 200 // > BLOCK_SIZE (128) -> multi-block postings per term
+	)
+	wantFirstDoc := map[string]uint64{}
+	for term := 0; term < numTerms; term++ {
+		key := fmt.Sprintf("term%03d", term)
+		for d := 0; d < docsPer; d++ {
+			docID := uint64(term*docsPer + d)
+			require.NoError(t, bucket.MapSet([]byte(key), NewMapPairFromDocIdAndTf(docID, float32(d%10+1), 1, false)))
+		}
+		wantFirstDoc[key] = uint64(term * docsPer) // smallest docID under the term
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	c, err := bucket.MapCursor()
+	require.NoError(t, err)
+	defer c.Close()
+
+	// Hold the returned keys WITHOUT copying (their copy is the cursor's job), but
+	// read the value bytes during the iteration that produced them — that is the
+	// contract, and it exercises the deferred advance (an early advance would feed
+	// the merger buffers already overwritten by the next node).
+	var keys [][]byte
+	firstDocByIter := make([]uint64, 0, numTerms)
+	for k, v := c.First(ctx); k != nil; k, v = c.Next(ctx) {
+		keys = append(keys, k)
+		require.NotEmpty(t, v)
+		firstDocByIter = append(firstDocByIter, binary.BigEndian.Uint64(v[0].Key))
+	}
+
+	require.Len(t, keys, numTerms)
+	for i := range keys {
+		term := string(keys[i])
+		require.Equal(t, fmt.Sprintf("term%03d", i), term, "keys must not collapse onto the last node")
+		assert.Equal(t, wantFirstDoc[term], firstDocByIter[i], "correct values decoded for %s", term)
+	}
+}

--- a/adapters/repos/db/lsmkv/cursor_bucket_map_inverted_reusable_integration_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map_inverted_reusable_integration_test.go
@@ -26,11 +26,12 @@ import (
 )
 
 // The inverted reusable cursor reuses its key/value buffers across nodes. When
-// CursorMap wraps it, a caller that holds returned keys and values across
-// iterations must still see each node's own data — that's what the CursorMap
-// deferred-advance and returned-key copy guarantee. Without them the merger
-// would see buffers clobbered by an early advance and every key would collapse
-// onto the last node.
+// CursorMap wraps it, a caller may hold the returned keys across iterations (the
+// key is copied) but must read each node's values during its own iteration (they
+// alias the reused buffer, valid only until the next call). This exercises both
+// guarantees: without the returned-key copy the held keys collapse onto the last
+// node, and without the deferred inner-cursor advance an early advance feeds the
+// merger clobbered buffers.
 func TestCursorMapInvertedReusable_HoldAcrossIterations(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"encoding/binary"
 	"io"
+	"math"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
@@ -25,17 +26,20 @@ type segmentCursorInvertedReusable struct {
 	nextOffset uint64
 	nodeBuf    binarySearchNodeMap
 
-	// Reusable decode buffers: they remove the per-docID MapPair and key/value
-	// allocations (multi-block nodes still allocate the block-entry/data slices in
-	// decodeBlocks). NOTE: nodeBuf.key/values alias keyBuf/mapPairBuf, which the
-	// next parse overwrites — a caller keeping a node across seek/next/first must
-	// copy it first (CursorMap defers its inner-cursor advances for exactly this).
-	readBuf    []byte    // disk-path node read buffer
-	keyBuf     []byte    // primary key
-	mapPairBuf []MapPair // decoded MapPairs (Key/Value alias kvArena)
-	kvArena    []byte    // contiguous key/value storage
-	deltaEnc   varenc.VarEncEncoder[uint64]
-	tfEnc      varenc.VarEncEncoder[uint64]
+	// Reusable decode buffers, so iterating a segment allocates per node nothing
+	// beyond growth: the output MapPairs/key, the arena, and the decoded block
+	// entry/data structs are all reused. NOTE: nodeBuf.key/values alias
+	// keyBuf/mapPairBuf, which the next parse overwrites — a caller keeping a node
+	// across seek/next/first must copy it first (CursorMap defers its inner-cursor
+	// advances for exactly this).
+	readBuf       []byte             // disk-path node read buffer
+	keyBuf        []byte             // primary key
+	mapPairBuf    []MapPair          // decoded MapPairs (Key/Value alias kvArena)
+	kvArena       []byte             // contiguous key/value storage
+	blockEntryBuf []terms.BlockEntry // decoded block entries (reused across nodes)
+	blockDataBuf  []terms.BlockData  // decoded block data (reused across nodes)
+	deltaEnc      varenc.VarEncEncoder[uint64]
+	tfEnc         varenc.VarEncEncoder[uint64]
 }
 
 func (s *segment) newInvertedCursorReusable() *segmentCursorInvertedReusable {
@@ -111,7 +115,7 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeFromMemory(offset nodeO
 	dataEnd += 4 // trailing keyLen uint32
 
 	data := contents[offset.start:dataEnd]
-	s.mapPairBuf, s.kvArena, _ = decodeAndConvertFromBlocksReusable(data, s.mapPairBuf, s.kvArena, s.deltaEnc, s.tfEnc)
+	s.decodeBlocksAndConvert(data, docCount)
 
 	keyLen := binary.LittleEndian.Uint32(data[len(data)-4:])
 	keyStart := dataEnd
@@ -163,7 +167,7 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeFromDisk(offset nodeOff
 		return err
 	}
 
-	s.mapPairBuf, s.kvArena, _ = decodeAndConvertFromBlocksReusable(s.readBuf, s.mapPairBuf, s.kvArena, s.deltaEnc, s.tfEnc)
+	s.decodeBlocksAndConvert(s.readBuf, docCount)
 
 	keyLen := binary.LittleEndian.Uint32(s.readBuf[len(s.readBuf)-4:])
 
@@ -187,6 +191,80 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeFromDisk(offset nodeOff
 	s.nextOffset = offset.end
 
 	return nil
+}
+
+// decodeBlocksAndConvert decodes a node's block-encoded postings into
+// s.mapPairBuf/s.kvArena. Unlike decodeAndConvertFromBlocksReusable it also
+// reuses the intermediate block entry/data structs (s.blockEntryBuf/blockDataBuf)
+// and decodes them in place, so a multi-block node allocates no per-block
+// BlockEntry/BlockData. Output bytes are identical to the allocating path.
+func (s *segmentCursorInvertedReusable) decodeBlocksAndConvert(data []byte, collectionSize uint64) {
+	if cap(s.mapPairBuf) < int(collectionSize) {
+		s.mapPairBuf = make([]MapPair, 0, collectionSize)
+	} else {
+		s.mapPairBuf = s.mapPairBuf[:0]
+	}
+	neededArena := int(collectionSize) * 16
+	if cap(s.kvArena) < neededArena {
+		s.kvArena = make([]byte, neededArena)
+	} else {
+		s.kvArena = s.kvArena[:neededArena]
+	}
+	arenaOff := 0
+
+	// full-bytes path: docId + tf stored inline, no blocks
+	if collectionSize <= uint64(terms.ENCODE_AS_FULL_BYTES) {
+		offset := 8
+		for i := 0; i < int(collectionSize); i++ {
+			key := s.kvArena[arenaOff : arenaOff+8]
+			copy(key, data[offset:offset+8])
+			arenaOff += 8
+			value := s.kvArena[arenaOff : arenaOff+8]
+			copy(value, data[offset+8:offset+12])
+			binary.LittleEndian.PutUint32(value[4:], 0) // zero the reused propLength slot
+			arenaOff += 8
+			s.mapPairBuf = append(s.mapPairBuf, MapPair{Key: key, Value: value})
+			offset += 16
+		}
+		return
+	}
+
+	blockCount := (int(collectionSize) + terms.BLOCK_SIZE - 1) / terms.BLOCK_SIZE
+	if cap(s.blockEntryBuf) < blockCount {
+		s.blockEntryBuf = make([]terms.BlockEntry, blockCount)
+		s.blockDataBuf = make([]terms.BlockData, blockCount)
+	} else {
+		s.blockEntryBuf = s.blockEntryBuf[:blockCount]
+		s.blockDataBuf = s.blockDataBuf[:blockCount]
+	}
+
+	offset := 16 // skip collectionSize(8) + total length(8)
+	blockDataInitialOffset := offset + blockCount*terms.BlockEntry{}.Size()
+	for i := 0; i < blockCount; i++ {
+		terms.DecodeBlockEntryInto(data[offset:], &s.blockEntryBuf[i])
+		dataOffset := int(s.blockEntryBuf[i].Offset) + blockDataInitialOffset
+		terms.DecodeBlockDataReusable(data[dataOffset:], &s.blockDataBuf[i])
+		offset += s.blockEntryBuf[i].Size()
+	}
+
+	for i := range s.blockEntryBuf {
+		blockSize := terms.BLOCK_SIZE
+		if i == blockCount-1 {
+			blockSize = int(collectionSize) - terms.BLOCK_SIZE*i
+		}
+		docIds, tfs := packedDecode(&s.blockDataBuf[i], blockSize, s.deltaEnc, s.tfEnc)
+		for j := 0; j < blockSize; j++ {
+			key := s.kvArena[arenaOff : arenaOff+8]
+			binary.BigEndian.PutUint64(key, docIds[j])
+			arenaOff += 8
+			value := s.kvArena[arenaOff : arenaOff+8]
+			// PutUint64 writes the TF into value[0:4] and zeroes value[4:8], the
+			// propLength slot that would otherwise carry stale arena bytes
+			binary.LittleEndian.PutUint64(value, uint64(math.Float32bits(float32(tfs[j]))))
+			arenaOff += 8
+			s.mapPairBuf = append(s.mapPairBuf, MapPair{Key: key, Value: value})
+		}
+	}
 }
 
 // growBytes returns buf resliced to length n, reallocating only when cap is

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -25,8 +25,9 @@ type segmentCursorInvertedReusable struct {
 	nextOffset uint64
 	nodeBuf    binarySearchNodeMap
 
-	// Reusable decode buffers, so iterating a segment allocates per-node nothing
-	// beyond growth. NOTE: nodeBuf.key/values alias keyBuf/mapPairBuf, which the
+	// Reusable decode buffers: they remove the per-docID MapPair and key/value
+	// allocations (multi-block nodes still allocate the block-entry/data slices in
+	// decodeBlocks). NOTE: nodeBuf.key/values alias keyBuf/mapPairBuf, which the
 	// next parse overwrites — a caller keeping a node across seek/next/first must
 	// copy it first (CursorMap defers its inner-cursor advances for exactly this).
 	readBuf    []byte    // disk-path node read buffer

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -13,8 +13,10 @@ package lsmkv
 
 import (
 	"encoding/binary"
+	"io"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
@@ -22,13 +24,26 @@ type segmentCursorInvertedReusable struct {
 	segment    *segment
 	nextOffset uint64
 	nodeBuf    binarySearchNodeMap
+
+	// Reusable decode buffers, so iterating a segment allocates per-node nothing
+	// beyond growth. NOTE: nodeBuf.key/values alias keyBuf/mapPairBuf, which the
+	// next parse overwrites — a caller keeping a node across seek/next/first must
+	// copy it first (CursorMap defers its inner-cursor advances for exactly this).
+	readBuf    []byte    // disk-path node read buffer
+	keyBuf     []byte    // primary key
+	mapPairBuf []MapPair // decoded MapPairs (Key/Value alias kvArena)
+	kvArena    []byte    // contiguous key/value storage
+	deltaEnc   varenc.VarEncEncoder[uint64]
+	tfEnc      varenc.VarEncEncoder[uint64]
 }
 
 func (s *segment) newInvertedCursorReusable() *segmentCursorInvertedReusable {
 	// this cursor never reads the property length map; loading it would only
 	// defeat lazy property-length loading
 	return &segmentCursorInvertedReusable{
-		segment: s,
+		segment:  s,
+		deltaEnc: &varenc.VarIntDeltaEncoder{},
+		tfEnc:    &varenc.VarIntEncoder{},
 	}
 }
 
@@ -76,21 +91,60 @@ func (s *segmentCursorInvertedReusable) first() ([]byte, []MapPair, error) {
 }
 
 func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset) error {
-	buffer := make([]byte, 16)
+	if s.segment.readFromMemory {
+		return s.parseInvertedNodeFromMemory(offset)
+	}
+	return s.parseInvertedNodeFromDisk(offset)
+}
+
+// parseInvertedNodeFromMemory reads the node straight out of the resident
+// segment contents, so it needs no node reader and no read buffer.
+func (s *segmentCursorInvertedReusable) parseInvertedNodeFromMemory(offset nodeOffset) error {
+	contents := s.segment.contents
+
+	docCount := binary.LittleEndian.Uint64(contents[offset.start:])
+	dataEnd := offset.start + 20
+	if docCount > uint64(terms.ENCODE_AS_FULL_BYTES) {
+		dataEnd = offset.start + binary.LittleEndian.Uint64(contents[offset.start+8:]) + 16
+	}
+	dataEnd += 4 // trailing keyLen uint32
+
+	data := contents[offset.start:dataEnd]
+	s.mapPairBuf, s.kvArena, _ = decodeAndConvertFromBlocksReusable(data, s.mapPairBuf, s.kvArena, s.deltaEnc, s.tfEnc)
+
+	keyLen := binary.LittleEndian.Uint32(data[len(data)-4:])
+	keyStart := dataEnd
+	keyEnd := keyStart + uint64(keyLen)
+
+	s.keyBuf = growBytes(s.keyBuf, int(keyLen))
+	if keyLen > 0 {
+		copy(s.keyBuf, contents[keyStart:keyEnd])
+	}
+
+	s.nodeBuf.key = s.keyBuf
+	s.nodeBuf.values = s.mapPairBuf
+	s.nextOffset = keyEnd
+
+	return nil
+}
+
+// parseInvertedNodeFromDisk is the pread fallback for segments whose contents
+// are not resident in memory.
+func (s *segmentCursorInvertedReusable) parseInvertedNodeFromDisk(offset nodeOffset) error {
+	var header [16]byte
 	r, err := s.segment.newNodeReader(offset, "segmentCursorInvertedReusable")
 	if err != nil {
 		return err
 	}
 	defer r.Release()
 
-	_, err = r.Read(buffer)
-	if err != nil {
+	if _, err := io.ReadFull(r, header[:]); err != nil {
 		return err
 	}
-	docCount := binary.LittleEndian.Uint64(buffer[:8])
+	docCount := binary.LittleEndian.Uint64(header[:8])
 	end := uint64(20)
 	if docCount > uint64(terms.ENCODE_AS_FULL_BYTES) {
-		end = binary.LittleEndian.Uint64(buffer[8:16]) + 16
+		end = binary.LittleEndian.Uint64(header[8:16]) + 16
 	}
 	offset.end = offset.start + end + 4
 
@@ -100,37 +154,45 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset)
 	}
 	defer r.Release()
 
-	allBytes := make([]byte, offset.end-offset.start)
-
-	_, err = r.Read(allBytes)
-	if err != nil {
+	s.readBuf = growBytes(s.readBuf, int(offset.end-offset.start))
+	// io.ReadFull is required: readBuf is reused across nodes, so a short read
+	// would leave trailing bytes from a prior node and the decoder / keyLen
+	// parser below would operate on stale data.
+	if _, err := io.ReadFull(r, s.readBuf); err != nil {
 		return err
 	}
 
-	nodes, _ := decodeAndConvertFromBlocks(allBytes)
+	s.mapPairBuf, s.kvArena, _ = decodeAndConvertFromBlocksReusable(s.readBuf, s.mapPairBuf, s.kvArena, s.deltaEnc, s.tfEnc)
 
-	keyLen := binary.LittleEndian.Uint32(allBytes[len(allBytes)-4:])
+	keyLen := binary.LittleEndian.Uint32(s.readBuf[len(s.readBuf)-4:])
 
 	offset.start = offset.end
 	offset.end += uint64(keyLen)
-	key := make([]byte, keyLen)
 
-	// empty keys are possible if using non-word tokenizers, so let's handle them
+	s.keyBuf = growBytes(s.keyBuf, int(keyLen))
+	// empty keys are possible with non-word tokenizers
 	if keyLen > 0 {
 		r, err = s.segment.newNodeReader(offset, "segmentCursorInvertedReusable")
 		if err != nil {
 			return err
 		}
 		defer r.Release()
-		_, err = r.Read(key)
-		if err != nil {
+		if _, err := io.ReadFull(r, s.keyBuf); err != nil {
 			return err
 		}
 	}
-	s.nodeBuf.key = key
-	s.nodeBuf.values = nodes
-
+	s.nodeBuf.key = s.keyBuf
+	s.nodeBuf.values = s.mapPairBuf
 	s.nextOffset = offset.end
 
 	return nil
+}
+
+// growBytes returns buf resliced to length n, reallocating only when cap is
+// too small.
+func growBytes(buf []byte, n int) []byte {
+	if cap(buf) < n {
+		return make([]byte, n)
+	}
+	return buf[:n]
 }


### PR DESCRIPTION
### What's being changed:

The read-side of the inverted-compaction allocation work: `segmentCursorInvertedReusable` now decodes each node into **reused buffers** instead of allocating per docID, and `CursorMap` is made safe for that reuse.

- **Cursor** (`cursor_segment_inverted_reusable.go`): decode into reused `mapPairBuf`/`kvArena`/`keyBuf`/`readBuf` via `decodeAndConvertFromBlocksReusable` (#12154) instead of a fresh `MapPair` + `make([]byte, 8)` per docID. Adds an **mmap fast path** that reads resident segment contents directly — no node reader, no read buffer — falling back to a pread path that reuses one read buffer with `io.ReadFull`. (Kept off main's lazy-proplen base: the cursor still never loads the property-length map.)
- **CursorMap** (`cursor_bucket_map.go`): because the inner cursor now reuses its Key/Value buffers across `next()`, `CursorMap` **copies the returned key** and **defers inner-cursor advances** to the next `Seek`/`Next`/`First` (advancing immediately only when the merged output is empty and discarded). Without this, an early advance would feed the merger buffers already overwritten by the next node.

The returned key is a fresh copy (safe to hold across iterations); the returned values are valid until the next call — the cursor's contract, which callers (the compactor; `MapList`-per-key readers) already honor.

> **Stacking:** depends on the reusable decode helpers (#12154) and the `MapCursorKeyOnly` fix (#12152). Opened against the integration branch that carries them. **Base will retarget to `stable/v1.37` once those merge.** Review the three files here.

### Tests

- `TestCursorMapInvertedReusable_HoldAcrossIterations` (integration): iterates a multi-block inverted segment via `MapCursor`, holding keys across iterations and reading each node's values during its iteration. Verified **red→green** for both protections — reverting the key-copy collapses all keys onto the last node; reverting the deferred-advance corrupts the decoded values.
- Full inverted read suite passes unchanged: `TestCompaction/compactionInverted*` (cursor read-back), BlockMax + WAND search, `TestTombstonesInverted_Compaction`.

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
