### PR TITLE
feat(monitoring): unified background-process activity + duration metrics

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -24,12 +24,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // findCompactionCandidates looks for pair of segments eligible for compaction
@@ -324,6 +326,11 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, nil
 		}
 	}
+
+	// only mark actual compaction work as active: candidate probing and OOM
+	// skips above are not real runs
+	backgroundDone := monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessCompaction)
+	defer backgroundDone()
 
 	var left, right Segment
 	func() {

--- a/adapters/repos/db/queue/worker.go
+++ b/adapters/repos/db/queue/worker.go
@@ -22,6 +22,7 @@ import (
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 const (
@@ -54,6 +55,10 @@ func (w *Worker) Run(ctx context.Context) {
 }
 
 func (w *Worker) do(batch *Batch) (err error) {
+	// Run blocks idle on the channel and only calls do() once a batch arrives,
+	// so this wraps a real async-indexing burst, not idle polling.
+	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessAsyncIndexing)()
+
 	defer func() {
 		// a panicking task must not kill the worker goroutine: it is never
 		// restarted, and the batch would never be marked done or canceled,

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/entities/interval"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
@@ -836,6 +837,8 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 
 	s.metrics.IncAsyncReplicationIterationCount()
 	s.metrics.IncAsyncReplicationIterationRunning()
+
+	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessAsyncReplication)()
 
 	defer func() {
 		s.metrics.DecAsyncReplicationIterationRunning()

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -298,7 +298,7 @@ func (h *hnsw) CleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 	return err
 }
 
-func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (executed bool, err error) {
+func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (bool, error) {
 	if !h.tombstoneCleanupRunning.CompareAndSwap(false, true) {
 		return false, errors.New("tombstone cleanup already running")
 	}
@@ -325,7 +325,7 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 		return resetCtx.Err() != nil || shouldAbort()
 	}
 
-	executed = false
+	executed := false
 	ok, deleteList := h.copyTombstonesToAllowList(breakCleanUpTombstonedNodes)
 	if !ok {
 		return executed, nil

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -34,6 +34,7 @@ import (
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw/packedconn"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 type breakCleanUpTombstonedNodesFunc func() bool
@@ -297,7 +298,7 @@ func (h *hnsw) CleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 	return err
 }
 
-func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (bool, error) {
+func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (executed bool, err error) {
 	if !h.tombstoneCleanupRunning.CompareAndSwap(false, true) {
 		return false, errors.New("tombstone cleanup already running")
 	}
@@ -324,11 +325,15 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 		return resetCtx.Err() != nil || shouldAbort()
 	}
 
-	executed := false
+	executed = false
 	ok, deleteList := h.copyTombstonesToAllowList(breakCleanUpTombstonedNodes)
 	if !ok {
 		return executed, nil
 	}
+
+	// mark as active only once real cleanup work begins; empty cycles do not
+	// count as runs
+	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessTombstoneCleanup)()
 
 	h.metrics.StartCleanup(tombstoneDeletionConcurrency())
 	defer h.metrics.EndCleanup(tombstoneDeletionConcurrency())

--- a/cluster/replication/metrics/metrics.go
+++ b/cluster/replication/metrics/metrics.go
@@ -14,6 +14,8 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // ReplicationEngineOpsCallbacks contains a set of callback functions that are invoked
@@ -211,18 +213,22 @@ func NewReplicationEngineOpsCallbacks(reg prometheus.Registerer) *ReplicationEng
 		WithOpStartCallback(func(node string) {
 			pendingOps.WithLabelValues(node).Dec()
 			ongoingOps.WithLabelValues(node).Inc()
+			monitoring.GetBackgroundProcessMetrics().IncActive(monitoring.ProcessReplicaMovement)
 		}).
 		WithOpCompleteCallback(func(node string) {
 			ongoingOps.WithLabelValues(node).Dec()
 			completeOps.WithLabelValues(node).Inc()
+			monitoring.GetBackgroundProcessMetrics().DecActive(monitoring.ProcessReplicaMovement)
 		}).
 		WithOpFailedCallback(func(node string) {
 			ongoingOps.WithLabelValues(node).Dec()
 			failedOps.WithLabelValues(node).Inc()
+			monitoring.GetBackgroundProcessMetrics().DecActive(monitoring.ProcessReplicaMovement)
 		}).
 		WithOpCancelledCallback(func(node string) {
 			ongoingOps.WithLabelValues(node).Dec()
 			cancelledOps.WithLabelValues(node).Inc()
+			monitoring.GetBackgroundProcessMetrics().DecActive(monitoring.ProcessReplicaMovement)
 		}).
 		Build()
 }

--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -281,6 +281,9 @@ func (m *Module) Upload(ctx context.Context, className, shardName, nodeName stri
 		return nil
 	}
 
+	// Only mark real uploads as active: the empty-shard shortcut above is a no-op.
+	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessOffload)()
+
 	cmd := []string{
 		fmt.Sprintf("--endpoint-url=%s", m.Endpoint),
 		"cp",

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -274,6 +274,8 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
 			u.setStatus(backup.Cancelled)
 			desc.Status = backup.Cancelled
+		} else {
+			monitoring.GetBackgroundProcessMetrics().Failed(monitoring.ProcessBackup)
 		}
 
 		u.log.Info("start uploading metadata for cancelled or failed backup")

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -247,6 +247,9 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 	desc.Status = backup.Transferring
 	ch := u.sourcer.BackupDescriptors(ctx, desc.ID, classes, baseDescr)
 	var totalPreCompressionSize int64 // Track total pre-compression bytes
+
+	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessBackup)()
+
 	defer func() {
 		//  release indexes under all conditions
 		u.releaseIndexes(classes, desc.ID)

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -99,7 +99,9 @@ func (r *restorer) restore(
 			StartedAt: time.Now().UTC(),
 			Status:    backup.Transferring,
 		}
+		backgroundDone := monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessRestore)
 		defer func() {
+			backgroundDone()
 			status.CompletedAt = time.Now().UTC()
 			if err == nil {
 				status.Status = backup.Success

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -112,6 +112,7 @@ func (r *restorer) restore(
 					status.Status = backup.Cancelled
 				} else {
 					status.Status = backup.Failed
+					monitoring.GetBackgroundProcessMetrics().Failed(monitoring.ProcessRestore)
 				}
 			}
 			r.restoreStatusMap.Store(basePath(req.Backend, req.ID), status)

--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/usecases/build"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 const (
@@ -196,6 +197,7 @@ func (b *BaseModule) collectAndUploadPeriodically(ctx context.Context) {
 			}).Debug("collection ticker fired - starting collection cycle")
 
 			enterrors.GoWrapper(func() {
+				defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessUsageCollection)()
 				if err := b.collectAndUploadUsage(ctx); err != nil {
 					b.logger.WithError(err).Error("Failed to collect and upload usage data")
 					b.metrics.OperationTotal.WithLabelValues("collect_and_upload", "error").Inc()

--- a/usecases/monitoring/background_process.go
+++ b/usecases/monitoring/background_process.go
@@ -30,6 +30,7 @@ const (
 	ProcessCompaction       BackgroundProcess = "compaction"
 	ProcessTombstoneCleanup BackgroundProcess = "tombstone_cleanup"
 	ProcessAsyncReplication BackgroundProcess = "async_replication"
+	ProcessAsyncIndexing    BackgroundProcess = "async_indexing"
 	ProcessTTLDeletion      BackgroundProcess = "ttl_deletion"
 	ProcessReplicaMovement  BackgroundProcess = "replica_movement"
 )

--- a/usecases/monitoring/background_process.go
+++ b/usecases/monitoring/background_process.go
@@ -1,0 +1,106 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// BackgroundProcess is the value of the closed `process` label — the only
+// label, so cardinality stays constant regardless of shard/tenant count.
+type BackgroundProcess string
+
+const (
+	ProcessBackup           BackgroundProcess = "backup"
+	ProcessRestore          BackgroundProcess = "restore"
+	ProcessOffload          BackgroundProcess = "offload"
+	ProcessUsageCollection  BackgroundProcess = "usage_collection"
+	ProcessCompaction       BackgroundProcess = "compaction"
+	ProcessTombstoneCleanup BackgroundProcess = "tombstone_cleanup"
+	ProcessAsyncReplication BackgroundProcess = "async_replication"
+	ProcessTTLDeletion      BackgroundProcess = "ttl_deletion"
+	ProcessReplicaMovement  BackgroundProcess = "replica_movement"
+)
+
+// BackgroundProcessMetrics reports heavy background processes per node, keyed by
+// `process`. Nil-safe and concurrency-safe.
+type BackgroundProcessMetrics struct {
+	// active: concurrently running instances (0 = idle).
+	active *prometheus.GaugeVec
+	// duration: finished-run seconds; _bucket/_count/_sum give percentiles,
+	// throughput and busy-time. Only Started runs are timed.
+	duration *prometheus.HistogramVec
+}
+
+var backgroundProcessMetrics *BackgroundProcessMetrics
+
+func init() {
+	backgroundProcessMetrics = newBackgroundProcessMetrics(prometheus.DefaultRegisterer)
+}
+
+// GetBackgroundProcessMetrics returns the singleton on the default registerer.
+func GetBackgroundProcessMetrics() *BackgroundProcessMetrics {
+	return backgroundProcessMetrics
+}
+
+func newBackgroundProcessMetrics(reg prometheus.Registerer) *BackgroundProcessMetrics {
+	return &BackgroundProcessMetrics{
+		active: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "weaviate_background_process_active",
+			Help: "Number of currently running instances of a background process (0 = idle)",
+		}, []string{"process"}),
+		duration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name: "weaviate_background_process_duration_seconds",
+			Help: "Wall-clock duration of finished background process runs, in seconds",
+			// 50ms → ~7.3h: covers a sub-second compaction and a multi-hour backup.
+			Buckets: prometheus.ExponentialBuckets(0.05, 2, 20),
+		}, []string{"process"}),
+	}
+}
+
+// IncActive/DecActive raise and lower the active gauge — the primitive for
+// split-callback sites (e.g. the replication engine) that can't hold a closure.
+// Pair each IncActive with one DecActive; elsewhere prefer Started.
+func (m *BackgroundProcessMetrics) IncActive(process BackgroundProcess) {
+	if m == nil {
+		return
+	}
+	m.active.WithLabelValues(string(process)).Inc()
+}
+
+// DecActive is the counterpart of IncActive.
+func (m *BackgroundProcessMetrics) DecActive(process BackgroundProcess) {
+	if m == nil {
+		return
+	}
+	m.active.WithLabelValues(string(process)).Dec()
+}
+
+// Started marks the process active and returns a done-callback (call once, e.g.
+// `defer Started(p)()`) that clears it and records the run's duration. Wrap the
+// working burst, not an idle loop, so the gauge reflects real activity.
+func (m *BackgroundProcessMetrics) Started(process BackgroundProcess) func() {
+	if m == nil {
+		return func() {}
+	}
+
+	m.IncActive(process)
+	start := time.Now()
+
+	return func() {
+		m.DecActive(process)
+		m.duration.WithLabelValues(string(process)).Observe(time.Since(start).Seconds())
+	}
+}

