### PR TITLE
chore(rplc-mvmnt): add more debug logging to ccl usage

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -351,6 +351,13 @@ func (i *Index) snapshotsPath() string {
 	return path.Join(i.path(), lsmkv.SnapshotsRootDir)
 }
 
+func (i *Index) debugLoggingEnabled() bool {
+	if logger, ok := i.logger.(*logrus.Logger); ok && logger.IsLevelEnabled(logrus.DebugLevel) {
+		return true
+	}
+	return false
+}
+
 // NewIndex creates an index with the specified amount of shards, using only
 // the shards that are local to a node
 func NewIndex(

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -352,10 +352,14 @@ func (i *Index) snapshotsPath() string {
 }
 
 func (i *Index) debugLoggingEnabled() bool {
-	if logger, ok := i.logger.(*logrus.Logger); ok && logger.IsLevelEnabled(logrus.DebugLevel) {
-		return true
+	switch logger := i.logger.(type) {
+	case *logrus.Logger:
+		return logger.IsLevelEnabled(logrus.DebugLevel)
+	case *logrus.Entry:
+		return logger.Logger.IsLevelEnabled(logrus.DebugLevel)
+	default:
+		return false
 	}
-	return false
 }
 
 // NewIndex creates an index with the specified amount of shards, using only

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -853,6 +853,7 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 	if len(updates) == 0 {
 		return nil
 	}
+	debugEnabled := idx.debugLoggingEnabled()
 
 	s, release, err := idx.getOrInitShard(ctx, shard)
 	if err != nil {
@@ -885,8 +886,10 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 				return fmt.Errorf("replay put batch: %w", e)
 			}
 		}
-		for _, o := range objs {
-			appliedPuts = append(appliedPuts, o.ID())
+		if debugEnabled {
+			for _, o := range objs {
+				appliedPuts = append(appliedPuts, o.ID())
+			}
 		}
 		clear(pending)
 		return nil
@@ -914,7 +917,9 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 		}
 
 		if currUpdateTime > u.LastUpdateTimeUnixMilli {
-			skippedStale = append(skippedStale, u.ID)
+			if debugEnabled {
+				skippedStale = append(skippedStale, u.ID)
+			}
 			continue
 		}
 
@@ -925,7 +930,9 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 			if err := s.DeleteObject(ctx, u.ID, time.UnixMilli(u.LastUpdateTimeUnixMilli)); err != nil {
 				return fmt.Errorf("replay delete for %s: %w", u.ID, err)
 			}
-			appliedDeletes = append(appliedDeletes, u.ID)
+			if debugEnabled {
+				appliedDeletes = append(appliedDeletes, u.ID)
+			}
 			continue
 		}
 

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/cluster/replication/changelog"
 	"github.com/weaviate/weaviate/cluster/router/types"
@@ -868,6 +869,8 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 	}
 	pending := map[strfmt.UUID]pendingPut{}
 
+	var appliedPuts, appliedDeletes, skippedStale []strfmt.UUID
+
 	flushPending := func() error {
 		if len(pending) == 0 {
 			return nil
@@ -881,6 +884,9 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 			if e != nil {
 				return fmt.Errorf("replay put batch: %w", e)
 			}
+		}
+		for _, o := range objs {
+			appliedPuts = append(appliedPuts, o.ID())
 		}
 		clear(pending)
 		return nil
@@ -908,6 +914,7 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 		}
 
 		if currUpdateTime > u.LastUpdateTimeUnixMilli {
+			skippedStale = append(skippedStale, u.ID)
 			continue
 		}
 
@@ -918,6 +925,7 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 			if err := s.DeleteObject(ctx, u.ID, time.UnixMilli(u.LastUpdateTimeUnixMilli)); err != nil {
 				return fmt.Errorf("replay delete for %s: %w", u.ID, err)
 			}
+			appliedDeletes = append(appliedDeletes, u.ID)
 			continue
 		}
 
@@ -940,7 +948,18 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 		pending[u.ID] = pendingPut{decoded: decoded, ts: u.LastUpdateTimeUnixMilli}
 	}
 
-	return flushPending()
+	if err := flushPending(); err != nil {
+		return err
+	}
+	idx.logger.WithFields(logrus.Fields{
+		"action":          "change_capture_log",
+		"shard":           shard,
+		"entries":         len(updates),
+		"puts_applied":    appliedPuts,
+		"deletes_applied": appliedDeletes,
+		"skipped_stale":   skippedStale,
+	}).Debug("change-capture log replay batch applied")
+	return nil
 }
 
 func (i *Index) DigestObjects(ctx context.Context,

--- a/adapters/repos/db/shard_changelog.go
+++ b/adapters/repos/db/shard_changelog.go
@@ -20,6 +20,9 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/replication/changelog"
 )
 
@@ -60,6 +63,12 @@ func (s *Shard) ActivateChangeLog(ctx context.Context, opID string) (*changelog.
 		return nil, fmt.Errorf("shard %q: open changelog for op %q: %w", s.ID(), opID, err)
 	}
 	changelog.Register(&s.changeLogs, opID, log)
+	s.index.logger.WithFields(logrus.Fields{
+		"action": "change_capture_log",
+		"op_id":  opID,
+		"shard":  s.ID(),
+		"path":   path,
+	}).Debug("change-capture log activated")
 	return log, nil
 }
 
@@ -77,6 +86,7 @@ func (s *Shard) FinalizeChangeLog(ctx context.Context, opID string) (uint64, err
 	if log == nil {
 		return 0, errNoSuchChangeLog
 	}
+	start := time.Now()
 	pending := s.replicationMap.keys()
 
 	ticker := time.NewTicker(5 * time.Millisecond)
@@ -93,7 +103,18 @@ func (s *Shard) FinalizeChangeLog(ctx context.Context, opID string) (uint64, err
 			}
 		}
 		if !draining {
-			return log.Finalize()
+			finalLSN, err := log.Finalize()
+			if err != nil {
+				return 0, err
+			}
+			s.index.logger.WithFields(logrus.Fields{
+				"action":     "change_capture_log",
+				"op_id":      opID,
+				"shard":      s.ID(),
+				"final_lsn":  finalLSN,
+				"drain_took": time.Since(start),
+			}).Debug("change-capture log sealed")
+			return finalLSN, nil
 		}
 		select {
 		case <-ctx.Done():
@@ -111,7 +132,14 @@ func (s *Shard) SnapshotChangeLogLSN(ctx context.Context, opID string) (uint64, 
 	if log == nil {
 		return 0, errNoSuchChangeLog
 	}
-	return log.LSN(), nil
+	lsn := log.LSN()
+	s.index.logger.WithFields(logrus.Fields{
+		"action": "change_capture_log",
+		"op_id":  opID,
+		"shard":  s.ID(),
+		"lsn":    lsn,
+	}).Debug("change-capture log LSN snapshotted")
+	return lsn, nil
 }
 
 func (s *Shard) StopChangeCapture(ctx context.Context, opID string) error {
@@ -120,7 +148,17 @@ func (s *Shard) StopChangeCapture(ctx context.Context, opID string) error {
 		return nil
 	}
 	changelog.Unregister(&s.changeLogs, opID)
-	return log.Deactivate()
+	lastLSN := log.LSN()
+	if err := log.Deactivate(); err != nil {
+		return err
+	}
+	s.index.logger.WithFields(logrus.Fields{
+		"action":   "change_capture_log",
+		"op_id":    opID,
+		"shard":    s.ID(),
+		"last_lsn": lastLSN,
+	}).Debug("change-capture log deactivated")
+	return nil
 }
 
 func (s *Shard) GetChangeLog(ctx context.Context, opID string) (*changelog.ChangeLog, bool) {
@@ -147,9 +185,10 @@ func (s *Shard) AppendChangeLogPut(idBytes []byte, updateTimeMillis int64, objBi
 	copy(uuidArr[:], idBytes)
 
 	set.ForEach(func(opID string, log *changelog.ChangeLog) {
-		_, appendErr := s.appendWithRetry(func() (uint64, error) {
+		lsn, appendErr := s.appendWithRetry(func() (uint64, error) {
 			return log.AppendPut(uuidArr, updateTimeMillis, objBinary)
 		})
+		s.logChangeLogAppend(opID, "put", uuidArr, updateTimeMillis, lsn, appendErr)
 		s.dispatchAppendResult(opID, log, appendErr)
 	})
 }
@@ -164,11 +203,37 @@ func (s *Shard) AppendChangeLogDelete(idBytes []byte, updateTimeMillis int64) {
 	copy(uuidArr[:], idBytes)
 
 	set.ForEach(func(opID string, log *changelog.ChangeLog) {
-		_, appendErr := s.appendWithRetry(func() (uint64, error) {
+		lsn, appendErr := s.appendWithRetry(func() (uint64, error) {
 			return log.AppendDelete(uuidArr, updateTimeMillis)
 		})
+		s.logChangeLogAppend(opID, "delete", uuidArr, updateTimeMillis, lsn, appendErr)
 		s.dispatchAppendResult(opID, log, appendErr)
 	})
+}
+
+func (s *Shard) logChangeLogAppend(opID, kind string, uuidArr [16]byte, updateTimeMillis int64, lsn uint64, appendErr error) {
+	if appendErr == nil {
+		s.index.logger.WithFields(logrus.Fields{
+			"action":         "change_capture_log",
+			"op_id":          opID,
+			"shard":          s.ID(),
+			"kind":           kind,
+			"uuid":           uuid.UUID(uuidArr),
+			"update_time_ms": updateTimeMillis,
+			"lsn":            lsn,
+		}).Debug("change-capture log entry appended")
+		return
+	}
+	if errors.Is(appendErr, changelog.ErrLogFinalized) || errors.Is(appendErr, changelog.ErrLogDeactivated) {
+		s.index.logger.WithFields(logrus.Fields{
+			"action":         "change_capture_log",
+			"op_id":          opID,
+			"shard":          s.ID(),
+			"kind":           kind,
+			"uuid":           uuid.UUID(uuidArr),
+			"update_time_ms": updateTimeMillis,
+		}).Debugf("change-capture log append dropped: %v", appendErr)
+	}
 }
 
 // appendWithRetry short-circuits ErrLogFinalized/ErrLogDeactivated (retry

--- a/adapters/repos/db/shard_changelog.go
+++ b/adapters/repos/db/shard_changelog.go
@@ -148,10 +148,10 @@ func (s *Shard) StopChangeCapture(ctx context.Context, opID string) error {
 		return nil
 	}
 	changelog.Unregister(&s.changeLogs, opID)
-	lastLSN := log.LSN()
 	if err := log.Deactivate(); err != nil {
 		return err
 	}
+	lastLSN := log.LSN()
 	s.index.logger.WithFields(logrus.Fields{
 		"action":   "change_capture_log",
 		"op_id":    opID,
@@ -212,6 +212,9 @@ func (s *Shard) AppendChangeLogDelete(idBytes []byte, updateTimeMillis int64) {
 }
 
 func (s *Shard) logChangeLogAppend(opID, kind string, uuidArr [16]byte, updateTimeMillis int64, lsn uint64, appendErr error) {
+	if !s.index.debugLoggingEnabled() {
+		return
+	}
 	if appendErr == nil {
 		s.index.logger.WithFields(logrus.Fields{
 			"action":         "change_capture_log",

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -281,11 +281,13 @@ func (c *coordinator[T, R]) Push(ctx context.Context,
 
 	//nolint:govet // we expressely don't want to cancel that context as the timeout will take care of it
 	ctxWithTimeout, _ := context.WithTimeout(context.Background(), 20*time.Second)
-	c.log.WithFields(logrus.Fields{
-		"action":   "coordinator_push",
-		"duration": 20 * time.Second,
-		"level":    level,
-	}).Debug("context.WithTimeout")
+	c.log.WithFields(writeRoutingPlan.LogFields()).WithFields(logrus.Fields{
+		"action":     "coordinator_push",
+		"duration":   20 * time.Second,
+		"level":      level,
+		"class":      c.Class,
+		"request_id": c.TxID,
+	}).Debug("pushing write to resolved replica set")
 
 	// create callback for metrics
 	// the use of an immediately invoked function expression (IIFE) captures the start time


### PR DESCRIPTION
### What's being changed:

Increase volume and verbosity of logs around ccl usage to print in ci flakes

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
