### PR TITLE
Fix reindex progress freeze after crash-resume (0-wi#317)

### DIFF
--- a/adapters/repos/db/inverted_reindex_resume_progress_test.go
+++ b/adapters/repos/db/inverted_reindex_resume_progress_test.go
@@ -1,0 +1,206 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestReindexTracker_GetProcessedObjectCount_SumsCheckpoints pins the
+// contract getProcessedObjectCount relies on: the cumulative processed
+// count is the SUM of every checkpoint's per-chunk "all N" count, not the
+// last checkpoint's count. markProgress writes one file per chunk with that
+// chunk's local count (it resets to 0 each OnAfterLsmInitAsync invocation),
+// so summing is the only way to recover cumulative progress after a resume.
+// weaviate/0-weaviate-issues#317.
+func TestReindexTracker_GetProcessedObjectCount_SumsCheckpoints(t *testing.T) {
+	keyParser := &UuidKeyParser{}
+	newKey := func() indexKey {
+		b, err := uuid.New().MarshalBinary()
+		require.NoError(t, err)
+		return keyParser.FromBytes(b)
+	}
+
+	tr := NewFileReindexTracker(t.TempDir(), "resume_progress_sum", keyParser)
+	require.NoError(t, tr.init())
+
+	// Fresh tracker, no checkpoints yet → 0.
+	got, err := tr.getProcessedObjectCount()
+	require.NoError(t, err)
+	require.Equal(t, 0, got, "no checkpoints must report zero processed objects")
+
+	// Chunk 1 processed 40 objects; chunk 2 processed a further 8. Each
+	// markProgress records that chunk's LOCAL count (40, then 8).
+	require.NoError(t, tr.markProgress(newKey(), 40, 40))
+	require.NoError(t, tr.markProgress(newKey(), 8, 8))
+
+	got, err = tr.getProcessedObjectCount()
+	require.NoError(t, err)
+	require.Equalf(t, 48, got,
+		"getProcessedObjectCount must SUM per-chunk checkpoints (40+8=48), not "+
+			"return the last chunk's count (8); got %d", got)
+}
+
+// TestReindexResumeProgress_AdvancesFromCheckpoint is the regression test
+// for weaviate/0-weaviate-issues#317: after a crash mid-reindex, the
+// resumed scan restarts from the persisted checkpoint key, but the live
+// /v1/tasks progress used to freeze at the pre-crash checkpoint value and
+// then jump to completion in one step.
+//
+// Root cause: the reindex loop reports progress as
+// (this-invocation processedCount) / totalObjects, and processedCount
+// resets to 0 every time OnAfterLsmInitAsync is (re-)entered. On resume the
+// emitted fraction therefore restarts near 0; because the FSM stores unit
+// progress monotonically (cluster/distributedtask.Manager.UpdateUnitProgress
+// drops regressions), the displayed value sticks at the checkpoint until the
+// resumed scan re-crosses it — which, for a late checkpoint, never happens
+// before completion. Operators cannot distinguish this freeze from a hang.
+//
+// The fix makes the numerator cumulative (baseline from prior checkpoints +
+// this invocation's processedCount), so the resumed scan reports at the same
+// granularity as a fresh scan.
+//
+// This test drives a real RoaringSetRefresh migration on an in-memory shard:
+//
+//	Phase 1 processes ~checkpointPct of the objects and stops WITHOUT
+//	        finishing (processingDuration=1ns forces a break at the first
+//	        checkProcessingEveryNoObjects boundary), persisting a checkpoint
+//	        — exactly the on-disk state a SIGKILL mid-build leaves behind.
+//	Phase 2 installs a progress callback and drives the resumed scan to
+//	        completion, capturing every emitted fraction.
+//
+// The captured sequence pins the operator-visible invariant: resumed progress
+// is monotonic AND never regresses below the pre-crash checkpoint fraction.
+// Pre-fix, phase 2's first emission is ~1/N (near zero), so both assertions
+// fail — precisely the "frozen then jump" symptom from the issue.
+func TestReindexResumeProgress_AdvancesFromCheckpoint(t *testing.T) {
+	const numObjects = 100
+
+	cases := []struct {
+		name string
+		// checkpointEvery is checkProcessingEveryNoObjects for phase 1; the
+		// scan breaks at the first multiple of it, so the checkpoint lands at
+		// ~checkpointEvery objects. Chosen to mirror the two crash points the
+		// issue reported (R2b ≈ 0.48, R2c ≈ 0.89).
+		checkpointEvery int
+	}{
+		{name: "checkpoint_at_~48pct_R2b", checkpointEvery: 48},
+		{name: "checkpoint_at_~89pct_R2c", checkpointEvery: 89},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			const propName = "title"
+			className := "ResumeProgress_" + uuid.NewString()[:8]
+			class := newTestClassWithProps(className, []string{propName})
+
+			shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+				false, false, false)
+			shard := shd.(*Shard)
+			defer shard.Shutdown(ctx)
+
+			for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
+				require.NoError(t, shard.PutObject(ctx, obj))
+			}
+			// Flush objects to disk so ObjectCountAsync (the progress
+			// denominator) sees all of them; it reads on-disk segments only.
+			require.NoError(t, shard.store.Bucket(helpers.ObjectsBucketLSM).FlushAndSwitch())
+
+			task, _ := newRoaringSetRefreshTask(t, idx)
+			require.NoError(t, task.OnAfterLsmInit(ctx, shard))
+
+			// --- Phase 1: pre-crash. Process ~checkpointEvery objects, then
+			// break without finishing, persisting a checkpoint. No callback
+			// installed — we only care about the resumed emissions.
+			task.config.checkProcessingEveryNoObjects = tc.checkpointEvery
+			task.config.processingDuration = time.Nanosecond
+			rerunAt, _, err := task.OnAfterLsmInitAsync(ctx, shard)
+			require.NoError(t, err)
+			require.Falsef(t, rerunAt.IsZero(),
+				"phase 1 must break mid-scan (not finish) so there is a resume to test")
+
+			// Read the persisted baseline via the same path the fix uses.
+			rt, err := task.newReindexTracker(shard.pathLSM())
+			require.NoError(t, err)
+			baseline, err := rt.getProcessedObjectCount()
+			require.NoError(t, err)
+			require.Greaterf(t, baseline, 0,
+				"phase 1 must persist a non-zero checkpoint; got baseline=%d", baseline)
+			require.Lessf(t, baseline, numObjects,
+				"phase 1 must NOT finish the whole scan; got baseline=%d of %d", baseline, numObjects)
+			checkpointFraction := float32(baseline) / float32(numObjects)
+			t.Logf("phase 1 checkpoint: %d/%d objects (fraction %.4f)",
+				baseline, numObjects, checkpointFraction)
+
+			// --- Phase 2: resume. Emit progress for every object and run to
+			// completion, capturing the fractions.
+			task.config.checkProcessingEveryNoObjects = 1
+			task.config.processingDuration = 10 * time.Minute
+
+			var mu sync.Mutex
+			var got []float32
+			task.SetProgressCallback(func(p float32) {
+				mu.Lock()
+				got = append(got, p)
+				mu.Unlock()
+			})
+
+			for {
+				rerunAt, _, err := task.OnAfterLsmInitAsync(ctx, shard)
+				require.NoError(t, err)
+				if rerunAt.IsZero() {
+					break
+				}
+			}
+
+			require.NotEmpty(t, got, "resumed scan must emit progress")
+
+			// Invariant 1: progress is monotonic non-decreasing — the operator
+			// never sees the bar go backwards.
+			for i := 1; i < len(got); i++ {
+				require.GreaterOrEqualf(t, got[i], got[i-1],
+					"progress regressed at emission %d: %v", i, got)
+			}
+
+			// Invariant 2 (the fix): the FIRST resumed emission already reflects
+			// the pre-crash checkpoint — it does not restart near zero. Pre-fix
+			// got[0] ≈ 1/N, far below checkpointFraction, so this fails.
+			require.GreaterOrEqualf(t, got[0], checkpointFraction,
+				"resumed progress restarted below the pre-crash checkpoint "+
+					"(got[0]=%.4f, checkpoint=%.4f) — the /v1/tasks freeze-then-jump bug. "+
+					"full sequence: %v", got[0], checkpointFraction, got)
+
+			// Invariant 3 ("verified not a hang"): progress visibly advances
+			// during the resumed work and climbs to near-complete. Pre-fix, for
+			// the late (89%) checkpoint the emitted max never exceeds ~0.11.
+			last := got[len(got)-1]
+			require.Greaterf(t, last, got[0],
+				"resumed progress did not advance during the rebuild (stuck at %.4f) — "+
+					"indistinguishable from a hang", got[0])
+			require.GreaterOrEqualf(t, last, float32(0.9),
+				"resumed progress did not climb to near-complete; final=%.4f, sequence=%v",
+				last, got)
+
+			t.Logf("resume emitted %d fractions: first=%.4f last=%.4f",
+				len(got), got[0], last)
+		})
+	}
+}

--- a/adapters/repos/db/inverted_reindex_resume_progress_test.go
+++ b/adapters/repos/db/inverted_reindex_resume_progress_test.go
@@ -23,13 +23,7 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// TestReindexTracker_GetProcessedObjectCount_SumsCheckpoints pins the
-// contract getProcessedObjectCount relies on: the cumulative processed
-// count is the SUM of every checkpoint's per-chunk "all N" count, not the
-// last checkpoint's count. markProgress writes one file per chunk with that
-// chunk's local count (it resets to 0 each OnAfterLsmInitAsync invocation),
-// so summing is the only way to recover cumulative progress after a resume.
-// weaviate/0-weaviate-issues#317.
+// Pins getProcessedObjectCount's contract: sum per-chunk counts, not just the last checkpoint's.
 func TestReindexTracker_GetProcessedObjectCount_SumsCheckpoints(t *testing.T) {
 	keyParser := &UuidKeyParser{}
 	newKey := func() indexKey {
@@ -46,8 +40,7 @@ func TestReindexTracker_GetProcessedObjectCount_SumsCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, got, "no checkpoints must report zero processed objects")
 
-	// Chunk 1 processed 40 objects; chunk 2 processed a further 8. Each
-	// markProgress records that chunk's LOCAL count (40, then 8).
+	// Two checkpoints (40, then 8) to verify summation, not last-value.
 	require.NoError(t, tr.markProgress(newKey(), 40, 40))
 	require.NoError(t, tr.markProgress(newKey(), 8, 8))
 
@@ -58,47 +51,14 @@ func TestReindexTracker_GetProcessedObjectCount_SumsCheckpoints(t *testing.T) {
 			"return the last chunk's count (8); got %d", got)
 }
 
-// TestReindexResumeProgress_AdvancesFromCheckpoint is the regression test
-// for weaviate/0-weaviate-issues#317: after a crash mid-reindex, the
-// resumed scan restarts from the persisted checkpoint key, but the live
-// /v1/tasks progress used to freeze at the pre-crash checkpoint value and
-// then jump to completion in one step.
-//
-// Root cause: the reindex loop reports progress as
-// (this-invocation processedCount) / totalObjects, and processedCount
-// resets to 0 every time OnAfterLsmInitAsync is (re-)entered. On resume the
-// emitted fraction therefore restarts near 0; because the FSM stores unit
-// progress monotonically (cluster/distributedtask.Manager.UpdateUnitProgress
-// drops regressions), the displayed value sticks at the checkpoint until the
-// resumed scan re-crosses it — which, for a late checkpoint, never happens
-// before completion. Operators cannot distinguish this freeze from a hang.
-//
-// The fix makes the numerator cumulative (baseline from prior checkpoints +
-// this invocation's processedCount), so the resumed scan reports at the same
-// granularity as a fresh scan.
-//
-// This test drives a real RoaringSetRefresh migration on an in-memory shard:
-//
-//	Phase 1 processes ~checkpointPct of the objects and stops WITHOUT
-//	        finishing (processingDuration=1ns forces a break at the first
-//	        checkProcessingEveryNoObjects boundary), persisting a checkpoint
-//	        — exactly the on-disk state a SIGKILL mid-build leaves behind.
-//	Phase 2 installs a progress callback and drives the resumed scan to
-//	        completion, capturing every emitted fraction.
-//
-// The captured sequence pins the operator-visible invariant: resumed progress
-// is monotonic AND never regresses below the pre-crash checkpoint fraction.
-// Pre-fix, phase 2's first emission is ~1/N (near zero), so both assertions
-// fail — precisely the "frozen then jump" symptom from the issue.
+// Regression test for weaviate/0-weaviate-issues#317: resumed reindex
+// progress must not restart near 0 / freeze at the pre-crash checkpoint.
 func TestReindexResumeProgress_AdvancesFromCheckpoint(t *testing.T) {
 	const numObjects = 100
 
 	cases := []struct {
 		name string
-		// checkpointEvery is checkProcessingEveryNoObjects for phase 1; the
-		// scan breaks at the first multiple of it, so the checkpoint lands at
-		// ~checkpointEvery objects. Chosen to mirror the two crash points the
-		// issue reported (R2b ≈ 0.48, R2c ≈ 0.89).
+		// checkProcessingEveryNoObjects for phase 1; checkpoint lands at ~checkpointEvery objects.
 		checkpointEvery int
 	}{
 		{name: "checkpoint_at_~48pct_R2b", checkpointEvery: 48},
@@ -120,16 +80,13 @@ func TestReindexResumeProgress_AdvancesFromCheckpoint(t *testing.T) {
 			for _, obj := range makeConvergenceTestObjects(t, numObjects, className) {
 				require.NoError(t, shard.PutObject(ctx, obj))
 			}
-			// Flush objects to disk so ObjectCountAsync (the progress
-			// denominator) sees all of them; it reads on-disk segments only.
+			// Flush so ObjectCountAsync (reads on-disk segments only) sees all objects.
 			require.NoError(t, shard.store.Bucket(helpers.ObjectsBucketLSM).FlushAndSwitch())
 
 			task, _ := newRoaringSetRefreshTask(t, idx)
 			require.NoError(t, task.OnAfterLsmInit(ctx, shard))
 
-			// --- Phase 1: pre-crash. Process ~checkpointEvery objects, then
-			// break without finishing, persisting a checkpoint. No callback
-			// installed — we only care about the resumed emissions.
+			// --- Phase 1: process ~checkpointEvery objects, then break (persists a checkpoint).
 			task.config.checkProcessingEveryNoObjects = tc.checkpointEvery
 			task.config.processingDuration = time.Nanosecond
 			rerunAt, _, err := task.OnAfterLsmInitAsync(ctx, shard)
@@ -150,8 +107,7 @@ func TestReindexResumeProgress_AdvancesFromCheckpoint(t *testing.T) {
 			t.Logf("phase 1 checkpoint: %d/%d objects (fraction %.4f)",
 				baseline, numObjects, checkpointFraction)
 
-			// --- Phase 2: resume. Emit progress for every object and run to
-			// completion, capturing the fractions.
+			// --- Phase 2: resume; emit and capture progress for every object to completion.
 			task.config.checkProcessingEveryNoObjects = 1
 			task.config.processingDuration = 10 * time.Minute
 
@@ -173,24 +129,19 @@ func TestReindexResumeProgress_AdvancesFromCheckpoint(t *testing.T) {
 
 			require.NotEmpty(t, got, "resumed scan must emit progress")
 
-			// Invariant 1: progress is monotonic non-decreasing — the operator
-			// never sees the bar go backwards.
+			// Invariant 1: progress never regresses (monotonic).
 			for i := 1; i < len(got); i++ {
 				require.GreaterOrEqualf(t, got[i], got[i-1],
 					"progress regressed at emission %d: %v", i, got)
 			}
 
-			// Invariant 2 (the fix): the FIRST resumed emission already reflects
-			// the pre-crash checkpoint — it does not restart near zero. Pre-fix
-			// got[0] ≈ 1/N, far below checkpointFraction, so this fails.
+			// Invariant 2: the first resumed emission already reflects the pre-crash checkpoint.
 			require.GreaterOrEqualf(t, got[0], checkpointFraction,
 				"resumed progress restarted below the pre-crash checkpoint "+
 					"(got[0]=%.4f, checkpoint=%.4f) — the /v1/tasks freeze-then-jump bug. "+
 					"full sequence: %v", got[0], checkpointFraction, got)
 
-			// Invariant 3 ("verified not a hang"): progress visibly advances
-			// during the resumed work and climbs to near-complete. Pre-fix, for
-			// the late (89%) checkpoint the emitted max never exceeds ~0.11.
+			// Invariant 3: progress advances and climbs to near-complete (not a hang).
 			last := got[len(got)-1]
 			require.Greaterf(t, last, got[0],
 				"resumed progress did not advance during the rebuild (stuck at %.4f) — "+

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1403,9 +1403,26 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	// avoid a "100% — still working" UX glitch when drift makes processed
 	// briefly exceed total.
 	var totalObjects int64
+	// baselineProcessed is the number of objects already processed in prior
+	// scan invocations (checkpoints persisted before this one). On a fresh scan
+	// it is 0; on a crash-resume it equals the object count up to the checkpoint
+	// key this iteration resumes from. processedCount below is per-invocation
+	// (reset to 0 above), so the reported fraction must add this baseline to
+	// stay cumulative — otherwise the resumed scan reports a fraction that
+	// restarts near 0, and the monotonic /v1/tasks progress freezes at the
+	// pre-crash checkpoint until the resumed scan re-crosses it.
+	// weaviate/0-weaviate-issues#317.
+	var baselineProcessed int
 	if t.progressCallback != nil {
 		if n, countErr := shard.ObjectCountAsync(ctx); countErr == nil && n > 0 {
 			totalObjects = n
+		}
+		if migrated, migErr := rt.getProcessedObjectCount(); migErr == nil {
+			baselineProcessed = migrated
+		} else {
+			logger.WithField("last_stored_key", lastStoredKey).
+				Debugf("could not read baseline processed count for progress reporting, "+
+					"resumed progress may under-report until it re-crosses the checkpoint: %v", migErr)
 		}
 	}
 
@@ -1491,14 +1508,18 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 			lastProcessedKey = md.key
 
 			// Emit live progress every checkProcessingEveryNoObjects iterations.
-			// The denominator is the ObjectCountAsync estimate from above; the
-			// throttled recorder above this layer caps wire frequency. Clamp at
-			// 0.99 so we never appear "complete" until the loop actually ends —
+			// The numerator is cumulative (baselineProcessed from prior
+			// checkpoints + this invocation's processedCount) so a resumed scan
+			// keeps advancing from the pre-crash checkpoint instead of freezing
+			// there; the denominator is the ObjectCountAsync estimate from above;
+			// the throttled recorder above this layer caps wire frequency. Clamp
+			// at 0.99 so we never appear "complete" until the loop actually ends —
 			// the final 1.0 is emitted by RecordDistributedTaskUnitCompletion on
 			// success or carried by the FAILED status on error.
+			// weaviate/0-weaviate-issues#317.
 			if processedCount%t.config.checkProcessingEveryNoObjects == 0 {
 				if t.progressCallback != nil && totalObjects > 0 {
-					p := float32(processedCount) / float32(totalObjects)
+					p := float32(baselineProcessed+processedCount) / float32(totalObjects)
 					if p > 0.99 {
 						p = 0.99
 					}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1403,15 +1403,8 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	// avoid a "100% — still working" UX glitch when drift makes processed
 	// briefly exceed total.
 	var totalObjects int64
-	// baselineProcessed is the number of objects already processed in prior
-	// scan invocations (checkpoints persisted before this one). On a fresh scan
-	// it is 0; on a crash-resume it equals the object count up to the checkpoint
-	// key this iteration resumes from. processedCount below is per-invocation
-	// (reset to 0 above), so the reported fraction must add this baseline to
-	// stay cumulative — otherwise the resumed scan reports a fraction that
-	// restarts near 0, and the monotonic /v1/tasks progress freezes at the
-	// pre-crash checkpoint until the resumed scan re-crosses it.
-	// weaviate/0-weaviate-issues#317.
+	// baselineProcessed carries prior-checkpoint progress so a resumed scan's
+	// reported fraction doesn't restart near 0 and appear frozen.
 	var baselineProcessed int
 	if t.progressCallback != nil {
 		if n, countErr := shard.ObjectCountAsync(ctx); countErr == nil && n > 0 {
@@ -1508,15 +1501,13 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 			lastProcessedKey = md.key
 
 			// Emit live progress every checkProcessingEveryNoObjects iterations.
-			// The numerator is cumulative (baselineProcessed from prior
-			// checkpoints + this invocation's processedCount) so a resumed scan
-			// keeps advancing from the pre-crash checkpoint instead of freezing
-			// there; the denominator is the ObjectCountAsync estimate from above;
-			// the throttled recorder above this layer caps wire frequency. Clamp
-			// at 0.99 so we never appear "complete" until the loop actually ends —
-			// the final 1.0 is emitted by RecordDistributedTaskUnitCompletion on
-			// success or carried by the FAILED status on error.
-			// weaviate/0-weaviate-issues#317.
+			// Numerator includes baselineProcessed so resumed scans don't
+			// restart near 0; the denominator is the ObjectCountAsync estimate
+			// from above; the throttled recorder above this layer caps wire
+			// frequency. Clamp at 0.99 so we never appear "complete" until the
+			// loop actually ends — the final 1.0 is emitted by
+			// RecordDistributedTaskUnitCompletion on success or carried by the
+			// FAILED status on error.
 			if processedCount%t.config.checkProcessingEveryNoObjects == 0 {
 				if t.progressCallback != nil && totalObjects > 0 {
 					p := float32(baselineProcessed+processedCount) / float32(totalObjects)

--- a/adapters/repos/db/inverted_reindex_tracker.go
+++ b/adapters/repos/db/inverted_reindex_tracker.go
@@ -36,6 +36,7 @@ type reindexTracker interface {
 
 	markProgress(lastProcessedKey indexKey, processedCount, indexedCount int) error
 	GetProgress() (indexKey, *time.Time, error)
+	getProcessedObjectCount() (int, error)
 
 	IsReindexed() bool
 	markReindexed() error
@@ -234,6 +235,32 @@ func (t *fileReindexTracker) GetProgress() (indexKey, *time.Time, error) {
 
 	t.progressCheckpoint = checkpoint + 1
 	return key, &tm, nil
+}
+
+// getProcessedObjectCount returns the cumulative number of objects processed
+// across every persisted checkpoint — the sum of each checkpoint's "all N"
+// count written by [fileReindexTracker.markProgress]. On a fresh scan with no
+// checkpoints it returns 0.
+//
+// It exists to keep live reindex progress reporting cumulative across
+// crash-resumes and chunk boundaries. The iteration loop's per-invocation
+// processedCount resets to 0 every time
+// [ShardReindexTaskGeneric.OnAfterLsmInitAsync] is (re-)entered — including
+// after a crash-resume, which restarts the scan from the persisted checkpoint
+// key rather than from zero. Without a baseline, the reported fraction would
+// restart near 0 on resume; because the /v1/tasks unit progress is monotonic
+// (see cluster/distributedtask.Manager.UpdateUnitProgress), the displayed value
+// would then freeze at the pre-crash checkpoint until the resumed scan
+// re-crossed it and jump to completion in one step. Feeding this value into the
+// reported fraction makes resumed-scan progress advance at the same granularity
+// as a fresh scan. weaviate/0-weaviate-issues#317.
+//
+// The persisted per-checkpoint counts are deliberately left per-chunk (this
+// function sums them), so the on-disk progress-file format is unchanged and an
+// operator mid-reindex who upgrades still sums correctly.
+func (t *fileReindexTracker) getProcessedObjectCount() (int, error) {
+	total, _, err := t.GetMigratedCount()
+	return total, err
 }
 
 func (t *fileReindexTracker) parseProgressFile(filename string) (lastProcessedKey indexKey, tm time.Time, allCount int, idxCount int, err error) {

--- a/adapters/repos/db/inverted_reindex_tracker.go
+++ b/adapters/repos/db/inverted_reindex_tracker.go
@@ -237,27 +237,9 @@ func (t *fileReindexTracker) GetProgress() (indexKey, *time.Time, error) {
 	return key, &tm, nil
 }
 
-// getProcessedObjectCount returns the cumulative number of objects processed
-// across every persisted checkpoint — the sum of each checkpoint's "all N"
-// count written by [fileReindexTracker.markProgress]. On a fresh scan with no
-// checkpoints it returns 0.
-//
-// It exists to keep live reindex progress reporting cumulative across
-// crash-resumes and chunk boundaries. The iteration loop's per-invocation
-// processedCount resets to 0 every time
-// [ShardReindexTaskGeneric.OnAfterLsmInitAsync] is (re-)entered — including
-// after a crash-resume, which restarts the scan from the persisted checkpoint
-// key rather than from zero. Without a baseline, the reported fraction would
-// restart near 0 on resume; because the /v1/tasks unit progress is monotonic
-// (see cluster/distributedtask.Manager.UpdateUnitProgress), the displayed value
-// would then freeze at the pre-crash checkpoint until the resumed scan
-// re-crossed it and jump to completion in one step. Feeding this value into the
-// reported fraction makes resumed-scan progress advance at the same granularity
-// as a fresh scan. weaviate/0-weaviate-issues#317.
-//
-// The persisted per-checkpoint counts are deliberately left per-chunk (this
-// function sums them), so the on-disk progress-file format is unchanged and an
-// operator mid-reindex who upgrades still sums correctly.
+// getProcessedObjectCount sums every persisted checkpoint's per-chunk count
+// (0 if none), giving cumulative progress across crash-resumes even though
+// each checkpoint only stores its own chunk's count.
 func (t *fileReindexTracker) getProcessedObjectCount() (int, error) {
 	total, _, err := t.GetMigratedCount()
 	return total, err


### PR DESCRIPTION
## What

Fixes [weaviate/0-weaviate-issues#317](https://github.com/weaviate/0-weaviate-issues/issues/317): after a crash mid-reindex, the resumed unit's `GET /v1/tasks` progress **freezes** at the pre-crash checkpoint (e.g. `0.4803`, `0.8924`) for the whole rebuild, then jumps to completion in one step. It is not a hang, but operators can't tell it apart from one.

## Root cause

`ShardReindexTaskGeneric.OnAfterLsmInitAsync` reports live progress as `processedCount / totalObjects`, and `processedCount` is reset to `0` on every (re-)entry of the function (`inverted_reindex_task_generic.go:1391`). On resume, iteration correctly restarts from the persisted checkpoint **key** (`rt.GetProgress()`), but the reported **numerator restarts at 0**, so the emitted fraction climbs from ~0.

The FSM stores unit progress **monotonically** — `cluster/distributedtask/manager.go:726` keeps `max(stored, new)` and drops regressions. So every resumed emission below the checkpoint is dropped, and the displayed value sticks at the checkpoint until the resumed scan's local count re-crosses it. For a late checkpoint (`0.89`, resume only re-processes ~11%) the emitted max never reaches the checkpoint, so it stays frozen for the entire resume and only the final `1.0` (from `RecordDistributedTaskUnitCompletion`) moves it.

The same freeze also affects any *fresh* reindex that spans more than one `processingDuration` chunk (default 10 min), because each chunk boundary re-enters the loop and re-zeroes the numerator. This fix covers both.

## Fix

Make the reported numerator **cumulative**:

- New tracker method `getProcessedObjectCount()` (`inverted_reindex_tracker.go`) sums the per-chunk `all N` counts already persisted in the `progress.mig.<N>` checkpoints.
- `OnAfterLsmInitAsync` reads that baseline once before the scan loop and reports `(baseline + processedCount) / totalObjects`.

Resumed-scan progress now advances at the same granularity as a fresh scan (checkpoint fraction → `0.99`) and never drops back toward 0 — avoiding **both** bad options the issue called out (freeze-at-checkpoint and reset-to-zero). The on-disk checkpoint format is unchanged (counts stay per-chunk; the fix only sums them), so an in-flight reindex survives the upgrade.

## Tests

`adapters/repos/db/inverted_reindex_resume_progress_test.go`:

- `TestReindexTracker_GetProcessedObjectCount_SumsCheckpoints` — pins the SUM (not last-value) semantics.
- `TestReindexResumeProgress_AdvancesFromCheckpoint` — drives a real `RoaringSetRefresh` migration on an in-memory shard, crashes it at **~48%** and **~89%** (the two points from the issue's `R2b`/`R2c` runs), resumes, and asserts the captured progress is monotonic, never regresses below the checkpoint fraction, and climbs to near-complete.

Verified **red without the fix**: the `0.89` case emits `[0.01 ... 0.11]` (frozen the whole resume) and the `0.48` case emits `[0.01 ... 0.52]` — exactly the freeze-then-jump from the report.

## Verification

- `go build ./adapters/repos/db/...`
- reindex/tracker/recovery/torn-resume test surface in `adapters/repos/db` (`-race`)
- `cluster/distributedtask/...` (`-race`)
- `gofmt`, `./tools/linter_go_routines.sh`, `golangci-lint run ./adapters/repos/db/...` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLEt7DyubVm2nVCVHA4aNM