### PR TITLE
fix(objects): wait for auto-schema version before single-object write, plus reindex CI forensics

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -765,9 +765,8 @@ jobs:
     name: reindex (${{ matrix.name }})
     runs-on: ubicloud-standard-4-ubuntu-2404
     env:
-      # Failure-only forensic dumps from the reindex acceptance tests land here
-      # (e.g. weaviate/0-weaviate-issues#335 shard LSM data dirs). Read by the
-      # tests; uploaded by the "Upload reindex forensic artifacts" step below.
+      # Where reindex acceptance tests write failure-only forensic dumps,
+      # uploaded by the "Upload reindex forensic artifacts" step below.
       REINDEX_FORENSICS_DIR: ${{ github.workspace }}/reindex-forensics
     strategy:
       fail-fast: false

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -764,6 +764,11 @@ jobs:
   Acceptance-Reindex-Tests:
     name: reindex (${{ matrix.name }})
     runs-on: ubicloud-standard-4-ubuntu-2404
+    env:
+      # Failure-only forensic dumps from the reindex acceptance tests land here
+      # (e.g. weaviate/0-weaviate-issues#335 shard LSM data dirs). Read by the
+      # tests; uploaded by the "Upload reindex forensic artifacts" step below.
+      REINDEX_FORENSICS_DIR: ${{ github.workspace }}/reindex-forensics
     strategy:
       fail-fast: false
       matrix:
@@ -813,6 +818,14 @@ jobs:
           max_attempts: 1
           command: ./test/run.sh ${{ matrix.test }}
           on_retry_command: ./test/run.sh --cleanup
+      - name: Upload reindex forensic artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: reindex-forensics-${{ matrix.name }}
+          path: ${{ github.workspace }}/reindex-forensics
+          if-no-files-found: ignore
+          retention-days: 14
   Acceptance-Tests-github-4-cores:
     name: acceptance large (${{ matrix.name }})
     runs-on: DB-ubuntu-24.04-4-cores

--- a/test/acceptance/namespace/auto_schema_test.go
+++ b/test/acceptance/namespace/auto_schema_test.go
@@ -44,7 +44,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 			Class:      class,
 			Properties: map[string]any{"title": "Inception"},
 		}, user1Key)
-		require.NoError(t, err)
+		require.NoError(t, err, "auto-create %s in %s: %s", class, ns1, helper.ErrorDetail(err))
 
 		// Namespaced principal sees the short class on read-back (response stripping).
 		got, err := helper.GetObjectAuth(t, class, id, user1Key)
@@ -62,7 +62,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 			Class:      class,
 			Properties: map[string]any{"title": "Memento"},
 		}, user2Key)
-		require.NoError(t, err)
+		require.NoError(t, err, "auto-create %s in %s: %s", class, ns2, helper.ErrorDetail(err))
 		t.Cleanup(func() { helper.DeleteClassAuth(t, ns2+":"+class, adminKey) })
 
 		gotClass2 := helper.GetClassAuth(t, ns2+":"+class, adminKey)

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -124,6 +124,13 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
+	// On failure, dump every node's logs so the leader side is visible. Without
+	// this the only record of a server-side 500 is the client's rendering of
+	// models.ErrorResponse, which prints the message slice as pointers.
+	if code != 0 {
+		sharedCompose.DumpWeaviateLogs(ctx, os.Stderr, 300)
+	}
+
 	if err := sharedCompose.Terminate(ctx); err != nil {
 		panic(errors.Wrap(err, "failed to terminate shared compose"))
 	}

--- a/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
+++ b/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
@@ -374,6 +374,13 @@ func assertRangeCountAllNodes(t *testing.T, compose *docker.DockerCompose, class
 		"%s: every replica must serve all %d updated objects over the sentinel band", phase, want)
 	if !ok {
 		t.Errorf("%s rangeable counts per node = %v, want %d on every node (silent rangeable write-loss)", phase, last, want)
+		// weaviate/0-weaviate-issues#335: the discriminating evidence is the
+		// migrated property's on-disk rangeable bucket shape at failure time
+		// (promoted-dir file listing + .wal presence/sizes). Capture it now,
+		// before the pre-restart failure path runs the rolling restart that
+		// would mutate the WAL state, so the next flake self-evidences instead
+		// of needing an eighth refuted producer.
+		captureRangeableDataDirsOnFailure(t, compose, className, propName, phase)
 	}
 }
 

