### PR TITLE
Improve segment index performance by using van Emde Boas layout

### DIFF
--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -202,8 +202,8 @@ func (t *DiskTree) seekAt(offset int64, key []byte, includingKey bool) (Node, er
 // segment where we need access to all keys, e.g. to build a bloom filter. This
 // should not run at query time.
 //
-// The binary tree is traversed in Level-Order so keys have no meaningful
-// order. Do not use this method if an In-Order traversal is required, but only
+// Keys are returned in the tree's on-disk (serialized) order, which is not
+// sorted. Do not use this method if an In-Order traversal is required, but only
 // for use cases who don't require a specific order, such as building a
 // bloom filter.
 func (t *DiskTree) AllKeys() ([][]byte, error) {

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -54,6 +54,8 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 	data := t.data
 	dataLen := uint64(len(data))
 	pos := uint64(0)
+	steps := 0
+	maxSteps := maxDescentSteps(len(data))
 
 	// jump through the buffer until the node with _key_ is found or return a
 	// NotFound error. Node keys are compared in place against the tree data, so
@@ -64,6 +66,14 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 	// every read is bounds-checked against dataLen-pos (never pos+n, which would
 	// wrap). Truncated or corrupt data yields NotFound or an error, never a panic.
 	for {
+		// A child pointer leading back to an already visited node would keep the
+		// descent going forever. No descent visits a node twice, so it cannot take
+		// more steps than the buffer can hold nodes.
+		steps++
+		if steps > maxSteps {
+			return out, errors.New("cyclic child pointers in segment index")
+		}
+
 		// node layout: [keyLen:4][key:keyLen][start:8][end:8][left:8][right:8].
 		if pos+4 > dataLen || pos+4 < 4 {
 			return out, lsmkv.NotFound
@@ -98,6 +108,13 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 			pos = binary.LittleEndian.Uint64(data[pos+24:]) // skip start+end+left, read right child
 		}
 	}
+}
+
+// maxDescentSteps bounds a root-to-leaf descent at the number of nodes a buffer
+// of this size can hold, which no descent following intact child pointers
+// reaches. It is what makes a cyclic pointer terminate.
+func maxDescentSteps(dataLen int) int {
+	return dataLen/TREE_KEY_STORE_OVERHEAD + 1
 }
 
 func (t *DiskTree) readNodeAt(offset int64) (dtNode, error) {
@@ -146,7 +163,7 @@ func (t *DiskTree) Seek(key []byte) (Node, error) {
 		return Node{}, lsmkv.NotFound
 	}
 
-	return t.seekAt(0, key, true)
+	return t.seekAt(0, key, true, maxDescentSteps(len(t.data)))
 }
 
 func (t *DiskTree) Next(key []byte) (Node, error) {
@@ -154,10 +171,16 @@ func (t *DiskTree) Next(key []byte) (Node, error) {
 		return Node{}, lsmkv.NotFound
 	}
 
-	return t.seekAt(0, key, false)
+	return t.seekAt(0, key, false, maxDescentSteps(len(t.data)))
 }
 
-func (t *DiskTree) seekAt(offset int64, key []byte, includingKey bool) (Node, error) {
+// budget is how many more nodes the descent may visit, so a child pointer
+// leading back to an already visited node fails instead of recursing forever.
+func (t *DiskTree) seekAt(offset int64, key []byte, includingKey bool, budget int) (Node, error) {
+	if budget <= 0 {
+		return Node{}, errors.New("cyclic child pointers in segment index")
+	}
+
 	node, err := t.readNodeAt(offset)
 	if err != nil {
 		return Node{}, err
@@ -178,7 +201,7 @@ func (t *DiskTree) seekAt(offset int64, key []byte, includingKey bool) (Node, er
 			return self, nil
 		}
 
-		left, err := t.seekAt(node.leftChild, key, includingKey)
+		left, err := t.seekAt(node.leftChild, key, includingKey, budget-1)
 		if err == nil {
 			return left, nil
 		}
@@ -193,7 +216,7 @@ func (t *DiskTree) seekAt(offset int64, key []byte, includingKey bool) (Node, er
 			return Node{}, lsmkv.NotFound
 		}
 
-		return t.seekAt(node.rightChild, key, includingKey)
+		return t.seekAt(node.rightChild, key, includingKey, budget-1)
 	}
 }
 

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -114,51 +114,60 @@ func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
 // outgrows the CPU caches.
 //
 // Run with: go test -run x -bench BenchmarkDiskTreeGet ./adapters/repos/db/lsmkv/segmentindex/
+//
+// For a single size anchor the sub-benchmark name — an unanchored n=100000 also
+// matches n=1000000 and n=10000000:
+//
+//	go test -run x -bench 'BenchmarkDiskTreeGet/^n=100000$' ./adapters/repos/db/lsmkv/segmentindex/
 func BenchmarkDiskTreeGet(b *testing.B) {
 	for _, n := range []int{100_000, 1_000_000, 10_000_000} {
-		keys := docIDKeys(n)
-		nodes := make(Nodes, n)
-		for i := range keys {
-			nodes[i] = Node{Key: keys[i].Key, Start: uint64(keys[i].ValueStart), End: uint64(keys[i].ValueEnd)}
-		}
+		// Setup lives inside the sub-benchmark so selecting one n does not build
+		// the blobs for the others (the 10M case costs GBs and minutes).
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			keys := docIDKeys(n)
+			nodes := make(Nodes, n)
+			for i := range keys {
+				nodes[i] = Node{Key: keys[i].Key, Start: uint64(keys[i].ValueStart), End: uint64(keys[i].ValueEnd)}
+			}
 
-		levelOrder := NewBalanced(nodes)
-		var levelBuf bytes.Buffer
-		_, err := levelOrder.MarshalBinaryInto(&levelBuf)
-		require.NoError(b, err)
+			levelOrder := NewBalanced(nodes)
+			var levelBuf bytes.Buffer
+			_, err := levelOrder.MarshalBinaryInto(&levelBuf)
+			require.NoError(b, err)
 
-		var vebBuf bytes.Buffer
-		_, err = MarshalSortedKeysFromKeys(&vebBuf, keys)
-		require.NoError(b, err)
+			var vebBuf bytes.Buffer
+			_, err = MarshalSortedKeysFromKeys(&vebBuf, keys)
+			require.NoError(b, err)
 
-		// Fixed random lookup order, shared across layouts for a fair comparison.
-		// A wide probe set spreads lookups across the index so its layout, rather
-		// than a few permanently-hot pages, drives the result. Length is a power of
-		// two for the cheap index mask below.
-		rng := rand.New(rand.NewSource(int64(n)))
-		probes := make([][]byte, 65536)
-		for i := range probes {
-			probes[i] = keys[rng.Intn(n)].Key
-		}
+			// Fixed random lookup order, shared across layouts for a fair comparison.
+			// A wide probe set spreads lookups across the index so its layout, rather
+			// than a few permanently-hot pages, drives the result. Length is a power of
+			// two for the cheap index mask below.
+			rng := rand.New(rand.NewSource(int64(n)))
+			probes := make([][]byte, 65536)
+			for i := range probes {
+				probes[i] = keys[rng.Intn(n)].Key
+			}
 
-		layouts := []struct {
-			name string
-			data []byte
-		}{
-			{"level-order", levelBuf.Bytes()},
-			{"van-Emde-Boas", vebBuf.Bytes()},
-		}
-		for _, l := range layouts {
-			tree := NewDiskTree(l.data)
-			b.Run(fmt.Sprintf("n=%d/%s", n, l.name), func(b *testing.B) {
-				b.ReportAllocs()
-				for i := 0; i < b.N; i++ {
-					if _, err := tree.Get(probes[i&(len(probes)-1)]); err != nil {
-						b.Fatal(err)
+			layouts := []struct {
+				name string
+				data []byte
+			}{
+				{"level-order", levelBuf.Bytes()},
+				{"van-Emde-Boas", vebBuf.Bytes()},
+			}
+			for _, l := range layouts {
+				tree := NewDiskTree(l.data)
+				b.Run(l.name, func(b *testing.B) {
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						if _, err := tree.Get(probes[i&(len(probes)-1)]); err != nil {
+							b.Fatal(err)
+						}
 					}
-				}
-			})
-		}
+				})
+			}
+		})
 	}
 }
 

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -16,8 +16,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
+	"runtime/debug"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,6 +106,153 @@ func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
 			_, _ = dTree.Seek([]byte("aaa"))
 		})
 	})
