### PR TITLE
fix(reindex): return 202 NO_OP, not 500, when cancel loses list→apply race

### DIFF
--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -847,14 +847,9 @@ func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, pro
 	})
 }
 
-// cancelApplyErrorResponse maps a cancel-apply failure to HTTP. If the task
-// left STARTED (finished/cancelled/failed → ErrTaskNotRunning) or its
-// versioned entry was removed (cleaned up/superseded → ErrTaskDoesNotExist)
-// between the task-list read above and this apply — the list-read→apply race
-// — there is nothing left to cancel, so it is a no-op (202 NO_OP), not a 500,
-// per the reindex GA RFC §1.8. These are the only two permanent sentinels
-// CancelTask can return; transient failures (RAFT unavailable, ctx cancelled)
-// stay 500.
+// cancelApplyErrorResponse: ErrTaskNotRunning/ErrTaskDoesNotExist mean the
+// task already finished or was removed before this apply (list→apply race),
+// so that's a no-op (202), not a 500.
 func (h *indexesHandlers) cancelApplyErrorResponse(
 	err error, principal *models.Principal, collection, propertyName, indexType string,
 ) middleware.Responder {

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -44,15 +44,8 @@ func setupIndexesHandlers(api *operations.WeaviateAPI, appState *state.State) {
 	api.SchemaSchemaObjectsIndexesUpdateHandler = schema.SchemaObjectsIndexesUpdateHandlerFunc(h.updateIndex)
 }
 
-// reindexTaskCanceler is the narrow cluster-service surface
-// cancelReindexTask depends on: enumerate the in-flight distributed tasks
-// and apply a cancel for the matched one. The handler consumes the
-// interface (rather than reaching through appState.ClusterService) so the
-// list→apply race mapping is exercisable without a live RAFT cluster: a
-// cancel that loses to the task finishing (ErrTaskNotRunning /
-// ErrTaskDoesNotExist) is a 202 NO_OP, not a 500. Implemented in
-// production by the RAFT-backed distributed-task state (cluster/raft.Raft),
-// mirroring [reindexInFlightChecker].
+// reindexTaskCanceler abstracts the cluster service so cancelReindexTask's
+// list→apply race handling is testable without a live RAFT cluster.
 type reindexTaskCanceler interface {
 	ListDistributedTasks(ctx context.Context) (map[string][]*distributedtask.Task, error)
 	CancelDistributedTask(ctx context.Context, namespace, taskID string, taskVersion uint64) error

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -748,8 +748,7 @@ func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, pro
 	if err := h.appState.ClusterService.CancelDistributedTask(
 		ctx, target.Namespace, target.ID, target.Version,
 	); err != nil {
-		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errorResponse(principal,
-			fmt.Sprintf("cancelling task: %v", err)))
+		return h.cancelApplyErrorResponse(err, principal, collection, propertyName, indexType)
 	}
 
 	// Drain the local reindex goroutine BEFORE cleaning partial on-disk
@@ -846,6 +845,34 @@ func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, pro
 		TaskID: namespacing.StripOwnNamespace(principal, target.ID),
 		Status: "CANCELLED",
 	})
