### PR TITLE
fix(replica-movement): atomic LWW on change-log replay

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -841,6 +841,19 @@ type ChangeLogReplayEntry struct {
 	Payload []byte
 }
 
+type changeLogReplayCtxKey struct{}
+
+// withChangeLogReplay marks a write as change-log replay so putObjectLSM/DeleteObject
+// drop it when the local object is newer (atomic under the docIdLock).
+func withChangeLogReplay(ctx context.Context) context.Context {
+	return context.WithValue(ctx, changeLogReplayCtxKey{}, true)
+}
+
+func fromChangeLogReplay(ctx context.Context) bool {
+	v, _ := ctx.Value(changeLogReplayCtxKey{}).(bool)
+	return v
+}
+
 // OverwriteObjectsFromChangeLog replays entries under pure LWW by
 // LastUpdateTimeUnixMilli — no StaleUpdateTime conflicts and no
 // DeletionStrategy, unlike OverwriteObjects. Entries MUST be in LSN order;
@@ -852,6 +865,8 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 	if len(updates) == 0 {
 		return nil
 	}
+
+	ctx = withChangeLogReplay(ctx)
 
 	s, release, err := idx.getOrInitShard(ctx, shard)
 	if err != nil {
@@ -891,25 +906,6 @@ func (idx *Index) OverwriteObjectsFromChangeLog(
 			return err
 		}
 		u := &updates[i]
-
-		var currUpdateTime int64
-		localObj, err := s.ObjectDigestErrDeleted(ctx, u.ID)
-		switch {
-		case err == nil:
-			currUpdateTime = localObj.UpdateTime
-		case errors.Is(err, lsmkv.Deleted):
-			var errDeleted lsmkv.ErrDeleted
-			if errors.As(err, &errDeleted) {
-				currUpdateTime = errDeleted.DeletionTime().UnixMilli()
-			}
-		case errors.Is(err, lsmkv.NotFound):
-		default:
-			return fmt.Errorf("read local digest for %s: %w", u.ID, err)
-		}
-
-		if currUpdateTime > u.LastUpdateTimeUnixMilli {
-			continue
-		}
 
 		if u.IsDelete {
 			if err := flushPending(); err != nil {

--- a/adapters/repos/db/replication_changelog_integration_test.go
+++ b/adapters/repos/db/replication_changelog_integration_test.go
@@ -445,6 +445,80 @@ func TestOverwriteObjectsFromChangeLog_NonMonotonicTimestampSameUUIDKeepsMax(t *
 	assert.EqualValues(t, "winner-t10", found.Object().Properties.(map[string]interface{})["stringProp"])
 }
 
+// TestOverwriteObjectsFromChangeLog_ReplayResolvesByUpdateTime pins the scale-out
+// stale-win race: a replayed entry older than local state must lose, decided
+// atomically under the docIdLock. Each case seeds local state, then replays one
+// stale entry against it.
+func TestOverwriteObjectsFromChangeLog_ReplayResolvesByUpdateTime(t *testing.T) {
+	id := strfmt.UUID("981c09f9-67f3-4e6e-a988-c53eaefbd58e")
+	const t5, t10, t20 = int64(5), int64(10), int64(20)
+
+	putLocal := func(t *testing.T, repo *DB, class string, ts int64, prop string) {
+		obj := &models.Object{
+			ID: id, Class: class, CreationTimeUnix: ts, LastUpdateTimeUnix: ts,
+			Properties: map[string]interface{}{"stringProp": prop}, Vector: []float32{1, 2, 3},
+		}
+		require.Nil(t, repo.PutObject(context.Background(), obj, obj.Vector, nil, nil, nil, 0))
+	}
+	putEntry := func(t *testing.T, class string, ts int64, prop string) ChangeLogReplayEntry {
+		obj := &models.Object{
+			ID: id, Class: class, CreationTimeUnix: ts, LastUpdateTimeUnix: ts,
+			Properties: map[string]interface{}{"stringProp": prop}, Vector: []float32{4, 5, 6},
+		}
+		return ChangeLogReplayEntry{ID: id, LastUpdateTimeUnixMilli: ts, Payload: mustMarshalPayload(t, obj, obj.Vector)}
+	}
+
+	tests := []struct {
+		name     string
+		seed     func(t *testing.T, repo *DB, class string)
+		entry    func(t *testing.T, class string) ChangeLogReplayEntry
+		wantProp string // "" => object must be absent
+	}{
+		{
+			name:     "replayed PUT must not clobber a newer local write",
+			seed:     func(t *testing.T, repo *DB, class string) { putLocal(t, repo, class, t20, "newest") },
+			entry:    func(t *testing.T, class string) ChangeLogReplayEntry { return putEntry(t, class, t10, "captured") },
+			wantProp: "newest",
+		},
+		{
+			name: "replayed PUT must not resurrect a newer delete",
+			seed: func(t *testing.T, repo *DB, class string) {
+				putLocal(t, repo, class, t5, "seed")
+				require.Nil(t, repo.DeleteObject(context.Background(), class, id, time.UnixMilli(t20), nil, "", 0))
+			},
+			entry:    func(t *testing.T, class string) ChangeLogReplayEntry { return putEntry(t, class, t10, "captured") },
+			wantProp: "",
+		},
+		{
+			name: "replayed DELETE must not remove a newer local write",
+			seed: func(t *testing.T, repo *DB, class string) { putLocal(t, repo, class, t20, "newest") },
+			entry: func(t *testing.T, class string) ChangeLogReplayEntry {
+				return ChangeLogReplayEntry{ID: id, LastUpdateTimeUnixMilli: t10, IsDelete: true}
+			},
+			wantProp: "newest",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, idx, shard, class := setupReplayShard(t)
+			tc.seed(t, repo, class.Class)
+
+			require.Nil(t, idx.OverwriteObjectsFromChangeLog(
+				context.Background(), shard, []ChangeLogReplayEntry{tc.entry(t, class.Class)}))
+
+			found, err := repo.Object(context.Background(), class.Class, id, nil, additional.Properties{}, nil, "")
+			require.Nil(t, err)
+			if tc.wantProp == "" {
+				assert.Nil(t, found)
+				return
+			}
+			require.NotNil(t, found)
+			assert.Equal(t, tc.wantProp, found.Object().Properties.(map[string]interface{})["stringProp"])
+		})
+	}
+}
+
 // TestOverwriteObjectsFromChangeLog_DecodeErrorAborts guards the
 // abort-on-first-error contract Phase 5 relies on: a mid-batch decode failure
 // must stop replay, and a following well-formed entry must NOT be applied.

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -19,13 +19,14 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
-	_, err := s.deleteObject(ctx, id, deletionTime, false)
+	_, err := s.deleteObject(ctx, id, deletionTime, fromChangeLogReplay(ctx))
 	return err
 }
 

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -188,6 +189,23 @@ func (s *Shard) updateMultiVectorIndex(ctx context.Context, vector [][]float32,
 	return updateVectorInVectorIndex(ctx, s, targetVector, vector, status)
 }
 
+// localIsNewer reports whether the shard's stored state for idBytes, the live
+// object, or a tombstone's deletion time so an older entry can't resurrect a
+// deleted object, is strictly newer than incoming. Callers hold the docIdLock.
+func (s *Shard) localIsNewer(bucket *lsmkv.Bucket, idBytes []byte, prevObj *storobj.Object, incoming int64) (bool, error) {
+	if prevObj != nil {
+		return prevObj.LastUpdateTimeUnix() > incoming, nil
+	}
+	deleted, deletionTime, err := bucket.WasDeleted(idBytes)
+	if err != nil {
+		return false, err
+	}
+	if !deleted || deletionTime.IsZero() {
+		return false, nil
+	}
+	return deletionTime.UnixMilli() > incoming, nil
+}
+
 func fetchObject(bucket *lsmkv.Bucket, idBytes []byte) (*storobj.Object, error) {
 	objBytes, err := bucket.Get(idBytes)
 	if err != nil {
@@ -269,6 +287,17 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 		prevObj, err = fetchObject(bucket, idBytes)
 		if err != nil {
 			return err
+		}
+
+		if fromChangeLogReplay(ctx) {
+			lIsNewer, err := s.localIsNewer(bucket, idBytes, prevObj, obj.LastUpdateTimeUnix())
+			if err != nil {
+				return err
+			}
+			if lIsNewer {
+				status = objectInsertStatus{skipUpsert: true}
+				return nil
+			}
 		}
 
 		status, err = s.determineInsertStatus(prevObj, obj)


### PR DESCRIPTION
### What's being changed:
Freshly scaled-out replicas end up with stale content or resurrected deletes. this for example appears clearly in the flakey `TestReplicaMovementShardScaleOutParallelWrites`.

During `COPY` scale-out, an `INTEGRATING` target receives direct writes while the change-capture log still drains onto it. The replay's LWW check (read digest → compare → PutObjectBatch) isn't atomic, so a newer direct write landing between
the read and the write is overwritten by an older replayed entry. in some cases for example a delete can be resurrected by a newer put.

the fix is decision to be made by update-time inside the per-UUID `docIdLock`, where both writers already serialize and last write wins:
- PUT: `putObjectLSM` skips a replayed entry when the live object or a tombstone is newer.
- DELETE: reuses the existing `skipIfLocalNewer`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
