### PR TITLE
Fix empty range results served after enable-rangeable reindex with INDEX_RANGEABLE_IN_MEMORY=true (forward-port to main)

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/loadlimiter"
@@ -491,6 +492,7 @@ func setupTestShardWithSettings(t *testing.T, ctx context.Context, class *models
 		scheduler:              repo.scheduler,
 		shardLoadLimiter:       loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
 		shardReindexer:         NewShardReindexerV3Noop(),
+		bitmapBufPool:          roaringset.NewBitmapBufPoolNoop(),
 		HFreshEnabled:          true,
 		replicator:             replicator,
 		router:                 mockRouter,

--- a/adapters/repos/db/inverted_reindex_rangeable_inmemory_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_rangeable_inmemory_finalize_test.go
@@ -1,0 +1,363 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// Regression tests for weaviate/weaviate#12215: a non-cancellation rebuild
+// failure at migration finalize must degrade to disk serving
+// (WARN-and-continue), not fail the migration. Failures are injected via
+// the rebuildRangeableRepFn seam since the real failure window is too
+// narrow to hit black-box.
+
+// newRangeableInMemoryTestTask installs a fault-injecting rebuildRangeableRepFn.
+func newRangeableInMemoryTestTask(t *testing.T, idx *Index, className, propName string, failing *atomic.Bool, calls *atomic.Int32,
+) (*ShardReindexTaskGeneric, *testFilterableToRangeableStrategyWrapper) {
+	t.Helper()
+	task, wrapped := newFilterableToRangeableTask(t, idx, className, propName)
+	task.rebuildRangeableRepFn = func(ctx context.Context, b *lsmkv.Bucket) error {
+		calls.Add(1)
+		if failing.Load() {
+			return fmt.Errorf("injected rebuild failure")
+		}
+		return b.RebuildRangeableSegmentInMemory(ctx)
+	}
+	return task, wrapped
+}
+
+// firstErrorEntry returns the first ERROR-level log entry captured by hook,
+// or nil if none was emitted.
+func firstErrorEntry(hook *test.Hook) *logrus.Entry {
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.ErrorLevel {
+			return e
+		}
+	}
+	return nil
+}
+
+// newRangeableFinalizeTestShard builds a shard+index with the rangeable
+// in-memory knob enabled.
+func newRangeableFinalizeTestShard(t *testing.T, classNamePrefix string) (context.Context, *Shard, *Index, string) {
+	t.Helper()
+	ctx := testCtx()
+	className := classNamePrefix + uuid.NewString()[:8]
+	class := newFilterableToRangeableTestClass(className)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false,
+		func(idx *Index) { idx.Config.IndexRangeableInMemory = true })
+	shard := shd.(*Shard)
+	t.Cleanup(func() { shard.Shutdown(ctx) })
+	return ctx, shard, idx, className
+}
+
+// putRangeableTestObjects loads numObjects test objects into shard.
+func putRangeableTestObjects(t *testing.T, ctx context.Context, shard *Shard, className string, numObjects int) {
+	t.Helper()
+	for _, obj := range makeFilterableToRangeableTestObjects(t, numObjects, className) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+}
+
+// runReindexToCompletionOrError drives OnAfterLsmInit + OnAfterLsmInitAsync
+// to convergence, returning the first error encountered (nil if the
+// migration converged cleanly).
+func runReindexToCompletionOrError(t *testing.T, ctx context.Context, task *ShardReindexTaskGeneric, shard *Shard) error {
+	t.Helper()
+	if err := task.OnAfterLsmInit(ctx, shard); err != nil {
+		return err
+	}
+	for {
+		rerunAt, _, err := task.OnAfterLsmInitAsync(ctx, shard)
+		if err != nil {
+			return err
+		}
+		if rerunAt.IsZero() {
+			return nil
+		}
+	}
+}
+
+// setupRangeableFinalizeDegradeFixture builds a shard, injects a
+// permanently failing rebuild, and drives the migration to completion: a
+// non-cancellation rebuild failure must not fail the migration, so
+// OnMigrationComplete still runs and range queries serve disk results.
+func setupRangeableFinalizeDegradeFixture(t *testing.T, classNamePrefix string) (
+	context.Context, *Shard, *Index, string, *ShardReindexTaskGeneric,
+	*testFilterableToRangeableStrategyWrapper, *atomic.Bool, *atomic.Int32, *test.Hook,
+) {
+	t.Helper()
+	const numObjects = 25
+	propName := filterableToRangeablePropName
+
+	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, classNamePrefix)
+
+	// The task captures idx.logger by value at construction, so swap in a
+	// hook-capturing logger first to assert on the ERROR log this fixture drives.
+	hookLogger, hook := test.NewNullLogger()
+	idx.logger = hookLogger
+
+	putRangeableTestObjects(t, ctx, shard, className, numObjects)
+
+	failing := &atomic.Bool{}
+	failing.Store(true)
+	calls := &atomic.Int32{}
+
+	task, wrapped := newRangeableInMemoryTestTask(t, idx, className, propName, failing, calls)
+	require.NoError(t, runReindexToCompletionOrError(t, ctx, task, shard),
+		"a non-cancellation rebuild failure must not fail the migration")
+
+	return ctx, shard, idx, className, task, wrapped, failing, calls, hook
+}
+
+// TestRangeableFinalize_RebuildFailure_ServesDiskNotMissingIndexError pins
+// weaviate/weaviate#12215: a non-cancellation rebuild failure at finalize
+// must FINISH the migration and serve correct disk results, never a
+// permanent FAILED or MissingFilterableIndexError.
+func TestRangeableFinalize_RebuildFailure_ServesDiskNotMissingIndexError(t *testing.T) {
+	propName := filterableToRangeablePropName
+	_, shard, _, _, _, wrapped, _, calls, hook := setupRangeableFinalizeDegradeFixture(t, "RangeableRebuildDegrade_")
+
+	assert.True(t, wrapped.migrationCompleted,
+		"OnMigrationComplete must still run on a non-cancellation rebuild failure (WARN-and-continue): "+
+			"in production this is exactly what flips the ready flag (setRangeableLocallyReady), so a "+
+			"replica reaching this point serves via hasUsableRangeableIndex, not MissingFilterableIndexError. "+
+			"This harness's test wrapper intentionally skips the real setRangeableLocallyReady side effect "+
+			"(see testFilterableToRangeableStrategyWrapper's doc comment), so this flag is the load-bearing "+
+			"proxy for it here; that side effect itself is unchanged, existing production code.")
+	assert.GreaterOrEqual(t, calls.Load(), int32(1), "rebuildRangeableRepFn must have been invoked")
+
+	bucket := shard.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, bucket)
+	assert.False(t, bucket.RangeableServesFromMemory(),
+		"the failed rebuild must not have activated in-memory serving")
+	fp := filterableToRangeableFingerprint(t, bucket)
+	require.Len(t, fp, filterableToRangeableNumDistinctValues,
+		"disk-path range reads must still return the full, correct term set")
+
+	errLine := firstErrorEntry(hook)
+	require.NotNil(t, errLine, "a rebuild failure must log at ERROR")
+	assert.Contains(t, errLine.Message, propName)
+	assert.Contains(t, errLine.Message, "built and data intact")
+
+	className := shard.Index().Config.ClassName.String()
+	metric, err := monitoring.GetMetrics().RangeableInMemoryRebuildDegraded.GetMetricWithLabelValues(className, shard.Name(), propName)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, testutil.ToFloat64(metric), float64(1), "a degrade must increment the metric")
+}
+
+// TestRangeableFinalize_RebuildCancellation_RoutesTransient pins
+// weaviate/weaviate#12215: cancellation must still abort the rebuild
+// loudly, preserving the scheduler's transient-ack routing.
+func TestRangeableFinalize_RebuildCancellation_RoutesTransient(t *testing.T) {
+	propName := filterableToRangeablePropName
+	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, "RangeableRebuildCancel_")
+	putRangeableTestObjects(t, ctx, shard, className, 5)
+
+	// Drive the migration to completion first so the rangeable bucket
+	// exists: cancellation must route through the rebuild-error branch
+	// here, not the (separately tested) nil-bucket branch.
+	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+	require.NoError(t, runReindexToCompletionOrError(t, ctx, task, shard))
+
+	bucketName := task.strategy.SourceBucketName(propName)
+	require.NotNil(t, shard.Store().Bucket(bucketName), "precondition: bucket must exist post-swap")
+
+	task2, _ := newFilterableToRangeableTask(t, idx, className, propName)
+	task2.rebuildRangeableRepFn = func(ctx context.Context, b *lsmkv.Bucket) error {
+		return fmt.Errorf("injected fault under cancellation")
+	}
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err := task2.rebuildRangeableInMemoryReps(cancelledCtx, idx.logger, shard, []string{propName})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled,
+		"a cancelled context must route directly through the rebuild-error branch too, preserving errors.Is compatibility")
+}
+
+// TestRangeableFinalize_DataWorkFailure_StillFAILED pins
+// weaviate/weaviate#12215: a data-work (swap) failure, unlike a rebuild
+// failure, must still fail the migration - WARN-and-continue is scoped to
+// the acceleration step only.
+func TestRangeableFinalize_DataWorkFailure_StillFAILED(t *testing.T) {
+	propName := filterableToRangeablePropName
+	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, "RangeableDataWorkFail_")
+	putRangeableTestObjects(t, ctx, shard, className, 5)
+
+	task, wrapped := newFilterableToRangeableTask(t, idx, className, propName)
+	task.processOneSwapPropFn = func(ctx context.Context, store *lsmkv.Store, rt reindexTracker, propIdx int, propName string) (*lsmkv.Bucket, error) {
+		return nil, fmt.Errorf("injected data-work swap failure")
+	}
+
+	err := runReindexToCompletionOrError(t, ctx, task, shard)
+	require.Error(t, err, "a data-work (swap) failure must still fail the migration - "+
+		"WARN-and-continue is scoped to the rebuild step only")
+	assert.Contains(t, err.Error(), "injected data-work swap failure")
+	assert.False(t, wrapped.migrationCompleted, "OnMigrationComplete must not run when the data work itself failed")
+}
+
+// TestRangeableFinalize_MultiReplica_FailedReplicaServesCorrectDiskResults
+// pins weaviate/weaviate#12215: two replicas where one's rebuild fails,
+// verifying both converge to identical, correct results.
+func TestRangeableFinalize_MultiReplica_FailedReplicaServesCorrectDiskResults(t *testing.T) {
+	const numObjects = 25
+	propName := filterableToRangeablePropName
+
+	newReplica := func(classNamePrefix string) (context.Context, *Shard, *Index, string) {
+		ctx, shard, idx, className := newRangeableFinalizeTestShard(t, classNamePrefix)
+		putRangeableTestObjects(t, ctx, shard, className, numObjects)
+		return ctx, shard, idx, className
+	}
+
+	// Replica A: rebuild succeeds. Its OnMigrationComplete models the
+	// cluster-wide RAFT commit of IndexRangeFilters=true that a real
+	// cluster's first-successful-shard triggers.
+	ctxA, shardA, idxA, classNameA := newReplica("RangeableMultiReplicaA_")
+	taskA, wrappedA := newFilterableToRangeableTask(t, idxA, classNameA, propName)
+	require.NoError(t, runReindexToCompletionOrError(t, ctxA, taskA, shardA))
+	require.True(t, wrappedA.migrationCompleted)
+
+	bucketA := shardA.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, bucketA)
+	require.True(t, bucketA.RangeableServesFromMemory())
+
+	// Replica B: rebuild is fault-injected to fail. In a real cluster the
+	// schema flag is already committed cluster-wide by replica A here;
+	// replica B's own OnMigrationComplete must still run so its local ready
+	// flag converges too. wrappedB.migrationCompleted proxies that flag
+	// since this harness's wrapper skips the real setRangeableLocallyReady
+	// side effect.
+	ctxB, shardB, idxB, classNameB := newReplica("RangeableMultiReplicaB_")
+	failing := &atomic.Bool{}
+	failing.Store(true)
+	calls := &atomic.Int32{}
+	taskB, wrappedB := newRangeableInMemoryTestTask(t, idxB, classNameB, propName, failing, calls)
+	require.NoError(t, runReindexToCompletionOrError(t, ctxB, taskB, shardB),
+		"a non-cancellation rebuild failure must not fail the migration")
+	require.True(t, wrappedB.migrationCompleted,
+		"replica B's OnMigrationComplete must still run so its local ready flag converges, "+
+			"exactly as it would need to once the cluster-wide schema flag is already true")
+	assert.GreaterOrEqual(t, calls.Load(), int32(1))
+
+	bucketB := shardB.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, bucketB)
+	assert.False(t, bucketB.RangeableServesFromMemory(),
+		"replica B's failed rebuild must not have activated in-memory serving")
+
+	fpA := filterableToRangeableFingerprint(t, bucketA)
+	fpB := filterableToRangeableFingerprint(t, bucketB)
+	assert.Equal(t, fpA, fpB,
+		"replica B, serving from disk, must return the identical result set to replica A, "+
+			"serving from memory - the staggered flip must never produce diverging results")
+
+	// Restart replica B: boot-time population rebuilds the rep from disk,
+	// restoring acceleration without any repair action.
+	shardName := shardB.Name()
+	require.NoError(t, shardB.Shutdown(ctxB))
+
+	taskB2, _ := newFilterableToRangeableTask(t, idxB, classNameB, propName)
+	idxB.shardReindexer = &testShardReindexer{task: taskB2}
+
+	shdB2, err := idxB.initShard(ctxB, shardName, newFilterableToRangeableTestClass(classNameB), nil, true, true)
+	require.NoError(t, err)
+	shardB2 := shdB2.(*Shard)
+	idxB.shards.Store(shardName, shdB2)
+	t.Cleanup(func() { shardB2.Shutdown(ctxB) })
+
+	restartedBucket := shardB2.store.Bucket(helpers.BucketRangeableFromPropNameLSM(propName))
+	require.NotNil(t, restartedBucket)
+	assert.True(t, restartedBucket.RangeableServesFromMemory(),
+		"restart must rebuild the rep from disk and restore in-memory acceleration")
+}
+
+// TestRebuildRangeableInMemoryReps_NilBucketRoutesContextCancellation pins
+// weaviate/weaviate#12215: a nil bucket (a legitimate, tolerated condition)
+// must not become a hard failure when the context is already done - it
+// must return the context error directly so errors.Is(err, context.Canceled)
+// still works.
+func TestRebuildRangeableInMemoryReps_NilBucketRoutesContextCancellation(t *testing.T) {
+	propName := filterableToRangeablePropName
+	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, "RangeableNilBucketCtxCancel_")
+	putRangeableTestObjects(t, ctx, shard, className, 5)
+
+	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+
+	// A prop whose bucket was never created: store.Bucket(...) returns nil
+	// for it regardless of context state, giving a deterministic nil-bucket
+	// branch without needing to race a real shutdown.
+	missingPropName := "never_created_prop"
+	require.Nil(t, shard.Store().Bucket(task.strategy.SourceBucketName(missingPropName)),
+		"precondition: no bucket exists for this prop")
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err := task.rebuildRangeableInMemoryReps(cancelledCtx, idx.logger, shard, []string{missingPropName})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled,
+		"a cancelled context must route directly, preserving errors.Is compatibility")
+	assert.NotContains(t, err.Error(), "not found post-swap",
+		"a cancelled context must short-circuit before the hard-fail message is built")
+}
+
+// TestRebuildRangeableInMemoryReps_NilBucketDegradesWithoutCancellation
+// pins weaviate/weaviate#12215: absent cancellation, a nil bucket also
+// degrades WARN-and-continue (ERROR log + metric) instead of failing the
+// migration.
+func TestRebuildRangeableInMemoryReps_NilBucketDegradesWithoutCancellation(t *testing.T) {
+	propName := filterableToRangeablePropName
+	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, "RangeableNilBucketDegrade_")
+
+	hookLogger, hook := test.NewNullLogger()
+	idx.logger = hookLogger
+
+	putRangeableTestObjects(t, ctx, shard, className, 5)
+
+	task, _ := newFilterableToRangeableTask(t, idx, className, propName)
+
+	missingPropName := "never_created_prop"
+	require.Nil(t, shard.Store().Bucket(task.strategy.SourceBucketName(missingPropName)))
+
+	err := task.rebuildRangeableInMemoryReps(ctx, idx.logger, shard, []string{missingPropName})
+	require.NoError(t, err, "a nil bucket without cancellation must degrade WARN-and-continue too, not hard-fail")
+	assert.False(t, errors.Is(err, context.Canceled))
+
+	errLine := firstErrorEntry(hook)
+	require.NotNil(t, errLine)
+	assert.Contains(t, errLine.Message, "not found post-swap")
+
+	className2 := shard.Index().Config.ClassName.String()
+	metric, err2 := monitoring.GetMetrics().RangeableInMemoryRebuildDegraded.GetMetricWithLabelValues(className2, shard.Name(), missingPropName)
+	require.NoError(t, err2)
+	assert.GreaterOrEqual(t, testutil.ToFloat64(metric), float64(1))
+}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -141,6 +141,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // ShardReindexTaskGeneric is a strategy-parameterized implementation of
@@ -231,6 +232,13 @@ type ShardReindexTaskGeneric struct {
 	// drop()-vs-MkdirAll race deterministic. Always set — no test-only
 	// branch runs in production.
 	trackerMkdirGuard func(shard ShardLike) func(func() error) error
+
+	// rebuildRangeableRepFn dispatches [rebuildRangeableInMemoryReps]'s
+	// per-prop bucket rebuild; defaults to
+	// [lsmkv.Bucket.RebuildRangeableSegmentInMemory], tests substitute a
+	// failure-injecting wrapper. Always set - no test-only branch runs in
+	// production.
+	rebuildRangeableRepFn func(ctx context.Context, b *lsmkv.Bucket) error
 }
 
 // NewShardReindexTaskGeneric creates a new generic reindex task.
