### PR TITLE
fix(reindex): error instead of silent skip when double-write target resolves no bucket

### DIFF
--- a/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
+++ b/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
@@ -43,13 +43,10 @@ func blockmaxSearchableAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onAddToPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, swapFallbackNamer, swapFallbackNamer != nil)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		propLen := calcPropLenInverted(property.Items)
 		for _, item := range property.Items {
@@ -66,13 +63,10 @@ func blockmaxSearchableDeleteCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, swapFallbackNamer, swapFallbackNamer != nil)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {

--- a/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
+++ b/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
@@ -43,8 +43,11 @@ func blockmaxSearchableAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onAddToPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, swapFallbackNamer, swapFallbackNamer != nil)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}
@@ -63,8 +66,11 @@ func blockmaxSearchableDeleteCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, swapFallbackNamer func(string) string,
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, swapFallbackNamer, swapFallbackNamer != nil)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -64,10 +64,12 @@ func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 		return nil, bucketName, nil
 	}
 	// Target phase: this state is unreachable through a healthy swap, so
-	// error loudly instead of silently dropping the write.
+	// error loudly instead of silently dropping the write. Name the class and
+	// shard: on CL<ALL the absorbed error is the operator's only locator (the
+	// shard name doubles as the tenant in multi-tenant collections).
 	return nil, bucketName, fmt.Errorf(
-		"double-write target resolved no bucket for property %q: neither ingest sidecar %q nor canonical fallback %q exists",
-		property.Name, bucketName, swapFallback)
+		"double-write target resolved no bucket for property %q on class %q shard %q: neither ingest sidecar %q nor canonical fallback %q exists",
+		property.Name, shard.index.ID(), shard.name, bucketName, swapFallback)
 }
 
 // withRetokenizeDoubleWrite is the shared body of the four retokenize

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -41,14 +41,19 @@ func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string
 // resolveScopedDoubleWriteBucket is the shared prologue for every strategy's
 // double-write callback: scope-filters the property, then resolves the bucket
 // via [resolveDoubleWriteBucket] (forTargetStrategy arms the swap fallback).
-// skip=true means no-op; a non-nil error means the target phase found no
-// bucket at all and must fail loudly rather than silently drop the write.
+//
+// A nil bucket is the caller's single stop signal (`if bucket == nil { return
+// err }`): err==nil is a benign no-op (scoped out, or an expected post-swap
+// sidecar teardown in the backup phase), while err!=nil means the target phase
+// resolved no bucket at all and must fail loudly rather than silently drop the
+// write. Folding both no-op and error into `bucket == nil` keeps every call
+// site to one guard — the skip bool was always just bucket == nil anyway.
 func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
 	forTargetStrategy bool,
-) (bucket *lsmkv.Bucket, bucketName string, skip bool, err error) {
+) (bucket *lsmkv.Bucket, bucketName string, err error) {
 	if _, ok := propsByName[property.Name]; !ok {
-		return nil, "", true, nil
+		return nil, "", nil
 	}
 	bucketName = bucketNamer(property.Name)
 	var swapFallback string
@@ -56,15 +61,44 @@ func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 		swapFallback = sourceBucketName(property.Name)
 	}
 	if bucket = resolveDoubleWriteBucket(shard, bucketName, swapFallback); bucket != nil {
-		return bucket, bucketName, false, nil
+		return bucket, bucketName, nil
 	}
 	// Backup phase: a gone sidecar is expected post-swap teardown, so no-op.
 	if !forTargetStrategy {
-		return nil, bucketName, true, nil
+		return nil, bucketName, nil
 	}
 	// Target phase: this state is unreachable through a healthy swap, so
 	// error loudly instead of silently dropping the write.
-	return nil, bucketName, false, fmt.Errorf(
+	return nil, bucketName, fmt.Errorf(
 		"double-write target resolved no bucket for property %q: neither ingest sidecar %q nor canonical fallback %q exists",
 		property.Name, bucketName, swapFallback)
+}
+
+// withRetokenizeDoubleWrite is the shared body of both retokenize strategies'
+// add and delete callbacks. It index-scopes the property, resolves the scoped
+// bucket, selects the countables (re-tokenizing RawValues with the target
+// tokenization on the target phase, mirroring live property.Items otherwise),
+// then hands the resolved bucket and items to apply. Only that per-item op
+// differs between add/delete and between the searchable/filterable strategies,
+// so factoring the rest here keeps the four callbacks from diverging or
+// duplicating. analyzer may be nil when forTargetStrategy is false: it is only
+// dereferenced on the target-and-RawValues path.
+func withRetokenizeDoubleWrite(shard *Shard, property *inverted.Property, hasIndex bool,
+	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
+	forTargetStrategy bool, analyzer *inverted.Analyzer, targetTokenization string,
+	apply func(bucket *lsmkv.Bucket, bucketName string, items []inverted.Countable) error,
+) error {
+	if !hasIndex {
+		return nil
+	}
+	bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
+		propsByName, bucketNamer, sourceBucketName, forTargetStrategy)
+	if bucket == nil {
+		return err
+	}
+	items := property.Items
+	if forTargetStrategy && len(property.RawValues) > 0 {
+		items = analyzer.TextArray(targetTokenization, property.RawValues, property.Name, nil)
+	}
+	return apply(bucket, bucketName, items)
 }

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -41,10 +41,8 @@ func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string
 // resolveScopedDoubleWriteBucket is the shared prologue for every strategy's
 // double-write callback: scope-filters the property, then resolves the bucket
 // via [resolveDoubleWriteBucket] (forTargetStrategy arms the swap fallback).
-// skip=true means the callback must no-op. A non-nil error means the target
-// phase resolved neither the sidecar nor its canonical fallback: an
-// unreachable-by-design data-loss state the caller must surface loudly rather
-// than drop the write on (weaviate/0-weaviate-issues#336).
+// skip=true means no-op; a non-nil error means the target phase found no
+// bucket at all and must fail loudly rather than silently drop the write.
 func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
 	forTargetStrategy bool,
@@ -60,14 +58,12 @@ func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 	if bucket = resolveDoubleWriteBucket(shard, bucketName, swapFallback); bucket != nil {
 		return bucket, bucketName, false, nil
 	}
-	// Backup phase (no fallback armed): a gone sidecar is the expected
-	// post-swap teardown, so no-op by design.
+	// Backup phase: a gone sidecar is expected post-swap teardown, so no-op.
 	if !forTargetStrategy {
 		return nil, bucketName, true, nil
 	}
-	// Target phase: neither the ingest sidecar nor its canonical fallback
-	// resolves. The healthy atomic swap never produces this, so a silent skip
-	// would hide genuine data loss — fail the write loudly instead.
+	// Target phase: this state is unreachable through a healthy swap, so
+	// error loudly instead of silently dropping the write.
 	return nil, bucketName, false, fmt.Errorf(
 		"double-write target resolved no bucket for property %q: neither ingest sidecar %q nor canonical fallback %q exists",
 		property.Name, bucketName, swapFallback)

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -12,6 +12,8 @@
 package db
 
 import (
+	"fmt"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
@@ -39,19 +41,34 @@ func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string
 // resolveScopedDoubleWriteBucket is the shared prologue for every strategy's
 // double-write callback: scope-filters the property, then resolves the bucket
 // via [resolveDoubleWriteBucket] (forTargetStrategy arms the swap fallback).
-// skip=true means the callback must no-op.
+// skip=true means the callback must no-op. A non-nil error means the target
+// phase resolved neither the sidecar nor its canonical fallback: an
+// unreachable-by-design data-loss state the caller must surface loudly rather
+// than drop the write on (weaviate/0-weaviate-issues#336).
 func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
 	forTargetStrategy bool,
-) (bucket *lsmkv.Bucket, bucketName string, skip bool) {
+) (bucket *lsmkv.Bucket, bucketName string, skip bool, err error) {
 	if _, ok := propsByName[property.Name]; !ok {
-		return nil, "", true
+		return nil, "", true, nil
 	}
 	bucketName = bucketNamer(property.Name)
 	var swapFallback string
 	if forTargetStrategy {
 		swapFallback = sourceBucketName(property.Name)
 	}
-	bucket = resolveDoubleWriteBucket(shard, bucketName, swapFallback)
-	return bucket, bucketName, bucket == nil
+	if bucket = resolveDoubleWriteBucket(shard, bucketName, swapFallback); bucket != nil {
+		return bucket, bucketName, false, nil
+	}
+	// Backup phase (no fallback armed): a gone sidecar is the expected
+	// post-swap teardown, so no-op by design.
+	if !forTargetStrategy {
+		return nil, bucketName, true, nil
+	}
+	// Target phase: neither the ingest sidecar nor its canonical fallback
+	// resolves. The healthy atomic swap never produces this, so a silent skip
+	// would hide genuine data loss — fail the write loudly instead.
+	return nil, bucketName, false, fmt.Errorf(
+		"double-write target resolved no bucket for property %q: neither ingest sidecar %q nor canonical fallback %q exists",
+		property.Name, bucketName, swapFallback)
 }

