### PR TITLE
fix(reindex): enforce per-collection reindex cap atomically at task-apply time

### DIFF
--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -610,15 +610,13 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		if err := h.appState.ClusterService.AddDistributedTaskWithGroupsBarrier(
 			ctx, db.ReindexNamespace, taskID, payload, unitSpecs, semantic,
 		); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(
-				errorResponse(principal, fmt.Sprintf("submitting task: %v", err)))
+			return submitTaskErrorResponder(principal, collection, err)
 		}
 	} else {
 		if err := h.appState.ClusterService.AddDistributedTaskWithBarrier(
 			ctx, db.ReindexNamespace, taskID, payload, unitIDs, semantic,
 		); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(
-				errorResponse(principal, fmt.Sprintf("submitting task: %v", err)))
+			return submitTaskErrorResponder(principal, collection, err)
 		}
 	}
 
@@ -1342,21 +1340,13 @@ func normalizeSearchableAlgorithm(s string) string {
 	return ""
 }
 
-// maxConcurrentReindexPerCollection caps how many STARTED reindex tasks
-// can target the same collection at once. Each task creates ingest +
-// backup buckets on every replica; without a cap, a script that runs
-// PUT /indexes/<prop> per property would fan out N tasks for an
-// N-property collection and overwhelm both LSM compaction and disk.
-//
-// The value is sized to comfortably accommodate realistic batch property
-// changes (e.g. retokenizing every text property on a ~20-property
-// collection in one go) while still preventing pathological unbounded
-// fan-out from a script that loops over hundreds of properties. The
-// original value of 4 was too restrictive: it rejected legitimate batch
-// migrations against modest-sized collections and broke the
-// reindex_concurrent acceptance test which exercises 15 simultaneous
-// non-conflicting submits.
-const maxConcurrentReindexPerCollection = 32
+// maxConcurrentReindexPerCollection caps how many concurrently active
+// reindex tasks can target the same collection at once. It aliases the
+// DTM-level constant: [distributedtask.Manager.AddTask] enforces the cap
+// atomically at apply time (a parallel submit burst defeats the pre-submit
+// check here), so both layers MUST reference the same value — see the
+// sizing rationale on [distributedtask.MaxConcurrentActiveTasksPerCollection].
+const maxConcurrentReindexPerCollection = distributedtask.MaxConcurrentActiveTasksPerCollection
 
 // reindexCapExceededResponder returns a 429 Too Many Requests response with
 // the standard ErrorResponse body shape. The swagger spec for
@@ -1381,6 +1371,25 @@ func reindexCapExceededResponder(principal *models.Principal, collection string,
 			panic(err)
 		}
 	})
+}
+
+// submitTaskErrorResponder maps a distributed-task submit failure to an HTTP
+// response. The DTM enforces the per-collection cap at apply time
+// ([distributedtask.Manager.AddTask]): a parallel submit burst can defeat
+// the pre-submit cap check above (every request counts in-flight tasks
+// before any of them has applied), so the FSM backstop rejects the over-cap
+// applies with [distributedtask.ErrTaskCapExceeded]. Map that rejection to
+// the same 429 the pre-check returns — one contract regardless of which
+// layer rejected. Every other submit failure keeps the generic 500 mapping.
+func submitTaskErrorResponder(principal *models.Principal, collection string, err error) middleware.Responder {
+	if errors.Is(err, distributedtask.ErrTaskCapExceeded) {
+		// The FSM only rejects at count >= cap, so cap is the truthful
+		// floor for the observed count in the response body.
+		return reindexCapExceededResponder(principal, collection,
+			maxConcurrentReindexPerCollection, maxConcurrentReindexPerCollection)
+	}
+	return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(
+		errorResponse(principal, fmt.Sprintf("submitting task: %v", err)))
 }
 
 // countStartedTasksForCollection counts in-flight reindex tasks for a

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -28,13 +28,17 @@ package rest
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/runtime/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/status"
 
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
@@ -1244,6 +1248,60 @@ func TestReindexCapExceededResponder_StatusAndBody(t *testing.T) {
 		"error message must name the offending collection")
 	assert.Contains(t, body.Error[0].Message, "32",
 		"error message must surface the cap and inflight count for operator triage")
+}
+
+// -----------------------------------------------------------------------------
+// submitTaskErrorResponder — the DTM apply-time cap backstop
+// (ErrTaskCapExceeded, raised when a parallel submit burst defeats the
+// handler's pre-check) must surface as the same 429 the pre-check returns;
+// every other submit failure keeps the 500 mapping. Both wire paths are
+// pinned: in-process %w wrapping (single node) and the gRPC-rehydrated
+// sentinel (cross-node submission).
+// -----------------------------------------------------------------------------
+
+func TestSubmitTaskErrorResponder(t *testing.T) {
+	write := func(resp middleware.Responder) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		resp.WriteResponse(rec, runtime.JSONProducer())
+		return rec
+	}
+
+	t.Run("in-process sentinel wrapping maps to 429", func(t *testing.T) {
+		// Single-node path: the FSM error reaches the handler through plain
+		// %w wrapping (raft_distributed_tasks_apply_endpoints.go).
+		err := fmt.Errorf("executing command: %w", distributedtask.ErrTaskCapExceeded)
+
+		rec := write(submitTaskErrorResponder(nil, "MyCollection", err))
+		require.Equal(t, http.StatusTooManyRequests, rec.Code,
+			"apply-time cap rejection must surface as the same 429 as the pre-check")
+
+		var body models.ErrorResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body),
+			"429 body must be the standard ErrorResponse shape")
+		require.Len(t, body.Error, 1)
+		assert.Contains(t, body.Error[0].Message, `"MyCollection"`)
+	})
+
+	t.Run("gRPC-rehydrated sentinel maps to 429", func(t *testing.T) {
+		// Cross-node path: the leader's FSM error crosses gRPC as
+		// (FailedPrecondition, "[dtm-perm/task-cap-exceeded] ...") and is
+		// rehydrated on the node serving the HTTP request.
+		onWire := status.Error(distributedtask.PermanentRejectionRPCCode,
+			`[dtm-perm/task-cap-exceeded] collection "MyCollection" already has 32 active tasks (max 32)`)
+		rehydrated := distributedtask.RehydratePermanentRejection(onWire)
+		require.True(t, errors.Is(rehydrated, distributedtask.ErrTaskCapExceeded),
+			"precondition: the rehydrated error must carry the cap sentinel")
+
+		rec := write(submitTaskErrorResponder(nil, "MyCollection",
+			fmt.Errorf("executing command: %w", rehydrated)))
+		require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	})
+
+	t.Run("generic submit error stays 500", func(t *testing.T) {
+		rec := write(submitTaskErrorResponder(nil, "MyCollection", errors.New("raft applyTimeout")))
+		require.Equal(t, http.StatusInternalServerError, rec.Code,
+			"non-cap submit failures must keep the generic 500 mapping")
+	})
 }
 
 // -----------------------------------------------------------------------------

--- a/cluster/distributedtask/errors.go
+++ b/cluster/distributedtask/errors.go
@@ -85,6 +85,15 @@ var (
 	// failed arrives — refusing here avoids overwriting a terminal
 	// status the operator (or fail-fast path) committed in the meantime.
 	ErrTaskNotInFinalizingState = errors.New("task is not in finalizing state")
+
+	// ErrTaskCapExceeded matches "collection ... already has N active tasks
+	// (max M)". Returned by [Manager.AddTask] when a collection already has
+	// [MaxConcurrentActiveTasksPerCollection] concurrently active tasks in
+	// the task's namespace. This is the apply-time backstop for the REST
+	// handler's pre-submit cap check: a parallel submit burst defeats the
+	// pre-check (every request counts before any has applied), so the cap
+	// is re-enforced here under the RAFT serialization point.
+	ErrTaskCapExceeded = errors.New("per-collection active task cap exceeded")
 )
 
 // ErrTaskCompletionPermanent marks an [UnitAwareProvider.OnTaskCompleted]