+}
+
+// fuzzReadDeadline bounds one input's worth of read calls. The reads follow
+// child pointers taken straight from the data, so a pointer that leads back to
+// an already-visited node keeps the descent going forever. Go's fuzzer has no
+// hang detection, so without this the run would sit on such an input until the
+// whole test binary times out.
+const fuzzReadDeadline = 10 * time.Second
+
+// FuzzDiskTreeRead feeds arbitrary bytes to every DiskTree read path. The bytes
+// come off disk, so a torn write or a bad sector can produce any of them, and
+// none of them may take the node down: reads must return NotFound or an error.
+//
+// TestDiskTreeCorruptDataNeverPanics covers the same ground for truncations of
+// one blob and two hand-placed corruptions. The fuzzer reaches what those miss:
+// corruption below the root, a child pointer landing inside a key rather than
+// out of bounds, and node headers that no valid writer emits.
+//
+// The seed corpus runs on every `go test`; mutation needs an explicit run:
+//
+//	go test -run x -fuzz FuzzDiskTreeRead ./adapters/repos/db/lsmkv/segmentindex/
+func FuzzDiskTreeRead(f *testing.F) {
+	keys := []Key{
+		{Key: []byte("aaa"), ValueStart: 1, ValueEnd: 2},
+		{Key: []byte("abc"), ValueStart: 4, ValueEnd: 5},
+		{Key: []byte("foobar"), ValueStart: 17, ValueEnd: 18},
+		{Key: []byte("zzz"), ValueStart: 34, ValueEnd: 35},
+		{Key: []byte("zzzz"), ValueStart: 100, ValueEnd: 102},
+	}
+	var vebBuf bytes.Buffer
+	_, err := MarshalSortedKeysFromKeys(&vebBuf, keys)
+	require.NoError(f, err)
+	veb := vebBuf.Bytes()
+
+	// The level-order writer is still reachable through Tree, and its root sits at
+	// a different offset, so seed both layouts.
+	var levelBuf bytes.Buffer
+	levelTree := NewBalanced(primaryNodes(keys))
+	_, err = levelTree.MarshalBinaryInto(&levelBuf)
+	require.NoError(f, err)
+
+	corruptKeyLen := bytes.Clone(veb)
+	binary.LittleEndian.PutUint32(corruptKeyLen[0:4], 0xFFFFFFFF)
+
+	// Root child pointers past the end of the buffer.
+	corruptChildren := bytes.Clone(veb)
+	childBase := 4 + int(binary.LittleEndian.Uint32(veb[0:4])) + 16
+	binary.LittleEndian.PutUint64(corruptChildren[childBase:], 0xFFFFFFFFFFFFFFFF)
+	binary.LittleEndian.PutUint64(corruptChildren[childBase+8:], uint64(len(veb))+1)
+
+	// Root's left child points back at the root, the shape that makes a descent
+	// loop rather than run out of buffer.
+	cyclic := bytes.Clone(veb)
+	binary.LittleEndian.PutUint64(cyclic[childBase:], 0)
+
+	blobs := [][]byte{
+		nil,
+		{},
+		{0x01, 0x02, 0x03},
+		veb,
+		cyclic,
+		levelBuf.Bytes(),
+		veb[:len(veb)-1],
+		veb[:len(veb)/2],
+		veb[:TREE_KEY_STORE_OVERHEAD],
+		veb[:4],
+		corruptKeyLen,
+		corruptChildren,
+	}
+	// Queries covering a match, both descent directions, and both ends of the
+	// key range.
+	queries := [][]byte{nil, []byte("aaa"), []byte("foobar"), []byte("m"), []byte("zzzzz")}
+
+	for _, blob := range blobs {
+		for _, query := range queries {
+			f.Add(blob, query)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, data, query []byte) {
+		tree := NewDiskTree(data)
+
+		var (
+			allKeys    [][]byte
+			allKeysErr error
+			eachKeys   [][]byte
+			keyCount   int
+		)
+		requireTerminates(t, func() {
+			_, _ = tree.Get(query)
+			_, _ = tree.Seek(query)
+			_, _ = tree.Next(query)
+			allKeys, allKeysErr = tree.AllKeys()
+			keyCount = tree.KeyCount()
+			tree.ForEachKey(func(key []byte) {
+				eachKeys = append(eachKeys, key)
+			})
+			_ = tree.QuantileKeys(8)
+		})
+
+		if allKeysErr != nil {
+			// AllKeys reports a node header it cannot parse, where KeyCount and
+			// ForEachKey stop walking, so the three legitimately disagree here.
+			return
+		}
+		// All three walk the blob sequentially with their own copy of the node-size
+		// arithmetic, so they must agree on what the blob holds.
+		assert.Equal(t, len(allKeys), keyCount, "KeyCount disagrees with AllKeys")
+		assert.Equal(t, allKeys, eachKeys, "ForEachKey disagrees with AllKeys")
+	})
+}
+
+// requireTerminates fails the test if fn panics or exceeds fuzzReadDeadline,
+// instead of taking the process down or hanging the fuzzer.
+func requireTerminates(t *testing.T, fn func()) {
+	t.Helper()
+
+	type failure struct {
+		value any
+		stack []byte
+	}
+
+	done := make(chan *failure, 1)
+	go func() {
+		var caught *failure
+		defer func() {
+			if r := recover(); r != nil {
+				caught = &failure{value: r, stack: debug.Stack()}
+			}
+			done <- caught
+		}()
+		fn()
+	}()
+
+	// A timer rather than time.After: fuzzing runs this millions of times and
+	// stopping the timer releases it right away instead of at the deadline.
+	timer := time.NewTimer(fuzzReadDeadline)
+	defer timer.Stop()
+
+	select {
+	case caught := <-done:
+		if caught != nil {
+			t.Fatalf("read panicked: %v\n%s", caught.value, caught.stack)
+		}
+	case <-timer.C:
+		t.Fatalf("read did not terminate within %s", fuzzReadDeadline)
+	}
 }
 
 // BenchmarkDiskTreeGet compares warm lookup latency between the two on-disk node

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -16,7 +16,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,23 +25,28 @@ import (
 // path (Get, Seek/Next, AllKeys) has to return NotFound or an error instead of
 // panicking on an out-of-range slice.
 func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
-	tree := NewTree(4)
-	elements := []struct {
-		key        []byte
-		start, end uint64
-	}{
-		{[]byte("foobar"), 17, 18}, // inserted first -> BST root at offset 0
-		{[]byte("abc"), 4, 5},
-		{[]byte("zzz"), 34, 35},
-		{[]byte("aaa"), 1, 2},
-		{[]byte("zzzz"), 100, 102},
+	// Sorted keys; the median ("foobar") becomes the BST root, which the van Emde
+	// Boas writer emits first and therefore places at offset 0.
+	keys := []Key{
+		{Key: []byte("aaa"), ValueStart: 1, ValueEnd: 2},
+		{Key: []byte("abc"), ValueStart: 4, ValueEnd: 5},
+		{Key: []byte("foobar"), ValueStart: 17, ValueEnd: 18},
+		{Key: []byte("zzz"), ValueStart: 34, ValueEnd: 35},
+		{Key: []byte("zzzz"), ValueStart: 100, ValueEnd: 102},
 	}
-	for _, e := range elements {
-		tree.Insert(e.key, e.start, e.end)
-	}
-	valid, err := tree.MarshalBinary()
+	var buf bytes.Buffer
+	_, err := MarshalSortedKeysFromKeys(&buf, keys)
 	require.NoError(t, err)
+	valid := buf.Bytes()
 	require.Greater(t, len(valid), TREE_KEY_STORE_OVERHEAD)
+
+	// The corruption cases below only mean something if the intact blob resolves.
+	for _, k := range keys {
+		node, err := NewDiskTree(valid).Get(k.Key)
+		require.NoError(t, err)
+		require.Equal(t, uint64(k.ValueStart), node.Start)
+		require.Equal(t, uint64(k.ValueEnd), node.End)
+	}
 
 	// queries span match, descend-left and descend-right branches plus misses.
 	queries := [][]byte{
@@ -109,9 +113,8 @@ func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
 // effect; the larger page-fault win under partial residency needs real I/O and
 // is not modelled here.
 //
-// Keys are 8-byte little-endian docIDs, matching the ever-increasing primary
-// keys of the object/vector stores, and the win grows with n as the index
-// outgrows the CPU caches.
+// Keys are 8-byte big-endian docIDs, as the binary-quantized vector store
+// writes them, and the win grows with n as the index outgrows the CPU caches.
 //
 // Run with: go test -run x -bench BenchmarkDiskTreeGet ./adapters/repos/db/lsmkv/segmentindex/
 //
@@ -125,12 +128,7 @@ func BenchmarkDiskTreeGet(b *testing.B) {
 		// the blobs for the others (the 10M case costs GBs and minutes).
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
 			keys := docIDKeys(n)
-			nodes := make(Nodes, n)
-			for i := range keys {
-				nodes[i] = Node{Key: keys[i].Key, Start: uint64(keys[i].ValueStart), End: uint64(keys[i].ValueEnd)}
-			}
-
-			levelOrder := NewBalanced(nodes)
+			levelOrder := NewBalanced(primaryNodes(keys))
 			var levelBuf bytes.Buffer
 			_, err := levelOrder.MarshalBinaryInto(&levelBuf)
 			require.NoError(b, err)
@@ -169,21 +167,4 @@ func BenchmarkDiskTreeGet(b *testing.B) {
 			}
 		})
 	}
-}
-
-// docIDKeys returns n keys shaped like the object/vector store's primary keys:
-// the little-endian uint64 of an ever-increasing docID, sorted by byte order.
-func docIDKeys(n int) []Key {
-	keys := make([]Key, n)
-	for i := 0; i < n; i++ {
-		k := make([]byte, 8)
-		binary.LittleEndian.PutUint64(k, uint64(i))
-		keys[i] = Key{Key: k}
-	}
-	slices.SortFunc(keys, func(a, b Key) int { return bytes.Compare(a.Key, b.Key) })
-	for i := range keys {
-		keys[i].ValueStart = i
-		keys[i].ValueEnd = i + 1
-	}
-	return keys
 }

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree_test.go
@@ -12,7 +12,11 @@
 package segmentindex
 
 import (
+	"bytes"
 	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -95,4 +99,82 @@ func TestDiskTreeCorruptDataNeverPanics(t *testing.T) {
 			_, _ = dTree.Seek([]byte("aaa"))
 		})
 	})
