### PR TITLE
Run the deferred shard teardown on its own goroutine with a deadline

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_snapshot.go
+++ b/adapters/repos/db/lsmkv/bucket_snapshot.go
@@ -143,6 +143,12 @@ func (b *Bucket) CreateSnapshot(ctx context.Context, snapshotsRoot, name string)
 
 	snapshotDir := filepath.Join(snapshotsRoot, SnapshotDirPrefix+name)
 
+	// An expired context means the caller is gone; the flush and hard-link steps
+	// below take no context and would run to completion.
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
 	if err := b.pauseCompaction(ctx); err != nil {
 		return "", fmt.Errorf("pause compaction: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/bucket_snapshot_test.go
+++ b/adapters/repos/db/lsmkv/bucket_snapshot_test.go
@@ -510,3 +510,55 @@ func cursorCount(t *testing.T, b *Bucket) int {
 	}
 	return n
 }
+
+// TestSnapshotExpiredContext pins that CreateSnapshot refuses an expired context.
+// The flush and hard-link steps take no context, so without the guard they run to
+// completion after the caller has given up.
+func TestSnapshotExpiredContext(t *testing.T) {
+	ctx := context.Background()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+
+	tests := []struct {
+		name    string
+		expired func() context.Context
+		wantErr error
+	}{
+		{
+			name: "cancelled",
+			expired: func() context.Context {
+				expired, cancel := context.WithCancel(ctx)
+				cancel()
+				return expired
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "deadline exceeded",
+			expired: func() context.Context {
+				expired, cancel := context.WithDeadline(ctx, time.Now())
+				t.Cleanup(cancel)
+				return expired
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", testLogger(), nil, noopCB, noopCB,
+				WithStrategy(StrategyReplace))
+			require.NoError(t, err)
+			defer bucket.Shutdown(ctx)
+
+			require.NoError(t, bucket.Put([]byte("k"), []byte("v")))
+
+			snapshotsRoot := t.TempDir()
+			_, err = bucket.CreateSnapshot(tt.expired(), snapshotsRoot, "snap")
+			require.ErrorIs(t, err, tt.wantErr)
+
+			entries, err := os.ReadDir(snapshotsRoot)
+			require.NoError(t, err)
+			assert.Empty(t, entries, "no snapshot may be produced for an expired context")
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/store_backup.go
+++ b/adapters/repos/db/lsmkv/store_backup.go
@@ -27,6 +27,11 @@ import (
 // to fail the backup attempt and retry later, than to block
 // indefinitely.
 func (s *Store) PauseCompaction(ctx context.Context) error {
+	// An expired context means the caller is gone; don't start pausing.
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "pause compaction")
+	}
+
 	if err := s.cycleCallbacks.compactionCallbacksCtrl.Deactivate(ctx); err != nil {
 		return errors.Wrap(err, "long-running compaction in progress")
 	}
@@ -72,6 +77,12 @@ func (s *Store) ResumeCompaction(ctx context.Context) error {
 // to fail the backup attempt and retry later, than to block
 // indefinitely.
 func (s *Store) FlushMemtables(ctx context.Context) error {
+	// An expired context means the caller is gone; the per-bucket flush below takes
+	// no context and would run to completion.
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "flush memtables")
+	}
+
 	if err := s.cycleCallbacks.flushCallbacksCtrl.Deactivate(ctx); err != nil {
 		return errors.Wrap(err, "long-running memtable flush in progress")
 	}

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -51,7 +51,7 @@ func TestStoreBackup(t *testing.T) {
 func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
-	t.Run("assert that context timeout works for long compactions", func(t *testing.T) {
+	t.Run("assert that an expired context fails fast", func(t *testing.T) {
 		for _, buckets := range [][]string{
 			{"test_bucket"},
 			{"test_bucket1", "test_bucket2"},
@@ -77,10 +77,7 @@ func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				defer cancel()
 
 				err = store.PauseCompaction(expiredCtx)
-				require.NotNil(t, err)
-				assert.Equal(t, "long-running compaction in progress:"+
-					" deactivating callback 'store/compaction-non-objects/.' of 'classCompactionNonObjects' failed:"+
-					" context deadline exceeded", err.Error())
+				require.ErrorIs(t, err, context.DeadlineExceeded)
 
 				err = store.Shutdown(ctx)
 				require.Nil(t, err)
@@ -186,7 +183,7 @@ func resumeCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
-	t.Run("assert that context timeout works for long flushes", func(t *testing.T) {
+	t.Run("assert that an expired context fails fast", func(t *testing.T) {
 		for _, buckets := range [][]string{
 			{"test_bucket"},
 			{"test_bucket1", "test_bucket2"},
@@ -212,10 +209,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				defer cancel()
 
 				err = store.FlushMemtables(expiredCtx)
-				require.NotNil(t, err)
-				assert.Equal(t, "long-running memtable flush in progress:"+
-					" deactivating callback 'store/flush/.' of 'classFlush' failed:"+
-					" context deadline exceeded", err.Error())
+				require.ErrorIs(t, err, context.DeadlineExceeded)
 
 				err = store.Shutdown(ctx)
 				require.Nil(t, err)

--- a/adapters/repos/db/shard_deferred_teardown_test.go
+++ b/adapters/repos/db/shard_deferred_teardown_test.go
@@ -1,0 +1,189 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// teardownProbe wraps a cycle callback controller so a test can see the teardown
+// arrive, hold it there, and choose the error it reports.
+type teardownProbe struct {
+	cyclemanager.CycleCallbackCtrl
+
+	entered       chan struct{}
+	enteredOnce   sync.Once
+	unblock       chan struct{}
+	unregisterErr error
+	sawDeadline   atomic.Bool
+}
+
+func newTeardownProbe(wrapped cyclemanager.CycleCallbackCtrl, unregisterErr error) *teardownProbe {
+	return &teardownProbe{
+		CycleCallbackCtrl: wrapped,
+		entered:           make(chan struct{}),
+		unblock:           make(chan struct{}),
+		unregisterErr:     unregisterErr,
+	}
+}
+
+func (p *teardownProbe) Unregister(ctx context.Context) error {
+	_, ok := ctx.Deadline()
+	p.sawDeadline.Store(ok)
+	p.enteredOnce.Do(func() { close(p.entered) })
+	<-p.unblock
+
+	if err := p.CycleCallbackCtrl.Unregister(ctx); err != nil {
+		return err
+	}
+	return p.unregisterErr
+}
+
+// installTeardownProbe puts a probe in front of the shard's compaction callback
+// controller, which the teardown unregisters while holding the shutdown lock.
+func installTeardownProbe(t *testing.T, shard *Shard, unregisterErr error) *teardownProbe {
+	t.Helper()
+
+	require.NotNil(t, shard.cycleCallbacks.compactionCallbacksCtrl)
+	probe := newTeardownProbe(shard.cycleCallbacks.compactionCallbacksCtrl, unregisterErr)
+	shard.cycleCallbacks.compactionCallbacksCtrl = probe
+	return probe
+}
+
+func deferredTeardownLogs(hook *logrustest.Hook) []*logrus.Entry {
+	var out []*logrus.Entry
+	for _, entry := range hook.AllEntries() {
+		if entry.Data["action"] == "shard_deferred_teardown" {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// TestShardDeferredTeardown covers the teardown that runs when the last shard
+// reference is released after Shutdown gave up: it must run off the releasing
+// goroutine, carry a deadline, and report a failure.
+func TestShardDeferredTeardown(t *testing.T) {
+	tests := []struct {
+		name          string
+		unregisterErr error
+		wantLogged    string
+	}{
+		{
+			name: "teardown succeeds",
+		},
+		{
+			name:          "teardown fails",
+			unregisterErr: errors.New("compaction callbacks stuck"),
+			wantLogged:    "compaction callbacks stuck",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			shardLike, idx := testShard(t, t.Context(), "DeferredTeardown")
+			shard := underlyingShard(t, shardLike)
+			logger, ok := idx.logger.(*logrus.Logger)
+			require.True(t, ok, "the test index must carry a concrete logger to hook")
+			hook := logrustest.NewLocal(logger)
+
+			probe := installTeardownProbe(t, shard, test.unregisterErr)
+
+			releaseFirst, err := shard.preventShutdown()
+			require.NoError(t, err)
+			releaseLast, err := shard.preventShutdown()
+			require.NoError(t, err)
+
+			// Shutdown gives up while the references are held, which leaves the
+			// teardown to whoever releases last.
+			require.ErrorContains(t, shard.Shutdown(t.Context()), "still in use")
+			require.True(t, shard.shutdownRequested.Load())
+
+			releaseFirst()
+			require.False(t, shard.shut.Load(), "teardown started while a reference was still held")
+
+			released := make(chan struct{})
+			enterrors.GoWrapper(func() {
+				releaseLast()
+				close(released)
+			}, idx.logger)
+
+			select {
+			case <-probe.entered:
+			case <-time.After(10 * time.Second):
+				t.Fatal("releasing the last reference did not start the teardown")
+			}
+			require.True(t, probe.sawDeadline.Load(), "the teardown ran without a deadline")
+
+			// The regression guard: the teardown is parked in the probe, so a
+			// release that returns proves it is not the goroutine running it.
+			select {
+			case <-released:
+			case <-time.After(10 * time.Second):
+				t.Fatal("release blocked until the teardown finished")
+			}
+
+			close(probe.unblock)
+
+			// Shutdown blocks on the shutdown lock until the teardown drops it, so
+			// it returning means the teardown ran to completion.
+			require.NoError(t, shard.Shutdown(context.Background()))
+			require.True(t, shard.shut.Load())
+
+			if test.wantLogged == "" {
+				require.Never(t, func() bool { return len(deferredTeardownLogs(hook)) > 0 },
+					time.Second, 20*time.Millisecond, "a successful teardown must not report an error")
+				return
+			}
+
+			require.Eventually(t, func() bool { return len(deferredTeardownLogs(hook)) > 0 },
+				10*time.Second, 10*time.Millisecond, "the teardown failure was not reported")
+			entry := deferredTeardownLogs(hook)[0]
+			require.Equal(t, logrus.ErrorLevel, entry.Level)
+			require.Equal(t, shard.name, entry.Data["shard"])
+			require.Contains(t, entry.Message, test.wantLogged)
+		})
+	}
+}
+
+// TestShardReleaseWithoutShutdownRequestKeepsShardAlive asserts that dropping
+// the last reference tears the shard down only when a shutdown was requested.
+func TestShardReleaseWithoutShutdownRequestKeepsShardAlive(t *testing.T) {
+	shardLike, _ := testShard(t, t.Context(), "NoShutdownRequested")
+	shard := underlyingShard(t, shardLike)
+
+	probe := installTeardownProbe(t, shard, nil)
+	close(probe.unblock) // a teardown here is a failure, so let it run rather than hang
+
+	release, err := shard.preventShutdown()
+	require.NoError(t, err)
+	release()
+
+	select {
+	case <-probe.entered:
+		t.Fatal("the last release tore down a shard that was not shutting down")
+	case <-time.After(time.Second):
+	}
+	require.False(t, shard.shut.Load())
+}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -209,7 +209,8 @@ func (s *Shard) refCountAdd() {
 }
 
 // shardTeardownTimeout bounds the teardown that runs when the last reference is
-// released. Deliberately generous: a backstop against a stuck cycle, not a budget.
+// released. Deliberately far above any normal teardown: it only exists to stop
+// a stuck cycle from running forever.
 const shardTeardownTimeout = 2 * time.Minute
 
 func (s *Shard) refCountSub() {

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
@@ -57,6 +58,11 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 // idempotent Shutdown methods. In other parts, it explicitly checks if a
 // component was initialized. If not, it turns it into a noop to prevent
 // blocking.
+//
+// The checks before s.shut is set can refuse and be retried; everything after
+// it is the teardown, which releases resources and cannot be undone. Since
+// s.shut is set first, a teardown that fails leaves the shard marked shut while
+// it still holds some of them.
 func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	s.shutdownLock.Lock()
 	defer s.shutdownLock.Unlock()
@@ -202,11 +208,27 @@ func (s *Shard) refCountAdd() {
 	s.inUseCounter.Add(1)
 }
 
+// shardTeardownTimeout bounds the teardown that runs when the last reference is
+// released. Deliberately generous: a backstop against a stuck cycle, not a budget.
+const shardTeardownTimeout = 2 * time.Minute
+
 func (s *Shard) refCountSub() {
 	s.inUseCounter.Add(-1)
 	// if the counter is 0, we can shutdown
 	if s.inUseCounter.Load() == 0 && s.shutdownRequested.Load() {
-		s.performShutdown(context.TODO())
+		// off the releasing goroutine: the last release can come from a request, a
+		// backup or a reindex task, none of which should block on a full store flush
+		enterrors.GoWrapper(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), shardTeardownTimeout)
+			defer cancel()
+
+			if err := s.performShutdown(ctx); err != nil {
+				s.index.logger.
+					WithField("action", "shard_deferred_teardown").
+					WithField("shard", s.name).
+					Error(err)
+			}
+		}, s.index.logger)
 	}
 }
 

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -120,9 +121,9 @@ func TestShardShutdownWhenIdleEventually(t *testing.T) {
 	// release shard 1x
 	release2()
 
-	// shutdown eventually completed, shard idle
-	requireShardShutdownRequested(t, shard, false)
-	requireShardShut(t, shard, true)
+	// shutdown eventually completed, shard idle. The last release hands the
+	// teardown to a background goroutine, so it does not complete inline.
+	requireShardShutEventually(t, shard)
 
 	// getting shard fails, shutdown completed
 	sameShardYetAgain, _, err := index.GetShard(context.Background(), shardName)
@@ -218,6 +219,13 @@ func requireShardShutdownRequested(t *testing.T, shard ShardLike, expected bool)
 	} else {
 		require.False(t, shard.(*LazyLoadShard).shard.shutdownRequested.Load(), "shard should not be marked for shut down")
 	}
+}
+
+func requireShardShutEventually(t *testing.T, shard ShardLike) {
+	inner := shard.(*LazyLoadShard).shard
+	require.Eventually(t, func() bool {
+		return inner.shut.Load() && !inner.shutdownRequested.Load()
+	}, 10*time.Second, 10*time.Millisecond, "shard should be shut down once the last reference is released")
 }
 
 func requireShardShut(t *testing.T, shard ShardLike, expected bool) {

--- a/entities/cyclemanager/cyclecallbackctrl.go
+++ b/entities/cyclemanager/cyclecallbackctrl.go
@@ -202,10 +202,11 @@ func (c *cycleCallbackCtrlNoop) Activate() error {
 	return nil
 }
 
+// There is no callback to wait for, so ctx never applies.
 func (c *cycleCallbackCtrlNoop) Deactivate(ctx context.Context) error {
-	return ctx.Err()
+	return nil
 }
 
 func (c *cycleCallbackCtrlNoop) Unregister(ctx context.Context) error {
-	return ctx.Err()
+	return nil
 }

--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -21,6 +21,41 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// startRunningCallbacks registers two callbacks and drives them with a cycle
+// manager, returning once both are executing and blocked. release lets them
+// finish and stops the manager.
+func startRunningCallbacks() (ctrl1, ctrl2 CycleCallbackCtrl, release func()) {
+	logger, _ := test.NewNullLogger()
+	started := make(chan struct{}, 2)
+	blocking := make(chan struct{})
+
+	// Both callbacks are rescheduled and run again once released, so the signal is
+	// dropped when nobody is reading it — a blocking send would deadlock release.
+	callback := func(shouldAbort ShouldAbortCallback) bool {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-blocking
+		return true
+	}
+
+	callbacks := NewCallbackGroup("id", logger, 2)
+	ctrl1 = callbacks.Register("c1", callback)
+	ctrl2 = callbacks.Register("c2", callback)
+
+	cycle := NewManager("test", NewFixedTicker(10*time.Millisecond), callbacks.CycleCallback, logger)
+	cycle.Start()
+
+	<-started
+	<-started
+
+	return ctrl1, ctrl2, func() {
+		close(blocking)
+		cycle.StopAndWait(context.Background())
+	}
+}
+
 func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
@@ -52,36 +87,35 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		assert.False(t, ctrl2.IsActive())
 	})
 
-	t.Run("does not unregister on expired context", func(t *testing.T) {
+	t.Run("does not unregister running callbacks on expired context", func(t *testing.T) {
+		ctrl1, ctrl2, release := startRunningCallbacks()
+		defer release()
+
 		expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
 		defer cancel()
 
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(100 * time.Millisecond)
-			return true
-		}
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(100 * time.Millisecond)
-			return true
-		}
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
 
-		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
-		cycle.Start()
-		defer cycle.StopAndWait(ctx)
-
 		err := combinedCtrl.Unregister(expiredCtx)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unregistering callback 'c1' of 'id' failed: context deadline exceeded")
 		assert.Contains(t, err.Error(), "unregistering callback 'c2' of 'id' failed: context deadline exceeded")
 
 		assert.True(t, combinedCtrl.IsActive())
 		assert.True(t, ctrl1.IsActive())
 		assert.True(t, ctrl2.IsActive())
+	})
+
+	t.Run("unregisters idle callbacks on expired context", func(t *testing.T) {
+		expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
+		defer cancel()
+
+		callbacks := NewCallbackGroup("id", logger, 2)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool { return true })
+		ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool { return true })
+		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
+
+		require.NoError(t, combinedCtrl.Unregister(expiredCtx))
 	})
 
 	t.Run("fails unregistering one", func(t *testing.T) {
@@ -150,36 +184,37 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		assert.False(t, ctrl2.IsActive())
 	})
 
-	t.Run("does not deactivate on expired context", func(t *testing.T) {
+	t.Run("does not deactivate running callbacks on expired context", func(t *testing.T) {
+		ctrl1, ctrl2, release := startRunningCallbacks()
+		defer release()
+
 		expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
 		defer cancel()
 
-		callback1 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(100 * time.Millisecond)
-			return true
-		}
-		callback2 := func(shouldAbort ShouldAbortCallback) bool {
-			time.Sleep(100 * time.Millisecond)
-			return true
-		}
-
-		callbacks := NewCallbackGroup("id", logger, 2)
-		ctrl1 := callbacks.Register("c1", callback1)
-		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
 
-		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
-		cycle.Start()
-		defer cycle.StopAndWait(ctx)
-
 		err := combinedCtrl.Deactivate(expiredCtx)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "deactivating callback 'c1' of 'id' failed: context deadline exceeded")
-		assert.Contains(t, err.Error(), "deactivating callback 'c1' of 'id' failed: context deadline exceeded")
+		assert.Contains(t, err.Error(), "deactivating callback 'c2' of 'id' failed: context deadline exceeded")
 
 		assert.True(t, combinedCtrl.IsActive())
 		assert.True(t, ctrl1.IsActive())
 		assert.True(t, ctrl2.IsActive())
+	})
+
+	t.Run("deactivates idle callbacks on expired context", func(t *testing.T) {
+		expiredCtx, cancel := context.WithDeadline(ctx, time.Now())
+		defer cancel()
+
+		callbacks := NewCallbackGroup("id", logger, 2)
+		ctrl1 := callbacks.Register("c1", func(shouldAbort ShouldAbortCallback) bool { return true })
+		ctrl2 := callbacks.Register("c2", func(shouldAbort ShouldAbortCallback) bool { return true })
+		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
+
+		require.NoError(t, combinedCtrl.Deactivate(expiredCtx))
+		assert.False(t, ctrl1.IsActive())
+		assert.False(t, ctrl2.IsActive())
 	})
 
 	t.Run("fails deactivating one, activates other again", func(t *testing.T) {
@@ -251,4 +286,29 @@ func TestCycleCombineCallbackCtrl_Activate(t *testing.T) {
 		assert.True(t, ctrl1.IsActive())
 		assert.True(t, ctrl2.IsActive())
 	})
+}
+
+// TestCycleCallbackCtrlNoop_IgnoresContext pins that the noop controller has no
+// callback to wait for, so a cancelled context must not make it report a failure
+// to callers that compound its error.
+func TestCycleCallbackCtrlNoop_IgnoresContext(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{name: "live context", ctx: context.Background()},
+		{name: "cancelled context", ctx: cancelledCtx},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := NewCallbackCtrlNoop()
+
+			require.NoError(t, ctrl.Deactivate(tt.ctx))
+			require.NoError(t, ctrl.Unregister(tt.ctx))
+		})
+	}
 }

--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -456,17 +456,14 @@ func (g *cycleCallbackGroup) tryCommitIdle(callbackId uint32, commit func(*cycle
 // unregister. One run's done channel is not enough: endRun reschedules a
 // still-active callback, so a fresh tick can start another run while we wait. It
 // retries tryCommitIdle after each finished run; commit is applied only once
-// tryCommitIdle observes the callback not running. A ctx deadline hit while
+// tryCommitIdle observes the callback not running. ctx bounds only the wait: a
+// callback that is not running commits even once ctx is done. A deadline hit while
 // waiting returns ctx.Err(), but an already-finished run takes priority so a
 // completed operation is never reported as a timeout. Every result passes through
 // wrap (which maps nil to nil).
 func (g *cycleCallbackGroup) commitIdle(ctx context.Context, callbackId uint32,
 	commit func(*cycleCallbackMeta), notFound error, wrap func(error) error,
 ) error {
-	if ctx.Err() != nil {
-		return wrap(ctx.Err())
-	}
-
 	for {
 		done, needWait, err := g.tryCommitIdle(callbackId, commit, notFound)
 		if !needWait {

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -1561,11 +1561,17 @@ func TestCycleCallback_DeactivatePriorityClaimedButNotStarted(t *testing.T) {
 	assert.Equal(t, int64(0), atomic.LoadInt64(&bodyEntered))
 }
 
-// TestCycleCallback_ControlErrorBranches covers the early-return error paths of
-// the control operations: acting on an absent callback id, and acting with an
-// already-cancelled context.
+// TestCycleCallback_ControlErrorBranches covers the early-return paths of the
+// control operations: acting on an absent callback id, and acting with an
+// already-cancelled context on a callback that is not running.
 func TestCycleCallback_ControlErrorBranches(t *testing.T) {
 	logger, _ := test.NewNullLogger()
+
+	cancelled := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
 
 	t.Run("absent id", func(t *testing.T) {
 		g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
@@ -1579,20 +1585,59 @@ func TestCycleCallback_ControlErrorBranches(t *testing.T) {
 		}
 
 		assert.ErrorIs(t, ghost.Activate(), ErrorCallbackNotFound)
-		assert.ErrorIs(t, ghost.Deactivate(context.Background()), ErrorCallbackNotFound)
-		// Unregister of an absent id is a no-op success, not an error.
-		assert.NoError(t, ghost.Unregister(context.Background()))
+
+		tests := []struct {
+			name string
+			ctx  context.Context
+		}{
+			{name: "live context", ctx: context.Background()},
+			{name: "cancelled context", ctx: cancelled()},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// A cancelled context must not mask the not-found result.
+				assert.ErrorIs(t, ghost.Deactivate(tt.ctx), ErrorCallbackNotFound)
+				// Unregister of an absent id is a no-op success, not an error.
+				assert.NoError(t, ghost.Unregister(tt.ctx))
+			})
+		}
 	})
 
-	t.Run("pre-cancelled context", func(t *testing.T) {
-		g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
-		ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
+	// A callback that is not running commits without waiting, so a cancelled
+	// context must not turn it into a failure that leaves the callback behind.
+	t.Run("cancelled context, callback not running", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			op     func(ctrl CycleCallbackCtrl, ctx context.Context) error
+			verify func(t *testing.T, g *cycleCallbackGroup, ctrl CycleCallbackCtrl)
+		}{
+			{
+				name: "deactivate",
+				op:   func(ctrl CycleCallbackCtrl, ctx context.Context) error { return ctrl.Deactivate(ctx) },
+				verify: func(t *testing.T, _ *cycleCallbackGroup, ctrl CycleCallbackCtrl) {
+					assert.False(t, ctrl.IsActive(), "deactivate must have committed active=false")
+				},
+			},
+			{
+				name: "unregister",
+				op:   func(ctrl CycleCallbackCtrl, ctx context.Context) error { return ctrl.Unregister(ctx) },
+				verify: func(t *testing.T, g *cycleCallbackGroup, _ CycleCallbackCtrl) {
+					g.Lock()
+					defer g.Unlock()
+					assert.Empty(t, g.metas, "unregister must have removed the callback")
+				},
+			},
+		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewCallbackGroup("id", logger, 1).(*cycleCallbackGroup)
+				ctrl := g.Register("c", func(shouldAbort ShouldAbortCallback) bool { return true })
 
-		assert.ErrorIs(t, ctrl.Deactivate(ctx), context.Canceled)
-		assert.ErrorIs(t, ctrl.Unregister(ctx), context.Canceled)
+				require.NoError(t, tt.op(ctrl, cancelled()))
+				tt.verify(t, g, ctrl)
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
### What's being changed:

`Shard.Shutdown` gives up after ~2s if the shard is still referenced, but doesn't abandon the shutdown: `shutdownRequested` stays set and whoever releases the **last** reference runs the teardown, from `refCountSub`. That path had three problems:

- **Ran inline on the releasing goroutine** — a request, a backup, or a reindex task paid for the full teardown (queue closes, vector index shutdown, `store.Shutdown`) while holding `shutdownLock.Lock()`, stalling every `preventShutdown` behind it.
- **Used `context.TODO()`** — no deadline, so a stuck cycle wedges that goroutine and the lock indefinitely.
- **Discarded the error** — `errcheck` is disabled here, so a half-torn-down shard produced no log output.

## Approach

Run the teardown on an `enterrors.GoWrapper` goroutine under a 2-minute `context.Background()` timeout, and log failures under `action=shard_deferred_teardown`.

- `context.Background()`, not `index.closingCtx` — that's cancelled at index shutdown, exactly when the teardown must finish.
- No spawn-once guard needed: `preventShutdown` rejects new references once `shutdownRequested` is set, so the counter crosses zero once.
- Fire-and-forget is safe: a later `Shutdown` blocks on `shutdownLock`, then returns nil via the `s.shut` check.

`performShutdown`'s godoc now records the asymmetry it always had: checks before `s.shut.Store(true)` can refuse and be retried; everything after cannot be undone.

## Deliberately not fixed

**`shutdownRequested` is not cleared on failure.** Every unload caller does `LoadAndDelete` *before* `Shutdown`. Clearing it would mean the teardown never fires, leaving the shard out of the map but fully alive — store open, cycle callbacks registered, `GlobalBucketRegistry` entry held — so reactivating that tenant would fail permanently instead of recovering once it drains.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
