### PR TITLE
Add MUVERA specific usage calculations

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -350,7 +350,13 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 		}
 		dimInfo := GetDimensionCategory(vectorIndexConfig, isDynamicUpgraded)
 
-		dimensionality, err := shard.DimensionsUsage(ctx, targetVector)
+		var dimensionality types.Dimensionality
+		var err error
+		if encodedDimensions := muveraEncodedDimensions(vectorIndexConfig); encodedDimensions > 0 {
+			dimensionality, err = shard.MuveraDimensionsUsage(ctx, targetVector, encodedDimensions)
+		} else {
+			dimensionality, err = shard.DimensionsUsage(ctx, targetVector)
+		}
 		if err != nil {
 			return err
 		}
@@ -425,11 +431,22 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 
 	// Get named vector data for cold shards from schema configuration
 	targetVectors := make([]string, 0, len(vectorConfigs))
-	for targetVector := range vectorConfigs {
+	muveraDimensions := make(map[string]int, len(vectorConfigs))
+	for targetVector, vectorConfig := range vectorConfigs {
 		targetVectors = append(targetVectors, targetVector)
+		if cfg, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig); ok {
+			if encodedDimensions := muveraEncodedDimensions(cfg); encodedDimensions > 0 {
+				muveraDimensions[targetVector] = encodedDimensions
+			}
+		}
 	}
 	// open the dimensions bucket once for all target vectors
 	dimensionalitiesAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, targetVectors)
+	if err != nil {
+		return nil, err
+	}
+	// MUVERA multi-vectors report the encoded dimensionality; raw dimensions keep driving the disk accounting below
+	muveraDimensionalities, err := shardusage.CalculateUnloadedMuveraDimensionsUsageAll(ctx, i.logger, i.path(), shardName, muveraDimensions)
 	if err != nil {
 		return nil, err
 	}
@@ -457,6 +474,9 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 
 		dimensionalities := dimensionalitiesAll[targetVector]
 		uncompressedVectorSize += uint64(dimensionalities.Count) * uint64(dimensionalities.Dimensions) * 4
+		if muvera, ok := muveraDimensionalities[targetVector]; ok {
+			dimensionalities = muvera
+		}
 		vectorUsage.Dimensionalities = append(vectorUsage.Dimensionalities, &dimensionalities)
 		vectorUsage.MultiVectorConfig = multiVectorConfigFromConfig(vectorIndexConfig)
 		namedVectors = append(namedVectors, vectorUsage)
@@ -507,6 +527,15 @@ func emptyShardUsageWithNameAndActivity(shardName, activity string) *types.Shard
 		ObjectsStorageBytes: 0,
 		VectorStorageBytes:  0,
 	}
+}
+
+// muveraEncodedDimensions returns the MUVERA-encoded dimensionality for multi-vector HNSW configs with MUVERA enabled, 0 otherwise
+func muveraEncodedDimensions(vectorConfig schemaConfig.VectorIndexConfig) int {
+	hnswConfig, ok := vectorConfig.(enthnsw.UserConfig)
+	if !ok || !hnswConfig.Multivector.Enabled || !hnswConfig.Multivector.MuveraConfig.Enabled {
+		return 0
+	}
+	return hnswConfig.Multivector.MuveraConfig.EncodedDimensions()
 }
 
 func multiVectorConfigFromConfig(vectorConfig schemaConfig.VectorIndexConfig) *types.MultiVectorConfig {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -350,16 +350,12 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 		}
 		dimInfo := GetDimensionCategory(vectorIndexConfig, isDynamicUpgraded)
 
-		encodedDimensions := muveraEncodedDimensions(vectorIndexConfig)
-		scan, err := shard.DimensionsUsage(ctx, targetVector, encodedDimensions > 0)
+		encodedDimensions := i.muveraEncodedDimensions(shard.Name(), targetVector, vectorIndexConfig)
+		scan, err := shard.DimensionsUsage(ctx, targetVector, encodedDimensions)
 		if err != nil {
 			return err
 		}
-		// MUVERA multi-vectors report the encoded dimensionality (what is held in memory per object)
-		dimensionality := scan.Dimensionality
-		if encodedDimensions > 0 {
-			dimensionality = scan.MuveraDimensionality(encodedDimensions)
-		}
+		dimensionality := scan.Reported
 
 		compressionRatio := vectorIndex.CompressionStats().CompressionRatio(dimensionality.Dimensions)
 
@@ -430,56 +426,55 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	}
 
 	// Get named vector data for cold shards from schema configuration
-	targetVectors := make([]string, 0, len(vectorConfigs))
-	muveraDimensions := make(map[string]int, len(vectorConfigs))
+	type coldTargetVector struct {
+		name      string
+		config    schemaConfig.VectorIndexConfig
+		indexType string
+	}
+	targetVectors := make([]coldTargetVector, 0, len(vectorConfigs))
+	encodedDimensions := make(map[string]int, len(vectorConfigs))
 	for targetVector, vectorConfig := range vectorConfigs {
-		targetVectors = append(targetVectors, targetVector)
 		cfg, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
 		if !ok {
-			return nil, fmt.Errorf("vector index config for %q is not of expected type", targetVector)
+			return nil, fmt.Errorf("class %s, shard %s: vector index config for target vector %q has unexpected type %T",
+				i.Config.ClassName, shardName, targetVector, vectorConfig.VectorIndexConfig)
 		}
-		if encodedDimensions := muveraEncodedDimensions(cfg); encodedDimensions > 0 {
-			muveraDimensions[targetVector] = encodedDimensions
-		}
+		targetVectors = append(targetVectors, coldTargetVector{
+			name:      targetVector,
+			config:    cfg,
+			indexType: vectorConfig.VectorIndexType,
+		})
+		encodedDimensions[targetVector] = i.muveraEncodedDimensions(shardName, targetVector, cfg)
 	}
-	// open the dimensions bucket once for all target vectors; MUVERA target vectors also get
-	// the total object count from the same pass
-	scansAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, targetVectors, muveraDimensions)
+	// open the dimensions bucket once for all target vectors
+	scansAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, encodedDimensions)
 	if err != nil {
 		return nil, err
 	}
 
 	var namedVectors types.VectorsUsage
 	uncompressedVectorSize := uint64(0) // calculate total uncompressed vector size for all vectors
-	for targetVector, vectorConfig := range vectorConfigs {
+	for _, targetVector := range targetVectors {
 		vectorUsage := &types.VectorUsage{
-			Name:                   targetVector,
+			Name:                   targetVector.name,
 			VectorCompressionRatio: 1.0, // Default ratio for cold shards
 		}
 
-		vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
-		if !ok {
-			return nil, fmt.Errorf("vector index config for %q is not of expected type", targetVector)
-		}
-
-		vectorUsage.IsDynamic = vectorConfig.VectorIndexType == common.IndexTypeDynamic
+		vectorUsage.IsDynamic = targetVector.indexType == common.IndexTypeDynamic
 		if !vectorUsage.IsDynamic {
 			// for cold tenants we cannot distinguish know if dynamic has been upgraded or not. Do not include wrong data
-			dimInfo := GetDimensionCategory(vectorIndexConfig, false)
+			dimInfo := GetDimensionCategory(targetVector.config, false)
 			vectorUsage.Compression = dimInfo.category.String()
-			vectorUsage.VectorIndexType = vectorIndexConfig.IndexType()
+			vectorUsage.VectorIndexType = targetVector.config.IndexType()
 		}
 
-		scan := scansAll[targetVector]
-		// raw dimensions keep driving the disk accounting; MUVERA multi-vectors report the
-		// encoded dimensionality (what is held in memory per object)
-		uncompressedVectorSize += uint64(scan.Count) * uint64(scan.Dimensions) * 4
-		dimensionalities := scan.Dimensionality
-		if encodedDimensions, ok := muveraDimensions[targetVector]; ok {
-			dimensionalities = scan.MuveraDimensionality(encodedDimensions)
-		}
+		scan := scansAll[targetVector.name]
+		// disk accounting keeps modelling raw dimensions, which is a single row and so
+		// under-counts multi-vectors with varying token counts
+		uncompressedVectorSize += uint64(scan.Raw.Count) * uint64(scan.Raw.Dimensions) * 4
+		dimensionalities := scan.Reported
 		vectorUsage.Dimensionalities = append(vectorUsage.Dimensionalities, &dimensionalities)
-		vectorUsage.MultiVectorConfig = multiVectorConfigFromConfig(vectorIndexConfig)
+		vectorUsage.MultiVectorConfig = multiVectorConfigFromConfig(targetVector.config)
 		namedVectors = append(namedVectors, vectorUsage)
 	}
 
@@ -530,13 +525,23 @@ func emptyShardUsageWithNameAndActivity(shardName, activity string) *types.Shard
 	}
 }
 
-// muveraEncodedDimensions returns the MUVERA-encoded dimensionality for multi-vector HNSW configs with MUVERA enabled, 0 otherwise
-func muveraEncodedDimensions(vectorConfig schemaConfig.VectorIndexConfig) int {
+// muveraEncodedDimensions returns the MUVERA-encoded dimensionality for HNSW configs with MUVERA enabled, 0 otherwise
+func (i *Index) muveraEncodedDimensions(shardName, targetVector string, vectorConfig schemaConfig.VectorIndexConfig) int {
 	hnswConfig, ok := vectorConfig.(enthnsw.UserConfig)
-	if !ok || !hnswConfig.Multivector.Enabled || !hnswConfig.Multivector.MuveraConfig.Enabled {
+	if !ok || !hnswConfig.Multivector.MuveraEnabled() {
 		return 0
 	}
-	return hnswConfig.Multivector.MuveraConfig.EncodedDimensions()
+	encodedDimensions := hnswConfig.Multivector.MuveraConfig.EncodedDimensions()
+	if encodedDimensions == 0 {
+		i.logger.WithFields(logrus.Fields{
+			"class":         i.Config.ClassName.String(),
+			"shard":         shardName,
+			"target_vector": targetVector,
+		}).Warnf("muvera config yields no encoded dimensionality (ksim %d, repetitions %d, dprojections %d); reporting raw vector dimensions",
+			hnswConfig.Multivector.MuveraConfig.KSim, hnswConfig.Multivector.MuveraConfig.Repetitions,
+			hnswConfig.Multivector.MuveraConfig.DProjections)
+	}
+	return encodedDimensions
 }
 
 func multiVectorConfigFromConfig(vectorConfig schemaConfig.VectorIndexConfig) *types.MultiVectorConfig {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -350,15 +350,15 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 		}
 		dimInfo := GetDimensionCategory(vectorIndexConfig, isDynamicUpgraded)
 
-		var dimensionality types.Dimensionality
-		var err error
-		if encodedDimensions := muveraEncodedDimensions(vectorIndexConfig); encodedDimensions > 0 {
-			dimensionality, err = shard.MuveraDimensionsUsage(ctx, targetVector, encodedDimensions)
-		} else {
-			dimensionality, err = shard.DimensionsUsage(ctx, targetVector)
-		}
+		encodedDimensions := muveraEncodedDimensions(vectorIndexConfig)
+		scan, err := shard.DimensionsUsage(ctx, targetVector, encodedDimensions > 0)
 		if err != nil {
 			return err
+		}
+		// MUVERA multi-vectors report the encoded dimensionality (what is held in memory per object)
+		dimensionality := scan.Dimensionality
+		if encodedDimensions > 0 {
+			dimensionality = scan.MuveraDimensionality(encodedDimensions)
 		}
 
 		compressionRatio := vectorIndex.CompressionStats().CompressionRatio(dimensionality.Dimensions)
@@ -442,13 +442,9 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 			muveraDimensions[targetVector] = encodedDimensions
 		}
 	}
-	// open the dimensions bucket once for all target vectors
-	dimensionalitiesAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, targetVectors)
-	if err != nil {
-		return nil, err
-	}
-	// MUVERA multi-vectors report the encoded dimensionality; raw dimensions keep driving the disk accounting below
-	muveraDimensionalities, err := shardusage.CalculateUnloadedMuveraDimensionsUsageAll(ctx, i.logger, i.path(), shardName, muveraDimensions)
+	// open the dimensions bucket once for all target vectors; MUVERA target vectors also get
+	// the total object count from the same pass
+	scansAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, targetVectors, muveraDimensions)
 	if err != nil {
 		return nil, err
 	}
