### PR TITLE
fix(rplc-mvmnt): `HaltForTransfer` overlap during concurrent COPY ops

### DIFF
--- a/adapters/repos/db/replica_snapshot.go
+++ b/adapters/repos/db/replica_snapshot.go
@@ -69,6 +69,8 @@ func (i *Index) IncomingCreateReplicaSnapshot(ctx context.Context, shardName, op
 			i.cleanupFailedReplicaSnapshot(stagingRoot, opID, false, nil)
 			return nil, err
 		}
+		i.logger.WithField("op_id", opID).WithField("shard", shardName).
+			Debugf("created replica snapshot: %d files", len(files))
 		i.recordReplicaSnapshot(opID, replicaSnapshotState{shardName: shardName, isSnapshot: true})
 		return files, nil
 	}
@@ -87,6 +89,8 @@ func (i *Index) IncomingCreateReplicaSnapshot(ctx context.Context, shardName, op
 		return nil, fmt.Errorf("shard %q could not list replica snapshot files: %w", shardName, err)
 	}
 
+	i.logger.WithField("op_id", opID).WithField("shard", shardName).
+		Debugf("created replica snapshot: %d files", len(files))
 	i.recordReplicaSnapshot(opID, replicaSnapshotState{shardName: shardName, isSnapshot: false})
 	return files, nil
 }

