### PR TITLE
Fix bugs in index shutdown

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3201,26 +3201,26 @@ func (i *Index) Shutdown(ctx context.Context) error {
 
 	i.closingCancel()
 
-	// TODO allow every resource cleanup to run, before returning early with error
-	if err := i.shards.RangeConcurrently(i.logger, func(name string, shard ShardLike) error {
+	ec := errorcompounder.NewSafe()
+
+	ec.Add(i.shards.RangeConcurrently(i.logger, func(name string, shard ShardLike) error {
 		i.backupLock.RLock(name)
 		defer i.backupLock.RUnlock(name)
 
 		if err := shard.Shutdown(ctx); err != nil {
 			if !errors.Is(err, errAlreadyShutdown) {
-				return errors.Wrapf(err, "shutdown shard %q", name)
+				ec.AddWrapf(err, "shutdown shard %q", name)
+				return nil
 			}
 			i.logger.WithField("shard", shard.Name()).Debug("was already shut or dropped")
 		}
 		return nil
-	}); err != nil {
-		return err
-	}
-	if err := i.stopCycleManagers(ctx, "shutdown"); err != nil {
-		return err
-	}
+	}))
 
-	return nil
+	// the cycle managers must stop even when a shard failed to shut down
+	ec.Add(i.stopCycleManagers(ctx, "shutdown"))
+
+	return ec.ToError()
 }
 
 func (i *Index) stopCycleManagers(ctx context.Context, usecase string) error {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3296,10 +3296,11 @@ func waitForCycleStop(ctx context.Context, stopResult chan bool) error {
 	var stopped bool
 	select {
 	case stopped = <-stopResult:
-	default:
+	case <-ctx.Done():
+		// select picks randomly when both are ready, so the result is checked again
 		select {
 		case stopped = <-stopResult:
-		case <-ctx.Done():
+		default:
 			return ctx.Err()
 		}
 	}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3153,7 +3153,9 @@ func (i *Index) dropShards(names []string) error {
 		})
 	}
 
-	eg.Wait()
+	// the error group only carries a recovered worker panic, which would
+	// otherwise leave the shard un-dropped without failing the call
+	ec.Add(eg.Wait())
 	return ec.ToError()
 }
 
@@ -3185,7 +3187,9 @@ func (i *Index) dropCloudShards(ctx context.Context, cloud modulecapabilities.Of
 		})
 	}
 
