### PR TITLE
perf(inverted): batch consistent-view acquisition and serial FastOr union for ContainsAny/ContainsAll

### DIFF
--- a/adapters/repos/db/inverted/containsany_chunking_integration_test.go
+++ b/adapters/repos/db/inverted/containsany_chunking_integration_test.go
@@ -379,3 +379,86 @@ func TestSearcher_ContainsAny_CancellationMidChunk(t *testing.T) {
 			"merely theoretical); if this ever fails, re-check cancelDelay/numValues against "+
 			"current hardware speed", attempts)
 }
+
+// TestSearcher_ContainsAny_DeleteThenReaddAcrossSegments guards oldest->newest
+// fold order across segment boundaries: deletes for "tombstone-readd" and
+// "deleted-forever" land in a segment newer than their additions, so a
+// wrong-order fold would resurrect a deleted doc ID.
+func TestSearcher_ContainsAny_DeleteThenReaddAcrossSegments(t *testing.T) {
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	const propName = "inverted-text-roaringset"
+
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	maxDocID := uint64(100)
+	bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(maxDocID))
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
+		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+	bucketName := helpers.BucketFromPropNameLSM(propName)
+	require.NoError(t, store.CreateOrLoadBucket(
+		context.Background(), bucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	))
+	bucket := store.Bucket(bucketName)
+
+	// segment 1 (oldest)
+	require.NoError(t, bucket.RoaringSetAddList([]byte("disk-seg1-only"), []uint64{1, 2, 3}))
+	require.NoError(t, bucket.RoaringSetAddList([]byte("tombstone-readd"), []uint64{10, 11}))
+	require.NoError(t, bucket.RoaringSetAddList([]byte("deleted-forever"), []uint64{20}))
+	require.NoError(t, bucket.RoaringSetAddList([]byte("shared-across-segments"), []uint64{30}))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// segment 2 (newer): deletes land here, newer than the additions
+	require.NoError(t, bucket.RoaringSetRemoveOne([]byte("tombstone-readd"), 10))
+	require.NoError(t, bucket.RoaringSetRemoveOne([]byte("deleted-forever"), 20))
+	require.NoError(t, bucket.RoaringSetAddList([]byte("disk-seg2-only"), []uint64{40, 41}))
+	require.NoError(t, bucket.RoaringSetAddList([]byte("shared-across-segments"), []uint64{31}))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// active memtable (never flushed)
+	require.NoError(t, bucket.RoaringSetAddList([]byte("tombstone-readd"), []uint64{12}))
+	require.NoError(t, bucket.RoaringSetAddList([]byte("shared-across-segments"), []uint64{32}))
+
+	values := []string{
+		"disk-seg1-only", "disk-seg2-only", "tombstone-readd", "deleted-forever",
+		"shared-across-segments", "never-existed",
+	}
+
+	filter := &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: filters.ContainsAny,
+			On:       &filters.Path{Class: className, Property: schema.PropertyName(propName)},
+			Value:    &filters.Value{Value: values, Type: schema.DataTypeText},
+		},
+	}
+
+	allowList, err := searcher.DocIDs(context.Background(), filter, additional.Properties{}, className)
+	require.NoError(t, err)
+	defer allowList.Close()
+
+	got := allowList.Slice()
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+
+	// hand-computed oracle, independent of the code under test: tombstone-readd
+	// nets to {11,12}, deleted-forever nets to {}, shared-across-segments
+	// accumulates to {30,31,32}.
+	want := []uint64{1, 2, 3, 11, 12, 30, 31, 32, 40, 41}
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+
+	require.Equal(t, want, got,
+		"ContainsAny over a delete-then-readd-across-segments fixture must fold oldest->newest "+
+			"through the floor's batch-acquired view + FastOr union: 'tombstone-readd' must resolve "+
+			"to {11,12} (not resurrect 10), 'deleted-forever' must contribute zero doc IDs (not error, "+
+			"not resurrect 20), and 'shared-across-segments' must accumulate across all three storage "+
+			"layers to {30,31,32}")
+}

