### PR TITLE
fix(db): ABBA deadlock between replication-config apply and lazy shard load wedges RAFT FSM

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -319,7 +319,10 @@ type Index struct {
 	allShardsReady atomic.Bool
 	allocChecker   memwatch.AllocChecker
 
-	replicationConfigLock     sync.RWMutex
+	replicationConfigLock sync.RWMutex
+	// serializes applyAsyncReplicationToLoadedShards fan-outs so a stale
+	// snapshot cannot clobber a fresher one
+	asyncReplicationApplyLock sync.Mutex
 	asyncReplicationScheduler *AsyncReplicationScheduler
 
 	shardLoadLimiter  *loadlimiter.LoadLimiter
@@ -939,31 +942,48 @@ func (i *Index) asyncReplicationGloballyDisabled() bool {
 }
 
 func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.ReplicationConfig) error {
-	i.replicationConfigLock.Lock()
-	defer i.replicationConfigLock.Unlock()
+	// The write lock must not span the fan-out: a mid-load shard holds its
+	// mutex while RLocking this config — ABBA deadlock wedging the RAFT FSM.
+	// Post-unlock loads read the new config, so no shard misses the update.
+	err := func() error {
+		i.replicationConfigLock.Lock()
+		defer i.replicationConfigLock.Unlock()
 
-	i.Config.ReplicationFactor = cfg.Factor
-	i.Config.DeletionStrategy = cfg.DeletionStrategy
+		i.Config.ReplicationFactor = cfg.Factor
+		i.Config.DeletionStrategy = cfg.DeletionStrategy
 
-	config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
+		config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
+		if err != nil {
+			return err
+		}
+		i.Config.AsyncReplicationConfig = config
+		return nil
+	}()
 	if err != nil {
 		return err
 	}
-	i.Config.AsyncReplicationConfig = config
 
 	// unloaded shards will fetch the latest config when they are loaded
-	return i.applyAsyncReplicationToLoadedShardsLocked(ctx)
+	return i.applyAsyncReplicationToLoadedShards(ctx)
 }
 
-// applyAsyncReplicationToLoadedShardsLocked (re-)applies the per-shard
+// applyAsyncReplicationToLoadedShards (re-)applies the per-shard
 // enable/disable decision to every loaded shard. The decision is per-shard, so
 // an over-replicated shard at ReplicationFactor 1 keeps async on (e.g. mid
 // scale-out, or while the factor is lowered before the extra replicas drain).
 //
-// Caller MUST hold i.replicationConfigLock for writing. enableAsyncReplication
-// does synchronous hashtree disk I/O, so hashbeat cycles stall until this ends.
-func (i *Index) applyAsyncReplicationToLoadedShardsLocked(ctx context.Context) error {
+// Caller must NOT hold i.replicationConfigLock (see updateReplicationConfig).
+// Fan-outs are serialized by asyncReplicationApplyLock and snapshot the config
+// at start, so the last one applies the freshest. enableAsyncReplication does
+// synchronous hashtree disk I/O, so hashbeat cycles stall until this ends.
+func (i *Index) applyAsyncReplicationToLoadedShards(ctx context.Context) error {
+	i.asyncReplicationApplyLock.Lock()
+	defer i.asyncReplicationApplyLock.Unlock()
+
+	i.replicationConfigLock.RLock()
 	cfg := i.Config.AsyncReplicationConfig
+	rf := i.Config.ReplicationFactor
+	i.replicationConfigLock.RUnlock()
 
 	// iterate concurrently so one shard's fault can't skip the rest (errors are
 	// accumulated, not first-error abort).
@@ -979,7 +999,7 @@ func (i *Index) applyAsyncReplicationToLoadedShardsLocked(ctx context.Context) e
 			return fmt.Errorf("shard %q does not implement asyncReplicationController", name)
 		}
 
-		if i.asyncReplicationEnabledForShard(name) {
+		if i.asyncReplicationEnabledForShardRF(name, rf) {
 			if err := ctrl.enableAsyncReplication(ctx, cfg); err != nil {
 				return fmt.Errorf("updating async replication on shard %q: %w", name, err)
 			}
@@ -1002,10 +1022,7 @@ func (i *Index) applyAsyncReplicationToLoadedShardsLocked(ctx context.Context) e
 // AsyncReplicationDisabled flag. Must not short-circuit on
 // ReplicationFactor <= 1 — over-replicated shards still need async.
 func (i *Index) reconcileAsyncReplication(ctx context.Context) error {
-	i.replicationConfigLock.Lock()
-	defer i.replicationConfigLock.Unlock()
-
-	return i.applyAsyncReplicationToLoadedShardsLocked(ctx)
+	return i.applyAsyncReplicationToLoadedShards(ctx)
 }
 
 // ReconcileAsyncReplication re-applies async replication to every loaded shard
@@ -1419,6 +1436,12 @@ func (i *Index) asyncReplicationEnabled() bool {
 // asyncReplicationEnabledForShard is the per-shard async-replication gate.
 // Caller MUST hold replicationConfigLock.
 func (i *Index) asyncReplicationEnabledForShard(shardName string) bool {
+	return i.asyncReplicationEnabledForShardRF(shardName, i.Config.ReplicationFactor)
+}
+
+// asyncReplicationEnabledForShardRF is asyncReplicationEnabledForShard with
+// the ReplicationFactor passed as a snapshot, so lock-free fan-outs can use it.
+func (i *Index) asyncReplicationEnabledForShardRF(shardName string, rf int64) bool {
 	if i.asyncReplicationScheduler == nil {
 		return false
 	}
@@ -1427,7 +1450,7 @@ func (i *Index) asyncReplicationEnabledForShard(shardName string) bool {
 		return false
 	}
 
-	if i.Config.ReplicationFactor > 1 {
+	if rf > 1 {
 		return true
 	}
 
@@ -1540,9 +1563,9 @@ func (i *Index) InitAsyncReplicationOnShard(ctx context.Context, shardName strin
 		return fmt.Errorf("shard %q does not implement asyncReplicationController", shardName)
 	}
 
-	// Hold replicationConfigLock across the apply so the config read and the
-	// enable cannot be interleaved by a concurrent updateReplicationConfig. See
-	// RevertAsyncReplicationOnShard for why this is deadlock-free.
+	// Hold replicationConfigLock across the apply so a concurrent config
+	// mutation can't interleave (a concurrent fan-out still may — it re-applies
+	// the freshest config). Deadlock-free per RevertAsyncReplicationOnShard.
 	i.replicationConfigLock.RLock()
 	defer i.replicationConfigLock.RUnlock()
 	return ctrl.enableAsyncReplication(ctx, i.Config.AsyncReplicationConfig)
@@ -1566,11 +1589,9 @@ func (i *Index) RevertAsyncReplicationOnShard(ctx context.Context, shardName str
 		return fmt.Errorf("shard %q does not implement asyncReplicationController", shardName)
 	}
 
-	// Hold replicationConfigLock across the apply (not just the snapshot) so a
-	// concurrent updateReplicationConfig cannot interleave and let stale state
-	// win. Deadlock-free: updateReplicationConfig already calls
-	// enable/disableAsyncReplication under the write lock, so they never
-	// reacquire replicationConfigLock.
+	// Hold replicationConfigLock across the apply so a concurrent config
+	// mutation can't let stale state win. Deadlock-free:
+	// enable/disableAsyncReplication never acquire replicationConfigLock.
 	i.replicationConfigLock.RLock()
 	defer i.replicationConfigLock.RUnlock()
 

--- a/adapters/repos/db/index_update_replication_config_deadlock_test.go
+++ b/adapters/repos/db/index_update_replication_config_deadlock_test.go
@@ -1,0 +1,217 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+const (
+	deadlockSyncTimeout = 10 * time.Second
+	deadlockTimeout     = 15 * time.Second
+)
+
+// No Shutdown cleanup: a reproduced deadlock would hang it forever.
+func newReplConfigDeadlockFixture(t *testing.T, className string) (*DB, *Index) {
+	t.Helper()
+	ctx := testCtx()
+	repo, migrator, schemaGetter := newLazyLoadRepo(t, singleShardState())
+
+	class := &models.Class{
+		Class:               className,
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+	}
+	require.NoError(t, migrator.AddClass(ctx, class))
+	schemaGetter.schema = schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+	index := repo.GetIndex(schema.ClassName(className))
+	require.NotNil(t, index)
+	return repo, index
+}
+
+func soleColdShard(t *testing.T, index *Index) *LazyLoadShard {
+	t.Helper()
+	var lazy *LazyLoadShard
+	index.shards.Range(func(name string, s ShardLike) error {
+		ls, ok := s.(*LazyLoadShard)
+		require.True(t, ok, "shard %q should be a LazyLoadShard", name)
+		lazy = ls
+		return nil
+	})
+	require.NotNil(t, lazy)
+	require.False(t, lazy.isLoaded())
+	return lazy
+}
+
+func deadlockStacks(full string) string {
+	var kept []string
+	for _, g := range strings.Split(full, "\n\n") {
+		if strings.Contains(g, "updateReplicationConfig") ||
+			strings.Contains(g, "reconcileAsyncReplication") ||
+			strings.Contains(g, "LazyLoadShard") ||
+			strings.Contains(g, "initNonVector") ||
+			strings.Contains(g, "ForEachLoadedShardConcurrently") {
+			kept = append(kept, g)
+		}
+	}
+	if len(kept) == 0 {
+		return full
+	}
+	return strings.Join(kept, "\n\n")
+}
+
+// gateAllocChecker parks Load inside its critical section, before its config reads.
+type gateAllocChecker struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (g gateAllocChecker) CheckAlloc(int64) error { return nil }
+
+func (g gateAllocChecker) CheckMappingAndReserve(int64, int) error {
+	close(g.entered)
+	<-g.release
+	return nil
+}
+
+func (g gateAllocChecker) Refresh(bool) {}
+
+func startGatedLoad(t *testing.T, lazy *LazyLoadShard) (gateAllocChecker, chan error) {
+	t.Helper()
+	gate := gateAllocChecker{entered: make(chan struct{}), release: make(chan struct{})}
+	lazy.memMonitor = gate
+
+	loadDone := make(chan error, 1)
+	go func() { loadDone <- lazy.Load(context.Background()) }()
+
+	select {
+	case <-gate.entered:
+	case <-time.After(deadlockSyncTimeout):
+		t.Fatal("Load never reached the gate inside its critical section — the fixture no longer exercises the interleaving")
+	}
+	return gate, loadDone
+}
+
+func requireBothComplete(t *testing.T, what string, loadDone, opDone chan error) {
+	t.Helper()
+	loadOK, opOK := false, false
+	timeout := time.After(deadlockTimeout)
+	for !loadOK || !opOK {
+		select {
+		case err := <-loadDone:
+			require.NoError(t, err)
+			loadOK = true
+		case err := <-opDone:
+			require.NoError(t, err)
+			opOK = true
+		case <-timeout:
+			buf := make([]byte, 1<<22)
+			stacks := string(buf[:runtime.Stack(buf, true)])
+			t.Fatalf("deadlock: %s and LazyLoadShard.Load wedged for %s (load done: %v, op done: %v).\n\ninvolved goroutines:\n\n%s",
+				what, deadlockTimeout, loadOK, opOK, deadlockStacks(stacks))
+		}
+	}
+}
+
+// Pins deadlock-test failures on the interleaving: both ops succeed when they don't overlap.
+func TestUpdateReplicationConfig_SequentialWithLazyShard(t *testing.T) {
+	ctx := context.Background()
+	repo, index := newReplConfigDeadlockFixture(t, "ReplConfigSequential")
+	lazy := soleColdShard(t, index)
+
+	require.NoError(t, lazy.Load(ctx))
+	require.NoError(t, index.updateReplicationConfig(ctx, &models.ReplicationConfig{Factor: 1}))
+	require.NoError(t, repo.Shutdown(context.Background()))
+}
+
+// Pins the ABBA cycle: the config write lock wants the shard mutex; a parked Load holds it wanting the config RLock.
+func TestUpdateReplicationConfig_DeadlocksAgainstLazyShardLoad(t *testing.T) {
+	ctx := context.Background()
+	repo, index := newReplConfigDeadlockFixture(t, "ReplConfigDeadlock")
+	lazy := soleColdShard(t, index)
+
+	gate, loadDone := startGatedLoad(t, lazy)
+
+	// makes the updater's queued write observable below
+	index.replicationConfigLock.RLock()
+
+	updateDone := make(chan error, 1)
+	go func() {
+		updateDone <- index.updateReplicationConfig(ctx, &models.ReplicationConfig{Factor: 1})
+	}()
+
+	writerQueued := false
+	for deadline := time.Now().Add(deadlockSyncTimeout); time.Now().Before(deadline); {
+		if !index.replicationConfigLock.TryRLock() {
+			writerQueued = true
+			break
+		}
+		index.replicationConfigLock.RUnlock()
+		runtime.Gosched()
+	}
+	if !writerQueued {
+		index.replicationConfigLock.RUnlock()
+		t.Fatal("updateReplicationConfig never queued for the config write lock")
+	}
+	index.replicationConfigLock.RUnlock()
+	close(gate.release)
+
+	requireBothComplete(t, "updateReplicationConfig", loadDone, updateDone)
+	require.NoError(t, repo.Shutdown(context.Background()))
+}
+
+// Same cycle via the runtime-config hook path.
+func TestReconcileAsyncReplication_DeadlocksAgainstLazyShardLoad(t *testing.T) {
+	ctx := context.Background()
+	repo, index := newReplConfigDeadlockFixture(t, "ReplConfigReconcileDeadlock")
+	lazy := soleColdShard(t, index)
+
+	gate, loadDone := startGatedLoad(t, lazy)
+
+	reconcileDone := make(chan error, 1)
+	go func() { reconcileDone <- index.reconcileAsyncReplication(ctx) }()
+
+	fanOutBlocked := false
+	buf := make([]byte, 1<<22)
+	for deadline := time.Now().Add(deadlockSyncTimeout); time.Now().Before(deadline); {
+		stacks := string(buf[:runtime.Stack(buf, true)])
+		for _, g := range strings.Split(stacks, "\n\n") {
+			if strings.Contains(g, "ForEachLoadedShardConcurrently") && strings.Contains(g, "isLoaded") {
+				fanOutBlocked = true
+				break
+			}
+		}
+		if fanOutBlocked {
+			break
+		}
+		runtime.Gosched()
+	}
+	if !fanOutBlocked {
+		t.Fatal("reconcile fan-out never blocked on the mid-load shard — the fixture no longer exercises the interleaving")
+	}
+	close(gate.release)
+
+	requireBothComplete(t, "reconcileAsyncReplication", loadDone, reconcileDone)
+	require.NoError(t, repo.Shutdown(context.Background()))
+}

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1090,10 +1090,9 @@ func (s *Shard) addTargetNodeOverride(ctx context.Context, targetNodeOverride ad
 		}
 		s.targetNodeOverrides = append(s.targetNodeOverrides, targetNodeOverride)
 	}()
-	// Ensure async replication is started. Hold replicationConfigLock across the
-	// apply so a concurrent updateReplicationConfig can't interleave (see
-	// RevertAsyncReplicationOnShard); read the config field directly, as the
-	// AsyncReplicationConfig() getter would reacquire the lock.
+	// Ensure async replication is started. Hold replicationConfigLock across
+	// the apply (see RevertAsyncReplicationOnShard); read the config field
+	// directly — the AsyncReplicationConfig() getter would reacquire the lock.
 	s.index.replicationConfigLock.RLock()
 	defer s.index.replicationConfigLock.RUnlock()
 	return s.enableAsyncReplication(ctx, s.index.Config.AsyncReplicationConfig)
@@ -1135,8 +1134,8 @@ func (s *Shard) removeTargetNodeOverride(ctx context.Context, targetNodeOverride
 	// was before overrides were added
 	if targetNodeOverrideLen == 0 {
 		// Restore the shard to the index's configured async-replication state,
-		// holding replicationConfigLock across the apply so a concurrent
-		// updateReplicationConfig can't interleave (see RevertAsyncReplicationOnShard).
+		// holding replicationConfigLock across the apply so a concurrent config
+		// mutation can't interleave (see RevertAsyncReplicationOnShard).
 		s.index.replicationConfigLock.RLock()
 		defer s.index.replicationConfigLock.RUnlock()
 		if s.index.asyncReplicationEnabledForShard(s.name) {

--- a/adapters/repos/db/shard_lazyloader_addproperty_test.go
+++ b/adapters/repos/db/shard_lazyloader_addproperty_test.go
@@ -56,7 +56,8 @@ type addPropertyLazyFixture struct {
 	schemaClass *models.Class
 }
 
-func newAddPropertyLazyFixture(t *testing.T, className string, shardState *sharding.State) *addPropertyLazyFixture {
+// newLazyLoadRepo wires a lazy-load-enabled repo whose shards start cold; it registers no Shutdown cleanup, callers own the lifecycle.
+func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, *fakeSchemaGetter) {
 	t.Helper()
 	ctx := testCtx()
 	logger, _ := test.NewNullLogger()
@@ -97,9 +98,15 @@ func newAddPropertyLazyFixture(t *testing.T, className string, shardState *shard
 	require.NoError(t, err)
 	repo.SetSchemaGetter(schemaGetter)
 	require.NoError(t, repo.WaitForStartup(ctx))
-	t.Cleanup(func() { repo.Shutdown(context.Background()) })
 
-	migrator := NewMigrator(repo, logger, "node1")
+	return repo, NewMigrator(repo, logger, "node1"), schemaGetter
+}
+
+func newAddPropertyLazyFixture(t *testing.T, className string, shardState *sharding.State) *addPropertyLazyFixture {
+	t.Helper()
+	ctx := testCtx()
+	repo, migrator, schemaGetter := newLazyLoadRepo(t, shardState)
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
 
 	require.NoError(t, migrator.AddClass(ctx, newClassWithWarmProp(className)))
 	// Serve a distinct class object from getClass() so that only the code path


### PR DESCRIPTION
## Motivation

Forward-port of #12238. `updateReplicationConfig` held `replicationConfigLock` for writing across the shard fan-out (`ForEachLoadedShardConcurrently`), whose `isLoaded()` check takes each `LazyLoadShard`'s mutex. A shard mid-load holds that mutex for the entire load and reads the replication config back through the index (RLock) from `initNonVector` — an ABBA cycle: the updater waits on the shard mutex while the loader's RLock parks behind the queued writer. `updateReplicationConfig` runs on the RAFT FSM apply path (schema update → executor → migrator), so the wedge blocks all further schema applies on that node. Hit whenever a replication-config change lands while a lazy shard loads, e.g. hashbeat-triggered loads right after a node rejoins.

## Approach

Scope the write lock to the config field mutation only, then fan out without it. This is safe: loads that start after the unlock read the new config, and `isLoaded()` blocks on in-flight loads, so no loaded shard can miss the update.

Where this diverges from #12238: there, the only fan-out caller is the single-threaded FSM apply, so dropping the lock was enough. Here `reconcileAsyncReplication` — the runtime `ASYNC_REPLICATION_DISABLED` flag hook, running on a background goroutine (`configure_api.go`) — shares the fan-out and previously took the same write lock, i.e. the identical deadlock existed on a second path, and two fan-outs can genuinely race. A new `asyncReplicationApplyLock` serializes complete fan-outs, and each fan-out snapshots the config and replication factor under a brief RLock after acquiring it, so the last fan-out always applies the freshest state and a stale snapshot can never clobber a fresher one.

Explicitly re-verified that #12034's orphan-Deregister protection is unaffected: that invariant is enforced per-shard by `asyncReplicationRWMux` (Deregister under the shard write lock plus the enable goroutines' self-deregister guards) and never depended on `replicationConfigLock` — `rebuildHashtree` already runs disable→enable without it.

## Key areas for review

- `adapters/repos/db/index.go` `updateReplicationConfig` — write lock now scoped to the field mutation (in a closure so the unlock is panic-safe); verify nothing relied on the lock spanning the fan-out
- `adapters/repos/db/index.go` `applyAsyncReplicationToLoadedShards` — the apply-lock + snapshot-at-start discipline; the stale-clobber argument lives here
- `adapters/repos/db/index.go` `asyncReplicationEnabledForShardRF` — RF passed as a snapshot so the lock-free fan-out can use it; the locked `asyncReplicationEnabledForShard` remains for callers already holding the RLock
- `adapters/repos/db/shard_async_replication.go` — comment-only updates: the "concurrent updateReplicationConfig can't interleave" reasoning changed now that the writer no longer spans applies

## Risks and mitigations

- **Stale config applied to shards**: concurrent FSM apply and runtime-flag reconcile could interleave per-shard enables. Mitigated by serializing whole fan-outs on `asyncReplicationApplyLock` with the snapshot taken after acquiring it — the later fan-out's snapshot is at least as fresh.
- **A shard misses the update**: a load finishing between unlock and fan-out already read the new config; a mid-load shard blocks `isLoaded()` until done and is then covered by the fan-out.
- **New lock ordering**: `asyncReplicationApplyLock` is only acquired in `applyAsyncReplicationToLoadedShards`, always before the config RLock and shard mutexes; no path holding anything the fan-out blocks on ever waits on it.
- **FSM apply latency**: a config apply can now queue behind an in-flight runtime-flag reconcile fan-out (hashtree disk I/O) — bounded by one fan-out, the same class of wait the old write lock already imposed.

## Testing

- Red phase (fix reverted): `TestUpdateReplicationConfig_DeadlocksAgainstLazyShardLoad` and `TestReconcileAsyncReplication_DeadlocksAgainstLazyShardLoad` both wedge for 15s and dump the exact cycle — `Load → initNonVector → AsyncReplicationEnabledForShard` parked in `RLock`, the fan-out parked in `isLoaded` on the shard mutex.
- The interleaving is forced deterministically (no retries, no sleeps): a gated alloc-checker parks `Load` inside its critical section before its config reads; the update path observes the queued writer via `TryRLock`, the reconcile path observes the fan-out blocked on the mid-load shard via stack inspection; every sync point fails the test loudly if not reached.
- `TestUpdateReplicationConfig_SequentialWithLazyShard` is the control: both ops succeed when they don't overlap, pinning failures on the interleaving rather than the fixture.
- Fixture: `newLazyLoadRepo` extracted unchanged from the add-property lazy tests; the deadlock tests register no Shutdown cleanup since a reproduced deadlock would hang it.
- Green: all three tests pass `-race -count 20`; full `./adapters/repos/db` unit suite (`-race`) and integration suite (`-tags integrationTest -race`) pass; `golangci-lint` and the goroutine linter are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
