### PR TITLE
fix(inverted): chunk ContainsAny/ContainsAll fan-out to bound goroutines under load

### DIFF
--- a/adapters/repos/db/inverted/containsany_chunking_integration_test.go
+++ b/adapters/repos/db/inverted/containsany_chunking_integration_test.go
@@ -19,9 +19,11 @@ import (
 	"runtime"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -64,7 +66,8 @@ func TestSearcher_ContainsAny_LargeValueSet(t *testing.T) {
 		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
 
 	bucketName := helpers.BucketFromPropNameLSM(propName)
-	require.NoError(t, store.CreateOrLoadBucket(context.Background(), bucketName,
+	require.NoError(t, store.CreateOrLoadBucket(
+		context.Background(), bucketName,
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
 		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
 	))
@@ -118,4 +121,347 @@ func TestSearcher_ContainsAny_LargeValueSet(t *testing.T) {
 	require.Equal(t, wantSorted, got,
 		"ContainsAny over %d values must OR-merge to exactly the union of every value's doc IDs, "+
 			"deduped, regardless of how leaves are chunked across goroutines", numValues)
+}
+
+// TestSearcher_ContainsAll_LargeValueSet is the AND-fold counterpart to
+// TestSearcher_ContainsAny_LargeValueSet. ContainsAll desugars to
+// filters.OperatorAnd on a flat (non-nested) property and shares the exact
+// same chunked resolveDocIDsAndOr path, but AND has the opposite
+// swapForEfficiency branch in mergeBitmapsAndOrWithDenyList (smaller bitmap
+// first, not larger), which the OR-only fixture above never exercises.
+//
+// Fixture: value i matches every doc ID in [0, maxDocID) EXCEPT i itself, so
+// each value's own contribution to the AND-fold is "exclude exactly my own
+// index, nothing else." The true intersection across all numValues values is
+// therefore exactly the buffer region [numValues, maxDocID) -- every index
+// in [0, numValues) is excluded by exactly one value, and only that value's
+// own presence in the fold excludes it. This is deliberately NOT a "common
+// core plus disjoint unique extras" design: a first draft of this fixture
+// used that shape and a chunk-local last-write-wins bug (keep only the last
+// leaf resolved per chunk, dropping the rest) passed anyway, because
+// dropping any subset of "extras" that are already disjoint from every other
+// value's contribution and from the common core leaves the intersection
+// unchanged regardless of which single representative survives per chunk.
+// The "exclude only my own index" shape closes that blind spot: dropping
+// value i's contribution within its chunk means index i is never excluded
+// by anyone else, so it wrongly survives into the final result -- directly
+// observable as an extra ID in got that isn't in want.
+func TestSearcher_ContainsAll_LargeValueSet(t *testing.T) {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	const propName = "inverted-text-roaringset"
+	const numValues = 200 // several multiples of GOMAXPROCS on any runner
+	const bufferSize = 10 // doc IDs no value excludes; the true AND result
+
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	maxDocID := uint64(numValues + bufferSize)
+	bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(maxDocID))
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
+		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+	bucketName := helpers.BucketFromPropNameLSM(propName)
+	require.NoError(t, store.CreateOrLoadBucket(
+		context.Background(), bucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	))
+	bucket := store.Bucket(bucketName)
+
+	values := make([]string, numValues)
+	for i := 0; i < numValues; i++ {
+		val := fmt.Sprintf("val_%05d", i)
+		values[i] = val
+		ids := make([]uint64, 0, maxDocID-1)
+		for id := uint64(0); id < maxDocID; id++ {
+			if id == uint64(i) {
+				continue // value i excludes only its own index
+			}
+			ids = append(ids, id)
+		}
+		require.NoError(t, bucket.RoaringSetAddList([]byte(val), ids))
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	filter := &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: filters.ContainsAll,
+			On:       &filters.Path{Class: className, Property: schema.PropertyName(propName)},
+			Value:    &filters.Value{Value: values, Type: schema.DataTypeText},
+		},
+	}
+
+	require.Greater(t, numValues, runtime.GOMAXPROCS(0),
+		"test fixture must exceed GOMAXPROCS so chunking exercises >1 leaf per goroutine")
+
+	allowList, err := searcher.DocIDs(context.Background(), filter, additional.Properties{}, className)
+	require.NoError(t, err)
+	defer allowList.Close()
+
+	got := allowList.Slice()
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+
+	want := make([]uint64, 0, bufferSize)
+	for id := uint64(numValues); id < maxDocID; id++ {
+		want = append(want, id)
+	}
+
+	require.Equal(t, want, got,
+		"ContainsAll over %d values must AND-fold to exactly the buffer region every value leaves "+
+			"untouched, with every value's own excluded index correctly dropped regardless of how "+
+			"leaves are chunked across goroutines",
+		numValues)
+}
+
+// TestSearcher_ContainsAny_DenyListLeafInChunk exercises the mixed
+// allow-list/deny-list branch of mergeBitmapsAndOrWithDenyList specifically
+// under chunk-local accumulation. No pre-existing test puts a deny-list leaf
+// (a NOT-wrapped operand) inside a compound large enough to force chunk size
+// > 1, so this is the first test where a single chunk goroutine folds an
+// allow-list result into a deny-list result via the local accumulator
+// chunking introduces, rather than every leaf going through the single
+// shared processDocIDs merger goroutine.
+//
+// Fixture: one deny-list leaf (NOT wrapping an Equal matching every doc ID
+// in [0, denyRangeSize)) OR'd with numReclaimLeaves disjoint single-doc
+// allow leaves, each matching exactly one doc ID inside the deny range
+// (reclaiming it) plus numPadLeaves allow leaves matching doc IDs entirely
+// outside the deny range (present in the result either way, padding the
+// operand count so chunking activates without affecting the expected set).
+// A first draft of this fixture used a single allow leaf disjoint from a
+// single-doc deny leaf; it passed even against a chunk-local
+// last-write-wins bug (keep only the last leaf resolved per chunk) because
+// "denylist(D) OR allow" collapses to "denylist(D)" whenever D and the
+// allow leaves are disjoint, independent of whether the allow leaves were
+// correctly folded in at all. Partial reclaim closes that blind spot:
+// denylist(D) OR allowlist(reclaimed subset of D) = denylist(D \ reclaimed),
+// so dropping ANY reclaiming allow leaf inside its chunk leaves that
+// specific doc ID wrongly excluded from the final result -- directly
+// observable as a missing ID in got that is present in want.
+func TestSearcher_ContainsAny_DenyListLeafInChunk(t *testing.T) {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	const propName = "inverted-text-roaringset"
+	const denyRangeSize = 150    // deny leaf excludes doc IDs [0, denyRangeSize)
+	const numReclaimLeaves = 100 // allow leaves [0, numReclaimLeaves) reclaim
+	// doc IDs [0, numReclaimLeaves), leaving [numReclaimLeaves, denyRangeSize)
+	// still excluded -- a genuine partial reclaim, not all-or-nothing
+	const numPadLeaves = 100 // extra allow leaves outside the deny range,
+	// just to push the total operand count well above GOMAXPROCS
+
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	maxDocID := uint64(denyRangeSize + numPadLeaves + 10)
+	bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(maxDocID))
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
+		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+	bucketName := helpers.BucketFromPropNameLSM(propName)
+	require.NoError(t, store.CreateOrLoadBucket(
+		context.Background(), bucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	))
+	bucket := store.Bucket(bucketName)
+
+	path := &filters.Path{Class: className, Property: schema.PropertyName(propName)}
+	operands := make([]filters.Clause, 0, numReclaimLeaves+numPadLeaves+1)
+
+	denyIDs := make([]uint64, denyRangeSize)
+	for i := range denyIDs {
+		denyIDs[i] = uint64(i)
+	}
+	const denyVal = "deny_value"
+	require.NoError(t, bucket.RoaringSetAddList([]byte(denyVal), denyIDs))
+	operands = append(operands, filters.Clause{
+		Operator: filters.OperatorNot,
+		Operands: []filters.Clause{
+			{
+				Operator: filters.OperatorEqual,
+				On:       path,
+				Value:    &filters.Value{Value: denyVal, Type: schema.DataTypeText},
+			},
+		},
+	})
+
+	for i := 0; i < numReclaimLeaves; i++ {
+		val := fmt.Sprintf("reclaim_%05d", i)
+		require.NoError(t, bucket.RoaringSetAddList([]byte(val), []uint64{uint64(i)}))
+		operands = append(operands, filters.Clause{
+			Operator: filters.OperatorEqual,
+			On:       path,
+			Value:    &filters.Value{Value: val, Type: schema.DataTypeText},
+		})
+	}
+	for i := 0; i < numPadLeaves; i++ {
+		id := uint64(denyRangeSize + i)
+		val := fmt.Sprintf("pad_%05d", i)
+		require.NoError(t, bucket.RoaringSetAddList([]byte(val), []uint64{id}))
+		operands = append(operands, filters.Clause{
+			Operator: filters.OperatorEqual,
+			On:       path,
+			Value:    &filters.Value{Value: val, Type: schema.DataTypeText},
+		})
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	filter := &filters.LocalFilter{
+		Root: &filters.Clause{Operator: filters.OperatorOr, Operands: operands},
+	}
+
+	require.Greater(t, len(operands), runtime.GOMAXPROCS(0),
+		"test fixture must exceed GOMAXPROCS so chunking exercises >1 leaf per goroutine, "+
+			"including at least one chunk that mixes a reclaiming allow leaf with the deny leaf")
+
+	allowList, err := searcher.DocIDs(context.Background(), filter, additional.Properties{}, className)
+	require.NoError(t, err)
+	defer allowList.Close()
+
+	got := allowList.Slice()
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+
+	stillExcluded := make([]uint64, 0, denyRangeSize-numReclaimLeaves)
+	for id := uint64(numReclaimLeaves); id < denyRangeSize; id++ {
+		stillExcluded = append(stillExcluded, id)
+	}
+	want := sroar.Prefill(maxDocID).AndNot(roaringset.NewBitmap(stillExcluded...)).ToArray()
+
+	require.Equal(t, want, got,
+		"OR of a deny-list leaf excluding [0,%d) with %d reclaiming allow leaves and %d padding "+
+			"allow leaves must fold to the deny-list's complement with exactly [%d,%d) still "+
+			"excluded, regardless of how leaves are chunked across goroutines",
+		denyRangeSize, numReclaimLeaves, numPadLeaves, numReclaimLeaves, denyRangeSize)
+}
+
+// TestSearcher_ContainsAny_CancellationMidChunk locks in the release-on-
+// cancel edge chunking introduces: a chunk goroutine that has already
+// accumulated a chunkResult from one or more successfully-resolved leaves
+// must release that chunkResult (not leak it) when it then observes ctx
+// cancellation before finishing its remaining leaves, whether that
+// cancellation is observed via the between-leaf gctx.Err() check or via a
+// leaf's own resolveDocIDs ctxExpired check.
+//
+// Bitmap-buffer leak detection is precise, not a proxy: the bucket's
+// BitmapBufPool is swapped for roaringset.BitmapBufPoolTracking, the same
+// pool implementation the disk-layer roaring-set read path
+// (segment_group.go / segment_roaring_set_strategy.go) actually allocates
+// leaf docBitmap buffers from, so Outstanding()==0 after a cancelled call
+// directly proves every allocated leaf buffer -- including any that were
+// already folded into a chunk's local accumulator before cancellation --
+// was released.
+//
+// This test also documents a real, empirically-verified finding that goes
+// beyond the architect design-gate's static review: chunking narrows how
+// many independent goroutines get a "chance" to observe ctx cancellation
+// per query (numChunks goroutines instead of one per leaf), which measurably
+// widens a pre-existing race window where a cancelled query returns a
+// SILENT SUCCESS with an incomplete/empty result instead of a context error
+// (verified: baseline never hit this in 24 runs of this exact fixture;
+// chunked hit it 1/24). That race-widening is not fixed here -- it is
+// out of scope for this diff per the architect's explicit
+// design-gate direction and the task's no-bug-in-perf-diff instruction --
+// and is pinned separately with a dedicated red test on branch
+// gh12242-adjacent-cancel-race-finding (see
+// Conversations/2026-07/2026-07-18-1246__pr-prep.md). This test therefore
+// only asserts what is ALWAYS true regardless of that race (no leak, ever;
+// any error observed is a context error) plus, in aggregate across 8
+// independent attempts, that the context-error path is real and reachable
+// (not merely theoretical).
+func TestSearcher_ContainsAny_CancellationMidChunk(t *testing.T) {
+	const propName = "inverted-text-roaringset"
+	const numValues = 5000 // wide enough that 2ms reliably lands mid-query,
+	// not before the first leaf or after the last
+	const cancelDelay = 2 * time.Millisecond
+	const attempts = 8
+
+	sawContextError := false
+	for attempt := 0; attempt < attempts; attempt++ {
+		t.Run(fmt.Sprintf("attempt_%d", attempt), func(t *testing.T) {
+			dirName := t.TempDir()
+			logger, _ := test.NewNullLogger()
+
+			store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+				cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop())
+			require.NoError(t, err)
+			t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+			maxDocID := uint64(numValues*3 + 10)
+			bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(maxDocID))
+			searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
+				stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
+				config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+			bucketName := helpers.BucketFromPropNameLSM(propName)
+			trackingPool := roaringset.NewBitmapBufPoolTracking()
+			require.NoError(t, store.CreateOrLoadBucket(
+				context.Background(), bucketName,
+				lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+				lsmkv.WithBitmapBufPool(trackingPool),
+			))
+			bucket := store.Bucket(bucketName)
+
+			values := make([]string, numValues)
+			for i := 0; i < numValues; i++ {
+				val := fmt.Sprintf("val_%05d", i)
+				values[i] = val
+				ids := []uint64{uint64(3 * i), uint64(3*i + 1), uint64(3*i + 2)}
+				require.NoError(t, bucket.RoaringSetAddList([]byte(val), ids))
+			}
+			require.NoError(t, bucket.FlushAndSwitch())
+
+			filter := &filters.LocalFilter{
+				Root: &filters.Clause{
+					Operator: filters.ContainsAny,
+					On:       &filters.Path{Class: className, Property: schema.PropertyName(propName)},
+					Value:    &filters.Value{Value: values, Type: schema.DataTypeText},
+				},
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			cancelFired := make(chan struct{})
+			go func() {
+				time.Sleep(cancelDelay)
+				cancel()
+				close(cancelFired)
+			}()
+
+			allowList, err := searcher.DocIDs(ctx, filter, additional.Properties{}, className)
+			<-cancelFired // ensure the cancel goroutine has fired before Outstanding() is read
+
+			if err != nil {
+				require.ErrorContains(t, err, "context canceled")
+				sawContextError = true
+			} else {
+				allowList.Close()
+			}
+
+			require.Zero(t, trackingPool.Outstanding(),
+				"cancellation mid-chunk must release every leaf bitmap buffer already folded "+
+					"into a chunk's local accumulator, not just the ones a later leaf error "+
+					"happens to unwind")
+		})
+	}
+
+	require.True(t, sawContextError,
+		"expected at least one of %d cancellation attempts to observe a context error "+
+			"(locks in that the release-on-cancel/error-propagation path is reachable, not "+
+			"merely theoretical); if this ever fails, re-check cancelDelay/numValues against "+
+			"current hardware speed", attempts)
 }

--- a/adapters/repos/db/inverted/containsany_chunking_integration_test.go
+++ b/adapters/repos/db/inverted/containsany_chunking_integration_test.go
@@ -1,0 +1,121 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package inverted
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// TestSearcher_ContainsAny_LargeValueSet exercises resolveDocIDsAndOr and
+// extractPropValuePairs with an operand/child count well above GOMAXPROCS,
+// so at least one chunk goroutine processes more than one leaf (the code
+// path introduced by GH 12242's chunked-bulk-resolution fix: local
+// mergeBitmapsAndOrWithDenyList accumulation inside a single chunk
+// goroutine, exercised zero times by any pre-existing test in this package
+// since all of them use <=3 operands, at or below GOMAXPROCS on any CI
+// runner). Result set is diffed against a hand-computed expected set built
+// directly from the fixture, not against a second implementation, so this
+// is a correctness oracle, not a differential test.
+func TestSearcher_ContainsAny_LargeValueSet(t *testing.T) {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	const propName = "inverted-text-roaringset"
+	const numValues = 2000 // several multiples of GOMAXPROCS on any runner
+
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	maxDocID := uint64(numValues*3 + 10)
+	bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(maxDocID))
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
+		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+	bucketName := helpers.BucketFromPropNameLSM(propName)
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(), bucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	))
+	bucket := store.Bucket(bucketName)
+
+	// Each value maps to 3 doc IDs: [3*i, 3*i+1, 3*i+2]. Every value's doc
+	// IDs are disjoint from every other value's, and a handful of values
+	// (every 7th) share one doc ID with the *next* value in the sequence so
+	// the OR-merge has real overlap to dedupe, not just disjoint unions.
+	values := make([]string, numValues)
+	expected := map[uint64]struct{}{}
+	for i := 0; i < numValues; i++ {
+		val := fmt.Sprintf("val_%05d", i)
+		values[i] = val
+		ids := []uint64{uint64(3 * i), uint64(3*i + 1), uint64(3*i + 2)}
+		if i%7 == 0 && i+1 < numValues {
+			// overlap this value's last ID with the next value's first ID
+			ids[2] = uint64(3 * (i + 1))
+		}
+		require.NoError(t, bucket.RoaringSetAddList([]byte(val), ids))
+		for _, id := range ids {
+			expected[id] = struct{}{}
+		}
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	filter := &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: filters.ContainsAny,
+			On:       &filters.Path{Class: className, Property: schema.PropertyName(propName)},
+			Value:    &filters.Value{Value: values, Type: schema.DataTypeText},
+		},
+	}
+
+	require.Greater(t, numValues, runtime.GOMAXPROCS(0),
+		"test fixture must exceed GOMAXPROCS so chunking exercises >1 leaf per goroutine")
+
+	allowList, err := searcher.DocIDs(context.Background(), filter, additional.Properties{}, className)
+	require.NoError(t, err)
+	defer allowList.Close()
+
+	got := allowList.Slice()
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+
+	wantSorted := make([]uint64, 0, len(expected))
+	for id := range expected {
+		wantSorted = append(wantSorted, id)
+	}
+	sort.Slice(wantSorted, func(i, j int) bool { return wantSorted[i] < wantSorted[j] })
+
+	require.Equal(t, wantSorted, got,
+		"ContainsAny over %d values must OR-merge to exactly the union of every value's doc IDs, "+
+			"deduped, regardless of how leaves are chunked across goroutines", numValues)
+}

--- a/adapters/repos/db/inverted/containsany_chunking_integration_test.go
+++ b/adapters/repos/db/inverted/containsany_chunking_integration_test.go
@@ -35,16 +35,8 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-// TestSearcher_ContainsAny_LargeValueSet exercises resolveDocIDsAndOr and
-// extractPropValuePairs with an operand/child count well above GOMAXPROCS,
-// so at least one chunk goroutine processes more than one leaf (the code
-// path introduced by GH 12242's chunked-bulk-resolution fix: local
-// mergeBitmapsAndOrWithDenyList accumulation inside a single chunk
-// goroutine, exercised zero times by any pre-existing test in this package
-// since all of them use <=3 operands, at or below GOMAXPROCS on any CI
-// runner). Result set is diffed against a hand-computed expected set built
-// directly from the fixture, not against a second implementation, so this
-// is a correctness oracle, not a differential test.
+// Regression test: resolveDocIDsAndOr/extractPropValuePairs chunked OR-merge
+// with operand count above GOMAXPROCS, so >1 leaf lands in the same chunk (GH 12242).
 func TestSearcher_ContainsAny_LargeValueSet(t *testing.T) {
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -123,29 +115,8 @@ func TestSearcher_ContainsAny_LargeValueSet(t *testing.T) {
 			"deduped, regardless of how leaves are chunked across goroutines", numValues)
 }
 
-// TestSearcher_ContainsAll_LargeValueSet is the AND-fold counterpart to
-// TestSearcher_ContainsAny_LargeValueSet. ContainsAll desugars to
-// filters.OperatorAnd on a flat (non-nested) property and shares the exact
-// same chunked resolveDocIDsAndOr path, but AND has the opposite
-// swapForEfficiency branch in mergeBitmapsAndOrWithDenyList (smaller bitmap
-// first, not larger), which the OR-only fixture above never exercises.
-//
-// Fixture: value i matches every doc ID in [0, maxDocID) EXCEPT i itself, so
-// each value's own contribution to the AND-fold is "exclude exactly my own
-// index, nothing else." The true intersection across all numValues values is
-// therefore exactly the buffer region [numValues, maxDocID) -- every index
-// in [0, numValues) is excluded by exactly one value, and only that value's
-// own presence in the fold excludes it. This is deliberately NOT a "common
-// core plus disjoint unique extras" design: a first draft of this fixture
-// used that shape and a chunk-local last-write-wins bug (keep only the last
-// leaf resolved per chunk, dropping the rest) passed anyway, because
-// dropping any subset of "extras" that are already disjoint from every other
-// value's contribution and from the common core leaves the intersection
-// unchanged regardless of which single representative survives per chunk.
-// The "exclude only my own index" shape closes that blind spot: dropping
-// value i's contribution within its chunk means index i is never excluded
-// by anyone else, so it wrongly survives into the final result -- directly
-// observable as an extra ID in got that isn't in want.
+// Regression test: ContainsAll chunked AND-fold must intersect every leaf
+// inside a chunk, not just the last one resolved (GH 12242).
 func TestSearcher_ContainsAll_LargeValueSet(t *testing.T) {
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -220,42 +191,17 @@ func TestSearcher_ContainsAll_LargeValueSet(t *testing.T) {
 		numValues)
 }
 
-// TestSearcher_ContainsAny_DenyListLeafInChunk exercises the mixed
-// allow-list/deny-list branch of mergeBitmapsAndOrWithDenyList specifically
-// under chunk-local accumulation. No pre-existing test puts a deny-list leaf
-// (a NOT-wrapped operand) inside a compound large enough to force chunk size
-// > 1, so this is the first test where a single chunk goroutine folds an
-// allow-list result into a deny-list result via the local accumulator
-// chunking introduces, rather than every leaf going through the single
-// shared processDocIDs merger goroutine.
-//
-// Fixture: one deny-list leaf (NOT wrapping an Equal matching every doc ID
-// in [0, denyRangeSize)) OR'd with numReclaimLeaves disjoint single-doc
-// allow leaves, each matching exactly one doc ID inside the deny range
-// (reclaiming it) plus numPadLeaves allow leaves matching doc IDs entirely
-// outside the deny range (present in the result either way, padding the
-// operand count so chunking activates without affecting the expected set).
-// A first draft of this fixture used a single allow leaf disjoint from a
-// single-doc deny leaf; it passed even against a chunk-local
-// last-write-wins bug (keep only the last leaf resolved per chunk) because
-// "denylist(D) OR allow" collapses to "denylist(D)" whenever D and the
-// allow leaves are disjoint, independent of whether the allow leaves were
-// correctly folded in at all. Partial reclaim closes that blind spot:
-// denylist(D) OR allowlist(reclaimed subset of D) = denylist(D \ reclaimed),
-// so dropping ANY reclaiming allow leaf inside its chunk leaves that
-// specific doc ID wrongly excluded from the final result -- directly
-// observable as a missing ID in got that is present in want.
+// Regression test: chunk-local accumulation must correctly OR-fold a
+// deny-list leaf with allow leaves that partially reclaim it, within a
+// single chunk (GH 12242).
 func TestSearcher_ContainsAny_DenyListLeafInChunk(t *testing.T) {
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 
 	const propName = "inverted-text-roaringset"
 	const denyRangeSize = 150    // deny leaf excludes doc IDs [0, denyRangeSize)
-	const numReclaimLeaves = 100 // allow leaves [0, numReclaimLeaves) reclaim
-	// doc IDs [0, numReclaimLeaves), leaving [numReclaimLeaves, denyRangeSize)
-	// still excluded -- a genuine partial reclaim, not all-or-nothing
-	const numPadLeaves = 100 // extra allow leaves outside the deny range,
-	// just to push the total operand count well above GOMAXPROCS
+	const numReclaimLeaves = 100 // allow leaves reclaiming [0, numReclaimLeaves) from the deny range
+	const numPadLeaves = 100     // padding leaves outside the deny range, to push operand count above GOMAXPROCS
 
 	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
 		cyclemanager.NewCallbackGroupNoop(),
@@ -347,44 +293,12 @@ func TestSearcher_ContainsAny_DenyListLeafInChunk(t *testing.T) {
 		denyRangeSize, numReclaimLeaves, numPadLeaves, numReclaimLeaves, denyRangeSize)
 }
 
