### PR TITLE
fix(reindex): redact foreign task IDs from pre-flight errors; authz before delete pre-flight (v1.38 backport)

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1405,7 +1405,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	db_users.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication, appState.ServerConfig.Config.Authorization, remoteDbUsers, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.NamespacesController, appState.Logger)
 	rest_namespaces.SetupHandlers(appState.ServerConfig.Config.Namespaces.Enabled, api, appState.ClusterService.Raft, appState.Authorizer, appState.Logger)
 
-	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks, appState.ServerConfig.Config.Namespaces.Enabled)
+	setupSchemaHandlers(api, appState.SchemaManager, appState.Authorizer, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks, appState.ServerConfig.Config.Namespaces.Enabled)
 	setupIndexesHandlers(api, appState)
 	setupTokenizeHandlers(api, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.Logger)
 	setupAliasesHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -539,30 +539,8 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 	if h.appState.ClusterService != nil {
 		tasks, err := h.appState.ClusterService.ListDistributedTasks(ctx)
 		if err == nil {
-			reason, checkErr := checkReindexConflict(collection, migrationType, properties, tasks[db.ReindexNamespace])
-			if checkErr != nil {
-				// An in-flight task has an unparseable payload — we cannot
-				// prove the new submit doesn't conflict with it, so refuse
-				// rather than race. Return 503 so the caller knows to retry
-				// after an operator inspects the in-flight task.
-				return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(principal, checkErr.Error()))
-			}
-			if reason != "" {
-				return schema.NewSchemaObjectsIndexesUpdateConflict().WithPayload(errorResponse(principal, reason))
-			}
-			// Per-collection cap on concurrent STARTED reindex tasks. Without
-			// this a caller scripting `for p in $(properties); do PUT
-			// .../indexes/$p; done` against an N-property collection submits N
-			// independent RAFT tasks, each fanning out ingest+backup buckets
-			// on every replica. The LSM compaction layer and disk would not
-			// survive that. Reject with 429 once the cap is reached — the
-			// semantics ("retry later, you're over a concurrency limit") map
-			// exactly to RFC 6585's Too Many Requests, not to 503's "server
-			// is unavailable". Returning 503 here misled callers and
-			// monitoring into thinking the cluster was unhealthy rather than
-			// rate-limiting them.
-			if inflight := countStartedTasksForCollection(collection, tasks[db.ReindexNamespace]); inflight >= maxConcurrentReindexPerCollection {
-				return reindexCapExceededResponder(principal, collection, inflight, maxConcurrentReindexPerCollection)
+			if resp := h.checkReindexAdmission(principal, collection, migrationType, properties, tasks[db.ReindexNamespace]); resp != nil {
+				return resp
 			}
 		}
 	}
@@ -1402,6 +1380,40 @@ func countStartedTasksForCollection(collection string, tasks []*distributedtask.
 		}
 	}
 	return n
+}
+
+// checkReindexAdmission runs the REST-boundary conflict + per-collection-cap
+// pre-flight against an already-fetched task snapshot. Returns nil when the
+// submit may proceed, or a typed responder (503 unverifiable / 409 conflict /
+// 429 cap) otherwise.
+func (h *indexesHandlers) checkReindexAdmission(principal *models.Principal, collection string,
+	migrationType db.ReindexMigrationType, properties []string, tasks []*distributedtask.Task,
+) middleware.Responder {
+	reason, checkErr := checkReindexConflict(collection, migrationType, properties, tasks)
+	if checkErr != nil {
+		// checkErr can name the ID of a foreign in-flight task (unparseable or
+		// informationally-empty payload) whose namespace the caller can't see,
+		// and StripErrorMessage strips only the caller's own namespace. Log the
+		// detail server-side; return a generic message so the task ID can't
+		// leak. Fail closed (503): we couldn't prove non-conflict.
+		h.appState.Logger.WithField("collection", collection).
+			Errorf("submit: cannot verify reindex conflict, failing closed: %v", checkErr)
+		return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(principal,
+			"cannot verify reindex preconditions: an in-flight reindex task has an unparseable or incomplete payload; retry after an operator inspects the task store"))
+	}
+	if reason != "" {
+		return schema.NewSchemaObjectsIndexesUpdateConflict().WithPayload(errorResponse(principal, reason))
+	}
+	// Per-collection cap on concurrent STARTED reindex tasks. Without this a
+	// caller scripting `for p in $(properties); do PUT .../indexes/$p; done`
+	// against an N-property collection submits N independent RAFT tasks, each
+	// fanning out ingest+backup buckets on every replica — the LSM compaction
+	// layer and disk would not survive that. 429 (RFC 6585) not 503: this is a
+	// concurrency limit, not cluster unavailability.
+	if inflight := countStartedTasksForCollection(collection, tasks); inflight >= maxConcurrentReindexPerCollection {
+		return reindexCapExceededResponder(principal, collection, inflight, maxConcurrentReindexPerCollection)
+	}
+	return nil
 }
 
 // checkReindexConflict checks if a new reindex task would conflict with any

