### PR TITLE
fix(reindex): fail-safe Touches* default; classify rebuild-searchable (v1.38 backport)

### DIFF
--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -818,9 +818,10 @@ func TestBuildUnitSpecs_DeterministicSort(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// touchesSearchable / touchesFilterable — exhaustive switch, including a
-// panic on unknown ReindexMigrationType so a future type cannot silently
-// bypass the conflict check.
+// touchesSearchable / touchesFilterable — exhaustive classification with a
+// fail-safe default: an unknown ReindexMigrationType returns true (never
+// panics) because these predicates are reachable from the RAFT FSM apply
+// path, where a panic is a cluster-wide poison pill.
 // -----------------------------------------------------------------------------
 
 func TestTouchesSearchable(t *testing.T) {
@@ -831,6 +832,7 @@ func TestTouchesSearchable(t *testing.T) {
 		{db.ReindexTypeChangeAlgorithm, true},
 		{db.ReindexTypeChangeTokenization, true},
 		{db.ReindexTypeEnableSearchable, true},
+		{db.ReindexTypeRebuildSearchable, true},
 		{db.ReindexTypeRepairFilterable, false},
 		{db.ReindexTypeEnableFilterable, false},
 		{db.ReindexTypeEnableRangeable, false},
@@ -852,6 +854,7 @@ func TestTouchesFilterable(t *testing.T) {
 		{db.ReindexTypeEnableFilterable, true},
 		{db.ReindexTypeChangeAlgorithm, false},
 		{db.ReindexTypeEnableSearchable, false},
+		{db.ReindexTypeRebuildSearchable, false},
 		{db.ReindexTypeEnableRangeable, false},
 	}
 	for _, tc := range cases {
@@ -861,20 +864,18 @@ func TestTouchesFilterable(t *testing.T) {
 	}
 }
 
-func TestTouchesSearchable_PanicsOnUnknownType(t *testing.T) {
-	require.PanicsWithValue(t,
-		`TouchesSearchable: unknown ReindexMigrationType "phantom" — add it to this switch`,
-		func() { db.TouchesSearchable(db.ReindexMigrationType("phantom")) },
-		"unknown migration type must panic so the gap is caught loudly",
-	)
+func TestTouchesSearchable_UnknownTypeFailsSafe(t *testing.T) {
+	require.NotPanics(t, func() {
+		require.True(t, db.TouchesSearchable(db.ReindexMigrationType("phantom")),
+			"unknown type must fail safe (conservatively touches), never panic the FSM apply path")
+	})
 }
 
-func TestTouchesFilterable_PanicsOnUnknownType(t *testing.T) {
-	require.PanicsWithValue(t,
-		`TouchesFilterable: unknown ReindexMigrationType "phantom" — add it to this switch`,
-		func() { db.TouchesFilterable(db.ReindexMigrationType("phantom")) },
-		"unknown migration type must panic so the gap is caught loudly",
-	)
+func TestTouchesFilterable_UnknownTypeFailsSafe(t *testing.T) {
+	require.NotPanics(t, func() {
+		require.True(t, db.TouchesFilterable(db.ReindexMigrationType("phantom")),
+			"unknown type must fail safe (conservatively touches), never panic the FSM apply path")
+	})
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/reindex_conflict.go
+++ b/adapters/repos/db/reindex_conflict.go
@@ -109,12 +109,12 @@ func (p *ReindexProvider) CheckConflict(newPayload []byte, existingTasks []*dist
 func typesConflictReason(newType ReindexMigrationType, newProps []string,
 	existType ReindexMigrationType, existProps []string,
 ) string {
-	// Sanity-check the migration types via the exhaustive bucket-touch
-	// predicates so an unknown ReindexMigrationType still panics
-	// loudly at the conflict-check boundary rather than slipping
-	// through as "no conflict". Result values are intentionally
-	// discarded — the conflict rule below does not depend on which
-	// buckets are touched, only that both types are known.
+	// Keep the bucket-touch classifiers on the production path (results
+	// discarded — the conflict rule below is property-overlap only and
+	// deliberately does NOT branch on bucket type; see the Sev1 note
+	// above). Their fail-safe default means a peer-written unknown type
+	// reaching this apply path degrades to a conservative classification
+	// instead of panicking the RAFT FSM.
 	_ = TouchesSearchable(newType)
 	_ = TouchesFilterable(newType)
 	_ = TouchesSearchable(existType)
@@ -162,19 +162,22 @@ func ReindexPropsOverlap(a, b []string) bool {
 }
 
 // TouchesSearchable reports whether migration type t writes to the
-// searchable bucket. Implemented as an exhaustive switch so that a
-// newly-added [ReindexMigrationType] cannot silently be treated as
-// "doesn't touch searchable" — the default case panics with a clear
-// message, surfacing the gap on the first request that exercises the
-// new type. This matters because [typesConflictReason] relies on
-// these answers (via the sanity-check at its entry) to gate
-// concurrent reindex submissions: a positive-list miss would allow
-// conflicting writes to the same bucket through.
+// searchable bucket.
+//
+// The default arm FAILS SAFE (returns true) rather than panicking: this
+// predicate is reachable from [CheckConflict], which runs in the RAFT
+// FSM AddTask apply path on every node. A panic there is a cluster-wide
+// poison pill — replayed on restart — so an unrecognized type (e.g. a
+// peer-written migration from a newer binary) must degrade to the
+// conservative "touches" answer, never crash the FSM. Every known type
+// is still classified explicitly so the exhaustive-switch tests catch a
+// missing classification at development time.
 func TouchesSearchable(t ReindexMigrationType) bool {
 	switch t {
 	case ReindexTypeChangeAlgorithm,
 		ReindexTypeChangeTokenization,
-		ReindexTypeEnableSearchable:
+		ReindexTypeEnableSearchable,
+		ReindexTypeRebuildSearchable:
 		return true
 	case ReindexTypeRepairFilterable,
 		ReindexTypeChangeTokenizationFilterable,
@@ -183,13 +186,14 @@ func TouchesSearchable(t ReindexMigrationType) bool {
 		ReindexTypeRepairRangeable:
 		return false
 	default:
-		panic(fmt.Sprintf("TouchesSearchable: unknown ReindexMigrationType %q — add it to this switch", t))
+		return true
 	}
 }
 
 // TouchesFilterable reports whether migration type t writes to the
-// filterable bucket. Same exhaustive-switch contract as
-// [TouchesSearchable].
+// filterable bucket. Same fail-safe default contract as
+// [TouchesSearchable] — an unrecognized type returns true rather than
+// panicking the RAFT FSM apply path.
 func TouchesFilterable(t ReindexMigrationType) bool {
 	switch t {
 	case ReindexTypeRepairFilterable,
@@ -200,10 +204,11 @@ func TouchesFilterable(t ReindexMigrationType) bool {
 	case ReindexTypeChangeAlgorithm,
 		ReindexTypeEnableSearchable,
 		ReindexTypeEnableRangeable,
-		ReindexTypeRepairRangeable:
+		ReindexTypeRepairRangeable,
+		ReindexTypeRebuildSearchable:
 		return false
 	default:
-		panic(fmt.Sprintf("TouchesFilterable: unknown ReindexMigrationType %q — add it to this switch", t))
+		return true
 	}
 }
 

--- a/adapters/repos/db/reindex_conflict_rebuildsearchable_test.go
+++ b/adapters/repos/db/reindex_conflict_rebuildsearchable_test.go
@@ -1,0 +1,104 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+)
+
+// TestCheckConflict_RebuildSearchable_NoPanic pins the latent
+// cluster-wide poison pill: ReindexTypeRebuildSearchable is submittable
+// (handlers_indexes.go) but was absent from the Touches* classification
+// switches, so their default arm panicked. CheckConflict exercises those
+// switches, and CheckConflict runs in the RAFT FSM AddTask apply path on
+// every node — so a rebuild-searchable request racing another active task
+// on the same collection crashed the whole cluster, replayed on restart.
+//
+// Both sub-tests drive the real CheckConflict (never a mocked switch): the
+// first directly, the second through Manager.AddTask, the actual FSM apply
+// entry point where the panic would poison the cluster.
+func TestCheckConflict_RebuildSearchable_NoPanic(t *testing.T) {
+	newPayload, err := json.Marshal(ReindexTaskPayload{
+		MigrationType: ReindexTypeRebuildSearchable,
+		Collection:    "C",
+		Properties:    []string{"title"},
+	})
+	require.NoError(t, err)
+
+	existPayload, err := json.Marshal(ReindexTaskPayload{
+		MigrationType: ReindexTypeEnableFilterable,
+		Collection:    "C",
+		Properties:    []string{"title"},
+	})
+	require.NoError(t, err)
+
+	t.Run("direct CheckConflict returns conflict, does not panic", func(t *testing.T) {
+		provider := &ReindexProvider{}
+		existing := []*distributedtask.Task{{
+			TaskDescriptor: distributedtask.TaskDescriptor{ID: "existing", Version: 1},
+			Status:         distributedtask.TaskStatusStarted,
+			Payload:        existPayload,
+		}}
+		require.NotPanics(t, func() {
+			err := provider.CheckConflict(newPayload, existing)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "conflict")
+		})
+	})
+
+	t.Run("Manager.AddTask apply path returns conflict, does not poison the FSM", func(t *testing.T) {
+		logger, _ := logrustest.NewNullLogger()
+		mgr := distributedtask.NewManager(distributedtask.ManagerParameters{
+			Clock:            clockwork.NewFakeClock(),
+			CompletedTaskTTL: time.Hour,
+			Logger:           logger,
+		})
+		mgr.SetConflictDetectors(map[string]distributedtask.ConflictDetector{
+			ReindexNamespace: &ReindexProvider{},
+		})
+
+		// First submit lands: no conflict against an empty task list.
+		require.NoError(t, mgr.AddTask(rebuildAddTaskCmd(t, existPayload, "existing"), 1))
+
+		// Second submit is rebuild-searchable on the same collection while
+		// the first is STARTED. Pre-fix this panicked inside CheckConflict;
+		// post-fix it must return a conflict error and leave the FSM intact.
+		var addErr error
+		require.NotPanics(t, func() {
+			addErr = mgr.AddTask(rebuildAddTaskCmd(t, newPayload, "rebuild"), 2)
+		})
+		require.Error(t, addErr)
+		require.Contains(t, addErr.Error(), "conflict")
+	})
+}
+
+func rebuildAddTaskCmd(t *testing.T, payload []byte, id string) *cmd.ApplyRequest {
+	t.Helper()
+	sub, err := json.Marshal(&cmd.AddDistributedTaskRequest{
+		Namespace:             ReindexNamespace,
+		Id:                    id,
+		Payload:               payload,
+		UnitIds:               []string{"u-1"},
+		SubmittedAtUnixMillis: 1,
+	})
+	require.NoError(t, err)
+	return &cmd.ApplyRequest{SubCommand: sub}
+}


### PR DESCRIPTION
SuperClaude here.

v1.38 backport of a pre-existing defect surfaced during review of weaviate/weaviate#12252. The GA-shaped equivalent lands on `main` via that PR, so the stable→main forward-merge reconciles; this PR is the v1.38-shaped fix only.

**Mechanism.** `ReindexTypeRebuildSearchable` (`{"searchable":{"rebuild":true}}`) is submittable via the reindex REST API but was absent from the `TouchesSearchable`/`TouchesFilterable` classification switches, whose `default:` arm panicked. Those predicates are exercised by `CheckConflict`, which runs in the RAFT FSM `AddTask` apply path on every node — so a rebuild-searchable request racing another active reindex task on the same collection panicked the whole cluster, replayed on restart. A poison pill.

**Fix.** Both switch defaults now fail safe (an unrecognized type conservatively "touches", never panics), and `rebuild-searchable` is classified explicitly (searchable=true, filterable=false). The conflict decision is property-overlap only, so the submit now returns a clean conflict instead of crashing the FSM.

**Test.** `TestCheckConflict_RebuildSearchable_NoPanic` drives the real `CheckConflict` both directly and through `Manager.AddTask` (the FSM apply entry point). Red→green confirmed — pre-fix both paths panic with `TouchesSearchable: unknown ReindexMigrationType "rebuild-searchable"`; post-fix both return a conflict. The `Touches*` unit tests were updated to assert the fail-safe default.

Local verification: `go build ./...`; `-race` unit tests green for `adapters/repos/db` (56.9s) and `adapters/handlers/rest` (95.6s); gofumpt + goimports clean; golangci-lint 0 issues.

— SuperClaude
