### PR TITLE
fix(db): guard nil objects bucket in putObjectLSM to prevent node panic

### DIFF
--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/dto"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -233,6 +234,11 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	if bucket == nil {
+		// nil while a shard is being created/activated/torn down; guard so a racing write returns instead of panicking the node
+		return objectInsertStatus{}, enterrors.NewErrUnprocessable(
+			fmt.Errorf("objects bucket for shard %q is not ready", s.name))
+	}
 	var prevObj *storobj.Object
 
 	// First the object bucket is checked if an object with the same uuid is alreadypresent,

--- a/adapters/repos/db/shard_write_put_test.go
+++ b/adapters/repos/db/shard_write_put_test.go
@@ -1,0 +1,117 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestShard_PutObject_NilObjectsBucket_ReturnsUnprocessable reproduces the
+// lifecycle race where a write reaches putObjectLSM while the objects bucket is
+// momentarily absent (shard create/activate/teardown). Before the nil guard the
+// write dereferenced a nil *lsmkv.Bucket in GetConsistentView and panicked the
+// whole node; it must now return an enterrors.ErrUnprocessable instead. Keeping
+// this assertion guards against the nil check being removed or moved below the
+// dereference.
+func TestShard_PutObject_NilObjectsBucket_ReturnsUnprocessable(t *testing.T) {
+	ctx := context.Background()
+	logger := logrus.New()
+
+	class := &models.Class{
+		Class:               "TestClass",
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+		MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+	}
+
+	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
+	mockSchemaGetter.On("NodeName").Return("node1")
+	mockSchemaGetter.On("ReadOnlyClass", "TestClass").Return(class).Maybe()
+
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+	shardState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"shard1": {Name: "shard1", BelongsToNodes: []string{"node1"}, Status: models.TenantActivityStatusHOT},
+		},
+		PartitioningEnabled: true,
+	}
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+			return readFunc(class, shardState)
+		}).Maybe()
+
+	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
+
+	index, err := NewIndex(ctx, IndexConfig{
+		ClassName:         schema.ClassName("TestClass"),
+		RootPath:          t.TempDir(),
+		ReplicationFactor: 1,
+		ShardLoadLimiter:  loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		hnsw.NewDefaultUserConfig(), nil, nil, shardResolver, mockSchemaGetter, mockSchemaReader, nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
+		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+	shard, err := NewShard(ctx, nil, "shard1", index, class, nil, scheduler, nil,
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+	require.NoError(t, err)
+	index.shards.Store("shard1", shard)
+
+	// A healthy shard has the objects bucket.
+	require.NotNil(t, shard.store.Bucket(helpers.ObjectsBucketLSM))
+
+	// Simulate the create/activate/teardown race: the objects bucket is gone,
+	// so store.Bucket(ObjectsBucketLSM) now returns nil.
+	require.NoError(t, shard.store.ShutdownBucket(ctx, helpers.ObjectsBucketLSM))
+	require.Nil(t, shard.store.Bucket(helpers.ObjectsBucketLSM))
+
+	obj := &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:    strfmt.UUID("40d3be3e-2ecc-49c8-b37c-d8983164848b"),
+			Class: "TestClass",
+		},
+	}
+
+	var putErr error
+	require.NotPanics(t, func() {
+		putErr = shard.PutObject(ctx, obj)
+	})
+	require.Error(t, putErr)
+
+	var unprocessable enterrors.ErrUnprocessable
+	require.ErrorAs(t, putErr, &unprocessable)
+}


### PR DESCRIPTION
## What

Adds a nil-guard for the objects bucket in `Shard.putObjectLSM` so a write racing shard lifecycle transitions returns a "shard not ready" error instead of dereferencing a nil `*lsmkv.Bucket` and **panicking the entire node**.

## Why

In CI ([weaviate-e2e-tests run 29713955021](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/29713955021/job/88264110689), weaviate `1.38.5-3f07bd7`) weaviate-2 crashed with a SIGSEGV during a multi-tenant shard-creation storm:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 ...]
...(*Bucket).GetConsistentView(0x0)          lsmkv/bucket.go:633
...db.fetchObject(0x0, ...)                   shard_write_put.go:210
...(*Shard).putObjectLSM.func1               shard_write_put.go:287
...(*objectsBatcher).storeObjectOfBatchInLSM shard_write_batch_objects.go:198
```

`putObjectLSM` did `bucket := s.store.Bucket(helpers.ObjectsBucketLSM)` and passed `bucket` straight into `fetchObject` with no nil check. During concurrent shard create/activate/teardown (many tenant shards created within the same second) the objects bucket was momentarily absent, `Bucket()` returned `nil`, and `fetchObject → Bucket.Get → GetConsistentView` dereferenced the nil receiver, taking down the whole process. The crash then triggered a restart + RAFT index reload, which failed an unrelated `near_text` query — one un-guarded write cascaded into unrelated query/test failures.

Full triage and evidence: weaviate/0-weaviate-issues#354.

## Design

Return `enterrors.NewErrUnprocessable(...)` ("shard ... not ready"), matching how `index.go` already signals in-flight requests hitting a shard mid-lifecycle. The essential property is **don't panic the process** — any error keeps the node alive and degrades a single batch item instead of crashing every shard on the node.

## Branch target

Opened against `stable/v1.36` (which also lacks the guard) so it **forward-syncs to v1.37 / v1.38 / main**. The same unguarded pattern exists on all of them — `v1.38` head `3f07bd7` is the exact commit that crashed. `putObjectLSM` has diverged slightly across branches, but the guarded line (`s.store.Bucket(helpers.ObjectsBucketLSM)`) is identical on each, so the forward-merge should apply cleanly.

## Testing / risk

- Regression test `TestShard_PutObject_NilObjectsBucket_ReturnsUnprocessable` (`shard_write_put_test.go`): builds a real shard, calls `store.ShutdownBucket(helpers.ObjectsBucketLSM)` so `store.Bucket(ObjectsBucketLSM)` returns `nil` (the lifecycle-race state), then asserts `PutObject` returns an `enterrors.ErrUnprocessable` and does **not** panic. Verified it fails with the exact CI nil-deref (`GetConsistentView` on a nil `*Bucket`) when the guard is removed, so it protects the guard from being deleted or moved below the dereference. Thanks @copilot for pointing out the `ShutdownBucket` seam — my original "no injection seam" note was wrong.
- `go build`, `go vet`, `go test -race` (the new test), and `golangci-lint run --new-from-rev=origin/stable/v1.36` are all clean (0 new issues). The production change is purely additive — a branch taken only when the bucket is `nil` — so every existing path is unchanged.
- Follow-up (out of scope, tracked in #354): forwarded queries during a *legitimate* index reload return a non-retryable `422`; returning a retryable status would let coordinators ride out the reload window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