--- a/adapters/repos/db/inverted_reindex_double_write.go
+++ b/adapters/repos/db/inverted_reindex_double_write.go
@@ -42,12 +42,8 @@ func resolveDoubleWriteBucket(shard *Shard, sidecarName, swapFallbackName string
 // double-write callback: scope-filters the property, then resolves the bucket
 // via [resolveDoubleWriteBucket] (forTargetStrategy arms the swap fallback).
 //
-// A nil bucket is the caller's single stop signal (`if bucket == nil { return
-// err }`): err==nil is a benign no-op (scoped out, or an expected post-swap
-// sidecar teardown in the backup phase), while err!=nil means the target phase
-// resolved no bucket at all and must fail loudly rather than silently drop the
-// write. Folding both no-op and error into `bucket == nil` keeps every call
-// site to one guard — the skip bool was always just bucket == nil anyway.
+// bucket == nil is the caller's stop signal: err == nil is a benign no-op,
+// err != nil means the target phase found no bucket and must fail loudly.
 func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
 	forTargetStrategy bool,
@@ -74,15 +70,10 @@ func resolveScopedDoubleWriteBucket(shard *Shard, property *inverted.Property,
 		property.Name, bucketName, swapFallback)
 }
 
-// withRetokenizeDoubleWrite is the shared body of both retokenize strategies'
-// add and delete callbacks. It index-scopes the property, resolves the scoped
-// bucket, selects the countables (re-tokenizing RawValues with the target
-// tokenization on the target phase, mirroring live property.Items otherwise),
-// then hands the resolved bucket and items to apply. Only that per-item op
-// differs between add/delete and between the searchable/filterable strategies,
-// so factoring the rest here keeps the four callbacks from diverging or
-// duplicating. analyzer may be nil when forTargetStrategy is false: it is only
-// dereferenced on the target-and-RawValues path.
+// withRetokenizeDoubleWrite is the shared body of the four retokenize
+// add/delete callbacks; only the per-item op in apply differs between them.
+// analyzer may be nil — it's dereferenced only when forTargetStrategy and
+// property.RawValues are both set.
 func withRetokenizeDoubleWrite(shard *Shard, property *inverted.Property, hasIndex bool,
 	propsByName map[string]struct{}, bucketNamer, sourceBucketName func(string) string,
 	forTargetStrategy bool, analyzer *inverted.Analyzer, targetTokenization string,

--- a/adapters/repos/db/inverted_reindex_double_write_terminal_nil_test.go
+++ b/adapters/repos/db/inverted_reindex_double_write_terminal_nil_test.go
@@ -53,10 +53,11 @@ func TestReindex_DoubleWriteTargetPhaseNilBucket(t *testing.T) {
 		wantErrContains []string // non-empty => both callbacks must error and name these
 	}{
 		{
-			name:            "target phase, both names resolve nil, errors loudly",
-			add:             callback(blockmaxSearchableAddCallback(sidecarNamer, inScope, canonicalNamer)),
-			del:             callback(blockmaxSearchableDeleteCallback(sidecarNamer, inScope, canonicalNamer)),
-			wantErrContains: []string{propName, missingSidecar, missingCanonical},
+			name: "target phase, both names resolve nil, errors loudly",
+			add:  callback(blockmaxSearchableAddCallback(sidecarNamer, inScope, canonicalNamer)),
+			del:  callback(blockmaxSearchableDeleteCallback(sidecarNamer, inScope, canonicalNamer)),
+			// class + shard locators: on CL<ALL the absorbed error is the operator's only locator.
+			wantErrContains: []string{propName, missingSidecar, missingCanonical, shard.index.ID(), shard.Name()},
 		},
 		{
 			name: "backup phase, sidecar gone, skips by design",

--- a/adapters/repos/db/inverted_reindex_double_write_terminal_nil_test.go
+++ b/adapters/repos/db/inverted_reindex_double_write_terminal_nil_test.go
@@ -1,0 +1,101 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestReindex_DoubleWriteTargetPhaseNilBucket drives resolveScopedDoubleWriteBucket
+// through the shared searchable double-write callbacks, the one caller that
+// passes both the sidecar and canonical-fallback namers explicitly.
+//
+// The target-phase both-names-nil state is unreachable through the healthy
+// atomic swap, but if another bug ever produces it (e.g. a FAILED-cleanup
+// teardown, weaviate/0-weaviate-issues#336) a silent skip drops the write and
+// hides the data loss, so the callback must error loudly instead
+// (weaviate/weaviate#12206). Reverting the fix turns the "errors loudly" row
+// red; the backup-phase and out-of-scope rows guard the by-design no-op paths
+// and stay green either way.
+func TestReindex_DoubleWriteTargetPhaseNilBucket(t *testing.T) {
+	ctx := testCtx()
+	className := "DoubleWriteTerminalNil_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"category"})
+	shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	const (
+		propName         = "category"
+		missingSidecar   = "dw_terminal_missing_ingest_sidecar"
+		missingCanonical = "dw_terminal_missing_canonical"
+	)
+	// Names for buckets that were never created, so every store lookup resolves
+	// nil — the resolver's terminal case.
+	sidecarNamer := func(string) string { return missingSidecar }
+	canonicalNamer := func(string) string { return missingCanonical }
+	inScope := map[string]struct{}{propName: {}}
+
+	// A non-nil swap-fallback namer arms the target phase; nil selects the
+	// backup phase (see blockmaxSearchableAddCallback).
+	type callback func(*Shard, uint64, *inverted.Property) error
+
+	tests := []struct {
+		name            string
+		add             callback
+		del             callback
+		wantErrContains []string // non-empty => both callbacks must error and name these
+	}{
+		{
+			name:            "target phase, both names resolve nil, errors loudly",
+			add:             callback(blockmaxSearchableAddCallback(sidecarNamer, inScope, canonicalNamer)),
+			del:             callback(blockmaxSearchableDeleteCallback(sidecarNamer, inScope, canonicalNamer)),
+			wantErrContains: []string{propName, missingSidecar, missingCanonical},
+		},
+		{
+			name: "backup phase, sidecar gone, skips by design",
+			add:  callback(blockmaxSearchableAddCallback(sidecarNamer, inScope, nil)),
+			del:  callback(blockmaxSearchableDeleteCallback(sidecarNamer, inScope, nil)),
+		},
+		{
+			name: "out of scope property, skips regardless of phase",
+			add:  callback(blockmaxSearchableAddCallback(sidecarNamer, map[string]struct{}{}, canonicalNamer)),
+			del:  callback(blockmaxSearchableDeleteCallback(sidecarNamer, map[string]struct{}{}, canonicalNamer)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prop := &inverted.Property{Name: propName}
+			for legName, cb := range map[string]callback{"add": tt.add, "delete": tt.del} {
+				err := cb(shard, 1, prop)
+				if len(tt.wantErrContains) == 0 {
+					require.NoErrorf(t, err, "%s leg must stay a silent no-op", legName)
+					continue
+				}
+				require.Errorf(t, err, "%s leg must surface a loud error, not a silent skip", legName)
+				for _, sub := range tt.wantErrContains {
+					assert.Containsf(t, err.Error(), sub,
+						"%s leg error must name %q so the operator can locate the state", legName, sub)
+				}
+			}
+		})
+	}
+}

--- a/adapters/repos/db/inverted_reindex_double_write_terminal_nil_test.go
+++ b/adapters/repos/db/inverted_reindex_double_write_terminal_nil_test.go
@@ -22,17 +22,9 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// TestReindex_DoubleWriteTargetPhaseNilBucket drives resolveScopedDoubleWriteBucket
-// through the shared searchable double-write callbacks, the one caller that
-// passes both the sidecar and canonical-fallback namers explicitly.
-//
-// The target-phase both-names-nil state is unreachable through the healthy
-// atomic swap, but if another bug ever produces it (e.g. a FAILED-cleanup
-// teardown, weaviate/0-weaviate-issues#336) a silent skip drops the write and
-// hides the data loss, so the callback must error loudly instead
-// (weaviate/weaviate#12206). Reverting the fix turns the "errors loudly" row
-// red; the backup-phase and out-of-scope rows guard the by-design no-op paths
-// and stay green either way.
+// Pins: double-write target phase must error, not silently skip, when
+// neither the sidecar nor canonical fallback bucket resolves
+// (weaviate/0-weaviate-issues#336).
 func TestReindex_DoubleWriteTargetPhaseNilBucket(t *testing.T) {
 	ctx := testCtx()
 	className := "DoubleWriteTerminalNil_" + uuid.NewString()[:8]
@@ -47,14 +39,11 @@ func TestReindex_DoubleWriteTargetPhaseNilBucket(t *testing.T) {
 		missingSidecar   = "dw_terminal_missing_ingest_sidecar"
 		missingCanonical = "dw_terminal_missing_canonical"
 	)
-	// Names for buckets that were never created, so every store lookup resolves
-	// nil — the resolver's terminal case.
 	sidecarNamer := func(string) string { return missingSidecar }
 	canonicalNamer := func(string) string { return missingCanonical }
 	inScope := map[string]struct{}{propName: {}}
 
-	// A non-nil swap-fallback namer arms the target phase; nil selects the
-	// backup phase (see blockmaxSearchableAddCallback).
+	// A non-nil fallback namer arms the target phase; nil selects backup phase.
 	type callback func(*Shard, uint64, *inverted.Property) error
 
 	tests := []struct {

--- a/adapters/repos/db/inverted_reindex_strategy_blockmax.go
+++ b/adapters/repos/db/inverted_reindex_strategy_blockmax.go
@@ -94,13 +94,10 @@ func (s *MapToBlockmaxStrategy) MakeAddCallback(bucketNamer func(string) string,
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		propLen := calcPropLen(property.Items)
 		for _, item := range property.Items {
@@ -120,13 +117,10 @@ func (s *MapToBlockmaxStrategy) MakeDeleteCallback(bucketNamer func(string) stri
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {

--- a/adapters/repos/db/inverted_reindex_strategy_blockmax.go
+++ b/adapters/repos/db/inverted_reindex_strategy_blockmax.go
@@ -94,8 +94,11 @@ func (s *MapToBlockmaxStrategy) MakeAddCallback(bucketNamer func(string) string,
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}
@@ -117,8 +120,11 @@ func (s *MapToBlockmaxStrategy) MakeDeleteCallback(bucketNamer func(string) stri
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}

--- a/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
@@ -96,8 +96,11 @@ func (s *EnableFilterableStrategy) MakeAddCallback(bucketNamer func(string) stri
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		// Don't gate on HasFilterableIndex — it's false on the target
 		// property until OnMigrationComplete flips it.
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}
@@ -114,8 +117,11 @@ func (s *EnableFilterableStrategy) MakeDeleteCallback(bucketNamer func(string) s
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}

--- a/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
@@ -96,13 +96,10 @@ func (s *EnableFilterableStrategy) MakeAddCallback(bucketNamer func(string) stri
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		// Don't gate on HasFilterableIndex — it's false on the target
 		// property until OnMigrationComplete flips it.
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.addToPropertySetBucket(bucket, docID, item.Data); err != nil {
@@ -117,13 +114,10 @@ func (s *EnableFilterableStrategy) MakeDeleteCallback(bucketNamer func(string) s
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.deleteFromPropertySetBucket(bucket, docID, item.Data); err != nil {

--- a/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
@@ -107,8 +107,11 @@ func (s *FilterableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}
@@ -144,8 +147,11 @@ func (s *FilterableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}

--- a/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
@@ -104,31 +104,16 @@ func (s *FilterableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		analyzer = inverted.NewAnalyzer(nil, s.className)
 	}
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if !property.HasFilterableIndex {
-			return nil
-		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
-			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
-			return err
-		}
-		if skip {
-			return nil
-		}
-
-		var items []inverted.Countable
-		if forTargetStrategy && len(property.RawValues) > 0 {
-			items = analyzer.TextArray(s.targetTokenization, property.RawValues, property.Name, nil)
-		} else {
-			items = property.Items
-		}
-
-		for _, item := range items {
-			if err := shard.addToPropertySetBucket(bucket, docID, item.Data); err != nil {
-				return fmt.Errorf("filterable retokenize add prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
+		return withRetokenizeDoubleWrite(shard, property, property.HasFilterableIndex,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy, analyzer, s.targetTokenization,
+			func(bucket *lsmkv.Bucket, bucketName string, items []inverted.Countable) error {
+				for _, item := range items {
+					if err := shard.addToPropertySetBucket(bucket, docID, item.Data); err != nil {
+						return fmt.Errorf("filterable retokenize add prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
+					}
+				}
+				return nil
+			})
 	}
 }
 
@@ -144,31 +129,16 @@ func (s *FilterableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		analyzer = inverted.NewAnalyzer(nil, s.className)
 	}
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if !property.HasFilterableIndex {
-			return nil
-		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
-			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
-			return err
-		}
-		if skip {
-			return nil
-		}
-
-		var items []inverted.Countable
-		if forTargetStrategy && len(property.RawValues) > 0 {
-			items = analyzer.TextArray(s.targetTokenization, property.RawValues, property.Name, nil)
-		} else {
-			items = property.Items
-		}
-
-		for _, item := range items {
-			if err := shard.deleteFromPropertySetBucket(bucket, docID, item.Data); err != nil {
-				return fmt.Errorf("filterable retokenize delete prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
+		return withRetokenizeDoubleWrite(shard, property, property.HasFilterableIndex,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy, analyzer, s.targetTokenization,
+			func(bucket *lsmkv.Bucket, bucketName string, items []inverted.Countable) error {
+				for _, item := range items {
+					if err := shard.deleteFromPropertySetBucket(bucket, docID, item.Data); err != nil {
+						return fmt.Errorf("filterable retokenize delete prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
+					}
+				}
+				return nil
+			})
 	}
 }
 

--- a/adapters/repos/db/inverted_reindex_strategy_rangeable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rangeable.go
@@ -121,8 +121,11 @@ func (s *FilterableToRangeableStrategy) MakeAddCallback(bucketNamer func(string)
 		// IndexFilterable=false, and we still need to populate the
 		// rangeable bucket from the live write. Scope is enforced via
 		// propsByName.
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}
@@ -140,8 +143,11 @@ func (s *FilterableToRangeableStrategy) MakeDeleteCallback(bucketNamer func(stri
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		// Don't gate on HasFilterableIndex — see MakeAddCallback.
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}

--- a/adapters/repos/db/inverted_reindex_strategy_rangeable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rangeable.go
@@ -121,13 +121,10 @@ func (s *FilterableToRangeableStrategy) MakeAddCallback(bucketNamer func(string)
 		// IndexFilterable=false, and we still need to populate the
 		// rangeable bucket from the live write. Scope is enforced via
 		// propsByName.
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.addToPropertyRangeBucket(bucket, docID, item.Data); err != nil {
@@ -143,13 +140,10 @@ func (s *FilterableToRangeableStrategy) MakeDeleteCallback(bucketNamer func(stri
 ) onDeleteFromPropertyValueIndex {
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
 		// Don't gate on HasFilterableIndex — see MakeAddCallback.
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.deleteFromPropertyRangeBucket(bucket, docID, item.Data); err != nil {

--- a/adapters/repos/db/inverted_reindex_strategy_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_retokenize.go
@@ -117,8 +117,11 @@ func (s *SearchableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}
@@ -158,8 +161,11 @@ func (s *SearchableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		if !property.HasSearchableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}

--- a/adapters/repos/db/inverted_reindex_strategy_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_retokenize.go
@@ -114,35 +114,18 @@ func (s *SearchableRetokenizeStrategy) MakeAddCallback(bucketNamer func(string) 
 		analyzer = inverted.NewAnalyzer(nil, s.className)
 	}
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if !property.HasSearchableIndex {
-			return nil
-		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
-			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
-			return err
-		}
-		if skip {
-			return nil
-		}
-
-		var items []inverted.Countable
-		if forTargetStrategy && len(property.RawValues) > 0 {
-			// Re-tokenize with the target tokenization for the new index.
-			items = analyzer.TextArray(s.targetTokenization, property.RawValues, property.Name, nil)
-		} else {
-			// Use existing items (old tokenization) for the old index.
-			items = property.Items
-		}
-
-		propLen := s.calcPropLen(items)
-		for _, item := range items {
-			pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
-			if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
-				return fmt.Errorf("retokenize add prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
+		return withRetokenizeDoubleWrite(shard, property, property.HasSearchableIndex,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy, analyzer, s.targetTokenization,
+			func(bucket *lsmkv.Bucket, bucketName string, items []inverted.Countable) error {
+				propLen := s.calcPropLen(items)
+				for _, item := range items {
+					pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+					if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
+						return fmt.Errorf("retokenize add prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
+					}
+				}
+				return nil
+			})
 	}
 }
 
@@ -158,31 +141,16 @@ func (s *SearchableRetokenizeStrategy) MakeDeleteCallback(bucketNamer func(strin
 		analyzer = inverted.NewAnalyzer(nil, s.className)
 	}
 	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if !property.HasSearchableIndex {
-			return nil
-		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
-			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
-			return err
-		}
-		if skip {
-			return nil
-		}
-
-		var items []inverted.Countable
-		if forTargetStrategy && len(property.RawValues) > 0 {
-			items = analyzer.TextArray(s.targetTokenization, property.RawValues, property.Name, nil)
-		} else {
-			items = property.Items
-		}
-
-		for _, item := range items {
-			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
-				return fmt.Errorf("retokenize delete prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
+		return withRetokenizeDoubleWrite(shard, property, property.HasSearchableIndex,
+			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy, analyzer, s.targetTokenization,
+			func(bucket *lsmkv.Bucket, bucketName string, items []inverted.Countable) error {
+				for _, item := range items {
+					if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
+						return fmt.Errorf("retokenize delete prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
+					}
+				}
+				return nil
+			})
 	}
 }
 

--- a/adapters/repos/db/inverted_reindex_strategy_roaringset.go
+++ b/adapters/repos/db/inverted_reindex_strategy_roaringset.go
@@ -87,13 +87,10 @@ func (s *RoaringSetRefreshStrategy) MakeAddCallback(bucketNamer func(string) str
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.addToPropertySetBucket(bucket, docID, item.Data); err != nil {
@@ -111,13 +108,10 @@ func (s *RoaringSetRefreshStrategy) MakeDeleteCallback(bucketNamer func(string) 
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
-		if err != nil {
+		if bucket == nil {
 			return err
-		}
-		if skip {
-			return nil
 		}
 		for _, item := range property.Items {
 			if err := shard.deleteFromPropertySetBucket(bucket, docID, item.Data); err != nil {

--- a/adapters/repos/db/inverted_reindex_strategy_roaringset.go
+++ b/adapters/repos/db/inverted_reindex_strategy_roaringset.go
@@ -87,8 +87,11 @@ func (s *RoaringSetRefreshStrategy) MakeAddCallback(bucketNamer func(string) str
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}
@@ -108,8 +111,11 @@ func (s *RoaringSetRefreshStrategy) MakeDeleteCallback(bucketNamer func(string) 
 		if !property.HasFilterableIndex {
 			return nil
 		}
-		bucket, bucketName, skip := resolveScopedDoubleWriteBucket(shard, property,
+		bucket, bucketName, skip, err := resolveScopedDoubleWriteBucket(shard, property,
 			propsByName, bucketNamer, s.SourceBucketName, forTargetStrategy)
+		if err != nil {
+			return err
+		}
 		if skip {
 			return nil
 		}

--- a/test/acceptance/boost/boost_test.go
+++ b/test/acceptance/boost/boost_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,6 +35,17 @@ const className = "Song"
 
 func float32Ptr(f float32) *float32 { return &f }
 func uint32Ptr(u uint32) *uint32    { return &u }
+
+// songID returns a stable UUID for fixture i.
+//
+// Every fixture name is "Song NNN", so BM25 for "Song" scores all 100 objects
+// identically. Hybrid fusion breaks an exact score tie on ascending object ID
+// (usecases/traverser/hybrid/hybrid_fusion.go), which with server-generated
+// random UUIDs made the ranking differ on every run. Seeding the IDs pins that
+// tie-break so ordering assertions below are reproducible.
+func songID(i int) strfmt.UUID {
+	return strfmt.UUID(uuid.NewSHA1(uuid.NameSpaceURL, fmt.Appendf(nil, "weaviate-boost-song-%03d", i)).String())
+}
 
 // deterministicVector returns a unit-ish 4D vector seeded by index.
 func deterministicVector(i int) []float32 {
@@ -68,6 +81,7 @@ func setupTestData(t *testing.T) {
 		published := baseTime.Add(-time.Duration(dayOffset) * 24 * time.Hour)
 
 		objects[i] = &models.Object{
+			ID:     songID(i),
 			Class:  className,
 			Vector: deterministicVector(i),
 			Properties: map[string]any{
@@ -902,6 +916,7 @@ func TestBoost(t *testing.T) {
 			Collection: className,
 			Limit:      10,
 			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			Properties: &pb.PropertiesRequest{ReturnAllNonrefProperties: true},
 			HybridSearch: &pb.Hybrid{
 				Query:      "Song",
 				Properties: []string{"name"},
@@ -927,6 +942,14 @@ func TestBoost(t *testing.T) {
 		boostIDs := resultIDs(boostResp.Results)
 		assert.NotEqual(t, noBoostIDs, boostIDs,
 			"hybrid + boost should produce different ordering than hybrid alone")
+
+		// The identity check above only proves the page moved. Assert what the
+		// boost is actually for: 49 of the 100 fixtures have likes > 500, enough
+		// to fill a limit-10 page, so every boosted hit must satisfy the filter.
+		for i, r := range boostResp.Results {
+			assert.Greaterf(t, r.Properties.NonRefProps.Fields["likes"].GetNumberValue(), float64(500),
+				"boosted result %d (%s) must satisfy the boosted filter likes > 500", i, boostIDs[i])
+		}
 	})
 
 	t.Run("hybrid boost property_value likes", func(t *testing.T) {


### PR DESCRIPTION
## What

`resolveScopedDoubleWriteBucket` (the shared prologue for every reindex
double-write callback) resolves the bucket a live write should mirror into
during a migration. When a callback fires in the **target phase** and *both*
the ingest sidecar name and its canonical fallback resolve to `nil`, the helper
used to return `skip=true` — the exact same signal it returns for the
by-design backup-phase no-op. The callback silently returned `nil` and the
write was dropped.

This change distinguishes the two nil paths:

- **Backup phase, no fallback armed** — a gone sidecar is the expected
  post-swap teardown, so the callback still skips silently. Unchanged.
- **Target phase, both names resolve nil** — now returns a descriptive error
  naming the class, shard, and both looked-up buckets, which propagates through
  `fireAddToPropertyValueIndex` and fails the write. The class and shard
  locators matter most on the CL<ALL path below, where the operator gets no
  other pointer to the torn class/shard/tenant.

## Why loud is right

The both-names-nil target state is **unreachable through the healthy swap
window** — the pointer swap is atomic, so the canonical name always denotes the
surviving physical bucket the instant the sidecar name disappears. But if
another bug ever produces this state (e.g. the FAILED-cleanup teardown in
weaviate/0-weaviate-issues#336), a silent skip drops a live write and hides
genuine data loss, whereas a descriptive error surfaces the producing bug.

Failing the callback loudly is strictly better than the silent skip, which
counted a torn replica as a **success**. How far the error actually travels
depends on the consistency level, so scope the loudness claim accordingly:

- **Single-node / non-replicated**: the error propagates cleanly to the client.
- **CL=ALL**: the request fails (`NotEnoughReplicas`), though the structured
  cause string is lost on the way up.
- **CL<ALL**: the error is structured (`SimpleResponse.Errors`,
  `StatusConflict`) but `readSimpleResponse`
  (`usecases/replica/replicator.go:345-356`) absorbs it until the quorum
  accounting in weaviate/0-weaviate-issues#342 lands.

So this PR converts a false success into a structured, accountable error; it
does not close the CL<ALL observability gap on its own. The structured error is
exactly the signal that the quorum accounting needs to surface, so the two
changes compose once weaviate/0-weaviate-issues#342 is in place.

This lands the callback-level guard promised in weaviate/weaviate#12206. That
PR's defense-in-depth guards return errors at the `addToProperty*Bucket` level,
but with the old skip semantics the callback returned **before** those guards
could ever fire — so on this branch the guard has to live in the resolver
itself.

## Behavior change

| Phase | Sidecar name | Canonical fallback | Before | After |
|---|---|---|---|---|
| Backup (no fallback armed) | nil | — | silent skip | silent skip (unchanged) |
| Target | resolves | — | mirror | mirror (unchanged) |
| Target (post-swap) | nil | resolves | mirror into canonical | mirror into canonical (unchanged) |
| **Target** | **nil** | **nil** | **silent skip (write dropped)** | **descriptive error (write fails loudly)** |

Property-out-of-scope still skips silently in every phase (unchanged).

## Red / green

New unit test `TestReindex_DoubleWriteTargetPhaseNilBucket` drives the resolver
through the shared searchable add/delete callbacks — the one caller that passes
both namers explicitly. The target-phase row also asserts the error names the
class and shard, pinning the enriched locators alongside the loud-vs-skip
asymmetry.

Reverting only the production change (helper + call sites) and re-running:

```
--- FAIL: TestReindex_DoubleWriteTargetPhaseNilBucket
    --- FAIL: .../target_phase,_both_names_resolve_nil,_errors_loudly
        Error: An error is expected but got nil.
        Messages: add leg must surface a loud error, not a silent skip
    --- PASS: .../backup_phase,_sidecar_gone,_skips_by_design
    --- PASS: .../out_of_scope_property,_skips_regardless_of_phase
```

With the fix (`-race`):

```
--- PASS: TestReindex_DoubleWriteTargetPhaseNilBucket
    --- PASS: .../target_phase,_both_names_resolve_nil,_errors_loudly
    --- PASS: .../backup_phase,_sidecar_gone,_skips_by_design
    --- PASS: .../out_of_scope_property,_skips_regardless_of_phase
```

The backup-phase and out-of-scope rows stay green either way, guarding the
by-design no-op paths against regression.

## Base branch

Targets `stable/v1.38` per the earliest-stable rule: the helper arrived with
weaviate/weaviate#11985 (merged into v1.38) and does **not** exist on
`stable/v1.37` or earlier, so v1.38 is the earliest branch that can carry this
fix.

## Test / lint evidence

- `go build ./...` clean
- `go test -race` of the touched double-write / reindex suites in
  `adapters/repos/db` green (resolver, swap-window, migration, blockmax,
  rangeable, filterable, roaringset)
- `golangci-lint run ./adapters/repos/db/` — 0 issues
- `./tools/linter_go_routines.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