--- a/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
+++ b/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
@@ -374,12 +374,8 @@ func assertRangeCountAllNodes(t *testing.T, compose *docker.DockerCompose, class
 		"%s: every replica must serve all %d updated objects over the sentinel band", phase, want)
 	if !ok {
 		t.Errorf("%s rangeable counts per node = %v, want %d on every node (silent rangeable write-loss)", phase, last, want)
-		// weaviate/0-weaviate-issues#335: the discriminating evidence is the
-		// migrated property's on-disk rangeable bucket shape at failure time
-		// (promoted-dir file listing + .wal presence/sizes). Capture it now,
-		// before the pre-restart failure path runs the rolling restart that
-		// would mutate the WAL state, so the next flake self-evidences instead
-		// of needing an eighth refuted producer.
+		// weaviate/0-weaviate-issues#335: capture on-disk state before a
+		// possible restart mutates it.
 		captureRangeableDataDirsOnFailure(t, compose, className, propName, phase)
 	}
 }

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -18,12 +18,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/docker"
@@ -693,6 +697,176 @@ func dumpStartupLogs(ctx context.Context, t *testing.T, compose *docker.DockerCo
 		}
 		t.Logf("=== Node %d logs (%d migration/reindex lines) ===\n%s", i, len(filtered), strings.Join(filtered, "\n"))
 	}