@@ -118,6 +127,7 @@ var permanentMarkers = []permanentMarker{
 	{ErrUnitAlreadyTerminal, "unit-terminal"},
 	{ErrUnitWrongNode, "unit-wrong-node"},
 	{ErrTaskNotInFinalizingState, "task-not-finalizing"},
+	{ErrTaskCapExceeded, "task-cap-exceeded"},
 }
 
 // markerByID looks up a sentinel by its on-wire id.

--- a/cluster/distributedtask/errors_test.go
+++ b/cluster/distributedtask/errors_test.go
@@ -36,6 +36,7 @@ func TestWrapPermanent_ErrorsIsClassification(t *testing.T) {
 		{"task-not-exist", ErrTaskDoesNotExist},
 		{"unit-already-terminal", ErrUnitAlreadyTerminal},
 		{"unit-wrong-node", ErrUnitWrongNode},
+		{"task-cap-exceeded", ErrTaskCapExceeded},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -108,6 +109,7 @@ func TestRehydratePermanentRejection_RoundTripsEverySentinel(t *testing.T) {
 		{"task-not-exist", ErrTaskDoesNotExist},
 		{"unit-already-terminal", ErrUnitAlreadyTerminal},
 		{"unit-wrong-node", ErrUnitWrongNode},
+		{"task-cap-exceeded", ErrTaskCapExceeded},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -174,6 +176,7 @@ func TestExtractMarkerID(t *testing.T) {
 	cases := map[string]string{
 		"[dtm-perm/task-not-running] hello":                  "task-not-running",
 		"[dtm-perm/unit-terminal] longer message with [text": "unit-terminal",
+		"[dtm-perm/task-cap-exceeded] over the cap":          "task-cap-exceeded",
 		"no marker at all":                                   "",
 		"[dtm-perm/] empty id":                               "",
 		"[dtm-perm/no-closing-bracket and rest":              "",

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +34,28 @@ func errTaskNotRunning(namespace, taskID string, version uint64) error {
 	return wrapPermanent(ErrTaskNotRunning,
 		fmt.Sprintf("task %s/%s/%d is no longer running", namespace, taskID, version))
 }
+
+// MaxConcurrentActiveTasksPerCollection caps how many concurrently active
+// (STARTED/PREPARING/SWAPPING, via [TaskStatus.IsActive]) tasks may target
+// the same collection within one task namespace. Each reindex task creates
+// ingest + backup buckets on every replica; without a cap, a script that
+// runs PUT /indexes/<prop> per property would fan out N tasks for an
+// N-property collection and overwhelm both LSM compaction and disk.
+//
+// The value is sized to comfortably accommodate realistic batch property
+// changes (e.g. retokenizing every text property on a ~20-property
+// collection in one go) while still preventing pathological unbounded
+// fan-out from a script that loops over hundreds of properties. The
+// original value of 4 was too restrictive: it rejected legitimate batch
+// migrations against modest-sized collections and broke the
+// reindex_concurrent acceptance test which exercises 15 simultaneous
+// non-conflicting submits.
+//
+// Enforced atomically at apply time in [Manager.AddTask] (under m.mu, at
+// the RAFT serialization point). The REST handler's pre-submit check is
+// only a fast path over this same constant — keep both layers referencing
+// it so they cannot drift.
+const MaxConcurrentActiveTasksPerCollection = 32
 
 // Manager is responsible for managing distributed tasks across the cluster.
 type Manager struct {
@@ -308,6 +331,47 @@ func (m *Manager) AddTask(c *api.ApplyRequest, seqNum uint64) error {
 		}
 		if err := cd.CheckConflict(r.Payload, existing); err != nil {
 			return fmt.Errorf("task %s/%s conflicts with existing task: %w", r.Namespace, r.Id, err)
+		}
+	}
+
+	// Apply-time backstop for the per-collection cap on concurrently active
+	// tasks. The REST handler enforces the same cap as a pre-submit check,
+	// but that check is a read-then-submit sequence a parallel submit burst
+	// defeats: every request observes the task list before any of them has
+	// applied. Re-checking here — under m.mu, at the RAFT serialization
+	// point — makes the cap atomic with the task insert.
+	//
+	// The error is returned TOP-LEVEL (never nested in another wrap): the
+	// "[dtm-perm/task-cap-exceeded]" marker must prefix the message so a
+	// cross-node caller can re-hydrate the sentinel after the gRPC
+	// round-trip (see errors.go's wire-format note).
+	//
+	// Namespaces without a registered [CollectionExtractor] are not
+	// collection-scoped and skip the cap. Payloads the extractor cannot
+	// decode also skip it — the same tolerance the handler-side counter
+	// shows toward unparseable payloads (a stray task must not block
+	// unrelated submits, and a mis-decoded new task must not be rejected
+	// for a cap we cannot attribute it to).
+	if extractor, ok := m.collectionExtractors[r.Namespace]; ok && extractor != nil {
+		if newCollection, ok := extractor(r.Payload); ok {
+			active := 0
+			for _, t := range m.tasks[r.Namespace] {
+				if !t.Status.IsActive() {
+					continue
+				}
+				collection, ok := extractor(t.Payload)
+				if !ok {
+					continue
+				}
+				if strings.EqualFold(collection, newCollection) {
+					active++
+				}
+			}
+			if active >= MaxConcurrentActiveTasksPerCollection {
+				return wrapPermanent(ErrTaskCapExceeded, fmt.Sprintf(
+					"collection %q already has %d active tasks (max %d); wait for one to finish before submitting another",
+					newCollection, active, MaxConcurrentActiveTasksPerCollection))
+			}
 		}
 	}
 

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -14,6 +14,7 @@ package distributedtask
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -128,6 +129,225 @@ func TestManager_AddTask_ConflictDetector(t *testing.T) {
 			UnitIds:               []string{"su-1"},
 		})
 		require.NoError(t, h.manager.AddTask(c, 100))
+	})
+}
+
+// TestManager_AddTask_CapBackstop pins the apply-time per-collection cap on
+// concurrently active tasks. The REST handler's pre-submit cap check is only
+// a fast path: a parallel submit burst defeats it because every request
+// observes the task list before any of them has applied. [Manager.AddTask]
+// therefore re-enforces the same cap under m.mu, at the RAFT serialization
+// point, so the cap holds no matter how parallel the submissions are.
+func TestManager_AddTask_CapBackstop(t *testing.T) {
+	const namespace = "test"
+
+	// testExtractor mirrors the contract of db.ExtractReindexTaskCollection
+	// (payload JSON with a top-level "collection" field) without importing
+	// the db package, which would create an import cycle.
+	testExtractor := func(payload []byte) (string, bool) {
+		var p struct {
+			Collection string `json:"collection"`
+		}
+		if err := json.Unmarshal(payload, &p); err != nil {
+			return "", false
+		}
+		return p.Collection, p.Collection != ""
+	}
+
+	payloadFor := func(t *testing.T, collection, prop string) []byte {
+		t.Helper()
+		raw, err := json.Marshal(struct {
+			MigrationType string   `json:"migrationType"`
+			Collection    string   `json:"collection"`
+			Properties    []string `json:"properties"`
+		}{"enable-filterable", collection, []string{prop}})
+		require.NoError(t, err)
+		return raw
+	}
+
+	addTask := func(t *testing.T, h *testHarness, id string, payload []byte, version uint64) error {
+		t.Helper()
+		return h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+			Namespace:             namespace,
+			Id:                    id,
+			Payload:               payload,
+			SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
+			UnitIds:               []string{"su-" + id},
+		}), version)
+	}
+
+	// fillToCap adds exactly MaxConcurrentActiveTasksPerCollection STARTED
+	// tasks for collection — distinct IDs, distinct properties, mirroring a
+	// burst of per-property reindex submits against one collection.
+	fillToCap := func(t *testing.T, h *testHarness, collection string) {
+		t.Helper()
+		for i := 0; i < MaxConcurrentActiveTasksPerCollection; i++ {
+			id := fmt.Sprintf("%s-task-%02d", collection, i)
+			err := addTask(t, h, id, payloadFor(t, collection, fmt.Sprintf("prop-%02d", i)), uint64(100+i))
+			require.NoError(t, err)
+		}
+	}
+
+	requireCapError := func(t *testing.T, err error, collection string) {
+		t.Helper()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrTaskCapExceeded),
+			"cap rejection must match the specific sentinel, got: %v", err)
+		require.True(t, errors.Is(err, ErrPermanentRejection),
+			"cap rejection must match the umbrella permanent-rejection sentinel, got: %v", err)
+		require.True(t, strings.HasPrefix(err.Error(), "[dtm-perm/task-cap-exceeded]"),
+			"message must START with the on-wire marker so a cross-node caller can re-hydrate the sentinel, got: %q", err.Error())
+		require.Contains(t, err.Error(), collection,
+			"message must name the capped collection")
+	}
+
+	t.Run("task beyond the cap is rejected", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+		fillToCap(t, h, "CollectionA")
+
+		err := addTask(t, h, "CollectionA-task-32", payloadFor(t, "CollectionA", "prop-32"), 200)
+		requireCapError(t, err, "CollectionA")
+		require.Contains(t, err.Error(), fmt.Sprint(MaxConcurrentActiveTasksPerCollection),
+			"message must surface the observed count and cap for operator triage")
+
+		// The rejected task must not have entered the FSM state.
+		tasks, lerr := h.manager.ListDistributedTasks(context.Background())
+		require.NoError(t, lerr)
+		require.Len(t, tasks[namespace], MaxConcurrentActiveTasksPerCollection,
+			"cap-rejected task MUST NOT be registered")
+	})
+
+	t.Run("cap is per-collection: another collection submits fine", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+		fillToCap(t, h, "CollectionA")
+
+		err := addTask(t, h, "CollectionB-task-00", payloadFor(t, "CollectionB", "prop-00"), 200)
+		require.NoError(t, err,
+			"a different collection is governed by its own counter")
+	})
+
+	t.Run("collection match is case-insensitive", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+		fillToCap(t, h, "MixedCase")
+
+		// Same collection spelled differently: the handler-side counter is
+		// case-insensitive (strings.EqualFold); the backstop must agree or
+		// the two layers could disagree on the count.
+		err := addTask(t, h, "mixedcase-task-32", payloadFor(t, "mixedcase", "prop-32"), 200)
+		requireCapError(t, err, "mixedcase")
+	})
+
+	t.Run("terminal tasks do not count toward the cap", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+		fillToCap(t, h, "CollectionA")
+
+		// Drive one task to FINISHED: complete its only unit (→ SWAPPING),
+		// then finalize (→ FINISHED).
+		completeUnit(t, h, namespace, "CollectionA-task-00", 100, "local-node", "su-CollectionA-task-00")
+
+		// SWAPPING is still active (IsActive): the cap must still reject —
+		// SWAPPING tasks hold tracker dirs and reindex buckets.
+		err := addTask(t, h, "CollectionA-task-32", payloadFor(t, "CollectionA", "prop-32"), 200)
+		requireCapError(t, err, "CollectionA")
+
+		require.NoError(t, h.manager.MarkTaskFinalized(toCmd(t, &cmd.MarkTaskFinalizedRequest{
+			Namespace:             namespace,
+			Id:                    "CollectionA-task-00",
+			Version:               100,
+			FinalizedAtUnixMillis: h.clock.Now().UnixMilli(),
+		})))
+
+		// A slot freed: the next submit for the collection is admitted.
+		err = addTask(t, h, "CollectionA-task-33", payloadFor(t, "CollectionA", "prop-33"), 201)
+		require.NoError(t, err, "FINISHED tasks must free their slot")
+	})
+
+	t.Run("dedup rejection takes precedence over the cap", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+		fillToCap(t, h, "CollectionA")
+
+		// Re-apply an existing task ID at the same version: this must hit the
+		// same-ID dedup branch, not the cap — otherwise a retried RAFT apply
+		// would be misreported as a cap rejection.
+		err := addTask(t, h, "CollectionA-task-00", payloadFor(t, "CollectionA", "prop-00"), 100)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already running")
+		require.False(t, errors.Is(err, ErrTaskCapExceeded),
+			"duplicate-ID error must not be classified as a cap rejection")
+	})
+
+	t.Run("conflict rejection takes precedence over the cap", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+		fillToCap(t, h, "CollectionA")
+
+		// With the collection already at cap, a detector that reports a
+		// conflict must surface ITS error — the conflict check runs before
+		// the cap check (mirroring the handler's conflict-then-cap order).
+		detector := &fakeConflictDetector{
+			rejectWith: fmt.Errorf("simulated conflict: parallel migration on same prop"),
+		}
+		h.manager.SetConflictDetectors(map[string]ConflictDetector{namespace: detector})
+
+		err := addTask(t, h, "CollectionA-task-32", payloadFor(t, "CollectionA", "prop-32"), 200)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "simulated conflict")
+		require.False(t, errors.Is(err, ErrTaskCapExceeded),
+			"conflict error must not be shadowed by the cap (check order: dedup → conflict → cap)")
+	})
+
+	t.Run("namespace without a collection extractor is not capped", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		// No extractor registered for the namespace: it is not
+		// collection-scoped (e.g. shard-noop debug tasks) and the cap must
+		// not apply.
+		for i := 0; i < MaxConcurrentActiveTasksPerCollection+1; i++ {
+			id := fmt.Sprintf("task-%02d", i)
+			err := addTask(t, h, id, []byte(fmt.Sprintf(`{"collection":"CollectionA","i":%d}`, i)), uint64(100+i))
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("new payload that fails extraction skips the cap", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+		fillToCap(t, h, "CollectionA")
+
+		// Unparseable payload: the cap check cannot attribute the task to a
+		// collection, so it tolerates the submit — the same tolerance the
+		// handler-side counter shows toward unparseable payloads.
+		err := addTask(t, h, "garbage-task", []byte("not valid json"), 200)
+		require.NoError(t, err)
+	})
+
+	t.Run("existing tasks with unextractable payloads do not count", func(t *testing.T) {
+		h := newTestHarness(t).init(t)
+		h.manager.RegisterCollectionExtractor(namespace, testExtractor)
+
+		// cap-1 attributable tasks …
+		for i := 0; i < MaxConcurrentActiveTasksPerCollection-1; i++ {
+			id := fmt.Sprintf("CollectionA-task-%02d", i)
+			err := addTask(t, h, id, payloadFor(t, "CollectionA", fmt.Sprintf("prop-%02d", i)), uint64(100+i))
+			require.NoError(t, err)
+		}
+		// … plus unparseable stragglers (e.g. written by an older binary) …
+		for i := 0; i < 3; i++ {
+			err := addTask(t, h, fmt.Sprintf("garbage-%02d", i), []byte("not valid json"), uint64(150+i))
+			require.NoError(t, err)
+		}
+		// … must not push the counter to the cap: the next attributable
+		// submit is still admitted.
+		err := addTask(t, h, "CollectionA-task-31", payloadFor(t, "CollectionA", "prop-31"), 200)
+		require.NoError(t, err,
+			"only cap-1 attributable active tasks exist; garbage payloads must not count")
+		// Now at the cap — the next one is rejected.
+		err = addTask(t, h, "CollectionA-task-32", payloadFor(t, "CollectionA", "prop-32"), 201)
+		requireCapError(t, err, "CollectionA")
 	})
 }
 

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -92,7 +92,10 @@ Response shapes:
 - `409 Conflict` — an in-flight task already touches this property.
   The error names the offending task ID and migration type.
 - `429 / 503` — per-collection in-flight cap reached (default 32) or
-  cluster-service unavailable.
+  cluster-service unavailable. The cap is enforced atomically at
+  task-apply time in the distributed-task FSM (`Manager.AddTask`); the
+  handler's pre-submit check is only a fast path, so a parallel submit
+  burst still gets a clean 429.
 
 ### `DELETE /v1/schema/{class}/properties/{property}/index/{indexName}`
 
@@ -917,7 +920,7 @@ migration must complete in operator-tractable time, and serializing
 them at 4 made multi-hour migrations into multi-week migrations. 32
 was chosen empirically as the point where LSM compaction throughput
 saturates on a single shard's disk for the typical migration mix; the
-REST handler returns 503 once the cap is reached.
+REST handler returns 429 once the cap is reached.
 
 **Per-collection worker pool** in `processUnits`. Bounded by the
 `concurrency` function passed to the provider (typically a

--- a/test/acceptance/helpers/reindex/cap_burst.go
+++ b/test/acceptance/helpers/reindex/cap_burst.go
@@ -1,0 +1,153 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindexhelpers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// WithStatus500Fatal overrides the fatal message used by
+// AssertCapBurstOutcome when a burst submit surfaces a 500. Used by the
+// follower-forwarded multinode variant, where a 500 means the
+// [dtm-perm/task-cap-exceeded] marker was lost on the follower→leader gRPC
+// round-trip instead of a plain unexpected-status failure.
+func WithStatus500Fatal(msg string) Option {
+	return func(o *options) { o.status500Fatal = msg }
+}
+
+// CapBurstProps builds n text properties named prop_00..prop_{n-1} — the
+// property set of the parallel cap-burst tests: one text property per
+// submit; IndexFilterable=false so {"filterable":{"enabled":true}} passes
+// validation for every property.
+func CapBurstProps(n int) []*models.Property {
+	props := make([]*models.Property, 0, n)
+	for i := 0; i < n; i++ {
+		props = append(props, &models.Property{
+			Name:            fmt.Sprintf("prop_%02d", i),
+			DataType:        []string{"text"},
+			Tokenization:    "word",
+			IndexFilterable: BoolPtr(false),
+			IndexSearchable: BoolPtr(true),
+		})
+	}
+	return props
+}
+
+// FireIndexUpdateRaw fires PUT /v1/schema/{collection}/indexes/{property}
+// with the supplied JSON body and reports the raw outcome. It performs no
+// assertions, so it is safe to call from errgroup goroutines.
+func FireIndexUpdateRaw(client *http.Client, restURI, collection, property, jsonBody string) (int, string, error) {
+	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, property)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(jsonBody)))
+	if err != nil {
+		return 0, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", err
+	}
+	return resp.StatusCode, string(body), nil
+}
+
+// IndexUpdateBurstResult is the per-property outcome of one submit in a
+// FireIndexUpdateBurst burst.
+type IndexUpdateBurstResult struct {
+	Property   string
+	StatusCode int
+	Body       string
+	Err        error
+}
+
+// FireIndexUpdateBurst fires n submits of
+// PUT /v1/schema/{collection}/indexes/prop_%02d with jsonBody against
+// restURI as a truly parallel burst and returns the per-property results in
+// submission order.
+//
+// Start barrier: every goroutine blocks on the gate until it is closed, so
+// all requests leave as simultaneously as the HTTP stack allows. No
+// assertions inside the goroutines (require.* must run on the test
+// goroutine); transport errors are reported per result. The returned error
+// is the errgroup result — nil by construction, asserted by callers.
+func FireIndexUpdateBurst(client *http.Client, restURI, collection, jsonBody string, n int) ([]IndexUpdateBurstResult, error) {
+	gate := make(chan struct{})
+	results := make([]IndexUpdateBurstResult, n)
+
+	var g errgroup.Group
+	for i := 0; i < n; i++ {
+		g.Go(func() error {
+			<-gate
+			prop := fmt.Sprintf("prop_%02d", i)
+			status, body, err := FireIndexUpdateRaw(client, restURI, collection, prop, jsonBody)
+			results[i] = IndexUpdateBurstResult{Property: prop, StatusCode: status, Body: body, Err: err}
+			return nil
+		})
+	}
+	close(gate)
+	return results, g.Wait()
+}
+
+// AssertCapBurstOutcome asserts the outcome of a cap-burst: exactly
+// expectedCap submits accepted (202) and expectedOverCap rejected (429).
+// Each 429 body must decode to the standard models.ErrorResponse shape and
+// name the capped collection; transport errors and any other status are
+// fatal. WithStatus500Fatal overrides the 500 fatal text. Returns the
+// observed accepted count for use in subsequent settle polls.
+func AssertCapBurstOutcome(t *testing.T, results []IndexUpdateBurstResult, collection string, expectedCap, expectedOverCap int, opts ...Option) int {
+	t.Helper()
+	o := applyOptions(opts)
+
+	var accepted, tooMany int
+	for _, res := range results {
+		require.NoError(t, res.Err, "request for %s failed at transport level", res.Property)
+		switch res.StatusCode {
+		case http.StatusAccepted:
+			accepted++
+		case http.StatusTooManyRequests:
+			tooMany++
+			var errResp models.ErrorResponse
+			require.NoError(t, json.Unmarshal([]byte(res.Body), &errResp),
+				"429 body must decode to the standard ErrorResponse shape: %s", res.Body)
+			require.NotEmpty(t, errResp.Error)
+			assert.Contains(t, errResp.Error[0].Message, collection,
+				"429 message must name the capped collection")
+		default:
+			if res.StatusCode == http.StatusInternalServerError && o.status500Fatal != "" {
+				t.Fatalf("500 for %s — %s: %s", res.Property, o.status500Fatal, res.Body)
+			}
+			t.Fatalf("unexpected status %d for %s: %s", res.StatusCode, res.Property, res.Body)
+		}
+	}
+	assert.Equal(t, expectedCap, accepted,
+		"exactly the cap may be admitted, no matter how parallel the burst")
+	assert.Equal(t, expectedOverCap, tooMany,
+		"the over-cap remainder must be rejected with 429")
+	return accepted
+}

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -33,8 +33,9 @@ import (
 type Option func(*options)
 
 type options struct {
-	tenants []string
-	timeout time.Duration
+	tenants        []string
+	timeout        time.Duration
+	status500Fatal string
 }
 
 func applyOptions(opts []Option) options {

--- a/test/acceptance/reindex_concurrent/parallel_cap_burst_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_cap_burst_test.go
@@ -12,18 +12,13 @@
 package reindex_concurrent
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
@@ -78,21 +73,9 @@ func TestParallelCapBurst(t *testing.T) {
 	)
 	numProps := capLimit + overCap
 
-	// One text property per submit; IndexFilterable=false so
-	// {"filterable":{"enabled":true}} passes validation for every property.
-	props := make([]*models.Property, 0, numProps)
-	for i := 0; i < numProps; i++ {
-		props = append(props, &models.Property{
-			Name:            fmt.Sprintf("prop_%02d", i),
-			DataType:        []string{"text"},
-			Tokenization:    "word",
-			IndexFilterable: reindexhelpers.BoolPtr(false),
-			IndexSearchable: reindexhelpers.BoolPtr(true),
-		})
-	}
 	helper.CreateClass(t, &models.Class{
 		Class:      collection,
-		Properties: props,
+		Properties: reindexhelpers.CapBurstProps(numProps),
 	})
 
 	// A modest corpus so the admitted migrations outlive the submit-burst
@@ -113,57 +96,15 @@ func TestParallelCapBurst(t *testing.T) {
 	}
 	helper.CreateObjectsBatch(t, objects)
 
-	type submitResult struct {
-		prop       string
-		statusCode int
-		body       string
-		err        error
-	}
-
-	// Start barrier: every goroutine blocks on the gate until the main
-	// goroutine closes it, so all requests leave as simultaneously as the
-	// HTTP stack allows. Results are collected per index — no assertions
-	// inside the goroutines (require.* must run on the test goroutine).
-	gate := make(chan struct{})
-	results := make([]submitResult, numProps)
+	// All submits leave as one truly parallel burst (start-barrier
+	// orchestration and per-property result collection live in the shared
+	// helper; no assertions inside the burst goroutines).
 	client := &http.Client{Timeout: 60 * time.Second}
+	results, err := reindexhelpers.FireIndexUpdateBurst(client, restURI, collection,
+		`{"filterable":{"enabled":true}}`, numProps)
+	require.NoError(t, err)
 
-	var g errgroup.Group
-	for i := 0; i < numProps; i++ {
-		g.Go(func() error {
-			<-gate
-			prop := fmt.Sprintf("prop_%02d", i)
-			status, body, err := fireIndexUpdate(client, restURI, collection, prop,
-				`{"filterable":{"enabled":true}}`)
-			results[i] = submitResult{prop: prop, statusCode: status, body: body, err: err}
-			return nil
-		})
-	}
-	close(gate)
-	require.NoError(t, g.Wait())
-
-	var accepted, tooMany int
-	for _, res := range results {
-		require.NoError(t, res.err, "request for %s failed at transport level", res.prop)
-		switch res.statusCode {
-		case http.StatusAccepted:
-			accepted++
-		case http.StatusTooManyRequests:
-			tooMany++
-			var errResp models.ErrorResponse
-			require.NoError(t, json.Unmarshal([]byte(res.body), &errResp),
-				"429 body must decode to the standard ErrorResponse shape: %s", res.body)
-			require.NotEmpty(t, errResp.Error)
-			assert.Contains(t, errResp.Error[0].Message, collection,
-				"429 message must name the capped collection")
-		default:
-			t.Fatalf("unexpected status %d for %s: %s", res.statusCode, res.prop, res.body)
-		}
-	}
-	assert.Equal(t, capLimit, accepted,
-		"exactly the cap may be admitted, no matter how parallel the burst")
-	assert.Equal(t, overCap, tooMany,
-		"the over-cap remainder must be rejected with 429")
+	accepted := reindexhelpers.AssertCapBurstOutcome(t, results, collection, capLimit, overCap)
 
 	// Let every admitted task run to completion so container teardown happens
 	// against a quiet node. Any FAILED/CANCELLED task aborts the poll early —
@@ -193,28 +134,4 @@ func TestParallelCapBurst(t *testing.T) {
 	require.Empty(t, terminalProblem)
 	require.Equal(t, accepted, finishedSeen,
 		"every admitted task must reach FINISHED")
-}
-
-// fireIndexUpdate fires PUT /v1/schema/{collection}/indexes/{property} and
-// reports the raw outcome. It performs no assertions so it is safe to call
-// from errgroup goroutines.
-func fireIndexUpdate(client *http.Client, restURI, collection, property, jsonBody string) (int, string, error) {
-	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, property)
-	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(jsonBody)))
-	if err != nil {
-		return 0, "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, "", err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return resp.StatusCode, "", err
-	}
-	return resp.StatusCode, string(body), nil
 }

