### PR TITLE
chore(rplc-mvmnt): remove `consumer.sync` from happy path due to redundancy

### DIFF
--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -755,10 +755,6 @@ func (c *CopyOpConsumer) processIntegratingOp(ctx context.Context, op ShardRepli
 	if err != nil {
 		if isCCLAlreadyGone(err) {
 			logger.Info("change log already sealed, integration already complete")
-			if err := c.sync(ctx, op); err != nil {
-				logger.WithError(err).Error("failure while syncing replica shard in integrating state")
-				return api.ShardReplicationState(""), err
-			}
 			return nextStateAfterIntegrating(op.Op.TransferType), nil
 		}
 		logger.WithError(err).Error("failure while snapshotting change log LSN")
@@ -781,10 +777,6 @@ func (c *CopyOpConsumer) processIntegratingOp(ctx context.Context, op ShardRepli
 		return api.ShardReplicationState(""), err
 	}
 
-	if err := c.sync(ctx, op); err != nil {
-		logger.WithError(err).Error("failure while syncing replica shard in integrating state")
-		return api.ShardReplicationState(""), err
-	}
 	return nextStateAfterIntegrating(op.Op.TransferType), nil
 }
 
@@ -832,10 +824,6 @@ func (c *CopyOpConsumer) processDehydratingOp(ctx context.Context, op ShardRepli
 		}
 	}
 
-	if err := c.sync(ctx, op); err != nil {
-		logger.WithError(err).Error("failure while syncing replica shard in dehydrating state")
-		return api.ShardReplicationState(""), err
-	}
 	return api.READY, nil
 }
 