+}
+
+// forensicCaptureByteBudget caps the total bytes copied off all nodes in a
+// single capture. The rangeable bucket for the fixtures here is KBs, so this is
+// pure runaway protection (a pathological on-disk state must never fill the CI
+// runner's disk or hang the job on an endless copy).
+const forensicCaptureByteBudget = 512 << 20 // 512 MiB
+
+// forensicFilesPerNodeCap bounds how many files are copied off one node, same
+// runaway-protection rationale as forensicCaptureByteBudget.
+const forensicFilesPerNodeCap = 4000
+
+// captureRangeableDataDirsOnFailure is a BEST-EFFORT forensic capture invoked
+// only when a per-node range-count assertion fails. For
+// weaviate/0-weaviate-issues#335 the discriminating evidence is the on-disk
+// shape of the migrated property's rangeable LSM bucket at failure time: which
+// generation dirs exist (canonical property_<prop>_rangeable vs the
+// __rangeable_ingest / __rangeable_reindex / __rangeable_backup sidecars) and,
+// inside the promoted dir, the segment + .wal file listing and sizes. Seven
+// candidate producers were refuted without this evidence; capturing it at the
+// moment of failure means the next flake self-evidences instead of needing an
+// eighth guess.
+//
+// Per node it (1) writes a name+size+mtime manifest of every rangeable bucket
+// generation into the test log — so the listing survives even when the CI
+// artifact is not downloaded — and (2) copies every file under those dirs off
+// the container into a host artifact dir (REINDEX_FORENSICS_DIR in CI, an OS
+// temp dir locally) so the raw segments and WAL can be inspected offline.
+//
+// Every step is wrapped so a capture error can never mask the original
+// assertion failure: it logs and continues.
+func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompose, className, propName, phase string) {
+	t.Helper()
+	// Self-contained, bounded context: the test's own ctx may be on the way to
+	// cancellation via the failure path, and capture must never hang CI.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	root := forensicArtifactRoot(t, className, phase)
+	t.Logf("range-count forensic capture [%s]: artifact root = %s", phase, root)
+
+	classDirLower := strings.ToLower(className)
+	// Every generation of the rangeable bucket dir shares this prefix, so one
+	// substring match covers canonical + all sidecars + the files within them.
+	bucketMatch := fmt.Sprintf("property_%s_rangeable", propName)
+
+	var copiedBytes int64
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		node := compose.GetWeaviateNode(nodeIdx)
+		if node == nil {
+			t.Logf("range-count forensic capture [%s]: node %d container unavailable", phase, nodeIdx)
+			continue
+		}
+		container := node.Container()
+
+		// 1) Manifest into the test log. `-path "*<match>*"` matches the bucket
+		//    dirs and every file within them; `ls -ld` gives perms+size+mtime
+		//    per entry. When nothing matches (a naming/casing surprise), fall
+		//    back to a full lsm listing so we still see what IS on disk.
+		manifestScript := fmt.Sprintf(
+			`for lsm in /data/%s/*/lsm; do [ -d "$lsm" ] || continue; echo "### $lsm"; `+
+				`m=$(find "$lsm" -path "*%s*" 2>/dev/null); `+
+				`if [ -n "$m" ]; then echo "$m" | while IFS= read -r p; do ls -ld "$p"; done; `+
+				`else echo "(no %s* bucket dirs found; full lsm listing:)"; ls -la "$lsm"; fi; done`,
+			classDirLower, bucketMatch, bucketMatch)
+		manifest := execCollect(ctx, container, []string{"sh", "-c", manifestScript})
+		t.Logf("range-count forensic capture [%s]: node %d rangeable bucket manifest:\n%s",
+			phase, nodeIdx, strings.TrimSpace(manifest))
+
+		// 2) Copy every matching file off the container.
+		fileList := execCollect(ctx, container, []string{"sh", "-c", fmt.Sprintf(
+			`find /data/%s -path "*%s*" -type f 2>/dev/null`, classDirLower, bucketMatch)})
+		copiedBytes += copyContainerFiles(ctx, t, container, root, nodeIdx, fileList, copiedBytes, phase)
+	}
+	t.Logf("range-count forensic capture [%s]: copied ~%d bytes into %s", phase, copiedBytes, root)
+}
+
+// forensicArtifactRoot returns a unique host dir for one capture. REINDEX_
+// FORENSICS_DIR is set by the reindex CI job (and uploaded as an artifact on
+// failure); locally it falls back to an OS temp dir. The subdir is unique per
+// test+phase+timestamp so pre-restart and post-restart captures in the same run
+// (and repeated CI retries) stay distinct.
+func forensicArtifactRoot(t *testing.T, className, phase string) string {
+	t.Helper()
+	base := os.Getenv("REINDEX_FORENSICS_DIR")
+	if base == "" {
+		base = filepath.Join(os.TempDir(), "reindex-forensics")
+	}
+	name := strings.ReplaceAll(t.Name(), "/", "_")
+	root := filepath.Join(base, fmt.Sprintf("%s_%s_%s_%d", name, className, phase, time.Now().UnixNano()))
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Logf("range-count forensic capture [%s]: mkdir %s failed: %v", phase, root, err)
+	}
+	return root
+}
+
+// execCollect runs cmd in the container and returns combined stdout+stderr as
+// clean text. tcexec.Multiplexed strips Docker's stream-framing headers, so the
+// output is usable both as a log manifest and as a newline-separated path list.
+// Best effort: on any exec error it returns a note rather than failing.
+func execCollect(ctx context.Context, container testcontainers.Container, cmd []string) string {
+	_, reader, err := container.Exec(ctx, cmd, tcexec.Multiplexed())
+	if err != nil {
+		return fmt.Sprintf("(exec error: %v)", err)
+	}
+	buf := new(strings.Builder)
+	if reader != nil {
+		_, _ = io.Copy(buf, reader)
+	}
+	return buf.String()
+}
+
+// copyContainerFiles copies each newline-separated container path into
+// <root>/node<nodeIdx>/<path-relative-to-/data>. alreadyCopied is the running
+// cross-node byte total so the shared budget is honoured. Returns the bytes
+// copied for this node.
+func copyContainerFiles(
+	ctx context.Context, t *testing.T, container testcontainers.Container,
+	root string, nodeIdx int, newlineSeparatedPaths string, alreadyCopied int64, phase string,
+) int64 {
+	t.Helper()
+	var nodeCopied int64
+	files := 0
+	for _, p := range strings.Split(strings.TrimSpace(newlineSeparatedPaths), "\n") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		files++
+		if files > forensicFilesPerNodeCap {
+			t.Logf("range-count forensic capture [%s]: node %d file cap (%d) hit; remaining files skipped",
+				phase, nodeIdx, forensicFilesPerNodeCap)
+			break
+		}
+		if alreadyCopied+nodeCopied >= forensicCaptureByteBudget {
+			t.Logf("range-count forensic capture [%s]: byte budget (%d) hit; remaining files skipped",
+				phase, forensicCaptureByteBudget)
+			break
+		}
+		n, err := copyOneContainerFile(ctx, container, root, nodeIdx, p)
+		if err != nil {
+			t.Logf("range-count forensic capture [%s]: node %d copy %s failed: %v", phase, nodeIdx, p, err)
+			continue
+		}
+		nodeCopied += n
+	}
+	return nodeCopied
+}
+
+// copyOneContainerFile streams a single container file onto the host, mirroring
+// its /data-relative path under <root>/node<nodeIdx>/.
+func copyOneContainerFile(
+	ctx context.Context, container testcontainers.Container, root string, nodeIdx int, containerPath string,
+) (int64, error) {
+	rc, err := container.CopyFileFromContainer(ctx, containerPath)
+	if err != nil {
+		return 0, err
+	}
+	defer rc.Close()
+	rel := strings.TrimPrefix(containerPath, "/data/")
+	dest := filepath.Join(root, fmt.Sprintf("node%d", nodeIdx), filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return 0, err
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	return io.Copy(f, rc)
 }
 
 // probeSample is one observation of a probe function against a node.

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -699,39 +699,20 @@ func dumpStartupLogs(ctx context.Context, t *testing.T, compose *docker.DockerCo
 	}
 }
 