--- a/test/acceptance/reindex_concurrent/parallel_cap_burst_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_cap_burst_test.go
@@ -1,0 +1,220 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_concurrent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestParallelCapBurst fires cap+8 enable-filterable submits for distinct
+// properties of one collection as a truly parallel burst and pins the
+// per-collection concurrency cap under the RAFT serialization point.
+//
+// Regression: the cap used to be enforced only as a handler-side pre-submit
+// check (list tasks → count in-flight → submit). Every request in a
+// simultaneous burst observed the task list before any of them had applied,
+// so all of them passed the pre-check and all of them were admitted — a
+// 40-parallel burst put 40 tasks in flight against a cap of 32. The fix
+// re-enforces the cap inside the distributed-task FSM at apply time
+// ([Manager.AddTask] under m.mu), so the cap holds no matter how parallel
+// the submissions are.
+//
+// Pre-fix this test is RED: all cap+8 submits return 202. Post-fix exactly
+// cap submits return 202 and the remaining 8 return 429 — rejected either
+// by the handler pre-check (if it observed the filled task list) or by the
+// apply-time backstop; both surface the same 429 contract.
+func TestParallelCapBurst(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviate().
+		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	restURI := compose.GetWeaviate().URI()
+	helper.SetupClient(restURI)
+
+	collection := "ParallelCapBurst"
+	// The cap is pinned to its externally observable value instead of
+	// referencing distributedtask.MaxConcurrentActiveTasksPerCollection on
+	// purpose: an acceptance test pins the user-facing contract, and
+	// hardcoding keeps the test compilable against a pre-fix build so it
+	// demonstrates the bug (every burst submit admitted) instead of
+	// failing to compile.
+	const (
+		capLimit = 32
+		overCap  = 8
+	)
+	numProps := capLimit + overCap
+
+	// One text property per submit; IndexFilterable=false so
+	// {"filterable":{"enabled":true}} passes validation for every property.
+	props := make([]*models.Property, 0, numProps)
+	for i := 0; i < numProps; i++ {
+		props = append(props, &models.Property{
+			Name:            fmt.Sprintf("prop_%02d", i),
+			DataType:        []string{"text"},
+			Tokenization:    "word",
+			IndexFilterable: reindexhelpers.BoolPtr(false),
+			IndexSearchable: reindexhelpers.BoolPtr(true),
+		})
+	}
+	helper.CreateClass(t, &models.Class{
+		Class:      collection,
+		Properties: props,
+	})
+
+	// A modest corpus so the admitted migrations outlive the submit-burst
+	// window: the burst must be counted while all admitted tasks are still
+	// in flight, otherwise a finished task frees a slot and more than cap
+	// submits get admitted.
+	const numObjects = 200
+	objects := make([]*models.Object, numObjects)
+	for i := range objects {
+		objProps := map[string]interface{}{}
+		for j := 0; j < numProps; j++ {
+			objProps[fmt.Sprintf("prop_%02d", j)] = fmt.Sprintf("hello world %d", i)
+		}
+		objects[i] = &models.Object{
+			Class:      collection,
+			Properties: objProps,
+		}
+	}
+	helper.CreateObjectsBatch(t, objects)
+
+	type submitResult struct {
+		prop       string
+		statusCode int
+		body       string
+		err        error
+	}
+
+	// Start barrier: every goroutine blocks on the gate until the main
+	// goroutine closes it, so all requests leave as simultaneously as the
+	// HTTP stack allows. Results are collected per index — no assertions
+	// inside the goroutines (require.* must run on the test goroutine).
+	gate := make(chan struct{})
+	results := make([]submitResult, numProps)
+	client := &http.Client{Timeout: 60 * time.Second}
+
+	var g errgroup.Group
+	for i := 0; i < numProps; i++ {
+		g.Go(func() error {
+			<-gate
+			prop := fmt.Sprintf("prop_%02d", i)
+			status, body, err := fireIndexUpdate(client, restURI, collection, prop,
+				`{"filterable":{"enabled":true}}`)
+			results[i] = submitResult{prop: prop, statusCode: status, body: body, err: err}
+			return nil
+		})
+	}
+	close(gate)
+	require.NoError(t, g.Wait())
+
+	var accepted, tooMany int
+	for _, res := range results {
+		require.NoError(t, res.err, "request for %s failed at transport level", res.prop)
+		switch res.statusCode {
+		case http.StatusAccepted:
+			accepted++
+		case http.StatusTooManyRequests:
+			tooMany++
+			var errResp models.ErrorResponse
+			require.NoError(t, json.Unmarshal([]byte(res.body), &errResp),
+				"429 body must decode to the standard ErrorResponse shape: %s", res.body)
+			require.NotEmpty(t, errResp.Error)
+			assert.Contains(t, errResp.Error[0].Message, collection,
+				"429 message must name the capped collection")
+		default:
+			t.Fatalf("unexpected status %d for %s: %s", res.statusCode, res.prop, res.body)
+		}
+	}
+	assert.Equal(t, capLimit, accepted,
+		"exactly the cap may be admitted, no matter how parallel the burst")
+	assert.Equal(t, overCap, tooMany,
+		"the over-cap remainder must be rejected with 429")
+
+	// Let every admitted task run to completion so container teardown happens
+	// against a quiet node. Any FAILED/CANCELLED task aborts the poll early —
+	// admitted tasks are expected to succeed.
+	var terminalProblem string
+	finishedSeen := 0
+	require.Eventually(t, func() bool {
+		tasks, ok := reindexhelpers.TryFetchTasks(restURI)
+		if !ok {
+			return false
+		}
+		finished := 0
+		for _, task := range tasks["reindex"] {
+			switch task.Status {
+			case "STARTED", "PREPARING", "SWAPPING":
+				return false
+			case "FAILED", "CANCELLED":
+				terminalProblem = fmt.Sprintf("task %s reached %s: %s", task.ID, task.Status, task.Error)
+				return true
+			case "FINISHED":
+				finished++
+			}
+		}
+		finishedSeen = finished
+		return finished == accepted
+	}, 5*time.Minute, time.Second, "all admitted reindex tasks should settle")
+	require.Empty(t, terminalProblem)
+	require.Equal(t, accepted, finishedSeen,
+		"every admitted task must reach FINISHED")
+}
+
+// fireIndexUpdate fires PUT /v1/schema/{collection}/indexes/{property} and
+// reports the raw outcome. It performs no assertions so it is safe to call
+// from errgroup goroutines.
+func fireIndexUpdate(client *http.Client, restURI, collection, property, jsonBody string) (int, string, error) {
+	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, property)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(jsonBody)))
+	if err != nil {
+		return 0, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", err
+	}
+	return resp.StatusCode, string(body), nil
+}

