### PR TITLE
fix(db): propagate usage-file removal error in NewShard instead of discarding it

### DIFF
--- a/adapters/repos/db/init_test.go
+++ b/adapters/repos/db/init_test.go
@@ -12,6 +12,7 @@
 package db
 
 import (
+	"context"
 	"os"
 	"path"
 	"testing"
@@ -21,6 +22,7 @@ import (
 
 	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/cluster/usage/types"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
@@ -85,6 +87,40 @@ func TestApplyLazyShardAutoDetection(t *testing.T) {
 			require.Equal(t, tt.expectedEnableLazy, got)
 		})
 	}
+}
+
+// TestNewShard_AbortsWhenUsageFileRemovalFails pins that NewShard propagates a
+// failure to remove the stale precomputed usage file, rather than silently
+// ignoring it. Otherwise the outdated usage.json.tmp survives and later gets
+// served as the shard's usage once it is treated as unloaded (deactivated/COLD
+// tenant, unloaded lazy shard), reporting wrong object counts/storage bytes.
+func TestNewShard_AbortsWhenUsageFileRemovalFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based test cannot run as root")
+	}
+
+	ctx := context.Background()
+	className := "UsageFileCleanup"
+	shard, index := testShard(t, ctx, className)
+	shardName := shard.Name()
+	// close the loaded shard so NewShard can re-init the same on-disk shard
+	require.NoError(t, shard.Shutdown(ctx))
+
+	// Make the usage-file removal fail in isolation: create usage.json.tmp as a
+	// non-empty directory and drop write permission on it, so os.RemoveAll fails
+	// on its child while the (writable) shard dir leaves the rest of NewShard
+	// unaffected.
+	usageTmp := path.Join(index.path(), shardName, "usage.json.tmp")
+	require.NoError(t, os.MkdirAll(usageTmp, 0o700))
+	require.NoError(t, os.WriteFile(path.Join(usageTmp, "child"), []byte("x"), 0o600))
+	require.NoError(t, os.Chmod(usageTmp, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(usageTmp, 0o700) })
+
+	_, err := NewShard(ctx, nil, shardName, index, &models.Class{Class: className},
+		index.centralJobQueue, index.scheduler, index.indexCheckpoints,
+		index.shardReindexer, false, index.bitmapBufPool)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "remove computed usage file")
 }
 
 func TestTotalShardSizeBytes_FallsBackToDirSizeWhenNoMeta(t *testing.T) {

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -45,7 +45,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		"index":  index.ID(),
 	}).Debugf("initializing shard %q", shardName)
 
-	if shardusage.RemoveComputedUsageDataForUnloadedShard(index.path(), shardName); err != nil {
+	if err := shardusage.RemoveComputedUsageDataForUnloadedShard(index.path(), shardName); err != nil {
 		return nil, fmt.Errorf("shard %q: remove computed usage file for unloaded shard: %w", shardName, err)
 	}
 


### PR DESCRIPTION
### What's being changed:

Fixes a silently discarded error in `NewShard`. The `if` used the usage-file removal call as its *init statement* and dropped the returned error, then tested the named return `err` — which is provably nil at that point — so the branch was dead and a failed removal of the stale `usage.json.tmp` was ignored with no log and no abort.

```go
// before
if shardusage.RemoveComputedUsageDataForUnloadedShard(index.path(), shardName); err != nil {
// after
if err := shardusage.RemoveComputedUsageDataForUnloadedShard(index.path(), shardName); err != nil {
```

Impact: the stale precomputed usage file survives and is later served once the shard is treated as unloaded (deactivated/COLD tenant, unloaded lazy shard, or startup lazy-load size estimation), reporting outdated object counts/storage bytes to usage/billing. Trigger requires `os.RemoveAll` to actually fail (permission/immutable/IO error).

Grepped the repo for the same malformed-if pattern — this is the only occurrence. Adds a regression test that makes the removal fail in isolation and asserts `NewShard` aborts (fails without the fix).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