--- a/adapters/handlers/rest/handlers_reindex_leak_test.go
+++ b/adapters/handlers/rest/handlers_reindex_leak_test.go
@@ -1,0 +1,154 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+)
+
+// foreignLeakTaskID embeds a namespace/collection/property the caller must
+// never see. The reindex conflict pre-flights emit task IDs BEFORE the
+// collection filter, and StripErrorMessage strips only the caller's own
+// namespace — so a foreign task ID would leak intact if returned to the
+// caller.
+const foreignLeakTaskID = "otherns:SecretCollection:change-tokenization:secretprop:beef"
+
+// TestCheckReindexAdmission_MalformedForeignTask_NoTaskIDLeak pins leak
+// site 1 (the indexes submit pre-flight): a malformed foreign in-flight
+// task must fail the submit closed (503) WITHOUT surfacing the foreign
+// task ID, while retaining it server-side for operators.
+func TestCheckReindexAdmission_MalformedForeignTask_NoTaskIDLeak(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+	h := &indexesHandlers{appState: &state.State{Logger: logger}}
+
+	tasks := []*distributedtask.Task{{
+		TaskDescriptor: distributedtask.TaskDescriptor{ID: foreignLeakTaskID},
+		Status:         distributedtask.TaskStatusStarted,
+		Payload:        []byte("not json"),
+	}}
+
+	principal := &models.Principal{Username: "customer1:u1", Namespace: "customer1"}
+	resp := h.checkReindexAdmission(principal, "customer1:MyClass", db.ReindexTypeEnableFilterable, []string{"p"}, tasks)
+
+	sua, ok := resp.(*schema.SchemaObjectsIndexesUpdateServiceUnavailable)
+	require.True(t, ok, "malformed in-flight payload must fail closed with 503")
+	require.NotEmpty(t, sua.Payload.Error)
+	require.NotContains(t, sua.Payload.Error[0].Message, foreignLeakTaskID,
+		"foreign task ID must not leak to the caller")
+	require.Contains(t, hook.LastEntry().Message, foreignLeakTaskID,
+		"task ID must be retained server-side so operators can act")
+}
+
+// TestCheckReindexConflictForPropertyMutation_MalformedForeignTask_NoTaskIDLeak
+// pins leak site 2 (the property-mutation pre-flight): a malformed foreign
+// in-flight task must still refuse the mutation but WITHOUT surfacing the
+// foreign task ID, while retaining it server-side.
+func TestCheckReindexConflictForPropertyMutation_MalformedForeignTask_NoTaskIDLeak(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+	h := &schemaHandlers{
+		logger: logger,
+		reindexTaskLister: fakeReindexTaskLister{tasks: map[string][]*distributedtask.Task{
+			db.ReindexNamespace: {{
+				Namespace:      db.ReindexNamespace,
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: foreignLeakTaskID},
+				Status:         distributedtask.TaskStatusStarted,
+				Payload:        []byte("not json"),
+			}},
+		}},
+	}
+
+	reason := h.checkReindexConflictForPropertyMutation(context.Background(), "customer1:MyClass", "title")
+	require.NotEmpty(t, reason, "a malformed in-flight task must still refuse the mutation")
+	require.NotContains(t, reason, foreignLeakTaskID, "foreign task ID must not leak to the caller")
+	require.Equal(t, foreignLeakTaskID, hook.LastEntry().Data["task_id"],
+		"task ID must be retained server-side so operators can act")
+}
+
+type recordingReindexTaskLister struct {
+	called bool
+	tasks  map[string][]*distributedtask.Task
+}
+
+func (r *recordingReindexTaskLister) ListDistributedTasks(ctx context.Context) (map[string][]*distributedtask.Task, error) {
+	r.called = true
+	return r.tasks, nil
+}
+
+type denyingAuthorizer struct{}
+
+func (denyingAuthorizer) Authorize(ctx context.Context, p *models.Principal, verb string, resources ...string) error {
+	return authzerrors.NewForbidden(p, verb, resources...)
+}
+
+func (denyingAuthorizer) AuthorizeSilent(ctx context.Context, p *models.Principal, verb string, resources ...string) error {
+	return authzerrors.NewForbidden(p, verb, resources...)
+}
+
+func (denyingAuthorizer) FilterAuthorizedResources(ctx context.Context, p *models.Principal, verb string, resources ...string) ([]string, error) {
+	return nil, nil
+}
+
+// TestDeleteClassPropertyIndex_UnprivilegedGets403BeforePreflight pins that
+// authorization runs at the top of the DELETE handler, before the reindex
+// conflict pre-flight — so an authenticated-but-unprivileged caller gets a
+// 403 and never reaches (and never leaks from) the pre-flight.
+func TestDeleteClassPropertyIndex_UnprivilegedGets403BeforePreflight(t *testing.T) {
+	// A real in-flight conflict on the caller's own (class, property): if
+	// authorization did NOT run first, the pre-flight would reach this task
+	// and return 422. Authorization must win with a 403 instead, and the
+	// pre-flight must never be consulted (rec.called stays false).
+	conflictPayload, err := json.Marshal(db.ReindexTaskPayload{
+		MigrationType: db.ReindexTypeChangeTokenization,
+		Collection:    "MyClass",
+		Properties:    []string{"title"},
+	})
+	require.NoError(t, err)
+
+	rec := &recordingReindexTaskLister{tasks: map[string][]*distributedtask.Task{
+		db.ReindexNamespace: {{
+			Namespace:      db.ReindexNamespace,
+			TaskDescriptor: distributedtask.TaskDescriptor{ID: "t1"},
+			Status:         distributedtask.TaskStatusStarted,
+			Payload:        conflictPayload,
+		}},
+	}}
+	h := &schemaHandlers{
+		authorizer:          denyingAuthorizer{},
+		metricRequestsTotal: newSchemaRequestsTotal(nil, logrus.New()),
+		reindexTaskLister:   rec,
+	}
+
+	resp := h.deleteClassPropertyIndex(schema.SchemaObjectsPropertiesDeleteParams{
+		HTTPRequest:  httptest.NewRequest("DELETE", "/", nil),
+		ClassName:    "MyClass",
+		PropertyName: "title",
+		IndexName:    "searchable",
+	}, &models.Principal{Username: "u1"})
+
+	_, ok := resp.(*schema.SchemaObjectsPropertiesDeleteForbidden)
+	require.True(t, ok, "unprivileged caller must get 403")
+	require.False(t, rec.called, "authorization must run before the reindex conflict pre-flight")
+}

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	uco "github.com/weaviate/weaviate/usecases/objects"
@@ -68,9 +69,11 @@ type reindexSubmitLockProvider interface {
 
 type schemaHandlers struct {
 	manager             *schemaUC.Manager
+	authorizer          authorization.Authorizer
 	metricRequestsTotal restApiRequestsTotal
 	reindexTaskLister   reindexInFlightChecker
 	reindexSubmitLocks  reindexSubmitLockProvider
+	logger              logrus.FieldLogger
 	namespacesEnabled   bool
 }
 
@@ -219,6 +222,25 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 			WithPayload(errPayloadFromSingleErr(principal, qErr))
 	}
 