@@ -264,6 +272,9 @@ func NewShardReindexTaskGeneric(name string, logger logrus.FieldLogger,
 		return shard.Index().withCloseRLockGuard
 	}
 	t.registerDoubleWriteCallbacksFn = t.registerDoubleWriteCallbacks
+	t.rebuildRangeableRepFn = func(ctx context.Context, b *lsmkv.Bucket) error {
+		return b.RebuildRangeableSegmentInMemory(ctx)
+	}
 	return t
 }
 
@@ -632,7 +643,7 @@ func (t *ShardReindexTaskGeneric) RunSwapOnShard(ctx context.Context, shard Shar
 		//    RunPrepareOnShard first): ingest buckets are loaded in
 		//    the LSM store. Do the in-memory atomic SwapBucketPointer
 		//    via [runtimeSwap]. Disk rename is deferred to next
-		//    startup via OnBeforeLsmInit's recoverRuntimeSwapBuckets.
+		//    startup via [FinalizeCompletedMigrations].
 		//  - **Recovery fallback**: ingest buckets are NOT loaded.
 		//    In practice this is rare — post-restart, OnBeforeLsmInit's
 		//    IsMerged && !IsSwapped branch typically does the disk
@@ -799,11 +810,89 @@ func (t *ShardReindexTaskGeneric) finalizeMigrationAfterRecovery(
 	ctx context.Context, logger logrus.FieldLogger, shard ShardLike,
 	rt reindexTracker, props []string,
 ) error {
+	// Ordering contract: rebuild must run and be checked before
+	// OnMigrationComplete (see runtimeSwap for the full reasoning).
+	if err := t.rebuildRangeableInMemoryReps(ctx, logger, shard, props); err != nil {
+		return err
+	}
 	if err := t.strategy.OnMigrationComplete(ctx, shard); err != nil {
 		return fmt.Errorf("on migration complete: %w", err)
 	}
 	t.trimOlderGenerationsLocked(logger, shard, rt, props)
 	logger.Info("RunSwapOnShard: recovery path complete")
+	return nil
+}
+
+// rebuildRangeableInMemoryReps restores the INDEX_RANGEABLE_IN_MEMORY
+// contract for buckets promoted by a reindex swap: ingest buckets open
+// without an in-memory rep, so without this they'd serve range reads from
+// disk until the next open. Idempotent.
+//
+// A rebuild failure degrades to disk serving (WARN-and-continue) instead of
+// failing the migration: data work (prepend, swap, tidy) has already
+// committed, disk serving is always correct, and only the in-memory
+// acceleration is deferred to next restart. Every degrade still logs at
+// ERROR and increments a metric so it stays visible.
+//
+// context.Canceled is the one error this function still returns, so
+// [runPerUnitPhase]'s errors.Is(context.Canceled) check keeps routing to
+// the transient ack path instead of a permanent FAILED or false FINISHED.
+func (t *ShardReindexTaskGeneric) rebuildRangeableInMemoryReps(ctx context.Context,
+	logger logrus.FieldLogger, shard ShardLike, props []string,
+) error {
+	if t.strategy.TargetStrategy() != lsmkv.StrategyRoaringSetRange ||
+		!shard.Index().Config.IndexRangeableInMemory {
+		return nil
+	}
+
+	store := shard.Store()
+	className := shard.Index().Config.ClassName.String()
+	shardName := shard.Name()
+	for _, propName := range props {
+		bucketName := t.strategy.SourceBucketName(propName)
+
+		bucket := store.Bucket(bucketName)
+		if bucket == nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				// Missing buckets have legitimate transient causes (shutdown
+				// draining, a property dropped mid-migration); only treat this
+				// as a hard failure once we know the caller isn't shutting down.
+				return fmt.Errorf("rangeable in-memory rebuild aborted for property %q: %w", propName, ctxErr)
+			}
+			err := fmt.Errorf(
+				"rangeable index for property %q could not be activated for in-memory "+
+					"serving: bucket %q not found post-swap, rebuild the index to repair it",
+				propName, bucketName,
+			)
+			logger.WithField("bucket", bucketName).Errorf("rangeable in-memory rebuild: %v", err)
+			monitoring.GetMetrics().IncRangeableInMemoryRebuildDegraded(className, shardName, propName)
+			continue
+		}
+
+		started := time.Now()
+		if err := t.rebuildRangeableRepFn(ctx, bucket); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				// Wrap ctxErr too: it guarantees errors.Is(context.Canceled)
+				// works even if the underlying err doesn't itself wrap
+				// ctx.Err(); err is kept for diagnostics.
+				return fmt.Errorf("rangeable in-memory rebuild aborted for property %q: %w: %w", propName, ctxErr, err)
+			}
+			wrapped := fmt.Errorf(
+				"rangeable index for property %q built and data intact, but could not be "+
+					"activated for in-memory serving: %w, rebuild the index to repair it",
+				propName, err,
+			)
+			logger.WithField("bucket", bucketName).Errorf("rangeable in-memory rebuild: %v", wrapped)
+			monitoring.GetMetrics().IncRangeableInMemoryRebuildDegraded(className, shardName, propName)
+			continue
+		}
+		if bucket.RangeableServesFromMemory() {
+			logger.WithFields(logrus.Fields{
+				"bucket": bucketName,
+				"took":   time.Since(started).String(),
+			}).Info("rangeable in-memory index built at migration finalize; serving range queries from memory")
+		}
+	}
 	return nil
 }
 
@@ -1371,6 +1460,12 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 				return zerotime, false, err
 			}
 		}