@@ -474,10 +470,13 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 			vectorUsage.VectorIndexType = vectorIndexConfig.IndexType()
 		}
 
-		dimensionalities := dimensionalitiesAll[targetVector]
-		uncompressedVectorSize += uint64(dimensionalities.Count) * uint64(dimensionalities.Dimensions) * 4
-		if muvera, ok := muveraDimensionalities[targetVector]; ok {
-			dimensionalities = muvera
+		scan := scansAll[targetVector]
+		// raw dimensions keep driving the disk accounting; MUVERA multi-vectors report the
+		// encoded dimensionality (what is held in memory per object)
+		uncompressedVectorSize += uint64(scan.Count) * uint64(scan.Dimensions) * 4
+		dimensionalities := scan.Dimensionality
+		if encodedDimensions, ok := muveraDimensions[targetVector]; ok {
+			dimensionalities = scan.MuveraDimensionality(encodedDimensions)
 		}
 		vectorUsage.Dimensionalities = append(vectorUsage.Dimensionalities, &dimensionalities)
 		vectorUsage.MultiVectorConfig = multiVectorConfigFromConfig(vectorIndexConfig)

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -434,10 +434,12 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	muveraDimensions := make(map[string]int, len(vectorConfigs))
 	for targetVector, vectorConfig := range vectorConfigs {
 		targetVectors = append(targetVectors, targetVector)
-		if cfg, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig); ok {
-			if encodedDimensions := muveraEncodedDimensions(cfg); encodedDimensions > 0 {
-				muveraDimensions[targetVector] = encodedDimensions
-			}
+		cfg, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
+		if !ok {
+			return nil, fmt.Errorf("vector index config for %q is not of expected type", targetVector)
+		}
+		if encodedDimensions := muveraEncodedDimensions(cfg); encodedDimensions > 0 {
+			muveraDimensions[targetVector] = encodedDimensions
 		}
 	}
 	// open the dimensions bucket once for all target vectors

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -607,11 +607,11 @@ func TestIndex_CalculateUnloadedDimensionsUsage(t *testing.T) {
 				require.True(t, ok)
 				require.NoError(t, lazyShard.Load(ctx))
 
-				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, false)
+				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, 0)
 				require.NoError(t, err)
 
-				assert.Equal(t, tt.expectedCount, dimensionality.Count)
-				assert.Equal(t, tt.expectedDims, dimensionality.Dimensions)
+				assert.Equal(t, tt.expectedCount, dimensionality.Raw.Count)
+				assert.Equal(t, tt.expectedDims, dimensionality.Raw.Dimensions)
 
 				// Release the shard (this will flush all data to disk)
 				release()
@@ -638,11 +638,11 @@ func TestIndex_CalculateUnloadedDimensionsUsage(t *testing.T) {
 				require.True(t, ok)
 				require.NoError(t, lazyShard.Load(ctx))
 
-				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, false)
+				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, 0)
 				require.NoError(t, err)
 
-				assert.Equal(t, tt.expectedCount, dimensionality.Count)
-				assert.Equal(t, tt.expectedDims, dimensionality.Dimensions)
+				assert.Equal(t, tt.expectedCount, dimensionality.Raw.Count)
+				assert.Equal(t, tt.expectedDims, dimensionality.Raw.Dimensions)
 
 				// Release the shard (this will flush all data to disk)
 				release()
@@ -823,7 +823,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	require.NoError(t, err)
 	activeVectorStorageSize += int64(commitLogSize)
 
-	dimensionality, err := shard.DimensionsUsage(ctx, "", false)
+	dimensionality, err := shard.DimensionsUsage(ctx, "", 0)
 	require.NoError(t, err)
 	activeObjectCount, err := activeShard.ObjectCount(ctx)
 	require.NoError(t, err)
@@ -832,8 +832,8 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	// Test that active calculations are correct
 	expectedSize := int64(objectCount*vectorDimensions*4) + int64(commitLogSize)
 	assert.Equal(t, expectedSize, activeVectorStorageSize, "Active vector storage size should be close to expected")
-	assert.Equal(t, objectCount, dimensionality.Count, "Active shard object count should match")
-	assert.Equal(t, vectorDimensions, dimensionality.Dimensions, "Active shard dimensions should match")
+	assert.Equal(t, objectCount, dimensionality.Raw.Count, "Active shard object count should match")
+	assert.Equal(t, vectorDimensions, dimensionality.Raw.Dimensions, "Active shard dimensions should match")
 	assert.Equal(t, objectCount, activeObjectCount, "Active object count should match")
 
 	// Release the shard (this will flush all data to disk)

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -607,7 +607,7 @@ func TestIndex_CalculateUnloadedDimensionsUsage(t *testing.T) {
 				require.True(t, ok)
 				require.NoError(t, lazyShard.Load(ctx))
 
-				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector)
+				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, false)
 				require.NoError(t, err)
 
 				assert.Equal(t, tt.expectedCount, dimensionality.Count)
@@ -638,7 +638,7 @@ func TestIndex_CalculateUnloadedDimensionsUsage(t *testing.T) {
 				require.True(t, ok)
 				require.NoError(t, lazyShard.Load(ctx))
 
-				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector)
+				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, false)
 				require.NoError(t, err)
 
 				assert.Equal(t, tt.expectedCount, dimensionality.Count)
@@ -823,7 +823,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	require.NoError(t, err)
 	activeVectorStorageSize += int64(commitLogSize)
 
-	dimensionality, err := shard.DimensionsUsage(ctx, "")
+	dimensionality, err := shard.DimensionsUsage(ctx, "", false)
 	require.NoError(t, err)
 	activeObjectCount, err := activeShard.ObjectCount(ctx)
 	require.NoError(t, err)

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -69,6 +69,15 @@ func (s *Shard) DimensionsUsage(ctx context.Context, targetVector string) (types
 	return s.calcTargetVectorDimensions(ctx, targetVector)
 }
 
+// MuveraDimensionsUsage reports the fixed MUVERA-encoded dimensionality with the total object count for a target vector
+func (s *Shard) MuveraDimensionsUsage(ctx context.Context, targetVector string, encodedDimensions int) (types.Dimensionality, error) {
+	b := s.store.Bucket(helpers.DimensionsBucketLSM)
+	if b == nil {
+		return types.Dimensionality{}, errors.Errorf("muveraDimensionsUsage: no bucket dimensions")
+	}
+	return shardusage.CalculateMuveraDimensionsUsageFromBucket(ctx, b, targetVector, encodedDimensions)
+}
+
 // Dimensions returns the total number of dimensions for a given vector
 func (s *Shard) Dimensions(ctx context.Context, targetVector string) (int, error) {
 	dimensionality, err := s.calcTargetVectorDimensions(ctx, targetVector)

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -64,18 +64,14 @@ func (c DimensionCategory) String() string {
 	}
 }
 
-// DimensionsUsage returns the total number of dimensions and the number of objects for a given vector
-func (s *Shard) DimensionsUsage(ctx context.Context, targetVector string) (types.Dimensionality, error) {
-	return s.calcTargetVectorDimensions(ctx, targetVector)
-}
-
-// MuveraDimensionsUsage reports the fixed MUVERA-encoded dimensionality with the total object count for a target vector
-func (s *Shard) MuveraDimensionsUsage(ctx context.Context, targetVector string, encodedDimensions int) (types.Dimensionality, error) {
+// DimensionsUsage scans the dimensions bucket for a given vector. With needTotal the object
+// count is additionally summed across all dimension rows (the MUVERA reading).
+func (s *Shard) DimensionsUsage(ctx context.Context, targetVector string, needTotal bool) (shardusage.DimensionsScan, error) {
 	b := s.store.Bucket(helpers.DimensionsBucketLSM)
 	if b == nil {
-		return types.Dimensionality{}, errors.Errorf("muveraDimensionsUsage: no bucket dimensions")
+		return shardusage.DimensionsScan{}, errors.Errorf("dimensionsUsage: no bucket dimensions")
 	}
-	return shardusage.CalculateMuveraDimensionsUsageFromBucket(ctx, b, targetVector, encodedDimensions)
+	return shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, needTotal)
 }
 
 // Dimensions returns the total number of dimensions for a given vector
@@ -97,11 +93,11 @@ func (s *Shard) QuantizedDimensions(ctx context.Context, targetVector string, se
 
 func (s *Shard) calcTargetVectorDimensions(ctx context.Context, targetVector string,
 ) (types.Dimensionality, error) {
-	b := s.store.Bucket(helpers.DimensionsBucketLSM)
-	if b == nil {
-		return types.Dimensionality{}, errors.Errorf("calcTargetVectorDimensions: no bucket dimensions")
+	scan, err := s.DimensionsUsage(ctx, targetVector, false)
+	if err != nil {
+		return types.Dimensionality{}, err
 	}
-	return shardusage.CalculateTargetVectorDimensionsFromBucket(ctx, b, targetVector)
+	return scan.Dimensionality, nil
 }
 
 // DimensionMetrics represents the dimension tracking metrics for a vector.

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -64,14 +64,13 @@ func (c DimensionCategory) String() string {
 	}
 }
 
-// DimensionsUsage scans the dimensions bucket for a given vector. With needTotal the object
-// count is additionally summed across all dimension rows (the MUVERA reading).
-func (s *Shard) DimensionsUsage(ctx context.Context, targetVector string, needTotal bool) (shardusage.DimensionsScan, error) {
+// DimensionsUsage scans the dimensions bucket for a given vector, see shardusage.ScanTargetVectorDimensions
+func (s *Shard) DimensionsUsage(ctx context.Context, targetVector string, encodedDimensions int) (shardusage.DimensionsScan, error) {
 	b := s.store.Bucket(helpers.DimensionsBucketLSM)
 	if b == nil {
 		return shardusage.DimensionsScan{}, errors.Errorf("dimensionsUsage: no bucket dimensions")
 	}
-	return shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, needTotal)
+	return shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, encodedDimensions)
 }
 
 // Dimensions returns the total number of dimensions for a given vector
@@ -93,11 +92,11 @@ func (s *Shard) QuantizedDimensions(ctx context.Context, targetVector string, se
 
 func (s *Shard) calcTargetVectorDimensions(ctx context.Context, targetVector string,
 ) (types.Dimensionality, error) {
-	scan, err := s.DimensionsUsage(ctx, targetVector, false)
+	scan, err := s.DimensionsUsage(ctx, targetVector, 0)
 	if err != nil {
 		return types.Dimensionality{}, err
 	}
-	return scan.Dimensionality, nil
+	return scan.Raw, nil
 }
 
 // DimensionMetrics represents the dimension tracking metrics for a vector.

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -143,21 +143,19 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 	}
 	defer bucket.Shutdown(ctx)
 
-	scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, false)
+	scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, 0)
 	if err != nil {
 		return types.Dimensionality{}, err
 	}
-	return scan.Dimensionality, nil
+	return scan.Raw, nil
 }
 
 // CalculateUnloadedDimensionsUsageAll calculates dimensions and object count for all target
 // vectors of an unloaded shard without loading it into memory. The dimensions bucket is opened
 // once and shared by all target vector calculations, instead of once per target vector.
-// Target vectors present in needTotal additionally get the object count summed across all rows
-// (the MUVERA reading); the others keep the cheaper first-complete-row scan.
+// targetVectors maps each vector name to its MUVERA-encoded dimensionality, or 0 if not MUVERA.
 func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