+}
+
+// cancelApplyErrorResponse maps a cancel-apply failure to HTTP. If the task
+// left STARTED (finished/cancelled/failed → ErrTaskNotRunning) or its
+// versioned entry was removed (cleaned up/superseded → ErrTaskDoesNotExist)
+// between the task-list read above and this apply — the list-read→apply race
+// — there is nothing left to cancel, so it is a no-op (202 NO_OP), not a 500,
+// per the reindex GA RFC §1.8. These are the only two permanent sentinels
+// CancelTask can return; transient failures (RAFT unavailable, ctx cancelled)
+// stay 500.
+func (h *indexesHandlers) cancelApplyErrorResponse(
+	err error, principal *models.Principal, collection, propertyName, indexType string,
+) middleware.Responder {
+	if errors.Is(err, distributedtask.ErrTaskNotRunning) ||
+		errors.Is(err, distributedtask.ErrTaskDoesNotExist) {
+		h.appState.Logger.WithFields(logrus.Fields{
+			"audit_event": "reindex_task_cancel_noop",
+			"collection":  collection,
+			"property":    propertyName,
+			"index_type":  indexType,
+			"principal":   principalUsername(principal),
+		}).Infof("cancel: task no longer running when applying cancel (%v); returning NO_OP", err)
+		return schema.NewSchemaObjectsIndexesUpdateAccepted().WithPayload(&models.IndexUpdateResponse{
+			Status: reindexCancelStatusNoOp,
+		})
+	}
+	return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errorResponse(principal,
+		fmt.Sprintf("cancelling task: %v", err)))
 }
 
 // reindexCancelStatusNoOp is the IndexUpdateResponse.Status value the

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -39,13 +39,28 @@ import (
 )
 
 func setupIndexesHandlers(api *operations.WeaviateAPI, appState *state.State) {
-	h := &indexesHandlers{appState: appState}
+	h := &indexesHandlers{appState: appState, clusterTasks: appState.ClusterService.Raft}
 	api.SchemaSchemaObjectsIndexesGetHandler = schema.SchemaObjectsIndexesGetHandlerFunc(h.getIndexes)
 	api.SchemaSchemaObjectsIndexesUpdateHandler = schema.SchemaObjectsIndexesUpdateHandlerFunc(h.updateIndex)
 }
 
+// reindexTaskCanceler is the narrow cluster-service surface
+// cancelReindexTask depends on: enumerate the in-flight distributed tasks
+// and apply a cancel for the matched one. The handler consumes the
+// interface (rather than reaching through appState.ClusterService) so the
+// list→apply race mapping is exercisable without a live RAFT cluster: a
+// cancel that loses to the task finishing (ErrTaskNotRunning /
+// ErrTaskDoesNotExist) is a 202 NO_OP, not a 500. Implemented in
+// production by the RAFT-backed distributed-task state (cluster/raft.Raft),
+// mirroring [reindexInFlightChecker].
+type reindexTaskCanceler interface {
+	ListDistributedTasks(ctx context.Context) (map[string][]*distributedtask.Task, error)
+	CancelDistributedTask(ctx context.Context, namespace, taskID string, taskVersion uint64) error
+}
+
 type indexesHandlers struct {
-	appState *state.State
+	appState     *state.State
+	clusterTasks reindexTaskCanceler
 }
 
 // submitLock returns the per-(collection, property) mutex for the
@@ -691,12 +706,12 @@ func requestedCancel(body *models.IndexUpdateRequest) (string, bool) {
 // ctx via runningHandles) is then cancelled, and the worker goroutine
 // returns.
 func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, propertyName, indexType string, principal *models.Principal) middleware.Responder {
-	if h.appState.ClusterService == nil {
+	if h.clusterTasks == nil {
 		return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(principal,
 			"cluster service unavailable; cannot cancel reindex task"))
 	}
 
-	tasks, err := h.appState.ClusterService.ListDistributedTasks(ctx)
+	tasks, err := h.clusterTasks.ListDistributedTasks(ctx)
 	if err != nil {
 		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errorResponse(principal,
 			fmt.Sprintf("listing tasks: %v", err)))
@@ -745,7 +760,7 @@ func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, pro
 		})
 	}
 