-	eg.Wait()
+	// the error group only carries a recovered worker panic, which would
+	// otherwise leave the shard un-dropped without failing the call
+	ec.Add(eg.Wait())
 	return ec.ToError()
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3139,7 +3139,7 @@ func (i *Index) dropShards(names []string) error {
 				// This ensures that we also delete inactive shards/tenants
 				if err := os.RemoveAll(shardPath(i.path(), name)); err != nil {
 					ec.Add(err)
-					i.logger.WithField("action", "drop_shard").WithField("shard", shard.ID()).Error(err)
+					i.logger.WithField("action", "drop_shard").WithField("shard", name).Error(err)
 				}
 			} else {
 				// If shard is loaded use the native primitive to drop it

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -50,6 +50,7 @@ import (
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/autocut"
 	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -3227,27 +3228,59 @@ func (i *Index) Shutdown(ctx context.Context) error {
 	return ec.ToError()
 }
 
+// stopCycleManagers asks every cycle to stop before waiting for any of them, so
+// one slow cycle cannot use up ctx before the others were asked. The index is
+// being closed or deleted, so the cycles are stopped even when ctx already
+// expired; ctx only bounds how long we wait. Joining keeps each failure matchable.
 func (i *Index) stopCycleManagers(ctx context.Context, usecase string) error {
-	if err := i.cycleCallbacks.compactionCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop objects compaction cycle: %w", usecase, err)
+	// which data each compaction cycle covers depends on SeparateObjectsCompactions
+	compaction, compactionAux := "compaction", "auxiliary compaction"
+	if i.Config.SeparateObjectsCompactions {
+		compaction, compactionAux = "non objects compaction", "objects compaction"
 	}
-	if err := i.cycleCallbacks.compactionAuxCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop non objects compaction cycle: %w", usecase, err)
+
+	cycles := []struct {
+		name  string
+		cycle cyclemanager.CycleManager
+	}{
+		{compaction, i.cycleCallbacks.compactionCycle},
+		{compactionAux, i.cycleCallbacks.compactionAuxCycle},
+		{"flush", i.cycleCallbacks.flushCycle},
+		{"vector commit logger", i.cycleCallbacks.vectorCommitLoggerCycle},
+		{"vector tombstone cleanup", i.cycleCallbacks.vectorTombstoneCleanupCycle},
+		{"geo props commit logger", i.cycleCallbacks.geoPropsCommitLoggerCycle},
+		{"geo props tombstone cleanup", i.cycleCallbacks.geoPropsTombstoneCleanupCycle},
 	}
-	if err := i.cycleCallbacks.flushCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop flush cycle: %w", usecase, err)
+
+	stopResults := make([]chan bool, len(cycles))
+	for j, c := range cycles {
+		stopResults[j] = c.cycle.Stop(context.Background())
 	}
-	if err := i.cycleCallbacks.vectorCommitLoggerCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop vector commit logger cycle: %w", usecase, err)
+
+	var errs []error
+	for j, c := range cycles {
+		if err := waitForCycleStop(ctx, stopResults[j]); err != nil {
+			errs = append(errs, fmt.Errorf("%s: stop %s cycle: %w", usecase, c.name, err))
+		}
 	}
-	if err := i.cycleCallbacks.vectorTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop vector tombstone cleanup cycle: %w", usecase, err)
+	return stderrors.Join(errs...)
+}
+
+// waitForCycleStop waits for a stop result, preferring it over an expired ctx when
+// both are ready, so a cycle that did stop is not reported as a failure.
+func waitForCycleStop(ctx context.Context, stopResult chan bool) error {
+	var stopped bool
+	select {
+	case stopped = <-stopResult:
+	default:
+		select {
+		case stopped = <-stopResult:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
-	if err := i.cycleCallbacks.geoPropsCommitLoggerCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop geo props commit logger cycle: %w", usecase, err)
-	}
-	if err := i.cycleCallbacks.geoPropsTombstoneCleanupCycle.StopAndWait(ctx); err != nil {
-		return fmt.Errorf("%s: stop geo props tombstone cleanup cycle: %w", usecase, err)
+	if !stopped {
+		return stderrors.New("cycle kept running")
 	}
 	return nil
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3063,9 +3063,9 @@ func (i *Index) drop() error {
 	lastBackup := i.lastBackup.Load()
 	keepFiles := lastBackup != nil
 
+	ec := errorcompounder.NewSafe()
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU * 2)
-	fields := logrus.Fields{"action": "drop_shard", "class": i.Config.ClassName}
 	dropShard := func(shardName string, _ ShardLike) error {
 		eg.Go(func() error {
 			i.backupLock.RLock(shardName)
@@ -3079,7 +3079,9 @@ func (i *Index) drop() error {
 				return nil // shard already does not exist
 			}
 			if err := shard.drop(keepFiles); err != nil {
-				logrus.WithFields(fields).WithField("id", shard.ID()).Error(err)
+				ec.Add(err)
+				i.logger.WithField("action", "drop_shard").
+					WithField("shard", shard.ID()).Error(err)
 			}
 
 			return nil
@@ -3088,34 +3090,52 @@ func (i *Index) drop() error {
 	}
 
 	i.shards.Range(dropShard)
-	if err := eg.Wait(); err != nil {
-		return err
-	}
+
+	// the error group only carries a recovered worker panic, which would
+	// otherwise leave the shard un-dropped without failing the call
+	ec.Add(eg.Wait())
 
 	// 1s target contract per weaviate/0-weaviate-issues#250; ctx errors
 	// are best-effort (flush doesn't honor ctx yet — separable follow-up).
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	if err := i.stopCycleManagers(ctx, "drop"); err != nil &&
-		!stderrors.Is(err, context.Canceled) && !stderrors.Is(err, context.DeadlineExceeded) {
-		return err
+	// the index is torn down regardless, so the cycles must stop and the
+	// directory must be renamed even when a shard or a cycle failed; a cycle that
+	// ran out of time must not hide one that failed for another reason
+	for _, cause := range causesOf(i.stopCycleManagers(ctx, "drop")) {
+		if !stderrors.Is(cause, context.Canceled) && !stderrors.Is(cause, context.DeadlineExceeded) {
+			ec.Add(cause)
+		}
 	}
 
 	if keepFiles {
 		// backup framework expects the DeleteMarkerAdd-prefixed rename
-		return os.Rename(i.path(), filepath.Join(i.Config.RootPath, backup.DeleteMarkerAdd(i.ID())))
+		if err := os.Rename(i.path(), filepath.Join(i.Config.RootPath, backup.DeleteMarkerAdd(i.ID()))); err != nil {
+			ec.Add(fmt.Errorf("rename index for delete marker: %w", err))
+		}
+	} else {
+		// rename sync (must complete even if ctx is expired); RemoveAll async
+		deleted, err := renameForAsyncDelete(i.path(), i.logger)
+		if err != nil {
+			ec.Add(fmt.Errorf("rename index for async delete: %w", err))
+		} else if deleted != "" {
+			spawnAsyncDelete(deleted, i.logger)
+		}
 	}
+	return ec.ToErrorLimited(maxReportedErrors)
+}
 
-	// rename sync (must complete even if ctx is expired); RemoveAll async
-	deleted, err := renameForAsyncDelete(i.path(), i.logger)
-	if err != nil {
-		return fmt.Errorf("rename index for async delete: %w", err)
+// causesOf splits a joined error into the errors it was built from, so a caller
+// can judge each one on its own. A nil error has no causes.
+func causesOf(err error) []error {
+	if err == nil {
+		return nil
 	}
-	if deleted != "" {
-		spawnAsyncDelete(deleted, i.logger)
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		return joined.Unwrap()
 	}
-	return nil
+	return []error{err}
 }
 
 func (i *Index) dropShards(names []string) error {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3121,7 +3121,7 @@ func (i *Index) dropShards(names []string) error {
 		return errAlreadyShutdown
 	}
 
-	ec := errorcompounder.New()
+	ec := errorcompounder.NewSafe()
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU * 2)
 
@@ -3165,7 +3165,7 @@ func (i *Index) dropCloudShards(ctx context.Context, cloud modulecapabilities.Of
 		return errAlreadyShutdown
 	}
 
-	ec := errorcompounder.New()
+	ec := errorcompounder.NewSafe()
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU * 2)
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -94,6 +94,10 @@ import (
 // NumCPU anyway, so we're not any worse off.
 var _NUMCPU = runtime.GOMAXPROCS(0)
 
+// maxReportedErrors bounds how many failures a shard-wide or index-wide operation
+// reports, so a node with many tenants cannot produce a multi-megabyte message.
+const maxReportedErrors = 10
+
 // shardMap is a sync.Map which specialized in storing shards
 type shardMap sync.Map
 
@@ -3157,7 +3161,7 @@ func (i *Index) dropShards(names []string) error {
 	// the error group only carries a recovered worker panic, which would
 	// otherwise leave the shard un-dropped without failing the call
 	ec.Add(eg.Wait())
-	return ec.ToError()
+	return ec.ToErrorLimited(maxReportedErrors)
 }
 
 func (i *Index) dropCloudShards(ctx context.Context, cloud modulecapabilities.OffloadCloud, names []string, nodeId string) error {
@@ -3191,7 +3195,7 @@ func (i *Index) dropCloudShards(ctx context.Context, cloud modulecapabilities.Of
 	// the error group only carries a recovered worker panic, which would
 	// otherwise leave the shard un-dropped without failing the call
 	ec.Add(eg.Wait())
-	return ec.ToError()
+	return ec.ToErrorLimited(maxReportedErrors)
 }
 
 func (i *Index) Shutdown(ctx context.Context) error {
@@ -3225,7 +3229,7 @@ func (i *Index) Shutdown(ctx context.Context) error {
 	// the cycle managers must stop even when a shard failed to shut down
 	ec.Add(i.stopCycleManagers(ctx, "shutdown"))
 
-	return ec.ToError()
+	return ec.ToErrorLimited(maxReportedErrors)
 }
 
 // stopCycleManagers asks every cycle to stop before waiting for any of them, so

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -69,14 +69,7 @@ func TestIndexDropShards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, hook := test.NewNullLogger()
-			idx := &Index{
-				logger:           logger,
-				shards:           shardMap{},
-				backupLock:       esync.NewKeyRWLocker(),
-				shardCreateLocks: esync.NewKeyRWLocker(),
-				Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
-			}
+			idx, hook := newDropTestIndex(t)
 
 			shardDir := shardPath(idx.path(), shardName)
 			require.NoError(t, os.MkdirAll(shardDir, 0o755))
@@ -149,14 +142,7 @@ func TestIndexDropShardsCollectsConcurrentFailures(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := test.NewNullLogger()
-			idx := &Index{
-				logger:           logger,
-				shards:           shardMap{},
-				backupLock:       esync.NewKeyRWLocker(),
-				shardCreateLocks: esync.NewKeyRWLocker(),
-				Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
-			}
+			idx, _ := newDropTestIndex(t)
 
 			names := make([]string, shardCount)
 			for i := range names {
@@ -197,14 +183,7 @@ func TestIndexDropCloudShards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := test.NewNullLogger()
-			idx := &Index{
-				logger:           logger,
-				shards:           shardMap{},
-				backupLock:       esync.NewKeyRWLocker(),
-				shardCreateLocks: esync.NewKeyRWLocker(),
-				Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
-			}
+			idx, _ := newDropTestIndex(t)
 
 			cloud := fakeOffloadCloud{deleteErrs: tt.deleteErrs}
 			err := idx.dropCloudShards(context.Background(), cloud, tt.names, "node1")
@@ -220,6 +199,101 @@ func TestIndexDropCloudShards(t *testing.T) {
 	}
 }
 
+// TestIndexDropShardsReportsWorkerPanic pins that a panicking drop worker makes
+// the call fail. The error group only logs the recovered panic, so a caller that
+// trusts the return value would otherwise treat the shard as dropped.
+func TestIndexDropShardsReportsWorkerPanic(t *testing.T) {
+	const (
+		shardName    = "shard1"
+		failingShard = "shard2"
+	)
+
+	panickingShard := func(t *testing.T) *MockShardLike {
+		shard := NewMockShardLike(t)
+		shard.EXPECT().drop(false).Run(func(bool) { panic("drop panicked") }).Return(nil).Once()
+		return shard
+	}
+	failingShardMock := func(t *testing.T) *MockShardLike {
+		shard := NewMockShardLike(t)
+		shard.EXPECT().ID().Return(failingShard).Maybe()
+		shard.EXPECT().drop(false).Return(errors.New("shard drop failed")).Once()
+		return shard
+	}
+
+	tests := []struct {
+		name            string
+		drop            func(t *testing.T, idx *Index) error
+		wantErrContains []string
+	}{
+		{
+			name: "dropShards",
+			drop: func(t *testing.T, idx *Index) error {
+				idx.shards.Store(shardName, panickingShard(t))
+				return idx.dropShards([]string{shardName})
+			},
+			wantErrContains: []string{"drop panicked"},
+		},
+		{
+			name: "dropCloudShards",
+			drop: func(t *testing.T, idx *Index) error {
+				cloud := fakeOffloadCloud{panicShard: shardName}
+				return idx.dropCloudShards(context.Background(), cloud, []string{shardName}, "node1")
+			},
+			wantErrContains: []string{"drop panicked"},
+		},
+		{
+			name: "dropShards reports the panic alongside a shard failure",
+			drop: func(t *testing.T, idx *Index) error {
+				idx.shards.Store(shardName, panickingShard(t))
+				idx.shards.Store(failingShard, failingShardMock(t))
+				return idx.dropShards([]string{shardName, failingShard})
+			},
+			wantErrContains: []string{"drop panicked", "shard drop failed"},
+		},
+		{
+			name: "dropCloudShards reports the panic alongside a delete failure",
+			drop: func(t *testing.T, idx *Index) error {
+				cloud := fakeOffloadCloud{
+					panicShard: shardName,
+					deleteErrs: map[string]error{failingShard: errors.New("cloud delete failed")},
+				}
+				return idx.dropCloudShards(context.Background(), cloud, []string{shardName, failingShard}, "node1")
+			},
+			wantErrContains: []string{"drop panicked", "cloud delete failed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// the integration suite exports this, which would let the panic kill the test
+			t.Setenv("DISABLE_RECOVERY_ON_PANIC", "false")
+
+			idx, _ := newDropTestIndex(t)
+			err := tt.drop(t, idx)
+
+			require.Error(t, err)
+			for _, want := range tt.wantErrContains {
+				require.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}
+
+// newDropTestIndex returns an index with an empty shard map under a temp root,
+// plus the hook capturing its log output.
+func newDropTestIndex(t *testing.T) (*Index, *test.Hook) {
+	t.Helper()
+	logger, hook := test.NewNullLogger()
+	return &Index{
+		logger:           logger,
+		shards:           shardMap{},
+		closingCtx:       context.Background(),
+		backupLock:       esync.NewKeyRWLocker(),
+		shardCreateLocks: esync.NewKeyRWLocker(),
+		Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
+	}, hook
+}
+
 // blockRemovalIn makes dir read-only so os.RemoveAll fails for its contents.
 func blockRemovalIn(t *testing.T, dir string) {
 	t.Helper()
@@ -230,10 +304,11 @@ func blockRemovalIn(t *testing.T, dir string) {
 	t.Cleanup(func() { os.Chmod(dir, 0o755) })
 }
 
-// fakeOffloadCloud fails Delete for the shards named in deleteErrs and succeeds
-// for the rest.
+// fakeOffloadCloud fails Delete for the shards named in deleteErrs, panics for
+// panicShard, and succeeds for the rest.
 type fakeOffloadCloud struct {
 	deleteErrs map[string]error
+	panicShard string
 }
 
 func (c fakeOffloadCloud) VerifyBucket(ctx context.Context) error { return nil }
@@ -247,6 +322,9 @@ func (c fakeOffloadCloud) Download(ctx context.Context, className, shardName, no
 }
 
 func (c fakeOffloadCloud) Delete(ctx context.Context, className, shardName, nodeName string) error {
+	if shardName == c.panicShard {
+		panic("drop panicked")
+	}
 	return c.deleteErrs[shardName]
 }
 

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -109,7 +109,8 @@ func TestIndexDropShards(t *testing.T) {
 }
 
 // TestIndexDropShardsCollectsConcurrentFailures pins that no shard error is lost
-// when many shards are dropped in parallel. Run with -race.
+// when many shards are dropped in parallel, and that the returned message stays
+// bounded. Run with -race.
 func TestIndexDropShardsCollectsConcurrentFailures(t *testing.T) {
 	const shardCount = 32
 
@@ -153,7 +154,9 @@ func TestIndexDropShardsCollectsConcurrentFailures(t *testing.T) {
 			err := tt.drop(t, idx, names)
 
 			require.Error(t, err)
-			require.Equal(t, shardCount, strings.Count(err.Error(), tt.wantErrPerShard))
+			reported := strings.Count(err.Error(), tt.wantErrPerShard)
+			require.Equal(t, maxReportedErrors, reported)
+			require.Contains(t, err.Error(), fmt.Sprintf("(and %d more)", shardCount-reported))
 		})
 	}
 }

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -12,8 +12,11 @@
 package db
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -66,10 +69,6 @@ func TestIndexDropShards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.blockRemoval && os.Geteuid() == 0 {
-				t.Skip("root ignores directory permissions, so os.RemoveAll cannot be made to fail")
-			}
-
 			logger, hook := test.NewNullLogger()
 			idx := &Index{
 				logger:           logger,
@@ -90,8 +89,7 @@ func TestIndexDropShards(t *testing.T) {
 			}
 
 			if tt.blockRemoval {
-				require.NoError(t, os.Chmod(idx.path(), 0o555))
-				t.Cleanup(func() { os.Chmod(idx.path(), 0o755) })
+				blockRemovalIn(t, idx.path())
 			}
 
 			err := idx.dropShards([]string{shardName})
@@ -115,6 +113,141 @@ func TestIndexDropShards(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIndexDropShardsCollectsConcurrentFailures pins that no shard error is lost
+// when many shards are dropped in parallel. Run with -race.
+func TestIndexDropShardsCollectsConcurrentFailures(t *testing.T) {
+	const shardCount = 32
+
+	tests := []struct {
+		name string
+		drop func(t *testing.T, idx *Index, names []string) error
+		// appears once per failed shard in the returned error
+		wantErrPerShard string
+	}{
+		{
+			name: "dropShards",
+			drop: func(t *testing.T, idx *Index, names []string) error {
+				blockRemovalIn(t, idx.path())
+				return idx.dropShards(names)
+			},
+			wantErrPerShard: "permission denied",
+		},
+		{
+			name: "dropCloudShards",
+			drop: func(t *testing.T, idx *Index, names []string) error {
+				cloud := fakeOffloadCloud{deleteErrs: map[string]error{}}
+				for _, name := range names {
+					cloud.deleteErrs[name] = errors.New("cloud delete failed")
+				}
+				return idx.dropCloudShards(context.Background(), cloud, names, "node1")
+			},
+			wantErrPerShard: "cloud delete failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			idx := &Index{
+				logger:           logger,
+				shards:           shardMap{},
+				backupLock:       esync.NewKeyRWLocker(),
+				shardCreateLocks: esync.NewKeyRWLocker(),
+				Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
+			}
+
+			names := make([]string, shardCount)
+			for i := range names {
+				names[i] = fmt.Sprintf("shard%d", i)
+				require.NoError(t, os.MkdirAll(shardPath(idx.path(), names[i]), 0o755))
+			}
+
+			err := tt.drop(t, idx, names)
+
+			require.Error(t, err)
+			require.Equal(t, shardCount, strings.Count(err.Error(), tt.wantErrPerShard))
+		})
+	}
+}
+
+func TestIndexDropCloudShards(t *testing.T) {
+	tests := []struct {
+		name            string
+		names           []string
+		deleteErrs      map[string]error
+		wantErrContains string
+	}{
+		{
+			name:  "no shard to drop",
+			names: []string{},
+		},
+		{
+			name:  "every shard is deleted",
+			names: []string{"shard1", "shard2", "shard3"},
+		},
+		{
+			name:            "only the failing shard is reported",
+			names:           []string{"shard1", "shard2", "shard3"},
+			deleteErrs:      map[string]error{"shard2": errors.New("cloud delete failed")},
+			wantErrContains: "cloud delete failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			idx := &Index{
+				logger:           logger,
+				shards:           shardMap{},
+				backupLock:       esync.NewKeyRWLocker(),
+				shardCreateLocks: esync.NewKeyRWLocker(),
+				Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
+			}
+
+			cloud := fakeOffloadCloud{deleteErrs: tt.deleteErrs}
+			err := idx.dropCloudShards(context.Background(), cloud, tt.names, "node1")
+
+			if tt.wantErrContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErrContains)
+			require.Equal(t, len(tt.deleteErrs), strings.Count(err.Error(), tt.wantErrContains))
+		})
+	}
+}
+
+// blockRemovalIn makes dir read-only so os.RemoveAll fails for its contents.
+func blockRemovalIn(t *testing.T, dir string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions, so os.RemoveAll cannot be made to fail")
+	}
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+}
+
+// fakeOffloadCloud fails Delete for the shards named in deleteErrs and succeeds
+// for the rest.
+type fakeOffloadCloud struct {
+	deleteErrs map[string]error
+}
+
+func (c fakeOffloadCloud) VerifyBucket(ctx context.Context) error { return nil }
+
+func (c fakeOffloadCloud) Upload(ctx context.Context, className, shardName, nodeName string) error {
+	return nil
+}
+
+func (c fakeOffloadCloud) Download(ctx context.Context, className, shardName, nodeName string) error {
+	return nil
+}
+
+func (c fakeOffloadCloud) Delete(ctx context.Context, className, shardName, nodeName string) error {
+	return c.deleteErrs[shardName]
 }
 
 func dropShardLogShard(t *testing.T, hook *test.Hook) any {

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -1,0 +1,129 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/schema"
+	esync "github.com/weaviate/weaviate/entities/sync"
+)
+
+func TestIndexDropShards(t *testing.T) {
+	const (
+		shardName = "shard1"
+		// what ShardLike.ID() reports for a loaded shard of class "Abc"
+		loadedShardID = "abc_" + shardName
+	)
+
+	tests := []struct {
+		name string
+		// loaded stores a mock shard under shardName, so drop() runs instead of
+		// removing the shard directory
+		loaded       bool
+		shardDropErr error
+		// blockRemoval makes the index directory read-only so os.RemoveAll fails
+		blockRemoval    bool
+		wantErrContains string
+		wantShardLog    string
+	}{
+		{
+			name: "unloaded shard is removed from disk",
+		},
+		{
+			name:            "unloaded shard removal failure is reported",
+			blockRemoval:    true,
+			wantErrContains: "permission denied",
+			wantShardLog:    shardName,
+		},
+		{
+			name:   "loaded shard is dropped",
+			loaded: true,
+		},
+		{
+			name:            "loaded shard drop failure is reported",
+			loaded:          true,
+			shardDropErr:    errors.New("drop failed"),
+			wantErrContains: "drop failed",
+			wantShardLog:    loadedShardID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.blockRemoval && os.Geteuid() == 0 {
+				t.Skip("root ignores directory permissions, so os.RemoveAll cannot be made to fail")
+			}
+
+			logger, hook := test.NewNullLogger()
+			idx := &Index{
+				logger:           logger,
+				shards:           shardMap{},
+				backupLock:       esync.NewKeyRWLocker(),
+				shardCreateLocks: esync.NewKeyRWLocker(),
+				Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
+			}
+
+			shardDir := shardPath(idx.path(), shardName)
+			require.NoError(t, os.MkdirAll(shardDir, 0o755))
+
+			if tt.loaded {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().ID().Return(loadedShardID).Maybe()
+				shard.EXPECT().drop(false).Return(tt.shardDropErr).Once()
+				idx.shards.Store(shardName, shard)
+			}
+
+			if tt.blockRemoval {
+				require.NoError(t, os.Chmod(idx.path(), 0o555))
+				t.Cleanup(func() { os.Chmod(idx.path(), 0o755) })
+			}
+
+			err := idx.dropShards([]string{shardName})
+
+			for _, entry := range hook.AllEntries() {
+				require.NotContains(t, entry.Message, "Recovered from panic")
+			}
+
+			if tt.wantErrContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrContains)
+				require.Equal(t, tt.wantShardLog, dropShardLogShard(t, hook))
+			}
+
+			require.Nil(t, idx.shards.Load(shardName))
+			if !tt.loaded {
+				_, err := os.Stat(shardDir)
+				require.Equal(t, tt.blockRemoval, err == nil)
+			}
+		})
+	}
+}
+
+func dropShardLogShard(t *testing.T, hook *test.Hook) any {
+	t.Helper()
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.ErrorLevel && entry.Data["action"] == "drop_shard" {
+			return entry.Data["shard"]
+		}
+	}
+	t.Fatalf("no drop_shard error log entry, got %d entries", len(hook.AllEntries()))
+	return nil
+}

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/schema"
 	esync "github.com/weaviate/weaviate/entities/sync"
 )
@@ -282,19 +284,207 @@ func TestIndexDropShardsReportsWorkerPanic(t *testing.T) {
 	}
 }
 
-// newDropTestIndex returns an index with an empty shard map under a temp root,
-// plus the hook capturing its log output.
+// TestIndexDropReportsFailures pins that dropping a whole index reports every
+// failure instead of only logging it, and still tears the index down: the cycle
+// managers stop and the index directory is renamed away even when a shard fails.
+func TestIndexDropReportsFailures(t *testing.T) {
+	const (
+		shardName   = "shard1"
+		secondShard = "shard2"
+		// what ShardLike.ID() reports for a loaded shard of class "Abc"
+		loadedShardID = "abc_" + shardName
+	)
+	errDrop := errors.New("drop failed")
+
+	tests := []struct {
+		name string
+		// noShards drops an index that has no shard left
+		noShards     bool
+		shardDropErr error
+		// secondShardFails adds a second shard whose drop fails
+		secondShardFails bool
+		// panicDrop makes the drop worker panic, which the error group only recovers
+		panicDrop bool
+		// refuseFlush makes the flush cycle report that it kept running
+		refuseFlush bool
+		// stallCompactions keeps both compaction cycles from reporting a stop, so
+		// they only fail once the drop timeout expires
+		stallCompactions bool
+		// keepFiles stands in for a backup in progress
+		keepFiles bool
+		// blockRename makes the root read-only so renaming the index fails
+		blockRename     bool
+		wantErrContains []string
+		wantShardLog    string
+	}{
+		{
+			name: "index is dropped",
+		},
+		{
+			name:     "index without shards is dropped",
+			noShards: true,
+		},
+		{
+			name:            "shard drop failure is reported",
+			shardDropErr:    errDrop,
+			wantErrContains: []string{"drop failed"},
+			wantShardLog:    loadedShardID,
+		},
+		{
+			name:            "worker panic is reported",
+			panicDrop:       true,
+			wantErrContains: []string{"drop panicked"},
+		},
+		{
+			name:             "panic and shard failure are both reported",
+			panicDrop:        true,
+			secondShardFails: true,
+			wantErrContains:  []string{"drop panicked", "second drop failed"},
+			wantShardLog:     "abc_" + secondShard,
+		},
+		{
+			name:            "cycle that refuses to stop is reported",
+			refuseFlush:     true,
+			wantErrContains: []string{"drop: stop flush cycle: cycle kept running"},
+		},
+		{
+			name:             "cycle that runs out of time is not a failure",
+			stallCompactions: true,
+		},
+		{
+			name:             "cycle failure is reported next to a cycle that ran out of time",
+			stallCompactions: true,
+			refuseFlush:      true,
+			wantErrContains:  []string{"drop: stop flush cycle: cycle kept running"},
+		},
+		{
+			name:            "shard and cycle failures are both reported",
+			shardDropErr:    errDrop,
+			refuseFlush:     true,
+			wantErrContains: []string{"drop failed", "drop: stop flush cycle"},
+			wantShardLog:    loadedShardID,
+		},
+		{
+			name:            "rename failure is reported alongside the shard failure",
+			shardDropErr:    errDrop,
+			blockRename:     true,
+			wantErrContains: []string{"drop failed", "rename index for async delete"},
+			wantShardLog:    loadedShardID,
+		},
+		{
+			name:      "backup in progress keeps the files",
+			keepFiles: true,
+		},
+		{
+			name:            "backup in progress still reports the shard failure",
+			keepFiles:       true,
+			shardDropErr:    errDrop,
+			wantErrContains: []string{"drop failed"},
+			wantShardLog:    loadedShardID,
+		},
+		{
+			name:            "delete marker rename failure is reported",
+			keepFiles:       true,
+			blockRename:     true,
+			wantErrContains: []string{"rename index for delete marker"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// the integration suite exports this, which would let the panic kill the test
+			t.Setenv("DISABLE_RECOVERY_ON_PANIC", "false")
+
+			idx, hook := newDropTestIndex(t)
+			require.NoError(t, os.MkdirAll(shardPath(idx.path(), shardName), 0o755))
+
+			if tt.keepFiles {
+				idx.lastBackup.Store(&BackupState{BackupID: "backup1", InProgress: true})
+			}
+
+			if !tt.noShards {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().ID().Return(loadedShardID).Maybe()
+				if tt.panicDrop {
+					shard.EXPECT().drop(tt.keepFiles).Run(func(bool) { panic("drop panicked") }).Return(nil).Once()
+				} else {
+					shard.EXPECT().drop(tt.keepFiles).Return(tt.shardDropErr).Once()
+				}
+				idx.shards.Store(shardName, shard)
+			}
+			if tt.secondShardFails {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().ID().Return("abc_" + secondShard).Maybe()
+				shard.EXPECT().drop(tt.keepFiles).Return(errors.New("second drop failed")).Once()
+				idx.shards.Store(secondShard, shard)
+			}
+
+			if tt.refuseFlush {
+				idx.cycleCallbacks.flushCycle = refusingCycle(idx.cycleCallbacks.flushCycle)
+			}
+			if tt.stallCompactions {
+				idx.cycleCallbacks.compactionCycle = stallingCycle(idx.cycleCallbacks.compactionCycle)
+				idx.cycleCallbacks.compactionAuxCycle = stallingCycle(idx.cycleCallbacks.compactionAuxCycle)
+			}
+			if tt.blockRename {
+				blockRemovalIn(t, idx.Config.RootPath)
+			}
+
+			err := idx.drop()
+
+			if len(tt.wantErrContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Contains(t, err.Error(), want)
+				}
+			}
+			if tt.wantShardLog != "" {
+				require.Equal(t, tt.wantShardLog, dropShardLogShard(t, hook))
+			}
+
+			require.Nil(t, idx.shards.Load(shardName))
+			require.Nil(t, idx.shards.Load(secondShard))
+			requireCyclesStopped(t, idx.cycleCallbacks)
+
+			_, pathErr := os.Stat(idx.path())
+			require.Equal(t, tt.blockRename, pathErr == nil)
+			_, markerErr := os.Stat(filepath.Join(idx.Config.RootPath, backup.DeleteMarkerAdd(idx.ID())))
+			require.Equal(t, tt.keepFiles && !tt.blockRename, markerErr == nil)
+		})
+	}
+}
+
+// newDropTestIndex returns an index with an empty shard map under a temp root
+// and all cycle managers running, plus the hook capturing its log output.
 func newDropTestIndex(t *testing.T) (*Index, *test.Hook) {
 	t.Helper()
 	logger, hook := test.NewNullLogger()
-	return &Index{
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	idx := &Index{
 		logger:           logger,
 		shards:           shardMap{},
-		closingCtx:       context.Background(),
+		closingCtx:       ctx,
+		closingCancel:    cancel,
+		cycleCallbacks:   newTestCycleCallbacks(logger),
 		backupLock:       esync.NewKeyRWLocker(),
 		shardCreateLocks: esync.NewKeyRWLocker(),
 		Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
-	}, hook
+	}
+	for _, cycle := range testCycles(idx.cycleCallbacks) {
+		cycle.Start()
+	}
+	t.Cleanup(func() {
+		// a cycle the index left running would otherwise outlive the test
+		for _, cycle := range testCycles(idx.cycleCallbacks) {
+			require.NoError(t, cycle.StopAndWait(context.Background()))
+		}
+	})
+	return idx, hook
 }
 
 // blockRemovalIn makes dir read-only so os.RemoveAll fails for its contents.

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -417,18 +417,21 @@ func (m *Migrator) updateIndexDeleteTenants(ctx context.Context,
 		return nil
 	}
 
-	if err := idx.dropShards(toRemove); err != nil {
-		return fmt.Errorf("drop tenant shards %v during update index: %w", toRemove, err)
-	}
+	// the cloud delete runs even when the local drop fails, otherwise the
+	// offloaded data is orphaned: the dropped shards are gone from the index,
+	// so a later update no longer lists them
+	ec := errorcompounder.New()
+	ec.Add(idx.dropShards(toRemove))
 
 	if m.cloud != nil {
 		// TODO-offload: currently we send all tenants and if it did find one in the cloud will delete
 		// better to filter the passed shards and get the frozen only
-		if err := idx.dropCloudShards(ctx, m.cloud, toRemove, m.nodeId); err != nil {
-			return fmt.Errorf("drop tenant shards %v during update index: %w", toRemove, err)
-		}
+		ec.Add(idx.dropCloudShards(ctx, m.cloud, toRemove, m.nodeId))
 	}
 
+	if err := ec.ToError(); err != nil {
+		return fmt.Errorf("drop tenant shards %v during update index: %w", toRemove, err)
+	}
 	return nil
 }
 
@@ -745,17 +748,17 @@ func (m *Migrator) DeleteTenants(ctx context.Context, class string, tenants []*m
 		}
 	}
 
-	if err := idx.dropShards(allTenantNames); err != nil {
-		return err
-	}
+	// the cloud delete runs even when the local drop fails, otherwise the
+	// offloaded data is orphaned: nothing retries once the schema entry is gone
+	ec := errorcompounder.New()
+	ec.Add(idx.dropShards(allTenantNames))
 
 	if m.cloud != nil && len(frozenTenants) > 0 {
-		if err := idx.dropCloudShards(ctx, m.cloud, frozenTenants, m.nodeId); err != nil {
-			return fmt.Errorf("drop tenant shards %v during update index: %w", frozenTenants, err)
-		}
+		ec.AddWrapf(idx.dropCloudShards(ctx, m.cloud, frozenTenants, m.nodeId),
+			"drop tenant shards %v during update index", frozenTenants)
 	}
 
-	return nil
+	return ec.ToError()
 }
 
 func (m *Migrator) UpdateVectorIndexConfig(ctx context.Context,

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -13,8 +13,10 @@ package db
 
 import (
 	"context"
+	"errors"
 	"hash/crc32"
 	"io"
+	"os"
 	"slices"
 	"testing"
 
@@ -29,6 +31,7 @@ import (
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/entities/loadlimiter"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -496,4 +499,207 @@ func TestListAndGetFilesWithIntegrityChecking(t *testing.T) {
 
 	err = index.IncomingResumeFileActivity(ctx, "shard1")
 	require.NoError(t, err)
+}
+
+func TestMigratorDeleteTenants(t *testing.T) {
+	const className = "Abc"
+
+	type tenant struct {
+		name   string
+		status string
+		// loaded stores a mock shard under name, so drop() runs instead of
+		// removing the shard directory
+		loaded   bool
+		dropErr  error
+		cloudErr error
+	}
+
+	tests := []struct {
+		name            string
+		tenants         []tenant
+		noCloud         bool
+		wantErrContains []string
+	}{
+		{
+			name: "no tenant to delete",
+		},
+		{
+			name: "loaded and unloaded tenants are dropped",
+			tenants: []tenant{
+				{name: "hot1", status: models.TenantActivityStatusHOT, loaded: true},
+				{name: "frozen1", status: models.TenantActivityStatusFROZEN},
+			},
+		},
+		{
+			name: "frozen tenant is deleted from the cloud even when another tenant's drop fails",
+			tenants: []tenant{
+				{
+					name:    "hot1",
+					status:  models.TenantActivityStatusHOT,
+					loaded:  true,
+					dropErr: errors.New("shard drop failed"),
+				},
+				{
+					name:     "frozen1",
+					status:   models.TenantActivityStatusFROZEN,
+					cloudErr: errors.New("cloud delete failed"),
+				},
+			},
+			wantErrContains: []string{"shard drop failed", "cloud delete failed"},
+		},
+		{
+			name: "cloud delete failure is reported",
+			tenants: []tenant{{
+				name:     "freezing1",
+				status:   models.TenantActivityStatusFREEZING,
+				cloudErr: errors.New("cloud delete failed"),
+			}},
+			wantErrContains: []string{"cloud delete failed"},
+		},
+		{
+			// the cloud error must not fire: only frozen tenants are offloaded
+			name: "hot tenant is not deleted from the cloud",
+			tenants: []tenant{{
+				name:     "hot1",
+				status:   models.TenantActivityStatusHOT,
+				cloudErr: errors.New("unexpected cloud delete"),
+			}},
+		},
+		{
+			name:    "drop failure is reported without a cloud backend",
+			noCloud: true,
+			tenants: []tenant{{
+				name:    "frozen1",
+				status:  models.TenantActivityStatusFROZEN,
+				loaded:  true,
+				dropErr: errors.New("shard drop failed"),
+			}},
+			wantErrContains: []string{"shard drop failed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, _ := newDropTestIndex(t)
+			cloud := fakeOffloadCloud{deleteErrs: map[string]error{}}
+			tenants := make([]*models.Tenant, 0, len(tt.tenants))
+
+			for _, tn := range tt.tenants {
+				tenants = append(tenants, &models.Tenant{Name: tn.name, ActivityStatus: tn.status})
+				require.NoError(t, os.MkdirAll(shardPath(idx.path(), tn.name), 0o755))
+
+				if tn.loaded {
+					storeDroppableShard(t, idx, tn.name, tn.dropErr)
+				}
+				if tn.cloudErr != nil {
+					cloud.deleteErrs[tn.name] = tn.cloudErr
+				}
+			}
+
+			var backend modulecapabilities.OffloadCloud
+			if !tt.noCloud {
+				backend = cloud
+			}
+
+			err := newDropTestMigrator(idx, className, backend).
+				DeleteTenants(context.Background(), className, tenants)
+
+			if len(tt.wantErrContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Contains(t, err.Error(), want)
+				}
+			}
+
+			for _, tn := range tt.tenants {
+				require.Nil(t, idx.shards.Load(tn.name))
+			}
+		})
+	}
+}
+
+func TestUpdateIndexDeleteTenants(t *testing.T) {
+	const (
+		className = "Abc"
+		keptShard = "kept"
+	)
+
+	tests := []struct {
+		name string
+		// loaded shards missing from the incoming state, and the error each
+		// one's drop returns
+		dropErrs        map[string]error
+		cloudErrs       map[string]error
+		wantErrContains []string
+	}{
+		{
+			name: "no shard to remove",
+		},
+		{
+			name:     "removed shard is dropped locally and in the cloud",
+			dropErrs: map[string]error{"shard1": nil},
+		},
+		{
+			name: "cloud shards are dropped even when a local drop fails",
+			dropErrs: map[string]error{
+				"shard1": errors.New("shard drop failed"),
+				"shard2": nil,
+			},
+			cloudErrs:       map[string]error{"shard2": errors.New("cloud delete failed")},
+			wantErrContains: []string{"shard drop failed", "cloud delete failed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, _ := newDropTestIndex(t)
+			idx.shards.Store(keptShard, NewMockShardLike(t))
+			for name, dropErr := range tt.dropErrs {
+				storeDroppableShard(t, idx, name, dropErr)
+			}
+
+			cloud := fakeOffloadCloud{deleteErrs: tt.cloudErrs}
+			m := newDropTestMigrator(idx, className, cloud)
+			incomingSS := &sharding.State{
+				Physical: map[string]sharding.Physical{keptShard: {Name: keptShard}},
+			}
+
+			err := m.updateIndexDeleteTenants(context.Background(), idx, incomingSS)
+
+			if len(tt.wantErrContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Contains(t, err.Error(), want)
+				}
+			}
+
+			require.NotNil(t, idx.shards.Load(keptShard))
+			for name := range tt.dropErrs {
+				require.Nil(t, idx.shards.Load(name))
+			}
+		})
+	}
+}
+
+// storeDroppableShard stores a mock shard under name whose drop returns dropErr.
+func storeDroppableShard(t *testing.T, idx *Index, name string, dropErr error) {
+	t.Helper()
+	shard := NewMockShardLike(t)
+	shard.EXPECT().ID().Return(name).Maybe()
+	shard.EXPECT().drop(false).Return(dropErr).Once()
+	idx.shards.Store(name, shard)
+}
+
+// newDropTestMigrator returns a migrator serving idx under className, offloading
+// to cloud unless it is nil.
+func newDropTestMigrator(idx *Index, className string, cloud modulecapabilities.OffloadCloud) *Migrator {
+	db := &DB{indices: map[string]*Index{indexID(schema.ClassName(className)): idx}}
+	m := NewMigrator(db, idx.logger, "node1")
+	m.nodeId = "node1"
+	m.cloud = cloud
+	return m
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -37,6 +37,7 @@ import (
 	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
@@ -607,11 +608,11 @@ func (db *DB) Shutdown(ctx context.Context) error {
 		}
 	}
 
+	// keep going on failure: a failing step must not skip the cleanup below
+	ec := errorcompounder.New()
+
 	// shut down the async workers
-	err := db.scheduler.Close(ctx)
-	if err != nil {
-		return errors.Wrap(err, "close scheduler")
-	}
+	ec.AddWrapf(db.scheduler.Close(ctx), "close scheduler")
 
 	if db.metricsObserver != nil {
 		db.metricsObserver.Shutdown()
@@ -621,8 +622,8 @@ func (db *DB) Shutdown(ctx context.Context) error {
 	defer db.indexLock.Unlock()
 	defer db.asyncReplicationScheduler.Close()
 	for id, index := range db.indices {
-		if err := index.Shutdown(ctx); err != nil {
-			return errors.Wrapf(err, "shutdown index %q", id)
+		if err := index.Shutdown(ctx); err != nil && !errors.Is(err, errAlreadyShutdown) {
+			ec.AddWrapf(err, "shutdown index %q", id)
 		}
 	}
 
@@ -632,7 +633,7 @@ func (db *DB) Shutdown(ctx context.Context) error {
 		db.indexCheckpoints.Close()
 	}
 
-	return nil
+	return ec.ToError()
 }
 
 type job struct {

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -633,7 +633,7 @@ func (db *DB) Shutdown(ctx context.Context) error {
 		db.indexCheckpoints.Close()
 	}
 
-	return ec.ToError()
+	return ec.ToErrorLimited(maxReportedErrors)
 }
 
 type job struct {

--- a/adapters/repos/db/shutdown_test.go
+++ b/adapters/repos/db/shutdown_test.go
@@ -106,6 +106,96 @@ func TestIndexStopCycleManagers(t *testing.T) {
 	}
 }
 
+func TestWaitForCycleStop(t *testing.T) {
+	expired := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+	stopResult := func(results ...bool) chan bool {
+		ch := make(chan bool, 1)
+		for _, result := range results {
+			ch <- result
+		}
+		return ch
+	}
+
+	tests := []struct {
+		name string
+		// newCase builds the context and stop result of a single run
+		newCase func() (context.Context, chan bool)
+		// runs repeats the case, as select picks randomly between ready channels
+		runs            int
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "a cycle that stopped",
+			newCase: func() (context.Context, chan bool) {
+				return context.Background(), stopResult(true)
+			},
+		},
+		{
+			name: "a cycle that kept running",
+			newCase: func() (context.Context, chan bool) {
+				return context.Background(), stopResult(false)
+			},
+			wantErrContains: "cycle kept running",
+		},
+		{
+			name: "a cycle that did not stop before ctx expired",
+			newCase: func() (context.Context, chan bool) {
+				return expired(), stopResult()
+			},
+			wantErrIs: context.Canceled,
+		},
+		{
+			name: "a stop landing together with the ctx expiry is not a failure",
+			newCase: func() (context.Context, chan bool) {
+				ch := stopResult()
+				return raceCtx{Context: expired(), stopResult: ch}, ch
+			},
+			runs: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for range max(tt.runs, 1) {
+				ctx, stopResult := tt.newCase()
+				err := waitForCycleStop(ctx, stopResult)
+
+				if tt.wantErrIs == nil && tt.wantErrContains == "" {
+					require.NoError(t, err)
+					continue
+				}
+				require.Error(t, err)
+				if tt.wantErrIs != nil {
+					require.ErrorIs(t, err, tt.wantErrIs)
+				}
+				if tt.wantErrContains != "" {
+					require.Contains(t, err.Error(), tt.wantErrContains)
+				}
+			}
+		})
+	}
+}
+
+// raceCtx reports a stop while Done is evaluated, so the stop and the expiry
+// reach the same select.
+type raceCtx struct {
+	context.Context
+	stopResult chan bool
+}
+
+func (c raceCtx) Done() <-chan struct{} {
+	select {
+	case c.stopResult <- true:
+	default:
+	}
+	return c.Context.Done()
+}
+
 // stubCycle takes over the stop result of the cycle it wraps. The wrapped cycle
 // is never asked to stop, so it keeps running until the test cleanup stops it.
 type stubCycle struct {

--- a/adapters/repos/db/shutdown_test.go
+++ b/adapters/repos/db/shutdown_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -25,6 +26,126 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	esync "github.com/weaviate/weaviate/entities/sync"
 )
+
+// TestIndexStopCycleManagers pins that every cycle manager stops even when another
+// one does not, and that Index.drop can still recognize a context error.
+func TestIndexStopCycleManagers(t *testing.T) {
+	tests := []struct {
+		name string
+		// stallCompactions keeps both compaction cycles from reporting a stop
+		stallCompactions bool
+		// refuseFlush makes the flush cycle report that it kept running
+		refuseFlush         bool
+		cancelCtx           bool
+		separateCompactions bool
+		wantErrContains     []string
+	}{
+		{name: "every cycle stops"},
+		{
+			name:            "a cycle that refuses to stop is reported",
+			refuseFlush:     true,
+			wantErrContains: []string{"drop: stop flush cycle: cycle kept running"},
+		},
+		{
+			name:             "a cycle that does not finish stopping is reported once ctx expires",
+			stallCompactions: true,
+			cancelCtx:        true,
+			wantErrContains: []string{
+				"drop: stop compaction cycle",
+				"drop: stop auxiliary compaction cycle",
+			},
+		},
+		{
+			name:                "separate compactions are named by the data they cover",
+			stallCompactions:    true,
+			cancelCtx:           true,
+			separateCompactions: true,
+			wantErrContains: []string{
+				"drop: stop non objects compaction cycle",
+				"drop: stop objects compaction cycle",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := newShutdownTestIndex(t, nil)
+			idx.Config.SeparateObjectsCompactions = tt.separateCompactions
+			if tt.stallCompactions {
+				idx.cycleCallbacks.compactionCycle = stallingCycle(idx.cycleCallbacks.compactionCycle)
+				idx.cycleCallbacks.compactionAuxCycle = stallingCycle(idx.cycleCallbacks.compactionAuxCycle)
+			}
+			if tt.refuseFlush {
+				idx.cycleCallbacks.flushCycle = refusingCycle(idx.cycleCallbacks.flushCycle)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancelCtx {
+				cancel()
+			}
+
+			err := idx.stopCycleManagers(ctx, "drop")
+
+			if len(tt.wantErrContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Contains(t, err.Error(), want)
+				}
+			}
+			if tt.cancelCtx {
+				// Index.drop tolerates context errors, so joining must keep them matchable
+				require.ErrorIs(t, err, context.Canceled)
+			}
+
+			requireCyclesStopped(t, idx.cycleCallbacks)
+		})
+	}
+}
+
+// stubCycle takes over the stop result of the cycle it wraps. The wrapped cycle
+// is never asked to stop, so it keeps running until the test cleanup stops it.
+type stubCycle struct {
+	cyclemanager.CycleManager
+	stopResult chan bool
+}
+
+func (c stubCycle) Stop(context.Context) chan bool {
+	return c.stopResult
+}
+
+// stallingCycle never reports a stop result.
+func stallingCycle(cycle cyclemanager.CycleManager) stubCycle {
+	return stubCycle{CycleManager: cycle, stopResult: make(chan bool)}
+}
+
+// refusingCycle reports that it kept running.
+func refusingCycle(cycle cyclemanager.CycleManager) stubCycle {
+	stopResult := make(chan bool, 1)
+	stopResult <- false
+	close(stopResult)
+	return stubCycle{CycleManager: cycle, stopResult: stopResult}
+}
+
+// requireCyclesStopped asserts that every cycle stopped. Stopping is asynchronous,
+// so an expired context can return before the cycles are done. Stubbed cycles are
+// skipped, as their stop never reaches the real cycle behind them.
+func requireCyclesStopped(t *testing.T, cc *indexCycleCallbacks) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		for _, cycle := range testCycles(cc) {
+			if _, stubbed := cycle.(stubCycle); stubbed {
+				continue
+			}
+			if cycle.Running() {
+				return false
+			}
+		}
+		return true
+	}, time.Second, 10*time.Millisecond, "cycle managers left running")
+}
 
 // newShutdownTestIndex builds an index with one mock shard per entry of shardErrs,
 // each returning its entry's error from Shutdown, and with all cycle managers running.
@@ -97,7 +218,8 @@ func TestIndexShutdownStopsCycleManagersDespiteShardFailure(t *testing.T) {
 	tests := []struct {
 		name      string
 		shardErrs map[string]error
-		// a cancelled context makes every cycle manager fail to stop
+		// a compaction cycle that never reports a stop fails once ctx expires
+		stallCompaction bool
 		cancelCtx       bool
 		wantErrContains []string
 		wantErrIs       []error
@@ -123,12 +245,13 @@ func TestIndexShutdownStopsCycleManagersDespiteShardFailure(t *testing.T) {
 			wantErrIs:       []error{errInUse, errDiskGone},
 		},
 		{
-			name:      "shard failure and cycle manager failure are both reported",
-			shardErrs: map[string]error{"shard1": errInUse},
-			cancelCtx: true,
+			name:            "shard failure and cycle manager failure are both reported",
+			shardErrs:       map[string]error{"shard1": errInUse},
+			stallCompaction: true,
+			cancelCtx:       true,
 			wantErrContains: []string{
 				`shutdown shard "shard1"`,
-				"shutdown: stop objects compaction cycle",
+				"shutdown: stop compaction cycle",
 				context.Canceled.Error(),
 			},
 			wantErrIs: []error{errInUse, context.Canceled},
@@ -138,6 +261,9 @@ func TestIndexShutdownStopsCycleManagersDespiteShardFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			idx := newShutdownTestIndex(t, tt.shardErrs)
+			if tt.stallCompaction {
+				idx.cycleCallbacks.compactionCycle = stallingCycle(idx.cycleCallbacks.compactionCycle)
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -159,11 +285,7 @@ func TestIndexShutdownStopsCycleManagersDespiteShardFailure(t *testing.T) {
 				require.ErrorIs(t, err, want)
 			}
 
-			if !tt.cancelCtx {
-				for _, cycle := range testCycles(idx.cycleCallbacks) {
-					require.False(t, cycle.Running())
-				}
-			}
+			requireCyclesStopped(t, idx.cycleCallbacks)
 		})
 	}
 }

--- a/adapters/repos/db/shutdown_test.go
+++ b/adapters/repos/db/shutdown_test.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -147,6 +148,15 @@ func requireCyclesStopped(t *testing.T, cc *indexCycleCallbacks) {
 	}, time.Second, 10*time.Millisecond, "cycle managers left running")
 }
 
+// failingShards names count shards that all fail to shut down with err.
+func failingShards(count int, err error) map[string]error {
+	shardErrs := make(map[string]error, count)
+	for i := range count {
+		shardErrs[fmt.Sprintf("shard%d", i)] = err
+	}
+	return shardErrs
+}
+
 // newShutdownTestIndex builds an index with one mock shard per entry of shardErrs,
 // each returning its entry's error from Shutdown, and with all cycle managers running.
 func newShutdownTestIndex(t *testing.T, shardErrs map[string]error) *Index {
@@ -245,6 +255,12 @@ func TestIndexShutdownStopsCycleManagersDespiteShardFailure(t *testing.T) {
 			wantErrIs:       []error{errInUse, errDiskGone},
 		},
 		{
+			name:            "shard failures beyond the limit are only counted",
+			shardErrs:       failingShards(maxReportedErrors+2, errInUse),
+			wantErrContains: []string{"still in use", "(and 2 more)"},
+			wantErrIs:       []error{errInUse},
+		},
+		{
 			name:            "shard failure and cycle manager failure are both reported",
 			shardErrs:       map[string]error{"shard1": errInUse},
 			stallCompaction: true,
@@ -300,6 +316,14 @@ func TestDBShutdownRunsEveryIndexAndCleanup(t *testing.T) {
 	errInUse := errors.New("still in use")
 	errDiskGone := errors.New("disk gone")
 
+	failingIndices := func(count int) []indexSpec {
+		specs := make([]indexSpec, count)
+		for i := range specs {
+			specs[i] = indexSpec{name: fmt.Sprintf("Class%d", i), shardErr: errInUse}
+		}
+		return specs
+	}
+
 	tests := []struct {
 		name            string
 		indices         []indexSpec
@@ -328,6 +352,12 @@ func TestDBShutdownRunsEveryIndexAndCleanup(t *testing.T) {
 			},
 			wantErrContains: []string{`shutdown index "Alpha"`, `shutdown index "Beta"`, "disk gone"},
 			wantErrIs:       []error{errInUse, errDiskGone},
+		},
+		{
+			name:            "index failures beyond the limit are only counted",
+			indices:         failingIndices(maxReportedErrors + 2),
+			wantErrContains: []string{"still in use", "(and 2 more)"},
+			wantErrIs:       []error{errInUse},
 		},
 	}
 

--- a/adapters/repos/db/shutdown_test.go
+++ b/adapters/repos/db/shutdown_test.go
@@ -1,0 +1,261 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	esync "github.com/weaviate/weaviate/entities/sync"
+)
+
+// newShutdownTestIndex builds an index with one mock shard per entry of shardErrs,
+// each returning its entry's error from Shutdown, and with all cycle managers running.
+func newShutdownTestIndex(t *testing.T, shardErrs map[string]error) *Index {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	idx := &Index{
+		logger:         logger,
+		shards:         shardMap{},
+		backupLock:     esync.NewKeyRWLocker(),
+		closingCtx:     ctx,
+		closingCancel:  cancel,
+		cycleCallbacks: newTestCycleCallbacks(logger),
+	}
+	for _, cycle := range testCycles(idx.cycleCallbacks) {
+		cycle.Start()
+	}
+	t.Cleanup(func() {
+		// a cycle the index left running would otherwise outlive the test
+		for _, cycle := range testCycles(idx.cycleCallbacks) {
+			require.NoError(t, cycle.StopAndWait(context.Background()))
+		}
+	})
+
+	for name, err := range shardErrs {
+		shard := NewMockShardLike(t)
+		shard.EXPECT().Name().Return(name).Maybe()
+		shard.EXPECT().Shutdown(mock.Anything).Return(err).Once()
+		idx.shards.Store(name, shard)
+	}
+	return idx
+}
+
+func newTestCycleCallbacks(logger logrus.FieldLogger) *indexCycleCallbacks {
+	newCycle := func(name string) cyclemanager.CycleManager {
+		return cyclemanager.NewManager(name, cyclemanager.NewNoopTicker(),
+			func(cyclemanager.ShouldAbortCallback) bool { return false }, logger)
+	}
+	return &indexCycleCallbacks{
+		compactionCycle:               newCycle("compaction"),
+		compactionAuxCycle:            newCycle("compaction-aux"),
+		flushCycle:                    newCycle("flush"),
+		vectorCommitLoggerCycle:       newCycle("vector-commit-logger"),
+		vectorTombstoneCleanupCycle:   newCycle("vector-tombstone-cleanup"),
+		geoPropsCommitLoggerCycle:     newCycle("geo-commit-logger"),
+		geoPropsTombstoneCleanupCycle: newCycle("geo-tombstone-cleanup"),
+	}
+}
+
+func testCycles(cc *indexCycleCallbacks) []cyclemanager.CycleManager {
+	return []cyclemanager.CycleManager{
+		cc.compactionCycle,
+		cc.compactionAuxCycle,
+		cc.flushCycle,
+		cc.vectorCommitLoggerCycle,
+		cc.vectorTombstoneCleanupCycle,
+		cc.geoPropsCommitLoggerCycle,
+		cc.geoPropsTombstoneCleanupCycle,
+	}
+}
+
+func TestIndexShutdownStopsCycleManagersDespiteShardFailure(t *testing.T) {
+	errInUse := errors.New("still in use")
+	errDiskGone := errors.New("disk gone")
+
+	tests := []struct {
+		name      string
+		shardErrs map[string]error
+		// a cancelled context makes every cycle manager fail to stop
+		cancelCtx       bool
+		wantErrContains []string
+		wantErrIs       []error
+	}{
+		{
+			name:      "no shard fails",
+			shardErrs: map[string]error{"shard1": nil, "shard2": nil},
+		},
+		{
+			name:      "already shut down shard is not a failure",
+			shardErrs: map[string]error{"shard1": errAlreadyShutdown, "shard2": nil},
+		},
+		{
+			name:            "one of two shards fails",
+			shardErrs:       map[string]error{"shard1": errInUse, "shard2": nil},
+			wantErrContains: []string{`shutdown shard "shard1"`, "still in use"},
+			wantErrIs:       []error{errInUse},
+		},
+		{
+			name:            "both shards fail",
+			shardErrs:       map[string]error{"shard1": errInUse, "shard2": errDiskGone},
+			wantErrContains: []string{`shutdown shard "shard1"`, `shutdown shard "shard2"`, "disk gone"},
+			wantErrIs:       []error{errInUse, errDiskGone},
+		},
+		{
+			name:      "shard failure and cycle manager failure are both reported",
+			shardErrs: map[string]error{"shard1": errInUse},
+			cancelCtx: true,
+			wantErrContains: []string{
+				`shutdown shard "shard1"`,
+				"shutdown: stop objects compaction cycle",
+				context.Canceled.Error(),
+			},
+			wantErrIs: []error{errInUse, context.Canceled},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := newShutdownTestIndex(t, tt.shardErrs)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancelCtx {
+				cancel()
+			}
+
+			err := idx.Shutdown(ctx)
+
+			if len(tt.wantErrContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Contains(t, err.Error(), want)
+				}
+			}
+			for _, want := range tt.wantErrIs {
+				require.ErrorIs(t, err, want)
+			}
+
+			if !tt.cancelCtx {
+				for _, cycle := range testCycles(idx.cycleCallbacks) {
+					require.False(t, cycle.Running())
+				}
+			}
+		})
+	}
+}
+
+func TestDBShutdownRunsEveryIndexAndCleanup(t *testing.T) {
+	type indexSpec struct {
+		name          string
+		shardErr      error
+		alreadyClosed bool
+	}
+
+	errInUse := errors.New("still in use")
+	errDiskGone := errors.New("disk gone")
+
+	tests := []struct {
+		name            string
+		indices         []indexSpec
+		wantErrContains []string
+		wantErrIs       []error
+	}{
+		{
+			name:    "no index fails",
+			indices: []indexSpec{{name: "Alpha"}, {name: "Beta"}},
+		},
+		{
+			name:    "already shut down index is not a failure",
+			indices: []indexSpec{{name: "Alpha", alreadyClosed: true}, {name: "Beta"}},
+		},
+		{
+			name:            "one of two indices fails",
+			indices:         []indexSpec{{name: "Alpha", shardErr: errInUse}, {name: "Beta"}},
+			wantErrContains: []string{`shutdown index "Alpha"`, "still in use"},
+			wantErrIs:       []error{errInUse},
+		},
+		{
+			name: "every index fails",
+			indices: []indexSpec{
+				{name: "Alpha", shardErr: errInUse},
+				{name: "Beta", shardErr: errDiskGone},
+			},
+			wantErrContains: []string{`shutdown index "Alpha"`, `shutdown index "Beta"`, "disk gone"},
+			wantErrIs:       []error{errInUse, errDiskGone},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+
+			checkpoints, err := indexcheckpoint.New(t.TempDir(), logger)
+			require.NoError(t, err)
+
+			db := &DB{
+				logger:                    logger,
+				shutdown:                  make(chan struct{}, 1),
+				bitmapBufPoolClose:        func() {},
+				AsyncIndexingEnabled:      true,
+				asyncReplicationScheduler: newSchedulerForUnitTest(t),
+				indexCheckpoints:          checkpoints,
+				indices:                   map[string]*Index{},
+			}
+
+			for _, spec := range tt.indices {
+				// a closed index has no shard to shut down, so it gets no mock shard
+				var idx *Index
+				if spec.alreadyClosed {
+					idx = newShutdownTestIndex(t, nil)
+					idx.closed = true
+				} else {
+					idx = newShutdownTestIndex(t, map[string]error{"shard1": spec.shardErr})
+				}
+				db.indices[spec.name] = idx
+			}
+
+			err = db.Shutdown(context.Background())
+
+			if len(tt.wantErrContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Contains(t, err.Error(), want)
+				}
+			}
+			for _, want := range tt.wantErrIs {
+				require.ErrorIs(t, err, want)
+			}
+
+			// closing the checkpoint store is the last statement after the index
+			// loop, so a closed store proves the whole post-loop cleanup ran
+			_, _, err = checkpoints.Get("shard1", "")
+			require.Error(t, err)
+		})
+	}
+}

