### PR TITLE
perf(lsmkv): reuse the propLengthsView across inverted compaction nodes

### DIFF
--- a/adapters/repos/db/lsmkv/compactor_inverted.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted.go
@@ -60,6 +60,10 @@ type compactorInverted struct {
 	// block re-encoding (via a cursor) and serialized directly — never a map.
 	propLengthIds  []uint64
 	propLengthLens []uint32
+	// one view over the arrays above, reused for every node's block re-encoding so
+	// the lookup allocates nothing per term. Its cursor is only a search hint that
+	// get() self-corrects on a backward docID, so no per-node reset is needed.
+	propLenView propLengthsView
 
 	invertedHeader *segmentindex.HeaderInverted
 
@@ -151,6 +155,7 @@ func (c *compactorInverted) do(ctx context.Context) error {
 
 	// drop the property lengths of docs cleanupValues removes from the older segment
 	c.propLengthIds, c.propLengthLens = mergePropLenPairs(ids1, lens1, ids2, lens2, c.tombstonesToClean)
+	c.propLenView = propLengthsView{ids: c.propLengthIds, lens: c.propLengthLens}
 
 	tombstones := c.computeTombstones()
 
@@ -396,14 +401,11 @@ func (c *compactorInverted) writeIndividualNode(offset int, key []byte,
 	// (https://github.com/weaviate/weaviate/issues/3517).
 	keyCopy := c.arena.CopyKey(key)
 
-	// fresh view per term: its docIDs ascend, so lookups stay amortized O(1)
-	view := propLengthsView{ids: c.propLengthIds, lens: c.propLengthLens}
-
 	return segmentInvertedNode{
 		values:      values,
 		primaryKey:  keyCopy,
 		offset:      offset,
-		propLengths: &view,
+		propLengths: &c.propLenView,
 	}.KeyIndexAndWriteToCompaction(c.segmentFile.BodyWriter(), c.writeBuf[:], &c.encodeBufs,
 		c.docIdEncoder, c.tfEncoder, c.k1, c.b, c.avgPropLen)
 }


### PR DESCRIPTION
### What's being changed:

`compactorInverted.writeIndividualNode` built a **fresh `propLengthsView` per term** and passed `&view` into the node encoder. Because that pointer escapes, it's **one heap allocation per term** — millions on a large segment (profiling a ~3 GB compacted output showed ~4.5 M allocations attributed to `writeIndividualNode`, the single largest remaining allocator once the block-decode/encode reuse is in place).

This hoists the view onto `compactorInverted`, built **once** in `do()` from the merged property-length arrays, and reuses `&c.propLenView` for every node.

**Why no per-node reset is needed:** the view's cursor is only a search *hint*. `propLengthsView.get` already self-corrects on a backward docID (`if c >= n || ids[c] > docID { c = 0 }`), so reusing one view across terms is correctness-safe and never slower than a fresh view — it forward-gallops when a term's docIDs continue upward and restarts from the front otherwise, exactly what a fresh `cur=0` view would do.

**Output is byte-identical.** `get` returns the same property length regardless of cursor state, so block MaxImpact metadata and the whole segment are unchanged.

### Tests

Existing inverted compaction suite passes unchanged, including the ones that would catch any deviation:
- `TestCompaction/compactionInvertedStrategy*` — asserts the **exact** compacted segment byte size (min == max).
- BlockMax + WAND search validation, cursor read-back, `TestTombstonesInverted_Compaction`.

### Review checklist

- [ ] Documentation has been updated, if necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