+}
+
+// BenchmarkDiskTreeGet compares warm lookup latency between the two on-disk node
+// orders the writers can produce: level order (Tree.MarshalBinaryInto) and van
+// Emde Boas (MarshalSortedKeysFromKeys, the production layout). Both blobs are
+// read through the same DiskTree, so the only difference is node placement. The
+// whole index is resident in RAM, so this isolates the CPU-cache/TLB locality
+// effect; the larger page-fault win under partial residency needs real I/O and
+// is not modelled here.
+//
+// Keys are 8-byte little-endian docIDs, matching the ever-increasing primary
+// keys of the object/vector stores, and the win grows with n as the index
+// outgrows the CPU caches.
+//
+// Run with: go test -run x -bench BenchmarkDiskTreeGet ./adapters/repos/db/lsmkv/segmentindex/
+func BenchmarkDiskTreeGet(b *testing.B) {
+	for _, n := range []int{100_000, 1_000_000, 10_000_000} {
+		keys := docIDKeys(n)
+		nodes := make(Nodes, n)
+		for i := range keys {
+			nodes[i] = Node{Key: keys[i].Key, Start: uint64(keys[i].ValueStart), End: uint64(keys[i].ValueEnd)}
+		}
+
+		levelOrder := NewBalanced(nodes)
+		var levelBuf bytes.Buffer
+		_, err := levelOrder.MarshalBinaryInto(&levelBuf)
+		require.NoError(b, err)
+
+		var vebBuf bytes.Buffer
+		_, err = MarshalSortedKeysFromKeys(&vebBuf, keys)
+		require.NoError(b, err)
+
+		// Fixed random lookup order, shared across layouts for a fair comparison.
+		// A wide probe set spreads lookups across the index so its layout, rather
+		// than a few permanently-hot pages, drives the result. Length is a power of
+		// two for the cheap index mask below.
+		rng := rand.New(rand.NewSource(int64(n)))
+		probes := make([][]byte, 65536)
+		for i := range probes {
+			probes[i] = keys[rng.Intn(n)].Key
+		}
+
+		layouts := []struct {
+			name string
+			data []byte
+		}{
+			{"level-order", levelBuf.Bytes()},
+			{"van-Emde-Boas", vebBuf.Bytes()},
+		}
+		for _, l := range layouts {
+			tree := NewDiskTree(l.data)
+			b.Run(fmt.Sprintf("n=%d/%s", n, l.name), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					if _, err := tree.Get(probes[i&(len(probes)-1)]); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// docIDKeys returns n keys shaped like the object/vector store's primary keys:
+// the little-endian uint64 of an ever-increasing docID, sorted by byte order.
+func docIDKeys(n int) []Key {
+	keys := make([]Key, n)
+	for i := 0; i < n; i++ {
+		k := make([]byte, 8)
+		binary.LittleEndian.PutUint64(k, uint64(i))
+		keys[i] = Key{Key: k}
+	}
+	slices.SortFunc(keys, func(a, b Key) int { return bytes.Compare(a.Key, b.Key) })
+	for i := range keys {
+		keys[i].ValueStart = i
+		keys[i].ValueEnd = i + 1
+	}
+	return keys
 }

--- a/adapters/repos/db/lsmkv/segmentindex/indexes.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes.go
@@ -65,16 +65,16 @@ func (s *Indexes) writeDirectly(w io.Writer) (written int64, err error) {
 
 	// Compute absolute file offsets for each secondary index.
 	offsets := make([]uint64, s.SecondaryIndexCount)
+	secSizes := make([]int64, s.SecondaryIndexCount)
 	secStart := dataEndOffset + offsetTableSize + uint64(primarySize)
 	for pos := range offsets {
 		offsets[pos] = secStart
-		var secSize int64
 		if s.SizesPrecomputed && pos < len(s.PrecomputedSecondaryIndexSizes) {
-			secSize = s.PrecomputedSecondaryIndexSizes[pos]
+			secSizes[pos] = s.PrecomputedSecondaryIndexSizes[pos]
 		} else {
-			secSize = computeSecondaryIndexSize(s.Keys, pos)
+			secSizes[pos] = computeSecondaryIndexSize(s.Keys, pos)
 		}
-		secStart += uint64(secSize)
+		secStart += uint64(secSizes[pos])
 	}
 
 	// Write the offset table.
@@ -93,6 +93,12 @@ func (s *Indexes) writeDirectly(w io.Writer) (written int64, err error) {
 		return written, err
 	}
 	written += n
+	if n != primarySize {
+		// The offset table above was already written from these sizes, so a
+		// mismatch leaves every offset pointing at the wrong bytes.
+		return written, fmt.Errorf("primary index size mismatch: expected %d bytes, wrote %d",
+			primarySize, n)
+	}
 
 	// Write each secondary index.
 	for pos := 0; pos < int(s.SecondaryIndexCount); pos++ {
@@ -101,6 +107,10 @@ func (s *Indexes) writeDirectly(w io.Writer) (written int64, err error) {
 			return written, fmt.Errorf("write secondary index %d: %w", pos, err)
 		}
 		written += n
+		if n != secSizes[pos] {
+			return written, fmt.Errorf("secondary index %d size mismatch: expected %d bytes, wrote %d",
+				pos, secSizes[pos], n)
+		}
 	}
 
 	return written, nil

--- a/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
@@ -68,11 +68,13 @@ func BenchmarkIndexesWriteTo(b *testing.B) {
 // TestMarshalSortedSecondaryFromKeys verifies that marshalSortedSecondaryFromKeys
 // builds the same tree as the NewBalanced + MarshalBinaryInto path.
 func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
+	// Secondary keys deliberately differ in length: equal-length keys give every
+	// node the same size, so a wrong node-size lookup still yields correct offsets.
 	keys := []Key{
-		{Key: []byte("aaa"), ValueStart: 0, ValueEnd: 10, SecondaryKeys: [][]byte{[]byte("zz"), []byte("mm")}},
-		{Key: []byte("bbb"), ValueStart: 10, ValueEnd: 20, SecondaryKeys: [][]byte{[]byte("aa"), []byte("zz")}},
-		{Key: []byte("ccc"), ValueStart: 20, ValueEnd: 30, SecondaryKeys: [][]byte{[]byte("mm"), []byte("aa")}},
-		{Key: []byte("ddd"), ValueStart: 30, ValueEnd: 40, SecondaryKeys: [][]byte{[]byte("ff"), []byte("ff")}},
+		{Key: []byte("aaa"), ValueStart: 0, ValueEnd: 10, SecondaryKeys: [][]byte{[]byte("zzzzzz"), []byte("m")}},
+		{Key: []byte("bbb"), ValueStart: 10, ValueEnd: 20, SecondaryKeys: [][]byte{[]byte("aa"), []byte("zzzz")}},
+		{Key: []byte("ccc"), ValueStart: 20, ValueEnd: 30, SecondaryKeys: [][]byte{[]byte("m"), []byte("aaaaaaa")}},
+		{Key: []byte("ddd"), ValueStart: 30, ValueEnd: 40, SecondaryKeys: [][]byte{[]byte("ffff"), []byte("ff")}},
 	}
 
 	for pos := 0; pos < 2; pos++ {
@@ -118,8 +120,8 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 		// Only some keys have a secondary key at pos=1.
 		partialKeys := []Key{
 			{Key: []byte("aaa"), ValueStart: 0, ValueEnd: 10, SecondaryKeys: [][]byte{[]byte("xx")}},
-			{Key: []byte("bbb"), ValueStart: 10, ValueEnd: 20, SecondaryKeys: [][]byte{[]byte("yy"), []byte("bb")}},
-			{Key: []byte("ccc"), ValueStart: 20, ValueEnd: 30, SecondaryKeys: [][]byte{[]byte("zz"), []byte("aa")}},
+			{Key: []byte("bbb"), ValueStart: 10, ValueEnd: 20, SecondaryKeys: [][]byte{[]byte("yy"), []byte("bbbbb")}},
+			{Key: []byte("ccc"), ValueStart: 20, ValueEnd: 30, SecondaryKeys: [][]byte{[]byte("zz"), []byte("a")}},
 		}
 
 		var secNodes Nodes

--- a/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"sort"
 	"testing"
 
@@ -193,6 +194,131 @@ func TestSortedKeyWritersLargeN(t *testing.T) {
 			})
 		}
 	}
+}
+
+// FuzzSortedKeyWriters generalizes TestSortedKeyWritersLargeN, which pins both
+// the key count and the key shape: one ascending family whose lengths cycle
+// through seven values. The fuzzer picks the key set instead, so it reaches
+// empty keys, keys sharing long prefixes, widths that vary from key to key, and
+// counts anywhere around the power-of-two boundaries where the tree gains a
+// level.
+//
+// Every case asserts the same thing: the writer's output resolves like the
+// balanced tree built by NewBalanced over the same nodes, which is the property
+// the van Emde Boas reordering has to preserve.
+//
+// The seed corpus runs on every `go test`; mutation needs an explicit run:
+//
+//	go test -run x -fuzz FuzzSortedKeyWriters ./adapters/repos/db/lsmkv/segmentindex/
+func FuzzSortedKeyWriters(f *testing.F) {
+	// Each seed is a length-prefixed key sequence, the encoding fuzzKeys reads.
+	f.Add([]byte{})
+	f.Add([]byte{0x00})                                   // a single empty key
+	f.Add([]byte{0x01, 'a', 0x01, 'b', 0x01, 'c'})        // three one-byte keys
+	f.Add([]byte{0x03, 'a', 'a', 'a', 0x01, 'z'})         // mixed widths
+	f.Add([]byte{0x02, 'a', 'a', 0x03, 'a', 'a', 'b'})    // shared prefix
+	f.Add(bytes.Repeat([]byte{0x01, 'k'}, 40))            // duplicates, deduped away
+	f.Add([]byte{0x05, 'k', 'e', 'y'})                    // length runs past the input
+	f.Add(bytes.Repeat([]byte{0x02, 'a', 'b', 0x00}, 64)) // many keys, empty ones mixed in
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		keys := fuzzKeys(raw)
+		if len(keys) == 0 {
+			return
+		}
+
+		for _, writer := range sortedKeyWriters() {
+			nodes := writer.indexedNodes(keys)
+
+			// Reference path: the level-order writer over the same nodes.
+			sort.Sort(nodes)
+			tree := NewBalanced(nodes)
+			var wantBuf bytes.Buffer
+			_, err := tree.MarshalBinaryInto(&wantBuf)
+			require.NoError(t, err, writer.name)
+
+			var gotBuf bytes.Buffer
+			gotN, err := writer.write(&gotBuf, keys)
+			require.NoError(t, err, writer.name)
+			require.Equal(t, int64(gotBuf.Len()), gotN,
+				"%s: reported size must match the bytes written", writer.name)
+
+			requireSameTree(t, wantBuf.Bytes(), gotBuf.Bytes(), nodeKeys(nodes))
+
+			// requireSameTree only proves the two writers agree. Check the values
+			// themselves too, since MarshalSortedKeys derives Start from the previous
+			// key's ValueEnd rather than reading it.
+			dTree := NewDiskTree(gotBuf.Bytes())
+			for _, node := range nodes {
+				got, err := dTree.Get(node.Key)
+				require.NoError(t, err, "%s: Get(%q)", writer.name, node.Key)
+				assert.Equal(t, node.Key, got.Key, writer.name)
+				assert.Equal(t, node.Start, got.Start, "%s: start of %q", writer.name, node.Key)
+				assert.Equal(t, node.End, got.End, "%s: end of %q", writer.name, node.Key)
+
+				// Seek descends through readNodeAt rather than Get's own loop, so it
+				// reads the child offsets the vEB reordering rewrote via a second path.
+				seeked, err := dTree.Seek(node.Key)
+				require.NoError(t, err, "%s: Seek(%q)", writer.name, node.Key)
+				assert.Equal(t, node.Key, seeked.Key, writer.name)
+			}
+
+			allKeys, err := dTree.AllKeys()
+			require.NoError(t, err, writer.name)
+			assert.ElementsMatch(t, nodeKeys(nodes), allKeys, writer.name)
+		}
+	})
+}
+
+// fuzzKeys decodes raw into the sorted, unique key set the writers require: a
+// sequence of one-byte lengths each followed by that many bytes. Duplicates are
+// dropped rather than passed on, since a duplicate key breaks the writers'
+// contract and would only rediscover Tree.insertAt's panic.
+func fuzzKeys(raw []byte) []Key {
+	// Bounded so one input stays cheap enough to keep the fuzzer's throughput up.
+	const (
+		maxKeys   = 256
+		maxKeyLen = 48
+	)
+
+	var raws [][]byte
+	for pos := 0; pos < len(raw) && len(raws) < maxKeys; {
+		keyLen := int(raw[pos]) % (maxKeyLen + 1)
+		pos++
+		if keyLen > len(raw)-pos {
+			keyLen = len(raw) - pos
+		}
+		raws = append(raws, raw[pos:pos+keyLen])
+		pos += keyLen
+	}
+
+	slices.SortFunc(raws, bytes.Compare)
+	raws = slices.CompactFunc(raws, bytes.Equal)
+
+	keys := make([]Key, len(raws))
+	offset := 0
+	for i, key := range raws {
+		// Every key holds a non-empty value, so Start and End differ and a writer
+		// that mixed the two up would not still pass.
+		span := len(key) + 1
+		keys[i] = Key{Key: key, ValueStart: offset, ValueEnd: offset + span}
+		offset += span
+
+		// Secondary keys are the primary key reversed — still unique, but in a
+		// different order — and absent on every third key, so the secondary writer
+		// has to sort and filter rather than mirror the primary index.
+		if i%3 != 0 {
+			keys[i].SecondaryKeys = [][]byte{reversedKey(key)}
+		}
+	}
+
+	return keys
+}
+
+func reversedKey(key []byte) []byte {
+	out := bytes.Clone(key)
+	slices.Reverse(out)
+	return out
 }
 
 // TestWriteDirectly verifies that writeDirectly produces valid output and that

--- a/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
@@ -80,18 +80,8 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 	for pos := 0; pos < 2; pos++ {
 		t.Run(fmt.Sprintf("pos=%d equivalent to NewBalanced+MarshalBinaryInto", pos), func(t *testing.T) {
 			// Reference path: build secondary nodes, sort, build tree, marshal.
-			var secNodes Nodes
-			var secKeys [][]byte
-			for _, key := range keys {
-				if pos < len(key.SecondaryKeys) {
-					secNodes = append(secNodes, Node{
-						Key:   key.SecondaryKeys[pos],
-						Start: uint64(key.ValueStart),
-						End:   uint64(key.ValueEnd),
-					})
-					secKeys = append(secKeys, key.SecondaryKeys[pos])
-				}
-			}
+			secNodes := secondaryNodes(keys, pos)
+			secKeys := nodeKeys(secNodes)
 			sort.Sort(secNodes)
 			tree := NewBalanced(secNodes)
 			var wantBuf bytes.Buffer
@@ -124,18 +114,8 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 			{Key: []byte("ccc"), ValueStart: 20, ValueEnd: 30, SecondaryKeys: [][]byte{[]byte("zz"), []byte("a")}},
 		}
 
-		var secNodes Nodes
-		var secKeys [][]byte
-		for _, key := range partialKeys {
-			if 1 < len(key.SecondaryKeys) {
-				secNodes = append(secNodes, Node{
-					Key:   key.SecondaryKeys[1],
-					Start: uint64(key.ValueStart),
-					End:   uint64(key.ValueEnd),
-				})
-				secKeys = append(secKeys, key.SecondaryKeys[1])
-			}
-		}
+		secNodes := secondaryNodes(partialKeys, 1)
+		secKeys := nodeKeys(secNodes)
 		sort.Sort(secNodes)
 		tree := NewBalanced(secNodes)
 		var wantBuf bytes.Buffer
@@ -188,10 +168,7 @@ func TestSortedKeyWritersLargeN(t *testing.T) {
 				}
 
 				nodes := writer.indexedNodes(keys)
-				keyBytes := make([][]byte, len(nodes))
-				for i, node := range nodes {
-					keyBytes[i] = node.Key
-				}
+				keyBytes := nodeKeys(nodes)
 
 				// Reference path.
 				sort.Sort(nodes)

--- a/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
@@ -166,45 +166,55 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 	})
 }
 
-// TestMarshalSortedKeysFromKeys_LargeN exercises key counts that produce
-// incomplete tree levels (non-power-of-two sizes) to catch off-by-one errors
-// in BFS position mapping.
-func TestMarshalSortedKeysFromKeys_LargeN(t *testing.T) {
-	for _, n := range []int{1, 2, 3, 7, 8, 15, 16, 31, 33, 100, 255, 1000} {
-		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
-			keys := make([]Key, n)
-			nodes := make(Nodes, n)
-			keyBytes := make([][]byte, n)
-			offset := 0
-			for i := 0; i < n; i++ {
-				k := []byte(fmt.Sprintf("key-%05d", i))
-				keys[i] = Key{Key: k, ValueStart: offset, ValueEnd: offset + 10}
-				nodes[i] = Node{Key: k, Start: uint64(offset), End: uint64(offset + 10)}
-				keyBytes[i] = k
-				offset += 10
-			}
+// TestSortedKeyWritersLargeN exercises key counts that produce incomplete tree
+// levels (non-power-of-two sizes) to catch off-by-one errors in BFS position
+// mapping, and counts from 9 up, where van Emde Boas order stops coinciding with
+// level order and every node's offset depends on the reordering.
+func TestSortedKeyWritersLargeN(t *testing.T) {
+	for _, writer := range sortedKeyWriters() {
+		for _, n := range []int{1, 2, 3, 7, 8, 9, 15, 16, 31, 33, 100, 255, 1000} {
+			t.Run(fmt.Sprintf("%s/n=%d", writer.name, n), func(t *testing.T) {
+				keys := make([]Key, n)
+				offset := 0
+				for i := 0; i < n; i++ {
+					keys[i] = Key{Key: varWidthKey(i), ValueStart: offset, ValueEnd: offset + 10}
+					// Secondary keys run in the opposite order and are absent on
+					// every third key, so the secondary writer has to sort and
+					// filter rather than mirror the primary index.
+					if i%3 != 0 {
+						keys[i].SecondaryKeys = [][]byte{varWidthKey(n - 1 - i)}
+					}
+					offset += 10
+				}
 
-			// Reference path.
-			sort.Sort(nodes)
-			tree := NewBalanced(nodes)
-			var wantBuf bytes.Buffer
-			_, err := tree.MarshalBinaryInto(&wantBuf)
-			require.NoError(t, err)
+				nodes := writer.indexedNodes(keys)
+				keyBytes := make([][]byte, len(nodes))
+				for i, node := range nodes {
+					keyBytes[i] = node.Key
+				}
 
-			// New path.
-			var gotBuf bytes.Buffer
-			gotN, err := MarshalSortedKeysFromKeys(&gotBuf, keys)
-			require.NoError(t, err)
+				// Reference path.
+				sort.Sort(nodes)
+				tree := NewBalanced(nodes)
+				var wantBuf bytes.Buffer
+				_, err := tree.MarshalBinaryInto(&wantBuf)
+				require.NoError(t, err)
 
-			assert.Equal(t, int64(wantBuf.Len()), gotN)
-			requireSameTree(t, wantBuf.Bytes(), gotBuf.Bytes(), keyBytes)
+				// New path.
+				var gotBuf bytes.Buffer
+				gotN, err := writer.write(&gotBuf, keys)
+				require.NoError(t, err)
 
-			// Verify round-trip through DiskTree.
-			dTree := NewDiskTree(gotBuf.Bytes())
-			allKeys, err := dTree.AllKeys()
-			require.NoError(t, err)
-			assert.Len(t, allKeys, n)
-		})
+				assert.Equal(t, int64(wantBuf.Len()), gotN)
+				requireSameTree(t, wantBuf.Bytes(), gotBuf.Bytes(), keyBytes)
+
+				// Verify round-trip through DiskTree.
+				dTree := NewDiskTree(gotBuf.Bytes())
+				allKeys, err := dTree.AllKeys()
+				require.NoError(t, err)
+				assert.Len(t, allKeys, len(keyBytes))
+			})
+		}
 	}
 }
 

