### PR TITLE
Return first letters of API keys for admins on namespaced clusters

### DIFF
--- a/adapters/handlers/rest/db_users/get_user_test.go
+++ b/adapters/handlers/rest/db_users/get_user_test.go
@@ -103,6 +103,88 @@ func TestSuccessGetUser(t *testing.T) {
 	}
 }
 
+// TestGetUserAPIKeyFirstLettersVisibility pins who sees the api-key hint on the
+// get endpoint: root always, a built-in admin only on namespace-enabled
+// clusters, everyone else never.
+func TestGetUserAPIKeyFirstLettersVisibility(t *testing.T) {
+	userID := "dynamic"
+	tests := []struct {
+		name              string
+		principal         *models.Principal
+		namespacesEnabled bool
+		callerRoles       map[string][]authorization.Policy
+		groupRoles        map[string][]authorization.Policy
+		wantFirstLetters  string
+	}{
+		{
+			name:              "root sees on namespaced cluster",
+			principal:         &models.Principal{Username: "root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: true,
+			wantFirstLetters:  "abc",
+		},
+		{
+			name:              "admin sees on namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: true,
+			callerRoles:       map[string][]authorization.Policy{authorization.Admin: {}},
+			wantFirstLetters:  "abc",
+		},
+		{
+			name:              "admin via group sees on namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb, Groups: []string{"admin-group"}},
+			namespacesEnabled: true,
+			callerRoles:       map[string][]authorization.Policy{},
+			groupRoles:        map[string][]authorization.Policy{authorization.Admin: {}},
+			wantFirstLetters:  "abc",
+		},
+		{
+			name:              "non-admin hidden on namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: true,
+			callerRoles:       map[string][]authorization.Policy{},
+			wantFirstLetters:  "",
+		},
+		{
+			name:              "admin hidden on non-namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: false,
+			callerRoles:       map[string][]authorization.Policy{authorization.Admin: {}},
+			wantFirstLetters:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := authorization.NewMockAuthorizer(t)
+			authorizer.On("Authorize", mock.Anything, tt.principal, authorization.READ, authorization.Users(userID)[0]).Return(nil)
+			dynUser := NewMockDbUserAndRolesGetter(t)
+			dynUser.On("GetUsers", userID).Return(map[string]apikey.UserView{userID: {Id: userID, ApiKeyFirstLetters: "abc"}}, nil)
+			// role-less target so role visibility never authorizes
+			dynUser.On("GetRolesForUserOrGroup", userID, authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{}, nil)
+			if tt.callerRoles != nil {
+				// Maybe: not consulted on non-namespaced clusters.
+				dynUser.On("GetRolesForUserOrGroup", tt.principal.Username, authentication.AuthTypeDb, false).Return(tt.callerRoles, nil).Maybe()
+			}
+			for _, group := range tt.principal.Groups {
+				dynUser.On("GetRolesForUserOrGroup", group, authentication.AuthTypeDb, true).Return(tt.groupRoles, nil).Maybe()
+			}
+
+			h := dynUserHandler{
+				dbUsers:           dynUser,
+				authorizer:        authorizer,
+				rbacConfig:        rbacconf.Config{Enabled: true, RootUsers: []string{"root"}},
+				dbUserEnabled:     true,
+				namespacesEnabled: tt.namespacesEnabled,
+			}
+
+			res := h.getUser(users.GetUserInfoParams{UserID: userID, HTTPRequest: req}, tt.principal)
+			parsed, ok := res.(*users.GetUserInfoOK)
+			require.True(t, ok, "got %T", res)
+			require.Equal(t, tt.wantFirstLetters, parsed.Payload.APIKeyFirstLetters)
+		})
+	}
+}
+
 func TestSuccessGetUserMultiNode(t *testing.T) {
 	returnedTime := time.Now()
 

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -135,12 +135,13 @@ func (h *dynUserHandler) listUsers(params users.ListAllUsersParams, principal *m
 	}
 
 	exposeNamespace := principal != nil && principal.IsGlobalOperator
+	showAPIKeyFirstLetters := isRootUser || h.callerHasAdminRole(principal)
 
 	allDynamicUsers := map[string]struct{}{}
 	response := make([]*models.DBUserInfo, 0, len(filteredUsers))
 	for _, dbUser := range filteredUsers {
 		apiKeyFirstLetter := ""
-		if isRootUser {
+		if showAPIKeyFirstLetters {
 			apiKeyFirstLetter = dbUser.ApiKeyFirstLetters
 		}
 		var lastUsedTime time.Time
@@ -249,7 +250,7 @@ func (h *dynUserHandler) getUser(params users.GetUserInfoParams, principal *mode
 		user := existingDbUsers[internalKey]
 		response.Active = &user.Active
 		response.CreatedAt = strfmt.DateTime(user.CreatedAt)
-		if isRootUser {
+		if isRootUser || h.callerHasAdminRole(principal) {
 			response.APIKeyFirstLetters = user.ApiKeyFirstLetters
 		}
 		if principal != nil && principal.IsGlobalOperator {
@@ -715,6 +716,35 @@ func (h *dynUserHandler) isRequestFromRootUser(principal *models.Principal) bool
 		return false
 	}
 	return h.rbacConfig.IsRootUser(principal.Username, principal.Groups)
+}
+
+// callerHasAdminRole reports whether the principal holds the built-in admin
+// role, directly or through one of its groups. Only consulted on
+// namespace-enabled clusters. A role lookup that errors is treated as non-admin
+// so the api-key hint stays hidden.
+func (h *dynUserHandler) callerHasAdminRole(principal *models.Principal) bool {
+	if principal == nil || !h.namespacesEnabled || !h.rbacConfig.Enabled {
+		return false
+	}
+	authType := authentication.AuthType(principal.UserType)
+	if h.subjectHasAdminRole(principal.Username, authType, false) {
+		return true
+	}
+	for _, group := range principal.Groups {
+		if h.subjectHasAdminRole(group, authType, true) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *dynUserHandler) subjectHasAdminRole(subject string, authType authentication.AuthType, isGroup bool) bool {
+	roles, err := h.dbUsers.GetRolesForUserOrGroup(subject, authType, isGroup)
+	if err != nil {
+		return false
+	}
+	_, ok := roles[authorization.Admin]
+	return ok
 }
 
 // validateRoleName validates that this string is a valid role name (format wise)

--- a/adapters/handlers/rest/db_users/list_all_users_test.go
+++ b/adapters/handlers/rest/db_users/list_all_users_test.go
@@ -93,6 +93,89 @@ func TestSuccessListAll(t *testing.T) {
 	}
 }
 
+// TestListUsersAPIKeyFirstLettersVisibility pins who sees the api-key hint on the
+// list endpoint: root always, a built-in admin only on namespace-enabled
+// clusters, everyone else never.
+func TestListUsersAPIKeyFirstLettersVisibility(t *testing.T) {
+	dbUser := "user1"
+	tests := []struct {
+		name              string
+		principal         *models.Principal
+		namespacesEnabled bool
+		callerRoles       map[string][]authorization.Policy
+		groupRoles        map[string][]authorization.Policy
+		wantFirstLetters  string
+	}{
+		{
+			name:              "root sees on namespaced cluster",
+			principal:         &models.Principal{Username: "root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: true,
+			wantFirstLetters:  "abc",
+		},
+		{
+			name:              "admin sees on namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: true,
+			callerRoles:       map[string][]authorization.Policy{authorization.Admin: {}},
+			wantFirstLetters:  "abc",
+		},
+		{
+			name:              "admin via group sees on namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb, Groups: []string{"admin-group"}},
+			namespacesEnabled: true,
+			callerRoles:       map[string][]authorization.Policy{},
+			groupRoles:        map[string][]authorization.Policy{authorization.Admin: {}},
+			wantFirstLetters:  "abc",
+		},
+		{
+			name:              "non-admin hidden on namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: true,
+			callerRoles:       map[string][]authorization.Policy{},
+			wantFirstLetters:  "",
+		},
+		{
+			name:              "admin hidden on non-namespaced cluster",
+			principal:         &models.Principal{Username: "not-root", UserType: models.UserTypeInputDb},
+			namespacesEnabled: false,
+			callerRoles:       map[string][]authorization.Policy{authorization.Admin: {}},
+			wantFirstLetters:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := authorization.NewMockAuthorizer(t)
+			authorizer.On("Authorize", mock.Anything, tt.principal, authorization.READ, authorization.Users()[0]).Return(nil)
+			dynUser := NewMockDbUserAndRolesGetter(t)
+			dynUser.On("GetUsers").Return(map[string]apikey.UserView{dbUser: {Id: dbUser, ApiKeyFirstLetters: "abc"}}, nil)
+			// role-less target so role visibility never authorizes
+			dynUser.On("GetRolesForUserOrGroup", dbUser, authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{}, nil)
+			if tt.callerRoles != nil {
+				// Maybe: not consulted on non-namespaced clusters.
+				dynUser.On("GetRolesForUserOrGroup", tt.principal.Username, authentication.AuthTypeDb, false).Return(tt.callerRoles, nil).Maybe()
+			}
+			for _, group := range tt.principal.Groups {
+				dynUser.On("GetRolesForUserOrGroup", group, authentication.AuthTypeDb, true).Return(tt.groupRoles, nil).Maybe()
+			}
+
+			h := dynUserHandler{
+				dbUsers:           dynUser,
+				authorizer:        authorizer,
+				rbacConfig:        rbacconf.Config{Enabled: true, RootUsers: []string{"root"}},
+				dbUserEnabled:     true,
+				namespacesEnabled: tt.namespacesEnabled,
+			}
+
+			res := h.listUsers(users.ListAllUsersParams{HTTPRequest: req}, tt.principal)
+			parsed, ok := res.(*users.ListAllUsersOK)
+			require.True(t, ok)
+			require.Len(t, parsed.Payload, 1)
+			require.Equal(t, tt.wantFirstLetters, parsed.Payload[0].APIKeyFirstLetters)
+		})
+	}
+}
+
 func TestSuccessListAllAfterImport(t *testing.T) {
 	exStaticUser := "static"
 	authorizer := authorization.NewMockAuthorizer(t)
@@ -341,7 +424,7 @@ func TestListUsers_CrossNamespaceIsolation(t *testing.T) {
 		"customer1:bob": {Id: "customer1:bob", Namespace: "customer1", Active: true},
 		"customer2:bob": {Id: "customer2:bob", Namespace: "customer2", Active: true},
 	}
-	principal := &models.Principal{Namespace: "customer1"}
+	principal := &models.Principal{Namespace: "customer1", UserType: models.UserTypeInputDb}
 	nullLogger, _ := test.NewNullLogger()
 
 	authorizer := authorization.NewMockAuthorizer(t)
@@ -356,6 +439,7 @@ func TestListUsers_CrossNamespaceIsolation(t *testing.T) {
 	dynUser := NewMockDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers").Return(stored, nil)
 	dynUser.On("GetRolesForUserOrGroup", "customer1:bob", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{}, nil)
+	dynUser.On("GetRolesForUserOrGroup", "", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{}, nil)
 
 	h := dynUserHandler{
 		dbUsers:           dynUser,

--- a/adapters/handlers/rest/db_users/namespaced_roles_test.go
+++ b/adapters/handlers/rest/db_users/namespaced_roles_test.go
@@ -55,6 +55,7 @@ func TestGetUserNamespacedRolesStrippedAndFiltered(t *testing.T) {
 
 	dynUser := NewMockDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers", "customer1:bob").Return(map[string]apikey.UserView{"customer1:bob": {Id: "customer1:bob"}}, nil)
+	dynUser.On("GetRolesForUserOrGroup", "customer1:admin", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{}, nil)
 	dynUser.On("GetRolesForUserOrGroup", "customer1:bob", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{
 		"customer1:editor": {},                                           // own-namespace local role, no permissions to gate
 		"customer2:secret": {},                                           // foreign namespace, hidden by name
@@ -113,6 +114,7 @@ func TestListUsersNamespacedRolesStrippedAndFiltered(t *testing.T) {
 
 	dynUser := NewMockDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers").Return(map[string]apikey.UserView{"customer1:bob": {Id: "customer1:bob"}}, nil)
+	dynUser.On("GetRolesForUserOrGroup", "customer1:admin", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{}, nil)
 	dynUser.On("GetRolesForUserOrGroup", "customer1:bob", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{
 		"customer1:editor": {},
 		"customer2:secret": {},

--- a/test/acceptance/namespace/user_mgmt_test.go
+++ b/test/acceptance/namespace/user_mgmt_test.go
@@ -92,6 +92,9 @@ func TestNamespacedAdminLifecycle(t *testing.T) {
 	require.Equal(t, "bob", *bobFromAdmin.UserID)
 	require.Empty(t, bobFromAdmin.Namespace)
 
+	// A namespaced admin (non-root) sees the api-key first letters.
+	require.Equal(t, bobKey[:3], bobFromAdmin.APIKeyFirstLetters)
+
 	// Admin can read bob's roles via the short id — proves the authz-handler
 	// resolver + matcher specialization end to end (bob has no roles yet).
 	require.Empty(t, helper.GetRolesForUser(t, "bob", nsAdminKey, false))
@@ -195,8 +198,10 @@ func TestNamespacedViewerDeniedUserMutations(t *testing.T) {
 
 	viewerKey := createNamespacedViewerUser(t, "dan", ns, adminKey)
 
-	// Reads: allowed.
-	require.Equal(t, "bob", *helper.GetUser(t, "bob", viewerKey).UserID)
+	// Reads: allowed, but a non-admin never sees the api-key first letters.
+	bobFromViewer := helper.GetUser(t, "bob", viewerKey)
+	require.Equal(t, "bob", *bobFromViewer.UserID)
+	require.Empty(t, bobFromViewer.APIKeyFirstLetters)
 	require.Len(t, helper.ListAllUsers(t, viewerKey), 2)
 
 	// Mutations: 403.


### PR DESCRIPTION
### What's being changed:

title, we want to display them in the console

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
