### PR TITLE
perf(replication): make hashbeat FSM target gate allocation-free

### DIFF
--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -252,16 +252,23 @@ func (s *ShardReplicationFSM) HasActiveReplicationForCollection(collection strin
 	return false
 }
 
-func (s *ShardReplicationFSM) HasActiveTargetReplicationForShard(collection, shard, replica string) bool {
-	ops, ok := s.GetOpsForTargetNode(replica)
-	if !ok {
-		return false
-	}
-	for _, o := range ops {
-		if o.Op.TargetShard.CollectionId != collection || o.Op.TargetShard.ShardId != shard {
+// HasActiveTargetReplicationForShard is an eventually-consistent hint read from this
+// node's local FSM (bounded by RAFT apply lag), not a synchronization barrier. It is
+// polled on every hashbeat cycle of every shard and must stay allocation-free.
+func (s *ShardReplicationFSM) HasActiveTargetReplicationForShard(collection, shard, targetNode string) bool {
+	s.opsLock.RLock()
+	defer s.opsLock.RUnlock()
+
+	for _, op := range s.opsByCollectionAndShard[collection][shard] {
+		if op.TargetShard.NodeId != targetNode ||
+			op.TargetShard.CollectionId != collection || op.TargetShard.ShardId != shard {
 			continue
 		}
-		switch o.Status.GetCurrentState() {
+		status, ok := s.statusById[op.ID]
+		if !ok {
+			continue
+		}
+		switch status.GetCurrentState() {
 		case api.READY, api.CANCELLED:
 			// terminal — does not block async-repl gating
 		default:

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -259,9 +259,10 @@ func (s *ShardReplicationFSM) HasActiveTargetReplicationForShard(collection, sha
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
 
+	// The source-keyed bucket holds exactly the ops targeting (collection, shard):
+	// both op constructors build TargetShard from the source collection/shard.
 	for _, op := range s.opsByCollectionAndShard[collection][shard] {
-		if op.TargetShard.NodeId != targetNode ||
-			op.TargetShard.CollectionId != collection || op.TargetShard.ShardId != shard {
+		if op.TargetShard.NodeId != targetNode {
 			continue
 		}
 		status, ok := s.statusById[op.ID]

--- a/cluster/replication/shard_replication_fsm_test.go
+++ b/cluster/replication/shard_replication_fsm_test.go
@@ -456,12 +456,15 @@ func TestShardReplicationFSM_HasActiveTargetReplicationForShardDoesNotAllocate(t
 
 func TestShardReplicationFSM_HasActiveTargetReplicationForShardConcurrent(t *testing.T) {
 	const (
-		coll       = "TestClass"
-		writers    = 4
-		readers    = 4
-		iterations = 500
+		coll        = "TestClass"
+		writers     = 4
+		readers     = 4
+		iterations  = 500
+		pinnedShard = "pinned-shard"
 	)
 	fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+	seedOpFull(t, fsm, writers*iterations+1, "node1", "node2", coll, pinnedShard, api.COPY)
+	driveToState(t, fsm, writers*iterations+1, api.HYDRATING)
 
 	var eg errgroup.Group
 	for w := range writers {
@@ -505,11 +508,22 @@ func TestShardReplicationFSM_HasActiveTargetReplicationForShardConcurrent(t *tes
 				shard := fmt.Sprintf("shard-%d-%d", (r+i)%writers, i%iterations)
 				fsm.HasActiveTargetReplicationForShard(coll, shard, "node2")
 				fsm.HasActiveReplicationForShard(coll, shard)
+				if !fsm.HasActiveTargetReplicationForShard(coll, pinnedShard, "node2") {
+					return fmt.Errorf("expected pinned op on %q to gate replication", pinnedShard)
+				}
 			}
 			return nil
 		})
 	}
 	require.NoError(t, eg.Wait())
+
+	for w := range writers {
+		for i := range iterations {
+			shard := fmt.Sprintf("shard-%d-%d", w, i)
+			assert.Equal(t, i%2 != 0, fsm.HasActiveTargetReplicationForShard(coll, shard, "node2"))
+		}
+	}
+	assert.True(t, fsm.HasActiveTargetReplicationForShard(coll, pinnedShard, "node2"))
 }
 
 func BenchmarkHasActiveTargetReplicationForShard(b *testing.B) {

--- a/cluster/replication/shard_replication_fsm_test.go
+++ b/cluster/replication/shard_replication_fsm_test.go
@@ -12,11 +12,14 @@
 package replication_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/replication"
@@ -286,4 +289,259 @@ func TestShardReplicationFSM_RemoveOneOfTwoTargetOps(t *testing.T) {
 	require.Empty(t, fsm.GetOpsForTarget("node2"))
 	require.Equal(t, []string{"node2"}, fsm.FilterOneShardReplicasRead(coll, shard, replicas))
 	require.Equal(t, []string{"node2"}, fsm.FilterOneShardReplicasWrite(coll, shard, replicas))
+}
+
+func TestShardReplicationFSM_HasActiveTargetReplicationForShard(t *testing.T) {
+	const (
+		coll  = "TestClass"
+		shard = "shard1"
+	)
+
+	cases := []struct {
+		name     string
+		seed     func(t *testing.T, fsm *replication.ShardReplicationFSM)
+		replica  string
+		expected bool
+	}{
+		{name: "empty fsm", seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {}, replica: "node2", expected: false},
+		{
+			name: "op targets another node",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node3", coll, shard, api.COPY)
+			},
+			replica: "node2", expected: false,
+		},
+		{
+			name: "op on another collection",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", "OtherClass", shard, api.COPY)
+			},
+			replica: "node2", expected: false,
+		},
+		{
+			name: "op on another shard",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, "other-shard", api.COPY)
+			},
+			replica: "node2", expected: false,
+		},
+		{
+			name: "op is REGISTERED",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+			},
+			replica: "node2", expected: true,
+		},
+		{
+			name: "op is HYDRATING",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				driveToState(t, fsm, 1, api.HYDRATING)
+			},
+			replica: "node2", expected: true,
+		},
+		{
+			name: "op is FINALIZING",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				driveToState(t, fsm, 1, api.FINALIZING)
+			},
+			replica: "node2", expected: true,
+		},
+		{
+			name: "op is INTEGRATING",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				driveToState(t, fsm, 1, api.INTEGRATING)
+			},
+			replica: "node2", expected: true,
+		},
+		{
+			name: "op is DEHYDRATING",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.MOVE)
+				driveToState(t, fsm, 1, api.DEHYDRATING)
+			},
+			replica: "node2", expected: true,
+		},
+		{
+			name: "op is READY",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				driveToState(t, fsm, 1, api.READY)
+			},
+			replica: "node2", expected: false,
+		},
+		{
+			name: "op is CANCELLED",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				driveToCancelled(t, fsm, 1)
+			},
+			replica: "node2", expected: false,
+		},
+		{
+			name: "op is READY and marked for deletion",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				uuid := seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				driveToState(t, fsm, 1, api.READY)
+				require.NoError(t, fsm.DeleteReplication(&api.ReplicationDeleteRequest{
+					Version: api.ReplicationCommandVersionV0,
+					Uuid:    uuid,
+				}))
+			},
+			replica: "node2", expected: false,
+		},
+		{
+			name: "queried replica is the source node",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+			},
+			replica: "node1", expected: false,
+		},
+		{
+			name: "active op beside terminal ops on same shard",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				driveToCancelled(t, fsm, 1)
+				seedOpFull(t, fsm, 2, "node1", "node3", coll, shard, api.COPY)
+				driveToState(t, fsm, 2, api.READY)
+				seedOpFull(t, fsm, 3, "node3", "node2", coll, shard, api.COPY)
+				driveToState(t, fsm, 3, api.HYDRATING)
+			},
+			replica: "node2", expected: true,
+		},
+		{
+			name: "op removed",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, 1, "node1", "node2", coll, shard, api.COPY)
+				require.NoError(t, fsm.RemoveReplicationOp(&api.ReplicationRemoveOpRequest{
+					Version: api.ReplicationCommandVersionV0,
+					Id:      1,
+				}))
+			},
+			replica: "node2", expected: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+			tt.seed(t, fsm)
+			assert.Equal(t, tt.expected, fsm.HasActiveTargetReplicationForShard(coll, shard, tt.replica))
+		})
+	}
+}
+
+func TestShardReplicationFSM_HasActiveTargetReplicationForShardDoesNotAllocate(t *testing.T) {
+	const (
+		coll   = "TestClass"
+		target = "node2"
+	)
+	fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+	for i := range 10_000 {
+		seedOpFull(t, fsm, uint64(i+1), "node1", target, coll, fmt.Sprintf("shard-%d", i), api.COPY)
+	}
+
+	require.Zero(t, testing.AllocsPerRun(100, func() {
+		fsm.HasActiveTargetReplicationForShard(coll, "shard-0", target)
+	}))
+	require.Zero(t, testing.AllocsPerRun(100, func() {
+		fsm.HasActiveTargetReplicationForShard(coll, "shard-0", "node3")
+	}))
+	require.Zero(t, testing.AllocsPerRun(100, func() {
+		fsm.HasActiveTargetReplicationForShard(coll, "no-such-shard", target)
+	}))
+}
+
+func TestShardReplicationFSM_HasActiveTargetReplicationForShardConcurrent(t *testing.T) {
+	const (
+		coll       = "TestClass"
+		writers    = 4
+		readers    = 4
+		iterations = 500
+	)
+	fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+
+	var eg errgroup.Group
+	for w := range writers {
+		eg.Go(func() error {
+			for i := range iterations {
+				id := uint64(w*iterations + i + 1)
+				shard := fmt.Sprintf("shard-%d-%d", w, i)
+				if err := fsm.Replicate(id, &api.ReplicationReplicateShardRequest{
+					Version:          api.ReplicationCommandVersionV0,
+					Uuid:             strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", id)),
+					SourceNode:       "node1",
+					SourceCollection: coll,
+					SourceShard:      shard,
+					TargetNode:       "node2",
+					TransferType:     api.COPY.String(),
+				}); err != nil {
+					return err
+				}
+				if err := fsm.UpdateReplicationOpStatus(&api.ReplicationUpdateOpStateRequest{
+					Version: api.ReplicationCommandVersionV0,
+					Id:      id,
+					State:   api.HYDRATING,
+				}); err != nil {
+					return err
+				}
+				if i%2 == 0 {
+					if err := fsm.RemoveReplicationOp(&api.ReplicationRemoveOpRequest{
+						Version: api.ReplicationCommandVersionV0,
+						Id:      id,
+					}); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+	}
+	for r := range readers {
+		eg.Go(func() error {
+			for i := range iterations * writers {
+				shard := fmt.Sprintf("shard-%d-%d", (r+i)%writers, i%iterations)
+				fsm.HasActiveTargetReplicationForShard(coll, shard, "node2")
+				fsm.HasActiveReplicationForShard(coll, shard)
+			}
+			return nil
+		})
+	}
+	require.NoError(t, eg.Wait())
+}
+
+func BenchmarkHasActiveTargetReplicationForShard(b *testing.B) {
+	const (
+		coll   = "TestClass"
+		target = "node2"
+	)
+	for _, n := range []int{10_000, 100_000} {
+		fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+		for i := range n {
+			id := uint64(i + 1)
+			require.NoError(b, fsm.Replicate(id, &api.ReplicationReplicateShardRequest{
+				Version:          api.ReplicationCommandVersionV0,
+				Uuid:             strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", id)),
+				SourceNode:       "node1",
+				SourceCollection: coll,
+				SourceShard:      fmt.Sprintf("shard-%d", i),
+				TargetNode:       target,
+				TransferType:     api.COPY.String(),
+			}))
+		}
+		b.Run(fmt.Sprintf("ops-%d/hit", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				fsm.HasActiveTargetReplicationForShard(coll, "shard-0", target)
+			}
+		})
+		b.Run(fmt.Sprintf("ops-%d/miss", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				fsm.HasActiveTargetReplicationForShard(coll, "no-such-shard", target)
+			}
+		})
+	}
 }

--- a/cluster/replication/types/replication_fsm_reader.go
+++ b/cluster/replication/types/replication_fsm_reader.go
@@ -22,5 +22,6 @@ type ReplicationFSMReader interface {
 	HasActiveReplicationForShard(collection string, shard string) bool
 	// HasActiveTargetReplicationForShard reports whether the FSM currently tracks any
 	// replication op for (collection, shard, targetNode) whose state is non-terminal.
+	// Eventually consistent with the RAFT log (local FSM read); not a synchronization barrier.
 	HasActiveTargetReplicationForShard(collection, shard, targetNode string) bool
 }


### PR DESCRIPTION
## Motivation

Production profiles from a v1.38.2 cluster showed `(*ShardReplicationFSM).getOpsWithStatus` dominating both the allocation and heap profiles: **85% of alloc_space (~136 TB cumulative)** and **23% of in-use heap (~11.7 GB)**, with pprof per-object size buckets of ~30–34 MB per call.

The cause is the async-replication hashbeat gate. `HasActiveTargetReplicationForShard` answers a per-shard boolean — "is this shard currently the target of a non-terminal replication op on this node?" — but was implemented via `GetOpsForTargetNode`, which materializes a fresh `[]ShardReplicationOpAndStatus` copy of **every op targeting the node cluster-wide** (~224 B/element), including terminal READY/CANCELLED ops that stay in the FSM until deleted. The gate is polled from every shard's `runHashbeatCycle` on every cycle, so with ~150k ops tracked (e.g. large-scale automated tenant movements) every cycle of every shard allocated a ~34 MB slice **while holding the FSM read lock**, producing multi-GB/s garbage, GC pressure, RSS inflation from large-object churn, and read-lock contention against RAFT apply.

## Approach

Answer the gate from the FSM's existing per-shard index instead: iterate `opsByCollectionAndShard[collection][shard]` (typically 0–2 entries) under the same `opsLock.RLock`, filter on `TargetShard.NodeId`, and check the status map directly — the exact pattern the sibling `HasActiveReplicationForShard` already uses. Zero allocations, O(ops on this one shard) instead of O(ops targeting the node).

Semantics are preserved exactly: same terminal-state set (READY/CANCELLED; DEHYDRATING remains active), same skip of ops missing a status, same collection/shard/replica match. The per-shard index is interchangeable with the per-target index for this query because `insertOpIntoFSM`/`removeReplicationOp` are the only index writers and keep both in sync, and source/target FQDNs always share collection+shard (a defensive target-side comparison is kept in the loop at zero cost). The gate remains what it always was — an eventually-consistent local FSM read polled per cycle, not a synchronization barrier — now documented in the godoc.

Benchmark (FSM seeded with N ops targeting the node):

| N | old | new |
|---|---|---|
| 10k | 511 µs/op, 2.4 MB/op, 1 alloc | 28 ns/op, 0 B, 0 allocs |
| 100k | 6.1 ms/op, 24 MB/op, 1 alloc | 28 ns/op, 0 B, 0 allocs |

## Key areas for review

- `cluster/replication/shard_replication_fsm.go:HasActiveTargetReplicationForShard` — the rewrite. The critical review question is semantic parity with the old `GetOpsForTargetNode`-based scan; the new table test pins the full op lifecycle.
- The RLock critical section shrinks from "copy ~150k structs" to "compare ≤ a few ops", so contention against `opsLock.Lock()` writers (RAFT apply) strictly improves. No new lock, no lock-ordering change.
- `getOpsWithStatus`/`GetOpsForTargetNode` and other callers are untouched — they genuinely need materialized lists and run at low frequency.

## Testing

- `TestShardReplicationFSM_HasActiveTargetReplicationForShard` — table test over the full lifecycle (all 5 non-terminal states → true; READY/CANCELLED/READY+marked-for-deletion/removed → false; wrong node/collection/shard → false; active op beside terminal ops → true; source-node-as-replica → false).
- `TestShardReplicationFSM_HasActiveTargetReplicationForShardDoesNotAllocate` — CI-enforced `testing.AllocsPerRun == 0` guard with 10k seeded ops, hit and miss paths. Fails on the old implementation (1 alloc, ~2.4 MB per run).
- `TestShardReplicationFSM_HasActiveTargetReplicationForShardConcurrent` — writers (Replicate/UpdateReplicationOpStatus/RemoveReplicationOp) vs readers under `-race`.
- `BenchmarkHasActiveTargetReplicationForShard` — numbers above.
- Full `./cluster/replication/...` with `-race`, plus the `test/acceptance/replication/async_replication` suite (3-node clusters, restarts) green against an image built from this branch.

## Notes / follow-ups

- `main` carries identical code and needs the same fix as a forward-port (deliberately deferred).
- The episode that produced the profiles implies ~150k replication ops resided in the FSM at capture time (later cleaned up — a fresh RAFT snapshot shows an empty FSM). Terminal-op residency and its cost to snapshots and query paths may deserve a separate cleanup-policy discussion.
- Local-only test-harness footgun found while validating: the async-replication suites `t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")`, silently overriding a caller-provided image; a stale local `weaviate/test-server` tag then runs the suite against the wrong binary. Harmless in CI (tag is always rebuilt), worth a separate test-infra tweak.

## Breaking changes

None. Read-path-only change to an FSM query; no RAFT apply/snapshot/wire changes.