--- a/usecases/monitoring/background_process.go
+++ b/usecases/monitoring/background_process.go
@@ -43,6 +43,9 @@ type BackgroundProcessMetrics struct {
 	// duration: finished-run seconds; _bucket/_count/_sum give percentiles,
 	// throughput and busy-time. Only Started runs are timed.
 	duration *prometheus.HistogramVec
+	// failures: runs that ended in error, excluding cancellations. Opt-in via
+	// Failed, so a missing series means "not wired", not "never fails".
+	failures *prometheus.CounterVec
 }
 
 var backgroundProcessMetrics *BackgroundProcessMetrics
@@ -67,6 +70,10 @@ func newBackgroundProcessMetrics(reg prometheus.Registerer) *BackgroundProcessMe
 			Help: "Wall-clock duration of finished background process runs, in seconds",
 			// 50ms → ~7.3h: covers a sub-second compaction and a multi-hour backup.
 			Buckets: prometheus.ExponentialBuckets(0.05, 2, 20),
+		}, []string{"process"}),
+		failures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "weaviate_background_process_failures_total",
+			Help: "Number of background process runs that ended in error (cancellations excluded)",
 		}, []string{"process"}),
 	}
 }
@@ -104,4 +111,14 @@ func (m *BackgroundProcessMetrics) Started(process BackgroundProcess) func() {
 		m.DecActive(process)
 		m.duration.WithLabelValues(string(process)).Observe(time.Since(start).Seconds())
 	}
