### PR TITLE
fix(telemetry): drain pending Track events before serving Get

### DIFF
--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -103,14 +103,12 @@ func newMapTracker[K comparable](logger logrus.FieldLogger, initCap, maxKeys, ma
 // Uses a priority select pattern to drain all tracking events before
 // handling Get/GetAndReset requests, ensuring consistent results.
 //
-// The leading priority select is not sufficient on its own: once the goroutine
-// is parked in the second select, a buffered trackChan event and an unbuffered
-// getChan/resetChan request can become ready at the same time, and Go picks a
-// ready case at random. Because Track is a fire-and-forget non-blocking send, a
-// sequential Track-then-Get on the caller side can then serve the Get while the
-// Track event is still buffered, undercounting the result. To honor the
-// drain-before-serve contract, the Get/GetAndReset cases first drain any events
-// still buffered in trackChan (via drainTrackChan) before copying the counts.
+// The leading priority select alone doesn't close the race: once parked in
+// the second select, a buffered trackChan event and an unbuffered
+// getChan/resetChan request can both be ready, and select picks at random.
+// Since Track is a non-blocking send, a sequential Track-then-Get could then
+// see Get served first and undercount. Get/GetAndReset call drainTrackChan
+// first to close this window.
 func (t *mapTracker[K]) run() {
 	counts := make(map[K]map[string]int64, t.initCap)
 	for {
@@ -146,12 +144,8 @@ func (t *mapTracker[K]) run() {
 	}
 }
 
-// drainTrackChan applies every tracking event currently buffered in trackChan
-// without blocking. It is called before serving a Get/GetAndReset so that a
-// Track event which became ready at the same instant as the request cannot be
-// left buffered while the counts are copied. This closes the drain-before-serve
-// hole in run's second select, where a random ready-case pick could otherwise
-// serve the request ahead of an already-queued Track event.
+// drainTrackChan flushes all events currently buffered in trackChan without
+// blocking. Called before Get/GetAndReset copy counts; see run for why.
 func (t *mapTracker[K]) drainTrackChan(counts map[K]map[string]int64) {
 	for {
 		select {

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -102,6 +102,15 @@ func newMapTracker[K comparable](logger logrus.FieldLogger, initCap, maxKeys, ma
 // It owns the counts map exclusively, eliminating the need for locks.
 // Uses a priority select pattern to drain all tracking events before
 // handling Get/GetAndReset requests, ensuring consistent results.
+//
+// The leading priority select is not sufficient on its own: once the goroutine
+// is parked in the second select, a buffered trackChan event and an unbuffered
+// getChan/resetChan request can become ready at the same time, and Go picks a
+// ready case at random. Because Track is a fire-and-forget non-blocking send, a
+// sequential Track-then-Get on the caller side can then serve the Get while the
+// Track event is still buffered, undercounting the result. To honor the
+// drain-before-serve contract, the Get/GetAndReset cases first drain any events
+// still buffered in trackChan (via drainTrackChan) before copying the counts.
 func (t *mapTracker[K]) run() {
 	counts := make(map[K]map[string]int64, t.initCap)
 	for {
@@ -123,13 +132,32 @@ func (t *mapTracker[K]) run() {
 			t.processEvent(counts, ev)
 
 		case respChan := <-t.getChan:
+			t.drainTrackChan(counts)
 			respChan <- t.deepCopy(counts)
 
 		case respChan := <-t.resetChan:
+			t.drainTrackChan(counts)
 			respChan <- t.deepCopy(counts)
 			counts = make(map[K]map[string]int64, t.initCap)
 
 		case <-t.stopChan:
+			return
+		}
+	}
+}
+
+// drainTrackChan applies every tracking event currently buffered in trackChan
+// without blocking. It is called before serving a Get/GetAndReset so that a
+// Track event which became ready at the same instant as the request cannot be
+// left buffered while the counts are copied. This closes the drain-before-serve
+// hole in run's second select, where a random ready-case pick could otherwise
+// serve the request ahead of an already-queued Track event.
+func (t *mapTracker[K]) drainTrackChan(counts map[K]map[string]int64) {
+	for {
+		select {
+		case ev := <-t.trackChan:
+			t.processEvent(counts, ev)
+		default:
 			return
 		}
 	}

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -1186,10 +1186,6 @@ func TestIdentifyIntegration(t *testing.T) {
 // TestMapTracker_TrackThenDrainingRead_NoUndercount pins the drain-before-serve
 // race in mapTracker.run, where a random select pick could serve a draining read
 // before an already-buffered Track event (weaviate/weaviate#12201).
-//
-// The getChan (Get) and resetChan (GetAndReset) drain paths are pinned
-// independently: each read mode is its own subtree, so dropping only one path's
-// drainTrackChan reds that mode's subtests while the other mode stays green.
 func TestMapTracker_TrackThenDrainingRead_NoUndercount(t *testing.T) {
 	// GOMAXPROCS=1 never triggers the race; pin to 2 for a stable repro
 	// regardless of the host's core count.
@@ -1197,8 +1193,6 @@ func TestMapTracker_TrackThenDrainingRead_NoUndercount(t *testing.T) {
 
 	const iterations = 100000
 
-	// Each tracker flavor exposes one draining-read closure selected by getReset:
-	// false → Get (getChan drain), true → GetAndReset (resetChan drain).
 	trackers := []struct {
 		name  string
 		build func() (track func(), count func(getReset bool) int64, stop func())
@@ -1245,15 +1239,13 @@ func TestMapTracker_TrackThenDrainingRead_NoUndercount(t *testing.T) {
 		wantCount func(iteration int) int64
 	}{
 		{
-			// Get never resets, so after i sequential Tracks the tracked key
-			// must read back exactly i.
+			// Get never resets: count accumulates across iterations.
 			name:      "Get",
 			getReset:  false,
 			wantCount: func(i int) int64 { return int64(i) },
 		},
 		{
-			// GetAndReset clears after returning, so each single-Track iteration
-			// must read back exactly 1.
+			// GetAndReset clears on read: count is always 1.
 			name:      "GetAndReset",
 			getReset:  true,
 			wantCount: func(int) int64 { return 1 },

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -1238,6 +1238,66 @@ func TestMapTracker_TrackThenGet_NoUndercount(t *testing.T) {
 	}
 }
 
+// TestMapTracker_TrackThenGetAndReset_NoUndercount is the GetAndReset sibling of
+// TestMapTracker_TrackThenGet_NoUndercount: it independently pins the resetChan
+// drain, so removing only that drain call (leaving the getChan one intact) is
+// caught here rather than relying on the shared helper for symmetry
+// (weaviate/weaviate#12201). GetAndReset clears the counts after returning them,
+// so each single-Track iteration starts from zero and the returned snapshot must
+// report exactly 1; an undrained buffered Track shows up as 0.
+func TestMapTracker_TrackThenGetAndReset_NoUndercount(t *testing.T) {
+	// GOMAXPROCS=1 never triggers the race; pin to 2 for a stable repro
+	// regardless of the host's core count.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
+
+	const iterations = 100000
+
+	tests := []struct {
+		name  string
+		build func() (track func(), count func() int64, stop func())
+	}{
+		{
+			name: "IntegrationTracker",
+			build: func() (func(), func() int64, func()) {
+				logger, _ := test.NewNullLogger()
+				tracker := NewIntegrationTracker(logger)
+				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
+				req.Header.Set(integrationHeaderKey, testMyIntegration)
+				return func() { tracker.Track(req) },
+					func() int64 { return tracker.GetAndReset()[testMyIntegration]["unknown"] },
+					tracker.Stop
+			},
+		},
+		{
+			name: "ClientTracker",
+			build: func() (func(), func() int64, func()) {
+				logger, _ := test.NewNullLogger()
+				tracker := NewClientTracker(logger)
+				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
+				req.Header.Set("X-Weaviate-Client", "weaviate-client-python/4.10.0")
+				return func() { tracker.Track(req) },
+					func() int64 { return tracker.GetAndReset()[ClientTypePython]["4.10.0"] },
+					tracker.Stop
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			track, count, stop := tc.build()
+			defer stop()
+
+			for i := 1; i <= iterations; i++ {
+				track()
+				require.Equalf(t, int64(1), count(),
+					"GetAndReset undercounted at iteration %d: a Track event queued "+
+						"before the GetAndReset was still buffered when the counts "+
+						"were copied", i)
+			}
+		})
+	}
+}
+
 // testMapTrackerStopBehavior verifies that get and getAndReset return nil
 // after the tracker has been stopped. Uses the inner mapTracker directly
 // since this test file is in the same package.

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -1183,6 +1183,79 @@ func TestIdentifyIntegration(t *testing.T) {
 	}
 }
 
+// TestMapTracker_TrackThenGet_NoUndercount is a regression test for the
+// drain-before-serve race in mapTracker.run (see weaviate/weaviate#12201).
+//
+// Track is a fire-and-forget non-blocking send onto a buffered channel, so a
+// sequential Track-then-Get from the same caller must always observe that
+// Track: by the time Get is served the event is already queued. Before the fix,
+// once run's background goroutine was parked in its second select a buffered
+// trackChan event and the unbuffered getChan request could become ready at the
+// same instant and Go would pick a ready case at random; when the Get won it
+// copied the still-stale counts and undercounted by one.
+//
+// The window only opens with real parallelism between the caller and the
+// background goroutine (with GOMAXPROCS=1 the leading priority select always
+// drains first), so the test pins GOMAXPROCS to 2 for a reliable, host- and
+// core-count-independent repro. Each iteration does a sequential Track then Get
+// and asserts the running count is exact. Before the fix this failed within a
+// few thousand iterations (tens of undercounts per 100k); with the fix it is
+// deterministically clean. Both concrete trackers are exercised because they
+// share the same mapTracker.run.
+func TestMapTracker_TrackThenGet_NoUndercount(t *testing.T) {
+	// Pin to 2 Ps: the race cannot occur with a single P, and pinning (rather
+	// than leaving the host default) keeps the repro rate high and stable
+	// regardless of how many cores the CI runner has. The test does not call
+	// t.Parallel, so no sibling test observes the changed value.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
+
+	const iterations = 100000
+
+	tests := []struct {
+		name  string
+		build func() (track func(), count func() int64, stop func())
+	}{
+		{
+			name: "IntegrationTracker",
+			build: func() (func(), func() int64, func()) {
+				logger, _ := test.NewNullLogger()
+				tracker := NewIntegrationTracker(logger)
+				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
+				req.Header.Set(integrationHeaderKey, testMyIntegration)
+				return func() { tracker.Track(req) },
+					func() int64 { return tracker.Get()[testMyIntegration]["unknown"] },
+					tracker.Stop
+			},
+		},
+		{
+			name: "ClientTracker",
+			build: func() (func(), func() int64, func()) {
+				logger, _ := test.NewNullLogger()
+				tracker := NewClientTracker(logger)
+				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
+				req.Header.Set("X-Weaviate-Client", "weaviate-client-python/4.10.0")
+				return func() { tracker.Track(req) },
+					func() int64 { return tracker.Get()[ClientTypePython]["4.10.0"] },
+					tracker.Stop
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			track, count, stop := tc.build()
+			defer stop()
+
+			for i := 1; i <= iterations; i++ {
+				track()
+				require.Equalf(t, int64(i), count(),
+					"Get undercounted at iteration %d: a Track event queued before "+
+						"the Get was still buffered when the counts were copied", i)
+			}
+		})
+	}
+}
+
 // testMapTrackerStopBehavior verifies that get and getAndReset return nil
 // after the tracker has been stopped. Uses the inner mapTracker directly
 // since this test file is in the same package.

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -1183,112 +1183,98 @@ func TestIdentifyIntegration(t *testing.T) {
 	}
 }
 
-// TestMapTracker_TrackThenGet_NoUndercount pins the drain-before-serve race in
-// mapTracker.run, where a random select pick could serve Get before an
-// already-buffered Track event (weaviate/weaviate#12201).
-func TestMapTracker_TrackThenGet_NoUndercount(t *testing.T) {
+// TestMapTracker_TrackThenDrainingRead_NoUndercount pins the drain-before-serve
+// race in mapTracker.run, where a random select pick could serve a draining read
+// before an already-buffered Track event (weaviate/weaviate#12201).
+//
+// The getChan (Get) and resetChan (GetAndReset) drain paths are pinned
+// independently: each read mode is its own subtree, so dropping only one path's
+// drainTrackChan reds that mode's subtests while the other mode stays green.
+func TestMapTracker_TrackThenDrainingRead_NoUndercount(t *testing.T) {
 	// GOMAXPROCS=1 never triggers the race; pin to 2 for a stable repro
 	// regardless of the host's core count.
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
 
 	const iterations = 100000
 
-	tests := []struct {
+	// Each tracker flavor exposes one draining-read closure selected by getReset:
+	// false → Get (getChan drain), true → GetAndReset (resetChan drain).
+	trackers := []struct {
 		name  string
-		build func() (track func(), count func() int64, stop func())
+		build func() (track func(), count func(getReset bool) int64, stop func())
 	}{
 		{
 			name: "IntegrationTracker",
-			build: func() (func(), func() int64, func()) {
+			build: func() (func(), func(bool) int64, func()) {
 				logger, _ := test.NewNullLogger()
 				tracker := NewIntegrationTracker(logger)
 				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
 				req.Header.Set(integrationHeaderKey, testMyIntegration)
 				return func() { tracker.Track(req) },
-					func() int64 { return tracker.Get()[testMyIntegration]["unknown"] },
+					func(getReset bool) int64 {
+						if getReset {
+							return tracker.GetAndReset()[testMyIntegration]["unknown"]
+						}
+						return tracker.Get()[testMyIntegration]["unknown"]
+					},
 					tracker.Stop
 			},
 		},
 		{
 			name: "ClientTracker",
-			build: func() (func(), func() int64, func()) {
+			build: func() (func(), func(bool) int64, func()) {
 				logger, _ := test.NewNullLogger()
 				tracker := NewClientTracker(logger)
 				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
 				req.Header.Set("X-Weaviate-Client", "weaviate-client-python/4.10.0")
 				return func() { tracker.Track(req) },
-					func() int64 { return tracker.Get()[ClientTypePython]["4.10.0"] },
+					func(getReset bool) int64 {
+						if getReset {
+							return tracker.GetAndReset()[ClientTypePython]["4.10.0"]
+						}
+						return tracker.Get()[ClientTypePython]["4.10.0"]
+					},
 					tracker.Stop
 			},
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			track, count, stop := tc.build()
-			defer stop()
-
-			for i := 1; i <= iterations; i++ {
-				track()
-				require.Equalf(t, int64(i), count(),
-					"Get undercounted at iteration %d: a Track event queued before "+
-						"the Get was still buffered when the counts were copied", i)
-			}
-		})
-	}
-}
-
-// TestMapTracker_TrackThenGetAndReset_NoUndercount pins the same race on the
-// resetChan drain, independently of the getChan case above
-// (weaviate/weaviate#12201).
-func TestMapTracker_TrackThenGetAndReset_NoUndercount(t *testing.T) {
-	// GOMAXPROCS=1 never triggers the race; pin to 2 for a stable repro
-	// regardless of the host's core count.
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
-
-	const iterations = 100000
-
-	tests := []struct {
-		name  string
-		build func() (track func(), count func() int64, stop func())
+	reads := []struct {
+		name      string
+		getReset  bool
+		wantCount func(iteration int) int64
 	}{
 		{
-			name: "IntegrationTracker",
-			build: func() (func(), func() int64, func()) {
-				logger, _ := test.NewNullLogger()
-				tracker := NewIntegrationTracker(logger)
-				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
-				req.Header.Set(integrationHeaderKey, testMyIntegration)
-				return func() { tracker.Track(req) },
-					func() int64 { return tracker.GetAndReset()[testMyIntegration]["unknown"] },
-					tracker.Stop
-			},
+			// Get never resets, so after i sequential Tracks the tracked key
+			// must read back exactly i.
+			name:      "Get",
+			getReset:  false,
+			wantCount: func(i int) int64 { return int64(i) },
 		},
 		{
-			name: "ClientTracker",
-			build: func() (func(), func() int64, func()) {
-				logger, _ := test.NewNullLogger()
-				tracker := NewClientTracker(logger)
-				req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
-				req.Header.Set("X-Weaviate-Client", "weaviate-client-python/4.10.0")
-				return func() { tracker.Track(req) },
-					func() int64 { return tracker.GetAndReset()[ClientTypePython]["4.10.0"] },
-					tracker.Stop
-			},
+			// GetAndReset clears after returning, so each single-Track iteration
+			// must read back exactly 1.
+			name:      "GetAndReset",
+			getReset:  true,
+			wantCount: func(int) int64 { return 1 },
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			track, count, stop := tc.build()
-			defer stop()
+	for _, read := range reads {
+		t.Run(read.name, func(t *testing.T) {
+			for _, tc := range trackers {
+				t.Run(tc.name, func(t *testing.T) {
+					track, count, stop := tc.build()
+					defer stop()
 
-			for i := 1; i <= iterations; i++ {
-				track()
-				require.Equalf(t, int64(1), count(),
-					"GetAndReset undercounted at iteration %d: a Track event queued "+
-						"before the GetAndReset was still buffered when the counts "+
-						"were copied", i)
+					for i := 1; i <= iterations; i++ {
+						track()
+						require.Equalf(t, read.wantCount(i), count(read.getReset),
+							"%s undercounted at iteration %d: a Track event queued "+
+								"before the draining read was still buffered when the "+
+								"counts were copied", read.name, i)
+					}
+				})
 			}
 		})
 	}

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -1238,13 +1238,9 @@ func TestMapTracker_TrackThenGet_NoUndercount(t *testing.T) {
 	}
 }
 
-// TestMapTracker_TrackThenGetAndReset_NoUndercount is the GetAndReset sibling of
-// TestMapTracker_TrackThenGet_NoUndercount: it independently pins the resetChan
-// drain, so removing only that drain call (leaving the getChan one intact) is
-// caught here rather than relying on the shared helper for symmetry
-// (weaviate/weaviate#12201). GetAndReset clears the counts after returning them,
-// so each single-Track iteration starts from zero and the returned snapshot must
-// report exactly 1; an undrained buffered Track shows up as 0.
+// TestMapTracker_TrackThenGetAndReset_NoUndercount pins the same race on the
+// resetChan drain, independently of the getChan case above
+// (weaviate/weaviate#12201).
 func TestMapTracker_TrackThenGetAndReset_NoUndercount(t *testing.T) {
 	// GOMAXPROCS=1 never triggers the race; pin to 2 for a stable repro
 	// regardless of the host's core count.

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -1183,30 +1183,12 @@ func TestIdentifyIntegration(t *testing.T) {
 	}
 }
 
-// TestMapTracker_TrackThenGet_NoUndercount is a regression test for the
-// drain-before-serve race in mapTracker.run (see weaviate/weaviate#12201).
-//
-// Track is a fire-and-forget non-blocking send onto a buffered channel, so a
-// sequential Track-then-Get from the same caller must always observe that
-// Track: by the time Get is served the event is already queued. Before the fix,
-// once run's background goroutine was parked in its second select a buffered
-// trackChan event and the unbuffered getChan request could become ready at the
-// same instant and Go would pick a ready case at random; when the Get won it
-// copied the still-stale counts and undercounted by one.
-//
-// The window only opens with real parallelism between the caller and the
-// background goroutine (with GOMAXPROCS=1 the leading priority select always
-// drains first), so the test pins GOMAXPROCS to 2 for a reliable, host- and
-// core-count-independent repro. Each iteration does a sequential Track then Get
-// and asserts the running count is exact. Before the fix this failed within a
-// few thousand iterations (tens of undercounts per 100k); with the fix it is
-// deterministically clean. Both concrete trackers are exercised because they
-// share the same mapTracker.run.
+// TestMapTracker_TrackThenGet_NoUndercount pins the drain-before-serve race in
+// mapTracker.run, where a random select pick could serve Get before an
+// already-buffered Track event (weaviate/weaviate#12201).
 func TestMapTracker_TrackThenGet_NoUndercount(t *testing.T) {
-	// Pin to 2 Ps: the race cannot occur with a single P, and pinning (rather
-	// than leaving the host default) keeps the repro rate high and stable
-	// regardless of how many cores the CI runner has. The test does not call
-	// t.Parallel, so no sibling test observes the changed value.
+	// GOMAXPROCS=1 never triggers the race; pin to 2 for a stable repro
+	// regardless of the host's core count.
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
 
 	const iterations = 100000


### PR DESCRIPTION
SuperClaude here.

Fixes weaviate/weaviate#12201.

## The race

`mapTracker.run()` (usecases/telemetry/client_tracker.go) uses a priority-drain select whose godoc promises all `Track` events are applied before a `Get`/`GetAndReset` is served. There is a hole: once the background goroutine is parked in the **second** select, a buffered `trackChan` event and an unbuffered `getChan`/`resetChan` request can become ready at the same instant, and Go picks a ready case at random. `Track` is a fire-and-forget non-blocking send, so a sequential `Track`-then-`Get` from one caller could serve the `Get` while the `Track` event was still buffered — returning a `deepCopy` of stale counts and undercounting by one.

This is a real correctness bug, not just test flakiness: the documented drain-before-serve contract is violated, so production `Get`/`GetAndReset` can under-report client/integration usage. It surfaced as intermittent `expected 1, actual 0` failures of `TestIntegrationTracker/tracks_integration_name_only_when_no_version_provided` under `-race`.

## The fix

Before serving `getChan`/`resetChan`, fully drain any events still buffered in `trackChan` via a new non-blocking `drainTrackChan` helper, then copy the counts. Because `Track`'s buffered send completes before the caller's `Get` send in the sequential case, the drain is guaranteed to observe the pending event. The leading priority select, shutdown path, and reset semantics are unchanged. The `run` godoc is updated to document the hole and how the drain closes it.

## Regression test + mutation proof

`TestMapTracker_TrackThenGet_NoUndercount` is table-driven over both concrete trackers (they share `mapTracker.run`). Each of 100k iterations does a sequential `Track` then `Get` and asserts the running count is exact, under `-race` with `GOMAXPROCS` pinned to 2 (the race is unobservable at `GOMAXPROCS=1`, where the leading priority select always drains first — so pinning makes the repro reliable and host-independent).

- **Without the fix:** fails every run — 5/5 runs red, tens of undercounts per 100k iterations, first failure within a few thousand iterations (observed first-fail range 7–35745).
- **With the fix:** deterministically clean — 0 undercounts across repeated `-race -count=5` runs.

## Verification

- `go test -race -count=5 ./usecases/telemetry/...` — green
- `go build ./...` — green
- `golangci-lint run ./usecases/telemetry/...` — 0 issues
- `./tools/linter_go_routines.sh` — clean (no new goroutines)
- gofumpt / goimports — clean

## Base branch

Based on `stable/v1.38`: it is the oldest stable branch that carries the generic `mapTracker`/`IntegrationTracker` code this fix targets. `stable/v1.36` and `stable/v1.37` still have the pre-refactor `ClientTracker` and carry the **same** race in their own `run()`, but that is a structurally different patch (this fix and test do not compile there); flagging so it can be handled separately if those branches need it.

— SuperClaude