+		// Same ordering contract as runtimeSwap (see there for reasoning):
+		// this re-entry branch must recheck the rebuild too, or a retry
+		// could flip the schema without it ever succeeding.
+		if err = t.rebuildRangeableInMemoryReps(ctx, logger, shard, props); err != nil {
+			return zerotime, false, err
+		}
 		err = t.strategy.OnMigrationComplete(ctx, shard)
 		if err != nil {
 			err = fmt.Errorf("updating inverted index config: %w", err)
@@ -1892,14 +1987,27 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	// markTidied signals that all on-disk cleanup that can be done inline
 	// has been done. The LIVE bucket's dir (ingest_<gen>) is still at its
 	// pre-swap name — that rename to the canonical name is deferred to
-	// next-restart recovery (OnBeforeLsmInit → recoverRuntimeSwapBuckets)
-	// because renaming a dir whose buckets are mmap'd by the in-memory
-	// store would corrupt the segment registry. At restart time, nothing
-	// has loaded that dir yet, so the rename is safe.
+	// next startup via [FinalizeCompletedMigrations], because renaming a
+	// dir whose buckets are mmap'd by the in-memory store would corrupt
+	// the segment registry. At restart time, nothing has loaded that dir
+	// yet, so the rename is safe.
 	if err := rt.markTidied(); err != nil {
 		return fmt.Errorf("marking tidied: %w", err)
 	}
 	logger.Debug("runtime swap: tidy complete (ingest→main rename deferred to next restart)")
+
+	// Ordering contract: rebuild must be checked before OnMigrationComplete.
+	//
+	// Unlike the semantic-migration family ([IsSemanticMigration]),
+	// FilterableToRangeableStrategy.OnMigrationComplete is not gated by
+	// task-terminal status - it RAFT-commits IndexRangeFilters=true
+	// unconditionally the first time any shard's swap reaches this line.
+	// Skipping the check would advertise range-query support while this
+	// shard still falls back to disk (or a corrupt segment parsed as empty
+	// - see [rebuildRangeableInMemoryReps]).
+	if err := t.rebuildRangeableInMemoryReps(ctx, logger, shard, props); err != nil {
+		return err
+	}
 
 	// OnMigrationComplete: no-op for semantic migrations (the cluster-
 	// wide schema flip lives in OnTaskCompleted.flipSemanticMigrationSchema).
@@ -2427,7 +2535,21 @@ func (t *ShardReindexTaskGeneric) loadIngestBuckets(ctx context.Context,
 	logger logrus.FieldLogger, shard *Shard, props []string,
 	keepLevelCompaction, keepTombstones bool,
 ) error {
-	bucketOpts := t.bucketOptions(shard, t.strategy.TargetStrategy(), keepLevelCompaction, keepTombstones, t.config.memtableOptFactor)
+	strategy := t.strategy.TargetStrategy()
+	bucketOpts := t.bucketOptions(shard, strategy, keepLevelCompaction, keepTombstones, t.config.memtableOptFactor)
+
+	// Only the ingest bucket becomes the main bucket post-swap; reindex/backup
+	// buckets are torn down and never serve reads.
+	if strategy == lsmkv.StrategyRoaringSetRange && shard.Index().Config.IndexRangeableInMemory {
+		bucketOpts = append(bucketOpts, lsmkv.WithRangeableInMemoryDeferred(true))
+		logger.WithField("props", props).Info(
+			"rangeable properties are serving from disk during reindex ingest; " +
+				"in-memory acceleration is restored automatically when the migration " +
+				"finalizes. A node restart, shard reload, or tenant reactivation only " +
+				"repairs this if that automatic rebuild fails.",
+		)
+	}
+
 	return t.loadBuckets(ctx, logger, shard, props, t.ingestBucketName, bucketOpts)
 }
 
@@ -2608,7 +2730,8 @@ func (t *ShardReindexTaskGeneric) bucketOptions(shard *Shard, strategy string,
 ) []lsmkv.BucketOption {
 	cfg := shard.Index().Config
 
-	return shard.makeDefaultBucketOptions(strategy,
+	opts := shard.makeDefaultBucketOptions(
+		strategy,
 		lsmkv.WithKeepLevelCompaction(keepLevelCompaction),
 		lsmkv.WithKeepTombstones(keepTombstones),
 		// overwrite DynamicMemtableSizing
@@ -2619,6 +2742,15 @@ func (t *ShardReindexTaskGeneric) bucketOptions(shard *Shard, strategy string,
 			memtableOptFactor*cfg.MemtablesMaxActiveSeconds,
 		),
 	)
+
+	// Override: RoaringSetRange ingest buckets never keep an in-memory rep.
+	// PrependSegmentsFromBucket can't rebuild it, so a kept rep would serve
+	// stale/empty range results until the next clean bucket open.
+	if strategy == lsmkv.StrategyRoaringSetRange {
+		opts = append(opts, lsmkv.WithKeepSegmentsInMemory(false))
+	}
+
+	return opts
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/diskio"
@@ -233,6 +234,21 @@ type Bucket struct {
 	// keep segments in memory for more performant search
 	// (currently used by roaringsetrange inverted indexes)
 	keepSegmentsInMemory bool
+
+	// rangeableInMemoryDeferred marks a bucket whose rep was intentionally left
+	// unbuilt (reindex ingest path). Selects a diagnostic log line only;
+	// rangeableServesFromMemory alone governs read-path selection.
+	rangeableInMemoryDeferred bool
+
+	// rangeableRepRebuilt flips once RebuildRangeableSegmentInMemory
+	// publishes a rep. Atomic and read unlocked; the false->true store
+	// happens under flushLock after the rep is fully built, so a reader
+	// observing true is guaranteed a populated rep.
+	rangeableRepRebuilt atomic.Bool
+
+	// Dedup for the rangeable diagnostic log lines, once per bucket-open.
+	rangeableDeferredLogOnce  sync.Once
+	rangeableFallbackWarnOnce sync.Once
 
 	// pool of buffers for bitmaps merges
 	// (currently used by roaringsetrange inverted indexes)
@@ -2188,7 +2204,7 @@ func (b *Bucket) atomicallyAddDiskSegmentAndRemoveFlushing(seg Segment) error {
 		}
 
 	case StrategyRoaringSetRange:
-		if b.keepSegmentsInMemory {
+		if b.rangeableServesFromMemory() {
 			b.disk.roaringSetRangeSegmentInMemory.MergeMemtableEventually(flushing.extractRoaringSetRange())
 		}
 	case StrategyInverted:

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -301,6 +301,16 @@ func WithKeepSegmentsInMemory(keep bool) BucketOption {
 	}
 }
 
+// WithRangeableInMemoryDeferred marks a bucket whose in-memory rep was left
+// unbuilt intentionally. Enables a diagnostic log line only; never affects
+// read-path selection.
+func WithRangeableInMemoryDeferred(deferred bool) BucketOption {
+	return func(b *Bucket) error {
+		b.rangeableInMemoryDeferred = deferred
+		return nil
+	}
+}
+
 func WithBitmapBufPool(bufPool roaringset.BitmapBufPool) BucketOption {
 	return func(b *Bucket) error {
 		b.bitmapBufPool = bufPool

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range.go
@@ -13,6 +13,9 @@ package lsmkv
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -20,6 +23,15 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
+)
+
+// ErrRangeableRepUnpopulatedAfterRebuild is returned by
+// RebuildRangeableSegmentInMemory when the rebuilt rep is empty but disk
+// segments exist; publication is refused and the bucket keeps serving from
+// disk.
+var ErrRangeableRepUnpopulatedAfterRebuild = errors.New(
+	"rangeable in-memory rebuild produced an empty representation while disk segments " +
+		"exist; leaving disk-serving in place",
 )
 
 func (b *Bucket) RoaringSetRangeAdd(key uint64, values ...uint64) error {
@@ -55,16 +67,69 @@ type ReaderRoaringSetRange interface {
 	Close()
 }
 
+// rangeableServesFromMemory reports whether range reads serve from the
+// in-memory rep. Both operands are safe to read unlocked: keepSegmentsInMemory
+// is immutable after open, rangeableRepRebuilt is atomic.
+func (b *Bucket) rangeableServesFromMemory() bool {
+	return b.keepSegmentsInMemory || b.rangeableRepRebuilt.Load()
+}
+
+// RangeableServesFromMemory exports rangeableServesFromMemory so
+// out-of-package callers (e.g. reindex finalize logging) can report which
+// path is actually serving.
+func (b *Bucket) RangeableServesFromMemory() bool {
+	return b.rangeableServesFromMemory()
+}
+
 func (b *Bucket) ReaderRoaringSetRange() ReaderRoaringSetRange {
 	MustBeExpectedStrategy(b.strategy, StrategyRoaringSetRange)
 
+	// A rep published via RebuildRangeableSegmentInMemory was already
+	// validated at install time against this same discriminant, so a reader
+	// can trust it unconditionally here without a per-read check.
+	if b.rangeableRepRebuilt.Load() {
+		return b.readerRoaringSetRangeFromSegmentInMemo()
+	}
+
 	if b.keepSegmentsInMemory {
+		// Boot-time population has no install-time gate, so this path still
+		// needs the per-read check; checking emptiness first keeps the hot
+		// path to one IsUnpopulated() call under the rep's RLock.
+		if b.disk.roaringSetRangeSegmentInMemory.IsUnpopulated() {
+			if n := b.disk.roaringSetRangeDiskSegmentCount(); n > 0 {
+				b.rangeableFallbackWarnOnce.Do(func() {
+					b.logger.WithField("bucket", b.dir).Warnf(
+						"rangeable in-memory index is empty but %d disk segment(s) exist; "+
+							"serving from disk instead. Results may be incorrect if those "+
+							"segments are corrupt or unreadable; rebuild the index to "+
+							"repair it.", n,
+					)
+				})
+				// Benign TOCTOU: the rep only empties via mass-delete, and the
+				// disk path is a correct superset either way.
+				return b.readerRoaringSetRangeFromSegments()
+			}
+		}
 		return b.readerRoaringSetRangeFromSegmentInMemo()
 	}
 	return b.readerRoaringSetRangeFromSegments()
 }
 
 func (b *Bucket) readerRoaringSetRangeFromSegments() ReaderRoaringSetRange {
+	// Deferred marker: emit the disk-serving diagnostic once per bucket-open;
+	// never affects read-path selection.
+	if b.rangeableInMemoryDeferred {
+		b.rangeableDeferredLogOnce.Do(func() {
+			b.logger.WithField("bucket", b.dir).Info(
+				"rangeable property serving range queries from disk; in-memory " +
+					"serving is restored automatically when the migration finalizes. " +
+					"If it persists after the migration has finished, the finalize " +
+					"rebuild failed; rebuild the index or reload the shard to " +
+					"repair it.",
+			)
+		})
+	}
+
 	view := b.GetConsistentView()
 
 	readers := make([]roaringsetrange.InnerReader, len(view.Disk))
@@ -107,4 +172,70 @@ func (b *Bucket) readerRoaringSetRangeFromSegmentInMemo() ReaderRoaringSetRange 
 	readers = append(readers, active.newRoaringSetRangeReader())
 
 	return roaringsetrange.NewCombinedReader(readers, release, concurrency.SROAR_MERGE, b.logger)
+}
+
+// RebuildRangeableSegmentInMemory builds the in-memory rep from disk
+// segments and switches range reads to in-memory serving, without a bucket
+// reopen. No-op if already serving from memory. Not safe for concurrent
+// self-invocation; the single finalize call site guarantees this.
+//
+// Locking order:
+//  1. Compaction is paused so the segment set can only grow via tail flush
+//     appends; a concurrent compaction could reorder add/delete layers and
+//     corrupt the merge.
+//  2. The bulk merge runs without flushLock so writes/flushes stay unblocked.
+//  3. Under flushLock, segments flushed during the merge are caught up, the
+//     rep is published, and the serving flag is set - so a racing flush
+//     either merges before us or sees the flag after, never losing a write.
+func (b *Bucket) RebuildRangeableSegmentInMemory(ctx context.Context) error {
+	if err := CheckStrategyRoaringSetRange(b.strategy); err != nil {
+		return err
+	}
+	if b.rangeableServesFromMemory() {
+		return nil
+	}
+
+	// Ref-counted at the bucket level so a concurrent snapshot, digest scan,
+	// or rebuild shares one pause instead of racing to resume under each
+	// other. A failed pause leaves the count where it started, so
+	// compaction is never left disabled.
+	if err := b.pauseCompaction(ctx); err != nil {
+		return fmt.Errorf("pause compaction for rangeable in-memory rebuild: %w", err)
+	}
+	defer func() {
+		if resumeErr := b.resumeCompaction(context.Background()); resumeErr != nil {
+			b.logger.Errorf("resume compaction after rangeable in-memory rebuild: %v", resumeErr)
+		}
+	}()
+
+	rep, alreadyMerged, releaseBuilt, err := b.disk.buildRoaringSetRangeRep(ctx)
+	if err != nil {
+		return fmt.Errorf("build rangeable in-memory rep: %w", err)
+	}
+
+	b.flushLock.Lock()
+	defer b.flushLock.Unlock()
+
+	if err := b.disk.installRoaringSetRangeRep(rep, alreadyMerged, releaseBuilt); err != nil {
+		return fmt.Errorf("install rangeable in-memory rep: %w", err)
+	}
+
+	// Gate publication on the same discriminant the per-read path uses,
+	// evaluated once here: a rep that folds empty while disk segments exist
+	// isn't trustworthy, so refuse to publish rather than advertise
+	// memory-serving for a rep that doesn't mirror disk.
+	if rep.IsUnpopulated() {
+		if n := b.disk.roaringSetRangeDiskSegmentCount(); n > 0 {
+			b.logger.WithField("bucket", b.dir).Warnf(
+				"rangeable in-memory rebuild produced an empty representation while "+
+					"%d disk segment(s) exist; leaving disk-serving in place instead of "+
+					"activating in-memory acceleration. May indicate mass deletion or a "+
+					"rep-population gap.", n,
+			)
+			return fmt.Errorf("%w (bucket=%s)", ErrRangeableRepUnpopulatedAfterRebuild, filepath.Base(b.dir))
+		}
+	}
+
+	b.rangeableRepRebuilt.Store(true)
+	return nil
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range_rebuild_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range_rebuild_test.go
@@ -1,0 +1,522 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+// readRangeEqual is a goroutine-safe readEqual: it returns an error instead
+// of calling testify assertions, which aren't safe off the test goroutine.
+func readRangeEqual(ctx context.Context, b *Bucket, value uint64) ([]uint64, error) {
+	reader := b.ReaderRoaringSetRange()
+	defer reader.Close()
+
+	v, release, err := reader.Read(ctx, value, filters.OperatorEqual)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	return v.ToArray(), nil
+}
+
+// TestSegmentGroupRoaringSetRangeRep_BuildThenCatchUp pins that a flush
+// landing between the bulk-build snapshot and the install/publish step is
+// still caught up into the rep, not lost.
+func TestSegmentGroupRoaringSetRangeRep_BuildThenCatchUp(t *testing.T) {
+	ctx := context.Background()
+	key1, key2, key3 := uint64(1), uint64(2), uint64(3)
+
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+	defer b.Shutdown(ctx)
+
+	require.NoError(t, b.RoaringSetRangeAdd(key1, 10))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RoaringSetRangeAdd(key2, 20))
+	require.NoError(t, b.FlushAndSwitch())
+	require.Equal(t, 2, b.disk.Len())
+
+	rep, merged, release, err := b.disk.buildRoaringSetRangeRep(ctx)
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+	require.Nil(t, b.disk.roaringSetRangeSegmentInMemory, "build alone must not publish")
+
+	// Race window: a flush lands a new tail segment between build and install.
+	require.NoError(t, b.RoaringSetRangeAdd(key3, 30))
+	require.NoError(t, b.FlushAndSwitch())
+	require.Equal(t, 3, b.disk.Len())
+
+	require.NoError(t, b.disk.installRoaringSetRangeRep(rep, merged, release))
+	assert.Same(t, rep, b.disk.roaringSetRangeSegmentInMemory, "install must publish the built rep")
+
+	b.rangeableRepRebuilt.Store(true)
+
+	for key, wantDocID := range map[uint64]uint64{key1: 10, key2: 20, key3: 30} {
+		got := readEqual(t, b, key)
+		assert.Equal(t, []uint64{wantDocID}, got, "key %d must be present after catch-up", key)
+	}
+}
+
+// TestSegmentGroupRoaringSetRangeRep_BuildRespectsContextCancel pins that a
+// cancelled context aborts the bulk merge instead of running to completion.
+func TestSegmentGroupRoaringSetRangeRep_BuildRespectsContextCancel(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	seg := newFakeRoaringSetRangeSegment(map[uint64]*sroar.Bitmap{1: roaringset.NewBitmap(1)}, sroar.NewBitmap())
+	sg := &SegmentGroup{logger: logger, segments: []Segment{seg}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, _, err := sg.buildRoaringSetRangeRep(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestBucketRebuildRangeableSegmentInMemory_Correctness pins that rebuild
+// results match the pre-rebuild disk read.
+func TestBucketRebuildRangeableSegmentInMemory_Correctness(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+	defer b.Shutdown(ctx)
+
+	entries := [][2]uint64{{1, 100}, {2, 200}, {3, 300}}
+	for _, kv := range entries {
+		require.NoError(t, b.RoaringSetRangeAdd(kv[0], kv[1]))
+		require.NoError(t, b.FlushAndSwitch())
+	}
+	require.Equal(t, 3, b.disk.Len(), "each add+flush must land its own segment")
+	require.Nil(t, b.disk.roaringSetRangeSegmentInMemory)
+	require.False(t, b.rangeableServesFromMemory())
+
+	preRebuild := map[uint64][]uint64{}
+	for _, kv := range entries {
+		preRebuild[kv[0]] = readEqual(t, b, kv[0])
+	}
+
+	require.NoError(t, b.RebuildRangeableSegmentInMemory(ctx))
+
+	assert.True(t, b.rangeableServesFromMemory())
+	require.NotNil(t, b.disk.roaringSetRangeSegmentInMemory)
+	assert.False(t, b.disk.roaringSetRangeSegmentInMemory.IsUnpopulated())
+
+	for _, kv := range entries {
+		assert.Equal(t, preRebuild[kv[0]], readEqual(t, b, kv[0]), "post-rebuild result must match pre-rebuild disk read")
+	}
+}
+
+// TestBucketRebuildRangeableSegmentInMemory_Idempotent pins the two no-op
+// cases: a repeated call, and a bucket already serving from memory.
+func TestBucketRebuildRangeableSegmentInMemory_Idempotent(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("second call on an already-rebuilt bucket is a no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+		defer b.Shutdown(ctx)
+
+		require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+		require.NoError(t, b.FlushAndSwitch())
+
+		require.NoError(t, b.RebuildRangeableSegmentInMemory(ctx))
+		repAfterFirst := b.disk.roaringSetRangeSegmentInMemory
+		require.NotNil(t, repAfterFirst)
+
+		require.NoError(t, b.RebuildRangeableSegmentInMemory(ctx))
+		assert.Same(t, repAfterFirst, b.disk.roaringSetRangeSegmentInMemory, "second call must not rebuild")
+	})
+
+	t.Run("bucket opened with keepSegmentsInMemory=true no-ops", func(t *testing.T) {
+		dir := t.TempDir()
+		b := createTestBucketRoaringSetRange(t, ctx, dir, true)
+		defer b.Shutdown(ctx)
+
+		require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+		require.NoError(t, b.FlushAndSwitch())
+
+		repAtOpen := b.disk.roaringSetRangeSegmentInMemory
+		require.NotNil(t, repAtOpen)
+
+		require.NoError(t, b.RebuildRangeableSegmentInMemory(ctx))
+		assert.Same(t, repAtOpen, b.disk.roaringSetRangeSegmentInMemory)
+		assert.False(t, b.rangeableRepRebuilt.Load(),
+			"keepSegmentsInMemory alone accounts for serving; the rebuilt flag must stay false")
+	})
+}
+
+// TestBucketRebuildRangeableSegmentInMemory_WrongStrategy pins that a
+// non-roaring-set-range bucket returns an error instead of panicking.
+func TestBucketRebuildRangeableSegmentInMemory_WrongStrategy(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucket(t, ctx, dir, StrategyReplace)
+	defer b.Shutdown(ctx)
+
+	err := b.RebuildRangeableSegmentInMemory(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), StrategyRoaringSetRange)
+}
+
+// TestBucketRebuildRangeableSegmentInMemory_FlushAfterPublishMergesIntoRep
+// pins that a flush completing after publish merges into the rep, not lost
+// (regression: gating on keepSegmentsInMemory alone).
+func TestBucketRebuildRangeableSegmentInMemory_FlushAfterPublishMergesIntoRep(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+	defer b.Shutdown(ctx)
+
+	require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RebuildRangeableSegmentInMemory(ctx))
+	require.True(t, b.rangeableServesFromMemory())
+
+	require.NoError(t, b.RoaringSetRangeAdd(2, 200))
+	require.NoError(t, b.FlushAndSwitch())
+
+	assert.Equal(t, []uint64{200}, readEqual(t, b, 2), "flush completed after publish must merge into the rep")
+	assert.Equal(t, []uint64{100}, readEqual(t, b, 1), "pre-existing rep content must survive the later flush")
+}
+
+// TestBucketRebuildRangeableSegmentInMemory_ConcurrentReadsAndWrites pins
+// that no write is lost and no reader observes a torn result while
+// concurrent with RebuildRangeableSegmentInMemory. Run with -race.
+func TestBucketRebuildRangeableSegmentInMemory_ConcurrentReadsAndWrites(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+	defer b.Shutdown(ctx)
+
+	const baselineCount = 40
+	for i := uint64(1); i <= baselineCount; i++ {
+		require.NoError(t, b.RoaringSetRangeAdd(i, i*10))
+		if i%7 == 0 {
+			require.NoError(t, b.FlushAndSwitch())
+		}
+	}
+	require.NoError(t, b.FlushAndSwitch())
+	require.Greater(t, b.disk.Len(), 1, "test needs multiple disk segments to be meaningful")
+
+	const writerBase = uint64(10_000)
+	const writerCount = 60
+
+	writerDone := make(chan struct{})
+	writerErrs := make(chan error, 1)
+	go func() {
+		defer close(writerDone)
+		for i := uint64(1); i <= writerCount; i++ {
+			if err := b.RoaringSetRangeAdd(writerBase+i, (writerBase+i)*10); err != nil {
+				writerErrs <- fmt.Errorf("writer add: %w", err)
+				return
+			}
+			if i%5 == 0 {
+				if err := b.FlushAndSwitch(); err != nil {
+					writerErrs <- fmt.Errorf("writer flush: %w", err)
+					return
+				}
+			}
+		}
+	}()
+
+	stopReaders := make(chan struct{})
+	var readerWG sync.WaitGroup
+	readerErrs := make(chan error, 4)
+	for r := 0; r < 4; r++ {
+		readerWG.Add(1)
+		go func() {
+			defer readerWG.Done()
+			for {
+				select {
+				case <-stopReaders:
+					return
+				default:
+				}
+				got, err := readRangeEqual(ctx, b, 3) // known-flushed baseline value
+				if err != nil {
+					readerErrs <- fmt.Errorf("reader error: %w", err)
+					return
+				}
+				if len(got) != 1 || got[0] != 30 {
+					readerErrs <- fmt.Errorf("baseline value 3 read %v mid-rebuild, want [30]", got)
+					return
+				}
+			}
+		}()
+	}
+
+	require.NoError(t, b.RebuildRangeableSegmentInMemory(ctx))
+
+	<-writerDone
+	select {
+	case err := <-writerErrs:
+		t.Fatalf("writer goroutine failed: %v", err)
+	default:
+	}
+	require.NoError(t, b.FlushAndSwitch(), "flush any writer data still in the active memtable")
+
+	close(stopReaders)
+	readerWG.Wait()
+	close(readerErrs)
+	for err := range readerErrs {
+		t.Error(err)
+	}
+
+	assert.True(t, b.rangeableServesFromMemory())
+	for i := uint64(1); i <= baselineCount; i++ {
+		assert.Equal(t, []uint64{i * 10}, readEqual(t, b, i), "baseline value %d lost or corrupted", i)
+	}
+	for i := uint64(1); i <= writerCount; i++ {
+		assert.Equal(t, []uint64{(writerBase + i) * 10}, readEqual(t, b, writerBase+i), "writer value %d lost or corrupted", i)
+	}
+}
+
+// TestSegmentGroupRoaringSetRangeRep_ShutdownDuringRebuildBlocksNotPanics pins
+// weaviate/weaviate#12215: shutdown must block on the rebuild's held segment
+// refs, not race its merge. Run with -race.
+func TestSegmentGroupRoaringSetRangeRep_ShutdownDuringRebuildBlocksNotPanics(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+
+	require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RoaringSetRangeAdd(2, 200))
+	require.NoError(t, b.FlushAndSwitch())
+	require.Equal(t, 2, b.disk.Len())
+
+	rep, merged, release, err := b.disk.buildRoaringSetRangeRep(ctx)
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- b.Shutdown(ctx) }()
+
+	select {
+	case err := <-shutdownDone:
+		t.Fatalf("shutdown completed while the rebuild still held segment refs (want: blocked): %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	require.NoError(t, b.disk.installRoaringSetRangeRep(rep, merged, release))
+
+	select {
+	case err := <-shutdownDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown did not complete after the rebuild released its segment refs")
+	}
+}
+
+// TestSegmentGroupRoaringSetRangeRep_InstallAfterGroupShutdownNoPanic pins
+// weaviate/weaviate#12215: installRoaringSetRangeRep must not slice-bounds
+// panic when segments were nil'd out (shutdown) between build and install.
+func TestSegmentGroupRoaringSetRangeRep_InstallAfterGroupShutdownNoPanic(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+	t.Cleanup(func() { b.Shutdown(ctx) })
+
+	require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RoaringSetRangeAdd(2, 200))
+	require.NoError(t, b.FlushAndSwitch())
+	require.Equal(t, 2, b.disk.Len())
+
+	rep, merged, release, err := b.disk.buildRoaringSetRangeRep(ctx)
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+
+	// Simulate a concurrent shutdown() completing between build and
+	// install: sg.segments = nil, exactly as SegmentGroup.shutdown does
+	// under maintenanceLock.Lock() after waitForReferenceCountToReachZero.
+	b.disk.maintenanceLock.Lock()
+	b.disk.segments = nil
+	b.disk.maintenanceLock.Unlock()
+
+	require.NotPanics(t, func() {
+		err = b.disk.installRoaringSetRangeRep(rep, merged, release)
+	})
+	require.NoError(t, err)
+}
+
+// TestSegmentGroupRoaringSetRangeRep_PanicMidMergeReleasesView pins
+// weaviate/weaviate#12215: a panic mid-merge must not leak the view's
+// segment refs, or shutdown() hangs forever.
+func TestSegmentGroupRoaringSetRangeRep_PanicMidMergeReleasesView(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+
+	require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.Equal(t, 1, b.disk.Len(), "need a real baseline segment to check its ref returns to zero")
+
+	realSeg := b.disk.segments[0]
+	require.Zero(t, realSeg.getRefs(), "precondition: no view held yet")
+
+	panicky := newFakeRoaringSetRangeSegment(nil, sroar.NewBitmap())
+	b.disk.maintenanceLock.Lock()
+	b.disk.segments = append(b.disk.segments, panicky)
+	b.disk.maintenanceLock.Unlock()
+
+	func() {
+		defer func() {
+			require.NotNil(t, recover(), "the fake segment's cursor must panic to reproduce the mid-merge fault")
+		}()
+		b.disk.buildRoaringSetRangeRep(ctx)
+		t.Fatal("expected a panic mid-merge, got a normal return")
+	}()
+
+	assert.Zero(t, realSeg.getRefs(), "the deferred release must run despite the panic, leaving no leaked ref")
+	assert.Zero(t, panicky.getRefs(), "the fake segment's ref must also be released")
+
+	b.disk.maintenanceLock.Lock()
+	b.disk.segments = b.disk.segments[:1]
+	b.disk.maintenanceLock.Unlock()
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- b.Shutdown(ctx) }()
+	select {
+	case err := <-shutdownDone:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown hung: a leaked segment ref from the mid-merge panic never released")
+	}
+}
+
+// alwaysRefuseAllocChecker refuses every allocation, simulating a
+// memory-constrained node.
+type alwaysRefuseAllocChecker struct{}
+
+func (alwaysRefuseAllocChecker) CheckAlloc(sizeInBytes int64) error {
+	return fmt.Errorf("simulated memory pressure: refusing %d bytes", sizeInBytes)
+}
+
+func (alwaysRefuseAllocChecker) CheckMappingAndReserve(numberMappings int64, reservationTimeInS int) error {
+	return nil
+}
+
+func (alwaysRefuseAllocChecker) Refresh(updateMappings bool) {}
+
+// TestSegmentGroupRoaringSetRangeRep_AllocCheckerRefusalSoftDegrades pins
+// weaviate/weaviate#12215: an allocChecker refusal must be an ordinary
+// error, not a panic, so the caller can soft-degrade to disk serving.
+func TestSegmentGroupRoaringSetRangeRep_AllocCheckerRefusalSoftDegrades(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucketRoaringSetRange(t, ctx, dir, false)
+	defer b.Shutdown(ctx)
+
+	require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.Equal(t, 1, b.disk.Len())
+
+	b.disk.allocChecker = alwaysRefuseAllocChecker{}
+
+	_, merged, release, err := b.disk.buildRoaringSetRangeRep(ctx)
+	require.Error(t, err, "an allocChecker refusal must be returned as an ordinary error")
+	assert.Contains(t, err.Error(), "memory pressure")
+	assert.Nil(t, merged)
+	assert.Nil(t, release, "no view should be left held on refusal")
+
+	require.Error(t, b.RebuildRangeableSegmentInMemory(ctx),
+		"the refusal must propagate through the full rebuild call, not panic")
+	assert.False(t, b.rangeableRepRebuilt.Load(), "a refused rebuild must not publish")
+}
+
+// TestRebuildRangeable_EmptyRepWithDiskSegments_DoesNotPublish pins
+// weaviate/weaviate#12215: a rebuild whose rep folds empty while disk
+// segments exist (e.g. all rows deleted) must not publish.
+func TestRebuildRangeable_EmptyRepWithDiskSegments_DoesNotPublish(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b, hook := createTestBucketRoaringSetRangeWithHook(t, ctx, dir, false)
+	defer b.Shutdown(ctx)
+
+	// Add then remove the same docID under the same value, flushed to
+	// separate segments, so bitmaps[0] folds empty while disk segments
+	// (tombstone-bearing) still exist - the all-deleted-property shape.
+	require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RoaringSetRangeRemove(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.Equal(t, 2, b.disk.Len())
+
+	err := b.RebuildRangeableSegmentInMemory(ctx)
+	require.ErrorIs(t, err, ErrRangeableRepUnpopulatedAfterRebuild)
+	assert.False(t, b.rangeableRepRebuilt.Load(), "an unpopulated rep with disk segments must not publish")
+
+	require.Equal(t, 1, countLogLevel(hook, logrus.WarnLevel), "the disk-serving diagnostic must be logged")
+	assert.Contains(t, hook.LastEntry().Message, "leaving disk-serving in place")
+
+	assert.Empty(t, readEqual(t, b, 1), "disk-path read must still return the correct (empty) result")
+}
+
+// deleteAllRangeableCursor deletes every docID in the given bitmap, used
+// to drain a published rep directly so tests can detect stale-rep reads.
+type deleteAllRangeableCursor struct {
+	deletions *sroar.Bitmap
+	yielded   bool
+}
+
+func (c *deleteAllRangeableCursor) First() (uint8, roaringset.BitmapLayer, bool) {
+	c.yielded = false
+	return c.Next()
+}
+
+func (c *deleteAllRangeableCursor) Next() (uint8, roaringset.BitmapLayer, bool) {
+	if c.yielded {
+		return 0, roaringset.BitmapLayer{}, false
+	}
+	c.yielded = true
+	return 0, roaringset.BitmapLayer{Additions: sroar.NewBitmap(), Deletions: c.deletions}, true
+}
+
+// TestReaderRoaringSetRange_PublishedFlagTrusted pins weaviate/weaviate#12215:
+// once published, reads must trust the rep unconditionally, even when it's
+// stale, and never re-run the per-read fallback check.
+func TestReaderRoaringSetRange_PublishedFlagTrusted(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b, hook := createTestBucketRoaringSetRangeWithHook(t, ctx, dir, false)
+	defer b.Shutdown(ctx)
+
+	require.NoError(t, b.RoaringSetRangeAdd(1, 100))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RebuildRangeableSegmentInMemory(ctx))
+	require.True(t, b.rangeableRepRebuilt.Load())
+
+	require.Equal(t, []uint64{100}, readEqual(t, b, 1), "precondition: the rep serves the real value before draining")
+
+	require.NoError(t, b.disk.roaringSetRangeSegmentInMemory.MergeSegmentByCursor(
+		&deleteAllRangeableCursor{deletions: roaringset.NewBitmap(100)}))
+
+	for range 3 {
+		assert.Empty(t, readEqual(t, b, 1),
+			"the fast path must serve the drained (stale) in-memory rep, not fall back to disk (which still has docID 100)")
+	}
+	assert.Zero(t, countLogLevel(hook, logrus.WarnLevel),
+		"a validated, published rep must never trigger the per-read fallback WARN, even when unpopulated")
+}

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_range_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_range_test.go
@@ -14,12 +14,16 @@ package lsmkv
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
@@ -213,6 +217,235 @@ func TestRoaringSetRangeReaderConsistentViewInMemo(t *testing.T) {
 		key3: {3},
 		key4: {4},
 	})(t)
+}
+
+func countLogLevel(hook *test.Hook, level logrus.Level) int {
+	n := 0
+	for _, e := range hook.AllEntries() {
+		if e.Level == level {
+			n++
+		}
+	}
+	return n
+}
+
+// newRangeableRepEmpty returns an unpopulated rep: presence set empty
+// (IsUnpopulated == true) despite the 65-bitmap skeleton giving Size() > 0.
+func newRangeableRepEmpty(logger logrus.FieldLogger) *roaringsetrange.SegmentInMemory {
+	return roaringsetrange.NewSegmentInMemory(logger)
+}
+
+func newRangeableRepPopulated(t *testing.T, logger logrus.FieldLogger, value, docID uint64) *roaringsetrange.SegmentInMemory {
+	t.Helper()
+	rep := roaringsetrange.NewSegmentInMemory(logger)
+	mt := roaringsetrange.NewMemtable(logger)
+	mt.Insert(value, []uint64{docID})
+	rep.MergeMemtableEventually(mt)
+	require.Eventually(t, func() bool { return !rep.IsUnpopulated() },
+		time.Second, 5*time.Millisecond, "rep must become populated")
+	return rep
+}
+
+func newRangeableDiskSegment(value, docID uint64) Segment {
+	return newFakeRoaringSetRangeSegment(
+		map[uint64]*sroar.Bitmap{value: roaringset.NewBitmap(docID)}, sroar.NewBitmap(),
+	)
+}
+
+func newRangeableBucket(logger logrus.FieldLogger, keepInMem, deferred bool,
+	rep *roaringsetrange.SegmentInMemory, disk []Segment,
+) *Bucket {
+	return &Bucket{
+		strategy:                  StrategyRoaringSetRange,
+		keepSegmentsInMemory:      keepInMem,
+		rangeableInMemoryDeferred: deferred,
+		logger:                    logger,
+		bitmapBufPool:             roaringset.NewBitmapBufPoolNoop(),
+		active:                    newTestMemtableRoaringSetRange(nil),
+		disk:                      &SegmentGroup{logger: logger, segments: disk, roaringSetRangeSegmentInMemory: rep},
+	}
+}
+
+func readEqual(t *testing.T, b *Bucket, value uint64) []uint64 {
+	t.Helper()
+	reader := b.ReaderRoaringSetRange()
+	defer reader.Close()
+	v, release, err := reader.Read(context.Background(), value, filters.OperatorEqual)
+	require.NoError(t, err)
+	defer release()
+	return v.ToArray()
+}
+
+// Pins weaviate/weaviate#12199: the last WithKeepSegmentsInMemory wins.
+func TestRoaringSetRangeKeepSegmentsInMemoryOverride(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	newBucket := func(t *testing.T, opts ...BucketOption) *Bucket {
+		t.Helper()
+		base := []BucketOption{
+			WithStrategy(StrategyRoaringSetRange),
+			WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+		}
+		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			append(base, opts...)...)
+		require.NoError(t, err)
+		b.SetMemtableThreshold(1e9)
+		return b
+	}
+
+	t.Run("knob default true builds the rep (control)", func(t *testing.T) {
+		b := newBucket(t, WithKeepSegmentsInMemory(true))
+		defer b.Shutdown(ctx)
+		assert.True(t, b.keepSegmentsInMemory)
+		assert.NotNil(t, b.disk.roaringSetRangeSegmentInMemory)
+	})
+
+	t.Run("override false after true wins: no rep, disk reader", func(t *testing.T) {
+		b := newBucket(t, WithKeepSegmentsInMemory(true), WithKeepSegmentsInMemory(false))
+		defer b.Shutdown(ctx)
+		assert.False(t, b.keepSegmentsInMemory)
+		assert.Nil(t, b.disk.roaringSetRangeSegmentInMemory, "no in-memory rep must be built")
+
+		require.NoError(t, b.RoaringSetRangeAdd(5, 100))
+		require.NoError(t, b.FlushAndSwitch())
+		assert.Equal(t, []uint64{100}, readEqual(t, b, 5))
+	})
+}
+
+// Pins weaviate/weaviate#12199: an unpopulated rep with disk segments must
+// fall back to disk and WARN once (rep/disk use different docIDs to prove
+// which path served the read).
+func TestRoaringSetRangeDiskFallback(t *testing.T) {
+	const value = uint64(5)
+
+	t.Run("populated rep + disk segments: in-mem path, no fallback, no WARN", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepPopulated(t, logger, value, 100)
+		disk := []Segment{newRangeableDiskSegment(value, 200)} // different docID
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		assert.Equal(t, []uint64{100}, readEqual(t, b, value), "served from the rep, not disk")
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("empty rep + disk segments: fallback, correct result, WARN", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		// Size() is the wrong discriminant: the skeleton reports non-zero Size()
+		// yet IsUnpopulated() is true.
+		require.Greater(t, rep.Size(), 0)
+		require.True(t, rep.IsUnpopulated())
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value), "served from disk")
+		assert.Equal(t, 1, countLogLevel(hook, logrus.WarnLevel))
+		assert.Contains(t, hook.LastEntry().Message, "rangeable in-memory index is empty")
+	})
+
+	t.Run("empty rep + no disk segments: no fallback, empty result, no WARN", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		b := newRangeableBucket(logger, true, false, rep, nil)
+
+		assert.Empty(t, readEqual(t, b, value))
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("mass-delete-emptied rep + disk segments: fallback, correct residual, WARN", func(t *testing.T) {
+		// Benign cause: mass-delete empties bitmaps[0] while disk tombstones
+		// remain and no restart occurred.
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, 1, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("WARN is deduplicated per bucket-open", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepEmpty(logger)
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, false, rep, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, 1, countLogLevel(hook, logrus.WarnLevel), "second read must not emit a second WARN")
+	})
+}
+
+// Pins weaviate/weaviate#12199: a deferred-marked bucket emits the
+// disk-serving INFO once; unmarked buckets never do.
+func TestRoaringSetRangeDeferredServingINFO(t *testing.T) {
+	const value = uint64(5)
+
+	t.Run("marked disk bucket: INFO once under repeated reads", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, false, true, nil, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Equal(t, 1, countLogLevel(hook, logrus.InfoLevel), "INFO fires exactly once per bucket-open")
+		assert.Contains(t, hook.LastEntry().Message, "restored automatically")
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+
+	t.Run("unmarked knob-off bucket: no INFO", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, false, false, nil, disk)
+
+		assert.Equal(t, []uint64{200}, readEqual(t, b, value))
+		assert.Zero(t, countLogLevel(hook, logrus.InfoLevel))
+	})
+
+	t.Run("marker selects a log line only, never a read path", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		rep := newRangeableRepPopulated(t, logger, value, 100)
+		disk := []Segment{newRangeableDiskSegment(value, 200)}
+		b := newRangeableBucket(logger, true, true, rep, disk)
+
+		assert.Equal(t, []uint64{100}, readEqual(t, b, value), "in-mem path served, not disk")
+		assert.Zero(t, countLogLevel(hook, logrus.InfoLevel), "marker must not trigger the disk-path INFO")
+		assert.Zero(t, countLogLevel(hook, logrus.WarnLevel))
+	})
+}
+
+// BenchmarkRoaringSetRangeReaderPopulatedHotPath bounds the overhead added to
+// the populated-rep hot path: one short-circuited IsEmpty() check.
+func BenchmarkRoaringSetRangeReaderPopulatedHotPath(b *testing.B) {
+	logger, _ := test.NewNullLogger()
+	rep := roaringsetrange.NewSegmentInMemory(logger)
+	mt := roaringsetrange.NewMemtable(logger)
+	mt.Insert(5, []uint64{100})
+	rep.MergeMemtableEventually(mt)
+	for rep.IsUnpopulated() {
+		time.Sleep(time.Millisecond)
+	}
+	bucket := newRangeableBucketForBench(logger, rep)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := bucket.ReaderRoaringSetRange()
+		r.Close()
+	}
+}
+
+func newRangeableBucketForBench(logger logrus.FieldLogger, rep *roaringsetrange.SegmentInMemory) *Bucket {
+	return &Bucket{
+		strategy:             StrategyRoaringSetRange,
+		keepSegmentsInMemory: true,
+		logger:               logger,
+		bitmapBufPool:        roaringset.NewBitmapBufPoolNoop(),
+		active:               newTestMemtableRoaringSetRange(nil),
+		disk:                 &SegmentGroup{logger: logger, roaringSetRangeSegmentInMemory: rep},
+	}
 }
 
 // TestRoaringSetRangeWritePathRefCount ensures that all write paths of the

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -593,6 +593,103 @@ func (sg *SegmentGroup) resumeCompaction(_ context.Context) error {
 	return sg.compactionCallbackCtrl.Activate()
 }
 