-// forensicCaptureByteBudget caps the total bytes copied off all nodes in a
-// single capture. The rangeable bucket for the fixtures here is KBs, so this is
-// pure runaway protection (a pathological on-disk state must never fill the CI
-// runner's disk or hang the job on an endless copy).
+// forensicCaptureByteBudget is runaway protection: capture must never fill
+// the CI runner's disk or hang the job on an endless copy.
 const forensicCaptureByteBudget = 512 << 20 // 512 MiB
 
-// forensicFilesPerNodeCap bounds how many files are copied off one node, same
-// runaway-protection rationale as forensicCaptureByteBudget.
+// forensicFilesPerNodeCap: same runaway-protection rationale as forensicCaptureByteBudget.
 const forensicFilesPerNodeCap = 4000
 
-// captureRangeableDataDirsOnFailure is a BEST-EFFORT forensic capture invoked
-// only when a per-node range-count assertion fails. For
-// weaviate/0-weaviate-issues#335 the discriminating evidence is the on-disk
-// shape of the migrated property's rangeable LSM bucket at failure time: which
-// generation dirs exist (canonical property_<prop>_rangeable vs the
-// __rangeable_ingest / __rangeable_reindex / __rangeable_backup sidecars) and,
-// inside the promoted dir, the segment + .wal file listing and sizes. Seven
-// candidate producers were refuted without this evidence; capturing it at the
-// moment of failure means the next flake self-evidences instead of needing an
-// eighth guess.
-//
-// Per node it (1) writes a name+size+mtime manifest of every rangeable bucket
-// generation into the test log — so the listing survives even when the CI
-// artifact is not downloaded — and (2) copies every file under those dirs off
-// the container into a host artifact dir (REINDEX_FORENSICS_DIR in CI, an OS
-// temp dir locally) so the raw segments and WAL can be inspected offline.
-//
-// Every step is wrapped so a capture error can never mask the original
-// assertion failure: it logs and continues.
+// captureRangeableDataDirsOnFailure is a best-effort dump of the rangeable
+// bucket's on-disk state (weaviate/0-weaviate-issues#335), for offline
+// post-mortem on a range-count failure. Capture errors are logged, never fatal.
 func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompose, className, propName, phase string) {
 	t.Helper()
-	// Self-contained, bounded context: the test's own ctx may be on the way to
-	// cancellation via the failure path, and capture must never hang CI.
+	// Independent of the test's ctx (which may be cancelling) and bounded, so
+	// capture can never hang CI.
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
@@ -739,8 +720,7 @@ func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompo
 	t.Logf("range-count forensic capture [%s]: artifact root = %s", phase, root)
 
 	classDirLower := strings.ToLower(className)
-	// Every generation of the rangeable bucket dir shares this prefix, so one
-	// substring match covers canonical + all sidecars + the files within them.
+	// Prefix shared by the canonical bucket dir and all its sidecar generations.
 	bucketMatch := fmt.Sprintf("property_%s_rangeable", propName)
 
 	var copiedBytes int64
@@ -752,10 +732,8 @@ func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompo
 		}
 		container := node.Container()
 