-	logger logrus.FieldLogger, path, tenantName string, targetVectors []string,
-	needTotal map[string]int,
+	logger logrus.FieldLogger, path, tenantName string, targetVectors map[string]int,
 ) (map[string]DimensionsScan, error) {
 	if len(targetVectors) == 0 {
 		return nil, nil
@@ -176,9 +174,8 @@ func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	defer bucket.Shutdown(ctx)
 
 	scans := make(map[string]DimensionsScan, len(targetVectors))
-	for _, targetVector := range targetVectors {
-		_, withTotal := needTotal[targetVector]
-		scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, withTotal)
+	for targetVector, encodedDimensions := range targetVectors {
+		scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, encodedDimensions)
 		if err != nil {
 			return nil, err
 		}
@@ -351,33 +348,19 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 	return vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, nil
 }
 
-// DimensionsScan holds both readings the usage report needs from a single pass over the
-// dimensions bucket.
 type DimensionsScan struct {
-	// Dimensionality is the first row with non-zero dimensions and a non-empty doc set —
-	// the classic single-vector reading.
-	types.Dimensionality
-	// TotalCount is the number of objects with a vector, summed across every row.
-	// Multi-vector objects are recorded under their varying per-object total dimensions,
-	// so no single row counts them all. Only populated when the scan runs with needTotal.
-	TotalCount int
+	Raw      types.Dimensionality
+	Reported types.Dimensionality
 }
 
-// MuveraDimensionality reports the fixed MUVERA-encoded dimensionality (what is held in
-// memory per object) with the object count summed across all rows. The scan must have run
-// with needTotal.
-func (s DimensionsScan) MuveraDimensionality(encodedDimensions int) types.Dimensionality {
-	if s.TotalCount == 0 {
-		return types.Dimensionality{}
-	}
-	return types.Dimensionality{Dimensions: encodedDimensions, Count: s.TotalCount}
-}
+const contextCheckInterval = 1024
 
-// ScanTargetVectorDimensions calculates dimensions and object count for a target vector from
-// an LSMKV bucket. With needTotal it additionally sums the object count across all rows (the
-// MUVERA reading); without it the scan stops at the first complete row.
+// ScanTargetVectorDimensions calculates dimensions and object count for a target vector from an
+// LSMKV bucket. A non-zero encodedDimensions reports that fixed dimensionality against the object
+// count summed across all rows, which costs a scan of the whole prefix instead of stopping at the
+// first complete row.
 func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVector string,
-	needTotal bool,
+	encodedDimensions int,
 ) (DimensionsScan, error) {
 	scan := DimensionsScan{}
 
@@ -388,10 +371,14 @@ func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVect
 	prefix := []byte(targetVector)
 	nameLen := len(targetVector)
 	expectedKeyLen := nameLen + 4 // vector name + uint32
-	// addRow feeds one bucket row into both readings and reports whether the scan may stop.
+	totalCount := 0
+	rows := 0
 	addRow := func(k []byte, count int) (done bool) {
+		// a full-prefix scan is long enough to need cancelling; the error is picked up after the loop
+		if rows++; rows%contextCheckInterval == 0 && ctx.Err() != nil {
+			return true
+		}
 		// a longer name sharing this prefix can sort before the target's own keys
-		// ("texts…" before "text\x80…"); rows with dims=0 are objects without a vector
 		if len(k) != expectedKeyLen {
 			return false
 		}
@@ -399,16 +386,17 @@ func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVect
 		if dimLength == 0 {
 			return false
 		}
-		if scan.Dimensions == 0 || scan.Count == 0 {
-			scan.Dimensions = int(dimLength)
-			scan.Count = count
+		if scan.Raw.Dimensions == 0 || scan.Raw.Count == 0 {
+			scan.Raw.Dimensions = int(dimLength)
+			scan.Raw.Count = count
 		}
-		if needTotal {
-			scan.TotalCount += count
+		if encodedDimensions > 0 {
+			totalCount += count
+			return false
 		}
-		// remaining rows cannot change a complete result unless the total is needed, and an
-		// empty name matches every key so the prefix check in the loop condition never fires
-		return !needTotal && scan.Dimensions != 0 && scan.Count != 0
+		// remaining keys cannot change a complete result, and an empty name
+		// matches every key so the prefix break above never fires
+		return scan.Raw.Dimensions != 0 && scan.Raw.Count != 0
 	}
 	var k []byte
 
@@ -453,6 +441,11 @@ func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVect
 
 	if err := ctx.Err(); err != nil {
 		return scan, err
+	}
+
+	scan.Reported = scan.Raw
+	if encodedDimensions > 0 && totalCount > 0 {
+		scan.Reported = types.Dimensionality{Dimensions: encodedDimensions, Count: totalCount}
 	}
 	return scan, nil
 }

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -143,15 +143,22 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 	}
 	defer bucket.Shutdown(ctx)
 
-	return CalculateTargetVectorDimensionsFromBucket(ctx, bucket, targetVector)
+	scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, false)
+	if err != nil {
+		return types.Dimensionality{}, err
+	}
+	return scan.Dimensionality, nil
 }
 
 // CalculateUnloadedDimensionsUsageAll calculates dimensions and object count for all target
 // vectors of an unloaded shard without loading it into memory. The dimensions bucket is opened
 // once and shared by all target vector calculations, instead of once per target vector.
+// Target vectors present in needTotal additionally get the object count summed across all rows
+// (the MUVERA reading); the others keep the cheaper first-complete-row scan.
 func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	logger logrus.FieldLogger, path, tenantName string, targetVectors []string,
-) (map[string]types.Dimensionality, error) {
+	needTotal map[string]int,
+) (map[string]DimensionsScan, error) {
 	if len(targetVectors) == 0 {
 		return nil, nil
 	}
@@ -168,48 +175,16 @@ func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	}
 	defer bucket.Shutdown(ctx)
 
-	dimensionalities := make(map[string]types.Dimensionality, len(targetVectors))
+	scans := make(map[string]DimensionsScan, len(targetVectors))
 	for _, targetVector := range targetVectors {
-		dimensionality, err := CalculateTargetVectorDimensionsFromBucket(ctx, bucket, targetVector)
+		_, withTotal := needTotal[targetVector]
+		scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, withTotal)
 		if err != nil {
 			return nil, err
 		}
-		dimensionalities[targetVector] = dimensionality
+		scans[targetVector] = scan
 	}
-	return dimensionalities, nil
-}
-
-// CalculateUnloadedMuveraDimensionsUsageAll reports the MUVERA-encoded dimensionality for the
-// given target vectors of an unloaded shard, keyed by target vector with its encoded dimensions
-// as value. An empty map is a no-op, so non-MUVERA shards never pay for the extra bucket open.
-func CalculateUnloadedMuveraDimensionsUsageAll(ctx context.Context,
-	logger logrus.FieldLogger, path, tenantName string, muveraDimensions map[string]int,
-) (map[string]types.Dimensionality, error) {
-	if len(muveraDimensions) == 0 {
-		return nil, nil
-	}
-
-	bucketPath := shardPathDimensionsLSM(path, tenantName)
-	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
-		return nil, fmt.Errorf("lock dimensions bucket: %w", err)
-	}
-	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
-
-	bucket, err := openUnloadedDimensionsBucket(ctx, logger, path, bucketPath)
-	if err != nil {
-		return nil, err
-	}
-	defer bucket.Shutdown(ctx)
-
-	dimensionalities := make(map[string]types.Dimensionality, len(muveraDimensions))
-	for targetVector, encodedDimensions := range muveraDimensions {
-		dimensionality, err := CalculateMuveraDimensionsUsageFromBucket(ctx, bucket, targetVector, encodedDimensions)
-		if err != nil {
-			return nil, err
-		}
-		dimensionalities[targetVector] = dimensionality
-	}
-	return dimensionalities, nil
+	return scans, nil
 }
 
 // CalculateUnloadedVectorsMetrics calculates vector storage size from disk
@@ -376,17 +351,65 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 	return vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, nil
 }
 
-// CalculateTargetVectorDimensionsFromBucket calculates dimensions and object count for a target vector from an LSMKV bucket
-func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Bucket, targetVector string,
-) (types.Dimensionality, error) {
-	dimensionality := types.Dimensionality{}
+// DimensionsScan holds both readings the usage report needs from a single pass over the
+// dimensions bucket.
+type DimensionsScan struct {
+	// Dimensionality is the first row with non-zero dimensions and a non-empty doc set —
+	// the classic single-vector reading.
+	types.Dimensionality
+	// TotalCount is the number of objects with a vector, summed across every row.
+	// Multi-vector objects are recorded under their varying per-object total dimensions,
+	// so no single row counts them all. Only populated when the scan runs with needTotal.
+	TotalCount int
+}
+
+// MuveraDimensionality reports the fixed MUVERA-encoded dimensionality (what is held in
+// memory per object) with the object count summed across all rows. The scan must have run
+// with needTotal.
+func (s DimensionsScan) MuveraDimensionality(encodedDimensions int) types.Dimensionality {
+	if s.TotalCount == 0 {
+		return types.Dimensionality{}
+	}
+	return types.Dimensionality{Dimensions: encodedDimensions, Count: s.TotalCount}
+}
+
+// ScanTargetVectorDimensions calculates dimensions and object count for a target vector from
+// an LSMKV bucket. With needTotal it additionally sums the object count across all rows (the
+// MUVERA reading); without it the scan stops at the first complete row.
+func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVector string,
+	needTotal bool,
+) (DimensionsScan, error) {
+	scan := DimensionsScan{}
 
 	if err := lsmkv.CheckExpectedStrategy(b.Strategy(), lsmkv.StrategyMapCollection, lsmkv.StrategyRoaringSet); err != nil {
-		return dimensionality, fmt.Errorf("calcTargetVectorDimensionsFromBucket: %w", err)
+		return scan, fmt.Errorf("scanTargetVectorDimensions: %w", err)
 	}
 
+	prefix := []byte(targetVector)
 	nameLen := len(targetVector)
 	expectedKeyLen := nameLen + 4 // vector name + uint32
+	// addRow feeds one bucket row into both readings and reports whether the scan may stop.
+	addRow := func(k []byte, count int) (done bool) {
+		// a longer name sharing this prefix can sort before the target's own keys
+		// ("texts…" before "text\x80…"); rows with dims=0 are objects without a vector
+		if len(k) != expectedKeyLen {
+			return false
+		}
+		dimLength := binary.LittleEndian.Uint32(k[nameLen:])
+		if dimLength == 0 {
+			return false
+		}
+		if scan.Dimensions == 0 || scan.Count == 0 {
+			scan.Dimensions = int(dimLength)
+			scan.Count = count
+		}
+		if needTotal {
+			scan.TotalCount += count
+		}
+		// remaining rows cannot change a complete result unless the total is needed, and an
+		// empty name matches every key so the prefix check in the loop condition never fires
+		return !needTotal && scan.Dimensions != 0 && scan.Count != 0
+	}
 	var k []byte
 
 	switch b.Strategy() {
@@ -396,99 +419,7 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 
 		c, err := b.MapCursor()
 		if err != nil {
-			return dimensionality, fmt.Errorf("create cursor: %w", err)
-		}
-		defer c.Close()
-
-		var v []lsmkv.MapPair
-		if nameLen == 0 {
-			k, v = c.First(ctx)
-		} else {
-			k, v = c.Seek(ctx, []byte(targetVector))
-		}
-		for ; k != nil; k, v = c.Next(ctx) {
-			if !strings.HasPrefix(string(k), targetVector) {
-				break
-			}
-			// a longer name sharing this prefix can sort before the target's own keys
-			if len(k) != expectedKeyLen {
-				continue
-			}
-
-			dimLength := binary.LittleEndian.Uint32(k[nameLen:])
-			if dimLength > 0 && (dimensionality.Dimensions == 0 || dimensionality.Count == 0) {
-				dimensionality.Dimensions = int(dimLength)
-				dimensionality.Count = len(v)
-			}
-			// remaining keys cannot change a complete result, and an empty name
-			// matches every key so the prefix break above never fires
-			if dimensionality.Dimensions != 0 && dimensionality.Count != 0 {
-				break
-			}
-		}
-	default:
-		c := b.CursorRoaringSet()
-		defer c.Close()
-
-		var v *sroar.Bitmap
-		if nameLen == 0 {
-			k, v = c.First()
-		} else {
-			k, v = c.Seek([]byte(targetVector))
-		}
-		for ; k != nil; k, v = c.Next() {
-			if !strings.HasPrefix(string(k), targetVector) {
-				break
-			}
-			// a longer name sharing this prefix can sort before the target's own keys
-			if len(k) != expectedKeyLen {
-				continue
-			}
-
-			dimLength := binary.LittleEndian.Uint32(k[nameLen:])
-			if dimLength > 0 && (dimensionality.Dimensions == 0 || dimensionality.Count == 0) {
-				dimensionality.Dimensions = int(dimLength)
-				dimensionality.Count = v.GetCardinality()
-			}
-			// remaining keys cannot change a complete result, and an empty name
-			// matches every key so the prefix break above never fires
-			if dimensionality.Dimensions != 0 && dimensionality.Count != 0 {
-				break
-			}
-		}
-	}
-
-	return dimensionality, nil
-}
-
-// CalculateMuveraDimensionsUsageFromBucket reports the fixed MUVERA-encoded dimensionality
-// (what is held in memory per object) with the object count summed across all bucket entries,
-// as multi-vector objects are recorded under their varying per-object total dimensions.
-func CalculateMuveraDimensionsUsageFromBucket(ctx context.Context, b *lsmkv.Bucket, targetVector string,
-	encodedDimensions int,
-) (types.Dimensionality, error) {
-	if err := lsmkv.CheckExpectedStrategy(b.Strategy(), lsmkv.StrategyMapCollection, lsmkv.StrategyRoaringSet); err != nil {
-		return types.Dimensionality{}, fmt.Errorf("calculateMuveraDimensionsUsageFromBucket: %w", err)
-	}
-
-	prefix := []byte(targetVector)
-	nameLen := len(targetVector)
-	expectedKeyLen := nameLen + 4 // vector name + uint32
-	totalCount := 0
-	// entries with dims=0 are objects without a vector; keys of other lengths are interleaved
-	// keys of longer vector names extending this one ("texts…" sorts before "text\x80…")
-	countEntry := func(k []byte, count int) {
-		if len(k) == expectedKeyLen && binary.LittleEndian.Uint32(k[nameLen:]) > 0 {
-			totalCount += count
-		}
-	}
-	var k []byte
-
-	switch b.Strategy() {
-	case lsmkv.StrategyMapCollection:
-		c, err := b.MapCursor()
-		if err != nil {
-			return types.Dimensionality{}, fmt.Errorf("create cursor: %w", err)
+			return scan, fmt.Errorf("create cursor: %w", err)
 		}
 		defer c.Close()
 
@@ -499,7 +430,9 @@ func CalculateMuveraDimensionsUsageFromBucket(ctx context.Context, b *lsmkv.Buck
 			k, v = c.Seek(ctx, prefix)
 		}
 		for ; k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next(ctx) {
-			countEntry(k, len(v))
+			if addRow(k, len(v)) {
+				break
+			}
 		}
 	default:
 		c := b.CursorRoaringSet()
@@ -512,12 +445,11 @@ func CalculateMuveraDimensionsUsageFromBucket(ctx context.Context, b *lsmkv.Buck
 			k, v = c.Seek(prefix)
 		}
 		for ; k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
-			countEntry(k, v.GetCardinality())
+			if addRow(k, v.GetCardinality()) {
+				break
+			}
 		}
 	}
 
