### PR TITLE
refact(telemetry) gate cluster-id commit on telemetry being enabled

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -576,6 +576,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		IsLocalHost:                     appState.ServerConfig.Config.Cluster.Localhost,
 		LoadLegacySchema:                schemaRepo.LoadLegacySchema,
 		SentryEnabled:                   appState.ServerConfig.Config.Sentry.Enabled,
+		TelemetryEnabled:                telemetryEnabled(appState),
 		AuthzController:                 appState.AuthzController,
 		RBAC:                            appState.RBAC,
 		DynamicUserController:           appState.APIKey.Dynamic,

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -156,6 +156,9 @@ type Config struct {
 	// capture traces
 	SentryEnabled bool
 
+	// TelemetryEnabled reports whether telemetry is enabled on this node.
+	TelemetryEnabled bool
+
 	// EnableOneNodeRecovery enables the actually one node recovery logic to avoid it running all the time when
 	// unnecessary
 	EnableOneNodeRecovery bool
@@ -975,7 +978,15 @@ func (st *Store) ClusterID() string {
 
 // maybeCommitClusterID commits a fresh UUID cluster identity via raft if one
 // isn't set yet. Caller must be the raft leader.
+//
+// No-op when telemetry is disabled. This is a leader-local decision: a cluster
+// with mixed settings still gets an identity if any leader has telemetry on,
+// and an already committed id is never removed by opting out later.
 func (st *Store) maybeCommitClusterID() {
+	if !st.cfg.TelemetryEnabled {
+		return
+	}
+
 	if st.ClusterID() != "" {
 		return
 	}

--- a/cluster/store_cluster_id_test.go
+++ b/cluster/store_cluster_id_test.go
@@ -99,6 +99,40 @@ func TestClusterID_ApplySemantics(t *testing.T) {
 	}
 }
 
+// TestClusterID_TelemetryDisabledSkipsCommit covers the telemetry gate on
+// maybeCommitClusterID. The store has no raft/schema manager, so without the
+// gate these cases panic in Execute instead of returning.
+func TestClusterID_TelemetryDisabledSkipsCommit(t *testing.T) {
+	tests := []struct {
+		name   string
+		preset string // simulate a snapshot restore before the leader callback ("" skips)
+		wantID string
+	}{
+		{
+			name:   "no id is committed",
+			wantID: "",
+		},
+		{
+			name:   "an already restored id is left untouched",
+			preset: "restored-id",
+			wantID: "restored-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := newStoreForClusterIDTests(t)
+			st.cfg.TelemetryEnabled = false
+			if tt.preset != "" {
+				st.setClusterID(tt.preset)
+			}
+
+			require.NotPanics(t, st.maybeCommitClusterID)
+			assert.Equal(t, tt.wantID, st.ClusterID())
+		})
+	}
+}
+
 // TestClusterID_SnapshotJSONCompat covers decoding a snapshot into the current
 // fsm.Snapshot struct and restoring the id into the store. The "present" case is
 // produced via json.Marshal so it also exercises the cluster_id encode tag.

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -1415,6 +1415,7 @@ func NewMockStore(t *testing.T, nodeID string, raftPort int) MockStore {
 			NodeSelector:           mocks.NewMockNodeSelector("localhost"),
 			Logger:                 logger,
 			ConsistencyWaitTimeout: time.Millisecond * 50,
+			TelemetryEnabled:       true,
 		},
 		replicationFSM: schema.NewMockreplicationFSM(t),
 	}


### PR DESCRIPTION
### What's being changed:
this makes sure the needed cluster id raft commit not triggered unless telemetry is enabled 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
