### PR TITLE
fix: error on dimension-mismatched nearVector queries against RQ/BQ HNSW indexes (#12207)

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
@@ -31,11 +31,22 @@ const (
 type BinaryRotationalQuantizer struct {
 	inputDim    uint32
 	originalDim uint32
-	rotation    *compression.FastRotation
-	distancer   distancer.Provider
-	rounding    []float32
-	l2          float32
-	cos         float32
+	// legacyAmbiguousDim is true only for a quantizer restored from a
+	// persisted originalDim that exactly equals minCodeBits. Releases before
+	// this fix persisted the padded rotation dimension (always minCodeBits
+	// for any true dimension < minCodeBits) instead of the true input
+	// dimension, so a restored originalDim of exactly minCodeBits could mean
+	// either a genuine minCodeBits-dimensional index or a smaller index whose
+	// true dimension was lost to that historical bug. A freshly constructed
+	// quantizer (NewBinaryRotationalQuantizer) is never ambiguous: its
+	// originalDim always reflects the real configured dimension. See
+	// NewDistancer.
+	legacyAmbiguousDim bool
+	rotation           *compression.FastRotation
+	distancer          distancer.Provider
+	rounding           []float32
+	l2                 float32
+	cos                float32
 }
 
 func (rq *BinaryRotationalQuantizer) Data() compression.RQData {
@@ -76,11 +87,14 @@ func NewBinaryRotationalQuantizer(inputDim int, seed uint64, distancer distancer
 	rq := &BinaryRotationalQuantizer{
 		inputDim:    uint32(inputDim),
 		originalDim: uint32(originalDim),
-		rotation:    rotation,
-		distancer:   distancer,
-		rounding:    rounding,
-		l2:          l2,
-		cos:         cos,
+		// Freshly constructed: originalDim is always the real, unambiguous
+		// configured dimension.
+		legacyAmbiguousDim: false,
+		rotation:           rotation,
+		distancer:          distancer,
+		rounding:           rounding,
+		l2:                 l2,
+		cos:                cos,
 	}
 	return rq, nil
 }
@@ -92,18 +106,26 @@ func RestoreBinaryRotationalQuantizer(inputDim int, outputDim int, rounds int, s
 	}
 
 	originalDim := inputDim
+	// Releases before this fix persisted the padded rotation dimension
+	// instead of the true input dimension whenever the true dimension was
+	// below minCodeBits, so a persisted inputDim of exactly minCodeBits is
+	// ambiguous: it might be a genuine minCodeBits-dimensional index, or it
+	// might be a smaller index whose true dimension was clobbered by that
+	// bug. See legacyAmbiguousDim and NewDistancer.
+	legacyAmbiguousDim := inputDim == minCodeBits
 	if inputDim < minCodeBits {
 		inputDim = minCodeBits
 	}
 
 	rq := &BinaryRotationalQuantizer{
-		inputDim:    uint32(inputDim),
-		originalDim: uint32(originalDim),
-		rotation:    RestoreFastRotation(outputDim, rounds, swaps, signs),
-		distancer:   distancer,
-		rounding:    rounding,
-		cos:         cos,
-		l2:          l2,
+		inputDim:           uint32(inputDim),
+		originalDim:        uint32(originalDim),
+		legacyAmbiguousDim: legacyAmbiguousDim,
+		rotation:           RestoreFastRotation(outputDim, rounds, swaps, signs),
+		distancer:          distancer,
+		rounding:           rounding,
+		cos:                cos,
+		l2:                 l2,
 	}
 	return rq, nil
 }
@@ -372,7 +394,19 @@ func (rq *BinaryRotationalQuantizer) NewDistancer(q []float32) *BinaryRQDistance
 		// validly-shaped (but meaningless) compressed code instead of
 		// erroring, mirroring the equivalent guard in
 		// RotationalQuantizer.NewDistancer / ProductQuantizer.NewDistancer.
-		d.err = fmt.Errorf("%w: %d vs %d", distancer.ErrVectorLength, len(q), rq.originalDim)
+		//
+		// Exception: for a quantizer restored from a legacy commit
+		// log/metadata entry whose persisted dimension is ambiguously exactly
+		// minCodeBits (see legacyAmbiguousDim), a query shorter than
+		// minCodeBits cannot be distinguished from a genuinely valid query
+		// against the collection's real (smaller, but lost) dimension. Erring
+		// on the side of the pre-fix behavior here avoids rejecting valid
+		// queries against existing indexes after upgrading; the ambiguity
+		// clears once the index is recompressed under this fixed
+		// PersistCompression.
+		if !rq.legacyAmbiguousDim || len(q) >= minCodeBits {
+			d.err = fmt.Errorf("%w: %d vs %d", distancer.ErrVectorLength, len(q), rq.originalDim)
+		}
 	}
 	return d
 }