-	if totalCount == 0 {
-		return types.Dimensionality{}, nil
-	}
-	return types.Dimensionality{Dimensions: encodedDimensions, Count: totalCount}, nil
+	return scan, nil
 }

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -12,6 +12,7 @@
 package shardusage
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
@@ -170,6 +171,39 @@ func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	dimensionalities := make(map[string]types.Dimensionality, len(targetVectors))
 	for _, targetVector := range targetVectors {
 		dimensionality, err := CalculateTargetVectorDimensionsFromBucket(ctx, bucket, targetVector)
+		if err != nil {
+			return nil, err
+		}
+		dimensionalities[targetVector] = dimensionality
+	}
+	return dimensionalities, nil
+}
+
+// CalculateUnloadedMuveraDimensionsUsageAll reports the MUVERA-encoded dimensionality for the
+// given target vectors of an unloaded shard, keyed by target vector with its encoded dimensions
+// as value. An empty map is a no-op, so non-MUVERA shards never pay for the extra bucket open.
+func CalculateUnloadedMuveraDimensionsUsageAll(ctx context.Context,
+	logger logrus.FieldLogger, path, tenantName string, muveraDimensions map[string]int,
+) (map[string]types.Dimensionality, error) {
+	if len(muveraDimensions) == 0 {
+		return nil, nil
+	}
+
+	bucketPath := shardPathDimensionsLSM(path, tenantName)
+	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
+		return nil, fmt.Errorf("lock dimensions bucket: %w", err)
+	}
+	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
+
+	bucket, err := openUnloadedDimensionsBucket(ctx, logger, path, bucketPath)
+	if err != nil {
+		return nil, err
+	}
+	defer bucket.Shutdown(ctx)
+
+	dimensionalities := make(map[string]types.Dimensionality, len(muveraDimensions))
+	for targetVector, encodedDimensions := range muveraDimensions {
+		dimensionality, err := CalculateMuveraDimensionsUsageFromBucket(ctx, bucket, targetVector, encodedDimensions)
 		if err != nil {
 			return nil, err
 		}
@@ -425,4 +459,65 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 	}
 
 	return dimensionality, nil
+}
+
+// CalculateMuveraDimensionsUsageFromBucket reports the fixed MUVERA-encoded dimensionality
+// (what is held in memory per object) with the object count summed across all bucket entries,
+// as multi-vector objects are recorded under their varying per-object total dimensions.
+func CalculateMuveraDimensionsUsageFromBucket(ctx context.Context, b *lsmkv.Bucket, targetVector string,
+	encodedDimensions int,
+) (types.Dimensionality, error) {
+	if err := lsmkv.CheckExpectedStrategy(b.Strategy(), lsmkv.StrategyMapCollection, lsmkv.StrategyRoaringSet); err != nil {
+		return types.Dimensionality{}, fmt.Errorf("calculateMuveraDimensionsUsageFromBucket: %w", err)
+	}
+
+	prefix := []byte(targetVector)
+	nameLen := len(targetVector)
+	expectedKeyLen := nameLen + 4 // vector name + uint32
+	totalCount := 0
+	// entries with dims=0 are objects without a vector; keys of other lengths are interleaved
+	// keys of longer vector names extending this one ("texts…" sorts before "text\x80…")
+	countEntry := func(k []byte, count int) {
+		if len(k) == expectedKeyLen && binary.LittleEndian.Uint32(k[nameLen:]) > 0 {
+			totalCount += count
+		}
+	}
+	var k []byte
+
+	switch b.Strategy() {
+	case lsmkv.StrategyMapCollection:
+		c, err := b.MapCursor()
+		if err != nil {
+			return types.Dimensionality{}, fmt.Errorf("create cursor: %w", err)
+		}
+		defer c.Close()
+
+		var v []lsmkv.MapPair
+		if nameLen == 0 {
+			k, v = c.First(ctx)
+		} else {
+			k, v = c.Seek(ctx, prefix)
+		}
+		for ; k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next(ctx) {
+			countEntry(k, len(v))
+		}
+	default:
+		c := b.CursorRoaringSet()
+		defer c.Close()
+
+		var v *sroar.Bitmap
+		if nameLen == 0 {
+			k, v = c.First()
+		} else {
+			k, v = c.Seek(prefix)
+		}
+		for ; k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
+			countEntry(k, v.GetCardinality())
+		}
+	}
+
+	if totalCount == 0 {
+		return types.Dimensionality{}, nil
+	}
+	return types.Dimensionality{Dimensions: encodedDimensions, Count: totalCount}, nil
 }

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -472,7 +472,7 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for range 10 {
-				if _, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, []string{"text"}, nil); err != nil {
+				if _, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, map[string]int{"text": 0}); err != nil {
 					errs <- err
 				}
 			}
@@ -525,30 +525,30 @@ func TestCalculateUnloadedDimensionsUsageAll(t *testing.T) {
 	require.NoError(t, b.FlushMemtable())
 	require.NoError(t, b.Shutdown(ctx))
 
-	targetVectors := []string{"text", "image", "missing"}
-	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors, nil)
+	targetVectors := map[string]int{"text": 0, "image": 0, "missing": 0}
+	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors)
 	require.NoError(t, err)
 	require.Len(t, all, len(targetVectors))
-	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, all["text"].Dimensionality)
-	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, all["image"].Dimensionality)
+	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, all["text"].Reported)
+	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, all["image"].Reported)
 	assert.Equal(t, DimensionsScan{}, all["missing"])
 
 	// parity with the single-vector variant
-	for _, targetVector := range targetVectors {
+	for targetVector := range targetVectors {
 		single, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, targetVector)
 		require.NoError(t, err)
-		assert.Equal(t, all[targetVector].Dimensionality, single, targetVector)
+		assert.Equal(t, all[targetVector].Raw, single, targetVector)
 	}
 
-	// target vectors listed in needTotal also get the object count summed across all rows
-	withTotal, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors,
-		map[string]int{"text": 2560})
+	withEncoded, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName,
+		map[string]int{"text": 2560, "image": 0})
 	require.NoError(t, err)
-	assert.Equal(t, DimensionsScan{Dimensionality: types.Dimensionality{Dimensions: 128, Count: 5}, TotalCount: 5}, withTotal["text"])
-	assert.Equal(t, 0, withTotal["image"].TotalCount, "not in needTotal → no total")
+	assert.Equal(t, types.Dimensionality{Dimensions: 2560, Count: 5}, withEncoded["text"].Reported)
+	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, withEncoded["text"].Raw)
+	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, withEncoded["image"].Reported)
 
 	// no target vectors → nothing to calculate, no bucket open
-	none, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, nil, nil)
+	none, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, nil)
 	require.NoError(t, err)
 	assert.Nil(t, none)
 }
