### PR TITLE
fix(memberlist): don't fail startup when a single node can't join (self-heal)

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1163,7 +1163,7 @@ func startupRoutine(ctx, serverShutdownCtx context.Context, options *swag.Comman
 	}
 
 	serverConfig.Config.Cluster.RaftBootstrapExpect = serverConfig.Config.Raft.BootstrapExpect
-	serverConfig.Config.Cluster.BootstrapTimeout = serverConfig.Config.Raft.BootstrapTimeout
+	serverConfig.Config.Cluster.RaftBootstrapTimeout = serverConfig.Config.Raft.BootstrapTimeout
 	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.Raft.TimeoutsMultiplier.Get(), dataPath, nonStorageNodes, logger)
 	if err != nil {
 		logger.WithField("action", "startup").WithError(err).

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1163,6 +1163,7 @@ func startupRoutine(ctx, serverShutdownCtx context.Context, options *swag.Comman
 	}
 
 	serverConfig.Config.Cluster.RaftBootstrapExpect = serverConfig.Config.Raft.BootstrapExpect
+	serverConfig.Config.Cluster.BootstrapTimeout = serverConfig.Config.Raft.BootstrapTimeout
 	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.Raft.TimeoutsMultiplier.Get(), dataPath, nonStorageNodes, logger)
 	if err != nil {
 		logger.WithField("action", "startup").WithError(err).

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -112,8 +112,8 @@ type Config struct {
 	// RaftBootstrapExpect is used to detect split-brain scenarios and attempt to rejoin the cluster
 	// TODO-RAFT-DB-63 : shall be removed once NodeAddress() is moved under raft cluster package
 	RaftBootstrapExpect int
-	// BootstrapTimeout bounds the startup join retry; mirrors RAFT_BOOTSTRAP_TIMEOUT.
-	BootstrapTimeout time.Duration
+	// RaftBootstrapTimeout bounds the startup join retry; mirrors RAFT_BOOTSTRAP_TIMEOUT.
+	RaftBootstrapTimeout time.Duration
 }
 
 type AuthConfig struct {
@@ -225,7 +225,7 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 	}
 
 	if len(joinAddr) > 0 {
-		timeout := userConfig.BootstrapTimeout
+		timeout := userConfig.RaftBootstrapTimeout
 		if timeout <= 0 {
 			timeout = joinTimeout
 		}

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -112,6 +112,8 @@ type Config struct {
 	// RaftBootstrapExpect is used to detect split-brain scenarios and attempt to rejoin the cluster
 	// TODO-RAFT-DB-63 : shall be removed once NodeAddress() is moved under raft cluster package
 	RaftBootstrapExpect int
+	// BootstrapTimeout bounds the startup join retry; mirrors RAFT_BOOTSTRAP_TIMEOUT.
+	BootstrapTimeout time.Duration
 }
 
 type AuthConfig struct {
@@ -223,6 +225,10 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 	}
 
 	if len(joinAddr) > 0 {
+		timeout := userConfig.BootstrapTimeout
+		if timeout <= 0 {
+			timeout = joinTimeout
+		}
 		joinHost := extractHost(joinAddr[0])
 		if _, err := net.LookupIP(joinHost); err != nil {
 			logger.WithFields(logrus.Fields{
@@ -231,24 +237,20 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 			}).Warnf("specified hostname to join cluster cannot be resolved. This is fine "+
 				"if this is the first node of a new cluster, but problematic otherwise: %v", err)
 		} else if err := backoff.Retry(func() error {
+			// Retry for every seed: even a single node can be racing DNS after a
+			// reschedule, where the join target briefly points at a dead pod IP.
 			_, err := state.list.Join(joinAddr)
-			if err != nil && userConfig.RaftBootstrapExpect <= 1 {
-				// A sole seed has no peer coming up behind it, so a failed join is
-				// a misconfiguration rather than a race. Waiting cannot fix it.
-				return backoff.Permanent(err)
-			}
 			return err
-		}, utils.NewExponentialBackoff(joinInitialInterval, joinTimeout)); err != nil {
+		}, utils.NewExponentialBackoff(joinInitialInterval, timeout)); err != nil {
 			entry := logger.WithFields(logrus.Fields{
 				"action":          "memberlist_init",
 				"remote_hostname": joinAddr,
 			})
 			if userConfig.RaftBootstrapExpect <= 1 {
-				entry.Errorf("memberlist join not successful: %v", err)
-				return nil, errors.Wrap(err, "join cluster")
+				entry.Warnf("memberlist join not successful, continuing as single-node cluster: %v", err)
+			} else {
+				entry.Warnf("memberlist join not successful, periodic rejoin will retry: %v", err)
 			}
-			// The periodic rejoin below still converges the cluster.
-			entry.Warnf("memberlist join not successful, periodic rejoin will retry: %v", err)
 		}
 	}
 

--- a/usecases/cluster/state_join_test.go
+++ b/usecases/cluster/state_join_test.go
@@ -76,12 +76,12 @@ func TestInitJoinRetryPolicy(t *testing.T) {
 			logger, hook := logrustest.NewNullLogger()
 
 			cfg := Config{
-				Hostname:            "node1",
-				Localhost:           true,
-				Join:                deadJoinAddr,
-				GossipBindPort:      gossipPort,
-				RaftBootstrapExpect: test.bootstrapExpect,
-				BootstrapTimeout:    testJoinTimeout,
+				Hostname:             "node1",
+				Localhost:            true,
+				Join:                 deadJoinAddr,
+				GossipBindPort:       gossipPort,
+				RaftBootstrapExpect:  test.bootstrapExpect,
+				RaftBootstrapTimeout: testJoinTimeout,
 			}
 
 			start := time.Now()

--- a/usecases/cluster/state_join_test.go
+++ b/usecases/cluster/state_join_test.go
@@ -13,6 +13,7 @@ package cluster
 
 import (
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,55 +40,39 @@ func freeGossipPort(t *testing.T) int {
 	return port
 }
 
-// shrinkJoinBudget makes the retry window small enough to sleep through in a
-// unit test, and restores it afterwards.
-func shrinkJoinBudget(t *testing.T, initial, total time.Duration) {
+// shrinkJoinInterval speeds up the retry backoff for a unit test; the retry
+// window itself comes from Config.BootstrapTimeout.
+func shrinkJoinInterval(t *testing.T, initial time.Duration) {
 	t.Helper()
 
-	origInitial, origTotal := joinInitialInterval, joinTimeout
-	joinInitialInterval, joinTimeout = initial, total
-	t.Cleanup(func() { joinInitialInterval, joinTimeout = origInitial, origTotal })
+	orig := joinInitialInterval
+	joinInitialInterval = initial
+	t.Cleanup(func() { joinInitialInterval = orig })
 }
 
-// TestInitJoinRetryPolicy pins who is allowed to wait for a peer.
+// TestInitJoinRetryPolicy verifies a failed startup join is retried and never
+// fatal, for both single and multi-node seeds.
 func TestInitJoinRetryPolicy(t *testing.T) {
-	// Long enough that a single retry is unmistakable, short enough to wait out.
 	const (
 		testInitialInterval = 200 * time.Millisecond
-		testJoinTimeout     = 2 * time.Second
+		testJoinTimeout     = 1 * time.Second
 	)
 
 	tests := []struct {
 		name            string
 		bootstrapExpect int
-		wantErr         bool
-		wantRetry       bool
+		wantLog         string
 	}{
-		{
-			name:            "sole seed: unreachable join address is fatal, and immediately so",
-			bootstrapExpect: 1,
-			wantErr:         true,
-			wantRetry:       false,
-		},
-		{
-			name:            "unset bootstrap expect is treated as a sole seed",
-			bootstrapExpect: 0,
-			wantErr:         true,
-			wantRetry:       false,
-		},
-		{
-			name:            "peers expected: retry the window, then start and let rejoin converge",
-			bootstrapExpect: 3,
-			wantErr:         false,
-			wantRetry:       true,
-		},
+		{"single-node seed", 1, "continuing as single-node cluster"},
+		{"unset bootstrap expect", 0, "continuing as single-node cluster"},
+		{"multi-node seed", 3, "periodic rejoin will retry"},
 	}
 
 	gossipPort := freeGossipPort(t)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			shrinkJoinBudget(t, testInitialInterval, testJoinTimeout)
+			shrinkJoinInterval(t, testInitialInterval)
 			logger, hook := logrustest.NewNullLogger()
 
 			cfg := Config{
@@ -96,33 +81,28 @@ func TestInitJoinRetryPolicy(t *testing.T) {
 				Join:                deadJoinAddr,
 				GossipBindPort:      gossipPort,
 				RaftBootstrapExpect: test.bootstrapExpect,
+				BootstrapTimeout:    testJoinTimeout,
 			}
 
 			start := time.Now()
 			state, err := Init(cfg, 1, t.TempDir(), nil, logger)
 			elapsed := time.Since(start)
 
-			if test.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, state)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, state)
-				t.Cleanup(func() { _ = state.list.Shutdown() })
-			}
+			require.NoError(t, err)
+			require.NotNil(t, state)
+			t.Cleanup(func() { _ = state.list.Shutdown() })
 
-			// The only signal that separates "retried" from "gave up at once" is
-			// time: one backoff sleep is the smallest observable retry.
-			if test.wantRetry {
-				assert.GreaterOrEqual(t, elapsed, testInitialInterval,
-					"returned before it could have slept even once; the join was not retried")
-			} else {
-				assert.Less(t, elapsed, testInitialInterval,
-					"slept at least one backoff interval; the sole seed retried instead of failing fast")
-			}
+			assert.GreaterOrEqual(t, elapsed, testInitialInterval,
+				"returned before it could sleep even once; the join was not retried")
 
-			// Neither giving up nor carrying on may happen quietly.
-			assert.NotEmpty(t, hook.AllEntries(), "an unreachable join must be logged")
+			var logged bool
+			for _, e := range hook.AllEntries() {
+				if strings.Contains(e.Message, test.wantLog) {
+					logged = true
+					break
+				}
+			}
+			assert.True(t, logged, "expected a log entry containing %q", test.wantLog)
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:
based on observation on rebalancing clusters. a single-node cluster treated a failed startup memberlist join as fatal error.

a pod reschedule the join target briefly resolves to the previous, now-dead pod IP, so the join fails, the node exits, gets a new IP, and chases the same stale address again,  **a crash loop** that only ends once Kubernetes DNS converges.

a single node cluster has no peer to wait for, so a failed join must not take it down. Retry the join for every
seed (a single node can also be racing DNS), and on failure log and continue instead of exiting: a single node bootstraps solo, a multi-node seed converges via the periodic rejoin. 

The retry window now comes from `RAFT_BOOTSTRAP_TIMEOUT` instead of a hardcoded 60s, so the gossip join and the raft bootstrap share one "wait for peers on restart" budget. 

Tradeoff: startup can now take longer, since the node retries the join until the correct IP resolves (up to `RAFT_BOOTSTRAP_TIMEOUT`) instead of failing fast.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/29580869924
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