--- a/entities/errorcompounder/compounder.go
+++ b/entities/errorcompounder/compounder.go
@@ -30,8 +30,6 @@ type ErrorCompounder interface {
 
 	First() error
 	ToError() error
-	// ToErrorLimited reports at most limit errors, but never fewer than one, and
-	// how many it left out.
 	ToErrorLimited(limit int) error
 }
 

--- a/entities/errorcompounder/compounder.go
+++ b/entities/errorcompounder/compounder.go
@@ -30,6 +30,8 @@ type ErrorCompounder interface {
 
 	First() error
 	ToError() error
+	// ToErrorLimited reports at most limit errors, but never fewer than one, and
+	// how many it left out.
 	ToErrorLimited(limit int) error
 }
 
@@ -127,6 +129,10 @@ func (ec *errorCompounder) toError(limit int) error {
 		return true
 	}
 	f(ec.top)
+	// without the count a truncated message reads like the complete list
+	if omitted := ec.Len() - len(errs); omitted > 0 {
+		fmt.Fprintf(&b, " (and %d more)", omitted)
+	}
 	return &compoundError{msg: b.String(), errs: errs}
 }
 

--- a/entities/errorcompounder/compounder.go
+++ b/entities/errorcompounder/compounder.go
@@ -91,6 +91,7 @@ func (ec *errorCompounder) toError(limit int) error {
 	}
 
 	var b strings.Builder