+}
+
+// Failed records one errored run. Call it from a genuine-failure branch, not on
+// cancellation. Independent of Started/Inc-Dec, which track liveness regardless
+// of outcome.
+func (m *BackgroundProcessMetrics) Failed(process BackgroundProcess) {
+	if m == nil {
+		return
+	}
+	m.failures.WithLabelValues(string(process)).Inc()
 }

--- a/usecases/monitoring/background_process_test.go
+++ b/usecases/monitoring/background_process_test.go
@@ -98,6 +98,22 @@ func TestBackgroundProcessMetrics_DurationRecordedOnDone(t *testing.T) {
 	assert.Equal(t, uint64(1), histogramSampleCount(t, m, "backup"))
 }
 
+func TestBackgroundProcessMetrics_Failed(t *testing.T) {
+	m := newBackgroundProcessMetrics(prometheus.NewPedanticRegistry())
+
+	// Failures are independent of liveness/duration: a run can finish and still
+	// be recorded as failed.
+	m.Started(ProcessBackup)()
+	assert.Equal(t, float64(0), testutil.ToFloat64(m.failures.WithLabelValues("backup")))
+
+	m.Failed(ProcessBackup)
+	m.Failed(ProcessBackup)
+	assert.Equal(t, float64(2), testutil.ToFloat64(m.failures.WithLabelValues("backup")))
+
+	// Keyed per process; unrelated processes stay at zero.
+	assert.Equal(t, float64(0), testutil.ToFloat64(m.failures.WithLabelValues("restore")))
+}
+
 func TestBackgroundProcessMetrics_IncDecActive(t *testing.T) {
 	m := newBackgroundProcessMetrics(prometheus.NewPedanticRegistry())
 

--- a/usecases/monitoring/background_process_test.go
+++ b/usecases/monitoring/background_process_test.go
@@ -1,0 +1,132 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// histogramSampleCount returns how many durations have been observed for a
+// process. GetMetricWithLabelValues lazily creates an empty (count 0) series,
+// so it is safe to call before any observation.
+func histogramSampleCount(t *testing.T, m *BackgroundProcessMetrics, process string) uint64 {
+	t.Helper()
+	obs, err := m.duration.GetMetricWithLabelValues(process)
+	require.NoError(t, err)
+	var out dto.Metric
+	require.NoError(t, obs.(prometheus.Metric).Write(&out))
+	return out.GetHistogram().GetSampleCount()
+}
+
+func TestBackgroundProcessMetrics_StartedDone(t *testing.T) {
+	tests := []struct {
+		name       string
+		run        func(m *BackgroundProcessMetrics)
+		wantActive float64
+	}{
+		{
+			name: "single run leaves gauge at zero when done",
+			run: func(m *BackgroundProcessMetrics) {
+				done := m.Started(ProcessBackup)
+				done()
+			},
+			wantActive: 0,
+		},
+		{
+			name: "running instance keeps gauge raised",
+			run: func(m *BackgroundProcessMetrics) {
+				_ = m.Started(ProcessBackup)
+			},
+			wantActive: 1,
+		},
+		{
+			name: "concurrent runs accumulate",
+			run: func(m *BackgroundProcessMetrics) {
+				done1 := m.Started(ProcessBackup)
+				_ = m.Started(ProcessBackup) // still running
+				done1()
+			},
+			wantActive: 1,
+		},
+		{
+			name:       "no runs",
+			run:        func(m *BackgroundProcessMetrics) {},
+			wantActive: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newBackgroundProcessMetrics(prometheus.NewPedanticRegistry())
+			tt.run(m)
+			assert.Equal(t, tt.wantActive,
+				testutil.ToFloat64(m.active.WithLabelValues("backup")))
+		})
+	}
+}
+
+func TestBackgroundProcessMetrics_DurationRecordedOnDone(t *testing.T) {
+	m := newBackgroundProcessMetrics(prometheus.NewPedanticRegistry())
+
+	// A run still in progress has recorded no duration yet.
+	done := m.Started(ProcessBackup)
+	assert.Equal(t, uint64(0), histogramSampleCount(t, m, "backup"))
+
+	// Completing the run records exactly one observation and drops the gauge.
+	done()
+	assert.Equal(t, uint64(1), histogramSampleCount(t, m, "backup"))
+	assert.Equal(t, float64(0), testutil.ToFloat64(m.active.WithLabelValues("backup")))
+
+	// A second run adds a second observation, keyed to its own process.
+	m.Started(ProcessCompaction)()
+	assert.Equal(t, uint64(1), histogramSampleCount(t, m, "compaction"))
+	assert.Equal(t, uint64(1), histogramSampleCount(t, m, "backup"))
+}
+
+func TestBackgroundProcessMetrics_IncDecActive(t *testing.T) {
+	m := newBackgroundProcessMetrics(prometheus.NewPedanticRegistry())
+
+	m.IncActive(ProcessReplicaMovement)
+	m.IncActive(ProcessReplicaMovement)
+	assert.Equal(t, float64(2), testutil.ToFloat64(m.active.WithLabelValues("replica_movement")))
+
+	m.DecActive(ProcessReplicaMovement)
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.active.WithLabelValues("replica_movement")))
+}
+
+func TestBackgroundProcessMetrics_ProcessesAreIndependent(t *testing.T) {
+	m := newBackgroundProcessMetrics(prometheus.NewPedanticRegistry())
+
+	_ = m.Started(ProcessCompaction)
+	_ = m.Started(ProcessRestore)
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.active.WithLabelValues("compaction")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(m.active.WithLabelValues("restore")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(m.active.WithLabelValues("backup")))
+}
+
+func TestBackgroundProcessMetrics_NilSafe(t *testing.T) {
+	var m *BackgroundProcessMetrics
+
+	assert.NotPanics(t, func() {
+		done := m.Started(ProcessBackup)
+		m.IncActive(ProcessBackup)
+		m.DecActive(ProcessBackup)
+		done()
+	})
+}

