### PR TITLE
fix(ci): cap preview docker tag slug to 128-char limit

### DIFF
--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -69,9 +69,8 @@ function release() {
     else
       tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}"
     fi
-    # Cap the slug at 80 chars so the docker tag stays under Docker's 128-char
-    # component limit ("preview-" + slug + "-" + 7-char sha + "." + arch = 22 +
-    # slug); re-strip any trailing dash the cut may leave so no tag ends in "-".
+    # Cap slug at 80 chars: Docker's tag limit is 128 and preview tags append a
+    # sha/arch suffix. Re-strip after cut, since it can leave a new trailing dash.
     pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g' | cut -c1-80 | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
       git_branch="$GITHUB_REF_NAME"

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -69,7 +69,10 @@ function release() {
     else
       tag_preview_semver="${DOCKER_REPO}:${weaviate_version}-${git_revision}"
     fi
-    pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
+    # Cap the slug at 80 chars so the docker tag stays under Docker's 128-char
+    # component limit ("preview-" + slug + "-" + 7-char sha + "." + arch = 22 +
+    # slug); re-strip any trailing dash the cut may leave so no tag ends in "-".
+    pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g' | cut -c1-80 | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
       git_branch="$GITHUB_REF_NAME"
       branch_name="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g')"

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -74,8 +74,7 @@ function release() {
     pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g' | cut -c1-80 | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
       git_branch="$GITHUB_REF_NAME"
-      # Same 80-char cap as pr_title above: this empty-title (non-PR) branch
-      # builds the preview tag from branch_name, so a long ref would overflow 128.
+      # Same 80-char cap as pr_title above (Docker tag limit).
       branch_name="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g' | cut -c1-80 | sed 's/-$//g')"
       tag_preview="${DOCKER_REPO}:${branch_name}-${git_revision}"
       weaviate_version="${branch_name}-${git_revision}"

--- a/ci/push_docker.sh
+++ b/ci/push_docker.sh
@@ -74,7 +74,9 @@ function release() {
     pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g' | cut -c1-80 | sed 's/-$//g')"
     if [ "$pr_title" == "" ]; then
       git_branch="$GITHUB_REF_NAME"
-      branch_name="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g')"
+      # Same 80-char cap as pr_title above: this empty-title (non-PR) branch
+      # builds the preview tag from branch_name, so a long ref would overflow 128.
+      branch_name="$(echo -n $GITHUB_REF_NAME | sed 's/\//-/g' | cut -c1-80 | sed 's/-$//g')"
       tag_preview="${DOCKER_REPO}:${branch_name}-${git_revision}"
       weaviate_version="${branch_name}-${git_revision}"
       git_branch="$GITHUB_HEAD_REF"


### PR DESCRIPTION
SuperClaude here.

## Root cause

`ci/push_docker.sh` built the PR preview docker tag from the full PR title with no length cap:

```sh
pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g')"
tag_preview="${DOCKER_REPO}:preview-${pr_title}-${git_revision}.${arch}"
```

Docker tag components have a hard **128-char limit**. A long PR title slugified in full overflows it, and `docker buildx build` fails with `invalid reference format`. This is exactly what broke docker-build on #12167 (108-char title → 129-char tag component, red since PR creation). Short-title PRs never hit it, which is why this stayed latent.

## Fix

Cap the slugified `pr_title` at **80 chars** at the source, right where it is computed. That single point feeds every downstream consumer: the preview tag, its per-arch variant, and the `preview-…` `weaviate_version`.

```sh
pr_title="$(echo -n "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -c -s '[:alnum:]' '-' | sed 's/-$//g' | cut -c1-80 | sed 's/-$//g')"
```

The trailing `sed 's/-$//g'` re-runs after the cut so a slice landing on a dash can't leave a tag ending in `-`.

## The 128 math

Fixed overhead around the slug: `preview-`(8) + `-`+7-char sha(8) + `.`+arch(6) = **22**. With the slug capped at 80, the tag component is at most **102 chars**, comfortably under 128.

## No behavior change for short titles

For any title whose slug is ≤80 chars (the overwhelming majority), `cut -c1-80` is a no-op and the trailing `sed` finds nothing to strip, so the slug is byte-identical to before.

Fixes the docker-build failure on https://github.com/weaviate/weaviate/pull/12167

— SuperClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM