### PR TITLE
fix(replication): load empty MT shards when async replication is enabled

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -491,7 +491,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				return nil
 			default:
 				// avoid footprint of empty shards
-				if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
+				if i.keepEmptyShardUnloaded(shardName) {
 					i.shards.Store(shardName, NewLazyLoadShard(ctx, promMetrics, shardName, i, class,
 						i.centralJobQueue, i.indexCheckpoints, i.allocChecker, i.shardLoadLimiter,
 						i.shardReindexer, false, i.bitmapBufPool))
@@ -585,6 +585,14 @@ func (i *Index) unloadedShardIsEmpty(shardName string) bool {
 	return err == nil && count == 0
 }
 
+// keepEmptyShardUnloaded reports whether a locally-empty tenant shard may stay
+// unloaded to save memory. With async replication on it must not: a shard empty
+// on this node may hold data on replicas (e.g. writes missed while this node was
+// down), and only loading it starts the per-shard hashbeater that converges it.
+func (i *Index) keepEmptyShardUnloaded(shardName string) bool {
+	return i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) && !i.AsyncReplicationEnabled()
+}
+
 func (i *Index) loadLocalShardIfActive(shardName string) error {
 	i.shardCreateLocks.Lock(shardName)
 	defer i.shardCreateLocks.Unlock(shardName)
@@ -598,7 +606,7 @@ func (i *Index) loadLocalShardIfActive(shardName string) error {
 	lazyShard, ok := shard.(*LazyLoadShard)
 	if ok {
 		// avoid footprint of empty shards
-		if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
+		if i.keepEmptyShardUnloaded(shardName) {
 			return nil
 		}
 		return lazyShard.Load(context.Background())


### PR DESCRIPTION
### What's being changed:
An empty tenant shard was kept lazyto save memory, but local-empty != cluster empty: a node that missed writes while down sees its shard as empty and never loads it, so the per-shard hashbeater never starts and async replication never converges the stale replica against peers.


fix : gate the empty-shard skip on async replication being off, with async replication on, empty HOT shards now load so their
hashbeater can pull data from replicas.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
