### PR TITLE
fix(lsmkv): GetBySecondary transient nil for live objects under flush

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -253,6 +253,22 @@ type Bucket struct {
 	// sequentialAccess hints the kernel (via fadvise) that segment files will
 	// be read sequentially. Set via WithSequentialAccess for snapshot buckets.
 	sequentialAccess bool
+
+	// secondaryRecheckHook is a nil-in-production instrumentation seam fired inside
+	// getBySecondaryCore AFTER the disk resolve and BEFORE the memtable/segment
+	// recheck. Tests set it to land a concurrent same-docID Put into the active
+	// memtable at exactly the resolve->recheck window, deterministically reproducing
+	// the gh#313 false-nil without relying on a timing race. Always nil in production.
+	secondaryRecheckHook func()
+
+	// secondaryResolveFlushingHook is a nil-in-production seam fired inside
+	// resolveSecondaryFromMemtables after the active-memtable probe (i==0) missed and
+	// the flushing-memtable probe (i==1) hit, immediately before the active-memtable
+	// re-check. Tests set it to land a same-secondary-key Put in the active memtable at
+	// exactly that window, deterministically reproducing the gh#313 false-nil in the
+	// flushing-memtable branch (the active memtable is read twice). Always nil in
+	// production.
+	secondaryResolveFlushingHook func()
 }
 
 func NewBucketCreator() *Bucket { return &Bucket{} }