+	var errs []error
 
 	var f func(*entry) bool
 	f = func(e *entry) bool {
@@ -100,6 +101,7 @@ func (ec *errorCompounder) toError(limit int) error {
 				b.WriteString(", ")
 			}
 			b.WriteString(err.Error())
+			errs = append(errs, err)
 			addComma = true
 
 			limit--
@@ -125,7 +127,7 @@ func (ec *errorCompounder) toError(limit int) error {
 		return true
 	}
 	f(ec.top)
-	return errors.New(b.String())
+	return &compoundError{msg: b.String(), errs: errs}
 }
 
 func (ec *errorCompounder) add(err error) {
@@ -150,6 +152,24 @@ func (ec *errorCompounder) addGroups(err error, groups ...string) {
 		target = group
 	}
 	target.errors = append(target.errors, err)
+}
+
+// ----------------------------------------------------------------------------
+
+// compoundError renders every collected error into a single message while
+// keeping those errors reachable for errors.Is and errors.As. A limited error
+// only exposes the errors its message covers.
+type compoundError struct {
+	msg  string
+	errs []error
+}
+
+func (e *compoundError) Error() string {
+	return e.msg
+}
+
+func (e *compoundError) Unwrap() []error {
+	return e.errs
 }
 
 // ----------------------------------------------------------------------------

