### PR TITLE
ci: build the -race reindex test image once and share it across shards

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -761,9 +761,50 @@ jobs:
           max_attempts: ${{ env.retry_max_attempts }}
           command: ./test/run.sh ${{ matrix.test }}
           on_retry_command: ./test/run.sh --cleanup
+  # Build the -race weaviate/test-server image ONCE per run and hand it to the
+  # reindex matrix shards below. Previously every reindex shard rebuilt the same
+  # image inside its own job (~175s of duplicate work per shard, 12 shards), and
+  # the build-cache variance made the ~10-minute per-shard budget a coin flip
+  # (see 0-weaviate-issues#330). This job builds the image, exports it as a
+  # gzipped docker-save tarball, and uploads it as a run-scoped artifact; the
+  # shards download + `docker load` it and set TEST_WEAVIATE_IMAGE so
+  # build_weaviate_test_image (test/run.sh) skips the local build entirely.
+  # Artifact (not registry) keeps this fork-safe and portable across branches:
+  # no registry secrets, no Docker Hub tag pollution, works the same on main.
+  Build-Reindex-Test-Image:
+    name: reindex (build -race image)
+    runs-on: ubicloud-standard-4-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      # Must run WITHOUT TEST_WEAVIATE_IMAGE set, otherwise build_weaviate_test_image
+      # early-returns and never builds. This builds & tags weaviate/test-server (-race).
+      - name: Build the -race weaviate/test-server image
+        run: ./test/run.sh --build-test-image
+      - name: Export image to a tarball
+        run: docker save weaviate/test-server | gzip > /tmp/weaviate-test-server.tar.gz
+      - name: Upload image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: reindex-race-test-image
+          path: /tmp/weaviate-test-server.tar.gz
+          retention-days: 1
+
   Acceptance-Reindex-Tests:
     name: reindex (${{ matrix.name }})
     runs-on: ubicloud-standard-4-ubuntu-2404
+    needs: [Build-Reindex-Test-Image]
+    # Shared -race image built once by Build-Reindex-Test-Image above. Setting
+    # this makes build_weaviate_test_image (test/run.sh) skip the per-shard build
+    # and reuse the loaded image, collapsing shard wall-clock to test time only.
+    env:
+      TEST_WEAVIATE_IMAGE: weaviate/test-server
     strategy:
       fail-fast: false
       matrix:
@@ -802,6 +843,13 @@ jobs:
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Download shared -race test image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: reindex-race-test-image
+          path: /tmp
+      - name: Load shared -race test image
+        run: docker load < /tmp/weaviate-test-server.tar.gz
       - name: Acceptance tests reindex
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:

--- a/test/run.sh
+++ b/test/run.sh
@@ -41,6 +41,7 @@ function main() {
   run_module_except_backup_tests=false
   run_module_except_offload_tests=false
   run_cleanup=false
+  build_test_image_only=false
   run_acceptance_go_client_named_vectors_single_node=false
   run_acceptance_go_client_named_vectors_cluster=false
   run_acceptance_lsmkv=false
@@ -119,6 +120,7 @@ function main() {
           --acceptance-reindex-backup|-arb) run_all_tests=false; run_acceptance_reindex_backup=true;;
           --benchmark-only|-b) run_all_tests=false; run_benchmark=true;;
           --cleanup) run_all_tests=false; run_cleanup=true;;
+          --build-test-image|-bti) run_all_tests=false; build_test_image_only=true;;
           --help|-h) printf '%s\n' \
               "Options:"\
               "--unit-only | -u"\
