### PR TITLE
async replication: resolve replicas locally, never implicitly activate a tenant

### DIFF
--- a/cluster/router/router.go
+++ b/cluster/router/router.go
@@ -490,6 +490,21 @@ func (r *multiTenantRouter) getReadReplicasLocation(collection string, tenant, s
 		return types.ReadReplicaSet{}, err
 	}
 
+	return r.readReplicasFromLocalSchema(collection, shard)
+}
+
+// readReplicasForPlan resolves read replicas honoring LocalOnly: local schema only
+// (no leader query, no tenant activation) when set, else the tenant-status path.
+func (r *multiTenantRouter) readReplicasForPlan(params types.RoutingPlanBuildOptions) (types.ReadReplicaSet, error) {
+	if params.LocalOnly {
+		return r.readReplicasFromLocalSchema(r.collection, params.Shard)
+	}
+	return r.getReadReplicasLocation(r.collection, params.Tenant, params.Shard)
+}
+
+// readReplicasFromLocalSchema resolves read replicas from local schema without any
+// tenant-status check; callers must not use it where activation semantics are required.
+func (r *multiTenantRouter) readReplicasFromLocalSchema(collection, shard string) (types.ReadReplicaSet, error) {
 	replicas, err := r.schemaReader.ShardReplicas(collection, shard)
 	if err != nil {
 		return types.ReadReplicaSet{}, err
@@ -588,7 +603,7 @@ func (r *multiTenantRouter) BuildReadRoutingPlan(params types.RoutingPlanBuildOp
 
 // buildReadRoutingPlan constructs a read routing plan for multi-tenant collections.
 func (r *multiTenantRouter) buildReadRoutingPlan(params types.RoutingPlanBuildOptions) (types.ReadRoutingPlan, error) {
-	readReplicas, err := r.getReadReplicasLocation(r.collection, params.Tenant, params.Shard)
+	readReplicas, err := r.readReplicasForPlan(params)
 	if err != nil {
 		return types.ReadRoutingPlan{}, err
 	}

--- a/cluster/router/router_test.go
+++ b/cluster/router/router_test.go
@@ -2131,3 +2131,70 @@ func TestSingleTenantRouter_BuildReadRoutingPlan_AllShards(t *testing.T) {
 	require.True(t, shardNames["shard1"], "should have replica from shard1")
 	require.True(t, shardNames["shard2"], "should have replica from shard2")
 }
+
+func TestRouter_BuildReadRoutingPlan_LocalOnly(t *testing.T) {
+	expected := []types.Replica{{NodeName: "node1", ShardName: "luke", HostAddr: "node1"}}
+
+	tests := []struct {
+		name         string
+		partitioning bool
+		localOnly    bool
+		setup        func(sg *schema.MockSchemaGetter, sr *schema.MockSchemaReader, fsm *replicationTypes.MockReplicationFSMReader)
+	}{
+		{
+			// Regression: LocalOnly must resolve replicas without OptimisticTenantStatus,
+			// so no leader read and no implicit tenant activation. No expectation on the
+			// getter ⇒ mockery fails if the tenant-status path is taken.
+			name:         "multi_tenant_local_only_skips_tenant_status",
+			partitioning: true,
+			localOnly:    true,
+			setup: func(sg *schema.MockSchemaGetter, sr *schema.MockSchemaReader, fsm *replicationTypes.MockReplicationFSMReader) {
+				sr.EXPECT().ShardReplicas("TestClass", "luke").Return([]string{"node1"}, nil)
+				fsm.EXPECT().FilterOneShardReplicasRead("TestClass", "luke", []string{"node1"}).Return([]string{"node1"})
+			},
+		},
+		{
+			name:         "multi_tenant_default_uses_tenant_status",
+			partitioning: true,
+			localOnly:    false,
+			setup: func(sg *schema.MockSchemaGetter, sr *schema.MockSchemaReader, fsm *replicationTypes.MockReplicationFSMReader) {
+				sg.EXPECT().OptimisticTenantStatus(mock.Anything, "TestClass", "luke").
+					Return(map[string]string{"luke": models.TenantActivityStatusHOT}, nil)
+				sr.EXPECT().ShardReplicas("TestClass", "luke").Return([]string{"node1"}, nil)
+				fsm.EXPECT().FilterOneShardReplicasRead("TestClass", "luke", []string{"node1"}).Return([]string{"node1"})
+			},
+		},
+		{
+			name:         "single_tenant_local_only_noop",
+			partitioning: false,
+			localOnly:    true,
+			setup: func(sg *schema.MockSchemaGetter, sr *schema.MockSchemaReader, fsm *replicationTypes.MockReplicationFSMReader) {
+				state := createShardingStateWithShards([]string{"luke"})
+				sr.EXPECT().Shards(mock.Anything).Return(state.AllPhysicalShards(), nil).Maybe()
+				sr.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+					return readFunc(&models.Class{Class: className}, state)
+				}).Maybe()
+				sr.EXPECT().ShardReplicas("TestClass", "luke").Return([]string{"node1"}, nil)
+				fsm.EXPECT().FilterOneShardReplicasRead("TestClass", "luke", []string{"node1"}).Return([]string{"node1"})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sg := schema.NewMockSchemaGetter(t)
+			sr := schema.NewMockSchemaReader(t)
+			fsm := replicationTypes.NewMockReplicationFSMReader(t)
+			ns := mocks.NewMockNodeSelector("node1", "node2")
+			tt.setup(sg, sr, fsm)
+
+			r := router.NewBuilder("TestClass", tt.partitioning, ns, sg, sr, fsm).Build()
+
+			opts := r.BuildRoutingPlanOptions("luke", "luke", types.ConsistencyLevelOne, "")
+			opts.LocalOnly = tt.localOnly
+			plan, err := r.BuildReadRoutingPlan(opts)
+			require.NoError(t, err)
+			require.Equal(t, expected, plan.ReplicaSet.Replicas)
+		})
+	}
+}

--- a/cluster/router/types/router_plan.go
+++ b/cluster/router/types/router_plan.go
@@ -33,14 +33,16 @@ type RoutingPlanBuildOptions struct {
 	Tenant              string
 	ConsistencyLevel    ConsistencyLevel
 	DirectCandidateNode string
+	// LocalOnly resolves replicas from local schema; no leader query, no tenant activation.
+	LocalOnly bool
 }
 
 // String returns a human-readable representation of the RoutingPlanBuildOptions.
 // Useful for debugging and logging.
 func (o RoutingPlanBuildOptions) String() string {
 	return fmt.Sprintf(
-		"RoutingPlanBuildOptions{shard: %q, tenant: %q, consistencyLevel: %s, directCandidateNode: %q}",
-		o.Shard, o.Tenant, o.ConsistencyLevel, o.DirectCandidateNode,
+		"RoutingPlanBuildOptions{shard: %q, tenant: %q, consistencyLevel: %s, directCandidateNode: %q, localOnly: %t}",
+		o.Shard, o.Tenant, o.ConsistencyLevel, o.DirectCandidateNode, o.LocalOnly,
 	)
 }
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1886,7 +1886,7 @@ const (
 	DefaultAsyncReplicationHashtreeInitConcurrency = 10
 	// Root pre-filter batch size: cluster-wide cap on same-collection hashtree roots
 	// compared per batched RPC. 1 disables it; <= 0 falls back to the default.
-	DefaultAsyncReplicationRootPrefilterBatchSize = 512
+	DefaultAsyncReplicationRootPrefilterBatchSize = 128
 	MaxAsyncReplicationRootPrefilterBatchSize     = 4096
 	DefaultMaximumAllowedCollectionsCount         = -1 // unlimited
 	DefaultMaximumAllowedObjectsCount             = -1 // unlimited

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -322,6 +322,13 @@ type ShardDifferenceReader struct {
 	RangeReader       hashtree.AggregatedHashTreeRangeReader
 }
 
+// localReadRoutingPlan resolves shardName's replicas from local schema only: no leader query, no implicit tenant activation. All async-replication resolution must use this.
+func (f *Finder) localReadRoutingPlan(shardName string) (types.ReadRoutingPlan, error) {
+	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
+	options.LocalOnly = true
+	return f.router.BuildReadRoutingPlan(options)
+}
+
 // CollectShardDifferences collects the differences between the local node and the target nodes.
 // It returns a ShardDifferenceReader that contains the differences and the target node name/address.
 // If no differences are found, it returns ErrNoDiffFound.
@@ -331,8 +338,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 	shardName string, ht hashtree.AggregatedHashTree, diffTimeoutPerNode time.Duration,
 	targetNodeOverrides []additional.AsyncReplicationTargetNodeOverride,
 ) (diffReader *ShardDifferenceReader, err error) {
-	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
-	routingPlan, err := f.router.BuildReadRoutingPlan(options)
+	routingPlan, err := f.localReadRoutingPlan(shardName)
 	if err != nil {
 		return nil, fmt.Errorf("%w : class %q shard %q", err, f.class, shardName)
 	}
@@ -478,8 +484,7 @@ func (f *Finder) CompareDigests(ctx context.Context,
 // targetHostAddrsForShard resolves a shard's remote replica host addresses
 // (excluding the local node), mirroring CollectShardDifferences.
 func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
-	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
-	routingPlan, err := f.router.BuildReadRoutingPlan(options)
+	routingPlan, err := f.localReadRoutingPlan(shardName)
 	if err != nil {
 		return nil, fmt.Errorf("%w : class %q shard %q", err, f.class, shardName)
 	}

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -18,14 +18,20 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
+	clusterMocks "github.com/weaviate/weaviate/usecases/cluster/mocks"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
 func genInputs(node, shard string, updateTime int64, ids []strfmt.UUID) ([]*storobj.Object, []types.RepairResponse) {
@@ -1118,5 +1124,39 @@ func TestFinderCheckConsistencyOne(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, want, xs)
 		})
+	}
+}
+
+func TestAsyncReplicationResolutionIsLocalOnly(t *testing.T) {
+	const (
+		class = "C"
+		local = "A"
+		shard = "s1"
+	)
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	metrics, err := replica.NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+
+	mr := types.NewMockRouter(t)
+	mr.EXPECT().BuildRoutingPlanOptions(shard, shard, types.ConsistencyLevelOne, "").
+		Return(types.RoutingPlanBuildOptions{Shard: shard, Tenant: shard, ConsistencyLevel: types.ConsistencyLevelOne})
+	mr.EXPECT().
+		BuildReadRoutingPlan(mock.MatchedBy(func(o types.RoutingPlanBuildOptions) bool { return o.LocalOnly })).
+		Return(types.ReadRoutingPlan{}, nil)
+
+	finder := replica.NewFinder(class, mr, clusterMocks.NewMockNodeSelector(local), local,
+		replica.NewMockRClient(t), metrics, logger, func() string { return "" })
+
+	sites := map[string]func(){
+		"PrefilterShardRoots": func() {
+			finder.PrefilterShardRoots(ctx, map[string]hashtree.Digest{shard: {}})
+		},
+		"CollectShardDifferences": func() {
+			finder.CollectShardDifferences(ctx, shard, nil, time.Second, nil)
+		},
+	}
+	for name, call := range sites {
+		t.Run(name, func(t *testing.T) { call() })
 	}
 }


### PR DESCRIPTION
Backport of #12113

## Motivation

Same as the original: async replication's replica resolution for multi-tenant collections went through the foreground tenant-status path (`OptimisticTenantStatus`), which (1) hits the RAFT leader every cycle for any non-HOT tenant, (2) can implicitly activate a COLD tenant via `UpdateTenants` as a side effect of a background diff/repair cycle, and (3) rejects genuinely cold-but-loaded shards with `ErrTenantNotActive`. Full rationale, alternatives, and concurrency analysis are in the [original PR](https://github.com/weaviate/weaviate/pull/12113) — this description covers only the backport delta.

## Backport delta vs. #12113

Single cherry-pick with two drops, both because the async-checkpoint feature does not exist on v1.37:

- the `remoteReplicaHosts` call-site conversion in `finder.go` (its caller, `BroadcastDeleteAsyncCheckpoint`, is v1.38-only)
- the corresponding third site in the `TestAsyncReplicationResolutionIsLocalOnly` table

Everything else applied cleanly: the `LocalOnly` flag on `RoutingPlanBuildOptions`, the `readReplicasForPlan` / `readReplicasFromLocalSchema` split in the multi-tenant router, and the `Finder.localReadRoutingPlan` funnel. On this branch the async-rep resolution sites are `CollectShardDifferences` and `targetHostAddrsForShard` (reached via `PrefilterShardRoots`); both route through `localReadRoutingPlan` ([finder.go:329](https://github.com/weaviate/weaviate/blob/fa2fc1d7b2998b1e43f9ed5595524574f6d53822/usecases/replica/finder.go#L329)).

The original PR's rider also carries over: `DefaultAsyncReplicationRootPrefilterBatchSize` 512 → 128 in `usecases/config/environment.go`, matching the v1.38 default so both branches exert the same per-RPC root-comparison load.

## Key areas for review

- `cluster/router/router.go:readReplicasForPlan` — verify the `LocalOnly` branch skips tenant status but keeps `FilterOneShardReplicasRead`; identical to the v1.38 version
- `usecases/replica/finder.go:localReadRoutingPlan` — confirm both v1.37 resolution sites funnel through it and no site was missed (v1.37 has two, not three)
- Foreground read/write paths (`coordinator.go`, `index.go`) are untouched — they still need activation semantics

## Risks and mitigations

Same risk profile as the original (stale-local-schema staleness is acceptable for a convergent background loop; the flag is scoped to `Finder.localReadRoutingPlan` and pinned by test). Backport-specific risk is a mis-adapted cherry-pick; mitigated by the diff being byte-identical to the original outside the two documented drops, and by both regression tests running green here.

## Testing

- `TestRouter_BuildReadRoutingPlan_LocalOnly` — mockery sets no expectation on `OptimisticTenantStatus` in the LocalOnly case, so any tenant-status call fails the test; default MT path and single-tenant no-op covered. Verified red against the unfixed v1.37 code (fails inside `OptimisticTenantStatus`), green with the fix.
- `TestAsyncReplicationResolutionIsLocalOnly` — asserts both v1.37 async-rep sites build their plans with `LocalOnly` set. Also verified red without the fix.
- Full `go test -race ./cluster/router/... ./usecases/replica/...` passes on this branch; `golangci-lint` and the goroutine linter are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