--- a/entities/errorcompounder/compounder_test.go
+++ b/entities/errorcompounder/compounder_test.go
@@ -87,7 +87,7 @@ func TestErrorCompounder(t *testing.T) {
 			ec.Add(err3)
 
 			err := ec.ToErrorLimited(2)
-			assert.EqualError(t, err, "111, 222")
+			assert.EqualError(t, err, "111, 222 (and 1 more)")
 			assert.ErrorIs(t, err, err1)
 			assert.ErrorIs(t, err, err2)
 			assert.NotErrorIs(t, err, err3)
@@ -276,13 +276,17 @@ func TestErrorCompounder(t *testing.T) {
 			ec.Add(err1)
 			ec.Add(err2)
 			assert.ErrorContains(t, ec.ToError(), "111, 222")
-			assert.ErrorContains(t, ec.ToErrorLimited(3), "111, 222")
+			// nothing is left out, so neither limit reports a count
+			assert.EqualError(t, ec.ToErrorLimited(3), "111, 222")
+			assert.EqualError(t, ec.ToErrorLimited(2), "111, 222")
 
 			ec.Add(err3)
 			ec.Add(err4)
 			ec.Add(err5)
-			assert.ErrorContains(t, ec.ToError(), "111, 222, 333, 444, 555")
-			assert.ErrorContains(t, ec.ToErrorLimited(3), "111, 222, 333")
+			assert.EqualError(t, ec.ToError(), "111, 222, 333, 444, 555")
+			assert.EqualError(t, ec.ToErrorLimited(3), "111, 222, 333 (and 2 more)")
+			// a limit below one still reports one error
+			assert.EqualError(t, ec.ToErrorLimited(0), "111 (and 4 more)")
 		}
 
 		run(t, New())
@@ -312,7 +316,8 @@ func TestErrorCompounder(t *testing.T) {
 			assert.ErrorContains(t, ec2.ToErrorLimited(2), "\"lvl1\": {111, 222}")
 			ec2.AddGroups(err5)
 			assert.ErrorContains(t, ec2.ToError(), "555, \"lvl1\": {111, 222, 333}")
-			assert.ErrorContains(t, ec2.ToErrorLimited(2), "555, \"lvl1\": {111}")
+			// the count covers the errors left out inside the group as well
+			assert.EqualError(t, ec2.ToErrorLimited(2), "555, \"lvl1\": {111} (and 2 more)")
 
 			ec3 := create()
 			ec3.AddGroups(err1, "lvl1", "lvl2")

--- a/entities/errorcompounder/compounder_test.go
+++ b/entities/errorcompounder/compounder_test.go
@@ -59,6 +59,44 @@ func TestErrorCompounder(t *testing.T) {
 		run(t, NewSafe())
 	})
 
+	t.Run("causes stay matchable", func(t *testing.T) {
+		run := func(t *testing.T, ec ErrorCompounder) {
+			t.Helper()
+
+			ec.Add(err1)
+			ec.AddWrapf(err2, "format%d", 2)
+			ec.AddGroups(err3, "lvl1")
+
+			err := ec.ToError()
+			assert.ErrorIs(t, err, err1)
+			assert.ErrorIs(t, err, err2)
+			assert.ErrorIs(t, err, err3)
+			assert.NotErrorIs(t, err, err4)
+		}
+
+		run(t, New())
+		run(t, NewSafe())
+	})
+
+	t.Run("a limited error only exposes the errors it reports", func(t *testing.T) {
+		run := func(t *testing.T, ec ErrorCompounder) {
+			t.Helper()
+
+			ec.Add(err1)
+			ec.Add(err2)
+			ec.Add(err3)
+
+			err := ec.ToErrorLimited(2)
+			assert.EqualError(t, err, "111, 222")
+			assert.ErrorIs(t, err, err1)
+			assert.ErrorIs(t, err, err2)
+			assert.NotErrorIs(t, err, err3)
+		}
+
+		run(t, New())
+		run(t, NewSafe())
+	})
+
 	t.Run("compound formats", func(t *testing.T) {
 		run := func(t *testing.T, ec ErrorCompounder) {
 			t.Helper()


### PR DESCRIPTION
### What's being changed:

Couple related fixes in one PR:
1. always shut down all indices (repo.go) and shards (index.go) and dont stop on first error
2. possible nil reference in a log message
3. of multiple shards fail at the same time we could some error messages
4. Return a missed error return
5. Stop all cyclemanagers even if one fails
6. Switch errorCompunder to keep original errors for errors.Is checks
7. Bound how many errors are reported
8. Fix shutdown in index.Drop 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
