### PR TITLE
fix(test): scrape metrics from the instance under test instead of hardcoded localhost:2112

### DIFF
--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -34,16 +34,20 @@ import (
 
 const metricClassPrefix = "MetricsClassPrefix"
 
-func metricsCount(t *testing.T) {
+// metricsCount asserts that the number of metrics lines does not grow with the
+// number of classes. metricsEndpoint is the host:port of the Prometheus
+// metrics listener of the instance under test: the host-mapped port of the
+// container (testcontainers setup) or localhost:2112 (legacy setup).
+func metricsCount(t *testing.T, metricsEndpoint string) {
 	defer cleanupMetricsClasses(t, 0, 20)
 	createImportQueryMetricsClasses(t, 0, 10)
 	backupID := startBackup(t, 0, 10)
 	helper.ExpectBackupEventuallyCreated(t, backupID, "filesystem", nil, helper.WithPollInterval(time.Second), helper.WithDeadline(helper.MaxDeadline))
-	metricsLinesBefore, linesBefore := countMetricsLines(t)
+	metricsLinesBefore, linesBefore := countMetricsLines(t, metricsEndpoint)
 	createImportQueryMetricsClasses(t, 10, 20)
 	backupID = startBackup(t, 0, 20)
 	helper.ExpectBackupEventuallyCreated(t, backupID, "filesystem", nil, helper.WithPollInterval(time.Second), helper.WithDeadline(helper.MaxDeadline))
-	metricsLinesAfter, linesAfter := countMetricsLines(t)
+	metricsLinesAfter, linesAfter := countMetricsLines(t, metricsEndpoint)
 	if metricsLinesAfter != metricsLinesBefore {
 		t.Logf("metric lines before:\n%s\n", strings.Join(linesBefore, "\n"))
 		t.Logf("metric lines after:\n%s\n", strings.Join(linesAfter, "\n"))
@@ -174,12 +178,13 @@ func randomVector(dims int) []float32 {
 	return out
 }
 
-func countMetricsLines(t *testing.T) (int, []string) {
+func countMetricsLines(t *testing.T, metricsEndpoint string) (int, []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	require.NotEmpty(t, metricsEndpoint, "no metrics endpoint configured for the instance under test")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://localhost:2112/metrics", nil)
+		fmt.Sprintf("http://%s/metrics", metricsEndpoint), nil)
 	require.Nil(t, err)
 
 	c := &http.Client{}

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -175,6 +175,37 @@ func randomVector(dims int) []float32 {
 	return out
 }
 
+// lazilyMaterializedSeries lists every series name of the metric families that
+// materialize lazily on first use: their presence depends on background LSM
+// activity rather than the number of classes. The file_io families are
+// summaries, so they also expose _sum and _count series. Exact names only, so
+// a future family that merely shares a prefix is still counted.
+var lazilyMaterializedSeries = map[string]bool{
+	"file_io_writes_total_bytes":       true,
+	"file_io_writes_total_bytes_sum":   true,
+	"file_io_writes_total_bytes_count": true,
+	"file_io_reads_total_bytes":        true,
+	"file_io_reads_total_bytes_sum":    true,
+	"file_io_reads_total_bytes_count":  true,
+	"mmap_operations_total":            true,
+}
+
+// metricName extracts the metric name from a Prometheus exposition line: the
+// family name for "# HELP"/"# TYPE" lines, otherwise the series name, i.e.
+// everything before the label set or the value.
+func metricName(line string) string {
+	if strings.HasPrefix(line, "# HELP ") || strings.HasPrefix(line, "# TYPE ") {
+		if fields := strings.Fields(line); len(fields) >= 3 {
+			return fields[2]
+		}
+		return ""
+	}
+	if i := strings.IndexAny(line, "{ "); i != -1 {
+		return line[:i]
+	}
+	return line
+}
+
 func countMetricsLines(t *testing.T, metricsEndpoint string) (int, []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -211,9 +242,7 @@ func countMetricsLines(t *testing.T, metricsEndpoint string) (int, []string) {
 		if strings.Contains(line, "weaviate_lsm_bucket_read_operation") {
 			continue
 		}
-		// these series materialize lazily on first use, so their count depends
-		// on background LSM activity rather than the number of classes
-		if strings.Contains(line, "file_io_") || strings.Contains(line, "mmap_operations") {
+		if lazilyMaterializedSeries[metricName(line)] {
 			continue
 		}
 		lineCount++

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -175,11 +175,8 @@ func randomVector(dims int) []float32 {
 	return out
 }
 
-// lazilyMaterializedSeries lists every series name of the metric families that
-// materialize lazily on first use: their presence depends on background LSM
-// activity rather than the number of classes. The file_io families are
-// summaries, so they also expose _sum and _count series. Exact names only, so
-// a future family that merely shares a prefix is still counted.
+// lazilyMaterializedSeries only appear after first use, so their count depends on
+// background LSM activity rather than class count; includes summary _sum/_count series.
 var lazilyMaterializedSeries = map[string]bool{
 	"file_io_writes_total_bytes":       true,
 	"file_io_writes_total_bytes_sum":   true,
@@ -190,9 +187,7 @@ var lazilyMaterializedSeries = map[string]bool{
 	"mmap_operations_total":            true,
 }
 
-// metricName extracts the metric name from a Prometheus exposition line: the
-// family name for "# HELP"/"# TYPE" lines, otherwise the series name, i.e.
-// everything before the label set or the value.
+// metricName returns the metric/series name from a Prometheus exposition line.
 func metricName(line string) string {
 	if strings.HasPrefix(line, "# HELP ") || strings.HasPrefix(line, "# TYPE ") {
 		if fields := strings.Fields(line); len(fields) >= 3 {

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -199,6 +199,13 @@ func countMetricsLines(t *testing.T, metricsEndpoint string) (int, []string) {
 	var lines []string
 	for scanner.Scan() {
 		line := scanner.Text()
+		// no metric line may ever leak a class name, not even the ones
+		// excluded from the count below
+		require.NotContains(
+			t,
+			strings.ToLower(line),
+			strings.ToLower(metricClassPrefix),
+		)
 		if strings.Contains(line, "shards_loaded") || strings.Contains(line, "shards_loading") || strings.Contains(line, "shards_unloading") || strings.Contains(line, "shards_unloaded") {
 			continue
 		}
@@ -208,11 +215,13 @@ func countMetricsLines(t *testing.T, metricsEndpoint string) (int, []string) {
 		if strings.Contains(line, "weaviate_lsm_bucket_read_operation") {
 			continue
 		}
-		require.NotContains(
-			t,
-			strings.ToLower(line),
-			strings.ToLower(metricClassPrefix),
-		)
+		// bounded-cardinality I/O metrics whose series materialize lazily on
+		// first use per label combination (e.g. the first segment-file read
+		// after a compaction), so their line count depends on background
+		// LSM activity, not on the number of classes
+		if strings.Contains(line, "file_io_") || strings.Contains(line, "mmap_operations") {
+			continue
+		}
 		lineCount++
 		lines = append(lines, line)
 	}

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -34,10 +34,7 @@ import (
 
 const metricClassPrefix = "MetricsClassPrefix"
 
-// metricsCount asserts that the number of metrics lines does not grow with the
-// number of classes. metricsEndpoint is the host:port of the Prometheus
-// metrics listener of the instance under test: the host-mapped port of the
-// container (testcontainers setup) or localhost:2112 (legacy setup).
+// metricsEndpoint is the host:port of the instance under test's Prometheus listener.
 func metricsCount(t *testing.T, metricsEndpoint string) {
 	defer cleanupMetricsClasses(t, 0, 20)
 	createImportQueryMetricsClasses(t, 0, 10)
@@ -199,8 +196,7 @@ func countMetricsLines(t *testing.T, metricsEndpoint string) (int, []string) {
 	var lines []string
 	for scanner.Scan() {
 		line := scanner.Text()
-		// no metric line may ever leak a class name, not even the ones
-		// excluded from the count below
+		// no line may leak a class name, including ones excluded below
 		require.NotContains(
 			t,
 			strings.ToLower(line),
@@ -215,10 +211,8 @@ func countMetricsLines(t *testing.T, metricsEndpoint string) (int, []string) {
 		if strings.Contains(line, "weaviate_lsm_bucket_read_operation") {
 			continue
 		}
-		// bounded-cardinality I/O metrics whose series materialize lazily on
-		// first use per label combination (e.g. the first segment-file read
-		// after a compaction), so their line count depends on background
-		// LSM activity, not on the number of classes
+		// these series materialize lazily on first use, so their count depends
+		// on background LSM activity rather than the number of classes
 		if strings.Contains(line, "file_io_") || strings.Contains(line, "mmap_operations") {
 			continue
 		}

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -43,20 +43,27 @@ func TestGraphQL_AsyncIndexing(t *testing.T) {
 		WithWeaviateEnv("ASYNC_INDEXING_STALE_TIMEOUT", "100ms").
 		WithWeaviateEnv("QUEUE_SCHEDULER_INTERVAL", "100ms").
 		WithWeaviateEnv("API_BASED_MODULES_DISABLED", "true").
+		// match the legacy docker-compose-test.yml monitoring setup, so that
+		// the metrics stability test scrapes this container instead of
+		// whatever else might listen on the host's port 2112
+		WithWeaviateEnv("PROMETHEUS_MONITORING_ENABLED", "true").
+		WithWeaviateEnv("PROMETHEUS_MONITORING_GROUP_CLASSES", "true").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, compose.Terminate(ctx))
 	}()
 
-	testGraphQL(t, compose.GetWeaviate().URI())
+	testGraphQL(t, compose.GetWeaviate().URI(), compose.GetWeaviate().MetricsURI())
 }
 
 func TestGraphQL_SyncIndexing(t *testing.T) {
-	testGraphQL(t, "localhost:8080")
+	// legacy setup: docker-compose-test.yml maps the metrics port to
+	// localhost:2112
+	testGraphQL(t, "localhost:8080", "localhost:2112")
 }
 
-func testGraphQL(t *testing.T, host string) {
+func testGraphQL(t *testing.T, host, metricsEndpoint string) {
 	helper.SetupClient(host)
 	// tests with classes that have objects with same uuids
 	t.Run("import test data (near object search class)", addTestDataNearObjectSearch)
@@ -123,7 +130,9 @@ func testGraphQL(t *testing.T, host string) {
 
 	t.Run("expected aggregate failures with invalid conditions", aggregatesWithExpectedFailures)
 
-	t.Run("metrics count is stable when more classes are added", metricsCount)
+	t.Run("metrics count is stable when more classes are added", func(t *testing.T) {
+		metricsCount(t, metricsEndpoint)
+	})
 
 	// tear down
 	deleteObjectClass(t, "Person")

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -43,9 +43,7 @@ func TestGraphQL_AsyncIndexing(t *testing.T) {
 		WithWeaviateEnv("ASYNC_INDEXING_STALE_TIMEOUT", "100ms").
 		WithWeaviateEnv("QUEUE_SCHEDULER_INTERVAL", "100ms").
 		WithWeaviateEnv("API_BASED_MODULES_DISABLED", "true").
-		// match the legacy docker-compose-test.yml monitoring setup, so that
-		// the metrics stability test scrapes this container instead of
-		// whatever else might listen on the host's port 2112
+		// so metricsCount scrapes this container, not whatever else is on :2112
 		WithWeaviateEnv("PROMETHEUS_MONITORING_ENABLED", "true").
 		WithWeaviateEnv("PROMETHEUS_MONITORING_GROUP_CLASSES", "true").
 		Start(ctx)
@@ -58,8 +56,7 @@ func TestGraphQL_AsyncIndexing(t *testing.T) {
 }
 
 func TestGraphQL_SyncIndexing(t *testing.T) {
-	// legacy setup: docker-compose-test.yml maps the metrics port to
-	// localhost:2112
+	// docker-compose-test.yml maps metrics to localhost:2112
 	testGraphQL(t, "localhost:8080", "localhost:2112")
 }
 

--- a/test/docker/container.go
+++ b/test/docker/container.go
@@ -58,9 +58,7 @@ func (d *DockerContainer) ClusterURI() string {
 	return d.GetEndpoint(CLUSTER)
 }
 
-// MetricsURI returns the host-mapped address of the Prometheus metrics
-// endpoint. It is only set when the container was started with
-// PROMETHEUS_MONITORING_ENABLED, otherwise it returns an empty string.
+// MetricsURI returns "" unless started with PROMETHEUS_MONITORING_ENABLED.
 func (d *DockerContainer) MetricsURI() string {
 	return d.GetEndpoint(METRICS)
 }

--- a/test/docker/container.go
+++ b/test/docker/container.go
@@ -23,6 +23,7 @@ var (
 	GRPC    EndpointName = "grpc"
 	DEBUG   EndpointName = "debug"
 	CLUSTER EndpointName = "cluster"
+	METRICS EndpointName = "metrics"
 )
 
 type endpoint struct {
@@ -55,6 +56,13 @@ func (d *DockerContainer) DebugURI() string {
 
 func (d *DockerContainer) ClusterURI() string {
 	return d.GetEndpoint(CLUSTER)
+}
+
+// MetricsURI returns the host-mapped address of the Prometheus metrics
+// endpoint. It is only set when the container was started with
+// PROMETHEUS_MONITORING_ENABLED, otherwise it returns an empty string.
+func (d *DockerContainer) MetricsURI() string {
+	return d.GetEndpoint(METRICS)
 }
 
 func (d *DockerContainer) GetEndpoint(name EndpointName) string {

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -136,10 +136,8 @@ func startWeaviate(ctx context.Context,
 		exposedPorts = append(exposedPorts, "6060/tcp")
 		waitStrategies = append(waitStrategies, wait.ForListeningPort(debugPort))
 	}
-	// Expose the Prometheus metrics port when monitoring is enabled, so tests
-	// can scrape /metrics through the host-mapped port instead of assuming a
-	// fixed localhost:2112 mapping (which only exists in the legacy
-	// docker-compose setup).
+	// Expose the metrics port when monitoring is enabled, so tests scrape the
+	// host-mapped port instead of assuming a fixed localhost:2112.
 	metricsPort := nat.Port("2112/tcp")
 	exposeMetricsPort := entcfg.Enabled(env["PROMETHEUS_MONITORING_ENABLED"])
 	if exposeMetricsPort {

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -23,6 +23,8 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+
+	entcfg "github.com/weaviate/weaviate/entities/config"
 )
 
 const (
@@ -134,6 +136,19 @@ func startWeaviate(ctx context.Context,
 		exposedPorts = append(exposedPorts, "6060/tcp")
 		waitStrategies = append(waitStrategies, wait.ForListeningPort(debugPort))
 	}
+	// Expose the Prometheus metrics port when monitoring is enabled, so tests
+	// can scrape /metrics through the host-mapped port instead of assuming a
+	// fixed localhost:2112 mapping (which only exists in the legacy
+	// docker-compose setup).
+	metricsPort := nat.Port("2112/tcp")
+	exposeMetricsPort := entcfg.Enabled(env["PROMETHEUS_MONITORING_ENABLED"])
+	if exposeMetricsPort {
+		if p := env["PROMETHEUS_MONITORING_PORT"]; p != "" {
+			metricsPort = nat.Port(fmt.Sprintf("%s/tcp", p))
+		}
+		exposedPorts = append(exposedPorts, string(metricsPort))
+		waitStrategies = append(waitStrategies, wait.ForListeningPort(metricsPort))
+	}
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: fromDockerFile,
 		Image:          weaviateImage,
@@ -207,6 +222,13 @@ func startWeaviate(ctx context.Context,
 			return nil, err
 		}
 		endpoints[DEBUG] = endpoint{debugPort, debugUri}
+	}
+	if exposeMetricsPort {
+		metricsUri, err := c.PortEndpoint(ctx, metricsPort, "")
+		if err != nil {
+			return nil, err
+		}
+		endpoints[METRICS] = endpoint{metricsPort, metricsUri}
 	}
 	return &DockerContainer{
 		name:        containerName,


### PR DESCRIPTION
SuperClaude here.

## Motivation

The metrics stability test (`metrics_count_is_stable`) hardcoded `http://localhost:2112/metrics`. That mapping only exists in the legacy docker-compose setup, so under testcontainers (`TestGraphQL_AsyncIndexing`) the test scraped whatever happened to listen on the host's port 2112: in CI that is the *legacy compose server* — a vacuous pass against the wrong instance — and locally it is usually nothing (connection refused). Credit to QA Claude's observation on [weaviate/weaviate#12194](https://github.com/weaviate/weaviate/issues/12194) (failed 2/3 local testcontainer runs) for surfacing this.

## Approach

- `test/docker` now exposes the container's metrics port (default 2112, honors `PROMETHEUS_MONITORING_PORT`) whenever `PROMETHEUS_MONITORING_ENABLED` is set, waits for it to listen, and maps it as a `METRICS` endpoint with a `MetricsURI()` accessor — reusable by any testcontainer suite that needs to scrape metrics.
- `TestGraphQL_AsyncIndexing` enables `PROMETHEUS_MONITORING_ENABLED` + `PROMETHEUS_MONITORING_GROUP_CLASSES` on its container (matching `docker-compose-test.yml`) and passes `MetricsURI()` down to the test.
- The legacy path (`TestGraphQL_SyncIndexing`) keeps `localhost:2112` explicitly, so CI behavior there is unchanged.
- `countMetricsLines` now fails loudly if no metrics endpoint is configured instead of silently scraping a port that may belong to a different process.

## What scraping the right instance exposed

Once the async variant scraped its own container, the count assertion failed with +4 lines: the `file_io_reads_total_bytes{operation="readSegmentFile"}` summary materializes lazily on the first segment-file read (compaction-timing dependent). This family — like `file_io_writes_total_bytes` and `mmap_operations_total` — has bounded, class-independent label cardinality (`operation`/`strategy` only), so it cannot indicate the per-class metric leak this test guards against. These families are now excluded from the line count, same as the existing `weaviate_lsm_bucket_read_operation` / cursor-duration exclusions.

To compensate, the guard got slightly stronger: the class-name-leak check (`require.NotContains(metricClassPrefix)`) now runs on **every** line, including excluded ones (previously excluded lines skipped it).

## Verification

- `TestGraphQL_AsyncIndexing` run locally under testcontainers with a prebuilt v1.36-based image: the metrics subtest scrapes the container's host-mapped port and passes.
- Smoke-tested the infra both ways: with `PROMETHEUS_MONITORING_ENABLED` the `METRICS` endpoint is mapped and serves Prometheus output; without it, no port is exposed and `MetricsURI()` is empty.
- `golangci-lint`, `go vet`, goroutine linter clean.
- Not re-verified here: the legacy `TestGraphQL_SyncIndexing` path (needs the compose server; its endpoint is byte-for-byte the previous default, CI covers it).

— SuperClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM
