### PR TITLE
fix(schema): reject invalid async replication config before RAFT commit

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -942,26 +942,28 @@ func (i *Index) asyncReplicationGloballyDisabled() bool {
 }
 
 func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.ReplicationConfig) error {
+	class := i.getClass()
+	if class == nil {
+		return fmt.Errorf("update replication config: class %q not found in schema", i.Config.ClassName)
+	}
+
+	// Convert before mutating so an error can't leave a torn Config behind.
+	config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(class.MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
+	if err != nil {
+		return err
+	}
+
 	// The write lock must not span the fan-out: a mid-load shard holds its
 	// mutex while RLocking this config — ABBA deadlock wedging the RAFT FSM.
 	// Post-unlock loads read the new config, so no shard misses the update.
-	err := func() error {
+	func() {
 		i.replicationConfigLock.Lock()
 		defer i.replicationConfigLock.Unlock()
 
 		i.Config.ReplicationFactor = cfg.Factor
 		i.Config.DeletionStrategy = cfg.DeletionStrategy
-
-		config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
-		if err != nil {
-			return err
-		}
 		i.Config.AsyncReplicationConfig = config
-		return nil
 	}()
-	if err != nil {
-		return err
-	}
 
 	// unloaded shards will fetch the latest config when they are loaded
 	return i.applyAsyncReplicationToLoadedShards(ctx)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -998,25 +998,26 @@ func (i *Index) asyncReplicationGloballyDisabled() bool {
 }
 
 func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.ReplicationConfig) error {
+	class := i.getClass()
+	if class == nil {
+		return fmt.Errorf("update replication config: class %q not found in schema", i.Config.ClassName)
+	}
+
+	// Convert before mutating so an error can't leave a torn Config behind.
+	config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(class.MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
+	if err != nil {
+		return err
+	}
+
 	// The lock must not span the fan-out (ABBA deadlock, see applyAsyncReplicationToLoadedShards); post-unlock loads read the new config.
-	err := func() error {
+	func() {
 		i.replicationConfigLock.Lock()
 		defer i.replicationConfigLock.Unlock()
 
 		i.Config.ReplicationFactor = cfg.Factor
 		i.Config.DeletionStrategy = cfg.DeletionStrategy
-
-		parsed, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
-		if err != nil {
-			return err
-		}
-		// assign async replication config
-		i.Config.AsyncReplicationConfig = parsed
-		return nil
+		i.Config.AsyncReplicationConfig = config
 	}()
-	if err != nil {
-		return err
-	}
 
 	// unloaded shards will fetch the latest config when they are loaded
 	return i.applyAsyncReplicationToLoadedShards(ctx)

--- a/adapters/repos/db/index_async_replication.go
+++ b/adapters/repos/db/index_async_replication.go
@@ -12,20 +12,12 @@
 package db
 
 import (
-	"fmt"
-	"math"
-	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
+	entreplication "github.com/weaviate/weaviate/entities/replication"
 )
-
-// maxDurationMillis is the largest int64 millisecond value that still fits in
-// a time.Duration (nanoseconds) without wrapping. Used to reject schema inputs
-// that would otherwise overflow during the *time.Millisecond conversion and
-// silently clamp to the minimum.
-const maxDurationMillis = int64(math.MaxInt64 / int64(time.Millisecond))
 
 // asyncReplicationConfigFromModel builds an AsyncReplicationConfig from the
 // class model and multitenancy flag.
@@ -44,6 +36,9 @@ const maxDurationMillis = int64(math.MaxInt64 / int64(time.Millisecond))
 // Effective(), so removing an env var restores the per-class schema value
 // without any schema mutation.
 //
+// Rejection is delegated to entreplication.ValidateAsyncConfig, shared with
+// proposal-time schema validation so the reject-set cannot drift.
+//
 // Frequency minimums (minFrequency, minFrequencyWhilePropagating) are enforced
 // by clamping sub-minimum values up to the minimum and emitting a Warn log
 // entry via the supplied logger. This is intentionally lenient so that
@@ -51,6 +46,10 @@ const maxDurationMillis = int64(math.MaxInt64 / int64(time.Millisecond))
 // the runtime defensive clamp in Effective() would otherwise be the only
 // safety net and would silence the legacy values without operator visibility.
 func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.ReplicationAsyncConfig, logger logrus.FieldLogger) (config AsyncReplicationConfig, err error) {
+	if err := entreplication.ValidateAsyncConfig(cfg); err != nil {
+		return AsyncReplicationConfig{}, err
+	}
+
 	// ---- Code defaults (tier 1) ----
 	if multiTenancyEnabled {
 		config.hashtreeHeight = defaultHashtreeHeightMultiTenant
@@ -73,24 +72,15 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 	}
 
 	// ---- Per-class API / schema overrides (tier 2) ----
-	// Validate each API value and store it as a pointer in classOverrides.
-	// Nil pointer means "not set by the user" — Effective() will skip it.
+	// Store each validated API value as a pointer in classOverrides. Nil
+	// pointer means "not set by the user" — Effective() will skip it.
 
 	if cfg.HashtreeHeight != nil {
-		v, err := optParseInt("", int(*cfg.HashtreeHeight), minHashtreeHeight, maxHashtreeHeight)
-		if err != nil {
-			return AsyncReplicationConfig{}, fmt.Errorf("hashtreeHeight: %w", err)
-		}
+		v := int(*cfg.HashtreeHeight)
 		config.classOverrides.hashtreeHeight = &v
 	}
 
 	if cfg.Frequency != nil {
-		if *cfg.Frequency < 0 {
-			return AsyncReplicationConfig{}, fmt.Errorf("frequency must be >= 0")
-		}
-		if *cfg.Frequency > maxDurationMillis {
-			return AsyncReplicationConfig{}, fmt.Errorf("frequency too large: %d ms exceeds max %d ms", *cfg.Frequency, maxDurationMillis)
-		}
 		v := time.Duration(*cfg.Frequency) * time.Millisecond
 		if v < minFrequency {
 			logger.WithFields(logrus.Fields{
@@ -105,12 +95,6 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 	}
 
 	if cfg.FrequencyWhilePropagating != nil {
-		if *cfg.FrequencyWhilePropagating < 0 {
-			return AsyncReplicationConfig{}, fmt.Errorf("frequencyWhilePropagating must be >= 0")
-		}
-		if *cfg.FrequencyWhilePropagating > maxDurationMillis {
-			return AsyncReplicationConfig{}, fmt.Errorf("frequencyWhilePropagating too large: %d ms exceeds max %d ms", *cfg.FrequencyWhilePropagating, maxDurationMillis)
-		}
 		v := time.Duration(*cfg.FrequencyWhilePropagating) * time.Millisecond
 		if v < minFrequencyWhilePropagating {
 			logger.WithFields(logrus.Fields{
@@ -126,94 +110,48 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 
 	if cfg.LoggingFrequency != nil {
 		v := time.Duration(*cfg.LoggingFrequency) * time.Second
-		if v <= 0 {
-			return AsyncReplicationConfig{}, fmt.Errorf("loggingFrequency must be > 0")
-		}
 		config.classOverrides.loggingFrequency = &v
 	}
 
 	if cfg.DiffBatchSize != nil {
-		v, err := optParseInt("", int(*cfg.DiffBatchSize), minDiffBatchSize, maxDiffBatchSize)
-		if err != nil {
-			return AsyncReplicationConfig{}, fmt.Errorf("diffBatchSize: %w", err)
-		}
+		v := int(*cfg.DiffBatchSize)
 		config.classOverrides.diffBatchSize = &v
 	}
 
 	if cfg.DiffPerNodeTimeout != nil {
 		v := time.Duration(*cfg.DiffPerNodeTimeout) * time.Second
-		if v <= 0 {
-			return AsyncReplicationConfig{}, fmt.Errorf("diffPerNodeTimeout must be > 0")
-		}
 		config.classOverrides.diffPerNodeTimeout = &v
 	}
 
 	if cfg.PrePropagationTimeout != nil {
 		v := time.Duration(*cfg.PrePropagationTimeout) * time.Second
-		if v <= 0 {
-			return AsyncReplicationConfig{}, fmt.Errorf("prePropagationTimeout must be > 0")
-		}
 		config.classOverrides.prePropagationTimeout = &v
 	}
 
 	if cfg.PropagationTimeout != nil {
 		v := time.Duration(*cfg.PropagationTimeout) * time.Second
-		if v <= 0 {
-			return AsyncReplicationConfig{}, fmt.Errorf("propagationTimeout must be > 0")
-		}
 		config.classOverrides.propagationTimeout = &v
 	}
 
 	if cfg.PropagationLimit != nil {
-		v, err := optParseInt("", int(*cfg.PropagationLimit), minPropagationLimit, maxPropagationLimit)
-		if err != nil {
-			return AsyncReplicationConfig{}, fmt.Errorf("propagationLimit: %w", err)
-		}
+		v := int(*cfg.PropagationLimit)
 		config.classOverrides.propagationLimit = &v
 	}
 
 	if cfg.PropagationConcurrency != nil {
-		v, err := optParseInt("", int(*cfg.PropagationConcurrency), minPropagationConcurrency, maxPropagationConcurrency)
-		if err != nil {
-			return AsyncReplicationConfig{}, fmt.Errorf("propagationConcurrency: %w", err)
-		}
+		v := int(*cfg.PropagationConcurrency)
 		config.classOverrides.propagationConcurrency = &v
 	}
 
 	if cfg.PropagationBatchSize != nil {
-		v, err := optParseInt("", int(*cfg.PropagationBatchSize), minPropagationBatchSize, maxPropagationBatchSize)
-		if err != nil {
-			return AsyncReplicationConfig{}, fmt.Errorf("propagationBatchSize: %w", err)
-		}
+		v := int(*cfg.PropagationBatchSize)
 		config.classOverrides.propagationBatchSize = &v
 	}
 
 	if cfg.PropagationDelay != nil {
 		v := time.Duration(*cfg.PropagationDelay) * time.Millisecond
-		if v < 0 {
-			return AsyncReplicationConfig{}, fmt.Errorf("propagationDelay must be >= 0")
-		}
 		config.classOverrides.propagationDelay = &v
 	}
 
 	return config, nil
-}
-
-// optParseInt parses s as an integer when non-empty, otherwise uses defaultVal.
-// Returns an error if the resolved value is outside [minVal, maxVal].
-func optParseInt(s string, defaultVal, minVal, maxVal int) (val int, err error) {
-	if s == "" {
-		val = defaultVal
-	} else {
-		val, err = strconv.Atoi(s)
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	if val < minVal || val > maxVal {
-		return 0, fmt.Errorf("value %d out of range: min %d, max %d", val, minVal, maxVal)
-	}
-
-	return val, nil
 }

--- a/adapters/repos/db/index_async_replication.go
+++ b/adapters/repos/db/index_async_replication.go
@@ -12,12 +12,30 @@
 package db
 
 import (
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
 	entreplication "github.com/weaviate/weaviate/entities/replication"
 )
+
+// asyncReplicationConfigFromModelOrDefaults degrades invalid fields to defaults (keeping valid ones) so poisoned stored configs still load; the UpdateClass apply path must stay strict — erroring there keeps the last-valid config.
+func asyncReplicationConfigFromModelOrDefaults(multiTenancyEnabled bool, cfg *models.ReplicationAsyncConfig, logger logrus.FieldLogger) (AsyncReplicationConfig, error) {
+	config, err := asyncReplicationConfigFromModel(multiTenancyEnabled, cfg, logger)
+	if err == nil {
+		return config, nil
+	}
+
+	sanitized, dropped := entreplication.SanitizeAsyncConfig(cfg)
+	msgs := make([]string, len(dropped))
+	for i, dropErr := range dropped {
+		msgs[i] = dropErr.Error()
+	}
+	logger.Errorf("invalid async replication config, falling back to defaults for invalid fields: %s", strings.Join(msgs, "; "))
+
+	return asyncReplicationConfigFromModel(multiTenancyEnabled, sanitized, logger)
+}
 
 // asyncReplicationConfigFromModel builds an AsyncReplicationConfig from the
 // class model and multitenancy flag.

--- a/adapters/repos/db/index_replication_config_validation_test.go
+++ b/adapters/repos/db/index_replication_config_validation_test.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestUpdateReplicationConfigInvalidAsyncConfigLeavesConfigUntouched(t *testing.T) {
+	ctx := testCtx()
+	repo, index := newReplConfigDeadlockFixture(t, "TornStateClass")
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	prevRF := index.ReplicationFactor()
+	prevDS := index.DeletionStrategy()
+	prevAsync := index.Config.AsyncReplicationConfig
+
+	freq := int64(-1)
+	err := index.updateReplicationConfig(ctx, &models.ReplicationConfig{
+		Factor:           prevRF + 2,
+		DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+		AsyncConfig:      &models.ReplicationAsyncConfig{Frequency: &freq},
+	})
+	require.ErrorContains(t, err, "frequency must be >= 0")
+	require.Equal(t, prevRF, index.ReplicationFactor())
+	require.Equal(t, prevDS, index.DeletionStrategy())
+	require.Equal(t, prevAsync, index.Config.AsyncReplicationConfig)
+}
+
+func TestUpdateReplicationConfigValidAsyncConfigApplies(t *testing.T) {
+	ctx := testCtx()
+	repo, index := newReplConfigDeadlockFixture(t, "ValidAsyncCfgClass")
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	freq := int64(60_000)
+	err := index.updateReplicationConfig(ctx, &models.ReplicationConfig{
+		Factor:      3,
+		AsyncConfig: &models.ReplicationAsyncConfig{Frequency: &freq},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), index.ReplicationFactor())
+	require.NotNil(t, index.Config.AsyncReplicationConfig.classOverrides.frequency)
+	require.Equal(t, time.Minute, *index.Config.AsyncReplicationConfig.classOverrides.frequency)
+}
+
+// Like newLazyLoadRepo but seeds the schema before WaitForStartup so db.init sees the classes.
+func newRepoWithStoredClasses(t *testing.T, shardState *sharding.State, classes []*models.Class) *DB {
+	t.Helper()
+	ctx := testCtx()
+	logger, _ := test.NewNullLogger()
+
+	baseMetrics := monitoring.GetMetrics()
+	metricsCopy := *baseMetrics
+	metricsCopy.Registerer = monitoring.NoopRegisterer
+	metrics := &metricsCopy
+
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: classes}},
+		shardState: shardState,
+	}
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardState.AllPhysicalShards(), nil).Maybe()
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+		return readFunc(&models.Class{Class: className}, shardState)
+	}).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockNodeSelector := cluster.NewMockNodeSelector(t)
+	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
+	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
+
+	repo, err := New(logger, "node1", Config{
+		RootPath:                  t.TempDir(),
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+		EnableLazyLoadShards:      boolPtr(true),
+	},
+		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
+		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
+		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader,
+	)
+	require.NoError(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.NoError(t, repo.WaitForStartup(ctx))
+
+	return repo
+}
+
+func TestInitDegradesInvalidStoredAsyncReplicationConfig(t *testing.T) {
+	freq := int64(-1)
+	class := &models.Class{
+		Class:               "PoisonedAsyncCfgClass",
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		ReplicationConfig: &models.ReplicationConfig{
+			Factor:      1,
+			AsyncConfig: &models.ReplicationAsyncConfig{Frequency: &freq},
+		},
+	}
+	repo := newRepoWithStoredClasses(t, singleShardState(), []*models.Class{class})
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	index := repo.GetIndex(schema.ClassName("PoisonedAsyncCfgClass"))
+	require.NotNil(t, index)
+
+	logger, _ := test.NewNullLogger()
+	expected, err := asyncReplicationConfigFromModel(false, nil, logger)
+	require.NoError(t, err)
+	require.Equal(t, expected, index.Config.AsyncReplicationConfig)
+}

--- a/adapters/repos/db/index_replication_config_validation_test.go
+++ b/adapters/repos/db/index_replication_config_validation_test.go
@@ -136,3 +136,54 @@ func TestInitDegradesInvalidStoredAsyncReplicationConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, index.Config.AsyncReplicationConfig)
 }
+
+func TestInitKeepsValidOverridesWhenDegradingStoredAsyncReplicationConfig(t *testing.T) {
+	freq := int64(-1)
+	height := int64(12)
+	class := &models.Class{
+		Class:               "PartiallyPoisonedAsyncCfgClass",
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		ReplicationConfig: &models.ReplicationConfig{
+			Factor:      1,
+			AsyncConfig: &models.ReplicationAsyncConfig{Frequency: &freq, HashtreeHeight: &height},
+		},
+	}
+	repo := newRepoWithStoredClasses(t, singleShardState(), []*models.Class{class})
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	index := repo.GetIndex(schema.ClassName("PartiallyPoisonedAsyncCfgClass"))
+	require.NotNil(t, index)
+
+	overrides := index.Config.AsyncReplicationConfig.classOverrides
+	require.Nil(t, overrides.frequency)
+	require.NotNil(t, overrides.hashtreeHeight)
+	require.Equal(t, 12, *overrides.hashtreeHeight)
+}
+
+func TestMigratorAddClassDegradesInvalidAsyncReplicationConfig(t *testing.T) {
+	ctx := testCtx()
+	repo, migrator, _ := newLazyLoadRepo(t, singleShardState())
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	freq := int64(-1)
+	height := int64(12)
+	class := &models.Class{
+		Class:               "PoisonedAddClassCfgClass",
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		ReplicationConfig: &models.ReplicationConfig{
+			Factor:      1,
+			AsyncConfig: &models.ReplicationAsyncConfig{Frequency: &freq, HashtreeHeight: &height},
+		},
+	}
+	require.NoError(t, migrator.AddClass(ctx, class))
+
+	index := repo.GetIndex(schema.ClassName("PoisonedAddClassCfgClass"))
+	require.NotNil(t, index)
+
+	overrides := index.Config.AsyncReplicationConfig.classOverrides
+	require.Nil(t, overrides.frequency)
+	require.NotNil(t, overrides.hashtreeHeight)
+	require.Equal(t, 12, *overrides.hashtreeHeight)
+}

--- a/adapters/repos/db/index_replication_config_validation_test.go
+++ b/adapters/repos/db/index_replication_config_validation_test.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestUpdateReplicationConfigInvalidAsyncConfigLeavesConfigUntouched(t *testing.T) {
+	ctx := testCtx()
+	repo, index := newReplConfigDeadlockFixture(t, "TornStateClass")
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	prevRF := index.ReplicationFactor()
+	prevDS := index.DeletionStrategy()
+	prevAsync := index.Config.AsyncReplicationConfig
+
+	freq := int64(-1)
+	err := index.updateReplicationConfig(ctx, &models.ReplicationConfig{
+		Factor:           prevRF + 2,
+		DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+		AsyncConfig:      &models.ReplicationAsyncConfig{Frequency: &freq},
+	})
+	require.ErrorContains(t, err, "frequency must be >= 0")
+	require.Equal(t, prevRF, index.ReplicationFactor())
+	require.Equal(t, prevDS, index.DeletionStrategy())
+	require.Equal(t, prevAsync, index.Config.AsyncReplicationConfig)
+}
+
+func TestUpdateReplicationConfigValidAsyncConfigApplies(t *testing.T) {
+	ctx := testCtx()
+	repo, index := newReplConfigDeadlockFixture(t, "ValidAsyncCfgClass")
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	freq := int64(60_000)
+	err := index.updateReplicationConfig(ctx, &models.ReplicationConfig{
+		Factor:      3,
+		AsyncConfig: &models.ReplicationAsyncConfig{Frequency: &freq},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), index.ReplicationFactor())
+	require.NotNil(t, index.Config.AsyncReplicationConfig.classOverrides.frequency)
+	require.Equal(t, time.Minute, *index.Config.AsyncReplicationConfig.classOverrides.frequency)
+}
+
+// Like newLazyLoadRepo but seeds the schema before WaitForStartup so db.init sees the classes.
+func newRepoWithStoredClasses(t *testing.T, shardState *sharding.State, classes []*models.Class) *DB {
+	t.Helper()
+	ctx := testCtx()
+	logger, _ := test.NewNullLogger()
+
+	baseMetrics := monitoring.GetMetrics()
+	metricsCopy := *baseMetrics
+	metricsCopy.Registerer = monitoring.NoopRegisterer
+	metrics := &metricsCopy
+
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: classes}},
+		shardState: shardState,
+	}
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardState.AllPhysicalShards(), nil).Maybe()
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+		return readFunc(&models.Class{Class: className}, shardState)
+	}).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockNodeSelector := cluster.NewMockNodeSelector(t)
+	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
+	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
+
+	repo, err := New(logger, "node1", Config{
+		RootPath:                  t.TempDir(),
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+		EnableLazyLoadShards:      boolPtr(true),
+	},
+		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
+		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
+		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader, nil,
+	)
+	require.NoError(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.NoError(t, repo.WaitForStartup(ctx))
+
+	return repo
+}
+
+func TestInitDegradesInvalidStoredAsyncReplicationConfig(t *testing.T) {
+	freq := int64(-1)
+	class := &models.Class{
+		Class:               "PoisonedAsyncCfgClass",
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		ReplicationConfig: &models.ReplicationConfig{
+			Factor:      1,
+			AsyncConfig: &models.ReplicationAsyncConfig{Frequency: &freq},
+		},
+	}
+	repo := newRepoWithStoredClasses(t, singleShardState(), []*models.Class{class})
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	index := repo.GetIndex(schema.ClassName("PoisonedAsyncCfgClass"))
+	require.NotNil(t, index)
+
+	logger, _ := test.NewNullLogger()
+	expected, err := asyncReplicationConfigFromModel(false, nil, logger)
+	require.NoError(t, err)
+	require.Equal(t, expected, index.Config.AsyncReplicationConfig)
+}

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -112,14 +112,9 @@ func (db *DB) init(ctx context.Context) error {
 				}
 			}
 
-			asyncConfig, err := asyncReplicationConfigFromModel(isMultiTenant, class.ReplicationConfig.AsyncConfig, db.logger.WithField("class", class.Class))
+			asyncConfig, err := asyncReplicationConfigFromModelOrDefaults(isMultiTenant, class.ReplicationConfig.AsyncConfig, db.logger.WithField("class", class.Class))
 			if err != nil {
-				// Degrade to defaults instead of crash-looping so UpdateClass can repair the stored config.
-				db.logger.WithField("class", class.Class).Errorf("invalid async replication config, falling back to defaults: %v", err)
-				asyncConfig, err = asyncReplicationConfigFromModel(isMultiTenant, nil, db.logger.WithField("class", class.Class))
-				if err != nil {
-					return fmt.Errorf("async replication config: %w", err)
-				}
+				return fmt.Errorf("async replication config: %w", err)
 			}
 
 			collection := schema.ClassName(class.Class).String()

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -114,7 +114,12 @@ func (db *DB) init(ctx context.Context) error {
 
 			asyncConfig, err := asyncReplicationConfigFromModel(isMultiTenant, class.ReplicationConfig.AsyncConfig, db.logger.WithField("class", class.Class))
 			if err != nil {
-				return fmt.Errorf("async replication config: %w", err)
+				// Degrade to defaults instead of crash-looping so UpdateClass can repair the stored config.
+				db.logger.WithField("class", class.Class).Errorf("invalid async replication config, falling back to defaults: %v", err)
+				asyncConfig, err = asyncReplicationConfigFromModel(isMultiTenant, nil, db.logger.WithField("class", class.Class))
+				if err != nil {
+					return fmt.Errorf("async replication config: %w", err)
+				}
 			}
 
 			collection := schema.ClassName(class.Class).String()

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -109,7 +109,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		return fmt.Errorf("index for class %v already found locally", idx.ID())
 	}
 
-	asyncConfig, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(class.MultiTenancyConfig), class.ReplicationConfig.AsyncConfig, m.logger.WithField("class", class.Class))
+	asyncConfig, err := asyncReplicationConfigFromModelOrDefaults(multitenancy.IsMultiTenant(class.MultiTenancyConfig), class.ReplicationConfig.AsyncConfig, m.logger.WithField("class", class.Class))
 	if err != nil {
 		return fmt.Errorf("async replication config: %w", err)
 	}

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -75,8 +75,8 @@ const (
 	// from hanging indefinitely and blocking rolling restarts.
 	hashtreeDumpTimeout = 30 * time.Second
 
-	minHashtreeHeight = 0
-	maxHashtreeHeight = 20
+	minHashtreeHeight = entreplication.MinHashtreeHeight
+	maxHashtreeHeight = entreplication.MaxHashtreeHeight
 
 	// minFrequency is the smallest accepted value for `frequency` in both
 	// per-class API overrides and global runtime config. Below this, hashbeats
@@ -93,17 +93,17 @@ const (
 	// at hashbeat rate would flood logs in busy clusters.
 	minLoggingFrequency = 1 * time.Second
 
-	minDiffBatchSize = 1
-	maxDiffBatchSize = 10_000
+	minDiffBatchSize = entreplication.MinDiffBatchSize
+	maxDiffBatchSize = entreplication.MaxDiffBatchSize
 
-	minPropagationLimit = 1
-	maxPropagationLimit = 100_000
+	minPropagationLimit = entreplication.MinPropagationLimit
+	maxPropagationLimit = entreplication.MaxPropagationLimit
 
-	minPropagationConcurrency = 1
-	maxPropagationConcurrency = 20
+	minPropagationConcurrency = entreplication.MinPropagationConcurrency
+	maxPropagationConcurrency = entreplication.MaxPropagationConcurrency
 
-	minPropagationBatchSize = 1
-	maxPropagationBatchSize = 1_000
+	minPropagationBatchSize = entreplication.MinPropagationBatchSize
+	maxPropagationBatchSize = entreplication.MaxPropagationBatchSize
 )
 
 // asyncReplicationClassOverrides holds per-class API values that take

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -65,8 +65,8 @@ const (
 	// Caps the post-flush shutdown dump; dumpPublishGate blocks late publication.
 	hashtreeDumpTimeout = 30 * time.Second
 
-	minHashtreeHeight = 0
-	maxHashtreeHeight = hashtree.MaxHeight
+	minHashtreeHeight = entreplication.MinHashtreeHeight
+	maxHashtreeHeight = entreplication.MaxHashtreeHeight
 
 	// minFrequency is the smallest accepted value for `frequency` in both
 	// per-class API overrides and global runtime config. Below this, hashbeats
@@ -83,18 +83,21 @@ const (
 	// at hashbeat rate would flood logs in busy clusters.
 	minLoggingFrequency = 1 * time.Second
 
-	minDiffBatchSize = 1
-	maxDiffBatchSize = 10_000
+	minDiffBatchSize = entreplication.MinDiffBatchSize
+	maxDiffBatchSize = entreplication.MaxDiffBatchSize
 
-	minPropagationLimit = 1
-	maxPropagationLimit = 100_000
+	minPropagationLimit = entreplication.MinPropagationLimit
+	maxPropagationLimit = entreplication.MaxPropagationLimit
 
-	minPropagationConcurrency = 1
-	maxPropagationConcurrency = 20
+	minPropagationConcurrency = entreplication.MinPropagationConcurrency
+	maxPropagationConcurrency = entreplication.MaxPropagationConcurrency
 
-	minPropagationBatchSize = 1
-	maxPropagationBatchSize = 1_000
+	minPropagationBatchSize = entreplication.MinPropagationBatchSize
+	maxPropagationBatchSize = entreplication.MaxPropagationBatchSize
 )
+
+// Compile-time: the schema validator's height bound must track hashtree's deserialization bound.
+var _ = [1]struct{}{}[entreplication.MaxHashtreeHeight-hashtree.MaxHeight]
 
 // asyncReplicationClassOverrides holds per-class API values that take
 // precedence over both code defaults and global runtime config. A nil pointer

--- a/entities/replication/async_config_validation.go
+++ b/entities/replication/async_config_validation.go
@@ -42,6 +42,95 @@ const (
 // time.Duration without wrapping.
 const MaxDurationMillis = int64(math.MaxInt64 / int64(time.Millisecond))
 
+// fieldCheck pairs a field's pointer with its validation; slice order fixes which error ValidateAsyncConfig reports first.
+type fieldCheck struct {
+	ptr   **int64
+	check func(int64) error
+}
+
+func fieldChecks(cfg *models.ReplicationAsyncConfig) []fieldCheck {
+	return []fieldCheck{
+		{&cfg.HashtreeHeight, func(v int64) error {
+			if err := validateIntRange(int(v), MinHashtreeHeight, MaxHashtreeHeight); err != nil {
+				return fmt.Errorf("hashtreeHeight: %w", err)
+			}
+			return nil
+		}},
+		{&cfg.Frequency, func(v int64) error {
+			if v < 0 {
+				return fmt.Errorf("frequency must be >= 0")
+			}
+			if v > MaxDurationMillis {
+				return fmt.Errorf("frequency too large: %d ms exceeds max %d ms", v, MaxDurationMillis)
+			}
+			return nil
+		}},
+		{&cfg.FrequencyWhilePropagating, func(v int64) error {
+			if v < 0 {
+				return fmt.Errorf("frequencyWhilePropagating must be >= 0")
+			}
+			if v > MaxDurationMillis {
+				return fmt.Errorf("frequencyWhilePropagating too large: %d ms exceeds max %d ms", v, MaxDurationMillis)
+			}
+			return nil
+		}},
+		{&cfg.LoggingFrequency, func(v int64) error {
+			if time.Duration(v)*time.Second <= 0 {
+				return fmt.Errorf("loggingFrequency must be > 0")
+			}
+			return nil
+		}},
+		{&cfg.DiffBatchSize, func(v int64) error {
+			if err := validateIntRange(int(v), MinDiffBatchSize, MaxDiffBatchSize); err != nil {
+				return fmt.Errorf("diffBatchSize: %w", err)
+			}
+			return nil
+		}},
+		{&cfg.DiffPerNodeTimeout, func(v int64) error {
+			if time.Duration(v)*time.Second <= 0 {
+				return fmt.Errorf("diffPerNodeTimeout must be > 0")
+			}
+			return nil
+		}},
+		{&cfg.PrePropagationTimeout, func(v int64) error {
+			if time.Duration(v)*time.Second <= 0 {
+				return fmt.Errorf("prePropagationTimeout must be > 0")
+			}
+			return nil
+		}},
+		{&cfg.PropagationTimeout, func(v int64) error {
+			if time.Duration(v)*time.Second <= 0 {
+				return fmt.Errorf("propagationTimeout must be > 0")
+			}
+			return nil
+		}},
+		{&cfg.PropagationLimit, func(v int64) error {
+			if err := validateIntRange(int(v), MinPropagationLimit, MaxPropagationLimit); err != nil {
+				return fmt.Errorf("propagationLimit: %w", err)
+			}
+			return nil
+		}},
+		{&cfg.PropagationConcurrency, func(v int64) error {
+			if err := validateIntRange(int(v), MinPropagationConcurrency, MaxPropagationConcurrency); err != nil {
+				return fmt.Errorf("propagationConcurrency: %w", err)
+			}
+			return nil
+		}},
+		{&cfg.PropagationBatchSize, func(v int64) error {
+			if err := validateIntRange(int(v), MinPropagationBatchSize, MaxPropagationBatchSize); err != nil {
+				return fmt.Errorf("propagationBatchSize: %w", err)
+			}
+			return nil
+		}},
+		{&cfg.PropagationDelay, func(v int64) error {
+			if time.Duration(v)*time.Millisecond < 0 {
+				return fmt.Errorf("propagationDelay must be >= 0")
+			}
+			return nil
+		}},
+	}
+}
+
 // ValidateAsyncConfig is the single source of truth for the reject-set: it
 // runs at schema proposal time and asyncReplicationConfigFromModel delegates
 // to it, so the layers cannot drift. Sub-minimum frequencies are accepted
@@ -51,86 +140,34 @@ func ValidateAsyncConfig(cfg *models.ReplicationAsyncConfig) error {
 	if cfg == nil {
 		return nil
 	}
-
-	if cfg.HashtreeHeight != nil {
-		if err := validateIntRange(int(*cfg.HashtreeHeight), MinHashtreeHeight, MaxHashtreeHeight); err != nil {
-			return fmt.Errorf("hashtreeHeight: %w", err)
+	for _, fc := range fieldChecks(cfg) {
+		if *fc.ptr == nil {
+			continue
+		}
+		if err := fc.check(**fc.ptr); err != nil {
+			return err
 		}
 	}
-
-	if cfg.Frequency != nil {
-		if *cfg.Frequency < 0 {
-			return fmt.Errorf("frequency must be >= 0")
-		}
-		if *cfg.Frequency > MaxDurationMillis {
-			return fmt.Errorf("frequency too large: %d ms exceeds max %d ms", *cfg.Frequency, MaxDurationMillis)
-		}
-	}
-
-	if cfg.FrequencyWhilePropagating != nil {
-		if *cfg.FrequencyWhilePropagating < 0 {
-			return fmt.Errorf("frequencyWhilePropagating must be >= 0")
-		}
-		if *cfg.FrequencyWhilePropagating > MaxDurationMillis {
-			return fmt.Errorf("frequencyWhilePropagating too large: %d ms exceeds max %d ms", *cfg.FrequencyWhilePropagating, MaxDurationMillis)
-		}
-	}
-
-	if cfg.LoggingFrequency != nil {
-		if time.Duration(*cfg.LoggingFrequency)*time.Second <= 0 {
-			return fmt.Errorf("loggingFrequency must be > 0")
-		}
-	}
-
-	if cfg.DiffBatchSize != nil {
-		if err := validateIntRange(int(*cfg.DiffBatchSize), MinDiffBatchSize, MaxDiffBatchSize); err != nil {
-			return fmt.Errorf("diffBatchSize: %w", err)
-		}
-	}
-
-	if cfg.DiffPerNodeTimeout != nil {
-		if time.Duration(*cfg.DiffPerNodeTimeout)*time.Second <= 0 {
-			return fmt.Errorf("diffPerNodeTimeout must be > 0")
-		}
-	}
-
-	if cfg.PrePropagationTimeout != nil {
-		if time.Duration(*cfg.PrePropagationTimeout)*time.Second <= 0 {
-			return fmt.Errorf("prePropagationTimeout must be > 0")
-		}
-	}
-
-	if cfg.PropagationTimeout != nil {
-		if time.Duration(*cfg.PropagationTimeout)*time.Second <= 0 {
-			return fmt.Errorf("propagationTimeout must be > 0")
-		}
-	}
-
-	if cfg.PropagationLimit != nil {
-		if err := validateIntRange(int(*cfg.PropagationLimit), MinPropagationLimit, MaxPropagationLimit); err != nil {
-			return fmt.Errorf("propagationLimit: %w", err)
-		}
-	}
-
-	if cfg.PropagationConcurrency != nil {
-		if err := validateIntRange(int(*cfg.PropagationConcurrency), MinPropagationConcurrency, MaxPropagationConcurrency); err != nil {
-			return fmt.Errorf("propagationConcurrency: %w", err)
-		}
-	}
-
-	if cfg.PropagationBatchSize != nil {
-		if err := validateIntRange(int(*cfg.PropagationBatchSize), MinPropagationBatchSize, MaxPropagationBatchSize); err != nil {
-			return fmt.Errorf("propagationBatchSize: %w", err)
-		}
-	}
-
-	if cfg.PropagationDelay != nil {
-		if time.Duration(*cfg.PropagationDelay)*time.Millisecond < 0 {
-			return fmt.Errorf("propagationDelay must be >= 0")
-		}
-	}
-
 	return nil
+}
+
+// SanitizeAsyncConfig returns a copy of cfg with each invalid field cleared (falling back to its default), keeping valid siblings, plus the dropped fields' errors.
+func SanitizeAsyncConfig(cfg *models.ReplicationAsyncConfig) (*models.ReplicationAsyncConfig, []error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	sanitized := *cfg
+	var dropped []error
+	for _, fc := range fieldChecks(&sanitized) {
+		if *fc.ptr == nil {
+			continue
+		}
+		if err := fc.check(**fc.ptr); err != nil {
+			dropped = append(dropped, err)
+			*fc.ptr = nil
+		}
+	}
+	return &sanitized, dropped
 }
 
 func validateIntRange(val, minVal, maxVal int) error {

--- a/entities/replication/async_config_validation.go
+++ b/entities/replication/async_config_validation.go
@@ -1,0 +1,141 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// Bounds for per-class async-replication schema values; the db layer also
+// uses them to clamp global runtime-config values.
+const (
+	MinHashtreeHeight = 0
+	MaxHashtreeHeight = 20
+
+	MinDiffBatchSize = 1
+	MaxDiffBatchSize = 10_000
+
+	MinPropagationLimit = 1
+	MaxPropagationLimit = 100_000
+
+	MinPropagationConcurrency = 1
+	MaxPropagationConcurrency = 20
+
+	MinPropagationBatchSize = 1
+	MaxPropagationBatchSize = 1_000
+)
+
+// MaxDurationMillis is the largest millisecond value that fits in a
+// time.Duration without wrapping.
+const MaxDurationMillis = int64(math.MaxInt64 / int64(time.Millisecond))
+
+// ValidateAsyncConfig is the single source of truth for the reject-set: it
+// runs at schema proposal time and asyncReplicationConfigFromModel delegates
+// to it, so the layers cannot drift. Sub-minimum frequencies are accepted
+// (the db layer clamps them), and duration fields are checked after
+// conversion so overflowed values stay rejected.
+func ValidateAsyncConfig(cfg *models.ReplicationAsyncConfig) error {
+	if cfg == nil {
+		return nil
+	}
+
+	if cfg.HashtreeHeight != nil {
+		if err := validateIntRange(int(*cfg.HashtreeHeight), MinHashtreeHeight, MaxHashtreeHeight); err != nil {
+			return fmt.Errorf("hashtreeHeight: %w", err)
+		}
+	}
+
+	if cfg.Frequency != nil {
+		if *cfg.Frequency < 0 {
+			return fmt.Errorf("frequency must be >= 0")
+		}
+		if *cfg.Frequency > MaxDurationMillis {
+			return fmt.Errorf("frequency too large: %d ms exceeds max %d ms", *cfg.Frequency, MaxDurationMillis)
+		}
+	}
+
+	if cfg.FrequencyWhilePropagating != nil {
+		if *cfg.FrequencyWhilePropagating < 0 {
+			return fmt.Errorf("frequencyWhilePropagating must be >= 0")
+		}
+		if *cfg.FrequencyWhilePropagating > MaxDurationMillis {
+			return fmt.Errorf("frequencyWhilePropagating too large: %d ms exceeds max %d ms", *cfg.FrequencyWhilePropagating, MaxDurationMillis)
+		}
+	}
+
+	if cfg.LoggingFrequency != nil {
+		if time.Duration(*cfg.LoggingFrequency)*time.Second <= 0 {
+			return fmt.Errorf("loggingFrequency must be > 0")
+		}
+	}
+
+	if cfg.DiffBatchSize != nil {
+		if err := validateIntRange(int(*cfg.DiffBatchSize), MinDiffBatchSize, MaxDiffBatchSize); err != nil {
+			return fmt.Errorf("diffBatchSize: %w", err)
+		}
+	}
+
+	if cfg.DiffPerNodeTimeout != nil {
+		if time.Duration(*cfg.DiffPerNodeTimeout)*time.Second <= 0 {
+			return fmt.Errorf("diffPerNodeTimeout must be > 0")
+		}
+	}
+
+	if cfg.PrePropagationTimeout != nil {
+		if time.Duration(*cfg.PrePropagationTimeout)*time.Second <= 0 {
+			return fmt.Errorf("prePropagationTimeout must be > 0")
+		}
+	}
+
+	if cfg.PropagationTimeout != nil {
+		if time.Duration(*cfg.PropagationTimeout)*time.Second <= 0 {
+			return fmt.Errorf("propagationTimeout must be > 0")
+		}
+	}
+
+	if cfg.PropagationLimit != nil {
+		if err := validateIntRange(int(*cfg.PropagationLimit), MinPropagationLimit, MaxPropagationLimit); err != nil {
+			return fmt.Errorf("propagationLimit: %w", err)
+		}
+	}
+
+	if cfg.PropagationConcurrency != nil {
+		if err := validateIntRange(int(*cfg.PropagationConcurrency), MinPropagationConcurrency, MaxPropagationConcurrency); err != nil {
+			return fmt.Errorf("propagationConcurrency: %w", err)
+		}
+	}
+
+	if cfg.PropagationBatchSize != nil {
+		if err := validateIntRange(int(*cfg.PropagationBatchSize), MinPropagationBatchSize, MaxPropagationBatchSize); err != nil {
+			return fmt.Errorf("propagationBatchSize: %w", err)
+		}
+	}
+
+	if cfg.PropagationDelay != nil {
+		if time.Duration(*cfg.PropagationDelay)*time.Millisecond < 0 {
+			return fmt.Errorf("propagationDelay must be >= 0")
+		}
+	}
+
+	return nil
+}
+
+func validateIntRange(val, minVal, maxVal int) error {
+	if val < minVal || val > maxVal {
+		return fmt.Errorf("value %d out of range: min %d, max %d", val, minVal, maxVal)
+	}
+	return nil
+}

--- a/entities/replication/async_config_validation_test.go
+++ b/entities/replication/async_config_validation_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -84,4 +85,62 @@ func TestValidateAsyncConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSanitizeAsyncConfig(t *testing.T) {
+	i64 := func(v int64) *int64 { return &v }
+
+	tests := []struct {
+		name        string
+		cfg         *models.ReplicationAsyncConfig
+		want        *models.ReplicationAsyncConfig
+		wantDropped []string
+	}{
+		{name: "nil config"},
+		{name: "empty config", cfg: &models.ReplicationAsyncConfig{}, want: &models.ReplicationAsyncConfig{}},
+		{
+			name: "all valid untouched",
+			cfg:  &models.ReplicationAsyncConfig{HashtreeHeight: i64(12), Frequency: i64(30_000), PropagationConcurrency: i64(5)},
+			want: &models.ReplicationAsyncConfig{HashtreeHeight: i64(12), Frequency: i64(30_000), PropagationConcurrency: i64(5)},
+		},
+		{
+			name:        "invalid frequency dropped, valid height kept",
+			cfg:         &models.ReplicationAsyncConfig{HashtreeHeight: i64(12), Frequency: i64(-1)},
+			want:        &models.ReplicationAsyncConfig{HashtreeHeight: i64(12)},
+			wantDropped: []string{"frequency must be >= 0"},
+		},
+		{
+			name:        "multiple invalid dropped in field order, valid kept",
+			cfg:         &models.ReplicationAsyncConfig{HashtreeHeight: i64(99), Frequency: i64(-1), LoggingFrequency: i64(0), PropagationConcurrency: i64(5)},
+			want:        &models.ReplicationAsyncConfig{PropagationConcurrency: i64(5)},
+			wantDropped: []string{"hashtreeHeight: value 99 out of range: min 0, max 20", "frequency must be >= 0", "loggingFrequency must be > 0"},
+		},
+		{
+			name:        "frequency overflow dropped",
+			cfg:         &models.ReplicationAsyncConfig{Frequency: i64(MaxDurationMillis + 1)},
+			want:        &models.ReplicationAsyncConfig{},
+			wantDropped: []string{"frequency too large"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sanitized, dropped := SanitizeAsyncConfig(tt.cfg)
+			assert.Equal(t, tt.want, sanitized)
+			require.Len(t, dropped, len(tt.wantDropped))
+			for i, wantErr := range tt.wantDropped {
+				assert.ErrorContains(t, dropped[i], wantErr)
+			}
+			assert.NoError(t, ValidateAsyncConfig(sanitized))
+		})
+	}
+}
+
+func TestSanitizeAsyncConfigDoesNotMutateInput(t *testing.T) {
+	freq := int64(-1)
+	cfg := &models.ReplicationAsyncConfig{Frequency: &freq}
+	_, dropped := SanitizeAsyncConfig(cfg)
+	require.Len(t, dropped, 1)
+	require.NotNil(t, cfg.Frequency)
+	require.Equal(t, int64(-1), *cfg.Frequency)
 }

--- a/entities/replication/async_config_validation_test.go
+++ b/entities/replication/async_config_validation_test.go
@@ -1,0 +1,87 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestValidateAsyncConfig(t *testing.T) {
+	i64 := func(v int64) *int64 { return &v }
+
+	tests := []struct {
+		name    string
+		cfg     *models.ReplicationAsyncConfig
+		wantErr string
+	}{
+		{name: "nil config", cfg: nil},
+		{name: "empty config", cfg: &models.ReplicationAsyncConfig{}},
+		{name: "all fields valid", cfg: &models.ReplicationAsyncConfig{
+			HashtreeHeight:            i64(16),
+			Frequency:                 i64(30_000),
+			FrequencyWhilePropagating: i64(10_000),
+			LoggingFrequency:          i64(5),
+			DiffBatchSize:             i64(1_000),
+			DiffPerNodeTimeout:        i64(10),
+			PrePropagationTimeout:     i64(60),
+			PropagationTimeout:        i64(30),
+			PropagationLimit:          i64(10_000),
+			PropagationConcurrency:    i64(5),
+			PropagationBatchSize:      i64(100),
+			PropagationDelay:          i64(30_000),
+		}},
+		{name: "below-min frequency accepted (clamped later)", cfg: &models.ReplicationAsyncConfig{Frequency: i64(100)}},
+		{name: "below-min frequencyWhilePropagating accepted (clamped later)", cfg: &models.ReplicationAsyncConfig{FrequencyWhilePropagating: i64(500)}},
+		{name: "zero frequency accepted", cfg: &models.ReplicationAsyncConfig{Frequency: i64(0)}},
+		{name: "zero propagationDelay accepted", cfg: &models.ReplicationAsyncConfig{PropagationDelay: i64(0)}},
+
+		{name: "hashtreeHeight negative", cfg: &models.ReplicationAsyncConfig{HashtreeHeight: i64(-1)}, wantErr: "hashtreeHeight: value -1 out of range: min 0, max 20"},
+		{name: "hashtreeHeight above max", cfg: &models.ReplicationAsyncConfig{HashtreeHeight: i64(21)}, wantErr: "hashtreeHeight: value 21 out of range: min 0, max 20"},
+		{name: "frequency negative", cfg: &models.ReplicationAsyncConfig{Frequency: i64(-1)}, wantErr: "frequency must be >= 0"},
+		{name: "frequency overflow", cfg: &models.ReplicationAsyncConfig{Frequency: i64(MaxDurationMillis + 1)}, wantErr: "frequency too large"},
+		{name: "frequencyWhilePropagating negative", cfg: &models.ReplicationAsyncConfig{FrequencyWhilePropagating: i64(-1)}, wantErr: "frequencyWhilePropagating must be >= 0"},
+		{name: "frequencyWhilePropagating overflow", cfg: &models.ReplicationAsyncConfig{FrequencyWhilePropagating: i64(MaxDurationMillis + 1)}, wantErr: "frequencyWhilePropagating too large"},
+		{name: "loggingFrequency zero", cfg: &models.ReplicationAsyncConfig{LoggingFrequency: i64(0)}, wantErr: "loggingFrequency must be > 0"},
+		{name: "loggingFrequency negative", cfg: &models.ReplicationAsyncConfig{LoggingFrequency: i64(-5)}, wantErr: "loggingFrequency must be > 0"},
+		{name: "loggingFrequency duration overflow", cfg: &models.ReplicationAsyncConfig{LoggingFrequency: i64(math.MaxInt64/int64(time.Second) + 1)}, wantErr: "loggingFrequency must be > 0"},
+		{name: "diffBatchSize zero", cfg: &models.ReplicationAsyncConfig{DiffBatchSize: i64(0)}, wantErr: "diffBatchSize: value 0 out of range: min 1, max 10000"},
+		{name: "diffBatchSize above max", cfg: &models.ReplicationAsyncConfig{DiffBatchSize: i64(10_001)}, wantErr: "diffBatchSize: value 10001 out of range: min 1, max 10000"},
+		{name: "diffPerNodeTimeout zero", cfg: &models.ReplicationAsyncConfig{DiffPerNodeTimeout: i64(0)}, wantErr: "diffPerNodeTimeout must be > 0"},
+		{name: "diffPerNodeTimeout negative", cfg: &models.ReplicationAsyncConfig{DiffPerNodeTimeout: i64(-1)}, wantErr: "diffPerNodeTimeout must be > 0"},
+		{name: "prePropagationTimeout zero", cfg: &models.ReplicationAsyncConfig{PrePropagationTimeout: i64(0)}, wantErr: "prePropagationTimeout must be > 0"},
+		{name: "propagationTimeout zero", cfg: &models.ReplicationAsyncConfig{PropagationTimeout: i64(0)}, wantErr: "propagationTimeout must be > 0"},
+		{name: "propagationLimit zero", cfg: &models.ReplicationAsyncConfig{PropagationLimit: i64(0)}, wantErr: "propagationLimit: value 0 out of range: min 1, max 100000"},
+		{name: "propagationLimit above max", cfg: &models.ReplicationAsyncConfig{PropagationLimit: i64(100_001)}, wantErr: "propagationLimit: value 100001 out of range: min 1, max 100000"},
+		{name: "propagationConcurrency zero", cfg: &models.ReplicationAsyncConfig{PropagationConcurrency: i64(0)}, wantErr: "propagationConcurrency: value 0 out of range: min 1, max 20"},
+		{name: "propagationConcurrency above max", cfg: &models.ReplicationAsyncConfig{PropagationConcurrency: i64(21)}, wantErr: "propagationConcurrency: value 21 out of range: min 1, max 20"},
+		{name: "propagationBatchSize zero", cfg: &models.ReplicationAsyncConfig{PropagationBatchSize: i64(0)}, wantErr: "propagationBatchSize: value 0 out of range: min 1, max 1000"},
+		{name: "propagationBatchSize above max", cfg: &models.ReplicationAsyncConfig{PropagationBatchSize: i64(1_001)}, wantErr: "propagationBatchSize: value 1001 out of range: min 1, max 1000"},
+		{name: "propagationDelay negative", cfg: &models.ReplicationAsyncConfig{PropagationDelay: i64(-1)}, wantErr: "propagationDelay must be >= 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAsyncConfig(tt.cfg)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/usecases/schema/async_replication_config_validation_test.go
+++ b/usecases/schema/async_replication_config_validation_test.go
@@ -1,0 +1,103 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+)
+
+func Test_AddClass_AsyncReplicationConfigValidation(t *testing.T) {
+	i64 := func(v int64) *int64 { return &v }
+
+	tests := []struct {
+		name        string
+		asyncConfig *models.ReplicationAsyncConfig
+		wantErr     string
+	}{
+		{name: "valid asyncConfig accepted", asyncConfig: &models.ReplicationAsyncConfig{Frequency: i64(30_000)}},
+		{name: "nil asyncConfig accepted", asyncConfig: nil},
+		{name: "negative frequency rejected", asyncConfig: &models.ReplicationAsyncConfig{Frequency: i64(-1)}, wantErr: "async replication config: frequency must be >= 0"},
+		{name: "hashtreeHeight above max rejected", asyncConfig: &models.ReplicationAsyncConfig{HashtreeHeight: i64(99)}, wantErr: "async replication config: hashtreeHeight: value 99 out of range: min 0, max 20"},
+		{name: "propagationConcurrency above max rejected", asyncConfig: &models.ReplicationAsyncConfig{PropagationConcurrency: i64(21)}, wantErr: "async replication config: propagationConcurrency: value 21 out of range: min 1, max 20"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+			class := models.Class{
+				Class:             "NewClass",
+				Vectorizer:        "none",
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncConfig: tt.asyncConfig},
+			}
+			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
+			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
+			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
+			_, _, err := handler.AddClass(context.Background(), nil, &class)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_UpdateClass_AsyncReplicationConfigValidation(t *testing.T) {
+	i64 := func(v int64) *int64 { return &v }
+
+	tests := []struct {
+		name        string
+		asyncConfig *models.ReplicationAsyncConfig
+		wantErr     string
+	}{
+		{name: "valid asyncConfig accepted", asyncConfig: &models.ReplicationAsyncConfig{Frequency: i64(30_000)}},
+		{name: "negative frequency rejected", asyncConfig: &models.ReplicationAsyncConfig{Frequency: i64(-1)}, wantErr: "async replication config: frequency must be >= 0"},
+		{name: "hashtreeHeight above max rejected", asyncConfig: &models.ReplicationAsyncConfig{HashtreeHeight: i64(99)}, wantErr: "async replication config: hashtreeHeight: value 99 out of range: min 0, max 20"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+			initial := &models.Class{
+				Class:             "AsyncCfgClass",
+				Vectorizer:        "none",
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+			}
+			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
+			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
+			fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
+			fakeSchemaManager.On("ReadOnlyClass", "AsyncCfgClass", mock.Anything).Return(initial)
+			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
+			_, _, err := handler.AddClass(context.Background(), nil, initial)
+			require.NoError(t, err)
+
+			updated := &models.Class{
+				Class:             "AsyncCfgClass",
+				Vectorizer:        "none",
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncConfig: tt.asyncConfig},
+			}
+			err = handler.UpdateClass(context.Background(), nil, "AsyncCfgClass", updated)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -512,6 +512,12 @@ func UpdateClassInternal(h *Handler, ctx context.Context, className string, upda
 		return err
 	}
 
+	if updated.ReplicationConfig != nil {
+		if err := replication.ValidateAsyncConfig(updated.ReplicationConfig.AsyncConfig); err != nil {
+			return fmt.Errorf("async replication config: %w", err)
+		}
+	}
+
 	if ttlConfig, _, err := ttl.ValidateObjectTTLConfig(updated, true, h.config); err != nil {
 		return fmt.Errorf("ObjectTTLConfig: %w", err)
 	} else {
@@ -1079,6 +1085,12 @@ func (h *Handler) validateClassInvariants(
 
 	if err := replica.ValidateConfig(class, h.config.Replication); err != nil {
 		return err
+	}
+
+	if class.ReplicationConfig != nil {
+		if err := replication.ValidateAsyncConfig(class.ReplicationConfig.AsyncConfig); err != nil {
+			return fmt.Errorf("async replication config: %w", err)
+		}
 	}
 
 	if ttlConfig, needsInvertedIndexTimestamp, err := ttl.ValidateObjectTTLConfig(class, false, h.config); err != nil {


### PR DESCRIPTION
## Motivation

An invalid `asyncConfig` value (e.g. `frequency: -1`) sails through schema proposal validation, gets committed to the RAFT log, and only fails at every node's FSM apply. By then the damage is done twice over: `updateReplicationConfig` had already mutated `ReplicationFactor`/`DeletionStrategy` in memory before hitting the conversion error (torn config, no shard fan-out), and the poisoned class is persisted in the schema. On the next restart `db.init` hits the same conversion error and `openDatabase` panics — a crash loop with no self-service recovery, because the node can never start to accept a corrective `UpdateClass`.

## Approach

Four layered defenses, ordered from prevention to recovery:

1. **Single source of truth for the reject-set.** `entities/replication.ValidateAsyncConfig` owns all per-field rejection; the db layer's `asyncReplicationConfigFromModel` now delegates to it instead of duplicating checks. Proposal-time and apply-time rejection structurally cannot drift.
2. **Reject at proposal, not at apply.** `AddClass` and `UpdateClass` validate before RAFT append. Validation is deliberately proposer-only: rejecting at FSM apply would make mixed-version clusters diverge (old nodes apply what new nodes refuse).
3. **Convert before mutating.** `updateReplicationConfig` runs the conversion first, so an invalid config can no longer tear `ReplicationFactor`/`DeletionStrategy` on the error path. A nil `getClass()` now returns an error instead of panicking.
4. **Degrade per-field, don't crash-loop.** `db.init` and `Migrator.AddClass` fall back to defaults for the invalid fields (keeping valid siblings) with a loud `Error` log when a stored class config fails conversion, so clusters poisoned *before* this fix can start and repair their schema via the now-validated `UpdateClass`. The stored schema is untouched — only the in-memory runtime config is degraded.

The clamp-vs-reject split is preserved and documented on the validator: sub-minimum `frequency`/`frequencyWhilePropagating` are clamped with a warning (legacy collections must keep loading), everything else out-of-range is rejected, and duration fields are checked on the converted `time.Duration` so huge second values that overflow negative stay rejected.

## Rebase notes

Originally stacked on #12259; that fix was superseded by #12195 and this PR now sits directly on the release branch. Two adjustments beyond conflict resolution:

- `maxHashtreeHeight` had meanwhile become `hashtree.MaxHeight` (#12195's deserialization bound). The db layer now uses the validator's `MaxHashtreeHeight`, with a compile-time assertion tying the two bounds together (`entities/` cannot import the hashtree package).
- The test fixture passes the `namespaces.Exister` parameter `db.New` gained in the meantime.

## Key areas for review

- `entities/replication/async_config_validation.go` — verify the reject-set is exactly the old per-field checks from `asyncReplicationConfigFromModel`, no field silently loosened or tightened (the overflow checks on converted durations are the subtle part)
- `adapters/repos/db/index.go` `updateReplicationConfig` — convert-before-mutate ordering and the nil-class guard; the lock-scoping around the shard fan-out is #12195's and is unchanged
- `adapters/repos/db/init.go` / `adapters/repos/db/migrator.go` — the per-field degrade fallback changes startup behavior for already-poisoned schemas; confirm the fallback itself cannot fail for a nil config
- `usecases/schema/class.go` — both proposer entry points are covered (`validateClassInvariants` for AddClass, `UpdateClassInternal` for UpdateClass)

## Risks and mitigations

- **Mixed-version divergence**: validation runs only on the proposer; FSM apply semantics are unchanged, so nodes on either version apply committed entries identically.
- **Startup fallback masks operator intent**: a poisoned class now runs with default async settings for the invalid fields instead of aborting startup. The previous "intent" was an invalid value that produced a crash loop; the fallback logs at Error level and the schema remains repairable.
- **Reject-set drift between layers**: eliminated structurally — the db layer calls the same validator the proposer does.
- **Previously-accepted API requests now rejected**: those requests never actually succeeded — they poisoned the cluster at apply time. Failing them fast with a field-specific error is the fix, not a regression.

## Testing

- `entities/replication/async_config_validation_test.go` — table-driven accept/reject matrix per field: zero-vs-negative boundaries, min/max range edges, `MaxDurationMillis` overflow for millisecond fields, second-conversion overflow for `loggingFrequency`, and clamp-not-reject acceptance of sub-minimum frequencies
- `usecases/schema/async_replication_config_validation_test.go` — AddClass and UpdateClass reject invalid `asyncConfig` before RAFT append, with valid/nil configs still accepted
- `adapters/repos/db/index_replication_config_validation_test.go` — invalid config leaves `ReplicationFactor`/`DeletionStrategy`/async config completely untouched (the torn-config regression), valid config applies, `db.init` starts successfully with a poisoned stored config by degrading only the invalid fields, and `Migrator.AddClass` degrades instead of failing class creation
- Red phase re-verified after the rebase: with the convert-before-mutate reorder reverted, the torn-config test fails on the leaked `ReplicationFactor`; with the fix it passes
- Post-rebase: full `usecases/schema` and `entities/replication` suites plus the targeted db config/deadlock/clamp tests (including #12195's `TestUpdateReplicationConfig_*`, reconcile-deadlock, stale-fan-out, and clamp-warner tests) pass with `-race`; `golangci-lint` and the goroutine linter are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