+	// Authorize BEFORE the conflict pre-flight below: the pre-flight can
+	// leak the ID of a foreign in-flight task to an unprivileged caller,
+	// and manager.DeleteClassPropertyIndex only authorizes deep inside its
+	// own body — after the pre-flight has already run. Same action+resource
+	// the manager enforces. nil-safe for tests constructing schemaHandlers
+	// directly.
+	if s.authorizer != nil {
+		if err := s.authorizer.Authorize(ctx, principal, authorization.UPDATE,
+			authorization.CollectionsMetadata(qualifiedClass)...); err != nil {
+			s.metricRequestsTotal.logError(params.ClassName, err)
+			if errors.As(err, &authzerrors.Forbidden{}) {
+				return schema.NewSchemaObjectsPropertiesDeleteForbidden().
+					WithPayload(errPayloadFromSingleErr(principal, err))
+			}
+			return schema.NewSchemaObjectsPropertiesDeleteUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(principal, err))
+		}
+	}
+
 	// Serialize with the reindex-submit REST handler on the same
 	// (collection, property) tuple. Without this lock, a parallel
 	// PUT /v1/schema/{class}/indexes/{prop} (which submits a reindex
@@ -311,10 +333,19 @@ func (s *schemaHandlers) checkReindexConflictForPropertyMutation(ctx context.Con
 			// Unparseable payload in flight is a hard reject reason on
 			// the apply side; mirror that here so the REST caller
 			// doesn't get a spurious "ok-then-FAILED" two-step.
+			//
+			// This fires BEFORE the collection filter below, so task.ID may
+			// name a namespace the caller can't see (StripErrorMessage strips
+			// only the caller's own). Log it server-side; return a generic
+			// message so a foreign task ID can't leak to the caller.
+			if s.logger != nil {
+				s.logger.WithField("task_id", task.ID).
+					Errorf("refusing property mutation on %s.%s: in-flight reindex task has an unparseable payload: %v", className, propertyName, err)
+			}
 			return fmt.Sprintf(
-				"in-flight reindex task %q has unparseable payload; "+
-					"refusing property mutation on %s.%s until the task "+
-					"is inspected", task.ID, className, propertyName)
+				"an in-flight reindex task has an unparseable payload; "+
+					"refusing property mutation on %s.%s until an operator "+
+					"inspects the task store", className, propertyName)
 		}
 		if !strings.EqualFold(payload.Collection, className) {
 			continue
@@ -607,12 +638,14 @@ func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principa
 	return schema.NewTenantExistsOK()
 }
 
