### PR TITLE
Reduce heap usage in HNSW condensor

### DIFF
--- a/adapters/repos/db/vector/common/fs.go
+++ b/adapters/repos/db/vector/common/fs.go
@@ -174,6 +174,7 @@ type TestFile struct {
 	OnWrite func(b []byte) (n int, err error)
 	OnRead  func(b []byte) (n int, err error)
 	OnSync  func() error
+	OnClose func() error
 }
 
 func (f *TestFile) Write(b []byte) (n int, err error) {
@@ -195,4 +196,11 @@ func (f *TestFile) Sync() error {
 		return f.OnSync()
 	}
 	return f.File.Sync()
+}
+
+func (f *TestFile) Close() error {
+	if f.OnClose != nil {
+		return f.OnClose()
+	}
+	return f.File.Close()
 }

--- a/adapters/repos/db/vector/hnsw/condensor.go
+++ b/adapters/repos/db/vector/hnsw/condensor.go
@@ -62,6 +62,14 @@ func (c *MemoryCondensor) Do(fileName string) error {
 
 	c.newLog = NewWriterSize(c.newLogFile, c.bufferSize)
 
+	// newLog and newLogFile are only used while condensing; release them on
+	// return so a reused condensor does not keep the write buffer in memory
+	// between runs.
+	defer func() {
+		c.newLog = nil
+		c.newLogFile = nil
+	}()
+
 	if res.Compressed {
 		if res.CompressionPQData != nil {
 			if err := c.AddPQCompression(*res.CompressionPQData); err != nil {

--- a/adapters/repos/db/vector/hnsw/condensor.go
+++ b/adapters/repos/db/vector/hnsw/condensor.go
@@ -64,8 +64,14 @@ func (c *MemoryCondensor) Do(fileName string) error {
 
 	// newLog and newLogFile are only used while condensing; release them on
 	// return so a reused condensor does not keep the write buffer in memory
-	// between runs.
+	// between runs. Without the close an early return leaks the descriptor.
 	defer func() {
+		if c.newLogFile != nil {
+			if err := c.newLogFile.Close(); err != nil {
+				c.logger.WithField("action", "hnsw_condensing").
+					Errorf("close new commit log: %v", err)
+			}
+		}
 		c.newLog = nil
 		c.newLogFile = nil
 	}()
@@ -169,14 +175,16 @@ func (c *MemoryCondensor) Do(fileName string) error {
 	}
 
 	if err := c.newLog.Flush(); err != nil {
-		return errors.Wrap(err, "close new commit log")
+		return errors.Wrap(err, "flush new commit log")
 	}
 
 	if err := newLogFile.Sync(); err != nil {
 		return errors.Wrap(err, "fsync new commit log")
 	}
 
-	if err := c.newLogFile.Close(); err != nil {
+	err = c.newLogFile.Close()
+	c.newLogFile = nil
+	if err != nil {
 		return errors.Wrap(err, "close new commit log")
 	}
 

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1192,6 +1194,114 @@ func TestCondensorCrashSafety(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, fsyncCalled)
 	})
+}
+
+func TestCondensorReleasesBuffersAfterDo(t *testing.T) {
+	// A condensor is created once per index and reused for every condense. Its
+	// 1MB write buffer must not survive a Do call, or every idle index would
+	// pin one buffer for its lifetime.
+	tests := []struct {
+		name    string
+		fs      func() common.FS
+		wantErr bool
+	}{
+		{
+			name:    "successful condense",
+			fs:      func() common.FS { return common.NewOSFS() },
+			wantErr: false,
+		},
+		{
+			name: "condense fails mid-write",
+			fs: func() common.FS {
+				fs := common.NewTestFS()
+				fs.OnOpenFile = func(f common.File) common.File {
+					return &common.TestFile{
+						File: f,
+						OnWrite: func(b []byte) (int, error) {
+							return 0, errors.New("fake write error")
+						},
+					}
+				}
+				return fs
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootPath := t.TempDir()
+			m, clFilename := newMemoryCondensor(t, rootPath, tt.fs())
+
+			err := m.Do(clFilename)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Nil(t, m.newLog)
+			assert.Nil(t, m.newLogFile)
+		})
+	}
+}
+
+// BenchmarkCondensorRetainedMemory reports the heap a condensor keeps alive
+// after Do returns. Releasing the write buffer drops this from ~1MB per
+// condensor to near zero. To see the difference, run it against the pre-fix
+// code with a bounded count so that run does not retain b.N MB:
+//
+//	go test -tags integrationTest -run x -bench RetainedMemory -benchtime=200x
+func BenchmarkCondensorRetainedMemory(b *testing.B) {
+	rootPath := b.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	// Build one small uncondensed commit log and capture its bytes. Do consumes
+	// its input file, so each iteration condenses a fresh copy.
+	cl, err := NewCommitLogger(rootPath, "bench_src", logger,
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(b, err)
+	b.Cleanup(func() { cl.Shutdown(context.Background()) })
+
+	for id := 0; id < 4; id++ {
+		cl.AddNode(&vertex{id: uint64(id), level: 1})
+	}
+	cl.ReplaceLinksAtLevel(0, 0, []uint64{1, 2, 3})
+	cl.SetEntryPointWithMaxLayer(0, 1)
+	require.NoError(b, cl.Flush())
+
+	srcName, ok, err := getCurrentCommitLogFileName(commitLogDirectory(rootPath, "bench_src"), common.NewOSFS())
+	require.NoError(b, err)
+	require.True(b, ok)
+	content, err := os.ReadFile(commitLogFileName(rootPath, "bench_src", srcName))
+	require.NoError(b, err)
+
+	files := make([]string, b.N)
+	for i := range files {
+		p := filepath.Join(rootPath, fmt.Sprintf("bench-%d.log", i))
+		require.NoError(b, os.WriteFile(p, content, 0o644))
+		files[i] = p
+	}
+
+	condensors := make([]*MemoryCondensor, 0, b.N)
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m := &MemoryCondensor{logger: logger, fs: common.NewOSFS(), bufferSize: 1024 * 1024}
+		require.NoError(b, m.Do(files[i]))
+		condensors = append(condensors, m)
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/float64(len(condensors)), "retained-B/condensor")
+	runtime.KeepAlive(condensors)
 }
 
 func assertIndicesFromCommitLogsMatch(t *testing.T, fileNameControl string, fileNames []string) {

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -1199,39 +1199,61 @@ func TestCondensorCrashSafety(t *testing.T) {
 func TestCondensorReleasesBuffersAfterDo(t *testing.T) {
 	// A condensor is created once per index and reused for every condense. Its
 	// 1MB write buffer must not survive a Do call, or every idle index would
-	// pin one buffer for its lifetime.
+	// pin one buffer for its lifetime. The condensed file must be closed too, or
+	// a repeatedly failing condense leaks descriptors.
+	failWrite := func(b []byte) (int, error) {
+		return 0, errors.New("fake write error")
+	}
+
 	tests := []struct {
-		name    string
-		fs      func() common.FS
-		wantErr bool
+		name     string
+		onWrite  func(b []byte) (int, error)
+		closeErr error
+		wantErr  bool
 	}{
 		{
 			name:    "successful condense",
-			fs:      func() common.FS { return common.NewOSFS() },
 			wantErr: false,
 		},
 		{
-			name: "condense fails mid-write",
-			fs: func() common.FS {
-				fs := common.NewTestFS()
-				fs.OnOpenFile = func(f common.File) common.File {
-					return &common.TestFile{
-						File: f,
-						OnWrite: func(b []byte) (int, error) {
-							return 0, errors.New("fake write error")
-						},
-					}
-				}
-				return fs
-			},
+			name:    "condense fails mid-write",
+			onWrite: failWrite,
 			wantErr: true,
+		},
+		{
+			name:     "close fails",
+			closeErr: errors.New("fake close error"),
+			wantErr:  true,
+		},
+		{
+			name:     "condense fails mid-write and close fails",
+			onWrite:  failWrite,
+			closeErr: errors.New("fake close error"),
+			wantErr:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rootPath := t.TempDir()
-			m, clFilename := newMemoryCondensor(t, rootPath, tt.fs())
+
+			var closes int
+			fs := common.NewTestFS()
+			fs.OnOpenFile = func(f common.File) common.File {
+				return &common.TestFile{
+					File:    f,
+					OnWrite: tt.onWrite,
+					OnClose: func() error {
+						closes++
+						if err := f.Close(); err != nil {
+							return err
+						}
+						return tt.closeErr
+					},
+				}
+			}
+
+			m, clFilename := newMemoryCondensor(t, rootPath, fs)
 
 			err := m.Do(clFilename)
 			if tt.wantErr {
@@ -1242,6 +1264,7 @@ func TestCondensorReleasesBuffersAfterDo(t *testing.T) {
 
 			assert.Nil(t, m.newLog)
 			assert.Nil(t, m.newLogFile)
+			assert.Equal(t, 1, closes)
 		})
 	}
 }
@@ -1300,8 +1323,15 @@ func BenchmarkCondensorRetainedMemory(b *testing.B) {
 	var after runtime.MemStats
 	runtime.ReadMemStats(&after)
 
-	b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/float64(len(condensors)), "retained-B/condensor")
+	// Everything allocated before the baseline sample has to survive the second
+	// one as well, otherwise it counts towards before but not after and drags
+	// the reported delta below zero.
+	runtime.KeepAlive(content)
+	runtime.KeepAlive(files)
 	runtime.KeepAlive(condensors)
+
+	retained := (float64(after.HeapAlloc) - float64(before.HeapAlloc)) / float64(len(condensors))
+	b.ReportMetric(retained, "retained-B/condensor")
 }
 
 func assertIndicesFromCommitLogsMatch(t *testing.T, fileNameControl string, fileNames []string) {


### PR DESCRIPTION
### What's being changed:

MemoryCondensor is created once per index and reused for every condense. Do() set newLogFile/newLog (a 1MB buffer) but never cleared them, so every index that had condensed pinned its buffer for its lifetime — ~924MB on a many-index node. Release both fields on Do() return.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