--- a/adapters/repos/db/replica_snapshot_shared_halt_test.go
+++ b/adapters/repos/db/replica_snapshot_shared_halt_test.go
@@ -1,0 +1,259 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// Pins the shared-halt lost-write bug: when a second transfer consumer halts a
+// shard that is already halted (haltForTransferCount>1), HaltForTransfer used to
+// early-return without re-sealing. A write that landed after the first
+// consumer's flush lived only in the active memtable/WAL — excluded from
+// ListBackupFiles — so the second consumer's snapshot silently dropped it.
+//
+// Both replica modes are covered: hardlink (segments staged) and fallback
+// halt-for-duration (segments served from the live shard root). The two
+// overlapping ops prove the re-seal is repeatable, not one-shot. In fallback
+// mode each op's halt outlives its call, so obj2 halts at count 1->2 and obj3 at
+// 2->3. In hardlink mode CreateReplicaSnapshot self-resumes after collecting
+// files, so obj2 and obj3 each drive an independent 1->2 shared-halt transition.
+func TestReplicaSnapshotSharedHaltSealsLateWrites(t *testing.T) {
+	const (
+		obj1 = strfmt.UUID("40d3be3e-2ecc-49c8-b37c-d8983164848b")
+		obj2 = strfmt.UUID("5a7b9c1d-0000-4000-8000-000000000002")
+		obj3 = strfmt.UUID("5a7b9c1d-0000-4000-8000-000000000003")
+		opB  = "00000000-0000-0000-0000-0000000000b0"
+		opC  = "00000000-0000-0000-0000-0000000000c0"
+	)
+
+	for _, tc := range []struct {
+		name            string
+		forceNoHardlink bool
+	}{
+		{name: "hardlink mode", forceNoHardlink: false},
+		{name: "fallback halt-for-duration mode", forceNoHardlink: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.forceNoHardlink {
+				t.Setenv("WEAVIATE_TEST_FORCE_NO_HARDLINK", "true")
+			}
+
+			index, shard := newSharedHaltTestShard(t)
+			ctx := context.Background()
+
+			// object1 is flushed to a segment by op A's initial halt below.
+			putSharedHaltObject(t, index, obj1, 0)
+
+			// op A: first halt, never resumed — count stays 1, holds the shard.
+			require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+			defer func() { _ = shard.resumeMaintenanceCycles(ctx) }()
+
+			var openOps []string
+			defer func() {
+				for _, opID := range openOps {
+					_ = index.IncomingReleaseReplicaSnapshot(ctx, opID)
+				}
+			}()
+
+			overlaps := []struct {
+				opID  string
+				objID strfmt.UUID
+				docID uint64
+			}{
+				{opID: opB, objID: obj2, docID: 1},
+				{opID: opC, objID: obj3, docID: 2},
+			}
+			for _, ov := range overlaps {
+				// Lands in the fresh active memtable/WAL; a halt never trips the
+				// bucket read-only guard, so the write is accepted but unsealed.
+				putSharedHaltObject(t, index, ov.objID, ov.docID)
+
+				files, err := index.IncomingCreateReplicaSnapshot(ctx, "shard1", ov.opID)
+				require.NoError(t, err)
+				require.NotEmpty(t, files)
+				openOps = append(openOps, ov.opID)
+
+				// Reconstruct the snapshot's objects bucket from EXACTLY the returned
+				// file list — this is what the target receives over the wire.
+				sourceRoot := replicaStagingDir(index.Config.RootPath, ov.opID,
+					schema.ClassName(index.Config.ClassName))
+				if tc.forceNoHardlink {
+					sourceRoot = shard.path()
+				}
+				require.Truef(t, snapshotHasObject(t, sourceRoot, files, ov.objID),
+					"write %s applied before op %s's halt is missing from its snapshot — "+
+						"the shared halt skipped the re-seal", ov.objID, ov.opID)
+			}
+		})
+	}
+}
+
+// A prep failure on the second (count>1) halt must roll back 2->1 via the
+// error defer, never unhalting the shard the first op still holds.
+func TestHaltForTransferSharedHaltPrepErrorKeepsShardHalted(t *testing.T) {
+	_, shard := newSharedHaltTestShard(t)
+	ctx := context.Background()
+
+	// op A holds the shard.
+	require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+
+	// op B's second halt seals with an already-cancelled context; at count>1 the
+	// pause steps are gated out, so only the seal steps run and FlushMemtables
+	// (cyclemanager Deactivate) returns ctx.Err() deterministically.
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.Error(t, shard.HaltForTransfer(cancelledCtx, false, 0))
+
+	shard.haltForTransferMux.Lock()
+	require.Equal(t, 1, shard.haltForTransferCount,
+		"failed count>1 halt must roll back 2->1, leaving op A's hold intact")
+	shard.haltForTransferMux.Unlock()
+
+	// op A's halt is intact and resumes cleanly to fully unhalted.
+	require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+	shard.haltForTransferMux.Lock()
+	require.Equal(t, 0, shard.haltForTransferCount)
+	shard.haltForTransferMux.Unlock()
+}
+
+// snapshotHasObject reconstructs the snapshot's objects bucket from the wire
+// file list (copying every listed lsm/objects/* file out of sourceRoot into a
+// throwaway dir), opens it read-only, and reports whether id is retrievable —
+// i.e. whether the write survives in a sealed, listable segment.
+func snapshotHasObject(t *testing.T, sourceRoot string, files []string, id strfmt.UUID) bool {
+	t.Helper()
+	ctx := context.Background()
+
+	const objectsPrefix = "lsm/objects/" // shard-relative segment path
+	recon := t.TempDir()
+	copied := false
+	for _, rel := range files {
+		if !strings.HasPrefix(rel, objectsPrefix) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(sourceRoot, rel))
+		require.NoError(t, err)
+		dst := filepath.Join(recon, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, os.WriteFile(dst, data, 0o644))
+		copied = true
+	}
+	require.True(t, copied, "no objects-bucket segment was listed for the snapshot")
+
+	logger := logrus.New()
+	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx, filepath.Join(recon, "lsm", "objects"), "",
+		logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+
+	key, err := uuid.MustParse(id.String()).MarshalBinary()
+	require.NoError(t, err)
+	val, err := bucket.Get(key)
+	require.NoError(t, err)
+	return val != nil
+}
+
+func putSharedHaltObject(t *testing.T, index *Index, id strfmt.UUID, docID uint64) {
+	t.Helper()
+	require.NoError(t, index.IncomingPutObject(context.Background(), "shard1", &storobj.Object{
+		MarshallerVersion: 1,
+		DocID:             docID,
+		Object: models.Object{
+			ID:    id,
+			Class: "TestClass",
+		},
+	}, 0))
+}
+
+// newSharedHaltTestShard builds a real Index+Shard+LSM store (single HOT tenant),
+// mirroring the harness in replica_snapshot_concurrent_test.go.
+func newSharedHaltTestShard(t *testing.T) (*Index, *Shard) {
+	t.Helper()
+
+	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
+	mockSchemaGetter.On("NodeName").Return("node1")
+
+	class := &models.Class{
+		Class:               "TestClass",
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+		MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+	}
+	mockSchemaGetter.On("ReadOnlyClass", "TestClass").Return(class).Maybe()
+
+	logger := logrus.New()
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+	ss := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"shard1": {
+				Name:           "shard1",
+				BelongsToNodes: []string{"node1"},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+		PartitioningEnabled: true,
+	}
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ string, _ bool, readFunc func(*models.Class, *sharding.State) error) error {
+			return readFunc(class, ss)
+		}).Maybe()
+
+	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
+
+	index, err := NewIndex(context.Background(), IndexConfig{
+		ClassName:         schema.ClassName("TestClass"),
+		RootPath:          t.TempDir(),
+		ReplicationFactor: 1,
+		ShardLoadLimiter:  loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		hnsw.NewDefaultUserConfig(), nil, nil, shardResolver, mockSchemaGetter, mockSchemaReader,
+		nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
+		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+	require.NoError(t, err)
+	index.db = stubDBWithNoLiveReindex()
+
+	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+	require.NoError(t, err)
+	index.shards.Store("shard1", shard)
+
+	return index, shard
+}

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -72,11 +72,10 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 		s.mayStopAsyncReplication()
 	}
 
