### PR TITLE
reindex: signpost the DELETE reversal endpoint on disable-shaped 400 (0-weaviate-issues#316)

### DIFF
--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -939,8 +939,6 @@ func TestValidateBodyExclusivity(t *testing.T) {
 		},
 
 		// --- zero verbs --------------------------------------------------------
-		// Empty body or several present-but-verbless groups: no single disable
-		// target to signpost, so the generic verb list is returned.
 		{
 			name:    "reject: empty body (all groups nil)",
 			body:    &models.IndexUpdateRequest{},
@@ -955,9 +953,8 @@ func TestValidateBodyExclusivity(t *testing.T) {
 			},
 			wantErr: "no actionable change detected; set one of",
 		},
-		// A single present-but-verbless group reads as a "disable" intent. The
-		// PUT has no disable verb, so the 400 must signpost the DELETE reversal
-		// endpoint for that specific index (0-weaviate-issues#316).
+		// A verbless group reads as "disable" intent; the 400 must signpost the
+		// DELETE reversal endpoint, not the generic list (0-weaviate-issues#316).
 		{
 			name: "reject: searchable present but no verb set — signpost DELETE",
 			body: &models.IndexUpdateRequest{
@@ -1081,24 +1078,15 @@ func TestValidateBodyExclusivity(t *testing.T) {
 	}
 }
 
-// TestValidateBodyExclusivity_DisableSignpostsReversalEndpoint pins the
-// discoverability fix for 0-weaviate-issues#316: a natural-looking "disable"
-// call — a single index group present with no actionable verb, e.g.
-// {"rangeable":{"enabled":false}} — must not return the bare generic verb
-// list. It must name the exact DELETE endpoint that actually reverses the
-// index, so a caller (human or agent) is not misled into concluding the
-// index is a one-way migration with no rollback path.
-//
-// The reversal endpoint and its indexName enum are defined on
-// DELETE /v1/schema/{className}/properties/{propertyName}/index/{indexName}
-// (indexName one of filterable / searchable / rangeFilters) in
-// openapi-specs/schema.json.
+// Pins 0-weaviate-issues#316: a disable-shaped body (single verbless group,
+// e.g. {"rangeable":{"enabled":false}}) must name the DELETE reversal
+// endpoint instead of the generic verb list.
 func TestValidateBodyExclusivity_DisableSignpostsReversalEndpoint(t *testing.T) {
 	cases := []struct {
 		name         string
 		body         *models.IndexUpdateRequest
-		wantEndpoint string // the exact DELETE path the message must name
-		wantVerb     string // an accepted PUT verb the message must still list
+		wantEndpoint string
+		wantVerb     string
 	}{
 		{
 			name: "rangeable enabled=false points at the rangeFilters DELETE",
@@ -1131,14 +1119,9 @@ func TestValidateBodyExclusivity_DisableSignpostsReversalEndpoint(t *testing.T) 
 			err := validateBodyExclusivity(tc.body)
 			require.Error(t, err)
 			msg := err.Error()
-			// Still recognisable as the "no actionable change" family.
 			assert.Contains(t, msg, "no actionable change")
-			// Must name the exact DELETE reversal endpoint (the whole point).
 			assert.Contains(t, msg, tc.wantEndpoint,
 				"disable-intent 400 must signpost the DELETE reversal endpoint")
-			// Must not mislead: the reversal is a DELETE, and the PUT verbs
-			// that ARE accepted are listed so the caller knows this endpoint's
-			// real grammar.
 			assert.Contains(t, msg, "DELETE")
 			assert.Contains(t, msg, tc.wantVerb)
 		})

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -939,31 +939,45 @@ func TestValidateBodyExclusivity(t *testing.T) {
 		},
 
 		// --- zero verbs --------------------------------------------------------
+		// Empty body or several present-but-verbless groups: no single disable
+		// target to signpost, so the generic verb list is returned.
 		{
 			name:    "reject: empty body (all groups nil)",
 			body:    &models.IndexUpdateRequest{},
-			wantErr: "no actionable change",
+			wantErr: "no actionable change detected; set one of",
 		},
 		{
-			name: "reject: searchable present but no verb set",
+			name: "reject: all three groups present but verbless (generic message)",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{},
+				Filterable: &models.IndexUpdateFilterable{},
+				Rangeable:  &models.IndexUpdateRangeable{},
+			},
+			wantErr: "no actionable change detected; set one of",
+		},
+		// A single present-but-verbless group reads as a "disable" intent. The
+		// PUT has no disable verb, so the 400 must signpost the DELETE reversal
+		// endpoint for that specific index (0-weaviate-issues#316).
+		{
+			name: "reject: searchable present but no verb set — signpost DELETE",
 			body: &models.IndexUpdateRequest{
 				Searchable: &models.IndexUpdateSearchable{},
 			},
-			wantErr: "no actionable change",
+			wantErr: "DELETE /v1/schema/{className}/properties/{propertyName}/index/searchable",
 		},
 		{
-			name: "reject: filterable present but no verb set",
+			name: "reject: filterable present but no verb set — signpost DELETE",
 			body: &models.IndexUpdateRequest{
 				Filterable: &models.IndexUpdateFilterable{},
 			},
-			wantErr: "no actionable change",
+			wantErr: "DELETE /v1/schema/{className}/properties/{propertyName}/index/filterable",
 		},
 		{
-			name: "reject: rangeable present but enabled=false",
+			name: "reject: rangeable present but enabled=false — signpost DELETE",
 			body: &models.IndexUpdateRequest{
 				Rangeable: &models.IndexUpdateRangeable{Enabled: false},
 			},
-			wantErr: "no actionable change",
+			wantErr: "DELETE /v1/schema/{className}/properties/{propertyName}/index/rangeFilters",
 		},
 
 		// --- multiple groups ---------------------------------------------------
@@ -1063,6 +1077,70 @@ func TestValidateBodyExclusivity(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
 			}
+		})
+	}
+}
+
+// TestValidateBodyExclusivity_DisableSignpostsReversalEndpoint pins the
+// discoverability fix for 0-weaviate-issues#316: a natural-looking "disable"
+// call — a single index group present with no actionable verb, e.g.
+// {"rangeable":{"enabled":false}} — must not return the bare generic verb
+// list. It must name the exact DELETE endpoint that actually reverses the
+// index, so a caller (human or agent) is not misled into concluding the
+// index is a one-way migration with no rollback path.
+//
+// The reversal endpoint and its indexName enum are defined on
+// DELETE /v1/schema/{className}/properties/{propertyName}/index/{indexName}
+// (indexName one of filterable / searchable / rangeFilters) in
+// openapi-specs/schema.json.
+func TestValidateBodyExclusivity_DisableSignpostsReversalEndpoint(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         *models.IndexUpdateRequest
+		wantEndpoint string // the exact DELETE path the message must name
+		wantVerb     string // an accepted PUT verb the message must still list
+	}{
+		{
+			name: "rangeable enabled=false points at the rangeFilters DELETE",
+			body: &models.IndexUpdateRequest{
+				Rangeable: &models.IndexUpdateRangeable{Enabled: false},
+			},
+			wantEndpoint: "DELETE /v1/schema/{className}/properties/{propertyName}/index/rangeFilters",
+			wantVerb:     "rangeable.enabled=true",
+		},
+		{
+			name: "filterable verbless points at the filterable DELETE",
+			body: &models.IndexUpdateRequest{
+				Filterable: &models.IndexUpdateFilterable{},
+			},
+			wantEndpoint: "DELETE /v1/schema/{className}/properties/{propertyName}/index/filterable",
+			wantVerb:     "filterable.enabled=true",
+		},
+		{
+			name: "searchable verbless points at the searchable DELETE",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{},
+			},
+			wantEndpoint: "DELETE /v1/schema/{className}/properties/{propertyName}/index/searchable",
+			wantVerb:     "searchable.enabled=true",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBodyExclusivity(tc.body)
+			require.Error(t, err)
+			msg := err.Error()
+			// Still recognisable as the "no actionable change" family.
+			assert.Contains(t, msg, "no actionable change")
+			// Must name the exact DELETE reversal endpoint (the whole point).
+			assert.Contains(t, msg, tc.wantEndpoint,
+				"disable-intent 400 must signpost the DELETE reversal endpoint")
+			// Must not mislead: the reversal is a DELETE, and the PUT verbs
+			// that ARE accepted are listed so the caller knows this endpoint's
+			// real grammar.
+			assert.Contains(t, msg, "DELETE")
+			assert.Contains(t, msg, tc.wantVerb)
 		})
 	}
 }