--- a/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
@@ -268,6 +268,85 @@ func TestWriteDirectly(t *testing.T) {
 		assert.True(t, buf.Len() > 16, "output must include offset table + indexes")
 	})
 
+	// The offset table is written before the indexes themselves, so a size that
+	// does not match what is written makes every offset point at the wrong bytes.
+	t.Run("sizes the offset table was built from must match what is written", func(t *testing.T) {
+		primarySize := computePrimaryIndexSize(keys)
+		secondarySizes := []int64{
+			computeSecondaryIndexSize(keys, 0),
+			computeSecondaryIndexSize(keys, 1),
+		}
+
+		tests := []struct {
+			name           string
+			keys           []Key
+			primarySize    int64
+			secondarySizes []int64
+			expectedErr    string
+		}{
+			{
+				name:           "primary too small",
+				keys:           keys,
+				primarySize:    primarySize - 1,
+				secondarySizes: secondarySizes,
+				expectedErr:    "primary index size mismatch",
+			},
+			{
+				name:           "primary too large",
+				keys:           keys,
+				primarySize:    primarySize + 1,
+				secondarySizes: secondarySizes,
+				expectedErr:    "primary index size mismatch",
+			},
+			{
+				name:           "first secondary wrong",
+				keys:           keys,
+				primarySize:    primarySize,
+				secondarySizes: []int64{secondarySizes[0] + 3, secondarySizes[1]},
+				expectedErr:    "secondary index 0 size mismatch",
+			},
+			{
+				name:           "last secondary wrong",
+				keys:           keys,
+				primarySize:    primarySize,
+				secondarySizes: []int64{secondarySizes[0], secondarySizes[1] - 3},
+				expectedErr:    "secondary index 1 size mismatch",
+			},
+			{
+				name:           "no keys but non-zero sizes",
+				keys:           nil,
+				primarySize:    primarySize,
+				secondarySizes: secondarySizes,
+				expectedErr:    "primary index size mismatch",
+			},
+			{
+				name:           "fewer precomputed sizes than secondary indexes falls back to computing",
+				keys:           keys,
+				primarySize:    primarySize,
+				secondarySizes: secondarySizes[:1],
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				idx := &Indexes{
+					Keys:                           test.keys,
+					SecondaryIndexCount:            2,
+					SizesPrecomputed:               true,
+					PrecomputedPrimaryIndexSize:    test.primarySize,
+					PrecomputedSecondaryIndexSizes: test.secondarySizes,
+				}
+				var buf bytes.Buffer
+				_, err := idx.WriteTo(&buf)
+				if test.expectedErr == "" {
+					require.NoError(t, err)
+					return
+				}
+				require.ErrorContains(t, err, test.expectedErr)
+			})
+		}
+	})
+
 	t.Run("no secondary indices bypasses writeDirectly", func(t *testing.T) {
 		primaryOnly := []Key{
 			{Key: []byte("aaa"), ValueStart: 0, ValueEnd: 10},

--- a/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/indexes_test.go
@@ -66,7 +66,7 @@ func BenchmarkIndexesWriteTo(b *testing.B) {
 }
 
 // TestMarshalSortedSecondaryFromKeys verifies that marshalSortedSecondaryFromKeys
-// produces byte-identical output to the old NewBalanced + MarshalBinaryInto path.
+// builds the same tree as the NewBalanced + MarshalBinaryInto path.
 func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 	keys := []Key{
 		{Key: []byte("aaa"), ValueStart: 0, ValueEnd: 10, SecondaryKeys: [][]byte{[]byte("zz"), []byte("mm")}},
@@ -76,9 +76,10 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 	}
 
 	for pos := 0; pos < 2; pos++ {
-		t.Run(fmt.Sprintf("pos=%d matches NewBalanced+MarshalBinaryInto", pos), func(t *testing.T) {
-			// Old path: build secondary nodes, sort, build tree, marshal.
+		t.Run(fmt.Sprintf("pos=%d equivalent to NewBalanced+MarshalBinaryInto", pos), func(t *testing.T) {
+			// Reference path: build secondary nodes, sort, build tree, marshal.
 			var secNodes Nodes
+			var secKeys [][]byte
 			for _, key := range keys {
 				if pos < len(key.SecondaryKeys) {
 					secNodes = append(secNodes, Node{
@@ -86,6 +87,7 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 						Start: uint64(key.ValueStart),
 						End:   uint64(key.ValueEnd),
 					})
+					secKeys = append(secKeys, key.SecondaryKeys[pos])
 				}
 			}
 			sort.Sort(secNodes)
@@ -100,8 +102,7 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, int64(wantBuf.Len()), n)
-			assert.Equal(t, wantBuf.Bytes(), gotBuf.Bytes(),
-				"secondary index at pos=%d must be byte-identical to tree-based serialization", pos)
+			requireSameTree(t, wantBuf.Bytes(), gotBuf.Bytes(), secKeys)
 		})
 	}
 
@@ -122,6 +123,7 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 		}
 
 		var secNodes Nodes
+		var secKeys [][]byte
 		for _, key := range partialKeys {
 			if 1 < len(key.SecondaryKeys) {
 				secNodes = append(secNodes, Node{
@@ -129,6 +131,7 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 					Start: uint64(key.ValueStart),
 					End:   uint64(key.ValueEnd),
 				})
+				secKeys = append(secKeys, key.SecondaryKeys[1])
 			}
 		}
 		sort.Sort(secNodes)
@@ -142,7 +145,7 @@ func TestMarshalSortedSecondaryFromKeys(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, int64(wantBuf.Len()), n)
-		assert.Equal(t, wantBuf.Bytes(), gotBuf.Bytes())
+		requireSameTree(t, wantBuf.Bytes(), gotBuf.Bytes(), secKeys)
 	})
 
 	t.Run("DiskTree can look up secondary keys", func(t *testing.T) {
@@ -169,15 +172,17 @@ func TestMarshalSortedKeysFromKeys_LargeN(t *testing.T) {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			keys := make([]Key, n)
 			nodes := make(Nodes, n)
+			keyBytes := make([][]byte, n)
 			offset := 0
 			for i := 0; i < n; i++ {
 				k := []byte(fmt.Sprintf("key-%05d", i))
 				keys[i] = Key{Key: k, ValueStart: offset, ValueEnd: offset + 10}
 				nodes[i] = Node{Key: k, Start: uint64(offset), End: uint64(offset + 10)}
+				keyBytes[i] = k
 				offset += 10
 			}
 
-			// Old path.
+			// Reference path.
 			sort.Sort(nodes)
 			tree := NewBalanced(nodes)
 			var wantBuf bytes.Buffer
@@ -190,8 +195,7 @@ func TestMarshalSortedKeysFromKeys_LargeN(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, int64(wantBuf.Len()), gotN)
-			assert.Equal(t, wantBuf.Bytes(), gotBuf.Bytes(),
-				"n=%d: output must be byte-identical", n)
+			requireSameTree(t, wantBuf.Bytes(), gotBuf.Bytes(), keyBytes)
 
 			// Verify round-trip through DiskTree.
 			dTree := NewDiskTree(gotBuf.Bytes())

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys.go
@@ -76,22 +76,28 @@ func (bfs *parallelBFS) parse(offset uint64, level int) {
 	}
 	rw := byteops.NewReadWriter(bfs.dt.data)
 	rw.Position = offset
-	keyLen := rw.ReadUint32()
-	nodeKeyBuffer := make([]byte, int(keyLen))
-	_, err := rw.CopyBytesFromBuffer(uint64(keyLen), nodeKeyBuffer)
+	keyLen := uint64(rw.ReadUint32())
+	// a corrupt keyLen would read past the buffer. Skipping the node loses one
+	// quantile, which only makes cursors less evenly distributed; the same node is
+	// reported as an error during normal .Get() operations.
+	if keyLen > uint64(len(bfs.dt.data))-rw.Position {
+		return
+	}
+
+	nodeKeyBuffer := make([]byte, keyLen)
+	_, err := rw.CopyBytesFromBuffer(keyLen, nodeKeyBuffer)
 	if err != nil {
-		// no special handling other than skipping this node. If the key could not
-		// be read correctly, we have much bigger problems worrying about quantile
-		// keys for cursor efficiency. This error is handled during normal .Get()
-		// operations. It is not worth changing the signature of quantile keys just
-		// to return this one error. We could also consider explicitly panic'ing
-		// here, so this error does not get lost.
 		return
 	}
 
 	bfs.keysDiscovered = append(bfs.keysDiscovered, nodeKeyBuffer)
 
 	if level+1 > bfs.maxDepth {
+		return
+	}
+
+	// a truncated node has no child pointers to descend into
+	if uint64(len(bfs.dt.data))-rw.Position < 4*8 {
 		return
 	}
 

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
@@ -135,22 +135,9 @@ func TestQuantileKeysDistribution(t *testing.T) {
 }
 
 func buildSampleDiskTree(t *testing.T, n int) *DiskTree {
-	nodes := make([]Node, 0, n)
-	for i := 0; i < n; i++ {
-		key := make([]byte, 8)
-		binary.BigEndian.PutUint64(key, uint64(i))
-		// the index positions do not matter for this test
-		start, end := uint64(0), uint64(0)
-		nodes = append(nodes, Node{Key: key, Start: start, End: end})
-	}
-
-	sort.Slice(nodes, func(a, b int) bool {
-		return bytes.Compare(nodes[a].Key, nodes[b].Key) < 0
-	})
-
-	balanced := NewBalanced(nodes)
+	balanced := NewBalanced(primaryNodes(docIDKeys(n)))
 	dt, err := balanced.MarshalBinary()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	return NewDiskTree(dt)
 }
@@ -159,15 +146,8 @@ func buildSampleDiskTree(t *testing.T, n int) *DiskTree {
 // the production van Emde Boas writer, so readers are exercised against the
 // on-disk layout.
 func buildSampleDiskTreeVEB(t *testing.T, n int) *DiskTree {
-	keys := make([]Key, 0, n)
-	for i := 0; i < n; i++ {
-		key := make([]byte, 8)
-		binary.BigEndian.PutUint64(key, uint64(i)) // ascending, so already sorted
-		keys = append(keys, Key{Key: key})
-	}
-
 	var buf bytes.Buffer
-	_, err := MarshalSortedKeysFromKeys(&buf, keys)
+	_, err := MarshalSortedKeysFromKeys(&buf, docIDKeys(n))
 	require.NoError(t, err)
 
 	return NewDiskTree(buf.Bytes())

--- a/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/quantile_keys_test.go
@@ -106,21 +106,31 @@ func FuzzQuantileKeys(f *testing.F) {
 }
 
 func TestQuantileKeysDistribution(t *testing.T) {
-	dt := buildSampleDiskTree(t, 1000)
-	keys := dt.QuantileKeys(8)
-	sort.Slice(keys, func(a, b int) bool {
-		return bytes.Compare(keys[a], keys[b]) < 0
-	})
-
-	asNumbers := make([]uint64, 0, len(keys))
-	for _, key := range keys {
-		asNumbers = append(asNumbers, binary.BigEndian.Uint64(key))
+	// QuantileKeys pointer-chases from the root, so it must return the same
+	// distribution regardless of on-disk node order. Run it on both layouts.
+	builders := map[string]func(*testing.T, int) *DiskTree{
+		"level-order":   buildSampleDiskTree,
+		"van Emde Boas": buildSampleDiskTreeVEB,
 	}
+	for name, build := range builders {
+		t.Run(name, func(t *testing.T) {
+			dt := build(t, 1000)
+			keys := dt.QuantileKeys(8)
+			sort.Slice(keys, func(a, b int) bool {
+				return bytes.Compare(keys[a], keys[b]) < 0
+			})
 
-	idealStepSize := float64(1000) / float64(len(asNumbers)+1)
-	for i, n := range asNumbers {
-		actualStepSize := float64(n) / float64(i+1)
-		assert.InEpsilon(t, idealStepSize, actualStepSize, 0.1)
+			asNumbers := make([]uint64, 0, len(keys))
+			for _, key := range keys {
+				asNumbers = append(asNumbers, binary.BigEndian.Uint64(key))
+			}
+
+			idealStepSize := float64(1000) / float64(len(asNumbers)+1)
+			for i, n := range asNumbers {
+				actualStepSize := float64(n) / float64(i+1)
+				assert.InEpsilon(t, idealStepSize, actualStepSize, 0.1)
+			}
+		})
 	}
 }
 
@@ -143,4 +153,22 @@ func buildSampleDiskTree(t *testing.T, n int) *DiskTree {
 	require.Nil(t, err)
 
 	return NewDiskTree(dt)
+}
+
+// buildSampleDiskTreeVEB builds the same tree as buildSampleDiskTree but through
+// the production van Emde Boas writer, so readers are exercised against the
+// on-disk layout.
+func buildSampleDiskTreeVEB(t *testing.T, n int) *DiskTree {
+	keys := make([]Key, 0, n)
+	for i := 0; i < n; i++ {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(i)) // ascending, so already sorted
+		keys = append(keys, Key{Key: key})
+	}
+
+	var buf bytes.Buffer
+	_, err := MarshalSortedKeysFromKeys(&buf, keys)
+	require.NoError(t, err)
+
+	return NewDiskTree(buf.Bytes())
 }

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -374,9 +374,9 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (in
 	if err := checkAllNodesEmitted(order, n); err != nil {
 		return 0, err
 	}
-	diskOffsets, totalSize := vebOffsets(order, capacity, func(p int32) int64 {
+	diskOffsets, totalSize := vebOffsets(order, bfsToSorted, n, func(si int32) int64 {
 		// node size: keyLen(4) + key + start(8) + end(8) + left(8) + right(8)
-		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[bfsToSorted[p]].Key))
+		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[si].Key))
 	})
 
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
@@ -394,8 +394,8 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (in
 		}
 		end := uint64(key.ValueEnd)
 
-		leftChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+1, capacity)
-		rightChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+2, capacity)
+		leftChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+1)
+		rightChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+2)
 
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(len(key.Key)))
 		binary.LittleEndian.PutUint64(buf[4:12], start)
@@ -440,8 +440,8 @@ func MarshalSortedKeysFromKeys(w io.Writer, keys []Key) (int64, error) {
 	if err := checkAllNodesEmitted(order, n); err != nil {
 		return 0, err
 	}
-	diskOffsets, totalSize := vebOffsets(order, capacity, func(p int32) int64 {
-		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[bfsToSorted[p]].Key))
+	diskOffsets, totalSize := vebOffsets(order, bfsToSorted, n, func(si int32) int64 {
+		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[si].Key))
 	})
 
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
@@ -449,8 +449,8 @@ func MarshalSortedKeysFromKeys(w io.Writer, keys []Key) (int64, error) {
 	for _, p := range order {
 		key := keys[bfsToSorted[p]]
 
-		leftChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+1, capacity)
-		rightChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+2, capacity)
+		leftChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+1)
+		rightChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+2)
 
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(len(key.Key)))
 		binary.LittleEndian.PutUint64(buf[4:12], uint64(key.ValueStart))
