### PR TITLE
test(async-repl): gate scheduler close tests on dispatch round-trips, not channel-buffer sampling

### DIFF
--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1465,14 +1465,16 @@ func TestSchedulerCloseWithConcurrentDispatches(t *testing.T) {
 		require.NoError(t, sched.Register(&Shard{}))
 	}
 
-	// Wait until the dispatcher has placed at least one entry into the worker
-	// pipeline. The shards have nil asyncRepCtx so runEntry returns immediately,
-	// but we must still observe that a dispatch cycle has started before calling
-	// Close() to exercise the concurrent-dispatch code path.
+	// Gate on nextSeq growth: sampling len(workCh)/len(resultCh) misses sends handed off directly to parked receivers.
+	sched.mu.Lock()
+	baseSeq := sched.nextSeq
+	sched.mu.Unlock()
 	require.Eventually(t, func() bool {
-		return len(sched.workCh) > 0 || len(sched.resultCh) > 0
-	}, 200*time.Millisecond, time.Millisecond,
-		"dispatcher did not produce any dispatches within 200ms")
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		return sched.nextSeq > baseSeq
+	}, 5*time.Second, time.Millisecond,
+		"dispatcher did not complete any dispatch round-trip within 5s")
 
 	done := make(chan struct{})
 	go func() {
@@ -1527,14 +1529,16 @@ func TestWorkerDrainsWorkChOnCtxCancel(t *testing.T) {
 		require.NoError(t, sched.Register(s))
 	}
 
-	// Wait until the dispatcher has buffered at least one entry in workCh,
-	// ensuring Close() fires while some items are still in the worker pipeline.
-	// With nil asyncRepCtx, runEntry returns immediately; items cycle quickly,
-	// so we poll until we observe a non-empty buffer rather than sleeping.
+	// Gate on nextSeq growth: sampling len(workCh)/len(resultCh) misses sends handed off directly to parked receivers.
+	sched.mu.Lock()
+	baseSeq := sched.nextSeq
+	sched.mu.Unlock()
 	require.Eventually(t, func() bool {
-		return len(sched.workCh) > 0 || len(sched.resultCh) > 0
-	}, 200*time.Millisecond, time.Millisecond,
-		"dispatcher did not buffer any work items within 200ms")
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		return sched.nextSeq > baseSeq
+	}, 5*time.Second, time.Millisecond,
+		"dispatcher did not complete any dispatch round-trip within 5s")
 
 	// Close cancels the scheduler context. Workers must drain any remaining
 	// buffered workCh items and call Done() for each to keep asyncRepWg balanced.


### PR DESCRIPTION
## Motivation

`TestSchedulerCloseWithConcurrentDispatches` and `TestWorkerDrainsWorkChOnCtxCancel` flake at their readiness gate, not at the behavior they actually test:

```
--- FAIL: TestSchedulerCloseWithConcurrentDispatches (0.21s)
    async_replication_scheduler_test.go:1472: Condition never satisfied
    dispatcher did not produce any dispatches within 200ms
```

The gate polled `len(workCh) > 0 || len(resultCh) > 0` for 200ms — but a Go channel send to an already-parked receiver hands the element over directly, without it ever appearing in the buffer. These tests register shards with nil `asyncRepCtx`, so `runEntry` returns instantly and workers are almost always parked: items stream through the pipeline at full speed while both buffers read as empty at every 1ms sample. The root pre-filter batching narrows the window further (all nil-index shards coalesce into a single `workCh` send — always a direct handoff). On a loaded CI runner (4 vCPU, `-race -covermode=atomic`, several package binaries in parallel) the 200ms window can expire without one non-zero observation, failing tests whose subject (`Close()` semantics) was behaving correctly.

## Approach

Gate on `sched.nextSeq` growth under `sched.mu` instead. `nextSeq` is bumped on every heap push, and once registration is done the only pushes come from the dispatch cycle (`onResultLocked` re-queue, dispatch rollback) — so `nextSeq > baseSeq` proves a full dispatch → worker → result → re-queue round-trip completed. That is a strictly stronger precondition than "saw a buffered item" and is immune to the direct-handoff race. The deadline widens 200ms → 5s as a ceiling only; `require.Eventually` returns as soon as the condition holds (milliseconds in practice).

## Key areas for review

- `TestWorkerDrainsWorkChOnCtxCancel` — the old comment claimed the gate ensured items were "buffered in workCh" at `Close()`. The old gate never guaranteed that either (the buffer could drain between the last poll and `Close()`); real coverage comes from continuous re-dispatch keeping items in flight plus the `asyncRepWg`-balance assertion. The new gate does not weaken the test.
- The gate reads scheduler internals (`nextSeq`) — white-box, but same-package and correctly under `sched.mu`, so race-detector clean.

## Testing

Test-only change; no production code touched.

- 200× both tests with `-race`: pass in 4.5s total (~11ms per run — the new gate trips in single-digit ms)
- 100× under CI-emulating stress (GOMAXPROCS=2, `-race -covermode=atomic`, all cores saturated by busy-loop processes): pass
- `golangci-lint run` and `tools/linter_go_routines.sh`: clean

Note: `stable/v1.38` and `main` carry the identical fragile gates; the same patch should be forward-ported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