-func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider, namespacesEnabled bool) {
+func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, authorizer authorization.Authorizer, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider, namespacesEnabled bool) {
 	h := &schemaHandlers{
 		manager:             manager,
+		authorizer:          authorizer,
 		metricRequestsTotal: newSchemaRequestsTotal(metrics, logger),
 		reindexTaskLister:   reindexTaskLister,
 		reindexSubmitLocks:  reindexSubmitLocks,
+		logger:              logger,
 		namespacesEnabled:   namespacesEnabled,
 	}
 


### PR DESCRIPTION
SuperClaude here.

v1.38 backport of two pre-existing defects surfaced during review of weaviate/weaviate#12252. The GA-shaped equivalents land on `main` via that PR, so the stable→main forward-merge reconciles; this PR is the v1.38-shaped fix only.

**Mechanism.** The preview reindex conflict pre-flights emit namespace-qualified task IDs (`<ns>:<collection>:<migrationType>:<property>`) in caller-facing errors on a malformed (unparseable/empty-payload) in-flight task, BEFORE the collection filter — so the offending task can belong to any namespace, not just the caller's. `StripErrorMessage` strips only the caller's own namespace, so a foreign task ID leaked intact at two sites: the indexes submit pre-flight and the property-mutation pre-flight. Separately, the property-index DELETE handler ran the conflict pre-flight BEFORE authorization (which lives deep inside `manager.DeleteClassPropertyIndex`), so an authenticated-but-unprivileged caller reached the leak.

**Fix.** (1) Redact the task ID from both caller-facing errors — logged server-side so operators can still act, generic message returned. (2) Add explicit `UPDATE` + `CollectionsMetadata` authorization at the top of the DELETE handler, before the submit lock and pre-flight, matching the permission the manager already enforces.

**Test.** A malformed foreign in-flight task now yields a caller error without the task ID at both sites (task ID retained in the server log); an unprivileged cross-namespace delete gets 403 before the pre-flight is consulted. Red→green confirmed per fix by toggling each fix line.

Local verification: `go build ./...`; `-race` unit tests green for `adapters/handlers/rest` (102s); gofumpt + goimports clean; golangci-lint 0 issues.

— SuperClaude