@@ -562,6 +562,8 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 
+	const encodedDims = 2560
+
 	stored := []struct {
 		targetVector string
 		dims         uint32
@@ -572,42 +574,90 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 		{targetVector: "texts", dims: 256, docIDs: []uint64{4, 5}},
 		{targetVector: "textbook", dims: 192, docIDs: []uint64{1, 2, 3, 4, 5}},
 		{targetVector: "", dims: 128, docIDs: []uint64{1, 2, 3, 4, 5, 6}},
+		// multi-vector objects vary in per-object total dims, dims=0 rows have no vector
+		{targetVector: "colbert", dims: 0, docIDs: []uint64{7, 8}},
+		{targetVector: "colbert", dims: 1280, docIDs: []uint64{1, 2}},
+		{targetVector: "colbert", dims: 2560, docIDs: []uint64{3, 4, 5}},
+		{targetVector: "colbert", dims: 12800, docIDs: []uint64{6}},
+		{targetVector: "novectors", dims: 0, docIDs: []uint64{1, 2, 3}},
 	}
 
 	tests := []struct {
-		name         string
-		targetVector string
-		expected     types.Dimensionality
+		name              string
+		targetVector      string
+		encodedDimensions int
+		expectedRaw       types.Dimensionality
+		expectedReported  types.Dimensionality
 	}{
 		{
-			name:         "no other name shares the prefix",
-			targetVector: "image",
-			expected:     types.Dimensionality{Dimensions: 512, Count: 4},
+			name:             "no other name shares the prefix",
+			targetVector:     "image",
+			expectedRaw:      types.Dimensionality{Dimensions: 512, Count: 4},
+			expectedReported: types.Dimensionality{Dimensions: 512, Count: 4},
 		},
 		{
-			name:         "name is a prefix of two longer names",
-			targetVector: "text",
-			expected:     types.Dimensionality{Dimensions: 384, Count: 3},
+			name:             "name is a prefix of two longer names",
+			targetVector:     "text",
+			expectedRaw:      types.Dimensionality{Dimensions: 384, Count: 3},
+			expectedReported: types.Dimensionality{Dimensions: 384, Count: 3},
 		},
 		{
-			name:         "name extends a shorter name",
-			targetVector: "texts",
-			expected:     types.Dimensionality{Dimensions: 256, Count: 2},
+			name:             "name extends a shorter name",
+			targetVector:     "texts",
+			expectedRaw:      types.Dimensionality{Dimensions: 256, Count: 2},
+			expectedReported: types.Dimensionality{Dimensions: 256, Count: 2},
 		},
 		{
-			name:         "name extends a shorter name and precedes a sibling",
-			targetVector: "textbook",
-			expected:     types.Dimensionality{Dimensions: 192, Count: 5},
+			name:             "name extends a shorter name and precedes a sibling",
+			targetVector:     "textbook",
+			expectedRaw:      types.Dimensionality{Dimensions: 192, Count: 5},
+			expectedReported: types.Dimensionality{Dimensions: 192, Count: 5},
 		},
 		{
-			name:         "unnamed vector alongside named ones",
-			targetVector: "",
-			expected:     types.Dimensionality{Dimensions: 128, Count: 6},
+			name:             "unnamed vector alongside named ones",
+			targetVector:     "",
+			expectedRaw:      types.Dimensionality{Dimensions: 128, Count: 6},
+			expectedReported: types.Dimensionality{Dimensions: 128, Count: 6},
 		},
 		{
-			name:         "vector without entries",
-			targetVector: "missing",
-			expected:     types.Dimensionality{},
+			name:             "vector without entries",
+			targetVector:     "missing",
+			expectedRaw:      types.Dimensionality{},
+			expectedReported: types.Dimensionality{},
+		},
+		{
+			name:              "muvera vector sums the count across all its rows",
+			targetVector:      "colbert",
+			encodedDimensions: encodedDims,
+			expectedRaw:       types.Dimensionality{Dimensions: 1280, Count: 2},
+			expectedReported:  types.Dimensionality{Dimensions: encodedDims, Count: 6},
+		},
+		{
+			name:             "muvera vector without muvera reporting keeps the raw reading",
+			targetVector:     "colbert",
+			expectedRaw:      types.Dimensionality{Dimensions: 1280, Count: 2},
+			expectedReported: types.Dimensionality{Dimensions: 1280, Count: 2},
+		},
+		{
+			name:              "muvera single-vector name is unaffected by the summing",
+			targetVector:      "image",
+			encodedDimensions: encodedDims,
+			expectedRaw:       types.Dimensionality{Dimensions: 512, Count: 4},
+			expectedReported:  types.Dimensionality{Dimensions: encodedDims, Count: 4},
+		},
+		{
+			name:              "muvera vector with only objects without a vector",
+			targetVector:      "novectors",
+			encodedDimensions: encodedDims,
+			expectedRaw:       types.Dimensionality{},
+			expectedReported:  types.Dimensionality{},
+		},
+		{
+			name:              "muvera vector without entries",
+			targetVector:      "missing",
+			encodedDimensions: encodedDims,
+			expectedRaw:       types.Dimensionality{},
+			expectedReported:  types.Dimensionality{},
 		},
 	}
 
@@ -631,9 +681,10 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 
 				for _, tt := range tests {
 					t.Run(tt.name, func(t *testing.T) {
-						scan, err := ScanTargetVectorDimensions(ctx, b, tt.targetVector, false)
+						scan, err := ScanTargetVectorDimensions(ctx, b, tt.targetVector, tt.encodedDimensions)
 						require.NoError(t, err)
-						assert.Equal(t, tt.expected, scan.Dimensionality)
+						assert.Equal(t, tt.expectedRaw, scan.Raw, "raw reading")
+						assert.Equal(t, tt.expectedReported, scan.Reported, "reported reading")
 					})
 				}
 			})
@@ -647,7 +698,7 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 		require.NoError(t, err)
 		defer b.Shutdown(ctx)
 
-		_, err = ScanTargetVectorDimensions(ctx, b, "text", false)
+		_, err = ScanTargetVectorDimensions(ctx, b, "text", 0)
 		require.Error(t, err)
 	})
 }
@@ -690,121 +741,4 @@ func TestLoadComputedUsageData(t *testing.T) {
 			assert.Equal(t, stored, loaded)
 		})
 	}
-}
-
-func TestCalculateUnloadedDimensionsUsageAll_Muvera(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	ctx := context.Background()
-	tenantName := "tenant"
-
-	dirName := t.TempDir()
-	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, shardPathDimensionsLSM(dirName, tenantName), "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
-	require.NoError(t, err)
-
-	// multi-vector objects are recorded under their varying per-object total dimensions
-	writeDims(t, b, "colbert", 1280, []uint64{1, 2})
-	writeDims(t, b, "colbert", 2560, []uint64{3, 4, 5})
-	require.NoError(t, b.FlushMemtable())
-	require.NoError(t, b.Shutdown(ctx))
-
-	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName,
-		[]string{"colbert", "missing"}, map[string]int{"colbert": 10240, "missing": 10240})
-	require.NoError(t, err)
-	assert.Equal(t, types.Dimensionality{Dimensions: 10240, Count: 5}, all["colbert"].MuveraDimensionality(10240))
-	assert.Equal(t, types.Dimensionality{Dimensions: 1280, Count: 2}, all["colbert"].Dimensionality,
-		"raw reading keeps its first-row semantics in the same pass")
-	assert.Equal(t, types.Dimensionality{}, all["missing"].MuveraDimensionality(10240), "no objects → no reported dimensionality")
-}
-
-func TestScanTargetVectorDimensions_TotalCount(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	ctx := context.Background()
-
-	const encodedDims = 2560
-
-	type dimEntry struct {
-		targetVector string
-		dims         uint32
-		docIDs       []uint64
-	}
-	// multi-vector objects vary in per-object total dims; dims=0 entries are objects without a vector
-	entries := []dimEntry{
-		{"colbert", 0, []uint64{7, 8}},
-		{"colbert", 1280, []uint64{1, 2}},
-		{"colbert", 2560, []uint64{3, 4, 5}},
-		{"colbert", 12800, []uint64{6}},
-		{"other", 0, []uint64{5}},
-		{"other", 128, []uint64{1, 2, 3, 4}},
-		{"novectors", 0, []uint64{1, 2, 3}},
-	}
-
-	tests := []struct {
-		name     string
-		strategy string
-	}{
-		{
-			name:     "roaring set strategy",
-			strategy: lsmkv.StrategyRoaringSet,
-		},
-		{
-			name:     "legacy map collection strategy",
-			strategy: lsmkv.StrategyMapCollection,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dirName := t.TempDir()
-			b, err := lsmkv.NewBucketCreator().NewBucket(ctx, filepath.Join(dirName, "dimensions"), "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				lsmkv.WithStrategy(tt.strategy))
-			require.NoError(t, err)
-			defer b.Shutdown(ctx)
-
-			for _, entry := range entries {
-				writeDims(t, b, entry.targetVector, entry.dims, entry.docIDs)
-			}
-			require.NoError(t, b.FlushMemtable())
-
-			colbert, err := ScanTargetVectorDimensions(ctx, b, "colbert", true)
-			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 6}, colbert.MuveraDimensionality(encodedDims))
-			// raw reading keeps its first-row semantics in the same pass
-			assert.Equal(t, types.Dimensionality{Dimensions: 1280, Count: 2}, colbert.Dimensionality)
-
-			other, err := ScanTargetVectorDimensions(ctx, b, "other", true)
-			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 4}, other.MuveraDimensionality(encodedDims))
-
-			missing, err := ScanTargetVectorDimensions(ctx, b, "missing", true)
-			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{}, missing.MuveraDimensionality(encodedDims))
-
-			noVectors, err := ScanTargetVectorDimensions(ctx, b, "novectors", true)
-			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{}, noVectors.MuveraDimensionality(encodedDims), "only dims=0 rows → zero report")
-		})
-	}
-}
-
-// Pins cache invalidation for pre-MUVERA usage data: payloads saved by older binaries must be
-// rejected on load so cold shards get recomputed with the encoded dimensionality report.
-func TestLoadComputedUsageData_RejectsOldVersion(t *testing.T) {
-	dirName := t.TempDir()
-	const tenantName = "tenant"
-	require.NoError(t, os.MkdirAll(filepath.Join(dirName, tenantName), 0o755))
-
-	usage := &types.ShardUsage{Name: tenantName, ObjectsCount: 42}
-	require.NoError(t, SaveComputedUsageData(dirName, tenantName, usage))
-	loaded, err := LoadComputedUsageData(dirName, tenantName)
-	require.NoError(t, err)
-	assert.Equal(t, usage, loaded)
-
-	legacy, err := json.Marshal(&types.UsageDisk{Version: types.UsageDiskVersion - 1, ShardUsage: usage})
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(usageTmpFilePath(dirName, tenantName), legacy, 0o600))
-	_, err = LoadComputedUsageData(dirName, tenantName)
-	require.ErrorContains(t, err, "version mismatch")
 }

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -684,3 +684,126 @@ func TestLoadComputedUsageData(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateUnloadedMuveraDimensionsUsageAll(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	tenantName := "tenant"
+
+	dirName := t.TempDir()
+	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, shardPathDimensionsLSM(dirName, tenantName), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
+	require.NoError(t, err)
+
+	// multi-vector objects are recorded under their varying per-object total dimensions
+	writeDims(t, b, "colbert", 1280, []uint64{1, 2})
+	writeDims(t, b, "colbert", 2560, []uint64{3, 4, 5})
+	require.NoError(t, b.FlushMemtable())
+	require.NoError(t, b.Shutdown(ctx))
+
+	all, err := CalculateUnloadedMuveraDimensionsUsageAll(ctx, logger, dirName, tenantName,
+		map[string]int{"colbert": 10240, "missing": 10240})
+	require.NoError(t, err)
+	assert.Equal(t, types.Dimensionality{Dimensions: 10240, Count: 5}, all["colbert"])
+	assert.Equal(t, types.Dimensionality{}, all["missing"], "no objects → no reported dimensionality")
+
+	// no MUVERA vectors → nothing to calculate, no bucket open
+	none, err := CalculateUnloadedMuveraDimensionsUsageAll(ctx, logger, dirName, tenantName, nil)
+	require.NoError(t, err)
+	assert.Nil(t, none)
+}
+
+func TestCalculateMuveraDimensionsUsageFromBucket(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	const encodedDims = 2560
+
+	type dimEntry struct {
+		targetVector string
+		dims         uint32
+		docIDs       []uint64
+	}
+	// multi-vector objects vary in per-object total dims; dims=0 entries are objects without a vector
+	entries := []dimEntry{
+		{"colbert", 0, []uint64{7, 8}},
+		{"colbert", 1280, []uint64{1, 2}},
+		{"colbert", 2560, []uint64{3, 4, 5}},
+		{"colbert", 12800, []uint64{6}},
+		{"other", 0, []uint64{5}},
+		{"other", 128, []uint64{1, 2, 3, 4}},
+		{"novectors", 0, []uint64{1, 2, 3}},
+	}
+
+	tests := []struct {
+		name     string
+		strategy string
+	}{
+		{
+			name:     "roaring set strategy",
+			strategy: lsmkv.StrategyRoaringSet,
+		},
+		{
+			name:     "legacy map collection strategy",
+			strategy: lsmkv.StrategyMapCollection,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+			b, err := lsmkv.NewBucketCreator().NewBucket(ctx, filepath.Join(dirName, "dimensions"), "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				lsmkv.WithStrategy(tt.strategy))
+			require.NoError(t, err)
+			defer b.Shutdown(ctx)
+
+			for _, entry := range entries {
+				writeDims(t, b, entry.targetVector, entry.dims, entry.docIDs)
+			}
+			require.NoError(t, b.FlushMemtable())
+
+			muvera, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "colbert", encodedDims)
+			require.NoError(t, err)
+			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 6}, muvera)
+
+			// raw calculation keeps its first-entry semantics for the same data
+			raw, err := CalculateTargetVectorDimensionsFromBucket(ctx, b, "colbert")
+			require.NoError(t, err)
+			assert.Equal(t, types.Dimensionality{Dimensions: 1280, Count: 2}, raw)
+
+			otherMuvera, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "other", encodedDims)
+			require.NoError(t, err)
+			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 4}, otherMuvera)
+
+			missing, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "missing", encodedDims)
+			require.NoError(t, err)
+			assert.Equal(t, types.Dimensionality{}, missing)
+
+			noVectors, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "novectors", encodedDims)
+			require.NoError(t, err)
+			assert.Equal(t, types.Dimensionality{}, noVectors, "only dims=0 entries → zero report")
+		})
+	}
+}
+
+// Pins cache invalidation for pre-MUVERA usage data: payloads saved by older binaries must be
+// rejected on load so cold shards get recomputed with the encoded dimensionality report.
+func TestLoadComputedUsageData_RejectsOldVersion(t *testing.T) {
+	dirName := t.TempDir()
+	const tenantName = "tenant"
+	require.NoError(t, os.MkdirAll(filepath.Join(dirName, tenantName), 0o755))
+
+	usage := &types.ShardUsage{Name: tenantName, ObjectsCount: 42}
+	require.NoError(t, SaveComputedUsageData(dirName, tenantName, usage))
+	loaded, err := LoadComputedUsageData(dirName, tenantName)
+	require.NoError(t, err)
+	assert.Equal(t, usage, loaded)
+
+	legacy, err := json.Marshal(&types.UsageDisk{Version: types.UsageDiskVersion - 1, ShardUsage: usage})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(usageTmpFilePath(dirName, tenantName), legacy, 0o600))
+	_, err = LoadComputedUsageData(dirName, tenantName)
+	require.ErrorContains(t, err, "version mismatch")
+}

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -472,7 +472,7 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for range 10 {
-				if _, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, []string{"text"}); err != nil {
+				if _, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, []string{"text"}, nil); err != nil {
 					errs <- err
 				}
 			}
