### PR TITLE
Improvement to compression persistence for compactv2

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
@@ -508,8 +508,8 @@ func (brq *BinaryRotationalQuantizer) NewQuantizerDistancer(vec []float32) quant
 func (brq *BinaryRotationalQuantizer) ReturnQuantizerDistancer(distancer quantizerDistancer[uint64]) {
 }
 
-func (brq *BinaryRotationalQuantizer) PersistCompression(logger CommitLogger) {
-	logger.AddBRQCompression(compression.BRQData{
+func (brq *BinaryRotationalQuantizer) PersistCompression(logger CommitLogger) error {
+	return logger.AddBRQCompression(compression.BRQData{
 		InputDim: brq.inputDim,
 		Rotation: *brq.rotation,
 		Rounding: brq.rounding,

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -83,7 +83,7 @@ type VectorCompressor interface {
 	NewDistancerFromID(id uint64) (CompressorDistancer, error)
 	NewBag() CompressionDistanceBag
 
-	PersistCompression(CommitLogger)
+	PersistCompression(CommitLogger) error
 	Stats() CompressionStats
 	Get(id uint64) ([]float32, error)
 	GetCompressed(id uint64) (any, error)
@@ -503,8 +503,8 @@ func (compressor *quantizedVectorsCompressor[T]) PrefillMultiCache(ctx context.C
 	}).Info("prefilled compressed vector cache for multivector")
 }
 
-func (compressor *quantizedVectorsCompressor[T]) PersistCompression(logger CommitLogger) {
-	compressor.quantizer.PersistCompression(logger)
+func (compressor *quantizedVectorsCompressor[T]) PersistCompression(logger CommitLogger) error {
+	return compressor.quantizer.PersistCompression(logger)
 }
 
 func NewHNSWPQCompressor(

--- a/adapters/repos/db/vector/compressionhelpers/kmeans_encoder.go
+++ b/adapters/repos/db/vector/compressionhelpers/kmeans_encoder.go
@@ -92,6 +92,21 @@ func (m *KMeansEncoder) Centroid(i byte) []float32 {
 	return m.centers[i]
 }
 
+func (m *KMeansEncoder) Valid(ks, subDim int) error {
+	if m == nil {
+		return fmt.Errorf("kmeans encoder is nil")
+	}
+	if len(m.centers) != ks {
+		return fmt.Errorf("has %d centroids, expected %d", len(m.centers), ks)
+	}
+	for i, c := range m.centers {
+		if len(c) != subDim {
+			return fmt.Errorf("centroid %d has length %d, expected %d", i, len(c), subDim)
+		}
+	}
+	return nil
+}
+
 func (m *KMeansEncoder) Add(x []float32) {
 	// Only here to satisfy the PQEncoder interface.
 }

--- a/adapters/repos/db/vector/compressionhelpers/pq_data_valid_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/pq_data_valid_test.go
@@ -1,0 +1,192 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compressionhelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/vectorindex/compression"
+)
+
+func kmeansEncoder(ks, subDim, nilIdx int) compression.PQSegmentEncoder {
+	centers := make([][]float32, ks)
+	for i := range centers {
+		if i == nilIdx {
+			continue // leave nil
+		}
+		centers[i] = make([]float32, subDim)
+	}
+	return NewKMeansEncoderWithCenters(ks, subDim, 0, centers)
+}
+
+func segmentEncoders(m, ks, subDim int) []compression.PQSegmentEncoder {
+	encs := make([]compression.PQSegmentEncoder, m)
+	for i := range encs {
+		encs[i] = kmeansEncoder(ks, subDim, -1)
+	}
+	return encs
+}
+
+func TestPQDataValid(t *testing.T) {
+	// A well-formed codebook: 4 segments, 16 centroids each, 8 dims total
+	// (subDim = 8/4 = 2).
+	valid := func() *compression.PQData {
+		return &compression.PQData{
+			Ks:         16,
+			M:          4,
+			Dimensions: 8,
+			Encoders:   segmentEncoders(4, 16, 2),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		data    *compression.PQData
+		wantErr string
+	}{
+		{
+			name: "valid",
+			data: valid(),
+		},
+		{
+			// Auto-segment (config Segments=0) resolves via
+			// CalculateOptimalSegments, which for a dims divisible only by 2
+			// returns dims/2. subDim = 12/6 = 2.
+			name: "auto-segment M = dimensions/2",
+			data: &compression.PQData{
+				Ks: 16, M: 6, Dimensions: 12, Encoders: segmentEncoders(6, 16, 2),
+			},
+		},
+		{
+			// Auto-segment fallback for a dims with no small divisor returns
+			// dims itself: M == Dimensions, subDim = 1. This must stay valid.
+			name: "auto-segment fallback M == dimensions (subDim 1)",
+			data: &compression.PQData{
+				Ks: 16, M: 7, Dimensions: 7, Encoders: segmentEncoders(7, 16, 1),
+			},
+		},
+		{
+			name:    "nil pq data",
+			data:    nil,
+			wantErr: "pq data is nil",
+		},
+		{
+			name: "zero segments",
+			data: &compression.PQData{
+				Ks: 16, M: 0, Dimensions: 8, Encoders: nil,
+			},
+			wantErr: "0 segments",
+		},
+		{
+			name: "zero centroids",
+			data: &compression.PQData{
+				Ks: 0, M: 4, Dimensions: 8, Encoders: segmentEncoders(4, 16, 2),
+			},
+			wantErr: "0 centroids",
+		},
+		{
+			name: "zero dimensions",
+			data: &compression.PQData{
+				Ks: 16, M: 4, Dimensions: 0, Encoders: segmentEncoders(4, 16, 2),
+			},
+			wantErr: "0 dimensions",
+		},
+		{
+			name: "dimensions not divisible by segments",
+			data: &compression.PQData{
+				Ks: 16, M: 3, Dimensions: 8, Encoders: segmentEncoders(3, 16, 2),
+			},
+			wantErr: "not divisible",
+		},
+		{
+			name: "too few encoders",
+			data: &compression.PQData{
+				Ks: 16, M: 4, Dimensions: 8, Encoders: segmentEncoders(3, 16, 2),
+			},
+			wantErr: "expected 4 (M)",
+		},
+		{
+			name: "too many encoders",
+			data: &compression.PQData{
+				Ks: 16, M: 4, Dimensions: 8, Encoders: segmentEncoders(5, 16, 2),
+			},
+			wantErr: "expected 4 (M)",
+		},
+		{
+			name: "nil encoder in slice",
+			data: &compression.PQData{
+				Ks: 16, M: 4, Dimensions: 8,
+				Encoders: []compression.PQSegmentEncoder{
+					kmeansEncoder(16, 2, -1),
+					nil,
+					kmeansEncoder(16, 2, -1),
+					kmeansEncoder(16, 2, -1),
+				},
+			},
+			wantErr: "segment encoder 1 is nil",
+		},
+		{
+			name: "encoder with nil centroid",
+			data: &compression.PQData{
+				Ks: 16, M: 4, Dimensions: 8,
+				Encoders: []compression.PQSegmentEncoder{
+					kmeansEncoder(16, 2, -1),
+					kmeansEncoder(16, 2, -1),
+					kmeansEncoder(16, 2, 7), // centroid 7 is nil
+					kmeansEncoder(16, 2, -1),
+				},
+			},
+			wantErr: "segment encoder 2: centroid 7 has length 0, expected 2",
+		},
+		{
+			name: "encoder with too few centroids",
+			data: &compression.PQData{
+				Ks: 16, M: 4, Dimensions: 8,
+				Encoders: []compression.PQSegmentEncoder{
+					kmeansEncoder(16, 2, -1),
+					kmeansEncoder(8, 2, -1), // only 8 of the expected 16
+					kmeansEncoder(16, 2, -1),
+					kmeansEncoder(16, 2, -1),
+				},
+			},
+			wantErr: "segment encoder 1: has 8 centroids, expected 16",
+		},
+		{
+			name: "encoder with wrong centroid dimension",
+			data: &compression.PQData{
+				Ks: 16, M: 4, Dimensions: 8,
+				Encoders: []compression.PQSegmentEncoder{
+					kmeansEncoder(16, 3, -1), // subDim should be 2
+					kmeansEncoder(16, 2, -1),
+					kmeansEncoder(16, 2, -1),
+					kmeansEncoder(16, 2, -1),
+				},
+			},
+			wantErr: "segment encoder 0: centroid 0 has length 3, expected 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.data.Valid()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/adapters/repos/db/vector/compressionhelpers/pq_persist_valid_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/pq_persist_valid_test.go
@@ -1,0 +1,100 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compressionhelpers
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/vectorindex/compression"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// fakeCommitLogger records whether a PQ codebook was actually handed to the
+// commit log, so a test can assert that an incomplete codebook is never written.
+type fakeCommitLogger struct {
+	pqCalled bool
+}
+
+func (f *fakeCommitLogger) AddPQCompression(compression.PQData) error   { f.pqCalled = true; return nil }
+func (f *fakeCommitLogger) AddSQCompression(compression.SQData) error   { return nil }
+func (f *fakeCommitLogger) AddRQCompression(compression.RQData) error   { return nil }
+func (f *fakeCommitLogger) AddBRQCompression(compression.BRQData) error { return nil }
+
+// pqCodebook builds m KMeans segment encoders with ks centroids of length
+// subDim. When nilSeg/nilK are in range, that centroid is left nil to model an
+// empty kmeans cluster / partially-fit codebook.
+func pqCodebook(m, ks, subDim, nilSeg, nilK int) []compression.PQSegmentEncoder {
+	encoders := make([]compression.PQSegmentEncoder, m)
+	for i := range encoders {
+		centers := make([][]float32, ks)
+		for k := range centers {
+			if i == nilSeg && k == nilK {
+				continue // leave nil
+			}
+			centers[k] = make([]float32, subDim)
+		}
+		encoders[i] = NewKMeansEncoderWithCenters(ks, subDim, i, centers)
+	}
+	return encoders
+}
+
+// Test_ProductQuantizer_PersistCompression_RejectsIncompleteCodebook pins the
+// write-side guard: the compress worker must never persist a codebook with a
+// nil/short centroid, because restoring it would segfault the AVX distancer on
+// the first Encode/search. PersistCompression returns an error and writes
+// nothing, so compress() leaves the index uncompressed and retries.
+func Test_ProductQuantizer_PersistCompression_RejectsIncompleteCodebook(t *testing.T) {
+	const (
+		dims   = 8
+		m      = 4
+		subDim = dims / m
+		ks     = 16
+	)
+
+	cfg := ent.PQConfig{
+		Enabled:   true,
+		Segments:  m,
+		Centroids: ks,
+		Encoder: ent.PQEncoder{
+			Type:         ent.PQEncoderTypeKMeans,
+			Distribution: ent.PQEncoderDistributionLogNormal,
+		},
+	}
+
+	t.Run("incomplete codebook is refused", func(t *testing.T) {
+		pq, err := NewProductQuantizer(cfg, distancer.NewL2SquaredProvider(), dims, logrus.New())
+		require.NoError(t, err)
+		pq.kms = pqCodebook(m, ks, subDim, m-1, 5) // centroid 5 of last segment is nil
+
+		logger := &fakeCommitLogger{}
+		err = pq.PersistCompression(logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "incomplete PQ codebook")
+		assert.False(t, logger.pqCalled, "an incomplete codebook must never reach the commit log")
+	})
+
+	t.Run("complete codebook is persisted", func(t *testing.T) {
+		pq, err := NewProductQuantizer(cfg, distancer.NewL2SquaredProvider(), dims, logrus.New())
+		require.NoError(t, err)
+		pq.kms = pqCodebook(m, ks, subDim, -1, -1) // all centroids set
+
+		logger := &fakeCommitLogger{}
+		err = pq.PersistCompression(logger)
+		require.NoError(t, err)
+		assert.True(t, logger.pqCalled, "a complete codebook must be persisted")
+	})
+}

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -301,8 +301,8 @@ func PutCode8(code byte, buffer []byte, index int) {
 	buffer[index] = code
 }
 
-func (pq *ProductQuantizer) PersistCompression(logger CommitLogger) {
-	logger.AddPQCompression(ent.PQData{
+func (pq *ProductQuantizer) PersistCompression(logger CommitLogger) error {
+	data := ent.PQData{
 		Dimensions:          uint16(pq.dimensions),
 		EncoderType:         pq.encoderType,
 		Ks:                  uint16(pq.ks),
@@ -310,7 +310,12 @@ func (pq *ProductQuantizer) PersistCompression(logger CommitLogger) {
 		EncoderDistribution: byte(pq.encoderDistribution),
 		Encoders:            pq.kms,
 		TrainingLimit:       pq.trainingLimit,
-	})
+	}
+	// Never persist an incomplete codebook.
+	if err := data.Valid(); err != nil {
+		return fmt.Errorf("refusing to persist incomplete PQ codebook: %w", err)
+	}
+	return logger.AddPQCompression(data)
 }
 
 func (pq *ProductQuantizer) DistanceBetweenCompressedVectors(x, y []byte) (float32, error) {

--- a/adapters/repos/db/vector/compressionhelpers/quantizer.go
+++ b/adapters/repos/db/vector/compressionhelpers/quantizer.go
@@ -29,7 +29,7 @@ type quantizer[T byte | uint64] interface {
 	ReturnQuantizerDistancer(distancer quantizerDistancer[T])
 	CompressedBytes(compressed []T) []byte
 	FromCompressedBytes(compressed []byte) []T
-	PersistCompression(logger CommitLogger)
+	PersistCompression(logger CommitLogger) error
 	Stats() CompressionStats
 
 	// FromCompressedBytesWithSubsliceBuffer is like FromCompressedBytes, but
@@ -39,7 +39,9 @@ type quantizer[T byte | uint64] interface {
 	FromCompressedBytesWithSubsliceBuffer(compressed []byte, buffer *[]T) []T
 }
 
-func (bq *BinaryQuantizer) PersistCompression(logger CommitLogger) {
+func (bq *BinaryQuantizer) PersistCompression(logger CommitLogger) error {
+	// BQ has no trained state to persist.
+	return nil
 }
 
 func (pq *ProductQuantizer) NewQuantizerDistancer(vec []float32) quantizerDistancer[byte] {

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization.go
@@ -363,8 +363,8 @@ func (rq *RotationalQuantizer) NewQuantizerDistancer(vec []float32) quantizerDis
 
 func (rq *RotationalQuantizer) ReturnQuantizerDistancer(distancer quantizerDistancer[byte]) {}
 
-func (rq *RotationalQuantizer) PersistCompression(logger CommitLogger) {
-	logger.AddRQCompression(compression.RQData{
+func (rq *RotationalQuantizer) PersistCompression(logger CommitLogger) error {
+	return logger.AddRQCompression(compression.RQData{
 		InputDim: rq.inputDim,
 		Bits:     rq.bits,
 		Rotation: *rq.rotation,

--- a/adapters/repos/db/vector/compressionhelpers/scalar_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/scalar_quantization.go
@@ -191,8 +191,8 @@ func (sq *ScalarQuantizer) FromCompressedBytes(compressed []byte) []byte {
 	return compressed
 }
 
-func (sq *ScalarQuantizer) PersistCompression(logger CommitLogger) {
-	logger.AddSQCompression(compression.SQData{
+func (sq *ScalarQuantizer) PersistCompression(logger CommitLogger) error {
+	return logger.AddSQCompression(compression.SQData{
 		A:          sq.a,
 		B:          sq.b,
 		Dimensions: uint16(sq.dimensions),

--- a/adapters/repos/db/vector/compressionhelpers/tile_encoder.go
+++ b/adapters/repos/db/vector/compressionhelpers/tile_encoder.go
@@ -13,6 +13,7 @@ package compressionhelpers
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 	"sync/atomic"
 
@@ -192,6 +193,19 @@ func (te *TileEncoder) centroid(b byte) []float32 {
 		res = append(res, float32(te.distribution.Quantile(mean)))
 	}
 	return res
+}
+
+func (te *TileEncoder) Valid(ks, subDim int) error {
+	if te == nil {
+		return fmt.Errorf("tile encoder is nil")
+	}
+	if te.bins <= 0 {
+		return fmt.Errorf("has %v bins", te.bins)
+	}
+	if te.distribution == nil {
+		return fmt.Errorf("has no distribution configured")
+	}
+	return nil
 }
 
 func (te *TileEncoder) Centroid(b byte) []float32 {

--- a/adapters/repos/db/vector/flat/metadata.go
+++ b/adapters/repos/db/vector/flat/metadata.go
@@ -353,7 +353,9 @@ func (index *flat) persistRQData() error {
 func (index *flat) serializeRQ1Data() (*RQ1Data, error) {
 	// Use a custom commit logger to capture the BRQ data
 	captureLogger := &dataCaptureLogger{}
-	index.quantizer.PersistCompression(captureLogger)
+	if err := index.quantizer.PersistCompression(captureLogger); err != nil {
+		return nil, err
+	}
 
 	if captureLogger.brqData == nil {
 		return nil, errors.New("no BRQ data captured from quantizer")
@@ -381,7 +383,9 @@ func (index *flat) serializeRQ1Data() (*RQ1Data, error) {
 func (index *flat) serializeRQ8Data() (*RQ8Data, error) {
 	// Use a custom commit logger to capture the RQ data
 	captureLogger := &dataCaptureLogger{}
-	index.quantizer.PersistCompression(captureLogger)
+	if err := index.quantizer.PersistCompression(captureLogger); err != nil {
+		return nil, err
+	}
 
 	if captureLogger.rqData == nil {
 		return nil, errors.New("no RQ data captured from quantizer")

--- a/adapters/repos/db/vector/flat/quantizer.go
+++ b/adapters/repos/db/vector/flat/quantizer.go
@@ -61,7 +61,7 @@ type Quantizer interface {
 	DistanceBetweenUint64Vectors(x, y []uint64) (float32, error)
 	DistanceBetweenByteVectors(x, y []byte) (float32, error)
 
-	PersistCompression(logger compressionhelpers.CommitLogger)
+	PersistCompression(logger compressionhelpers.CommitLogger) error
 	Stats() compressionhelpers.CompressionStats
 	Type() QuantizerType
 

--- a/adapters/repos/db/vector/hnsw/compact/in_memory_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/in_memory_reader.go
@@ -142,8 +142,16 @@ func (r *InMemoryReader) Do(initialState *ent.DeserializationResult, keepLinkRep
 			// Reset compression state - ResetIndex clears everything
 			out.Compression = nil
 		case *AddPQCommit:
-			out.SetCompressionPQData(commit.Data)
-			out.SetCompressed(true)
+			// Only enable compression from a complete codebook
+			if verr := commit.Data.Valid(); verr != nil {
+				r.logger.WithFields(logrus.Fields{
+					"action": "hnsw_skip_incomplete_pq_codebook",
+					"commit": "AddPQ",
+				}).Warnf("skipping incomplete PQ codebook, compression will be retried: %v", verr)
+			} else {
+				out.SetCompressionPQData(commit.Data)
+				out.SetCompressed(true)
+			}
 		case *AddSQCommit:
 			out.SetCompressionSQData(commit.Data)
 			out.SetCompressed(true)

--- a/adapters/repos/db/vector/hnsw/compact/in_memory_reader_pq_valid_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/in_memory_reader_pq_valid_test.go
@@ -1,0 +1,96 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package compact
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/entities/vectorindex/compression"
+)
+
+func kmeansPQData(dims, m, ks uint16) *compression.PQData {
+	segmentSize := int(dims / m)
+	encoders := make([]compression.PQSegmentEncoder, m)
+	for i := uint16(0); i < m; i++ {
+		centers := make([][]float32, ks)
+		for k := uint16(0); k < ks; k++ {
+			center := make([]float32, segmentSize)
+			for j := 0; j < segmentSize; j++ {
+				center[j] = float32(k)*0.01 + float32(j)*0.001
+			}
+			centers[k] = center
+		}
+		encoders[i] = compressionhelpers.NewKMeansEncoderWithCenters(int(ks), segmentSize, int(i), centers)
+	}
+	return &compression.PQData{
+		Dimensions:  dims,
+		EncoderType: compression.UseKMeansEncoder,
+		Ks:          ks,
+		M:           m,
+		Encoders:    encoders,
+	}
+}
+
+func Test_InMemoryReader_SkipsIncompletePQCodebook(t *testing.T) {
+	tests := []struct {
+		name           string
+		pqData         *compression.PQData
+		wantCompressed bool
+	}{
+		{
+			name:           "complete codebook enables compression",
+			pqData:         kmeansPQData(128, 4, 256),
+			wantCompressed: true,
+		},
+		{
+			name:           "zero segments is skipped",
+			pqData:         &compression.PQData{Dimensions: 8, EncoderType: compression.UseKMeansEncoder, Ks: 16, M: 0},
+			wantCompressed: false,
+		},
+		{
+			// dims not divisible by segments: the restored codebook would be
+			// internally inconsistent, so compression must be skipped.
+			name:           "dimensions not divisible by segments is skipped",
+			pqData:         kmeansPQData(10, 4, 16),
+			wantCompressed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Sanity-check the fixture actually models the intended (in)validity.
+			if tt.wantCompressed {
+				require.NoError(t, tt.pqData.Valid())
+			} else {
+				require.Error(t, tt.pqData.Valid())
+			}
+
+			var buf bytes.Buffer
+			require.NoError(t, NewWALWriter(&buf).WriteAddPQ(tt.pqData))
+
+			reader := NewWALCommitReader(&buf, testLogger())
+			res, err := NewInMemoryReader(reader, testLogger()).Do(nil, false)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantCompressed, res.Compressed(),
+				"compressed state must reflect codebook validity")
+			if tt.wantCompressed {
+				require.NotNil(t, res.CompressionPQData())
+			}
+		})
+	}
+}

--- a/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
+++ b/adapters/repos/db/vector/hnsw/compact/snapshot_reader.go
@@ -322,6 +322,16 @@ func (r *SnapshotReader) readPQData(reader io.Reader, res *ent.DeserializationRe
 		pqData.Encoders = append(pqData.Encoders, encoder)
 	}
 
+	// Only keep compression enabled for a complete codebook
+	if verr := pqData.Valid(); verr != nil {
+		if r.logger != nil {
+			r.logger.WithField("action", "hnsw_skip_incomplete_pq_codebook").
+				Warnf("skipping incomplete PQ codebook from snapshot, compression will be retried: %v", verr)
+		}
+		res.SetCompressed(false)
+		return nil
+	}
+
 	res.SetCompressionPQData(pqData)
 	return nil
 }

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -149,7 +149,10 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			})
 	}
 
-	h.compressor.PersistCompression(h.commitLog)
+	// Persist the codebook before flipping the index to compressed.
+	if err := h.compressor.PersistCompression(h.commitLog); err != nil {
+		return fmt.Errorf("persisting compression: %w", err)
+	}
 	h.compressed.Store(true)
 	h.cache.Drop()
 	return nil

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -155,7 +155,7 @@ func (h *hnsw) checkAndCompress() error {
 					h.cache.Drop()
 				}
 				h.cache = nil
-				h.compressor.PersistCompression(h.commitLog)
+				err = h.compressor.PersistCompression(h.commitLog)
 			}
 		})
 	}

--- a/entities/vectorindex/compression/pq_data.go
+++ b/entities/vectorindex/compression/pq_data.go
@@ -11,6 +11,8 @@
 
 package compression
 
+import "fmt"
+
 // Encoder constants for PQ encoder types.
 const (
 	PQEncoderTypeTile              = "tile"
@@ -35,6 +37,7 @@ type PQSegmentEncoder interface {
 	Add(x []float32)
 	Fit(data [][]float32) error
 	ExposeDataForRestore() []byte
+	Valid(ks, subDim int) error
 }
 
 // PQData holds the serialization data for Product Quantization compression.
@@ -47,4 +50,35 @@ type PQData struct {
 	Encoders            []PQSegmentEncoder
 	UseBitsEncoding     bool
 	TrainingLimit       int
+}
+
+func (pq *PQData) Valid() error {
+	if pq == nil {
+		return fmt.Errorf("pq data is nil")
+	}
+	if pq.M == 0 {
+		return fmt.Errorf("pq data has 0 segments (M)")
+	}
+	if pq.Ks == 0 {
+		return fmt.Errorf("pq data has 0 centroids per segment (Ks)")
+	}
+	if pq.Dimensions == 0 {
+		return fmt.Errorf("pq data has 0 dimensions")
+	}
+	if pq.Dimensions%pq.M != 0 {
+		return fmt.Errorf("pq data dimensions %d is not divisible by segments %d", pq.Dimensions, pq.M)
+	}
+	if len(pq.Encoders) != int(pq.M) {
+		return fmt.Errorf("pq data has %d segment encoders, expected %d (M)", len(pq.Encoders), pq.M)
+	}
+	subDim := int(pq.Dimensions / pq.M)
+	for i, enc := range pq.Encoders {
+		if enc == nil {
+			return fmt.Errorf("pq data segment encoder %d is nil", i)
+		}
+		if err := enc.Valid(int(pq.Ks), subDim); err != nil {
+			return fmt.Errorf("pq data segment encoder %d: %w", i, err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
### What's being changed:
- Ensure compactv2 / snapshots don't persist bad PQ data
- Validate PQ data at write
- If PQ data produces a bad centroid, fail the compression (so can be retried via async indexing)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