@@ -533,8 +533,8 @@ func marshalSortedSecondaryFromKeys(w io.Writer, keys []Key, pos int) (int64, er
 	if err := checkAllNodesEmitted(order, n); err != nil {
 		return 0, err
 	}
-	diskOffsets, totalSize := vebOffsets(order, capacity, func(p int32) int64 {
-		ki := sortedIndices[bfsToIdx[p]]
+	diskOffsets, totalSize := vebOffsets(order, bfsToIdx, n, func(si int32) int64 {
+		ki := sortedIndices[si]
 		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[ki].SecondaryKeys[pos]))
 	})
 
@@ -544,8 +544,8 @@ func marshalSortedSecondaryFromKeys(w io.Writer, keys []Key, pos int) (int64, er
 		key := keys[ki]
 		secKey := key.SecondaryKeys[pos]
 
-		leftChild := childOffset(diskOffsets, bfsToIdx, 2*int(p)+1, capacity)
-		rightChild := childOffset(diskOffsets, bfsToIdx, 2*int(p)+2, capacity)
+		leftChild := childOffset(diskOffsets, bfsToIdx, 2*int(p)+1)
+		rightChild := childOffset(diskOffsets, bfsToIdx, 2*int(p)+2)
 
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(len(secKey)))
 		binary.LittleEndian.PutUint64(buf[4:12], uint64(key.ValueStart))
@@ -650,28 +650,30 @@ func checkAllNodesEmitted(order []int32, n int) error {
 	return nil
 }
 
-// vebOffsets assigns each present heap position its byte offset in the
-// serialized output by walking positions in write order. In van Emde Boas
-// order write order and offset order differ, so offsets need this separate pass
-// before children can be pointed at. The returned slice is indexed by heap
-// position (-1 for empty positions, which the reader never dereferences).
-func vebOffsets(order []int32, capacity int, nodeSize func(heapPos int32) int64) (offsetOf []int64, total int64) {
-	offsetOf = make([]int64, capacity)
+// vebOffsets assigns each present node its byte offset in the serialized output
+// by walking heap positions in write order. In van Emde Boas order write order
+// and offset order differ, so offsets need this separate pass before children can
+// be pointed at. The result is indexed by sorted index (mapping[heapPos]), so it
+// holds nodeCount entries instead of the tree capacity, which is up to 2x larger.
+func vebOffsets(order, mapping []int32, nodeCount int, nodeSize func(sortedIdx int32) int64) (offsetOf []int64, total int64) {
+	offsetOf = make([]int64, nodeCount)
+	// An unassigned offset would read as 0, pointing a parent back at the root.
 	for i := range offsetOf {
 		offsetOf[i] = -1
 	}
 	for _, p := range order {
-		offsetOf[p] = total
-		total += nodeSize(p)
+		si := mapping[p]
+		offsetOf[si] = total
+		total += nodeSize(si)
 	}
 	return offsetOf, total
 }
 
 // childOffset returns the serialized byte offset of the child at heap position
 // childPos, or -1 when that position holds no node.
-func childOffset(offsetOf []int64, mapping []int32, childPos, capacity int) int64 {
-	if childPos < capacity && mapping[childPos] >= 0 {
-		return offsetOf[childPos]
+func childOffset(offsetOf []int64, mapping []int32, childPos int) int64 {
+	if childPos < len(mapping) && mapping[childPos] >= 0 {
+		return offsetOf[mapping[childPos]]
 	}
 	return -1
 }

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -371,13 +371,13 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (in
 	// Emit nodes in van Emde Boas order; their offsets follow the write order,
 	// so compute them in a first pass before writing.
 	order := vebPositions(bfsToSorted, n)
-	if err := checkAllNodesEmitted(order, n); err != nil {
-		return 0, err
-	}
-	diskOffsets, totalSize := vebOffsets(order, bfsToSorted, n, func(si int32) int64 {
+	diskOffsets, totalSize, err := vebOffsets(order, bfsToSorted, n, func(si int32) int64 {
 		// node size: keyLen(4) + key + start(8) + end(8) + left(8) + right(8)
 		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[si].Key))
 	})
+	if err != nil {
+		return 0, err
+	}
 
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
 
@@ -437,12 +437,12 @@ func MarshalSortedKeysFromKeys(w io.Writer, keys []Key) (int64, error) {
 	fillBFS(bfsToSorted, 0, 0, n-1)
 
 	order := vebPositions(bfsToSorted, n)
-	if err := checkAllNodesEmitted(order, n); err != nil {
-		return 0, err
-	}
-	diskOffsets, totalSize := vebOffsets(order, bfsToSorted, n, func(si int32) int64 {
+	diskOffsets, totalSize, err := vebOffsets(order, bfsToSorted, n, func(si int32) int64 {
 		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[si].Key))
 	})
+	if err != nil {
+		return 0, err
+	}
 
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
 
@@ -530,13 +530,13 @@ func marshalSortedSecondaryFromKeys(w io.Writer, keys []Key, pos int) (int64, er
 	// Emit nodes in van Emde Boas order; their offsets follow the write order,
 	// so compute them in a first pass before writing.
 	order := vebPositions(bfsToIdx, n)
-	if err := checkAllNodesEmitted(order, n); err != nil {
-		return 0, err
-	}
-	diskOffsets, totalSize := vebOffsets(order, bfsToIdx, n, func(si int32) int64 {
+	diskOffsets, totalSize, err := vebOffsets(order, bfsToIdx, n, func(si int32) int64 {
 		ki := sortedIndices[si]
 		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[ki].SecondaryKeys[pos]))
 	})
+	if err != nil {
+		return 0, err
+	}
 
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
 	for _, p := range order {
@@ -639,34 +639,36 @@ func vebPositions(mapping []int32, nodeCount int) []int32 {
 	return out
 }
 
-// checkAllNodesEmitted fails if vebPositions did not emit every key. vebPositions
-// prunes on an empty heap position, which is safe only while every present node
-// has a present parent (guaranteed by fillBFS); a dropped node would silently
-// omit a key from the index.
-func checkAllNodesEmitted(order []int32, n int) error {
-	if len(order) != n {
-		return fmt.Errorf("segment index writer emitted %d of %d nodes", len(order), n)
-	}
-	return nil
-}
-
 // vebOffsets assigns each present node its byte offset in the serialized output
 // by walking heap positions in write order. In van Emde Boas order write order
 // and offset order differ, so offsets need this separate pass before children can
 // be pointed at. The result is indexed by sorted index (mapping[heapPos]), so it
 // holds nodeCount entries instead of the tree capacity, which is up to 2x larger.
-func vebOffsets(order, mapping []int32, nodeCount int, nodeSize func(sortedIdx int32) int64) (offsetOf []int64, total int64) {
+//
+// It fails unless order lists every node exactly once. vebPositions prunes on an
+// empty heap position: a node it dropped would be missing from the index while its
+// parent still points at offset 0, the root, and a node listed twice would be
+// written twice.
+func vebOffsets(order, mapping []int32, nodeCount int, nodeSize func(sortedIdx int32) int64) (offsetOf []int64, total int64, err error) {
 	offsetOf = make([]int64, nodeCount)
-	// An unassigned offset would read as 0, pointing a parent back at the root.
 	for i := range offsetOf {
 		offsetOf[i] = -1
 	}
 	for _, p := range order {
 		si := mapping[p]
+		if offsetOf[si] >= 0 {
+			return nil, 0, fmt.Errorf("segment index writer listed sorted index %d twice", si)
+		}
 		offsetOf[si] = total
 		total += nodeSize(si)
 	}
-	return offsetOf, total
+	for si, offset := range offsetOf {
+		if offset < 0 {
+			return nil, 0, fmt.Errorf("segment index writer assigned no offset to sorted index %d of %d",
+				si, nodeCount)
+		}
+	}
+	return offsetOf, total, nil
 }
 
 // childOffset returns the serialized byte offset of the child at heap position

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -368,29 +368,21 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (in
 	}
 	fillBFS(bfsToSorted, 0, 0, n-1)
 
-	// Compute the byte offset of each BFS position in the serialized output.
-	// Nil positions contribute 0 bytes, so their offset equals the next
-	// non-nil position's offset.
-	diskOffsets := make([]int64, capacity)
-	var currentOffset int64
-	for i := 0; i < capacity; i++ {
-		diskOffsets[i] = currentOffset
-		if si := bfsToSorted[i]; si >= 0 {
-			// node size: keyLen(4) + key + start(8) + end(8) + left(8) + right(8)
-			currentOffset += int64(TREE_KEY_STORE_OVERHEAD + len(keys[si].Key))
-		}
+	// Emit nodes in van Emde Boas order; their offsets follow the write order,
+	// so compute them in a first pass before writing.
+	order := vebPositions(bfsToSorted)
+	if err := checkAllNodesEmitted(order, n); err != nil {
+		return 0, err
 	}
-	totalSize := currentOffset
+	diskOffsets, totalSize := vebOffsets(order, capacity, func(p int32) int64 {
+		// node size: keyLen(4) + key + start(8) + end(8) + left(8) + right(8)
+		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[bfsToSorted[p]].Key))
+	})
 
-	// Write nodes in BFS order (matching MarshalBinaryInto output).
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
 
-	for i := 0; i < capacity; i++ {
-		si := bfsToSorted[i]
-		if si < 0 {
-			continue
-		}
-
+	for _, p := range order {
+		si := bfsToSorted[p]
 		key := keys[si]
 
 		// Derive Start from the previous key's ValueEnd.
@@ -402,15 +394,8 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (in
 		}
 		end := uint64(key.ValueEnd)
 
-		// Compute child byte offsets in the serialized output.
-		leftChild := int64(-1)
-		if leftPos := 2*i + 1; leftPos < capacity && bfsToSorted[leftPos] >= 0 {
-			leftChild = diskOffsets[leftPos]
-		}
-		rightChild := int64(-1)
-		if rightPos := 2*i + 2; rightPos < capacity && bfsToSorted[rightPos] >= 0 {
-			rightChild = diskOffsets[rightPos]
-		}
+		leftChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+1, capacity)
+		rightChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+2, capacity)
 
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(len(key.Key)))
 		binary.LittleEndian.PutUint64(buf[4:12], start)
@@ -451,34 +436,21 @@ func MarshalSortedKeysFromKeys(w io.Writer, keys []Key) (int64, error) {
 	}
 	fillBFS(bfsToSorted, 0, 0, n-1)
 
-	diskOffsets := make([]int64, capacity)
-	var currentOffset int64
-	for i := 0; i < capacity; i++ {
-		diskOffsets[i] = currentOffset
-		if si := bfsToSorted[i]; si >= 0 {
-			currentOffset += int64(TREE_KEY_STORE_OVERHEAD + len(keys[si].Key))
-		}
+	order := vebPositions(bfsToSorted)
+	if err := checkAllNodesEmitted(order, n); err != nil {
+		return 0, err
 	}
-	totalSize := currentOffset
+	diskOffsets, totalSize := vebOffsets(order, capacity, func(p int32) int64 {
+		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[bfsToSorted[p]].Key))
+	})
 
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
 
-	for i := 0; i < capacity; i++ {
-		si := bfsToSorted[i]
-		if si < 0 {
-			continue
-		}
+	for _, p := range order {
+		key := keys[bfsToSorted[p]]
 
-		key := keys[si]
-
-		leftChild := int64(-1)
-		if leftPos := 2*i + 1; leftPos < capacity && bfsToSorted[leftPos] >= 0 {
-			leftChild = diskOffsets[leftPos]
-		}
-		rightChild := int64(-1)
-		if rightPos := 2*i + 2; rightPos < capacity && bfsToSorted[rightPos] >= 0 {
-			rightChild = diskOffsets[rightPos]
-		}
+		leftChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+1, capacity)
+		rightChild := childOffset(diskOffsets, bfsToSorted, 2*int(p)+2, capacity)
 
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(len(key.Key)))
 		binary.LittleEndian.PutUint64(buf[4:12], uint64(key.ValueStart))
@@ -555,37 +527,25 @@ func marshalSortedSecondaryFromKeys(w io.Writer, keys []Key, pos int) (int64, er
 	}
 	fillBFS(bfsToIdx, 0, 0, n-1)
 
-	// Compute the byte offset of each BFS position in the serialized output.
-	diskOffsets := make([]int64, capacity)
-	var currentOffset int64
-	for i := 0; i < capacity; i++ {
-		diskOffsets[i] = currentOffset
-		if si := bfsToIdx[i]; si >= 0 {
-			ki := sortedIndices[si]
-			currentOffset += int64(TREE_KEY_STORE_OVERHEAD + len(keys[ki].SecondaryKeys[pos]))
-		}
+	// Emit nodes in van Emde Boas order; their offsets follow the write order,
+	// so compute them in a first pass before writing.
+	order := vebPositions(bfsToIdx)
+	if err := checkAllNodesEmitted(order, n); err != nil {
+		return 0, err
 	}
-	totalSize := currentOffset
+	diskOffsets, totalSize := vebOffsets(order, capacity, func(p int32) int64 {
+		ki := sortedIndices[bfsToIdx[p]]
+		return int64(TREE_KEY_STORE_OVERHEAD + len(keys[ki].SecondaryKeys[pos]))
+	})
 
-	// Write nodes in BFS order (matching MarshalBinaryInto output).
 	buf := make([]byte, TREE_KEY_STORE_OVERHEAD)
-	for i := 0; i < capacity; i++ {
-		si := bfsToIdx[i]
-		if si < 0 {
-			continue
-		}
-		ki := sortedIndices[si]
+	for _, p := range order {
+		ki := sortedIndices[bfsToIdx[p]]
 		key := keys[ki]
 		secKey := key.SecondaryKeys[pos]
 
-		leftChild := int64(-1)
-		if leftPos := 2*i + 1; leftPos < capacity && bfsToIdx[leftPos] >= 0 {
-			leftChild = diskOffsets[leftPos]
-		}
-		rightChild := int64(-1)
-		if rightPos := 2*i + 2; rightPos < capacity && bfsToIdx[rightPos] >= 0 {
-			rightChild = diskOffsets[rightPos]
-		}
+		leftChild := childOffset(diskOffsets, bfsToIdx, 2*int(p)+1, capacity)
+		rightChild := childOffset(diskOffsets, bfsToIdx, 2*int(p)+2, capacity)
 
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(len(secKey)))
 		binary.LittleEndian.PutUint64(buf[4:12], uint64(key.ValueStart))
@@ -616,4 +576,100 @@ func fillBFS(bfsToSorted []int32, targetPos, leftBound, rightBound int) {
 	bfsToSorted[targetPos] = int32(mid)
 	fillBFS(bfsToSorted, 2*targetPos+1, leftBound, mid-1)
 	fillBFS(bfsToSorted, 2*targetPos+2, mid+1, rightBound)
+}
+
+// vebPositions returns the heap positions of all present nodes in disk-write
+// order, using the van Emde Boas layout. The nodes are ordered to keep each node
+// near its children in the file, so a root-to-leaf lookup stays within a few
+// pages.
+//
+// Level order (write all of depth 0, then all of depth 1, ...) does the opposite:
+// a parent and its children fall in levels that grow exponentially, so they drift
+// far apart, and a deep lookup hits a new page at almost every step.
+//
+// Van Emde Boas order keeps subtrees together instead. Cut the tree in half by
+// height into one top subtree and many bottom subtrees, write the top subtree,
+// then each bottom subtree, and order each of them the same way recursively. For
+// a full height-4 tree (positions 0..14, children of p at 2p+1/2p+2) that is
+// 0,1,2, 3,7,8, 4,9,10, 5,11,12, 6,13,14 — top subtree {0,1,2}, then the four
+// bottom subtrees {3,7,8}, {4,9,10}, {5,11,12}, {6,13,14} — instead of level
+// order's 0..14. A subtree of any size then occupies one contiguous run of bytes,
+// so loading a page pulls in a whole subtree of the path rather than scattered
+// nodes.
+//
+// The cut is by height, not by page size, on purpose: each cut makes subtrees
+// about the square root in size of the level above, so their sizes fan out across
+// scales. Whatever the page size is, some level of the recursion has subtrees
+// about that big — the same layout is right for the 4 KiB page and the 64 B cache
+// line at once, with no constant to tune. A root-to-leaf lookup then crosses into
+// a new page only a handful of times.
+//
+// Page-sized blocking is the obvious alternative and was measured: it touches
+// slightly fewer pages (4.1 vs 4.9 per lookup at 10M keys) but runs ~10% slower
+// warm, because filling pages to the brim gives up cache-line locality. It also
+// needs a page size baked into the writer, which is wrong on 16 KiB-page
+// platforms, and any padding breaks AllKeys/KeyCount/ForEachKey, which assume
+// nodes are contiguous.
+//
+// mapping[p] is >= 0 for a present node and -1 for an empty position; its length
+// is the tree capacity and must be a power of two. The root (position 0) is
+// always emitted first, so it lands at offset 0.
+func vebPositions(mapping []int32) []int32 {
+	out := make([]int32, 0, len(mapping))
+	height := bits.Len(uint(len(mapping))) - 1 // capacity == 1<<height
+	var rec func(root, h int)
+	rec = func(root, h int) {
+		if h <= 0 || root >= len(mapping) || mapping[root] < 0 {
+			return
+		}
+		if h == 1 {
+			out = append(out, int32(root))
+			return
+		}
+		topH := (h + 1) / 2
+		rec(root, topH)
+		base := ((root + 1) << topH) - 1 // first descendant at relative depth topH
+		for j := 0; j < 1<<topH; j++ {
+			rec(base+j, h-topH)
+		}
+	}
+	rec(0, height)
+	return out
+}
+
+// checkAllNodesEmitted fails if vebPositions did not emit every key. vebPositions
+// prunes on an empty heap position, which is safe only while every present node
+// has a present parent (guaranteed by fillBFS); a dropped node would silently
+// omit a key from the index.
+func checkAllNodesEmitted(order []int32, n int) error {
+	if len(order) != n {
+		return fmt.Errorf("segment index writer emitted %d of %d nodes", len(order), n)
+	}
+	return nil
+}
+
+// vebOffsets assigns each present heap position its byte offset in the
+// serialized output by walking positions in write order. In van Emde Boas
+// order write order and offset order differ, so offsets need this separate pass
+// before children can be pointed at. The returned slice is indexed by heap
+// position (-1 for empty positions, which the reader never dereferences).
+func vebOffsets(order []int32, capacity int, nodeSize func(heapPos int32) int64) (offsetOf []int64, total int64) {
+	offsetOf = make([]int64, capacity)
+	for i := range offsetOf {
+		offsetOf[i] = -1
+	}
+	for _, p := range order {
+		offsetOf[p] = total
+		total += nodeSize(p)
+	}
+	return offsetOf, total
+}
+
+// childOffset returns the serialized byte offset of the child at heap position
+// childPos, or -1 when that position holds no node.
+func childOffset(offsetOf []int64, mapping []int32, childPos, capacity int) int64 {
+	if childPos < capacity && mapping[childPos] >= 0 {
+		return offsetOf[childPos]
+	}
+	return -1
 }

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -370,7 +370,7 @@ func MarshalSortedKeys(w io.Writer, keys []KeyRedux, dataStartOffset uint64) (in
 
 	// Emit nodes in van Emde Boas order; their offsets follow the write order,
 	// so compute them in a first pass before writing.
-	order := vebPositions(bfsToSorted)
+	order := vebPositions(bfsToSorted, n)
 	if err := checkAllNodesEmitted(order, n); err != nil {
 		return 0, err
 	}
@@ -436,7 +436,7 @@ func MarshalSortedKeysFromKeys(w io.Writer, keys []Key) (int64, error) {
 	}
 	fillBFS(bfsToSorted, 0, 0, n-1)
 
-	order := vebPositions(bfsToSorted)
+	order := vebPositions(bfsToSorted, n)
 	if err := checkAllNodesEmitted(order, n); err != nil {
 		return 0, err
 	}
@@ -529,7 +529,7 @@ func marshalSortedSecondaryFromKeys(w io.Writer, keys []Key, pos int) (int64, er
 
 	// Emit nodes in van Emde Boas order; their offsets follow the write order,
 	// so compute them in a first pass before writing.
-	order := vebPositions(bfsToIdx)
+	order := vebPositions(bfsToIdx, n)
 	if err := checkAllNodesEmitted(order, n); err != nil {
 		return 0, err
 	}
@@ -612,10 +612,12 @@ func fillBFS(bfsToSorted []int32, targetPos, leftBound, rightBound int) {
 // nodes are contiguous.
 //
 // mapping[p] is >= 0 for a present node and -1 for an empty position; its length
-// is the tree capacity and must be a power of two. The root (position 0) is
-// always emitted first, so it lands at offset 0.
-func vebPositions(mapping []int32) []int32 {
-	out := make([]int32, 0, len(mapping))
+// is the tree capacity and must be a power of two. nodeCount is how many present
+// nodes mapping holds; it sizes the result exactly, where the capacity would
+// over-allocate it by up to 2x. The root (position 0) is always emitted first, so
+// it lands at offset 0.
+func vebPositions(mapping []int32, nodeCount int) []int32 {
+	out := make([]int32, 0, nodeCount)
 	height := bits.Len(uint(len(mapping))) - 1 // capacity == 1<<height
 	var rec func(root, h int)
 	rec = func(root, h int) {

--- a/adapters/repos/db/lsmkv/segmentindex/tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree.go
@@ -579,43 +579,24 @@ func fillBFS(bfsToSorted []int32, targetPos, leftBound, rightBound int) {
 }
 
 // vebPositions returns the heap positions of all present nodes in disk-write
-// order, using the van Emde Boas layout. The nodes are ordered to keep each node
-// near its children in the file, so a root-to-leaf lookup stays within a few
-// pages.
+// order, using the van Emde Boas layout: cut the tree in half by height, write
+// the top subtree, then each bottom subtree, ordering every one of them the same
+// way recursively. For a full height-4 tree (positions 0..14, children of p at
+// 2p+1/2p+2) that is 0,1,2, 3,7,8, 4,9,10, 5,11,12, 6,13,14 — top subtree
+// {0,1,2}, then the four bottom subtrees {3,7,8}, {4,9,10}, {5,11,12}, {6,13,14}
+// — instead of level order's 0..14.
 //
-// Level order (write all of depth 0, then all of depth 1, ...) does the opposite:
-// a parent and its children fall in levels that grow exponentially, so they drift
-// far apart, and a deep lookup hits a new page at almost every step.
-//
-// Van Emde Boas order keeps subtrees together instead. Cut the tree in half by
-// height into one top subtree and many bottom subtrees, write the top subtree,
-// then each bottom subtree, and order each of them the same way recursively. For
-// a full height-4 tree (positions 0..14, children of p at 2p+1/2p+2) that is
-// 0,1,2, 3,7,8, 4,9,10, 5,11,12, 6,13,14 — top subtree {0,1,2}, then the four
-// bottom subtrees {3,7,8}, {4,9,10}, {5,11,12}, {6,13,14} — instead of level
-// order's 0..14. A subtree of any size then occupies one contiguous run of bytes,
-// so loading a page pulls in a whole subtree of the path rather than scattered
-// nodes.
-//
-// The cut is by height, not by page size, on purpose: each cut makes subtrees
-// about the square root in size of the level above, so their sizes fan out across
-// scales. Whatever the page size is, some level of the recursion has subtrees
-// about that big — the same layout is right for the 4 KiB page and the 64 B cache
-// line at once, with no constant to tune. A root-to-leaf lookup then crosses into
-// a new page only a handful of times.
-//
-// Page-sized blocking is the obvious alternative and was measured: it touches
-// slightly fewer pages (4.1 vs 4.9 per lookup at 10M keys) but runs ~10% slower
-// warm, because filling pages to the brim gives up cache-line locality. It also
-// needs a page size baked into the writer, which is wrong on 16 KiB-page
-// platforms, and any padding breaks AllKeys/KeyCount/ForEachKey, which assume
-// nodes are contiguous.
+// Every subtree the recursion cuts out is written as one contiguous run. Cutting
+// by height rather than by a page size means some level of the recursion always
+// has subtrees about the size of a page, whatever that page size is, so a
+// root-to-leaf lookup reads only a few pages. In level order a node and its
+// children sit exponentially far apart, so almost every step reads a new page.
 //
 // mapping[p] is >= 0 for a present node and -1 for an empty position; its length
 // is the tree capacity and must be a power of two. nodeCount is how many present
 // nodes mapping holds; it sizes the result exactly, where the capacity would
 // over-allocate it by up to 2x. The root (position 0) is always emitted first, so
-// it lands at offset 0.
+// it sits at offset 0, where readers start.
 func vebPositions(mapping []int32, nodeCount int) []int32 {
 	out := make([]int32, 0, nodeCount)
 	height := bits.Len(uint(len(mapping))) - 1 // capacity == 1<<height
@@ -640,15 +621,18 @@ func vebPositions(mapping []int32, nodeCount int) []int32 {
 }
 
 // vebOffsets assigns each present node its byte offset in the serialized output
-// by walking heap positions in write order. In van Emde Boas order write order
-// and offset order differ, so offsets need this separate pass before children can
-// be pointed at. The result is indexed by sorted index (mapping[heapPos]), so it
-// holds nodeCount entries instead of the tree capacity, which is up to 2x larger.
+// by walking heap positions in write order. Children are always written after
+// their parent, so a parent's child offsets are not known yet when it is
+// written and this pass has to run first. The result is indexed by sorted index
+// (mapping[heapPos]), so it holds nodeCount entries instead of the tree
+// capacity, which is up to 2x larger.
 //
-// It fails unless order lists every node exactly once. vebPositions prunes on an
-// empty heap position: a node it dropped would be missing from the index while its
-// parent still points at offset 0, the root, and a node listed twice would be
-// written twice.
+// Offsets run back to back with no padding, which AllKeys, KeyCount and
+// ForEachKey rely on to walk the blob sequentially.
+//
+// It fails unless order lists every node exactly once: a node missing from order
+// would keep offset -1, so its parent would read as having no child and its
+// whole subtree would be unreachable; a node listed twice would be written twice.
 func vebOffsets(order, mapping []int32, nodeCount int, nodeSize func(sortedIdx int32) int64) (offsetOf []int64, total int64, err error) {
 	offsetOf = make([]int64, nodeCount)
 	for i := range offsetOf {

--- a/adapters/repos/db/lsmkv/segmentindex/tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree_test.go
@@ -474,6 +474,61 @@ func TestMarshalSortedKeysEmptyInput(t *testing.T) {
 	assert.Equal(t, 0, buf.Len())
 }
 
+// Comparing only len(order) against the node count misses an order that has the
+// right length yet lists one node twice and another not at all, so vebOffsets
+// checks per node instead.
+func TestVEBOffsets(t *testing.T) {
+	// 3 keys in a height-2 tree: heap positions 0, 1, 2 hold sorted indices 1, 0, 2.
+	const nodeCount = 3
+	mapping := []int32{1, 0, 2, -1}
+	nodeSize := func(int32) int64 { return 10 }
+
+	tests := []struct {
+		name      string
+		order     []int32
+		wantErr   bool
+		wantOff   []int64
+		wantTotal int64
+	}{
+		{
+			name:      "every node emitted",
+			order:     []int32{0, 1, 2},
+			wantOff:   []int64{10, 0, 20},
+			wantTotal: 30,
+		},
+		{
+			name:    "node dropped",
+			order:   []int32{0, 1},
+			wantErr: true,
+		},
+		{
+			name:    "node listed twice in place of another",
+			order:   []int32{0, 1, 1},
+			wantErr: true,
+		},
+		{
+			name:    "node listed twice on top of a complete order",
+			order:   []int32{0, 1, 2, 1},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			offsets, total, err := vebOffsets(test.order, mapping, nodeCount, nodeSize)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, offsets)
+				assert.Zero(t, total)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.wantOff, offsets)
+			assert.Equal(t, test.wantTotal, total)
+		})
+	}
+}
+
 // A dataStartOffset past the first key's ValueEnd would serialize start > end;
 // MarshalSortedKeys must reject it rather than emit a corrupt index.
 func TestMarshalSortedKeysRejectsOffsetPastFirstValueEnd(t *testing.T) {

--- a/adapters/repos/db/lsmkv/segmentindex/tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree_test.go
@@ -14,6 +14,8 @@ package segmentindex
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +38,76 @@ func requireSameTree(t *testing.T, want, got []byte, keys [][]byte) {
 		require.NoError(t, wantErr, "key=%q", k)
 		require.NoError(t, gotErr, "key=%q", k)
 		require.Equal(t, wantNode, gotNode, "key=%q", k)
+	}
+}
+
+// varWidthKey returns key i of an ascending sequence whose keys differ in
+// length. Equal-length keys give every node the same size, so a wrong node-size
+// computation still yields correct offsets and the test stays green.
+func varWidthKey(i int) []byte {
+	return []byte(fmt.Sprintf("key-%05d%s", i, strings.Repeat("x", i%7)))
+}
+
+// sortedKeyWriter adapts one of the writers that serialize a sorted key slice
+// into a segment index, so one test covers all of them. Each ValueStart must
+// equal the previous ValueEnd, the first being 0, which is what
+// MarshalSortedKeys derives rather than reads.
+type sortedKeyWriter struct {
+	name string
+	// indexedNodes returns the entries this writer puts in the index: the key it
+	// indexes by, and the start and end that key must resolve to. It feeds the
+	// reference NewBalanced path the writer's output is compared against.
+	indexedNodes func(keys []Key) Nodes
+	write        func(w io.Writer, keys []Key) (int64, error)
+}
+
+func primaryNodes(keys []Key) Nodes {
+	nodes := make(Nodes, len(keys))
+	for i, key := range keys {
+		nodes[i] = Node{Key: key.Key, Start: uint64(key.ValueStart), End: uint64(key.ValueEnd)}
+	}
+	return nodes
+}
+
+func sortedKeyWriters() []sortedKeyWriter {
+	return []sortedKeyWriter{
+		{
+			name:         "MarshalSortedKeysFromKeys",
+			indexedNodes: primaryNodes,
+			write: func(w io.Writer, keys []Key) (int64, error) {
+				return MarshalSortedKeysFromKeys(w, keys)
+			},
+		},
+		{
+			name:         "MarshalSortedKeys",
+			indexedNodes: primaryNodes,
+			write: func(w io.Writer, keys []Key) (int64, error) {
+				redux := make([]KeyRedux, len(keys))
+				for i, key := range keys {
+					redux[i] = KeyRedux{Key: key.Key, ValueEnd: key.ValueEnd}
+				}
+				return MarshalSortedKeys(w, redux, 0)
+			},
+		},
+		{
+			name: "marshalSortedSecondaryFromKeys",
+			indexedNodes: func(keys []Key) Nodes {
+				var nodes Nodes
+				for _, key := range keys {
+					if len(key.SecondaryKeys) > 0 {
+						nodes = append(nodes, Node{
+							Key:   key.SecondaryKeys[0],
+							Start: uint64(key.ValueStart),
+							End:   uint64(key.ValueEnd),
+						})
+					}
+				}
+				return nodes
+			},
+			write: func(w io.Writer, keys []Key) (int64, error) {
+				return marshalSortedSecondaryFromKeys(w, keys, 0)
+			},
+		},
 	}
 }
 
@@ -324,35 +396,38 @@ func TestMarshalSortedKeysFromKeys(t *testing.T) {
 
 // TestMarshalSortedKeysVanEmdeBoasOrder pins the on-disk node order to the van
 // Emde Boas layout. For a full tree of height 4 (15 keys) it differs from level
-// order, so this fails if the writer regresses to level order. The expected
+// order, so this fails if a writer regresses to level order. The expected
 // permutation is the sorted-key indices in write order, hand-derived from the
-// vEB recursion (top block {0,1,2}, then bottom subtrees under 3,4,5,6).
+// vEB recursion (top block {0,1,2}, then bottom subtrees under 3,4,5,6). The
+// root comes first, so it sits at offset 0 where pointer-chasing readers start.
 func TestMarshalSortedKeysVanEmdeBoasOrder(t *testing.T) {
 	const n = 15
 	keys := make([]Key, n)
 	for i := 0; i < n; i++ {
-		keys[i] = Key{Key: []byte(fmt.Sprintf("key-%05d", i)), ValueStart: i, ValueEnd: i + 1}
+		// Each secondary key repeats its primary key, so all three writers index
+		// the same 15 keys in the same order and share one expected permutation.
+		k := varWidthKey(i)
+		keys[i] = Key{Key: k, ValueStart: i * 10, ValueEnd: (i + 1) * 10, SecondaryKeys: [][]byte{k}}
 	}
-
-	var buf bytes.Buffer
-	_, err := MarshalSortedKeysFromKeys(&buf, keys)
-	require.NoError(t, err)
-
-	// AllKeys walks the blob sequentially, so it returns keys in write order.
-	got, err := NewDiskTree(buf.Bytes()).AllKeys()
-	require.NoError(t, err)
 
 	vebSortedIndices := []int{7, 3, 11, 1, 0, 2, 5, 4, 6, 9, 8, 10, 13, 12, 14}
 	want := make([][]byte, n)
 	for i, idx := range vebSortedIndices {
-		want[i] = []byte(fmt.Sprintf("key-%05d", idx))
+		want[i] = varWidthKey(idx)
 	}
-	assert.Equal(t, want, got)
 
-	// The root must sit at offset 0 so pointer-chasing readers start there.
-	root, err := NewDiskTree(buf.Bytes()).Get([]byte("key-00007"))
-	require.NoError(t, err)
-	assert.Equal(t, want[0], root.Key)
+	for _, writer := range sortedKeyWriters() {
+		t.Run(writer.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			_, err := writer.write(&buf, keys)
+			require.NoError(t, err)
+
+			// AllKeys walks the blob sequentially, so it returns keys in write order.
+			got, err := NewDiskTree(buf.Bytes()).AllKeys()
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
 }
 
 // MarshalSortedKeys must place the first key's data at the caller-provided
@@ -389,6 +464,14 @@ func TestMarshalSortedKeysDataStartOffset(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(55), n.Start)
 	assert.Equal(t, uint64(70), n.End)
+}
+
+func TestMarshalSortedKeysEmptyInput(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := MarshalSortedKeys(&buf, nil, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	assert.Equal(t, 0, buf.Len())
 }
 
 // A dataStartOffset past the first key's ValueEnd would serialize start > end;

--- a/adapters/repos/db/lsmkv/segmentindex/tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree_test.go
@@ -13,8 +13,11 @@ package segmentindex
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
+	"math/bits"
 	"strings"
 	"testing"
 
@@ -24,14 +27,28 @@ import (
 )
 
 // requireSameTree asserts two serialized index blobs describe the same tree:
-// identical total size and identical resolution of every key through DiskTree.
-// The van Emde Boas writer reorders nodes relative to the level-order Tree
-// serializer, so the guarantee is semantic, not byte-for-byte.
+// identical total size, node count and depth, and identical resolution of every
+// key through DiskTree. The van Emde Boas writer reorders nodes relative to the
+// level-order Tree serializer, so the guarantee is semantic, not byte-for-byte.
 func requireSameTree(t *testing.T, want, got []byte, keys [][]byte) {
 	t.Helper()
 	require.Equal(t, len(want), len(got), "serialized size must match")
 	wantTree := NewDiskTree(want)
 	gotTree := NewDiskTree(got)
+
+	nodeCount := gotTree.KeyCount()
+	require.Equal(t, wantTree.KeyCount(), nodeCount, "node count must match")
+
+	wantDepth, err := treeDepth(wantTree)
+	require.NoError(t, err)
+	gotDepth, err := treeDepth(gotTree)
+	require.NoError(t, err)
+	// Size and per-key lookups are also satisfied by a degenerate spine over the
+	// same keys, so compare depth too. A balanced tree over n nodes is exactly
+	// bits.Len(n) levels deep.
+	require.Equal(t, wantDepth, gotDepth, "tree depth must match")
+	require.Equal(t, bits.Len(uint(nodeCount)), gotDepth, "tree must be balanced")
+
 	for _, k := range keys {
 		wantNode, wantErr := wantTree.Get(k)
 		gotNode, gotErr := gotTree.Get(k)
@@ -41,11 +58,57 @@ func requireSameTree(t *testing.T, want, got []byte, keys [][]byte) {
 	}
 }
 
+// treeDepth returns the number of nodes on the longest root-to-leaf path.
+func treeDepth(tree *DiskTree) (int, error) {
+	if tree.Size() == 0 {
+		return 0, nil
+	}
+	return depthAt(tree, 0, tree.KeyCount())
+}
+
+// depthAt follows the child pointers below offset. budget is how many more
+// nodes the descent may visit, so a child pointer that loops back fails instead
+// of recursing forever.
+func depthAt(tree *DiskTree, offset int64, budget int) (int, error) {
+	if offset < 0 {
+		return 0, nil
+	}
+	if budget <= 0 {
+		return 0, errors.New("child pointers descend past the node count")
+	}
+	node, err := tree.readNodeAt(offset)
+	if err != nil {
+		return 0, err
+	}
+	left, err := depthAt(tree, node.leftChild, budget-1)
+	if err != nil {
+		return 0, err
+	}
+	right, err := depthAt(tree, node.rightChild, budget-1)
+	if err != nil {
+		return 0, err
+	}
+	return 1 + max(left, right), nil
+}
+
 // varWidthKey returns key i of an ascending sequence whose keys differ in
 // length. Equal-length keys give every node the same size, so a wrong node-size
 // computation still yields correct offsets and the test stays green.
 func varWidthKey(i int) []byte {
 	return []byte(fmt.Sprintf("key-%05d%s", i, strings.Repeat("x", i%7)))
+}
+
+// docIDKeys returns n keys shaped like those the binary-quantized vector store
+// writes: 8-byte big-endian docIDs, fixed width and ascending in byte order.
+// Values chain one byte per key.
+func docIDKeys(n int) []Key {
+	keys := make([]Key, n)
+	for i := 0; i < n; i++ {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(i))
+		keys[i] = Key{Key: key, ValueStart: i, ValueEnd: i + 1}
+	}
+	return keys
 }
 
 // sortedKeyWriter adapts one of the writers that serialize a sorted key slice
@@ -67,6 +130,30 @@ func primaryNodes(keys []Key) Nodes {
 		nodes[i] = Node{Key: key.Key, Start: uint64(key.ValueStart), End: uint64(key.ValueEnd)}
 	}
 	return nodes
+}
+
+// secondaryNodes returns the nodes the secondary index at pos holds. Keys
+// without a secondary key at pos are left out.
+func secondaryNodes(keys []Key, pos int) Nodes {
+	var nodes Nodes
+	for _, key := range keys {
+		if pos < len(key.SecondaryKeys) {
+			nodes = append(nodes, Node{
+				Key:   key.SecondaryKeys[pos],
+				Start: uint64(key.ValueStart),
+				End:   uint64(key.ValueEnd),
+			})
+		}
+	}
+	return nodes
+}
+
+func nodeKeys(nodes Nodes) [][]byte {
+	keys := make([][]byte, len(nodes))
+	for i, node := range nodes {
+		keys[i] = node.Key
+	}
+	return keys
 }
 
 func sortedKeyWriters() []sortedKeyWriter {
@@ -92,17 +179,7 @@ func sortedKeyWriters() []sortedKeyWriter {
 		{
 			name: "marshalSortedSecondaryFromKeys",
 			indexedNodes: func(keys []Key) Nodes {
-				var nodes Nodes
-				for _, key := range keys {
-					if len(key.SecondaryKeys) > 0 {
-						nodes = append(nodes, Node{
-							Key:   key.SecondaryKeys[0],
-							Start: uint64(key.ValueStart),
-							End:   uint64(key.ValueEnd),
-						})
-					}
-				}
-				return nodes
+				return secondaryNodes(keys, 0)
 			},
 			write: func(w io.Writer, keys []Key) (int64, error) {
 				return marshalSortedSecondaryFromKeys(w, keys, 0)
@@ -324,12 +401,8 @@ func TestMarshalSortedKeysFromKeys(t *testing.T) {
 	t.Run("equivalent to tree MarshalBinary", func(t *testing.T) {
 		// Build the same balanced tree via NewBalanced and marshal it.
 		// NewBalanced (not Insert) produces a balanced BST over the same keys.
-		nodes := make(Nodes, len(sortedKeys))
-		keyBytes := make([][]byte, len(sortedKeys))
-		for i, k := range sortedKeys {
-			nodes[i] = Node{Key: k.Key, Start: uint64(k.ValueStart), End: uint64(k.ValueEnd)}
-			keyBytes[i] = k.Key
-		}
+		nodes := primaryNodes(sortedKeys)
+		keyBytes := nodeKeys(nodes)
 		tree := NewBalanced(nodes)
 		want, err := tree.MarshalBinary()
 		require.NoError(t, err)
@@ -386,11 +459,7 @@ func TestMarshalSortedKeysFromKeys(t *testing.T) {
 		keys, err := dTree.AllKeys()
 		require.NoError(t, err)
 
-		expected := make([][]byte, len(sortedKeys))
-		for i, k := range sortedKeys {
-			expected[i] = k.Key
-		}
-		assert.ElementsMatch(t, expected, keys)
+		assert.ElementsMatch(t, nodeKeys(primaryNodes(sortedKeys)), keys)
 	})
 }
 
@@ -426,6 +495,64 @@ func TestMarshalSortedKeysVanEmdeBoasOrder(t *testing.T) {
 			got, err := NewDiskTree(buf.Bytes()).AllKeys()
 			require.NoError(t, err)
 			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// A balanced tree and a right spine over the same keys serialize to the same
+// number of bytes and resolve every key, so depth is the only thing that tells
+// the two shapes apart. requireSameTree relies on that.
+func TestTreeDepth(t *testing.T) {
+	const n = 15
+	nodes := make(Nodes, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = Node{Key: varWidthKey(i), Start: uint64(i), End: uint64(i + 1)}
+	}
+
+	balancedTree := NewBalanced(nodes)
+	balanced, err := balancedTree.MarshalBinary()
+	require.NoError(t, err)
+
+	// Keys arrive in ascending order, so plain BST inserts give a right spine.
+	spineTree := NewTree(n)
+	for _, node := range nodes {
+		spineTree.Insert(node.Key, node.Start, node.End)
+	}
+	spine, err := spineTree.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, len(balanced), len(spine), "both shapes must serialize to the same size")
+
+	// Root node layout: [keyLen:4][key][start:8][end:8][left:8][right:8].
+	rootLeftChild := 4 + int(binary.LittleEndian.Uint32(balanced[0:4])) + 16
+
+	cyclic := bytes.Clone(balanced)
+	binary.LittleEndian.PutUint64(cyclic[rootLeftChild:], 0) // points at itself
+
+	pastBuffer := bytes.Clone(balanced)
+	binary.LittleEndian.PutUint64(pastBuffer[rootLeftChild:], uint64(len(balanced))+1)
+
+	tests := []struct {
+		name      string
+		data      []byte
+		wantDepth int
+		wantErr   bool
+	}{
+		{name: "empty", data: nil, wantDepth: 0},
+		{name: "balanced", data: balanced, wantDepth: bits.Len(uint(n))},
+		{name: "right spine", data: spine, wantDepth: n},
+		{name: "child pointer loops back", data: cyclic, wantErr: true},
+		{name: "child pointer past the buffer", data: pastBuffer, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			depth, err := treeDepth(NewDiskTree(test.data))
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.wantDepth, depth)
 		})
 	}
 }

--- a/adapters/repos/db/lsmkv/segmentindex/tree_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/tree_test.go
@@ -13,12 +13,31 @@ package segmentindex
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
+
+// requireSameTree asserts two serialized index blobs describe the same tree:
+// identical total size and identical resolution of every key through DiskTree.
+// The van Emde Boas writer reorders nodes relative to the level-order Tree
+// serializer, so the guarantee is semantic, not byte-for-byte.
+func requireSameTree(t *testing.T, want, got []byte, keys [][]byte) {
+	t.Helper()
+	require.Equal(t, len(want), len(got), "serialized size must match")
+	wantTree := NewDiskTree(want)
+	gotTree := NewDiskTree(got)
+	for _, k := range keys {
+		wantNode, wantErr := wantTree.Get(k)
+		gotNode, gotErr := gotTree.Get(k)
+		require.NoError(t, wantErr, "key=%q", k)
+		require.NoError(t, gotErr, "key=%q", k)
+		require.Equal(t, wantNode, gotNode, "key=%q", k)
+	}
+}
 
 func TestTree(t *testing.T) {
 	type elem struct {
@@ -230,12 +249,14 @@ func TestMarshalSortedKeysFromKeys(t *testing.T) {
 		assert.Equal(t, 0, buf.Len())
 	})
 
-	t.Run("output matches tree MarshalBinary", func(t *testing.T) {
+	t.Run("equivalent to tree MarshalBinary", func(t *testing.T) {
 		// Build the same balanced tree via NewBalanced and marshal it.
-		// NewBalanced (not Insert) produces a balanced BST matching MarshalSortedKeysFromKeys.
+		// NewBalanced (not Insert) produces a balanced BST over the same keys.
 		nodes := make(Nodes, len(sortedKeys))
+		keyBytes := make([][]byte, len(sortedKeys))
 		for i, k := range sortedKeys {
 			nodes[i] = Node{Key: k.Key, Start: uint64(k.ValueStart), End: uint64(k.ValueEnd)}
+			keyBytes[i] = k.Key
 		}
 		tree := NewBalanced(nodes)
 		want, err := tree.MarshalBinary()
@@ -245,10 +266,9 @@ func TestMarshalSortedKeysFromKeys(t *testing.T) {
 		var buf bytes.Buffer
 		n, err := MarshalSortedKeysFromKeys(&buf, sortedKeys)
 		require.NoError(t, err)
-		got := buf.Bytes()
 
-		assert.Equal(t, int64(len(want)), n)
-		assert.Equal(t, want, got)
+		assert.Equal(t, int64(buf.Len()), n)
+		requireSameTree(t, want, buf.Bytes(), keyBytes)
 	})
 
 	t.Run("DiskTree can Get every key", func(t *testing.T) {
@@ -300,6 +320,39 @@ func TestMarshalSortedKeysFromKeys(t *testing.T) {
 		}
 		assert.ElementsMatch(t, expected, keys)
 	})
+}
+
+// TestMarshalSortedKeysVanEmdeBoasOrder pins the on-disk node order to the van
+// Emde Boas layout. For a full tree of height 4 (15 keys) it differs from level
+// order, so this fails if the writer regresses to level order. The expected
+// permutation is the sorted-key indices in write order, hand-derived from the
+// vEB recursion (top block {0,1,2}, then bottom subtrees under 3,4,5,6).
+func TestMarshalSortedKeysVanEmdeBoasOrder(t *testing.T) {
+	const n = 15
+	keys := make([]Key, n)
+	for i := 0; i < n; i++ {
+		keys[i] = Key{Key: []byte(fmt.Sprintf("key-%05d", i)), ValueStart: i, ValueEnd: i + 1}
+	}
+
+	var buf bytes.Buffer
+	_, err := MarshalSortedKeysFromKeys(&buf, keys)
+	require.NoError(t, err)
+
+	// AllKeys walks the blob sequentially, so it returns keys in write order.
+	got, err := NewDiskTree(buf.Bytes()).AllKeys()
+	require.NoError(t, err)
+
+	vebSortedIndices := []int{7, 3, 11, 1, 0, 2, 5, 4, 6, 9, 8, 10, 13, 12, 14}
+	want := make([][]byte, n)
+	for i, idx := range vebSortedIndices {
+		want[i] = []byte(fmt.Sprintf("key-%05d", idx))
+	}
+	assert.Equal(t, want, got)
+
+	// The root must sit at offset 0 so pointer-chasing readers start there.
+	root, err := NewDiskTree(buf.Bytes()).Get([]byte("key-00007"))
+	require.NoError(t, err)
+	assert.Equal(t, want[0], root.Key)
 }
 
 // MarshalSortedKeys must place the first key's data at the caller-provided


### PR DESCRIPTION
### What's being changed:

This improves the layout of our on disk indices that are part of the segments. The layout change is backward compatible to all users. Only the layout of the nodes changes, not the node-format itself.

Note that this is only changing newly written segments including on compaction. So the change will propagate to all segments automatically over time.

There are two improvements:
- better **warm** cache performance by improving memory locality (nodes are closer together in memory)
- better **cold** cache performance by touching less disk pages per lookup which also allows to keep the upper levels of the tree in the page cache for longer

  ### Distinct blocks touched per lookup (lower is better)

  | n | granularity | level-order | vEB |
  |:---|:---|---:|---:|
  | 1M | 4 KiB page | 13.58 | **4.51** |
  | 1M | 64 B line | 28.55 | **24.90** |
  | 10M | 4 KiB page | 16.97 | **4.93** |
  | 10M | 64 B line | 33.84 | **29.93** |

  ### Warm latency (ns/op)

  | n | level-order | vEB | speedup |
  |:---|---:|---:|---:|
  | 100k | 184.8 | **172.9** | 1.07× |
  | 1M | 357.6 | **284.0** | 1.26× |
  | 10M | 771.2 | **474.4** | **1.63×** |

  Both layouts are the same balanced BST read through the same `DiskTree`; only node
  placement differs. 8-byte little-endian docID keys (44 B nodes), uniform random lookups
  of existing keys, index fully resident in RAM. Allocations are identical (8 B/op, 1 alloc/op) — the gain is purely memory locality.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