--- a/adapters/repos/db/inverted/merge_doc_ids_fastor_test.go
+++ b/adapters/repos/db/inverted/merge_doc_ids_fastor_test.go
@@ -1,0 +1,164 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+func allowListDBM(ids ...uint64) *docBitmap {
+	bm := sroar.NewBitmap()
+	bm.SetMany(ids)
+	return &docBitmap{docIDs: bm, isDenyList: false, release: func() {}}
+}
+
+func denyListDBM(ids ...uint64) *docBitmap {
+	bm := sroar.NewBitmap()
+	bm.SetMany(ids)
+	return &docBitmap{docIDs: bm, isDenyList: true, release: func() {}}
+}
+
+// pairwiseOrReference reimplements the pre-FastOr mergeDocIDs algorithm as
+// an independent oracle for the FastOr path.
+func pairwiseOrReference(dbms []*docBitmap, maxConc int) []uint64 {
+	cp := make([]*docBitmap, len(dbms))
+	for i, dbm := range dbms {
+		bm := sroar.NewBitmap()
+		bm.SetMany(dbm.docIDs.ToArray())
+		cp[i] = &docBitmap{docIDs: bm, isDenyList: dbm.isDenyList, release: func() {}}
+	}
+	for i := 0; i < len(cp)-1; i++ {
+		cp[0] = mergeBitmapsAndOrWithDenyList(cp[0], cp[i+1], filters.OperatorOr, maxConc)
+	}
+	out := cp[0].docIDs.ToArray()
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// TestMergeDocIDs_FastOrPath_MatchesPairwiseReference checks the FastOr
+// path's output, key for key, against an independent reimplementation of
+// the pairwise algorithm it replaces.
+func TestMergeDocIDs_FastOrPath_MatchesPairwiseReference(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+
+	for _, numPartials := range []int{2, 3, 16, 32} {
+		t.Run(fmt.Sprintf("numPartials=%d", numPartials), func(t *testing.T) {
+			var fastInput []*docBitmap
+			var refInput []*docBitmap
+			for i := 0; i < numPartials; i++ {
+				ids := make([]uint64, 0, 50)
+				for j := 0; j < 50; j++ {
+					ids = append(ids, uint64(rng.Intn(500)))
+				}
+				fastInput = append(fastInput, allowListDBM(ids...))
+				refInput = append(refInput, allowListDBM(ids...))
+			}
+
+			want := pairwiseOrReference(refInput, 4)
+
+			merged := mergeDocIDs(filters.OperatorOr, fastInput, 4)
+			require.Len(t, merged, 1)
+			got := merged[0].docIDs.ToArray()
+			sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+
+			require.Equal(t, want, got,
+				"FastOr-merged allowlist union must exactly match the pairwise-OrConc "+
+					"reference algorithm it replaces")
+		})
+	}
+}
+
+// TestMergeDocIDs_DenyListPresent_SkipsFastOrPath proves the FastOr path is
+// never taken when any input is a deny-list.
+func TestMergeDocIDs_DenyListPresent_SkipsFastOrPath(t *testing.T) {
+	deny := denyListDBM(1, 2, 3, 4, 5) // excludes [1,5]
+	allow1 := allowListDBM(2)          // reclaims doc 2
+	allow2 := allowListDBM(4)          // reclaims doc 4
+
+	merged := mergeDocIDs(filters.OperatorOr, []*docBitmap{deny, allow1, allow2}, 4)
+	require.Len(t, merged, 1)
+	require.True(t, merged[0].IsDenyList(),
+		"a batch containing a deny-list input must still produce a deny-list result -- "+
+			"if FastOr's plain-union path were mistakenly taken here, the result would "+
+			"come back as an (incorrect) allowlist instead")
+
+	excluded := merged[0].docIDs.ToArray()
+	sort.Slice(excluded, func(i, j int) bool { return excluded[i] < excluded[j] })
+	require.Equal(t, []uint64{1, 3, 5}, excluded,
+		"the merged deny-list must still exclude exactly {1,3,5} -- docs 2 and 4 were "+
+			"reclaimed by the allowlist operands and must no longer be excluded")
+}
+
+// TestMergeDocIDs_AndOperator_SkipsFastOrPath proves OperatorAnd never
+// routes through fastOrMerge, since FastOr is a union-only primitive with
+// no intersection semantics.
+func TestMergeDocIDs_AndOperator_SkipsFastOrPath(t *testing.T) {
+	a := allowListDBM(1, 2, 3, 4)
+	b := allowListDBM(2, 3, 4, 5)
+	c := allowListDBM(3, 4, 5, 6)
+
+	merged := mergeDocIDs(filters.OperatorAnd, []*docBitmap{a, b, c}, 4)
+	require.Len(t, merged, 1)
+	got := merged[0].docIDs.ToArray()
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	require.Equal(t, []uint64{3, 4}, got, "AND of the three sets must be exactly their intersection")
+}
+
+// BenchmarkMergeDocIDs_FastOrVsPairwise compares FastOr against the pairwise
+// reduce at the partial counts (16, 32) typical post-chunking.
+func BenchmarkMergeDocIDs_FastOrVsPairwise(b *testing.B) {
+	rng := rand.New(rand.NewSource(7))
+
+	for _, numPartials := range []int{16, 32} {
+		partials := make([][]uint64, numPartials)
+		for i := range partials {
+			ids := make([]uint64, 0, 3000)
+			for j := 0; j < 3000; j++ {
+				ids = append(ids, uint64(rng.Intn(100000)))
+			}
+			partials[i] = ids
+		}
+
+		b.Run(fmt.Sprintf("FastOr/numPartials=%d", numPartials), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				dbms := make([]*docBitmap, numPartials)
+				for j, ids := range partials {
+					dbms[j] = allowListDBM(ids...)
+				}
+				b.StartTimer()
+				_ = mergeDocIDs(filters.OperatorOr, dbms, 4)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Pairwise/numPartials=%d", numPartials), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				dbms := make([]*docBitmap, numPartials)
+				for j, ids := range partials {
+					dbms[j] = allowListDBM(ids...)
+				}
+				b.StartTimer()
+				for k := 0; k < len(dbms)-1; k++ {
+					dbms[0] = mergeBitmapsAndOrWithDenyList(dbms[0], dbms[k+1], filters.OperatorOr, 4)
+				}
+			}
+		})
+	}
+}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -21,10 +21,17 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
+
+// maxBatchViewHoldKeys caps how many keys share one lsmkv.BucketConsistentView.
+// Larger ranges are split into sequential slabs, each acquiring its own view,
+// so a held view never stalls compaction cleanup for longer than one slab.
+const maxBatchViewHoldKeys = 500
 
 type propValuePair struct {
 	prop     string
@@ -137,6 +144,62 @@ func chunkBounds(n, numChunks int) [][2]int {
 	return bounds
 }
 
+// flatEqualChildrenBucket returns the shared lsmkv.Bucket if every child of
+// pv is a non-nested OperatorEqual leaf against the same roaring-set bucket
+// (the shape ContainsAny/ContainsAll desugar into), or nil otherwise. Batch
+// view acquisition is only safe when every read targets the same bucket.
+func (pv *propValuePair) flatEqualChildrenBucket(s *Searcher) *lsmkv.Bucket {
+	if len(pv.children) == 0 {
+		return nil
+	}
+	first := pv.children[0]
+	if first.operator != filters.OperatorEqual || first.nested.isNested {
+		return nil
+	}
+	bucketName := first.getBucketName()
+	if bucketName == "" {
+		return nil
+	}
+	b := s.store.Bucket(bucketName)
+	if b == nil || b.Strategy() != lsmkv.StrategyRoaringSet {
+		return nil
+	}
+	for _, child := range pv.children[1:] {
+		if child.operator != filters.OperatorEqual || child.nested.isNested || child.getBucketName() != bucketName {
+			return nil
+		}
+	}
+	return b
+}
+
+// resolveFlatEqualSlab resolves pv.children[start:end] (caller-bounded to
+// <=maxBatchViewHoldKeys) sequentially under one shared
+// lsmkv.BucketConsistentView instead of one view per value.
+func resolveFlatEqualSlab(ctx context.Context, s *Searcher, pv *propValuePair, bucket *lsmkv.Bucket,
+	start, end, limit, mergeConc int,
+) (*docBitmap, error) {
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	viewCtx := lsmkv.ContextWithConsistentView(ctx, view)
+
+	var result *docBitmap
+	for i := start; i < end; i++ {
+		dbm, err := pv.children[i].resolveDocIDs(viewCtx, s, limit)
+		if err != nil {
+			if result != nil {
+				result.release()
+			}
+			return nil, errors.Wrapf(err, "nested child %d", i)
+		}
+		if result == nil {
+			result = dbm
+		} else {
+			result = mergeBitmapsAndOrWithDenyList(result, dbm, pv.operator, mergeConc)
+		}
+	}
+	return result, nil
+}
+
 func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*docBitmap, error) {
 	// Explicitly set the limit to 0 (=unlimited) as this is a nested filter,
 	// otherwise we run into situations where each subfilter on their own
@@ -158,28 +221,42 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 		processDocIDs(maxN, pv.operator, dbmCh, resultCh, mergeConc)
 	}, s.logger)
 