-	if s.haltForTransferCount > 1 {
-		// shard was already halted
-		return nil
-	}
-
+	// Placed before the pause branch so it also covers count>1 callers: on error
+	// mayForceResumeMaintenanceCycles(ctx, false) decrements our own increment and
+	// only truly resumes at count==0, so a failed count>1 caller rolls back 2→1
+	// without unhalting the shard the first op still holds.
 	defer func() {
 		if err != nil {
 			// each preparation step below wraps its own error; only append
@@ -87,15 +86,28 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 		}
 	}()
 
-	if err = s.store.PauseCompaction(innerCtx); err != nil {
-		return fmt.Errorf("pause compaction: %w", err)
+	// Pause steps run only on the first halt. Re-pausing per halt would strand the
+	// per-bucket pause-timer refcount (1 pause : 1 stop) and never observe the
+	// Prometheus pause-duration timer.
+	if s.haltForTransferCount == 1 {
+		if err = s.store.PauseCompaction(innerCtx); err != nil {
+			return fmt.Errorf("pause compaction: %w", err)
+		}
+		if err = s.cycleCallbacks.vectorCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
+			return fmt.Errorf("pause vector maintenance: %w", err)
+		}
+		if err = s.cycleCallbacks.geoPropsCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
+			return fmt.Errorf("pause geo props maintenance: %w", err)
+		}
+	} else {
+		s.index.logger.WithField("shard", s.name).
+			Debugf("shard already halted for transfer (count=%d); re-sealing state on shared halt", s.haltForTransferCount)
 	}
-	if err = s.cycleCallbacks.vectorCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
-		return fmt.Errorf("pause vector maintenance: %w", err)
-	}
-	if err = s.cycleCallbacks.geoPropsCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
-		return fmt.Errorf("pause geo props maintenance: %w", err)
-	}
+
+	// Seal steps run on EVERY halt: a second consumer's snapshot deliberately
+	// excludes the active memtable/WAL and the active HNSW commit-log, so any
+	// write that landed after the first consumer's flush must be re-sealed here or
+	// it is silently dropped from the second consumer's snapshot.
 
 	// get the queues ready for backup (e.g. enable maintenance mode, switch to new chunks)
 	_ = s.ForEachVectorQueue(func(targetVector string, q *VectorIndexQueue) error {


### PR DESCRIPTION
When two data-transfer operations overlapped on the same shard (for example two replica copies during scale-out, or a backup started during a copy), the second operation could take an incomplete snapshot and silently lose a write that the client had already been told was saved. This change makes every transfer flush the shard's in-memory state to disk before its snapshot is taken, so the second operation's copy is always complete.

### What's being changed

- `HaltForTransfer` used to prepare the shard (flush in-memory data, seal the vector index's log) only for the first caller; any overlapping caller got no preparation at all. Now the sealing steps run for every caller, while the pause steps (stopping compaction and maintenance) still run only once so pausing and resuming stay balanced.
- If preparation fails for an overlapping caller, the shard now correctly stays halted for the first caller instead of being released early.
- Two debug logs are added so this situation is visible in future investigations: one when a transfer joins a shard that is already halted, and one when a replica snapshot is created (operation id, shard, and file count).
- A new regression test reproduces the exact overlap deterministically, without relying on timing: it fails on the old code and passes with the fix, for both snapshot modes (hardlinked files and files served directly from the shard).


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