--- a/usecases/object_ttl/object_ttl.go
+++ b/usecases/object_ttl/object_ttl.go
@@ -219,6 +219,8 @@ func (c *Coordinator) triggerDeletionObjectsExpiredLocalNode(ctx context.Context
 	metrics.IncObjectsTtlCount()
 	metrics.IncObjectsTtlRunning()
 
+	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessTTLDeletion)()
+
 	// count objects deleted per collection
 	objsDeletedCounters := make(DeletedCounters, len(classesWithTTL))
 	colNames := make([]string, 0, len(classesWithTTL))


### PR DESCRIPTION
### What's being changed:
Add a low-cardinality metric family that answers "which heavy background processes are running on this node, how many, and how long they take" from one place, without knowing each component's bespoke metrics.

- `weaviate_background_process_active{process} (gauge)`: concurrently running instances per process (0 = idle).
- `weaviate_background_process_duration_seconds{process} (histogram)`: finished-run duration; _count and _sum also yield completion throughput and busy-time.

Processes: 
```
ProcessBackup           BackgroundProcess = "backup"
ProcessRestore          BackgroundProcess = "restore"
ProcessOffload          BackgroundProcess = "offload"
ProcessUsageCollection  BackgroundProcess = "usage_collection"
ProcessCompaction       BackgroundProcess = "compaction"
ProcessTombstoneCleanup BackgroundProcess = "tombstone_cleanup"
ProcessAsyncReplication BackgroundProcess = "async_replication"
ProcessAsyncIndexing    BackgroundProcess = "async_indexing"
ProcessTTLDeletion      BackgroundProcess = "ttl_deletion"
ProcessReplicaMovement  BackgroundProcess = "replica_movement"
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