--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -723,8 +723,7 @@ func (c *CopyOpConsumer) processFinalizingOp(ctx context.Context, op ShardReplic
 // processIntegratingOp is the shared seal+drain phase for COPY and MOVE.
 // It waits for INTEGRATING to converge across every node — making the target
 // a counted write replica everywhere — then does a capped drain and seals the
-// source CCL. Idempotent: re-running after a prior seal sees "log gone" and
-// finishes via sync.
+// source CCL. Idempotent: re-running after a prior seal sees "log gone".
 //
 // Returns READY for COPY (source stays), DEHYDRATING for MOVE (source removed
 // next by processDehydratingOp).
@@ -750,7 +749,7 @@ func (c *CopyOpConsumer) processIntegratingOp(ctx context.Context, op ShardRepli
 	}
 
 	// Capped drain shrinks the gap before the final seal. "Log gone" on retry
-	// means a prior attempt already sealed; sync and finish.
+	// means a prior attempt already sealed.
 	snap, err := c.replicaCopier.SnapshotChangeLogLSN(ctx, src, coll, shard, opID)
 	if err != nil {
 		if isCCLAlreadyGone(err) {

--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -85,14 +85,6 @@ func TestConsumerWithCallbacks(t *testing.T) {
 		mockFSMUpdater.EXPECT().
 			ReplicationAddReplicaToShard(mock.Anything, "TestCollection", "shard1", "node2", uint64(opId)).
 			Return(uint64(0), nil)
-		mockFSMUpdater.EXPECT().
-			SyncShard(mock.Anything, "TestCollection", "shard1", "node1").
-			Return(uint64(0), nil).
-			Times(1)
-		mockFSMUpdater.EXPECT().
-			SyncShard(mock.Anything, "TestCollection", "shard1", "node2").
-			Return(uint64(0), nil).
-			Times(1)
 		mockReplicaCopier.EXPECT().
 			CopyReplicaFiles(
 				mock.Anything,
@@ -391,8 +383,6 @@ func TestConsumerWithCallbacks(t *testing.T) {
 				ReplicationAddReplicaToShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, uint64(opId)).
 				Return(uint64(i), nil)
 			expectChangeCaptureMocks(mockReplicaCopier, mockFSMUpdater)
-			mockFSMUpdater.EXPECT().
-				SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(i), nil)
 		}
 
 		var (
@@ -692,8 +682,6 @@ func TestConsumerWithCallbacks(t *testing.T) {
 					ReplicationAddReplicaToShard(mock.Anything, "TestCollection", mock.Anything, mock.Anything, uint64(opID)).
 					Return(uint64(i), nil)
 				expectChangeCaptureMocks(mockReplicaCopier, mockFSMUpdater)
-				mockFSMUpdater.EXPECT().
-					SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(i), nil)
 				completionWg.Add(1)
 			} else {
 				require.False(t, opsCache.LoadOrStore(opID), "operation should not be stored twice in cache")
@@ -1154,8 +1142,6 @@ func TestConsumerOpDuplication(t *testing.T) {
 		LoadLocalShard(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 	expectChangeCaptureMocks(mockReplicaCopier, mockFSMUpdater)
-	mockFSMUpdater.EXPECT().
-		SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(1), nil)
 
 	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
 	status := replication.NewShardReplicationStatus(api.FINALIZING)
@@ -1288,8 +1274,6 @@ func TestConsumerOpSkip(t *testing.T) {
 		ReplicationAddReplicaToShard(mock.Anything, "TestCollection", "shard1", "node2", uint64(1)).
 		Return(uint64(1), nil)
 	expectChangeCaptureMocks(mockReplicaCopier, mockFSMUpdater)
-	mockFSMUpdater.EXPECT().
-		SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uint64(1), nil)
 	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
 	status := replication.NewShardReplicationStatus(api.FINALIZING)
 
@@ -1479,14 +1463,6 @@ func TestConsumerCopyIntegratingState(t *testing.T) {
 		StopChangeCapture(mock.Anything, "node1", "TestCollection", "shard1", mock.Anything).
 		Return(nil)
 	mockFSMUpdater.EXPECT().
-		SyncShard(mock.Anything, "TestCollection", "shard1", "node2").
-		Return(uint64(0), nil).
-		Times(1)
-	mockFSMUpdater.EXPECT().
-		SyncShard(mock.Anything, "TestCollection", "shard1", "node1").
-		Return(uint64(0), nil).
-		Times(1)
-	mockFSMUpdater.EXPECT().
 		ReplicationUpdateReplicaOpStatus(mock.Anything, opId, api.READY).
 		Return(nil).
 		Times(1)
@@ -1573,14 +1549,6 @@ func TestConsumerCopyIntegratingRetryAfterSeal(t *testing.T) {
 	mockReplicaCopier.EXPECT().
 		SnapshotChangeLogLSN(mock.Anything, "node1", "TestCollection", "shard1", mock.Anything).
 		Return(uint64(0), errors.New("snapshot change-log LSN on node1: shard: "+changelog.ErrMsgNoActiveChangeCaptureLog+" for that op-id")).
-		Times(1)
-	mockFSMUpdater.EXPECT().
-		SyncShard(mock.Anything, "TestCollection", "shard1", "node2").
-		Return(uint64(0), nil).
-		Times(1)
-	mockFSMUpdater.EXPECT().
-		SyncShard(mock.Anything, "TestCollection", "shard1", "node1").
-		Return(uint64(0), nil).
 		Times(1)
 	mockFSMUpdater.EXPECT().
 		ReplicationUpdateReplicaOpStatus(mock.Anything, opId, api.READY).

--- a/cluster/replication/producer_consumer_test.go
+++ b/cluster/replication/producer_consumer_test.go
@@ -78,9 +78,6 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					ReplicationAddReplicaToShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, uint64(opId)).
 					Return(uint64(0), nil)
 				mockFSMUpdater.EXPECT().
-					SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(uint64(0), nil)
-				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.INTEGRATING).
 					Return(nil)
 				mockFSMUpdater.EXPECT().
@@ -122,9 +119,6 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 				expectChangeCaptureMocks(mockReplicaCopier, mockFSMUpdater)
 				mockFSMUpdater.EXPECT().
 					ReplicationAddReplicaToShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, uint64(opId)).
-					Return(uint64(0), nil)
-				mockFSMUpdater.EXPECT().
-					SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(uint64(0), nil)
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.INTEGRATING).
@@ -173,9 +167,6 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					ReplicationAddReplicaToShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, uint64(opId)).
 					Return(uint64(0), nil)
 				mockFSMUpdater.EXPECT().
-					SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(uint64(0), nil)
-				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.INTEGRATING).
 					Return(nil)
 				mockFSMUpdater.EXPECT().
@@ -216,9 +207,6 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 					ReplicationAddReplicaToShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, uint64(opId)).
 					Return(uint64(0), nil)
 				mockFSMUpdater.EXPECT().
-					SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(uint64(0), nil)
-				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.INTEGRATING).
 					Return(nil)
 				mockFSMUpdater.EXPECT().
@@ -256,9 +244,6 @@ func TestConsumerStateChangeOrder(t *testing.T) {
 				expectChangeCaptureMocks(mockReplicaCopier, mockFSMUpdater)
 				mockFSMUpdater.EXPECT().
 					ReplicationAddReplicaToShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, uint64(opId)).
-					Return(uint64(0), nil)
-				mockFSMUpdater.EXPECT().
-					SyncShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(uint64(0), nil)
 				mockFSMUpdater.EXPECT().
 					ReplicationUpdateReplicaOpStatus(mock.Anything, uint64(opId), api.INTEGRATING).


### PR DESCRIPTION
### What's being changed:

Shards do not need to be force-synced as part of the replica movement happy path journey. At best, this is a no-op and, at worst, this can forcefully teardown shards mid-operation leading to torn writes, e.g. "shard not found" during data replication

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
