### PR TITLE
fix(test): widen flaky RansomNote aggregate count assertion

### DIFF
--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1222,12 +1222,7 @@ func localMetaWithObjectLimit(t *testing.T) {
 			count := meta.(map[string]interface{})["count"]
 			countInt, err := count.(json.Number).Int64()
 			require.Nil(t, err)
-			// The 500 RansomNote objects have random per-run contents, so a
-			// few vectors can legitimately fall outside the distance cut or be
-			// missed by distance-bounded HNSW traversal (deltas of up to 7
-			// observed in CI). The test only needs to prove that no
-			// objectLimit-style cap was applied (sibling subtests cap at 100),
-			// so a generous lower bound is enough.
+			// HNSW traversal near the distance cut can miss boundary objects (weaviate/weaviate#12193).
 			assert.Greater(t, countInt, int64(450))
 			assert.LessOrEqual(t, countInt, int64(500))
 		})
@@ -1258,8 +1253,7 @@ func localMetaWithObjectLimit(t *testing.T) {
 			count := meta.(map[string]interface{})["count"]
 			countInt, err := count.(json.Number).Int64()
 			require.Nil(t, err)
-			// See the distance-variant subtest above for why the count is
-			// bounded rather than pinned to exactly 500.
+			// See distance-cut subtest above (weaviate/weaviate#12193).
 			assert.Greater(t, countInt, int64(450))
 			assert.LessOrEqual(t, countInt, int64(500))
 		})

--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1278,7 +1278,7 @@ func localMetaWithObjectLimit(t *testing.T) {
 		count := meta.(map[string]interface{})["count"]
 		countInt, err := count.(json.Number).Int64()
 		require.Nil(t, err)
-		// Without a vector filter the count comes from the object store, not ANN traversal, so it is exact.
+		// No vector filter: count is exact, from the object store rather than ANN.
 		assert.Equal(t, int64(500), countInt)
 	})
 

--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1259,6 +1259,29 @@ func localMetaWithObjectLimit(t *testing.T) {
 		})
 	})
 
+	t.Run("unfiltered count is exact", func(t *testing.T) {
+		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
+			{
+				Aggregate {
+					RansomNote {
+						meta {
+							count
+						}
+					}
+				}
+			}
+		`)
+
+		res := result.Get("Aggregate", "RansomNote").AsSlice()
+		require.Len(t, res, 1)
+		meta := res[0].(map[string]interface{})["meta"]
+		count := meta.(map[string]interface{})["count"]
+		countInt, err := count.(json.Number).Int64()
+		require.Nil(t, err)
+		// Without a vector filter the count comes from the object store, not ANN traversal, so it is exact.
+		assert.Equal(t, int64(500), countInt)
+	})
+
 	t.Run("with nearObject and low distance (few results), high objectLimit", func(t *testing.T) {
 		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, `
 			{

--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1222,7 +1222,14 @@ func localMetaWithObjectLimit(t *testing.T) {
 			count := meta.(map[string]interface{})["count"]
 			countInt, err := count.(json.Number).Int64()
 			require.Nil(t, err)
-			assert.InDelta(t, 500, countInt, 1)
+			// The 500 RansomNote objects have random per-run contents, so a
+			// few vectors can legitimately fall outside the distance cut or be
+			// missed by distance-bounded HNSW traversal (deltas of up to 7
+			// observed in CI). The test only needs to prove that no
+			// objectLimit-style cap was applied (sibling subtests cap at 100),
+			// so a generous lower bound is enough.
+			assert.Greater(t, countInt, int64(450))
+			assert.LessOrEqual(t, countInt, int64(500))
 		})
 	})
 
@@ -1251,7 +1258,10 @@ func localMetaWithObjectLimit(t *testing.T) {
 			count := meta.(map[string]interface{})["count"]
 			countInt, err := count.(json.Number).Int64()
 			require.Nil(t, err)
-			assert.InDelta(t, 500, countInt, 1)
+			// See the distance-variant subtest above for why the count is
+			// bounded rather than pinned to exactly 500.
+			assert.Greater(t, countInt, int64(450))
+			assert.LessOrEqual(t, countInt, int64(500))
 		})
 	})
 


### PR DESCRIPTION
SuperClaude here.

Fixes weaviate/weaviate#12193.

## Problem

`TestGraphQL_SyncIndexing/aggregates_local_meta_with_objectLimit_and_nearMedia_filters` flakes in the two "no objectLimit" subtests (`very_high_distance` and `very_low_certainty` variants). They assert `assert.InDelta(t, 500, countInt, 1)`, but the count of a distance-bounded aggregate is produced by an approximate HNSW range traversal: recall near the distance cut is not guaranteed, so poorly-connected boundary nodes can be missed and the count legitimately lands below 500. The graph itself is built nondeterministically (random level generation, concurrent batch inserts), so no data seeding can pin the result.

CI observed count=498 (delta 2, run 29435911841, 2026-07-15) and count=493 (delta 7, run 28784446823, 2026-07-06, push to stable/v1.36).

## Fix

The subtests exist to prove that WITHOUT `objectLimit` the aggregate is NOT capped (sibling subtests cap at `objectLimit: 100`). Replace the pinned assertion at both sites with:

```go
assert.Greater(t, countInt, int64(450))
assert.LessOrEqual(t, countInt, int64(500))
```

This still fails hard if an objectLimit-style cap were wrongly applied (count would be <= 100) while tolerating the traversal-recall variance. These are the only two `InDelta(500, ..., 1)` sites in the package; the objectLimit-bearing siblings already use loose `assert.Less` bounds.

Additionally, a new subtest ("unfiltered count is exact") asserts that an unfiltered `Aggregate { RansomNote { meta { count } } }` returns exactly 500 — that count comes from the object store, not ANN traversal, so it is deterministic and guards that all imported objects remain aggregable.

Targets `stable/v1.36` (oldest applicable stable branch); both flake occurrences reproduce there.

## Verification

- `go vet ./test/acceptance/graphql_resolvers/` clean
- `gofumpt -l` / `goimports -l` clean on the touched file
- `golangci-lint run ./test/acceptance/graphql_resolvers/` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM

— SuperClaude
