### PR TITLE
fix(cyclemanager): roll back shouldAbort when ctx expires while callback runs

### DIFF
--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -340,10 +340,12 @@ func (c *cycleCallbackGroup) mutateCallback(ctx context.Context, callbackId uint
 		runningCtx := meta.runningCtx
 		running := runningCtx != nil && runningCtx.Err() == nil
 
+		prevShouldAbort := meta.shouldAbort
 		if err := onMetaFound(callbackId, meta, running); err != nil {
 			c.Unlock()
 			return err
 		}
+		postShouldAbort := meta.shouldAbort
 		if !running {
 			c.Unlock()
 			return nil
@@ -364,7 +366,15 @@ func (c *cycleCallbackGroup) mutateCallback(ctx context.Context, callbackId uint
 				// was not changed. If not, loop will finish on runningCtx.Err() != nil check
 				continue
 			}
-			// input ctx expired
+			// input ctx expired while the callback is still running and the caller
+			// treats the mutation as failed. Roll back shouldAbort to avoid silently
+			// aborting every subsequent cycle, unless a racing activate/deactivate
+			// changed the flag in the meantime.
+			c.Lock()
+			if meta, ok := c.callbacks[callbackId]; ok && meta.shouldAbort == postShouldAbort {
+				meta.shouldAbort = prevShouldAbort
+			}
+			c.Unlock()
 			return ctx.Err()
 		}
 	}

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -367,14 +367,16 @@ func (c *cycleCallbackGroup) mutateCallback(ctx context.Context, callbackId uint
 				continue
 			}
 			// input ctx expired while the callback is still running and the caller
-			// treats the mutation as failed. Roll back shouldAbort to avoid silently
-			// aborting every subsequent cycle, unless a racing activate/deactivate
-			// changed the flag in the meantime.
-			c.Lock()
-			if meta, ok := c.callbacks[callbackId]; ok && meta.shouldAbort == postShouldAbort {
-				meta.shouldAbort = prevShouldAbort
+			// treats the mutation as failed. Roll back the shouldAbort change to
+			// avoid silently aborting every subsequent cycle, unless a racing
+			// activate/deactivate changed the flag in the meantime.
+			if prevShouldAbort != postShouldAbort {
+				c.Lock()
+				if meta, ok := c.callbacks[callbackId]; ok && meta.shouldAbort == postShouldAbort {
+					meta.shouldAbort = prevShouldAbort
+				}
+				c.Unlock()
 			}
-			c.Unlock()
 			return ctx.Err()
 		}
 	}

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -2027,3 +2027,166 @@ func TestCycleCallback_Sequential_Deactivate(t *testing.T) {
 		})
 	})
 }