-// TestSearcher_ContainsAny_CancellationMidChunk locks in the release-on-
-// cancel edge chunking introduces: a chunk goroutine that has already
-// accumulated a chunkResult from one or more successfully-resolved leaves
-// must release that chunkResult (not leak it) when it then observes ctx
-// cancellation before finishing its remaining leaves, whether that
-// cancellation is observed via the between-leaf gctx.Err() check or via a
-// leaf's own resolveDocIDs ctxExpired check.
-//
-// Bitmap-buffer leak detection is precise, not a proxy: the bucket's
-// BitmapBufPool is swapped for roaringset.BitmapBufPoolTracking, the same
-// pool implementation the disk-layer roaring-set read path
-// (segment_group.go / segment_roaring_set_strategy.go) actually allocates
-// leaf docBitmap buffers from, so Outstanding()==0 after a cancelled call
-// directly proves every allocated leaf buffer -- including any that were
-// already folded into a chunk's local accumulator before cancellation --
-// was released.
-//
-// This test also documents a real, empirically-verified finding that goes
-// beyond the architect design-gate's static review: chunking narrows how
-// many independent goroutines get a "chance" to observe ctx cancellation
-// per query (numChunks goroutines instead of one per leaf), which measurably
-// widens a pre-existing race window where a cancelled query returns a
-// SILENT SUCCESS with an incomplete/empty result instead of a context error
-// (verified: baseline never hit this in 24 runs of this exact fixture;
-// chunked hit it 1/24). That race-widening is not fixed here -- it is
-// out of scope for this diff per the architect's explicit
-// design-gate direction and the task's no-bug-in-perf-diff instruction --
-// and is pinned separately with a dedicated red test on branch
-// gh12242-adjacent-cancel-race-finding (see
-// Conversations/2026-07/2026-07-18-1246__pr-prep.md). This test therefore
-// only asserts what is ALWAYS true regardless of that race (no leak, ever;
-// any error observed is a context error) plus, in aggregate across 8
-// independent attempts, that the context-error path is real and reachable
-// (not merely theoretical).
+// Regression test: a chunk goroutine must release its accumulated
+// chunkResult (no bitmap-buffer leak) when it observes cancellation
+// mid-chunk, before finishing its remaining leaves.
 func TestSearcher_ContainsAny_CancellationMidChunk(t *testing.T) {
 	const propName = "inverted-text-roaringset"
-	const numValues = 5000 // wide enough that 2ms reliably lands mid-query,
-	// not before the first leaf or after the last
+	const numValues = 5000 // wide enough that cancelDelay reliably lands mid-query
 	const cancelDelay = 2 * time.Millisecond
 	const attempts = 8
 

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -113,6 +113,32 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 	}
 }
 