--- a/adapters/handlers/rest/handlers_reindex.go
+++ b/adapters/handlers/rest/handlers_reindex.go
@@ -394,6 +394,46 @@ func validateBodyExclusivity(body *models.IndexUpdateRequest) error {
 		return fmt.Errorf("multiple index groups set in one request (%v) — issue separate requests, one per group", groupsSet)
 	}
 	if len(groupsSet) == 0 {
+		// Zero actionable verbs. Distinguish two shapes:
+		//
+		//  1. Exactly one index group was present but carried no verb — the
+		//     canonical case being {"rangeable":{"enabled":false}}. Enabled is
+		//     a plain bool with omitempty, so enabled:false is wire-identical
+		//     to an absent enabled; both land here. The natural intent behind
+		//     such a call is to DISABLE the index (enabled:true is the enable
+		//     call, so enabled:false reads as its symmetric inverse). This PUT
+		//     has no disable verb — reversal lives on a DIFFERENT URL, a DELETE
+		//     against the property's index. Naming that exact endpoint turns a
+		//     dead-end 400 into an actionable signpost. The old generic verb
+		//     list did not mention DELETE at all, which led a prod-scale QA
+		//     effort to conclude a built rangeable index was a one-way
+		//     migration with no rollback path (0-weaviate-issues#316); the
+		//     DELETE (shipped v1.36.0) fully reverses it.
+		//
+		//  2. Empty body, or several groups present-but-verbless — there is no
+		//     single disable target to name, so fall back to the generic verb
+		//     list below.
+		//
+		// The DELETE indexName enum (filterable / searchable / rangeFilters) is
+		// defined on DELETE /v1/schema/{className}/properties/{propertyName}/index/{indexName}
+		// in openapi-specs/schema.json.
+		switch {
+		case body.Rangeable != nil && body.Filterable == nil && body.Searchable == nil:
+			return fmt.Errorf("no actionable change detected in rangeable. " +
+				"To disable range filters (reverse enable-rangeable), use " +
+				"DELETE /v1/schema/{className}/properties/{propertyName}/index/rangeFilters. " +
+				"This PUT accepts only rangeable.enabled=true, rangeable.rebuild, or rangeable.cancel")
+		case body.Filterable != nil && body.Rangeable == nil && body.Searchable == nil:
+			return fmt.Errorf("no actionable change detected in filterable. " +
+				"To remove the filterable index, use " +
+				"DELETE /v1/schema/{className}/properties/{propertyName}/index/filterable. " +
+				"This PUT accepts only filterable.enabled=true, filterable.rebuild, filterable.tokenization, or filterable.cancel")
+		case body.Searchable != nil && body.Rangeable == nil && body.Filterable == nil:
+			return fmt.Errorf("no actionable change detected in searchable. " +
+				"To remove the searchable index, use " +
+				"DELETE /v1/schema/{className}/properties/{propertyName}/index/searchable. " +
+				"This PUT accepts only searchable.enabled=true, searchable.rebuild, searchable.algorithm, searchable.tokenization, or searchable.cancel")
+		}
 		// Keep this verb list in lockstep with the default-case 400
 		// in handlers_indexes.go::updateIndex.
 		return fmt.Errorf("no actionable change detected; set one of: " +

--- a/adapters/handlers/rest/handlers_reindex.go
+++ b/adapters/handlers/rest/handlers_reindex.go
@@ -394,29 +394,10 @@ func validateBodyExclusivity(body *models.IndexUpdateRequest) error {
 		return fmt.Errorf("multiple index groups set in one request (%v) — issue separate requests, one per group", groupsSet)
 	}
 	if len(groupsSet) == 0 {
-		// Zero actionable verbs. Distinguish two shapes:
-		//
-		//  1. Exactly one index group was present but carried no verb — the
-		//     canonical case being {"rangeable":{"enabled":false}}. Enabled is
-		//     a plain bool with omitempty, so enabled:false is wire-identical
-		//     to an absent enabled; both land here. The natural intent behind
-		//     such a call is to DISABLE the index (enabled:true is the enable
-		//     call, so enabled:false reads as its symmetric inverse). This PUT
-		//     has no disable verb — reversal lives on a DIFFERENT URL, a DELETE
-		//     against the property's index. Naming that exact endpoint turns a
-		//     dead-end 400 into an actionable signpost. The old generic verb
-		//     list did not mention DELETE at all, which led a prod-scale QA
-		//     effort to conclude a built rangeable index was a one-way
-		//     migration with no rollback path (0-weaviate-issues#316); the
-		//     DELETE (shipped v1.36.0) fully reverses it.
-		//
-		//  2. Empty body, or several groups present-but-verbless — there is no
-		//     single disable target to name, so fall back to the generic verb
-		//     list below.
-		//
-		// The DELETE indexName enum (filterable / searchable / rangeFilters) is
-		// defined on DELETE /v1/schema/{className}/properties/{propertyName}/index/{indexName}
-		// in openapi-specs/schema.json.
+		// A single group with no verb (incl. enabled:false, wire-identical to
+		// absent) reads as disable intent, but this PUT has no disable verb —
+		// only DELETE .../index/{indexName} reverses it. Name that endpoint
+		// here instead of falling through to the generic list (0-weaviate-issues#316).
 		switch {
 		case body.Rangeable != nil && body.Filterable == nil && body.Searchable == nil:
 			return fmt.Errorf("no actionable change detected in rangeable. " +

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -155,18 +155,24 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 			body: `{"searchable":`, wantStatus: http.StatusBadRequest,
 		},
 		{
+			// Several groups present but all verbless: no single disable
+			// target to signpost, so the generic verb list is returned.
 			name:       "no actionable flags",
 			collection: stClass, property: "text_word",
 			body:        `{"searchable":{},"filterable":{},"rangeable":{}}`,
 			wantStatus:  http.StatusBadRequest,
-			wantBodyHas: "no actionable change",
+			wantBodyHas: "no actionable change detected; set one of",
 		},
 		{
+			// A single group present with only false/absent verbs reads as a
+			// "disable" intent. The 400 must signpost the DELETE reversal
+			// endpoint for that index rather than the bare verb list
+			// (0-weaviate-issues#316).
 			name:       "explicitly false flags only",
 			collection: stClass, property: "text_word",
 			body:        `{"searchable":{"enabled":false,"rebuild":false}}`,
 			wantStatus:  http.StatusBadRequest,
-			wantBodyHas: "no actionable change",
+			wantBodyHas: "index/searchable",
 		},
 		{
 			name:       "unknown collection",

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -155,8 +155,6 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 			body: `{"searchable":`, wantStatus: http.StatusBadRequest,
 		},
 		{
-			// Several groups present but all verbless: no single disable
-			// target to signpost, so the generic verb list is returned.
 			name:       "no actionable flags",
 			collection: stClass, property: "text_word",
 			body:        `{"searchable":{},"filterable":{},"rangeable":{}}`,
@@ -164,10 +162,7 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 			wantBodyHas: "no actionable change detected; set one of",
 		},
 		{
-			// A single group present with only false/absent verbs reads as a
-			// "disable" intent. The 400 must signpost the DELETE reversal
-			// endpoint for that index rather than the bare verb list
-			// (0-weaviate-issues#316).
+			// Signposts the DELETE reversal endpoint (0-weaviate-issues#316).
 			name:       "explicitly false flags only",
 			collection: stClass, property: "text_word",
 			body:        `{"searchable":{"enabled":false,"rebuild":false}}`,


### PR DESCRIPTION
## Motivation

`PUT /v1/schema/{class}/indexes/{prop}` uses a verb-based grammar (`enabled:true` / `rebuild` / `cancel`). The natural-looking "disable rangeable" call —

```
PUT /v1/schema/{class}/indexes/{prop}   {"rangeable":{"enabled":false}}
```

— sets no verb, so the handler rejected it with a generic `400 "no actionable change detected"` that pointed at nothing. Because `{"rangeable":{"enabled":true}}` is the *enable* call, `{"enabled":false}` reads as its symmetric *disable* — but reversal actually lives on a **different URL**: the `DELETE .../index/rangeFilters` endpoint (shipped v1.36.0). The misleading 400 sent a prod-scale QA effort down a "rangeable is a one-way migration with no rollback path" dead end. Fixes [weaviate/0-weaviate-issues#316](https://github.com/weaviate/0-weaviate-issues/issues/316).

## Change

`validateBodyExclusivity` now detects the single-group-present-but-verbless shape and returns a targeted 400 that names the exact reversal endpoint plus the verbs this PUT *does* accept:

> no actionable change detected in rangeable. To disable range filters (reverse enable-rangeable), use DELETE /v1/schema/{className}/properties/{propertyName}/index/rangeFilters. This PUT accepts only rangeable.enabled=true, rangeable.rebuild, or rangeable.cancel

Covers all three index groups — rangeable / filterable / searchable — each pointing at its own `DELETE .../index/{rangeFilters|filterable|searchable}` (the `indexName` enum verified in `openapi-specs/schema.json`). Empty bodies and multi-group-verbless bodies keep the generic verb list unchanged.

`Enabled` is a plain `bool` with `omitempty`, so `enabled:false` is wire-identical to an absent `enabled`; both land in this branch and both get signposted.

## Tests

- Extend `TestValidateBodyExclusivity` for the three disable-intent shapes.
- Add `TestValidateBodyExclusivity_DisableSignpostsReversalEndpoint` asserting each group names its exact DELETE path and still lists the accepted PUT verbs.
- Update the `reindex_singlenode` api-validation acceptance cases.

## Scope

DX / discoverability only. The 400 message text changes; the reversal endpoint itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM
