### PR TITLE
Key the auth singleflight on the key, not just the user

### DIFF
--- a/usecases/auth/authentication/apikey/db_user_singleflight_test.go
+++ b/usecases/auth/authentication/apikey/db_user_singleflight_test.go
@@ -1,0 +1,98 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package apikey
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
+)
+
+// TestValidateAndExtractSingleFlightPerKey pins that a key authenticates even
+// while another key for the same user is being verified. The Argon2
+// verification is deduplicated, so a request that joins an in-flight
+// verification must not inherit a verdict reached for a different key.
+//
+// The rotate journey hits this: the caller polls with the superseded key while
+// the new key's first use lands, and both resolve to the same user.
+//
+// The in-flight verification is simulated by occupying the singleflight slot
+// that keying on the user alone would use, rather than racing a real one, so
+// the test fails without the fix instead of depending on timing.
+func TestValidateAndExtractSingleFlightPerKey(t *testing.T) {
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	require.NoError(t, err)
+
+	goodKey, goodHash, goodIdentifier, err := keys.CreateApiKeyAndHash()
+	require.NoError(t, err)
+	require.NoError(t, dynUsers.CreateUser("bob", goodHash, goodIdentifier, "", time.Now()))
+
+	goodSecret, _, err := keys.DecodeApiKey(goodKey)
+	require.NoError(t, err)
+
+	// A second, unrelated key. It is not bob's stored key, so on its own it must
+	// fail — and it must not decide the outcome for the real key.
+	otherKey, _, _, err := keys.CreateApiKeyAndHash()
+	require.NoError(t, err)
+	otherSecret, _, err := keys.DecodeApiKey(otherKey)
+	require.NoError(t, err)
+
+	_, err = dynUsers.ValidateAndExtract(otherSecret, goodIdentifier)
+	require.Error(t, err, "a key that is not the user's stored key must be rejected")
+
+	occupied := make(chan struct{})
+	release := make(chan struct{})
+	// Keying on the user alone makes the call below join the occupied slot and
+	// block on it, so the slot has to be released for the test to report rather
+	// than deadlock.
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	defer releaseOnce()
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_, _, _ = dynUsers.singleFlight.Do("auth:bob", func() (any, error) {
+			close(occupied)
+			<-release
+			return nil, errors.New("verification failed for a different key")
+		})
+	})
+
+	// Returns once the slot is registered, so the call below joins it if the
+	// singleflight key does not include the key itself.
+	<-occupied
+
+	var principal *models.Principal
+	done := make(chan error, 1)
+	wg.Go(func() {
+		var err error
+		principal, err = dynUsers.ValidateAndExtract(goodSecret, goodIdentifier)
+		done <- err
+	})
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "the correct key must authenticate regardless of a concurrent verification for the same user")
+		require.NotNil(t, principal)
+	case <-time.After(30 * time.Second):
+		releaseOnce()
+		t.Fatal("the correct key blocked on an in-flight verification for a different key")
+	}
+
+	releaseOnce()
+	wg.Wait()
+}

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -420,13 +420,20 @@ func (c *DBUser) ValidateAndExtract(key, userIdentifier string) (*models.Princip
 	}
 	weakHashValue, ok := c.memoryOnlyData.weakKeyStorageById.Load(userId)
 	if !ok {
-		// Ensure only one Argon2 verification runs for this user
-		if _, err, _ := c.singleFlight.Do("auth:"+userId, func() (any, error) {
+		// Ensure only one Argon2 verification runs per user and key. Keying on
+		// the user alone would let a request joining an in-flight verification
+		// inherit a verdict reached for a different key.
+		keyHash := sha256.Sum256([]byte(key))
+		if _, err, _ := c.singleFlight.Do("auth:"+userId+":"+string(keyHash[:]), func() (any, error) {
 			return nil, c.validateStrongHash(key, secureHash, userId)
 		}); err != nil {
 			return nil, err
 		}
-		weakHashValue, _ = c.memoryOnlyData.weakKeyStorageById.Load(userId)
+		// A missing entry here would panic the type assertion below.
+		weakHashValue, ok = c.memoryOnlyData.weakKeyStorageById.Load(userId)
+		if !ok {
+			return nil, fmt.Errorf("invalid token")
+		}
 	}
 
 	weakHash := weakHashValue.([sha256.Size]byte)


### PR DESCRIPTION
### What's being changed:

The singleflight around the Argon2 verification in `ValidateAndExtract` is keyed on the user ID only. Two requests for the same user with *different* keys overlap, the second joins the in-flight call and inherits its result — so a valid key gets rejected because someone else's wrong key lost the race, or a wrong key rides along on a valid verification.

Key rotation is the journey that hits this: the client keeps polling with the superseded key while the new key's first use lands, and both resolve to the same user.

Fix is to fold a hash of the key into the singleflight key, so dedup only collapses genuinely identical verifications.

Also replaced the discarded `ok` on the weak-hash reload after verification with an explicit `invalid token`. This one is defensive rather than a live bug — `ValidateAndExtract` holds the read lock for its whole body and `RotateKey`/`DeleteUser` take the write lock, so the entry can't actually disappear underneath it today. Worth having, since the alternative on a miss is a panic in the type assertion rather than an error.

Test starts a verification for the user with a wrong key, joins mid-flight with the correct one, and asserts the correct key still authenticates.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