+// buildRoaringSetRangeRep merges the current disk segments (ref-counted,
+// oldest to newest) into a fresh unpublished rep. Caller must have paused
+// compaction so the merged segments stay a stable prefix for
+// installRoaringSetRangeRep's catch-up.
+//
+// Caller must not call the returned release until installRoaringSetRangeRep
+// returns: holding the ref keeps a concurrent shutdown() from closing these
+// segments mid-merge. The release is deferred and only suppressed on
+// success, so a panic mid-merge still releases it instead of leaking a ref
+// that would hang the next shutdown() forever.
+func (sg *SegmentGroup) buildRoaringSetRangeRep(ctx context.Context) (*roaringsetrange.SegmentInMemory, []Segment, func(), error) {
+	segments, release := sg.getConsistentViewOfSegments()
+	ownershipTransferred := false
+	defer func() {
+		if !ownershipTransferred {
+			release()
+		}
+	}()
+
+	if sg.allocChecker != nil {
+		// Unbounded full-property build; refuse on memory pressure so the
+		// caller degrades to disk serving instead of risking an OOM kill.
+		var totalSize int64
+		for _, seg := range segments {
+			totalSize += seg.Size()
+		}
+		if err := sg.allocChecker.CheckAlloc(totalSize); err != nil {
+			sg.logger.WithFields(logrus.Fields{
+				"action":   "rangeable_inmemory_rebuild",
+				"event":    "rebuild_skipped_oom",
+				"bucket":   filepath.Base(sg.dir),
+				"segments": len(segments),
+			}).Warnf("skipping rangeable in-memory rebuild due to memory pressure: %v", err)
+			return nil, nil, nil, err
+		}
+	}
+
+	t := time.Now()
+	rep := roaringsetrange.NewSegmentInMemory(sg.logger)
+	for _, seg := range segments {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
+		if err := rep.MergeSegmentByCursor(seg.newRoaringSetRangeCursor()); err != nil {
+			return nil, nil, nil, fmt.Errorf("merge segment into rangeable rep: %w", err)
+		}
+	}
+	sg.logger.WithFields(logrus.Fields{
+		"took":     time.Since(t).String(),
+		"bucket":   filepath.Base(sg.dir),
+		"segments": len(segments),
+		"size_mb":  fmt.Sprintf("%.3f", float64(rep.Size())/1024/1024),
+	}).Debug("rangeable segment-in-memory rebuilt")
+	ownershipTransferred = true
+	return rep, segments, release, nil
+}
+
+// installRoaringSetRangeRep merges segments appended after the bulk build
+// (flush appends only; compaction must stay paused) and publishes the rep.
+// Caller must hold the bucket's flushLock so no flush races the catch-up
+// with the publish. releaseBuilt always runs via defer, so a group shut
+// down mid-rebuild is never blocked past this call.
+//
+// Compaction staying paused for the whole span means appends only grow the
+// tail, so the catch-up view is always a superset of alreadyMerged. The
+// publish assignment pairs maintenanceLock.Lock() here with the RLock()
+// guard in PrependSegmentsFromBucket.
+func (sg *SegmentGroup) installRoaringSetRangeRep(rep *roaringsetrange.SegmentInMemory, alreadyMerged []Segment, releaseBuilt func()) error {
+	defer releaseBuilt()
+
+	segments, release := sg.getConsistentViewOfSegments()
+	defer release()
+
+	catchUpFrom := len(alreadyMerged)
+	if catchUpFrom > len(segments) {
+		// Should be unreachable while compaction stays paused (segments
+		// only grow); guard defensively against a slice-bounds panic.
+		sg.logger.WithFields(logrus.Fields{
+			"bucket":         filepath.Base(sg.dir),
+			"already_merged": catchUpFrom,
+			"current":        len(segments),
+		}).Debug("rangeable rep catch-up: segment count shrank since bulk build, skipping catch-up merge")
+		catchUpFrom = len(segments)
+	}
+
+	for _, seg := range segments[catchUpFrom:] {
+		if err := rep.MergeSegmentByCursor(seg.newRoaringSetRangeCursor()); err != nil {
+			return fmt.Errorf("catch-up merge segment into rangeable rep: %w", err)
+		}
+	}
+
+	sg.maintenanceLock.Lock()
+	sg.roaringSetRangeSegmentInMemory = rep
+	sg.maintenanceLock.Unlock()
+	return nil
+}
+
 func (sg *SegmentGroup) makeExistsOn(segments []Segment) existsOnLowerSegmentsFn {
 	return func(key []byte) (bool, error) {
 		if len(segments) == 0 {
@@ -1003,6 +1100,15 @@ func (sg *SegmentGroup) count() int {
 	defer release()
 
 	return sg.countWithSegmentList(segments)
+}
+
+// roaringSetRangeDiskSegmentCount returns the on-disk segment count via a
+// cheap read lock only. Must not be held while bitmapsLock is held.
+func (sg *SegmentGroup) roaringSetRangeDiskSegmentCount() int {
+	sg.maintenanceLock.RLock()
+	defer sg.maintenanceLock.RUnlock()
+
+	return len(sg.segments)
 }
 
 func (sg *SegmentGroup) countWithSegmentList(segments []Segment) int {

--- a/adapters/repos/db/lsmkv/segment_group_prepend.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -22,6 +23,16 @@ import (
 	"strconv"
 	"strings"
 	"time"
+)
+
+// ErrPrependWouldDesyncInMemoryRep is returned by PrependSegmentsFromBucket when
+// the target RoaringSetRange group keeps an active in-memory rep: splicing would
+// desync it from disk and silently serve empty/partial range results. Open with
+// keepSegmentsInMemory=false.
+var ErrPrependWouldDesyncInMemoryRep = errors.New(
+	"prepend segments: RoaringSetRange bucket has an active in-memory representation " +
+		"which this operation cannot maintain; open the bucket with " +
+		"keepSegmentsInMemory=false, or implement a full-rebuild merge",
 )
 
 // PrependSegmentsFromBucket copies all segments from srcDir and atomically
@@ -41,11 +52,31 @@ import (
 //     segments, which would produce incorrect object counts.
 //   - Supported strategies: RoaringSet, RoaringSetRange, SetCollection,
 //     MapCollection, Inverted.
+//
+// Per-strategy derived-state obligation (any new strategy must answer this):
+// splicing mutates sg.segments, so segment-group-level derived state must be
+// maintained, guarded, or the mutation rejected.
+//
+//	Replace                          -> rejected (countNetAdditions)
+//	Inverted                         -> maintained (avgPropertyLengths, below)
+//	RoaringSetRange                  -> guarded (in-memory rep can't be spliced)
+//	RoaringSet/SetCollection/MapCollection -> no derived state to maintain
 func (sg *SegmentGroup) PrependSegmentsFromBucket(ctx context.Context, srcDir string) error {
 	// Step 1: Validate strategy — Replace is not supported.
 	if sg.strategy == StrategyReplace {
 		return fmt.Errorf("prepend segments: strategy %q is not supported because "+
 			"countNetAdditions cannot be recalculated for prepended segments", sg.strategy)
+	}
+
+	// Reject splicing into a RoaringSetRange group with an active in-memory
+	// rep: an older-onto-newer merge could let a stale value win, and an
+	// unrebuilt rep would silently serve empty/partial results. This RLock()
+	// pairs with installRoaringSetRangeRep's Lock() publish.
+	sg.maintenanceLock.RLock()
+	hasInMemoryRep := sg.strategy == StrategyRoaringSetRange && sg.roaringSetRangeSegmentInMemory != nil
+	sg.maintenanceLock.RUnlock()
+	if hasInMemoryRep {
+		return fmt.Errorf("%w (bucket=%s)", ErrPrependWouldDesyncInMemoryRep, filepath.Base(sg.dir))
 	}
 
 	// Step 2: Discover source segments (.db files).
@@ -94,12 +125,15 @@ func (sg *SegmentGroup) PrependSegmentsFromBucket(ctx context.Context, srcDir st
 	}
 
 	// Step 5: Atomic prepend under maintenanceLock.
-	sg.maintenanceLock.Lock()
-	newSegments := make([]Segment, 0, len(initialized)+len(sg.segments))
-	newSegments = append(newSegments, initialized...)
-	newSegments = append(newSegments, sg.segments...)
-	sg.segments = newSegments
-	sg.maintenanceLock.Unlock()
+	func() {
+		sg.maintenanceLock.Lock()
+		defer sg.maintenanceLock.Unlock()
+
+		newSegments := make([]Segment, 0, len(initialized)+len(sg.segments))
+		newSegments = append(newSegments, initialized...)
+		newSegments = append(newSegments, sg.segments...)
+		sg.segments = newSegments
+	}()
 
 	// Update metrics and the average-property-length accounting for the newly
 	// added segments. The accounting has to land before the deferred

--- a/adapters/repos/db/lsmkv/segment_group_prepend_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_prepend_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,20 +29,33 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
-// createTestBucketRoaringSet creates a RoaringSet bucket in the given
-// directory, suitable for testing PrependSegmentsFromBucket.
-func createTestBucketRoaringSet(t *testing.T, ctx context.Context, dir string) *Bucket {
+// createTestBucketWithOptionsAndLogger creates a bucket with the given
+// options and logger; shared by the createTestBucket* helpers below.
+func createTestBucketWithOptionsAndLogger(t *testing.T, ctx context.Context, dir string, logger logrus.FieldLogger, opts ...BucketOption) *Bucket {
 	t.Helper()
-	logger, _ := test.NewNullLogger()
-	opts := []BucketOption{
-		WithStrategy(StrategyRoaringSet),
-		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
-	}
 	b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
 	require.NoError(t, err)
 	b.SetMemtableThreshold(1e9) // prevent auto-flush
 	return b
+}
+
+// createTestBucketWithOptions is createTestBucketWithOptionsAndLogger with
+// a discarded logger.
+func createTestBucketWithOptions(t *testing.T, ctx context.Context, dir string, opts ...BucketOption) *Bucket {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	return createTestBucketWithOptionsAndLogger(t, ctx, dir, logger, opts...)
+}
+
+// createTestBucketRoaringSet creates a RoaringSet bucket in the given
+// directory, suitable for testing PrependSegmentsFromBucket.
+func createTestBucketRoaringSet(t *testing.T, ctx context.Context, dir string) *Bucket {
+	t.Helper()
+	return createTestBucketWithOptions(t, ctx, dir,
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+	)
 }
 
 func TestSegmentGroup_PrependSegments(t *testing.T) {
@@ -304,7 +318,7 @@ func TestSegmentGroup_PrependSegments(t *testing.T) {
 		// compacted target bucket, further compaction merges src segments
 		// into dest segments (not just compacting each side independently).
 		//
-		// Setup (per reviewer request):
+		// Setup:
 		//   7 src segments → compact → 3 segments at levels [2, 1, 0]
 		//   9 dest segments → compact → 2 segments at levels [3, 0]
 		//   prepend → 5 segments: [2, 1, 0, 3, 0]
@@ -657,6 +671,90 @@ func TestSegmentGroup_PrependSegments(t *testing.T) {
 	})
 }
 
+func createTestBucketRoaringSetRange(t *testing.T, ctx context.Context, dir string, keepSegmentsInMemory bool) *Bucket {
+	t.Helper()
+	return createTestBucketWithOptions(t, ctx, dir,
+		WithStrategy(StrategyRoaringSetRange),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+		WithKeepSegmentsInMemory(keepSegmentsInMemory),
+	)
+}
+
+// createTestBucketRoaringSetRangeWithHook is createTestBucketRoaringSetRange
+// with the log hook preserved, for tests asserting on log output.
+func createTestBucketRoaringSetRangeWithHook(t *testing.T, ctx context.Context, dir string, keepSegmentsInMemory bool) (*Bucket, *test.Hook) {
+	t.Helper()
+	logger, hook := test.NewNullLogger()
+	b := createTestBucketWithOptionsAndLogger(t, ctx, dir, logger,
+		WithStrategy(StrategyRoaringSetRange),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+		WithKeepSegmentsInMemory(keepSegmentsInMemory),
+	)
+	return b, hook
+}
+
+// TestSegmentGroup_PrependSegments_RoaringSetRangeGuard pins the
+// weaviate/weaviate#12199 guard: prepend into an active in-memory rep is
+// rejected before any file copy or splice.
+func TestSegmentGroup_PrependSegments_RoaringSetRangeGuard(t *testing.T) {
+	ctx := context.Background()
+
+	makeSource := func(t *testing.T) string {
+		t.Helper()
+		srcDir := t.TempDir()
+		src := createTestBucketRoaringSetRange(t, ctx, srcDir, false)
+		require.NoError(t, src.RoaringSetRangeAdd(42, 100))
+		require.NoError(t, src.FlushAndSwitch())
+		require.NoError(t, src.Shutdown(ctx))
+		return srcDir
+	}
+
+	t.Run("active rep: prepend rejected before mutation", func(t *testing.T) {
+		srcDir := makeSource(t)
+
+		tgtDir := t.TempDir()
+		tgt := createTestBucketRoaringSetRange(t, ctx, tgtDir, true) // rep active
+		defer tgt.Shutdown(ctx)
+		require.NotNil(t, tgt.disk.roaringSetRangeSegmentInMemory,
+			"keepSegmentsInMemory=true must build the rep at open")
+
+		segsBefore := tgt.disk.Len()
+		filesBefore := countDBFiles(t, tgtDir)
+
+		err := tgt.PrependSegmentsFromBucket(ctx, srcDir)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrPrependWouldDesyncInMemoryRep)
+		assert.Contains(t, err.Error(), "active in-memory representation")
+		assert.Contains(t, err.Error(), "keepSegmentsInMemory=false")
+
+		assert.Equal(t, segsBefore, tgt.disk.Len(), "segment list must be unmutated")
+		assert.Equal(t, filesBefore, countDBFiles(t, tgtDir), "no segment files may be copied")
+	})
+
+	t.Run("no rep: prepend proceeds as before", func(t *testing.T) {
+		srcDir := makeSource(t)
+
+		tgtDir := t.TempDir()
+		tgt := createTestBucketRoaringSetRange(t, ctx, tgtDir, false) // no rep
+		defer tgt.Shutdown(ctx)
+		require.Nil(t, tgt.disk.roaringSetRangeSegmentInMemory)
+
+		require.NoError(t, tgt.RoaringSetRangeAdd(7, 999))
+		require.NoError(t, tgt.FlushAndSwitch())
+		segsBefore := tgt.disk.Len()
+
+		require.NoError(t, tgt.PrependSegmentsFromBucket(ctx, srcDir))
+		assert.Equal(t, segsBefore+1, tgt.disk.Len(), "source segment must be spliced in")
+	})
+}
+
+func countDBFiles(t *testing.T, dir string) int {
+	t.Helper()
+	files, err := discoverDBFiles(dir)
+	require.NoError(t, err)
+	return len(files)
+}
+
 func TestParseSegmentTimestamp(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -858,18 +956,13 @@ func TestApplyTimestampShift(t *testing.T) {
 // createTestBucket creates a bucket with the given strategy.
 func createTestBucket(t *testing.T, ctx context.Context, dir, strategy string) *Bucket {
 	t.Helper()
-	logger, _ := test.NewNullLogger()
 	opts := []BucketOption{
 		WithStrategy(strategy),
 	}
 	if strategy == StrategyRoaringSet {
 		opts = append(opts, WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 	}
-	b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
-	require.NoError(t, err)
-	b.SetMemtableThreshold(1e9)
-	return b
+	return createTestBucketWithOptions(t, ctx, dir, opts...)
 }
 
 // assertRoaringSetContains verifies that getting the key from the bucket

--- a/adapters/repos/db/roaringsetrange/segment_in_memory.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory.go
@@ -68,6 +68,9 @@ func (s *SegmentInMemory) MergeSegmentByCursor(cursor SegmentCursor) error {
 		}
 	}
 	for ; ok; key, layer, ok = cursor.Next() {
+		if int(key) >= len(s.bitmaps) {
+			return fmt.Errorf("invalid key %d from merged segment cursor: exceeds rangeable bitmap count %d", key, len(s.bitmaps))
+		}
 		s.bitmaps[key].OrConc(layer.Additions, concurrency.SROAR_MERGE)
 	}
 	return nil
@@ -122,6 +125,27 @@ func (s *SegmentInMemory) countPendingMemtables() int {
 	defer s.memtablesLock.Unlock()
 
 	return len(s.memtables)
+}
+
+// IsUnpopulated reports whether the rep would serve no rows. Size() can't
+// substitute: an unpopulated rep still allocates 65 empty bitmap skeletons.
+// Also checks pending memtables to avoid a false positive in the post-flush
+// window, where bitmaps[0] is briefly empty but Readers() already serves it.
+//
+// Locks bitmapsLock then memtablesLock (matches Readers()); never alongside
+// the segment group's maintenanceLock.
+func (s *SegmentInMemory) IsUnpopulated() bool {
+	s.bitmapsLock.RLock()
+	defer s.bitmapsLock.RUnlock()
+
+	if !s.bitmaps[0].IsEmpty() {
+		return false
+	}
+
+	s.memtablesLock.Lock()
+	defer s.memtablesLock.Unlock()
+
+	return len(s.memtables) == 0
 }
 
 func (s *SegmentInMemory) Size() int {

--- a/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
@@ -190,6 +190,38 @@ func TestSegmentInMemory(t *testing.T) {
 	})
 }
 
+// outOfRangeSecondKeyCursor yields a valid key then an out-of-range key,
+// reproducing a corrupt/truncated segment without a byte-corrupt fixture.
+type outOfRangeSecondKeyCursor struct{ step int }
+
+func (c *outOfRangeSecondKeyCursor) First() (uint8, roaringset.BitmapLayer, bool) {
+	c.step = 0
+	return c.Next()
+}
+
+func (c *outOfRangeSecondKeyCursor) Next() (uint8, roaringset.BitmapLayer, bool) {
+	defer func() { c.step++ }()
+	switch c.step {
+	case 0:
+		return 0, roaringset.BitmapLayer{Additions: sroar.NewBitmap(), Deletions: sroar.NewBitmap()}, true
+	case 1:
+		return 200, roaringset.BitmapLayer{Additions: sroar.NewBitmap()}, true
+	default:
+		return 0, roaringset.BitmapLayer{}, false
+	}
+}
+
+// TestSegmentInMemoryMergeSegmentByCursor_RejectsOutOfRangeKey pins
+// weaviate/weaviate#12215: an out-of-range key must return an error, not panic.
+func TestSegmentInMemoryMergeSegmentByCursor_RejectsOutOfRangeKey(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	s := NewSegmentInMemory(logger)
+
+	err := s.MergeSegmentByCursor(&outOfRangeSecondKeyCursor{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key")
+}
+
 func TestSegmentInMemoryReader(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	mt1, mt2, mt3 := createTestMemtables(logger)
@@ -482,6 +514,65 @@ func TestSegmentInMemoryReaderBufPool(t *testing.T) {
 				assert.Equal(t, 0, bufPool.InUseCounter())
 			})
 		}
+	})
+}
+
+// Pins weaviate/weaviate#12199: folding segments out of order (newest before
+// oldest) lets a stale value silently win, even though the docID's membership
+// still checks out.
+func TestSegmentInMemoryFoldOrderValueIntegrity(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	bufPool := roaringset.NewBitmapBufPoolNoop()
+
+	const (
+		docX      = uint64(500) // value changes across the two segments
+		docStable = uint64(99)  // never changes; membership backstop
+		valOld    = uint64(3)
+		valNew    = uint64(5)
+		valStable = uint64(42)
+	)
+
+	olderSegment := func() SegmentCursor {
+		mt := NewMemtable(logger)
+		mt.Insert(valOld, []uint64{docX})
+		mt.Insert(valStable, []uint64{docStable})
+		return newFakeSegmentCursor(mt)
+	}
+	newerSegment := func() SegmentCursor {
+		mt := NewMemtable(logger)
+		mt.Insert(valNew, []uint64{docX})
+		return newFakeSegmentCursor(mt)
+	}
+
+	equalDocIDs := func(t *testing.T, seg *SegmentInMemory, value uint64) []uint64 {
+		t.Helper()
+		readers, release := seg.Readers(bufPool)
+		defer release()
+		require.Len(t, readers, 1)
+		layer, relRead, err := readers[0].Read(context.Background(), value, filters.OperatorEqual)
+		require.NoError(t, err)
+		defer relRead()
+		return layer.Additions.ToArray()
+	}
+
+	t.Run("correct oldest->newest fold: newest value wins", func(t *testing.T) {
+		seg := NewSegmentInMemory(logger)
+		require.NoError(t, seg.MergeSegmentByCursor(olderSegment()))
+		require.NoError(t, seg.MergeSegmentByCursor(newerSegment()))
+
+		assert.Equal(t, []uint64{docX}, equalDocIDs(t, seg, valNew))
+		assert.NotContains(t, equalDocIDs(t, seg, valOld), docX)
+		// The untouched docID keeps its value (membership + value backstop).
+		assert.Equal(t, []uint64{docStable}, equalDocIDs(t, seg, valStable))
+	})
+
+	t.Run("trap: incremental older-onto-newer fold corrupts the value (old wins)", func(t *testing.T) {
+		seg := NewSegmentInMemory(logger)
+		require.NoError(t, seg.MergeSegmentByCursor(newerSegment()))
+		require.NoError(t, seg.MergeSegmentByCursor(olderSegment()))
+
+		assert.Equal(t, []uint64{docX}, equalDocIDs(t, seg, valOld))
+		assert.NotContains(t, equalDocIDs(t, seg, valNew), docX)
 	})
 }
 

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -20,9 +20,11 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
@@ -940,6 +942,84 @@ func countLatePartials(t *testing.T, samples []probeSample, baseline, expectedAf
 		}
 	}
 	return late
+}
+
+// awaitRangeCountSettledNoFallback polls until the range count converges,
+// then asserts the disk-fallback WARN never appeared in the container logs.
+func awaitRangeCountSettledNoFallback(
+	ctx context.Context, t *testing.T,
+	container interface {
+		Logs(context.Context) (io.ReadCloser, error)
+	},
+	restURI, className string, lo, hi, expected int,
+	countFailMsgFmt string, countFailArg interface{},
+	warnFailMsg string,
+) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		c, e := rangeCount(restURI, className, "score", lo, hi)
+		return e == nil && c == expected
+	}, 60*time.Second, 200*time.Millisecond, countFailMsgFmt, countFailArg)
+
+	for i := 0; i < 5; i++ {
+		_, _ = rangeCount(restURI, className, "score", lo, hi)
+	}
+	time.Sleep(2 * time.Second) // let the container flush stdout
+
+	assert.Zero(t, countInLogs(ctx, t, container, fallbackWARNSubstr), warnFailMsg)
+}
+
+// rangeCountProbeCounters aggregates the results of a background polling
+// loop started by startRangeCountPolling.
+type rangeCountProbeCounters struct {
+	wrongCounts atomic.Int64
+	queryRuns   atomic.Int64
+	queryErrors atomic.Int64
+}
+
+// startRangeCountPolling launches one goroutine per node, firing a
+// range-count query every 50ms until stopCh closes. onWrong/onError run
+// concurrently and must be goroutine-safe.
+func startRangeCountPolling(
+	compose *docker.DockerCompose, className string, lo, hi, expected, nodeCount int,
+	onWrong func(nodeIdx, got int), onError func(nodeIdx int, err error),
+) (counters *rangeCountProbeCounters, stopCh chan struct{}, wg *sync.WaitGroup) {
+	counters = &rangeCountProbeCounters{}
+	stopCh = make(chan struct{})
+	wg = &sync.WaitGroup{}
+	for nodeIdx := 1; nodeIdx <= nodeCount; nodeIdx++ {
+		wg.Add(1)
+		uri := restURIOf(compose, nodeIdx)
+		idx := nodeIdx
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(50 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopCh:
+					return
+				case <-ticker.C:
+				}
+				count, err := rangeCount(uri, className, "score", lo, hi)
+				counters.queryRuns.Add(1)
+				if err != nil {
+					counters.queryErrors.Add(1)
+					if onError != nil {
+						onError(idx, err)
+					}
+					continue
+				}
+				if count != expected {
+					counters.wrongCounts.Add(1)
+					if onWrong != nil {
+						onWrong(idx, count)
+					}
+				}
+			}
+		}()
+	}
+	return counters, stopCh, wg
 }
 
 // Pins a false positive: out-of-order partial timestamps must not regress LastPartial.

