### PR TITLE
fix(batch): handle tiktoken initialization failure with read-only filesystem

### DIFF
--- a/usecases/modulecomponents/batch/tokenization.go
+++ b/usecases/modulecomponents/batch/tokenization.go
@@ -69,7 +69,10 @@ func ReturnBatchTokenizerWithAltNames(multiplier float32, moduleName string, alt
 				if err != nil {
 					tke, _ = tiktoken.EncodingForModel("text-embedding-ada-002")
 				}
-				encoderCache.Set(modelString, tke)
+				// Only cache if we successfully created the tokenizer
+				if tke != nil {
+					encoderCache.Set(modelString, tke)
+				}
 			}
 		}
 
@@ -86,8 +89,12 @@ func ReturnBatchTokenizerWithAltNames(multiplier float32, moduleName string, alt
 				continue
 			}
 			texts[i] = text
-			if multiplier > 0 {
+			if multiplier > 0 && tke != nil {
 				tokenCounts[i] = int(float32(GetTokensCount(modelString, text, tke)) * multiplier)
+			} else if multiplier > 0 {
+				// Fallback when tiktoken is unavailable (e.g., read-only filesystem)
+				// Use a rough estimate: ~0.75 tokens per character for English text
+				tokenCounts[i] = int(float32(len(text)*3/4) * multiplier)
 			}
 		}
 		return texts, tokenCounts, skipObject, skipAll, nil


### PR DESCRIPTION
**What's being changed:**

Fixed a panic that occurred when running Weaviate with `readOnlyRootFilesystem: true` in Kubernetes deployments. The text2vec module (and other text2vec modules using tiktoken) attempted to initialize tiktoken encoders, which require filesystem access for caching. When both the primary and fallback tiktoken initialization failed due to read-only filesystem restrictions, the tokenizer (`tke`) remained nil, causing a nil pointer dereference panic in `GetTokensCount` during batch operations.

The fix adds a nil check before calling `GetTokensCount` in `usecases/modulecomponents/batch/tokenization.go`. When tiktoken is unavailable, the code now uses a character-based fallback estimation (approximately 0.75 tokens per character) to calculate token counts. This allows batch vectorization to proceed even when tiktoken cannot initialize its cache files.

**Review checklist:**
- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

Fixes #8679