### PR TITLE
Forward-port #12215 to main: fix empty range results after enable-rangeable reindex with INDEX_RANGEABLE_IN_MEMORY=true

### DIFF
--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2385,13 +2385,9 @@ func (t *ShardReindexTaskGeneric) loadIngestBuckets(ctx context.Context,
 	strategy := t.strategy.TargetStrategy()
 	bucketOpts := t.bucketOptions(shard, strategy, keepLevelCompaction, keepTombstones, t.config.memtableOptFactor)
 
-	// GH#12199: when the global in-mem rangeable knob is on, the ingest bucket is
-	// the one that becomes the main bucket after the per-shard swap and serves
-	// range reads from disk (its rep is forced off in bucketOptions). Mark it so
-	// the read path can emit a durable, query-time "serving from disk; in-mem knob
-	// deferred" signal, and log the deferred-acceleration trade-off once here at
-	// ingest-bucket creation. Only the ingest bucket is marked: the reindex and
-	// backup buckets are torn down and never serve production reads.
+	// GH#12199: mark only the ingest bucket - it becomes the main bucket after
+	// the swap and serves range reads from disk (rep forced off below).
+	// Reindex/backup buckets are torn down and never serve production reads.
 	if strategy == lsmkv.StrategyRoaringSetRange && shard.Index().Config.IndexRangeableInMemory {
 		bucketOpts = append(bucketOpts, lsmkv.WithRangeableInMemoryDeferred(true))
 		logger.WithField("props", props).Info(
@@ -2578,14 +2574,10 @@ func (t *ShardReindexTaskGeneric) bucketOptions(shard *Shard, strategy string,
 		),
 	)
 
-	// GH#12199: reindex/ingest RoaringSetRange buckets must never build an
-	// in-memory representation. The backfill enters via PrependSegmentsFromBucket,
-	// which does not (and safely cannot) rebuild the rep, so a kept-in-memory rep
-	// would serve empty/partial range results after the per-shard swap until the
-	// next clean bucket open. Force keepSegmentsInMemory=false regardless of the
-	// global knob (custom options apply after the strategy defaults, so this
-	// wins); the knob's in-memory acceleration resumes on the next bucket open,
-	// when boot population rebuilds the rep from all disk segments.
+	// GH#12199: force keepSegmentsInMemory=false for RoaringSetRange reindex/ingest
+	// buckets - PrependSegmentsFromBucket can't rebuild the in-memory rep, so a kept
+	// rep would serve stale/empty range results until the next clean bucket open.
+	// This overrides the global knob; opts are appended after the strategy defaults.
 	if strategy == lsmkv.StrategyRoaringSetRange {
 		opts = append(opts, lsmkv.WithKeepSegmentsInMemory(false))
 	}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2382,7 +2382,27 @@ func (t *ShardReindexTaskGeneric) loadIngestBuckets(ctx context.Context,
 	logger logrus.FieldLogger, shard *Shard, props []string,
 	keepLevelCompaction, keepTombstones bool,
 ) error {
-	bucketOpts := t.bucketOptions(shard, t.strategy.TargetStrategy(), keepLevelCompaction, keepTombstones, t.config.memtableOptFactor)
+	strategy := t.strategy.TargetStrategy()
+	bucketOpts := t.bucketOptions(shard, strategy, keepLevelCompaction, keepTombstones, t.config.memtableOptFactor)
+
+	// GH#12199: when the global in-mem rangeable knob is on, the ingest bucket is
+	// the one that becomes the main bucket after the per-shard swap and serves
+	// range reads from disk (its rep is forced off in bucketOptions). Mark it so
+	// the read path can emit a durable, query-time "serving from disk; in-mem knob
+	// deferred" signal, and log the deferred-acceleration trade-off once here at
+	// ingest-bucket creation. Only the ingest bucket is marked: the reindex and
+	// backup buckets are torn down and never serve production reads.
+	if strategy == lsmkv.StrategyRoaringSetRange && shard.Index().Config.IndexRangeableInMemory {
+		bucketOpts = append(bucketOpts, lsmkv.WithRangeableInMemoryDeferred(true))
+		logger.WithField("props", props).Info(
+			"INDEX_RANGEABLE_IN_MEMORY is on, but the enable-rangeable reindex opens its " +
+				"ingest buckets with keepSegmentsInMemory=false to avoid serving empty range " +
+				"results from an unpopulated in-memory representation (GH#12199). Range queries " +
+				"on these properties serve correctly from disk after the swap; the in-memory " +
+				"acceleration takes effect at the next bucket open (node restart, shard reload, " +
+				"or tenant reactivation).")
+	}
+
 	return t.loadBuckets(ctx, logger, shard, props, t.ingestBucketName, bucketOpts)
 }
 
@@ -2546,7 +2566,7 @@ func (t *ShardReindexTaskGeneric) bucketOptions(shard *Shard, strategy string,
 ) []lsmkv.BucketOption {
 	cfg := shard.Index().Config
 
-	return shard.makeDefaultBucketOptions(strategy,
+	opts := shard.makeDefaultBucketOptions(strategy,
 		lsmkv.WithKeepLevelCompaction(keepLevelCompaction),
 		lsmkv.WithKeepTombstones(keepTombstones),
 		// overwrite DynamicMemtableSizing
@@ -2557,6 +2577,20 @@ func (t *ShardReindexTaskGeneric) bucketOptions(shard *Shard, strategy string,
 			memtableOptFactor*cfg.MemtablesMaxActiveSeconds,
 		),
 	)
+
+	// GH#12199: reindex/ingest RoaringSetRange buckets must never build an
+	// in-memory representation. The backfill enters via PrependSegmentsFromBucket,
+	// which does not (and safely cannot) rebuild the rep, so a kept-in-memory rep
+	// would serve empty/partial range results after the per-shard swap until the
+	// next clean bucket open. Force keepSegmentsInMemory=false regardless of the
+	// global knob (custom options apply after the strategy defaults, so this
+	// wins); the knob's in-memory acceleration resumes on the next bucket open,
+	// when boot population rebuilds the rep from all disk segments.
+	if strategy == lsmkv.StrategyRoaringSetRange {
+		opts = append(opts, lsmkv.WithKeepSegmentsInMemory(false))
+	}
+
+	return opts
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -228,6 +228,20 @@ type Bucket struct {
 	// (currently used by roaringsetrange inverted indexes)
 	keepSegmentsInMemory bool
 
+	// rangeableInMemoryDeferred marks a RoaringSetRange bucket opened with
+	// keepSegmentsInMemory forced off while the global INDEX_RANGEABLE_IN_MEMORY
+	// knob is on (the reindex ingest path, GH#12199). It selects a diagnostic log
+	// line only (the deferred-serving INFO) and never influences read-path
+	// selection, which is governed purely by keepSegmentsInMemory.
+	rangeableInMemoryDeferred bool
+
+	// per-bucket-open dedup for the two GH#12199 diagnostic log lines: the
+	// deferred-serving INFO (marked disk-path bucket) and the (c) disk-fallback
+	// WARN (unpopulated rep with disk segments present). A fresh Bucket is built
+	// on every open, so a plain sync.Once yields once-per-bucket-open semantics.
+	rangeableDeferredLogOnce  sync.Once
+	rangeableFallbackWarnOnce sync.Once
+
 	// pool of buffers for bitmaps merges
 	// (currently used by roaringsetrange inverted indexes)
 	bitmapBufPool roaringset.BitmapBufPool

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -228,17 +228,15 @@ type Bucket struct {
 	// (currently used by roaringsetrange inverted indexes)
 	keepSegmentsInMemory bool
 
-	// rangeableInMemoryDeferred marks a RoaringSetRange bucket opened with
-	// keepSegmentsInMemory forced off while the global INDEX_RANGEABLE_IN_MEMORY
-	// knob is on (the reindex ingest path, GH#12199). It selects a diagnostic log
-	// line only (the deferred-serving INFO) and never influences read-path
-	// selection, which is governed purely by keepSegmentsInMemory.
+	// rangeableInMemoryDeferred marks a RoaringSetRange bucket whose rep was left
+	// unbuilt while INDEX_RANGEABLE_IN_MEMORY is on (GH#12199 reindex ingest path).
+	// It only selects a diagnostic log line; keepSegmentsInMemory alone governs
+	// read-path selection.
 	rangeableInMemoryDeferred bool
 
-	// per-bucket-open dedup for the two GH#12199 diagnostic log lines: the
-	// deferred-serving INFO (marked disk-path bucket) and the (c) disk-fallback
-	// WARN (unpopulated rep with disk segments present). A fresh Bucket is built
-	// on every open, so a plain sync.Once yields once-per-bucket-open semantics.
+	// Dedup for the two GH#12199 diagnostic log lines (deferred-serving INFO,
+	// disk-fallback WARN). A fresh Bucket per open gives sync.Once
+	// once-per-bucket-open semantics.
 	rangeableDeferredLogOnce  sync.Once
 	rangeableFallbackWarnOnce sync.Once
 

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -301,6 +301,18 @@ func WithKeepSegmentsInMemory(keep bool) BucketOption {
 	}
 }
 
+// WithRangeableInMemoryDeferred marks a RoaringSetRange bucket whose in-memory
+// representation was intentionally deferred: keepSegmentsInMemory was forced off
+// while the global INDEX_RANGEABLE_IN_MEMORY knob is on (the reindex ingest path,
+// GH#12199). The marker only enables a query-time diagnostic log line; it never
+// selects a read path. Set exclusively by the reindex ingest-bucket load path.
+func WithRangeableInMemoryDeferred(deferred bool) BucketOption {
+	return func(b *Bucket) error {
+		b.rangeableInMemoryDeferred = deferred
+		return nil
+	}
+}
+
 func WithBitmapBufPool(bufPool roaringset.BitmapBufPool) BucketOption {
 	return func(b *Bucket) error {
 		b.bitmapBufPool = bufPool

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -302,10 +302,8 @@ func WithKeepSegmentsInMemory(keep bool) BucketOption {
 }
 
 // WithRangeableInMemoryDeferred marks a RoaringSetRange bucket whose in-memory
-// representation was intentionally deferred: keepSegmentsInMemory was forced off
-// while the global INDEX_RANGEABLE_IN_MEMORY knob is on (the reindex ingest path,
-// GH#12199). The marker only enables a query-time diagnostic log line; it never
-// selects a read path. Set exclusively by the reindex ingest-bucket load path.
+// rep was intentionally left unbuilt (reindex ingest path, GH#12199). It only
+// enables a diagnostic log line and never affects read-path selection.
 func WithRangeableInMemoryDeferred(deferred bool) BucketOption {
 	return func(b *Bucket) error {
 		b.rangeableInMemoryDeferred = deferred

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
@@ -59,13 +59,12 @@ func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 	MustBeExpectedStrategy(b.strategy, StrategyRoaringSetRange)
 
 	if b.keepSegmentsInMemory {
-		// (c) GH#12199: if the in-memory rep is unpopulated but disk segments
-		// exist, the rep is out of sync with disk (a rep-population gap such as a
-		// mass-delete, or a future segment-splice bug). Serve from the
-		// always-correct disk reader and WARN once per bucket-open. Check rep
-		// emptiness FIRST and short-circuit, so the populated hot path pays only
-		// one IsEmpty() under the rep's own RLock and never touches
-		// maintenanceLock. The two locks are never held simultaneously.
+		// (c) GH#12199: rep unpopulated but disk segments exist means the rep is
+		// out of sync with disk (mass-delete or a rep-population gap) - fall back
+		// to the always-correct disk reader and WARN once. Check emptiness first
+		// so the populated hot path only pays one IsEmpty() under the rep's own
+		// RLock and never touches maintenanceLock; the two locks are never held
+		// together.
 		if b.disk.roaringSetRangeSegmentInMemory.IsUnpopulated() {
 			if n := b.disk.roaringSetRangeDiskSegmentCount(); n > 0 {
 				b.rangeableFallbackWarnOnce.Do(func() {
@@ -77,8 +76,7 @@ func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 							"gap; restart the node or reload the shard to rebuild the in-memory "+
 							"representation (GH#12199).", n)
 				})
-				// The TOCTOU between this emptiness check and the reader build
-				// below is benign: the rep only empties via mass-delete and the
+				// Benign TOCTOU: the rep only empties via mass-delete, and the
 				// disk path is a correct superset either way.
 				return b.readerRoaringSetRangeFromSegments()
 			}
@@ -89,11 +87,10 @@ func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 }
 
 func (b *Bucket) readerRoaringSetRangeFromSegments() ReaderRoaringSetRange {
-	// GH#12199: a bucket marked deferred was opened with keepSegmentsInMemory
-	// forced off while the global knob is on (the reindex ingest path). Emit a
-	// durable, query-time signal once per bucket-open at the first range read so
-	// an operator investigating slow range filters can find the reason and the
-	// remedy. The marker gates only this log line; it never selects a read path.
+	// GH#12199: bucket marked deferred means keepSegmentsInMemory was forced off
+	// while the global knob is on (reindex ingest path). Emit the diagnostic once
+	// per bucket-open at the first range read; the marker gates only this log
+	// line, never read-path selection.
 	if b.rangeableInMemoryDeferred {
 		b.rangeableDeferredLogOnce.Do(func() {
 			b.logger.WithField("bucket", b.dir).Info(

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
@@ -59,12 +59,50 @@ func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 	MustBeExpectedStrategy(b.strategy, StrategyRoaringSetRange)
 
 	if b.keepSegmentsInMemory {
+		// (c) GH#12199: if the in-memory rep is unpopulated but disk segments
+		// exist, the rep is out of sync with disk (a rep-population gap such as a
+		// mass-delete, or a future segment-splice bug). Serve from the
+		// always-correct disk reader and WARN once per bucket-open. Check rep
+		// emptiness FIRST and short-circuit, so the populated hot path pays only
+		// one IsEmpty() under the rep's own RLock and never touches
+		// maintenanceLock. The two locks are never held simultaneously.
+		if b.disk.roaringSetRangeSegmentInMemory.IsUnpopulated() {
+			if n := b.disk.roaringSetRangeDiskSegmentCount(); n > 0 {
+				b.rangeableFallbackWarnOnce.Do(func() {
+					b.logger.WithField("bucket", b.dir).Warnf(
+						"rangeable in-memory representation is empty but %d disk segment(s) "+
+							"exist; falling back to the disk range reader "+
+							"(INV-RANGEABLE-REP-EQUALS-DISK). Results remain correct. This may "+
+							"indicate a mass deletion of the indexed property or a rep-population "+
+							"gap; restart the node or reload the shard to rebuild the in-memory "+
+							"representation (GH#12199).", n)
+				})
+				// The TOCTOU between this emptiness check and the reader build
+				// below is benign: the rep only empties via mass-delete and the
+				// disk path is a correct superset either way.
+				return b.readerRoaringSetRangeFromSegments()
+			}
+		}
 		return b.readerRoaringSetRangeFromSegmentInMemo()
 	}
 	return b.readerRoaringSetRangeFromSegments()
 }
 
 func (b *Bucket) readerRoaringSetRangeFromSegments() ReaderRoaringSetRange {
+	// GH#12199: a bucket marked deferred was opened with keepSegmentsInMemory
+	// forced off while the global knob is on (the reindex ingest path). Emit a
+	// durable, query-time signal once per bucket-open at the first range read so
+	// an operator investigating slow range filters can find the reason and the
+	// remedy. The marker gates only this log line; it never selects a read path.
+	if b.rangeableInMemoryDeferred {
+		b.rangeableDeferredLogOnce.Do(func() {
+			b.logger.WithField("bucket", b.dir).Info(
+				"rangeable property serving from disk; in-memory knob deferred until next " +
+					"reload (GH#12199). Restart the node or reload the shard to rebuild the " +
+					"in-memory representation and resume in-memory acceleration.")
+		})
+	}
+
 	view := b.GetConsistentView()
 
 	readers := make([]roaringsetrange.InnerReader, len(view.Disk))

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range_test.go
@@ -231,7 +231,7 @@ func countLogLevel(hook *test.Hook, level logrus.Level) int {
 	return n
 }
 
-// newRangeableRep returns an unpopulated rep (the 65-bitmap skeleton). Its
+// newRangeableRepEmpty returns an unpopulated rep (the 65-bitmap skeleton). Its
 // presence set is empty (IsUnpopulated == true) but Size() > 0.
 func newRangeableRepEmpty(logger logrus.FieldLogger) *roaringsetrange.SegmentInMemory {
 	return roaringsetrange.NewSegmentInMemory(logger)
@@ -279,11 +279,9 @@ func readEqual(t *testing.T, b *Bucket, value uint64) []uint64 {
 	return v.ToArray()
 }
 
-// TestRoaringSetRangeKeepSegmentsInMemoryOverride verifies the (b) mechanism
-// (GH#12199): the reindex path appends WithKeepSegmentsInMemory(false) after the
-// strategy default WithKeepSegmentsInMemory(knob); because options apply in order
-// and the last write wins, the override deterministically forces the rep off, so
-// the bucket serves range reads from the disk reader with no in-memory rep built.
+// TestRoaringSetRangeKeepSegmentsInMemoryOverride: the last
+// WithKeepSegmentsInMemory wins, forcing the rep off regardless of the
+// strategy default (GH#12199 (b)).
 func TestRoaringSetRangeKeepSegmentsInMemoryOverride(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
@@ -322,10 +320,10 @@ func TestRoaringSetRangeKeepSegmentsInMemoryOverride(t *testing.T) {
 	})
 }
 
-// TestRoaringSetRangeDiskFallback is the (c) four-case matrix (GH#12199): when
-// keepSegmentsInMemory is on, an unpopulated rep with disk segments present must
-// fall back to the disk reader and WARN once per bucket-open. The rep and disk
-// hold DIFFERENT docIDs so the returned result proves which path served the read.
+// TestRoaringSetRangeDiskFallback pins the (c) four-case matrix (GH#12199): an
+// unpopulated rep with disk segments present must fall back to disk and WARN
+// once per bucket-open. Rep and disk hold DIFFERENT docIDs so the result proves
+// which path served the read.
 func TestRoaringSetRangeDiskFallback(t *testing.T) {
 	const value = uint64(5)
 
@@ -342,8 +340,8 @@ func TestRoaringSetRangeDiskFallback(t *testing.T) {
 	t.Run("empty rep + disk segments: fallback, correct result, WARN", func(t *testing.T) {
 		logger, hook := test.NewNullLogger()
 		rep := newRangeableRepEmpty(logger)
-		// Pin the "Size() is the wrong discriminant" reasoning in code: the
-		// unpopulated skeleton reports a non-zero Size() yet IsUnpopulated.
+		// Size() is the wrong discriminant: the skeleton reports non-zero Size()
+		// yet IsUnpopulated() is true.
 		require.Greater(t, rep.Size(), 0)
 		require.True(t, rep.IsUnpopulated())
 		disk := []Segment{newRangeableDiskSegment(value, 200)}
@@ -364,10 +362,8 @@ func TestRoaringSetRangeDiskFallback(t *testing.T) {
 	})
 
 	t.Run("mass-delete-emptied rep + disk segments: fallback, correct residual, WARN", func(t *testing.T) {
-		// A knob-on bucket where every object carrying the property was deleted
-		// empties bitmaps[0] while disk (tombstone) segments remain and no restart
-		// happened. The fallback fires, disk serves the correct residual, and the
-		// WARN is emitted (its text names mass-deletion as a benign cause).
+		// Benign cause: mass-delete empties bitmaps[0] while disk tombstones
+		// remain and no restart occurred.
 		logger, hook := test.NewNullLogger()
 		rep := newRangeableRepEmpty(logger)
 		disk := []Segment{newRangeableDiskSegment(value, 200)}
@@ -390,10 +386,9 @@ func TestRoaringSetRangeDiskFallback(t *testing.T) {
 	})
 }
 
-// TestRoaringSetRangeDeferredServingINFO covers the durable deferred-acceleration
-// indicator (GH#12199): a bucket marked deferred emits a query-time INFO once per
-// bucket-open at the first disk-path range read; unmarked buckets never do; and
-// the marker selects a log line only, never a read path.
+// TestRoaringSetRangeDeferredServingINFO pins GH#12199: a deferred-marked bucket
+// emits the disk-serving INFO once per bucket-open; unmarked buckets never do,
+// and the marker never affects read-path selection.
 func TestRoaringSetRangeDeferredServingINFO(t *testing.T) {
 	const value = uint64(5)
 
@@ -420,10 +415,9 @@ func TestRoaringSetRangeDeferredServingINFO(t *testing.T) {
 	})
 
 	t.Run("marker selects a log line only, never a read path", func(t *testing.T) {
-		// keepSegmentsInMemory=true + marked + populated rep: read-path selection
-		// is governed by keepSegmentsInMemory, so the in-mem path is taken (rep
-		// populated => no fallback). The deferred INFO lives on the disk path, so
-		// it must NOT fire here, proving the marker does not select the path.
+		// keepSegmentsInMemory=true + marked + populated rep: in-mem path is
+		// taken, so the disk-path INFO must not fire, proving the marker doesn't
+		// select the path.
 		logger, hook := test.NewNullLogger()
 		rep := newRangeableRepPopulated(t, logger, value, 100)
 		disk := []Segment{newRangeableDiskSegment(value, 200)}
@@ -435,9 +429,8 @@ func TestRoaringSetRangeDeferredServingINFO(t *testing.T) {
 	})
 }
 
-// BenchmarkRoaringSetRangeReaderPopulatedHotPath measures the populated-rep hot
-// path, which the (c) fix extends by exactly one bitmaps[0].IsEmpty() call under
-// the rep's own RLock (short-circuited before any maintenanceLock access).
+// BenchmarkRoaringSetRangeReaderPopulatedHotPath bounds the overhead the (c) fix
+// adds to the populated-rep hot path: one short-circuited IsEmpty() check.
 func BenchmarkRoaringSetRangeReaderPopulatedHotPath(b *testing.B) {
 	logger, _ := test.NewNullLogger()
 	rep := roaringsetrange.NewSegmentInMemory(logger)

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range_test.go
@@ -14,12 +14,16 @@ package lsmkv
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -213,6 +217,255 @@ func TestRoaringSetRangeReaderConsistentViewInMemo(t *testing.T) {
 		key3: {3},
 		key4: {4},
 	})(t)
+}
+
+// --- GH#12199 (c) disk-fallback + deferred-INFO marker test helpers ---
+
+func countLogLevel(hook *test.Hook, level logrus.Level) int {
+	n := 0
+	for _, e := range hook.AllEntries() {
+		if e.Level == level {
+			n++
+		}
+	}
+	return n
+}
+
+// newRangeableRep returns an unpopulated rep (the 65-bitmap skeleton). Its
+// presence set is empty (IsUnpopulated == true) but Size() > 0.
+func newRangeableRepEmpty(logger logrus.FieldLogger) *roaringsetrange.SegmentInMemory {
+	return roaringsetrange.NewSegmentInMemory(logger)
+}
+
+// newRangeableRepPopulated returns a rep whose presence set has been populated
+// with docID at the given value (IsUnpopulated == false).
+func newRangeableRepPopulated(t *testing.T, logger logrus.FieldLogger, value, docID uint64) *roaringsetrange.SegmentInMemory {
+	t.Helper()
+	rep := roaringsetrange.NewSegmentInMemory(logger)
+	mt := roaringsetrange.NewMemtable(logger)
+	mt.Insert(value, []uint64{docID})
+	rep.MergeMemtableEventually(mt)
+	require.Eventually(t, func() bool { return !rep.IsUnpopulated() },
+		time.Second, 5*time.Millisecond, "rep must become populated")
+	return rep
+}
+
+func newRangeableDiskSegment(value, docID uint64) Segment {
+	return newFakeRoaringSetRangeSegment(
+		map[uint64]*sroar.Bitmap{value: roaringset.NewBitmap(docID)}, sroar.NewBitmap())
+}
+
+func newRangeableBucket(logger logrus.FieldLogger, keepInMem, deferred bool,
+	rep *roaringsetrange.SegmentInMemory, disk []Segment,
+) *Bucket {
+	return &Bucket{
+		strategy:                  StrategyRoaringSetRange,
+		keepSegmentsInMemory:      keepInMem,
+		rangeableInMemoryDeferred: deferred,
+		logger:                    logger,
+		bitmapBufPool:             roaringset.NewBitmapBufPoolNoop(),
+		active:                    newTestMemtableRoaringSetRange(nil),
+		disk:                      &SegmentGroup{logger: logger, segments: disk, roaringSetRangeSegmentInMemory: rep},
+	}
+}
+
+func readEqual(t *testing.T, b *Bucket, value uint64) []uint64 {
+	t.Helper()
+	reader := b.ReaderRoaringSetRange()
+	defer reader.Close()
+	v, release, err := reader.Read(context.Background(), value, filters.OperatorEqual)
+	require.NoError(t, err)
+	defer release()
+	return v.ToArray()
+}
+
+// TestRoaringSetRangeKeepSegmentsInMemoryOverride verifies the (b) mechanism
+// (GH#12199): the reindex path appends WithKeepSegmentsInMemory(false) after the
+// strategy default WithKeepSegmentsInMemory(knob); because options apply in order
+// and the last write wins, the override deterministically forces the rep off, so
+// the bucket serves range reads from the disk reader with no in-memory rep built.
+func TestRoaringSetRangeKeepSegmentsInMemoryOverride(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	newBucket := func(t *testing.T, opts ...BucketOption) *Bucket {
+		t.Helper()
+		base := []BucketOption{
+			WithStrategy(StrategyRoaringSetRange),
+			WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+		}
+		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			append(base, opts...)...)
+		require.NoError(t, err)
+		b.SetMemtableThreshold(1e9)
+		return b
+	}
+
+	t.Run("knob default true builds the rep (control)", func(t *testing.T) {
+		b := newBucket(t, WithKeepSegmentsInMemory(true))
+		defer b.Shutdown(ctx)
+		assert.True(t, b.keepSegmentsInMemory)
+		assert.NotNil(t, b.disk.roaringSetRangeSegmentInMemory)
+	})
+
+	t.Run("override false after true wins: no rep, disk reader", func(t *testing.T) {
+		b := newBucket(t, WithKeepSegmentsInMemory(true), WithKeepSegmentsInMemory(false))
+		defer b.Shutdown(ctx)
+		assert.False(t, b.keepSegmentsInMemory)
+		assert.Nil(t, b.disk.roaringSetRangeSegmentInMemory, "no in-memory rep must be built")
+
+		// The reader is the disk reader and serves correctly (no nil-rep panic).
+		require.NoError(t, b.RoaringSetRangeAdd(5, 100))
+		require.NoError(t, b.FlushAndSwitch())
+		assert.Equal(t, []uint64{100}, readEqual(t, b, 5))
+	})
+}
+
+// TestRoaringSetRangeDiskFallback is the (c) four-case matrix (GH#12199): when
+// keepSegmentsInMemory is on, an unpopulated rep with disk segments present must
+// fall back to the disk reader and WARN once per bucket-open. The rep and disk
+// hold DIFFERENT docIDs so the returned result proves which path served the read.
+func TestRoaringSetRangeDiskFallback(t *testing.T) {
+	const value = uint64(5)
+
+	t.Run("populated rep + disk segments: in-mem path, no fallback, no WARN", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepPopulated(t, logger, value, 100)
+		disk := []Segment{newRangeableDiskSegment(value, 200)} // different docID
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		assert.Equal(t, []uint64{100}, readEqual(t, b, value), "served from the rep, not disk")
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("empty rep + disk segments: fallback, correct result, WARN", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		// Pin the "Size() is the wrong discriminant" reasoning in code: the
+		// unpopulated skeleton reports a non-zero Size() yet IsUnpopulated.
+		require.Greater(t, rep.Size(), 0)
+		require.True(t, rep.IsUnpopulated())
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value), "served from disk")
+		assert.Equal(t, 1, countLogLevel(hook, logrus.WarnLevel))
+		assert.Contains(t, hook.LastEntry().Message, "INV-RANGEABLE-REP-EQUALS-DISK")
+	})
+
+	t.Run("empty rep + no disk segments: no fallback, empty result, no WARN", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		b := newRangeableBucket(logger, true, false, rep, nil)
+
+		assert.Empty(t, readEqual(t, b, value))
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("mass-delete-emptied rep + disk segments: fallback, correct residual, WARN", func(t *testing.T) {
+		// A knob-on bucket where every object carrying the property was deleted
+		// empties bitmaps[0] while disk (tombstone) segments remain and no restart
+		// happened. The fallback fires, disk serves the correct residual, and the
+		// WARN is emitted (its text names mass-deletion as a benign cause).
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, 1, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("WARN is deduplicated per bucket-open", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		// Two fallback-triggering reads on the same bucket-open.
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, 1, countLogLevel(hook, logrus.WarnLevel), "second read must not emit a second WARN")
+	})
+}
+
+// TestRoaringSetRangeDeferredServingINFO covers the durable deferred-acceleration
+// indicator (GH#12199): a bucket marked deferred emits a query-time INFO once per
+// bucket-open at the first disk-path range read; unmarked buckets never do; and
+// the marker selects a log line only, never a read path.
+func TestRoaringSetRangeDeferredServingINFO(t *testing.T) {
+	const value = uint64(5)
+
+	t.Run("marked disk bucket: INFO once under repeated reads", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		// (b) deferred bucket: keepSegmentsInMemory forced off, marker set.
+		b := newRangeableBucket(logger, false, true, nil, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, 1, countLogLevel(hook, logrus.InfoLevel), "INFO fires exactly once per bucket-open")
+		assert.Contains(t, hook.LastEntry().Message, "deferred")
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("unmarked knob-off bucket: no INFO", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, false, false, nil, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Zero(t, countLogLevel(hook, logrus.InfoLevel))
+	})
+
+	t.Run("marker selects a log line only, never a read path", func(t *testing.T) {
+		// keepSegmentsInMemory=true + marked + populated rep: read-path selection
+		// is governed by keepSegmentsInMemory, so the in-mem path is taken (rep
+		// populated => no fallback). The deferred INFO lives on the disk path, so
+		// it must NOT fire here, proving the marker does not select the path.
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepPopulated(t, logger, value, 100)
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, true, rep, disk)
+
+		assert.Equal(t, []uint64{100}, readEqual(t, b, value), "in-mem path served, not disk")
+		assert.Zero(t, countLogLevel(hook, logrus.InfoLevel), "marker must not trigger the disk-path INFO")
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+}
+
+// BenchmarkRoaringSetRangeReaderPopulatedHotPath measures the populated-rep hot
+// path, which the (c) fix extends by exactly one bitmaps[0].IsEmpty() call under
+// the rep's own RLock (short-circuited before any maintenanceLock access).
+func BenchmarkRoaringSetRangeReaderPopulatedHotPath(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	rep := roaringsetrange.NewSegmentInMemory(logger)
+	mt := roaringsetrange.NewMemtable(logger)
+	mt.Insert(5, []uint64{100})
+	rep.MergeMemtableEventually(mt)
+	for rep.IsUnpopulated() {
+		time.Sleep(time.Millisecond)
+	}
+	bucket := newRangeableBucketForBench(logger, rep)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := bucket.ReaderRoaringSetRange()
+		r.Close()
+	}
+}
+
+func newRangeableBucketForBench(logger logrus.FieldLogger, rep *roaringsetrange.SegmentInMemory) *Bucket {
+	return &Bucket{
+		strategy:             StrategyRoaringSetRange,
+		keepSegmentsInMemory: true,
+		logger:               logger,
+		bitmapBufPool:        roaringset.NewBitmapBufPoolNoop(),
+		active:               newTestMemtableRoaringSetRange(nil),
+		disk:                 &SegmentGroup{logger: logger, roaringSetRangeSegmentInMemory: rep},
+	}
 }
 
 // TestRoaringSetRangeWritePathRefCount ensures that all write paths of the

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -980,6 +980,18 @@ func (sg *SegmentGroup) count() int {
 	return sg.countWithSegmentList(segments)
 }
 
+// roaringSetRangeDiskSegmentCount returns the number of on-disk segments using
+// only a cheap read lock. Unlike getConsistentViewOfSegments / Len / count, it
+// does not incRef every segment or allocate a slice; the disk-fallback
+// discriminant (GH#12199) only needs the count, and only pays for it on the rare
+// unpopulated-rep path. It must not be held while bitmapsLock is held.
+func (sg *SegmentGroup) roaringSetRangeDiskSegmentCount() int {
+	sg.maintenanceLock.RLock()
+	defer sg.maintenanceLock.RUnlock()
+
+	return len(sg.segments)
+}
+
 func (sg *SegmentGroup) countWithSegmentList(segments []Segment) int {
 	count := 0
 	for _, seg := range segments {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -980,11 +980,10 @@ func (sg *SegmentGroup) count() int {
 	return sg.countWithSegmentList(segments)
 }
 
-// roaringSetRangeDiskSegmentCount returns the number of on-disk segments using
-// only a cheap read lock. Unlike getConsistentViewOfSegments / Len / count, it
-// does not incRef every segment or allocate a slice; the disk-fallback
-// discriminant (GH#12199) only needs the count, and only pays for it on the rare
-// unpopulated-rep path. It must not be held while bitmapsLock is held.
+// roaringSetRangeDiskSegmentCount returns the on-disk segment count via a cheap
+// read lock only (no incRef/allocation like Len/count) - the disk-fallback
+// discriminant (GH#12199) only needs the count, and only on the rare
+// unpopulated-rep path. Must not be held while bitmapsLock is held.
 func (sg *SegmentGroup) roaringSetRangeDiskSegmentCount() int {
 	sg.maintenanceLock.RLock()
 	defer sg.maintenanceLock.RUnlock()

--- a/adapters/repos/db/lsmkv/segment_group_prepend.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend.go
@@ -28,12 +28,9 @@ import (
 )
 
 // ErrPrependWouldDesyncInMemoryRep is returned by PrependSegmentsFromBucket when
-// the target is a RoaringSetRange segment group that keeps an active in-memory
-// representation. Splicing segments into such a group without rebuilding the rep
-// would leave the rep out of sync with disk (INV-RANGEABLE-REP-EQUALS-DISK) and
-// silently serve empty or partial range results with no error and no fallback
-// (GH#12199). Callers must open the bucket with keepSegmentsInMemory=false, or
-// implement a full oldest-to-newest rep rebuild before splicing.
+// the target RoaringSetRange group keeps an active in-memory rep: splicing would
+// desync it from disk (INV-RANGEABLE-REP-EQUALS-DISK) and silently serve
+// empty/partial range results (GH#12199). Open with keepSegmentsInMemory=false.
 var ErrPrependWouldDesyncInMemoryRep = errors.New(
 	"prepend segments: RoaringSetRange bucket has an active in-memory representation " +
 		"which this operation cannot maintain (INV-RANGEABLE-REP-EQUALS-DISK); " +
@@ -57,10 +54,9 @@ var ErrPrependWouldDesyncInMemoryRep = errors.New(
 //   - Supported strategies: RoaringSet, RoaringSetRange, SetCollection,
 //     MapCollection, Inverted.
 //
-// Per-strategy derived-state obligations (whoever adds the next strategy here
-// MUST answer this): splicing segments mutates sg.segments, so any strategy that
-// keeps segment-group-level derived state has to maintain it, be guarded, or be
-// rejected before mutation.
+// Per-strategy derived-state obligations (next strategy added here MUST answer
+// this): splicing mutates sg.segments, so any strategy with segment-group-level
+// derived state must maintain it, guard it, or reject the mutation.
 //
 //	Replace         -> rejected (countNetAdditions not recalculable)
 //	Inverted        -> maintained (avgPropertyLengths, below)
@@ -75,17 +71,12 @@ func (sg *SegmentGroup) PrependSegmentsFromBucket(ctx context.Context, srcDir st
 			"countNetAdditions cannot be recalculated for prepended segments", sg.strategy)
 	}
 
-	// Step 1b: A RoaringSetRange group with an active in-memory representation
-	// cannot be spliced. Prepending logically-older backfill segments cannot be
-	// folded into a rep that already holds newer live values without corrupting
-	// them (an incremental older-onto-newer merge lets the OLD value win), and
-	// leaving the rep untouched serves empty/partial range results with no signal
-	// (GH#12199). Reject before any file copy or splice so the failure is clean
-	// (no files copied, segment list unmutated), mirroring the Replace rejection.
-	// The rep pointer is assigned once in newSegmentGroup before the group is
-	// published and never reassigned, so this read needs no lock. The strategy
-	// conjunct is redundant (the field is only ever set for RoaringSetRange) but
-	// kept to document intent.
+	// Step 1b: reject splicing into a RoaringSetRange group with an active
+	// in-memory rep - an incremental older-onto-newer merge could let a stale
+	// value win, and an unrebuilt rep silently serves empty/partial results
+	// (INV-RANGEABLE-REP-EQUALS-DISK, GH#12199). Reject before any copy/splice
+	// so the failure is clean. The rep pointer is set once in newSegmentGroup and
+	// never reassigned, so this read needs no lock.
 	if sg.strategy == StrategyRoaringSetRange && sg.roaringSetRangeSegmentInMemory != nil {
 		return fmt.Errorf("%w (bucket=%s)", ErrPrependWouldDesyncInMemoryRep, filepath.Base(sg.dir))
 	}

--- a/adapters/repos/db/lsmkv/segment_group_prepend.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -25,6 +26,18 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 )
+
+// ErrPrependWouldDesyncInMemoryRep is returned by PrependSegmentsFromBucket when
+// the target is a RoaringSetRange segment group that keeps an active in-memory
+// representation. Splicing segments into such a group without rebuilding the rep
+// would leave the rep out of sync with disk (INV-RANGEABLE-REP-EQUALS-DISK) and
+// silently serve empty or partial range results with no error and no fallback
+// (GH#12199). Callers must open the bucket with keepSegmentsInMemory=false, or
+// implement a full oldest-to-newest rep rebuild before splicing.
+var ErrPrependWouldDesyncInMemoryRep = errors.New(
+	"prepend segments: RoaringSetRange bucket has an active in-memory representation " +
+		"which this operation cannot maintain (INV-RANGEABLE-REP-EQUALS-DISK); " +
+		"open the bucket with keepSegmentsInMemory=false, or implement a full-rebuild merge - see GH#12199")
 
 // PrependSegmentsFromBucket copies all segments from srcDir and atomically
 // prepends them into this SegmentGroup's segment list. The copied segments
@@ -43,11 +56,38 @@ import (
 //     segments, which would produce incorrect object counts.
 //   - Supported strategies: RoaringSet, RoaringSetRange, SetCollection,
 //     MapCollection, Inverted.
+//
+// Per-strategy derived-state obligations (whoever adds the next strategy here
+// MUST answer this): splicing segments mutates sg.segments, so any strategy that
+// keeps segment-group-level derived state has to maintain it, be guarded, or be
+// rejected before mutation.
+//
+//	Replace         -> rejected (countNetAdditions not recalculable)
+//	Inverted        -> maintained (avgPropertyLengths, below)
+//	RoaringSetRange -> guarded (rep desync would be silent; see the guard below
+//	                   and INV-RANGEABLE-REP-EQUALS-DISK / GH#12199)
+//	RoaringSet, SetCollection, MapCollection -> no segment-group-level derived
+//	                   state exists on this tree, so nothing to maintain
 func (sg *SegmentGroup) PrependSegmentsFromBucket(ctx context.Context, srcDir string) error {
 	// Step 1: Validate strategy — Replace is not supported.
 	if sg.strategy == StrategyReplace {
 		return fmt.Errorf("prepend segments: strategy %q is not supported because "+
 			"countNetAdditions cannot be recalculated for prepended segments", sg.strategy)
+	}
+
+	// Step 1b: A RoaringSetRange group with an active in-memory representation
+	// cannot be spliced. Prepending logically-older backfill segments cannot be
+	// folded into a rep that already holds newer live values without corrupting
+	// them (an incremental older-onto-newer merge lets the OLD value win), and
+	// leaving the rep untouched serves empty/partial range results with no signal
+	// (GH#12199). Reject before any file copy or splice so the failure is clean
+	// (no files copied, segment list unmutated), mirroring the Replace rejection.
+	// The rep pointer is assigned once in newSegmentGroup before the group is
+	// published and never reassigned, so this read needs no lock. The strategy
+	// conjunct is redundant (the field is only ever set for RoaringSetRange) but
+	// kept to document intent.
+	if sg.strategy == StrategyRoaringSetRange && sg.roaringSetRangeSegmentInMemory != nil {
+		return fmt.Errorf("%w (bucket=%s)", ErrPrependWouldDesyncInMemoryRep, filepath.Base(sg.dir))
 	}
 
 	// Step 2: Discover source segments (.db files).

--- a/adapters/repos/db/lsmkv/segment_group_prepend_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend_test.go
@@ -675,16 +675,10 @@ func createTestBucketRoaringSetRange(t *testing.T, ctx context.Context, dir stri
 	return b
 }
 
-// TestSegmentGroup_PrependSegments_RoaringSetRangeGuard verifies the GH#12199
-// guard: prepending into a RoaringSetRange bucket that keeps an active in-memory
-// representation is rejected before any file copy or splice, because the rep
-// cannot be maintained through a splice (folding logically-older backfill
-// segments onto a rep holding newer live values corrupts the value; see the
-// fold-order value-integrity test in the roaringsetrange package). This guard is
-// the STRUCTURAL defense against option (a): a future incremental-merge attempt
-// inside PrependSegmentsFromBucket hits this error before any merge runs.
-// Compaction is exempt from the invariant (it changes physical layout only and
-// never references the rep), so it is not guarded here.
+// TestSegmentGroup_PrependSegments_RoaringSetRangeGuard pins the GH#12199 guard:
+// splicing older backfill onto a RoaringSetRange bucket's active in-memory rep
+// would corrupt it, so the prepend is rejected before any file copy or splice.
+// Compaction is exempt - it only changes physical layout, never the rep.
 func TestSegmentGroup_PrependSegments_RoaringSetRangeGuard(t *testing.T) {
 	ctx := context.Background()
 
@@ -719,7 +713,6 @@ func TestSegmentGroup_PrependSegments_RoaringSetRangeGuard(t *testing.T) {
 		assert.Contains(t, err.Error(), "keepSegmentsInMemory=false")
 		assert.Contains(t, err.Error(), "GH#12199")
 
-		// Pre-mutation failure: segment list unmutated, no files copied.
 		assert.Equal(t, segsBefore, tgt.disk.Len(), "segment list must be unmutated")
 		assert.Equal(t, filesBefore, countDBFiles(t, tgtDir), "no segment files may be copied")
 	})

--- a/adapters/repos/db/lsmkv/segment_group_prepend_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend_test.go
@@ -657,6 +657,98 @@ func TestSegmentGroup_PrependSegments(t *testing.T) {
 	})
 }
 
+// createTestBucketRoaringSetRange creates a RoaringSetRange bucket. When
+// keepSegmentsInMemory is true the bucket builds an in-memory representation at
+// open, which is the state the PrependSegmentsFromBucket guard protects.
+func createTestBucketRoaringSetRange(t *testing.T, ctx context.Context, dir string, keepSegmentsInMemory bool) *Bucket {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	opts := []BucketOption{
+		WithStrategy(StrategyRoaringSetRange),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+		WithKeepSegmentsInMemory(keepSegmentsInMemory),
+	}
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+	require.NoError(t, err)
+	b.SetMemtableThreshold(1e9)
+	return b
+}
+
+// TestSegmentGroup_PrependSegments_RoaringSetRangeGuard verifies the GH#12199
+// guard: prepending into a RoaringSetRange bucket that keeps an active in-memory
+// representation is rejected before any file copy or splice, because the rep
+// cannot be maintained through a splice (folding logically-older backfill
+// segments onto a rep holding newer live values corrupts the value; see the
+// fold-order value-integrity test in the roaringsetrange package). This guard is
+// the STRUCTURAL defense against option (a): a future incremental-merge attempt
+// inside PrependSegmentsFromBucket hits this error before any merge runs.
+// Compaction is exempt from the invariant (it changes physical layout only and
+// never references the rep), so it is not guarded here.
+func TestSegmentGroup_PrependSegments_RoaringSetRangeGuard(t *testing.T) {
+	ctx := context.Background()
+
+	// Build a source RoaringSetRange bucket with one flushed segment, so that if
+	// the guard did NOT fire, files WOULD be copied into the target.
+	makeSource := func(t *testing.T) string {
+		t.Helper()
+		srcDir := t.TempDir()
+		src := createTestBucketRoaringSetRange(t, ctx, srcDir, false)
+		require.NoError(t, src.RoaringSetRangeAdd(42, 100))
+		require.NoError(t, src.FlushAndSwitch())
+		require.NoError(t, src.Shutdown(ctx))
+		return srcDir
+	}
+
+	t.Run("active rep: prepend rejected before mutation", func(t *testing.T) {
+		srcDir := makeSource(t)
+
+		tgtDir := t.TempDir()
+		tgt := createTestBucketRoaringSetRange(t, ctx, tgtDir, true) // rep active
+		defer tgt.Shutdown(ctx)
+		require.NotNil(t, tgt.disk.roaringSetRangeSegmentInMemory,
+			"keepSegmentsInMemory=true must build the rep at open")
+
+		segsBefore := tgt.disk.Len()
+		filesBefore := countDBFiles(t, tgtDir)
+
+		err := tgt.PrependSegmentsFromBucket(ctx, srcDir)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrPrependWouldDesyncInMemoryRep)
+		assert.Contains(t, err.Error(), "INV-RANGEABLE-REP-EQUALS-DISK")
+		assert.Contains(t, err.Error(), "keepSegmentsInMemory=false")
+		assert.Contains(t, err.Error(), "GH#12199")
+
+		// Pre-mutation failure: segment list unmutated, no files copied.
+		assert.Equal(t, segsBefore, tgt.disk.Len(), "segment list must be unmutated")
+		assert.Equal(t, filesBefore, countDBFiles(t, tgtDir), "no segment files may be copied")
+	})
+
+	t.Run("no rep: prepend proceeds as before", func(t *testing.T) {
+		srcDir := makeSource(t)
+
+		tgtDir := t.TempDir()
+		tgt := createTestBucketRoaringSetRange(t, ctx, tgtDir, false) // no rep
+		defer tgt.Shutdown(ctx)
+		require.Nil(t, tgt.disk.roaringSetRangeSegmentInMemory)
+
+		// Give the target one segment so the prepend is a real splice.
+		require.NoError(t, tgt.RoaringSetRangeAdd(7, 999))
+		require.NoError(t, tgt.FlushAndSwitch())
+		segsBefore := tgt.disk.Len()
+
+		require.NoError(t, tgt.PrependSegmentsFromBucket(ctx, srcDir))
+		assert.Equal(t, segsBefore+1, tgt.disk.Len(), "source segment must be spliced in")
+	})
+}
+
+func countDBFiles(t *testing.T, dir string) int {
+	t.Helper()
+	files, err := discoverDBFiles(dir)
+	require.NoError(t, err)
+	return len(files)
+}
+
 func TestParseSegmentTimestamp(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/adapters/repos/db/roaringsetrange/segment_in_memory.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory.go
@@ -124,6 +124,40 @@ func (s *SegmentInMemory) countPendingMemtables() int {
 	return len(s.memtables)
 }
 
+// IsUnpopulated reports whether the representation would return no rows for any
+// query: its presence set (bitmaps[0], the base every reader clones) is empty
+// AND it has no pending flushed-memtables queued for merge. This is the correct
+// emptiness discriminant for the disk-fallback decision (GH#12199).
+//
+// Two subtleties this encodes:
+//   - Size() is NOT usable, because an unpopulated rep still allocates 65 bitmap
+//     skeletons with non-zero byte size.
+//   - The pending-memtable check excludes the transient window right after a
+//     flush where bitmaps[0] is briefly empty but the data is already readable
+//     via the pending-memtable queue (Readers() serves it). Without this, the
+//     read path would needlessly fall back to disk on the first flush of a fresh
+//     bucket. A genuine rep desync (the prepend-bypass bug, or a mass-delete
+//     after its deletes merged) has an empty presence set AND no pending
+//     memtables, so this still detects it.
+//
+// It acquires bitmapsLock then memtablesLock, the same order Readers() uses, so
+// no new lock-order edge is introduced. Callers must never hold either lock
+// simultaneously with the segment group's maintenanceLock (read the disk-segment
+// count in a separate step).
+func (s *SegmentInMemory) IsUnpopulated() bool {
+	s.bitmapsLock.RLock()
+	defer s.bitmapsLock.RUnlock()
+
+	if !s.bitmaps[0].IsEmpty() {
+		return false
+	}
+
+	s.memtablesLock.Lock()
+	defer s.memtablesLock.Unlock()
+
+	return len(s.memtables) == 0
+}
+
 func (s *SegmentInMemory) Size() int {
 	size := 0
 	for i := range s.bitmaps {

--- a/adapters/repos/db/roaringsetrange/segment_in_memory.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory.go
@@ -124,26 +124,19 @@ func (s *SegmentInMemory) countPendingMemtables() int {
 	return len(s.memtables)
 }
 
-// IsUnpopulated reports whether the representation would return no rows for any
-// query: its presence set (bitmaps[0], the base every reader clones) is empty
-// AND it has no pending flushed-memtables queued for merge. This is the correct
-// emptiness discriminant for the disk-fallback decision (GH#12199).
+// IsUnpopulated reports whether the rep would return no rows for any query:
+// presence set (bitmaps[0]) is empty AND no pending flushed-memtables are
+// queued for merge. This is the emptiness discriminant for the disk-fallback
+// decision (GH#12199).
 //
-// Two subtleties this encodes:
-//   - Size() is NOT usable, because an unpopulated rep still allocates 65 bitmap
-//     skeletons with non-zero byte size.
-//   - The pending-memtable check excludes the transient window right after a
-//     flush where bitmaps[0] is briefly empty but the data is already readable
-//     via the pending-memtable queue (Readers() serves it). Without this, the
-//     read path would needlessly fall back to disk on the first flush of a fresh
-//     bucket. A genuine rep desync (the prepend-bypass bug, or a mass-delete
-//     after its deletes merged) has an empty presence set AND no pending
-//     memtables, so this still detects it.
+// Size() is not usable: an unpopulated rep still allocates 65 bitmap skeletons
+// with non-zero byte size. The pending-memtable check avoids a false-positive
+// fallback in the transient post-flush window where bitmaps[0] is briefly empty
+// but Readers() already serves the data from the pending-memtable queue; a
+// genuine desync (prepend-bypass bug, mass-delete) has both empty.
 //
-// It acquires bitmapsLock then memtablesLock, the same order Readers() uses, so
-// no new lock-order edge is introduced. Callers must never hold either lock
-// simultaneously with the segment group's maintenanceLock (read the disk-segment
-// count in a separate step).
+// Locks bitmapsLock then memtablesLock (Readers()'s order). Callers must never
+// hold either alongside the segment group's maintenanceLock.
 func (s *SegmentInMemory) IsUnpopulated() bool {
 	s.bitmapsLock.RLock()
 	defer s.bitmapsLock.RUnlock()

--- a/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
@@ -486,16 +486,11 @@ func TestSegmentInMemoryReaderBufPool(t *testing.T) {
 }
 
 // TestSegmentInMemoryFoldOrderValueIntegrity pins INV-RANGEABLE-REP-EQUALS-DISK
-// at the value level (not just membership). The rep is a flattened fold whose
-// correctness depends on applying segments oldest->newest: each segment's
-// presence-node Deletions wipe every touched docID from all 65 bitmaps before
-// its Additions re-add them, so the LAST (newest) segment to touch a docID wins.
-//
-// This is the primary tripwire for the rejected option (a) (GH#12199): the
-// enable-rangeable backfill segments are timestamp-shifted to be logically
-// OLDEST, so folding them incrementally on top of a rep that already holds newer
-// live values makes the OLD value win - a wrong VALUE, not a missing member.
-// Membership assertions cannot catch this because the docID stays present.
+// at the value level: the rep is a flattened fold correct only when applied
+// oldest->newest (each segment's Deletions wipe stale bitmaps before its
+// Additions). Folding an older segment onto a newer one lets a stale value win
+// silently - a wrong VALUE with the docID still present, so membership checks
+// alone can't catch it (GH#12199, the rejected option-(a) merge shape).
 func TestSegmentInMemoryFoldOrderValueIntegrity(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	bufPool := roaringset.NewBitmapBufPoolNoop()
@@ -508,14 +503,12 @@ func TestSegmentInMemoryFoldOrderValueIntegrity(t *testing.T) {
 		valStable = uint64(42)
 	)
 
-	// olderSegment sets docX = valOld and docStable = valStable.
 	olderSegment := func() SegmentCursor {
 		mt := NewMemtable(logger)
 		mt.Insert(valOld, []uint64{docX})
 		mt.Insert(valStable, []uint64{docStable})
 		return newFakeSegmentCursor(mt)
 	}
-	// newerSegment sets docX = valNew (a mid-migration live update of docX).
 	newerSegment := func() SegmentCursor {
 		mt := NewMemtable(logger)
 		mt.Insert(valNew, []uint64{docX})
@@ -538,7 +531,6 @@ func TestSegmentInMemoryFoldOrderValueIntegrity(t *testing.T) {
 		require.NoError(t, seg.MergeSegmentByCursor(olderSegment()))
 		require.NoError(t, seg.MergeSegmentByCursor(newerSegment()))
 
-		// docX serves the NEW value; the old value returns nothing for docX.
 		assert.Equal(t, []uint64{docX}, equalDocIDs(t, seg, valNew))
 		assert.NotContains(t, equalDocIDs(t, seg, valOld), docX)
 		// The untouched docID keeps its value (membership + value backstop).
@@ -546,15 +538,12 @@ func TestSegmentInMemoryFoldOrderValueIntegrity(t *testing.T) {
 	})
 
 	t.Run("trap: incremental older-onto-newer fold corrupts the value (old wins)", func(t *testing.T) {
-		// This is exactly what an option-(a) incremental merge of the
-		// timestamp-older prepended backfill onto a rep already holding newer
-		// live values produces. It is why option (a) is rejected and the
-		// PrependSegmentsFromBucket guard exists.
+		// This is exactly what a rejected option-(a) incremental merge of the
+		// timestamp-older backfill onto a live rep would produce - why the guard exists.
 		seg := NewSegmentInMemory(logger)
 		require.NoError(t, seg.MergeSegmentByCursor(newerSegment()))
 		require.NoError(t, seg.MergeSegmentByCursor(olderSegment()))
 
-		// The OLD value now wrongly wins for docX; the new value is gone.
 		assert.Equal(t, []uint64{docX}, equalDocIDs(t, seg, valOld))
 		assert.NotContains(t, equalDocIDs(t, seg, valNew), docX)
 	})

--- a/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
@@ -485,6 +485,81 @@ func TestSegmentInMemoryReaderBufPool(t *testing.T) {
 	})
 }
 
+// TestSegmentInMemoryFoldOrderValueIntegrity pins INV-RANGEABLE-REP-EQUALS-DISK
+// at the value level (not just membership). The rep is a flattened fold whose
+// correctness depends on applying segments oldest->newest: each segment's
+// presence-node Deletions wipe every touched docID from all 65 bitmaps before
+// its Additions re-add them, so the LAST (newest) segment to touch a docID wins.
+//
+// This is the primary tripwire for the rejected option (a) (GH#12199): the
+// enable-rangeable backfill segments are timestamp-shifted to be logically
+// OLDEST, so folding them incrementally on top of a rep that already holds newer
+// live values makes the OLD value win - a wrong VALUE, not a missing member.
+// Membership assertions cannot catch this because the docID stays present.
+func TestSegmentInMemoryFoldOrderValueIntegrity(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	bufPool := roaringset.NewBitmapBufPoolNoop()
+
+	const (
+		docX      = uint64(500) // value changes across the two segments
+		docStable = uint64(99)  // never changes; membership backstop
+		valOld    = uint64(3)
+		valNew    = uint64(5)
+		valStable = uint64(42)
+	)
+
+	// olderSegment sets docX = valOld and docStable = valStable.
+	olderSegment := func() SegmentCursor {
+		mt := NewMemtable(logger)
+		mt.Insert(valOld, []uint64{docX})
+		mt.Insert(valStable, []uint64{docStable})
+		return newFakeSegmentCursor(mt)
+	}
+	// newerSegment sets docX = valNew (a mid-migration live update of docX).
+	newerSegment := func() SegmentCursor {
+		mt := NewMemtable(logger)
+		mt.Insert(valNew, []uint64{docX})
+		return newFakeSegmentCursor(mt)
+	}
+
+	equalDocIDs := func(t *testing.T, seg *SegmentInMemory, value uint64) []uint64 {
+		t.Helper()
+		readers, release := seg.Readers(bufPool)
+		defer release()
+		require.Len(t, readers, 1)
+		layer, relRead, err := readers[0].Read(context.Background(), value, filters.OperatorEqual)
+		require.NoError(t, err)
+		defer relRead()
+		return layer.Additions.ToArray()
+	}
+
+	t.Run("correct oldest->newest fold: newest value wins", func(t *testing.T) {
+		seg := NewSegmentInMemory(logger)
+		require.NoError(t, seg.MergeSegmentByCursor(olderSegment()))
+		require.NoError(t, seg.MergeSegmentByCursor(newerSegment()))
+
+		// docX serves the NEW value; the old value returns nothing for docX.
+		assert.Equal(t, []uint64{docX}, equalDocIDs(t, seg, valNew))
+		assert.NotContains(t, equalDocIDs(t, seg, valOld), docX)
+		// The untouched docID keeps its value (membership + value backstop).
+		assert.Equal(t, []uint64{docStable}, equalDocIDs(t, seg, valStable))
+	})
+
+	t.Run("trap: incremental older-onto-newer fold corrupts the value (old wins)", func(t *testing.T) {
+		// This is exactly what an option-(a) incremental merge of the
+		// timestamp-older prepended backfill onto a rep already holding newer
+		// live values produces. It is why option (a) is rejected and the
+		// PrependSegmentsFromBucket guard exists.
+		seg := NewSegmentInMemory(logger)
+		require.NoError(t, seg.MergeSegmentByCursor(newerSegment()))
+		require.NoError(t, seg.MergeSegmentByCursor(olderSegment()))
+
+		// The OLD value now wrongly wins for docX; the new value is gone.
+		assert.Equal(t, []uint64{docX}, equalDocIDs(t, seg, valOld))
+		assert.NotContains(t, equalDocIDs(t, seg, valNew), docX)
+	})
+}
+
 func assertElemsByBit(t *testing.T, s *SegmentInMemory, expectedElemsByBit map[int][]uint64) {
 	t.Helper()
 	for bit := 0; bit < 65; bit++ {

--- a/test/acceptance/reindex_multinode/rangeable_in_memory_gh12199_test.go
+++ b/test/acceptance/reindex_multinode/rangeable_in_memory_gh12199_test.go
@@ -33,45 +33,31 @@ import (
 )
 
 // This file is the GH#12199 regression suite: with INDEX_RANGEABLE_IN_MEMORY=true,
-// an enable-rangeable reindex must NOT serve empty range results from an
+// an enable-rangeable reindex must not serve empty range results from an
 // unpopulated in-memory representation after the per-shard swap (no restart
-// required). It codifies Etienne's R2d empirical confirmation (0 vs 20003 golden,
-// 0.011 MB empty rep) into permanent tests, and pins the two operator log signals
-// added by the fix.
+// required). It also pins the two operator log signals added by the fix.
 //
-// Log substrings emitted by the fix (adapters/repos/db/lsmkv/bucket_roaring_set_range.go):
-//   - deferredINFOSubstr: fires once per bucket-open at the first disk-path range
-//     read on a bucket the reindex ingest path marked (keepSegmentsInMemory forced
-//     off while the knob is on). Its PRESENCE confirms (b)'s marker path is applied
-//     at the fix SHA: only the (b) marker path sets the marker.
-//   - fallbackWARNSubstr: the (c) disk-fallback WARN. On the fixed path it must NOT
-//     fire, because the post-swap serving bucket has keepSegmentsInMemory=false.
+// Log substrings emitted by the fix (bucket_roaring_set_range.go):
+//   - deferredINFOSubstr: fires once per bucket-open on the marked ingest
+//     bucket's first disk-path read; presence confirms (b)'s marker path is
+//     applied.
+//   - fallbackWARNSubstr: the (c) disk-fallback WARN. Must NOT fire on the
+//     fixed path (serving bucket has keepSegmentsInMemory=false).
 //
-// Per-mechanism revert-probe mapping (verified empirically; QA round 1 correction):
-//   - (b) alone       -> caught by the child-1 prepend GUARD at reindex time, NOT by
-//     the WARN/INFO assertions below. Reverting ONLY (b) (drop the
-//     WithKeepSegmentsInMemory(false) override + the deferred marker,
-//     KEEP the guard) leaves the ingest bucket keepSegmentsInMemory=
-//     true, so it builds an ACTIVE in-memory rep; the child-1 prepend
-//     guard then rejects the backfill prepend and the reindex FAILS at
-//     AwaitReindexFinished with the INV-RANGEABLE-REP-EQUALS-DISK
-//     sentinel, before any post-swap query runs. That reindex failure
-//     is the single (b)-alone red condition, and it is caught by this
-//     acceptance repro at the AwaitReindexFinished step.
-//   - WARN/INFO pair  -> the fallbackWARNSubstr-absence + deferredINFOSubstr-presence
-//     assertions serve two roles: (i) positive happy-path proof that
-//     (b) IS applied at the fix SHA, and (ii) a tripwire for a (b) AND
-//     guard DOUBLE revert. Only when BOTH (b) and the guard are
-//     reverted does the empty-rep-served state actually arise: the
-//     reindex then completes, the post-swap read takes the (c)
-//     fallback so the WARN APPEARS, and the marker is unset so the
-//     deferred INFO DISAPPEARS (two conditions). A counts-only probe
-//     cannot catch that double-revert while (c) is in the tree; these
-//     assertions can. (The earlier "reverting (b) alone -> WARN+INFO
-//     redness" narrative was wrong: that probe had disabled the guard
-//     too. Corrected per QA round 1.)
-//   - (c) alone       -> child-1 Layer-1 four-case matrix (empty rep + disk segments
-//     must fall back), unit-scale, already red-green verified.
+// Per-mechanism revert-probe mapping:
+//   - (b) alone       -> caught by the child-1 prepend GUARD, not the WARN/INFO
+//     assertions: reverting only (b) leaves keepSegmentsInMemory=true on the
+//     ingest bucket, so the guard rejects the backfill prepend and
+//     AwaitReindexFinished fails with INV-RANGEABLE-REP-EQUALS-DISK before any
+//     post-swap query runs.
+//   - WARN/INFO pair  -> the WARN-absence + INFO-presence assertions serve two
+//     roles: (i) proof (b) is applied at the fix SHA, and (ii) a tripwire for a
+//     (b) AND guard DOUBLE revert - only then does the reindex complete with an
+//     empty rep served, so the WARN appears and the INFO (marker unset)
+//     disappears. A counts-only probe can't catch that double revert; these
+//     assertions can.
+//   - (c) alone       -> child-1 Layer-1 four-case matrix (empty rep + disk
+//     segments must fall back).
 //   - guard alone     -> child-1 guard unit test (active-rep prepend errors).
 //   - option-(a) trap -> child-1 fold-order value-integrity unit test.
 const (
@@ -101,9 +87,8 @@ func countInLogs(ctx context.Context, t *testing.T, c interface {
 }
 
 // startSingleNodeRangeableInMemCluster starts a 1-node cluster with the in-mem
-// rangeable knob on. INDEX_RANGEABLE_IN_MEMORY=true is the precondition for
-// GH#12199; LOG_LEVEL=info makes the deferred-serving INFO (and any (c) WARN)
-// visible in the container logs the assertions grep.
+// rangeable knob on (GH#12199 precondition) and LOG_LEVEL=info so the deferred
+// INFO / fallback WARN are visible in the logs the assertions grep.
 func startSingleNodeRangeableInMemCluster(ctx context.Context, t *testing.T) (*docker.DockerCompose, func()) {
 	t.Helper()
 	compose, err := docker.New().
@@ -116,10 +101,9 @@ func startSingleNodeRangeableInMemCluster(ctx context.Context, t *testing.T) (*d
 	return compose, func() { require.NoError(t, compose.Terminate(ctx)) }
 }
 
-// scoreForGH12199 maps import index i to a numeric score in [10_000, 60_000)
-// with step 5, so a [30_000, 40_000] band selects exactly 2001 of 10_000 objects
-// (mirrors in_flight_rangeable_test.go so a half-built bucket returns a visibly
-// wrong count).
+// scoreForGH12199 maps import index i to a score in [10_000, 60_000) step 5, so
+// [30_000, 40_000] selects exactly 2001/10_000 objects (mirrors
+// in_flight_rangeable_test.go; a half-built bucket returns a visibly wrong count).
 func scoreForGH12199(i int) int { return 10_000 + i*5 }
 
 const (
@@ -167,15 +151,14 @@ func TestRangeableInMemory_GH12199_SingleNode_AcceptanceAndRestartHandoff(t *tes
 	require.NoError(t, err)
 	require.Equal(t, gh12199Baseline, golden, "pre-migration filterable baseline")
 
-	// Enable rangeable and wait for the migration to fully finish. NO restart.
+	// NO restart before the checks below - that's the core repro condition.
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
 		`{"rangeable":{"enabled":true}}`)
 	t.Logf("submitted enable-rangeable task: %s", taskID)
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
 
-	// (1) Counts correct post-swap WITHOUT restart. The pre-fix image returns 0
-	// here (empty in-memory rep served; Etienne R2d). Poll briefly for the
-	// per-shard swap + schema flip to settle.
+	// (1) Counts correct post-swap without restart (pre-fix served 0: empty
+	// in-memory rep). Poll briefly for the per-shard swap + schema flip to settle.
 	require.Eventually(t, func() bool {
 		c, e := rangeCount(restURI, className, "score", gh12199RangeLo, gh12199RangeHi)
 		return e == nil && c == gh12199Baseline
@@ -189,25 +172,19 @@ func TestRangeableInMemory_GH12199_SingleNode_AcceptanceAndRestartHandoff(t *tes
 	}
 	time.Sleep(2 * time.Second) // let the container flush stdout
 
-	// (2) The (c) disk-fallback WARN must NOT fire on the fixed path: the serving
-	// bucket has keepSegmentsInMemory=false, so ReaderRoaringSetRange never reaches
-	// the (c) branch. Its presence would mean BOTH (b) and the prepend guard were
-	// reverted (the empty-rep-served state); a (b)-alone revert fails the reindex at
-	// the guard above and never reaches here.
+	// (2) The (c) WARN must not fire on the fixed path (serving bucket has
+	// keepSegmentsInMemory=false) - see the revert-probe mapping above.
 	assert.Zero(t, countInLogs(ctx, t, container, fallbackWARNSubstr),
 		"(c) disk-fallback WARN must not fire on the fixed path (WARN present => (b) AND guard both reverted, empty rep served, GH#12199)")
 
-	// (3) The deferred-serving INFO MUST be present: only the (b) marker path sets
-	// the marker, so its presence is the positive "(b) applied at the fix SHA" signal.
+	// (3) The deferred-serving INFO must be present - only the (b) marker path
+	// sets the marker (see revert-probe mapping above).
 	assert.Positive(t, countInLogs(ctx, t, container, deferredINFOSubstr),
 		"deferred-serving INFO must fire post-swap (marker set + first disk read); absence => (b) marker not applied, GH#12199")
 
 	// --- Post-restart in-memory hand-off case ---
-	// After a restart the rangeable bucket reopens via the normal shard path
-	// (knob on), so boot-time population rebuilds the in-memory rep from the now
-	// fully-populated disk segments. Range reads then serve from the rebuilt rep,
-	// counts stay correct, and no (c) WARN fires (rep populated). This pins the
-	// deferred-acceleration hand-off and the restart self-heal.
+	// After restart, boot-time population rebuilds the in-memory rep from disk,
+	// so reads serve from the rep again and no (c) WARN fires (rep populated).
 	require.NoError(t, compose.StopAt(ctx, 0, nil))
 	require.NoError(t, compose.StartAt(ctx, 0))
 	restURI = compose.GetWeaviate().URI()
@@ -235,11 +212,10 @@ func TestRangeableInMemory_GH12199_SingleNode_AcceptanceAndRestartHandoff(t *tes
 		"no (c) WARN after restart: the rep is rebuilt at boot and serves in-memory")
 }
 
-// TestRangeableInMemory_GH12199_MultiNode_InFlightStatisticalProbe is the 3-node
-// statistical probe per reference_migration_window_race_reproducer.md: fire range
-// queries at every node throughout the migration window and count divergences
-// (non-error, non-golden), not single-shot. Silent wrong results, not errors, are
-// the failure mode.
+// TestRangeableInMemory_GH12199_MultiNode_InFlightStatisticalProbe is a 3-node
+// statistical probe: fire range queries at every node throughout the migration
+// window and count divergences, not single-shot - silent wrong results, not
+// errors, are the failure mode.
 func TestRangeableInMemory_GH12199_MultiNode_InFlightStatisticalProbe(t *testing.T) {
 	ctx := context.Background()
 	compose, cleanup := start3NodeReindexCluster(ctx, t,
@@ -334,12 +310,10 @@ func TestRangeableInMemory_GH12199_MultiNode_InFlightStatisticalProbe(t *testing
 			"served from an empty in-memory rep instead of the disk path.")
 }
 
-// TestRangeableInMemory_GH12199_WriteWorkloadValueIntegrity runs the migration
-// under concurrent live writes that CHANGE a subset of objects' value, then
-// asserts VALUE integrity (not just membership): post-swap, a mover's NEW value
-// query returns it and its OLD value query does not. Fold-order corruption (the
-// rejected option (a)) would leave the old value winning; the empty-rep bug would
-// drop the movers entirely. Both are value/membership-discriminating here.
+// TestRangeableInMemory_GH12199_WriteWorkloadValueIntegrity migrates under
+// concurrent live writes that change movers' value, then asserts a mover's NEW
+// value query returns it and its OLD value query returns nothing - catches both
+// fold-order corruption (option (a)) and the empty-rep bug (movers dropped).
 func TestRangeableInMemory_GH12199_WriteWorkloadValueIntegrity(t *testing.T) {
 	ctx := context.Background()
 	compose, cleanup := startSingleNodeRangeableInMemCluster(ctx, t)

--- a/test/acceptance/reindex_multinode/rangeable_in_memory_gh12199_test.go
+++ b/test/acceptance/reindex_multinode/rangeable_in_memory_gh12199_test.go
@@ -1,0 +1,457 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_multinode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+// This file is the GH#12199 regression suite: with INDEX_RANGEABLE_IN_MEMORY=true,
+// an enable-rangeable reindex must NOT serve empty range results from an
+// unpopulated in-memory representation after the per-shard swap (no restart
+// required). It codifies Etienne's R2d empirical confirmation (0 vs 20003 golden,
+// 0.011 MB empty rep) into permanent tests, and pins the two operator log signals
+// added by the fix.
+//
+// Log substrings emitted by the fix (adapters/repos/db/lsmkv/bucket_roaring_set_range.go):
+//   - deferredINFOSubstr: fires once per bucket-open at the first disk-path range
+//     read on a bucket the reindex ingest path marked (keepSegmentsInMemory forced
+//     off while the knob is on). Its PRESENCE confirms (b)'s marker path is applied
+//     at the fix SHA: only the (b) marker path sets the marker.
+//   - fallbackWARNSubstr: the (c) disk-fallback WARN. On the fixed path it must NOT
+//     fire, because the post-swap serving bucket has keepSegmentsInMemory=false.
+//
+// Per-mechanism revert-probe mapping (verified empirically; QA round 1 correction):
+//   - (b) alone       -> caught by the child-1 prepend GUARD at reindex time, NOT by
+//     the WARN/INFO assertions below. Reverting ONLY (b) (drop the
+//     WithKeepSegmentsInMemory(false) override + the deferred marker,
+//     KEEP the guard) leaves the ingest bucket keepSegmentsInMemory=
+//     true, so it builds an ACTIVE in-memory rep; the child-1 prepend
+//     guard then rejects the backfill prepend and the reindex FAILS at
+//     AwaitReindexFinished with the INV-RANGEABLE-REP-EQUALS-DISK
+//     sentinel, before any post-swap query runs. That reindex failure
+//     is the single (b)-alone red condition, and it is caught by this
+//     acceptance repro at the AwaitReindexFinished step.
+//   - WARN/INFO pair  -> the fallbackWARNSubstr-absence + deferredINFOSubstr-presence
+//     assertions serve two roles: (i) positive happy-path proof that
+//     (b) IS applied at the fix SHA, and (ii) a tripwire for a (b) AND
+//     guard DOUBLE revert. Only when BOTH (b) and the guard are
+//     reverted does the empty-rep-served state actually arise: the
+//     reindex then completes, the post-swap read takes the (c)
+//     fallback so the WARN APPEARS, and the marker is unset so the
+//     deferred INFO DISAPPEARS (two conditions). A counts-only probe
+//     cannot catch that double-revert while (c) is in the tree; these
+//     assertions can. (The earlier "reverting (b) alone -> WARN+INFO
+//     redness" narrative was wrong: that probe had disabled the guard
+//     too. Corrected per QA round 1.)
+//   - (c) alone       -> child-1 Layer-1 four-case matrix (empty rep + disk segments
+//     must fall back), unit-scale, already red-green verified.
+//   - guard alone     -> child-1 guard unit test (active-rep prepend errors).
+//   - option-(a) trap -> child-1 fold-order value-integrity unit test.
+const (
+	deferredINFOSubstr = "in-memory knob deferred until next reload"
+	fallbackWARNSubstr = "falling back to the disk range reader"
+)
+
+// countInLogs returns the number of lines in a container's logs that contain
+// substr. Used to assert presence/absence of the two GH#12199 log signals.
+func countInLogs(ctx context.Context, t *testing.T, c interface {
+	Logs(context.Context) (io.ReadCloser, error)
+}, substr string,
+) int {
+	t.Helper()
+	reader, err := c.Logs(ctx)
+	require.NoError(t, err, "reading container logs")
+	defer reader.Close()
+	raw, err := io.ReadAll(reader)
+	require.NoError(t, err, "draining container logs")
+	n := 0
+	for _, line := range strings.Split(string(raw), "\n") {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// startSingleNodeRangeableInMemCluster starts a 1-node cluster with the in-mem
+// rangeable knob on. INDEX_RANGEABLE_IN_MEMORY=true is the precondition for
+// GH#12199; LOG_LEVEL=info makes the deferred-serving INFO (and any (c) WARN)
+// visible in the container logs the assertions grep.
+func startSingleNodeRangeableInMemCluster(ctx context.Context, t *testing.T) (*docker.DockerCompose, func()) {
+	t.Helper()
+	compose, err := docker.New().
+		WithWeaviate().
+		WithWeaviateEnv("INDEX_RANGEABLE_IN_MEMORY", "true").
+		WithWeaviateEnv("LOG_LEVEL", "info").
+		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	return compose, func() { require.NoError(t, compose.Terminate(ctx)) }
+}
+
+// scoreForGH12199 maps import index i to a numeric score in [10_000, 60_000)
+// with step 5, so a [30_000, 40_000] band selects exactly 2001 of 10_000 objects
+// (mirrors in_flight_rangeable_test.go so a half-built bucket returns a visibly
+// wrong count).
+func scoreForGH12199(i int) int { return 10_000 + i*5 }
+
+const (
+	gh12199Total    = 10_000
+	gh12199RangeLo  = 30_000
+	gh12199RangeHi  = 40_000
+	gh12199Baseline = 2001
+)
+
+func rangeableScoreProps() []*models.Property {
+	trueVal, falseVal := true, false
+	return []*models.Property{
+		{Name: "name", DataType: []string{"text"}},
+		{
+			Name:              "score",
+			DataType:          []string{"int"},
+			IndexFilterable:   &trueVal,
+			IndexRangeFilters: &falseVal,
+		},
+	}
+}
+
+// TestRangeableInMemory_GH12199_SingleNode_AcceptanceAndRestartHandoff is the
+// core acceptance repro (single-node, knob on, NO restart) with the triple
+// assertion, followed by the post-restart in-memory hand-off case.
+func TestRangeableInMemory_GH12199_SingleNode_AcceptanceAndRestartHandoff(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := startSingleNodeRangeableInMemCluster(ctx, t)
+	defer cleanup()
+
+	restURI := compose.GetWeaviate().URI()
+	container := compose.GetWeaviate().Container()
+
+	const className = "RangeableInMemAcceptance"
+	// 3 shards on the single node => 3 rangeable ingest buckets, each marked
+	// deferred, so the INFO fires per bucket.
+	createCollection(t, compose, restURI, className, 3, 1, rangeableScoreProps())
+	// Read the URI lazily at cleanup time: the restart below re-maps the host
+	// port, so a URI captured now would be stale by the time this defer runs.
+	defer func() { deleteCollection(t, compose.GetWeaviate().URI(), className) }()
+	batchImportNumeric(t, restURI, className, gh12199Total, scoreForGH12199)
+
+	// Golden baseline from the filterable path, before the migration.
+	golden, err := rangeCount(restURI, className, "score", gh12199RangeLo, gh12199RangeHi)
+	require.NoError(t, err)
+	require.Equal(t, gh12199Baseline, golden, "pre-migration filterable baseline")
+
+	// Enable rangeable and wait for the migration to fully finish. NO restart.
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
+		`{"rangeable":{"enabled":true}}`)
+	t.Logf("submitted enable-rangeable task: %s", taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+
+	// (1) Counts correct post-swap WITHOUT restart. The pre-fix image returns 0
+	// here (empty in-memory rep served; Etienne R2d). Poll briefly for the
+	// per-shard swap + schema flip to settle.
+	require.Eventually(t, func() bool {
+		c, e := rangeCount(restURI, className, "score", gh12199RangeLo, gh12199RangeHi)
+		return e == nil && c == gh12199Baseline
+	}, 60*time.Second, 200*time.Millisecond,
+		"GH#12199: post-swap range count must equal golden %d WITHOUT restart", gh12199Baseline)
+
+	// Drive a few more range reads so the deferred-serving INFO's first-disk-read
+	// trigger has definitely run on every marked bucket.
+	for i := 0; i < 5; i++ {
+		_, _ = rangeCount(restURI, className, "score", gh12199RangeLo, gh12199RangeHi)
+	}
+	time.Sleep(2 * time.Second) // let the container flush stdout
+
+	// (2) The (c) disk-fallback WARN must NOT fire on the fixed path: the serving
+	// bucket has keepSegmentsInMemory=false, so ReaderRoaringSetRange never reaches
+	// the (c) branch. Its presence would mean BOTH (b) and the prepend guard were
+	// reverted (the empty-rep-served state); a (b)-alone revert fails the reindex at
+	// the guard above and never reaches here.
+	assert.Zero(t, countInLogs(ctx, t, container, fallbackWARNSubstr),
+		"(c) disk-fallback WARN must not fire on the fixed path (WARN present => (b) AND guard both reverted, empty rep served, GH#12199)")
+
+	// (3) The deferred-serving INFO MUST be present: only the (b) marker path sets
+	// the marker, so its presence is the positive "(b) applied at the fix SHA" signal.
+	assert.Positive(t, countInLogs(ctx, t, container, deferredINFOSubstr),
+		"deferred-serving INFO must fire post-swap (marker set + first disk read); absence => (b) marker not applied, GH#12199")
+
+	// --- Post-restart in-memory hand-off case ---
+	// After a restart the rangeable bucket reopens via the normal shard path
+	// (knob on), so boot-time population rebuilds the in-memory rep from the now
+	// fully-populated disk segments. Range reads then serve from the rebuilt rep,
+	// counts stay correct, and no (c) WARN fires (rep populated). This pins the
+	// deferred-acceleration hand-off and the restart self-heal.
+	require.NoError(t, compose.StopAt(ctx, 0, nil))
+	require.NoError(t, compose.StartAt(ctx, 0))
+	restURI = compose.GetWeaviate().URI()
+	container = compose.GetWeaviate().Container()
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/v1/.well-known/ready", restURI))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 90*time.Second, 200*time.Millisecond, "node must be ready after restart")
+
+	require.Eventually(t, func() bool {
+		c, e := rangeCount(restURI, className, "score", gh12199RangeLo, gh12199RangeHi)
+		return e == nil && c == gh12199Baseline
+	}, 60*time.Second, 200*time.Millisecond,
+		"post-restart range count must still equal golden %d (rep rebuilt at boot)", gh12199Baseline)
+
+	for i := 0; i < 5; i++ {
+		_, _ = rangeCount(restURI, className, "score", gh12199RangeLo, gh12199RangeHi)
+	}
+	time.Sleep(2 * time.Second)
+	assert.Zero(t, countInLogs(ctx, t, container, fallbackWARNSubstr),
+		"no (c) WARN after restart: the rep is rebuilt at boot and serves in-memory")
+}
+
+// TestRangeableInMemory_GH12199_MultiNode_InFlightStatisticalProbe is the 3-node
+// statistical probe per reference_migration_window_race_reproducer.md: fire range
+// queries at every node throughout the migration window and count divergences
+// (non-error, non-golden), not single-shot. Silent wrong results, not errors, are
+// the failure mode.
+func TestRangeableInMemory_GH12199_MultiNode_InFlightStatisticalProbe(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := start3NodeReindexCluster(ctx, t,
+		"INDEX_RANGEABLE_IN_MEMORY", "true", "LOG_LEVEL", "info")
+	defer cleanup()
+	defer dumpContainerLogs(ctx, t, compose)
+
+	const className = "RangeableInMemInFlight"
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, rangeableScoreProps())
+	defer deleteCollection(t, restURIOf(compose, 1), className)
+	batchImportNumeric(t, restURIOf(compose, 1), className, gh12199Total, scoreForGH12199)
+
+	// Every replica agrees on the baseline before the migration.
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		c, err := rangeCount(restURIOf(compose, nodeIdx), className, "score", gh12199RangeLo, gh12199RangeHi)
+		require.NoError(t, err, "pre-migration baseline on node %d", nodeIdx)
+		require.Equal(t, gh12199Baseline, c, "node %d baseline", nodeIdx)
+	}
+
+	var (
+		wrongCounts atomic.Int64
+		queryRuns   atomic.Int64
+		queryErrors atomic.Int64
+		stopCh      = make(chan struct{})
+		wg          sync.WaitGroup
+	)
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		wg.Add(1)
+		uri := restURIOf(compose, nodeIdx)
+		idx := nodeIdx
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(50 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopCh:
+					return
+				case <-ticker.C:
+				}
+				c, err := rangeCount(uri, className, "score", gh12199RangeLo, gh12199RangeHi)
+				queryRuns.Add(1)
+				if err != nil {
+					queryErrors.Add(1)
+					continue
+				}
+				if c != gh12199Baseline {
+					wrongCounts.Add(1)
+					t.Logf("GH#12199 in-flight divergence: node %d returned %d (expected %d)", idx, c, gh12199Baseline)
+				}
+			}
+		}()
+	}
+
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURIOf(compose, 1), className, "score",
+		`{"rangeable":{"enabled":true}}`)
+	t.Logf("submitted enable-rangeable task: %s", taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID, reindexhelpers.WithTimeout(180*time.Second))
+
+	// Keep probing until every replica converges to the correct rangeable count.
+	require.Eventually(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			c, err := rangeCount(restURIOf(compose, nodeIdx), className, "score", gh12199RangeLo, gh12199RangeHi)
+			if err != nil || c != gh12199Baseline {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 50*time.Millisecond, "all replicas must converge to %d", gh12199Baseline)
+	close(stopCh)
+	wg.Wait()
+
+	t.Logf("in-flight probes: %d runs, %d transient errors, %d wrong counts",
+		queryRuns.Load(), queryErrors.Load(), wrongCounts.Load())
+
+	// The schema flip committed on every node.
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		cls := getClassFromNode(t, restURIOf(compose, nodeIdx), className)
+		ok := false
+		for _, prop := range cls.Properties {
+			if prop.Name == "score" && prop.IndexRangeFilters != nil && *prop.IndexRangeFilters {
+				ok = true
+				break
+			}
+		}
+		assert.True(t, ok, "node %d: IndexRangeFilters should be true", nodeIdx)
+	}
+
+	assert.Zero(t, wrongCounts.Load(),
+		"GH#12199: zero silent-wrong range counts during the in-flight enable-rangeable "+
+			"window with INDEX_RANGEABLE_IN_MEMORY=true. A non-zero count means a replica "+
+			"served from an empty in-memory rep instead of the disk path.")
+}
+
+// TestRangeableInMemory_GH12199_WriteWorkloadValueIntegrity runs the migration
+// under concurrent live writes that CHANGE a subset of objects' value, then
+// asserts VALUE integrity (not just membership): post-swap, a mover's NEW value
+// query returns it and its OLD value query does not. Fold-order corruption (the
+// rejected option (a)) would leave the old value winning; the empty-rep bug would
+// drop the movers entirely. Both are value/membership-discriminating here.
+func TestRangeableInMemory_GH12199_WriteWorkloadValueIntegrity(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := startSingleNodeRangeableInMemCluster(ctx, t)
+	defer cleanup()
+	restURI := compose.GetWeaviate().URI()
+
+	const className = "RangeableInMemWriteWorkload"
+	// Single shard keeps the mover UUIDs deterministic and the value assertions
+	// simple; the value-integrity property is per-shard.
+	createCollection(t, compose, restURI, className, 1, 1, rangeableScoreProps())
+	defer deleteCollection(t, restURI, className)
+
+	const (
+		total      = 4_000
+		moverCount = 500
+		oldValue   = 20_000 // movers start here (in the [oldLo,oldHi] band)
+		newValue   = 55_000 // movers are updated to here mid-migration
+		stableVal  = 12_345 // non-movers; must never change
+	)
+	// Deterministic UUIDs so we can overwrite the movers by re-importing them.
+	moverID := func(i int) string {
+		return uuid.NewSHA1(uuid.NameSpaceOID, []byte(fmt.Sprintf("gh12199-mover-%d", i))).String()
+	}
+
+	// Seed: movers at oldValue, the rest at stableVal.
+	seed := make([]map[string]interface{}, 0, total)
+	for i := 0; i < total; i++ {
+		id := uuid.NewSHA1(uuid.NameSpaceOID, []byte(fmt.Sprintf("gh12199-obj-%d", i))).String()
+		score := stableVal
+		if i < moverCount {
+			id = moverID(i)
+			score = oldValue
+		}
+		seed = append(seed, map[string]interface{}{
+			"class":      className,
+			"id":         id,
+			"properties": map[string]interface{}{"name": fmt.Sprintf("item-%d", i), "score": score},
+		})
+	}
+	postObjects(t, restURI, seed)
+
+	// Baseline: exactly moverCount objects have score == oldValue.
+	c, err := rangeCount(restURI, className, "score", oldValue, oldValue)
+	require.NoError(t, err)
+	require.Equal(t, moverCount, c, "pre-migration movers at oldValue")
+
+	// Start the migration, then overwrite the movers to newValue WHILE it runs.
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
+		`{"rangeable":{"enabled":true}}`)
+	updates := make([]map[string]interface{}, 0, moverCount)
+	for i := 0; i < moverCount; i++ {
+		updates = append(updates, map[string]interface{}{
+			"class":      className,
+			"id":         moverID(i),
+			"properties": map[string]interface{}{"name": fmt.Sprintf("item-%d", i), "score": newValue},
+		})
+	}
+	postObjects(t, restURI, updates) // overwrite by same UUID, in-flight
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+
+	// Post-swap value integrity, no restart. Poll for settle.
+	require.Eventually(t, func() bool {
+		atNew, e1 := rangeCount(restURI, className, "score", newValue, newValue)
+		atOld, e2 := rangeCount(restURI, className, "score", oldValue, oldValue)
+		return e1 == nil && e2 == nil && atNew == moverCount && atOld == 0
+	}, 60*time.Second, 200*time.Millisecond,
+		"post-swap: movers must serve their NEW value (%d at %d) and none at the OLD value %d",
+		moverCount, newValue, oldValue)
+
+	// Membership backstop: the stable (backfilled-only) objects are all present.
+	atStable, err := rangeCount(restURI, className, "score", stableVal, stableVal)
+	require.NoError(t, err)
+	assert.Equal(t, total-moverCount, atStable, "non-mover objects must remain at their stable value")
+}
+
+// postObjects batch-imports objects (200 per batch) with consistency_level=ALL.
+// Reused by the value-integrity test for both the seed and the in-flight
+// overwrite (same UUIDs overwrite the prior value).
+func postObjects(t *testing.T, restURI string, objects []map[string]interface{}) {
+	t.Helper()
+	const batchSize = 200
+	for start := 0; start < len(objects); start += batchSize {
+		end := start + batchSize
+		if end > len(objects) {
+			end = len(objects)
+		}
+		body, err := json.Marshal(map[string]interface{}{"objects": objects[start:end]})
+		require.NoError(t, err)
+		resp, err := http.Post(
+			fmt.Sprintf("http://%s/v1/batch/objects?consistency_level=ALL", restURI),
+			"application/json",
+			bytes.NewReader(body),
+		)
+		require.NoError(t, err)
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "batch %d-%d failed: %s", start, end, string(respBody))
+
+		var batchResp []struct {
+			Result struct {
+				Errors *struct {
+					Error []struct {
+						Message string `json:"message"`
+					} `json:"error"`
+				} `json:"errors,omitempty"`
+			} `json:"result"`
+		}
+		require.NoError(t, json.Unmarshal(respBody, &batchResp))
+		for i, br := range batchResp {
+			if br.Result.Errors != nil && len(br.Result.Errors.Error) > 0 {
+				t.Fatalf("batch %d-%d object %d errored: %s", start, end, i, br.Result.Errors.Error[0].Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hey, Claudette here :robot: :wave:

Fixes #12199. With `INDEX_RANGEABLE_IN_MEMORY=true`, an enable-rangeable reindex serves empty (or partial) range-filter results from the moment of the per-shard swap until the next process restart, with no error and no log. This PR fixes the silent-wrong-results and adds two independent guards against the whole class of "the in-memory representation should have been populated but wasn't."

### Mechanism

When the global knob is on, every `StrategyRoaringSetRange` bucket is opened with `keepSegmentsInMemory=true` and range queries are served exclusively from an in-memory bit-sliced representation, with no disk fallback (`ReaderRoaringSetRange`, `bucket_roaring_set_range.go:58`). That representation is populated at exactly two sites: bucket open (fold over all disk segments) and memtable flush.

The enable-rangeable runtime reindex delivers its bulk backfill through a third segment-list mutation site, `PrependSegmentsFromBucket` (`segment_group_prepend.go:67`), a file-level segment copy and splice. That function has a derived-state branch for the Inverted strategy (average property lengths) but none for RoaringSetRange. So the freshly created ingest bucket starts with an empty representation, receives only live double-writes into it during migration, and after `SwapBucketPointer` (a pure map re-point) it serves range queries from that empty or partial representation while the complete postings sit on disk. Empty under a read-only workload, partial under writes. The reproduction numbers are already in the issue (golden matches versus zero post-swap; restart heals). This affects single-node and multi-node alike.

### Fix

Four layers. Layers 1-3 make the migration serve correct results with the knob on; layer 4 restores the knob's in-memory performance immediately at migration finalize.

1. Primary: force `keepSegmentsInMemory=false` for reindex rangeable ingest buckets (`inverted_reindex_task_generic.go:2601`). The override is gated on `strategy == StrategyRoaringSetRange` and forces `false` unconditionally inside the gate, so the ingest bucket never builds a representation and post-swap range reads go through the already-correct disk path (newest-to-oldest layering with deletion masking under a consistent view). Correct results immediately after each per-shard swap, no restart required.

2. Structural guard: `PrependSegmentsFromBucket` now returns an error instead of silently splicing when called on a RoaringSetRange group that has a live in-memory representation (`ErrPrependWouldDesyncInMemoryRep`, a package-level sentinel wrapped with bucket context via `%w`). It is a step-1 early return before the file copy and the splice, so the failure is clean (no files copied, segment list unmutated) and propagates per-shard through the existing error path. The message names the invariant and both remedies. This converts any future caller that recreates the broken state (a second migration type, restore-into-live, a refactor that drops the override above) from silent-wrong-results into a loud, local, pre-mutation failure.

3. Install-time publish gate: the rebuild validates the representation once, at install time, under the flush lock, before publishing it - a representation that folds up empty while disk segments exist is never published, and the bucket stays on the already-correct disk path with a loud diagnostic. The discriminant is `bitmaps[0].IsEmpty()` (the presence set every reader clones as its base), not `Size()==0`, because the empty skeleton is 65 allocated bitmaps with nonzero byte size and `Size()==0` would never fire. A genuinely empty bucket has an empty representation and zero disk segments, so it publishes normally and returns the correct empty result at full speed. The read path keeps one narrow defensive branch for the boot-time `keepSegmentsInMemory` load path, which does not pass through the install gate; everywhere else the published flag is trusted, so there is no per-read re-check and no silent serving-mode change after publication.

4. Immediate in-memory serving via rebuild-at-finalize: `rebuildRangeableInMemoryReps` runs at migration finalize on every completion path (the happy path in `runtimeSwap`, the recovery path in `finalizeMigrationAfterRecovery`, and the re-entrant `IsTidied` branch of `OnAfterLsmInitAsync`) and calls the bucket's `RebuildRangeableSegmentInMemory`: pause compaction via the ref-counted bucket-level wrappers, take a ref-counted consistent view of the disk segments (held across the whole build+install span, so a concurrent shutdown or tenant deactivation waits on the refcount instead of unmapping under the cursor), bulk-merge into a fresh representation WITHOUT holding the flush lock (writes and flushes stay unblocked), then under the flush lock catch up any segments flushed during the bulk phase, validate, publish, and atomically flip the bucket to in-memory serving. The fold consults the allocation checker before building, so a memory-constrained node degrades to disk serving instead of risking an OOM kill. The migrated property serves range queries from memory within seconds of the migration finishing - no restart, no reload.

### Rebuild design notes

Two rebuild shapes were considered; only one is safe. An incremental merge of the prepended segments into the live representation is corrupting: the representation is a flattened fold whose correctness depends on oldest-to-newest application order, and prepended segments are timestamp-shifted to sort as logically oldest while the representation may already hold newer live double-writes - folding older segments on top of newer state ORs stale bit-slices into current values (wrong VALUES, not just wrong membership; older deletions masking newer additions). The shipped rebuild is therefore a full from-scratch fold with explicit serialization: compaction paused for the whole rebuild (the segment set can only grow by flush appends at the tail), bulk merge outside the flush lock, tail catch-up plus publish inside it. The `PrependSegmentsFromBucket` guard (layer 2) still stands: prepends target only pre-swap ingest buckets, which never have a live representation; the rebuild runs post-swap after all prepends are done.

### Failure semantics and operator signals

The happy path needs no operator action: an INFO ("rangeable in-memory index built at migration finalize; serving range queries from memory") marks the switch per bucket.

If the finalize rebuild fails (a segment read error, an allocation-checker refusal, or a representation that validates as unpopulated), the failure is scoped to what it actually is: a degraded read-side acceleration on data that is complete and correct on disk. The rebuild logs at ERROR ("built and data intact, could not be activated for in-memory serving"), increments the `RangeableInMemoryRebuildDegraded` metric so the degrade is dashboard-visible, and the migration proceeds to completion - the property serves correct results from the disk path, and the next restart or reload rebuilds the in-memory representation and restores acceleration. This matters in multi-replica deployments: the first replica to finish commits the schema flag cluster-wide, and a replica whose rebuild failed must keep answering queries (correctly, from disk) rather than erroring until someone restarts it. Failures in the data work itself (prepend, swap, tidy) still report FAILED; only the acceleration step degrades. Both behaviors are pinned by fault-injection tests, including cancellation routing (`Canceled` and `DeadlineExceeded` both route to the transient retry path, never to FAILED or a spurious FINISHED).

### Strategy-coverage audit of PrependSegmentsFromBucket

While in the function I audited every supported strategy's derived-state obligation, since this is the second time this function has been flagged for strategy-incompleteness:

| Strategy | Segment-group derived state | Status after this PR |
|---|---|---|
| Inverted | avg property lengths | maintained (existing branch) |
| RoaringSetRange | in-memory representation | guarded (this PR) |
| RoaringSet | none | n/a |
| SetCollection | none | n/a |
| MapCollection | none | n/a |
| Replace | countNetAdditions (not recalculable) | rejected already |

The function's doc comment now carries this table, so the next strategy added to it has to answer the question explicitly.

### Tests

Unit (fast, `-race`): the (b) override, the guard (fires on an active representation, and is unreachable from the fixed reindex path; the sentinel and pre-mutation cleanliness are asserted), the (c) four-case matrix (empty-or-populated representation crossed with zero-or-more disk segments), and a fold-order value-integrity test that pins the corruption the rejected in-place rebuild would introduce. The finalize-degrade semantics are pinned by their own set: rebuild-failure-still-completes (asserting correct disk results and no missing-index error on the affected property), cancellation-stays-transient, data-work-failure-stays-FAILED, empty-representation-never-publishes, published-flag-trusted, a shard-level staggered-flip test, the degrade-metric assertion, and a shutdown-during-rebuild race test.

Acceptance (testcontainers, single and three-node): the enable-rangeable repro with no restart, asserting the post-swap range count equals the golden count, the (c) WARN does not fire on the fixed path, and the deferred-serving INFO does fire; a three-node in-flight statistical probe firing range queries at every node throughout the migration window and counting divergences (silent wrong results, not errors, are the failure mode); a write-workload variant asserting value integrity (a docID whose value changed mid-migration is returned by new-value queries and not by old-value queries); and restart-recovery plus post-restart in-memory hand-off. The acceptance suite codifies the reproduction already confirmed in the issue rather than re-deriving it.

How each test maps to a layer of the fix, if you want to verify the coverage is not redundant:

- A strict revert of the primary override alone (guard kept) is caught by the guard: the ingest bucket keeps an active representation, the guard rejects the backfill prepend, and the reindex fails with the `INV-RANGEABLE-REP-EQUALS-DISK` sentinel before any post-swap query runs.
- The WARN-absence and INFO-presence assertions are positive proof the override is applied, and a tripwire for a double revert of the override and the guard together, which is the only way to reach the empty-representation-served state.
- The (c) four-case matrix pins the read-path fallback.
- The fold-order value-integrity test pins the rejected in-place-rebuild trap.

Replay:

```
go test -race -count=1 ./adapters/repos/db/lsmkv/... ./adapters/repos/db/roaringsetrange/...
TEST_WEAVIATE_IMAGE=<prebuilt-image> go test -count=1 -race -timeout 20m ./test/acceptance/reindex_multinode/ -run TestRangeableInMemory
```

### Operator notes (release-note material)

1. During an enable-rangeable reindex on a deployment running `INDEX_RANGEABLE_IN_MEMORY=true`, range queries on the migrating property are served from DISK (correct results, temporarily without the in-memory speed) for the duration of the migration only. At migration finalize the in-memory index is rebuilt and serving switches to memory immediately, with no restart. An INFO log line ("rangeable in-memory index built at migration finalize") marks the switch. The remaining during-migration window is inherent to any online migration.

2. If the in-memory rebuild at finalize fails, the migration still completes and the property serves correct results from disk, without the in-memory speed. The signal is an ERROR log ("built and data intact, could not be activated for in-memory serving") plus the `RangeableInMemoryRebuildDegraded` metric; a restart or reload restores in-memory serving. No query errors, no wrong results, no operator action required beyond noticing the degrade.

### Out of scope

- The full in-place-rebuild machinery (rejected above; the guard forces any future need to be built consciously).
- The adjacent double-write gaps tracked separately; this fix deliberately does not depend on double-write coverage.
- Any change to `INDEX_RANGEABLE_IN_MEMORY` semantics for non-reindex paths.
- Corrupt-segment-header validation at open (`segmentindex.ParseHeader`): split into its own PR against `stable/v1.38` per review, since its upgrade-behavior change deserves independent reasoning and its own release note.

### Relationship to #12215

This PR is the forward-port to `main` of #12215 (merged into `stable/v1.38`). The diff is content-identical to the merged final state of that PR, applied onto current `main` (all 17 files applied cleanly; the two branches had already converged on the mechanism sites via main's periodic merges of `stable/v1.38`). The full review history, including the three-round review saga with QA Claude and the request-changes cycle, lives on #12215.

### Verification

- [x] go build ./... clean
- [x] golangci-lint clean on the touched packages (including the previously red ST1005 pair)
- [x] goroutine linter clean
- [x] unit tests green with `-race` (full `adapters/repos/db/...`, `usecases/monitoring`)
- [x] acceptance suite green at the fix (single-node, three-node, write-workload)
- [ ] full acceptance CI pending on the PR

Claudette

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171Q1Fe5rpEYq2GeKarJbV9