--- a/test/acceptance/reindex_multinode/parallel_cap_burst_follower_forward_test.go
+++ b/test/acceptance/reindex_multinode/parallel_cap_burst_follower_forward_test.go
@@ -12,21 +12,16 @@
 package reindex_multinode
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
-	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 )
 
@@ -66,19 +61,8 @@ func TestMultiNode_ParallelCapBurst_FollowerForwarded429(t *testing.T) {
 	)
 	numProps := capLimit + overCap
 
-	// One text property per submit; IndexFilterable=false so
-	// {"filterable":{"enabled":true}} passes validation for every property.
-	props := make([]*models.Property, 0, numProps)
-	for i := 0; i < numProps; i++ {
-		props = append(props, &models.Property{
-			Name:            fmt.Sprintf("prop_%02d", i),
-			DataType:        []string{"text"},
-			Tokenization:    "word",
-			IndexFilterable: reindexhelpers.BoolPtr(false),
-			IndexSearchable: reindexhelpers.BoolPtr(true),
-		})
-	}
-	createCollection(t, compose, restURIOf(compose, 1), collection, 3, 3, props)
+	createCollection(t, compose, restURIOf(compose, 1), collection, 3, 3,
+		reindexhelpers.CapBurstProps(numProps))
 
 	// A modest corpus so the admitted migrations outlive the submit-burst
 	// window: the burst must be counted while all admitted tasks are still
@@ -110,61 +94,20 @@ func TestMultiNode_ParallelCapBurst_FollowerForwarded429(t *testing.T) {
 	t.Logf("RAFT leader is weaviate-%d; firing burst at non-leader weaviate-%d (%s)",
 		leaderIdx, targetIdx, targetURI)
 
-	type submitResult struct {
-		prop       string
-		statusCode int
-		body       string
-		err        error
-	}
-
-	// Start barrier: every goroutine blocks on the gate until the main
-	// goroutine closes it, so all requests leave as simultaneously as the
-	// HTTP stack allows. Results are collected per index — no assertions
-	// inside the goroutines (require.* must run on the test goroutine).
-	gate := make(chan struct{})
-	results := make([]submitResult, numProps)
+	// All submits leave as one truly parallel burst (start-barrier
+	// orchestration and per-property result collection live in the shared
+	// helper; no assertions inside the burst goroutines).
 	client := &http.Client{Timeout: 60 * time.Second}
+	results, err := reindexhelpers.FireIndexUpdateBurst(client, targetURI, collection,
+		`{"filterable":{"enabled":true}}`, numProps)
+	require.NoError(t, err)
 
-	var g errgroup.Group
-	for i := 0; i < numProps; i++ {
-		g.Go(func() error {
-			<-gate
-			prop := fmt.Sprintf("prop_%02d", i)
-			status, body, err := fireIndexUpdateFollower(client, targetURI, collection, prop,
-				`{"filterable":{"enabled":true}}`)
-			results[i] = submitResult{prop: prop, statusCode: status, body: body, err: err}
-			return nil
-		})
-	}
-	close(gate)
-	require.NoError(t, g.Wait())
-
-	var accepted, tooMany int
-	for _, res := range results {
-		require.NoError(t, res.err, "request for %s failed at transport level", res.prop)
-		switch res.statusCode {
-		case http.StatusAccepted:
-			accepted++
-		case http.StatusTooManyRequests:
-			tooMany++
-			var errResp models.ErrorResponse
-			require.NoError(t, json.Unmarshal([]byte(res.body), &errResp),
-				"429 body must decode to the standard ErrorResponse shape: %s", res.body)
-			require.NotEmpty(t, errResp.Error)
-			assert.Contains(t, errResp.Error[0].Message, collection,
-				"429 message must name the capped collection")
-		case http.StatusInternalServerError:
-			t.Fatalf("500 for %s — the [dtm-perm/task-cap-exceeded] marker was lost on the "+
-				"follower→leader gRPC round-trip, so a cap rejection surfaced as a generic "+
-				"server error instead of 429: %s", res.prop, res.body)
-		default:
-			t.Fatalf("unexpected status %d for %s: %s", res.statusCode, res.prop, res.body)
-		}
-	}
-	assert.Equal(t, capLimit, accepted,
-		"exactly the cap may be admitted, no matter how parallel the burst")
-	assert.Equal(t, overCap, tooMany,
-		"the over-cap remainder must be rejected with 429, re-hydrated from the gRPC wire error")
+	// A 500 means the cap-rejection marker did not survive the
+	// follower→leader gRPC round-trip — fail with that explicit diagnosis.
+	accepted := reindexhelpers.AssertCapBurstOutcome(t, results, collection, capLimit, overCap,
+		reindexhelpers.WithStatus500Fatal("the [dtm-perm/task-cap-exceeded] marker was lost on the "+
+			"follower→leader gRPC round-trip, so a cap rejection surfaced as a generic server "+
+			"error instead of 429"))
 
 	// Cluster-side state: the 8 rejected submits must never have become
 	// tasks — exactly `accepted` reindex tasks exist for the collection.
@@ -231,28 +174,4 @@ func reindexTaskCollection(payload interface{}) string {
 		return ""
 	}
 	return p.Collection
-}
-
-// fireIndexUpdateFollower fires PUT /v1/schema/{collection}/indexes/{property}
-// and reports the raw outcome. It performs no assertions so it is safe to
-// call from errgroup goroutines.
-func fireIndexUpdateFollower(client *http.Client, restURI, collection, property, jsonBody string) (int, string, error) {
-	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, property)
-	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(jsonBody)))
-	if err != nil {
-		return 0, "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, "", err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return resp.StatusCode, "", err
-	}
-	return resp.StatusCode, string(body), nil
 }

