### PR TITLE
feat(telemetry): persistent cluster and node identity for correlatable telemetry

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -955,9 +955,14 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.DB,
 		appState.SchemaManager,
 		appState.Logger,
-		getTelemetryURL(appState),
-		appState.ServerConfig.Config.TelemetryPushInterval,
-		telemetryEnabled(appState),
+		telemetry.Config{
+			ConsumerURL:          getTelemetryURL(appState),
+			PushInterval:         appState.ServerConfig.Config.TelemetryPushInterval,
+			Enabled:              telemetryEnabled(appState),
+			NodeID:               appState.ServerConfig.Config.Cluster.Hostname,
+			AsyncIndexingEnabled: appState.ServerConfig.Config.AsyncIndexingEnabled,
+			ClusterID:            appState.ClusterService.ClusterID,
+		},
 	)
 
 	var grpcInstrument []grpc.ServerOption

--- a/cluster/fsm/snapshot.go
+++ b/cluster/fsm/snapshot.go
@@ -35,6 +35,9 @@ type Snapshot struct {
 	ReplicationOps []byte `json:"replication_ops,omitempty"`
 	// DbUsers is the state of dynamic db users that will be used to restore the FSM
 	DbUsers []byte `json:"dbusers,omitempty"`
+
+	// ClusterID is the stable UUID committed once per cluster lifetime.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // Snapshotter is used to snapshot and restore any (FSM) state

--- a/cluster/proto/api/message.pb.go
+++ b/cluster/proto/api/message.pb.go
@@ -76,6 +76,8 @@ const (
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_CANCEL                                    ApplyRequest_Type = 301
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED                     ApplyRequest_Type = 302
 	ApplyRequest_TYPE_DISTRIBUTED_TASK_CLEAN_UP                                  ApplyRequest_Type = 303
+	// Cluster identity - set once by the raft leader; replayed during recovery.
+	ApplyRequest_TYPE_CLUSTER_ID_SET ApplyRequest_Type = 400
 )
 
 // Enum value maps for ApplyRequest_Type.
@@ -131,6 +133,7 @@ var (
 		301: "TYPE_DISTRIBUTED_TASK_CANCEL",
 		302: "TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED",
 		303: "TYPE_DISTRIBUTED_TASK_CLEAN_UP",
+		400: "TYPE_CLUSTER_ID_SET",
 	}
 	ApplyRequest_Type_value = map[string]int32{
 		"TYPE_UNSPECIFIED":                                                0,
@@ -183,6 +186,7 @@ var (
 		"TYPE_DISTRIBUTED_TASK_CANCEL":                                    301,
 		"TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED":                     302,
 		"TYPE_DISTRIBUTED_TASK_CLEAN_UP":                                  303,
+		"TYPE_CLUSTER_ID_SET":                                             400,
 	}
 )
 
@@ -1742,6 +1746,52 @@ func (x *DeleteAliasRequest) GetAlias() string {
 	return ""
 }
 
+// SetClusterIDRequest carries the stable cluster identity committed once per
+// cluster lifetime via TYPE_CLUSTER_ID_SET. Field numbers are permanent.
+type SetClusterIDRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ClusterId     string                 `protobuf:"bytes,1,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetClusterIDRequest) Reset() {
+	*x = SetClusterIDRequest{}
+	mi := &file_api_message_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetClusterIDRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetClusterIDRequest) ProtoMessage() {}
+
+func (x *SetClusterIDRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_message_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetClusterIDRequest.ProtoReflect.Descriptor instead.
+func (*SetClusterIDRequest) Descriptor() ([]byte, []int) {
+	return file_api_message_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *SetClusterIDRequest) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
+}
+
 var File_api_message_proto protoreflect.FileDescriptor
 
 const file_api_message_proto_rawDesc = "" +
@@ -1760,13 +1810,13 @@ const file_api_message_proto_rawDesc = "" +
 	"\x11NotifyPeerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x14\n" +
-	"\x12NotifyPeerResponse\"\x97\x0f\n" +
+	"\x12NotifyPeerResponse\"\xb1\x0f\n" +
 	"\fApplyRequest\x12@\n" +
 	"\x04type\x18\x01 \x01(\x0e2,.weaviate.internal.cluster.ApplyRequest.TypeR\x04type\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x04R\aversion\x12\x1f\n" +
 	"\vsub_command\x18\x04 \x01(\fR\n" +
-	"subCommand\"\xf3\r\n" +
+	"subCommand\"\x8d\x0e\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eTYPE_ADD_CLASS\x10\x01\x12\x15\n" +
@@ -1818,7 +1868,8 @@ const file_api_message_proto_rawDesc = "" +
 	"\x19TYPE_DISTRIBUTED_TASK_ADD\x10\xac\x02\x12!\n" +
 	"\x1cTYPE_DISTRIBUTED_TASK_CANCEL\x10\xad\x02\x120\n" +
 	"+TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED\x10\xae\x02\x12#\n" +
-	"\x1eTYPE_DISTRIBUTED_TASK_CLEAN_UP\x10\xaf\x02\"\x04\bc\x10c\"A\n" +
+	"\x1eTYPE_DISTRIBUTED_TASK_CLEAN_UP\x10\xaf\x02\x12\x18\n" +
+	"\x13TYPE_CLUSTER_ID_SET\x10\x90\x03\"\x04\bc\x10c\"A\n" +
 	"\rApplyResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\x04R\aversion\x12\x16\n" +
 	"\x06leader\x18\x02 \x01(\tR\x06leader\"\x91\b\n" +
@@ -1924,7 +1975,10 @@ const file_api_message_proto_rawDesc = "" +
 	"collection\x12\x14\n" +
 	"\x05alias\x18\x02 \x01(\tR\x05alias\"*\n" +
 	"\x12DeleteAliasRequest\x12\x14\n" +
-	"\x05alias\x18\x01 \x01(\tR\x05alias2\x8d\x04\n" +
+	"\x05alias\x18\x01 \x01(\tR\x05alias\"4\n" +
+	"\x13SetClusterIDRequest\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\x01 \x01(\tR\tclusterId2\x8d\x04\n" +
 	"\x0eClusterService\x12k\n" +
 	"\n" +
 	"RemovePeer\x12,.weaviate.internal.cluster.RemovePeerRequest\x1a-.weaviate.internal.cluster.RemovePeerResponse\"\x00\x12e\n" +
@@ -1948,7 +2002,7 @@ func file_api_message_proto_rawDescGZIP() []byte {
 }
 
 var file_api_message_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_api_message_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_api_message_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_api_message_proto_goTypes = []any{
 	(ApplyRequest_Type)(0),                             // 0: weaviate.internal.cluster.ApplyRequest.Type
 	(QueryRequest_Type)(0),                             // 1: weaviate.internal.cluster.QueryRequest.Type
@@ -1978,6 +2032,7 @@ var file_api_message_proto_goTypes = []any{
 	(*CreateAliasRequest)(nil),                         // 25: weaviate.internal.cluster.CreateAliasRequest
 	(*ReplaceAliasRequest)(nil),                        // 26: weaviate.internal.cluster.ReplaceAliasRequest
 	(*DeleteAliasRequest)(nil),                         // 27: weaviate.internal.cluster.DeleteAliasRequest
+	(*SetClusterIDRequest)(nil),                        // 28: weaviate.internal.cluster.SetClusterIDRequest
 }
 var file_api_message_proto_depIdxs = []int32{
 	0,  // 0: weaviate.internal.cluster.ApplyRequest.type:type_name -> weaviate.internal.cluster.ApplyRequest.Type
@@ -2017,7 +2072,7 @@ func file_api_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_message_proto_rawDesc), len(file_api_message_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -99,6 +99,8 @@ message ApplyRequest {
     TYPE_DISTRIBUTED_TASK_CANCEL = 301;
     TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED = 302;
     TYPE_DISTRIBUTED_TASK_CLEAN_UP = 303;
+
+    TYPE_CLUSTER_ID_SET = 400;
   }
   Type type = 1;
   string class = 2;
@@ -246,4 +248,10 @@ message ReplaceAliasRequest {
 
 message DeleteAliasRequest {
   string alias = 1;
+}
+
+// SetClusterIDRequest carries the stable cluster identity committed once per
+// cluster lifetime via TYPE_CLUSTER_ID_SET.
+message SetClusterIDRequest {
+  string cluster_id = 1;
 }

--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -86,3 +86,8 @@ func (s *Raft) ReplicationFsm() *replication.ShardReplicationFSM {
 func (s *Raft) IsLeader() bool {
 	return s.store.IsLeader()
 }
+
+// ClusterID returns the stable cluster identity UUIDv7, or "" if not yet committed.
+func (s *Raft) ClusterID() string {
+	return s.store.ClusterID()
+}

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -608,3 +608,37 @@ func TestApplyReplicationScalePlan(t *testing.T) {
 		require.ErrorContains(t, err, "invalid scale plan: source node")
 	})
 }
+
+// TestClusterID_CommittedByRealRaftLeader drives cluster-id commit through a
+// real single-node raft leader end to end (onLeaderFound -> Execute -> Apply -> commit).
+func TestClusterID_CommittedByRealRaftLeader(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
+	m.indexer.On("Open", mock.Anything).Return(nil)
+	m.indexer.On("Close", mock.Anything).Return(nil)
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+
+	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
+	defer srv.Close(ctx)
+	require.NoError(t, srv.Open(ctx, m.indexer))
+	require.NoError(t, srv.store.Notify(m.cfg.NodeID, addr))
+
+	require.True(t, tryNTimesWithWait(25, 200*time.Millisecond, srv.store.IsLeader),
+		"node did not become raft leader")
+	require.True(t, tryNTimesWithWait(10, 200*time.Millisecond, srv.Ready),
+		"node did not become ready")
+
+	// generous ceiling for a loaded CI runner; onLeaderFound commits once a leader is found
+	require.True(t, tryNTimesWithWait(75, 200*time.Millisecond, func() bool {
+		return srv.store.ClusterID() != ""
+	}), "leader did not commit a clusterId via real raft within timeout")
+
+	id := srv.store.ClusterID()
+	require.NotEmpty(t, id)
+
+	// Set-once under real raft: another leader commit attempt must not change it.
+	srv.store.maybeCommitClusterID()
+	assert.Equal(t, id, srv.store.ClusterID(),
+		"clusterId must be stable once committed (set-once)")
+}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -961,9 +961,7 @@ func (st *Store) recoverSingleNode(force bool) error {
 func (st *Store) setClusterID(clusterID string) {
 	id := clusterID
 	if !st.clusterID.CompareAndSwap(nil, &id) {
-		st.log.WithFields(logrus.Fields{
-			"existing_cluster_id":  st.ClusterID(),
-			"duplicate_cluster_id": clusterID}).Debug("duplicate cluster-id set, no-op (set-once)")
+		st.log.WithFields(logrus.Fields{"existing_cluster_id": st.ClusterID(), "duplicate_cluster_id": clusterID}).Debug("duplicate cluster-id set, no-op (set-once)")
 	}
 }
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -21,17 +21,20 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/raft"
 	raftbolt "github.com/hashicorp/raft-boltdb/v2"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
+	googleproto "google.golang.org/protobuf/proto"
 
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/cluster/dynusers"
 	"github.com/weaviate/weaviate/cluster/fsm"
 	"github.com/weaviate/weaviate/cluster/log"
+	api "github.com/weaviate/weaviate/cluster/proto/api"
 	rbacRaft "github.com/weaviate/weaviate/cluster/rbac"
 	"github.com/weaviate/weaviate/cluster/replication"
 	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
@@ -252,6 +255,9 @@ type Store struct {
 	authZController authorization.Controller
 
 	metrics *storeMetrics
+
+	// clusterID is the stable UUID committed once per cluster lifetime via raft.
+	clusterID atomic.Pointer[string]
 }
 
 // storeMetrics exposes RAFT store related prometheus metrics
@@ -512,6 +518,10 @@ func (st *Store) onLeaderFound(timeout time.Duration) {
 			} else {
 				st.log.Info("migration from the old schema has been successfully completed")
 			}
+		}
+
+		if st.IsLeader() {
+			st.maybeCommitClusterID()
 		}
 		return
 	}
@@ -944,4 +954,55 @@ func (st *Store) recoverSingleNode(force bool) error {
 	st.schemaManager.ReplaceStatesNodeName(string(newNode.ID))
 
 	return nil
+}
+
+// setClusterID records the cluster identity in memory, set-once (first
+// writer wins; a duplicate from replay or snapshot restore is a logged no-op).
+func (st *Store) setClusterID(clusterID string) {
+	id := clusterID
+	if !st.clusterID.CompareAndSwap(nil, &id) {
+		st.log.WithFields(logrus.Fields{
+			"existing_cluster_id":  st.ClusterID(),
+			"duplicate_cluster_id": clusterID}).Debug("duplicate cluster-id set, no-op (set-once)")
+	}
+}
+
+// ClusterID returns the committed cluster identity, or "" if not yet set.
+func (st *Store) ClusterID() string {
+	if p := st.clusterID.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// maybeCommitClusterID commits a fresh UUID cluster identity via raft if one
+// isn't set yet. Caller must be the raft leader.
+func (st *Store) maybeCommitClusterID() {
+	if st.ClusterID() != "" {
+		return
+	}
+
+	uid, err := uuid.NewV7()
+	if err != nil {
+		// fall back to v4 if the monotonic-random source fails
+		uid = uuid.New()
+	}
+	id := uid.String()
+	req := &api.SetClusterIDRequest{
+		ClusterId: id,
+	}
+	subCmd, err := googleproto.Marshal(req)
+	if err != nil {
+		st.log.WithFields(logrus.Fields{"cluster_id": id}).Warnf("marshal cluster-id set subcommand: %v", err)
+		return
+	}
+	applyReq := &api.ApplyRequest{
+		Type:       api.ApplyRequest_TYPE_CLUSTER_ID_SET,
+		SubCommand: subCmd,
+	}
+	// A new leader may commit a duplicate before replaying the existing entry;
+	// harmless, since applyClusterIDSet is set-once.
+	if _, err := st.Execute(applyReq); err != nil {
+		st.log.WithFields(logrus.Fields{"cluster_id": id}).Warnf("commit cluster-id set command: %v", err)
+	}
 }

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -401,6 +401,10 @@ func (st *Store) Apply(l *raft.Log) any {
 		f = func() {
 			ret.Error = st.distributedTasksManager.CleanUpTask(&cmd)
 		}
+	case api.ApplyRequest_TYPE_CLUSTER_ID_SET:
+		f = func() {
+			ret.Error = st.applyClusterIDSet(&cmd)
+		}
 
 	default:
 		// This could occur when a new command has been introduced in a later app version
@@ -429,4 +433,17 @@ func (st *Store) Apply(l *raft.Log) any {
 
 func (st *Store) numberOfNodesInTheCluster() int {
 	return len(st.raft.GetConfiguration().Configuration().Servers)
+}
+
+// applyClusterIDSet applies a TYPE_CLUSTER_ID_SET log entry, set-once.
+func (st *Store) applyClusterIDSet(cmd *api.ApplyRequest) error {
+	req := &api.SetClusterIDRequest{}
+	if err := proto.Unmarshal(cmd.SubCommand, req); err != nil {
+		return fmt.Errorf("unmarshal cluster-id set command: %w", err)
+	}
+	if req.ClusterId == "" {
+		return fmt.Errorf("empty cluster_id in cluster-id set command")
+	}
+	st.setClusterID(req.ClusterId)
+	return nil
 }

--- a/cluster/store_cluster_id_test.go
+++ b/cluster/store_cluster_id_test.go
@@ -1,0 +1,153 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"encoding/json"
+	"testing"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	googleproto "google.golang.org/protobuf/proto"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/fsm"
+	api "github.com/weaviate/weaviate/cluster/proto/api"
+)
+
+func newStoreForClusterIDTests(t *testing.T) *Store {
+	t.Helper()
+	logger, _ := logrustest.NewNullLogger()
+	return &Store{log: logger}
+}
+
+func buildClusterIDApplyRequest(t *testing.T, clusterID string) *api.ApplyRequest {
+	t.Helper()
+	req := &api.SetClusterIDRequest{
+		ClusterId: clusterID,
+	}
+	b, err := googleproto.Marshal(req)
+	require.NoError(t, err)
+	return &api.ApplyRequest{
+		Type:       api.ApplyRequest_TYPE_CLUSTER_ID_SET,
+		SubCommand: b,
+	}
+}
+
+// TestClusterID_ApplySemantics covers the set-once apply/restore behavior: a
+// sequence of operations against the store and the resulting ClusterID().
+func TestClusterID_ApplySemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		preset  string   // simulate a snapshot restore via setClusterID before applies ("" skips)
+		applies []string // cluster ids applied in order via applyClusterIDSet
+		wantID  string   // expected ClusterID() after all applies
+		wantErr bool     // whether the final apply must return an error
+	}{
+		{
+			name:    "first set wins",
+			applies: []string{"id-A", "id-B"},
+			wantID:  "id-A",
+		},
+		{
+			name:    "idempotent on replay",
+			applies: []string{"replay-id", "replay-id"},
+			wantID:  "replay-id",
+		},
+		{
+			name:    "restore then replay is a no-op",
+			preset:  "original-id",
+			applies: []string{"original-id", "other-id"},
+			wantID:  "original-id",
+		},
+		{
+			name:    "empty cluster_id is rejected",
+			applies: []string{""},
+			wantID:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := newStoreForClusterIDTests(t)
+			if tt.preset != "" {
+				st.setClusterID(tt.preset)
+			}
+
+			var lastErr error
+			for _, id := range tt.applies {
+				lastErr = st.applyClusterIDSet(buildClusterIDApplyRequest(t, id))
+				if !tt.wantErr {
+					require.NoError(t, lastErr)
+				}
+			}
+			if tt.wantErr {
+				require.Error(t, lastErr)
+			}
+			assert.Equal(t, tt.wantID, st.ClusterID())
+		})
+	}
+}
+
+// TestClusterID_SnapshotJSONCompat covers decoding a snapshot into the current
+// fsm.Snapshot struct and restoring the id into the store. The "present" case is
+// produced via json.Marshal so it also exercises the cluster_id encode tag.
+func TestClusterID_SnapshotJSONCompat(t *testing.T) {
+	withID, err := json.Marshal(fsm.Snapshot{NodeID: "node1", ClusterID: "snap-cluster-id"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		snapshotJSON  string
+		wantClusterID string
+	}{
+		{
+			name:          "new snapshot round-trips cluster_id",
+			snapshotJSON:  string(withID),
+			wantClusterID: "snap-cluster-id",
+		},
+		{
+			name:          "old snapshot without cluster_id decodes empty",
+			snapshotJSON:  `{"node_id":"n1","snapshot_id":"s1"}`,
+			wantClusterID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var snap fsm.Snapshot
+			require.NoError(t, json.Unmarshal([]byte(tt.snapshotJSON), &snap))
+			assert.Equal(t, tt.wantClusterID, snap.ClusterID)
+
+			// Restore applies the decoded id set-once into the store.
+			st := newStoreForClusterIDTests(t)
+			if snap.ClusterID != "" {
+				st.setClusterID(snap.ClusterID)
+			}
+			assert.Equal(t, tt.wantClusterID, st.ClusterID())
+		})
+	}
+}
+
+// Kept standalone: it decodes into an OLD struct that lacks the ClusterID field
+// (backward compat — an older binary reading a new snapshot ignores cluster_id),
+// so it doesn't share a shape with the fsm.Snapshot table above.
+func TestClusterID_NewSnapshotToOldStructIgnored(t *testing.T) {
+	newSnap := `{"node_id":"n1","cluster_id":"xyz","cluster_created_at":12345}`
+	type oldSnapshot struct {
+		NodeID string `json:"node_id"`
+	}
+	var old oldSnapshot
+	require.NoError(t, json.Unmarshal([]byte(newSnap), &old))
+	assert.Equal(t, "n1", old.NodeID)
+}

--- a/cluster/store_snapshot.go
+++ b/cluster/store_snapshot.go
@@ -67,6 +67,7 @@ func (s *Store) Persist(sink raft.SnapshotSink) (err error) {
 		DbUsers:          dbUserSnapshot,
 		DistributedTasks: tasksSnapshot,
 		ReplicationOps:   replicationSnapshot,
+		ClusterID:        s.ClusterID(),
 	}
 	if err := json.NewEncoder(sink).Encode(&snap); err != nil {
 		return fmt.Errorf("encode: %w", err)
@@ -166,6 +167,10 @@ func (st *Store) Restore(rc io.ReadCloser) error {
 				st.log.WithError(err).Error("restoring db user from snapshot")
 				return fmt.Errorf("restore db user from snapshot: %w", err)
 			}
+		}
+
+		if snap.ClusterID != "" {
+			st.setClusterID(snap.ClusterID)
 		}
 
 		if st.cfg.MetadataOnlyVoters {

--- a/test/acceptance/telemetry_cluster_id/cluster_id_test.go
+++ b/test/acceptance/telemetry_cluster_id/cluster_id_test.go
@@ -231,4 +231,23 @@ func TestTelemetryClusterID_ThreeNodes(t *testing.T) {
 		t.Logf("clusterId after restarting %s: %s", restarted, after)
 		assert.Equal(t, clusterID, after, "clusterId must be unchanged after a node restart")
 	})
+
+	t.Run("clusterId survives a full cluster restart", func(t *testing.T) {
+		// Cold restart: with every node down, the id can only come back from disk
+		// (snapshot + log replay), and the set-once guard must not re-mint it.
+		timeout := 30 * time.Second
+		for i := 1; i <= len(nodes); i++ {
+			require.NoError(t, compose.StopNode(ctx, i, &timeout))
+		}
+		sink.forget(nodes...)
+		for i := 1; i <= len(nodes); i++ {
+			require.NoError(t, compose.StartNode(ctx, i))
+		}
+
+		for _, n := range nodes {
+			after := sink.waitClusterID(t, n, waitTimeout)
+			t.Logf("clusterId after full restart for %s: %s", n, after)
+			assert.Equal(t, clusterID, after, "clusterId must survive a full cluster restart")
+		}
+	})
 }

--- a/test/acceptance/telemetry_cluster_id/cluster_id_test.go
+++ b/test/acceptance/telemetry_cluster_id/cluster_id_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/usecases/telemetry"
@@ -240,9 +241,15 @@ func TestTelemetryClusterID_ThreeNodes(t *testing.T) {
 			require.NoError(t, compose.StopNode(ctx, i, &timeout))
 		}
 		sink.forget(nodes...)
+
+		// Start concurrently: a 3-node cluster needs quorum to elect a leader before
+		// any node passes its readiness check, so a lone node started first would
+		// hang. Bringing them up together lets quorum re-form.
+		var eg errgroup.Group
 		for i := 1; i <= len(nodes); i++ {
-			require.NoError(t, compose.StartNode(ctx, i))
+			eg.Go(func() error { return compose.StartNode(ctx, i) })
 		}
+		require.NoError(t, eg.Wait())
 
 		for _, n := range nodes {
 			after := sink.waitClusterID(t, n, waitTimeout)

--- a/test/acceptance/telemetry_cluster_id/cluster_id_test.go
+++ b/test/acceptance/telemetry_cluster_id/cluster_id_test.go
@@ -1,0 +1,234 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package telemetry_cluster_id
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/usecases/telemetry"
+)
+
+// telemetrySink records telemetry payloads POSTed by the Weaviate containers.
+// The clusterId is exposed nowhere else, so the payload is the only way to
+// observe it.
+type telemetrySink struct {
+	server *httptest.Server
+	port   int
+
+	mu     sync.Mutex
+	latest map[string]telemetry.Payload
+	total  int
+}
+
+func newTelemetrySink(t *testing.T) *telemetrySink {
+	t.Helper()
+	s := &telemetrySink{latest: make(map[string]telemetry.Payload)}
+
+	// Bind all interfaces (not httptest's default loopback) so containers can
+	// reach the sink through the host-gateway IP.
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	s.port = ln.Addr().(*net.TCPAddr).Port
+
+	s.server = &httptest.Server{
+		Listener: ln,
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			var p telemetry.Payload
+			_ = json.Unmarshal(body, &p)
+			s.mu.Lock()
+			s.total++
+			if p.NodeID != "" {
+				s.latest[p.NodeID] = p
+			}
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusOK) // any non-200 is an error to the pusher
+		})},
+	}
+	s.server.Start()
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+// telemetryURL points Weaviate at this sink; being non-empty, it also stops
+// telemetry.New from ever falling back to the production endpoint.
+func (s *telemetrySink) telemetryURL() string {
+	return fmt.Sprintf("http://host.docker.internal:%d", s.port)
+}
+
+func (s *telemetrySink) received() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.total
+}
+
+func (s *telemetrySink) clusterIDFor(nodeID string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.latest[nodeID]
+	if !ok || p.ClusterID == "" {
+		return "", false
+	}
+	return p.ClusterID, true
+}
+
+func (s *telemetrySink) dump(t *testing.T) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t.Logf("SINK total=%d nodes=%d", s.total, len(s.latest))
+	for id, p := range s.latest {
+		t.Logf("SINK nodeId=%q type=%s clusterId=%q", id, p.Type, p.ClusterID)
+	}
+}
+
+func (s *telemetrySink) forget(nodeIDs ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range nodeIDs {
+		delete(s.latest, id)
+	}
+}
+
+func (s *telemetrySink) waitClusterID(t *testing.T, nodeID string, timeout time.Duration) string {
+	t.Helper()
+	var id string
+	require.Eventuallyf(t, func() bool {
+		got, ok := s.clusterIDFor(nodeID)
+		if ok {
+			id = got
+		}
+		return ok
+	}, timeout, 500*time.Millisecond,
+		"timed out waiting for a non-empty clusterId from node %q", nodeID)
+	return id
+}
+
+func nodeNames(size int) []string {
+	names := make([]string, size)
+	for i := range names {
+		names[i] = fmt.Sprintf("node%d", i+1)
+	}
+	return names
+}
+
+// waitTimeout covers leader election plus a few push intervals: the first push
+// can fire before the leader commits the clusterId, so a later push backfills it.
+const waitTimeout = 90 * time.Second
+
+func TestTelemetryClusterID_SingleNode(t *testing.T) {
+	ctx := context.Background()
+	sink := newTelemetrySink(t)
+
+	compose, err := docker.New().
+		WithWeaviate().
+		WithWeaviateHostGateway().
+		WithWeaviateEnv("TELEMETRY_URL", sink.telemetryURL()).
+		WithWeaviateEnv("TELEMETRY_PUSH_INTERVAL", "2s").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	t.Cleanup(func() { sink.dump(t) })
+
+	const node = "node1"
+
+	var before string
+	t.Run("clusterId is created", func(t *testing.T) {
+		before = sink.waitClusterID(t, node, waitTimeout)
+		require.Positive(t, sink.received(), "redirect took effect; nothing went to the real endpoint")
+		require.NotEmpty(t, before)
+		t.Logf("clusterId before restart: %s", before)
+	})
+
+	t.Run("clusterId is stable across a restart", func(t *testing.T) {
+		timeout := 30 * time.Second
+		require.NoError(t, compose.StopNode(ctx, 1, &timeout))
+		sink.forget(node) // drop the shutdown TERMINATE push; assert only post-restart payloads
+		require.NoError(t, compose.StartNode(ctx, 1))
+
+		after := sink.waitClusterID(t, node, waitTimeout)
+		t.Logf("clusterId after restart:  %s", after)
+		assert.Equal(t, before, after, "clusterId must survive a restart on the same volume")
+	})
+}
+
+func TestTelemetryClusterID_ThreeNodes(t *testing.T) {
+	ctx := context.Background()
+	sink := newTelemetrySink(t)
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateHostGateway().
+		WithWeaviateEnv("TELEMETRY_URL", sink.telemetryURL()).
+		WithWeaviateEnv("TELEMETRY_PUSH_INTERVAL", "2s").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	t.Cleanup(func() { sink.dump(t) })
+
+	nodes := nodeNames(3)
+
+	var clusterID string
+	t.Run("all nodes share one clusterId with distinct nodeIds", func(t *testing.T) {
+		ids := make(map[string]string, len(nodes))
+		for _, n := range nodes {
+			ids[n] = sink.waitClusterID(t, n, waitTimeout)
+			t.Logf("clusterId for %s: %s", n, ids[n])
+		}
+		require.Positive(t, sink.received(), "redirect took effect; nothing went to the real endpoint")
+		require.Len(t, ids, 3)
+
+		clusterID = ids[nodes[0]]
+		for _, n := range nodes {
+			assert.Equal(t, clusterID, ids[n], "all nodes must share the same cluster-wide clusterId")
+		}
+	})
+
+	t.Run("clusterId is unchanged after restarting a node", func(t *testing.T) {
+		const restarted = "node2"
+		timeout := 30 * time.Second
+		require.NoError(t, compose.StopNode(ctx, 2, &timeout))
+		sink.forget(restarted)
+		require.NoError(t, compose.StartNode(ctx, 2))
+
+		after := sink.waitClusterID(t, restarted, waitTimeout)
+		t.Logf("clusterId after restarting %s: %s", restarted, after)
+		assert.Equal(t, clusterID, after, "clusterId must be unchanged after a node restart")
+	})
+}

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -158,6 +158,7 @@ type Compose struct {
 	weaviateEnvs                   map[string]string
 	removeEnvs                     map[string]struct{}
 	weaviateFiles                  []testcontainers.ContainerFile
+	weaviateHostGateway            bool
 }
 
 func New() *Compose {
@@ -603,6 +604,19 @@ func (d *Compose) WithWeaviateEnv(name, value string) *Compose {
 	return d
 }
 
+// WithWeaviateHostGateway adds a "host.docker.internal:host-gateway" entry to
+// every Weaviate container, letting container-side clients (e.g. the telemetry
+// pusher via TELEMETRY_URL) reach a server bound on the test host. Opt-in, so
+// existing tests are unaffected.
+//
+// Unlike testcontainers HostAccessPorts (which starts a per-container sshd
+// sidecar torn down on Stop), this is a plain extra-host entry that survives
+// container Stop/Start, so it works with the restart-based tests.
+func (d *Compose) WithWeaviateHostGateway() *Compose {
+	d.weaviateHostGateway = true
+	return d
+}
+
 // WithWeaviateFiles copies the given files into each Weaviate container
 // before it starts. Useful for injecting configuration files such as runtime
 // override YAML.
@@ -692,7 +706,16 @@ func (d *Compose) WithAutoschema() *Compose {
 }
 
 func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
-	d.weaviateEnvs["DISABLE_TELEMETRY"] = "true"
+	// Telemetry is off by default so nothing reaches the real endpoint. Setting
+	// TELEMETRY_URL opts in and redirects every payload to that sink. An explicit
+	// DISABLE_TELEMETRY (either value) always wins.
+	if _, ok := d.weaviateEnvs["DISABLE_TELEMETRY"]; !ok {
+		if d.weaviateEnvs["TELEMETRY_URL"] != "" {
+			d.weaviateEnvs["DISABLE_TELEMETRY"] = "false"
+		} else {
+			d.weaviateEnvs["DISABLE_TELEMETRY"] = "true"
+		}
+	}
 	network, err := tescontainersnetwork.New(
 		ctx,
 		tescontainersnetwork.WithAttachable(),
@@ -938,7 +961,7 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 		delete(secondWeaviateSettings, "RAFT_PORT")
 		delete(secondWeaviateSettings, "RAFT_INTERNAL_PORT")
 		delete(secondWeaviateSettings, "RAFT_JOIN")
-		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, "/v1/.well-known/ready", d.weaviateFiles)
+		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, "/v1/.well-known/ready", d.weaviateFiles, d.weaviateHostGateway)
 		if err != nil {
 			return nil, errors.Wrapf(err, "start %s", hostname)
 		}
@@ -986,7 +1009,10 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	cs := make([]*DockerContainer, size)
 	image := os.Getenv(envTestWeaviateImage)
 	networkName := settings["network"]
-	settings["DISABLE_TELEMETRY"] = "true"
+	// Start already resolves DISABLE_TELEMETRY; default it only if unset.
+	if _, ok := settings["DISABLE_TELEMETRY"]; !ok {
+		settings["DISABLE_TELEMETRY"] = "true"
+	}
 	settings["DEBUG_ENDPOINTS_ENABLED"] = "true"
 	if d.withWeaviateBasicAuth {
 		settings["CLUSTER_BASIC_AUTH_USERNAME"] = d.withWeaviateBasicAuthUsername
@@ -1074,7 +1100,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	}
 	eg.Go(func() (err error) {
 		cs[0], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
-			config1, networkName, image, Weaviate1, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, wellKnownEndpointFunc("node1"), d.weaviateFiles)
+			config1, networkName, image, Weaviate1, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, wellKnownEndpointFunc("node1"), d.weaviateFiles, d.weaviateHostGateway)
 		if err != nil {
 			return errors.Wrapf(err, "start %s", Weaviate1)
 		}
@@ -1090,7 +1116,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		eg.Go(func() (err error) {
 			time.Sleep(time.Second * 10) // node1 needs to be up before we can start this node
 			cs[1], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
-				config2, networkName, image, Weaviate2, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, wellKnownEndpointFunc("node2"), d.weaviateFiles)
+				config2, networkName, image, Weaviate2, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, wellKnownEndpointFunc("node2"), d.weaviateFiles, d.weaviateHostGateway)
 			if err != nil {
 				return errors.Wrapf(err, "start %s", Weaviate2)
 			}
@@ -1107,7 +1133,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 		eg.Go(func() (err error) {
 			time.Sleep(time.Second * 10) // node1 needs to be up before we can start this node
 			cs[2], err = startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
-				config3, networkName, image, Weaviate3, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, wellKnownEndpointFunc("node3"), d.weaviateFiles)
+				config3, networkName, image, Weaviate3, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, wellKnownEndpointFunc("node3"), d.weaviateFiles, d.weaviateHostGateway)
 			if err != nil {
 				return errors.Wrapf(err, "start %s", Weaviate3)
 			}

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -40,6 +41,7 @@ func startWeaviate(ctx context.Context,
 	exposeGRPCPort, exposeDebugPort bool,
 	wellKnownEndpoint string,
 	files []testcontainers.ContainerFile,
+	hostGateway bool,
 ) (*DockerContainer, error) {
 	fromDockerFile := testcontainers.FromDockerfile{}
 	if len(weaviateImage) == 0 {
@@ -167,6 +169,14 @@ func startWeaviate(ctx context.Context,
 				},
 			},
 		},
+	}
+	if hostGateway {
+		// Map host.docker.internal to the host gateway so container-side clients
+		// can reach a server on the test host. A plain extra-host entry, so it
+		// survives container Stop/Start (unlike testcontainers HostAccessPorts).
+		req.HostConfigModifier = func(hc *container.HostConfig) {
+			hc.ExtraHosts = append(hc.ExtraHosts, "host.docker.internal:host-gateway")
+		}
 	}
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/usecases/telemetry/curated_fields_test.go
+++ b/usecases/telemetry/curated_fields_test.go
@@ -1,0 +1,215 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+)
+
+func ptrTo[T any](v T) *T { return &v }
+
+func TestCuratedFields_Extraction(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := schemaUC.NewMockSchemaGetter(t)
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{NodeID: "node-abc", AsyncIndexingEnabled: true, ClusterID: func() string { return "00000000-0000-7000-0000-0000000000aa" }})
+
+	sm.EXPECT().Nodes().Return([]string{"n1", "n2", "n3"}).Maybe()
+	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
+		&models.NodeStatus{Stats: &models.NodeStats{ObjectCount: 0}},
+	)
+
+	classes := []*models.Class{
+		{
+			Class:              "A",
+			VectorIndexType:    "hnsw",
+			ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: false},
+		},
+		{
+			Class:              "B",
+			VectorIndexType:    "flat",
+			ReplicationConfig:  &models.ReplicationConfig{Factor: 1},
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		},
+		{
+			Class:              "C",
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+			VectorConfig: map[string]models.VectorConfig{
+				"v1": {VectorIndexType: "dynamic"},
+				"v2": {VectorIndexType: "flat"},
+			},
+		},
+	}
+
+	sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{
+		Objects: &models.Schema{Classes: classes},
+	}).Maybe()
+
+	payload, err := tel.buildPayload(context.Background(), PayloadType.Init)
+	require.NoError(t, err)
+
+	require.NotNil(t, payload.NodeCount)
+	assert.Equal(t, 3, *payload.NodeCount)
+	require.NotNil(t, payload.MaxReplicationFactor)
+	assert.Equal(t, 3, *payload.MaxReplicationFactor)
+	require.NotNil(t, payload.ReplicationEnabled)
+	assert.True(t, *payload.ReplicationEnabled, "RF>1 → replicationEnabled=true")
+	require.NotNil(t, payload.MTCollectionCount)
+	assert.Equal(t, 2, *payload.MTCollectionCount)
+	require.NotNil(t, payload.NamedVectorCollectionCount)
+	assert.Equal(t, 1, *payload.NamedVectorCollectionCount, "only class C has VectorConfig")
+	require.NotNil(t, payload.AsyncIndexingEnabled)
+	assert.True(t, *payload.AsyncIndexingEnabled)
+	require.NotNil(t, payload.VectorIndexTypeCounts)
+	// class A → hnsw, class B → flat, class C → dynamic(1)+flat(1)
+	assert.Equal(t, 1, payload.VectorIndexTypeCounts["hnsw"])
+	assert.Equal(t, 2, payload.VectorIndexTypeCounts["flat"])
+	assert.Equal(t, 1, payload.VectorIndexTypeCounts["dynamic"])
+}
+
+func TestUsedModules_NilModuleConfigFallback(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := schemaUC.NewMockSchemaGetter(t)
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{ClusterID: func() string { return "" }})
+
+	classes := []*models.Class{
+		{
+			Class:        "WithVectorizer",
+			ModuleConfig: nil,
+			Vectorizer:   "text2vec-openai",
+		},
+		{
+			Class:        "BYOV",
+			ModuleConfig: nil,
+			Vectorizer:   "none",
+		},
+		{
+			Class:        "EmptyVectorizer",
+			ModuleConfig: nil,
+			Vectorizer:   "",
+		},
+		{
+			Class: "ProperlyConfigured",
+			ModuleConfig: map[string]interface{}{
+				"text2vec-cohere": map[string]interface{}{},
+			},
+			Vectorizer: "text2vec-cohere",
+		},
+	}
+
+	sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{
+		Objects: &models.Schema{Classes: classes},
+	}).Maybe()
+
+	modules, err := tel.getUsedModules()
+	require.NoError(t, err)
+	assert.Contains(t, modules, "text2vec-openai", "fallback must add vectorizer when ModuleConfig is nil")
+	assert.Contains(t, modules, "text2vec-cohere", "properly-configured class unchanged")
+	assert.NotContains(t, modules, "none", "BYOV vectorizer 'none' must not appear")
+	assert.NotContains(t, modules, "", "empty vectorizer must not appear")
+}
+
+func TestCuratedFields_NodeCount(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := schemaUC.NewMockSchemaGetter(t)
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{ClusterID: func() string { return "" }})
+
+	sm.EXPECT().Nodes().Return([]string{"a", "b"}).Maybe()
+	sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
+	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
+		&models.NodeStatus{Stats: &models.NodeStats{}},
+	)
+
+	payload, err := tel.buildPayload(context.Background(), PayloadType.Init)
+	require.NoError(t, err)
+	require.NotNil(t, payload.NodeCount)
+	assert.Equal(t, 2, *payload.NodeCount)
+}
+
+// Pointer fields serialize a measured zero/false instead of being dropped by
+// omitempty; nil means unmeasured.
+func TestPayload_PointerSemantics_JSON(t *testing.T) {
+	t.Run("measured zero/false serialize", func(t *testing.T) {
+		p := Payload{
+			NodeCount:                  ptrTo(0),
+			MaxReplicationFactor:       ptrTo(0),
+			ReplicationEnabled:         ptrTo(false),
+			MTCollectionCount:          ptrTo(0),
+			NamedVectorCollectionCount: ptrTo(0),
+			AsyncIndexingEnabled:       ptrTo(false),
+		}
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		s := string(b)
+
+		assert.Contains(t, s, `"nodeCount":0`)
+		assert.Contains(t, s, `"maxReplicationFactor":0`)
+		assert.Contains(t, s, `"replicationEnabled":false`)
+		assert.Contains(t, s, `"mtCollectionCount":0`)
+		assert.Contains(t, s, `"namedVectorCollectionCount":0`)
+		assert.Contains(t, s, `"asyncIndexingEnabled":false`)
+	})
+
+	t.Run("nil curated fields omitted; measured field present", func(t *testing.T) {
+		p := Payload{
+			ClusterID: "00000000-0000-7000-0000-000000000001",
+			NodeCount: ptrTo(3),
+		}
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		s := string(b)
+
+		assert.Contains(t, s, `"clusterId":"00000000-0000-7000-0000-000000000001"`)
+		assert.Contains(t, s, `"nodeCount":3`)
+		assert.NotContains(t, s, "replicationEnabled")
+		assert.NotContains(t, s, "asyncIndexingEnabled")
+		assert.NotContains(t, s, "mtCollectionCount")
+	})
+}
+
+func TestCuratedFields_DefaultVectorIndexType(t *testing.T) {
+	sg := &fakeNodesStatusGetter{}
+	sm := schemaUC.NewMockSchemaGetter(t)
+	logger, _ := test.NewNullLogger()
+	tel := New(sg, sm, logger, Config{ClusterID: func() string { return "" }})
+
+	sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{Class: "X", VectorIndexType: ""},
+			},
+		},
+	}).Maybe()
+	sm.EXPECT().Nodes().Return([]string{"node1"}).Maybe()
+	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
+		&models.NodeStatus{Stats: &models.NodeStats{}},
+	)
+
+	payload, err := tel.buildPayload(context.Background(), PayloadType.Init)
+	require.NoError(t, err)
+	require.NotNil(t, payload.VectorIndexTypeCounts)
+	assert.Equal(t, 1, payload.VectorIndexTypeCounts["hnsw"], "empty VectorIndexType defaults to hnsw")
+	assert.Equal(t, 0, payload.VectorIndexTypeCounts[""])
+}

--- a/usecases/telemetry/fakes_for_test.go
+++ b/usecases/telemetry/fakes_for_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 )
 
 type fakeNodesStatusGetter struct {
@@ -31,20 +30,6 @@ func (n *fakeNodesStatusGetter) LocalNodeStatus(ctx context.Context,
 		return args.Get(0).(*models.NodeStatus)
 	}
 	return nil
-}
-
-type fakeSchemaManager struct {
-	mock.Mock
-}
-
-func (f *fakeSchemaManager) GetSchemaSkipAuth() schema.Schema {
-	if len(f.ExpectedCalls) > 0 {
-		args := f.Called()
-		if args.Get(0) != nil {
-			return args.Get(0).(schema.Schema)
-		}
-	}
-	return schema.Schema{}
 }
 
 type fakeCloudInfoProvider struct {

--- a/usecases/telemetry/payload.go
+++ b/usecases/telemetry/payload.go
@@ -39,4 +39,19 @@ type Payload struct {
 	ClientUsage      map[ClientType]map[string]int64 `json:"clientUsage,omitempty"`
 	CloudProvider    *string                         `json:"cloudProvider,omitempty"`
 	UniqueID         *string                         `json:"uniqueID,omitempty"`
+
+	// NodeID is CLUSTER_HOSTNAME (the raft node name): a stable per-node identity.
+	NodeID string `json:"nodeId,omitempty"`
+	// ClusterID is the UUID committed once per cluster lifetime via raft.
+	ClusterID string `json:"clusterId,omitempty"`
+
+	// Pointers so a measured zero/false serializes instead of being dropped by
+	// omitempty; nil means unmeasured.
+	NodeCount                  *int           `json:"nodeCount,omitempty"`
+	MaxReplicationFactor       *int           `json:"maxReplicationFactor,omitempty"`
+	ReplicationEnabled         *bool          `json:"replicationEnabled,omitempty"`
+	MTCollectionCount          *int           `json:"mtCollectionCount,omitempty"`
+	NamedVectorCollectionCount *int           `json:"namedVectorCollectionCount,omitempty"`
+	AsyncIndexingEnabled       *bool          `json:"asyncIndexingEnabled,omitempty"`
+	VectorIndexTypeCounts      map[string]int `json:"vectorIndexTypeCounts,omitempty"`
 }

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -13,6 +13,7 @@ package telemetry
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -27,11 +28,12 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/schema"
 )
 
 const (
@@ -44,15 +46,11 @@ type nodesStatusGetter interface {
 	LocalNodeStatus(ctx context.Context, className, shardName, output string) *models.NodeStatus
 }
 
-type schemaManager interface {
-	GetSchemaSkipAuth() schema.Schema
-}
-
 // Telemeter is responsible for managing the transmission of telemetry data
 type Telemeter struct {
 	machineID         strfmt.UUID
 	nodesStatusGetter nodesStatusGetter
-	schemaManager     schemaManager
+	schemaManager     schema.SchemaGetter
 	logger            logrus.FieldLogger
 	shutdown          chan struct{}
 	failedToStart     bool
@@ -60,32 +58,50 @@ type Telemeter struct {
 	pushInterval      time.Duration
 	clientTracker     *ClientTracker
 	cloudInfoHelper   *cloudInfoHelper
+
+	// nodeID is CLUSTER_HOSTNAME (the raft node name): a stable per-node identity.
+	nodeID string
+	// clusterID is the raft-committed cluster identity, read on every push.
+	clusterID            func() string
+	asyncIndexingEnabled bool
+}
+
+// Config holds the scalar settings for a Telemeter.
+type Config struct {
+	// ConsumerURL is base64-encoded. If empty, DefaultTelemetryConsumerURL is used.
+	ConsumerURL string
+	// PushInterval defaults to DefaultTelemetryPushInterval if zero.
+	PushInterval time.Duration
+	// Enabled gates whether usage trackers spin up and payloads are pushed.
+	Enabled bool
+	// NodeID is CLUSTER_HOSTNAME (the raft node name): a stable per-node identity.
+	NodeID string
+	// AsyncIndexingEnabled is wired from server config.
+	AsyncIndexingEnabled bool
+	// ClusterID returns the UUID committed once per cluster lifetime via raft. It is
+	// called on every push and MUST be non-nil (return "" until the id is committed).
+	ClusterID func() string
 }
 
 // New creates a new Telemeter instance.
-// consumerURL should be base64-encoded. If empty, uses DefaultTelemetryConsumerURL.
-// pushInterval defaults to DefaultTelemetryPushInterval if zero.
-func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
-	logger logrus.FieldLogger, consumerURL string, pushInterval time.Duration,
-	telemetryEnabled bool,
-) *Telemeter {
-	if consumerURL == "" {
-		consumerURL = DefaultTelemetryConsumerURL
-	}
-	if pushInterval == 0 {
-		pushInterval = DefaultTelemetryPushInterval
-	}
+func New(nodesStatusGetter nodesStatusGetter, schemaManager schema.SchemaGetter, logger logrus.FieldLogger, cfg Config) *Telemeter {
+	consumerURL := cmp.Or(cfg.ConsumerURL, DefaultTelemetryConsumerURL)
+	pushInterval := cmp.Or(cfg.PushInterval, DefaultTelemetryPushInterval)
 
 	tel := &Telemeter{
-		machineID:         strfmt.UUID(uuid.NewString()),
-		nodesStatusGetter: nodesStatusGetter,
-		schemaManager:     schemaManager,
-		logger:            logger,
-		shutdown:          make(chan struct{}),
-		consumer:          consumerURL,
-		pushInterval:      pushInterval,
-		clientTracker:     NewClientTracker(logger),
-		cloudInfoHelper:   newCloudInfoHelper(logger, telemetryEnabled),
+		// machineID is a fresh UUID per process, distinct from nodeID.
+		machineID:            strfmt.UUID(uuid.NewString()),
+		nodesStatusGetter:    nodesStatusGetter,
+		schemaManager:        schemaManager,
+		logger:               logger,
+		shutdown:             make(chan struct{}),
+		consumer:             consumerURL,
+		pushInterval:         pushInterval,
+		clientTracker:        NewClientTracker(logger),
+		cloudInfoHelper:      newCloudInfoHelper(logger, cfg.Enabled),
+		nodeID:               cfg.NodeID,
+		asyncIndexingEnabled: cfg.AsyncIndexingEnabled,
+		clusterID:            cfg.ClusterID,
 	}
 	return tel
 }
@@ -234,19 +250,103 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 
 	cloudProvider, uniqueID := tel.getCloudInfo()
 
+	cf := tel.curatedFields()
+	asyncIndexing := tel.asyncIndexingEnabled
+
 	return &Payload{
-		MachineID:        tel.machineID,
-		Type:             payloadType,
-		Version:          config.ServerVersion,
-		ObjectsCount:     objs,
-		OS:               runtime.GOOS,
-		Arch:             runtime.GOARCH,
-		UsedModules:      usedMods,
-		CollectionsCount: cols,
-		ClientUsage:      clientUsage,
-		CloudProvider:    cloudProvider,
-		UniqueID:         uniqueID,
+		MachineID:                  tel.machineID,
+		Type:                       payloadType,
+		Version:                    config.ServerVersion,
+		ObjectsCount:               objs,
+		OS:                         runtime.GOOS,
+		Arch:                       runtime.GOARCH,
+		UsedModules:                usedMods,
+		CollectionsCount:           cols,
+		ClientUsage:                clientUsage,
+		CloudProvider:              cloudProvider,
+		UniqueID:                   uniqueID,
+		NodeID:                     tel.nodeID,
+		ClusterID:                  tel.clusterID(),
+		NodeCount:                  &cf.nodeCount,
+		MaxReplicationFactor:       &cf.maxReplicationFactor,
+		ReplicationEnabled:         &cf.replicationEnabled,
+		MTCollectionCount:          &cf.mtCollectionCount,
+		NamedVectorCollectionCount: &cf.namedVectorCount,
+		AsyncIndexingEnabled:       &asyncIndexing,
+		VectorIndexTypeCounts:      cf.vectorIndexTypeCounts,
 	}, nil
+}
+
+// curatedFields holds the schema-derived telemetry signal fields.
+type curatedFields struct {
+	nodeCount             int
+	maxReplicationFactor  int
+	replicationEnabled    bool
+	mtCollectionCount     int
+	namedVectorCount      int
+	vectorIndexTypeCounts map[string]int
+}
+
+// curatedFields extracts the schema-derived signal fields in a single schema pass.
+func (tel *Telemeter) curatedFields() curatedFields {
+	cf := curatedFields{nodeCount: len(tel.schemaManager.Nodes())}
+
+	sch := tel.schemaManager.GetSchemaSkipAuth()
+	if sch.Objects == nil {
+		return cf
+	}
+
+	counts := make(map[string]int)
+	for _, class := range sch.Objects.Classes {
+		if class == nil {
+			continue
+		}
+		if rf := replicationFactor(class); rf > cf.maxReplicationFactor {
+			cf.maxReplicationFactor = rf
+		}
+		if class.MultiTenancyConfig != nil && class.MultiTenancyConfig.Enabled {
+			cf.mtCollectionCount++
+		}
+		if countVectorIndexTypes(class, counts) {
+			cf.namedVectorCount++
+		}
+	}
+
+	cf.replicationEnabled = cf.maxReplicationFactor > 1
+	if len(counts) > 0 {
+		cf.vectorIndexTypeCounts = counts
+	}
+	return cf
+}
+
+// replicationFactor returns the class replication factor, or 0 if unset.
+func replicationFactor(class *models.Class) int {
+	if class.ReplicationConfig == nil {
+		return 0
+	}
+	return int(class.ReplicationConfig.Factor)
+}
+
+// countVectorIndexTypes records the vector index type(s) for one class into counts
+// (defaulting "" to "hnsw") and reports whether the class uses named vectors.
+func countVectorIndexTypes(class *models.Class, counts map[string]int) (named bool) {
+	if len(class.VectorConfig) > 0 {
+		for _, vc := range class.VectorConfig {
+			counts[orHNSW(vc.VectorIndexType)]++
+		}
+		return true
+	}
+	// legacy single-vector: read from class-level VectorIndexType
+	counts[orHNSW(class.VectorIndexType)]++
+	return false
+}
+
+// orHNSW maps an empty vector index type to the "hnsw" default.
+func orHNSW(vectorIndexType string) string {
+	if vectorIndexType == "" {
+		return "hnsw"
+	}
+	return vectorIndexType
 }
 
 func (tel *Telemeter) getUsedModules() ([]string, error) {
@@ -255,10 +355,17 @@ func (tel *Telemeter) getUsedModules() ([]string, error) {
 
 	if sch.Objects != nil {
 		for _, class := range sch.Objects.Classes {
+			if class == nil {
+				continue
+			}
 			if modCfg, ok := class.ModuleConfig.(map[string]interface{}); ok {
 				for name, cfg := range modCfg {
 					usedModulesMap[tel.determineModule(name, cfg)] = struct{}{}
 				}
+			} else if class.Vectorizer != "" && class.Vectorizer != "none" {
+				// Fallback for classes with nil ModuleConfig but a set class-level
+				// Vectorizer (pre-v1.14 schemas). "none" (BYOV) is excluded - not a module.
+				usedModulesMap[class.Vectorizer] = struct{}{}
 			}
 			for _, vectorConfig := range class.VectorConfig {
 				if modCfg, ok := vectorConfig.Vectorizer.(map[string]interface{}); ok {

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -31,19 +31,20 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/usecases/config"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
 func TestTelemetry_BuildPayload(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		t.Run("on init", func(t *testing.T) {
-			tel, sg, sm, ci := newTestTelemeterWithCloudInfo()
+			tel, sg, sm, ci := newTestTelemeterWithCloudInfo(t)
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
 						ObjectCount: 100,
 					},
 				})
-			sm.On("GetSchemaSkipAuth").Return(
+			sm.EXPECT().GetSchemaSkipAuth().Return(
 				schema.Schema{
 					Objects: &models.Schema{Classes: []*models.Class{
 						{
@@ -151,14 +152,14 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 		})
 
 		t.Run("on update", func(t *testing.T) {
-			tel, sg, sm, ci := newTestTelemeterWithCloudInfo()
+			tel, sg, sm, ci := newTestTelemeterWithCloudInfo(t)
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
 						ObjectCount: 1000,
 					},
 				})
-			sm.On("GetSchemaSkipAuth").Return(
+			sm.EXPECT().GetSchemaSkipAuth().Return(
 				schema.Schema{
 					Objects: &models.Schema{Classes: []*models.Class{
 						{
@@ -232,7 +233,8 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 		})
 
 		t.Run("on terminate", func(t *testing.T) {
-			tel, sg, _, ci := newTestTelemeterWithCloudInfo()
+			tel, sg, sm, ci := newTestTelemeterWithCloudInfo(t)
+			sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
@@ -268,14 +270,14 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 		})
 
 		t.Run("on update with no client usage", func(t *testing.T) {
-			tel, sg, sm := newTestTelemeter()
+			tel, sg, sm := newTestTelemeter(t)
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
 						ObjectCount: 1000,
 					},
 				})
-			sm.On("GetSchemaSkipAuth").Return(
+			sm.EXPECT().GetSchemaSkipAuth().Return(
 				schema.Schema{
 					Objects: &models.Schema{Classes: []*models.Class{}},
 				})
@@ -289,7 +291,8 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 
 	t.Run("failure path", func(t *testing.T) {
 		t.Run("fail to get node status", func(t *testing.T) {
-			tel, sg, _ := newTestTelemeter()
+			tel, sg, sm := newTestTelemeter(t)
+			sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(nil)
 			payload, err := tel.buildPayload(context.Background(), PayloadType.Terminate)
 			assert.Nil(t, payload)
@@ -298,7 +301,8 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 		})
 
 		t.Run("fail to get node status stats", func(t *testing.T) {
-			tel, sg, _ := newTestTelemeter()
+			tel, sg, sm := newTestTelemeter(t)
+			sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(&models.NodeStatus{})
 			payload, err := tel.buildPayload(context.Background(), PayloadType.Terminate)
 			assert.Nil(t, payload)
@@ -329,7 +333,7 @@ func TestTelemetry_WithConsumer(t *testing.T) {
 		withConsumerURL(consumerURL),
 		withPushInterval(100 * time.Millisecond),
 	}
-	tel, sg, sm := newTestTelemeter(opts...)
+	tel, sg, sm := newTestTelemeter(t, opts...)
 
 	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 		&models.NodeStatus{
@@ -338,7 +342,7 @@ func TestTelemetry_WithConsumer(t *testing.T) {
 			},
 		})
 
-	sm.On("GetSchemaSkipAuth").Return(
+	sm.EXPECT().GetSchemaSkipAuth().Return(
 		schema.Schema{
 			Objects: &models.Schema{Classes: []*models.Class{
 				{
@@ -438,14 +442,14 @@ func TestTelemetry_WithConsumer(t *testing.T) {
 
 func TestTelemetry_BuildPayload_WithCloudInfo(t *testing.T) {
 	t.Run("on init with cloud info present", func(t *testing.T) {
-		tel, sg, sm, ci := newTestTelemeterWithCloudInfo()
+		tel, sg, sm, ci := newTestTelemeterWithCloudInfo(t)
 		sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 			&models.NodeStatus{
 				Stats: &models.NodeStats{
 					ObjectCount: 100,
 				},
 			})
-		sm.On("GetSchemaSkipAuth").Return(
+		sm.EXPECT().GetSchemaSkipAuth().Return(
 			schema.Schema{
 				Objects: &models.Schema{Classes: []*models.Class{
 					{
@@ -478,7 +482,8 @@ func TestTelemetry_BuildPayload_WithCloudInfo(t *testing.T) {
 	})
 
 	t.Run("on update with only cloud provider present", func(t *testing.T) {
-		tel, sg, _, ci := newTestTelemeterWithCloudInfo()
+		tel, sg, sm, ci := newTestTelemeterWithCloudInfo(t)
+		sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
 		sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 			&models.NodeStatus{
 				Stats: &models.NodeStats{
@@ -503,7 +508,8 @@ func TestTelemetry_BuildPayload_WithCloudInfo(t *testing.T) {
 	})
 
 	t.Run("on terminate with empty cloud info", func(t *testing.T) {
-		tel, sg, _, ci := newTestTelemeterWithCloudInfo()
+		tel, sg, sm, ci := newTestTelemeterWithCloudInfo(t)
+		sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
 		sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 			&models.NodeStatus{
 				Stats: &models.NodeStats{
@@ -530,7 +536,8 @@ func TestTelemetry_BuildPayload_WithCloudInfo(t *testing.T) {
 func TestTelemetry_WithCloudInfoConsumer_GCP(t *testing.T) {
 	server := httptest.NewServer(&gcpTestConsumer{t})
 	defer server.Close()
-	tel, sg, _ := newTestTelemeterWithCustomCloudInfo(newGCPCloudInfo(server.URL))
+	tel, sg, sm := newTestTelemeterWithCustomCloudInfo(t, newGCPCloudInfo(server.URL))
+	sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
 
 	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 		&models.NodeStatus{
@@ -557,7 +564,8 @@ func TestTelemetry_WithCloudInfoConsumer_GCP(t *testing.T) {
 func TestTelemetry_WithCloudInfoConsumer_AWS(t *testing.T) {
 	server := httptest.NewServer(&awsTestConsumer{t})
 	defer server.Close()
-	tel, sg, _ := newTestTelemeterWithCustomCloudInfo(newAWSCloudInfo(server.URL))
+	tel, sg, sm := newTestTelemeterWithCustomCloudInfo(t, newAWSCloudInfo(server.URL))
+	sm.EXPECT().GetSchemaSkipAuth().Return(schema.Schema{}).Maybe()
 
 	sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 		&models.NodeStatus{
@@ -596,33 +604,39 @@ func withPushInterval(interval time.Duration) telemetryOpt {
 	}
 }
 
-func newTestTelemeter(opts ...telemetryOpt,
-) (*Telemeter, *fakeNodesStatusGetter, *fakeSchemaManager,
+func newTestTelemeter(t *testing.T, opts ...telemetryOpt,
+) (*Telemeter, *fakeNodesStatusGetter, *schemaUC.MockSchemaGetter,
 ) {
 	sg := &fakeNodesStatusGetter{}
-	sm := &fakeSchemaManager{}
+	sm := schemaUC.NewMockSchemaGetter(t)
+	// Mirror the previous hand-written fake's default: a single node unless a
+	// test overrides it, so nodeCount assertions stay at 1 by default.
+	sm.EXPECT().Nodes().Return([]string{"node1"}).Maybe()
 	logger, _ := test.NewNullLogger()
-	// Pass empty url/duration to use defaults
-	tel := New(sg, sm, logger, "", 0, false)
+	// stubClusterID returns a fixed id so payloads carry clusterId in tests.
+	stubClusterID := func() string {
+		return "00000000-0000-7000-0000-000000000001"
+	}
+	tel := New(sg, sm, logger, Config{ClusterID: stubClusterID})
 	for _, opt := range opts {
 		opt(tel)
 	}
 	return tel, sg, sm
 }
 
-func newTestTelemeterWithCloudInfo(opts ...telemetryOpt,
-) (*Telemeter, *fakeNodesStatusGetter, *fakeSchemaManager, *fakeCloudInfoProvider,
+func newTestTelemeterWithCloudInfo(t *testing.T, opts ...telemetryOpt,
+) (*Telemeter, *fakeNodesStatusGetter, *schemaUC.MockSchemaGetter, *fakeCloudInfoProvider,
 ) {
-	tel, sg, sm := newTestTelemeter(opts...)
+	tel, sg, sm := newTestTelemeter(t, opts...)
 	ci := &fakeCloudInfoProvider{}
 	tel.cloudInfoHelper = &cloudInfoHelper{provider: ci}
 	return tel, sg, sm, ci
 }
 
-func newTestTelemeterWithCustomCloudInfo(ci cloudInfoProvider, opts ...telemetryOpt,
-) (*Telemeter, *fakeNodesStatusGetter, *fakeSchemaManager,
+func newTestTelemeterWithCustomCloudInfo(t *testing.T, ci cloudInfoProvider, opts ...telemetryOpt,
+) (*Telemeter, *fakeNodesStatusGetter, *schemaUC.MockSchemaGetter,
 ) {
-	tel, sg, sm := newTestTelemeter(opts...)
+	tel, sg, sm := newTestTelemeter(t, opts...)
 	tel.cloudInfoHelper = &cloudInfoHelper{provider: ci}
 	return tel, sg, sm
 }


### PR DESCRIPTION
### What's being changed:
OSS telemetry could not be correlated across restarts: the payload was keyed on a per-process machineId, so every restart looked like a brand-new deployment. Add two stable identities plus a curated set of schema signals.

This PR adds the cluster id and some other fields of configs to telemetry
replacement for this https://github.com/weaviate/weaviate/pull/11897
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