--- a/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
+++ b/test/acceptance/reindex_multinode/in_flight_rangeable_test.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -103,8 +101,9 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 	batchImportNumeric(t, restURIOf(compose, 1), className, totalObjects, scoreFor)
 
 	// Capture baseline: every replica must agree on the count BEFORE the
-	// migration starts. If they don't, this isn't an Issue C repro, the
-	// import-replication path is broken — fail loudly.
+	// migration starts. If they don't, this isn't a reproduction of the
+	// in-flight migration bug, the import-replication path is broken - fail
+	// loudly.
 	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
 		count, err := rangeCount(restURIOf(compose, nodeIdx), className, "score", rangeLo, rangeHi)
 		require.NoError(t, err, "pre-migration baseline query on node %d failed", nodeIdx)
@@ -118,46 +117,16 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 	// every node directly. We count every wrong, non-baseline,
 	// non-transient-error result as a failure. The migration on 10 k
 	// objects across 3 shards takes seconds, so 50 ms poll spacing yields
-	// dozens of in-flight samples per goroutine.
-	var (
-		wrongCounts atomic.Int64
-		queryRuns   atomic.Int64
-		queryErrors atomic.Int64
-		stopCh      = make(chan struct{})
-		wg          sync.WaitGroup
-	)
-
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		wg.Add(1)
-		uri := restURIOf(compose, nodeIdx)
-		idx := nodeIdx
-		go func() {
-			defer wg.Done()
-			ticker := time.NewTicker(50 * time.Millisecond)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-stopCh:
-					return
-				case <-ticker.C:
-				}
-				count, err := rangeCount(uri, className, "score", rangeLo, rangeHi)
-				queryRuns.Add(1)
-				if err != nil {
-					// Transient HTTP / RAFT-busy errors are tolerated; a
-					// query that errors out is at least signalling "I
-					// can't answer" rather than returning a wrong
-					// number. We log but don't count them as failures.
-					queryErrors.Add(1)
-					t.Logf("node %d transient error: %v", idx, err)
-				} else if count != expectedBaseline {
-					wrongCounts.Add(1)
-					t.Logf("ISSUE C REPRO: node %d returned partial count %d (expected %d)",
-						idx, count, expectedBaseline)
-				}
-			}
-		}()
-	}
+	// dozens of in-flight samples per goroutine. Transient errors are logged,
+	// not counted as failures - they signal "can't answer", not a wrong number.
+	counters, stopCh, wg := startRangeCountPolling(compose, className, rangeLo, rangeHi, expectedBaseline, 3,
+		func(nodeIdx, got int) {
+			t.Logf("node %d returned partial count %d during in-flight migration (expected %d)",
+				nodeIdx, got, expectedBaseline)
+		},
+		func(nodeIdx int, err error) {
+			t.Logf("node %d transient error: %v", nodeIdx, err)
+		})
 
 	// Submit enable-rangeable. We do this via the same handler the demo
 	// hits, so the on-the-wire shape matches the production failure.
