### PR TITLE
Make number of files that are deduplicated in incremental backups configurable

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2265,6 +2265,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.ExportDefaultBucket = appState.ServerConfig.Config.Export.DefaultBucket
 		registered.ExportDefaultPath = appState.ServerConfig.Config.Export.DefaultPath
 		registered.ExportParallelism = appState.ServerConfig.Config.ExportParallelism
+		registered.BackupMaxIndividualFiles = appState.ServerConfig.Config.Backup.MaxIndividualFiles
 		registered.DebugEndpointsEnabled = appState.ServerConfig.Config.Profiling.DebugEndpointsEnabled
 
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -342,10 +342,11 @@ type ShardAndID struct {
 type FileList struct {
 	Files     []string
 	FileSizes map[string]int64 // map of relative file path to file size in bytes
-	// Top100Size is the size of the 100th biggest file (or smallest if fewer than 100 files),
-	// with a minimum of 1MB. This can be used for chunk size optimization.
-	Top100Size int64
-	start      int
+	// BigFileThreshold is the size of the n-th biggest file, clamped to a minimum chunk size,
+	// where n is the configured number of files that may get their own chunk, minus the files
+	// reused from the base backup.
+	BigFileThreshold int64
+	start            int
 }
 
 // Len returns the number of files in the list

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -342,11 +342,11 @@ type ShardAndID struct {
 type FileList struct {
 	Files     []string
 	FileSizes map[string]int64 // map of relative file path to file size in bytes
-	// BigFileThreshold is the size of the n-th biggest file, clamped to a minimum chunk size,
+	// BigFilesThreshold is the size of the n-th biggest file, clamped to a minimum chunk size,
 	// where n is the configured number of files that may get their own chunk, minus the files
 	// reused from the base backup.
-	BigFileThreshold int64
-	start            int
+	BigFilesThreshold int64
+	start             int
 }
 
 // Len returns the number of files in the list

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -533,7 +533,7 @@ func (u *uploader) compress(ctx context.Context,
 
 	// bigFileThreshold: files >= this size are "big" and get their own chunk (tracked for incremental dedup).
 	// chunkTargetSize controls the max size when packing small files together; it must be at least bigFileThreshold.
-	bigFileThreshold := max(u.cfg.MinChunkSize, filesInShard.Top100Size)
+	bigFileThreshold := max(u.cfg.MinChunkSize, filesInShard.BigFileThreshold)
 	chunkTargetSize := max(u.cfg.ChunkTargetSize, bigFileThreshold)
 	zip, reader, err := NewZip(sourcePath, u.Level, chunkTargetSize, bigFileThreshold, u.cfg.SplitFileSize)
 	if err != nil {
@@ -629,7 +629,7 @@ func (u *uploader) calculateShardPreCompressionSize(shard *backup.ShardDescripto
 }
 
 // createFileList creates a FileList from a ShardDescriptor with Files copied,
-// FileSizes map populated, and Top100Size calculated (size of 100th biggest file, minimum 1MB).
+// FileSizes map populated, and BigFileThreshold calculated.
 // This allows file sizes to be collected once at the start of processing rather than repeatedly during compression.
 // Returns an error if any file in the shard doesn't exist at either the normal path or delete marker path.
 func (u *uploader) createFileList(shard *backup.ShardDescriptor, sourcePath string) (*backup.FileList, error) {
@@ -658,17 +658,26 @@ func (u *uploader) createFileList(shard *backup.ShardDescriptor, sourcePath stri
 	filesCopy := make([]string, len(files))
 	copy(filesCopy, files)
 
+	// A config not built by FromEnv leaves this nil, so Get yields 0.
+	maxIndividualFiles := u.cfg.MaxIndividualFiles.Get()
+	if maxIndividualFiles <= 0 {
+		maxIndividualFiles = config.DefaultBackupMaxIndividualFiles
+	}
+
 	return &backup.FileList{
-		Files:      filesCopy,
-		FileSizes:  fileSizes,
-		Top100Size: calculateTop100Size(fileSizes, shard.IncrementalBackupInfo.NumFilesSkipped, u.cfg.MinChunkSize),
+		Files:     filesCopy,
+		FileSizes: fileSizes,
+		BigFileThreshold: calculateBigFileThreshold(fileSizes, shard.IncrementalBackupInfo.NumFilesSkipped,
+			maxIndividualFiles, u.cfg.MinChunkSize),
 	}, nil
 }
 
-// calculateTop100Size returns the size of the 100th biggest file (or smallest if fewer than 100),
-// with a minimum of minSize. Uses a min-heap of size 100 for O(n) time and O(1) space complexity.
-func calculateTop100Size(fileSizes map[string]int64, numSkippedFiles int, minSize int64) int64 {
-	k := max(100-numSkippedFiles, 1) // take into account that this might be an incremental backup with skipped files
+// calculateBigFileThreshold returns the size of the k-th biggest file, clamped to minSize,
+// where k is maxIndividualFiles reduced by numSkippedFiles and at least 1. Returns the
+// smallest file's size if there are fewer than k files.
+// Uses a min-heap for O(n) time and O(min(k, n)) space.
+func calculateBigFileThreshold(fileSizes map[string]int64, numSkippedFiles, maxIndividualFiles int, minSize int64) int64 {
+	k := max(maxIndividualFiles-numSkippedFiles, 1) // take into account that this might be an incremental backup with skipped files
 
 	if len(fileSizes) == 0 {
 		return minSize

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -531,11 +531,11 @@ func (u *uploader) compress(ctx context.Context,
 		eg                 = enterrors.NewErrorGroupWrapper(u.log)
 	)
 
-	// bigFileThreshold: files >= this size are "big" and get their own chunk (tracked for incremental dedup).
-	// chunkTargetSize controls the max size when packing small files together; it must be at least bigFileThreshold.
-	bigFileThreshold := max(u.cfg.MinChunkSize, filesInShard.BigFileThreshold)
-	chunkTargetSize := max(u.cfg.ChunkTargetSize, bigFileThreshold)
-	zip, reader, err := NewZip(sourcePath, u.Level, chunkTargetSize, bigFileThreshold, u.cfg.SplitFileSize)
+	// bigFilesThreshold: files >= this size are "big" and get their own chunk (tracked for incremental dedup).
+	// chunkTargetSize controls the max size when packing small files together; it must be at least bigFilesThreshold.
+	bigFilesThreshold := max(u.cfg.MinChunkSize, filesInShard.BigFilesThreshold)
+	chunkTargetSize := max(u.cfg.ChunkTargetSize, bigFilesThreshold)
+	zip, reader, err := NewZip(sourcePath, u.Level, chunkTargetSize, bigFilesThreshold, u.cfg.SplitFileSize)
 	if err != nil {
 		return nil, preCompressionSize.Load(), err
 	}
@@ -629,7 +629,7 @@ func (u *uploader) calculateShardPreCompressionSize(shard *backup.ShardDescripto
 }
 
 // createFileList creates a FileList from a ShardDescriptor with Files copied,
-// FileSizes map populated, and BigFileThreshold calculated.
+// FileSizes map populated, and BigFilesThreshold calculated.
 // This allows file sizes to be collected once at the start of processing rather than repeatedly during compression.
 // Returns an error if any file in the shard doesn't exist at either the normal path or delete marker path.
 func (u *uploader) createFileList(shard *backup.ShardDescriptor, sourcePath string) (*backup.FileList, error) {
@@ -667,16 +667,16 @@ func (u *uploader) createFileList(shard *backup.ShardDescriptor, sourcePath stri
 	return &backup.FileList{
 		Files:     filesCopy,
 		FileSizes: fileSizes,
-		BigFileThreshold: calculateBigFileThreshold(fileSizes, shard.IncrementalBackupInfo.NumFilesSkipped,
+		BigFilesThreshold: calculateBigFilesThreshold(fileSizes, shard.IncrementalBackupInfo.NumFilesSkipped,
 			maxIndividualFiles, u.cfg.MinChunkSize),
 	}, nil
 }
 
-// calculateBigFileThreshold returns the size of the k-th biggest file, clamped to minSize,
+// calculateBigFilesThreshold returns the size of the k-th biggest file, clamped to minSize,
 // where k is maxIndividualFiles reduced by numSkippedFiles and at least 1. Returns the
 // smallest file's size if there are fewer than k files.
 // Uses a min-heap for O(n) time and O(min(k, n)) space.
-func calculateBigFileThreshold(fileSizes map[string]int64, numSkippedFiles, maxIndividualFiles int, minSize int64) int64 {
+func calculateBigFilesThreshold(fileSizes map[string]int64, numSkippedFiles, maxIndividualFiles int, minSize int64) int64 {
 	k := max(maxIndividualFiles-numSkippedFiles, 1) // take into account that this might be an incremental backup with skipped files
 
 	if len(fileSizes) == 0 {

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/usecases/config"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 func TestCalculateShardPreCompressionSize(t *testing.T) {
@@ -166,14 +167,92 @@ func TestCreateFileList(t *testing.T) {
 		assert.Contains(t, err.Error(), "missing.db")
 		assert.Contains(t, err.Error(), "not found")
 	})
+
+	// Three files sized 100/200/300 with MinChunkSize=0, so BigFileThreshold is the n-th
+	// biggest size unclamped.
+	bigFileThresholdTests := []struct {
+		name               string
+		maxIndividualFiles *configRuntime.DynamicValue[int]
+		expected           int64
+	}{
+		{
+			name:               "only the biggest file gets its own chunk",
+			maxIndividualFiles: configRuntime.NewDynamicValue(1),
+			expected:           300,
+		},
+		{
+			name:               "every file gets its own chunk",
+			maxIndividualFiles: configRuntime.NewDynamicValue(3),
+			expected:           100,
+		},
+		{
+			name:               "limit above the file count lets every file qualify",
+			maxIndividualFiles: configRuntime.NewDynamicValue(500),
+			expected:           100,
+		},
+		{
+			name:               "nil config value falls back to the default",
+			maxIndividualFiles: nil,
+			expected:           100, // default of 100 exceeds the 3 files, so the smallest wins
+		},
+	}
+
+	writeSizedFiles := func(t *testing.T) (string, []string) {
+		t.Helper()
+		tempDir := t.TempDir()
+		testFiles := []string{"file1.db", "file2.db", "file3.db"}
+		for i, filename := range testFiles {
+			err := os.WriteFile(filepath.Join(tempDir, filename), make([]byte, 100*(i+1)), 0o644)
+			require.NoError(t, err)
+		}
+		return tempDir, testFiles
+	}
+
+	for _, tc := range bigFileThresholdTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tempDir, testFiles := writeSizedFiles(t)
+
+			shard := &backup.ShardDescriptor{Name: "test-shard", Node: "test-node", Files: testFiles}
+			u := &uploader{
+				log: logrus.New(),
+				cfg: config.Backup{MaxIndividualFiles: tc.maxIndividualFiles},
+			}
+
+			fileList, err := u.createFileList(shard, tempDir)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, fileList.BigFileThreshold)
+		})
+	}
+
+	// The uploader copies config.Backup, so an in-place override only reaches it if the
+	// DynamicValue pointer survives that copy.
+	t.Run("runtime override reaches an existing uploader", func(t *testing.T) {
+		t.Parallel()
+		tempDir, testFiles := writeSizedFiles(t)
+
+		shard := &backup.ShardDescriptor{Name: "test-shard", Node: "test-node", Files: testFiles}
+		cfg := config.Backup{MaxIndividualFiles: configRuntime.NewDynamicValue(3)}
+		u := &uploader{log: logrus.New(), cfg: cfg}
+
+		fileList, err := u.createFileList(shard, tempDir)
+		require.NoError(t, err)
+		require.Equal(t, int64(100), fileList.BigFileThreshold)
+
+		require.NoError(t, cfg.MaxIndividualFiles.SetValue(1))
+
+		fileList, err = u.createFileList(shard, tempDir)
+		require.NoError(t, err)
+		assert.Equal(t, int64(300), fileList.BigFileThreshold)
+	})
 }
 
 // TestProcessShard tests the full write path from shard files to chunks with only
 // the storage backend mocked. Real files are created on disk, and the real compress
 // + createFileList logic runs end-to-end.
 //
-// Sizing note: with fewer than 100 files, Top100Size equals the smallest file size
-// (clamped to MinChunkSize). bigFileThreshold = max(MinChunkSize, Top100Size).
+// Sizing note: with fewer than 100 files, BigFileThreshold equals the smallest file size
+// (clamped to MinChunkSize). bigFileThreshold = max(MinChunkSize, BigFileThreshold).
 // Files >= bigFileThreshold are "big" and get their own chunk.
 // chunkTargetSize = max(ChunkTargetSize, bigFileThreshold).
 // To have small files pack together, set MinChunkSize above the file sizes.
@@ -241,7 +320,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/big.db", 500},
 				{"shard1/small2.db", 50},
 			},
-			// MinChunkSize=200 → Top100Size=max(50,200)=200, minIndiv=200, chunkTarget=5000.
+			// MinChunkSize=200 → BigFileThreshold=max(50,200)=200, minIndiv=200, chunkTarget=5000.
 			// small(50) < 200 → packs. big(500) >= 200 → big → deferred.
 			// Chunk 1: in-mem(150) + small(50) = 200. big is next but "big" and !firstFile
 			//   → fillChunkWithSmallFiles picks up small2(50) = 250.
@@ -261,7 +340,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/small.db", 50},
 				{"shard1/huge.db", 1000},
 			},
-			// MinChunkSize=200 → Top100Size=max(50,200)=200, minIndiv=200, chunkTarget=300.
+			// MinChunkSize=200 → BigFileThreshold=max(50,200)=200, minIndiv=200, chunkTarget=300.
 			// small(50) < 200 → packs. huge(1000) >= 200 → big.
 			// Chunk 1: in-mem(150) + small(50) = 200. huge deferred (big, !firstFile).
 			// Chunk 2: huge is first file, big → WriteRegular: 1000 > 300 (splitFileSize)
@@ -287,7 +366,7 @@ func TestProcessShard(t *testing.T) {
 			files: []testFile{
 				{"shard1/big.db", 500},
 			},
-			// MinChunkSize=200 → Top100Size=max(500,200)=500, minIndiv=500, chunkTarget=5000.
+			// MinChunkSize=200 → BigFileThreshold=max(500,200)=500, minIndiv=500, chunkTarget=5000.
 			// Chunk 1 (firstChunk=true): in-mem(150). big.db(500) >= 500 → big, !firstFile → deferred.
 			// Chunk 2 (firstChunk=false): big.db first, big → written alone. Tracked in BigFilesChunk.
 			minChunkSize:         200,
@@ -305,7 +384,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/huge.db", 1000},
 				{"shard1/small.db", 50},
 			},
-			// small.db brings Top100Size down: max(50, 200) = 200.
+			// small.db brings BigFileThreshold down: max(50, 200) = 200.
 			// minIndiv=200, chunkTarget=max(300, 200)=300, splitFileSize=300.
 			// huge(1000) >= 200 → big. small(50) < 200 → packs.
 			// Chunk 1: in-mem(150). huge is first but big & !firstFile → fillSmall picks small(50)=200.
@@ -323,7 +402,7 @@ func TestProcessShard(t *testing.T) {
 			files: []testFile{
 				{"shard1/huge.db", 1000},
 			},
-			// With a single file, Top100Size = max(fileSize, MinChunkSize) >= fileSize.
+			// With a single file, BigFileThreshold = max(fileSize, MinChunkSize) >= fileSize.
 			// So chunkTargetSize >= bigFileThreshold >= fileSize, and
 			// 0+fileSize > chunkTargetSize is always false → file is written whole.
 			minChunkSize:    200,
@@ -338,7 +417,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/huge1.db", 900},
 				{"shard1/huge2.db", 900},
 			},
-			// MinChunkSize=200 → Top100Size=max(50,200)=200, minIndiv=200, chunkTarget=300.
+			// MinChunkSize=200 → BigFileThreshold=max(50,200)=200, minIndiv=200, chunkTarget=300.
 			// small(50) < 200 → packs. huge1(900) >= 200 → big. huge2(900) >= 200 → big.
 			// Chunk 1: in-mem(150) + small(50) = 200. huge1 deferred (big, !firstFile).
 			// Chunk 2: huge1 first, big → WriteRegular: 900 > 300 → WriteSplitFile writes first 300.
@@ -358,7 +437,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/b.db", 200},
 				{"shard1/c.db", 300},
 			},
-			// MinChunkSize=0 → Top100Size=100 (smallest), minIndiv=100, chunkTarget=10000.
+			// MinChunkSize=0 → BigFileThreshold=100 (smallest), minIndiv=100, chunkTarget=10000.
 			// All files >= 100 → all "big" → each gets own chunk.
 			// Chunk 1: in-mem(150). a.db is big, !firstFile → fillSmall: none → return.
 			// Chunk 2: a.db alone. Chunk 3: b.db alone. Chunk 4: c.db alone.
@@ -687,7 +766,7 @@ func TestProcessShardEvenSplitSizes(t *testing.T) {
 	}
 }
 
-func TestCalculateTop100Size(t *testing.T) {
+func TestCalculateBigFileThreshold(t *testing.T) {
 	const mb = 1 << 20
 
 	// Helper to create fileSizes map with n files of increasing size starting at 2MB
@@ -702,77 +781,137 @@ func TestCalculateTop100Size(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		fileSizes       map[string]int64
-		numSkippedFiles int
-		expected        int64
+		name               string
+		fileSizes          map[string]int64
+		numSkippedFiles    int
+		maxIndividualFiles int
+		expected           int64
 	}{
 		{
-			name:            "empty files returns minSize",
-			fileSizes:       map[string]int64{},
-			numSkippedFiles: 0,
-			expected:        mb,
+			name:               "empty files returns minSize",
+			fileSizes:          map[string]int64{},
+			numSkippedFiles:    0,
+			maxIndividualFiles: 100,
+			expected:           mb,
 		},
 		{
-			name:            "empty files with skipped returns minSize",
-			fileSizes:       map[string]int64{},
-			numSkippedFiles: 50,
-			expected:        mb,
+			name:               "empty files with skipped returns minSize",
+			fileSizes:          map[string]int64{},
+			numSkippedFiles:    50,
+			maxIndividualFiles: 100,
+			expected:           mb,
 		},
 		{
-			name:            "single small file no skipped",
-			fileSizes:       map[string]int64{"a.db": 500},
-			numSkippedFiles: 0,
-			expected:        mb, // below minSize
+			name:               "single small file no skipped",
+			fileSizes:          map[string]int64{"a.db": 500},
+			numSkippedFiles:    0,
+			maxIndividualFiles: 100,
+			expected:           mb, // below minSize
 		},
 		{
-			name:            "single large file no skipped",
-			fileSizes:       map[string]int64{"a.db": 5 * mb},
-			numSkippedFiles: 0,
-			expected:        5 * mb,
+			name:               "single large file no skipped",
+			fileSizes:          map[string]int64{"a.db": 5 * mb},
+			numSkippedFiles:    0,
+			maxIndividualFiles: 100,
+			expected:           5 * mb,
 		},
 		{
-			name:            "fewer than k files - returns smallest",
-			fileSizes:       map[string]int64{"a.db": 2 * mb, "b.db": 5 * mb, "c.db": 3 * mb},
-			numSkippedFiles: 0,
-			expected:        2 * mb, // k=100, only 3 files, smallest is 2MB
+			name:               "fewer than k files - returns smallest",
+			fileSizes:          map[string]int64{"a.db": 2 * mb, "b.db": 5 * mb, "c.db": 3 * mb},
+			numSkippedFiles:    0,
+			maxIndividualFiles: 100,
+			expected:           2 * mb, // k=100, only 3 files, smallest is 2MB
 		},
 		{
-			name:            "skipped reduces k - changes result",
-			fileSizes:       makeFiles(105), // files from 2MB to 106MB
-			numSkippedFiles: 0,
-			expected:        7 * mb, // k=100, 105 files, 100th largest = 6th smallest (index 5) = 7MB
+			name:               "skipped reduces k - changes result",
+			fileSizes:          makeFiles(105), // files from 2MB to 106MB
+			numSkippedFiles:    0,
+			maxIndividualFiles: 100,
+			expected:           7 * mb, // k=100, 105 files, 100th largest = 6th smallest (index 5) = 7MB
 		},
 		{
-			name:            "skipped 50 reduces k to 50",
-			fileSizes:       makeFiles(105), // files from 2MB to 106MB
-			numSkippedFiles: 50,
-			expected:        57 * mb, // k=50, 50th largest = 56th smallest (index 55) = 57MB
+			name:               "skipped 50 reduces k to 50",
+			fileSizes:          makeFiles(105), // files from 2MB to 106MB
+			numSkippedFiles:    50,
+			maxIndividualFiles: 100,
+			expected:           57 * mb, // k=50, 50th largest = 56th smallest (index 55) = 57MB
 		},
 		{
-			name:            "skipped 99 reduces k to 1 - returns largest",
-			fileSizes:       makeFiles(105),
-			numSkippedFiles: 99,
-			expected:        106 * mb, // k=1, returns the largest file
+			name:               "skipped 99 reduces k to 1 - returns largest",
+			fileSizes:          makeFiles(105),
+			numSkippedFiles:    99,
+			maxIndividualFiles: 100,
+			expected:           106 * mb, // k=1, returns the largest file
 		},
 		{
-			name:            "skipped >= 100 clamps k to 1",
-			fileSizes:       makeFiles(105),
-			numSkippedFiles: 100,
-			expected:        106 * mb, // k=max(100-100,1)=1, returns largest
+			name:               "skipped >= 100 clamps k to 1",
+			fileSizes:          makeFiles(105),
+			numSkippedFiles:    100,
+			maxIndividualFiles: 100,
+			expected:           106 * mb, // k=max(100-100,1)=1, returns largest
 		},
 		{
-			name:            "skipped > 100 clamps k to 1",
-			fileSizes:       makeFiles(105),
-			numSkippedFiles: 200,
-			expected:        106 * mb,
+			name:               "skipped > 100 clamps k to 1",
+			fileSizes:          makeFiles(105),
+			numSkippedFiles:    200,
+			maxIndividualFiles: 100,
+			expected:           106 * mb,
+		},
+		{
+			name:               "limit below default shrinks k",
+			fileSizes:          makeFiles(105), // files from 2MB to 106MB
+			numSkippedFiles:    0,
+			maxIndividualFiles: 10,
+			expected:           97 * mb, // k=10, 10th largest = 96th smallest (index 95) = 97MB
+		},
+		{
+			name:               "limit above default grows k",
+			fileSizes:          makeFiles(105), // files from 2MB to 106MB
+			numSkippedFiles:    0,
+			maxIndividualFiles: 105,
+			expected:           2 * mb, // k=105, all files qualify, smallest is 2MB
+		},
+		{
+			name:               "limit above file count returns smallest",
+			fileSizes:          makeFiles(105),
+			numSkippedFiles:    0,
+			maxIndividualFiles: 500,
+			expected:           2 * mb,
+		},
+		{
+			name:               "raised limit still clamps to minSize",
+			fileSizes:          map[string]int64{"a.db": 500, "b.db": 800, "c.db": 1200},
+			numSkippedFiles:    0,
+			maxIndividualFiles: 500, // every file qualifies, but all are below minSize
+			expected:           mb,
+		},
+		{
+			name:               "lowered limit still clamps to minSize",
+			fileSizes:          map[string]int64{"a.db": 500, "b.db": 800, "c.db": 1200},
+			numSkippedFiles:    0,
+			maxIndividualFiles: 1, // biggest file is still below minSize
+			expected:           mb,
+		},
+		{
+			name:               "limit of 1 returns largest",
+			fileSizes:          makeFiles(105),
+			numSkippedFiles:    0,
+			maxIndividualFiles: 1,
+			expected:           106 * mb,
+		},
+		{
+			name:               "skipped exceeds raised limit clamps k to 1",
+			fileSizes:          makeFiles(105),
+			numSkippedFiles:    200,
+			maxIndividualFiles: 150,
+			expected:           106 * mb, // k=max(150-200,1)=1, returns largest
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			result := calculateTop100Size(tc.fileSizes, tc.numSkippedFiles, mb)
+			result := calculateBigFileThreshold(tc.fileSizes, tc.numSkippedFiles, tc.maxIndividualFiles, mb)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -1270,7 +1409,7 @@ func TestIncrementalBackupChainWithManySplitFiles(t *testing.T) {
 	}
 
 	// --- Shard layout ---
-	// Each shard has a small anchor file (keeps Top100Size low so bigFileThreshold=100)
+	// Each shard has a small anchor file (keeps BigFileThreshold low so bigFileThreshold=100)
 	// and 8 large files that will each be split into many chunks (3-20 parts).
 	// 4 shards × 8 split files = 32 split files total.
 	mkShard := func(name string) []fileSpec {

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -168,9 +168,9 @@ func TestCreateFileList(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 
-	// Three files sized 100/200/300 with MinChunkSize=0, so BigFileThreshold is the n-th
+	// Three files sized 100/200/300 with MinChunkSize=0, so BigFilesThreshold is the n-th
 	// biggest size unclamped.
-	bigFileThresholdTests := []struct {
+	bigFilesThresholdTests := []struct {
 		name               string
 		maxIndividualFiles *configRuntime.DynamicValue[int]
 		expected           int64
@@ -208,7 +208,7 @@ func TestCreateFileList(t *testing.T) {
 		return tempDir, testFiles
 	}
 
-	for _, tc := range bigFileThresholdTests {
+	for _, tc := range bigFilesThresholdTests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tempDir, testFiles := writeSizedFiles(t)
@@ -221,7 +221,7 @@ func TestCreateFileList(t *testing.T) {
 
 			fileList, err := u.createFileList(shard, tempDir)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expected, fileList.BigFileThreshold)
+			assert.Equal(t, tc.expected, fileList.BigFilesThreshold)
 		})
 	}
 
@@ -237,13 +237,13 @@ func TestCreateFileList(t *testing.T) {
 
 		fileList, err := u.createFileList(shard, tempDir)
 		require.NoError(t, err)
-		require.Equal(t, int64(100), fileList.BigFileThreshold)
+		require.Equal(t, int64(100), fileList.BigFilesThreshold)
 
 		require.NoError(t, cfg.MaxIndividualFiles.SetValue(1))
 
 		fileList, err = u.createFileList(shard, tempDir)
 		require.NoError(t, err)
-		assert.Equal(t, int64(300), fileList.BigFileThreshold)
+		assert.Equal(t, int64(300), fileList.BigFilesThreshold)
 	})
 }
 
@@ -251,10 +251,10 @@ func TestCreateFileList(t *testing.T) {
 // the storage backend mocked. Real files are created on disk, and the real compress
 // + createFileList logic runs end-to-end.
 //
-// Sizing note: with fewer than 100 files, BigFileThreshold equals the smallest file size
-// (clamped to MinChunkSize). bigFileThreshold = max(MinChunkSize, BigFileThreshold).
-// Files >= bigFileThreshold are "big" and get their own chunk.
-// chunkTargetSize = max(ChunkTargetSize, bigFileThreshold).
+// Sizing note: with fewer than 100 files, BigFilesThreshold equals the smallest file size
+// (clamped to MinChunkSize). bigFilesThreshold = max(MinChunkSize, BigFilesThreshold).
+// Files >= bigFilesThreshold are "big" and get their own chunk.
+// chunkTargetSize = max(ChunkTargetSize, bigFilesThreshold).
 // To have small files pack together, set MinChunkSize above the file sizes.
 //
 // Cases with expectChunkFiles also verify chunk isolation: metadata files never
@@ -304,7 +304,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/c.db", 200},
 				{"shard1/d.db", 200},
 			},
-			// MinChunkSize=500 → bigFileThreshold=500, chunkTargetSize=500.
+			// MinChunkSize=500 → bigFilesThreshold=500, chunkTargetSize=500.
 			// Files (200 each) < 500 → pack together.
 			// Chunk 1: in-mem(150) + a(200) = 350. b: 550 > 500 → full.
 			// Chunk 2: b(200) + c(200) = 400. d: 600 > 500 → full.
@@ -320,7 +320,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/big.db", 500},
 				{"shard1/small2.db", 50},
 			},
-			// MinChunkSize=200 → BigFileThreshold=max(50,200)=200, minIndiv=200, chunkTarget=5000.
+			// MinChunkSize=200 → BigFilesThreshold=max(50,200)=200, minIndiv=200, chunkTarget=5000.
 			// small(50) < 200 → packs. big(500) >= 200 → big → deferred.
 			// Chunk 1: in-mem(150) + small(50) = 200. big is next but "big" and !firstFile
 			//   → fillChunkWithSmallFiles picks up small2(50) = 250.
@@ -340,7 +340,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/small.db", 50},
 				{"shard1/huge.db", 1000},
 			},
-			// MinChunkSize=200 → BigFileThreshold=max(50,200)=200, minIndiv=200, chunkTarget=300.
+			// MinChunkSize=200 → BigFilesThreshold=max(50,200)=200, minIndiv=200, chunkTarget=300.
 			// small(50) < 200 → packs. huge(1000) >= 200 → big.
 			// Chunk 1: in-mem(150) + small(50) = 200. huge deferred (big, !firstFile).
 			// Chunk 2: huge is first file, big → WriteRegular: 1000 > 300 (splitFileSize)
@@ -366,7 +366,7 @@ func TestProcessShard(t *testing.T) {
 			files: []testFile{
 				{"shard1/big.db", 500},
 			},
-			// MinChunkSize=200 → BigFileThreshold=max(500,200)=500, minIndiv=500, chunkTarget=5000.
+			// MinChunkSize=200 → BigFilesThreshold=max(500,200)=500, minIndiv=500, chunkTarget=5000.
 			// Chunk 1 (firstChunk=true): in-mem(150). big.db(500) >= 500 → big, !firstFile → deferred.
 			// Chunk 2 (firstChunk=false): big.db first, big → written alone. Tracked in BigFilesChunk.
 			minChunkSize:         200,
@@ -384,7 +384,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/huge.db", 1000},
 				{"shard1/small.db", 50},
 			},
-			// small.db brings BigFileThreshold down: max(50, 200) = 200.
+			// small.db brings BigFilesThreshold down: max(50, 200) = 200.
 			// minIndiv=200, chunkTarget=max(300, 200)=300, splitFileSize=300.
 			// huge(1000) >= 200 → big. small(50) < 200 → packs.
 			// Chunk 1: in-mem(150). huge is first but big & !firstFile → fillSmall picks small(50)=200.
@@ -402,8 +402,8 @@ func TestProcessShard(t *testing.T) {
 			files: []testFile{
 				{"shard1/huge.db", 1000},
 			},
-			// With a single file, BigFileThreshold = max(fileSize, MinChunkSize) >= fileSize.
-			// So chunkTargetSize >= bigFileThreshold >= fileSize, and
+			// With a single file, BigFilesThreshold = max(fileSize, MinChunkSize) >= fileSize.
+			// So chunkTargetSize >= bigFilesThreshold >= fileSize, and
 			// 0+fileSize > chunkTargetSize is always false → file is written whole.
 			minChunkSize:    200,
 			chunkTargetSize: 300,
@@ -417,7 +417,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/huge1.db", 900},
 				{"shard1/huge2.db", 900},
 			},
-			// MinChunkSize=200 → BigFileThreshold=max(50,200)=200, minIndiv=200, chunkTarget=300.
+			// MinChunkSize=200 → BigFilesThreshold=max(50,200)=200, minIndiv=200, chunkTarget=300.
 			// small(50) < 200 → packs. huge1(900) >= 200 → big. huge2(900) >= 200 → big.
 			// Chunk 1: in-mem(150) + small(50) = 200. huge1 deferred (big, !firstFile).
 			// Chunk 2: huge1 first, big → WriteRegular: 900 > 300 → WriteSplitFile writes first 300.
@@ -437,7 +437,7 @@ func TestProcessShard(t *testing.T) {
 				{"shard1/b.db", 200},
 				{"shard1/c.db", 300},
 			},
-			// MinChunkSize=0 → BigFileThreshold=100 (smallest), minIndiv=100, chunkTarget=10000.
+			// MinChunkSize=0 → BigFilesThreshold=100 (smallest), minIndiv=100, chunkTarget=10000.
 			// All files >= 100 → all "big" → each gets own chunk.
 			// Chunk 1: in-mem(150). a.db is big, !firstFile → fillSmall: none → return.
 			// Chunk 2: a.db alone. Chunk 3: b.db alone. Chunk 4: c.db alone.
@@ -682,7 +682,7 @@ func TestProcessShardEvenSplitSizes(t *testing.T) {
 			tempDir := t.TempDir()
 			require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "shard1"), os.ModePerm))
 
-			// Small file pulls bigFileThreshold down so the large file takes the split path.
+			// Small file pulls bigFilesThreshold down so the large file takes the split path.
 			require.NoError(t, os.WriteFile(
 				filepath.Join(tempDir, "shard1", "small.db"),
 				bytes.Repeat([]byte("s"), 50), 0o644))
@@ -766,7 +766,7 @@ func TestProcessShardEvenSplitSizes(t *testing.T) {
 	}
 }
 
-func TestCalculateBigFileThreshold(t *testing.T) {
+func TestCalculateBigFilesThreshold(t *testing.T) {
 	const mb = 1 << 20
 
 	// Helper to create fileSizes map with n files of increasing size starting at 2MB
@@ -911,7 +911,7 @@ func TestCalculateBigFileThreshold(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			result := calculateBigFileThreshold(tc.fileSizes, tc.numSkippedFiles, tc.maxIndividualFiles, mb)
+			result := calculateBigFilesThreshold(tc.fileSizes, tc.numSkippedFiles, tc.maxIndividualFiles, mb)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -1409,12 +1409,12 @@ func TestIncrementalBackupChainWithManySplitFiles(t *testing.T) {
 	}
 
 	// --- Shard layout ---
-	// Each shard has a small anchor file (keeps BigFileThreshold low so bigFileThreshold=100)
+	// Each shard has a small anchor file (keeps BigFilesThreshold low so bigFilesThreshold=100)
 	// and 8 large files that will each be split into many chunks (3-20 parts).
 	// 4 shards × 8 split files = 32 split files total.
 	mkShard := func(name string) []fileSpec {
 		return []fileSpec{
-			{name + "/small.db", 50},     // anchor: keeps bigFileThreshold=100
+			{name + "/small.db", 50},     // anchor: keeps bigFilesThreshold=100
 			{name + "/seg-001.db", 800},  // 8 parts
 			{name + "/seg-002.db", 600},  // 6 parts
 			{name + "/seg-003.db", 1200}, // 12 parts

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -75,7 +75,8 @@ type zip struct {
 // NewZip creates a new zip writer for backup chunks. There are three size thresholds:
 //
 //   - bigFileThreshold: files >= this size get their own dedicated chunk (auto-calculated
-//     from the 100 biggest files in the shard).
+//     from the configured number of biggest files in the shard, see
+//     BACKUP_MAX_INDIVIDUAL_FILES).
 //   - splitFileSize: files exceeding this size are split across multiple chunks.
 //     Must be >= bigFileThreshold.
 //   - chunkTargetSize: the target size for chunks that pack multiple small files together.

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -68,19 +68,19 @@ type zip struct {
 	compressorWriter    compressor
 	pipeWriter          *io.PipeWriter
 	maxChunkSizeInBytes int64
-	bigFileThreshold    int64
+	bigFilesThreshold   int64
 	splitFileSizeBytes  int64
 }
 
 // NewZip creates a new zip writer for backup chunks. There are three size thresholds:
 //
-//   - bigFileThreshold: files >= this size get their own dedicated chunk (auto-calculated
+//   - bigFilesThreshold: files >= this size get their own dedicated chunk (auto-calculated
 //     from the configured number of biggest files in the shard, see
 //     BACKUP_MAX_INDIVIDUAL_FILES).
 //   - splitFileSize: files exceeding this size are split across multiple chunks.
-//     Must be >= bigFileThreshold.
+//     Must be >= bigFilesThreshold.
 //   - chunkTargetSize: the target size for chunks that pack multiple small files together.
-func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFileThreshold int64, splitFileSize int64) (zip, entBackup.ReadCloserWithError, error) {
+func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFilesThreshold int64, splitFileSize int64) (zip, entBackup.ReadCloserWithError, error) {
 	pr, pw := io.Pipe()
 	reader := &readCloser{src: pr, n: 0}
 
@@ -111,17 +111,17 @@ func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFileThreshol
 	default:
 		return zip{}, nil, fmt.Errorf("unknown compression level %v", level)
 	}
-	// splitFileSize must be at least bigFileThreshold, otherwise there would be no splitting.
+	// splitFileSize must be at least bigFilesThreshold, otherwise there would be no splitting.
 	// Check before zero-defaults turn disabled values into MaxInt64.
-	if bigFileThreshold > 0 && splitFileSize > 0 && splitFileSize < bigFileThreshold {
-		splitFileSize = bigFileThreshold
+	if bigFilesThreshold > 0 && splitFileSize > 0 && splitFileSize < bigFilesThreshold {
+		splitFileSize = bigFilesThreshold
 	}
 	chunkTargetSizeInBytes := chunkTargetSize
 	if chunkTargetSizeInBytes == 0 {
 		chunkTargetSizeInBytes = int64(1<<63 - 1) // effectively no limit
 	}
-	if bigFileThreshold == 0 {
-		bigFileThreshold = int64(1<<63 - 1) // effectively no big files
+	if bigFilesThreshold == 0 {
+		bigFilesThreshold = int64(1<<63 - 1) // effectively no big files
 	}
 	if splitFileSize == 0 {
 		splitFileSize = int64(1<<63 - 1) // effectively no limit
@@ -132,7 +132,7 @@ func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFileThreshol
 		w:                   tarW,
 		pipeWriter:          pw,
 		maxChunkSizeInBytes: chunkTargetSizeInBytes,
-		bigFileThreshold:    bigFileThreshold,
+		bigFilesThreshold:   bigFilesThreshold,
 		splitFileSizeBytes:  splitFileSize,
 	}, reader, nil
 }
@@ -220,7 +220,7 @@ func (z *zip) WriteRegulars(ctx context.Context, sd *entBackup.ShardDescriptor, 
 
 		// File doesn't fit in current chunk: either it's a big file that needs its own chunk, or it would exceed the
 		// chunk target size. Fill remaining space with small files and return.
-		if !firstFile && (fileSize >= z.bigFileThreshold || preCompressionSize.Load()+fileSize > z.maxChunkSizeInBytes) {
+		if !firstFile && (fileSize >= z.bigFilesThreshold || preCompressionSize.Load()+fileSize > z.maxChunkSizeInBytes) {
 			n, err := z.fillChunkWithSmallFiles(ctx, sd, filesInShard, preCompressionSize, chunkKey)
 			written += n
 			return written, nil, err
@@ -236,7 +236,7 @@ func (z *zip) WriteRegulars(ctx context.Context, sd *entBackup.ShardDescriptor, 
 			return written, splitFile, nil
 		}
 		// Big file was first and got its own chunk — return immediately.
-		if fileSize >= z.bigFileThreshold {
+		if fileSize >= z.bigFilesThreshold {
 			return written, nil, nil
 		}
 	}
@@ -272,9 +272,9 @@ func (z *zip) fillChunkWithSmallFiles(ctx context.Context, sd *entBackup.ShardDe
 		// Also skip files that exceed the split threshold: WriteRegular
 		// would split them and return a SplitFile that we cannot propagate
 		// from here, so they must be handled by the main WriteRegulars loop.
-		// NewZip already enforces splitFileSize >= bigFileThreshold, so the
+		// NewZip already enforces splitFileSize >= bigFilesThreshold, so the
 		// first check normally covers this; the second is a defensive guard.
-		if fileSize >= z.bigFileThreshold || fileSize > z.splitFileSizeBytes {
+		if fileSize >= z.bigFilesThreshold || fileSize > z.splitFileSizeBytes {
 			continue
 		}
 		if preCompressionSize.Load()+fileSize > z.maxChunkSizeInBytes {
@@ -326,7 +326,7 @@ func (z *zip) WriteRegular(ctx context.Context, sd *entBackup.ShardDescriptor, r
 	// Only immutable files are tracked for incremental dedup. Mutable files can be
 	// rewritten in place without a reliable size+mtime change signal, so they are
 	// re-uploaded on every incremental rather than deduplicated.
-	if fileSize >= z.bigFileThreshold && entBackup.IsImmutableFile(relPath) {
+	if fileSize >= z.bigFilesThreshold && entBackup.IsImmutableFile(relPath) {
 		sd.TrackBigFileChunk(relPath, fileSize, info.ModTime(), chunkKey)
 	}
 

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -335,35 +335,35 @@ func TestNewZipClampsSplitFileSize(t *testing.T) {
 	tests := []struct {
 		name                  string
 		chunkTargetSize       int64
-		bigFileThreshold      int64
+		bigFilesThreshold     int64
 		splitFileSize         int64
 		expectedSplitFileSize int64
 	}{
 		{
-			name:                  "splitFileSize already above bigFileThreshold",
+			name:                  "splitFileSize already above bigFilesThreshold",
 			chunkTargetSize:       500,
-			bigFileThreshold:      300,
+			bigFilesThreshold:     300,
 			splitFileSize:         1000,
 			expectedSplitFileSize: 1000,
 		},
 		{
-			name:                  "splitFileSize equals bigFileThreshold",
+			name:                  "splitFileSize equals bigFilesThreshold",
 			chunkTargetSize:       500,
-			bigFileThreshold:      1000,
+			bigFilesThreshold:     1000,
 			splitFileSize:         1000,
 			expectedSplitFileSize: 1000,
 		},
 		{
-			name:                  "splitFileSize below bigFileThreshold gets clamped up",
+			name:                  "splitFileSize below bigFilesThreshold gets clamped up",
 			chunkTargetSize:       500,
-			bigFileThreshold:      1000,
+			bigFilesThreshold:     1000,
 			splitFileSize:         300,
 			expectedSplitFileSize: 1000,
 		},
 		{
-			name:                  "splitFileSize below chunkTargetSize stays as-is when bigFileThreshold is zero",
+			name:                  "splitFileSize below chunkTargetSize stays as-is when bigFilesThreshold is zero",
 			chunkTargetSize:       1000,
-			bigFileThreshold:      0,
+			bigFilesThreshold:     0,
 			splitFileSize:         500,
 			expectedSplitFileSize: 500,
 		},
@@ -371,7 +371,7 @@ func TestNewZipClampsSplitFileSize(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			z, rc, err := NewZip(dir, int(GzipBestSpeed), tc.chunkTargetSize, tc.bigFileThreshold, tc.splitFileSize)
+			z, rc, err := NewZip(dir, int(GzipBestSpeed), tc.chunkTargetSize, tc.bigFilesThreshold, tc.splitFileSize)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSplitFileSize, z.splitFileSizeBytes)
 			go func() { io.Copy(io.Discard, rc) }()
@@ -434,8 +434,8 @@ func TestWriteRegulars(t *testing.T) {
 			files: []testFile{
 				{"shard/huge.db", 5000},
 			},
-			// chunkTargetSize=1000, bigFileThreshold=1000, splitFileSize=500.
-			// splitFileSize clamped to bigFileThreshold=1000.
+			// chunkTargetSize=1000, bigFilesThreshold=1000, splitFileSize=500.
+			// splitFileSize clamped to bigFilesThreshold=1000.
 			// fileSize(5000) > splitFileSizeBytes(1000) → numParts=ceil(5000/1000)=5, partSize=ceil(5000/5)=1000.
 			// WriteSplitFile writes first 1000 bytes.
 			chunkTargetSize:      1000,
@@ -444,7 +444,7 @@ func TestWriteRegulars(t *testing.T) {
 			expectTarFiles:       []string{"shard/huge.db"},
 			expectRemainingFiles: nil,
 			expectSplitFile:      "shard/huge.db",
-			expectAlreadyWritten: 1000, // splitFileSize clamped to bigFileThreshold
+			expectAlreadyWritten: 1000, // splitFileSize clamped to bigFilesThreshold
 		},
 		{
 			name: "small file exceeding split threshold returns SplitFile with first part written",
@@ -1993,7 +1993,7 @@ func TestBackupRestoreEndToEnd(t *testing.T) {
 }
 
 // TestWriteRegularsBigFileReturnsSplitFile verifies that when a "big" file
-// (>= bigFileThreshold) also exceeds splitFileSizeBytes, WriteRegulars
+// (>= bigFilesThreshold) also exceeds splitFileSizeBytes, WriteRegulars
 // returns the SplitFile so the caller can split it across chunks instead of
 // silently dropping it.
 // makeTestData creates deterministic test data of the given size.

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -785,11 +785,22 @@ const DefaultBackupChunkTargetSize = 10 * 1024 * 1024 // 10MB
 // DefaultBackupSplitFileSize is the default size for splitting large files during backup
 const DefaultBackupSplitFileSize = 50 * 1024 * 1024 * 1024 // 50GB
 
+// DefaultBackupMaxIndividualFiles is the default number of files per shard targeted to get their own chunk
+const DefaultBackupMaxIndividualFiles = 100
+
 // Backup contains backup-related configuration
 type Backup struct {
 	MinChunkSize    int64 `json:"min_chunk_size" yaml:"min_chunk_size"`
 	ChunkTargetSize int64 `json:"chunk_target_size" yaml:"chunk_target_size"`
 	SplitFileSize   int64 `json:"split_file_size" yaml:"split_file_size"`
+
+	// MaxIndividualFiles is how many of a shard's biggest files are targeted to get their own
+	// chunk. Only those can be reused by a later incremental backup, so raising it improves
+	// deduplication at the cost of more chunks. It is a target, not a cap: files of equal size
+	// at the resulting threshold all qualify. An incremental backup counts the files it reuses
+	// from its base against the number, so it applies across a backup chain.
+	// Env: BACKUP_MAX_INDIVIDUAL_FILES, runtime config: backup_max_individual_files.
+	MaxIndividualFiles *runtime.DynamicValue[int] `json:"max_individual_files" yaml:"max_individual_files"`
 
 	// SkipAccessCheck disables the write+delete probe the backup client runs on
 	// initialize, deferring write/permission errors to backup time. Use it for

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -783,6 +783,13 @@ func FromEnv(config *Config) error {
 		config.Backup.SplitFileSize = DefaultBackupSplitFileSize
 	}
 
+	if err := parser.ParseDynamicIntWithValidation("BACKUP_MAX_INDIVIDUAL_FILES",
+		DefaultBackupMaxIndividualFiles,
+		parser.ValidateIntGreaterThan0,
+		func(val *configRuntime.DynamicValue[int]) { config.Backup.MaxIndividualFiles = val }); err != nil {
+		return err
+	}
+
 	if entcfg.Enabled(os.Getenv("BACKUP_SKIP_ACCESS_CHECK")) {
 		config.Backup.SkipAccessCheck = true
 	}

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -376,6 +376,38 @@ func TestEnvironmentDisableLazyLoadShardsBackwardCompat(t *testing.T) {
 	})
 }
 
+func TestEnvironmentBackupMaxIndividualFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected int
+		wantErr  bool
+	}{
+		{name: "unset uses the default", value: "", expected: DefaultBackupMaxIndividualFiles},
+		{name: "valid value is parsed", value: "250", expected: 250},
+		{name: "one is the smallest accepted value", value: "1", expected: 1},
+		{name: "zero is rejected", value: "0", wantErr: true},
+		{name: "negative is rejected", value: "-1", wantErr: true},
+		{name: "non-numeric is rejected", value: "many", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BACKUP_MAX_INDIVIDUAL_FILES", tc.value)
+
+			conf := Config{}
+			err := FromEnv(&conf)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "BACKUP_MAX_INDIVIDUAL_FILES")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, conf.Backup.MaxIndividualFiles.Get())
+		})
+	}
+}
+
 func TestEnvironmentSkipAccessCheck(t *testing.T) {
 	t.Run("unset defaults to false for both", func(t *testing.T) {
 		t.Setenv("BACKUP_SKIP_ACCESS_CHECK", "")

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -84,6 +84,9 @@ type WeaviateRuntimeConfig struct {
 	ObjectsTTLPauseDuration       *runtime.DynamicValue[time.Duration] `json:"objects_ttl_pause_duration" yaml:"objects_ttl_pause_duration"`
 	ObjectsTTLConcurrencyFactor   *runtime.DynamicValue[float64]       `json:"objects_ttl_concurrency_factor" yaml:"objects_ttl_concurrency_factor"`
 
+	// Backup settings
+	BackupMaxIndividualFiles *runtime.DynamicValue[int] `json:"backup_max_individual_files" yaml:"backup_max_individual_files"`
+
 	// Export settings
 	ExportEnabled       *runtime.DynamicValue[bool]   `json:"export_enabled" yaml:"export_enabled"`
 	ExportDefaultBucket *runtime.DynamicValue[string] `json:"export_default_bucket" yaml:"export_default_bucket"`

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -147,6 +147,34 @@ autoschema_enabled: true`)
 	})
 }
 
+func TestBackupMaxIndividualFilesRuntimeOverride(t *testing.T) {
+	// ParseRuntimeConfig ignores unknown keys, so only an explicit assertion catches a
+	// renamed or misspelled yaml tag.
+	t.Run("yaml key is parsed", func(t *testing.T) {
+		cfg, err := ParseRuntimeConfig([]byte(`backup_max_individual_files: 250`))
+		require.NoError(t, err)
+		assert.Equal(t, 250, cfg.BackupMaxIndividualFiles.Get())
+	})
+
+	t.Run("override applies to the env-registered value and rejects non-positive", func(t *testing.T) {
+		t.Setenv("BACKUP_MAX_INDIVIDUAL_FILES", "40")
+		conf := Config{}
+		require.NoError(t, FromEnv(&conf))
+		require.Equal(t, 40, conf.Backup.MaxIndividualFiles.Get())
+
+		require.NoError(t, conf.Backup.MaxIndividualFiles.SetValue(250))
+		assert.Equal(t, 250, conf.Backup.MaxIndividualFiles.Get())
+
+		// The validator is attached to the value, so it guards the runtime path too.
+		require.Error(t, conf.Backup.MaxIndividualFiles.SetValue(0))
+		assert.Equal(t, 250, conf.Backup.MaxIndividualFiles.Get())
+
+		// Removing the key from the overrides file restores the env-supplied value.
+		conf.Backup.MaxIndividualFiles.Reset()
+		assert.Equal(t, 40, conf.Backup.MaxIndividualFiles.Get())
+	})
+}
+
 func TestUpdateRuntimeConfig(t *testing.T) {
 	log := logrus.New()
 	log.SetOutput(io.Discard)


### PR DESCRIPTION
### What's being changed:

The number is currently hardcoded to 100

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
