### PR TITLE
fix(drop-vector-index): drop-epoch generation token in the marker - identity survives task-record loss

### DIFF
--- a/adapters/handlers/rest/drop_vector_index_enqueuer.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer.go
@@ -134,7 +134,7 @@ func (e *dropVectorIndexEnqueuer) EnqueueDropVectorIndex(ctx context.Context, co
 	// snapshot. A target that is no longer marked dropped (class deleted and
 	// re-created, or already finalized elsewhere) must not get a cleanup task —
 	// that task would strip a live vector.
-	targets, err := e.stillDroppedTargets(collection, targets)
+	targets, markerEpoch, err := e.stillDroppedTargets(collection, targets)
 	if err != nil {
 		return fmt.Errorf("drop-vector enqueue: verify targets for %q: %w", collection, err)
 	}
@@ -162,7 +162,7 @@ func (e *dropVectorIndexEnqueuer) EnqueueDropVectorIndex(ctx context.Context, co
 		return fmt.Errorf("drop-vector enqueue: no shards for collection %q", collection)
 	}
 
-	epoch, cleaned, err := e.epochAndInheritedCoverage(ctx, collection, targets, state)
+	epoch, cleaned, err := e.epochAndInheritedCoverage(ctx, collection, targets, state, markerEpoch)
 	if err != nil {
 		return fmt.Errorf("drop-vector enqueue: coverage inheritance for %q: %w", collection, err)
 	}
@@ -203,49 +203,35 @@ func (e *dropVectorIndexEnqueuer) EnqueueDropVectorIndex(ctx context.Context, co
 	return e.clusterService.AddDistributedTaskWithGroups(ctx, db.DropVectorIndexNamespace, taskID, payload, specs)
 }
 
-// epochAndInheritedCoverage resolves the drop epoch and the cleaned-shard set
-// accumulated by completed tasks of that epoch.
-//
-// A marker can only coexist with an INCOMPLETE chain of its own drop: the
-// previous drop's marker can vanish only via finalize (which requires a
-// complete chain) or class delete (which cascade-deletes the task records).
-// So a complete chain — or no usable chain — next to a marker is a closed
-// epoch's residue (re-created then re-dropped name, or a finalize that never
-// landed): mint a fresh epoch and re-clean everything, never trust it. That
-// costs one idempotent full re-clean; the alternative trusts stale coverage
-// and finalizes over unstripped vectors.
+// epochAndInheritedCoverage returns the payload epoch for a new task of this
+// drop and the cleaned-shard set accumulated by its completed earlier tasks.
+// The marker's generation token IS the epoch: minted with the marker itself,
+// it identifies the drop regardless of which task records survived, so records
+// of a previous drop of a re-created name can never be inherited (they carry
+// the previous token). A pre-token marker ("" — written by an older node) gets
+// a fresh unique epoch per task and inherits nothing: pre-chain semantics,
+// never stale coverage.
 func (e *dropVectorIndexEnqueuer) epochAndInheritedCoverage(ctx context.Context,
-	collection string, targets []string, state *sharding.State,
+	collection string, targets []string, state *sharding.State, markerEpoch string,
 ) (string, []string, error) {
+	if markerEpoch == "" {
+		return uuid.NewString(), nil, nil
+	}
 	tasks, err := e.clusterService.ListDistributedTasks(ctx)
 	if err != nil {
 		return "", nil, err
 	}
-	// The newest matching task (raft-assigned Version: monotonic and
-	// deterministic, unlike node wall clocks) names the candidate epoch.
-	var newest *db.DropVectorIndexTaskPayload
-	var newestVersion uint64
-	matching := make(map[*distributedtask.Task]*db.DropVectorIndexTaskPayload)
+	covered := map[string]struct{}{}
 	for _, task := range tasks[db.DropVectorIndexNamespace] {
+		if !task.Status.IsCompleted() {
+			continue
+		}
 		p, err := db.DecodeDropVectorIndexTaskPayload(task.Payload)
 		if err != nil {
 			e.warnSkippedPayload("coverage-inheritance", task.ID, err)
 			continue
 		}
-		if !strings.EqualFold(p.Collection, collection) || !sameTargetSet(p.Targets, targets) {
-			continue
-		}
-		matching[task] = p
-		if newest == nil || task.Version > newestVersion {
-			newest, newestVersion = p, task.Version
-		}
-	}
-	if newest == nil || newest.DropEpochID == "" {
-		return uuid.NewString(), nil, nil
-	}
-	covered := map[string]struct{}{}
-	for task, p := range matching {
-		if p.DropEpochID != newest.DropEpochID || !task.Status.IsCompleted() {
+		if p.DropEpochID != markerEpoch || !strings.EqualFold(p.Collection, collection) || !sameTargetSet(p.Targets, targets) {
 			continue
 		}
 		for shard := range p.CoveredShards() {
@@ -261,11 +247,7 @@ func (e *dropVectorIndexEnqueuer) epochAndInheritedCoverage(ctx context.Context,
 		}
 	}
 	sort.Strings(cleaned)
-	if len(shardsNotIn(state, cleaned)) == 0 {
-		// Complete chain next to a marker — closed-epoch residue. See above.
-		return uuid.NewString(), nil, nil
-	}
-	return newest.DropEpochID, cleaned, nil
+	return markerEpoch, cleaned, nil
 }
 
 // sameTargetSet reports whether two target lists contain the same names with
@@ -314,36 +296,35 @@ func withoutCleanedShards(ownership map[string][]string, cleaned []string) map[s
 }
 
 // shardsNotIn returns the state's shards absent from the given set, sorted.
-func shardsNotIn(state *sharding.State, set []string) []string {
-	covered := make(map[string]struct{}, len(set))
-	for _, shard := range set {
-		covered[shard] = struct{}{}
-	}
-	shardNames := make([]string, 0, len(state.Physical))
-	for shard := range state.Physical {
-		shardNames = append(shardNames, shard)
-	}
-	return db.ShardsNotCovered(shardNames, covered)
-}
-
-// stillDroppedTargets filters targets to those still present and marked dropped
-// in the leader-consistent class. A missing class means nothing to clean.
-func (e *dropVectorIndexEnqueuer) stillDroppedTargets(collection string, targets []string) ([]string, error) {
+// stillDroppedTargets filters targets to those still present and marked
+// dropped in the leader-consistent class, and returns their shared drop epoch
+// (the marker's generation token; "" for markers written by pre-token nodes).
+// A missing class means nothing to clean. Multi-target enqueues must share one
+// epoch — every current caller is single-target.
+func (e *dropVectorIndexEnqueuer) stillDroppedTargets(collection string, targets []string) ([]string, string, error) {
 	vclasses, err := e.schemaState.QueryReadOnlyClasses(collection)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	class := vclasses[collection].Class
 	if class == nil {
-		return nil, nil
+		return nil, "", nil
 	}
 	var still []string
+	var epoch string
 	for _, target := range targets {
-		if cfg, ok := class.VectorConfig[target]; ok && modelsext.IsVectorIndexDropped(cfg) {
-			still = append(still, target)
+		cfg, ok := class.VectorConfig[target]
+		if !ok || !modelsext.IsVectorIndexDropped(cfg) {
+			continue
 		}
+		targetEpoch := modelsext.DropEpochID(cfg)
+		if len(still) > 0 && targetEpoch != epoch {
+			return nil, "", fmt.Errorf("targets %v span different drop epochs; enqueue them separately", targets)
+		}
+		still = append(still, target)
+		epoch = targetEpoch
 	}
-	return still, nil
+	return still, epoch, nil
 }
 
 // activeShardOwnership builds node -> shard-names from a sharding state, limited

--- a/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
@@ -453,9 +453,14 @@ func TestSameTargetSet(t *testing.T) {
 // mint a wrong epoch, so the error surfaces for the caller to retry.
 func TestEnqueueDropVectorIndex_TaskListError_Surfaces(t *testing.T) {
 	cluster := &fakeClusterDropClient{listErr: fmt.Errorf("no leader")}
-	state := &fakeShardingState{state: shardingState(false, map[string]sharding.Physical{
-		"s1": {BelongsToNodes: []string{"n1"}},
-	})}
+	state := &fakeShardingState{
+		state: shardingState(false, map[string]sharding.Physical{
+			"s1": {BelongsToNodes: []string{"n1"}},
+		}),
+		// A token-bearing marker: inheritance needs the task list, so the
+		// list failure must surface (a pre-token marker skips the list).
+		vectorCfg: map[string]models.VectorConfig{"v1": droppedWithEpoch("E1")},
+	}
 	enq := &dropVectorIndexEnqueuer{clusterService: cluster, schemaState: state}
 
 	err := enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"})
@@ -463,42 +468,50 @@ func TestEnqueueDropVectorIndex_TaskListError_Surfaces(t *testing.T) {
 	require.Empty(t, cluster.gotTaskID)
 }
 
-// TestEnqueueDropVectorIndex_GrownShardSetAfterFinalize is the RED pin for the
-// closed-epoch fence hole: a finalized epoch whose collection gained a shard
-// afterwards looks INCOMPLETE against the grown shard set, so the fence fails
-// to fire and the stale epoch's coverage is inherited into a genuinely new
-// drop — its completion would finalize with the re-created vectors on the old
-// shards never stripped. The new drop must start a fresh epoch and clean
-// every shard.
+// droppedWithEpoch is a marker entry carrying the drop's generation token.
+func droppedWithEpoch(epoch string) models.VectorConfig {
+	return models.VectorConfig{
+		VectorIndexType:   modelsext.VectorIndexTypeNone,
+		VectorIndexConfig: map[string]any{modelsext.DropEpochIDKey: epoch},
+	}
+}
+
+// TestEnqueueDropVectorIndex_GrownShardSetAfterFinalize pins the re-drop repro
+// that broke the record-inference fence: the previous drop's FINISHED record
+// covers everything that existed at its finalize, a shard was created since,
+// and the marker belongs to a NEW drop. The marker's generation token makes
+// the stale record unmistakable — the new task must carry the marker's epoch,
+// inherit nothing, and clean every shard.
 func TestEnqueueDropVectorIndex_GrownShardSetAfterFinalize(t *testing.T) {
 	hot := func(nodes ...string) sharding.Physical {
 		return sharding.Physical{Status: models.TenantActivityStatusHOT, BelongsToNodes: nodes}
 	}
 	cluster := &fakeClusterDropClient{tasks: map[string][]*distributedtask.Task{
 		db.DropVectorIndexNamespace: {
-			// The previous drop's record: covered everything that existed then.
 			epochTask(t, "C", "t1", "E1", 1, distributedtask.TaskStatusFinished, []string{"s1", "s2"}, nil),
 		},
 	}}
-	state := &fakeShardingState{state: shardingState(true, map[string]sharding.Physical{
-		"s1": hot("n1"), "s2": hot("n1"), "s3": hot("n1"), // s3 created after the finalize
-	})}
+	state := &fakeShardingState{
+		state: shardingState(true, map[string]sharding.Physical{
+			"s1": hot("n1"), "s2": hot("n1"), "s3": hot("n1"), // s3 created after the finalize
+		}),
+		vectorCfg: map[string]models.VectorConfig{"v1": droppedWithEpoch("E2")},
+	}
 	enq := &dropVectorIndexEnqueuer{clusterService: cluster, schemaState: state}
 
 	require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
 	p := decodeEnqueuedPayload(t, cluster)
-	require.NotEqual(t, "E1", p.DropEpochID, "a finalized epoch must not be continued")
+	require.Equal(t, "E2", p.DropEpochID, "the task carries the marker's epoch, not the record's")
 	require.Empty(t, p.CleanedShards, "stale coverage must not be inherited")
 	require.Equal(t, map[string]string{"s1__n1": "s1", "s2__n1": "s2", "s3__n1": "s3"}, p.UnitToShard,
 		"every shard must be cleaned by the new drop")
 }
 
-// TestEnqueueDropVectorIndex_CoverageInheritance pins the chain rules: inherit
-// cleaned-shard coverage only from completed same-epoch tasks of an INCOMPLETE
-// chain — a complete chain next to a marker is a closed epoch's residue
-// (re-created then re-dropped name, or a missed finalize) and must start a
-// fresh epoch with a full re-clean. Cleaned shards get no unit; when every
-// active shard is cleaned and the remainder is inactive, nothing is enqueued.
+// TestEnqueueDropVectorIndex_CoverageInheritance pins the chain rules: the
+// marker's generation token is the epoch; coverage is inherited only from
+// completed task records carrying that same token. Cleaned shards get no
+// unit; when every active shard is cleaned and the remainder is inactive,
+// nothing is enqueued. A pre-token marker inherits nothing.
 func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 	hot := func(nodes ...string) sharding.Physical {
 		return sharding.Physical{Status: models.TenantActivityStatusHOT, BelongsToNodes: nodes}
@@ -510,6 +523,7 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		markerEpoch string // "" = pre-token marker
 		tasks       []*distributedtask.Task
 		shards      map[string]sharding.Physical
 		nonMT       bool
@@ -519,7 +533,8 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 		wantNoTask  bool
 	}{
 		{
-			name:        "incomplete chain: inherit coverage, skip cleaned shards",
+			name:        "matching records: inherit coverage, skip cleaned shards",
+			markerEpoch: "E1",
 			tasks:       []*distributedtask.Task{epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil)},
 			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1"), "s3": cold("n1")},
 			wantEpoch:   "E1",
@@ -527,17 +542,27 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			wantUnits:   map[string]string{"s2__n1": "s2"},
 		},
 		{
-			// The P0 re-create pin: a chain that covers every current shard can
-			// only be a finalized (closed) epoch's residue — trusting it would
-			// finalize a re-dropped name with nothing stripped.
-			name:      "complete chain is closed-epoch residue: fresh epoch, full re-clean",
-			tasks:     []*distributedtask.Task{epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1", "s2"}, nil)},
-			shards:    map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
-			wantEpoch: "",
-			wantUnits: map[string]string{"s1__n1": "s1", "s2__n1": "s2"},
+			name:        "a previous drop's records are not inherited (re-created + re-dropped name)",
+			markerEpoch: "E2",
+			tasks:       []*distributedtask.Task{epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1", "s2"}, nil)},
+			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
+			wantEpoch:   "E2",
+			wantUnits:   map[string]string{"s1__n1": "s1", "s2__n1": "s2"},
 		},
 		{
-			name: "active same-epoch task contributes nothing",
+			name:        "SWAPPING earlier task's coverage is inherited",
+			markerEpoch: "E1",
+			tasks: []*distributedtask.Task{
+				epochTask(t, "C", "t1", "E1", 1, distributedtask.TaskStatusSwapping, []string{"s1"}, nil),
+			},
+			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1"), "s3": cold("n1")},
+			wantEpoch:   "E1",
+			wantCleaned: []string{"s1"},
+			wantUnits:   map[string]string{"s2__n1": "s2"},
+		},
+		{
+			name:        "active same-epoch task contributes nothing",
+			markerEpoch: "E1",
 			tasks: []*distributedtask.Task{
 				epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil),
 				epochTask(t, "C", "t2", "E1", 2, distributedtask.TaskStatusStarted, []string{"s2"}, nil),
@@ -548,7 +573,8 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			wantUnits:   map[string]string{"s2__n1": "s2", "s3__n1": "s3"},
 		},
 		{
-			name: "FAILED task contributes nothing",
+			name:        "FAILED task contributes nothing",
+			markerEpoch: "E1",
 			tasks: []*distributedtask.Task{
 				epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil),
 				epochTask(t, "C", "t2", "E1", 2, distributedtask.TaskStatusFailed, []string{"s2"}, nil),
@@ -559,54 +585,8 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			wantUnits:   map[string]string{"s2__n1": "s2", "s3__n1": "s3"},
 		},
 		{
-			name: "coverage does not cross epochs",
-			tasks: []*distributedtask.Task{
-				epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1", "s2"}, nil),
-				epochTask(t, "C", "t2", "E2", 2, fin, []string{"s2"}, nil),
-			},
-			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
-			wantEpoch:   "E2",
-			wantCleaned: []string{"s2"},
-			wantUnits:   map[string]string{"s1__n1": "s1"},
-		},
-		{
-			name: "current epoch picked by raft version, not record order",
-			tasks: []*distributedtask.Task{
-				epochTask(t, "C", "t2", "E2", 7, fin, []string{"s2"}, nil),
-				epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1", "s2"}, nil),
-			},
-			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
-			wantEpoch:   "E2",
-			wantCleaned: []string{"s2"},
-			wantUnits:   map[string]string{"s1__n1": "s1"},
-		},
-		{
-			name:      "chain-less records (older nodes or aged out) start a fresh epoch",
-			tasks:     []*distributedtask.Task{epochTask(t, "C", "t1", "", 1, fin, []string{"s1"}, nil)},
-			shards:    map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
-			wantEpoch: "",
-			wantUnits: map[string]string{"s1__n1": "s1", "s2__n1": "s2"},
-		},
-		{
-			name:      "foreign collection records are ignored",
-			tasks:     []*distributedtask.Task{epochTask(t, "Other", "t1", "E1", 1, fin, []string{"s1", "s2"}, nil)},
-			shards:    map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
-			wantEpoch: "",
-			wantUnits: map[string]string{"s1__n1": "s1", "s2__n1": "s2"},
-		},
-		{
-			// Rule-9 pin for TaskStatus.IsCompleted's SWAPPING half at this level.
-			name: "SWAPPING earlier task's coverage is inherited",
-			tasks: []*distributedtask.Task{
-				epochTask(t, "C", "t1", "E1", 1, distributedtask.TaskStatusSwapping, []string{"s1"}, nil),
-			},
-			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1"), "s3": cold("n1")},
-			wantEpoch:   "E1",
-			wantCleaned: []string{"s1"},
-			wantUnits:   map[string]string{"s2__n1": "s2"},
-		},
-		{
-			name: "corrupt records are skipped, not fatal",
+			name:        "corrupt records are skipped, not fatal",
+			markerEpoch: "E1",
 			tasks: []*distributedtask.Task{
 				corruptRecordTask("bad"),
 				epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil),
@@ -617,9 +597,9 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			wantUnits:   map[string]string{"s2__n1": "s2"},
 		},
 		{
-			name: "inherited coverage is pruned to current shards",
+			name:        "inherited coverage is pruned to current shards",
+			markerEpoch: "E1",
 			tasks: []*distributedtask.Task{
-				// sDeleted's tenant is gone; it must not ride along in payloads forever.
 				epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, []string{"sDeleted"}),
 			},
 			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1"), "s3": cold("n1")},
@@ -628,7 +608,8 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			wantUnits:   map[string]string{"s2__n1": "s2"},
 		},
 		{
-			name: "a node whose every shard is cleaned gets no units",
+			name:        "a node whose every shard is cleaned gets no units",
+			markerEpoch: "E1",
 			tasks: []*distributedtask.Task{
 				epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1", "s2"}, nil),
 			},
@@ -638,8 +619,25 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			wantUnits:   map[string]string{"s3__n2": "s3"},
 		},
 		{
+			name:        "pre-token marker inherits nothing and mints a unique epoch",
+			markerEpoch: "",
+			tasks:       []*distributedtask.Task{epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil)},
+			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
+			wantEpoch:   "",
+			wantUnits:   map[string]string{"s1__n1": "s1", "s2__n1": "s2"},
+		},
+		{
+			name:        "foreign collection records are ignored",
+			markerEpoch: "E1",
+			tasks:       []*distributedtask.Task{epochTask(t, "Other", "t1", "E1", 1, fin, []string{"s1", "s2"}, nil)},
+			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": hot("n1")},
+			wantEpoch:   "E1",
+			wantUnits:   map[string]string{"s1__n1": "s1", "s2__n1": "s2"},
+		},
+		{
 			// Non-MT shards carry no tenant status; the chain rules apply the same.
-			name:        "non-MT collection: incomplete chain inherits and skips cleaned",
+			name:        "non-MT collection: matching records inherit and skip cleaned",
+			markerEpoch: "E1",
 			tasks:       []*distributedtask.Task{epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil)},
 			shards:      map[string]sharding.Physical{"s1": {BelongsToNodes: []string{"n1"}}, "s2": {BelongsToNodes: []string{"n1"}}},
 			nonMT:       true,
@@ -648,10 +646,11 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			wantUnits:   map[string]string{"s2__n1": "s2"},
 		},
 		{
-			name:       "all active shards cleaned, remainder cold: defer without a task",
-			tasks:      []*distributedtask.Task{epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil)},
-			shards:     map[string]sharding.Physical{"s1": hot("n1"), "s2": cold("n1")},
-			wantNoTask: true,
+			name:        "all active shards cleaned, remainder cold: defer without a task",
+			markerEpoch: "E1",
+			tasks:       []*distributedtask.Task{epochTask(t, "C", "t1", "E1", 1, fin, []string{"s1"}, nil)},
+			shards:      map[string]sharding.Physical{"s1": hot("n1"), "s2": cold("n1")},
+			wantNoTask:  true,
 		},
 	}
 
@@ -660,7 +659,14 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 			cluster := &fakeClusterDropClient{tasks: map[string][]*distributedtask.Task{
 				db.DropVectorIndexNamespace: tt.tasks,
 			}}
-			state := &fakeShardingState{state: shardingState(!tt.nonMT, tt.shards)}
+			marker := dropped()
+			if tt.markerEpoch != "" {
+				marker = droppedWithEpoch(tt.markerEpoch)
+			}
+			state := &fakeShardingState{
+				state:     shardingState(!tt.nonMT, tt.shards),
+				vectorCfg: map[string]models.VectorConfig{"v1": marker},
+			}
 			enq := &dropVectorIndexEnqueuer{clusterService: cluster, schemaState: state}
 
 			require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
@@ -673,7 +679,9 @@ func TestEnqueueDropVectorIndex_CoverageInheritance(t *testing.T) {
 				require.NotEmpty(t, p.DropEpochID)
 				for _, task := range tt.tasks {
 					prev, err := db.DecodeDropVectorIndexTaskPayload(task.Payload)
-					require.NoError(t, err)
+					if err != nil {
+						continue
+					}
 					require.NotEqual(t, prev.DropEpochID, p.DropEpochID,
 						"a fresh epoch must not continue any recorded epoch")
 				}

--- a/adapters/repos/db/drop_vector_index_conflict.go
+++ b/adapters/repos/db/drop_vector_index_conflict.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/modelsext"
 )
 
 // CheckConflict implements distributedtask.ConflictDetector. Called under the
@@ -105,14 +106,14 @@ func (p *DropVectorIndexProvider) CheckTenantMutation(className string, tenants 
 // the name a stale record would remove the new drop's marker over unstripped
 // vectors. A marker whose finalize was missed heals through reconciliation
 // (fresh-epoch re-clean), not through record replay.
-func (p *DropVectorIndexProvider) CheckVectorConfigRemoval(className string, removedVectors, shards []string, existingTasks []*distributedtask.Task) error {
+func (p *DropVectorIndexProvider) CheckVectorConfigRemoval(className string, removedVectors, shards []string, epochs map[string]string, existingTasks []*distributedtask.Task) error {
 	for _, vec := range removedVectors {
 		if id, active := p.dropCovers(className, vec, existingTasks, stillStrippingStatus); active {
 			return fmt.Errorf(
 				"cannot remove dropped vector %q on %s: cleanup task %q is still active for it",
 				vec, className, id)
 		}
-		vouched, coversVec, uncovered := p.completedDropVoucher(className, vec, shards, existingTasks)
+		vouched, coversVec, uncovered := p.completedDropVoucher(className, vec, shards, epochs[vec], existingTasks)
 		if vouched {
 			continue
 		}
@@ -136,11 +137,14 @@ func (p *DropVectorIndexProvider) CheckVectorConfigRemoval(className string, rem
 // missing shards of the closest task — mirroring the finalize deferral, which
 // keeps the marker until a single task covers everyone.
 func (p *DropVectorIndexProvider) completedDropVoucher(className, vec string, shards []string,
-	existingTasks []*distributedtask.Task,
+	markerEpoch string, existingTasks []*distributedtask.Task,
 ) (vouched, coversVec bool, uncovered []string) {
 	swappingOnly := func(s distributedtask.TaskStatus) bool { return s == distributedtask.TaskStatusSwapping }
 	p.eachDropCovering(className, vec, existingTasks, swappingOnly,
 		func(task *distributedtask.Task, existP *DropVectorIndexTaskPayload) bool {
+			if !modelsext.DropEpochMatches(markerEpoch, existP.DropEpochID) {
+				return true // a different drop of the same name — no say over this marker
+			}
 			coversVec = true
 			missing := ShardsNotCovered(shards, existP.CoveredShards())
 			if len(missing) == 0 {

--- a/adapters/repos/db/drop_vector_index_finalizer_test.go
+++ b/adapters/repos/db/drop_vector_index_finalizer_test.go
@@ -63,7 +63,7 @@ func TestRemoveDroppedVectorConfig(t *testing.T) {
 		}}}
 		f := &schemaVectorConfigFinalizer{mgr: up}
 
-		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}))
+		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}, ""))
 		require.Equal(t, 1, up.updateCalls)
 		require.NotContains(t, up.updated.VectorConfig, "drop")
 		require.Contains(t, up.updated.VectorConfig, "keep")
@@ -79,7 +79,7 @@ func TestRemoveDroppedVectorConfig(t *testing.T) {
 		}}}
 		f := &schemaVectorConfigFinalizer{mgr: up}
 
-		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}))
+		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}, ""))
 		require.Equal(t, 1, up.updateCalls)
 		require.NotContains(t, up.updated.VectorConfig, "drop")
 		require.Contains(t, up.updated.VectorConfig, "Drop", "the sibling's marker must survive")
@@ -91,7 +91,7 @@ func TestRemoveDroppedVectorConfig(t *testing.T) {
 		}}}
 		f := &schemaVectorConfigFinalizer{mgr: up}
 
-		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}))
+		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}, ""))
 		require.Zero(t, up.updateCalls, "nothing to remove must not issue an update")
 	})
 
@@ -101,13 +101,13 @@ func TestRemoveDroppedVectorConfig(t *testing.T) {
 		}}}
 		f := &schemaVectorConfigFinalizer{mgr: up}
 
-		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}))
+		require.NoError(t, f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}, ""))
 		require.Zero(t, up.updateCalls, "a live same-name entry must not be removed")
 	})
 
 	t.Run("class not found errors", func(t *testing.T) {
 		f := &schemaVectorConfigFinalizer{mgr: &fakeClassUpdater{class: nil}}
-		require.Error(t, f.RemoveDroppedVectorConfig(ctx, "missing", []string{"drop"}))
+		require.Error(t, f.RemoveDroppedVectorConfig(ctx, "missing", []string{"drop"}, ""))
 	})
 
 	t.Run("retry exhaustion surfaces the last error", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestRemoveDroppedVectorConfig(t *testing.T) {
 		}
 		f := &schemaVectorConfigFinalizer{mgr: up}
 
-		err := f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"})
+		err := f.RemoveDroppedVectorConfig(ctx, "C", []string{"drop"}, "")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "raft busy")
 		require.Equal(t, dropVectorFinalizeMaxAttempts, up.updateCalls, "must exhaust the bounded retry")
@@ -132,7 +132,7 @@ func TestRemoveDroppedVectorConfig(t *testing.T) {
 		cctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		require.Error(t, f.RemoveDroppedVectorConfig(cctx, "C", []string{"drop"}))
+		require.Error(t, f.RemoveDroppedVectorConfig(cctx, "C", []string{"drop"}, ""))
 		require.LessOrEqual(t, up.updateCalls, dropVectorFinalizeMaxAttempts)
 	})
 }
@@ -172,7 +172,7 @@ func TestRemoveDroppedVectorConfig_UpdatedClassDoesNotAliasOriginal(t *testing.T
 	up := &fakeClassUpdater{class: orig}
 	f := &schemaVectorConfigFinalizer{mgr: up}
 
-	require.NoError(t, f.RemoveDroppedVectorConfig(context.Background(), "C", []string{"drop"}))
+	require.NoError(t, f.RemoveDroppedVectorConfig(context.Background(), "C", []string{"drop"}, ""))
 	require.NotNil(t, up.updated)
 
 	keptCfg, ok := up.updated.VectorConfig["keep"].VectorIndexConfig.(map[string]interface{})

--- a/adapters/repos/db/drop_vector_index_provider.go
+++ b/adapters/repos/db/drop_vector_index_provider.go
@@ -58,11 +58,12 @@ type dropVectorShards interface {
 	EnsureDroppedVectorFilesRemoved(collection, shard string, targets []string) error
 }
 
-// dropVectorSchemaFinalizer removes the dropped named-vector entries from a
-// class's VectorConfig cluster-wide via fresh read-modify-write. Idempotent:
-// re-running after the entries are already gone is a no-op.
+// dropVectorSchemaFinalizer removes the dropped named-vector entries of the
+// given drop epoch from a class's VectorConfig cluster-wide via fresh
+// read-modify-write. Idempotent: re-running after the entries are already gone
+// is a no-op; entries of a DIFFERENT epoch are left untouched.
 type dropVectorSchemaFinalizer interface {
-	RemoveDroppedVectorConfig(ctx context.Context, collection string, targets []string) error
+	RemoveDroppedVectorConfig(ctx context.Context, collection string, targets []string, dropEpochID string) error
 }
 
 // dropVectorSchemaReader provides leader-consistent schema reads: the sharding
@@ -523,7 +524,7 @@ func (p *DropVectorIndexProvider) OnTaskCompleted(task *distributedtask.Task) er
 		return nil
 	}
 