@@ -189,7 +158,7 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 	wg.Wait()
 
 	t.Logf("background queries: %d runs, %d transient errors, %d wrong counts",
-		queryRuns.Load(), queryErrors.Load(), wrongCounts.Load())
+		counters.queryRuns.Load(), counters.queryErrors.Load(), counters.wrongCounts.Load())
 
 	// Verify the schema flip eventually committed on every node.
 	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
@@ -215,7 +184,7 @@ func TestMultiNode_EnableRangeable_NoPartialCountsInFlight(t *testing.T) {
 
 	// The whole point: ZERO wrong (non-error, non-baseline) counts during
 	// the in-flight window. A non-zero count here is a #212-Issue-C repro.
-	assert.Zero(t, wrongCounts.Load(),
+	assert.Zero(t, counters.wrongCounts.Load(),
 		"GH #212 Issue C: expected zero partial counts during in-flight "+
 			"enable-rangeable migration. The migration must either still serve "+
 			"the filterable bucket walk (correct, slow) or the fully-swapped "+

--- a/test/acceptance/reindex_multinode/rangeable_in_memory_test.go
+++ b/test/acceptance/reindex_multinode/rangeable_in_memory_test.go
@@ -1,0 +1,384 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_multinode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+// This file is the weaviate/weaviate#12199 regression suite: with
+// INDEX_RANGEABLE_IN_MEMORY=true, an enable-rangeable reindex must not serve
+// empty range results after the per-shard swap (no restart required). Also
+// pins the disk-fallback WARN and rebuild-at-finalize INFO log signals.
+const (
+	fallbackWARNSubstr        = "rangeable in-memory index is empty"
+	rebuildFinalizeINFOSubstr = "rangeable in-memory index built at migration finalize"
+)
+
+// countInLogs returns the number of lines in a container's logs containing substr.
+func countInLogs(ctx context.Context, t *testing.T, c interface {
+	Logs(context.Context) (io.ReadCloser, error)
+}, substr string,
+) int {
+	t.Helper()
+	reader, err := c.Logs(ctx)
+	require.NoError(t, err, "reading container logs")
+	defer reader.Close()
+	raw, err := io.ReadAll(reader)
+	require.NoError(t, err, "draining container logs")
+	n := 0
+	for _, line := range strings.Split(string(raw), "\n") {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// assertRebuildFinalizeThenNoFallbackWarn requires the rebuild INFO at least
+// once, then no fallback WARN after the last such INFO line.
+func assertRebuildFinalizeThenNoFallbackWarn(ctx context.Context, t *testing.T, container interface {
+	Logs(context.Context) (io.ReadCloser, error)
+}, failMsgInfo, failMsgWarn string,
+) {
+	t.Helper()
+	reader, err := container.Logs(ctx)
+	require.NoError(t, err, "reading container logs")
+	defer reader.Close()
+	raw, err := io.ReadAll(reader)
+	require.NoError(t, err, "draining container logs")
+
+	lines := strings.Split(string(raw), "\n")
+	lastInfoIdx := -1
+	for i, line := range lines {
+		if strings.Contains(line, rebuildFinalizeINFOSubstr) {
+			lastInfoIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, lastInfoIdx, 0, failMsgInfo)
+
+	for i, line := range lines[lastInfoIdx+1:] {
+		if strings.Contains(line, fallbackWARNSubstr) {
+			t.Fatalf("%s (found at log line %d, after the rebuild-finalize INFO at line %d)", failMsgWarn, lastInfoIdx+1+i, lastInfoIdx)
+		}
+	}
+}
+
+// startSingleNodeRangeableInMemCluster starts a 1-node cluster with the
+// in-mem rangeable knob on and LOG_LEVEL=info so the rebuild-at-finalize
+// INFO / fallback WARN are visible in the logs the assertions grep.
+func startSingleNodeRangeableInMemCluster(ctx context.Context, t *testing.T) (*docker.DockerCompose, func()) {
+	t.Helper()
+	compose, err := docker.New().
+		WithWeaviate().
+		WithWeaviateEnv("INDEX_RANGEABLE_IN_MEMORY", "true").
+		WithWeaviateEnv("LOG_LEVEL", "info").
+		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	return compose, func() { require.NoError(t, compose.Terminate(ctx)) }
+}
+
+// scoreForRangeableTest maps import index i to a score in [10_000, 60_000) step 5,
+// so [30_000, 40_000] selects exactly 2001/10_000 objects.
+func scoreForRangeableTest(i int) int { return 10_000 + i*5 }
+
+const (
+	totalObjects     = 10_000
+	rangeLo          = 30_000
+	rangeHi          = 40_000
+	expectedBaseline = 2001
+)
+
+func rangeableScoreProps() []*models.Property {
+	trueVal, falseVal := true, false
+	return []*models.Property{
+		{Name: "name", DataType: []string{"text"}},
+		{
+			Name:              "score",
+			DataType:          []string{"int"},
+			IndexFilterable:   &trueVal,
+			IndexRangeFilters: &falseVal,
+		},
+	}
+}
+
+// Pins weaviate/weaviate#12199: single-node acceptance repro (no restart),
+// plus the post-restart in-memory hand-off case.
+func TestRangeableInMemory_SingleNode_AcceptanceAndRestartHandoff(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := startSingleNodeRangeableInMemCluster(ctx, t)
+	defer cleanup()
+
+	restURI := compose.GetWeaviate().URI()
+	container := compose.GetWeaviate().Container()
+
+	const className = "RangeableInMemAcceptance"
+	// 3 shards => 3 rangeable buckets, each rebuilt at migration finalize,
+	// so the rebuild-at-finalize INFO fires per bucket.
+	createCollection(t, compose, restURI, className, 3, 1, rangeableScoreProps())
+	// Read the URI lazily at cleanup time: the restart below re-maps the host
+	// port, so a URI captured now would be stale by the time this defer runs.
+	defer func() { deleteCollection(t, compose.GetWeaviate().URI(), className) }()
+	batchImportNumeric(t, restURI, className, totalObjects, scoreForRangeableTest)
+
+	// Golden baseline from the filterable path, before the migration.
+	golden, err := rangeCount(restURI, className, "score", rangeLo, rangeHi)
+	require.NoError(t, err)
+	require.Equal(t, expectedBaseline, golden, "pre-migration filterable baseline")
+
+	// NO restart before the checks below - that's the core repro condition.
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
+		`{"rangeable":{"enabled":true}}`)
+	t.Logf("submitted enable-rangeable task: %s", taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+
+	// Poll briefly for the per-shard swap + schema flip to settle, then check
+	// counts and the disk-fallback WARN.
+	awaitRangeCountSettledNoFallback(ctx, t, container, restURI, className,
+		rangeLo, rangeHi, expectedBaseline,
+		"weaviate/weaviate#12199: post-swap range count must equal golden %d WITHOUT restart", expectedBaseline,
+		"disk-fallback WARN must not fire on the fixed path; its presence means an empty in-memory rep was served (weaviate/weaviate#12199)")
+
+	// Promoted buckets must serve range queries from memory immediately
+	// after the swap, no restart.
+	assertRebuildFinalizeThenNoFallbackWarn(ctx, t, container,
+		"rebuild-at-finalize INFO must fire post-swap WITHOUT restart; absence means the in-memory rep was not rebuilt synchronously at migration finalize",
+		"disk-fallback WARN must not fire after the rebuild-at-finalize INFO; its presence means a read fell back to disk after the rep was supposedly rebuilt")
+
+	// Post-restart: boot-time population rebuilds the in-memory rep from disk,
+	// so reads serve from the rep again and no fallback WARN fires.
+	require.NoError(t, compose.StopAt(ctx, 0, nil))
+	require.NoError(t, compose.StartAt(ctx, 0))
+	restURI = compose.GetWeaviate().URI()
+	container = compose.GetWeaviate().Container()
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/v1/.well-known/ready", restURI))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 90*time.Second, 200*time.Millisecond, "node must be ready after restart")
+
+	awaitRangeCountSettledNoFallback(ctx, t, container, restURI, className,
+		rangeLo, rangeHi, expectedBaseline,
+		"post-restart range count must still equal golden %d (rep rebuilt at boot)", expectedBaseline,
+		"no disk-fallback WARN after restart: the rep is rebuilt at boot and serves in-memory")
+}
+
+// Pins weaviate/weaviate#12199: 3-node statistical probe for silent wrong
+// range counts during the in-flight enable-rangeable migration window.
+func TestRangeableInMemory_MultiNode_InFlightStatisticalProbe(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := start3NodeReindexCluster(ctx, t,
+		"INDEX_RANGEABLE_IN_MEMORY", "true", "LOG_LEVEL", "info")
+	defer cleanup()
+	defer dumpContainerLogs(ctx, t, compose)
+
+	const className = "RangeableInMemInFlight"
+	createCollection(t, compose, restURIOf(compose, 1), className, 3, 3, rangeableScoreProps())
+	defer deleteCollection(t, restURIOf(compose, 1), className)
+	batchImportNumeric(t, restURIOf(compose, 1), className, totalObjects, scoreForRangeableTest)
+
+	// Every replica agrees on the baseline before the migration.
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		c, err := rangeCount(restURIOf(compose, nodeIdx), className, "score", rangeLo, rangeHi)
+		require.NoError(t, err, "pre-migration baseline on node %d", nodeIdx)
+		require.Equal(t, expectedBaseline, c, "node %d baseline", nodeIdx)
+	}
+
+	counters, stopCh, wg := startRangeCountPolling(compose, className,
+		rangeLo, rangeHi, expectedBaseline, 3,
+		func(nodeIdx, got int) {
+			t.Logf("weaviate/weaviate#12199 in-flight divergence: node %d returned %d (expected %d)", nodeIdx, got, expectedBaseline)
+		}, nil)
+
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURIOf(compose, 1), className, "score",
+		`{"rangeable":{"enabled":true}}`)
+	t.Logf("submitted enable-rangeable task: %s", taskID)
+	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID, reindexhelpers.WithTimeout(180*time.Second))
+
+	// Keep probing until every replica converges to the correct rangeable count.
+	require.Eventually(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			c, err := rangeCount(restURIOf(compose, nodeIdx), className, "score", rangeLo, rangeHi)
+			if err != nil || c != expectedBaseline {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 50*time.Millisecond, "all replicas must converge to %d", expectedBaseline)
+	close(stopCh)
+	wg.Wait()
+
+	t.Logf("in-flight probes: %d runs, %d transient errors, %d wrong counts",
+		counters.queryRuns.Load(), counters.queryErrors.Load(), counters.wrongCounts.Load())
+
+	// The schema flip committed on every node.
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		cls := getClassFromNode(t, restURIOf(compose, nodeIdx), className)
+		ok := false
+		for _, prop := range cls.Properties {
+			if prop.Name == "score" && prop.IndexRangeFilters != nil && *prop.IndexRangeFilters {
+				ok = true
+				break
+			}
+		}
+		assert.True(t, ok, "node %d: IndexRangeFilters should be true", nodeIdx)
+	}
+
+	assert.Zero(t, counters.wrongCounts.Load(),
+		"weaviate/weaviate#12199: zero silent-wrong range counts during the in-flight enable-rangeable "+
+			"window with INDEX_RANGEABLE_IN_MEMORY=true. A non-zero count means a replica "+
+			"served from an empty in-memory rep instead of the disk path.")
+}
+
+// Pins weaviate/weaviate#12199: migrates under concurrent live writes that
+// change movers' value, then asserts each mover serves its NEW value only.
+func TestRangeableInMemory_WriteWorkloadValueIntegrity(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := startSingleNodeRangeableInMemCluster(ctx, t)
+	defer cleanup()
+	restURI := compose.GetWeaviate().URI()
+
+	const className = "RangeableInMemWriteWorkload"
+	// Single shard keeps the mover UUIDs deterministic and the value assertions
+	// simple; the value-integrity property is per-shard.
+	createCollection(t, compose, restURI, className, 1, 1, rangeableScoreProps())
+	defer deleteCollection(t, restURI, className)
+
+	const (
+		total      = 4_000
+		moverCount = 500
+		oldValue   = 20_000 // movers start here; a single point value used for exact-match range queries (lo == hi)
+		newValue   = 55_000 // movers are updated to here mid-migration
+		stableVal  = 12_345 // non-movers; must never change
+	)
+	// Deterministic UUIDs so we can overwrite the movers by re-importing them.
+	moverID := func(i int) string {
+		return uuid.NewSHA1(uuid.NameSpaceOID, []byte(fmt.Sprintf("rangeable-mover-%d", i))).String()
+	}
+
+	// Seed: movers at oldValue, the rest at stableVal.
+	seed := make([]map[string]interface{}, 0, total)
+	for i := 0; i < total; i++ {
+		id := uuid.NewSHA1(uuid.NameSpaceOID, []byte(fmt.Sprintf("rangeable-obj-%d", i))).String()
+		score := stableVal
+		if i < moverCount {
+			id = moverID(i)
+			score = oldValue
+		}
+		seed = append(seed, map[string]interface{}{
+			"class":      className,
+			"id":         id,
+			"properties": map[string]interface{}{"name": fmt.Sprintf("item-%d", i), "score": score},
+		})
+	}
+	postObjects(t, restURI, seed)
+
+	// Baseline: exactly moverCount objects have score == oldValue.
+	c, err := rangeCount(restURI, className, "score", oldValue, oldValue)
+	require.NoError(t, err)
+	require.Equal(t, moverCount, c, "pre-migration movers at oldValue")
+
+	// Wait for the migration to be live before overwriting movers, or the
+	// backfill could simply read newValue and the double-write scenario
+	// wouldn't be exercised.
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
+		`{"rangeable":{"enabled":true}}`)
+	reindexhelpers.AwaitReindexLive(t, restURI, taskID)
+
+	// AwaitReindexLive guarantees only a live task status, not backfill
+	// cursor progress; movers are UUID-hashed pseudo-randomly across the
+	// keyspace, so this overwrite likely lands mid-backfill without a hard
+	// per-mover guarantee. The test asserts what must hold either way:
+	// movers end at newValue, none at oldValue.
+	updates := make([]map[string]interface{}, 0, moverCount)
+	for i := 0; i < moverCount; i++ {
+		updates = append(updates, map[string]interface{}{
+			"class":      className,
+			"id":         moverID(i),
+			"properties": map[string]interface{}{"name": fmt.Sprintf("item-%d", i), "score": newValue},
+		})
+	}
+	postObjects(t, restURI, updates) // overwrite by same UUID, in-flight
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
+
+	// Post-swap value integrity, no restart. Poll for settle.
+	require.Eventually(t, func() bool {
+		atNew, e1 := rangeCount(restURI, className, "score", newValue, newValue)
+		atOld, e2 := rangeCount(restURI, className, "score", oldValue, oldValue)
+		return e1 == nil && e2 == nil && atNew == moverCount && atOld == 0
+	}, 60*time.Second, 200*time.Millisecond,
+		"post-swap: movers must serve their NEW value (%d at %d) and none at the OLD value %d",
+		moverCount, newValue, oldValue)
+
+	// Membership backstop: the stable (backfilled-only) objects are all present.
+	atStable, err := rangeCount(restURI, className, "score", stableVal, stableVal)
+	require.NoError(t, err)
+	assert.Equal(t, total-moverCount, atStable, "non-mover objects must remain at their stable value")
+}
+
+// postObjects batch-imports objects (200 per batch) with consistency_level=ALL.
+func postObjects(t *testing.T, restURI string, objects []map[string]interface{}) {
+	t.Helper()
+	const batchSize = 200
+	for start := 0; start < len(objects); start += batchSize {
+		end := start + batchSize
+		if end > len(objects) {
+			end = len(objects)
+		}
+		body, err := json.Marshal(map[string]interface{}{"objects": objects[start:end]})
+		require.NoError(t, err)
+		resp, err := http.Post(
+			fmt.Sprintf("http://%s/v1/batch/objects?consistency_level=ALL", restURI),
+			"application/json",
+			bytes.NewReader(body),
+		)
+		require.NoError(t, err)
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "batch %d-%d failed: %s", start, end, string(respBody))
+
+		var batchResp []struct {
+			Result struct {
+				Errors *struct {
+					Error []struct {
+						Message string `json:"message"`
+					} `json:"error"`
+				} `json:"errors,omitempty"`
+			} `json:"result"`
+		}
+		require.NoError(t, json.Unmarshal(respBody, &batchResp))
+		for i, br := range batchResp {
+			if br.Result.Errors != nil && len(br.Result.Errors.Error) > 0 {
+				t.Fatalf("batch %d-%d object %d errored: %s", start, end, i, br.Result.Errors.Error[0].Message)
+			}
+		}
+	}
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -73,6 +73,9 @@ type PrometheusMetrics struct {
 	MmapOperations                      *prometheus.CounterVec
 	MmapProcMaps                        prometheus.Gauge
 
+	// Reindex metrics
+	RangeableInMemoryRebuildDegraded *prometheus.CounterVec
+
 	// Backup/Restore metrics
 	BackupRestoreDurations            *prometheus.SummaryVec
 	BackupStoreDurations              *prometheus.SummaryVec
@@ -348,6 +351,7 @@ func (pm *PrometheusMetrics) DeleteShard(className, shardName string) error {
 	pm.StartupProgress.DeletePartialMatch(labels)
 	pm.StartupDurations.DeletePartialMatch(labels)
 	pm.StartupDiskIO.DeletePartialMatch(labels)
+	pm.RangeableInMemoryRebuildDegraded.DeletePartialMatch(labels)
 	return nil
 }
 
@@ -579,6 +583,12 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "mmap_proc_maps",
 			Help: "Number of entries in /proc/self/maps",
 		}),
+
+		// Reindex metrics
+		RangeableInMemoryRebuildDegraded: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "rangeable_inmemory_rebuild_degraded_total",
+			Help: "Number of times the rangeable in-memory rebuild at reindex finalize degraded to disk serving instead of activating in-memory acceleration",
+		}, []string{"class_name", "shard_name", "property"}),
 
 		// Queue metrics
 		QueueSize: promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -1014,6 +1024,14 @@ func (m *PrometheusMetrics) initObjectsTtl() error {
 	}
 
 	return nil
+}
+
+func (m *PrometheusMetrics) IncRangeableInMemoryRebuildDegraded(className, shardName, propName string) {
+	m.RangeableInMemoryRebuildDegraded.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+		"property":   propName,
+	}).Inc()
 }
 
 // --- Objects TTL: main ---


### PR DESCRIPTION
Hey, Claudette here :robot: :wave:

Fixes #12199. With `INDEX_RANGEABLE_IN_MEMORY=true`, an enable-rangeable reindex serves empty (or partial) range-filter results from the moment of the per-shard swap until the next process restart, with no error and no log. This PR fixes the silent-wrong-results and adds two independent guards against the whole class of "the in-memory representation should have been populated but wasn't."

### Mechanism

When the global knob is on, every `StrategyRoaringSetRange` bucket is opened with `keepSegmentsInMemory=true` and range queries are served exclusively from an in-memory bit-sliced representation, with no disk fallback (`ReaderRoaringSetRange`, `bucket_roaring_set_range.go:58`). That representation is populated at exactly two sites: bucket open (fold over all disk segments) and memtable flush.

The enable-rangeable runtime reindex delivers its bulk backfill through a third segment-list mutation site, `PrependSegmentsFromBucket` (`segment_group_prepend.go:67`), a file-level segment copy and splice. That function has a derived-state branch for the Inverted strategy (average property lengths) but none for RoaringSetRange. So the freshly created ingest bucket starts with an empty representation, receives only live double-writes into it during migration, and after `SwapBucketPointer` (a pure map re-point) it serves range queries from that empty or partial representation while the complete postings sit on disk. Empty under a read-only workload, partial under writes. The reproduction numbers are already in the issue (golden matches versus zero post-swap; restart heals). This affects single-node and multi-node alike.

### Fix

Four layers. Layers 1-3 make the migration serve correct results with the knob on; layer 4 restores the knob's in-memory performance immediately at migration finalize.

1. Primary: force `keepSegmentsInMemory=false` for reindex rangeable ingest buckets (`inverted_reindex_task_generic.go:2601`). The override is gated on `strategy == StrategyRoaringSetRange` and forces `false` unconditionally inside the gate, so the ingest bucket never builds a representation and post-swap range reads go through the already-correct disk path (newest-to-oldest layering with deletion masking under a consistent view). Correct results immediately after each per-shard swap, no restart required.

2. Structural guard: `PrependSegmentsFromBucket` now returns an error instead of silently splicing when called on a RoaringSetRange group that has a live in-memory representation (`ErrPrependWouldDesyncInMemoryRep`, a package-level sentinel wrapped with bucket context via `%w`). It is a step-1 early return before the file copy and the splice, so the failure is clean (no files copied, segment list unmutated) and propagates per-shard through the existing error path. The message names the invariant and both remedies. This converts any future caller that recreates the broken state (a second migration type, restore-into-live, a refactor that drops the override above) from silent-wrong-results into a loud, local, pre-mutation failure.

3. Install-time publish gate: the rebuild validates the representation once, at install time, under the flush lock, before publishing it - a representation that folds up empty while disk segments exist is never published, and the bucket stays on the already-correct disk path with a loud diagnostic. The discriminant is `bitmaps[0].IsEmpty()` (the presence set every reader clones as its base), not `Size()==0`, because the empty skeleton is 65 allocated bitmaps with nonzero byte size and `Size()==0` would never fire. A genuinely empty bucket has an empty representation and zero disk segments, so it publishes normally and returns the correct empty result at full speed. The read path keeps one narrow defensive branch for the boot-time `keepSegmentsInMemory` load path, which does not pass through the install gate; everywhere else the published flag is trusted, so there is no per-read re-check and no silent serving-mode change after publication.

4. Immediate in-memory serving via rebuild-at-finalize: `rebuildRangeableInMemoryReps` runs at migration finalize on every completion path (the happy path in `runtimeSwap`, the recovery path in `finalizeMigrationAfterRecovery`, and the re-entrant `IsTidied` branch of `OnAfterLsmInitAsync`) and calls the bucket's `RebuildRangeableSegmentInMemory`: pause compaction via the ref-counted bucket-level wrappers, take a ref-counted consistent view of the disk segments (held across the whole build+install span, so a concurrent shutdown or tenant deactivation waits on the refcount instead of unmapping under the cursor), bulk-merge into a fresh representation WITHOUT holding the flush lock (writes and flushes stay unblocked), then under the flush lock catch up any segments flushed during the bulk phase, validate, publish, and atomically flip the bucket to in-memory serving. The fold consults the allocation checker before building, so a memory-constrained node degrades to disk serving instead of risking an OOM kill. The migrated property serves range queries from memory within seconds of the migration finishing - no restart, no reload.

### Rebuild design notes

Two rebuild shapes were considered; only one is safe. An incremental merge of the prepended segments into the live representation is corrupting: the representation is a flattened fold whose correctness depends on oldest-to-newest application order, and prepended segments are timestamp-shifted to sort as logically oldest while the representation may already hold newer live double-writes - folding older segments on top of newer state ORs stale bit-slices into current values (wrong VALUES, not just wrong membership; older deletions masking newer additions). The shipped rebuild is therefore a full from-scratch fold with explicit serialization: compaction paused for the whole rebuild (the segment set can only grow by flush appends at the tail), bulk merge outside the flush lock, tail catch-up plus publish inside it. The `PrependSegmentsFromBucket` guard (layer 2) still stands: prepends target only pre-swap ingest buckets, which never have a live representation; the rebuild runs post-swap after all prepends are done.

### Failure semantics and operator signals

The happy path needs no operator action: an INFO ("rangeable in-memory index built at migration finalize; serving range queries from memory") marks the switch per bucket.

If the finalize rebuild fails (a segment read error, an allocation-checker refusal, or a representation that validates as unpopulated), the failure is scoped to what it actually is: a degraded read-side acceleration on data that is complete and correct on disk. The rebuild logs at ERROR ("built and data intact, could not be activated for in-memory serving"), increments the `RangeableInMemoryRebuildDegraded` metric so the degrade is dashboard-visible, and the migration proceeds to completion - the property serves correct results from the disk path, and the next restart or reload rebuilds the in-memory representation and restores acceleration. This matters in multi-replica deployments: the first replica to finish commits the schema flag cluster-wide, and a replica whose rebuild failed must keep answering queries (correctly, from disk) rather than erroring until someone restarts it. Failures in the data work itself (prepend, swap, tidy) still report FAILED; only the acceleration step degrades. Both behaviors are pinned by fault-injection tests, including cancellation routing (`Canceled` and `DeadlineExceeded` both route to the transient retry path, never to FAILED or a spurious FINISHED).

### Strategy-coverage audit of PrependSegmentsFromBucket

While in the function I audited every supported strategy's derived-state obligation, since this is the second time this function has been flagged for strategy-incompleteness:

| Strategy | Segment-group derived state | Status after this PR |
|---|---|---|
| Inverted | avg property lengths | maintained (existing branch) |
| RoaringSetRange | in-memory representation | guarded (this PR) |
| RoaringSet | none | n/a |
| SetCollection | none | n/a |
| MapCollection | none | n/a |
| Replace | countNetAdditions (not recalculable) | rejected already |

The function's doc comment now carries this table, so the next strategy added to it has to answer the question explicitly.

### Tests

Unit (fast, `-race`): the (b) override, the guard (fires on an active representation, and is unreachable from the fixed reindex path; the sentinel and pre-mutation cleanliness are asserted), the (c) four-case matrix (empty-or-populated representation crossed with zero-or-more disk segments), and a fold-order value-integrity test that pins the corruption the rejected in-place rebuild would introduce. The finalize-degrade semantics are pinned by their own set: rebuild-failure-still-completes (asserting correct disk results and no missing-index error on the affected property), cancellation-stays-transient, data-work-failure-stays-FAILED, empty-representation-never-publishes, published-flag-trusted, a shard-level staggered-flip test, the degrade-metric assertion, and a shutdown-during-rebuild race test.

Acceptance (testcontainers, single and three-node): the enable-rangeable repro with no restart, asserting the post-swap range count equals the golden count, the (c) WARN does not fire on the fixed path, and the deferred-serving INFO does fire; a three-node in-flight statistical probe firing range queries at every node throughout the migration window and counting divergences (silent wrong results, not errors, are the failure mode); a write-workload variant asserting value integrity (a docID whose value changed mid-migration is returned by new-value queries and not by old-value queries); and restart-recovery plus post-restart in-memory hand-off. The acceptance suite codifies the reproduction already confirmed in the issue rather than re-deriving it.

How each test maps to a layer of the fix, if you want to verify the coverage is not redundant:

- A strict revert of the primary override alone (guard kept) is caught by the guard: the ingest bucket keeps an active representation, the guard rejects the backfill prepend, and the reindex fails with the `INV-RANGEABLE-REP-EQUALS-DISK` sentinel before any post-swap query runs.
- The WARN-absence and INFO-presence assertions are positive proof the override is applied, and a tripwire for a double revert of the override and the guard together, which is the only way to reach the empty-representation-served state.
- The (c) four-case matrix pins the read-path fallback.
- The fold-order value-integrity test pins the rejected in-place-rebuild trap.

Replay:

```
go test -race -count=1 ./adapters/repos/db/lsmkv/... ./adapters/repos/db/roaringsetrange/...
TEST_WEAVIATE_IMAGE=<prebuilt-image> go test -count=1 -race -timeout 20m ./test/acceptance/reindex_multinode/ -run TestRangeableInMemory
```

### Operator notes (release-note material)

1. During an enable-rangeable reindex on a deployment running `INDEX_RANGEABLE_IN_MEMORY=true`, range queries on the migrating property are served from DISK (correct results, temporarily without the in-memory speed) for the duration of the migration only. At migration finalize the in-memory index is rebuilt and serving switches to memory immediately, with no restart. An INFO log line ("rangeable in-memory index built at migration finalize") marks the switch. The remaining during-migration window is inherent to any online migration.

2. If the in-memory rebuild at finalize fails, the migration still completes and the property serves correct results from disk, without the in-memory speed. The signal is an ERROR log ("built and data intact, could not be activated for in-memory serving") plus the `RangeableInMemoryRebuildDegraded` metric; a restart or reload restores in-memory serving. No query errors, no wrong results, no operator action required beyond noticing the degrade.

### Out of scope

- The full in-place-rebuild machinery (rejected above; the guard forces any future need to be built consciously).
- The adjacent double-write gaps tracked separately; this fix deliberately does not depend on double-write coverage.
- Any change to `INDEX_RANGEABLE_IN_MEMORY` semantics for non-reindex paths.
- Corrupt-segment-header validation at open (`segmentindex.ParseHeader`): split into its own PR against `stable/v1.38` per review, since its upgrade-behavior change deserves independent reasoning and its own release note.

### Relationship to #12215

This PR is the forward-port to `main` of #12215 (merged into `stable/v1.38`). The diff is content-identical to the merged final state of that PR, applied onto current `main` (all 17 files applied cleanly; the two branches had already converged on the mechanism sites via main's periodic merges of `stable/v1.38`). The full review history, including the three-round review saga with QA Claude and the request-changes cycle, lives on #12215.

### Verification

- [x] go build ./... clean
- [x] golangci-lint clean on the touched packages (including the previously red ST1005 pair)
- [x] goroutine linter clean
- [x] unit tests green with `-race` (full `adapters/repos/db/...`, `usecases/monitoring`)
- [x] acceptance suite green at the fix (single-node, three-node, write-workload)
- [ ] full acceptance CI pending on the PR

Claudette

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171Q1Fe5rpEYq2GeKarJbV9







Supersedes #12216, which cannot be reopened after the branch was rebuilt on current `main` (GitHub blocks reopening once the head moves). Same branch, same content: byte-identical to the merged #12215.