--- a/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
@@ -341,6 +341,7 @@ type BinaryRQDistancer struct {
 	cos       float32
 	l2        float32
 	cq        RQMultiBitCode
+	err       error
 }
 
 func (d *BinaryRQDistancer) QueryCode() RQMultiBitCode {
@@ -356,7 +357,7 @@ func (rq *BinaryRotationalQuantizer) NewDistancer(q []float32) *BinaryRQDistance
 	if rq.distancer.Type() == "l2-squared" {
 		l2 = 1.0
 	}
-	return &BinaryRQDistancer{
+	d := &BinaryRQDistancer{
 		query:     q,
 		distancer: rq.distancer,
 		rq:        rq,
@@ -364,6 +365,16 @@ func (rq *BinaryRotationalQuantizer) NewDistancer(q []float32) *BinaryRQDistance
 		l2:        l2,
 		cq:        rq.encodeQuery(q),
 	}
+	if len(q) != int(rq.originalDim) {
+		// Guard against a dimension-mismatched query vector. encodeQuery()
+		// silently rotates/pads q to the (padded) input dimension, so without
+		// this check a wrong-dimension query would otherwise produce a
+		// validly-shaped (but meaningless) compressed code instead of
+		// erroring, mirroring the equivalent guard in
+		// RotationalQuantizer.NewDistancer / ProductQuantizer.NewDistancer.
+		d.err = fmt.Errorf("%w: %d vs %d", distancer.ErrVectorLength, len(q), rq.originalDim)
+	}
+	return d
 }
 
 func HammingDist(x, y []uint64) int {
@@ -385,6 +396,9 @@ func HammingDistSIMD(x, y []uint64) float32 {
 // if-statement to determine whether to use SIMD also comes at a cost.
 // For binary quantization we always use SIMD, so maybe that is the way to go.
 func (d *BinaryRQDistancer) Distance(x []uint64) (float32, error) {
+	if d.err != nil {
+		return 0, d.err
+	}
 	cx := RQOneBitCode(x)
 	bits := cx.Bits()
 	const hammingDistSIMDThreshold = 512
@@ -510,7 +524,12 @@ func (brq *BinaryRotationalQuantizer) ReturnQuantizerDistancer(distancer quantiz
 
 func (brq *BinaryRotationalQuantizer) PersistCompression(logger CommitLogger) {
 	logger.AddBRQCompression(compression.BRQData{
-		InputDim: brq.inputDim,
+		// originalDim (not inputDim, which is padded up to minCodeBits) is the
+		// true configured vector dimension. Persisting the padded value here
+		// corrupted originalDim on restore (RestoreBinaryRotationalQuantizer
+		// derives originalDim from this field), which this method's own Data()
+		// counterpart already gets right.
+		InputDim: brq.originalDim,
 		Rotation: *brq.rotation,
 		Rounding: brq.rounding,
 	})

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization.go
@@ -171,9 +171,15 @@ func (rq *RotationalQuantizer) Encode(x []float32) []byte {
 }
 
 func (rq *RotationalQuantizer) Decode(compressed []byte) []float32 {
-	// restore the vector from its compressed form, creating a new slice
-	// then un-rotate in place and return
-	return rq.rotation.UnRotateInPlace(rq.Restore(compressed))
+	// restore the vector from its compressed form, creating a new slice,
+	// then un-rotate in place and truncate back down to the true (unpadded)
+	// input dimension. Restore() produces a vector sized to the rotation's
+	// padded output dimension (the next multiple of 64), so without this
+	// truncation Decode() silently returns extra trailing elements whenever
+	// the real dimension isn't already a multiple of 64 — mirroring the
+	// equivalent truncation in BinaryRotationalQuantizer.Decode.
+	unrotated := rq.rotation.UnRotateInPlace(rq.Restore(compressed))
+	return unrotated[:rq.inputDim]
 }
 
 func dotProduct(x, y []float32) float32 {
@@ -270,7 +276,16 @@ func (rq *RotationalQuantizer) newDistancer(q []float32, cq RQCode) *RQDistancer
 
 func (rq *RotationalQuantizer) NewDistancer(q []float32) *RQDistancer {
 	var cq RQCode = rq.Encode(q)
-	return rq.newDistancer(q, cq)
+	d := rq.newDistancer(q, cq)
+	if d.err == nil && len(q) != int(rq.inputDim) {
+		// Guard against a dimension-mismatched query vector. Encode() silently
+		// truncates/pads q to the fixed output dimension, so without this check
+		// a wrong-dimension query would otherwise produce a validly-shaped (but
+		// meaningless) compressed code instead of erroring, mirroring the
+		// equivalent guard in ProductQuantizer.NewDistancer.
+		d.err = fmt.Errorf("%w: %d vs %d", distancer.ErrVectorLength, len(q), rq.inputDim)
+	}
+	return d
 }
 
 // Optimized distance computation that precomputes as much as possible and

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
@@ -105,4 +106,78 @@ func TestBinaryRQDistancerQueryDimensionMismatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Regression test for a backward-compatibility bug identified during review
+// of the fix above (PR #12255, flagged by a bot reviewer on
+// BinaryRotationalQuantizer.NewDistancer): releases before this fix persisted
+// the padded rotation dimension (minCodeBits) instead of the true input
+// dimension in BRQ commit logs and flat RQ1 metadata whenever the true
+// dimension was below minCodeBits. Restoring such a legacy entry therefore
+// yields an originalDim of minCodeBits even though the collection's real
+// configured dimension is smaller (e.g. 64), and that true dimension cannot be
+// recovered since it was never correctly persisted. Without special-casing
+// this, the new dimension-mismatch guard would incorrectly reject the
+// collection's genuinely correct queries after upgrading. This test simulates
+// restoring from such a legacy-format entry and asserts a query at the real
+// (smaller) dimension is still accepted.
+func TestBinaryRQDistancerLegacyRestoredDimensionIsAmbiguous(t *testing.T) {
+	const legacyPersistedInputDim = 256 // what pre-fix releases wrote for any true dim < minCodeBits
+	dimensions := 64
+	rng := newRNG(246813)
+	indexed := randomUnitVector(dimensions, rng)
+
+	// Build a real quantizer first to obtain valid rotation parameters, then
+	// restore from them using the legacy (corrupted) persisted dimension
+	// instead of the true one, mirroring what RestoreBinaryRotationalQuantizer
+	// would see when reading a pre-fix commit log / metadata entry.
+	original, err := compressionhelpers.NewBinaryRotationalQuantizer(dimensions, 42, distancer.NewCosineDistanceProvider())
+	require.NoError(t, err)
+	data := original.Data()
+
+	restored, err := compressionhelpers.RestoreBinaryRotationalQuantizer(
+		legacyPersistedInputDim,
+		int(data.Rotation.OutputDim),
+		int(data.Rotation.Rounds),
+		data.Rotation.Swaps,
+		data.Rotation.Signs,
+		data.Rounding,
+		distancer.NewCosineDistanceProvider(),
+	)
+	require.NoError(t, err)
+
+	encoded := restored.Encode(indexed)
+
+	// A query at the real (true) dimension must still succeed, even though
+	// restored.originalDim reads as the legacy padded value (256), not 64.
+	query := make([]float32, dimensions)
+	for i := range query {
+		query[i] = float32(i%7) - 3
+	}
+	d := restored.NewDistancer(query)
+	_, err = d.Distance(encoded)
+	assert.NoError(t, err)
+}
+
+// Companion to TestBinaryRQDistancerLegacyRestoredDimensionIsAmbiguous:
+// confirms the ambiguity carve-out is scoped only to restored quantizers
+// whose persisted dimension is exactly minCodeBits, and does not weaken the
+// guard for a freshly constructed (unambiguous) minCodeBits-dimensional
+// quantizer, which must still reject a mismatched query.
+func TestBinaryRQDistancerFreshMinCodeBitsQuantizerStillGuards(t *testing.T) {
+	dimensions := 256 // == minCodeBits, but unambiguous since freshly constructed
+	rng := newRNG(135792)
+	indexed := randomUnitVector(dimensions, rng)
+
+	rq, err := compressionhelpers.NewBinaryRotationalQuantizer(dimensions, 42, distancer.NewCosineDistanceProvider())
+	require.NoError(t, err)
+	encoded := rq.Encode(indexed)
+
+	query := make([]float32, dimensions-64)
+	for i := range query {
+		query[i] = float32(i%7) - 3
+	}
+	d := rq.NewDistancer(query)
+	_, err = d.Distance(encoded)
+	assert.ErrorIs(t, err, distancer.ErrVectorLength)
 }

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
@@ -1,6 +1,6 @@
 //                           _       _
 // __      _____  __ ___   ___  __ _| |_ ___
-// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+// \ \ /\\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
 //  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
 //   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
 //
@@ -21,6 +21,48 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
+// dimensionMismatchCases returns the shared table of query-dimension cases
+// for an index of the given dimension: a correctly-sized query must succeed,
+// while over- and under-dimensioned queries must be rejected with
+// distancer.ErrVectorLength. Both the RQ and single-bit (BQ/RQ-bits=1) code
+// paths exercise the same guard contract, so they share this table rather
+// than duplicating it.
+func dimensionMismatchCases(dimensions int) []struct {
+	name     string
+	queryLen int
+	wantErr  bool
+} {
+	return []struct {
+		name     string
+		queryLen int
+		wantErr  bool
+	}{
+		{name: "query matches index dimensions", queryLen: dimensions},
+		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
+		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
+	}
+}
+
+// assertDimensionGuard builds a query of the given length and asserts that
+// constructing a distancer for it (via newDistancer) either succeeds or fails
+// with distancer.ErrVectorLength, per wantErr. The caller supplies
+// newDistancer, which closes over the quantizer and its encoded index
+// representation so the helper stays agnostic to the concrete distancer type
+// (RQDistancer takes a []byte, BinaryRQDistancer takes a []uint64).
+func assertDimensionGuard(t *testing.T, queryLen int, wantErr bool, newDistancer func(query []float32) error) {
+	t.Helper()
+	query := make([]float32, queryLen)
+	for i := range query {
+		query[i] = float32(i%7) - 3
+	}
+	err := newDistancer(query)
+	if wantErr {
+		assert.ErrorIs(t, err, distancer.ErrVectorLength)
+	} else {
+		assert.NoError(t, err)
+	}
+}
+
 // Regression test for https://github.com/weaviate/weaviate/issues/12207:
 // a nearVector query with the wrong dimensionality against an RQ-compressed
 // HNSW index used to silently return an empty result set instead of
@@ -38,31 +80,12 @@ func TestRQDistancerQueryDimensionMismatch(t *testing.T) {
 	rq := compressionhelpers.NewRotationalQuantizer(dimensions, 42, bits, distancer.NewCosineDistanceProvider())
 	encoded := rq.Encode(indexed)
 
-	tests := []struct {
-		name     string
-		queryLen int
-		wantErr  bool
-	}{
-		{name: "query matches index dimensions", queryLen: dimensions},
-		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
-		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range dimensionMismatchCases(dimensions) {
 		t.Run(tt.name, func(t *testing.T) {
-			query := make([]float32, tt.queryLen)
-			for i := range query {
-				query[i] = float32(i%7) - 3
-			}
-
-			d := rq.NewDistancer(query)
-
-			_, err := d.Distance(encoded)
-			if tt.wantErr {
-				assert.ErrorIs(t, err, distancer.ErrVectorLength)
-			} else {
-				assert.NoError(t, err)
-			}
+			assertDimensionGuard(t, tt.queryLen, tt.wantErr, func(query []float32) error {
+				_, err := rq.NewDistancer(query).Distance(encoded)
+				return err
+			})
 		})
 	}
 }
@@ -76,34 +99,15 @@ func TestBinaryRQDistancerQueryDimensionMismatch(t *testing.T) {
 	indexed := randomUnitVector(dimensions, rng)
 
 	rq, err := compressionhelpers.NewBinaryRotationalQuantizer(dimensions, 42, distancer.NewCosineDistanceProvider())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	encoded := rq.Encode(indexed)
 
-	tests := []struct {
-		name     string
-		queryLen int
-		wantErr  bool
-	}{
-		{name: "query matches index dimensions", queryLen: dimensions},
-		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
-		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range dimensionMismatchCases(dimensions) {
 		t.Run(tt.name, func(t *testing.T) {
-			query := make([]float32, tt.queryLen)
-			for i := range query {
-				query[i] = float32(i%7) - 3
-			}
-
-			d := rq.NewDistancer(query)
-
-			_, err := d.Distance(encoded)
-			if tt.wantErr {
-				assert.ErrorIs(t, err, distancer.ErrVectorLength)
-			} else {
-				assert.NoError(t, err)
-			}
+			assertDimensionGuard(t, tt.queryLen, tt.wantErr, func(query []float32) error {
+				_, err := rq.NewDistancer(query).Distance(encoded)
+				return err
+			})
 		})
 	}
 }

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
@@ -1,0 +1,108 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compressionhelpers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+)
+
+// Regression test for https://github.com/weaviate/weaviate/issues/12207:
+// a nearVector query with the wrong dimensionality against an RQ-compressed
+// HNSW index used to silently return an empty result set instead of
+// erroring, because RQ's query encoder pads/truncates the query to its fixed
+// output dimension, masking the mismatch before it ever reaches a length
+// check. RotationalQuantizer.NewDistancer must reject a dimension-mismatched
+// query up front, mirroring ProductQuantizer.NewDistancer (see
+// TestPQDistancerQueryDimensionMismatch).
+func TestRQDistancerQueryDimensionMismatch(t *testing.T) {
+	dimensions := 64
+	bits := 8
+	rng := newRNG(123489)
+	indexed := randomUnitVector(dimensions, rng)
+
+	rq := compressionhelpers.NewRotationalQuantizer(dimensions, 42, bits, distancer.NewCosineDistanceProvider())
+	encoded := rq.Encode(indexed)
+
+	tests := []struct {
+		name     string
+		queryLen int
+		wantErr  bool
+	}{
+		{name: "query matches index dimensions", queryLen: dimensions},
+		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
+		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := make([]float32, tt.queryLen)
+			for i := range query {
+				query[i] = float32(i%7) - 3
+			}
+
+			d := rq.NewDistancer(query)
+
+			_, err := d.Distance(encoded)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, distancer.ErrVectorLength)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Same regression as TestRQDistancerQueryDimensionMismatch, but for the
+// single-bit ("RQ bits=1") code path, which uses the separate
+// BinaryRotationalQuantizer/BinaryRQDistancer implementation.
+func TestBinaryRQDistancerQueryDimensionMismatch(t *testing.T) {
+	dimensions := 64
+	rng := newRNG(987654)
+	indexed := randomUnitVector(dimensions, rng)
+
+	rq, err := compressionhelpers.NewBinaryRotationalQuantizer(dimensions, 42, distancer.NewCosineDistanceProvider())
+	assert.NoError(t, err)
+	encoded := rq.Encode(indexed)
+
+	tests := []struct {
+		name     string
+		queryLen int
+		wantErr  bool
+	}{
+		{name: "query matches index dimensions", queryLen: dimensions},
+		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
+		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := make([]float32, tt.queryLen)
+			for i := range query {
+				query[i] = float32(i%7) - 3
+			}
+
+			d := rq.NewDistancer(query)
+
+			_, err := d.Distance(encoded)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, distancer.ErrVectorLength)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
@@ -1,6 +1,6 @@
 //                           _       _
 // __      _____  __ ___   ___  __ _| |_ ___
-// \ \ /\\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
 //  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
 //   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
 //
@@ -21,48 +21,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
-// dimensionMismatchCases returns the shared table of query-dimension cases
-// for an index of the given dimension: a correctly-sized query must succeed,
-// while over- and under-dimensioned queries must be rejected with
-// distancer.ErrVectorLength. Both the RQ and single-bit (BQ/RQ-bits=1) code
-// paths exercise the same guard contract, so they share this table rather
-// than duplicating it.
-func dimensionMismatchCases(dimensions int) []struct {
-	name     string
-	queryLen int
-	wantErr  bool
-} {
-	return []struct {
-		name     string
-		queryLen int
-		wantErr  bool
-	}{
-		{name: "query matches index dimensions", queryLen: dimensions},
-		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
-		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
-	}
-}
-
-// assertDimensionGuard builds a query of the given length and asserts that
-// constructing a distancer for it (via newDistancer) either succeeds or fails
-// with distancer.ErrVectorLength, per wantErr. The caller supplies
-// newDistancer, which closes over the quantizer and its encoded index
-// representation so the helper stays agnostic to the concrete distancer type
-// (RQDistancer takes a []byte, BinaryRQDistancer takes a []uint64).
-func assertDimensionGuard(t *testing.T, queryLen int, wantErr bool, newDistancer func(query []float32) error) {
-	t.Helper()
-	query := make([]float32, queryLen)
-	for i := range query {
-		query[i] = float32(i%7) - 3
-	}
-	err := newDistancer(query)
-	if wantErr {
-		assert.ErrorIs(t, err, distancer.ErrVectorLength)
-	} else {
-		assert.NoError(t, err)
-	}
-}
-
 // Regression test for https://github.com/weaviate/weaviate/issues/12207:
 // a nearVector query with the wrong dimensionality against an RQ-compressed
 // HNSW index used to silently return an empty result set instead of
@@ -80,12 +38,31 @@ func TestRQDistancerQueryDimensionMismatch(t *testing.T) {
 	rq := compressionhelpers.NewRotationalQuantizer(dimensions, 42, bits, distancer.NewCosineDistanceProvider())
 	encoded := rq.Encode(indexed)
 
-	for _, tt := range dimensionMismatchCases(dimensions) {
+	tests := []struct {
+		name     string
+		queryLen int
+		wantErr  bool
+	}{
+		{name: "query matches index dimensions", queryLen: dimensions},
+		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
+		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
+	}
+
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertDimensionGuard(t, tt.queryLen, tt.wantErr, func(query []float32) error {
-				_, err := rq.NewDistancer(query).Distance(encoded)
-				return err
-			})
+			query := make([]float32, tt.queryLen)
+			for i := range query {
+				query[i] = float32(i%7) - 3
+			}
+
+			d := rq.NewDistancer(query)
+
+			_, err := d.Distance(encoded)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, distancer.ErrVectorLength)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }
@@ -99,15 +76,34 @@ func TestBinaryRQDistancerQueryDimensionMismatch(t *testing.T) {
 	indexed := randomUnitVector(dimensions, rng)
 
 	rq, err := compressionhelpers.NewBinaryRotationalQuantizer(dimensions, 42, distancer.NewCosineDistanceProvider())
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	encoded := rq.Encode(indexed)
 
-	for _, tt := range dimensionMismatchCases(dimensions) {
+	tests := []struct {
+		name     string
+		queryLen int
+		wantErr  bool
+	}{
+		{name: "query matches index dimensions", queryLen: dimensions},
+		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
+		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
+	}
+
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertDimensionGuard(t, tt.queryLen, tt.wantErr, func(query []float32) error {
-				_, err := rq.NewDistancer(query).Distance(encoded)
-				return err
-			})
+			query := make([]float32, tt.queryLen)
+			for i := range query {
+				query[i] = float32(i%7) - 3
+			}
+
+			d := rq.NewDistancer(query)
+
+			_, err := d.Distance(encoded)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, distancer.ErrVectorLength)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go
@@ -21,6 +21,48 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
+// dimensionMismatchCases returns the shared table of query-dimension cases
+// for an index of the given dimension: a correctly-sized query must succeed,
+// while over- and under-dimensioned queries must be rejected with
+// distancer.ErrVectorLength. Both the RQ and single-bit (BQ/RQ-bits=1) code
+// paths exercise the same guard contract, so they share this table rather
+// than duplicating it.
+func dimensionMismatchCases(dimensions int) []struct {
+	name     string
+	queryLen int
+	wantErr  bool
+} {
+	return []struct {
+		name     string
+		queryLen int
+		wantErr  bool
+	}{
+		{name: "query matches index dimensions", queryLen: dimensions},
+		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
+		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
+	}
+}
+
+// assertDimensionGuard builds a query of the given length and asserts that
+// constructing a distancer for it (via newDistancer) either succeeds or fails
+// with distancer.ErrVectorLength, per wantErr. The caller supplies
+// newDistancer, which closes over the quantizer and its encoded index
+// representation so the helper stays agnostic to the concrete distancer type
+// (RQDistancer takes a []byte, BinaryRQDistancer takes a []uint64).
+func assertDimensionGuard(t *testing.T, queryLen int, wantErr bool, newDistancer func(query []float32) error) {
+	t.Helper()
+	query := make([]float32, queryLen)
+	for i := range query {
+		query[i] = float32(i%7) - 3
+	}
+	err := newDistancer(query)
+	if wantErr {
+		assert.ErrorIs(t, err, distancer.ErrVectorLength)
+	} else {
+		assert.NoError(t, err)
+	}
+}
+
 // Regression test for https://github.com/weaviate/weaviate/issues/12207:
 // a nearVector query with the wrong dimensionality against an RQ-compressed
 // HNSW index used to silently return an empty result set instead of
@@ -38,31 +80,12 @@ func TestRQDistancerQueryDimensionMismatch(t *testing.T) {
 	rq := compressionhelpers.NewRotationalQuantizer(dimensions, 42, bits, distancer.NewCosineDistanceProvider())
 	encoded := rq.Encode(indexed)
 
-	tests := []struct {
-		name     string
-		queryLen int
-		wantErr  bool
-	}{
-		{name: "query matches index dimensions", queryLen: dimensions},
-		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
-		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range dimensionMismatchCases(dimensions) {
 		t.Run(tt.name, func(t *testing.T) {
-			query := make([]float32, tt.queryLen)
-			for i := range query {
-				query[i] = float32(i%7) - 3
-			}
-
-			d := rq.NewDistancer(query)
-
-			_, err := d.Distance(encoded)
-			if tt.wantErr {
-				assert.ErrorIs(t, err, distancer.ErrVectorLength)
-			} else {
-				assert.NoError(t, err)
-			}
+			assertDimensionGuard(t, tt.queryLen, tt.wantErr, func(query []float32) error {
+				_, err := rq.NewDistancer(query).Distance(encoded)
+				return err
+			})
 		})
 	}
 }
@@ -76,34 +99,15 @@ func TestBinaryRQDistancerQueryDimensionMismatch(t *testing.T) {
 	indexed := randomUnitVector(dimensions, rng)
 
 	rq, err := compressionhelpers.NewBinaryRotationalQuantizer(dimensions, 42, distancer.NewCosineDistanceProvider())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	encoded := rq.Encode(indexed)
 
-	tests := []struct {
-		name     string
-		queryLen int
-		wantErr  bool
-	}{
-		{name: "query matches index dimensions", queryLen: dimensions},
-		{name: "query longer than index dimensions (over-dim)", queryLen: dimensions + 32, wantErr: true},
-		{name: "query shorter than index dimensions (under-dim)", queryLen: dimensions - 32, wantErr: true},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range dimensionMismatchCases(dimensions) {
 		t.Run(tt.name, func(t *testing.T) {
-			query := make([]float32, tt.queryLen)
-			for i := range query {
-				query[i] = float32(i%7) - 3
-			}
-
-			d := rq.NewDistancer(query)
-
-			_, err := d.Distance(encoded)
-			if tt.wantErr {
-				assert.ErrorIs(t, err, distancer.ErrVectorLength)
-			} else {
-				assert.NoError(t, err)
-			}
+			assertDimensionGuard(t, tt.queryLen, tt.wantErr, func(query []float32) error {
+				_, err := rq.NewDistancer(query).Distance(encoded)
+				return err
+			})
 		})
 	}
 }

--- a/adapters/repos/db/vector/flat/metadata_test.go
+++ b/adapters/repos/db/vector/flat/metadata_test.go
@@ -213,7 +213,11 @@ func Test_RQDataSerialization(t *testing.T) {
 		originalRQ1Data, err := index.serializeRQ1Data()
 		require.Nil(t, err)
 		require.NotNil(t, originalRQ1Data)
-		require.Equal(t, uint32(256), originalRQ1Data.InputDim)
+		// InputDim must be the true (unpadded) vector dimension, not the
+		// internal padded-to-minCodeBits rotation size (256 here). Persisting
+		// the padded value corrupted BinaryRotationalQuantizer.originalDim on
+		// restore (see BinaryRotationalQuantizer.PersistCompression).
+		require.Equal(t, uint32(4), originalRQ1Data.InputDim)
 		require.Greater(t, originalRQ1Data.OutputDim, uint32(0))
 		require.Greater(t, originalRQ1Data.Rounds, uint32(0))
 

--- a/adapters/repos/db/vector/hnsw/bq_query_dimension_mismatch_test.go
+++ b/adapters/repos/db/vector/hnsw/bq_query_dimension_mismatch_test.go
@@ -1,0 +1,93 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// Regression test for https://github.com/weaviate/weaviate/issues/12207:
+// a nearVector query with an under-dimensioned vector against a
+// BQ-compressed HNSW index used to silently return an empty result set
+// instead of erroring. This is because BQ's compressed byte-length only
+// depends on how many 64-bit blocks a vector packs into: a query whose
+// dimension is smaller than the index dimension, but which still packs into
+// the same number of blocks, produces a validly-shaped (but meaningless)
+// compressed code that passes every length check downstream. (An
+// over-dimensioned query that crosses a block boundary already errors
+// correctly, since it changes the compressed byte length.)
+func TestSearchByVector_BQUnderDimensionedQueryErrors(t *testing.T) {
+	ctx := context.Background()
+	dimensions := 64 // exactly one 64-bit block
+	vectors, _ := testinghelpers.RandomVecs(50, 0, dimensions)
+
+	cfg := createVectorHnswIndexTestConfig()
+	cfg.DistanceProvider = distancer.NewCosineDistanceProvider()
+	cfg.VectorForIDThunk = func(ctx context.Context, id uint64) ([]float32, error) {
+		return vectors[int(id)], nil
+	}
+	cfg.TempVectorForIDWithViewThunk = func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		copy(container.Slice, vectors[int(id)])
+		return container.Slice, nil
+	}
+
+	uc := ent.UserConfig{
+		MaxConnections: 30,
+		EFConstruction: 60,
+		EF:             36,
+		BQ:             ent.BQConfig{Enabled: true},
+	}
+
+	index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+	t.Cleanup(func() {
+		_ = index.Shutdown(ctx)
+	})
+
+	for i, vec := range vectors {
+		require.Nil(t, index.Add(ctx, uint64(i), vec))
+	}
+
+	t.Run("matching dimension succeeds", func(t *testing.T) {
+		_, _, err := index.SearchByVector(ctx, vectors[0], 3, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("under-dimensioned query errors instead of returning empty results", func(t *testing.T) {
+		underDim := make([]float32, dimensions-32)
+		copy(underDim, vectors[0])
+
+		res, _, err := index.SearchByVector(ctx, underDim, 3, nil)
+		assert.Error(t, err, "expected a dimension-mismatch error, got a silent result: %v", res)
+		if err != nil {
+			assert.ErrorIs(t, err, distancer.ErrVectorLength)
+		}
+	})
+
+	t.Run("over-dimensioned query also errors", func(t *testing.T) {
+		overDim := make([]float32, dimensions+32)
+		copy(overDim, vectors[0])
+
+		res, _, err := index.SearchByVector(ctx, overDim, 3, nil)
+		assert.Error(t, err, "expected a dimension-mismatch error, got a silent result: %v", res)
+	})
+}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -83,6 +83,22 @@ func (h *hnsw) SearchByVector(ctx context.Context, vector []float32,
 	defer h.compressActionLock.RUnlock()
 
 	vector = h.normalizeVec(vector)
+
+	// BQ's compressed byte-length only depends on the number of 64-bit blocks
+	// a vector packs into, so an under-dimensioned query that lands in the
+	// same block count as the index dimension produces a validly-shaped (but
+	// meaningless) compressed code instead of erroring during distance
+	// computation, unlike PQ/RQ/SQ which carry the expected dimension on
+	// their quantizer and guard against this in NewDistancer. BQ's quantizer
+	// is stateless and constructed before the index dimension is known, so we
+	// guard here instead, using the dimension established by the first
+	// inserted vector.
+	if h.bqConfig.Enabled {
+		if dims := int(h.dims.Load()); dims != 0 && dims != len(vector) {
+			return nil, nil, errors.Wrapf(distancer.ErrVectorLength, "%d vs %d", len(vector), dims)
+		}
+	}
+
 	flatSearchCutoff := int(atomic.LoadInt64(&h.flatSearchCutoff))
 	if allowList != nil && !h.forbidFlat && allowList.Len() < flatSearchCutoff {
 		helpers.AnnotateSlowQueryLog(ctx, "hnsw_flat_search", true)

--- a/test/acceptance_with_python/test_pq_vector_dims_match.py
+++ b/test/acceptance_with_python/test_pq_vector_dims_match.py
@@ -43,6 +43,28 @@ def test_pq_dims_match(collection_factory: CollectionFactory):
     )
 
 
+def assert_wrong_dims_rejected(col):
+    """Populate col with VEC_DIMS-wide vectors, then assert that nearVector
+    queries with the wrong dimensionality raise the standard "vector lengths
+    don't match" error.
+
+    Both an over- and an under-dimensioned query are exercised, since the two
+    used to fail differently, to guard against regressions in either direction.
+    """
+    with col.batch.dynamic() as batch:
+        for i in range(OBJ_NUM):
+            batch.add_object(properties={"someText": f"object-{i}"}, vector=generate_vec(VEC_DIMS))
+
+    for wrong_dims in (VEC_DIMS + 32, VEC_DIMS - 32):
+        with pytest.raises(WeaviateQueryError) as exc:
+            col.query.near_vector(
+                near_vector=generate_vec(wrong_dims),
+                limit=2,
+                return_metadata=MetadataQuery(distance=True),
+            )
+        assert "vector lengths don't match" in str(exc.value)
+
+
 # Regression tests for https://github.com/weaviate/weaviate/issues/12207:
 # a nearVector query with the wrong dimensionality against an RQ-compressed
 # (any bits) or BQ-compressed (under-dimensioned) HNSW index used to silently
@@ -61,18 +83,7 @@ def test_rq_dims_match(collection_factory: CollectionFactory, bits: int):
         ),
     )
 
-    with col.batch.dynamic() as batch:
-        for i in range(OBJ_NUM):
-            batch.add_object(properties={"someText": f"object-{i}"}, vector=generate_vec(VEC_DIMS))
-
-    for wrong_dims in (VEC_DIMS + 32, VEC_DIMS - 32):
-        with pytest.raises(WeaviateQueryError) as exc:
-            col.query.near_vector(
-                near_vector=generate_vec(wrong_dims),
-                limit=2,
-                return_metadata=MetadataQuery(distance=True),
-            )
-        assert "vector lengths don't match" in str(exc.value)
+    assert_wrong_dims_rejected(col)
 
 
 def test_bq_dims_match(collection_factory: CollectionFactory):
@@ -84,22 +95,10 @@ def test_bq_dims_match(collection_factory: CollectionFactory):
         ),
     )
 
-    with col.batch.dynamic() as batch:
-        for i in range(OBJ_NUM):
-            batch.add_object(properties={"someText": f"object-{i}"}, vector=generate_vec(VEC_DIMS))
-
-    # Over-dimensioned queries already error before this fix (they cross a
-    # 64-bit block boundary); under-dimensioned queries within the same
-    # block did not. Cover both to guard against regressions in either
-    # direction.
-    for wrong_dims in (VEC_DIMS + 32, VEC_DIMS - 32):
-        with pytest.raises(WeaviateQueryError) as exc:
-            col.query.near_vector(
-                near_vector=generate_vec(wrong_dims),
-                limit=2,
-                return_metadata=MetadataQuery(distance=True),
-            )
-        assert "vector lengths don't match" in str(exc.value)
+    # For BQ specifically, over-dimensioned queries already errored before this
+    # fix (they cross a 64-bit block boundary); under-dimensioned queries within
+    # the same block did not.
+    assert_wrong_dims_rejected(col)
 
 
 def generate_vec(dims):

--- a/test/acceptance_with_python/test_pq_vector_dims_match.py
+++ b/test/acceptance_with_python/test_pq_vector_dims_match.py
@@ -43,5 +43,64 @@ def test_pq_dims_match(collection_factory: CollectionFactory):
     )
 
 
+# Regression tests for https://github.com/weaviate/weaviate/issues/12207:
+# a nearVector query with the wrong dimensionality against an RQ-compressed
+# (any bits) or BQ-compressed (under-dimensioned) HNSW index used to silently
+# return an empty result set (HTTP 200, no errors) instead of raising the
+# same "vector lengths don't match" error that uncompressed HNSW, flat, and
+# SQ-compressed indexes correctly raise. Unlike the PQ test above, RQ and BQ
+# are enabled from collection creation (no separate compress/quantize step is
+# needed), matching how the issue was reproduced.
+@pytest.mark.parametrize("bits", [1, 8])
+def test_rq_dims_match(collection_factory: CollectionFactory, bits: int):
+    col = collection_factory(
+        name="CompressedVectorRQ",
+        vectorizer_config=Configure.Vectorizer.none(),
+        vector_index_config=Configure.VectorIndex.hnsw(
+            quantizer=Configure.VectorIndex.Quantizer.rq(bits=bits),
+        ),
+    )
+
+    with col.batch.dynamic() as batch:
+        for i in range(OBJ_NUM):
+            batch.add_object(properties={"someText": f"object-{i}"}, vector=generate_vec(VEC_DIMS))
+
+    for wrong_dims in (VEC_DIMS + 32, VEC_DIMS - 32):
+        with pytest.raises(WeaviateQueryError) as exc:
+            col.query.near_vector(
+                near_vector=generate_vec(wrong_dims),
+                limit=2,
+                return_metadata=MetadataQuery(distance=True),
+            )
+        assert "vector lengths don't match" in str(exc.value)
+
+
+def test_bq_dims_match(collection_factory: CollectionFactory):
+    col = collection_factory(
+        name="CompressedVectorBQ",
+        vectorizer_config=Configure.Vectorizer.none(),
+        vector_index_config=Configure.VectorIndex.hnsw(
+            quantizer=Configure.VectorIndex.Quantizer.bq(),
+        ),
+    )
+
+    with col.batch.dynamic() as batch:
+        for i in range(OBJ_NUM):
+            batch.add_object(properties={"someText": f"object-{i}"}, vector=generate_vec(VEC_DIMS))
+
+    # Over-dimensioned queries already error before this fix (they cross a
+    # 64-bit block boundary); under-dimensioned queries within the same
+    # block did not. Cover both to guard against regressions in either
+    # direction.
+    for wrong_dims in (VEC_DIMS + 32, VEC_DIMS - 32):
+        with pytest.raises(WeaviateQueryError) as exc:
+            col.query.near_vector(
+                near_vector=generate_vec(wrong_dims),
+                limit=2,
+                return_metadata=MetadataQuery(distance=True),
+            )
+        assert "vector lengths don't match" in str(exc.value)
+
+
 def generate_vec(dims):
     return np.random.random(dims).tolist()


### PR DESCRIPTION
Fixes #12207

## Root cause

RQ (both `bits=8` and `bits=1`) and BQ (in the under-dimensioned case) HNSW indexes silently returned an empty result set instead of erroring when queried with a `nearVector` of the wrong dimensionality. RQ's query encoder pads/truncates the query to a fixed internal size before any length check runs, and BQ's compressed byte-length only depends on how many 64-bit blocks a vector packs into — an under-dimensioned query that still packs into the same block count produces a validly-shaped but meaningless compressed code. Uncompressed HNSW, SQ, and PQ already guard against this correctly.

## What changed and why

- `RotationalQuantizer.NewDistancer` and `BinaryRotationalQuantizer.NewDistancer` (RQ `bits=8` and `bits=1`) now reject a dimension-mismatched query vector up front, mirroring the existing `ProductQuantizer.NewDistancer` guard, so the error surfaces at the entrypoint distance check before rescore can swallow it.
- `hnsw.SearchByVector` now rejects an under-dimensioned query against a BQ-compressed index, using the dimension established by the first inserted vector (`h.dims`). `BinaryQuantizer` itself is stateless and constructed before the index dimension is known, so the guard lives at the HNSW layer instead of inside the quantizer.

While building regression tests for the above, two adjacent latent bugs surfaced — previously unobservable because nothing validated these dimensions — and are fixed in the same change rather than deferred, per this repo's convention:
- `BinaryRotationalQuantizer.PersistCompression` persisted the *padded* rotation dimension instead of the true vector dimension, corrupting `originalDim` after a commit-log restore of an RQ `bits=1` index (caught by `TestRestoreQuantization_Integration/RQ_1bit` and `flat`'s `Test_RQDataSerialization`, both updated to assert the correct value).
- `RotationalQuantizer.Decode` did not truncate the un-rotated vector back to the true input dimension, leaking padded trailing elements whenever the dimension wasn't already a multiple of 64 (caught by hfresh's `TestAppendImmediatelySplitsWhenPostingFarAboveThreshold` and sibling merge/split tests, which use a centroid HNSW sub-index compressed with RQ `bits=8`).

## Tests

Added:
- `TestRQDistancerQueryDimensionMismatch` / `TestBinaryRQDistancerQueryDimensionMismatch` (`adapters/repos/db/vector/compressionhelpers/rotational_quantization_distancer_test.go`) — Go unit tests proving RQ bits=8 and bits=1 now error on over/under-dimensioned queries.
- `TestSearchByVector_BQUnderDimensionedQueryErrors` (`adapters/repos/db/vector/hnsw/bq_query_dimension_mismatch_test.go`) — Go test proving a BQ-compressed HNSW index now errors (instead of silently returning `[]`) on an under-dimensioned query.
- Extended `test/acceptance_with_python/test_pq_vector_dims_match.py` with `test_rq_dims_match` (parametrized over bits 1/8) and `test_bq_dims_match`, mirroring the existing skipped PQ test as a template, for CI's Python acceptance suite.

All three new/changed Go tests were confirmed to **fail against the pre-fix code** (reproducing the exact silent-`[]` bug, e.g. BQ under-dim returned `[]` with no error) and **pass after the fix**, by toggling the fix in and out of the working tree and re-running.

Command + evidence (full targeted suite, race-enabled, run after all fixes were in place):

```
$ go test -race -count 1 \
    ./adapters/repos/db/vector/compressionhelpers/... \
    ./adapters/repos/db/vector/hnsw/... \
    ./adapters/repos/db/vector/flat/... \
    ./adapters/repos/db/vector/hfresh/...

ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers	70.170s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw	139.574s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/commitlog	9.212s [no tests to run]
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/compact	69.068s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer	7.099s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer/asm	1.827s [no tests to run]
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/visited	2.466s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/flat	8.569s
ok  	github.com/weaviate/weaviate/adapters/repos/db/vector/hfresh	90.189s
```

```
$ golangci-lint run ./adapters/repos/db/vector/compressionhelpers/... ./adapters/repos/db/vector/hnsw/... ./adapters/repos/db/vector/flat/... ./adapters/repos/db/vector/hfresh/...
0 issues.

$ ./tools/linter_go_routines.sh
(no output — no bare goroutines introduced)
```

The Python acceptance test extension (`test_rq_dims_match`, `test_bq_dims_match`) could not be exercised locally in this environment — the local Docker daemon repeatedly hit `rpc error: code = Unavailable desc = error reading from server: EOF` mid-build across two attempts, unrelated to this change. It's included for CI (`test/acceptance_with_python/run.sh`) to run and structured identically to the existing (skipped) PQ test in the same file.

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.
