### PR TITLE
fix(lsmkv): repair stable/v1.37 build broken by the v1.36 merge (blockenc.PackedDecode)

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"math"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/blockenc"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -252,7 +253,7 @@ func (s *segmentCursorInvertedReusable) decodeBlocksAndConvert(data []byte, coll
 		if i == blockCount-1 {
 			blockSize = int(collectionSize) - terms.BLOCK_SIZE*i
 		}
-		docIds, tfs := packedDecode(&s.blockDataBuf[i], blockSize, s.deltaEnc, s.tfEnc)
+		docIds, tfs := blockenc.PackedDecode(&s.blockDataBuf[i], blockSize, s.deltaEnc, s.tfEnc)
 		for j := 0; j < blockSize; j++ {
 			key := s.kvArena[arenaOff : arenaOff+8]
 			binary.BigEndian.PutUint64(key, docIds[j])


### PR DESCRIPTION
## Motivation

`stable/v1.37` does not compile since the v1.36 merge (#12254) landed:

```
adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go:255:18: undefined: packedDecode (typecheck)
```

Every CI job on the branch (and on every PR targeting it, e.g. #12256) fails with this error — docker builds, golangci, all acceptance groups. The branch's own `Tests` run for the merge commit f78047dd1d is red.

## Root cause

A semantic merge conflict the textual merge could not detect: #12244 (came in via the v1.36 merge) extracted the inverted block codec into `adapters/repos/db/inverted/blockenc` and deleted the package-private `packedDecode` from lsmkv, updating all callers that exist on v1.36. But `cursor_segment_inverted_reusable.go` is v1.37-only (added by #12154/#12163, never backported to v1.36), so the refactor never touched its call site and the merge left it referencing the removed function.

## Fix

One line: qualify the call as `blockenc.PackedDecode` (identical signature — the extraction moved the function verbatim) plus the import, exactly matching how the sibling call sites in `segment_serialization_inverted.go` were rewritten by the refactor.

## Verification

- `go build ./...` at the branch tip fails with the error above; passes with this fix
- `go vet ./...` across the tree shows no other leftovers from the merge (only pre-existing warnings)
- `go test -race -run Inverted ./adapters/repos/db/lsmkv/` passes
- `golangci-lint run ./adapters/repos/db/lsmkv/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)