### PR TITLE
Stop commit log churn flaking vector storage size test

### DIFF
--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -42,6 +42,7 @@ import (
 	vectorIndex "github.com/weaviate/weaviate/entities/vectorindex/common"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
@@ -760,7 +761,9 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 		TrackVectorDimensions: true,
 		EnableLazyLoadShards:  false, // we have to make sure lazyload shard disabled to load directly
 		MaxReuseWalSize:       4096,  // with recovery from .wal
-
+		// Left at 0, the commit logger switches and condenses on every maintenance
+		// tick, so the measured commit log size changes mid-test.
+		HNSWMaxLogSize: config.DefaultPersistenceHNSWMaxLogSize,
 	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		enthnsw.UserConfig{
 			VectorCacheMaxObjects: 1000,
@@ -801,8 +804,6 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	// but we don't need DB for this test. Gimicky, but it does the job.
 	db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
 	publishVectorMetricsFromDB(t, db)
-	// Give time for HNSW commit logger condensing process to finish
-	time.Sleep(1 * time.Second)
 	// Test active shard vector storage size
 	activeShard, release, err := index.GetShard(ctx, tenantNamePopulated)
 	require.NoError(t, err)
@@ -870,6 +871,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 		TrackVectorDimensions: true,
 		MaxReuseWalSize:       4096,
 		EnableLazyLoadShards:  true, // we have to make sure lazyload enabled
+		HNSWMaxLogSize:        config.DefaultPersistenceHNSWMaxLogSize,
 	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		enthnsw.UserConfig{
 			VectorCacheMaxObjects: 1000,


### PR DESCRIPTION
### What's being changed:

  The test was flaky, not wrong-valued. TestIndex_VectorStorageSize_ActiveVsUnloaded never set HNSWMaxLogSize, leaving it at Go's zero value. That flows through shard_init_vector.go:127 into hnsw.WithCommitlogThreshold(0/5) = 0, and switchCommitLogs only skips when size <= 0 — so any non-empty commit log got switched on every maintenance tick. That produced a second file, which made condenseLogs condense the first one, on a repeating cycle.

The test measures the commit-log directory twice (active at line 824, unloaded at line 892) and compares them. Because condensor.Do writes X.condensed and only afterwards removes X (condensor.go:171-177), a measurement landing in that window double-counts. The CI arithmetic confirms it exactly: 50 × 1536 × 4 = 307,200 vectors, leaving 1,859 vs 661 bytes of  commit log — and 1,859 = 1,198 (raw) + 661 (condensed).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