@@ -526,32 +526,39 @@ func TestCalculateUnloadedDimensionsUsageAll(t *testing.T) {
 	require.NoError(t, b.Shutdown(ctx))
 
 	targetVectors := []string{"text", "image", "missing"}
-	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors)
+	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors, nil)
 	require.NoError(t, err)
 	require.Len(t, all, len(targetVectors))
-	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, all["text"])
-	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, all["image"])
-	assert.Equal(t, types.Dimensionality{}, all["missing"])
+	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, all["text"].Dimensionality)
+	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, all["image"].Dimensionality)
+	assert.Equal(t, DimensionsScan{}, all["missing"])
 
 	// parity with the single-vector variant
 	for _, targetVector := range targetVectors {
 		single, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, targetVector)
 		require.NoError(t, err)
-		assert.Equal(t, all[targetVector], single, targetVector)
+		assert.Equal(t, all[targetVector].Dimensionality, single, targetVector)
 	}
 
+	// target vectors listed in needTotal also get the object count summed across all rows
+	withTotal, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors,
+		map[string]int{"text": 2560})
+	require.NoError(t, err)
+	assert.Equal(t, DimensionsScan{Dimensionality: types.Dimensionality{Dimensions: 128, Count: 5}, TotalCount: 5}, withTotal["text"])
+	assert.Equal(t, 0, withTotal["image"].TotalCount, "not in needTotal → no total")
+
 	// no target vectors → nothing to calculate, no bucket open
-	none, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, nil)
+	none, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, none)
 }
 
-// TestCalculateTargetVectorDimensionsFromBucket pins that a vector name which is a prefix of a
+// TestScanTargetVectorDimensions pins that a vector name which is a prefix of a
 // longer name still reports its own dimensions and object count: its dimension bytes sort after
 // the longer name's keys ("texts…" before "text\x80…" at 384 dimensions), so the scan has to skip
 // past those instead of stopping at them. Every vector gets its own dimensions and object count,
 // so a scan that lands on a neighbour's key cannot pass.
-func TestCalculateTargetVectorDimensionsFromBucket(t *testing.T) {
+func TestScanTargetVectorDimensions(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 
@@ -624,9 +631,9 @@ func TestCalculateTargetVectorDimensionsFromBucket(t *testing.T) {
 
 				for _, tt := range tests {
 					t.Run(tt.name, func(t *testing.T) {
-						dimensionality, err := CalculateTargetVectorDimensionsFromBucket(ctx, b, tt.targetVector)
+						scan, err := ScanTargetVectorDimensions(ctx, b, tt.targetVector, false)
 						require.NoError(t, err)
-						assert.Equal(t, tt.expected, dimensionality)
+						assert.Equal(t, tt.expected, scan.Dimensionality)
 					})
 				}
 			})
@@ -640,7 +647,7 @@ func TestCalculateTargetVectorDimensionsFromBucket(t *testing.T) {
 		require.NoError(t, err)
 		defer b.Shutdown(ctx)
 
-		_, err = CalculateTargetVectorDimensionsFromBucket(ctx, b, "text")
+		_, err = ScanTargetVectorDimensions(ctx, b, "text", false)
 		require.Error(t, err)
 	})
 }
@@ -685,7 +692,7 @@ func TestLoadComputedUsageData(t *testing.T) {
 	}
 }
 
-func TestCalculateUnloadedMuveraDimensionsUsageAll(t *testing.T) {
+func TestCalculateUnloadedDimensionsUsageAll_Muvera(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 	tenantName := "tenant"
@@ -702,19 +709,16 @@ func TestCalculateUnloadedMuveraDimensionsUsageAll(t *testing.T) {
 	require.NoError(t, b.FlushMemtable())
 	require.NoError(t, b.Shutdown(ctx))
 
-	all, err := CalculateUnloadedMuveraDimensionsUsageAll(ctx, logger, dirName, tenantName,
-		map[string]int{"colbert": 10240, "missing": 10240})
+	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName,
+		[]string{"colbert", "missing"}, map[string]int{"colbert": 10240, "missing": 10240})
 	require.NoError(t, err)
-	assert.Equal(t, types.Dimensionality{Dimensions: 10240, Count: 5}, all["colbert"])
-	assert.Equal(t, types.Dimensionality{}, all["missing"], "no objects → no reported dimensionality")
-
-	// no MUVERA vectors → nothing to calculate, no bucket open
-	none, err := CalculateUnloadedMuveraDimensionsUsageAll(ctx, logger, dirName, tenantName, nil)
-	require.NoError(t, err)
-	assert.Nil(t, none)
+	assert.Equal(t, types.Dimensionality{Dimensions: 10240, Count: 5}, all["colbert"].MuveraDimensionality(10240))
+	assert.Equal(t, types.Dimensionality{Dimensions: 1280, Count: 2}, all["colbert"].Dimensionality,
+		"raw reading keeps its first-row semantics in the same pass")
+	assert.Equal(t, types.Dimensionality{}, all["missing"].MuveraDimensionality(10240), "no objects → no reported dimensionality")
 }
 
-func TestCalculateMuveraDimensionsUsageFromBucket(t *testing.T) {
+func TestScanTargetVectorDimensions_TotalCount(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 
@@ -764,26 +768,23 @@ func TestCalculateMuveraDimensionsUsageFromBucket(t *testing.T) {
 			}
 			require.NoError(t, b.FlushMemtable())
 
-			muvera, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "colbert", encodedDims)
+			colbert, err := ScanTargetVectorDimensions(ctx, b, "colbert", true)
 			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 6}, muvera)
+			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 6}, colbert.MuveraDimensionality(encodedDims))
+			// raw reading keeps its first-row semantics in the same pass
+			assert.Equal(t, types.Dimensionality{Dimensions: 1280, Count: 2}, colbert.Dimensionality)
 
-			// raw calculation keeps its first-entry semantics for the same data
-			raw, err := CalculateTargetVectorDimensionsFromBucket(ctx, b, "colbert")
+			other, err := ScanTargetVectorDimensions(ctx, b, "other", true)
 			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{Dimensions: 1280, Count: 2}, raw)
+			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 4}, other.MuveraDimensionality(encodedDims))
 
-			otherMuvera, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "other", encodedDims)
+			missing, err := ScanTargetVectorDimensions(ctx, b, "missing", true)
 			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{Dimensions: encodedDims, Count: 4}, otherMuvera)
+			assert.Equal(t, types.Dimensionality{}, missing.MuveraDimensionality(encodedDims))
 
-			missing, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "missing", encodedDims)
+			noVectors, err := ScanTargetVectorDimensions(ctx, b, "novectors", true)
 			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{}, missing)
