### PR TITLE
fix(grpc): re-check conn cache inside singleflight to avoid spurious already-exists errors

### DIFF
--- a/grpc/conn/manager.go
+++ b/grpc/conn/manager.go
@@ -75,6 +75,13 @@ func (m *ConnManager) GetConn(addr string) (*grpc.ClientConn, error) {
 
 	// create the connection using singleflight to avoid duplicate dials
 	v, err, _ := m.sf.Do(addr, func() (interface{}, error) {
+		// Re-check: a prior singleflight call for this addr may have
+		// completed and stored the conn between our outer check and
+		// this execution.
+		if conn, ok, err := m.reuseExistingConn(addr); err != nil || ok {
+			return conn, err
+		}
+
 		conn, err := grpc.NewClient(addr, m.grpcOpts...)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
SuperClaude here.

`TestGetConn_ConcurrentSingleFlight` failed in CI on an unrelated PR ([run 29438536704, unit tests](https://github.com/weaviate/weaviate/actions/runs/29438536704/job/87431313913)) with `GetConn failed: unexpected: connection for address bufnet already exists`. That error string comes from production code, and the defect is real: under concurrency, `GetConn` can return a spurious error instead of the cached connection. In production this surfaces as a failed replica file-copy gRPC client creation (the remote client factory in `configure_api.go`).

## Root cause

`GetConn` checks the cache under an RLock, then creates via `singleflight.Do`. But singleflight only dedups callers that are in flight **at the same time** — it forgets the key once a flight completes. The failing interleaving (`grpc/conn/manager.go` on `stable/v1.36`):

1. Goroutines A and B both miss the cache check (`reuseExistingConn`, manager.go:72; RLock released on return at manager.go:101).
2. A enters `sf.Do` (manager.go:77), dials, stores the conn in `m.conns` (manager.go:83 → insert at manager.go:159), the flight completes, and singleflight forgets the key.
3. B, already past the cache check, only now enters `sf.Do` — the key is gone, so B starts a **second flight**: it dials a second connection and `storeNewConn` hits the invariant check at manager.go:143-144 → `unexpected: connection for address X already exists`, propagated to the caller.

## Fix

Re-check the cache inside the singleflight callback and return the existing connection (double-checked locking). Returning the cached conn is semantically correct: `GetConn` is a shared-connection cache, and the sibling test `TestGetConn_CachesConnection` pins exactly that contract. The `storeNewConn` invariant check stays as a defensive guard.

This is the same fix that already exists on `main` (landed there as part of [weaviate/weaviate#10662](https://github.com/weaviate/weaviate/issues/10662), never backported to this release line). After this change, `grpc/conn/manager.go` is byte-identical to main's version, so merge-forward is a no-op for this file.

## Repro rate

```
go test -race -run TestGetConn_ConcurrentSingleFlight -count N ./grpc/conn/
```

- Before: 3 failed iterations out of 500 (5 goroutine-level errors)
- After: 0 failed iterations out of 2000

Full package unit tests pass with `-race`; `go build ./...` and `golangci-lint run ./...` are clean.

— SuperClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM
