### PR TITLE
fix(hnsw): entrypoint repair test flake

### DIFF
--- a/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_repair_test.go
@@ -348,6 +348,8 @@ func TestEntrypointRepair_ConcurrentInserts(t *testing.T) {
 	require.NoError(t, err)
 	defer index.Drop(ctx, false)
 
+	index.randFunc = func() float64 { return 0.5 }
+
 	// Insert initial nodes
 	for i := 0; i < len(vectors); i++ {
 		err := index.Add(ctx, uint64(i), vectors[i])


### PR DESCRIPTION
### What's being changed:

-  `TestEntrypointRepair_ConcurrentInserts` was flaky in CI: occasionally all 10 concurrent inserts succeeded but no entrypoint repair was ever persisted, leaving the final entrypoint as the original under-maintenance node and failing all three post-insert assertions.
- The root cause is HNSW's random level assignment. In roughly 1% of runs, two of the five initial nodes draw level ≥ 1 (each node has a ~3.3% chance at MaxConnections: 30). When that happens and the second upper-layer node is closer to the insert vectors than the broken entrypoint, `findBestEntrypointForNode` hops to that healthy node during the upper-layer descent (it explicitly refuses to keep an under-maintenance candidate). Every insert then reaches pickEntrypoint with a usable candidate, so the repair path in repairGlobalEntrypoint is never entered — legitimate behavior since search-time entrypoint repair (#11956, #12131), but not the scenario this test asserts. The failure mode was reproduced deterministically by pinning randFunc to force that level layout.
- The fix pins index.randFunc to a constant in the test so every node draws level 0. This keeps all the original strict assertions rather than loosening them (a relaxed test would be vacuous in exactly the runs where the bypass occurs). 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
