### PR TITLE
fix(usage): abort in-flight usage scan when its collection is dropped

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -266,6 +266,13 @@ type Index struct {
 	// RUnlock all picked indices
 	dropIndex sync.RWMutex
 
+	// dropRequestedCtx is cancelled as soon as a drop of this index is requested,
+	// before the drop starts waiting for dropIndex. Long-running readers holding
+	// dropIndex.RLock (e.g. usage scans) watch it to abort promptly and unblock
+	// the drop.
+	dropRequestedCtx    context.Context
+	signalDropRequested context.CancelFunc
+
 	// The other locks in the index should always be called in the given order to prevent deadlocks:
 	// 1. closeLock
 	// 2. backupLock (for a specific shard)
@@ -419,6 +426,7 @@ func NewIndex(
 		HFreshEnabled:           cfg.HFreshEnabled,
 		tenantsManager:          tenantsManager,
 	}
+	index.dropRequestedCtx, index.signalDropRequested = context.WithCancel(context.Background())
 	index.stopwordProvider.Store(stopwords.NewProvider(sd, presetDetectors))
 
 	getDeletionStrategy := func() string {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -64,7 +64,20 @@ func (db *DB) UsageForIndex(ctx context.Context, className schema.ClassName, sha
 		index.dropIndex.RUnlock()
 	}()
 
-	return index.usageForCollection(ctx, shardReadSem, exactObjectCount, vectorsConfig)
+	// abort the scan as soon as a drop of this index is requested, so the drop
+	// does not wait behind the dropIndex.RLock held above
+	usageCtx, usageCancel := context.WithCancel(ctx)
+	defer usageCancel()
+	stop := context.AfterFunc(index.dropRequestedCtx, usageCancel)
+	defer stop()
+
+	usage, err := index.usageForCollection(usageCtx, shardReadSem, exactObjectCount, vectorsConfig)
+	if err != nil && index.dropRequestedCtx.Err() != nil && ctx.Err() == nil {
+		// the collection is being dropped: skip it, the report continues without it
+		db.logger.Infof("usage scan aborted: collection %q is being dropped", className)
+		return nil, nil
+	}
+	return usage, err
 }
 
 func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.Weighted, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.CollectionUsage, error) {
@@ -177,6 +190,10 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 func (i *Index) usageForShard(ctx context.Context, shardName string, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.ShardUsage, error) {
 	i.shardCreateLocks.RLock(shardName)
 	defer i.shardCreateLocks.RUnlock(shardName)
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	shard := i.shards.Load(shardName)
 	var localStatus string

--- a/adapters/repos/db/index_usage_drop_test.go
+++ b/adapters/repos/db/index_usage_drop_test.go
@@ -1,0 +1,141 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+
+	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/cluster/usage/types"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	entschema "github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestDeleteIndexAbortsInFlightUsageScan verifies that dropping a collection aborts an
+// in-flight usage scan of that collection instead of waiting behind its dropIndex.RLock,
+// and that the aborted scan is reported as skipped (nil usage, nil error).
+func TestDeleteIndexAbortsInFlightUsageScan(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+	className := "DropDuringUsage"
+	shardName := "shard1"
+
+	class := &models.Class{
+		Class:             className,
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		VectorConfig:      map[string]models.VectorConfig{"vec": {VectorIndexConfig: enthnsw.UserConfig{}}},
+	}
+	shardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			shardName: {Name: shardName, BelongsToNodes: []string{nodeName}, Status: models.TenantActivityStatusHOT},
+		},
+	}
+	shardingState.SetLocalName(nodeName)
+
+	scanInCollection := make(chan struct{}, 8)
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ string, _ bool, fn func(*models.Class, *sharding.State) error) error {
+			select {
+			case scanInCollection <- struct{}{}:
+			default:
+			}
+			return fn(class, shardingState)
+		}).Maybe()
+	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardingState.AllPhysicalShards(), nil).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{shardName}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{nodeName}, nil).Maybe()
+
+	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
+	mockSchemaGetter.EXPECT().GetSchemaSkipAuth().Return(entschema.Schema{
+		Objects: &models.Schema{Classes: []*models.Class{class}},
+	}).Maybe()
+	mockSchemaGetter.EXPECT().ReadOnlyClass(className).Return(class).Maybe()
+	mockSchemaGetter.EXPECT().NodeName().Return(nodeName).Maybe()
+
+	mockNodeSelector := cluster.NewMockNodeSelector(t)
+	mockNodeSelector.EXPECT().LocalName().Return(nodeName).Maybe()
+	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return(nodeName, true).Maybe()
+	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{nodeName}).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{nodeName}, nil).Maybe()
+
+	logger, _ := logrustest.NewNullLogger()
+	repo, err := New(logger, nodeName, Config{
+		RootPath:                  t.TempDir(),
+		MaxImportGoroutinesFactor: 1,
+	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil,
+		memwatch.NewDummyMonitor(), mockNodeSelector, mockSchemaReader, mockReplicationFSMReader)
+	require.NoError(t, err)
+	repo.SetSchemaGetter(mockSchemaGetter)
+	require.NoError(t, repo.WaitForStartup(ctx))
+	defer repo.Shutdown(ctx)
+
+	// drain the shard-reader semaphore so the scan blocks while holding dropIndex.RLock —
+	// only a scan abort can unblock it
+	sem := semaphore.NewWeighted(1)
+	require.NoError(t, sem.Acquire(ctx, 1))
+
+	type scanResult struct {
+		usage *types.CollectionUsage
+		err   error
+	}
+	scanDone := make(chan scanResult, 1)
+	enterrors.GoWrapper(func() {
+		usage, err := repo.UsageForIndex(ctx, entschema.ClassName(className), sem, false, class.VectorConfig)
+		scanDone <- scanResult{usage, err}
+	}, logger)
+
+	select {
+	case <-scanInCollection:
+	case <-time.After(5 * time.Second):
+		t.Fatal("usage scan did not start")
+	}
+
+	deleteDone := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		deleteDone <- repo.DeleteIndex(entschema.ClassName(className))
+	}, logger)
+
+	select {
+	case err := <-deleteDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("DeleteIndex is blocked behind the in-flight usage scan")
+	}
+
+	select {
+	case res := <-scanDone:
+		assert.NoError(t, res.err)
+		assert.Nil(t, res.usage, "scan of a dropped collection should be skipped")
+	case <-time.After(5 * time.Second):
+		t.Fatal("usage scan did not abort")
+	}
+
+	assert.Nil(t, repo.GetIndex(entschema.ClassName(className)))
+}

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -572,6 +572,10 @@ func (db *DB) DeleteIndex(className schema.ClassName) error {
 		return nil
 	}
 
+	// abort in-flight usage scans so the dropIndex write lock below is not
+	// blocked behind an hours-long reader while db.indexLock is held
+	index.signalDropRequested()
+
 	// drop index
 	db.indexLock.Lock()
 	defer db.indexLock.Unlock()


### PR DESCRIPTION
### What's being changed:

This PR aborts in-flight usage scan when its collection is dropped.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
