### PR TITLE
fix(test): join usage poll goroutines so they cannot assert after test completion

### DIFF
--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -73,8 +73,10 @@ func TestTenantStatusChanges(t *testing.T) {
 		require.NoError(t, err)
 	}
 	endUsage := atomic.Bool{}
-
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			if endUsage.Load() {
 				return
@@ -97,6 +99,10 @@ func TestTenantStatusChanges(t *testing.T) {
 			require.Equal(t, len(names), len(tenants))
 		}
 	}()
+	defer func() {
+		endUsage.Store(true)
+		wg.Wait()
+	}()
 
 	var eg errgroup.Group
 	for i := range tenants {
@@ -113,7 +119,6 @@ func TestTenantStatusChanges(t *testing.T) {
 		)
 	}
 	require.NoError(t, eg.Wait())
-	endUsage.Store(true)
 }
 
 func TestUsageTenantDelete(t *testing.T) {
@@ -156,7 +161,10 @@ func TestUsageTenantDelete(t *testing.T) {
 
 	endUsage := atomic.Bool{}
 	deletedTenants := atomic.Int32{}
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			if endUsage.Load() {
 				return
@@ -185,12 +193,16 @@ func TestUsageTenantDelete(t *testing.T) {
 		}
 	}()
 
+	defer func() {
+		endUsage.Store(true)
+		wg.Wait()
+	}()
+
 	for i := range tenants {
 		err := c.Schema().TenantsDeleter().WithClassName(className).WithTenants(tenants[i].Name).Do(ctx)
 		require.NoError(t, err)
 		deletedTenants.Add(1)
 	}
-	endUsage.Store(true)
 }
 
 func TestCollectionDeletion(t *testing.T) {
@@ -225,7 +237,10 @@ func TestCollectionDeletion(t *testing.T) {
 
 	endUsage := atomic.Bool{}
 	deletedClasses := atomic.Int32{}
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			if endUsage.Load() {
 				return
@@ -242,12 +257,16 @@ func TestCollectionDeletion(t *testing.T) {
 		}
 	}()
 
+	defer func() {
+		endUsage.Store(true)
+		wg.Wait()
+	}()
+
 	for i := 0; i < numClasses; i++ {
 		className := getClassName(t, i)
 		require.NoError(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
 		deletedClasses.Add(1)
 	}
-	endUsage.Store(true)
 }
 
 func TestAlterSchemaDropPropertyIndex(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Fixes:
```
Running acceptance_tests_with_client/usage
panic: Fail in goroutine after TestUsageTenantDelete has completed

goroutine 170 [running]:
testing.(*common).Fail(0xc000b8a008)
	/opt/hostedtoolcache/go/1.26.5/x64/src/testing/testing.go:969 +0x179
testing.(*common).Errorf(0xc000b8a008, {0x28671c1, 0x3}, {0xc0001642c0, 0x1, 0x1})
	/opt/hostedtoolcache/go/1.26.5/x64/src/testing/testing.go:1214 +0x99
github.com/stretchr/testify/assert.Fail({0x2c17780, 0xc000b8a008}, {0xc000736060, 0x60}, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:387 +0x436
github.com/stretchr/testify/assert.NoError({0x2c17780, 0xc000b8a008}, {0x2c17640, 0xc000164280}, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/assert/assertions.go:1638 +0x13a
github.com/stretchr/testify/require.NoError({0x2c3cf68, 0xc000b8a008}, {0x2c17640, 0xc000164280}, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/require/require.go:1398 +0xc5
acceptance_tests_with_client/usage.TestUsageTenantDelete.func1()
	/home/runner/work/weaviate/weaviate/test/acceptance_with_go_client/usage/usage_test.go:166 +0xd2
created by acceptance_tests_with_client/usage.TestUsageTenantDelete in goroutine 62
	/home/runner/work/weaviate/weaviate/test/acceptance_with_go_client/usage/usage_test.go:159 +0xc65
FAIL	acceptance_tests_with_client/usage	4.443s
FAIL
Test for acceptance_tests_with_client/usage failed

```


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
