### PR TITLE
fix(test): wait for usage pollers before teardown in tenant/collection usage tests

### DIFF
--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -74,7 +74,30 @@ func TestTenantStatusChanges(t *testing.T) {
 	}
 	endUsage := atomic.Bool{}
 
+	// The debug usage report is populated from db.indices, which lags a class/tenant
+	// creation by one local-index-bootstrap cycle after the RAFT schema commit
+	// (adapters/repos/db/index_usage.go UsageForIndex: if the local index entry
+	// doesn't exist yet, it returns (nil, nil) and the collection is silently
+	// dropped from the report). Wait for that bootstrap window to close and the
+	// report to reach the expected shard count before starting the strict poller
+	// below, so require.* only fires once the report is expected to be consistent.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		usage, err := GetDebugUsageForCollection(className)
+		require.NoError(ct, err)
+		require.NotNil(ct, usage)
+		require.Equal(ct, len(tenants), len(usage.Shards))
+	}, 30*time.Second, 500*time.Millisecond)
+
+	// pollerWg is waited on below, before the function returns, so the deferred
+	// ClassDeleter above cannot race the poller's still-in-flight
+	// GetDebugUsageForCollection call. Without this, endUsage.Store(true) followed
+	// by an immediate return lets the deferred delete commit while the poller is
+	// mid-read, producing the exact "collection ... not found in debug usage
+	// report" failure independent of any bootstrap-timing window.
+	var pollerWg sync.WaitGroup
+	pollerWg.Add(1)
 	go func() {
+		defer pollerWg.Done()
 		for {
 			if endUsage.Load() {
 				return
@@ -114,6 +137,7 @@ func TestTenantStatusChanges(t *testing.T) {
 	}
 	require.NoError(t, eg.Wait())
 	endUsage.Store(true)
+	pollerWg.Wait()
 }
 
 func TestUsageTenantDelete(t *testing.T) {
@@ -156,7 +180,24 @@ func TestUsageTenantDelete(t *testing.T) {
 
 	endUsage := atomic.Bool{}
 	deletedTenants := atomic.Int32{}
+
+	// See the matching comment in TestTenantStatusChanges: wait for the local-index
+	// bootstrap window to close before starting the strict poller below.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		usage, err := GetDebugUsageForCollection(className)
+		require.NoError(ct, err)
+		require.NotNil(ct, usage)
+		require.Equal(ct, len(tenants), len(usage.Shards))
+	}, 30*time.Second, 500*time.Millisecond)
+
+	// pollerWg is waited on below, before the function returns, so the deferred
+	// ClassDeleter above cannot race the poller's still-in-flight
+	// GetDebugUsageForCollection call. See the matching comment in
+	// TestTenantStatusChanges.
+	var pollerWg sync.WaitGroup
+	pollerWg.Add(1)
 	go func() {
+		defer pollerWg.Done()
 		for {
 			if endUsage.Load() {
 				return
@@ -191,6 +232,7 @@ func TestUsageTenantDelete(t *testing.T) {
 		deletedTenants.Add(1)
 	}
 	endUsage.Store(true)
+	pollerWg.Wait()
 }
 
 func TestCollectionDeletion(t *testing.T) {
@@ -225,7 +267,27 @@ func TestCollectionDeletion(t *testing.T) {
 
 	endUsage := atomic.Bool{}
 	deletedClasses := atomic.Int32{}
+
+	// See the matching comment in TestTenantStatusChanges: wait for the local-index
+	// bootstrap window to close for all numClasses classes before starting the
+	// strict poller below, otherwise the wiggle room below (which is only sized for
+	// in-flight deletions) can be exceeded by classes that simply haven't appeared yet.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		usage, err := getDebugUsage()
+		require.NoError(ct, err)
+		require.NotNil(ct, usage)
+		require.Equal(ct, numClasses, len(usage.Collections))
+	}, 30*time.Second, 500*time.Millisecond)
+
+	// pollerWg is waited on below, before the function returns. Go's testing.T
+	// requires that a goroutine calling T methods (require.* included) complete
+	// before the outer test function returns; without this, the poller can still
+	// be mid-read (or racing this function's own deferred class cleanup, see
+	// TestTenantStatusChanges) after the test is considered finished.
+	var pollerWg sync.WaitGroup
+	pollerWg.Add(1)
 	go func() {
+		defer pollerWg.Done()
 		for {
 			if endUsage.Load() {
 				return
@@ -248,6 +310,7 @@ func TestCollectionDeletion(t *testing.T) {
 		deletedClasses.Add(1)
 	}
 	endUsage.Store(true)
+	pollerWg.Wait()
 }
 
 func TestAlterSchemaDropPropertyIndex(t *testing.T) {

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -50,11 +50,12 @@ import (
 // If pollInterval is non-zero, it is slept (with a re-check of stop in between) at the top
 // of each iteration so the poller doesn't hammer the debug endpoint.
 //
-// The caller must invoke stop() before the test function returns, not just defer it
-// alongside other cleanup: stop() signals the goroutine to exit and waits for it to finish,
-// so a deferred class/tenant delete cannot race the poller's still-in-flight debug-usage
-// call, and Go's testing.T requirement that a goroutine calling T methods complete before
-// the test returns is satisfied.
+// The caller must `defer stop()` immediately at the call site. Because the class/tenant
+// cleanup defer is registered earlier, LIFO ordering runs stop() first on every exit path
+// including require.FailNow, so the poller is joined before teardown can race its
+// still-in-flight debug-usage call, and Go's testing.T requirement that a goroutine
+// calling T methods complete before the test returns holds even on failure. stop() is
+// idempotent, so tests that need the poller stopped mid-test call it explicitly as well.
 func startUsagePoller(t *testing.T, baselineWait func(ct *assert.CollectT), pollInterval time.Duration, poll func()) (stop func()) {
 	t.Helper()
 
@@ -124,7 +125,8 @@ func TestTenantStatusChanges(t *testing.T) {
 			}).Do(ctx)
 		require.NoError(t, err)
 	}
-	stopPoller := startUsagePoller(t,
+	stopPoller := startUsagePoller(
+		t,
 		func(ct *assert.CollectT) {
 			usage, err := GetDebugUsageForCollection(className)
 			require.NoError(ct, err)
@@ -150,15 +152,18 @@ func TestTenantStatusChanges(t *testing.T) {
 			require.Equal(t, len(names), len(tenants))
 		},
 	)
+	defer stopPoller()
 
 	var eg errgroup.Group
 	for i := range tenants {
 		eg.Go(
 			func() error {
-				require.NoError(t,
+				require.NoError(
+					t,
 					c.Schema().TenantsUpdater().WithClassName(className).WithTenants(models.Tenant{Name: fmt.Sprintf("tenant%d", i), ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx),
 				)
-				require.NoError(t,
+				require.NoError(
+					t,
 					c.Schema().TenantsUpdater().WithClassName(className).WithTenants(models.Tenant{Name: fmt.Sprintf("tenant%d", i), ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx),
 				)
 				return nil
@@ -166,7 +171,6 @@ func TestTenantStatusChanges(t *testing.T) {
 		)
 	}
 	require.NoError(t, eg.Wait())
-	stopPoller()
 }
 
 func TestUsageTenantDelete(t *testing.T) {
@@ -209,7 +213,8 @@ func TestUsageTenantDelete(t *testing.T) {
 
 	deletedTenants := atomic.Int32{}
 
-	stopPoller := startUsagePoller(t,
+	stopPoller := startUsagePoller(
+		t,
 		func(ct *assert.CollectT) {
 			usage, err := GetDebugUsageForCollection(className)
 			require.NoError(ct, err)
@@ -241,13 +246,13 @@ func TestUsageTenantDelete(t *testing.T) {
 			}
 		},
 	)
+	defer stopPoller()
 
 	for i := range tenants {
 		err := c.Schema().TenantsDeleter().WithClassName(className).WithTenants(tenants[i].Name).Do(ctx)
 		require.NoError(t, err)
 		deletedTenants.Add(1)
 	}
-	stopPoller()
 }
 
 func TestCollectionDeletion(t *testing.T) {
@@ -282,7 +287,8 @@ func TestCollectionDeletion(t *testing.T) {
 
 	deletedClasses := atomic.Int32{}
 
-	stopPoller := startUsagePoller(t,
+	stopPoller := startUsagePoller(
+		t,
 		func(ct *assert.CollectT) {
 			usage, err := getDebugUsage()
 			require.NoError(ct, err)
@@ -302,13 +308,13 @@ func TestCollectionDeletion(t *testing.T) {
 			require.GreaterOrEqual(t, len(usage.Collections), numClasses-int(deletedClassesAfterCall)-1)
 		},
 	)
+	defer stopPoller()
 
 	for i := 0; i < numClasses; i++ {
 		className := getClassName(t, i)
 		require.NoError(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
 		deletedClasses.Add(1)
 	}
-	stopPoller()
 }
 
 func TestAlterSchemaDropPropertyIndex(t *testing.T) {
@@ -379,6 +385,7 @@ func TestAlterSchemaDropPropertyIndex(t *testing.T) {
 		require.Greater(t, usage.Shards[0].FullShardStorageBytes, uint64(0))
 		assert.Less(t, usage.Shards[0].FullShardStorageBytes, initialStorage)
 	})
+	defer stopPoller()
 
 	// Drop all property indices using the Go client
 	require.NoError(t, c.Schema().PropertyIndexDeleter().
@@ -984,10 +991,12 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 		// deactivate and activate to flush data to disk and have it comparable
 		for _, class := range []*models.Class{classDynamic, classFlat, classHnsw} {
-			require.NoError(t,
+			require.NoError(
+				t,
 				c.Schema().TenantsUpdater().WithClassName(class.Class).WithTenants(models.Tenant{Name: tenant, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx),
 			)
-			require.NoError(t,
+			require.NoError(
+				t,
 				c.Schema().TenantsUpdater().WithClassName(class.Class).WithTenants(models.Tenant{Name: tenant, ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx),
 			)
 		}
@@ -1044,10 +1053,12 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 		// deactivate and activate to flush data to disk and have it comparable
 		for _, class := range []*models.Class{classDynamic, classFlat, classHnsw} {
-			require.NoError(t,
+			require.NoError(
+				t,
 				c.Schema().TenantsUpdater().WithClassName(class.Class).WithTenants(models.Tenant{Name: tenant, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx),
 			)
-			require.NoError(t,
+			require.NoError(
+				t,
 				c.Schema().TenantsUpdater().WithClassName(class.Class).WithTenants(models.Tenant{Name: tenant, ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx),
 			)
 		}

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -88,15 +88,18 @@ func startUsagePoller(t *testing.T, baselineWait func(ct *assert.CollectT), poll
 	}
 }
 
-func TestTenantStatusChanges(t *testing.T) {
-	ctx := context.Background()
-	c, err := client.NewClient(client.Config{Scheme: "http", Host: wvhost.REST()})
-	require.Nil(t, err)
-
-	className := t.Name() + "Class"
+// createTenantedClass creates a fresh multi-tenancy-enabled collection named className with
+// a single "first" text property and numTenants tenants (tenant0..tenantN-1), deleting any
+// pre-existing collection with that name first. It captures the class/tenant bootstrap
+// shared by TestTenantStatusChanges, TestUsageTenantDelete and TestRestart below.
+//
+// The caller must `defer cleanup()` immediately at the call site, mirroring the startUsagePoller
+// contract above: cleanup only deletes the collection, so its ordering relative to other
+// defers at the call site (e.g. TestRestart's container teardown) is the caller's to control.
+func createTenantedClass(t *testing.T, ctx context.Context, c *client.Client, className string, numTenants int) (tenants []models.Tenant, cleanup func()) {
+	t.Helper()
 
 	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
-	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 
 	class := &models.Class{
 		Class: className,
@@ -110,13 +113,22 @@ func TestTenantStatusChanges(t *testing.T) {
 	}
 	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
 
-	tenants := make([]models.Tenant, 10)
+	tenants = make([]models.Tenant, numTenants)
 	for i := range tenants {
 		tenants[i] = models.Tenant{Name: fmt.Sprintf("tenant%d", i)}
 	}
 	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).WithTenants(tenants...).Do(ctx))
 
-	// add some data
+	return tenants, func() {
+		c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	}
+}
+
+// seedTenantTextData writes one object per tenant to className, each with a distinct "first"
+// property value. Shared by TestTenantStatusChanges and TestUsageTenantDelete below.
+func seedTenantTextData(t *testing.T, ctx context.Context, c *client.Client, className string, tenants []models.Tenant) {
+	t.Helper()
+
 	for i, tenant := range tenants {
 		_, err := c.Data().Creator().WithClassName(className).
 			WithTenant(tenant.Name).
@@ -125,6 +137,19 @@ func TestTenantStatusChanges(t *testing.T) {
 			}).Do(ctx)
 		require.NoError(t, err)
 	}
+}
+
+func TestTenantStatusChanges(t *testing.T) {
+	ctx := context.Background()
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: wvhost.REST()})
+	require.Nil(t, err)
+
+	className := t.Name() + "Class"
+	tenants, cleanup := createTenantedClass(t, ctx, c, className, 10)
+	defer cleanup()
+
+	seedTenantTextData(t, ctx, c, className, tenants)
+
 	stopPoller := startUsagePoller(
 		t,
 		func(ct *assert.CollectT) {
@@ -179,37 +204,10 @@ func TestUsageTenantDelete(t *testing.T) {
 	require.Nil(t, err)
 
 	className := t.Name() + "Class"
+	tenants, cleanup := createTenantedClass(t, ctx, c, className, 100)
+	defer cleanup()
 
-	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
-	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
-
-	class := &models.Class{
-		Class: className,
-		Properties: []*models.Property{
-			{
-				Name:     "first",
-				DataType: []string{string(schema.DataTypeText)},
-			},
-		},
-		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
-	}
-	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
-
-	tenants := make([]models.Tenant, 100)
-	for i := range tenants {
-		tenants[i] = models.Tenant{Name: fmt.Sprintf("tenant%d", i)}
-	}
-	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).WithTenants(tenants...).Do(ctx))
-
-	// add some data
-	for i, tenant := range tenants {
-		_, err := c.Data().Creator().WithClassName(className).
-			WithTenant(tenant.Name).
-			WithProperties(map[string]interface{}{
-				"first": fmt.Sprintf("hello%d", i),
-			}).Do(ctx)
-		require.NoError(t, err)
-	}
+	seedTenantTextData(t, ctx, c, className, tenants)
 
 	deletedTenants := atomic.Int32{}
 
@@ -551,27 +549,8 @@ func TestRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	className := t.Name() + "Class"
-
-	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
-	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
-
-	class := &models.Class{
-		Class: className,
-		Properties: []*models.Property{
-			{
-				Name:     "first",
-				DataType: []string{string(schema.DataTypeText)},
-			},
-		},
-		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
-	}
-	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
-
-	tenants := make([]models.Tenant, 100)
-	for i := range tenants {
-		tenants[i] = models.Tenant{Name: fmt.Sprintf("tenant%d", i)}
-	}
-	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).WithTenants(tenants...).Do(ctx))
+	tenants, cleanup := createTenantedClass(t, ctx, c, className, 100)
+	defer cleanup()
 
 	// add some data
 	for i, tenant := range tenants {

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -35,6 +35,58 @@ import (
 	"acceptance_tests_with_client/internal/wvhost"
 )
 
+// startUsagePoller spawns a background goroutine that repeatedly calls poll until the
+// returned stop function is invoked. It captures the WaitGroup + poller-goroutine +
+// quiescent-baseline pattern shared by the usage tests below.
+//
+// If baselineWait is non-nil, it is polled via assert.EventuallyWithT before the poller
+// goroutine starts. The debug usage report is populated from db.indices, which lags a
+// class/tenant creation by one local-index-bootstrap cycle after the RAFT schema commit
+// (adapters/repos/db/index_usage.go UsageForIndex: if the local index entry doesn't exist
+// yet, it returns (nil, nil) and the collection is silently dropped from the report).
+// Waiting for that bootstrap window to close before starting the poller means poll's
+// require.* calls only fire once the report is expected to be consistent.
+//
+// If pollInterval is non-zero, it is slept (with a re-check of stop in between) at the top
+// of each iteration so the poller doesn't hammer the debug endpoint.
+//
+// The caller must invoke stop() before the test function returns, not just defer it
+// alongside other cleanup: stop() signals the goroutine to exit and waits for it to finish,
+// so a deferred class/tenant delete cannot race the poller's still-in-flight debug-usage
+// call, and Go's testing.T requirement that a goroutine calling T methods complete before
+// the test returns is satisfied.
+func startUsagePoller(t *testing.T, baselineWait func(ct *assert.CollectT), pollInterval time.Duration, poll func()) (stop func()) {
+	t.Helper()
+
+	if baselineWait != nil {
+		assert.EventuallyWithT(t, baselineWait, 30*time.Second, 500*time.Millisecond)
+	}
+
+	endUsage := atomic.Bool{}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			if endUsage.Load() {
+				return
+			}
+			if pollInterval > 0 {
+				time.Sleep(pollInterval)
+				if endUsage.Load() {
+					return
+				}
+			}
+			poll()
+		}
+	}()
+
+	return func() {
+		endUsage.Store(true)
+		wg.Wait()
+	}
+}
+
 func TestTenantStatusChanges(t *testing.T) {
 	ctx := context.Background()
 	c, err := client.NewClient(client.Config{Scheme: "http", Host: wvhost.REST()})
@@ -72,37 +124,15 @@ func TestTenantStatusChanges(t *testing.T) {
 			}).Do(ctx)
 		require.NoError(t, err)
 	}
-	endUsage := atomic.Bool{}
-
-	// The debug usage report is populated from db.indices, which lags a class/tenant
-	// creation by one local-index-bootstrap cycle after the RAFT schema commit
-	// (adapters/repos/db/index_usage.go UsageForIndex: if the local index entry
-	// doesn't exist yet, it returns (nil, nil) and the collection is silently
-	// dropped from the report). Wait for that bootstrap window to close and the
-	// report to reach the expected shard count before starting the strict poller
-	// below, so require.* only fires once the report is expected to be consistent.
-	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-		usage, err := GetDebugUsageForCollection(className)
-		require.NoError(ct, err)
-		require.NotNil(ct, usage)
-		require.Equal(ct, len(tenants), len(usage.Shards))
-	}, 30*time.Second, 500*time.Millisecond)
-
-	// pollerWg is waited on below, before the function returns, so the deferred
-	// ClassDeleter above cannot race the poller's still-in-flight
-	// GetDebugUsageForCollection call. Without this, endUsage.Store(true) followed
-	// by an immediate return lets the deferred delete commit while the poller is
-	// mid-read, producing the exact "collection ... not found in debug usage
-	// report" failure independent of any bootstrap-timing window.
-	var pollerWg sync.WaitGroup
-	pollerWg.Add(1)
-	go func() {
-		defer pollerWg.Done()
-		for {
-			if endUsage.Load() {
-				return
-			}
-
+	stopPoller := startUsagePoller(t,
+		func(ct *assert.CollectT) {
+			usage, err := GetDebugUsageForCollection(className)
+			require.NoError(ct, err)
+			require.NotNil(ct, usage)
+			require.Equal(ct, len(tenants), len(usage.Shards))
+		},
+		0,
+		func() {
 			usage, err := GetDebugUsageForCollection(className)
 			require.NoError(t, err)
 			require.NotNil(t, usage)
@@ -118,8 +148,8 @@ func TestTenantStatusChanges(t *testing.T) {
 				names[shard.Name] = struct{}{}
 			}
 			require.Equal(t, len(names), len(tenants))
-		}
-	}()
+		},
+	)
 
 	var eg errgroup.Group
 	for i := range tenants {
@@ -136,8 +166,7 @@ func TestTenantStatusChanges(t *testing.T) {
 		)
 	}
 	require.NoError(t, eg.Wait())
-	endUsage.Store(true)
-	pollerWg.Wait()
+	stopPoller()
 }
 
 func TestUsageTenantDelete(t *testing.T) {
@@ -178,30 +207,17 @@ func TestUsageTenantDelete(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	endUsage := atomic.Bool{}
 	deletedTenants := atomic.Int32{}
 
-	// See the matching comment in TestTenantStatusChanges: wait for the local-index
-	// bootstrap window to close before starting the strict poller below.
-	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-		usage, err := GetDebugUsageForCollection(className)
-		require.NoError(ct, err)
-		require.NotNil(ct, usage)
-		require.Equal(ct, len(tenants), len(usage.Shards))
-	}, 30*time.Second, 500*time.Millisecond)
-
-	// pollerWg is waited on below, before the function returns, so the deferred
-	// ClassDeleter above cannot race the poller's still-in-flight
-	// GetDebugUsageForCollection call. See the matching comment in
-	// TestTenantStatusChanges.
-	var pollerWg sync.WaitGroup
-	pollerWg.Add(1)
-	go func() {
-		defer pollerWg.Done()
-		for {
-			if endUsage.Load() {
-				return
-			}
+	stopPoller := startUsagePoller(t,
+		func(ct *assert.CollectT) {
+			usage, err := GetDebugUsageForCollection(className)
+			require.NoError(ct, err)
+			require.NotNil(ct, usage)
+			require.Equal(ct, len(tenants), len(usage.Shards))
+		},
+		0,
+		func() {
 			deletedTenantsBeforeCall := deletedTenants.Load()
 			usage, err := GetDebugUsageForCollection(className)
 			require.NoError(t, err)
@@ -223,16 +239,15 @@ func TestUsageTenantDelete(t *testing.T) {
 				}
 				names[shard.Name] = struct{}{}
 			}
-		}
-	}()
+		},
+	)
 
 	for i := range tenants {
 		err := c.Schema().TenantsDeleter().WithClassName(className).WithTenants(tenants[i].Name).Do(ctx)
 		require.NoError(t, err)
 		deletedTenants.Add(1)
 	}
-	endUsage.Store(true)
-	pollerWg.Wait()
+	stopPoller()
 }
 
 func TestCollectionDeletion(t *testing.T) {
@@ -265,33 +280,17 @@ func TestCollectionDeletion(t *testing.T) {
 		require.NoError(t, classCreator.WithClass(class).Do(ctx))
 	}
 
-	endUsage := atomic.Bool{}
 	deletedClasses := atomic.Int32{}
 
-	// See the matching comment in TestTenantStatusChanges: wait for the local-index
-	// bootstrap window to close for all numClasses classes before starting the
-	// strict poller below, otherwise the wiggle room below (which is only sized for
-	// in-flight deletions) can be exceeded by classes that simply haven't appeared yet.
-	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-		usage, err := getDebugUsage()
-		require.NoError(ct, err)
-		require.NotNil(ct, usage)
-		require.Equal(ct, numClasses, len(usage.Collections))
-	}, 30*time.Second, 500*time.Millisecond)
-
-	// pollerWg is waited on below, before the function returns. Go's testing.T
-	// requires that a goroutine calling T methods (require.* included) complete
-	// before the outer test function returns; without this, the poller can still
-	// be mid-read (or racing this function's own deferred class cleanup, see
-	// TestTenantStatusChanges) after the test is considered finished.
-	var pollerWg sync.WaitGroup
-	pollerWg.Add(1)
-	go func() {
-		defer pollerWg.Done()
-		for {
-			if endUsage.Load() {
-				return
-			}
+	stopPoller := startUsagePoller(t,
+		func(ct *assert.CollectT) {
+			usage, err := getDebugUsage()
+			require.NoError(ct, err)
+			require.NotNil(ct, usage)
+			require.Equal(ct, numClasses, len(usage.Collections))
+		},
+		0,
+		func() {
 			deletedClassesBeforeCall := deletedClasses.Load()
 			usage, err := getDebugUsage()
 			require.NoError(t, err)
@@ -301,16 +300,15 @@ func TestCollectionDeletion(t *testing.T) {
 			// we add a bit of wiggle room here as the usage endpoint might take a bit to reflect the changes
 			require.LessOrEqual(t, len(usage.Collections), numClasses-int(deletedClassesBeforeCall)+1)
 			require.GreaterOrEqual(t, len(usage.Collections), numClasses-int(deletedClassesAfterCall)-1)
-		}
-	}()
+		},
+	)
 
 	for i := 0; i < numClasses; i++ {
 		className := getClassName(t, i)
 		require.NoError(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
 		deletedClasses.Add(1)
 	}
-	endUsage.Store(true)
-	pollerWg.Wait()
+	stopPoller()
 }
 
 func TestAlterSchemaDropPropertyIndex(t *testing.T) {
@@ -374,26 +372,13 @@ func TestAlterSchemaDropPropertyIndex(t *testing.T) {
 	require.Greater(t, initialStorage, uint64(0))
 
 	// Concurrently poll shard usage while dropping property indices
-	endUsage := atomic.Bool{}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for {
-			if endUsage.Load() {
-				return
-			}
-			time.Sleep(500 * time.Millisecond)
-			if endUsage.Load() {
-				return
-			}
-			usage, err := GetDebugUsageForCollection(className)
-			require.NoError(t, err)
-			require.Len(t, usage.Shards, 1)
-			require.Greater(t, usage.Shards[0].FullShardStorageBytes, uint64(0))
-			assert.Less(t, usage.Shards[0].FullShardStorageBytes, initialStorage)
-		}
-	}()
+	stopPoller := startUsagePoller(t, nil, 500*time.Millisecond, func() {
+		usage, err := GetDebugUsageForCollection(className)
+		require.NoError(t, err)
+		require.Len(t, usage.Shards, 1)
+		require.Greater(t, usage.Shards[0].FullShardStorageBytes, uint64(0))
+		assert.Less(t, usage.Shards[0].FullShardStorageBytes, initialStorage)
+	})
 
 	// Drop all property indices using the Go client
 	require.NoError(t, c.Schema().PropertyIndexDeleter().
@@ -405,8 +390,7 @@ func TestAlterSchemaDropPropertyIndex(t *testing.T) {
 	require.NoError(t, c.Schema().PropertyIndexDeleter().
 		WithClassName(className).WithPropertyName(numberProp).WithRangeFilters().Do(ctx))
 
-	endUsage.Store(true)
-	wg.Wait()
+	stopPoller()
 
 	// Verify that storage dropped after removing all property indices
 	colUsageAfter, err := GetDebugUsageForCollection(className)


### PR DESCRIPTION
Fixes weaviate/0-weaviate-issues#346.

## The bug

`TestTenantStatusChanges`, `TestUsageTenantDelete`, and `TestCollectionDeletion` each spawn a tight-loop poller goroutine reading the debug usage report and asserting on every read, then set `endUsage` and return with no `sync.WaitGroup` guaranteeing the poller exited. The deferred `ClassDeleter` fires the instant the test returns and can commit while the poller is mid-flight, so its next read sees a schema without the class: `collection ... not found in debug usage report`, near-deterministically. `TestAlterSchemaDropPropertyIndex` in the same file already models the correct pattern. A secondary window exists right after class creation before the local index bootstrap catches up (`UsageForIndex` returning `(nil, nil)`).

## The fix

All three tests get a `sync.WaitGroup` around the poller with `wg.Wait()` after `endUsage.Store(true)` (closes the teardown race), plus an `assert.EventuallyWithT` quiescent-baseline wait before the poller starts (closes the creation-bootstrap window), following the file's existing pattern.

## Red/green

Unfixed head, three tests sequential x10: 4 failures with the exact reported text (runs 1, 3, 7). Fixed: 10/10 green. Test-only diff, single file.

This unblocks the merges of weaviate/weaviate#12221 (QA-complete, this red was its last gate) and weaviate/weaviate#12252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPmvsB7uLmLm8VcLDH7PD3