-	if err := h.appState.ClusterService.CancelDistributedTask(
+	if err := h.clusterTasks.CancelDistributedTask(
 		ctx, target.Namespace, target.ID, target.Version,
 	); err != nil {
 		return h.cancelApplyErrorResponse(err, principal, collection, propertyName, indexType)

--- a/adapters/handlers/rest/handlers_indexes_cancel_race_test.go
+++ b/adapters/handlers/rest/handlers_indexes_cancel_race_test.go
@@ -27,21 +27,15 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// TestCancelReindexTask_ListToApplyRace pins the reindex-cancel race: the
-// handler reads the task list (sees the target STARTED), the task flips to a
-// terminal state, and the cancel apply then fails with a permanent FSM
-// rejection. Per reindex GA RFC §1.8 "already finished" must be 202 NO_OP,
-// not 500 (which is reserved for genuine internal errors).
-//
-// The errors below reproduce exactly what ClusterService.CancelDistributedTask
-// returns to the handler: applyDistributedTaskCommand runs
-// RehydratePermanentRejection over the apply error and wraps it in
-// "executing command: %w", so the sentinel is errors.Is-matchable on both the
-// local-leader (raw wrapped) and remote-leader (marker-rehydrated) paths.
+// TestCancelReindexTask_ListToApplyRace pins: cancel apply failing with
+// ErrTaskNotRunning/ErrTaskDoesNotExist (list→apply race) must be 202 NO_OP,
+// not 500.
 func TestCancelReindexTask_ListToApplyRace(t *testing.T) {
 	h := &indexesHandlers{appState: &state.State{Logger: logrus.New()}}
 	principal := &models.Principal{Username: "u1"}
 
+	// remote mimics the wrapped+rehydrated error shape a remote-leader RPC
+	// returns, so the sentinel is still errors.Is-matchable.
 	remote := func(marker string) error {
 		return fmt.Errorf("executing command: %w",
 			distributedtask.RehydratePermanentRejection(
@@ -71,9 +65,6 @@ func TestCancelReindexTask_ListToApplyRace(t *testing.T) {
 			wantNoOp: true,
 		},
 		{
-			// Same list→apply window: the versioned task was cleaned up or
-			// superseded, so CancelTask's findVersionedTaskWithLock returns
-			// ErrTaskDoesNotExist — still "nothing to cancel", still NO_OP.
 			name:     "remote-leader rehydrated ErrTaskDoesNotExist",
 			err:      remote("[dtm-perm/task-not-exist] task ns/t/3 does not exist"),
 			wantNoOp: true,

--- a/adapters/handlers/rest/handlers_indexes_cancel_race_test.go
+++ b/adapters/handlers/rest/handlers_indexes_cancel_race_test.go
@@ -1,0 +1,106 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/status"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// TestCancelReindexTask_ListToApplyRace pins the reindex-cancel race: the
+// handler reads the task list (sees the target STARTED), the task flips to a
+// terminal state, and the cancel apply then fails with a permanent FSM
+// rejection. Per reindex GA RFC §1.8 "already finished" must be 202 NO_OP,
+// not 500 (which is reserved for genuine internal errors).
+//
+// The errors below reproduce exactly what ClusterService.CancelDistributedTask
+// returns to the handler: applyDistributedTaskCommand runs
+// RehydratePermanentRejection over the apply error and wraps it in
+// "executing command: %w", so the sentinel is errors.Is-matchable on both the
+// local-leader (raw wrapped) and remote-leader (marker-rehydrated) paths.
+func TestCancelReindexTask_ListToApplyRace(t *testing.T) {
+	h := &indexesHandlers{appState: &state.State{Logger: logrus.New()}}
+	principal := &models.Principal{Username: "u1"}
+
+	remote := func(marker string) error {
+		return fmt.Errorf("executing command: %w",
+			distributedtask.RehydratePermanentRejection(
+				status.Error(distributedtask.PermanentRejectionRPCCode, marker)))
+	}
+
+	tests := []struct {
+		name     string
+		err      error
+		wantNoOp bool
+	}{
+		{
+			name:     "raw ErrTaskNotRunning (local leader, unwrapped)",
+			err:      distributedtask.ErrTaskNotRunning,
+			wantNoOp: true,
+		},
+		{
+			name: "local-leader wrapped permanent rejection",
+			err: fmt.Errorf("executing command: %w",
+				fmt.Errorf("[dtm-perm/task-not-running] task ns/t/3 is no longer running: %w",
+					errors.Join(distributedtask.ErrTaskNotRunning, distributedtask.ErrPermanentRejection))),
+			wantNoOp: true,
+		},
+		{
+			name:     "remote-leader rehydrated ErrTaskNotRunning",
+			err:      remote("[dtm-perm/task-not-running] task ns/t/3 is no longer running"),
+			wantNoOp: true,
+		},
+		{
+			// Same list→apply window: the versioned task was cleaned up or
+			// superseded, so CancelTask's findVersionedTaskWithLock returns
+			// ErrTaskDoesNotExist — still "nothing to cancel", still NO_OP.
+			name:     "remote-leader rehydrated ErrTaskDoesNotExist",
+			err:      remote("[dtm-perm/task-not-exist] task ns/t/3 does not exist"),
+			wantNoOp: true,
+		},
+		{
+			name:     "transient RAFT error stays 500",
+			err:      errors.New("raft: leadership lost while committing log"),
+			wantNoOp: false,
+		},
+		{
+			name:     "context cancelled stays 500",
+			err:      context.Canceled,
+			wantNoOp: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := h.cancelApplyErrorResponse(tt.err, principal, "C", "title", "searchable")
+			if tt.wantNoOp {
+				accepted, ok := resp.(*schema.SchemaObjectsIndexesUpdateAccepted)
+				require.Truef(t, ok, "want 202 Accepted NO_OP, got %T", resp)
+				require.Equal(t, reindexCancelStatusNoOp, accepted.Payload.Status)
+			} else {
+				_, ok := resp.(*schema.SchemaObjectsIndexesUpdateInternalServerError)
+				require.Truef(t, ok, "want 500 InternalServerError, got %T", resp)
+			}
+		})
+	}
+}

--- a/adapters/handlers/rest/handlers_indexes_cancel_wiring_test.go
+++ b/adapters/handlers/rest/handlers_indexes_cancel_wiring_test.go
@@ -1,0 +1,97 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// fakeClusterTaskCanceler surfaces one matching STARTED task, then fails the
+// cancel apply with a caller-supplied error — driving cancelReindexTask's
+// list→apply path.
+type fakeClusterTaskCanceler struct {
+	tasks     map[string][]*distributedtask.Task
+	cancelErr error
+}
+
+func (f fakeClusterTaskCanceler) ListDistributedTasks(context.Context) (map[string][]*distributedtask.Task, error) {
+	return f.tasks, nil
+}
+
+func (f fakeClusterTaskCanceler) CancelDistributedTask(context.Context, string, string, uint64) error {
+	return f.cancelErr
+}
+
+// TestCancelReindexTask_ApplyRaceWiring pins the call-site that hands a failed
+// cancel apply to cancelApplyErrorResponse: driving the real handler (not the
+// helper), a cancel that loses the list→apply race (ErrTaskNotRunning /
+// ErrTaskDoesNotExist) must yield 202 NO_OP, a successful cancel 202 CANCELLED,
+// and a transient error 500. The sibling TestCancelReindexTask_ListToApplyRace
+// calls cancelApplyErrorResponse directly, so reverting the wiring back to an
+// inline 500 would compile-pass there; this test catches that revert
+// behaviorally.
+func TestCancelReindexTask_ApplyRaceWiring(t *testing.T) {
+	payload := db.ReindexTaskPayload{
+		MigrationType: db.ReindexTypeChangeTokenization,
+		Collection:    "C",
+		Properties:    []string{"title"},
+	}
+
+	tests := []struct {
+		name       string
+		cancelErr  error
+		wantAccept bool   // true => 202 Accepted; false => 500
+		wantStatus string // asserted Payload.Status when wantAccept
+	}{
+		{"apply race ErrTaskNotRunning -> 202 NO_OP", distributedtask.ErrTaskNotRunning, true, reindexCancelStatusNoOp},
+		{"apply race ErrTaskDoesNotExist -> 202 NO_OP", distributedtask.ErrTaskDoesNotExist, true, reindexCancelStatusNoOp},
+		{"successful cancel -> 202 CANCELLED", nil, true, "CANCELLED"},
+		{"transient raft error -> 500", errors.New("raft: leadership lost while committing log"), false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &indexesHandlers{
+				appState: &state.State{Logger: logrus.New()},
+				clusterTasks: fakeClusterTaskCanceler{
+					tasks: map[string][]*distributedtask.Task{
+						db.ReindexNamespace: {buildTask(t, "t1", distributedtask.TaskStatusStarted, payload, nil)},
+					},
+					cancelErr: tt.cancelErr,
+				},
+			}
+
+			resp := h.cancelReindexTask(context.Background(), "C", "title", "searchable",
+				&models.Principal{Username: "u1"})
+
+			if tt.wantAccept {
+				accepted, ok := resp.(*schema.SchemaObjectsIndexesUpdateAccepted)
+				require.Truef(t, ok, "want 202 Accepted, got %T", resp)
+				require.Equal(t, tt.wantStatus, accepted.Payload.Status)
+			} else {
+				_, ok := resp.(*schema.SchemaObjectsIndexesUpdateInternalServerError)
+				require.Truef(t, ok, "want 500 InternalServerError, got %T", resp)
+			}
+		})
+	}
+}

--- a/adapters/handlers/rest/handlers_indexes_cancel_wiring_test.go
+++ b/adapters/handlers/rest/handlers_indexes_cancel_wiring_test.go
@@ -26,9 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// fakeClusterTaskCanceler surfaces one matching STARTED task, then fails the
-// cancel apply with a caller-supplied error — driving cancelReindexTask's
-// list→apply path.
+// fakeClusterTaskCanceler is a scriptable reindexTaskCanceler test double.
 type fakeClusterTaskCanceler struct {
 	tasks     map[string][]*distributedtask.Task
 	cancelErr error
@@ -42,14 +40,8 @@ func (f fakeClusterTaskCanceler) CancelDistributedTask(context.Context, string, 
 	return f.cancelErr
 }
 
-// TestCancelReindexTask_ApplyRaceWiring pins the call-site that hands a failed
-// cancel apply to cancelApplyErrorResponse: driving the real handler (not the
-// helper), a cancel that loses the list→apply race (ErrTaskNotRunning /
-// ErrTaskDoesNotExist) must yield 202 NO_OP, a successful cancel 202 CANCELLED,
-// and a transient error 500. The sibling TestCancelReindexTask_ListToApplyRace
-// calls cancelApplyErrorResponse directly, so reverting the wiring back to an
-// inline 500 would compile-pass there; this test catches that revert
-// behaviorally.
+// TestCancelReindexTask_ApplyRaceWiring pins: cancelReindexTask must route a
+// failed cancel apply through cancelApplyErrorResponse, not an inline 500.
 func TestCancelReindexTask_ApplyRaceWiring(t *testing.T) {
 	payload := db.ReindexTaskPayload{
 		MigrationType: db.ReindexTypeChangeTokenization,


### PR DESCRIPTION
SuperClaude here.

Pre-existing bug on `stable/v1.38` (not from the reindex-GA-API work): the reindex cancel endpoint returns **500** instead of **202 `{"status":"NO_OP"}`** when the target task finishes between the handler's task-list read and the cancel apply.

Sequence: handler lists tasks (target STARTED) → task flips terminal → `CancelDistributedTask` apply fails with a permanent FSM rejection (`ErrTaskNotRunning`, or `ErrTaskDoesNotExist` if the versioned entry was cleaned up/superseded in the same window) → mapped unconditionally to 500. Per reindex GA RFC §1.8, "already finished" is a no-op (202 NO_OP); 500 is reserved for genuine internal errors.

Fix (`adapters/handlers/rest/handlers_indexes.go`): at the cancel-apply site, both permanent "nothing-to-cancel" sentinels map to NO_OP via `errors.Is`; transient failures (RAFT unavailable, ctx cancelled) still return 500. Table-driven test covers local-leader (raw + wrapped) and remote-leader (marker-rehydrated) forms of both sentinels plus the two genuine-500 cases — red without the fix, green with it.

Pre-existing since 3f6e94f23 / 6b4a41f25, independent of the 12252 branch. Found by QA Kimi (item 2 on weaviate/weaviate#12252).

— SuperClaude