+	// non-nil only for the ContainsAny/ContainsAll flat-equal shape; enables
+	// batch view acquisition below instead of one view per value.
+	batchViewBucket := pv.flatEqualChildrenBucket(s)
+
 	outerConcurrencyLimit := concurrency.BudgetFromCtx(ctx, concurrency.GOMAXPROCS)
 	if outerConcurrencyLimit <= 1 {
-		// resolve docIDs sequentially in main goroutine
-		for i, child := range pv.children {
-			dbm, err2 := child.resolveDocIDs(ctx, s, limit)
-			if err2 != nil {
-				// break on first error
-				err = errors.Wrapf(err2, "nested child %d", i)
-				break
+		if batchViewBucket != nil {
+			// resolve docIDs sequentially in main goroutine, batching the
+			// consistent view across <=maxBatchViewHoldKeys-key slabs
+			for slabStart := 0; slabStart < len(pv.children); slabStart += maxBatchViewHoldKeys {
+				slabEnd := min(slabStart+maxBatchViewHoldKeys, len(pv.children))
+				dbm, err2 := resolveFlatEqualSlab(ctx, s, pv, batchViewBucket, slabStart, slabEnd, limit, mergeConc)
+				if err2 != nil {
+					err = err2
+					break
+				}
+				if dbm != nil {
+					dbmCh <- dbm
+				}
 			}
-			dbmCh <- dbm
+		} else {
+			// resolve docIDs sequentially in main goroutine
+			for i, child := range pv.children {
+				dbm, err2 := child.resolveDocIDs(ctx, s, limit)
+				if err2 != nil {
+					// break on first error
+					err = errors.Wrapf(err2, "nested child %d", i)
+					break
+				}
+				dbmCh <- dbm
+			}
 		}
 	} else {
 		// Resolve docIDs in parallel, chunked to at most outerConcurrencyLimit-1
-		// goroutines instead of one goroutine per child. A ContainsAny/ContainsAll
-		// with N values produces N children here; spawning one errgroup goroutine
-		// (and one dbmCh send) per child scales goroutine creation and channel-send
-		// volume with N per request, with no cap across concurrent requests (GH
-		// 12242). Each chunk goroutine resolves its slice of children sequentially
-		// and merges them locally with mergeBitmapsAndOrWithDenyList before a
-		// single dbmCh send, so per-request goroutine count and channel-send count
-		// are both bounded by outerConcurrencyLimit regardless of N.
+		// goroutines instead of one goroutine per child, which previously scaled
+		// goroutine/channel-send count with N unbounded across requests (GH 12242).
 		numChunks := min(len(pv.children), outerConcurrencyLimit-1)
 		if numChunks < 1 {
 			numChunks = 1
@@ -195,6 +272,43 @@ func (pv *propValuePair) resolveDocIDsAndOr(ctx context.Context, s *Searcher) (*
 		for _, bounds := range chunks {
 			start, end := bounds[0], bounds[1]
 			eg.Go(func() error {
+				if batchViewBucket != nil {
+					// process this chunk's range in <=maxBatchViewHoldKeys slabs,
+					// each under one shared consistent view
+					var chunkResult *docBitmap
+					for slabStart := start; slabStart < end; slabStart += maxBatchViewHoldKeys {
+						if err := gctx.Err(); err != nil {
+							// some chunk failed, skip remaining slabs
+							if chunkResult != nil {
+								chunkResult.release()
+							}
+							return nil
+						}
+						slabEnd := min(slabStart+maxBatchViewHoldKeys, end)
+						childCtx := concurrency.ContextWithFractionalBudget(ctx, numChunks, concurrency.GOMAXPROCS)
+						slabResult, err := resolveFlatEqualSlab(childCtx, s, pv, batchViewBucket, slabStart, slabEnd, limit, mergeConc)
+						if err != nil {
+							ec.Add(err)
+							if chunkResult != nil {
+								chunkResult.release()
+							}
+							return err
+						}
+						if slabResult == nil {
+							continue
+						}
+						if chunkResult == nil {
+							chunkResult = slabResult
+						} else {
+							chunkResult = mergeBitmapsAndOrWithDenyList(chunkResult, slabResult, pv.operator, mergeConc)
+						}
+					}
+					if chunkResult != nil {
+						dbmCh <- chunkResult
+					}
+					return nil
+				}
+
 				var chunkResult *docBitmap
 				for i := start; i < end; i++ {
 					if err := gctx.Err(); err != nil {
@@ -377,9 +491,17 @@ func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator, m
 // If slice of size 0 or 1 is provided, it is returned without any change.
 // Merge is performed starting from bitmap with most containers for OR operator
 // or starting from bitmap with least containers for AND operator.
+//
+// A pure-allowlist OR batch routes through fastOrMerge's single-pass FastOr
+// instead; FastOr has no deny-list algebra, so any other shape falls through
+// to the pairwise reduce below.
 func mergeDocIDs(operator filters.Operator, dbms []*docBitmap, maxConc int) []*docBitmap {
 	if len(dbms) <= 1 {
 		return dbms
+	}
+
+	if operator == filters.OperatorOr && allAllowLists(dbms) {
+		return []*docBitmap{fastOrMerge(dbms)}
 	}
 
 	for i := 0; i < len(dbms)-1; i++ {
@@ -387,6 +509,45 @@ func mergeDocIDs(operator filters.Operator, dbms []*docBitmap, maxConc int) []*d
 	}
 
 	return dbms[:1]
+}
+
+// allAllowLists reports whether every docBitmap in dbms is an allowlist;
+// FastOr has no deny-list algebra, so it's only safe when this holds.
+func allAllowLists(dbms []*docBitmap) bool {
+	for _, dbm := range dbms {
+		if dbm.IsDenyList() {
+			return false
+		}
+	}
+	return true
+}
+
+// fastOrMerge unions every docBitmap in dbms (all confirmed allowlists by
+// the caller) in a single sroar.FastOr pass instead of the M-1 pairwise
+// OrConc reduce.
+//
+// Never calls sroar.FastParOr: FastParOr v0.0.15 (bitmap.go:1176-1195) has a
+// data race between its launching goroutine's `append` and concurrent
+// indexed writes from already-spawned goroutines into the same slice -- a
+// bug in the vendored dependency, not this call site. The parallelism it
+// would offer is redundant anyway, since every fastOrMerge call already runs
+// inside one of resolveDocIDsAndOr's chunk goroutines.
+//
+// FastOr always allocates a fresh destination bitmap for the >1-input case
+// reached here, so every input's buffer can be released immediately after.
+func fastOrMerge(dbms []*docBitmap) *docBitmap {
+	bitmaps := make([]*sroar.Bitmap, len(dbms))
+	for i, dbm := range dbms {
+		bitmaps[i] = dbm.docIDs
+	}
+
+	merged := sroar.FastOr(bitmaps...)
+
+	for _, dbm := range dbms {
+		dbm.release()
+	}
+
+	return &docBitmap{docIDs: merged, isDenyList: false, release: func() {}}
 }
 
 // fetchDocIDs resolves a value filter on a flat (non-nested) property.

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -573,9 +573,8 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 	eg.SetLimit(outerConcurrencyLimit)
 
 	// Chunk operands into at most outerConcurrencyLimit groups instead of one
-	// goroutine per operand, bounding goroutine/channel fan-out for large
-	// ContainsAny/ContainsAll value sets (GH 12242). Each goroutine writes only
-	// its own children[] slice, so no synchronization is needed.
+	// goroutine per operand, to bound fan-out for large ContainsAny/ContainsAll
+	// value sets (GH 12242). Each goroutine writes only its own children[] slice.
 	numChunks := min(len(operands), outerConcurrencyLimit)
 	if numChunks < 1 {
 		numChunks = 1

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -685,6 +685,28 @@ func (cv BucketConsistentView) ReleaseView() {
 	cv.release()
 }
 
+type consistentViewCtxKey struct{}
+
+// ContextWithConsistentView attaches an already-acquired BucketConsistentView
+// to ctx so reads scoped to the same Bucket reuse it instead of each
+// individually acquiring/releasing their own. The caller retains ownership:
+// it must still call view.ReleaseView() once every read using this context
+// has completed.
+func ContextWithConsistentView(ctx context.Context, view BucketConsistentView) context.Context {
+	return context.WithValue(ctx, consistentViewCtxKey{}, view)
+}
+
+// consistentViewFromCtx returns the view ctx carries only if it was acquired
+// for this bucket; a view attached for a different bucket is ignored
+// (ok=false) since using it here would silently read the wrong data.
+func (b *Bucket) consistentViewFromCtx(ctx context.Context) (BucketConsistentView, bool) {
+	v, ok := ctx.Value(consistentViewCtxKey{}).(BucketConsistentView)
+	if !ok || v.Bucket != b {
+		return BucketConsistentView{}, false
+	}
+	return v, true
+}
+
 // GetConsistentView returns a consistent view of the bucket that can be used
 // for multiple reads without acquiring locks for each read. The caller must
 // call ReleaseView() on the returned view when done to avoid blocking compactions.

--- a/adapters/repos/db/lsmkv/bucket_consistent_view_compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/bucket_consistent_view_compaction_integration_test.go
@@ -1,0 +1,107 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestBatchViewAcquisition_CompactionDuringHeldView guards the
+// compaction/held-view lifetime contract (GH 12242): compactOnce swaps the
+// merged segment in immediately regardless of a held view, while physical
+// removal of the old segments is deferred to dropSegmentsAwaiting() until
+// the view's refcount reaches zero.
+func TestBatchViewAcquisition_CompactionDuringHeldView(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	// never auto-flush; two explicit flushes give exactly one compactable pair
+	b.SetMemtableThreshold(1e9)
+
+	require.NoError(t, b.RoaringSetAddList([]byte("k1"), []uint64{1, 2}))
+	require.NoError(t, b.FlushAndSwitch()) // segment 1
+
+	require.NoError(t, b.RoaringSetAddList([]byte("k1"), []uint64{3}))
+	require.NoError(t, b.RoaringSetAddList([]byte("k2"), []uint64{4, 5}))
+	require.NoError(t, b.FlushAndSwitch()) // segment 2
+
+	require.Len(t, b.disk.segments, 2, "test setup must produce exactly one compactable pair")
+
+	assertReads := func(t *testing.T, ctx context.Context) {
+		t.Helper()
+		bm1, rel1, err := b.RoaringSetGet(ctx, []byte("k1"))
+		require.NoError(t, err)
+		require.Equal(t, []uint64{1, 2, 3}, bm1.ToArray())
+		rel1()
+
+		bm2, rel2, err := b.RoaringSetGet(ctx, []byte("k2"))
+		require.NoError(t, err)
+		require.Equal(t, []uint64{4, 5}, bm2.ToArray())
+		rel2()
+	}
+
+	// acquire once, reuse across reads (mirrors resolveFlatEqualSlab)
+	view := b.GetConsistentView()
+	viewCtx := ContextWithConsistentView(ctx, view)
+
+	// reads through the held view, before compaction runs
+	assertReads(t, viewCtx)
+
+	compacted, err := b.disk.compactOnce(ctx)
+	require.NoError(t, err)
+	require.True(t, compacted, "the two flushed segments must have been a valid compaction pair")
+
+	require.Len(t, b.disk.segments, 1,
+		"compaction must swap the new merged segment into the live segment list immediately, "+
+			"regardless of the held view -- it must never stall waiting for a reader's refcount")
+	require.Len(t, b.disk.segmentsAwaitingDrop, 2,
+		"the two pre-compaction segments must be pushed to the deferred-drop queue -- "+
+			"they cannot be physically removed while the held view's refcount is nonzero")
+
+	// still-held view must keep reading the frozen pre-compaction segments
+	assertReads(t, viewCtx)
+
+	droppedWhileHeld, err := b.disk.dropSegmentsAwaiting()
+	require.NoError(t, err)
+	require.Zero(t, droppedWhileHeld,
+		"dropSegmentsAwaiting must refuse to remove a segment with nonzero refcount "+
+			"while the batch view is still held")
+	require.Len(t, b.disk.segmentsAwaitingDrop, 2, "both old segments must still be waiting")
+
+	view.ReleaseView()
+
+	droppedAfterRelease, err := b.disk.dropSegmentsAwaiting()
+	require.NoError(t, err)
+	require.Equal(t, 2, droppedAfterRelease,
+		"releasing the batch view must unblock the deferred drop on the next cleanup pass")
+	require.Empty(t, b.disk.segmentsAwaitingDrop)
+
+	// non-batch read path must still be correct post-cleanup
+	assertReads(t, ctx)
+}

--- a/adapters/repos/db/lsmkv/bucket_consistent_view_context_test.go
+++ b/adapters/repos/db/lsmkv/bucket_consistent_view_context_test.go
@@ -1,0 +1,130 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestConsistentViewFromCtx pins that a view attached to ctx is only ever
+// handed back to the same bucket that acquired it (GH 12242).
+func TestConsistentViewFromCtx(t *testing.T) {
+	bucketA := &Bucket{strategy: StrategyRoaringSet}
+	bucketB := &Bucket{strategy: StrategyRoaringSet}
+	viewA := BucketConsistentView{Bucket: bucketA}
+
+	t.Run("no view attached", func(t *testing.T) {
+		_, ok := bucketA.consistentViewFromCtx(context.Background())
+		require.False(t, ok, "a plain context must never be mistaken for carrying a view")
+	})
+
+	t.Run("view attached for the same bucket is returned", func(t *testing.T) {
+		ctx := ContextWithConsistentView(context.Background(), viewA)
+		got, ok := bucketA.consistentViewFromCtx(ctx)
+		require.True(t, ok)
+		require.Same(t, bucketA, got.Bucket)
+	})
+
+	t.Run("view attached for a different bucket is ignored, not misapplied", func(t *testing.T) {
+		ctx := ContextWithConsistentView(context.Background(), viewA)
+		_, ok := bucketB.consistentViewFromCtx(ctx)
+		require.False(t, ok,
+			"bucketB must never receive bucketA's view -- using it would apply the wrong bucket's "+
+				"segment snapshot to bucketB's reads")
+	})
+}
+
+// TestRoaringSetGet_ReusesContextConsistentView proves RoaringSetGet, given a
+// ctx-supplied view, returns the same result as the default per-call
+// GetConsistentView path (GH 12242).
+func TestRoaringSetGet_ReusesContextConsistentView(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.RoaringSetAddList([]byte("k1"), []uint64{1, 2, 3}))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RoaringSetAddList([]byte("k1"), []uint64{4}))
+
+	// default path: RoaringSetGet acquires its own view internally
+	wantBM, wantRelease, err := b.RoaringSetGet(ctx, []byte("k1"))
+	require.NoError(t, err)
+	want := wantBM.ToArray()
+	wantRelease()
+
+	// ctx-supplied view path: acquire once, attach, reuse
+	view := b.GetConsistentView()
+	viewCtx := ContextWithConsistentView(ctx, view)
+	gotBM, gotRelease, err := b.RoaringSetGet(viewCtx, []byte("k1"))
+	require.NoError(t, err)
+	got := gotBM.ToArray()
+	gotRelease()
+	view.ReleaseView()
+
+	require.Equal(t, want, got,
+		"RoaringSetGet via a caller-supplied ContextWithConsistentView must return the exact "+
+			"same result as the default per-call GetConsistentView path")
+}
+
+// TestRoaringSetGet_MismatchedBucketViewFallsBackSafely proves RoaringSetGet
+// falls back to its own view, not another bucket's, when ctx carries a
+// mismatched one.
+func TestRoaringSetGet_MismatchedBucketViewFallsBackSafely(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	bA, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bA.Shutdown(ctx)) })
+	require.NoError(t, bA.RoaringSetAddList([]byte("shared-key"), []uint64{100, 200}))
+	require.NoError(t, bA.FlushAndSwitch())
+
+	bB, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bB.Shutdown(ctx)) })
+	require.NoError(t, bB.RoaringSetAddList([]byte("shared-key"), []uint64{7, 8, 9}))
+	require.NoError(t, bB.FlushAndSwitch())
+
+	viewA := bA.GetConsistentView()
+	defer viewA.ReleaseView()
+	ctxWithAsView := ContextWithConsistentView(ctx, viewA)
+
+	bm, release, err := bB.RoaringSetGet(ctxWithAsView, []byte("shared-key"))
+	require.NoError(t, err)
+	defer release()
+
+	require.Equal(t, []uint64{7, 8, 9}, bm.ToArray(),
+		"bucket B must return its own data, not bucket A's, when handed a context carrying "+
+			"bucket A's consistent view")
+}

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -116,10 +116,17 @@ func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
 	return active.roaringSetAddBitmap(key, bm)
 }
 
-// RoaringSetGet consults ctx only for the concurrency budget, not for cancellation.
+// RoaringSetGet consults ctx for the concurrency budget and, if attached via
+// ContextWithConsistentView, a pre-acquired view scoped to this bucket to
+// reuse instead of acquiring a fresh one -- ctx is not otherwise consulted
+// for cancellation.
 func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitmap, release func(), err error) {
 	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return nil, noopRelease, err
+	}
+
+	if view, ok := b.consistentViewFromCtx(ctx); ok {
+		return b.roaringSetGetFromConsistentView(ctx, view, key)
 	}
 
 	view := b.GetConsistentView()


### PR DESCRIPTION
Stacks on **[#12264](https://github.com/weaviate/weaviate/pull/12264)**; do not merge before it. All diffs and benchmark deltas below are measured against #12264.

## Summary

Building on #12264's chunked resolution, this PR removes two remaining per-value cost lines from `ContainsAny`/`ContainsAll` at large value-set sizes: a `GetConsistentView()`/`ReleaseView()` pair on every individual filter value, and an M-1 pairwise bitmap-union reduce on the final OR-merge step. Under concurrent load with distinct value sets per request, this is a further **+13.5% to +25.4%** throughput improvement on top of #12264, measured on a clean, uncontaminated box across all 4 tested worker counts.

## Mechanism

Two remaining cost lines survive #12264's chunking fix:

- **View churn**: `Bucket.RoaringSetGet` (`adapters/repos/db/lsmkv/bucket_roaring_set.go:120`) still acquires and releases its own `BucketConsistentView` on every call. A 100K-value `ContainsAny` still pays 100,000 acquire/release cycles, just spread across `outerConcurrencyLimit` chunk goroutines instead of one goroutine per value.
- **Merge-step reallocation**: `mergeDocIDs` (`adapters/repos/db/inverted/prop_value_pairs.go`) folds a chunk's partial results via `mergeBitmapsAndOrWithDenyList` in an M-1 sequential pairwise reduce, reallocating the accumulator's containers on every step.

## Fix

**Batch view acquisition.** `lsmkv.ContextWithConsistentView`/`consistentViewFromCtx` thread a pre-acquired `BucketConsistentView` through `context.Context`, mirroring the existing `concurrency.ContextWithFractionalBudget` pattern in the same file. The view carries an identity check against the target `*Bucket`, so it can never be misapplied to an unrelated bucket in a mixed AND/OR filter tree. `inverted.resolveDocIDsAndOr` detects the flat same-bucket-`Equal` shape `ContainsAny`/`ContainsAll` desugar into and, only in that case, acquires one view per <=500-key slab instead of the default one-view-per-value -- the same view-hold cap the sibling `GetBySecondaryBatchWithView` design established and already runs in production. Any other shape (mixed properties/operators, nested, non-roaringset) falls through to the original per-child code path, byte for byte unmodified.

**Serial FastOr union.** For a pure-allowlist `OperatorOr` batch -- the shape `ContainsAny`'s chunk-level partials always are when no deny-list leaf is present -- `mergeDocIDs` now routes through `sroar.FastOr`, which pre-sizes the destination bitmap's containers once from the per-key worst-case cardinality summed across every input, instead of the M-1 pairwise reduce. `OperatorAnd` and any OR batch with a deny-list operand still fall through to the original pairwise reduce, since FastOr has no deny-list/tombstone algebra.

**Why serial `FastOr`, never `FastParOr`.** `sroar` (vendored, v0.0.15) ships both a serial `FastOr` and a parallel `FastParOr`. This PR calls `FastOr` only. `FastParOr` has a genuine, 100%-reproducible data race in its own internal goroutine-grouping logic (`bitmap.go:1176-1195`): `res` is grown via `append` in the launching goroutine while previously-spawned goroutines concurrently write into it by index, and the spawned closures capture the `res` *variable*, not a snapshot, so a later `append`-triggered reallocation races an in-flight goroutine's indexed write. This is a bug in the vendored dependency's own code, not a misuse of its API, confirmed via `go test -race` (100% reproducible) and independently isolated in a standalone repro against `sroar` alone with no weaviate code involved. The fix is simply "never call `FastParOr`" -- its nested parallelism was redundant anyway, since every `fastOrMerge` call already runs inside one of #12264's chunk goroutines, so this call site never needed its own intra-merge fan-out on top of the existing per-request concurrency. We plan to file this as an upstream `weaviate/sroar` issue separately from this PR.

## Key areas for review

- `bucket.go` / `bucket_roaring_set.go` -- the `*Bucket`-identity check on `consistentViewFromCtx`: a view acquired for bucket A must never be applied to bucket B's reads in a mixed AND/OR tree. `TestRoaringSetGet_MismatchedBucketViewFallsBackSafely` pins this.
- `prop_value_pairs.go`'s `flatEqualChildrenBucket` -- the gate that decides whether a `propValuePair` qualifies for batch view acquisition at all (flat, non-nested, all-`Equal`, single roaring-set bucket). Any other shape must fall through unchanged.
- `prop_value_pairs.go`'s `allAllowLists` gate on the FastOr path -- the single guard keeping deny-list/tombstone algebra out of a plain-union merge. A deny-list operand slipping past this gate would silently resurrect deleted doc IDs.
- The 500-key view-hold cap (`maxBatchViewHoldKeys`): a held view pins segment refcounts and blocks `dropSegmentsAwaiting` until released. This cap is what bounds that hold duration; see the soak/compaction evidence in Testing below for why it's sufficient under sustained concurrent load.

## Risks and mitigations

- **Compaction starvation under a held batch view**: mitigated by the 500-key cap keeping any single view's hold duration short, verified two ways: (1) `TestBatchViewAcquisition_CompactionDuringHeldView` proves a real `compactOnce` never blocks on a held view (segments swap into `segmentsAwaitingDrop` synchronously, unconditionally) and that reads through the still-held view stay correct against the pre-drop segments; (2) a 300-second soak test under sustained concurrent read+write load with active compaction, described in Testing, shows zero `lsm_drop_segments_awaiting` backlog warnings.
- **Bitmap-buffer release on cancel/error mid-slab**: a chunk goroutine that has accumulated a partial result from earlier slabs must release it exactly once on cancellation, with no leak and no double-free. `TestSearcher_ContainsAny_CancellationMidChunk` (carried from #12264, re-verified here) covers this with bitmap-buffer-leak tracking via `roaringset.BitmapBufPoolTracking`.
- **Cross-bucket view misapplication in a mixed AND/OR tree**: `TestRoaringSetGet_MismatchedBucketViewFallsBackSafely` proves a view acquired for one bucket never leaks into another bucket's reads.
- **Fold-order correctness across storage layers (delete-then-readd)**: `TestSearcher_ContainsAny_DeleteThenReaddAcrossSegments` writes across two disk segments plus the active memtable specifically to exercise oldest-to-newest fold order through the new batch-view + FastOr path, with a hand-computed independent oracle (not derived from the code under test).
- **Single-query regression at very large value sets**: see Disclosures below. Does not block ship; the primary regime this PR targets is concurrent throughput, not single-query latency.

## Negative results (kept here so nobody re-derives them)

- **`C2` global admission-control semaphore**: already documented and rejected in #12264 -- box-benchmarked strictly worse than baseline at every worker count. Not re-litigated here; see #12264's Fix section.
- **`MultiGetRoaringSet` (deeper read-op-collapse prototype)**: built and validated (byte-exact correctness, including its own delete-then-readd tombstone fixture), then shelved rather than shipped. A composition review comparing all three candidates against a common baseline found `MultiGetRoaringSet`'s unique differentiator -- collapsing 100K per-value reads to 2 batch reads -- measured *neutral* end-to-end at this data shape (33% selectivity, warm cache): distinct-page-touch analysis showed no locality win to recover, and the production incident this whole effort investigates was alloc-rate/goroutine-driven, not read-op-count-driven. `MultiGetRoaringSet` also regressed at low concurrency (-2.5% at 16 workers) due to an unavoidable bitmap-clone cost this PR's simpler batch-view approach never pays. It clears no bar over what ships here. Preserved as a validated-but-shelved branch with named re-open triggers (prod goes cold-cache/pread, low-selectivity filters become common, or a future PR moves interception to extraction and removes the O(100K) per-value pair-building cost this PR leaves untouched) rather than discarded outright, so it isn't silently re-invented later.

## Out of scope

- **Upstream `sroar` `FastParOr` fix**: the race lives in vendored dependency code, not this call site. This PR's fix ("don't call `FastParOr`") stands alone and doesn't require patching the vendor. Plan to file separately.
- **Everything already out of scope in #12264** (the cancellation-race-widening finding, the row-reader unreleased-buffer investigation, the slow-query-log serialization issue): unchanged by this PR, not re-touched here.
- **`MultiGetRoaringSet`**: shelved per the negative-results section above, not part of this ship.

## Testing

- Unit + integration (`-race`) for `adapters/repos/db/inverted` (all 4 subpackages) and the broader `adapters/repos/db` package: all green, zero data races.
- `golangci-lint run ./adapters/repos/db/inverted/... ./adapters/repos/db/lsmkv/...`: 0 issues. `./tools/linter_go_routines.sh`: clean.
- Box-scale correctness corpus (12 queries, sizes 1-100K plus edges and nested compounds) byte-exact vs #12264's own baseline, under both default (mmap) and `PERSISTENCE_LSM_ACCESS_STRATEGY=pread` postures -- 12/12 match both.
- New/carried tests, all `-race`-clean: `TestConsistentViewFromCtx`, `TestRoaringSetGet_ReusesContextConsistentView`, `TestRoaringSetGet_MismatchedBucketViewFallsBackSafely`, `TestBatchViewAcquisition_CompactionDuringHeldView` (batch view); `TestMergeDocIDs_FastOrPath_MatchesPairwiseReference`, `TestMergeDocIDs_DenyListPresent_SkipsFastOrPath`, `TestMergeDocIDs_AndOperator_SkipsFastOrPath` (FastOr); `TestSearcher_ContainsAny_DeleteThenReaddAcrossSegments` (cross-segment tombstone fold order).
- A 300-second soak: sustained `w64` concurrent-query load running alongside a concurrent light-import loop forcing real memtable flushes, new segment creation, and compaction under load. Segment count/disk-size sampled every 30s (oscillates 3-10 files, never grows unbounded); zero `lsm_drop_segments_awaiting` backlog warnings across the entire window; query throughput held steady under the combined read+write load (17.87 rps sustained vs 17.90 rps isolated).

### Benchmark table (concurrent distinct-set throughput, over #12264, 16-core box, distinct random 100K-of-300K id set per request)

| Workers | #12264 rps | This PR rps | Δ | #12264 p99 | This PR p99 | Δ |
|---|---|---|---|---|---|---|
| 16 | 16.88 | 19.16 | **+13.5%** | 1.48s | 1.344s | -9.2% |
| 32 | 16.28 | 18.71 | **+14.9%** | 3.57s | 2.798s | -21.6% |
| 64 | 15.51 | 17.90 | **+15.4%** | 6.47s | 5.941s | -8.2% |
| 100 | 13.96 | 17.51 | **+25.4%** | 10.65s | 9.678s | -9.1% |

Measured on a quiet box (single container, no competing bench, 1-min load <2 verified before every phase), non-reuse self-check `violations=0` on every phase.

### Goroutine census + CPU (mid-load, 100-worker phase)

| Metric | #12264 | This PR |
|---|---|---|
| Goroutines mid-load (`debug=2`) | 508 | 484 |
| CPU % of 1600% cap, mid-load | 79.3% | 91.4% |
| rps per CPU% (derived efficiency) | 0.01101 | 0.01197 (**+8.7%**) |

No material goroutine re-inflation (484 vs 508, actually lower). One new wait-state class appears (`semacquire`, 36 goroutines, absent from #12264), attributable to the new batch-view acquisition mechanism's semaphore/refcount primitive -- expected, not concerning: `runnable` and `sync.Mutex.Lock` both drop (190->140, 55->39), consistent with less per-value goroutine/lock churn now that view acquisition is batched. Raw CPU is higher, but so is throughput -- rps-per-CPU-percent improves, i.e. this PR isn't less efficient per unit of work, it simply isn't bottlenecked on goroutine/channel congestion anymore and can push more concurrent work through the box's available headroom.

## Disclosures (honest findings that don't block ship)

- **Single-query latency regresses ~7-8% at the 100K value-set size specifically.** Value-set sizes 100/1K/10K are flat-to-improved (100 is actually meaningfully faster, -12%); 100K is the one size that regresses. First reading (same-session re-anchored baseline) measured **+6.8%**; repeated 3x to rule out a one-off blip, averaging **+8.3%** (~105.5ms baseline avg vs ~114.2ms this-PR avg). Consistent and reproducible across all 3 runs, isolated to the one size, not a systemic latency regression. Likely mechanism (not verified by profiling): at 100K values this PR's batch-view acquires ~200 separate consistent views (one per <=500-key slab) versus the baseline's 100,000 independent per-value acquisitions; at concurrency=1 (single query, no cross-request contention to amortize against), the per-call cost of the baseline's simpler acquisition path is likely cheap enough that the batch-view's per-slab bookkeeping (slab-boundary arithmetic, shape checks) nets out slightly worse when multiplied across ~200 slabs with nothing to amortize it against. This does not reverse the ship decision: (1) it's a single-query (concurrency=1) measurement, and the concurrent-throughput win above -- the regime this PR is built for and the regime production traffic actually hits -- is +13.5% to +25.4% across all 4 worker counts; (2) 8% on a 114ms single-query call is an absolute delta under 9ms, well below any client-facing timeout or user-perceptible threshold; (3) this is the first time this specific sweep (single-query latency at 100/1K/10K/100K) was ever run against the fully composed change -- it's a measured fact turning a prior assumption into data, not evidence of a regression that was previously hidden.
- **An unrelated, pre-existing HNSW vector-index panic surfaced once during the 300-second soak** (1 of 5,406 requests, 99.98% success), recovered cleanly by the existing panic-recovery wrapper with no server crash; confirmed via `git diff --stat` against this PR's own changes that nothing in `adapters/repos/db/vector/hnsw/*` or `entities/vectorindex/hnsw/packedconn/*` is touched by this diff, so this is a latent, pre-existing concurrency bug in an unrelated subsystem that would reproduce identically on baseline or #12264, surfaced here only because this soak is the first bench in the whole GH-12242 effort to run concurrent writes alongside concurrent vector-search reads. Recommend filing as a separate issue, not gh12242-scoped.

## Verification

- [x] `go build ./adapters/repos/db/...` clean
- [x] `golangci-lint run ./adapters/repos/db/inverted/... ./adapters/repos/db/lsmkv/...`: 0 issues
- [x] `./tools/linter_go_routines.sh`: clean
- [x] Unit tests green, `-race`: `adapters/repos/db/inverted` (+ `nested`, `stopwords`, `terms` subpackages), `adapters/repos/db/lsmkv` (+ `gobenc`, `segmentindex`, `varenc` subpackages), `adapters/repos/db`
- [x] Integration tests (`-race`, `-tags=integrationTest`) green, zero data races: same packages
- [x] Box-scale correctness corpus: 12/12 byte-exact vs #12264 baseline, both mmap and pread postures
- [x] Concurrent distinct-set throughput, 16/32/64/100 workers, clean box: beats #12264 at 4/4 worker counts
- [x] Goroutine + CPU census, mid-load: no material re-inflation
- [x] 300s soak (sustained concurrent read+write, active compaction): zero backlog-drain warnings

---

Related: [GH 12242](https://github.com/weaviate/weaviate/issues/12242), stacks on [#12264](https://github.com/weaviate/weaviate/pull/12264).
