### PR TITLE
Reduce allocations for auto schema time/uuid parsing

### DIFF
--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -214,17 +214,38 @@ func (m *AutoSchemaManager) getDataTypes(dataTypes []schema.DataType) []string {
 	return dtypes
 }
 
+// couldBeRFC3339 reports whether s has the shape of an RFC3339 timestamp: '-' at
+// 4 and 7, 'T'/'t' at 10, length >= len("2006-01-02T15:04:05Z"). Necessary
+// condition only — it must never reject a value time.Parse would accept.
+func couldBeRFC3339(s string) bool {
+	return len(s) >= 20 && s[4] == '-' && s[7] == '-' && (s[10] == 'T' || s[10] == 't')
+}
+
+// couldBeUUID reports whether s has a length uuid.Parse could accept: 32 (no
+// hyphens) to 45 (urn:uuid: prefixed). Necessary condition only — it must never
+// reject a valid UUID.
+func couldBeUUID(s string) bool {
+	return len(s) >= 32 && len(s) <= 45
+}
+
 func (m *AutoSchemaManager) determineType(value interface{}, ofNestedProp bool) ([]schema.DataType, error) {
 	fallbackDataType := []schema.DataType{schema.DataTypeText}
 	fallbackArrayDataType := []schema.DataType{schema.DataTypeTextArray}
 
 	switch typedValue := value.(type) {
 	case string:
-		if _, err := time.Parse(time.RFC3339, typedValue); err == nil {
-			return []schema.DataType{schema.DataType(m.config.DefaultDate)}, nil
+		// Guard the parses: on the common non-date/non-uuid string, time.Parse and
+		// uuid.Parse clone the input into a discarded error on failure, the dominant
+		// auto-schema allocation. The shape checks skip that for values that cannot match.
+		if couldBeRFC3339(typedValue) {
+			if _, err := time.Parse(time.RFC3339, typedValue); err == nil {
+				return []schema.DataType{schema.DataType(m.config.DefaultDate)}, nil
+			}
 		}
-		if _, err := uuid.Parse(typedValue); err == nil {
-			return []schema.DataType{schema.DataTypeUUID}, nil
+		if couldBeUUID(typedValue) {
+			if _, err := uuid.Parse(typedValue); err == nil {
+				return []schema.DataType{schema.DataTypeUUID}, nil
+			}
 		}
 		if m.config.DefaultString != "" {
 			return []schema.DataType{schema.DataType(m.config.DefaultString)}, nil
@@ -332,11 +353,16 @@ func (m *AutoSchemaManager) determineArrayType(value interface{}, ofNestedProp b
 ) (schema.DataType, schema.DataType, error) {
 	switch typedValue := value.(type) {
 	case string:
-		if _, err := time.Parse(time.RFC3339, typedValue); err == nil {
-			return schema.DataTypeDateArray, "", nil
+		// Shape checks skip the allocating parse for non-matches, as in determineType.
+		if couldBeRFC3339(typedValue) {
+			if _, err := time.Parse(time.RFC3339, typedValue); err == nil {
+				return schema.DataTypeDateArray, "", nil
+			}
 		}
-		if _, err := uuid.Parse(typedValue); err == nil {
-			return schema.DataTypeUUIDArray, "", nil
+		if couldBeUUID(typedValue) {
+			if _, err := uuid.Parse(typedValue); err == nil {
+				return schema.DataTypeUUIDArray, "", nil
+			}
 		}
 		if schema.DataType(m.config.DefaultString) == schema.DataTypeString {
 			return schema.DataTypeStringArray, "", nil

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -222,10 +222,11 @@ func couldBeRFC3339(s string) bool {
 }
 
 // couldBeUUID reports whether s has a length uuid.Parse could accept: 32 (no
-// hyphens) to 45 (urn:uuid: prefixed). Necessary condition only — it must never
-// reject a valid UUID.
+// hyphens), 36 (canonical), 38 ({} braced), or 45 (urn:uuid: prefixed).
+// Necessary condition only — it must never reject a valid UUID.
 func couldBeUUID(s string) bool {
-	return len(s) >= 32 && len(s) <= 45
+	l := len(s)
+	return l == 32 || l == 36 || l == 38 || l == 45
 }
 
 func (m *AutoSchemaManager) determineType(value interface{}, ofNestedProp bool) ([]schema.DataType, error) {

--- a/usecases/objects/auto_schema_test.go
+++ b/usecases/objects/auto_schema_test.go
@@ -150,6 +150,34 @@ func Test_autoSchemaManager_determineType(t *testing.T) {
 			want: []schema.DataType{schema.DataTypeText},
 		},
 		{
+			// Passes the RFC3339 shape guard but fails the parse (month 13) - must
+			// still fall through to text, not be treated as a date.
+			name: "determine text for date-shaped invalid string",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled: runtime.NewDynamicValue(true),
+				},
+			},
+			args: args{
+				value: "2002-13-02T15:00:00Z",
+			},
+			want: []schema.DataType{schema.DataTypeText},
+		},
+		{
+			// Passes the uuid length guard (36) but fails the parse (non-hex) - must
+			// still fall through to text, not be treated as a uuid.
+			name: "determine text for uuid-shaped invalid string",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled: runtime.NewDynamicValue(true),
+				},
+			},
+			args: args{
+				value: "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
+			},
+			want: []schema.DataType{schema.DataTypeText},
+		},
+		{
 			name: "determine date",
 			fields: fields{
 				config: config.AutoSchema{
@@ -185,6 +213,43 @@ func Test_autoSchemaManager_determineType(t *testing.T) {
 				value: "5b2cbe85c38a41f79e8c7406ff6d15aa",
 			},
 			want: []schema.DataType{schema.DataTypeUUID},
+		},
+		{
+			name: "determine uuid (braced)",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled: runtime.NewDynamicValue(true),
+				},
+			},
+			args: args{
+				value: "{5b2cbe85-c38a-41f7-9e8c-7406ff6d15aa}",
+			},
+			want: []schema.DataType{schema.DataTypeUUID},
+		},
+		{
+			name: "determine uuid (urn)",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled: runtime.NewDynamicValue(true),
+				},
+			},
+			args: args{
+				value: "urn:uuid:5b2cbe85-c38a-41f7-9e8c-7406ff6d15aa",
+			},
+			want: []schema.DataType{schema.DataTypeUUID},
+		},
+		{
+			name: "determine date with numeric offset",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled:     runtime.NewDynamicValue(true),
+					DefaultDate: "date",
+				},
+			},
+			args: args{
+				value: "2002-10-02T15:00:00+07:00",
+			},
+			want: []schema.DataType{schema.DataTypeDate},
 		},
 		{
 			name: "determine int",
@@ -405,6 +470,34 @@ func Test_autoSchemaManager_determineType(t *testing.T) {
 			want: []schema.DataType{schema.DataTypeUUIDArray},
 		},
 		{
+			name: "determine uuid array (braced and urn forms)",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled: runtime.NewDynamicValue(true),
+				},
+			},
+			args: args{
+				value: []interface{}{
+					"{5b2cbe85-c38a-41f7-9e8c-7406ff6d15aa}",
+					"urn:uuid:57a8564d-089b-4cd9-be39-56681605e0da",
+				},
+			},
+			want: []schema.DataType{schema.DataTypeUUIDArray},
+		},
+		{
+			name: "determine date array with numeric offset",
+			fields: fields{
+				config: config.AutoSchema{
+					Enabled:     runtime.NewDynamicValue(true),
+					DefaultDate: "date",
+				},
+			},
+			args: args{
+				value: []interface{}{"2002-10-02T15:00:00+07:00", "2002-10-02T15:01:00+07:00"},
+			},
+			want: []schema.DataType{schema.DataTypeDateArray},
+		},
+		{
 			name: "determine mixed string arrays, string first",
 			fields: fields{
 				config: config.AutoSchema{
@@ -582,6 +675,56 @@ func Test_autoSchemaManager_determineType(t *testing.T) {
 				}
 				assert.Nil(t, got)
 			}
+		})
+	}
+}
+
+func Test_couldBeRFC3339(t *testing.T) {
+	// Guard must accept every string time.Parse(RFC3339) can accept and may be
+	// broader; it must never reject a valid timestamp.
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "minimal Zulu", value: "2002-10-02T15:00:00Z", want: true},
+		{name: "numeric offset", value: "2002-10-02T15:00:00+07:00", want: true},
+		{name: "fractional seconds", value: "2002-10-02T15:00:00.123Z", want: true},
+		{name: "lowercase t accepted", value: "2002-10-02t15:00:00z", want: true},
+		{name: "too short", value: "2002-10-02T15:00:0", want: false},
+		{name: "wrong separator at 4", value: "2002/10-02T15:00:00Z", want: false},
+		{name: "wrong separator at 7", value: "2002-10/02T15:00:00Z", want: false},
+		{name: "wrong separator at 10", value: "2002-10-02 15:00:00Z", want: false},
+		{name: "plain text", value: "just a sentence value", want: false},
+		{name: "empty", value: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, couldBeRFC3339(tt.value))
+		})
+	}
+}
+
+func Test_couldBeUUID(t *testing.T) {
+	// Guard must accept every length uuid.Parse can accept (32, 36, 38, 45) and
+	// may be broader; it must never reject a valid UUID.
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "no hyphens (32)", value: "5b2cbe85c38a41f79e8c7406ff6d15aa", want: true},
+		{name: "canonical (36)", value: "5b2cbe85-c38a-41f7-9e8c-7406ff6d15aa", want: true},
+		{name: "braced (38)", value: "{5b2cbe85-c38a-41f7-9e8c-7406ff6d15aa}", want: true},
+		{name: "urn (45)", value: "urn:uuid:5b2cbe85-c38a-41f7-9e8c-7406ff6d15aa", want: true},
+		{name: "too short (31)", value: "5b2cbe85c38a41f79e8c7406ff6d15a", want: false},
+		{name: "too long (46)", value: "urn:uuid:5b2cbe85-c38a-41f7-9e8c-7406ff6d15aax", want: false},
+		{name: "plain text", value: "string", want: false},
+		{name: "empty", value: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, couldBeUUID(tt.value))
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:

Auto schema checks for every string property if its a time or uuid. The parse functions cause allocations (24GB over a day on a customer cluster) when creating an error (that we then throw away) as they copy the input string.

This optimizes the checks by adding a cheap precheck if the respective strings can be time/uuid before giving it to the parse function.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