@@ -883,40 +899,16 @@ func (b *Bucket) getBySecondaryCore(ctx context.Context, pos int, seckey []byte,
 	memtables, count := viewMemtables(view)
 
 	var memtablesTook [2]time.Duration
-	for i := range count {
-		beforeMemtable := time.Now()
-		k, v, err := b.getBySecondaryFromMemtable(pos, seckey, memtables[i], memtableNames[i])
-		memtablesTook[i] = time.Since(beforeMemtable)
-		if err == nil {
-			if i == 1 {
-				// if the item is found in the flushing memtable,
-				// we need to check if it exists in the primary key of the active memtable,
-				// to avoid returning an item that was deleted and re-added with the same secondary key
-				// - exists(k) == nil: a newer version of the doc exists, return lsmkv.NotFound
-				// - exists(k) == lsmkv.Deleted: the doc was deleted and not re-added, return lsmkv.Deleted
-				// - exists(k) == any other error != lsmkv.NotFound: return the error, since we can't be sure about the state of the doc
-				// - "default" exists(k) == lsmkv.NotFound: the doc was not found, so we can return the item found in the flushing memtable
-				err = memtables[0].exists(k)
-				if err == nil {
-					return nil, nil, lsmkv.NotFound
-				} else if errors.Is(err, lsmkv.Deleted) {
-					return nil, nil, err
-				} else if !errors.Is(err, lsmkv.NotFound) {
-					return nil, nil, fmt.Errorf("Bucket::getBySecondary() %q: %w", memtableNames[0], err)
-				}
-			}
-			// item found and no error, return and stop searching, since the strategy
-			// is replace
-			return v, buffer, nil
-		}
-		if errors.Is(err, lsmkv.Deleted) {
-			// deleted in the mem-table (which is always the latest) means we don't
-			// have to check the disk segments, return nil now
+	v, resolved, err := b.resolveSecondaryFromMemtables(pos, seckey, memtables, count, &memtablesTook)
+	if resolved {
+		if err != nil {
+			// terminal memtable decision: lsmkv.Deleted, lsmkv.NotFound
+			// (flushing-hit-but-newer-active-version), or a real error.
 			return nil, nil, err
 		}
-		if !errors.Is(err, lsmkv.NotFound) {
-			return nil, nil, fmt.Errorf("Bucket::getBySecondary() %q: %w", memtableNames[i], err)
-		}
+		// item found and no error, return and stop searching, since the strategy
+		// is replace
+		return v, buffer, nil
 	}
 
 	beforeSegments := time.Now()
@@ -929,6 +921,10 @@ func (b *Bucket) getBySecondaryCore(ctx context.Context, pos int, seckey []byte,
 	// additional validation to ensure the primary key has not been marked as deleted
 	beforeReCheck := time.Now()
 
+	if b.secondaryRecheckHook != nil {
+		b.secondaryRecheckHook()
+	}
+
 	// Check if a later version of the document is accesible by primary key.
 	// Only check up to, not including, the segment (secSegIndex+1) where the item was found,
 	// to avoid disk access for items that were deleted and re-added with the same secondary key in a later segment
@@ -937,6 +933,30 @@ func (b *Bucket) getBySecondaryCore(ctx context.Context, pos int, seckey []byte,
 	// if it exists on a later segment for priKey (err == nil), it means it was updated
 	// thus, we return lsmkv.NotFound to avoid returning stale data.
 	if err == nil {
+		// The recheck found priKey in a newer position. This is either a genuine
+		// supersede (a newer segment holds priKey) or a false positive: the view
+		// captures the active memtable BY POINTER, so a concurrent same-secondary-key
+		// Put landing between the disk resolve above and this recheck makes the resolve
+		// miss seckey in the memtable (resolving from an older segment) while the
+		// recheck finds priKey live in the memtable, yielding a false nil for a live
+		// object (gh#313). Segments are immutable and refcount-pinned within a view, so
+		// the ONLY thing that can change mid-read is the memtable. Re-resolve seckey
+		// against the (now-current) memtables: present there means the memtable holds
+		// the authoritative newest version (newest-wins); still absent means the
+		// supersede is genuine and we honor NotFound.
+		v2, resolved2, err2 := b.resolveSecondaryFromMemtables(pos, seckey, memtables, count, nil)
+		if resolved2 {
+			if err2 != nil {
+				// memtable tombstone / newer-version-under-different-docID / real error
+				return nil, nil, err2
+			}
+			if b.logger != nil {
+				b.logger.WithFields(logrus.Fields{
+					"action": "lsm_get_by_secondary_recheck_recovered",
+				}).Debug("recheck supersede overridden by memtable re-resolve (gh#313 window)")
+			}
+			return v2, buffer, nil
+		}
 		return nil, nil, lsmkv.NotFound
 	}
 
@@ -957,6 +977,113 @@ func (b *Bucket) getBySecondaryCore(ctx context.Context, pos int, seckey []byte,
 	})
 
 	return v, allocBuf, nil
+}
+
+// resolveSecondaryFromMemtables replicates the memtable phase of secondary-key
+// resolution over a view-pinned memtable set (active at index 0, then flushing at
+// index 1). It is the single home of the flushing-memtable deleted+re-added
+// three-way branch, shared by getBySecondaryCore's initial resolution and the
+// recheck re-resolve, so that branch is never duplicated and cannot drift.
+//
+// Return contract:
+//   - (value, true, nil): a live value was found in a memtable; stop, do not
+//     consult disk segments.
+//   - (nil, true, lsmkv.Deleted): the key is tombstoned in a memtable.
+//   - (nil, true, lsmkv.NotFound): the key hit the flushing memtable, its primary key
+//     is live in the active memtable, and the active memtable does NOT map this
+//     secondary key (the primary was re-added under a DIFFERENT secondary key), so it
+//     must resolve to not-found. When the active memtable DOES still map this secondary
+//     key (a same-secondary-key re-put), the active value is returned instead
+//     (newest-wins); see resolveSecondaryActiveOnly.
+//   - (nil, true, <wrapped error>): a real error was encountered.
+//   - (nil, false, nil): not found in any memtable; the caller proceeds to the
+//     disk segment group.
+//
+// When took is non-nil, took[i] receives the per-memtable probe duration (for the
+// single-key slow-log's ActiveMemtable / FlushingMemtable fields). Pass nil when the
+// caller does its own aggregate timing.
+func (b *Bucket) resolveSecondaryFromMemtables(pos int, seckey []byte, memtables [2]memtable, count int,
+	took *[2]time.Duration,
+) (v []byte, resolved bool, err error) {
+	for i := range count {
+		beforeMemtable := time.Now()
+		k, val, mErr := b.getBySecondaryFromMemtable(pos, seckey, memtables[i], memtableNames[i])
+		if took != nil {
+			took[i] = time.Since(beforeMemtable)
+		}
+		if mErr == nil {
+			if i == 1 {
+				// The secondary key was found in the flushing memtable. Check whether a
+				// newer version of its primary key exists in the (newer) active memtable,
+				// which would mean the flushing hit is stale.
+				// - exists(k) == lsmkv.NotFound: no newer primary version; return the
+				//   flushing value.
+				// - exists(k) == lsmkv.Deleted: the doc was deleted and not re-added;
+				//   return lsmkv.Deleted.
+				// - exists(k) == any other error != NotFound: return the error.
+				// - exists(k) == nil: a newer primary version is live in the active
+				//   memtable. This is NOT necessarily a re-key: the active memtable is
+				//   read twice here (once by the i==0 getBySecondary probe above, once by
+				//   this exists check), so a concurrent same-secondary-key Put landing
+				//   after the i==0 probe missed makes the active hold both priKey and
+				//   seckey while this loop still routes through the flushing hit (gh#313).
+				//   Re-probe the active memtable for THIS secondary key: present -> it is
+				//   the authoritative newest version (return it); absent -> the primary
+				//   really was re-added under a different secondary key -> NotFound.
+				if b.secondaryResolveFlushingHook != nil {
+					b.secondaryResolveFlushingHook()
+				}
+				existsErr := memtables[0].exists(k)
+				if existsErr == nil {
+					aVal, aResolved, aErr := b.resolveSecondaryActiveOnly(pos, seckey, memtables[0])
+					if aResolved {
+						return aVal, true, aErr
+					}
+					return nil, true, lsmkv.NotFound
+				} else if errors.Is(existsErr, lsmkv.Deleted) {
+					return nil, true, existsErr
+				} else if !errors.Is(existsErr, lsmkv.NotFound) {
+					return nil, true, fmt.Errorf("Bucket::getBySecondary() %q: %w", memtableNames[0], existsErr)
+				}
+			}
+			// item found and no error; stop searching, since the strategy is replace
+			return val, true, nil
+		}
+		if errors.Is(mErr, lsmkv.Deleted) {
+			// deleted in the mem-table (which is always the latest) means we don't
+			// have to check the disk segments
+			return nil, true, mErr
+		}
+		if !errors.Is(mErr, lsmkv.NotFound) {
+			return nil, true, fmt.Errorf("Bucket::getBySecondary() %q: %w", memtableNames[i], mErr)
+		}
+	}
+	return nil, false, nil
+}
+
+// resolveSecondaryActiveOnly probes ONLY the active memtable for a secondary key. It
+// is the tie-breaker for the flushing-memtable branch of resolveSecondaryFromMemtables:
+// when the active memtable's primary key exists but we reached the flushing hit anyway
+// (the active is read twice and a concurrent same-secondary-key Put may have landed in
+// between, gh#313), this asks the authoritative question "does the active memtable map
+// THIS secondary key?" as a single atomic read. Returns:
+//   - (value, true, nil): active maps the secondary key to a live value (newest-wins).
+//   - (nil, true, lsmkv.Deleted): active tombstones the secondary key's primary.
+//   - (nil, true, <wrapped error>): a real error.
+//   - (nil, false, nil): the active memtable does not map the secondary key (the primary
+//     was genuinely re-added under a different secondary key).
+func (b *Bucket) resolveSecondaryActiveOnly(pos int, seckey []byte, active memtable) ([]byte, bool, error) {
+	_, val, err := b.getBySecondaryFromMemtable(pos, seckey, active, memtableNames[0])
+	if err == nil {
+		return val, true, nil
+	}
+	if errors.Is(err, lsmkv.Deleted) {
+		return nil, true, err
+	}
+	if errors.Is(err, lsmkv.NotFound) {
+		return nil, false, nil
+	}
+	return nil, true, fmt.Errorf("Bucket::resolveSecondaryActiveOnly() %q: %w", memtableNames[0], err)
 }
 
 func (b *Bucket) getFromMemtable(key []byte, memtable memtable, component string) (v []byte, err error) {

--- a/adapters/repos/db/lsmkv/getbysecondary_recheck_nil_test.go
+++ b/adapters/repos/db/lsmkv/getbysecondary_recheck_nil_test.go
@@ -1,0 +1,315 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// gh#313: getBySecondaryCore reads the pointer-captured active memtable twice (the
+// resolve, then the recheck) with a disk read in between. A same-docID Put landing in
+// that window makes the resolve miss the secondary key in the memtable (resolving from
+// an older segment) while the recheck finds the primary key live in the memtable,
+// yielding a transient nil for an object that is live the whole time. The
+// secondaryRecheckHook / secondaryResolveFlushingHook seams land that concurrent Put at
+// exactly the vulnerable point so the false-nil reproduces deterministically instead of
+// relying on a timing race.
+
+const secondaryPos = 0
+
+// encodeDocID mirrors the little-endian docID secondary key produced by
+// upsertObjectDataLSM in shard_write_put.go.
+func encodeDocID(docID uint64) []byte {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], docID)
+	return b[:]
+}
+
+// encodePrimaryKey is a 16-byte UUID-shaped primary key, unique per docID.
+func encodePrimaryKey(docID uint64) []byte {
+	var b [16]byte
+	binary.BigEndian.PutUint64(b[8:], docID)
+	return b[:]
+}
+
+// newSecondaryTestBucket builds a Replace bucket with one secondary index, the
+// production LTK pread value path, compaction disabled, and any non-empty segment
+// mapped so the bloom flag alone picks the read path.
+func newSecondaryTestBucket(t testing.TB, useBloom bool) *Bucket {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	b, err := NewBucketCreator().NewBucket(
+		ctx, dir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace),
+		WithSecondaryIndices(1),
+		WithPread(true),
+		WithMinMMapSize(0),
+		WithUseBloomFilter(useBloom),
+		WithDisableCompaction(true),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+	return b
+}
+
+// forceFlushingMemtable moves the current active memtable into the flushing slot
+// (installing a fresh active), so a resolution view observes active + flushing +
+// segments at once. Because the test cycle managers are no-ops, nothing drains the
+// flushing memtable in the background; the registered cleanup (LIFO, runs before the
+// bucket's own Shutdown cleanup) flushes it to a segment, otherwise Shutdown blocks
+// forever waiting for b.flushing to clear. Requires a non-empty active memtable (the
+// switch is a no-op on an empty one).
+func forceFlushingMemtable(t testing.TB, b *Bucket) {
+	t.Helper()
+	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	require.NoError(t, err)
+	require.True(t, switched, "expected a non-empty active memtable to switch into flushing")
+	t.Cleanup(func() {
+		if b.flushing == nil {
+			return
+		}
+		b.waitForZeroWriters(b.flushing)
+		segmentPath, err := b.flushing.flush()
+		require.NoError(t, err)
+		seg, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
+		require.NoError(t, err)
+		require.NoError(t, b.atomicallyAddDiskSegmentAndRemoveFlushing(seg))
+	})
+}
+
+// TestBucketGetBySecondaryRecheckTransientNilSerial pins the serial
+// GetBySecondaryWithBuffer form. RED on head (returns nil); GREEN with the memtable
+// re-resolve fix (returns the newest value).
+func TestBucketGetBySecondaryRecheckTransientNilSerial(t *testing.T) {
+	ctx := context.Background()
+	b := newSecondaryTestBucket(t, false)
+
+	const docID = uint64(4242)
+	priKey := encodePrimaryKey(docID)
+	secKey := encodeDocID(docID)
+
+	v1 := make([]byte, 24)
+	v1[0] = 1
+	require.NoError(t, b.Put(priKey, v1, WithSecondaryKey(secondaryPos, secKey)))
+	require.NoError(t, b.FlushAndSwitch()) // secKey->priKey now in a segment; active memtable empty of it
+
+	got, _, err := b.GetBySecondaryWithBuffer(ctx, secondaryPos, secKey, nil)
+	require.NoError(t, err)
+	require.Equal(t, v1, got, "sanity: pre-race resolve returns the flushed value")
+
+	v2 := make([]byte, 24)
+	v2[0] = 2
+	var once sync.Once
+	b.secondaryRecheckHook = func() {
+		once.Do(func() {
+			require.NoError(t, b.Put(priKey, v2, WithSecondaryKey(secondaryPos, secKey)))
+		})
+	}
+	defer func() { b.secondaryRecheckHook = nil }()
+
+	got, _, err = b.GetBySecondaryWithBuffer(ctx, secondaryPos, secKey, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got, "gh#313: live object must not transiently read as nil under a flush-window re-put")
+	require.Equal(t, v2, got, "recovered value must be the newest (memtable) version (newest-wins preserved)")
+}
+
+// TestBucketGetBySecondaryResolveFlushingTransientNilSerial pins the SECOND gh#313
+// window (distinct from the recheck): resolveSecondaryFromMemtables reads the active
+// memtable twice - once by the i==0 secondary probe, once by the i==1 flushing branch's
+// active-exists check. A same-secondary-key Put landing in the active memtable between
+// those two reads makes the i==0 probe miss while the active-exists check finds the
+// primary live, so the branch wrongly concludes "re-added under a different secondary
+// key" and returns nil for a live object. RED on head; GREEN with resolveSecondaryActiveOnly.
+func TestBucketGetBySecondaryResolveFlushingTransientNilSerial(t *testing.T) {
+	ctx := context.Background()
+	b := newSecondaryTestBucket(t, false)
+
+	const docID = uint64(31337)
+	priKey := encodePrimaryKey(docID)
+	secKey := encodeDocID(docID)
+
+	v1 := make([]byte, 24)
+	v1[0] = 1
+	require.NoError(t, b.Put(priKey, v1, WithSecondaryKey(secondaryPos, secKey)))
+	forceFlushingMemtable(t, b) // secKey->priKey now lives in the flushing memtable; active is empty
+
+	v2 := make([]byte, 24)
+	v2[0] = 2
+	var once sync.Once
+	b.secondaryResolveFlushingHook = func() {
+		once.Do(func() {
+			require.NoError(t, b.Put(priKey, v2, WithSecondaryKey(secondaryPos, secKey)))
+		})
+	}
+	defer func() { b.secondaryResolveFlushingHook = nil }()
+
+	got, _, err := b.GetBySecondaryWithBuffer(ctx, secondaryPos, secKey, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got, "gh#313 flushing branch: live object must not read as nil under a same-docID re-put")
+	require.Equal(t, v2, got, "recovered value must be the newest (active memtable) version")
+}
+
+// TestBucketGetBySecondaryRecheckDeletedReAddedPreserved guards the genuine-supersede
+// semantics the recheck exists for: a docID deleted in the active memtable must still
+// read as nil even though its primary key is present (as a tombstone). The gh#313 fix
+// must not turn a genuine delete into a spurious hit.
+func TestBucketGetBySecondaryRecheckDeletedReAddedPreserved(t *testing.T) {
+	ctx := context.Background()
+	b := newSecondaryTestBucket(t, false)
+
+	const docID = uint64(777)
+	priKey := encodePrimaryKey(docID)
+	secKey := encodeDocID(docID)
+
+	v1 := make([]byte, 24)
+	v1[0] = 1
+	require.NoError(t, b.Put(priKey, v1, WithSecondaryKey(secondaryPos, secKey)))
+	require.NoError(t, b.FlushAndSwitch())
+
+	// Delete lands in the active memtable (tombstone under priKey) at the recheck window.
+	var once sync.Once
+	b.secondaryRecheckHook = func() {
+		once.Do(func() {
+			require.NoError(t, b.Delete(priKey, WithSecondaryKey(secondaryPos, secKey)))
+		})
+	}
+	defer func() { b.secondaryRecheckHook = nil }()
+
+	got, _, err := b.GetBySecondaryWithBuffer(ctx, secondaryPos, secKey, nil)
+	require.NoError(t, err)
+	require.Nil(t, got, "a genuine memtable delete in the recheck window must still resolve to nil")
+}
+
+// TestBucketGetBySecondaryFlushingReKeyedPreserved guards the flushing-branch guard's
+// original purpose: a primary key present in the flushing memtable under secKey1, then
+// re-added in the active memtable under a DIFFERENT secondary key secKey2, must still
+// resolve to nil when queried by the stale secKey1. The gh#313 fix (which recovers the
+// same-secondary-key re-put) must NOT turn this genuine re-key into a spurious hit.
+func TestBucketGetBySecondaryFlushingReKeyedPreserved(t *testing.T) {
+	ctx := context.Background()
+	b := newSecondaryTestBucket(t, false)
+
+	const docID, newDocID = uint64(880), uint64(881)
+	priKey := encodePrimaryKey(docID)
+	secKey1 := encodeDocID(docID)
+	secKey2 := encodeDocID(newDocID)
+
+	v1 := make([]byte, 24)
+	v1[0] = 1
+	require.NoError(t, b.Put(priKey, v1, WithSecondaryKey(secondaryPos, secKey1)))
+	forceFlushingMemtable(t, b) // secKey1->priKey in flushing; active empty
+
+	v2 := make([]byte, 24)
+	v2[0] = 2
+	require.NoError(t, b.Put(priKey, v2, WithSecondaryKey(secondaryPos, secKey2))) // re-keyed in active
+
+	got, _, err := b.GetBySecondaryWithBuffer(ctx, secondaryPos, secKey1, nil)
+	require.NoError(t, err)
+	require.Nil(t, got, "querying the stale secondary key of a re-keyed primary must resolve to nil")
+
+	gotNew, _, err := b.GetBySecondaryWithBuffer(ctx, secondaryPos, secKey2, nil)
+	require.NoError(t, err)
+	require.Equal(t, v2, gotNew, "the new secondary key must resolve to the re-keyed value")
+}
+
+// TestBucketGetBySecondaryRecheckStressNoFalseNil is a probabilistic backstop: real
+// concurrent same-docID re-puts + FlushAndSwitch while readers resolve the same docID
+// via the serial path, asserting an always-live object never reads as nil. Duration is
+// GH313_STRESS_SECONDS (default 3s; set to 20+ for a soak).
+func TestBucketGetBySecondaryRecheckStressNoFalseNil(t *testing.T) {
+	secs := 3
+	if v := os.Getenv("GH313_STRESS_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			secs = n
+		}
+	}
+
+	ctx := context.Background()
+	b := newSecondaryTestBucket(t, true) // bloom on (production shape)
+
+	const docID = uint64(555)
+	priKey := encodePrimaryKey(docID)
+	secKey := encodeDocID(docID)
+
+	// seed and flush so a segment holds the key and the active memtable starts empty
+	seed := make([]byte, 24)
+	seed[0] = 1
+	require.NoError(t, b.Put(priKey, seed, WithSecondaryKey(secondaryPos, secKey)))
+	require.NoError(t, b.FlushAndSwitch())
+
+	stop := make(chan struct{})
+	var falseNils atomic.Int64
+	var version atomic.Uint64
+	var wg sync.WaitGroup
+
+	// writer: never deletes docID, so it is live for the whole run; a nil read is a bug.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		lastFlush := time.Now()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			ver := version.Add(1)
+			val := make([]byte, 24)
+			val[0] = byte(ver)
+			_ = b.Put(priKey, val, WithSecondaryKey(secondaryPos, secKey))
+			if time.Since(lastFlush) > 20*time.Millisecond {
+				_ = b.FlushAndSwitch()
+				lastFlush = time.Now()
+			}
+		}
+	}()
+
+	readers := 6
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				v, _, err := b.GetBySecondaryWithBuffer(ctx, secondaryPos, secKey, nil)
+				if err == nil && v == nil {
+					falseNils.Add(1)
+				}
+			}
+		}()
+	}
+
+	time.Sleep(time.Duration(secs) * time.Second)
+	close(stop)
+	wg.Wait()
+
+	require.Zero(t, falseNils.Load(),
+		"gh#313: an always-live object read nil %d time(s) under flush-concurrent re-puts", falseNils.Load())
+}


