### PR TITLE
Namespace suspend scaffolding (errors etc)

### DIFF
--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -453,11 +453,12 @@ func TestCreateUser_Namespaces(t *testing.T) {
 }
 
 // TestCreateUser_MapsApplyNamespaceErrors asserts the createUser handler
-// classifies apply-layer namespace sentinels: a deleting namespace is a
-// transient state conflict (409), the rest of the lifecycle family renders
-// 422, and everything else is 500. The handler's pre-flight Exists check can
+// classifies apply-layer namespace sentinels: the lifecycle family renders
+// 422 and everything else is 500. The handler's pre-flight Exists check can
 // race with a concurrent namespace delete, so a 500 would be misleading: the
 // request is well-formed, the namespace just changed state underneath it.
+// Deleting matches the pre-check's own 422 so the race cannot flip the
+// status a client sees.
 func TestCreateUser_MapsApplyNamespaceErrors(t *testing.T) {
 	const userID = "ns1:user"
 
@@ -472,9 +473,9 @@ func TestCreateUser_MapsApplyNamespaceErrors(t *testing.T) {
 			expect:   &users.CreateUserUnprocessableEntity{},
 		},
 		{
-			name:     "ErrNamespaceDeleting returns 409",
+			name:     "ErrNamespaceDeleting returns 422",
 			applyErr: fmt.Errorf("apply: %w", namespaces.ErrNamespaceDeleting),
-			expect:   &users.CreateUserConflict{},
+			expect:   &users.CreateUserUnprocessableEntity{},
 		},
 		{
 			name:     "ErrNamespaceSuspended returns 422",

--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -477,6 +477,21 @@ func TestCreateUser_MapsApplyNamespaceErrorsTo422(t *testing.T) {
 			expect:   &users.CreateUserUnprocessableEntity{},
 		},
 		{
+			name:     "ErrNamespaceSuspended returns 422",
+			applyErr: fmt.Errorf("apply: %w", namespaces.ErrNamespaceSuspended),
+			expect:   &users.CreateUserUnprocessableEntity{},
+		},
+		{
+			name:     "ErrNamespaceNotEmpty returns 422",
+			applyErr: fmt.Errorf("apply: %w", namespaces.ErrNamespaceNotEmpty),
+			expect:   &users.CreateUserUnprocessableEntity{},
+		},
+		{
+			name:     "ErrInvalidState returns 422",
+			applyErr: fmt.Errorf("apply: %w", namespaces.ErrInvalidState),
+			expect:   &users.CreateUserUnprocessableEntity{},
+		},
+		{
 			name:     "unrelated error returns 500",
 			applyErr: errors.New("disk full"),
 			expect:   &users.CreateUserInternalServerError{},

--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -452,13 +452,13 @@ func TestCreateUser_Namespaces(t *testing.T) {
 	}
 }
 
-// TestCreateUser_MapsApplyNamespaceErrorsTo422 asserts the createUser
-// handler classifies apply-layer namespace sentinels as retryable client
-// errors (422) and everything else as 500. The handler's pre-flight
-// Exists check can race with a concurrent namespace delete, so a 500
-// would be misleading: the request is well-formed, the namespace just
-// vanished underneath it.
-func TestCreateUser_MapsApplyNamespaceErrorsTo422(t *testing.T) {
+// TestCreateUser_MapsApplyNamespaceErrors asserts the createUser handler
+// classifies apply-layer namespace sentinels: a deleting namespace is a
+// transient state conflict (409), the rest of the lifecycle family renders
+// 422, and everything else is 500. The handler's pre-flight Exists check can
+// race with a concurrent namespace delete, so a 500 would be misleading: the
+// request is well-formed, the namespace just changed state underneath it.
+func TestCreateUser_MapsApplyNamespaceErrors(t *testing.T) {
 	const userID = "ns1:user"
 
 	tests := []struct {
@@ -472,9 +472,9 @@ func TestCreateUser_MapsApplyNamespaceErrorsTo422(t *testing.T) {
 			expect:   &users.CreateUserUnprocessableEntity{},
 		},
 		{
-			name:     "ErrNamespaceDeleting returns 422",
+			name:     "ErrNamespaceDeleting returns 409",
 			applyErr: fmt.Errorf("apply: %w", namespaces.ErrNamespaceDeleting),
-			expect:   &users.CreateUserUnprocessableEntity{},
+			expect:   &users.CreateUserConflict{},
 		},
 		{
 			name:     "ErrNamespaceSuspended returns 422",

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -459,12 +459,9 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 	}
 
 	if err := h.dbUsers.CreateUser(ctx, internalKey, hash, userIdentifier, apiKey[:3], ns, time.Now()); err != nil {
-		// Apply-time race against a namespace lifecycle change. A deleting
-		// namespace is a transient state conflict (409); a gone/suspended/
-		// invalid-state namespace renders 422.
-		if errors.Is(err, namespaces.ErrNamespaceDeleting) {
-			return users.NewCreateUserConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))
-		}
+		// The namespace changed state between the pre-check above and the
+		// apply. Deleting renders 422 like the pre-check does — the namespace
+		// never returns to active, so the create is not retryable.
 		status, ok := cerrors.HTTPStatusForNamespaceErr(err)
 		if errors.Is(err, namespaces.ErrNamespaceGone) || (ok && status == http.StatusUnprocessableEntity) {
 			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -16,6 +16,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"sync"
 	"time"
@@ -458,9 +459,10 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 	}
 
 	if err := h.dbUsers.CreateUser(ctx, internalKey, hash, userIdentifier, apiKey[:3], ns, time.Now()); err != nil {
-		// Apply-time race: surface a deleted/deleting namespace as 422 so
-		// clients can retry against current state.
-		if errors.Is(err, namespaces.ErrNamespaceGone) || errors.Is(err, namespaces.ErrNamespaceDeleting) {
+		// Apply-time race: surface a gone/deleting/suspended namespace as 422
+		// so clients can retry against current state.
+		status, ok := cerrors.HTTPStatusForNamespaceErr(err)
+		if errors.Is(err, namespaces.ErrNamespaceGone) || (ok && status == http.StatusUnprocessableEntity) {
 			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))
 		}
 		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -459,8 +459,12 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 	}
 
 	if err := h.dbUsers.CreateUser(ctx, internalKey, hash, userIdentifier, apiKey[:3], ns, time.Now()); err != nil {
-		// Apply-time race: surface a gone/deleting/suspended namespace as 422
-		// so clients can retry against current state.
+		// Apply-time race against a namespace lifecycle change. A deleting
+		// namespace is a transient state conflict (409); a gone/suspended/
+		// invalid-state namespace renders 422.
+		if errors.Is(err, namespaces.ErrNamespaceDeleting) {
+			return users.NewCreateUserConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))
+		}
 		status, ok := cerrors.HTTPStatusForNamespaceErr(err)
 		if errors.Is(err, namespaces.ErrNamespaceGone) || (ok && status == http.StatusUnprocessableEntity) {
 			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3016,14 +3016,8 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
-          "409": {
-            "description": "The namespace is being deleted; ` + "`" + `home_node` + "`" + ` cannot be updated while the namespace is in the ` + "`" + `deleting` + "`" + ` state.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
           "422": {
-            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, or unknown home_node).",
+            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, unknown home_node, or the namespace being in the ` + "`" + `deleting` + "`" + ` state).",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -13982,14 +13976,8 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
-          "409": {
-            "description": "The namespace is being deleted; ` + "`" + `home_node` + "`" + ` cannot be updated while the namespace is in the ` + "`" + `deleting` + "`" + ` state.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
           "422": {
-            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, or unknown home_node).",
+            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, unknown home_node, or the namespace being in the ` + "`" + `deleting` + "`" + ` state).",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/adapters/handlers/rest/errors/errors.go
+++ b/adapters/handlers/rest/errors/errors.go
@@ -22,16 +22,16 @@ import (
 )
 
 // HTTPStatusForNamespaceErr maps a namespace/collection lifecycle sentinel
-// to its REST status: the terminal family (deleting, not-empty,
-// invalid-state, suspended) renders 422, a resuming namespace renders 503.
-// ok is false for anything else, so the caller falls through to its own
-// default.
+// to its REST status: the terminal family (not-empty, invalid-state,
+// suspended) renders 422, a resuming namespace renders 503. A deleting
+// namespace is deliberately excluded — callers render it as a 409 state
+// conflict. ok is false for anything else, so the caller falls through to
+// its own default.
 func HTTPStatusForNamespaceErr(err error) (status int, ok bool) {
 	switch {
 	case errors.Is(err, namespaces.ErrNamespaceResuming):
 		return http.StatusServiceUnavailable, true
-	case errors.Is(err, namespaces.ErrNamespaceDeleting),
-		errors.Is(err, namespaces.ErrNamespaceNotEmpty),
+	case errors.Is(err, namespaces.ErrNamespaceNotEmpty),
 		errors.Is(err, namespaces.ErrInvalidState),
 		errors.Is(err, namespaces.ErrNamespaceSuspended),
 		errors.Is(err, namespaces.ErrCollectionSuspended):

--- a/adapters/handlers/rest/errors/errors.go
+++ b/adapters/handlers/rest/errors/errors.go
@@ -36,8 +36,9 @@ func HTTPStatusForNamespaceErr(err error) (status int, ok bool) {
 		errors.Is(err, namespaces.ErrNamespaceSuspended),
 		errors.Is(err, namespaces.ErrCollectionSuspended):
 		return http.StatusUnprocessableEntity, true
+	default:
+		return 0, false
 	}
-	return 0, false
 }
 
 // ErrPayloadFromSingleErr builds a single-message ErrorResponse with the

--- a/adapters/handlers/rest/errors/errors.go
+++ b/adapters/handlers/rest/errors/errors.go
@@ -22,16 +22,16 @@ import (
 )
 
 // HTTPStatusForNamespaceErr maps a namespace/collection lifecycle sentinel
-// to its REST status: the terminal family (not-empty, invalid-state,
-// suspended) renders 422, a resuming namespace renders 503. A deleting
-// namespace is deliberately excluded — callers render it as a 409 state
-// conflict. ok is false for anything else, so the caller falls through to
-// its own default.
+// to its REST status: the terminal family (deleting, not-empty,
+// invalid-state, suspended) renders 422, a resuming namespace renders 503.
+// ok is false for anything else, so the caller falls through to its own
+// default.
 func HTTPStatusForNamespaceErr(err error) (status int, ok bool) {
 	switch {
 	case errors.Is(err, namespaces.ErrNamespaceResuming):
 		return http.StatusServiceUnavailable, true
-	case errors.Is(err, namespaces.ErrNamespaceNotEmpty),
+	case errors.Is(err, namespaces.ErrNamespaceDeleting),
+		errors.Is(err, namespaces.ErrNamespaceNotEmpty),
 		errors.Is(err, namespaces.ErrInvalidState),
 		errors.Is(err, namespaces.ErrNamespaceSuspended),
 		errors.Is(err, namespaces.ErrCollectionSuspended):

--- a/adapters/handlers/rest/errors/errors.go
+++ b/adapters/handlers/rest/errors/errors.go
@@ -12,11 +12,33 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
+
+// HTTPStatusForNamespaceErr maps a namespace/collection lifecycle sentinel
+// to its REST status: the terminal family (deleting, not-empty,
+// invalid-state, suspended) renders 422, a resuming namespace renders 503.
+// ok is false for anything else, so the caller falls through to its own
+// default.
+func HTTPStatusForNamespaceErr(err error) (status int, ok bool) {
+	switch {
+	case errors.Is(err, namespaces.ErrNamespaceResuming):
+		return http.StatusServiceUnavailable, true
+	case errors.Is(err, namespaces.ErrNamespaceDeleting),
+		errors.Is(err, namespaces.ErrNamespaceNotEmpty),
+		errors.Is(err, namespaces.ErrInvalidState),
+		errors.Is(err, namespaces.ErrNamespaceSuspended),
+		errors.Is(err, namespaces.ErrCollectionSuspended):
+		return http.StatusUnprocessableEntity, true
+	}
+	return 0, false
+}
 
 // ErrPayloadFromSingleErr builds a single-message ErrorResponse with the
 // principal's own namespace prefix stripped from err. Pass nil for global

--- a/adapters/handlers/rest/errors/errors_test.go
+++ b/adapters/handlers/rest/errors/errors_test.go
@@ -68,7 +68,7 @@ func TestHTTPStatusForNamespaceErr(t *testing.T) {
 		wantStatus int
 		wantOK     bool
 	}{
-		{name: "deleting → 422", err: namespaces.ErrNamespaceDeleting, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
+		{name: "deleting is not in the family (callers render 409)", err: namespaces.ErrNamespaceDeleting, wantStatus: 0, wantOK: false},
 		{name: "not-empty → 422", err: namespaces.ErrNamespaceNotEmpty, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
 		{name: "invalid-state → 422", err: namespaces.ErrInvalidState, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
 		{name: "namespace-suspended → 422", err: namespaces.ErrNamespaceSuspended, wantStatus: http.StatusUnprocessableEntity, wantOK: true},

--- a/adapters/handlers/rest/errors/errors_test.go
+++ b/adapters/handlers/rest/errors/errors_test.go
@@ -68,7 +68,7 @@ func TestHTTPStatusForNamespaceErr(t *testing.T) {
 		wantStatus int
 		wantOK     bool
 	}{
-		{name: "deleting is not in the family (callers render 409)", err: namespaces.ErrNamespaceDeleting, wantStatus: 0, wantOK: false},
+		{name: "deleting → 422", err: namespaces.ErrNamespaceDeleting, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
 		{name: "not-empty → 422", err: namespaces.ErrNamespaceNotEmpty, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
 		{name: "invalid-state → 422", err: namespaces.ErrInvalidState, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
 		{name: "namespace-suspended → 422", err: namespaces.ErrNamespaceSuspended, wantStatus: http.StatusUnprocessableEntity, wantOK: true},

--- a/adapters/handlers/rest/errors/errors_test.go
+++ b/adapters/handlers/rest/errors/errors_test.go
@@ -13,10 +13,14 @@ package errors
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 func TestErrPayloadFromSingleErr(t *testing.T) {
@@ -53,6 +57,36 @@ func TestErrPayloadFromSingleErr(t *testing.T) {
 			got := ErrPayloadFromSingleErr(tt.principal, tt.err)
 			require.Len(t, got.Error, 1)
 			require.Equal(t, tt.want, got.Error[0].Message)
+		})
+	}
+}
+
+func TestHTTPStatusForNamespaceErr(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantOK     bool
+	}{
+		{name: "deleting → 422", err: namespaces.ErrNamespaceDeleting, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
+		{name: "not-empty → 422", err: namespaces.ErrNamespaceNotEmpty, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
+		{name: "invalid-state → 422", err: namespaces.ErrInvalidState, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
+		{name: "namespace-suspended → 422", err: namespaces.ErrNamespaceSuspended, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
+		{name: "collection-suspended → 422", err: namespaces.ErrCollectionSuspended, wantStatus: http.StatusUnprocessableEntity, wantOK: true},
+		{name: "wrapped suspended still classifies", err: fmt.Errorf("apply: %w", namespaces.ErrNamespaceSuspended), wantStatus: http.StatusUnprocessableEntity, wantOK: true},
+		{name: "resuming → 503", err: namespaces.ErrNamespaceResuming, wantStatus: http.StatusServiceUnavailable, wantOK: true},
+		{name: "invalid-state-transition is not in the family", err: namespaces.ErrInvalidStateTransition, wantStatus: 0, wantOK: false},
+		{name: "mt-disabled is not in the family", err: schema.ErrMTDisabled, wantStatus: 0, wantOK: false},
+		{name: "gone is not in the family", err: namespaces.ErrNamespaceGone, wantStatus: 0, wantOK: false},
+		{name: "already-exists is not in the family", err: namespaces.ErrAlreadyExists, wantStatus: 0, wantOK: false},
+		{name: "bad-request is not in the family", err: namespaces.ErrBadRequest, wantStatus: 0, wantOK: false},
+		{name: "untyped error is not in the family", err: errors.New("boom"), wantStatus: 0, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, ok := HTTPStatusForNamespaceErr(tt.err)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantStatus, status)
 		})
 	}
 }

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -128,19 +128,23 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 	}
 	created, _, err := h.raft.AddNamespace(ctx, cmd.Namespace{Name: name, HomeNodes: homeNodes})
 	if err != nil {
-		if status, ok := cerrors.HTTPStatusForNamespaceErr(err); ok && status == http.StatusUnprocessableEntity {
-			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
-		}
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrAlreadyExists):
 			return nsops.NewCreateNamespaceConflict().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q already exists", name)))
+		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
+			// Deleting is a transient state conflict — 409 to retry after
+			// cleanup, not the terminal-family 422.
+			return nsops.NewCreateNamespaceConflict().WithPayload(
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; retry after cleanup completes", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
 			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
-		default:
-			return nsops.NewCreateNamespaceInternalServerError().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating namespace: %w", err)))
 		}
+		if status, ok := cerrors.HTTPStatusForNamespaceErr(err); ok && status == http.StatusUnprocessableEntity {
+			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
+		}
+		return nsops.NewCreateNamespaceInternalServerError().WithPayload(
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating namespace: %w", err)))
 	}
 
 	return nsops.NewCreateNamespaceCreated().WithPayload(&models.Namespace{
@@ -180,19 +184,23 @@ func (h *namespaceHandler) updateNamespace(params nsops.UpdateNamespaceParams, p
 	}
 
 	if _, err := h.raft.UpdateNamespace(ctx, cmd.Namespace{Name: name, HomeNodes: []string{homeNode}}); err != nil {
-		if status, ok := cerrors.HTTPStatusForNamespaceErr(err); ok && status == http.StatusUnprocessableEntity {
-			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
-		}
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrNotFound):
 			return nsops.NewUpdateNamespaceNotFound().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q not found", name)))
+		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
+			// Deleting is a transient state conflict — 409 to retry after
+			// cleanup, not the terminal-family 422.
+			return nsops.NewUpdateNamespaceConflict().WithPayload(
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; home_node cannot be updated", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
 			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
-		default:
-			return nsops.NewUpdateNamespaceInternalServerError().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("updating namespace: %w", err)))
 		}
+		if status, ok := cerrors.HTTPStatusForNamespaceErr(err); ok && status == http.StatusUnprocessableEntity {
+			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
+		}
+		return nsops.NewUpdateNamespaceInternalServerError().WithPayload(
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("updating namespace: %w", err)))
 	}
 
 	// Read State from the controller rather than hardcoding active so the

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -189,8 +189,9 @@ func (h *namespaceHandler) updateNamespace(params nsops.UpdateNamespaceParams, p
 			return nsops.NewUpdateNamespaceNotFound().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q not found", name)))
 		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
-			// Deleting is a transient state conflict — 409 to retry after
-			// cleanup, not the terminal-family 422.
+			// 409 rather than the family's 422: the delete is a state conflict
+			// on the namespace this request addresses. Not retryable — once
+			// cleanup finishes the namespace is gone and this returns 404.
 			return nsops.NewUpdateNamespaceConflict().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; home_node cannot be updated", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -189,10 +189,10 @@ func (h *namespaceHandler) updateNamespace(params nsops.UpdateNamespaceParams, p
 			return nsops.NewUpdateNamespaceNotFound().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q not found", name)))
 		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
-			// 409 rather than the family's 422: the delete is a state conflict
-			// on the namespace this request addresses. Not retryable — once
-			// cleanup finishes the namespace is gone and this returns 404.
-			return nsops.NewUpdateNamespaceConflict().WithPayload(
+			// Not a retryable conflict: the namespace never leaves deleting, so
+			// no later retry of this update can succeed. Cased explicitly for
+			// the tailored message; the status matches the family's 422.
+			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; home_node cannot be updated", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
 			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -128,13 +128,13 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 	}
 	created, _, err := h.raft.AddNamespace(ctx, cmd.Namespace{Name: name, HomeNodes: homeNodes})
 	if err != nil {
+		if status, ok := cerrors.HTTPStatusForNamespaceErr(err); ok && status == http.StatusUnprocessableEntity {
+			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
+		}
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrAlreadyExists):
 			return nsops.NewCreateNamespaceConflict().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q already exists", name)))
-		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
-			return nsops.NewCreateNamespaceConflict().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; retry after cleanup completes", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
 			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		default:
@@ -180,13 +180,13 @@ func (h *namespaceHandler) updateNamespace(params nsops.UpdateNamespaceParams, p
 	}
 
 	if _, err := h.raft.UpdateNamespace(ctx, cmd.Namespace{Name: name, HomeNodes: []string{homeNode}}); err != nil {
+		if status, ok := cerrors.HTTPStatusForNamespaceErr(err); ok && status == http.StatusUnprocessableEntity {
+			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
+		}
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrNotFound):
 			return nsops.NewUpdateNamespaceNotFound().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q not found", name)))
-		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
-			return nsops.NewUpdateNamespaceConflict().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; home_node cannot be updated", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
 			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		default:

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -244,21 +244,40 @@ func TestCreateNamespace_UnprocessableEntity(t *testing.T) {
 	}
 }
 
-// TestCreateNamespace_Conflict checks that create returns 409 with an
-// "already exists" message when the name belongs to an existing namespace.
+// TestCreateNamespace_Conflict checks the 409 paths: an existing name and a
+// namespace mid-deletion both return Conflict with a distinguishing message.
 func TestCreateNamespace_Conflict(t *testing.T) {
 	principal := &models.Principal{}
-	h, authz, raft := newHandler(t)
-	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(
-		nil, 0, fmt.Errorf("%w: %q", usecasesNamespaces.ErrAlreadyExists, "customer1"))
+	cases := []struct {
+		name       string
+		raftErr    error
+		wantSubstr string
+	}{
+		{
+			name:       "already exists",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrAlreadyExists, "customer1"),
+			wantSubstr: "already exists",
+		},
+		{
+			name:       "being deleted",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, "customer1"),
+			wantSubstr: "being deleted",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, authz, raft := newHandler(t)
+			authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
+			raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(nil, 0, tc.raftErr)
 
-	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
-	parsed, ok := res.(*nsops.CreateNamespaceConflict)
-	require.True(t, ok, "expected 409, got %T", res)
-	require.NotNil(t, parsed.Payload)
-	require.Len(t, parsed.Payload.Error, 1)
-	assert.Contains(t, parsed.Payload.Error[0].Message, "already exists")
+			res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
+			parsed, ok := res.(*nsops.CreateNamespaceConflict)
+			require.True(t, ok, "expected 409, got %T", res)
+			require.NotNil(t, parsed.Payload)
+			require.Len(t, parsed.Payload.Error, 1)
+			assert.Contains(t, parsed.Payload.Error[0].Message, tc.wantSubstr)
+		})
+	}
 }
 
 // TestCreateNamespace_LifecycleErrorsReturn422 checks that the namespace
@@ -270,11 +289,6 @@ func TestCreateNamespace_LifecycleErrorsReturn422(t *testing.T) {
 		raftErr    error
 		wantSubstr string
 	}{
-		{
-			name:       "being deleted",
-			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, "customer1"),
-			wantSubstr: "being deleted",
-		},
 		{
 			name:       "namespace suspended",
 			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceSuspended, "customer1"),
@@ -473,9 +487,9 @@ func TestUpdateNamespace_RaftErrorMapping(t *testing.T) {
 			wantTyped: &nsops.UpdateNamespaceNotFound{},
 		},
 		{
-			name:      "ErrNamespaceDeleting → 422",
+			name:      "ErrNamespaceDeleting → 409",
 			raftErr:   fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, "customer1"),
-			wantTyped: &nsops.UpdateNamespaceUnprocessableEntity{},
+			wantTyped: &nsops.UpdateNamespaceConflict{},
 		},
 		{
 			name:      "ErrNamespaceSuspended → 422",

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -244,12 +244,26 @@ func TestCreateNamespace_UnprocessableEntity(t *testing.T) {
 	}
 }
 
-// TestCreateNamespace_Conflict checks that create returns 409 in two
-// cases: when the name belongs to an active namespace, and when the name
-// belongs to one that is still being deleted. Both map to the same
-// response type, so the test also asserts each carries its own distinct
-// message so clients can tell the two situations apart.
+// TestCreateNamespace_Conflict checks that create returns 409 with an
+// "already exists" message when the name belongs to an existing namespace.
 func TestCreateNamespace_Conflict(t *testing.T) {
+	principal := &models.Principal{}
+	h, authz, raft := newHandler(t)
+	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
+	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(
+		nil, 0, fmt.Errorf("%w: %q", usecasesNamespaces.ErrAlreadyExists, "customer1"))
+
+	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
+	parsed, ok := res.(*nsops.CreateNamespaceConflict)
+	require.True(t, ok, "expected 409, got %T", res)
+	require.NotNil(t, parsed.Payload)
+	require.Len(t, parsed.Payload.Error, 1)
+	assert.Contains(t, parsed.Payload.Error[0].Message, "already exists")
+}
+
+// TestCreateNamespace_LifecycleErrorsReturn422 checks that the namespace
+// lifecycle sentinels render 422 with a message that distinguishes them.
+func TestCreateNamespace_LifecycleErrorsReturn422(t *testing.T) {
 	principal := &models.Principal{}
 	cases := []struct {
 		name       string
@@ -257,14 +271,29 @@ func TestCreateNamespace_Conflict(t *testing.T) {
 		wantSubstr string
 	}{
 		{
-			name:       "already exists",
-			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrAlreadyExists, "customer1"),
-			wantSubstr: "already exists",
-		},
-		{
-			name:       "is being deleted",
+			name:       "being deleted",
 			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, "customer1"),
 			wantSubstr: "being deleted",
+		},
+		{
+			name:       "namespace suspended",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceSuspended, "customer1"),
+			wantSubstr: "suspended",
+		},
+		{
+			name:       "collection suspended",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrCollectionSuspended, "customer1"),
+			wantSubstr: "suspended",
+		},
+		{
+			name:       "namespace still has resources",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceNotEmpty, "customer1"),
+			wantSubstr: "owned resources",
+		},
+		{
+			name:       "namespace in invalid state",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrInvalidState, "customer1"),
+			wantSubstr: "invalid state",
 		},
 	}
 	for _, tc := range cases {
@@ -274,8 +303,8 @@ func TestCreateNamespace_Conflict(t *testing.T) {
 			raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(nil, 0, tc.raftErr)
 
 			res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
-			parsed, ok := res.(*nsops.CreateNamespaceConflict)
-			require.True(t, ok, "expected 409, got %T", res)
+			parsed, ok := res.(*nsops.CreateNamespaceUnprocessableEntity)
+			require.True(t, ok, "expected 422, got %T", res)
 			require.NotNil(t, parsed.Payload)
 			require.Len(t, parsed.Payload.Error, 1)
 			assert.Contains(t, parsed.Payload.Error[0].Message, tc.wantSubstr)
@@ -444,9 +473,19 @@ func TestUpdateNamespace_RaftErrorMapping(t *testing.T) {
 			wantTyped: &nsops.UpdateNamespaceNotFound{},
 		},
 		{
-			name:      "ErrNamespaceDeleting → 409",
+			name:      "ErrNamespaceDeleting → 422",
 			raftErr:   fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, "customer1"),
-			wantTyped: &nsops.UpdateNamespaceConflict{},
+			wantTyped: &nsops.UpdateNamespaceUnprocessableEntity{},
+		},
+		{
+			name:      "ErrNamespaceSuspended → 422",
+			raftErr:   fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceSuspended, "customer1"),
+			wantTyped: &nsops.UpdateNamespaceUnprocessableEntity{},
+		},
+		{
+			name:      "ErrCollectionSuspended → 422",
+			raftErr:   fmt.Errorf("%w: %q", usecasesNamespaces.ErrCollectionSuspended, "customer1"),
+			wantTyped: &nsops.UpdateNamespaceUnprocessableEntity{},
 		},
 		{
 			name:      "ErrBadRequest → 422",

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -487,9 +487,11 @@ func TestUpdateNamespace_RaftErrorMapping(t *testing.T) {
 			wantTyped: &nsops.UpdateNamespaceNotFound{},
 		},
 		{
-			name:      "ErrNamespaceDeleting → 409",
+			// No retry can succeed: cleanup removes the namespace, so a
+			// later update 404s.
+			name:      "ErrNamespaceDeleting → 422",
 			raftErr:   fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, "customer1"),
-			wantTyped: &nsops.UpdateNamespaceConflict{},
+			wantTyped: &nsops.UpdateNamespaceUnprocessableEntity{},
 		},
 		{
 			name:      "ErrNamespaceSuspended → 422",

--- a/adapters/handlers/rest/operations/namespaces/update_namespace_responses.go
+++ b/adapters/handlers/rest/operations/namespaces/update_namespace_responses.go
@@ -33,7 +33,6 @@ UpdateNamespaceOK Namespace updated successfully.
 swagger:response updateNamespaceOK
 */
 type UpdateNamespaceOK struct {
-
 	/*
 	  In: Body
 	*/
@@ -42,7 +41,6 @@ type UpdateNamespaceOK struct {
 
 // NewUpdateNamespaceOK creates UpdateNamespaceOK with default headers values
 func NewUpdateNamespaceOK() *UpdateNamespaceOK {
-
 	return &UpdateNamespaceOK{}
 }
 
@@ -59,7 +57,6 @@ func (o *UpdateNamespaceOK) SetPayload(payload *models.Namespace) {
 
 // WriteResponse to the client
 func (o *UpdateNamespaceOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(200)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -77,19 +74,16 @@ UpdateNamespaceUnauthorized Unauthorized or invalid credentials.
 
 swagger:response updateNamespaceUnauthorized
 */
-type UpdateNamespaceUnauthorized struct {
-}
+type UpdateNamespaceUnauthorized struct{}
 
 // NewUpdateNamespaceUnauthorized creates UpdateNamespaceUnauthorized with default headers values
 func NewUpdateNamespaceUnauthorized() *UpdateNamespaceUnauthorized {
-
 	return &UpdateNamespaceUnauthorized{}
 }
 
 // WriteResponse to the client
 func (o *UpdateNamespaceUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+	rw.Header().Del(runtime.HeaderContentType) // Remove Content-Type on empty responses
 
 	rw.WriteHeader(401)
 }
@@ -103,7 +97,6 @@ UpdateNamespaceForbidden Forbidden
 swagger:response updateNamespaceForbidden
 */
 type UpdateNamespaceForbidden struct {
-
 	/*
 	  In: Body
 	*/
@@ -112,7 +105,6 @@ type UpdateNamespaceForbidden struct {
 
 // NewUpdateNamespaceForbidden creates UpdateNamespaceForbidden with default headers values
 func NewUpdateNamespaceForbidden() *UpdateNamespaceForbidden {
-
 	return &UpdateNamespaceForbidden{}
 }
 
@@ -129,7 +121,6 @@ func (o *UpdateNamespaceForbidden) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *UpdateNamespaceForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(403)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -148,7 +139,6 @@ UpdateNamespaceNotFound Not Found - Namespace does not exist, or the namespaces 
 swagger:response updateNamespaceNotFound
 */
 type UpdateNamespaceNotFound struct {
-
 	/*
 	  In: Body
 	*/
@@ -157,7 +147,6 @@ type UpdateNamespaceNotFound struct {
 
 // NewUpdateNamespaceNotFound creates UpdateNamespaceNotFound with default headers values
 func NewUpdateNamespaceNotFound() *UpdateNamespaceNotFound {
-
 	return &UpdateNamespaceNotFound{}
 }
 
@@ -174,53 +163,7 @@ func (o *UpdateNamespaceNotFound) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *UpdateNamespaceNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(404)
-	if o.Payload != nil {
-		payload := o.Payload
-		if err := producer.Produce(rw, payload); err != nil {
-			panic(err) // let the recovery middleware deal with this
-		}
-	}
-}
-
-// UpdateNamespaceConflictCode is the HTTP code returned for type UpdateNamespaceConflict
-const UpdateNamespaceConflictCode int = 409
-
-/*
-UpdateNamespaceConflict The namespace is being deleted; `home_node` cannot be updated while the namespace is in the `deleting` state.
-
-swagger:response updateNamespaceConflict
-*/
-type UpdateNamespaceConflict struct {
-
-	/*
-	  In: Body
-	*/
-	Payload *models.ErrorResponse `json:"body,omitempty"`
-}
-
-// NewUpdateNamespaceConflict creates UpdateNamespaceConflict with default headers values
-func NewUpdateNamespaceConflict() *UpdateNamespaceConflict {
-
-	return &UpdateNamespaceConflict{}
-}
-
-// WithPayload adds the payload to the update namespace conflict response
-func (o *UpdateNamespaceConflict) WithPayload(payload *models.ErrorResponse) *UpdateNamespaceConflict {
-	o.Payload = payload
-	return o
-}
-
-// SetPayload sets the payload to the update namespace conflict response
-func (o *UpdateNamespaceConflict) SetPayload(payload *models.ErrorResponse) {
-	o.Payload = payload
-}
-
-// WriteResponse to the client
-func (o *UpdateNamespaceConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.WriteHeader(409)
 	if o.Payload != nil {
 		payload := o.Payload
 		if err := producer.Produce(rw, payload); err != nil {
@@ -233,12 +176,11 @@ func (o *UpdateNamespaceConflict) WriteResponse(rw http.ResponseWriter, producer
 const UpdateNamespaceUnprocessableEntityCode int = 422
 
 /*
-UpdateNamespaceUnprocessableEntity The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, or unknown home_node).
+UpdateNamespaceUnprocessableEntity The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, unknown home_node, or the namespace being in the `deleting` state).
 
 swagger:response updateNamespaceUnprocessableEntity
 */
 type UpdateNamespaceUnprocessableEntity struct {
-
 	/*
 	  In: Body
 	*/
@@ -247,7 +189,6 @@ type UpdateNamespaceUnprocessableEntity struct {
 
 // NewUpdateNamespaceUnprocessableEntity creates UpdateNamespaceUnprocessableEntity with default headers values
 func NewUpdateNamespaceUnprocessableEntity() *UpdateNamespaceUnprocessableEntity {
-
 	return &UpdateNamespaceUnprocessableEntity{}
 }
 
@@ -264,7 +205,6 @@ func (o *UpdateNamespaceUnprocessableEntity) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *UpdateNamespaceUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(422)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -283,7 +223,6 @@ UpdateNamespaceInternalServerError An error has occurred while trying to fulfill
 swagger:response updateNamespaceInternalServerError
 */
 type UpdateNamespaceInternalServerError struct {
-
 	/*
 	  In: Body
 	*/
@@ -292,7 +231,6 @@ type UpdateNamespaceInternalServerError struct {
 
 // NewUpdateNamespaceInternalServerError creates UpdateNamespaceInternalServerError with default headers values
 func NewUpdateNamespaceInternalServerError() *UpdateNamespaceInternalServerError {
-
 	return &UpdateNamespaceInternalServerError{}
 }
 
@@ -309,7 +247,6 @@ func (o *UpdateNamespaceInternalServerError) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *UpdateNamespaceInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(500)
 	if o.Payload != nil {
 		payload := o.Payload

--- a/adapters/handlers/rest/operations/namespaces/update_namespace_responses.go
+++ b/adapters/handlers/rest/operations/namespaces/update_namespace_responses.go
@@ -33,6 +33,7 @@ UpdateNamespaceOK Namespace updated successfully.
 swagger:response updateNamespaceOK
 */
 type UpdateNamespaceOK struct {
+
 	/*
 	  In: Body
 	*/
@@ -41,6 +42,7 @@ type UpdateNamespaceOK struct {
 
 // NewUpdateNamespaceOK creates UpdateNamespaceOK with default headers values
 func NewUpdateNamespaceOK() *UpdateNamespaceOK {
+
 	return &UpdateNamespaceOK{}
 }
 
@@ -57,6 +59,7 @@ func (o *UpdateNamespaceOK) SetPayload(payload *models.Namespace) {
 
 // WriteResponse to the client
 func (o *UpdateNamespaceOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(200)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -74,16 +77,19 @@ UpdateNamespaceUnauthorized Unauthorized or invalid credentials.
 
 swagger:response updateNamespaceUnauthorized
 */
-type UpdateNamespaceUnauthorized struct{}
+type UpdateNamespaceUnauthorized struct {
+}
 
 // NewUpdateNamespaceUnauthorized creates UpdateNamespaceUnauthorized with default headers values
 func NewUpdateNamespaceUnauthorized() *UpdateNamespaceUnauthorized {
+
 	return &UpdateNamespaceUnauthorized{}
 }
 
 // WriteResponse to the client
 func (o *UpdateNamespaceUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-	rw.Header().Del(runtime.HeaderContentType) // Remove Content-Type on empty responses
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
 
 	rw.WriteHeader(401)
 }
@@ -97,6 +103,7 @@ UpdateNamespaceForbidden Forbidden
 swagger:response updateNamespaceForbidden
 */
 type UpdateNamespaceForbidden struct {
+
 	/*
 	  In: Body
 	*/
@@ -105,6 +112,7 @@ type UpdateNamespaceForbidden struct {
 
 // NewUpdateNamespaceForbidden creates UpdateNamespaceForbidden with default headers values
 func NewUpdateNamespaceForbidden() *UpdateNamespaceForbidden {
+
 	return &UpdateNamespaceForbidden{}
 }
 
@@ -121,6 +129,7 @@ func (o *UpdateNamespaceForbidden) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *UpdateNamespaceForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(403)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -139,6 +148,7 @@ UpdateNamespaceNotFound Not Found - Namespace does not exist, or the namespaces 
 swagger:response updateNamespaceNotFound
 */
 type UpdateNamespaceNotFound struct {
+
 	/*
 	  In: Body
 	*/
@@ -147,6 +157,7 @@ type UpdateNamespaceNotFound struct {
 
 // NewUpdateNamespaceNotFound creates UpdateNamespaceNotFound with default headers values
 func NewUpdateNamespaceNotFound() *UpdateNamespaceNotFound {
+
 	return &UpdateNamespaceNotFound{}
 }
 
@@ -163,6 +174,7 @@ func (o *UpdateNamespaceNotFound) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *UpdateNamespaceNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(404)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -181,6 +193,7 @@ UpdateNamespaceUnprocessableEntity The request syntax is correct, but the server
 swagger:response updateNamespaceUnprocessableEntity
 */
 type UpdateNamespaceUnprocessableEntity struct {
+
 	/*
 	  In: Body
 	*/
@@ -189,6 +202,7 @@ type UpdateNamespaceUnprocessableEntity struct {
 
 // NewUpdateNamespaceUnprocessableEntity creates UpdateNamespaceUnprocessableEntity with default headers values
 func NewUpdateNamespaceUnprocessableEntity() *UpdateNamespaceUnprocessableEntity {
+
 	return &UpdateNamespaceUnprocessableEntity{}
 }
 
@@ -205,6 +219,7 @@ func (o *UpdateNamespaceUnprocessableEntity) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *UpdateNamespaceUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(422)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -223,6 +238,7 @@ UpdateNamespaceInternalServerError An error has occurred while trying to fulfill
 swagger:response updateNamespaceInternalServerError
 */
 type UpdateNamespaceInternalServerError struct {
+
 	/*
 	  In: Body
 	*/
@@ -231,6 +247,7 @@ type UpdateNamespaceInternalServerError struct {
 
 // NewUpdateNamespaceInternalServerError creates UpdateNamespaceInternalServerError with default headers values
 func NewUpdateNamespaceInternalServerError() *UpdateNamespaceInternalServerError {
+
 	return &UpdateNamespaceInternalServerError{}
 }
 
@@ -247,6 +264,7 @@ func (o *UpdateNamespaceInternalServerError) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *UpdateNamespaceInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(500)
 	if o.Payload != nil {
 		payload := o.Payload

--- a/client/namespaces/update_namespace_responses.go
+++ b/client/namespaces/update_namespace_responses.go
@@ -132,6 +132,7 @@ func (o *UpdateNamespaceOK) GetPayload() *models.Namespace {
 }
 
 func (o *UpdateNamespaceOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.Namespace)
 
 	// response payload
@@ -152,7 +153,8 @@ UpdateNamespaceUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type UpdateNamespaceUnauthorized struct{}
+type UpdateNamespaceUnauthorized struct {
+}
 
 // IsSuccess returns true when this update namespace unauthorized response has a 2xx status code
 func (o *UpdateNamespaceUnauthorized) IsSuccess() bool {
@@ -193,6 +195,7 @@ func (o *UpdateNamespaceUnauthorized) String() string {
 }
 
 func (o *UpdateNamespaceUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	return nil
 }
 
@@ -253,6 +256,7 @@ func (o *UpdateNamespaceForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *UpdateNamespaceForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -320,6 +324,7 @@ func (o *UpdateNamespaceNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *UpdateNamespaceNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -387,6 +392,7 @@ func (o *UpdateNamespaceUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *UpdateNamespaceUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -454,6 +460,7 @@ func (o *UpdateNamespaceInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *UpdateNamespaceInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/namespaces/update_namespace_responses.go
+++ b/client/namespaces/update_namespace_responses.go
@@ -58,12 +58,6 @@ func (o *UpdateNamespaceReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
-	case 409:
-		result := NewUpdateNamespaceConflict()
-		if err := result.readResponse(response, consumer, o.formats); err != nil {
-			return nil, err
-		}
-		return nil, result
 	case 422:
 		result := NewUpdateNamespaceUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -138,7 +132,6 @@ func (o *UpdateNamespaceOK) GetPayload() *models.Namespace {
 }
 
 func (o *UpdateNamespaceOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Namespace)
 
 	// response payload
@@ -159,8 +152,7 @@ UpdateNamespaceUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type UpdateNamespaceUnauthorized struct {
-}
+type UpdateNamespaceUnauthorized struct{}
 
 // IsSuccess returns true when this update namespace unauthorized response has a 2xx status code
 func (o *UpdateNamespaceUnauthorized) IsSuccess() bool {
@@ -201,7 +193,6 @@ func (o *UpdateNamespaceUnauthorized) String() string {
 }
 
 func (o *UpdateNamespaceUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -262,7 +253,6 @@ func (o *UpdateNamespaceForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *UpdateNamespaceForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -330,75 +320,6 @@ func (o *UpdateNamespaceNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *UpdateNamespaceNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
-	o.Payload = new(models.ErrorResponse)
-
-	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
-		return err
-	}
-
-	return nil
-}
-
-// NewUpdateNamespaceConflict creates a UpdateNamespaceConflict with default headers values
-func NewUpdateNamespaceConflict() *UpdateNamespaceConflict {
-	return &UpdateNamespaceConflict{}
-}
-
-/*
-UpdateNamespaceConflict describes a response with status code 409, with default header values.
-
-The namespace is being deleted; `home_node` cannot be updated while the namespace is in the `deleting` state.
-*/
-type UpdateNamespaceConflict struct {
-	Payload *models.ErrorResponse
-}
-
-// IsSuccess returns true when this update namespace conflict response has a 2xx status code
-func (o *UpdateNamespaceConflict) IsSuccess() bool {
-	return false
-}
-
-// IsRedirect returns true when this update namespace conflict response has a 3xx status code
-func (o *UpdateNamespaceConflict) IsRedirect() bool {
-	return false
-}
-
-// IsClientError returns true when this update namespace conflict response has a 4xx status code
-func (o *UpdateNamespaceConflict) IsClientError() bool {
-	return true
-}
-
-// IsServerError returns true when this update namespace conflict response has a 5xx status code
-func (o *UpdateNamespaceConflict) IsServerError() bool {
-	return false
-}
-
-// IsCode returns true when this update namespace conflict response a status code equal to that given
-func (o *UpdateNamespaceConflict) IsCode(code int) bool {
-	return code == 409
-}
-
-// Code gets the status code for the update namespace conflict response
-func (o *UpdateNamespaceConflict) Code() int {
-	return 409
-}
-
-func (o *UpdateNamespaceConflict) Error() string {
-	return fmt.Sprintf("[PUT /namespaces/{namespace_id}][%d] updateNamespaceConflict  %+v", 409, o.Payload)
-}
-
-func (o *UpdateNamespaceConflict) String() string {
-	return fmt.Sprintf("[PUT /namespaces/{namespace_id}][%d] updateNamespaceConflict  %+v", 409, o.Payload)
-}
-
-func (o *UpdateNamespaceConflict) GetPayload() *models.ErrorResponse {
-	return o.Payload
-}
-
-func (o *UpdateNamespaceConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -417,7 +338,7 @@ func NewUpdateNamespaceUnprocessableEntity() *UpdateNamespaceUnprocessableEntity
 /*
 UpdateNamespaceUnprocessableEntity describes a response with status code 422, with default header values.
 
-The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, or unknown home_node).
+The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, unknown home_node, or the namespace being in the `deleting` state).
 */
 type UpdateNamespaceUnprocessableEntity struct {
 	Payload *models.ErrorResponse
@@ -466,7 +387,6 @@ func (o *UpdateNamespaceUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *UpdateNamespaceUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -534,7 +454,6 @@ func (o *UpdateNamespaceInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *UpdateNamespaceInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -333,6 +333,12 @@ func fromRPCError(err error) error {
 			return errors.Join(err, namespaces.ErrInvalidStateTransition)
 		case strings.Contains(msg, namespaces.ErrInvalidState.Error()):
 			return errors.Join(err, namespaces.ErrInvalidState)
+		case strings.Contains(msg, namespaces.ErrNamespaceSuspended.Error()):
+			return errors.Join(err, namespaces.ErrNamespaceSuspended)
+		case strings.Contains(msg, namespaces.ErrCollectionSuspended.Error()):
+			return errors.Join(err, namespaces.ErrCollectionSuspended)
+		case strings.Contains(msg, namespaces.ErrNamespaceResuming.Error()):
+			return errors.Join(err, namespaces.ErrNamespaceResuming)
 		}
 	case codes.AlreadyExists:
 		if strings.Contains(msg, namespaces.ErrAlreadyExists.Error()) {

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/namespaces"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
@@ -156,6 +157,9 @@ func TestFromRPCError_NamespaceSentinels(t *testing.T) {
 		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
 		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
 		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},
+		{name: "ErrNamespaceSuspended", send: namespaces.ErrNamespaceSuspended},
+		{name: "ErrCollectionSuspended", send: namespaces.ErrCollectionSuspended},
+		{name: "ErrNamespaceResuming", send: namespaces.ErrNamespaceResuming},
 		{name: "ErrNotFound", send: namespaces.ErrNotFound},
 	}
 	for _, tc := range tests {
@@ -184,6 +188,9 @@ func TestClient_Apply_ReChainsNamespaceSentinels(t *testing.T) {
 		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
 		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
 		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},
+		{name: "ErrNamespaceSuspended", send: namespaces.ErrNamespaceSuspended},
+		{name: "ErrCollectionSuspended", send: namespaces.ErrCollectionSuspended},
+		{name: "ErrNamespaceResuming", send: namespaces.ErrNamespaceResuming},
 		{name: "ErrNotFound", send: namespaces.ErrNotFound},
 	}
 	for _, tc := range tests {
@@ -236,4 +243,42 @@ func TestFromRPCError_NotFoundDisambiguation(t *testing.T) {
 	parsed = fromRPCError(toRPCError(namespaces.ErrNotFound))
 	require.ErrorIs(t, parsed, namespaces.ErrNotFound)
 	require.NotErrorIs(t, parsed, schemaUC.ErrNotFound)
+}
+
+// TestFromRPCError_SentinelMessagesMutuallyNonSubstring pins that no
+// FailedPrecondition-arm sentinel message is a substring of another, so
+// fromRPCError's substring re-chain can't chain the wrong sentinel.
+func TestFromRPCError_SentinelMessagesMutuallyNonSubstring(t *testing.T) {
+	sentinels := []struct {
+		name string
+		err  error
+	}{
+		{name: "ErrNamespaceSuspended", err: namespaces.ErrNamespaceSuspended},
+		{name: "ErrCollectionSuspended", err: namespaces.ErrCollectionSuspended},
+		{name: "ErrNamespaceResuming", err: namespaces.ErrNamespaceResuming},
+		{name: "ErrNamespaceDeleting", err: namespaces.ErrNamespaceDeleting},
+		{name: "ErrNamespaceNotEmpty", err: namespaces.ErrNamespaceNotEmpty},
+		{name: "ErrInvalidState", err: namespaces.ErrInvalidState},
+		{name: "ErrInvalidStateTransition", err: namespaces.ErrInvalidStateTransition},
+		{name: "ErrMTDisabled", err: schema.ErrMTDisabled},
+	}
+	for _, a := range sentinels {
+		for _, b := range sentinels {
+			if a.name == b.name {
+				continue
+			}
+			require.NotContains(t, a.err.Error(), b.err.Error(),
+				"%s message must not contain %s message", a.name, b.name)
+		}
+	}
+}
+
+// TestNamespaceResuming_NotRetryable checks ErrNamespaceResuming maps to
+// FailedPrecondition and that code is not in the Apply/Query retry set, so
+// a resuming rejection is never silently retried.
+func TestNamespaceResuming_NotRetryable(t *testing.T) {
+	st, ok := status.FromError(toRPCError(namespaces.ErrNamespaceResuming))
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.NotContains(t, serviceConfig, "FAILED_PRECONDITION")
 }

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -242,6 +242,9 @@ func toRPCError(err error) error {
 		errors.Is(err, namespaces.ErrNamespaceNotEmpty),
 		errors.Is(err, namespaces.ErrInvalidState),
 		errors.Is(err, namespaces.ErrInvalidStateTransition),
+		errors.Is(err, namespaces.ErrNamespaceSuspended),
+		errors.Is(err, namespaces.ErrCollectionSuspended),
+		errors.Is(err, namespaces.ErrNamespaceResuming),
 		errors.Is(err, schema.ErrMTDisabled):
 		ec = codes.FailedPrecondition
 	case errors.Is(err, namespaces.ErrAlreadyExists):

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -423,6 +423,21 @@ func TestToRPCError(t *testing.T) {
 			expected: codes.FailedPrecondition,
 		},
 		{
+			name:     "ErrNamespaceSuspended maps to FailedPrecondition",
+			err:      namespaces.ErrNamespaceSuspended,
+			expected: codes.FailedPrecondition,
+		},
+		{
+			name:     "ErrCollectionSuspended maps to FailedPrecondition",
+			err:      namespaces.ErrCollectionSuspended,
+			expected: codes.FailedPrecondition,
+		},
+		{
+			name:     "ErrNamespaceResuming maps to FailedPrecondition",
+			err:      namespaces.ErrNamespaceResuming,
+			expected: codes.FailedPrecondition,
+		},
+		{
 			name:     "Unknown error maps to Internal",
 			err:      errors.New("unknown error"),
 			expected: codes.Internal,

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -9855,14 +9855,8 @@
               "$ref": "#/definitions/ErrorResponse"
             }
           },
-          "409": {
-            "description": "The namespace is being deleted; `home_node` cannot be updated while the namespace is in the `deleting` state.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
           "422": {
-            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, or unknown home_node).",
+            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues (e.g. invalid name format, reserved name, unknown home_node, or the namespace being in the `deleting` state).",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -66,6 +66,18 @@ var (
 	// ErrInvalidStateTransition is returned by ChangeState when the target
 	// state is unreachable from the namespace's current state.
 	ErrInvalidStateTransition = errors.New("invalid namespace state transition")
+
+	// ErrNamespaceSuspended is returned when an operation targets a suspended
+	// namespace.
+	ErrNamespaceSuspended = errors.New("namespace is suspended")
+
+	// ErrCollectionSuspended is returned when an operation targets a suspended
+	// collection.
+	ErrCollectionSuspended = errors.New("collection is suspended")
+
+	// ErrNamespaceResuming is returned when an operation targets a namespace
+	// that is resuming.
+	ErrNamespaceResuming = errors.New("namespace is resuming")
 )
 
 // reservedNames are refused at Create time. Kept as a package variable (not a


### PR DESCRIPTION
### What's being changed:

This PR adds basic scaffolding such as error sentinels for the new namespace states (suspend, resume) which will come in follow up PRs

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
