### PR TITLE
Skip lazy-unloaded tenant shards in TTL sweep

### DIFF
--- a/adapters/repos/db/index_objects_ttl.go
+++ b/adapters/repos/db/index_objects_ttl.go
@@ -53,6 +53,13 @@ type tenantTTLLoop struct {
 	processBatch          func(ctx context.Context, uuids []strfmt.UUID) error
 }
 
+// shardIsLazyUnloaded reports whether the named shard is a lazy shard not yet materialized.
+// Only HOT tenants are lazy shards, so this never hides a COLD tenant from auto-activation.
+func (i *Index) shardIsLazyUnloaded(shardName string) bool {
+	lazy, ok := i.shards.Load(shardName).(*LazyLoadShard)
+	return ok && !lazy.isLoaded()
+}
+
 func (i *Index) IncomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.ErrorGroupWrapper, ec errorcompounder.ErrorCompounder,
 	deleteOnPropName string, ttlThreshold, deletionTime time.Time, countDeleted func(int32), schemaVersion uint64,
 ) {
@@ -98,6 +105,10 @@ func (i *Index) incomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.
 		autoActivationEnabled := schema.AutoTenantActivationEnabled(class)
 
 		for _, tenant := range tenants {
+			// Don't force-load an idle tenant on every sweep; it's cleaned once it materializes.
+			if i.shardIsLazyUnloaded(tenant) {
+				continue
+			}
 			eg.Go(func() error {
 				// processedBatches is intentionally shared between the findUUIDs and processBatch
 				// closures below — both run within this single goroutine, so there is no race.

--- a/adapters/repos/db/index_objects_ttl_integration_test.go
+++ b/adapters/repos/db/index_objects_ttl_integration_test.go
@@ -1,0 +1,124 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/replication"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestTTLSkipsLazyUnloadedTenant guards that the TTL sweep leaves a lazy-unloaded HOT tenant
+// unloaded. Reaching findUUIDs would call the unmocked router and force-load the shard,
+// failing the test.
+func TestTTLSkipsLazyUnloadedTenant(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	const (
+		className = "TestTTLLazyClass"
+		nodeName  = "test-node"
+		tenant    = "idle-tenant"
+	)
+
+	class := &models.Class{
+		Class:               className,
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+		MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+		ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+	}
+	fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+	shardState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			tenant: {
+				Name:           tenant,
+				BelongsToNodes: []string{nodeName},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+		PartitioningEnabled: true,
+	}
+	shardState.SetLocalName(nodeName)
+
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ string, _ bool, readerFunc func(*models.Class, *sharding.State) error) error {
+			return readerFunc(class, shardState)
+		}).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
+	mockSchemaReader.EXPECT().Shards(className).Return([]string{tenant}, nil).Once()
+
+	mockSchema := schemaUC.NewMockSchemaGetter(t)
+	mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+	mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
+	mockSchema.EXPECT().NodeName().Maybe().Return(nodeName)
+
+	// No read-routing expectations: the skip means findUUIDs is never reached. Removing the
+	// skip would call BuildReadRoutingPlan and fail on an unexpected mock call.
+	mockRouter := types.NewMockRouter(t)
+
+	schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
+	shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
+
+	index, err := NewIndex(ctx, IndexConfig{
+		RootPath:             t.TempDir(),
+		ClassName:            schema.ClassName(className),
+		ReplicationFactor:    1,
+		ShardLoadLimiter:     loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+		EnableLazyLoadShards: true,
+	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
+		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
+		class, nil, scheduler, nil, nil,
+		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+	require.NoError(t, err)
+	defer index.Shutdown(ctx)
+
+	stored := index.shards.Load(tenant)
+	lazy, isLazy := stored.(*LazyLoadShard)
+	require.True(t, isLazy, "HOT tenant should be a lazy wrapper, got %T", stored)
+	require.False(t, lazy.isLoaded(), "tenant must be unloaded before the sweep")
+
+	eg := enterrors.NewErrorGroupWrapper(logger)
+	ec := errorcompounder.New()
+	index.incomingDeleteObjectsExpired(ctx, eg, ec, "expiresAt", time.Now(), time.Now(),
+		func(int32) {}, 0)
+	eg.Wait()
+
+	require.NoError(t, ec.ToError())
+	require.False(t, lazy.isLoaded(), "TTL sweep must not force-load a lazy-unloaded tenant")
+}

--- a/adapters/repos/db/index_objects_ttl_test.go
+++ b/adapters/repos/db/index_objects_ttl_test.go
@@ -86,6 +86,31 @@ func newTestLoop(t *testing.T, mgr *fakeTTLTenantsManager, autoActivation bool,
 	}
 }
 
+// TestShardIsLazyUnloaded checks that only a lazy shard not yet materialized is skipped;
+// absent (COLD), loaded lazy, and non-lazy shards are not.
+func TestShardIsLazyUnloaded(t *testing.T) {
+	tests := []struct {
+		name  string
+		shard ShardLike // nil means the tenant is absent from the shard map
+		want  bool
+	}{
+		{name: "absent tenant", shard: nil, want: false},
+		{name: "lazy shard not loaded", shard: &LazyLoadShard{loaded: false}, want: true},
+		{name: "lazy shard loaded", shard: &LazyLoadShard{loaded: true}, want: false},
+		{name: "non-lazy shard", shard: &Shard{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := &Index{}
+			if tt.shard != nil {
+				idx.shards.Store("tenant_0", tt.shard)
+			}
+			assert.Equal(t, tt.want, idx.shardIsLazyUnloaded("tenant_0"))
+		})
+	}
+}
+
 // TestTenantTTLLoop_ContextCancelAfterActivation is the primary regression test for
 // the server bug reported in:
 //


### PR DESCRIPTION
### What's being changed:

title - lazy shards are loaded in the background so we will get to them at some point

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