@@ -165,6 +167,7 @@ function main() {
               "--acceptance-reindex-concurrent | -arc"\
               "--acceptance-reindex-mt | -armt"\
               "--acceptance-reindex-backup | -arb"\
+              "--build-test-image | -bti"\
               "--only-acceptance-{packageName}"
               "--only-module-{moduleName}"
               "--benchmark-only | -b" \
@@ -325,6 +328,18 @@ function main() {
   if $run_cleanup; then
     echo_green "Cleaning up all running docker containers..."
     docker rm -f $(docker ps -a -q)
+  fi
+
+  # --build-test-image builds the -race weaviate/test-server image once and
+  # exits without running any tests. CI uses this in a single upstream job and
+  # shares the resulting image with the reindex matrix shards via a
+  # docker save/load artifact + TEST_WEAVIATE_IMAGE, so each shard skips its
+  # own (~175s) duplicate build. build_weaviate_test_image early-returns when
+  # TEST_WEAVIATE_IMAGE is already set, so this must run WITHOUT that env set.
+  if $build_test_image_only; then
+    build_weaviate_test_image
+    echo_green "Built ${TEST_WEAVIATE_IMAGE}; skipping tests (--build-test-image)."
+    return 0
   fi
 
   if $run_acceptance_lsmkv || $run_acceptance_tests || $run_all_tests; then


### PR DESCRIPTION
## Motivation

Every `reindex (…)` matrix shard rebuilds the **same** `-race`
`weaviate/test-server` image inside its own job. `test/run.sh`'s
`build_weaviate_test_image` runs a full `docker compose … build --build-arg
EXTRA_BUILD_ARGS=-race` per shard. With 12 shards that is 12 copies of one
identical build per push.

Two concrete costs, both filed with receipts in
[weaviate/0-weaviate-issues#330](https://github.com/weaviate/0-weaviate-issues/issues/330):

- **Duplicate compute.** ~175s of build per shard × 11 redundant shards ≈ 32
  minutes of runner-time burned per run on work that produces one image.
- **Budget noise.** The build-cache state makes per-shard wall-clock swing
  ~±90s run-to-run with identical content (`multinode-changetok` measured
  10m27s vs 10m56s with the same 62s test; `multinode-restart-b` swung 9m40s →
  10m39s). That turns the ~10-minute per-shard budget into a coin flip and
  already burned two rebalance iterations fitting placement to noise.

### Baseline per-shard wall-clock (run [29513643836](https://github.com/weaviate/weaviate/actions/runs/29513643836))

Each shard's duration below includes the ~290s fixed tax (image build +
compile + container setup), of which the `-race` image build is ~175s.

| shard | wall-clock | shard | wall-clock |
|---|---|---|---|
| multinode-restart-a | 13m04s | multinode | 9m28s |
| multinode-scale | 11m27s | multinode-changetok | 8m15s |
| singlenode-a | 10m48s | backup | 7m56s |
| multinode-aj | 10m03s | concurrent | 7m52s |
| multinode-rm | 9m26s | multinode-restart-b | 7m51s |
| singlenode-b | 6m56s | mt | 5m45s |

Sum ≈ 109 minutes of runner-compute per run; the shards near ~10–11m are the
ones whose budget the build variance makes meaningless.

## Design

Build the `-race` image **once** per run and hand it to the shards.

1. **New `test/run.sh` flag `--build-test-image` (`-bti`).** Builds the `-race`
   `weaviate/test-server` image (via the existing `build_weaviate_test_image`)
   and exits without running tests. This keeps a single source of truth for how
   the image is built, so the upstream job and local dev stay identical.
2. **New upstream job `Build-Reindex-Test-Image`.** Runs `./test/run.sh
   --build-test-image`, then `docker save weaviate/test-server | gzip` and
   uploads it as a run-scoped artifact (`retention-days: 1`).
3. **Reindex shards gain `needs: [Build-Reindex-Test-Image]` + `env:
   TEST_WEAVIATE_IMAGE: weaviate/test-server`**, plus two steps that
   `download-artifact` and `docker load` the image. `build_weaviate_test_image`
   already early-returns when `TEST_WEAVIATE_IMAGE` is set, so **all 12 shard
   functions skip their local build with no per-function change** (verified: all
   twelve `run_acceptance_reindex_*` call `build_weaviate_test_image` first).

### Why an artifact and not the registry

The existing `PR-Docker-Build` / `Multi-Arch-Docker-Build` jobs push the
**production** image (`CGO_ENABLED=0`, no `-race`) to
`semitechnologies/weaviate`. The reindex tests need the `-race` build, so that
pushed image cannot be reused. A dedicated `-race` build is required either way.
Given that, an artifact is the smaller, more portable choice:

- **Fork-safe.** No registry secrets, so fork PRs (which already run reindex by
  building locally) keep working.
- **No Docker Hub tag pollution / cleanup.** The image lives 1 day as a
  run-scoped artifact.
- **Portable to `main`.** No coupling to `push_docker.sh`'s tag scheme, so the
  same diff applies to `main` unchanged (this targets `stable/v1.38` where the
  GA shards live).

testcontainers uses the locally-present image (no force-pull; `weaviate/test-server`
is never in any registry today and the current CI already depends on this), so
`docker load` + `TEST_WEAVIATE_IMAGE=weaviate/test-server` behaves exactly like
today's local build.

## Expected effect

- **Duplicate build compute removed:** 11 × ~175s ≈ **~32 min/run** of runner
  time (one build now, not twelve).
- **Per-shard reported duration collapses to test + setup** (no build), so the
  ~10-minute budget becomes meaningful and the ±90s cache variance disappears.
- **Trade-off (named honestly):** the single build is now a serial upstream step
  (~4 min incl. checkout + `-race` compile), and each shard adds ~40s of
  download + `docker load`. Net time-to-green on the critical-path shard is
  roughly flat to ~+1–2 min, traded for the compute and variance wins above.
  This is the "build-once first, then re-measure" path; the numbers below decide
  whether a first-shard-builds variant is worth the extra complexity.

## Validation

- `bash -n test/run.sh` clean; `actionlint` on the workflow adds **zero** new
  findings vs the base branch (only the pre-existing `ubicloud-*` custom-label
  false positive, once, for the new job's `runs-on`).
- Dry-runs with a stubbed `docker`: `--build-test-image` with no
  `TEST_WEAVIATE_IMAGE` issues exactly one `docker compose … build …
  EXTRA_BUILD_ARGS=-race weaviate` then exits; with `TEST_WEAVIATE_IMAGE`
  preset it issues **zero** build calls (the shard path).
- The real proof is **this PR's own CI run** — it exercises the build-once job
  and all 12 shards end-to-end.

## Re-measure plan

Compare this PR's reindex shard wall-clocks against baseline run
[29513643836](https://github.com/weaviate/weaviate/actions/runs/29513643836).
Expect each shard to drop by roughly the build time and the run-to-run variance
to collapse to test-execution time. Only if `restart-a` / `singlenode-a` are
**still >10m** after this change do we split them further — that decision now
rests on build-free, lower-variance numbers.

Refs: [weaviate/0-weaviate-issues#330](https://github.com/weaviate/0-weaviate-issues/issues/330)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM
