### PR TITLE
fix(rbac): error on unknown command version instead of looping forever during migration

### DIFF
--- a/cluster/rbac/migration.go
+++ b/cluster/rbac/migration.go
@@ -63,7 +63,7 @@ UPDATE_LOOP:
 		case cmd.RBACLatestCommandPolicyVersion:
 			break UPDATE_LOOP
 		default:
-			continue
+			return nil, fmt.Errorf("unsupported RBAC command version %d, was this log written by a newer Weaviate?", req.Version)
 		}
 		req.Version += 1
 	}
@@ -161,7 +161,7 @@ UPDATE_LOOP:
 		case cmd.RBACLatestCommandPolicyVersion:
 			break UPDATE_LOOP
 		default:
-			continue
+			return nil, fmt.Errorf("unsupported RBAC command version %d, was this log written by a newer Weaviate?", req.Version)
 		}
 		req.Version += 1
 	}

--- a/cluster/rbac/migration_test.go
+++ b/cluster/rbac/migration_test.go
@@ -12,7 +12,9 @@
 package rbac
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/weaviate/weaviate/usecases/config"
 
@@ -22,6 +24,57 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 )
+
+// TestMigration_UnsupportedFutureVersion pins that a command carrying a version
+// newer than this binary knows about returns an error instead of spinning
+// forever. Such an entry can reach the RAFT FSM apply loop on a rollback or a
+// mixed-version rolling upgrade; an infinite loop there would stall startup
+// replay with one core pegged and no diagnostics.
+func TestMigration_UnsupportedFutureVersion(t *testing.T) {
+	futureVersions := []int{
+		cmd.RBACLatestCommandPolicyVersion + 1,
+		cmd.RBACLatestCommandPolicyVersion + 5,
+	}
+
+	migrations := []struct {
+		name string
+		run  func(version int) error
+	}{
+		{
+			name: "upsert",
+			run: func(version int) error {
+				_, err := migrateUpsertRolesPermissions(&cmd.CreateRolesRequest{
+					Version: version, Roles: map[string][]authorization.Policy{},
+				})
+				return err
+			},
+		},
+		{
+			name: "remove",
+			run: func(version int) error {
+				_, err := migrateRemovePermissions(&cmd.RemovePermissionsRequest{Version: version})
+				return err
+			},
+		},
+	}
+
+	for _, m := range migrations {
+		for _, v := range futureVersions {
+			t.Run(fmt.Sprintf("%s/version=%d", m.name, v), func(t *testing.T) {
+				done := make(chan error, 1)
+				go func() { done <- m.run(v) }()
+
+				select {
+				case err := <-done:
+					require.Error(t, err)
+					require.ErrorContains(t, err, "unsupported RBAC command version")
+				case <-time.After(2 * time.Second):
+					t.Fatal("migration did not return: infinite loop on unknown version")
+				}
+			})
+		}
+	}
+}
 
 func TestMigrationsUpsert(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### What's being changed:

Fixes an infinite loop in the RBAC command migration that can permanently stall the RAFT FSM apply loop.

`migrateUpsertRolesPermissions` / `migrateRemovePermissions` walk `req.Version` up to `RBACLatestCommandPolicyVersion` via `for { switch req.Version {...} }`. The `default` arm ran `continue`, which restarts the `for` loop **without** incrementing `req.Version` — so any version outside the known range (e.g. an entry stamped version 5 by a newer binary) loops forever. On a rollback or mixed-version rolling upgrade, replaying such a log entry stalls startup replay permanently: one core pegged, node never ready, no diagnostics.

Both `default` arms now return an error (`unsupported RBAC command version %d, was this log written by a newer Weaviate?`); the FSM apply path already surfaces and logs it. This matches the codebase's stated intent to tolerate mixed versions (see the adjacent unknown-command-type arm that logs "consider upgrading" rather than hanging).

Latent today (no released binary writes version > 4); it would fire the first time a future release adds a new migration and an older node applies that entry. Adds a table-driven regression test (both functions × future versions) with a timeout guard so a regression fails instead of hanging the suite.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
