### PR TITLE
Use a view instead of copy in hnsw packed connection

### DIFF
--- a/entities/vectorindex/hnsw/packedconn/connections.go
+++ b/entities/vectorindex/hnsw/packedconn/connections.go
@@ -92,8 +92,10 @@ func NewWithData(data []byte) *Connections {
 			break // Malformed data
 		}
 
-		layerData := make([]byte, dataLen)
-		copy(layerData, data[offset:offset+int(dataLen)])
+		// View into the caller's blob rather than a copy. cap==len forces any
+		// later append on this layer to reallocate instead of writing into the
+		// blob and corrupting the neighboring layer's bytes.
+		layerData := data[offset : offset+int(dataLen) : offset+int(dataLen)]
 		offset += int(dataLen)
 
 		c.layers[i] = LayerData{

--- a/entities/vectorindex/hnsw/packedconn/connections_benchmark_test.go
+++ b/entities/vectorindex/hnsw/packedconn/connections_benchmark_test.go
@@ -208,6 +208,23 @@ func BenchmarkBulkInsert_Allocations(b *testing.B) {
 	})
 }
 
+// Reports allocations per NewWithData call. Each layer is a view into the blob
+// rather than a fresh make+copy, so allocs/op stays flat regardless of layer
+// count instead of growing one allocation per layer.
+func BenchmarkNewWithData_Allocs(b *testing.B) {
+	c, _ := NewWithMaxLayer(3)
+	for l := uint8(0); l <= 3; l++ {
+		c.ReplaceLayer(l, generateTestData(32, 65535))
+	}
+	blob := c.Data()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NewWithData(blob)
+	}
+}
+
 // Benchmark with realistic workload patterns
 func BenchmarkBulkInsert_RealisticWorkload(b *testing.B) {
 	// Simulate building a connection list incrementally

--- a/entities/vectorindex/hnsw/packedconn/connections_test.go
+++ b/entities/vectorindex/hnsw/packedconn/connections_test.go
@@ -1343,3 +1343,69 @@ func TestConnections_DataSerialization_MalformedData(t *testing.T) {
 	assert.Len(t, copied.GetLayer(0), 0)
 	assert.Len(t, copied.GetLayer(1), 0)
 }
+
+// NewWithData views the caller's blob per layer instead of copying it. Growing
+// one layer via append must reallocate so it never writes into the blob region
+// an adjacent layer still reads from. Appends stay within the layer's current
+// scheme so they take the in-place append path (the one aliasing would break),
+// not the decode-and-re-encode path which reallocates regardless.
+func TestNewWithData_AppendDoesNotCorruptAdjacentLayer(t *testing.T) {
+	cases := []struct {
+		name        string
+		layers      [][]uint64
+		targetLayer uint8
+		appends     []uint64
+	}{
+		{
+			name:        "2-byte scheme, append to first of two layers",
+			layers:      [][]uint64{{10, 20, 30}, {111, 222, 333, 444}},
+			targetLayer: 0,
+			appends:     []uint64{40, 50, 60, 70, 80},
+		},
+		{
+			name:        "3-byte scheme, append to first of two layers",
+			layers:      [][]uint64{{100000, 200000}, {300000, 400000, 500000}},
+			targetLayer: 0,
+			appends:     []uint64{600000, 700000, 800000, 900000},
+		},
+		{
+			name:        "append to middle of three layers",
+			layers:      [][]uint64{{1, 2}, {100, 200, 300}, {1000, 2000}},
+			targetLayer: 1,
+			appends:     []uint64{111, 222, 333, 444, 555},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewWithMaxLayer(uint8(len(tc.layers) - 1))
+			require.NoError(t, err)
+			for i, vals := range tc.layers {
+				c.ReplaceLayer(uint8(i), vals)
+			}
+
+			loaded := NewWithData(c.Data())
+
+			// Round-trip: every layer reads back identically to the source.
+			for i, vals := range tc.layers {
+				require.ElementsMatch(t, vals, loaded.GetLayer(uint8(i)))
+			}
+
+			for _, v := range tc.appends {
+				loaded.InsertAtLayer(v, tc.targetLayer)
+			}
+
+			wantTarget := append(append([]uint64{}, tc.layers[tc.targetLayer]...), tc.appends...)
+			require.ElementsMatch(t, wantTarget, loaded.GetLayer(tc.targetLayer))
+
+			// Growing the target layer must not have corrupted any other layer's
+			// bytes: this fails under two-index slicing (cap to end of blob).
+			for i, vals := range tc.layers {
+				if uint8(i) == tc.targetLayer {
+					continue
+				}
+				require.ElementsMatch(t, vals, loaded.GetLayer(uint8(i)))
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

NewWithData copied each HNSW node layer's bytes out of the caller's blob  into a fresh `[]byte`. Subslice the blob with three-index slicing (data[start:end:end]) so each layer is a `cap==len` view; the `cap==len` invariant forces any later append to reallocate rather than corrupt an adjacent layer's bytes.

Drops per-node layer allocations (6->2 allocs/op in the added benchmark).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