### PR DESCRIPTION
Hey, Claudette here :robot: :wave:

### Summary

Under a concurrent writer doing same-secondary-key re-puts plus `FlushAndSwitch`, a present, live object can transiently read as `nil` through `GetBySecondary` on a Replace bucket. This fixes both windows that produce the false nil and adds deterministic regression tests plus a stress backstop. The bug is a correctness issue (a live object momentarily invisible by secondary key), pre-existing since #10655; it is not a new regression.

### Mechanism

A `GetBySecondary` read captures the active memtable by pointer for the duration of the view. Segments are immutable and refcount-pinned, so the only surface that can change mid-read is that memtable. Two spots read it twice with no snapshot in between, and a same-secondary-key `Put` landing in the gap flips the second read:

1. Recheck window (`getBySecondaryCore`). After resolving the secondary key from a disk segment, the code rechecks whether the primary key has a newer version via `existsWithConsistentViewUpTo`. If a same-secondary-key `Put` lands after the segment resolve, the resolve had already missed the key in the memtable (resolving from an older segment) while the recheck now finds the primary key live in the memtable. The code reads that as "a newer version supersedes this" and returns `NotFound` for an object that was live the whole time.

2. Flushing-branch window (the flushing-memtable branch of the memtable resolution). The active memtable is read twice here too: once by the initial secondary probe, once by the flushing branch's `exists` check on the primary key. A same-secondary-key `Put` landing between them makes the first probe miss while the `exists` check finds the primary live, so the branch wrongly concludes the primary was re-added under a different secondary key and returns `NotFound`. Same class as window 1, distinct code path; it surfaces under a 20s+ `-race` stress soak.

Neutering the recheck entirely made the divergence vanish, which pins the mechanism to these two-phase reads rather than the disk path.

### Fix

On any supersede conclusion, re-resolve the secondary key against the current memtables before honoring `NotFound`. Present there means the memtable holds the authoritative newest version, so return it (newest-wins). Still absent means the supersede is genuine (a real re-key or a newer segment version), so `NotFound` stands. The flushing branch gets the same tie-breaker via a single atomic active-memtable re-probe of the actual secondary key. Both paths preserve the two semantics the recheck exists for: a genuine delete in the window still resolves to nil, and a primary re-added under a different secondary key still resolves to nil when queried by the stale key.

The memtable phase of `getBySecondaryCore` is extracted into one helper so the initial resolution and the recheck re-resolve share a single home for the flushing-memtable branch and it cannot drift between the two. Both recovery paths emit a Debug log naming the absorption, so a future regression is greppable rather than silent.

### Tests

`getbysecondary_recheck_nil_test.go` pins both windows on the serial `GetBySecondaryWithBuffer` path. Each reproduction lands a same-docID re-put at exactly the vulnerable point through a nil-in-production instrumentation seam, so the false nil reproduces deterministically instead of relying on a timing race. Both are RED on the unfixed logic and GREEN with the fix (verified by neuter-revert). Two controls, a genuine memtable delete and a genuine re-key under a different secondary key, both still resolve to nil and stay green in the neutered tree, proving the fix does not broaden semantics. A stress backstop runs real concurrent re-puts plus `FlushAndSwitch` against serial readers and asserts an always-live object never reads nil; validated clean at 30s under `-race`.

### Out of scope

- The batched `GetBySecondary` resolver is not present on this branch, so its analogue of this fix ships separately alongside the batch work. The mechanism and the fix principle are identical; only the code shape differs.

### Verification

- [x] `go build ./adapters/repos/db/lsmkv/...` clean
- [x] `go vet` clean, gofumpt clean
- [x] deterministic tests GREEN on fix, RED on the neutered tree (both repros fail, both controls pass)
- [x] full `lsmkv` package `go test -race -count=1` green
- [x] 30s `-race` stress soak, zero false nils
- [ ] CI acceptance pending
- [ ] 3-node validation deferred: this is a within-shard read-path fix (a TOCTOU between two memtable reads under one consistent view); replication sits above the shard and adds no new interleaving, so it is fully exercised single-node

Claudette