-		// 1) Manifest into the test log. `-path "*<match>*"` matches the bucket
-		//    dirs and every file within them; `ls -ld` gives perms+size+mtime
-		//    per entry. When nothing matches (a naming/casing surprise), fall
-		//    back to a full lsm listing so we still see what IS on disk.
+		// Manifest into the test log so it survives even without the artifact
+		// download; fall back to a full listing if nothing matches.
 		manifestScript := fmt.Sprintf(
 			`for lsm in /data/%s/*/lsm; do [ -d "$lsm" ] || continue; echo "### $lsm"; `+
 				`m=$(find "$lsm" -path "*%s*" 2>/dev/null); `+
@@ -766,7 +744,6 @@ func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompo
 		t.Logf("range-count forensic capture [%s]: node %d rangeable bucket manifest:\n%s",
 			phase, nodeIdx, strings.TrimSpace(manifest))
 
-		// 2) Copy every matching file off the container.
 		fileList := execCollect(ctx, container, []string{"sh", "-c", fmt.Sprintf(
 			`find /data/%s -path "*%s*" -type f 2>/dev/null`, classDirLower, bucketMatch)})
 		copiedBytes += copyContainerFiles(ctx, t, container, root, nodeIdx, fileList, copiedBytes, phase)
@@ -774,11 +751,9 @@ func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompo
 	t.Logf("range-count forensic capture [%s]: copied ~%d bytes into %s", phase, copiedBytes, root)
 }
 