-	if err := p.schema.RemoveDroppedVectorConfig(p.serverCtx, payload.Collection, payload.Targets); err != nil {
+	if err := p.schema.RemoveDroppedVectorConfig(p.serverCtx, payload.Collection, payload.Targets, payload.DropEpochID); err != nil {
 		// Leave the marker in place; reconciliation re-cleans and re-finalizes.
 		logger.Errorf("drop-vector: task-completion: removing VectorConfig entries failed: %v", err)
 		return nil
@@ -557,9 +558,12 @@ func (p *DropVectorIndexProvider) activeOverlappingDrop(task *distributedtask.Ta
 	return false, nil
 }
 
-// targetsStillDropped reports whether every payload target is still present and
-// marked dropped in the leader-consistent class. A missing class or entry means
-// the drop was superseded (class deleted/re-created, or the name freed).
+// targetsStillDropped reports whether every payload target is still present,
+// marked dropped, AND belongs to this payload's drop epoch in the
+// leader-consistent class. A missing class or entry means the drop was
+// superseded (class deleted/re-created, or the name freed); an epoch mismatch
+// means the marker belongs to a NEWER drop of a re-created name, which this
+// task's records must not act on.
 func (p *DropVectorIndexProvider) targetsStillDropped(payload *DropVectorIndexTaskPayload) (bool, error) {
 	vclasses, err := p.sharding.QueryReadOnlyClasses(payload.Collection)
 	if err != nil {
@@ -571,7 +575,8 @@ func (p *DropVectorIndexProvider) targetsStillDropped(payload *DropVectorIndexTa
 	}
 	for _, target := range payload.Targets {
 		cfg, ok := class.VectorConfig[target]
-		if !ok || !modelsext.IsVectorIndexDropped(cfg) {
+		if !ok || !modelsext.IsVectorIndexDropped(cfg) ||
+			!modelsext.DropEpochMatches(modelsext.DropEpochID(cfg), payload.DropEpochID) {
 			return false, nil
 		}
 	}

--- a/adapters/repos/db/drop_vector_index_provider_test.go
+++ b/adapters/repos/db/drop_vector_index_provider_test.go
@@ -177,7 +177,7 @@ type fakeFinalizer struct {
 	err        error
 }
 
-func (f *fakeFinalizer) RemoveDroppedVectorConfig(ctx context.Context, collection string, targets []string) error {
+func (f *fakeFinalizer) RemoveDroppedVectorConfig(ctx context.Context, collection string, targets []string, dropEpochID string) error {
 	f.called = true
 	f.collection = collection
 	f.targets = targets
@@ -738,6 +738,25 @@ func TestOnGroupCompleted_ReplayAfterRecreate_SkipsFileRemoval(t *testing.T) {
 	require.Empty(t, shards.removed, "a live index's files must not be touched")
 }
 
+// TestOnGroupCompleted_OldEpochReplay_SkipsFileRemoval: the marker belongs to
+// a NEWER drop of the re-created name; the old epoch's replayed completion
+// must not touch its files.
+func TestOnGroupCompleted_OldEpochReplay_SkipsFileRemoval(t *testing.T) {
+	shards := &fakeShards{}
+	p := newTestDropProvider(shards, &fakeFinalizer{}, newFakeRecorder())
+	p.sharding = &fakeShardingReader{
+		shards: []string{"shard1"},
+		vectorCfg: map[string]models.VectorConfig{"v1": {
+			VectorIndexType:   "none",
+			VectorIndexConfig: map[string]any{"dropEpochId": "E2"},
+		}},
+	}
+
+	// dropTask's payload is epoch-less — a record from the previous drop.
+	require.NoError(t, p.OnGroupCompleted(dropTask(distributedtask.TaskStatusFinished, nil), "g", []string{"u1"}))
+	require.Empty(t, shards.removed, "an old epoch's replay must not act on a newer drop's marker")
+}
+
 // TestOnGroupCompleted_VerifyError_SurfacesForRetry: an unverifiable marker
 // state must not proceed to file removal.
 func TestOnGroupCompleted_VerifyError_SurfacesForRetry(t *testing.T) {
@@ -1053,37 +1072,37 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	t.Run("finished task never vouches (stale-record replay safety)", func(t *testing.T) {
 		// A FINISHED record outlives finalize by the task TTL; after a
 		// re-create + re-drop it would remove the new drop's marker.
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{finishedDropTask("t1", "C", "v1", "v2")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "only the completing cleanup task")
 	})
 
 	t.Run("collection matches case-insensitively, target exact-case only", func(t *testing.T) {
-		require.NoError(t, p.CheckVectorConfigRemoval("c", []string{"v1"}, nil,
+		require.NoError(t, p.CheckVectorConfigRemoval("c", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{swappingDropTask("t1", "C", "v1")}),
 			"collection names are case-insensitive")
-		require.Error(t, p.CheckVectorConfigRemoval("C", []string{"V1"}, nil,
+		require.Error(t, p.CheckVectorConfigRemoval("C", []string{"V1"}, nil, nil,
 			[]*distributedtask.Task{swappingDropTask("t1", "C", "v1")}),
 			"a case-differing sibling is a DIFFERENT vector; a voucher for v1 must not vouch for V1")
 	})
 
 	t.Run("swapping task covering the vector allows removal", func(t *testing.T) {
 		// OnTaskCompleted fires at SWAPPING; rejecting it self-blocks the finalizer.
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{swappingDropTask("t1", "C", "v1")})
 		require.NoError(t, err)
 	})
 
 	t.Run("corrupt swapping task does not vouch", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{corruptDropTask("t1", distributedtask.TaskStatusSwapping)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "only the completing cleanup task")
 	})
 
 	t.Run("corrupt active task does not block a valid voucher", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{
 				corruptDropTask("t1", distributedtask.TaskStatusStarted),
 				swappingDropTask("t2", "C", "v1"),
@@ -1092,7 +1111,7 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	})
 
 	t.Run("active (not finished) task rejects removal", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{activeDropTask("t1", "C", "v1")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "still active")
@@ -1101,44 +1120,44 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	t.Run("newer active task blocks a replayed old task's removal", func(t *testing.T) {
 		// Epoch-blindness: an old FINISHED task covers v1, but a newer drop of the
 		// re-used name is running — removal would free the name mid-cleanup.
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{finishedDropTask("t1", "C", "v1"), activeDropTask("t2", "C", "v1")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "still active")
 	})
 
 	t.Run("no task at all rejects removal (manual PATCH to skip cleanup)", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil)
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil, nil)
 		require.Error(t, err)
 	})
 
 	t.Run("finished task on a different collection does not vouch", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{finishedDropTask("t1", "Other", "v1")})
 		require.Error(t, err)
 	})
 
 	t.Run("finished task not covering the vector does not vouch", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, nil, nil,
 			[]*distributedtask.Task{finishedDropTask("t1", "C", "v9")})
 		require.Error(t, err)
 	})
 
 	t.Run("every removed vector must be covered", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1", "v2"}, nil,
+		err := p.CheckVectorConfigRemoval("C", []string{"v1", "v2"}, nil, nil,
 			[]*distributedtask.Task{finishedDropTask("t1", "C", "v1")})
 		require.Error(t, err, "v2 has no finished task")
 	})
 
 	t.Run("empty removal list is a no-op", func(t *testing.T) {
-		require.NoError(t, p.CheckVectorConfigRemoval("C", nil, nil, nil))
+		require.NoError(t, p.CheckVectorConfigRemoval("C", nil, nil, nil, nil))
 	})
 
 	// Coverage half of the gate: a completed task vouches only if its units
 	// covered every current shard — a FINISHED task that deferred finalize over
 	// a cold tenant must not double as a removal voucher.
 	t.Run("swapping task covering all shards vouches", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"}, nil,
 			[]*distributedtask.Task{swappingDropTaskCovering("t1", "C", []string{"s1", "s2"}, "v1")})
 		require.NoError(t, err)
 	})
@@ -1146,14 +1165,14 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	t.Run("finished task covering all shards still does not vouch", func(t *testing.T) {
 		// The re-drop repro's manual-removal half: a closed epoch's FINISHED
 		// record covers everything yet must not remove a newer drop's marker.
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"}, nil,
 			[]*distributedtask.Task{finishedDropTaskCovering("t1", "C", []string{"s1", "s2"}, "v1")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "only the completing cleanup task")
 	})
 
 	t.Run("swapping task with an uncovered shard does not vouch", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2", "s3"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2", "s3"}, nil,
 			[]*distributedtask.Task{swappingDropTaskCovering("t1", "C", []string{"s1", "s2"}, "v1")})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not covered")