+
+func TestCycleCallback_Sequential_DeactivateCtxCancelledWhileRunning(t *testing.T) {
+	testDeactivateCtxCancelledWhileRunning(t, 1)
+}
+
+func TestCycleCallback_Parallel_DeactivateCtxCancelledWhileRunning(t *testing.T) {
+	testDeactivateCtxCancelledWhileRunning(t, 2)
+}
+
+func testDeactivateCtxCancelledWhileRunning(t *testing.T, routinesLimit int) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	chStarted := make(chan struct{}, 1)
+	chGate := make(chan struct{})
+	startedCounter := 0
+	callback := func(shouldAbort ShouldAbortCallback) bool {
+		if shouldAbort() {
+			return false
+		}
+		startedCounter++
+		if startedCounter == 1 {
+			chStarted <- struct{}{}
+		}
+		<-chGate
+		return true
+	}
+
+	callbacks := NewCallbackGroup("id", logger, routinesLimit)
+	ctrl := callbacks.Register("c", callback)
+
+	// single registered callback gets id 0
+	isShouldAbort := func() bool {
+		group := callbacks.(*cycleCallbackGroup)
+		group.Lock()
+		defer group.Unlock()
+		return group.callbacks[0].shouldAbort
+	}
+
+	// 1st cycle with the callback blocking on the gate
+	chCycle1 := make(chan bool, 1)
+	go func() {
+		chCycle1 <- callbacks.CycleCallback(shouldNotAbort)
+	}()
+	<-chStarted
+
+	// deactivate with ctx cancelled while the callback is still running
+	ctxDeactivate, cancelDeactivate := context.WithCancel(ctx)
+	chDeactivated := make(chan error, 1)
+	go func() {
+		chDeactivated <- ctrl.Deactivate(ctxDeactivate)
+	}()
+
+	// wait for the abort flag to make sure deactivate mutated the callback
+	// and is now waiting for the running one to finish
+	require.Eventually(t, isShouldAbort, time.Second, time.Millisecond)
+	cancelDeactivate()
+
+	err := <-chDeactivated
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// failed deactivate must not leave the abort flag behind,
+	// otherwise it would silently abort every subsequent cycle
+	assert.False(t, isShouldAbort())
+
+	close(chGate)
+	assert.True(t, <-chCycle1)
+
+	// subsequent cycle executes the callback again
+	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+	assert.Equal(t, 2, startedCounter)
+
+	// regular deactivate/activate flow is unaffected
+	require.NoError(t, ctrl.Deactivate(ctx))
+	assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+	assert.Equal(t, 2, startedCounter)
+
+	require.NoError(t, ctrl.Activate())
+	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+	assert.Equal(t, 3, startedCounter)
+}
+
+func TestCycleCallback_Sequential_UnregisterCtxCancelledWhileRunning(t *testing.T) {
+	testUnregisterCtxCancelledWhileRunning(t, 1)
+}
+
+func TestCycleCallback_Parallel_UnregisterCtxCancelledWhileRunning(t *testing.T) {
+	testUnregisterCtxCancelledWhileRunning(t, 2)
+}
+
+func testUnregisterCtxCancelledWhileRunning(t *testing.T, routinesLimit int) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	chStarted := make(chan struct{}, 1)
+	chGate := make(chan struct{})
+	startedCounter := 0
+	callback := func(shouldAbort ShouldAbortCallback) bool {
+		if shouldAbort() {
+			return false
+		}
+		startedCounter++
+		if startedCounter == 1 {
+			chStarted <- struct{}{}
+		}
+		<-chGate
+		return true
+	}
+
+	callbacks := NewCallbackGroup("id", logger, routinesLimit)
+	ctrl := callbacks.Register("c", callback)
+
+	// single registered callback gets id 0
+	isShouldAbort := func() bool {
+		group := callbacks.(*cycleCallbackGroup)
+		group.Lock()
+		defer group.Unlock()
+		return group.callbacks[0].shouldAbort
+	}
+
+	// 1st cycle with the callback blocking on the gate
+	chCycle1 := make(chan bool, 1)
+	go func() {
+		chCycle1 <- callbacks.CycleCallback(shouldNotAbort)
+	}()
+	<-chStarted
+
+	// unregister with ctx cancelled while the callback is still running
+	ctxUnregister, cancelUnregister := context.WithCancel(ctx)
+	chUnregistered := make(chan error, 1)
+	go func() {
+		chUnregistered <- ctrl.Unregister(ctxUnregister)
+	}()
+
+	// wait for the abort flag to make sure unregister mutated the callback
+	// and is now waiting for the running one to finish
+	require.Eventually(t, isShouldAbort, time.Second, time.Millisecond)
+	cancelUnregister()
+
+	err := <-chUnregistered
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// failed unregister must neither leave the abort flag behind nor drop
+	// the callback, otherwise it would silently abort every subsequent cycle
+	assert.False(t, isShouldAbort())
+	assert.True(t, ctrl.IsActive())
+
+	close(chGate)
+	assert.True(t, <-chCycle1)
+
+	// subsequent cycle executes the callback again
+	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+	assert.Equal(t, 2, startedCounter)
+
+	// regular unregister is unaffected
+	require.NoError(t, ctrl.Unregister(ctx))
+	assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+	assert.Equal(t, 2, startedCounter)
+}

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -2036,7 +2036,46 @@ func TestCycleCallback_Parallel_DeactivateCtxCancelledWhileRunning(t *testing.T)
 	testDeactivateCtxCancelledWhileRunning(t, 2)
 }
 
+// ctxCancelledWhileRunningSpec parameterizes testCtxCancelledWhileRunning with
+// the controller op under test (Deactivate or Unregister): which op is invoked
+// with the cancellable ctx, which op-specific assertions run after it failed,
+// and the op-specific regression block at the end.
+type ctxCancelledWhileRunningSpec struct {
+	// mutate is the controller op called with the cancellable ctx while the
+	// callback is still running.
+	mutate func(ctrl CycleCallbackCtrl, ctx context.Context) error
+	// afterFailedMutate runs right after mutate returned context.Canceled
+	// (may be nil); the shared body already asserts the shouldAbort flag
+	// was restored.
+	afterFailedMutate func(t *testing.T, ctrl CycleCallbackCtrl)
+	// tail is the op-specific regression block proving the regular flow is
+	// unaffected by the failed op. startedCounter reports how often the
+	// callback body has run so far.
+	tail func(t *testing.T, callbacks CycleCallbackGroup, ctrl CycleCallbackCtrl,
+		shouldNotAbort ShouldAbortCallback, startedCounter func() int)
+}
+
 func testDeactivateCtxCancelledWhileRunning(t *testing.T, routinesLimit int) {
+	testCtxCancelledWhileRunning(t, routinesLimit, ctxCancelledWhileRunningSpec{
+		mutate: func(ctrl CycleCallbackCtrl, ctx context.Context) error {
+			return ctrl.Deactivate(ctx)
+		},
+		tail: func(t *testing.T, callbacks CycleCallbackGroup, ctrl CycleCallbackCtrl,
+			shouldNotAbort ShouldAbortCallback, startedCounter func() int,
+		) {
+			// regular deactivate/activate flow is unaffected
+			require.NoError(t, ctrl.Deactivate(context.Background()))
+			assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, 2, startedCounter())
+
+			require.NoError(t, ctrl.Activate())
+			assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, 3, startedCounter())
+		},
+	})
+}
+
+func testCtxCancelledWhileRunning(t *testing.T, routinesLimit int, spec ctxCancelledWhileRunningSpec) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 	shouldNotAbort := func() bool { return false }
@@ -2074,25 +2113,28 @@ func testDeactivateCtxCancelledWhileRunning(t *testing.T, routinesLimit int) {
 	}()
 	<-chStarted
 
-	// deactivate with ctx cancelled while the callback is still running
-	ctxDeactivate, cancelDeactivate := context.WithCancel(ctx)
-	chDeactivated := make(chan error, 1)
+	// mutate with ctx cancelled while the callback is still running
+	ctxMutate, cancelMutate := context.WithCancel(ctx)
+	chMutated := make(chan error, 1)
 	go func() {
-		chDeactivated <- ctrl.Deactivate(ctxDeactivate)
+		chMutated <- spec.mutate(ctrl, ctxMutate)
 	}()
 
-	// wait for the abort flag to make sure deactivate mutated the callback
+	// wait for the abort flag to make sure the op mutated the callback
 	// and is now waiting for the running one to finish
 	require.Eventually(t, isShouldAbort, time.Second, time.Millisecond)
-	cancelDeactivate()
+	cancelMutate()
 
-	err := <-chDeactivated
+	err := <-chMutated
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 
-	// failed deactivate must not leave the abort flag behind,
+	// the failed op must not leave the abort flag behind,
 	// otherwise it would silently abort every subsequent cycle
 	assert.False(t, isShouldAbort())
+	if spec.afterFailedMutate != nil {
+		spec.afterFailedMutate(t, ctrl)
+	}
 
 	close(chGate)
 	assert.True(t, <-chCycle1)
@@ -2101,14 +2143,8 @@ func testDeactivateCtxCancelledWhileRunning(t *testing.T, routinesLimit int) {
 	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
 	assert.Equal(t, 2, startedCounter)
 
-	// regular deactivate/activate flow is unaffected
-	require.NoError(t, ctrl.Deactivate(ctx))
-	assert.False(t, callbacks.CycleCallback(shouldNotAbort))
-	assert.Equal(t, 2, startedCounter)
-
-	require.NoError(t, ctrl.Activate())
-	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-	assert.Equal(t, 3, startedCounter)
+	// op-specific regression block
+	spec.tail(t, callbacks, ctrl, shouldNotAbort, func() int { return startedCounter })
 }
 
 func TestCycleCallback_Sequential_UnregisterCtxCancelledWhileRunning(t *testing.T) {
@@ -2120,73 +2156,22 @@ func TestCycleCallback_Parallel_UnregisterCtxCancelledWhileRunning(t *testing.T)
 }
 
 func testUnregisterCtxCancelledWhileRunning(t *testing.T, routinesLimit int) {
-	ctx := context.Background()
-	logger, _ := test.NewNullLogger()
-	shouldNotAbort := func() bool { return false }
-
-	chStarted := make(chan struct{}, 1)
-	chGate := make(chan struct{})
-	startedCounter := 0
-	callback := func(shouldAbort ShouldAbortCallback) bool {
-		if shouldAbort() {
-			return false
-		}
-		startedCounter++
-		if startedCounter == 1 {
-			chStarted <- struct{}{}
-		}
-		<-chGate
-		return true
-	}
-
-	callbacks := NewCallbackGroup("id", logger, routinesLimit)
-	ctrl := callbacks.Register("c", callback)
-
-	// single registered callback gets id 0
-	isShouldAbort := func() bool {
-		group := callbacks.(*cycleCallbackGroup)
-		group.Lock()
-		defer group.Unlock()
-		return group.callbacks[0].shouldAbort
-	}
-
-	// 1st cycle with the callback blocking on the gate
-	chCycle1 := make(chan bool, 1)
-	go func() {
-		chCycle1 <- callbacks.CycleCallback(shouldNotAbort)
-	}()
-	<-chStarted
-
-	// unregister with ctx cancelled while the callback is still running
-	ctxUnregister, cancelUnregister := context.WithCancel(ctx)
-	chUnregistered := make(chan error, 1)
-	go func() {
-		chUnregistered <- ctrl.Unregister(ctxUnregister)
-	}()
-
-	// wait for the abort flag to make sure unregister mutated the callback
-	// and is now waiting for the running one to finish
-	require.Eventually(t, isShouldAbort, time.Second, time.Millisecond)
-	cancelUnregister()
-
-	err := <-chUnregistered
-	require.Error(t, err)
-	assert.ErrorIs(t, err, context.Canceled)
-
-	// failed unregister must neither leave the abort flag behind nor drop
-	// the callback, otherwise it would silently abort every subsequent cycle
-	assert.False(t, isShouldAbort())
-	assert.True(t, ctrl.IsActive())
-
-	close(chGate)
-	assert.True(t, <-chCycle1)
-
-	// subsequent cycle executes the callback again
-	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
-	assert.Equal(t, 2, startedCounter)
-
-	// regular unregister is unaffected
-	require.NoError(t, ctrl.Unregister(ctx))
-	assert.False(t, callbacks.CycleCallback(shouldNotAbort))
-	assert.Equal(t, 2, startedCounter)
+	testCtxCancelledWhileRunning(t, routinesLimit, ctxCancelledWhileRunningSpec{
+		mutate: func(ctrl CycleCallbackCtrl, ctx context.Context) error {
+			return ctrl.Unregister(ctx)
+		},
+		afterFailedMutate: func(t *testing.T, ctrl CycleCallbackCtrl) {
+			// failed unregister must not drop the callback either,
+			// otherwise every subsequent cycle would lose it
+			assert.True(t, ctrl.IsActive())
+		},
+		tail: func(t *testing.T, callbacks CycleCallbackGroup, ctrl CycleCallbackCtrl,
+			shouldNotAbort ShouldAbortCallback, startedCounter func() int,
+		) {
+			// regular unregister is unaffected
+			require.NoError(t, ctrl.Unregister(context.Background()))
+			assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, 2, startedCounter())
+		},
+	})
 }

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -2175,3 +2175,94 @@ func testUnregisterCtxCancelledWhileRunning(t *testing.T, routinesLimit int) {
 		},
 	})
 }
+
+// A mutation that left shouldAbort untouched has nothing to roll back when the
+// input ctx expires, so it must not reach for the group lock. The test holds the
+// lock while the ctx is cancelled: a rollback attempt would block on it.
+func TestCycleCallback_MutateCallbackCtxCancelledWithoutFlagChange(t *testing.T) {
+	type testCase struct {
+		name          string
+		routinesLimit int
+		// value of shouldAbort before and after the mutation
+		shouldAbort bool
+	}
+
+	testCases := []testCase{
+		{name: "sequential, flag stays false", routinesLimit: 1, shouldAbort: false},
+		{name: "sequential, flag stays true", routinesLimit: 1, shouldAbort: true},
+		{name: "parallel, flag stays false", routinesLimit: 2, shouldAbort: false},
+		{name: "parallel, flag stays true", routinesLimit: 2, shouldAbort: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			shouldNotAbort := func() bool { return false }
+
+			chStarted := make(chan struct{}, 1)
+			chGate := make(chan struct{})
+			callback := func(shouldAbort ShouldAbortCallback) bool {
+				chStarted <- struct{}{}
+				<-chGate
+				return true
+			}
+
+			callbacks := NewCallbackGroup("id", logger, tc.routinesLimit)
+			callbacks.Register("c", callback)
+			group := callbacks.(*cycleCallbackGroup)
+
+			// single registered callback gets id 0. true stands for a
+			// deactivate already waiting for the running callback to finish
+			group.Lock()
+			group.callbacks[0].shouldAbort = tc.shouldAbort
+			group.Unlock()
+
+			// 1st cycle with the callback blocking on the gate
+			chCycle := make(chan bool, 1)
+			go func() {
+				chCycle <- callbacks.CycleCallback(shouldNotAbort)
+			}()
+			<-chStarted
+
+			ctxMutate, cancelMutate := context.WithCancel(context.Background())
+			defer cancelMutate()
+
+			chEntered := make(chan struct{}, 1)
+			chMutated := make(chan error, 1)
+			go func() {
+				chMutated <- group.mutateCallback(ctxMutate, 0,
+					func(callbackId uint32) error { return nil },
+					func(callbackId uint32, meta *cycleCallbackMeta, running bool) error {
+						chEntered <- struct{}{}
+						return nil
+					},
+				)
+			}()
+
+			// onMetaFound runs under the group lock, so acquiring it here waits until
+			// mutateCallback released it and is about to wait for the running callback
+			<-chEntered
+			group.Lock()
+			cancelMutate()
+
+			var err error
+			timedOut := false
+			select {
+			case err = <-chMutated:
+			case <-time.After(5 * time.Second):
+				timedOut = true
+			}
+			group.Unlock()
+
+			require.False(t, timedOut, "mutateCallback waited for the group lock instead of skipping the rollback")
+			assert.ErrorIs(t, err, context.Canceled)
+
+			group.Lock()
+			assert.Equal(t, tc.shouldAbort, group.callbacks[0].shouldAbort)
+			group.Unlock()
+
+			close(chGate)
+			assert.True(t, <-chCycle)
+		})
+	}
+}


### PR DESCRIPTION
SuperKimi here.

### What's being changed:

Fixes weaviate/0-weaviate-issues#350 (filed by QA Claude during reindex-GA QA; pre-existing, not GA-blocking).

The single-callback cycle controller's `Deactivate` was not atomic on a context error: `mutateCallback` sets `meta.shouldAbort = true` under lock, then waits for the in-flight callback to finish. If the caller's `ctx` expired first (e.g. an operator cancels an in-progress reindex at the wrong tens-of-ms instant), it returned `ctx.Err()` leaving `shouldAbort=true, active=true`. The caller treats the pause as failed and never calls `Activate()`, so every subsequent cycle aborts immediately — compaction and tombstone cleanup silently no-op forever on that segment group (no error surfaced; restart or an opportunistic later pause/resume is the only recovery). The combined controller already rolls back on partial failure; the single controller did not. `unregister` shares the same state machine and leaked identically.

Fix: in `mutateCallback`, snapshot the flag before/after the mutation under the already-held lock, and on the ctx-expired-while-running path restore the previous value — but only if it still equals the post-mutation value, so a racing activate/deactivate is never clobbered. 12 lines in `entities/cyclemanager/cyclecallbackgroup.go`. All downstream call sites (`PrependSegmentsFromBucket`, `ApplyToObjectDigests`, `CreateSnapshot`, plus the rangeable in-mem rebuild on later branches) are fixed at once, since the gap was in the controller.

Targeting stable/v1.36 as the minimal branch carrying the gap; merges forward per the stable-branch flow.

Regression coverage: 4 new tests (`Deactivate`/`Unregister` × sequential/parallel limits) that park a callback mid-cycle on a channel gate, cancel the deactivate/unregister ctx while `mutateCallback` waits, then pin: `context.Canceled` returned, the abort flag restored, and the callback executing again on the next cycle — plus unaffected-flow guards (normal Deactivate pauses, Activate resumes, later Unregister works). **Red pre-fix** (stuck flag + every subsequent cycle no-ops) / **green post-fix**, including under `-race` (full package, 6s).

Verification: `go test ./entities/cyclemanager/... -race -count=1` ok; `go build ./...` clean; gofumpt clean; `golangci-lint run ./entities/...` 0 issues; `tools/linter_go_routines.sh` clean.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary (internal controller semantics; godoc unchanged in meaning)
- [x] Chaos pipeline run or not necessary. Not necessary — unit-level state-machine fix with deterministic pins.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary — two bool snapshots + one conditional store under an already-held lock on the error path only.

— SuperKimi
