### PR TITLE
Namespace suspend: Check namespace status for DB Users

### DIFF
--- a/adapters/handlers/rest/configure_server.go
+++ b/adapters/handlers/rest/configure_server.go
@@ -141,7 +141,7 @@ func configureCrons(appState *state.State, serverShutdownCtx context.Context) *c
 }
 
 func configureAPIKey(appState *state.State) *apikey.ApiKey {
-	c, err := apikey.New(appState.ServerConfig.Config, appState.Logger)
+	c, err := apikey.New(appState.ServerConfig.Config, appState.Logger, appState.NamespacesController)
 	if err != nil {
 		appState.Logger.WithField("action", "api_keys_init").WithError(err).Fatal("apikey client could not start up")
 		os.Exit(1)

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3097,7 +3097,7 @@ func init() {
         }
       },
       "delete": {
-        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
+        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state, which stops its dynamic users from authenticating; their rows, along with classes and aliases, are reclaimed by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
         "tags": [
           "namespaces"
         ],
@@ -14057,7 +14057,7 @@ func init() {
         }
       },
       "delete": {
-        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
+        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state, which stops its dynamic users from authenticating; their rows, along with classes and aliases, are reclaimed by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
         "tags": [
           "namespaces"
         ],

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -38,7 +38,6 @@ type NamespaceRaftGetter interface {
 	AddNamespace(ctx context.Context, ns cmd.Namespace) (cmd.Namespace, uint64, error)
 	UpdateNamespace(ctx context.Context, ns cmd.Namespace) (uint64, error)
 	ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) (uint64, error)
-	DeleteUsersInNamespace(ctx context.Context, name string) error
 	GetNamespaces(names ...string) ([]cmd.Namespace, error)
 	StorageCandidates() []string
 }
@@ -267,11 +266,9 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 		return nsops.NewDeleteNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
-	// Two-phase delete. First flip to deleting; the apply handler is
-	// idempotent on already-deleting (returns nil). Then issue the
-	// namespace-scoped user delete. Order matters: marking first ensures
-	// the dynusers active-namespace gate rejects any concurrent CreateUser
-	// before we drain the user list.
+	// Flip to deleting; the apply handler is idempotent on already-deleting
+	// (returns nil). Keys in the namespace stop authenticating as soon as the
+	// flip applies, and the rows are reclaimed by the cleanup tick.
 	if _, err := h.raft.ChangeNamespaceState(ctx, name, cmd.NamespaceStateDeleting); err != nil {
 		if errors.Is(err, usecasesNamespaces.ErrNotFound) {
 			return nsops.NewDeleteNamespaceNotFound().WithPayload(
@@ -279,10 +276,6 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 		}
 		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
 			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("marking namespace for deletion: %w", err)))
-	}
-	if err := h.raft.DeleteUsersInNamespace(ctx, name); err != nil {
-		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("deleting users in namespace: %w", err)))
 	}
 
 	return nsops.NewDeleteNamespaceAccepted()

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -65,10 +65,6 @@ func (m *mockRaft) ChangeNamespaceState(ctx context.Context, name string, target
 	return uint64(args.Int(0)), args.Error(1)
 }
 
-func (m *mockRaft) DeleteUsersInNamespace(ctx context.Context, name string) error {
-	return m.Called(ctx, name).Error(0)
-}
-
 func (m *mockRaft) GetNamespaces(names ...string) ([]cmd.Namespace, error) {
 	// Convert variadic to []interface{} for Called.
 	args := make([]interface{}, len(names))
@@ -663,21 +659,15 @@ func TestGetNamespace_OK(t *testing.T) {
 // deleteNamespace
 // -----------------------------------------------------------------------------
 
-// TestDeleteNamespace_TwoPhase exercises the two-phase delete: each case
-// configures the ChangeNamespaceState and (optionally) DeleteUsersInNamespace
-// mocks and asserts the expected typed HTTP response. The happy path also
-// covers the idempotent recall: deleting → deleting returns nil, the user
-// drain is a no-op, and the handler returns 202 again.
-func TestDeleteNamespace_TwoPhase(t *testing.T) {
+// TestDeleteNamespace flips the namespace to deleting and asserts the typed
+// HTTP response. The auth guard invalidates the namespace's keys, so the
+// handler issues no user drain; the cleanup tick reclaims the rows.
+func TestDeleteNamespace(t *testing.T) {
 	principal := &models.Principal{}
 	cases := []struct {
 		name           string
 		changeStateErr error
-		// When the test exercises the user-drain step, drainErr is set.
-		// callDrain controls whether the mock expectation is registered.
-		callDrain bool
-		drainErr  error
-		wantTyped any
+		wantTyped      any
 	}{
 		{
 			name:           "ChangeNamespaceState returns ErrNotFound → 404",
@@ -690,19 +680,7 @@ func TestDeleteNamespace_TwoPhase(t *testing.T) {
 			wantTyped:      &nsops.DeleteNamespaceInternalServerError{},
 		},
 		{
-			name:      "DeleteUsersInNamespace untyped error → 500",
-			callDrain: true,
-			drainErr:  errors.New("dynusers boom"),
-			wantTyped: &nsops.DeleteNamespaceInternalServerError{},
-		},
-		{
 			name:      "happy path returns 202",
-			callDrain: true,
-			wantTyped: &nsops.DeleteNamespaceAccepted{},
-		},
-		{
-			name:      "idempotent re-call returns 202",
-			callDrain: true,
 			wantTyped: &nsops.DeleteNamespaceAccepted{},
 		},
 	}
@@ -711,12 +689,10 @@ func TestDeleteNamespace_TwoPhase(t *testing.T) {
 			h, authz, raft := newHandler(t)
 			authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
 			raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(0, tc.changeStateErr)
-			if tc.callDrain {
-				raft.On("DeleteUsersInNamespace", mock.Anything, "customer1").Return(tc.drainErr)
-			}
 
 			res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 			assert.IsType(t, tc.wantTyped, res)
+			raft.AssertNotCalled(t, "DeleteUsersInNamespace")
 		})
 	}
 }

--- a/adapters/handlers/rest/operations/namespaces/delete_namespace.go
+++ b/adapters/handlers/rest/operations/namespaces/delete_namespace.go
@@ -47,7 +47,7 @@ func NewDeleteNamespace(ctx *middleware.Context, handler DeleteNamespaceHandler)
 
 # Delete a namespace
 
-Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the "deleting" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the "deleting" state are idempotent and return 202.
+Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the "deleting" state, which stops its dynamic users from authenticating; their rows, along with classes and aliases, are reclaimed by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the "deleting" state are idempotent and return 202.
 */
 type DeleteNamespace struct {
 	Context *middleware.Context

--- a/client/namespaces/namespaces_client.go
+++ b/client/namespaces/namespaces_client.go
@@ -98,7 +98,7 @@ func (a *Client) CreateNamespace(params *CreateNamespaceParams, authInfo runtime
 /*
 DeleteNamespace deletes a namespace
 
-Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the "deleting" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the "deleting" state are idempotent and return 202.
+Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the "deleting" state, which stops its dynamic users from authenticating; their rows, along with classes and aliases, are reclaimed by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the "deleting" state are idempotent and return 202.
 */
 func (a *Client) DeleteNamespace(params *DeleteNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNamespaceAccepted, error) {
 	// TODO: Validate the params before sending

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -147,11 +147,11 @@ func (m *Manager) GetUsers(req *cmd.QueryRequest) ([]byte, error) {
 		return []byte{}, fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	// Rebuild *apikey.User for the wire to keep the response shape stable;
+	// Rebuild the wire type to keep the response shape stable;
 	// these pointers are local and never shared.
-	wireUsers := make(map[string]*apikey.User, len(users))
+	wireUsers := make(map[string]*cmd.UserWire, len(users))
 	for id, v := range users {
-		wireUsers[id] = &apikey.User{
+		wireUsers[id] = &cmd.UserWire{
 			Id:                 v.Id,
 			Active:             v.Active,
 			InternalIdentifier: v.InternalIdentifier,

--- a/cluster/dynusers/dynamic_users_test.go
+++ b/cluster/dynusers/dynamic_users_test.go
@@ -66,7 +66,7 @@ func newTestManager(t *testing.T, ns usecasesNamespaces.Exister) (*Manager, *api
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
-	dynUser, err := apikey.NewDBUser(t.TempDir(), false, logger)
+	dynUser, err := apikey.NewDBUser(t.TempDir(), false, logger, ns)
 	require.NoError(t, err)
 	return NewManager(dynUser, ns, false, logger), dynUser
 }
@@ -80,7 +80,7 @@ func mustMarshalJSON(t *testing.T, v any) []byte {
 
 func TestNewManager_NilNamespacesPanics(t *testing.T) {
 	logger, _ := test.NewNullLogger()
-	dynUser, err := apikey.NewDBUser(t.TempDir(), false, logger)
+	dynUser, err := apikey.NewDBUser(t.TempDir(), false, logger, newNamespacesMock(t))
 	require.NoError(t, err)
 	assert.Panics(t, func() { NewManager(dynUser, nil, false, logger) })
 }
@@ -174,7 +174,7 @@ func TestManager_CreateUser_NamespacesEnabledRejectsEmpty(t *testing.T) {
 
 	ns := newNamespacesMock(t)
 	logger, _ := test.NewNullLogger()
-	dynUser, err := apikey.NewDBUser(t.TempDir(), false, logger)
+	dynUser, err := apikey.NewDBUser(t.TempDir(), false, logger, ns)
 	require.NoError(t, err)
 	m := NewManager(dynUser, ns, true, logger)
 

--- a/cluster/proto/api/dyn_user_requests.go
+++ b/cluster/proto/api/dyn_user_requests.go
@@ -14,8 +14,6 @@ package api
 import (
 	"crypto/sha256"
 	"time"
-
-	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 )
 
 const (
@@ -76,8 +74,22 @@ type QueryGetUsersRequest struct {
 	UserIds []string
 }
 
+// UserWire is the serialization shape of a DB user in QueryGetUsersResponse.
+// It carries the fields without the locking type, since the wire value is never
+// a live user.
+type UserWire struct {
+	Id                 string
+	Active             bool
+	InternalIdentifier string
+	ApiKeyFirstLetters string
+	CreatedAt          time.Time
+	LastUsedAt         time.Time
+	ImportedWithKey    bool
+	Namespace          string
+}
+
 type QueryGetUsersResponse struct {
-	Users map[string]*apikey.User
+	Users map[string]*UserWire
 }
 
 type QueryUserIdentifierExistsRequest struct {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -9871,7 +9871,7 @@
       },
       "delete": {
         "summary": "Delete a namespace",
-        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
+        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state, which stops its dynamic users from authenticating; their rows, along with classes and aliases, are reclaimed by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
         "operationId": "deleteNamespace",
         "tags": [
           "namespaces"

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -82,9 +82,9 @@ func TestNamespaces_DeleteHappyPath(t *testing.T) {
 
 // TestNamespaces_DeleteUserAuthBlockedClusterWide creates a namespace +
 // DB user, deletes the namespace, and asserts the user's API key
-// eventually fails with 401 against every replica. The leader applies
-// the synchronous DeleteUsersInNamespace before returning 202; followers
-// apply asynchronously, so each node is polled until auth is rejected.
+// eventually fails with 401 against every replica. The auth guard rejects
+// the key on any node that has applied the flip to deleting; followers apply
+// asynchronously, so each node is polled until auth is rejected.
 func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
 	ns := uniqueNS()
 	const userID = "bob"
@@ -97,8 +97,9 @@ func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
 	require.NoError(t, err, "fresh DB user should authenticate")
 
 	// Issue the delete; do not wait for full cleanup — the auth-blocked
-	// guarantee is established by the synchronous user-delete RAFT
-	// command, which has committed by the time the 202 is received.
+	// guarantee comes from the flip to deleting, which the auth guard
+	// enforces on every node that has applied it, before the cleanup tick
+	// reclaims the user rows.
 	helper.DeleteNamespace(t, ns, adminKey, helper.WithoutWaitForCleanup())
 
 	// On every replica, the user's API key must eventually be rejected.

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -25,14 +25,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 var log, _ = test.NewNullLogger()
 
+// activeExister reports every namespace as active, so tests that don't exercise
+// the namespace guard keep authenticating.
+type activeExister struct{}
+
+func (activeExister) GetNamespace(string) (cmd.Namespace, bool) {
+	return cmd.Namespace{State: cmd.NamespaceStateActive}, true
+}
+
 func TestDynUserConcurrency(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 
 	numUsers := 10
@@ -79,7 +89,7 @@ func TestUserView_MirrorsUserFields(t *testing.T) {
 
 // Concurrent Activate/Deactivate vs GetUsers field reads must stay race-free under -race.
 func TestGetUsers_NoRaceWithMutators(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 
 	const numUsers = 5
@@ -133,7 +143,7 @@ func TestGetUsers_NoRaceWithMutators(t *testing.T) {
 }
 
 func TestConcurrentValidate(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	userId1 := "id"
 	userId2 := "id2"
@@ -177,7 +187,7 @@ func TestConcurrentValidate(t *testing.T) {
 }
 
 func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	userId := "id"
 
@@ -208,7 +218,7 @@ func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	userId := "id"
 
@@ -252,7 +262,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestCheckUserIdentifierExists(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 
 	userId := "id"
@@ -275,7 +285,7 @@ func TestCheckUserIdentifierExists(t *testing.T) {
 }
 
 func TestSnapShotAndRestore(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 
 	userId1 := "id-1"
@@ -317,7 +327,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 	snapShot, err := dynUsers.Snapshot()
 	require.NoError(t, err)
 
-	dynUsers2, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers2, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	require.NoError(t, dynUsers2.Restore(snapShot, false))
 
@@ -349,7 +359,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 }
 
 func TestSuspendAfterDelete(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	userId := "id"
 
@@ -372,7 +382,7 @@ func TestSuspendAfterDelete(t *testing.T) {
 }
 
 func TestLastUsedTime(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	userId := "user"
 
@@ -415,7 +425,7 @@ func TestLastUsedTime(t *testing.T) {
 }
 
 func TestUpdateLastUsedTimestamp_NonExistentUser(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 
 	// Should not panic when updating timestamp for a user that doesn't exist
@@ -427,7 +437,7 @@ func TestUpdateLastUsedTimestamp_NonExistentUser(t *testing.T) {
 }
 
 func TestImportingAndSuspendingStaticKeys(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 
 	createdAt := time.Now()
@@ -466,7 +476,7 @@ func TestImportingAndSuspendingStaticKeys(t *testing.T) {
 }
 
 func TestImportingStaticKeys(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	createdAt := time.Now()
 	for i := 0; i < 10; i++ {
@@ -522,7 +532,7 @@ func TestImportingStaticKeys(t *testing.T) {
 }
 
 func TestImportingStaticKeysWithTime(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	createdAt := time.Now().Add(-time.Hour)
 
@@ -539,7 +549,7 @@ func TestImportingStaticKeysWithTime(t *testing.T) {
 }
 
 func TestSnapshotRestoreEmpty(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	userId := "user"
 
@@ -561,7 +571,7 @@ func TestSnapshotRestoreEmpty(t *testing.T) {
 }
 
 func TestRestoreInvalidData(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 
 	require.Error(t, dynUsers.Restore([]byte("invalid json"), false))
@@ -578,7 +588,7 @@ func TestCreateUserStoresNamespace(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dynUsers, err := NewDBUser(t.TempDir(), true, log)
+			dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 			require.NoError(t, err)
 
 			_, hash, identifier, err := keys.CreateApiKeyAndHash()
@@ -594,7 +604,7 @@ func TestCreateUserStoresNamespace(t *testing.T) {
 }
 
 func TestSnapshotRestoreMultipleNamespaces(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), false, log)
+	dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 
 	type seed struct {
@@ -616,7 +626,7 @@ func TestSnapshotRestoreMultipleNamespaces(t *testing.T) {
 	snap, err := dynUsers.Snapshot()
 	require.NoError(t, err)
 
-	restored, err := NewDBUser(t.TempDir(), false, log)
+	restored, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	require.NoError(t, restored.Restore(snap, false))
 
@@ -639,7 +649,7 @@ func TestValidateAndExtractReturnsNamespace(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			dynUsers, err := NewDBUser(t.TempDir(), true, log)
+			dynUsers, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 			require.NoError(t, err)
 
 			apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
@@ -657,8 +667,273 @@ func TestValidateAndExtractReturnsNamespace(t *testing.T) {
 	}
 }
 
+// countingExister reports a settable namespace state and counts lookups, so the
+// warm-path test can switch state between logins and assert the guard consults
+// it exactly once.
+type countingExister struct {
+	state cmd.NamespaceState
+	found bool
+	calls int
+}
+
+func (c *countingExister) GetNamespace(string) (cmd.Namespace, bool) {
+	c.calls++
+	return cmd.Namespace{State: c.state}, c.found
+}
+
+// mockNamespace returns a setup that expects exactly one GetNamespace(name)
+// lookup returning the given state and found flag.
+func mockNamespace(name string, state cmd.NamespaceState, found bool) func(*testing.T) *namespaces.MockExister {
+	return func(t *testing.T) *namespaces.MockExister {
+		m := namespaces.NewMockExister(t)
+		m.EXPECT().GetNamespace(name).Return(cmd.Namespace{Name: name, State: state}, found).Once()
+		return m
+	}
+}
+
+// createNamespacedUser adds user "u1" in the given namespace and returns the
+// decoded login key and identifier.
+func createNamespacedUser(tb testing.TB, dyn *DBUser, namespace string) (userId, key, identifier string) {
+	tb.Helper()
+	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
+	require.NoError(tb, err)
+	require.NoError(tb, dyn.CreateUser("u1", hash, identifier, "", namespace, time.Now()))
+	key, _, err = keys.DecodeApiKey(apiKey)
+	require.NoError(tb, err)
+	return "u1", key, identifier
+}
+
+func TestValidateAndExtract_NamespaceGuard(t *testing.T) {
+	const nsName = "customer1"
+
+	tests := []struct {
+		name       string
+		userNs     string
+		setupMock  func(t *testing.T) *namespaces.MockExister
+		tamper     func(t *testing.T, dyn *DBUser, userId, validKey string) (presentKey string)
+		wantOK     bool
+		wantErrIs  error
+		wantErrMsg string
+		assertMock func(t *testing.T, m *namespaces.MockExister)
+	}{
+		{
+			name:      "active",
+			userNs:    nsName,
+			setupMock: mockNamespace(nsName, cmd.NamespaceStateActive, true),
+			wantOK:    true,
+		},
+		{
+			name:      "suspended",
+			userNs:    nsName,
+			setupMock: mockNamespace(nsName, cmd.NamespaceStateSuspended, true),
+			wantErrIs: namespaces.ErrNamespaceSuspended,
+		},
+		{
+			name:      "resuming",
+			userNs:    nsName,
+			setupMock: mockNamespace(nsName, cmd.NamespaceStateResuming, true),
+			wantErrIs: namespaces.ErrNamespaceResuming,
+		},
+		{
+			name:      "deleting",
+			userNs:    nsName,
+			setupMock: mockNamespace(nsName, cmd.NamespaceStateDeleting, true),
+			wantErrIs: namespaces.ErrNamespaceDeleting,
+		},
+		{
+			name:      "unknown state",
+			userNs:    nsName,
+			setupMock: mockNamespace(nsName, cmd.NamespaceState("garbage"), true),
+			wantErrIs: namespaces.ErrInvalidState,
+		},
+		{
+			name:      "missing from exister",
+			userNs:    nsName,
+			setupMock: mockNamespace(nsName, cmd.NamespaceStateActive, false),
+			wantErrIs: namespaces.ErrNamespaceGone,
+		},
+		{
+			name:   "no namespace, exister never consulted",
+			userNs: "",
+			// Strict mock with no expectations: any GetNamespace call panics.
+			setupMock: func(t *testing.T) *namespaces.MockExister { return namespaces.NewMockExister(t) },
+			wantOK:    true,
+			assertMock: func(t *testing.T, m *namespaces.MockExister) {
+				m.AssertNotCalled(t, "GetNamespace")
+			},
+		},
+		{
+			name:      "wrong key on suspended namespace",
+			userNs:    nsName,
+			setupMock: func(t *testing.T) *namespaces.MockExister { return namespaces.NewMockExister(t) },
+			tamper: func(t *testing.T, dyn *DBUser, userId, validKey string) string {
+				return validKey + "-tampered"
+			},
+			wantErrMsg: "invalid token",
+			assertMock: func(t *testing.T, m *namespaces.MockExister) {
+				// hash verification fails before the guard, so it is never reached.
+				m.AssertNotCalled(t, "GetNamespace")
+			},
+		},
+		{
+			name:      "revoked key on suspended namespace",
+			userNs:    nsName,
+			setupMock: func(t *testing.T) *namespaces.MockExister { return namespaces.NewMockExister(t) },
+			tamper: func(t *testing.T, dyn *DBUser, userId, validKey string) string {
+				dyn.data.UserKeyRevoked[userId] = struct{}{}
+				return validKey
+			},
+			wantErrMsg: "key is revoked",
+			assertMock: func(t *testing.T, m *namespaces.MockExister) {
+				m.AssertNotCalled(t, "GetNamespace")
+			},
+		},
+		{
+			name:      "deactivated user on suspended namespace",
+			userNs:    nsName,
+			setupMock: func(t *testing.T) *namespaces.MockExister { return namespaces.NewMockExister(t) },
+			tamper: func(t *testing.T, dyn *DBUser, userId, validKey string) string {
+				require.NoError(t, dyn.DeactivateUser(userId, false))
+				return validKey
+			},
+			wantErrMsg: "user deactivated",
+			assertMock: func(t *testing.T, m *namespaces.MockExister) {
+				m.AssertNotCalled(t, "GetNamespace")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.setupMock(t)
+			dyn, err := NewDBUser(t.TempDir(), true, log, m)
+			require.NoError(t, err)
+
+			userId, key, identifier := createNamespacedUser(t, dyn, tc.userNs)
+			if tc.tamper != nil {
+				key = tc.tamper(t, dyn, userId, key)
+			}
+
+			principal, err := dyn.ValidateAndExtract(key, identifier)
+
+			if tc.wantOK {
+				require.NoError(t, err)
+				require.NotNil(t, principal)
+				require.Equal(t, tc.userNs, principal.Namespace)
+			} else {
+				require.Error(t, err)
+				require.Nil(t, principal)
+				if tc.wantErrIs != nil {
+					require.ErrorIs(t, err, tc.wantErrIs)
+				}
+				if tc.wantErrMsg != "" {
+					require.EqualError(t, err, tc.wantErrMsg)
+				}
+			}
+			if tc.assertMock != nil {
+				tc.assertMock(t, m)
+			}
+		})
+	}
+}
+
+// TestValidateAndExtract_GuardIsWarmPathOnly pins that once the weak-hash cache
+// is warm, a suspended rejection consults the exister exactly once and does not
+// re-enter the Argon2/strong-hash path.
+func TestValidateAndExtract_GuardIsWarmPathOnly(t *testing.T) {
+	ex := &countingExister{state: cmd.NamespaceStateActive, found: true}
+	dyn, err := NewDBUser(t.TempDir(), true, log, ex)
+	require.NoError(t, err)
+
+	userId, key, identifier := createNamespacedUser(t, dyn, "customer1")
+
+	// First login warms the weak-hash cache via the strong-hash path.
+	_, err = dyn.ValidateAndExtract(key, identifier)
+	require.NoError(t, err)
+	_, warm := dyn.memoryOnlyData.weakKeyStorageById.Load(userId)
+	require.True(t, warm, "first login should warm the weak-hash cache")
+	callsAfterWarm := ex.calls
+
+	ex.state = cmd.NamespaceStateSuspended
+	principal, err := dyn.ValidateAndExtract(key, identifier)
+	require.Nil(t, principal)
+	require.ErrorIs(t, err, namespaces.ErrNamespaceSuspended)
+
+	require.Equal(t, 1, ex.calls-callsAfterWarm, "suspended rejection must consult the exister exactly once")
+	_, stillWarm := dyn.memoryOnlyData.weakKeyStorageById.Load(userId)
+	require.True(t, stillWarm, "rejection must not evict or bypass the warm weak-hash cache")
+}
+
+// TestValidateAndExtract_RejectionLeavesLastUsedAt pins that a namespace
+// rejection performs no per-user write.
+func TestValidateAndExtract_RejectionLeavesLastUsedAt(t *testing.T) {
+	ex := &countingExister{state: cmd.NamespaceStateSuspended, found: true}
+	dyn, err := NewDBUser(t.TempDir(), true, log, ex)
+	require.NoError(t, err)
+
+	userId, key, identifier := createNamespacedUser(t, dyn, "customer1")
+	before := dyn.data.Users[userId].LastUsedAt
+
+	_, err = dyn.ValidateAndExtract(key, identifier)
+	require.ErrorIs(t, err, namespaces.ErrNamespaceSuspended)
+
+	require.Equal(t, before, dyn.data.Users[userId].LastUsedAt, "a rejected login must not touch LastUsedAt")
+}
+
+// TestValidateAndExtract_MissingUserRecordFailsClosed pins that a resolvable
+// identifier whose user record is gone fails closed with a generic error
+// instead of panicking or aliasing to the empty (global) namespace.
+func TestValidateAndExtract_MissingUserRecordFailsClosed(t *testing.T) {
+	dyn, err := NewDBUser(t.TempDir(), true, log, activeExister{})
+	require.NoError(t, err)
+
+	userId, key, identifier := createNamespacedUser(t, dyn, "customer1")
+	// Drop the user record but keep the identifier and secure-hash maps, so the
+	// hash gate passes and the nil user reaches the guard.
+	delete(dyn.data.Users, userId)
+
+	principal, err := dyn.ValidateAndExtract(key, identifier)
+	require.Nil(t, principal)
+	require.EqualError(t, err, "invalid token")
+}
+
+// TestValidateImportedKey_MissingUserRecordFailsClosed mirrors the fail-closed
+// hardening on the imported-key path.
+func TestValidateImportedKey_MissingUserRecordFailsClosed(t *testing.T) {
+	dyn, err := NewDBUser(t.TempDir(), true, log, activeExister{})
+	require.NoError(t, err)
+
+	const token = "imported-token"
+	dyn.data.ImportedApiKeysWeakHash["ghost"] = sha256.Sum256([]byte(token))
+
+	principal, err := dyn.ValidateImportedKey(token)
+	require.Nil(t, principal)
+	require.EqualError(t, err, "invalid token")
+}
+
+func BenchmarkValidateAndExtract(b *testing.B) {
+	run := func(b *testing.B, state cmd.NamespaceState) {
+		ex := &countingExister{state: cmd.NamespaceStateActive, found: true}
+		dyn, err := NewDBUser(b.TempDir(), true, log, ex)
+		require.NoError(b, err)
+		_, key, identifier := createNamespacedUser(b, dyn, "customer1")
+		// Warm the weak-hash cache, then measure the target state.
+		_, err = dyn.ValidateAndExtract(key, identifier)
+		require.NoError(b, err)
+		ex.state = state
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _ = dyn.ValidateAndExtract(key, identifier)
+		}
+	}
+
+	b.Run("active", func(b *testing.B) { run(b, cmd.NamespaceStateActive) })
+	b.Run("suspended", func(b *testing.B) { run(b, cmd.NamespaceStateSuspended) })
+}
+
 func TestUsersInNamespace(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), false, log)
+	dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 
 	seeds := []struct {
@@ -683,7 +958,7 @@ func TestUsersInNamespace(t *testing.T) {
 
 func TestDeleteUsersInNamespace(t *testing.T) {
 	t.Run("removes only matching users", func(t *testing.T) {
-		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 		require.NoError(t, err)
 
 		seeds := []struct {
@@ -712,7 +987,7 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 	})
 
 	t.Run("rerun on empty namespace is a no-op", func(t *testing.T) {
-		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 		require.NoError(t, err)
 
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
@@ -725,7 +1000,7 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 	})
 
 	t.Run("frees the user id for re-creation", func(t *testing.T) {
-		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 		require.NoError(t, err)
 
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
@@ -744,7 +1019,7 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 	})
 
 	t.Run("empty namespace argument is rejected", func(t *testing.T) {
-		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 		require.NoError(t, err)
 		require.Error(t, dynUsers.DeleteUsersInNamespace(""))
 	})
@@ -786,7 +1061,7 @@ func requireNoLogin(t *testing.T, u *DBUser, login, identifier string) {
 // excluded user's credentials must not travel and must not authenticate after
 // restore. This is the assertion that fails if filterDBUserData stops filtering.
 func TestSnapshotRestore_IncludeUsers_NonNamespaced(t *testing.T) {
-	src, err := NewDBUser(t.TempDir(), false, log)
+	src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 
 	login1, ident1 := seedUser(t, src, "u1", "")
@@ -796,7 +1071,7 @@ func TestSnapshotRestore_IncludeUsers_NonNamespaced(t *testing.T) {
 	snap, err := src.Snapshot("u1", "u3")
 	require.NoError(t, err)
 
-	dst, err := NewDBUser(t.TempDir(), false, log)
+	dst, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	require.NoError(t, dst.Restore(snap, false))
 
@@ -837,7 +1112,7 @@ func TestSnapshotRestore_IncludeUsers_Namespaced(t *testing.T) {
 				return MakeUserKey(short, "ns1")
 			}
 
-			src, err := NewDBUser(t.TempDir(), false, log)
+			src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 			require.NoError(t, err)
 
 			login1, ident1 := seedUser(t, src, MakeUserKey("u1", "ns1"), "ns1")
@@ -847,7 +1122,7 @@ func TestSnapshotRestore_IncludeUsers_Namespaced(t *testing.T) {
 			snap, err := src.Snapshot(MakeUserKey("u1", "ns1"), MakeUserKey("u2", "ns1"))
 			require.NoError(t, err)
 
-			dst, err := NewDBUser(t.TempDir(), false, log)
+			dst, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 			require.NoError(t, err)
 			require.NoError(t, dst.Restore(snap, tc.stripNamespaces))
 
@@ -872,7 +1147,7 @@ func TestSnapshotRestore_IncludeUsers_Namespaced(t *testing.T) {
 // exist must fail loudly at snapshot time rather than ship an incomplete backup
 // that silently drops the missing id.
 func TestSnapshot_IncludeUsers_RejectsUnknownID(t *testing.T) {
-	src, err := NewDBUser(t.TempDir(), false, log)
+	src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	seedUser(t, src, "u1", "")
 
@@ -887,7 +1162,7 @@ func TestSnapshot_IncludeUsers_RejectsUnknownID(t *testing.T) {
 // silently overwrite one user's credentials with the other's, and the target's
 // existing users must survive the rejected restore.
 func TestSnapshotRestore_IncludeUsers_GraduationAliasCollision(t *testing.T) {
-	src, err := NewDBUser(t.TempDir(), false, log)
+	src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	seedUser(t, src, MakeUserKey("alice", "ns1"), "ns1")
 	seedUser(t, src, MakeUserKey("alice", "ns2"), "ns2")
@@ -895,7 +1170,7 @@ func TestSnapshotRestore_IncludeUsers_GraduationAliasCollision(t *testing.T) {
 	snap, err := src.Snapshot(MakeUserKey("alice", "ns1"), MakeUserKey("alice", "ns2"))
 	require.NoError(t, err)
 
-	dst, err := NewDBUser(t.TempDir(), false, log)
+	dst, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	loginIncumbent, identIncumbent := seedUser(t, dst, "incumbent", "")
 
@@ -916,7 +1191,7 @@ func TestSnapshotRestore_IncludeUsers_GraduationAliasCollision(t *testing.T) {
 // store at all, mirroring the scheduler on clusters where dynamic users are
 // disabled yet a restored snapshot would still be applied.
 func TestValidateNamespaceStrip(t *testing.T) {
-	src, err := NewDBUser(t.TempDir(), false, log)
+	src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	seedUser(t, src, MakeUserKey("alice", "ns1"), "ns1")
 	seedUser(t, src, MakeUserKey("alice", "ns2"), "ns2")
@@ -959,14 +1234,14 @@ func TestValidateNamespaceStrip(t *testing.T) {
 // incumbent user in the target is wiped, so stale credentials cannot linger
 // past a restore.
 func TestSnapshotRestore_IncludeUsers_RestoreReplacesTarget(t *testing.T) {
-	src, err := NewDBUser(t.TempDir(), false, log)
+	src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	login1, ident1 := seedUser(t, src, "u1", "")
 
 	snap, err := src.Snapshot("u1")
 	require.NoError(t, err)
 
-	dst, err := NewDBUser(t.TempDir(), false, log)
+	dst, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	loginIncumbent, identIncumbent := seedUser(t, dst, "incumbent", "")
 
@@ -986,7 +1261,7 @@ func TestSnapshotRestore_IncludeUsers_RestoreReplacesTarget(t *testing.T) {
 // revocation must survive an includeUsers backup, or a restore would silently
 // re-enable a disabled credential.
 func TestSnapshotRestore_IncludeUsers_PreservesStatus(t *testing.T) {
-	src, err := NewDBUser(t.TempDir(), false, log)
+	src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	loginActive, identActive := seedUser(t, src, "active", "")
 	loginDeact, identDeact := seedUser(t, src, "deactivated", "")
@@ -995,7 +1270,7 @@ func TestSnapshotRestore_IncludeUsers_PreservesStatus(t *testing.T) {
 	snap, err := src.Snapshot("active", "deactivated")
 	require.NoError(t, err)
 
-	dst, err := NewDBUser(t.TempDir(), false, log)
+	dst, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	require.NoError(t, dst.Restore(snap, false))
 
@@ -1013,7 +1288,7 @@ func TestSnapshotRestore_IncludeUsers_PreservesStatus(t *testing.T) {
 // selected by includeUsers must still validate after a graduation restore,
 // alongside a stripped namespaced dynamic user.
 func TestSnapshotRestore_IncludeUsers_ImportedKey(t *testing.T) {
-	src, err := NewDBUser(t.TempDir(), false, log)
+	src, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 
 	seedUser(t, src, MakeUserKey("u1", "ns1"), "ns1")
@@ -1023,7 +1298,7 @@ func TestSnapshotRestore_IncludeUsers_ImportedKey(t *testing.T) {
 	snap, err := src.Snapshot(MakeUserKey("u1", "ns1"), "svc")
 	require.NoError(t, err)
 
-	dst, err := NewDBUser(t.TempDir(), false, log)
+	dst, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 	require.NoError(t, dst.Restore(snap, true)) // graduation strip
 
@@ -1039,7 +1314,7 @@ func TestSnapshotRestore_IncludeUsers_ImportedKey(t *testing.T) {
 }
 
 func TestRestoreIncompleteData(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), false, log)
+	dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 
 	snapShot, err := dynUsers.Snapshot()
@@ -1053,7 +1328,7 @@ func TestRestoreIncompleteData(t *testing.T) {
 	snapShot, err = json.Marshal(root)
 	require.NoError(t, err)
 
-	dynUsers2, err := NewDBUser(t.TempDir(), true, log)
+	dynUsers2, err := NewDBUser(t.TempDir(), true, log, activeExister{})
 	require.NoError(t, err)
 	err = dynUsers2.Restore(snapShot, false)
 	require.NoError(t, err)
@@ -1068,7 +1343,7 @@ func TestRestoreIncompleteData(t *testing.T) {
 }
 
 func TestListAllUsers(t *testing.T) {
-	dynUsers, err := NewDBUser(t.TempDir(), false, log)
+	dynUsers, err := NewDBUser(t.TempDir(), false, log, activeExister{})
 	require.NoError(t, err)
 
 	// create users in different namespaces

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -29,6 +29,7 @@ import (
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
@@ -114,6 +115,7 @@ type DBUser struct {
 	memoryOnlyData memoryOnlyData
 	path           string
 	enabled        bool
+	nsExister      namespaces.Exister
 }
 
 type DBUserSnapshot struct {
@@ -144,7 +146,10 @@ type memoryOnlyData struct {
 	importedApiKeysBlocked [][sha256.Size]byte
 }
 
-func NewDBUser(path string, enabled bool, logger logrus.FieldLogger) (*DBUser, error) {
+func NewDBUser(path string, enabled bool, logger logrus.FieldLogger, nsExister namespaces.Exister) (*DBUser, error) {
+	if nsExister == nil {
+		panic("apikey: namespaces exister must not be nil")
+	}
 	fullpath := fmt.Sprintf("%s/raft/db_users/", path)
 	err := createStorage(fullpath + FileName)
 	if err != nil {
@@ -171,7 +176,8 @@ func NewDBUser(path string, enabled bool, logger logrus.FieldLogger) (*DBUser, e
 			weakKeyStorageById:     &sync.Map{},
 			importedApiKeysBlocked: make([][sha256.Size]byte, 0),
 		},
-		enabled: enabled,
+		enabled:   enabled,
+		nsExister: nsExister,
 	}
 
 	// we save every change to file after a request is done, EXCEPT the lastUsedAt time as we do not want to write to a
@@ -466,7 +472,12 @@ func (c *DBUser) ValidateImportedKey(token string) (*models.Principal, error) {
 		if subtle.ConstantTimeCompare(keyHashGiven[:], keyHashStored[:]) != 1 {
 			continue
 		}
-		if c.data.Users[userId] != nil && !c.data.Users[userId].Active {
+		u := c.data.Users[userId]
+		if u == nil {
+			// the user record is missing though its key resolved; fail closed
+			return nil, fmt.Errorf("invalid token")
+		}
+		if !u.Active {
 			return nil, fmt.Errorf("user deactivated")
 		}
 
@@ -475,15 +486,15 @@ func (c *DBUser) ValidateImportedKey(token string) (*models.Principal, error) {
 		}
 
 		// imported keys are always without a namespace, something is seriously wrong here
-		if c.data.Users[userId].Namespace != "" {
-			return nil, fmt.Errorf("imported key with namespace %v", c.data.Users[userId].Namespace)
+		if u.Namespace != "" {
+			return nil, fmt.Errorf("imported key with namespace %v", u.Namespace)
 		}
 
 		// Last used time does not have to be exact. If we have multiple concurrent requests for the same
 		// user, only recording one of them is good enough
-		if c.data.Users[userId].TryLock() {
-			c.data.Users[userId].LastUsedAt = time.Now()
-			c.data.Users[userId].Unlock()
+		if u.TryLock() {
+			u.LastUsedAt = time.Now()
+			u.Unlock()
 		}
 
 		return &models.Principal{
@@ -536,24 +547,32 @@ func (c *DBUser) ValidateAndExtract(key, userIdentifier string) (*models.Princip
 		return nil, err
 	}
 
-	if c.data.Users[userId] != nil && !c.data.Users[userId].Active {
+	u := c.data.Users[userId]
+	if u == nil {
+		// the user record is missing though its key resolved; fail closed
+		return nil, fmt.Errorf("invalid token")
+	}
+	if !u.Active {
 		return nil, fmt.Errorf("user deactivated")
 	}
 	if _, ok := c.data.UserKeyRevoked[userId]; ok {
 		return nil, fmt.Errorf("key is revoked")
 	}
+	if err := namespaces.RequireActive(c.nsExister, u.Namespace); err != nil {
+		return nil, err
+	}
 
 	// Last used time does not have to be exact. If we have multiple concurrent requests for the same
 	// user, only recording one of them is good enough
-	if c.data.Users[userId].TryLock() {
-		c.data.Users[userId].LastUsedAt = time.Now()
-		c.data.Users[userId].Unlock()
+	if u.TryLock() {
+		u.LastUsedAt = time.Now()
+		u.Unlock()
 	}
 
 	return &models.Principal{
 		Username:         userId,
 		UserType:         models.UserTypeInputDb,
-		Namespace:        c.data.Users[userId].Namespace,
+		Namespace:        u.Namespace,
 		IsGlobalOperator: false,
 	}, nil
 }

--- a/usecases/auth/authentication/apikey/namespace_gate_integration_test.go
+++ b/usecases/auth/authentication/apikey/namespace_gate_integration_test.go
@@ -1,0 +1,89 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package apikey
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/namespaces"
+)
+
+// TestNamespaceGate_SuspendResumeDelete drives a real controller, DB-user store
+// and API-key wrapper through the namespace lifecycle, asserting that a user's
+// key tracks its namespace state while a second namespace's user is unaffected.
+func TestNamespaceGate_SuspendResumeDelete(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	ctrl := namespaces.NewController(logger)
+	require.NoError(t, ctrl.Create(cmd.Namespace{Name: "customer1", HomeNodes: []string{"node-1"}}))
+	require.NoError(t, ctrl.Create(cmd.Namespace{Name: "other", HomeNodes: []string{"node-1"}}))
+
+	wrapper, err := New(config.Config{
+		Persistence:    config.Persistence{DataPath: t.TempDir()},
+		Authentication: config.Authentication{DBUsers: config.DbUsers{Enabled: true}},
+	}, logger, ctrl)
+	require.NoError(t, err)
+
+	key1 := createUser(t, wrapper, "u1", "customer1")
+	key2 := createUser(t, wrapper, "u2", "other")
+
+	login := func(key string) error {
+		_, err := wrapper.ValidateAndExtract(key, nil)
+		return err
+	}
+
+	// Both namespaces active: both keys authenticate.
+	require.NoError(t, login(key1))
+	require.NoError(t, login(key2))
+
+	steps := []struct {
+		target   cmd.NamespaceState
+		index    uint64
+		wantBody string // "" means login must succeed
+	}{
+		{target: cmd.NamespaceStateSuspended, index: 1, wantBody: "unauthorized: instance suspended"},
+		{target: cmd.NamespaceStateResuming, index: 2, wantBody: "unauthorized: instance resuming, retry shortly"},
+		{target: cmd.NamespaceStateActive, index: 3, wantBody: ""},
+		{target: cmd.NamespaceStateDeleting, index: 4, wantBody: "unauthorized: instance unavailable"},
+	}
+
+	for _, step := range steps {
+		require.NoError(t, ctrl.ChangeState("customer1", step.target, step.index))
+
+		err := login(key1)
+		if step.wantBody == "" {
+			require.NoError(t, err, "state %s must authenticate", step.target)
+		} else {
+			require.EqualError(t, err, step.wantBody, "state %s", step.target)
+		}
+
+		// The untouched namespace's user authenticates throughout.
+		require.NoError(t, login(key2), "state %s must not affect the other namespace", step.target)
+	}
+}
+
+func createUser(t *testing.T, w *ApiKey, userId, namespace string) (apiKey string) {
+	t.Helper()
+	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
+	require.NoError(t, err)
+	require.NoError(t, w.Dynamic.CreateUser(userId, hash, identifier, "", namespace, time.Now()))
+	return apiKey
+}

--- a/usecases/auth/authentication/apikey/wrapper.go
+++ b/usecases/auth/authentication/apikey/wrapper.go
@@ -72,6 +72,9 @@ func (a *ApiKey) ValidateAndExtract(token string, scopes []string) (*models.Prin
 
 	principal, err := validate(token, scopes)
 	if err != nil {
+		if msg, ok := namespaces.PublicMessage(err); ok {
+			return nil, errors.New(401, "unauthorized: %s", msg)
+		}
 		return nil, errors.New(401, "unauthorized: %v", err)
 	}
 	return principal, nil

--- a/usecases/auth/authentication/apikey/wrapper.go
+++ b/usecases/auth/authentication/apikey/wrapper.go
@@ -19,6 +19,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 type ApiKey struct {
@@ -26,12 +27,12 @@ type ApiKey struct {
 	Dynamic *DBUser
 }
 
-func New(cfg config.Config, logger logrus.FieldLogger) (*ApiKey, error) {
+func New(cfg config.Config, logger logrus.FieldLogger, nsExister namespaces.Exister) (*ApiKey, error) {
 	static, err := NewStatic(cfg)
 	if err != nil {
 		return nil, err
 	}
-	dynamic, err := NewDBUser(cfg.Persistence.DataPath, cfg.Authentication.DBUsers.Enabled, logger)
+	dynamic, err := NewDBUser(cfg.Persistence.DataPath, cfg.Authentication.DBUsers.Enabled, logger, nsExister)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/auth/authentication/apikey/wrapper_test.go
+++ b/usecases/auth/authentication/apikey/wrapper_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
 	"github.com/weaviate/weaviate/usecases/config"
 
@@ -136,6 +137,66 @@ func TestValidDynamicKey(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, principal)
 			}
+		})
+	}
+}
+
+// TestValidateAndExtract_NeutralNamespaceMessage pins that a key rejected for
+// its namespace state renders the neutral copy at the 401 boundary, leaking
+// neither the concept nor the namespace name, while a genuine bad key keeps its
+// detail.
+func TestValidateAndExtract_NeutralNamespaceMessage(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := test.NewNullLogger()
+	const nsName = "customer1"
+
+	tests := []struct {
+		name       string
+		state      cmd.NamespaceState
+		found      bool
+		wrongKey   bool
+		wantExact  string
+		wantDetail bool
+	}{
+		{name: "suspended", state: cmd.NamespaceStateSuspended, found: true, wantExact: "unauthorized: instance suspended"},
+		{name: "resuming", state: cmd.NamespaceStateResuming, found: true, wantExact: "unauthorized: instance resuming, retry shortly"},
+		{name: "deleting", state: cmd.NamespaceStateDeleting, found: true, wantExact: "unauthorized: instance unavailable"},
+		{name: "missing", state: cmd.NamespaceStateActive, found: false, wantExact: "unauthorized: instance unavailable"},
+		{name: "bad key keeps detail", state: cmd.NamespaceStateSuspended, found: true, wrongKey: true, wantDetail: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := config.Config{
+				Persistence:    config.Persistence{DataPath: t.TempDir()},
+				Authentication: config.Authentication{DBUsers: config.DbUsers{Enabled: true}},
+			}
+			wrapper, err := New(conf, logger, &countingExister{state: tc.state, found: tc.found})
+			require.NoError(t, err)
+
+			apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
+			require.NoError(t, err)
+			require.NoError(t, wrapper.Dynamic.CreateUser("u1", hash, identifier, "", nsName, time.Now()))
+
+			token := apiKey
+			if tc.wrongKey {
+				// A valid, well-formed key for an unregistered identifier is
+				// rejected during key validation, before the namespace guard.
+				token, _, _, err = keys.CreateApiKeyAndHash()
+				require.NoError(t, err)
+			}
+
+			_, err = wrapper.ValidateAndExtract(token, nil)
+			require.Error(t, err)
+			if tc.wantDetail {
+				require.Contains(t, err.Error(), "unauthorized: invalid api key")
+				require.NotContains(t, err.Error(), "instance")
+				return
+			}
+			require.EqualError(t, err, tc.wantExact)
+			require.NotContains(t, err.Error(), "namespace")
+			require.NotContains(t, err.Error(), nsName)
 		})
 	}
 }

--- a/usecases/auth/authentication/apikey/wrapper_test.go
+++ b/usecases/auth/authentication/apikey/wrapper_test.go
@@ -45,7 +45,7 @@ func TestInvalidApiKey(t *testing.T) {
 					APIKey:  config.StaticAPIKey{Enabled: testCase.staticEnabled, AllowedKeys: []string{"valid-key"}, Users: []string{"user1"}},
 				},
 			}
-			wrapper, err := New(conf, logger)
+			wrapper, err := New(conf, logger, activeExister{})
 			require.NoError(t, err)
 
 			_, err = wrapper.ValidateAndExtract("invalid-key", nil)
@@ -79,7 +79,7 @@ func TestValidStaticKey(t *testing.T) {
 					APIKey:  config.StaticAPIKey{Enabled: testCase.staticEnabled, AllowedKeys: []string{"valid-key"}, Users: []string{"user1"}},
 				},
 			}
-			wrapper, err := New(conf, logger)
+			wrapper, err := New(conf, logger, activeExister{})
 			require.NoError(t, err)
 
 			principal, err := wrapper.ValidateAndExtract("valid-key", nil)
@@ -118,7 +118,7 @@ func TestValidDynamicKey(t *testing.T) {
 					APIKey:  config.StaticAPIKey{Enabled: testCase.staticEnabled, AllowedKeys: []string{"valid-key"}, Users: []string{"user1"}},
 				},
 			}
-			wrapper, err := New(conf, logger)
+			wrapper, err := New(conf, logger, activeExister{})
 			require.NoError(t, err)
 
 			userId := "id"

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -1856,7 +1857,7 @@ func TestSchedulerCreateBackupRecordsUsers(t *testing.T) {
 func makeUserSnapshot(t *testing.T, ids ...string) []byte {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
-	dbu, err := apikey.NewDBUser(t.TempDir(), true, logger)
+	dbu, err := apikey.NewDBUser(t.TempDir(), true, logger, namespaces.NewController(logger))
 	require.NoError(t, err)
 	for _, id := range ids {
 		require.NoError(t, dbu.CreateUser(id, "hash-"+id, "ident-"+id, "", namespacing.NamespaceFromQualified(id), time.Now()))

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -14,9 +14,9 @@
 //
 // Deletion is split into a fast synchronous half and a slow
 // asynchronous half. The DELETE handler flips the namespace to
-// deleting, drains its DB users, and returns 202. This package then
-// removes the rest on a periodic tick: aliases, then classes, then
-// the namespace entry itself. Aliases come before classes because an
+// deleting and returns 202. This package then removes the contents on
+// a periodic tick: DB users, then aliases, then classes, then the
+// namespace entry itself. Aliases come before classes because an
 // alias points at a class. Class deletion is the slow part, which is
 // why it lives here rather than in the request path.
 //
@@ -26,9 +26,6 @@
 // cluster needs an after-the-fact cleanup path regardless; once that
 // path exists, routing the bulk of the work through it is cheaper
 // than duplicating the logic in the request handler.
-//
-// The user delete is re-run as a safety net whenever leftover users remain,
-// in case the handler crashed between marking and the eager drain.
 //
 // Every step is a separate replicated command, so any failure is
 // retried on the next tick. Because the coordinator's view of what
@@ -179,7 +176,7 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, namespace stri
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// Skip the no-op RAFT entry when no users remain to redrain.
+	// Skip the no-op RAFT entry when no users remain.
 	if len(c.users.UsersInNamespace(namespace)) > 0 {
 		if err := c.raft.DeleteUsersInNamespace(ctx, namespace); err != nil {
 			return err

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -10,8 +10,8 @@
 //
 
 // Package namespaces owns the namespace control-plane state and exposes a
-// typed domain API for callers that need direct existence checks without
-// reaching for RAFT subcommand types.
+// typed domain API for callers that need direct existence checks. Lookups
+// return the RAFT subcommand namespace type.
 package namespaces
 
 import (


### PR DESCRIPTION
### What's being changed:

DB Users now check the state of the namespace on auth and any non-active state is rejected. Currently only deleting can be reached and resume/suspend will come in a follow up.

As a further cleanup deleting a namespace does _not_ delete all users in a namespace anymore, as the gate added above is sufficient to ensure that nobody in the namespace can login anymore

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