@@ -1161,7 +1180,7 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	})
 
 	t.Run("any single swapping task covering everything vouches", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"}, nil,
 			[]*distributedtask.Task{
 				finishedDropTaskCovering("t1", "C", []string{"s1"}, "v1"),
 				swappingDropTaskCovering("t2", "C", []string{"s1", "s2"}, "v1"),
@@ -1173,7 +1192,7 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 		// Mirrors the finalize deferral: a single task must cover everyone —
 		// cross-task memory travels as that task's CleanedShards, not by
 		// unioning arbitrary records here.
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"}, nil,
 			[]*distributedtask.Task{
 				swappingDropTaskCovering("t1", "C", []string{"s1"}, "v1"),
 				swappingDropTaskCovering("t2", "C", []string{"s2"}, "v1"),
@@ -1183,7 +1202,7 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	})
 
 	t.Run("the closest task's missing shards are reported", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2", "s3"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2", "s3"}, nil,
 			[]*distributedtask.Task{
 				swappingDropTaskCovering("t1", "C", []string{"s1"}, "v1"),       // misses s2, s3
 				swappingDropTaskCovering("t2", "C", []string{"s1", "s2"}, "v1"), // misses only s3
@@ -1194,9 +1213,44 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	})
 
 	t.Run("a multi-target voucher covers each removed vector", func(t *testing.T) {
-		err := p.CheckVectorConfigRemoval("C", []string{"v1", "v2"}, []string{"s1"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1", "v2"}, []string{"s1"}, nil,
 			[]*distributedtask.Task{swappingDropTaskCovering("t1", "C", []string{"s1"}, "v1", "v2")})
 		require.NoError(t, err)
+	})
+
+	t.Run("a voucher from a different drop epoch has no say", func(t *testing.T) {
+		// The re-drop repro's gate half: the marker carries a generation
+		// token; a SWAPPING task of another epoch — however complete — must
+		// not remove it.
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"},
+			map[string]string{"v1": "E2"},
+			[]*distributedtask.Task{swappingDropTaskCovering("t1", "C", []string{"s1"}, "v1")}) // epoch-less payload
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "only the completing cleanup task")
+	})
+
+	t.Run("a matching-epoch voucher is accepted", func(t *testing.T) {
+		task := swappingDropTaskCovering("t1", "C", []string{"s1"}, "v1")
+		payload := &DropVectorIndexTaskPayload{
+			Collection: "C", Targets: []string{"v1"}, OpID: "op-t1",
+			UnitToShard: map[string]string{"s1__u0": "s1"}, DropEpochID: "E2",
+		}
+		task.Payload, _ = payload.encode()
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"},
+			map[string]string{"v1": "E2"}, []*distributedtask.Task{task})
+		require.NoError(t, err)
+	})
+
+	t.Run("a pre-token marker accepts any epoch (wildcard)", func(t *testing.T) {
+		task := swappingDropTaskCovering("t1", "C", []string{"s1"}, "v1")
+		payload := &DropVectorIndexTaskPayload{
+			Collection: "C", Targets: []string{"v1"}, OpID: "op-t1",
+			UnitToShard: map[string]string{"s1__u0": "s1"}, DropEpochID: "E9",
+		}
+		task.Payload, _ = payload.encode()
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"},
+			map[string]string{"v1": ""}, []*distributedtask.Task{task})
+		require.NoError(t, err, "markers written by pre-token nodes keep pre-token semantics")
 	})
 
 	t.Run("a task's inherited CleanedShards count as coverage", func(t *testing.T) {
@@ -1207,7 +1261,7 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 			CleanedShards: []string{"s2"},
 		}
 		task.Payload, _ = payload.encode()
-		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"},
+		err := p.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1", "s2"}, nil,
 			[]*distributedtask.Task{task})
 		require.NoError(t, err, "units plus the inherited cleaned set span all shards")
 	})

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -155,7 +155,7 @@ func deepCopyClass(c *models.Class) (*models.Class, error) {
 
 const dropVectorFinalizeMaxAttempts = 5
 
-func (f *schemaVectorConfigFinalizer) RemoveDroppedVectorConfig(ctx context.Context, collection string, targets []string) error {
+func (f *schemaVectorConfigFinalizer) RemoveDroppedVectorConfig(ctx context.Context, collection string, targets []string, dropEpochID string) error {
 	var lastErr error
 	for attempt := 0; attempt < dropVectorFinalizeMaxAttempts; attempt++ {
 		// Fresh read each attempt so a concurrent update doesn't get clobbered.
@@ -178,8 +178,10 @@ func (f *schemaVectorConfigFinalizer) RemoveDroppedVectorConfig(ctx context.Cont
 		for name, cfg := range next.VectorConfig {
 			// Exact-case match (target vector names are case-sensitive identifiers:
 			// a case-differing sibling is a DIFFERENT vector whose marker must stay);
-			// only remove an entry still marked dropped (keep a live re-creation).
-			if slices.Contains(targets, name) && modelsext.IsVectorIndexDropped(cfg) {
+			// only remove an entry still marked dropped (keep a live re-creation)
+			// AND belonging to this drop's epoch (never a re-dropped name's marker).
+			if slices.Contains(targets, name) && modelsext.IsVectorIndexDropped(cfg) &&
+				modelsext.DropEpochMatches(modelsext.DropEpochID(cfg), dropEpochID) {
 				delete(next.VectorConfig, name)
 				changed = true
 			}

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -157,7 +157,7 @@ func (m *Manager) CheckTenantMutation(className string, tenants []string) error 
 // that also implements [VectorConfigRemovalGate]. Called from the schema FSM's
 // UpdateClass apply; a non-nil error rejects the update. Same RAFT-determinism
 // contract as [Manager.CheckClassMutation].
-func (m *Manager) CheckVectorConfigRemoval(className string, removedVectors, shards []string) error {
+func (m *Manager) CheckVectorConfigRemoval(className string, removedVectors, shards []string, epochs map[string]string) error {
 	if len(removedVectors) == 0 {
 		return nil
 	}
@@ -172,7 +172,7 @@ func (m *Manager) CheckVectorConfigRemoval(className string, removedVectors, sha
 		for _, t := range m.tasks[namespace] {
 			existing = append(existing, t)
 		}
-		if err := gate.CheckVectorConfigRemoval(className, removedVectors, shards, existing); err != nil {
+		if err := gate.CheckVectorConfigRemoval(className, removedVectors, shards, epochs, existing); err != nil {
 			return err
 		}
 	}

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -1639,7 +1639,7 @@ type fakeRemovalGate struct {
 	gateReject    error
 }
 
-func (f *fakeRemovalGate) CheckVectorConfigRemoval(className string, removed, shards []string, existing []*Task) error {
+func (f *fakeRemovalGate) CheckVectorConfigRemoval(className string, removed, shards []string, epochs map[string]string, existing []*Task) error {
 	f.gateCalled++
 	f.lastClassName = className
 	f.lastRemoved = removed
@@ -1655,14 +1655,14 @@ func (f *fakeRemovalGate) CheckVectorConfigRemoval(className string, removed, sh
 func TestManager_CheckVectorConfigRemoval_DispatchToGates(t *testing.T) {
 	t.Run("no detectors registered → nil", func(t *testing.T) {
 		h := newTestHarness(t).init(t)
-		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"}))
+		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"}, nil))
 	})
 
 	t.Run("empty removal list → gate not consulted", func(t *testing.T) {
 		h := newTestHarness(t).init(t)
 		gate := &fakeRemovalGate{fakeSchemaMutationDetector: &fakeSchemaMutationDetector{}, gateReject: fmt.Errorf("should not be reached")}
 		h.manager.SetSchemaMutationDetectors(map[string]SchemaMutationDetector{"drop-vector-index": gate})
-		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", nil, []string{"s1"}))
+		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", nil, []string{"s1"}, nil))
 		require.Equal(t, 0, gate.gateCalled)
 	})
 
@@ -1677,7 +1677,7 @@ func TestManager_CheckVectorConfigRemoval_DispatchToGates(t *testing.T) {
 		})
 		require.NoError(t, h.manager.AddTask(c, 100))
 
-		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"}))
+		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"}, nil))
 		require.Equal(t, 1, gate.gateCalled)
 		require.Equal(t, []string{"v1"}, gate.lastRemoved)
 		require.Equal(t, []string{"s1"}, gate.lastShards, "gate must receive the shard set")
@@ -1688,7 +1688,7 @@ func TestManager_CheckVectorConfigRemoval_DispatchToGates(t *testing.T) {
 		h := newTestHarness(t).init(t)
 		gate := &fakeRemovalGate{fakeSchemaMutationDetector: &fakeSchemaMutationDetector{}, gateReject: fmt.Errorf("cleanup not FINISHED")}
 		h.manager.SetSchemaMutationDetectors(map[string]SchemaMutationDetector{"drop-vector-index": gate})
-		err := h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"})
+		err := h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"}, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cleanup not FINISHED")
 	})
@@ -1699,7 +1699,7 @@ func TestManager_CheckVectorConfigRemoval_DispatchToGates(t *testing.T) {
 		h.manager.SetSchemaMutationDetectors(map[string]SchemaMutationDetector{
 			"reindex": &fakeSchemaMutationDetector{rejectWith: fmt.Errorf("should not be reached")},
 		})
-		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"}))
+		require.NoError(t, h.manager.CheckVectorConfigRemoval("C", []string{"v1"}, []string{"s1"}, nil))
 	})
 }
 

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -251,9 +251,10 @@ type SchemaMutationDetector interface {
 type VectorConfigRemovalGate interface {
 	// CheckVectorConfigRemoval is called under [Manager.mu] from the schema FSM's
 	// UpdateClass apply; non-nil rejects. shards is the collection's shard set
-	// from the FSM state being applied; existingTasks is the namespace-scoped
-	// list at apply time.
-	CheckVectorConfigRemoval(className string, removedVectors, shards []string, existingTasks []*Task) error
+	// and epochs the removed markers' generation tokens, both read from the FSM
+	// pre-image of the entry being applied; existingTasks is the
+	// namespace-scoped list at apply time.
+	CheckVectorConfigRemoval(className string, removedVectors, shards []string, epochs map[string]string, existingTasks []*Task) error
 }
 
 // RecoveryAwareProvider is an optional interface providers implement to

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -73,9 +73,11 @@ type MutationGuard interface {
 	CheckTenantMutation(className string, tenants []string) error
 
 	// CheckVectorConfigRemoval gates removal of dropped ("none") VectorConfig
-	// entries on a completed cleanup task that covered every shard in shards.
+	// entries: only the completing (SWAPPING) cleanup task of the SAME drop
+	// epoch, covering every shard in shards, vouches. epochs maps each removed
+	// vector to its marker's generation token ("" for pre-token markers).
 	// Returns non-nil to reject.
-	CheckVectorConfigRemoval(className string, removedVectors, shards []string) error
+	CheckVectorConfigRemoval(className string, removedVectors, shards []string, epochs map[string]string) error
 }
 
 // Narrow slice of *cluster/distributedtask.Manager so schema doesn't
@@ -476,7 +478,11 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 					shards = append(shards, name)
 				}
 				sort.Strings(shards)
-				if err := s.mutationGuard.CheckVectorConfigRemoval(meta.Class.Class, removed, shards); err != nil {
+				epochs := make(map[string]string, len(removed))
+				for _, name := range removed {
+					epochs[name] = modelsext.DropEpochID(meta.Class.VectorConfig[name])
+				}
+				if err := s.mutationGuard.CheckVectorConfigRemoval(meta.Class.Class, removed, shards, epochs); err != nil {
 					return fmt.Errorf("%w: %w", ErrBadRequest, err)
 				}
 			}

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -603,6 +603,7 @@ type recordingMutationGuard struct {
 	lastProp    string
 	lastRemoved []string
 	lastShards  []string
+	lastEpochs  map[string]string
 	rejectWith  error
 }
 
@@ -625,11 +626,12 @@ func (g *recordingMutationGuard) CheckTenantMutation(class string, tenants []str
 	return g.rejectWith
 }
 
-func (g *recordingMutationGuard) CheckVectorConfigRemoval(class string, removedVectors, shards []string) error {
+func (g *recordingMutationGuard) CheckVectorConfigRemoval(class string, removedVectors, shards []string, epochs map[string]string) error {
 	g.called++
 	g.lastClass = class
 	g.lastRemoved = removedVectors
 	g.lastShards = shards
+	g.lastEpochs = epochs
 	return g.rejectWith
 }
 
@@ -830,8 +832,11 @@ func TestSchemaManager_UpdateClass_VectorConfigRemovalGate(t *testing.T) {
 			sm.SetMutationGuard(guard)
 		}
 		initial := &models.Class{
-			Class:        "C",
-			VectorConfig: map[string]models.VectorConfig{"keep": hnsw, "vec1": none},
+			Class: "C",
+			VectorConfig: map[string]models.VectorConfig{
+				"keep": hnsw,
+				"vec1": {VectorIndexType: "none", VectorIndexConfig: map[string]interface{}{"dropEpochId": "E1"}},
+			},
 		}
 		ss := &sharding.State{Physical: map[string]sharding.Physical{
 			"shardB": {Name: "shardB"}, "shardA": {Name: "shardA"}, "shardC": {Name: "shardC"},
@@ -852,6 +857,8 @@ func TestSchemaManager_UpdateClass_VectorConfigRemovalGate(t *testing.T) {
 		require.Equal(t, []string{"vec1"}, guard.lastRemoved)
 		require.Equal(t, []string{"shardA", "shardB", "shardC"}, guard.lastShards,
 			"gate must receive the FSM's shard set, sorted")
+		require.Equal(t, map[string]string{"vec1": "E1"}, guard.lastEpochs,
+			"gate must receive the removed marker's generation token")
 	})
 
 	t.Run("removing a dropped entry succeeds when the gate allows", func(t *testing.T) {

--- a/entities/modelsext/class.go
+++ b/entities/modelsext/class.go
@@ -53,6 +53,32 @@ func IsVectorIndexDropped(cfg models.VectorConfig) bool {
 	return cfg.VectorIndexType == VectorIndexTypeNone
 }
 
+// DropEpochIDKey carries the drop's generation token inside a dropped entry's
+// otherwise-unused (and unparsed) VectorIndexConfig. Minted in the same raft
+// commit that sets the "none" marker, immutable for the drop's lifetime, and
+// removed with the entry at finalize — so cleanup-task records of a PREVIOUS
+// drop of a re-created name can never be mistaken for the current drop's.
+const DropEpochIDKey = "dropEpochId"
+
+// DropEpochID returns the dropped entry's generation token, or "" for markers
+// written by nodes predating the token (treated as a wildcard by verifiers,
+// and as chain-less by coverage inheritance).
+func DropEpochID(cfg models.VectorConfig) string {
+	m, ok := cfg.VectorIndexConfig.(map[string]any)
+	if !ok {
+		return ""
+	}
+	epoch, _ := m[DropEpochIDKey].(string)
+	return epoch
+}
+
+// DropEpochMatches reports whether a cleanup-task payload epoch may act on a
+// marker with the given epoch: an epoch-less marker (older node) accepts any
+// payload; a token-bearing marker accepts only its own epoch.
+func DropEpochMatches(markerEpoch, payloadEpoch string) bool {
+	return markerEpoch == "" || markerEpoch == payloadEpoch
+}
+
 func ClassUsesVectorisation(class *models.Class) bool {
 	needsVectorisation := func(name string) bool {
 		return name != "" && name != "none"

--- a/test/acceptance/drop_vector_index/redrop_test.go
+++ b/test/acceptance/drop_vector_index/redrop_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-// testRedropAfterRecreate pins the closed-epoch fence end to end: drop a
-// vector, let it finalize, re-create the name and write new vectors, then
-// re-drop through an all-cold window so the fresh enqueue mints no task while
-// the previous drop's FINISHED records still exist. The re-drop must re-clean
-// the re-created vectors — adopting the stale records' coverage would finalize
-// with the new vectors never stripped.
+// testRedropAfterRecreate pins the generation token end to end: drop a
+// vector, let it finalize, re-create the name and write new vectors, add a
+// NEW tenant, then re-drop through an all-cold window so the fresh enqueue
+// mints no task while the previous drop's FINISHED records still exist. The
+// grown tenant set is the shape that broke record-only epoch inference (the
+// stale records look "incomplete" against it); the marker's token makes them
+// unmistakable — the re-drop must re-clean every tenant, never finalize over
+// the re-created vectors.
 func testRedropAfterRecreate() func(t *testing.T) {
 	return func(t *testing.T) {
 		const (
@@ -39,15 +41,16 @@ func testRedropAfterRecreate() func(t *testing.T) {
 			dim       = 32
 			perTenant = 8
 			tenant    = "tenant-1"
+			tenant2   = "tenant-2" // created between the drops — the grown-set twist
 		)
 
-		insert := func(t *testing.T, idBase int) {
+		insert := func(t *testing.T, target string, idBase int) {
 			batch := make([]*models.Object, perTenant)
 			for i := range perTenant {
 				batch[i] = &models.Object{
 					ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-0000000024%02d", idBase+i)),
 					Class:      className,
-					Tenant:     tenant,
+					Tenant:     target,
 					Properties: map[string]any{"name": fmt.Sprintf("object-%d", idBase+i)},
 					Vectors: models.Vectors{
 						dropped: randVec(dim, float32(idBase+i)),
@@ -78,37 +81,44 @@ func testRedropAfterRecreate() func(t *testing.T) {
 				clschema.NewSchemaObjectsCreateParams().WithObjectClass(cls), nil)
 			require.NoError(t, err)
 			helper.CreateTenants(t, className, []*models.Tenant{{Name: tenant}})
-			insert(t, 0)
+			insert(t, tenant, 0)
 
 			dropTargetVector(t, className, dropped)
 			eventuallyTargetVectorRemoved(t, className, dropped)
 		})
 
-		t.Run("re-create the name and write new vectors", func(t *testing.T) {
+		t.Run("re-create the name, write new vectors, add a tenant", func(t *testing.T) {
 			cls := helper.GetClass(t, className)
 			cls.VectorConfig[dropped] = noneVectorConfig()
 			_, err := helper.Client(t).Schema.SchemaObjectsUpdate(
 				clschema.NewSchemaObjectsUpdateParams().WithClassName(className).WithObjectClass(cls), nil)
 			require.NoError(t, err)
-			insert(t, 50)
+			insert(t, tenant, 50)
+
+			helper.CreateTenants(t, className, []*models.Tenant{{Name: tenant2}})
+			insert(t, tenant2, 80)
 		})
 
 		t.Run("re-drop through an all-cold window", func(t *testing.T) {
 			// Cold BEFORE the drop: the fresh enqueue then mints no task, and
 			// only the previous drop's records exist when reconciliation runs.
 			setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusCOLD)
+			setTenantStatusEventually(t, className, tenant2, models.TenantActivityStatusCOLD)
 			dropTargetVector(t, className, dropped)
 			setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusHOT)
+			setTenantStatusEventually(t, className, tenant2, models.TenantActivityStatusHOT)
 		})
 
-		t.Run("the re-drop re-cleans instead of adopting stale coverage", func(t *testing.T) {
+		t.Run("the re-drop re-cleans every tenant instead of adopting stale coverage", func(t *testing.T) {
 			eventuallyTargetVectorRemoved(t, className, dropped)
-			objs := listTenantObjectsWithVectors(t, className, tenant)
-			require.Len(t, objs, 2*perTenant)
-			for _, obj := range objs {
-				require.NotContains(t, obj.Vectors, dropped,
-					"the re-dropped vectors must be stripped, not finalized over")
-				require.Equal(t, dim, vecDim(t, obj.Vectors[sibling]))
+			for tenantName, want := range map[string]int{tenant: 2 * perTenant, tenant2: perTenant} {
+				objs := listTenantObjectsWithVectors(t, className, tenantName)
+				require.Len(t, objs, want)
+				for _, obj := range objs {
+					require.NotContains(t, obj.Vectors, dropped,
+						"the re-dropped vectors must be stripped, not finalized over")
+					require.Equal(t, dim, vecDim(t, obj.Vectors[sibling]))
+				}
 			}
 		})
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -538,6 +538,22 @@ func UpdateClassInternal(h *Handler, ctx context.Context, className string, upda
 	// in validateVectorSettingsAgainst.
 	initial := h.schemaReader.ReadOnlyClass(className)
 
+	// Dropped entries are system-owned: their VectorIndexConfig carries the
+	// drop's generation token, and a client update must not be able to alter
+	// it (matching an old drop's epoch would let that drop's task records act
+	// on this marker). Copy the current entry's config through; dropped→live
+	// flips are still rejected by the parser, and removals are gated by the
+	// FSM. Same copy-through pattern as SkipDefaultQuantization.
+	if initial != nil {
+		for name, updatedCfg := range updated.VectorConfig {
+			initialCfg, ok := initial.VectorConfig[name]
+			if ok && modelsext.IsVectorIndexDropped(initialCfg) && modelsext.IsVectorIndexDropped(updatedCfg) {
+				updatedCfg.VectorIndexConfig = initialCfg.VectorIndexConfig
+				updated.VectorConfig[name] = updatedCfg
+			}
+		}
+	}
+
 	if err := rejectVectorIndexTypeNone(initial, updated); err != nil {
 		vclasses, qErr := h.schemaManager.QueryReadOnlyClasses(className)
 		if qErr != nil {

--- a/usecases/schema/class_drop_vector_test.go
+++ b/usecases/schema/class_drop_vector_test.go
@@ -137,6 +137,57 @@ func TestDropVectorIndex_UpdateClassRejectsNoneIntroduction(t *testing.T) {
 	require.ErrorContains(t, err, "internal sentinel for dropped indexes")
 }
 
+// TestDropVectorIndex_UpdateClassPreservesMarkerConfig pins the copy-through:
+// a client update cannot alter a dropped entry's VectorIndexConfig — it holds
+// the drop's generation token, and matching an old epoch would let that
+// drop's task records act on this marker.
+func TestDropVectorIndex_UpdateClassPreservesMarkerConfig(t *testing.T) {
+	ctx := context.Background()
+	handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+
+	className := "DropSentinelClass"
+	current := &models.Class{
+		Class: className,
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {
+				VectorIndexType:   modelsext.VectorIndexTypeNone,
+				VectorIndexConfig: map[string]interface{}{modelsext.DropEpochIDKey: "genuine-epoch"},
+				Vectorizer:        map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+			},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+	}
+	fakeSchemaManager.On("ReadOnlyClass", className).Return(current)
+	fakeSchemaManager.On("QueryReadOnlyClasses", []string{className}).
+		Return(map[string]versioned.Class{className: {Class: current}}, nil)
+	fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
+
+	tampered := &models.Class{
+		Class:       className,
+		Description: "tampering attempt",
+		VectorConfig: map[string]models.VectorConfig{
+			"foo": {
+				VectorIndexType:   modelsext.VectorIndexTypeNone,
+				VectorIndexConfig: map[string]interface{}{modelsext.DropEpochIDKey: "forged-epoch"},
+				Vectorizer:        map[string]interface{}{"text2vec-contextionary": map[string]interface{}{}},
+			},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+	}
+
+	require.NoError(t, handler.UpdateClass(ctx, nil, className, tampered))
+
+	var sent *models.Class
+	for _, call := range fakeSchemaManager.Calls {
+		if call.Method == "UpdateClass" {
+			sent = call.Arguments[0].(*models.Class)
+		}
+	}
+	require.NotNil(t, sent)
+	require.Equal(t, "genuine-epoch", modelsext.DropEpochID(sent.VectorConfig["foo"]),
+		"the marker's token must be copied through, not the client's value")
+}
+
 func TestDropVectorIndex_UpdateClassAllowsExistingNoneOnStaleNode(t *testing.T) {
 	ctx := context.Background()
 	handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})

--- a/usecases/schema/drop_vector_index_test.go
+++ b/usecases/schema/drop_vector_index_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/vectorindex"
 	"github.com/weaviate/weaviate/entities/versioned"
 )
@@ -70,6 +71,8 @@ func TestDeleteClassVectorIndex_FreshDrop_SetsMarkerAndEnqueues(t *testing.T) {
 
 	require.Equal(t, vectorindex.VectorIndexTypeNone, cls.VectorConfig["foo"].VectorIndexType,
 		"marker must be set on the dropped vector")
+	require.NotEmpty(t, modelsext.DropEpochID(cls.VectorConfig["foo"]),
+		"the marker must carry its generation token from the same commit")
 	sm.AssertCalled(t, "UpdateClass", mock.Anything, mock.Anything)
 	require.Equal(t, [][]string{{"foo"}}, enq.enqueued)
 	require.Equal(t, []string{"C"}, enq.enqueuedAt)

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	entcfg "github.com/weaviate/weaviate/entities/config"
@@ -293,6 +294,10 @@ func (h *Handler) DeleteClassVectorIndex(ctx context.Context, principal *models.
 	class.VectorConfig[vectorIndexName] = models.VectorConfig{
 		Vectorizer:      cfg.Vectorizer,
 		VectorIndexType: vectorindex.VectorIndexTypeNone,
+		// The generation token: identity of THIS drop, minted with the marker
+		// itself so it exists even if no cleanup task is ever enqueued. Every
+		// verifier compares task payloads against it (see modelsext.DropEpochID).
+		VectorIndexConfig: map[string]any{modelsext.DropEpochIDKey: uuid.NewString()},
 	}
 
 	if _, err = h.schemaManager.UpdateClass(ctx, class, nil); err != nil {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