+// chunkBounds splits [0, n) into numChunks contiguous, roughly equal-sized
+// half-open ranges [start, end), distributing any remainder across the
+// leading chunks. numChunks is clamped to [1, n]. Used to bound per-request
+// goroutine fan-out to numChunks instead of one goroutine per element.
+func chunkBounds(n, numChunks int) [][2]int {
+	if numChunks < 1 {
+		numChunks = 1
+	}
+	if numChunks > n {
+		numChunks = n
+	}
+	bounds := make([][2]int, 0, numChunks)
+	base, rem := n/numChunks, n%numChunks
+	start := 0
+	for i := 0; i < numChunks; i++ {
+		size := base
+		if i < rem {
+			size++
+		}
+		end := start + size
+		bounds = append(bounds, [2]int{start, end})
+		start = end
+	}
+	return bounds
+}
+
 func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*docBitmap, error) {
 	// Explicitly set the limit to 0 (=unlimited) as this is a nested filter,
 	// otherwise we run into situations where each subfilter on their own
@@ -147,8 +173,20 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 			dbmCh <- dbm
 		}
 	} else {
-		// resolve docIDs in parallel using goroutines
-		concurrencyReductionFactor := min(len(pv.children), outerConcurrencyLimit)
+		// Resolve docIDs in parallel, chunked to at most outerConcurrencyLimit-1
+		// goroutines instead of one goroutine per child. A ContainsAny/ContainsAll
+		// with N values produces N children here; spawning one errgroup goroutine
+		// (and one dbmCh send) per child scales goroutine creation and channel-send
+		// volume with N per request, with no cap across concurrent requests (GH
+		// 12242). Each chunk goroutine resolves its slice of children sequentially
+		// and merges them locally with mergeBitmapsAndOrWithDenyList before a
+		// single dbmCh send, so per-request goroutine count and channel-send count
+		// are both bounded by outerConcurrencyLimit regardless of N.
+		numChunks := min(len(pv.children), outerConcurrencyLimit-1)
+		if numChunks < 1 {
+			numChunks = 1
+		}
+		chunks := chunkBounds(len(pv.children), numChunks)
 
 		// collect all errors from goroutines (not only 1st one)
 		ec := errorcompounder.NewSafe()
@@ -156,25 +194,41 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 		eg, gctx := enterrors.NewErrorGroupWithContextWrapper(s.logger, ctx)
 		eg.SetLimit(outerConcurrencyLimit - 1)
 
-		for i, child := range pv.children {
-			i, child := i, child
+		for _, bounds := range chunks {
+			start, end := bounds[0], bounds[1]
 			eg.Go(func() error {
-				if err := gctx.Err(); err != nil {
-					// some child failed, skip processing
-					return nil
-				}
+				var chunkResult *docBitmap
+				for i := start; i < end; i++ {
+					if err := gctx.Err(); err != nil {
+						// some child failed, skip processing
+						if chunkResult != nil {
+							chunkResult.release()
+						}
+						return nil
+					}
 
-				ctx := concurrency.ContextWithFractionalBudget(ctx, concurrencyReductionFactor, concurrency.GOMAXPROCS)
-				dbm, err := child.resolveDocIDs(ctx, s, limit)
-				if err != nil {
-					err = errors.Wrapf(err, "nested child %d", i)
-					ec.Add(err)
-					return err
+					ctx := concurrency.ContextWithFractionalBudget(ctx, numChunks, concurrency.GOMAXPROCS)
+					dbm, err := pv.children[i].resolveDocIDs(ctx, s, limit)
+					if err != nil {
+						err = errors.Wrapf(err, "nested child %d", i)
+						ec.Add(err)
+						if chunkResult != nil {
+							chunkResult.release()
+						}
+						return err
+					}
+					if chunkResult == nil {
+						chunkResult = dbm
+					} else {
+						chunkResult = mergeBitmapsAndOrWithDenyList(chunkResult, dbm, pv.operator, mergeConc)
+					}
 				}
-				dbmCh <- dbm
+				if chunkResult != nil {
+					dbmCh <- chunkResult
+				}
 				return nil
 			})
-			// some child failed, skip remaining children
+			// some child failed, skip remaining chunks
 			if gctx.Err() != nil {
 				break
 			}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -182,6 +182,20 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 		// and merges them locally with mergeBitmapsAndOrWithDenyList before a
 		// single dbmCh send, so per-request goroutine count and channel-send count
 		// are both bounded by outerConcurrencyLimit regardless of N.
+		//
+		// Two budget/concurrency shifts from pre-chunking behavior, both benign:
+		// (a) the per-child fractional budget divisor is now numChunks (the
+		// actual concurrent-goroutine count) instead of the old
+		// min(len(children), outerConcurrencyLimit) - numChunks is always <=
+		// the old divisor, so nested Equal/range/GeoRange children get equal or
+		// marginally more budget, never less; (b) mergeBitmapsAndOrWithDenyList
+		// (called via mergeConc, sized once above from the outer ctx) now runs
+		// inside up to numChunks chunk goroutines concurrently instead of a
+		// single dedicated merger, so effective merge parallelism rises from
+		// 1x mergeConc to up to numChunks x mergeConc. This widens the existing
+		// "deliberate mild overshoot" already accepted above; the bench showed
+		// net CPU/goroutine metrics falling regardless, so the overshoot pays
+		// for itself.
 		numChunks := min(len(pv.children), outerConcurrencyLimit-1)
 		if numChunks < 1 {
 			numChunks = 1

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -113,10 +113,8 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 	}
 }
 
-// chunkBounds splits [0, n) into numChunks contiguous, roughly equal-sized
-// half-open ranges [start, end), distributing any remainder across the
-// leading chunks. numChunks is clamped to [1, n]. Used to bound per-request
-// goroutine fan-out to numChunks instead of one goroutine per element.
+// chunkBounds splits [0, n) into numChunks contiguous, roughly equal ranges
+// (remainder distributed to the leading chunks); numChunks is clamped to [1, n].
 func chunkBounds(n, numChunks int) [][2]int {
 	if numChunks < 1 {
 		numChunks = 1
@@ -182,12 +180,6 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 		// and merges them locally with mergeBitmapsAndOrWithDenyList before a
 		// single dbmCh send, so per-request goroutine count and channel-send count
 		// are both bounded by outerConcurrencyLimit regardless of N.
-		//
-		// mergeConc (above) now runs inside up to numChunks concurrent chunk
-		// goroutines, widening the "deliberate mild overshoot" already noted
-		// above. The per-child fractional budget divisor is numChunks, always
-		// <= min(len(children), outerConcurrencyLimit), so nested Equal/range/
-		// GeoRange children never get less budget than the unchunked path.
 		numChunks := min(len(pv.children), outerConcurrencyLimit-1)
 		if numChunks < 1 {
 			numChunks = 1

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -183,19 +183,11 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 		// single dbmCh send, so per-request goroutine count and channel-send count
 		// are both bounded by outerConcurrencyLimit regardless of N.
 		//
-		// Two budget/concurrency shifts from pre-chunking behavior, both benign:
-		// (a) the per-child fractional budget divisor is now numChunks (the
-		// actual concurrent-goroutine count) instead of the old
-		// min(len(children), outerConcurrencyLimit) - numChunks is always <=
-		// the old divisor, so nested Equal/range/GeoRange children get equal or
-		// marginally more budget, never less; (b) mergeBitmapsAndOrWithDenyList
-		// (called via mergeConc, sized once above from the outer ctx) now runs
-		// inside up to numChunks chunk goroutines concurrently instead of a
-		// single dedicated merger, so effective merge parallelism rises from
-		// 1x mergeConc to up to numChunks x mergeConc. This widens the existing
-		// "deliberate mild overshoot" already accepted above; the bench showed
-		// net CPU/goroutine metrics falling regardless, so the overshoot pays
-		// for itself.
+		// mergeConc (above) now runs inside up to numChunks concurrent chunk
+		// goroutines, widening the "deliberate mild overshoot" already noted
+		// above. The per-child fractional budget divisor is numChunks, always
+		// <= min(len(children), outerConcurrencyLimit), so nested Equal/range/
+		// GeoRange children never get less budget than the unchunked path.
 		numChunks := min(len(pv.children), outerConcurrencyLimit-1)
 		if numChunks < 1 {
 			numChunks = 1

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -579,6 +579,12 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 	// across concurrent requests (GH 12242). Each chunk goroutine builds its
 	// slice of clauses sequentially, writing into its own children[] slots
 	// (distinct per goroutine, so no synchronization needed on the writes).
+	//
+	// The per-child fractional budget below is now divided by numChunks
+	// (the actual goroutine count) rather than by min(len(operands),
+	// outerConcurrencyLimit) as before chunking: numChunks is always <=
+	// the old divisor, so nested Equal/range/GeoRange children never
+	// receive less budget than before, only equal or marginally more.
 	numChunks := min(len(operands), outerConcurrencyLimit)
 	if numChunks < 1 {
 		numChunks = 1
@@ -602,7 +608,7 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 				children[i] = child
 			}
 			return nil
-		})
+		}, start, end)
 	}
 	if err := eg.Wait(); err != nil {
 		return nil, fmt.Errorf("nested query: %w", err)

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -572,17 +572,10 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 	outerConcurrencyLimit := concurrency.BudgetFromCtx(ctx, concurrency.GOMAXPROCS)
 	eg.SetLimit(outerConcurrencyLimit)
 
-	// Chunk operands into at most outerConcurrencyLimit contiguous groups
-	// instead of spawning one goroutine per operand: a 100K-value
-	// ContainsAny/ContainsAll used to call eg.Go() once per value here, scaling
-	// per-request goroutine creation with the value-set size and with no cap
-	// across concurrent requests (GH 12242). Each chunk goroutine builds its
-	// slice of clauses sequentially, writing into its own children[] slots
-	// (distinct per goroutine, so no synchronization needed on the writes).
-	//
-	// The per-child fractional budget divisor is numChunks, always <=
-	// min(len(operands), outerConcurrencyLimit), so nested Equal/range/
-	// GeoRange children never get less budget than the unchunked path.
+	// Chunk operands into at most outerConcurrencyLimit groups instead of one
+	// goroutine per operand, bounding goroutine/channel fan-out for large
+	// ContainsAny/ContainsAll value sets (GH 12242). Each goroutine writes only
+	// its own children[] slice, so no synchronization is needed.
 	numChunks := min(len(operands), outerConcurrencyLimit)
 	if numChunks < 1 {
 		numChunks = 1

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -580,11 +580,9 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 	// slice of clauses sequentially, writing into its own children[] slots
 	// (distinct per goroutine, so no synchronization needed on the writes).
 	//
-	// The per-child fractional budget below is now divided by numChunks
-	// (the actual goroutine count) rather than by min(len(operands),
-	// outerConcurrencyLimit) as before chunking: numChunks is always <=
-	// the old divisor, so nested Equal/range/GeoRange children never
-	// receive less budget than before, only equal or marginally more.
+	// The per-child fractional budget divisor is numChunks, always <=
+	// min(len(operands), outerConcurrencyLimit), so nested Equal/range/
+	// GeoRange children never get less budget than the unchunked path.
 	numChunks := min(len(operands), outerConcurrencyLimit)
 	if numChunks < 1 {
 		numChunks = 1

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -572,23 +572,37 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 	outerConcurrencyLimit := concurrency.BudgetFromCtx(ctx, concurrency.GOMAXPROCS)
 	eg.SetLimit(outerConcurrencyLimit)
 
-	concurrencyReductionFactor := min(len(operands), outerConcurrencyLimit)
+	// Chunk operands into at most outerConcurrencyLimit contiguous groups
+	// instead of spawning one goroutine per operand: a 100K-value
+	// ContainsAny/ContainsAll used to call eg.Go() once per value here, scaling
+	// per-request goroutine creation with the value-set size and with no cap
+	// across concurrent requests (GH 12242). Each chunk goroutine builds its
+	// slice of clauses sequentially, writing into its own children[] slots
+	// (distinct per goroutine, so no synchronization needed on the writes).
+	numChunks := min(len(operands), outerConcurrencyLimit)
+	if numChunks < 1 {
+		numChunks = 1
+	}
+	chunks := chunkBounds(len(operands), numChunks)
 
-	for i, clause := range operands {
-		i, clause := i, clause
+	for _, bounds := range chunks {
+		start, end := bounds[0], bounds[1]
 		eg.Go(func() error {
-			ctx := concurrency.ContextWithFractionalBudget(ctx, concurrencyReductionFactor, concurrency.GOMAXPROCS)
-			child, err := s.buildPropValuePair(ctx, &clause, className, class)
-			// check for stopword errors on ContainsAny operator only at the end
-			if err != nil && errors.Is(err, ErrOnlyStopwords) && operator == filters.ContainsAny {
-				return nil
+			ctx := concurrency.ContextWithFractionalBudget(ctx, numChunks, concurrency.GOMAXPROCS)
+			for i := start; i < end; i++ {
+				clause := operands[i]
+				child, err := s.buildPropValuePair(ctx, &clause, className, class)
+				// check for stopword errors on ContainsAny operator only at the end
+				if err != nil && errors.Is(err, ErrOnlyStopwords) && operator == filters.ContainsAny {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("nested clause at pos %d: %w", i, err)
+				}
+				children[i] = child
 			}
-			if err != nil {
-				return fmt.Errorf("nested clause at pos %d: %w", i, err)
-			}
-			children[i] = child
 			return nil
-		}, clause)
+		})
 	}
 	if err := eg.Wait(); err != nil {
 		return nil, fmt.Errorf("nested query: %w", err)


### PR DESCRIPTION
## Summary

A `ContainsAny`/`ContainsAll` filter with a large value set (100K in the reported case) collapses cluster throughput under concurrent load: unbounded per-request goroutine fan-out (one goroutine per filter value, bounded only per-request, never across requests) feeds a single merger goroutine, so total live goroutines scale with concurrent-requests times fan-out width with no cap. At high concurrency the scheduler and GC spend most of the CPU budget managing tens of thousands of goroutines rather than doing query work. Confirmed at production scale on a live 100 RPS benchmark (goroutine census: 8,228 of ~16K goroutines in the per-leaf producer function, only 146 in the single merger; 58.96% of wall-clock time in a channel send).

Fixes the primary mechanism reported in #12242.

## Mechanism

Two hot-path functions build one `errgroup.Go()` per filter value/child:

- `extractPropValuePairs` (`adapters/repos/db/inverted/searcher.go`): one goroutine per operand, building the filter tree.
- `resolveDocIDsAndOr` (`adapters/repos/db/inverted/prop_value_pairs.go`): one goroutine per child, each doing one LSMKV bucket read then sending into a `dbmCh` channel buffered to 32, drained by exactly one merger goroutine. Producer:consumer imbalance means most producers end up parked on `dbmCh <-` under load, which is the `runtime.chansend`-dominated wall-clock time the production capture showed.

## Fix

Chunk operands/children into at most `outerConcurrencyLimit` (searcher.go) / `outerConcurrencyLimit-1` (prop_value_pairs.go) contiguous slices via a new `chunkBounds(n, numChunks)` helper. Each chunk goroutine processes its slice **sequentially** (no per-leaf `errgroup.Go`) and, in `resolveDocIDsAndOr`, locally OR/AND-merges its own leaves with the **existing** `mergeBitmapsAndOrWithDenyList` (reused verbatim, so the AND/OR/deny-list algebra and intermediate-bitmap release semantics are untouched) before a single `dbmCh` send per chunk. This collapses per-request goroutine count and channel-send count from `len(children)` (up to 100K) to `outerConcurrencyLimit` (e.g. 16 on a 16-core box), regardless of value-set size.

For any filter small enough that chunking would matter to latency (N <= `outerConcurrencyLimit`), `chunkBounds` yields one chunk per leaf, so the emitted goroutine topology is byte-identical to the pre-chunking baseline. The improvement is entirely at large N, which is exactly the confirmed bottleneck.

**Alternative considered and rejected:** a global (cross-request) admission-control semaphore, gated at the leaf-terminal bucket read to avoid a hold-and-wait deadlock across nested filter trees. Benchmarked: strictly worse than baseline at every worker count tested (throughput ~half, client-timeout errors appear at 100 workers where baseline had none), and gets *worse*, not better, with a 4x looser budget -- confirming the mechanism itself (not tuning) is the problem: gating without also reducing goroutine creation just adds semaphore-wait overhead on top of an unchanged goroutine-explosion. Combining it with chunking inherits the regression. Not shipped; documented here as a negative result so nobody re-derives it.

## Key areas for review

- `prop_value_pairs.go` (`resolveDocIDsAndOr`) -- the chunk goroutine's release-on-error/release-on-cancel discipline (`chunkResult.release()` on both early-return paths, transferred to `dbmCh` on success, mutually exclusive and exactly-once).
- `mergeBitmapsAndOrWithDenyList` (reused verbatim, unchanged) -- worth re-confirming it's genuinely untouched; the correctness argument for chunk-local accumulation rests entirely on this function's existing associativity/commutativity, not on anything new.
- The two documented budget/concurrency shifts (godoc on both changed functions): fractional-budget divisor is now `numChunks` (always <= the old divisor, never a regression); `mergeBitmapsAndOrWithDenyList` now runs across up to `numChunks` concurrent chunk goroutines instead of one dedicated merger (widens the pre-existing "deliberate mild overshoot" already accepted in the surrounding code).

## Risks and mitigations

- **Correctness of chunk-local accumulation**: mitigated by reusing `mergeBitmapsAndOrWithDenyList` verbatim (same function the baseline's single merger already depends on for the identical associativity property) plus a 12-query byte-exact correctness corpus (sizes 1 to 100K, edges, nested compounds) run against baseline on identical data, 36/36 match, and three new unit-level tests specifically targeting chunk size > 1: `ContainsAll` (AND fold, the opposite `swapForEfficiency` branch from the existing OR-only coverage), a deny-list leaf inside a chunk (mixed allow/deny algebra under chunk-local accumulation), and cancellation mid-chunk (release-on-cancel, verified via `roaringset.BitmapBufPoolTracking`, the pool the disk-layer read path actually allocates leaf buffers from).
- **Peak memory at large fan-out**: bounded concurrent large-bitmap count at ~`numChunks` (vs baseline's ~`outerConcurrencyLimit` in-flight producers plus up to 32 buffered in `dbmCh`). See the low-cardinality/high-overlap characterization below.
- **Nested filter trees**: no global semaphore is introduced, so the hold-and-wait deadlock class the rejected alternative required a specific fix for structurally cannot occur here. The real-scale `nested_AND_of_two_contains_any` corpus row confirms.
- **A cancellation-behavior finding surfaced while writing this test suite** (not a regression this PR should fix): chunking measurably narrows the number of independent goroutines that get a "chance" to observe context cancellation via a real propagated error (numChunks instead of one per leaf). This widens a pre-existing race where a cancelled query can return a silent, incomplete success instead of a context error -- verified baseline never hits this in 24-100 sample runs of a fixed fixture, chunked hits it roughly 1/10 to 1/24. Pinned with a dedicated red test on branch `gh12242-adjacent-cancel-race-finding`, not fixed in this diff. Happy to open a follow-up issue for it once this PR is up.

## Out of scope

- **The cancellation-race-widening finding above**: real, verified, deliberately out of this diff; see the risks section and the pinned branch.
- **A suspected "leaf errors after allocating its bitmap -> unreleased buffer" path in the row-reader layer** (`searcher_doc_bitmap.go`): investigated directly (reproduction attempt using a multi-key `Like` scan cancelled mid-iteration, tracked via `roaringset.BitmapBufPoolTracking`). Could not reproduce: every multi-key row-reader iteration path checked (`RowReaderRoaringSet.greaterThan/lessThan/like`, `RowReader`'s equivalents) passes `noopRelease` to its read callback, so there is no live pool buffer to leak on a later error; the only path with a real pool-backed release (`RowReaderRoaringSet.equal`) never calls its read callback more than once. Flagging as "needs a fresh look, possibly in `RoaringSetRange` or the nested-property path" rather than a confirmed bug.
- **Global (cross-request) admission control**: investigated and benchmarked; strictly regresses under load (see Fix section). Not shipped.
- **The slow-query log's full filter-value-list serialization** (called out as a separate, smaller issue in #12242's own "suggested fix directions"): unrelated code path, not touched here.

## Testing

- Unit + integration (`-race`) locally for `adapters/repos/db/inverted` (all 4 subpackages) and the broader `adapters/repos/db` package: all green.
- `golangci-lint run ./adapters/repos/db/inverted/...`: 0 issues. `./tools/linter_go_routines.sh`: clean.
- 12-query correctness corpus (sizes 1-100K, zero-result edge, duplicate-heavy edge, partial-nonexistent edge, AND-compound, OR-compound, nested-AND-compound) diffed byte-exact (sorted UUID lists, not just counts) against baseline on identical data: 36/36 match.
- 3 new unit-level tests specifically targeting the chunked code path (chunk size > 1), each verified RED before GREEN by injecting the exact bug shape it guards against: `TestSearcher_ContainsAll_LargeValueSet`, `TestSearcher_ContainsAny_DenyListLeafInChunk`, `TestSearcher_ContainsAny_CancellationMidChunk`.

### Benchmark: single-query latency (16-core box, 300K objects, unique-per-object high-cardinality property)

| Value-set size | Baseline p50 | Chunked p50 | Delta |
|---|---|---|---|
| 100 | 1.15ms | 1.07ms | -7% |
| 1,000 | 3.85ms | 2.60ms | -32% |
| 10,000 | 35.4ms | 16.3ms | -54% |
| 100,000 | 245ms | 106ms | -57% |

### Benchmark: concurrent load, 100K-value filter, 16-core box

| Metric | Baseline (100 workers) | Chunked (100 workers) | Delta |
|---|---|---|---|
| Throughput | 7.90 rps | 15.21 rps | ~1.9x |
| p99 latency | 14.85s | 12.79s | -14% |
| Goroutines (mid-load) | 3,058 | 508 | -83% |
| CPU (of 16-core cap) | 96.6% | 79.3% | -18pp |
| Client-timeout errors | 0 | 0 | - |

**Distinct-id-set re-run (stricter harness).** The table above draws each request's 100K-value set from a small reused pool. Re-running the chunked sweep with a distinct, non-reused random 100K-of-300K id-set per in-flight request (pool of 1,200 pre-generated sets; in-flight non-reuse proven by a post-run sweep-line self-check, 0 violations across 2,911 requests, 0 errors) costs a modest -4.5% to -8.2% throughput versus the reused-set harness:

| Workers | Reused-set rps | Distinct-set rps | Delta |
|---|---|---|---|
| 16 | 17.98 | 16.88 | -6.1% |
| 32 | 17.07 | 16.28 | -4.6% |
| 64 | 16.24 | 15.51 | -4.5% |
| 100 | 15.21 | 13.96 | -8.2% |

At 100 workers that is still ~1.8x over baseline; throughput does not collapse with concurrency under the stricter harness, so the gain is not an artifact of id-set reuse warming caches. (Real-world traffic carries different id lists per request, so the distinct-set numbers are the representative ones.)

### Low-cardinality, high-overlap characterization

The benchmarks above used a unique-per-object (low-memory-per-leaf) property. Peak-allocation behavior at the opposite shape -- low-cardinality property (few distinct values), each matching a large fraction of the corpus, so cross-chunk OR-merge overlap is high -- was characterized separately (1,000 distinct values, 20K-doc corpus, ~67% match overlap per value, `runtime.MemStats` peak-heap sampling every 200us):

**Single query, no concurrent load** (5 runs each): peak-heap delta comparable between baseline (~6.2-7.4MB) and chunked (~6.3-7.7MB), within run-to-run noise -- a single query's resource bound is similar order of magnitude for both variants when the value count already exceeds `outerConcurrencyLimit` for both. Latency consistently lower for chunked (~5.65ms avg vs ~7.9ms avg, ~28% faster).

**50 concurrent clients x 3 requests (150 total), same fixture** -- the shape that actually exercises the mechanism this PR targets, averaged over 3 runs each:

| Metric | Baseline | Chunked | Delta |
|---|---|---|---|
| Elapsed (150 requests) | ~433ms | ~320ms | -26% |
| Peak goroutines | ~1,094 | ~659 | -40% |
| Peak heap delta | ~93.3MB | ~76.6MB | -18% |

Consistent across all 3 runs on both metrics: lower peak heap, fewer goroutines, and lower latency at the low-cardinality/high-overlap shape too, not just the high-cardinality shape.

Refs #12242 (kept open: this PR addresses the primary fan-out mechanism; a follow-up PR stacking further wins on this branch is in preparation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMinAsVKyEEv1EvNKmHxLL
