### PR TITLE
feat(usage): warn when collection cycles overlap the collection interval

### DIFF
--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -55,6 +56,9 @@ type BaseModule struct {
 	// mu mutex to protect shared fields to run concurrently the collection and upload
 	// to avoid interval overlap for the tickers
 	mu sync.RWMutex
+	// collectionsInFlight counts running collection cycles to detect ticks
+	// overlapping a report that takes longer than the collection interval
+	collectionsInFlight atomic.Int32
 }
 
 // NewBaseModule creates a new base module instance
@@ -211,12 +215,7 @@ func (b *BaseModule) collectAndUploadPeriodically(ctx context.Context) {
 			}).Debug("collection ticker fired - starting collection cycle")
 
 			enterrors.GoWrapper(func() {
-				if err := b.collectAndUploadUsage(ctx); err != nil {
-					b.logger.WithError(err).Error("Failed to collect and upload usage data")
-					b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "error").Inc()
-				} else {
-					b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "success").Inc()
-				}
+				b.runCollectAndUpload(ctx)
 			}, b.logger)
 
 			// save last push date
@@ -239,6 +238,23 @@ func (b *BaseModule) collectAndUploadPeriodically(ctx context.Context) {
 			b.logger.Info("stop signal received - stopping periodic collection")
 			return
 		}
+	}
+}
+
+// runCollectAndUpload runs one collection cycle. Overlapping cycles are
+// allowed but logged, as they indicate reports taking longer than the
+// collection interval.
+func (b *BaseModule) runCollectAndUpload(ctx context.Context) {
+	if inFlight := b.collectionsInFlight.Add(1); inFlight > 1 {
+		b.logger.Warnf("starting a usage collection cycle while %d previous cycle(s) are still running: usage report generation takes longer than the collection interval", inFlight-1)
+	}
+	defer b.collectionsInFlight.Add(-1)
+
+	if err := b.collectAndUploadUsage(ctx); err != nil {
+		b.logger.Errorf("Failed to collect and upload usage data: %v", err)
+		b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "error").Inc()
+	} else {
+		b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "success").Inc()
 	}
 }
 

--- a/usecases/modulecomponents/usage/base_module_test.go
+++ b/usecases/modulecomponents/usage/base_module_test.go
@@ -15,16 +15,21 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	clusterusage "github.com/weaviate/weaviate/cluster/usage"
+	"github.com/weaviate/weaviate/cluster/usage/types"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 	configruntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
@@ -103,4 +108,63 @@ func TestBaseModule_RuntimeOverridesConcurrencyReachesService(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("usage service did not receive the shard concurrency from runtime overrides")
 	}
+}
+
+// TestBaseModule_WarnsOnOverlappingCollection verifies overlapping collection
+// cycles are allowed to run concurrently but emit a warning log.
+func TestBaseModule_WarnsOnOverlappingCollection(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+
+	mockStorage := NewMockStorageBackend(t)
+	mockStorage.EXPECT().UploadUsageData(mock.Anything, mock.Anything).Return(nil).Times(2)
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	mockService := clusterusage.NewMockService(t)
+	mockService.EXPECT().Usage(mock.Anything, false).RunAndReturn(
+		func(context.Context, bool) (*types.Report, error) {
+			entered <- struct{}{}
+			<-release
+			return &types.Report{}, nil
+		}).Times(2)
+
+	module := NewBaseModule("test-module", mockStorage)
+
+	cfg := &config.Config{}
+	cfg.Cluster.Hostname = "test-node"
+	cfg.Persistence.DataPath = t.TempDir()
+	require.NoError(t, ParseCommonUsageConfig(cfg))
+	require.NoError(t, module.InitializeCommon(context.Background(), cfg, logger,
+		NewMetrics(prometheus.NewRegistry(), "test-module")))
+	// set the service directly to avoid starting the periodic collector
+	module.usageService = mockService
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			module.runCollectAndUpload(context.Background())
+		}, logger)
+	}
+
+	// both cycles are inside Usage at the same time
+	for range 2 {
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("collection cycles did not run concurrently")
+		}
+	}
+	close(release)
+	wg.Wait()
+
+	var warned bool
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.WarnLevel && strings.Contains(entry.Message, "still running") {
+			warned = true
+		}
+	}
+	assert.True(t, warned, "expected a warning about overlapping collection cycles")
+	assert.Equal(t, int32(0), module.collectionsInFlight.Load())
 }


### PR DESCRIPTION
### What's being changed:

The usage module ticker starts a new collection cycle on every tick with no visibility into overlap — when a report takes longer than the collection interval, cycles silently pile up.

- Track running cycles with an `atomic.Int32` counter; when a tick starts while previous cycles are still running, emit a warning log. Overlapping cycles are still allowed to run.
- Test: `TestBaseModule_WarnsOnOverlappingCollection`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
