### PR TITLE
Ensure shutdown waits for compress action

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
@@ -33,7 +34,12 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			h.compressActionLock.Unlock()
 		}
 	}()
-	data := h.cache.All()
+	if err := h.shutdownCtx.Err(); err != nil {
+		return err
+	}
+	h.cache.LockAll()
+	data := slices.Clone(h.cache.All())
+	h.cache.UnlockAll()
 	singleVector := !h.multivector.Load() || h.muvera.Load()
 	if cfg.PQ.Enabled || cfg.SQ.Enabled {
 		if h.isEmpty() {

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -133,7 +133,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 	if singleVector {
 		compressionhelpers.Concurrently(h.logger, uint64(len(data)),
 			func(index uint64) {
-				if len(data[index]) == 0 {
+				if h.shutdownCtx.Err() != nil || len(data[index]) == 0 {
 					return
 				}
 				h.compressor.Preload(index, data[index])
@@ -141,12 +141,16 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 	} else {
 		compressionhelpers.Concurrently(h.logger, uint64(len(data)),
 			func(index uint64) {
-				if len(data[index]) == 0 {
+				if h.shutdownCtx.Err() != nil || len(data[index]) == 0 {
 					return
 				}
 				docID, relativeID := h.cache.GetKeys(index)
 				h.compressor.PreloadPassage(index, docID, relativeID, data[index])
 			})
+	}
+
+	if h.shutdownCtx.Err() != nil {
+		return h.shutdownCtx.Err()
 	}
 
 	h.compressor.PersistCompression(h.commitLog)

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -183,12 +183,18 @@ func (h *hnsw) compressThenCallback(callback func()) {
 		RQ: h.rqConfig,
 	}
 	if err := h.compress(uc); err != nil {
-		h.logger.WithFields(logrus.Fields{
+		fields := logrus.Fields{
 			"action":       "compress",
 			"shard":        h.shardName,
 			"collection":   h.className,
 			"targetVector": h.getTargetVector(),
-		}).WithError(err).Error("vector compression failed")
+		}
+		if h.shutdownCtx.Err() != nil {
+			// expected on shutdown, compression restarts with the shard
+			h.logger.WithFields(fields).Infof("vector compression interrupted by shutdown: %v", err)
+			return
+		}
+		h.logger.WithFields(fields).WithError(err).Error("vector compression failed")
 		return
 	}
 	h.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -796,6 +796,9 @@ func (h *hnsw) Shutdown(ctx context.Context) error {
 		return errors.Wrap(err, "hnsw shutdown")
 	}
 
+	h.compressActionLock.Lock()
+	defer h.compressActionLock.Unlock()
+
 	if h.compressed.Load() {
 		err := h.compressor.Drop()
 		if err != nil {

--- a/adapters/repos/db/vector/hnsw/shutdown_compress_race_test.go
+++ b/adapters/repos/db/vector/hnsw/shutdown_compress_race_test.go
@@ -1,0 +1,89 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+func Test_ShutdownWaitsForInFlightCompress(t *testing.T) {
+	dist := distancer.NewL2SquaredProvider()
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	uc := ent.UserConfig{}
+	uc.SetDefaults()
+	uc.VectorCacheMaxObjects = 1e12
+
+	store := testinghelpers.NewDummyStore(t)
+	defer store.Shutdown(context.Background())
+
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "shutdown-compress-race",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      dist,
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		MakeBucketOptions:     lsmkv.MakeNoopBucketOptions,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return nil, storobj.NewErrNotFoundf(id, "out of range")
+		},
+		GetViewThunk: func() common.BucketView {
+			return &noopBucketView{}
+		},
+		TempVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+			return nil, storobj.NewErrNotFoundf(id, "out of range")
+		},
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.NoError(t, err)
+
+	// Stand in for an in-flight compress(): it holds compressActionLock across
+	// the whole Preload phase.
+	index.compressActionLock.Lock()
+
+	done := make(chan error, 1)
+	enterrors.GoWrapper(func() { done <- index.Shutdown(ctx) }, logger)
+
+	// Shutdown must not complete (and therefore not drop the cache) while the
+	// lock is held.
+	select {
+	case <-done:
+		t.Fatal("Shutdown completed while compression still held compressActionLock; the cache drop would race the Preload readers")
+	case <-time.After(200 * time.Millisecond):
+		// expected: Shutdown is blocked on compressActionLock
+	}
+
+	// Once the in-flight compress finishes, Shutdown proceeds cleanly.
+	index.compressActionLock.Unlock()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not complete after compressActionLock was released")
+	}
+}


### PR DESCRIPTION
### What's being changed:
- Fix a shutdown-vs-compression data race: a graceful Shutdown could drop the vector cache while an in-flight PQ compression worker was still reading vectors out of the cache's backing slice, causing a torn-slice read that segfaulted the AVX distancer (l2_256).
- Shutdown now waits on `compressActionLock` (acquired after tombstone-cleanup Unregister to avoid a lock-ordering deadlock) before dropping the cache/compressor, and compress() bails out on shutdownCtx cancellation instead of persisting a half-preloaded codebook. (Note: the async RQ path releases the lock early and is not covered here — separate follow-up.)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