--- a/test/acceptance/reindex_multinode/parallel_cap_burst_follower_forward_test.go
+++ b/test/acceptance/reindex_multinode/parallel_cap_burst_follower_forward_test.go
@@ -1,0 +1,258 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_multinode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+)
+
+// TestMultiNode_ParallelCapBurst_FollowerForwarded429 is the cross-node
+// variant of the single-node TestParallelCapBurst (package
+// reindex_concurrent): it fires the same cap+8 enable-filterable burst for
+// distinct properties of one collection, but aims every request at a
+// NON-LEADER node. The follower then forwards each submit to the RAFT
+// leader's distributed-task FSM over gRPC, and the apply-time cap rejection
+// ([distributedtask.Manager.AddTask]) travels back as
+// (FailedPrecondition, "[dtm-perm/task-cap-exceeded] ..."). The submitting
+// node must re-hydrate that wire error into the ErrTaskCapExceeded sentinel
+// so the handler can map it to 429 — if the marker is lost on the
+// round-trip, the client sees a generic 500 instead. This test pins the
+// follower-forwarded contract: exactly cap×202 + over×429 and zero 5xx.
+//
+// Regression: pre-fix there is no apply-time cap, so all cap+8 submits are
+// admitted (RED: 40×202, 0×429). The single-node variant never exercises the
+// gRPC re-hydrate path at all; QA Claude verified this journey live on a
+// 3-node cluster while reviewing weaviate/weaviate#12263, and this test is
+// the permanent CI guard for it.
+//
+// The cap is pinned to its externally observable value instead of
+// referencing distributedtask.MaxConcurrentActiveTasksPerCollection on
+// purpose: an acceptance test pins the user-facing contract.
+func TestMultiNode_ParallelCapBurst_FollowerForwarded429(t *testing.T) {
+	ctx := context.Background()
+
+	compose, cleanup := start3NodeReindexCluster(ctx, t)
+	defer cleanup()
+	defer dumpContainerLogs(ctx, t, compose)
+
+	collection := "ParallelCapBurstFollower"
+	const (
+		capLimit = 32
+		overCap  = 8
+	)
+	numProps := capLimit + overCap
+
+	// One text property per submit; IndexFilterable=false so
+	// {"filterable":{"enabled":true}} passes validation for every property.
+	props := make([]*models.Property, 0, numProps)
+	for i := 0; i < numProps; i++ {
+		props = append(props, &models.Property{
+			Name:            fmt.Sprintf("prop_%02d", i),
+			DataType:        []string{"text"},
+			Tokenization:    "word",
+			IndexFilterable: reindexhelpers.BoolPtr(false),
+			IndexSearchable: reindexhelpers.BoolPtr(true),
+		})
+	}
+	createCollection(t, compose, restURIOf(compose, 1), collection, 3, 3, props)
+
+	// A modest corpus so the admitted migrations outlive the submit-burst
+	// window: the burst must be counted while all admitted tasks are still
+	// in flight, otherwise a finished task frees a slot and more than cap
+	// submits get admitted.
+	const numObjects = 200
+	batchImportMultiProp(t, restURIOf(compose, 1), collection, numObjects,
+		func(i int) map[string]interface{} {
+			objProps := map[string]interface{}{}
+			for j := 0; j < numProps; j++ {
+				objProps[fmt.Sprintf("prop_%02d", j)] = fmt.Sprintf("hello world %d", i)
+			}
+			return objProps
+		})
+
+	// Aim the burst at a NON-LEADER node: resolve the RAFT leader, pick the
+	// next node, then re-resolve right before firing and re-pick if
+	// leadership moved in between — a burst that accidentally lands on the
+	// leader would silently skip the gRPC re-hydrate path under test.
+	leaderIdx := raftLeaderIndex(t, compose)
+	targetIdx := (leaderIdx + 1) % 3
+	leaderIdx = raftLeaderIndex(t, compose)
+	if targetIdx == leaderIdx {
+		targetIdx = (leaderIdx + 1) % 3
+	}
+	require.NotEqual(t, leaderIdx, targetIdx,
+		"burst target weaviate-%d must be a non-leader (leader is weaviate-%d)", targetIdx, leaderIdx)
+	targetURI := compose.GetWeaviateNode(targetIdx + 1).URI()
+	t.Logf("RAFT leader is weaviate-%d; firing burst at non-leader weaviate-%d (%s)",
+		leaderIdx, targetIdx, targetURI)
+
+	type submitResult struct {
+		prop       string
+		statusCode int
+		body       string
+		err        error
+	}
+
+	// Start barrier: every goroutine blocks on the gate until the main
+	// goroutine closes it, so all requests leave as simultaneously as the
+	// HTTP stack allows. Results are collected per index — no assertions
+	// inside the goroutines (require.* must run on the test goroutine).
+	gate := make(chan struct{})
+	results := make([]submitResult, numProps)
+	client := &http.Client{Timeout: 60 * time.Second}
+
+	var g errgroup.Group
+	for i := 0; i < numProps; i++ {
+		g.Go(func() error {
+			<-gate
+			prop := fmt.Sprintf("prop_%02d", i)
+			status, body, err := fireIndexUpdateFollower(client, targetURI, collection, prop,
+				`{"filterable":{"enabled":true}}`)
+			results[i] = submitResult{prop: prop, statusCode: status, body: body, err: err}
+			return nil
+		})
+	}
+	close(gate)
+	require.NoError(t, g.Wait())
+
+	var accepted, tooMany int
+	for _, res := range results {
+		require.NoError(t, res.err, "request for %s failed at transport level", res.prop)
+		switch res.statusCode {
+		case http.StatusAccepted:
+			accepted++
+		case http.StatusTooManyRequests:
+			tooMany++
+			var errResp models.ErrorResponse
+			require.NoError(t, json.Unmarshal([]byte(res.body), &errResp),
+				"429 body must decode to the standard ErrorResponse shape: %s", res.body)
+			require.NotEmpty(t, errResp.Error)
+			assert.Contains(t, errResp.Error[0].Message, collection,
+				"429 message must name the capped collection")
+		case http.StatusInternalServerError:
+			t.Fatalf("500 for %s — the [dtm-perm/task-cap-exceeded] marker was lost on the "+
+				"follower→leader gRPC round-trip, so a cap rejection surfaced as a generic "+
+				"server error instead of 429: %s", res.prop, res.body)
+		default:
+			t.Fatalf("unexpected status %d for %s: %s", res.statusCode, res.prop, res.body)
+		}
+	}
+	assert.Equal(t, capLimit, accepted,
+		"exactly the cap may be admitted, no matter how parallel the burst")
+	assert.Equal(t, overCap, tooMany,
+		"the over-cap remainder must be rejected with 429, re-hydrated from the gRPC wire error")
+
+	// Cluster-side state: the 8 rejected submits must never have become
+	// tasks — exactly `accepted` reindex tasks exist for the collection.
+	// Queried on node 1 (any node works; /v1/tasks reflects the RAFT FSM).
+	// Then let every admitted task run to completion so container teardown
+	// happens against a quiet cluster. Any FAILED/CANCELLED task — or a
+	// task count above the admitted number at any sample — aborts the poll
+	// early.
+	var terminalProblem string
+	finishedSeen, taskCountSeen := 0, 0
+	require.Eventually(t, func() bool {
+		tasks, ok := reindexhelpers.TryFetchTasks(restURIOf(compose, 1))
+		if !ok {
+			return false
+		}
+		finished := 0
+		count := 0
+		for _, task := range tasks["reindex"] {
+			if !strings.EqualFold(reindexTaskCollection(task.Payload), collection) {
+				continue
+			}
+			count++
+			switch task.Status {
+			case "STARTED", "PREPARING", "SWAPPING":
+				return false
+			case "FAILED", "CANCELLED":
+				terminalProblem = fmt.Sprintf("task %s reached %s: %s", task.ID, task.Status, task.Error)
+				return true
+			case "FINISHED":
+				finished++
+			}
+		}
+		taskCountSeen = count
+		if count > accepted {
+			terminalProblem = fmt.Sprintf(
+				"found %d reindex tasks for collection %s, but only %d submits were admitted — "+
+					"an over-cap submit became a task", count, collection, accepted)
+			return true
+		}
+		finishedSeen = finished
+		return count == accepted && finished == accepted
+	}, 5*time.Minute, time.Second, "all admitted reindex tasks should settle")
+	require.Empty(t, terminalProblem)
+	require.Equal(t, accepted, taskCountSeen,
+		"the rejected over-cap submits must never have become tasks")
+	require.Equal(t, accepted, finishedSeen,
+		"every admitted task must reach FINISHED")
+}
+
+// reindexTaskCollection extracts the collection name from a reindex task's
+// payload as served by GET /v1/tasks. Round-tripping through JSON keeps this
+// tolerant of the payload's decoded shape (interface{} on
+// models.DistributedTask); an unreadable payload yields "" and simply never
+// matches the collection filter.
+func reindexTaskCollection(payload interface{}) string {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	var p struct {
+		Collection string `json:"collection"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return ""
+	}
+	return p.Collection
+}
+
+// fireIndexUpdateFollower fires PUT /v1/schema/{collection}/indexes/{property}
+// and reports the raw outcome. It performs no assertions so it is safe to
+// call from errgroup goroutines.
+func fireIndexUpdateFollower(client *http.Client, restURI, collection, property, jsonBody string) (int, string, error) {
+	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, property)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(jsonBody)))
+	if err != nil {
+		return 0, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", err
+	}
+	return resp.StatusCode, string(body), nil
+}


### PR DESCRIPTION
SuperKimi here.

### What's being changed:

The per-collection cap of 32 concurrently active reindex tasks was enforced only as a REST handler pre-submit check: list tasks → count in-flight → submit. A truly parallel submit burst defeats it — every request counts in-flight tasks before any of them has applied. Live-reproduced by QA on a 40-way parallel burst: **40/40 admitted** (the GA API RFC's §1.11 states the cap as a hard invariant). Filed in [QA's re-QA on weaviate/weaviate#12252](https://github.com/weaviate/weaviate/pull/12252#issuecomment-5010845860); pre-existing on stable/v1.38, hence this PR against stable.

Fix: re-enforce the same cap atomically at task-apply time, inside the distributed-task FSM at the RAFT serialization point:

- `Manager.AddTask` counts active tasks for the incoming task's collection (via the namespace's registered `CollectionExtractor`) under `m.mu` and rejects over-cap applies with a new permanent sentinel `ErrTaskCapExceeded` (`[dtm-perm/task-cap-exceeded]`). The marker prefixes the message, so the sentinel survives the cross-node gRPC round-trip.
- Check order dedup → conflict → cap mirrors the handler. Terminal tasks don't count; `PREPARING`/`SWAPPING` do. Namespaces without an extractor and undecodable payloads skip the cap — the same tolerance as the handler-side counter.
- The cap constant moves to `distributedtask.MaxConcurrentActiveTasksPerCollection`, referenced by both layers so they cannot drift.
- The handler maps the apply-time rejection to the same 429 the pre-check returns — one contract regardless of which layer rejected. The pre-check stays as the fast path (and its fail-open hole on list errors is now covered by the backstop).

Regression coverage:

- `TestManager_AddTask_CapBackstop` (unit, real Manager): rejection past cap, per-collection isolation, case-insensitive match, terminal-tasks-free-slots (`SWAPPING` still counts), dedup-before-cap, conflict-before-cap, no-extractor-no-cap.
- Marker + gRPC round-trip cases for the new sentinel; `TestSubmitTaskErrorResponder` pins the 429-vs-500 mapping on both the in-process and the gRPC-rehydrated path.
- `TestParallelCapBurst` (acceptance, single node): 40 truly parallel submits (start barrier) → exactly **32×202 + 8×429**, 429 bodies in the standard ErrorResponse shape. **Red pre-fix** (base image: 40/40 admitted, 0×429) / **green post-fix**; whole `reindex_concurrent` package green. CI covers it via the dedicated `reindex-concurrent` job (ungrouped package run, no `-run` filter).

Verification: `go test ./cluster/distributedtask/ -race` ok; handler + conflict suites ok; `go build ./...` clean; gofumpt clean; `golangci-lint` 0 issues on touched packages; `tools/linter_go_routines.sh` clean. Docs updated (`docs/runtime-reindex.md`: cap returns 429, not 503; atomic apply-time enforcement noted).

Merge-up note: the DTM code touched here is identical on main (the v1.39 GA API rework, weaviate/weaviate#12252, has its own handler). The FSM backstop carries to main on the next stable→main merge; the GA handler's submit path will additionally need the same `errors.Is(ErrTaskCapExceeded)` → 429 mapping when it syncs with this branch.

Release-note candidate: during mixed-version rolling upgrades, an old leader still over-admits under a parallel submit burst while upgraded followers reject those entries at apply — a transient logical-divergence window in the same accepted risk class as the existing apply-time ConflictDetector.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: `docs/runtime-reindex.md` (in this diff)
- [x] Chaos pipeline run or not necessary. Not necessary — FSM apply-path guard + REST error mapping, covered by unit and acceptance tests.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary — the apply-time count is a single pass over the namespace's TTL-bounded task list under an already-held lock; task lists are cap-sized.

— SuperKimi