-
-			noVectors, err := CalculateMuveraDimensionsUsageFromBucket(ctx, b, "novectors", encodedDims)
-			require.NoError(t, err)
-			assert.Equal(t, types.Dimensionality{}, noVectors, "only dims=0 entries → zero report")
+			assert.Equal(t, types.Dimensionality{}, noVectors.MuveraDimensionality(encodedDims), "only dims=0 rows → zero report")
 		})
 	}
 }

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -306,11 +306,11 @@ func New(cfg Config, uc ent.UserConfig,
 	var vectorCache cache.Cache[float32]
 
 	var muveraEncoder *multivector.MuveraEncoder
-	if uc.Multivector.Enabled && !uc.Multivector.MuveraConfig.Enabled {
+	if uc.Multivector.Enabled && !uc.Multivector.MuveraEnabled() {
 		vectorCache = cache.NewShardedMultiFloat32LockCache(cfg.MultiVectorForIDThunk, uc.VectorCacheMaxObjects,
 			cfg.Logger, normalizeOnRead, cache.DefaultDeletionInterval, cfg.AllocChecker)
 	} else {
-		if uc.Multivector.MuveraConfig.Enabled {
+		if uc.Multivector.MuveraEnabled() {
 			muveraEncoder = multivector.NewMuveraEncoder(uc.Multivector.MuveraConfig, store)
 			err := store.CreateOrLoadBucket(
 				context.Background(),
@@ -411,11 +411,11 @@ func New(cfg Config, uc ent.UserConfig,
 	index.acornSearch.Store(uc.FilterStrategy == ent.FilterStrategyAcorn)
 
 	index.multivector.Store(uc.Multivector.Enabled)
-	index.muvera.Store(uc.Multivector.MuveraConfig.Enabled)
+	index.muvera.Store(uc.Multivector.MuveraEnabled())
 
 	if uc.BQ.Enabled {
 		var err error
-		if uc.Multivector.Enabled && !uc.Multivector.MuveraConfig.Enabled {
+		if uc.Multivector.Enabled && !uc.Multivector.MuveraEnabled() {
 			index.compressor, err = compressionhelpers.NewBQMultiCompressor(
 				index.distancerProvider, uc.VectorCacheMaxObjects, cfg.Logger, store,
 				cfg.MakeBucketOptions, cfg.AllocChecker, index.getTargetVector(), index.vectorForID)
@@ -438,7 +438,7 @@ func New(cfg Config, uc ent.UserConfig,
 
 	if uc.Multivector.Enabled {
 		index.multiDistancerProvider = distancer.NewDotProductProvider()
-		if !uc.Multivector.MuveraConfig.Enabled {
+		if !uc.Multivector.MuveraEnabled() {
 			err := index.store.CreateOrLoadBucket(
 				context.Background(),
 				cfg.ID+"_mv_mappings",

--- a/adapters/repos/db/vector/multivector/muvera_test.go
+++ b/adapters/repos/db/vector/multivector/muvera_test.go
@@ -1,0 +1,81 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package multivector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// MuveraConfig.EncodedDimensions() computes the encoded length independently of the encoder,
+// pin that the two cannot drift.
+func TestEncodedVectorMatchesConfiguredDimensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     ent.MuveraConfig
+		dimensions int
+		tokens     int
+	}{
+		{
+			name: "defaults",
+			config: ent.MuveraConfig{
+				KSim:         ent.DefaultMultivectorKSim,
+				DProjections: ent.DefaultMultivectorDProjections,
+				Repetitions:  ent.DefaultMultivectorRepetitions,
+			},
+			dimensions: 128,
+			tokens:     7,
+		},
+		{
+			name: "single repetition",
+			config: ent.MuveraConfig{
+				KSim:         3,
+				DProjections: 8,
+				Repetitions:  1,
+			},
+			dimensions: 64,
+			tokens:     1,
+		},
+		{
+			name: "ksim at the validated upper bound",
+			config: ent.MuveraConfig{
+				KSim:         10,
+				DProjections: 4,
+				Repetitions:  2,
+			},
+			dimensions: 32,
+			tokens:     3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoder := NewMuveraEncoder(tt.config, nil)
+			encoder.InitEncoder(tt.dimensions)
+
+			tokens := make([][]float32, tt.tokens)
+			for i := range tokens {
+				tokens[i] = make([]float32, tt.dimensions)
+				for j := range tokens[i] {
+					tokens[i][j] = float32(i+1) / float32(j+1)
+				}
+			}
+
+			expected := tt.config.EncodedDimensions()
+			assert.Positive(t, expected)
+			assert.Len(t, encoder.EncodeDoc(tokens), expected)
+			assert.Len(t, encoder.EncodeQuery(tokens), expected)
+		})
+	}
+}

--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -319,6 +319,10 @@ func (u *UserConfig) validate() error {
 		return fmt.Errorf("invalid hnsw config: ksim must be less than 10")
 	}
 
+	if u.Multivector.MuveraConfig.Enabled && u.Multivector.MuveraConfig.KSim < 0 {
+		return fmt.Errorf("invalid hnsw config: ksim must not be negative")
+	}
+
 	return nil
 }
 

--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -316,11 +316,7 @@ func (u *UserConfig) validate() error {
 	}
 
 	if u.Multivector.MuveraConfig.Enabled && u.Multivector.MuveraConfig.KSim > 10 {
-		return fmt.Errorf("invalid hnsw config: ksim must be less than 10")
-	}
-
-	if u.Multivector.MuveraConfig.Enabled && u.Multivector.MuveraConfig.KSim < 0 {
-		return fmt.Errorf("invalid hnsw config: ksim must not be negative")
+		return fmt.Errorf("invalid hnsw config: ksim must be at most 10")
 	}
 
 	return nil

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -653,6 +653,34 @@ func Test_UserConfig(t *testing.T) {
 				"with a minimum of 4",
 		},
 		{
+			name: "invalid negative muvera ksim",
+			input: map[string]interface{}{
+				"multivector": map[string]interface{}{
+					"enabled": true,
+					"muvera": map[string]interface{}{
+						"enabled": true,
+						"ksim":    json.Number("-1"),
+					},
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "ksim must not be negative",
+		},
+		{
+			name: "invalid too large muvera ksim",
+			input: map[string]interface{}{
+				"multivector": map[string]interface{}{
+					"enabled": true,
+					"muvera": map[string]interface{}{
+						"enabled": true,
+						"ksim":    json.Number("11"),
+					},
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "ksim must be less than 10",
+		},
+		{
 			name: "with bq",
 			input: map[string]interface{}{
 				"cleanupIntervalSeconds": float64(11),

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"math"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -653,34 +654,6 @@ func Test_UserConfig(t *testing.T) {
 				"with a minimum of 4",
 		},
 		{
-			name: "invalid negative muvera ksim",
-			input: map[string]interface{}{
-				"multivector": map[string]interface{}{
-					"enabled": true,
-					"muvera": map[string]interface{}{
-						"enabled": true,
-						"ksim":    json.Number("-1"),
-					},
-				},
-			},
-			expectErr:    true,
-			expectErrMsg: "ksim must not be negative",
-		},
-		{
-			name: "invalid too large muvera ksim",
-			input: map[string]interface{}{
-				"multivector": map[string]interface{}{
-					"enabled": true,
-					"muvera": map[string]interface{}{
-						"enabled": true,
-						"ksim":    json.Number("11"),
-					},
-				},
-			},
-			expectErr:    true,
-			expectErrMsg: "ksim must be less than 10",
-		},
-		{
 			name: "with bq",
 			input: map[string]interface{}{
 				"cleanupIntervalSeconds": float64(11),
@@ -1223,4 +1196,39 @@ func Test_UserConfigFilterStrategy(t *testing.T) {
 		assert.Equal(t, FilterStrategySweeping, cfg.FilterStrategy)
 		assert.Nil(t, os.Unsetenv("HNSW_DEFAULT_FILTER_STRATEGY"))
 	})
+}
+
+// The ksim bound is an upper bound only, a degenerate value must stay parseable so that restore
+// and log replay, which run the same validation, cannot fail on an already persisted class.
+func TestUserConfigMuveraKSimBound(t *testing.T) {
+	tests := []struct {
+		name         string
+		ksim         int
+		expectErrMsg string
+	}{
+		{name: "default", ksim: DefaultMultivectorKSim},
+		{name: "at the upper bound", ksim: 10},
+		{name: "above the upper bound", ksim: 11, expectErrMsg: "ksim must be at most 10"},
+		{name: "negative is not rejected", ksim: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ParseAndValidateConfig(map[string]interface{}{
+				"multivector": map[string]interface{}{
+					"enabled": true,
+					"muvera": map[string]interface{}{
+						"enabled": true,
+						"ksim":    json.Number(strconv.Itoa(tt.ksim)),
+					},
+				},
+			}, true)
+			if tt.expectErrMsg != "" {
+				require.ErrorContains(t, err, tt.expectErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.ksim, parsed.(UserConfig).Multivector.MuveraConfig.KSim)
+		})
+	}
 }

--- a/entities/vectorindex/hnsw/multivector_config.go
+++ b/entities/vectorindex/hnsw/multivector_config.go
@@ -44,6 +44,11 @@ type MuveraConfig struct {
 	Repetitions  int  `json:"repetitions"`
 }
 
+// EncodedDimensions returns the dimensionality of a MUVERA-encoded vector: Repetitions × 2^KSim clusters × DProjections.
+func (m MuveraConfig) EncodedDimensions() int {
+	return m.Repetitions * (1 << m.KSim) * m.DProjections
+}
+
 func validAggregation(v string) error {
 	switch v {
 	case MultivectorAggregationMaxSim:

--- a/entities/vectorindex/hnsw/multivector_config.go
+++ b/entities/vectorindex/hnsw/multivector_config.go
@@ -45,7 +45,11 @@ type MuveraConfig struct {
 }
 
 // EncodedDimensions returns the dimensionality of a MUVERA-encoded vector: Repetitions × 2^KSim clusters × DProjections.
+// Returns 0 for a negative KSim, which can occur in configs persisted before the lower bound was validated.
 func (m MuveraConfig) EncodedDimensions() int {
+	if m.KSim < 0 {
+		return 0
+	}
 	return m.Repetitions * (1 << m.KSim) * m.DProjections
 }
 

--- a/entities/vectorindex/hnsw/multivector_config.go
+++ b/entities/vectorindex/hnsw/multivector_config.go
@@ -44,10 +44,16 @@ type MuveraConfig struct {
 	Repetitions  int  `json:"repetitions"`
 }
 
+// MuveraEnabled reports whether vectors are held MUVERA-encoded. The multivector flag is
+// deliberately not part of it, hnsw.New arms the encoder on the muvera flag alone.
+func (c MultivectorConfig) MuveraEnabled() bool {
+	return c.MuveraConfig.Enabled
+}
+
 // EncodedDimensions returns the dimensionality of a MUVERA-encoded vector: Repetitions × 2^KSim clusters × DProjections.
-// Returns 0 for a negative KSim, which can occur in configs persisted before the lower bound was validated.
+// Returns 0 unless all three factors are positive, validation only bounds the upper end of KSim.
 func (m MuveraConfig) EncodedDimensions() int {
-	if m.KSim < 0 {
+	if m.KSim < 0 || m.Repetitions < 1 || m.DProjections < 1 {
 		return 0
 	}
 	return m.Repetitions * (1 << m.KSim) * m.DProjections

--- a/entities/vectorindex/hnsw/multivector_config_test.go
+++ b/entities/vectorindex/hnsw/multivector_config_test.go
@@ -1,0 +1,51 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMuveraConfigEncodedDimensions(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   MuveraConfig
+		expected int
+	}{
+		{
+			name: "defaults",
+			config: MuveraConfig{
+				KSim:         DefaultMultivectorKSim,
+				DProjections: DefaultMultivectorDProjections,
+				Repetitions:  DefaultMultivectorRepetitions,
+			},
+			expected: 10 * 16 * 16, // repetitions × 2^ksim × dprojections
+		},
+		{
+			name: "custom values",
+			config: MuveraConfig{
+				KSim:         3,
+				DProjections: 8,
+				Repetitions:  5,
+			},
+			expected: 5 * 8 * 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.EncodedDimensions())
+		})
+	}
+}

--- a/entities/vectorindex/hnsw/multivector_config_test.go
+++ b/entities/vectorindex/hnsw/multivector_config_test.go
@@ -42,11 +42,56 @@ func TestMuveraConfigEncodedDimensions(t *testing.T) {
 			expected: 5 * 8 * 8,
 		},
 		{
+			name: "ksim at the validated upper bound",
+			config: MuveraConfig{
+				KSim:         10,
+				DProjections: DefaultMultivectorDProjections,
+				Repetitions:  DefaultMultivectorRepetitions,
+			},
+			expected: 10 * 1024 * 16,
+		},
+		{
 			name: "negative ksim does not panic",
 			config: MuveraConfig{
 				KSim:         -1,
 				DProjections: 16,
 				Repetitions:  10,
+			},
+			expected: 0,
+		},
+		{
+			name: "zero repetitions",
+			config: MuveraConfig{
+				KSim:         DefaultMultivectorKSim,
+				DProjections: DefaultMultivectorDProjections,
+				Repetitions:  0,
+			},
+			expected: 0,
+		},
+		{
+			name: "negative repetitions",
+			config: MuveraConfig{
+				KSim:         DefaultMultivectorKSim,
+				DProjections: DefaultMultivectorDProjections,
+				Repetitions:  -1,
+			},
+			expected: 0,
+		},
+		{
+			name: "zero dprojections",
+			config: MuveraConfig{
+				KSim:         DefaultMultivectorKSim,
+				DProjections: 0,
+				Repetitions:  DefaultMultivectorRepetitions,
+			},
+			expected: 0,
+		},
+		{
+			name: "negative dprojections",
+			config: MuveraConfig{
+				KSim:         DefaultMultivectorKSim,
+				DProjections: -1,
+				Repetitions:  DefaultMultivectorRepetitions,
 			},
 			expected: 0,
 		},

--- a/entities/vectorindex/hnsw/multivector_config_test.go
+++ b/entities/vectorindex/hnsw/multivector_config_test.go
@@ -41,6 +41,15 @@ func TestMuveraConfigEncodedDimensions(t *testing.T) {
 			},
 			expected: 5 * 8 * 8,
 		},
+		{
+			name: "negative ksim does not panic",
+			config: MuveraConfig{
+				KSim:         -1,
+				DProjections: 16,
+				Repetitions:  10,
+			},
+			expected: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"acceptance_tests_with_client/internal/wvhost"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -32,8 +34,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/test/docker"
-
-	"acceptance_tests_with_client/internal/wvhost"
 )
 
 func TestTenantStatusChanges(t *testing.T) {
@@ -1220,4 +1220,171 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 func sanitizeName(name string) string {
 	name = strings.ReplaceAll(name, "/", "_")
 	return name
+}
+
+func TestUsageMuvera(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateWithDebugPort().
+		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
+	require.NoError(t, err)
+	debug := compose.GetWeaviate().DebugURI()
+
+	className := t.Name() + "Class"
+	tenantName := "tenant"
+	muveraVec := "muvera"
+	colbertVec := "colbert"
+	regularVec := "regular"
+
+	const (
+		numObjects  = 20
+		tokenDim    = 32
+		fixedTokens = 3
+
+		ksim         = 4
+		dprojections = 16
+		repetitions  = 10
+		encodedDims  = repetitions * (1 << ksim) * dprojections // what MUVERA holds in memory per object
+	)
+
+	// the MUVERA vector reports its fixed encoded dimensionality, the plain multi-vector keeps
+	// reporting raw per-object dims, and the single vector is a control
+	expected := map[string]usagetypes.Dimensionality{
+		muveraVec:  {Dimensions: encodedDims, Count: numObjects},
+		colbertVec: {Dimensions: fixedTokens * tokenDim, Count: numObjects},
+		regularVec: {Dimensions: tokenDim, Count: numObjects},
+	}
+
+	multivectorIndexConfig := func(muvera bool) map[string]any {
+		cfg := map[string]any{"enabled": true}
+		if muvera {
+			cfg["muvera"] = map[string]any{
+				"enabled":      true,
+				"ksim":         ksim,
+				"dprojections": dprojections,
+				"repetitions":  repetitions,
+			}
+		}
+		return map[string]any{"multivector": cfg}
+	}
+
+	class := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: []string{schema.DataTypeText.String()},
+			},
+		},
+		VectorConfig: map[string]models.VectorConfig{
+			muveraVec: {
+				Vectorizer:        map[string]any{"none": map[string]any{}},
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: multivectorIndexConfig(true),
+			},
+			colbertVec: {
+				Vectorizer:        map[string]any{"none": map[string]any{}},
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: multivectorIndexConfig(false),
+			},
+			regularVec: {
+				Vectorizer:      map[string]any{"none": map[string]any{}},
+				VectorIndexType: "hnsw",
+			},
+		},
+		// the COLD/HOT cycle below routes the report through the unloaded-shard path
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+	}
+	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
+	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName}).Do(ctx))
+
+	objs := make([]*models.Object, numObjects)
+	for i := range numObjects {
+		objs[i] = &models.Object{
+			Class:  className,
+			ID:     strfmt.UUID(uuid.NewString()),
+			Tenant: tenantName,
+			Properties: map[string]any{
+				"name": fmt.Sprintf("name %d", i),
+			},
+			Vectors: models.Vectors{
+				// varying token counts spread the raw dimension rows over several per-object
+				// totals, so a report that only picks up one row cannot reach the full count
+				muveraVec:  generateRandomMultiVector(2+i%3, tokenDim),
+				colbertVec: generateRandomMultiVector(fixedTokens, tokenDim),
+				regularVec: generateRandomVector(tokenDim),
+			},
+		}
+	}
+	batchResp, err := c.Batch().ObjectsBatcher().WithObjects(objs...).Do(ctx)
+	require.NoError(t, err)
+	for _, r := range batchResp {
+		require.NotNil(t, r.Result)
+		require.NotNil(t, r.Result.Status)
+		require.Equal(t, models.ObjectsGetResponseAO2ResultStatusSUCCESS, *r.Result.Status)
+	}
+	testAllObjectsIndexed(t, c, className)
+
+	// asserting the status pins which report path served the shard: active = loaded, inactive =
+	// read from disk without loading
+	assertUsage := func(t require.TestingT, expectedStatus string) {
+		colUsage, err := getDebugUsageWithPortAndCollection(debug, className)
+		require.NoError(t, err)
+		require.Len(t, colUsage.Shards, 1)
+		shard := colUsage.Shards[0]
+		require.Equal(t, strings.ToLower(expectedStatus), shard.Status)
+		if expectedStatus == models.TenantActivityStatusACTIVE {
+			require.Equal(t, int64(numObjects), shard.ObjectsCount)
+		}
+		require.Equal(t, expected, namedVectorDimensionalities(t, shard))
+
+		for _, v := range shard.NamedVectors {
+			if v.Name != muveraVec {
+				continue
+			}
+			require.NotNil(t, v.MultiVectorConfig, "muvera vector must report its multi-vector config")
+			require.NotNil(t, v.MultiVectorConfig.MuveraConfig)
+			assert.True(t, v.MultiVectorConfig.MuveraConfig.Enabled)
+			assert.Equal(t, ksim, v.MultiVectorConfig.MuveraConfig.KSim)
+			assert.Equal(t, dprojections, v.MultiVectorConfig.MuveraConfig.DProjections)
+			assert.Equal(t, repetitions, v.MultiVectorConfig.MuveraConfig.Repetitions)
+		}
+	}
+
+	// the schema-level tenant status flips before the local shard finishes its activation or
+	// deactivation, so reports around a transition are polled until they converge
+	assertUsageEventually := func(expectedStatus string) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			assertUsage(ct, expectedStatus)
+		}, 30*time.Second, 500*time.Millisecond)
+	}
+
+	assertUsageEventually(models.TenantActivityStatusACTIVE)
+
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+	assertUsageEventually(models.TenantActivityStatusINACTIVE)
+	// a second cold report is served from the on-disk usage cache instead of recomputing
+	assertUsage(t, models.TenantActivityStatusINACTIVE)
+
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx))
+	assertUsageEventually(models.TenantActivityStatusACTIVE)
+}
+
+func generateRandomMultiVector(tokens, dimensionality int) [][]float32 {
+	multiVector := make([][]float32, tokens)
+	for i := range multiVector {
+		multiVector[i] = generateRandomVector(dimensionality)
+	}
+	return multiVector
 }

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -588,6 +588,15 @@ func TestRestart(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, usage2)
 	require.NoError(t, ReportsDifference(usage, usage2))
+
+	// piggybacks on this container instead of starting its own — same env (debug port +
+	// dimension tracking). Runs after the restart, so URIs must be re-fetched: the mapped
+	// ports change across a container stop/start.
+	t.Run("muvera usage", func(t *testing.T) {
+		c, err := client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
+		require.NoError(t, err)
+		testUsageMuvera(t, c, compose.GetWeaviate().DebugURI())
+	})
 }
 
 func testAllObjectsIndexed(t *testing.T, c *client.Client, className string) {
@@ -1222,23 +1231,17 @@ func sanitizeName(name string) string {
 	return name
 }
 
-func TestUsageMuvera(t *testing.T) {
+// testUsageMuvera runs on a caller-provided instance so it can share a testcontainer with
+// another test instead of paying for its own start. The instance must expose the debug port
+// and have TRACK_VECTOR_DIMENSIONS enabled.
+func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateWithDebugPort().
-		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
+	className := "UsageMuveraClass"
 
-	c, err := client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
-	require.NoError(t, err)
-	debug := compose.GetWeaviate().DebugURI()
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 
-	className := t.Name() + "Class"
 	tenantName := "tenant"
 	muveraVec := "muvera"
 	colbertVec := "colbert"

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -589,9 +589,8 @@ func TestRestart(t *testing.T) {
 	require.NotNil(t, usage2)
 	require.NoError(t, ReportsDifference(usage, usage2))
 
-	// piggybacks on this container instead of starting its own — same env (debug port +
-	// dimension tracking). Runs after the restart, so URIs must be re-fetched: the mapped
-	// ports change across a container stop/start.
+	// shares this container instead of starting its own, URIs are re-fetched because the
+	// mapped ports change across the restart above
 	t.Run("muvera usage", func(t *testing.T) {
 		c, err := client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
 		require.NoError(t, err)
@@ -1231,9 +1230,8 @@ func sanitizeName(name string) string {
 	return name
 }
 
-// testUsageMuvera runs on a caller-provided instance so it can share a testcontainer with
-// another test instead of paying for its own start. The instance must expose the debug port
-// and have TRACK_VECTOR_DIMENSIONS enabled.
+// testUsageMuvera takes an instance so it can share a testcontainer, it must expose the
+// debug port and have TRACK_VECTOR_DIMENSIONS enabled.
 func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	ctx := context.Background()
 
@@ -1255,11 +1253,9 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 		ksim         = 4
 		dprojections = 16
 		repetitions  = 10
-		encodedDims  = repetitions * (1 << ksim) * dprojections // what MUVERA holds in memory per object
+		encodedDims  = repetitions * (1 << ksim) * dprojections
 	)
 
-	// the MUVERA vector reports its fixed encoded dimensionality, the plain multi-vector keeps
-	// reporting raw per-object dims, and the single vector is a control
 	expected := map[string]usagetypes.Dimensionality{
 		muveraVec:  {Dimensions: encodedDims, Count: numObjects},
 		colbertVec: {Dimensions: fixedTokens * tokenDim, Count: numObjects},
@@ -1303,7 +1299,6 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 				VectorIndexType: "hnsw",
 			},
 		},
-		// the COLD/HOT cycle below routes the report through the unloaded-shard path
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	}
 	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
@@ -1320,8 +1315,8 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 				"name": fmt.Sprintf("name %d", i),
 			},
 			Vectors: models.Vectors{
-				// varying token counts spread the raw dimension rows over several per-object
-				// totals, so a report that only picks up one row cannot reach the full count
+				// varying token counts spread the raw dims over several rows, so a
+				// single-row report cannot reach the full count
 				muveraVec:  generateRandomMultiVector(2+i%3, tokenDim),
 				colbertVec: generateRandomMultiVector(fixedTokens, tokenDim),
 				regularVec: generateRandomVector(tokenDim),
@@ -1337,8 +1332,7 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	}
 	testAllObjectsIndexed(t, c, className)
 
-	// asserting the status pins which report path served the shard: active = loaded, inactive =
-	// read from disk without loading
+	// the status pins which path served the report: active = loaded, inactive = read from disk
 	assertUsage := func(t require.TestingT, expectedStatus string) {
 		colUsage, err := getDebugUsageWithPortAndCollection(debug, className)
 		require.NoError(t, err)
@@ -1363,8 +1357,7 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 		}
 	}
 
-	// the schema-level tenant status flips before the local shard finishes its activation or
-	// deactivation, so reports around a transition are polled until they converge
+	// the tenant status flips before the local shard finishes activating, so poll until converged
 	assertUsageEventually := func(expectedStatus string) {
 		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 			assertUsage(ct, expectedStatus)
@@ -1376,7 +1369,6 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
 		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
 	assertUsageEventually(models.TenantActivityStatusINACTIVE)
-	// a second cold report is served from the on-disk usage cache instead of recomputing
 	assertUsage(t, models.TenantActivityStatusINACTIVE)
 
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).

--- a/test/acceptance_with_python/test_usage.py
+++ b/test/acceptance_with_python/test_usage.py
@@ -32,6 +32,9 @@ def tenant_objects_count(tenant_id: int) -> int:
 
 vector_names = ["first", "second", "third", "fourth"]
 
+# muvera holds a fixed encoded vector per object: repetitions x 2^ksim x dprojections
+muvera_encoded_dimensions = 10 * (1 << 4) * 16
+
 
 def test_usage_adding_named_vector(collection_factory: CollectionFactory):
     vec_config = vectors.self_provided(
@@ -334,7 +337,7 @@ def test_multi_vector(collection_factory: CollectionFactory):
     assert named_vector_muvera.name == vector_names[1]
     assert len(named_vector_muvera.dimensionalities) == 1
     dimensionality = named_vector_muvera.dimensionalities[0]
-    assert dimensionality.dimensions == 6  # 3 vectors of 2 dimensions each
+    assert dimensionality.dimensions == muvera_encoded_dimensions
     assert dimensionality.count == 2
     assert named_vector_muvera.compression == "standard"
     assert named_vector_muvera.vector_compression_ratio == 1
@@ -345,7 +348,7 @@ def test_multi_vector(collection_factory: CollectionFactory):
     assert named_vector_muvera_bq.name == vector_names[2]
     assert len(named_vector_muvera_bq.dimensionalities) == 1
     dimensionality = named_vector_muvera_bq.dimensionalities[0]
-    assert dimensionality.dimensions == 6  # 3 vectors of 2 dimensions each
+    assert dimensionality.dimensions == muvera_encoded_dimensions
     assert dimensionality.count == 2
     assert named_vector_muvera_bq.compression == "bq"
     assert named_vector_muvera_bq.vector_compression_ratio == 32


### PR DESCRIPTION
### Add MUVERA-specific usage calculations

- The usage report derives billable vector RAM from Dimensionalities (count × dims), but MUVERA-enabled multi-vector collections reported raw per-object token dimensions instead of what is actually held in memory: the fixed encoded dimensionality (Repetitions × 2^KSim × DProjections).
- This PR makes MUVERA multi-vector HNSW report the encoded dimensionality with the object count summed across all per-object dimension entries, in both the loaded and unloaded (cold tenant) shard paths.
- Disk accounting is deliberately unchanged — raw dimensions still drive the ObjectsStorageBytes/VectorStorageBytes split — so only the in-memory signal changes.