-// forensicArtifactRoot returns a unique host dir for one capture. REINDEX_
-// FORENSICS_DIR is set by the reindex CI job (and uploaded as an artifact on
-// failure); locally it falls back to an OS temp dir. The subdir is unique per
-// test+phase+timestamp so pre-restart and post-restart captures in the same run
-// (and repeated CI retries) stay distinct.
+// forensicArtifactRoot returns a unique host dir for one capture: under
+// REINDEX_FORENSICS_DIR in CI, an OS temp dir locally. Unique per
+// test+phase+timestamp so repeated captures in the same run don't collide.
 func forensicArtifactRoot(t *testing.T, className, phase string) string {
 	t.Helper()
 	base := os.Getenv("REINDEX_FORENSICS_DIR")
@@ -793,10 +768,9 @@ func forensicArtifactRoot(t *testing.T, className, phase string) string {
 	return root
 }
 
-// execCollect runs cmd in the container and returns combined stdout+stderr as
-// clean text. tcexec.Multiplexed strips Docker's stream-framing headers, so the
-// output is usable both as a log manifest and as a newline-separated path list.
-// Best effort: on any exec error it returns a note rather than failing.
+// execCollect runs cmd in the container and returns combined stdout+stderr.
+// tcexec.Multiplexed strips Docker's stream-framing headers so the output is
+// plain text. Best effort: exec errors are returned as a note, not an error.
 func execCollect(ctx context.Context, container testcontainers.Container, cmd []string) string {
 	_, reader, err := container.Exec(ctx, cmd, tcexec.Multiplexed())
 	if err != nil {
@@ -809,10 +783,8 @@ func execCollect(ctx context.Context, container testcontainers.Container, cmd []
 	return buf.String()
 }
 
-// copyContainerFiles copies each newline-separated container path into
-// <root>/node<nodeIdx>/<path-relative-to-/data>. alreadyCopied is the running
-// cross-node byte total so the shared budget is honoured. Returns the bytes
-// copied for this node.
+// copyContainerFiles copies each container path to disk. alreadyCopied is the
+// running cross-node total, so the shared byte budget applies across nodes.
 func copyContainerFiles(
 	ctx context.Context, t *testing.T, container testcontainers.Container,
 	root string, nodeIdx int, newlineSeparatedPaths string, alreadyCopied int64, phase string,
@@ -846,8 +818,7 @@ func copyContainerFiles(
 	return nodeCopied
 }
 
-// copyOneContainerFile streams a single container file onto the host, mirroring
-// its /data-relative path under <root>/node<nodeIdx>/.
+// copyOneContainerFile mirrors containerPath's /data-relative path under <root>/node<nodeIdx>/.
 func copyOneContainerFile(
 	ctx context.Context, container testcontainers.Container, root string, nodeIdx int, containerPath string,
 ) (int64, error) {

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -286,6 +286,36 @@ func CreateObjectWithResponse(t *testing.T, object *models.Object) (*models.Obje
 	return resp.Payload, nil
 }
 
+// ErrorDetail renders the server-side message carried by a swagger client
+// error. The generated error types format models.ErrorResponse with %+v, and
+// because its Error field is a slice of pointers that renders as
+// "&{Error:[0xc000acd5a0]}" -- the address, not the reason the server rejected
+// the request. Use it in assertion messages so a failure is diagnosable from
+// the test log alone.
+func ErrorDetail(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	var carrier interface{ GetPayload() *models.ErrorResponse }
+	if !errors.As(err, &carrier) {
+		return err.Error()
+	}
+	payload := carrier.GetPayload()
+	if payload == nil {
+		return err.Error()
+	}
+	msgs := make([]string, 0, len(payload.Error))
+	for _, item := range payload.Error {
+		if item != nil {
+			msgs = append(msgs, item.Message)
+		}
+	}
+	if len(msgs) == 0 {
+		return err.Error()
+	}
+	return fmt.Sprintf("%s: %s", err.Error(), strings.Join(msgs, "; "))
+}
+
 func CreateObjectWithResponseAuth(t *testing.T, object *models.Object, key string) (*models.Object, error) {
 	t.Helper()
 	params := objects.NewObjectsCreateParams().WithBody(object)

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -107,6 +107,15 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 	}
 	maxSchemaVersion = max(maxSchemaVersion, autoTenantSchemaVersion)
 
+	// The caller already waited, but only for the version known before
+	// auto-schema ran. When auto-schema creates the class the index is
+	// materialised inside the raft apply, so a node that has not yet applied
+	// that entry resolves no index and the write fails with "import into
+	// non-existing index". Wait again on the post-auto-schema version.
+	if err := m.schemaManager.WaitForUpdate(ctx, maxSchemaVersion); err != nil {
+		return nil, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", maxSchemaVersion, err)
+	}
+
 	class := fetchedClasses[object.Class].Class
 
 	err = m.validateObjectAndNormalizeNames(ctx, principal, repl, object, nil, fetchedClasses)

--- a/usecases/objects/add_test.go
+++ b/usecases/objects/add_test.go
@@ -582,3 +582,63 @@ func Test_AddObjectWithUUIDProps(t *testing.T) {
 	assert.Equal(t, expectedID, addedObject.Properties.(map[string]interface{})["my_id"])
 	assert.Equal(t, expectedIDz, addedObject.Properties.(map[string]interface{})["my_idz"])
 }
+
+// Test_Add_Object_Waits_For_AutoSchema_Version_Before_Write pins the contract
+// that a write is never issued at a schema version the local node has not
+// waited for. Auto-schema materialises the index inside the raft apply, so
+// writing at an unawaited version lets a node that has not applied that entry
+// resolve no index and fail with "import into non-existing index".
+func Test_Add_Object_Waits_For_AutoSchema_Version_Before_Write(t *testing.T) {
+	const autoSchemaVersion uint64 = 41
+
+	existingClass := &models.Class{
+		Class: "FooExisting", Vectorizer: config.VectorizerModuleNone,
+		VectorIndexConfig: hnsw.UserConfig{},
+	}
+
+	tests := []struct {
+		name   string
+		schema schema.Schema
+		object *models.Object
+	}{
+		{
+			name:   "auto-schema creates the collection",
+			schema: schema.Schema{Objects: &models.Schema{Classes: []*models.Class{}}},
+			object: &models.Object{Class: "FooBrandNew", Properties: map[string]any{"title": "a"}},
+		},
+		{
+			name:   "auto-schema adds a property to an existing collection",
+			schema: schema.Schema{Objects: &models.Schema{Classes: []*models.Class{existingClass}}},
+			object: &models.Object{Class: "FooExisting", Properties: map[string]any{"title": "a"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vectorRepo := &fakeVectorRepo{}
+			vectorRepo.On("PutObject", mock.Anything, mock.Anything).Return(nil).Once()
+			schemaManager := &fakeSchemaManager{
+				GetSchemaResponse: tt.schema,
+				AutoSchemaVersion: autoSchemaVersion,
+			}
+			cfg := &config.WeaviateConfig{Config: config.Config{
+				AutoSchema: config.AutoSchema{Enabled: runtime.NewDynamicValue(true)},
+			}}
+			logger, _ := test.NewNullLogger()
+			modulesProvider := getFakeModulesProvider()
+			modulesProvider.On("UpdateVector", mock.Anything, mock.AnythingOfType(FindObjectFn)).Return(nil, nil)
+			manager := NewManager(schemaManager, cfg, logger, mocks.NewMockAuthorizer(), vectorRepo,
+				modulesProvider, &fakeMetrics{}, nil,
+				NewAutoSchemaManager(schemaManager, vectorRepo, cfg, logger, prometheus.NewPedanticRegistry()))
+
+			_, err := manager.AddObject(context.Background(), nil, tt.object, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, autoSchemaVersion, vectorRepo.CapturedSchemaVersion,
+				"the write must carry the version auto-schema produced")
+			assert.GreaterOrEqual(t, schemaManager.MaxWaitedSchemaVersion, vectorRepo.CapturedSchemaVersion,
+				"must wait for the schema version it then writes at; waited versions were %v",
+				schemaManager.WaitedVersions)
+		})
+	}
+}


### PR DESCRIPTION
This PR carries two halves: a fix for a read-your-own-write defect in the single-object write path, and the failure-forensics work that made that defect visible in the first place.

## The write-path defect

`Manager.AddObject` waits for the local schema to catch up at `usecases/objects/add.go:75` — but that wait uses the version known **before** auto-schema runs. Auto-schema then creates the collection inside `addObjectToConnectorAndSchema`, `maxSchemaVersion` is raised to the version that creation returned, and the write proceeds at that raised version **without waiting again**.

The index for a new collection is materialised inside the raft apply (`cluster/store_apply.go:194` → `usecases/schema/executor.go:102` → `Migrator.AddClass`). A node that has not yet applied that entry therefore resolves no index, and `DB.PutObject` fails at `adapters/repos/db/crud.go:43`:

```
put object: import into non-existing index for AutoCreated
```

which reaches the caller as an opaque `[POST /objects][500]`. It is a read-your-own-write violation: the request that created the collection is the one that cannot see it.

## The asymmetry — three sibling paths, one wrong

Each of these assembles a post-auto-schema version before writing. Two waited on it; one did not:

| Path | Waits on the post-auto-schema version? |
| --- | --- |
| `batch_add.go:138` — after `validateObjectsConcurrently` returns it | yes |
| `auto_schema.go:589` — inside `addTenants`, before returning the tenant version | yes |
| `auto_schema.go:146` — `createClass` returns its version unawaited | **no** |

Only the collection-creation path was missing it. The fix adds the wait in `addObjectToConnectorAndSchema` once `maxSchemaVersion` is final — which is exactly what the pre-existing comment at `add.go:73` already claimed the earlier wait covered.

The `update` (PUT) and `merge` (PATCH) paths also wait before running auto-schema, but both require the object to already exist, so auto-schema there only adds properties and never needs a new index. They are not exposed to this failure.

## Red-proof

`Test_Add_Object_Waits_For_AutoSchema_Version_Before_Write` is table-driven over collection creation and property addition, and asserts the contract rather than a symptom: the manager must never write at a version it has not waited for (`MaxWaitedSchemaVersion >= CapturedSchemaVersion`). Remove the wait and both rows go red with:

```
must wait for the schema version it then writes at; waited versions were [0]
```

End to end against `./test/acceptance/namespace` under full-package parallel load, the `import into non-existing index` signature appeared in **1 of 3** baseline runs and **0 of 4** runs after the fix. `usecases/objects` unit tests pass under `-race`.

## Making failures legible

The defect above survived undiagnosed because both halves of the evidence were being discarded.

**Server error messages.** The generated swagger error types format `models.ErrorResponse` with `%+v`, and its `Error` field is a slice of pointers, so a 500 rendered as its own address:

```
[POST /objects][500] objectsCreateInternalServerError &{Error:[0xc000acd5a0]}
```

`helper.ErrorDetail` unwraps the payload through the `GetPayload()` interface the generated types already expose and joins the messages, so assertion output names the actual server-side reason.

**Node logs.** `test/acceptance/namespace` terminated its compose without ever dumping container logs, while its sibling `namespace_limits` already did. Added the same failure-only `DumpWeaviateLogs(ctx, os.Stderr, 300)`.

## Reindex forensic artifacts (weaviate/etienne-claude-issues#67)

The `node-3` flake of `TestMultiNode_EnableRangeable_ConcurrentUpdatesNoLossNoPanic` has resisted diagnosis: seven candidate producers were refuted because the one discriminating piece of evidence was never captured — the **on-disk shape of the migrated property's rangeable LSM bucket at the moment the assertion fails**. That means which generation dirs exist (canonical `property_dateInt_rangeable` vs the `__rangeable_ingest` / `__rangeable_reindex` / `__rangeable_backup` sidecars) and, inside them, the segment + `.wal` listing and sizes.

`captureRangeableDataDirsOnFailure` runs **only** when a range-count assertion fails (both the pre-restart and post-restart calls route through the same helper). For every node it:

1. Writes a `name+size+mtime` manifest of every rangeable bucket generation into the **test log itself**, so the listing survives even without downloading the artifact. Falls back to a full `lsm/` listing if the targeted glob matches nothing (naming/casing surprise).
2. Copies every file under those dirs off the container via the testcontainers `CopyFileFromContainer` API into `REINDEX_FORENSICS_DIR`, preserving a `node<N>/<class>/<shard>/lsm/...` layout.

Capture is **best-effort** (every step log-and-continue, so a capture error can never mask the original assertion failure) and **bounded** (per-node file cap + total byte budget), so a pathological on-disk state cannot fill the runner or hang CI.

### Workflow change (please review deliberately)

The `Acceptance-Reindex-Tests` job had no artifact upload. Scoped to that job only:

- a job-level `REINDEX_FORENSICS_DIR: ${{ github.workspace }}/reindex-forensics` env var (read by the tests), and
- a failure-only `actions/upload-artifact` step (`if: failure()`, `if-no-files-found: ignore`, `retention-days: 14`) uploading that dir as `reindex-forensics-<matrix>`.

No restructuring, no other job touched. `actions/upload-artifact` is pinned to the same SHA already used elsewhere in the workflow.

### Verification of the capture path

Built the image from this branch and ran the target test with a **temporarily-forced** `want=1501` assert (reverted before commit):

- capture fired at the pre-restart failure;
- the manifest landed in the test log — each shard showed its `property_dateInt_rangeable__rangeable_ingest_1` dir with the `.l0.s4.db` segment and the `.wal`, sizes+mtimes;
- 18 files (~2 MB: 3 nodes x 3 shards x [segment + WAL]) landed in the artifact dir in the expected layout;
- on the **passing** post-restart assert, **no** capture fired — confirming it is failure-scoped.

`go vet`, `gofmt`/`gofumpt`/`goimports`, `golangci-lint`, and the goroutine linter all pass on the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019g2rCuaCqspGofsdCy3Geg
