### PR TITLE
fix(drop-vector-index): purge the previous drop's task records when a new marker is introduced

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -661,6 +661,9 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 			db.ReindexNamespace:         db.ExtractReindexTaskCollection,
 			db.DropVectorIndexNamespace: db.ExtractDropVectorIndexTaskCollection,
 		},
+		DistributedTaskTargetExtractors: map[string]distributedtask.TargetExtractor{
+			db.DropVectorIndexNamespace: db.ExtractDropVectorIndexTaskTargets,
+		},
 		ReplicaMovementEnabled:  appState.ServerConfig.Config.ReplicaMovementEnabled,
 		DrainSleep:              appState.ServerConfig.Config.Raft.DrainSleep.Get(),
 		MaxTenantsPerCollection: appState.ServerConfig.Config.UsageLimits.MaxTenantsPerCollection,

--- a/adapters/handlers/rest/drop_vector_index_enqueuer.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer.go
@@ -214,6 +214,11 @@ func (e *dropVectorIndexEnqueuer) EnqueueDropVectorIndex(ctx context.Context, co
 // landed): mint a fresh epoch and re-clean everything, never trust it. That
 // costs one idempotent full re-clean; the alternative trusts stale coverage
 // and finalizes over unstripped vectors.
+//
+// The inference is sound only because stale records cannot coexist with a
+// marker they don't belong to: introducing a marker purges the previous
+// drop's records in the same raft apply (schema FSM marker-introduction
+// purge). Do not weaken that purge without revisiting this function.
 func (e *dropVectorIndexEnqueuer) epochAndInheritedCoverage(ctx context.Context,
 	collection string, targets []string, state *sharding.State,
 ) (string, []string, error) {

--- a/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
+++ b/adapters/handlers/rest/drop_vector_index_enqueuer_test.go
@@ -463,35 +463,15 @@ func TestEnqueueDropVectorIndex_TaskListError_Surfaces(t *testing.T) {
 	require.Empty(t, cluster.gotTaskID)
 }
 
-// TestEnqueueDropVectorIndex_GrownShardSetAfterFinalize is the RED pin for the
-// closed-epoch fence hole: a finalized epoch whose collection gained a shard
-// afterwards looks INCOMPLETE against the grown shard set, so the fence fails
-// to fire and the stale epoch's coverage is inherited into a genuinely new
-// drop — its completion would finalize with the re-created vectors on the old
-// shards never stripped. The new drop must start a fresh epoch and clean
-// every shard.
-func TestEnqueueDropVectorIndex_GrownShardSetAfterFinalize(t *testing.T) {
-	hot := func(nodes ...string) sharding.Physical {
-		return sharding.Physical{Status: models.TenantActivityStatusHOT, BelongsToNodes: nodes}
-	}
-	cluster := &fakeClusterDropClient{tasks: map[string][]*distributedtask.Task{
-		db.DropVectorIndexNamespace: {
-			// The previous drop's record: covered everything that existed then.
-			epochTask(t, "C", "t1", "E1", 1, distributedtask.TaskStatusFinished, []string{"s1", "s2"}, nil),
-		},
-	}}
-	state := &fakeShardingState{state: shardingState(true, map[string]sharding.Physical{
-		"s1": hot("n1"), "s2": hot("n1"), "s3": hot("n1"), // s3 created after the finalize
-	})}
-	enq := &dropVectorIndexEnqueuer{clusterService: cluster, schemaState: state}
-
-	require.NoError(t, enq.EnqueueDropVectorIndex(context.Background(), "C", []string{"v1"}))
-	p := decodeEnqueuedPayload(t, cluster)
-	require.NotEqual(t, "E1", p.DropEpochID, "a finalized epoch must not be continued")
-	require.Empty(t, p.CleanedShards, "stale coverage must not be inherited")
-	require.Equal(t, map[string]string{"s1__n1": "s1", "s2__n1": "s2", "s3__n1": "s3"}, p.UnitToShard,
-		"every shard must be cleaned by the new drop")
-}
+// NOTE on the grown-shard-set re-drop hazard: given a STALE record (a
+// finalized previous drop of a re-created name) plus a shard created since,
+// this enqueuer's fence alone would mis-inherit — the state is locally
+// indistinguishable from an in-progress chain. Soundness comes from upstream:
+// the schema FSM purges the previous drop's records in the same raft apply
+// that introduces a new marker (see
+// TestSchemaManager_UpdateClass_MarkerIntroductionPurgesRecords and the
+// re-drop e2e), so stale records cannot exist next to a marker they don't
+// belong to.
 
 // TestEnqueueDropVectorIndex_CoverageInheritance pins the chain rules: inherit
 // cleaned-shard coverage only from completed same-epoch tasks of an INCOMPLETE

--- a/adapters/repos/db/drop_vector_index_payload.go
+++ b/adapters/repos/db/drop_vector_index_payload.go
@@ -111,6 +111,19 @@ func decodeDropVectorIndexPayload(data []byte) (*DropVectorIndexTaskPayload, err
 	return &p, nil
 }
 
+// ExtractDropVectorIndexTaskTargets is the target extractor registered with
+// the DTM Manager so a NEW drop's marker introduction can purge the previous
+// drop's task records for the same (collection, target) — stale records must
+// not exist while a marker they don't belong to stands, or coverage
+// inheritance could adopt them. ok is false on an unparseable payload.
+func ExtractDropVectorIndexTaskTargets(payload []byte) (collection string, targets []string, ok bool) {
+	p, err := decodeDropVectorIndexPayload(payload)
+	if err != nil {
+		return "", nil, false
+	}
+	return p.Collection, p.Targets, true
+}
+
 // ExtractDropVectorIndexTaskCollection is the collection extractor registered
 // with the DTM Manager so the DeleteClass cascade can drop this namespace's task
 // records (mirrors ExtractReindexTaskCollection). ok is false on an unparseable

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -278,14 +278,56 @@ func (m *Manager) RegisterTargetExtractor(namespace string, extractor TargetExtr
 	m.targetExtractors[namespace] = extractor
 }
 
+// HasActiveTasksForCollectionTargets reports whether any ACTIVE task in a
+// target-extractor namespace binds to `collection` and overlaps `targets`.
+// Consulted by the schema FSM before a drop-vector marker introduction: an
+// active task survives the purge, and a marker born next to it would inherit
+// the previous drop's records once it completes.
+func (m *Manager) HasActiveTasksForCollectionTargets(collection string, targets []string) bool {
+	if collection == "" || len(targets) == 0 {
+		return false
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	targetSet := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		targetSet[t] = struct{}{}
+	}
+	for namespace, tasksByID := range m.tasks {
+		extractor, ok := m.targetExtractors[namespace]
+		if !ok || extractor == nil {
+			continue
+		}
+		for _, task := range tasksByID {
+			if !task.Status.IsActive() {
+				continue
+			}
+			c, taskTargets, ok := extractor(task.Payload)
+			if !ok || c != collection {
+				continue
+			}
+			for _, t := range taskTargets {
+				if _, ok := targetSet[t]; ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // DeleteTasksForCollectionTargets drops NON-ACTIVE tasks whose payload binds to
 // `collection` and overlaps `targets`, in namespaces with a registered target
 // extractor. Called deterministically from the schema FSM when a new
 // drop-vector marker is introduced, so the previous drop of a re-created name
 // leaves no records for coverage inheritance or removal vouching to
-// misattribute to the new drop. Active tasks are skipped: one cannot exist for
-// a name whose marker is only now being introduced, and skipping keeps the
-// scheduler's running handles consistent.
+// misattribute to the new drop. Active tasks are skipped to keep the
+// scheduler's running handles consistent — the caller must therefore REFUSE
+// the introduction when HasActiveTasksForCollectionTargets is true (the
+// previous drop's task can still be SWAPPING for a moment after its finalize
+// removed the old marker), or the survivor would seed stale inheritance.
 func (m *Manager) DeleteTasksForCollectionTargets(collection string, targets []string) []TaskDescriptor {
 	if collection == "" || len(targets) == 0 {
 		return nil

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -63,6 +63,7 @@ type Manager struct {
 	// Per-namespace payload→collection extractors. Absent ⇒ namespace is
 	// not collection-scoped and survives DeleteTasksForCollection.
 	collectionExtractors map[string]CollectionExtractor
+	targetExtractors     map[string]TargetExtractor
 
 	completedTaskTTL time.Duration
 
@@ -245,6 +246,7 @@ func NewManager(params ManagerParameters) *Manager {
 	return &Manager{
 		tasks:                make(map[string]map[string]*Task),
 		collectionExtractors: make(map[string]CollectionExtractor),
+		targetExtractors:     make(map[string]TargetExtractor),
 
 		completedTaskTTL: params.CompletedTaskTTL,
 
@@ -263,6 +265,68 @@ func (m *Manager) RegisterCollectionExtractor(namespace string, extractor Collec
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.collectionExtractors[namespace] = extractor
+}
+
+// RegisterTargetExtractor opts a task namespace into
+// DeleteTasksForCollectionTargets. Same contract as RegisterCollectionExtractor.
+func (m *Manager) RegisterTargetExtractor(namespace string, extractor TargetExtractor) {
+	if namespace == "" || extractor == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.targetExtractors[namespace] = extractor
+}
+
+// DeleteTasksForCollectionTargets drops NON-ACTIVE tasks whose payload binds to
+// `collection` and overlaps `targets`, in namespaces with a registered target
+// extractor. Called deterministically from the schema FSM when a new
+// drop-vector marker is introduced, so the previous drop of a re-created name
+// leaves no records for coverage inheritance or removal vouching to
+// misattribute to the new drop. Active tasks are skipped: one cannot exist for
+// a name whose marker is only now being introduced, and skipping keeps the
+// scheduler's running handles consistent.
+func (m *Manager) DeleteTasksForCollectionTargets(collection string, targets []string) []TaskDescriptor {
+	if collection == "" || len(targets) == 0 {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	targetSet := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		targetSet[t] = struct{}{}
+	}
+	var removed []TaskDescriptor
+	for namespace, tasksByID := range m.tasks {
+		extractor, ok := m.targetExtractors[namespace]
+		if !ok || extractor == nil {
+			continue
+		}
+		for taskID, task := range tasksByID {
+			if task.Status.IsActive() {
+				continue
+			}
+			c, taskTargets, ok := extractor(task.Payload)
+			if !ok || c != collection {
+				continue
+			}
+			overlaps := false
+			for _, t := range taskTargets {
+				if _, ok := targetSet[t]; ok {
+					overlaps = true
+					break
+				}
+			}
+			if !overlaps {
+				continue
+			}
+			delete(tasksByID, taskID)
+			removed = append(removed, task.TaskDescriptor)
+		}
+	}
+	return removed
 }
 
 // DeleteTasksForCollection drops tasks whose payload binds to `collection`. Called

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -1780,6 +1780,13 @@ func TestManager_DeleteTasksForCollectionTargets(t *testing.T) {
 
 	require.Empty(t, h.manager.DeleteTasksForCollectionTargets("", []string{"v1"}))
 	require.Empty(t, h.manager.DeleteTasksForCollectionTargets("Foo", nil))
+
+	// The probe the schema FSM consults before allowing a marker introduction:
+	// only the surviving ACTIVE match reports true.
+	require.True(t, h.manager.HasActiveTasksForCollectionTargets("Foo", []string{"v1"}))
+	require.False(t, h.manager.HasActiveTasksForCollectionTargets("Foo", []string{"v9"}))
+	require.False(t, h.manager.HasActiveTasksForCollectionTargets("Bar", []string{"v9"}))
+	require.False(t, h.manager.HasActiveTasksForCollectionTargets("", []string{"v1"}))
 }
 
 func TestManager_DeleteTasksForCollection(t *testing.T) {

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -1735,6 +1735,53 @@ func TestManager_CheckTenantMutation_DispatchToDetectors(t *testing.T) {
 	})
 }
 
+func TestManager_DeleteTasksForCollectionTargets(t *testing.T) {
+	targetExtractor := func(payload []byte) (string, []string, bool) {
+		var p struct {
+			Collection string   `json:"collection"`
+			Targets    []string `json:"targets"`
+		}
+		if err := json.Unmarshal(payload, &p); err != nil || p.Collection == "" {
+			return "", nil, false
+		}
+		return p.Collection, p.Targets, true
+	}
+
+	h := newTestHarness(t).init(t)
+	h.manager.RegisterTargetExtractor("drop", targetExtractor)
+
+	mkTask := func(id string, payload any, status TaskStatus) {
+		t.Helper()
+		bytes, err := json.Marshal(payload)
+		require.NoError(t, err)
+		require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
+			Namespace:             "drop",
+			Id:                    id,
+			Payload:               bytes,
+			SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
+			UnitIds:               []string{"u-" + id},
+		}), 1))
+		h.manager.tasks["drop"][id].Status = status
+	}
+	mkTask("match-1", map[string]any{"collection": "Foo", "targets": []string{"v1"}}, TaskStatusFinished)
+	mkTask("match-2", map[string]any{"collection": "Foo", "targets": []string{"v1", "v2"}}, TaskStatusFailed)
+	mkTask("other-target", map[string]any{"collection": "Foo", "targets": []string{"v9"}}, TaskStatusFinished)
+	mkTask("other-coll", map[string]any{"collection": "Bar", "targets": []string{"v1"}}, TaskStatusFinished)
+	mkTask("still-active", map[string]any{"collection": "Foo", "targets": []string{"v1"}}, TaskStatusStarted)
+
+	removed := h.manager.DeleteTasksForCollectionTargets("Foo", []string{"v1"})
+	removedIDs := make([]string, 0, len(removed))
+	for _, d := range removed {
+		removedIDs = append(removedIDs, d.ID)
+	}
+	sort.Strings(removedIDs)
+	require.Equal(t, []string{"match-1", "match-2"}, removedIDs,
+		"non-active records overlapping the target are purged; other targets, collections, and active tasks survive")
+
+	require.Empty(t, h.manager.DeleteTasksForCollectionTargets("", []string{"v1"}))
+	require.Empty(t, h.manager.DeleteTasksForCollectionTargets("Foo", nil))
+}
+
 func TestManager_DeleteTasksForCollection(t *testing.T) {
 	// Conservative: ("", false) on parse error keeps the cascade from
 	// matching when the payload is not the expected shape.

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -37,6 +37,11 @@ type SchedulerNotifier interface {
 // CollectionExtractor returns the schema-collection a task's payload is
 // bound to ("", false for non-scoped / unparseable). Register via
 // [Manager.RegisterCollectionExtractor] to opt a namespace into
+// TargetExtractor reads a task payload's (collection, target vectors) binding
+// for [Manager.DeleteTasksForCollectionTargets]; ok=false skips the record.
+// Same determinism contract as [CollectionExtractor].
+type TargetExtractor func(payload []byte) (collection string, targets []string, ok bool)
+
 // [Manager.DeleteTasksForCollection] — closes
 // weaviate/0-weaviate-issues#231.
 type CollectionExtractor func(payload []byte) (collection string, ok bool)

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -82,6 +82,7 @@ type MutationGuard interface {
 // depend on the full Manager surface and tests can stub it. nil-safe.
 type distributedTaskCascadeDeleter interface {
 	DeleteTasksForCollection(collection string) []distributedtask.TaskDescriptor
+	DeleteTasksForCollectionTargets(collection string, targets []string) []distributedtask.TaskDescriptor
 }
 
 type SchemaManager struct {
@@ -465,6 +466,23 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 			}
 		}
 
+		// A NEWLY introduced drop marker purges the previous drop's task records
+		// for the same (collection, target) in this same apply — atomically and
+		// RAFT-deterministically. A re-created then re-dropped name therefore
+		// starts with a clean record slate: stale records must not exist next to
+		// a marker they don't belong to, or coverage inheritance and removal
+		// vouching could misattribute them to the new drop.
+		if s.distributedTaskManager != nil {
+			if introduced := introducedDroppedVectorConfigs(&meta.Class, u); len(introduced) > 0 {
+				if removed := s.distributedTaskManager.DeleteTasksForCollectionTargets(meta.Class.Class, introduced); len(removed) > 0 {
+					s.log.WithField("class", meta.Class.Class).
+						WithField("targets", introduced).
+						WithField("removed_count", len(removed)).
+						Info("purged previous drop's task records on new drop-vector marker")
+				}
+			}
+		}
+
 		// Gate at apply time so the verdict is RAFT-deterministic. The FSM's own
 		// sharding state is the coverage baseline: a shard neither in the vouching
 		// task's units nor its inherited cleaned-shard set has not been cleaned,
@@ -514,6 +532,24 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 			enableSchemaCallback: enableSchemaCallback,
 		},
 	)
+}
+
+// introducedDroppedVectorConfigs returns the names of VectorConfig entries that
+// are dropped ("none") in next but were live or absent in prev — i.e. markers
+// this update introduces.
+func introducedDroppedVectorConfigs(prev, next *models.Class) []string {
+	var introduced []string
+	for name, cfg := range next.VectorConfig {
+		if !modelsext.IsVectorIndexDropped(cfg) {
+			continue
+		}
+		if prevCfg, ok := prev.VectorConfig[name]; ok && modelsext.IsVectorIndexDropped(prevCfg) {
+			continue
+		}
+		introduced = append(introduced, name)
+	}
+	sort.Strings(introduced)
+	return introduced
 }
 
 // removedDroppedVectorConfigs returns the names of dropped ("none") VectorConfig

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -83,6 +83,7 @@ type MutationGuard interface {
 type distributedTaskCascadeDeleter interface {
 	DeleteTasksForCollection(collection string) []distributedtask.TaskDescriptor
 	DeleteTasksForCollectionTargets(collection string, targets []string) []distributedtask.TaskDescriptor
+	HasActiveTasksForCollectionTargets(collection string, targets []string) bool
 }
 
 type SchemaManager struct {
@@ -474,6 +475,15 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 		// vouching could misattribute them to the new drop.
 		if s.distributedTaskManager != nil {
 			if introduced := introducedDroppedVectorConfigs(&meta.Class, u); len(introduced) > 0 {
+				// The purge skips active tasks, so an introduction next to one
+				// (the previous drop still SWAPPING for a moment after its
+				// finalize) must be refused — the survivor would outlive the
+				// purge and seed stale coverage inheritance. Deterministic and
+				// retryable: the window closes when the task flips FINISHED.
+				if s.distributedTaskManager.HasActiveTasksForCollectionTargets(meta.Class.Class, introduced) {
+					return fmt.Errorf("%w: a previous drop of %v on %q is still completing; retry",
+						ErrBadRequest, introduced, meta.Class.Class)
+				}
 				if removed := s.distributedTaskManager.DeleteTasksForCollectionTargets(meta.Class.Class, introduced); len(removed) > 0 {
 					s.log.WithField("class", meta.Class.Class).
 						WithField("targets", introduced).

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -805,10 +805,15 @@ func TestSchemaManager_DeleteClass_MutationGuard(t *testing.T) {
 // issues on drop-vector marker introduction.
 type fakeCascadeDeleter struct {
 	collectionCalls []string
+	activeMatch     bool
 	targetCalls     []struct {
 		collection string
 		targets    []string
 	}
+}
+
+func (f *fakeCascadeDeleter) HasActiveTasksForCollectionTargets(collection string, targets []string) bool {
+	return f.activeMatch
 }
 
 func (f *fakeCascadeDeleter) DeleteTasksForCollection(collection string) []distributedtask.TaskDescriptor {
@@ -863,6 +868,22 @@ func TestSchemaManager_UpdateClass_MarkerIntroductionPurgesRecords(t *testing.T)
 		require.Len(t, deleter.targetCalls, 1)
 		require.Equal(t, "C", deleter.targetCalls[0].collection)
 		require.Equal(t, []string{"vec1"}, deleter.targetCalls[0].targets)
+	})
+
+	t.Run("introduction is rejected while a matching task is still active", func(t *testing.T) {
+		// The SWAPPING race: the previous drop's task finalized (marker gone)
+		// but has not flipped FINISHED yet. Purging skips active tasks and
+		// never re-runs, so letting the marker in would leave a stale
+		// inheritance seed — the birth must be refused (retryable, ms window).
+		deleter := &fakeCascadeDeleter{activeMatch: true}
+		initial := &models.Class{Class: "C", VectorConfig: map[string]models.VectorConfig{"vec1": hnsw}}
+		parsed := &models.Class{Class: "C", VectorConfig: map[string]models.VectorConfig{"vec1": {VectorIndexType: none}}}
+		sm := newSM(deleter, initial, parsed)
+
+		err := sm.UpdateClass(mkRequest(parsed), "test-node", true, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "still completing")
+		require.Empty(t, deleter.targetCalls, "no purge may run when the introduction is refused")
 	})
 
 	t.Run("an already-dropped entry does not re-purge", func(t *testing.T) {

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	gproto "google.golang.org/protobuf/proto"
 
+	"github.com/weaviate/weaviate/cluster/distributedtask"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/fakes"
@@ -797,6 +798,83 @@ func TestSchemaManager_DeleteClass_MutationGuard(t *testing.T) {
 		err := sm.DeleteClass(mkRequest("C"), true, false)
 		require.NoError(t, err,
 			"with no guard registered and schemaOnly=true, DeleteClass on a non-existent class is a no-op")
+	})
+}
+
+// fakeCascadeDeleter records the target-scoped purge calls the schema FSM
+// issues on drop-vector marker introduction.
+type fakeCascadeDeleter struct {
+	collectionCalls []string
+	targetCalls     []struct {
+		collection string
+		targets    []string
+	}
+}
+
+func (f *fakeCascadeDeleter) DeleteTasksForCollection(collection string) []distributedtask.TaskDescriptor {
+	f.collectionCalls = append(f.collectionCalls, collection)
+	return nil
+}
+
+func (f *fakeCascadeDeleter) DeleteTasksForCollectionTargets(collection string, targets []string) []distributedtask.TaskDescriptor {
+	f.targetCalls = append(f.targetCalls, struct {
+		collection string
+		targets    []string
+	}{collection, targets})
+	return []distributedtask.TaskDescriptor{{ID: "purged", Version: 1}}
+}
+
+// TestSchemaManager_UpdateClass_MarkerIntroductionPurgesRecords pins the stale
+// record purge: introducing a drop marker deletes the previous drop's task
+// records for that (collection, target) in the SAME apply — a re-created then
+// re-dropped name must start with a clean slate, or coverage inheritance and
+// removal vouching could adopt the closed drop's records.
+func TestSchemaManager_UpdateClass_MarkerIntroductionPurgesRecords(t *testing.T) {
+	const none = "none"
+	hnsw := models.VectorConfig{VectorIndexType: "hnsw"}
+
+	mkRequest := func(updated *models.Class) *cmd.ApplyRequest {
+		sub, err := json.Marshal(&cmd.UpdateClassRequest{Class: updated, State: nil})
+		require.NoError(t, err)
+		return &cmd.ApplyRequest{
+			Type:       cmd.ApplyRequest_TYPE_UPDATE_CLASS,
+			Class:      "C",
+			Version:    2,
+			SubCommand: sub,
+		}
+	}
+	newSM := func(deleter *fakeCascadeDeleter, initial, parsed *models.Class) *SchemaManager {
+		parser := fakes.NewMockParser()
+		parser.On("ParseClassUpdate", mock.Anything, mock.Anything).Return(parsed, nil)
+		sm := NewSchemaManager("test-node", nil, parser, prometheus.NewPedanticRegistry(), logrus.New())
+		sm.SetDistributedTaskManager(deleter)
+		require.NoError(t, sm.schema.addClass(initial,
+			&sharding.State{Physical: map[string]sharding.Physical{}}, 1))
+		return sm
+	}
+
+	t.Run("live to none purges the target's records", func(t *testing.T) {
+		deleter := &fakeCascadeDeleter{}
+		initial := &models.Class{Class: "C", VectorConfig: map[string]models.VectorConfig{"vec1": hnsw}}
+		parsed := &models.Class{Class: "C", VectorConfig: map[string]models.VectorConfig{"vec1": {VectorIndexType: none}}}
+		sm := newSM(deleter, initial, parsed)
+
+		require.NoError(t, sm.UpdateClass(mkRequest(parsed), "test-node", true, false))
+		require.Len(t, deleter.targetCalls, 1)
+		require.Equal(t, "C", deleter.targetCalls[0].collection)
+		require.Equal(t, []string{"vec1"}, deleter.targetCalls[0].targets)
+	})
+
+	t.Run("an already-dropped entry does not re-purge", func(t *testing.T) {
+		deleter := &fakeCascadeDeleter{}
+		cfg := map[string]models.VectorConfig{"vec1": {VectorIndexType: none}, "keep": hnsw}
+		initial := &models.Class{Class: "C", VectorConfig: cfg}
+		parsed := &models.Class{Class: "C", VectorConfig: cfg}
+		sm := newSM(deleter, initial, parsed)
+
+		require.NoError(t, sm.UpdateClass(mkRequest(parsed), "test-node", true, false))
+		require.Empty(t, deleter.targetCalls,
+			"retriggers and unrelated updates must not purge the ACTIVE drop's records")
 	})
 }
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -191,6 +191,9 @@ type Config struct {
 	// miss tasks resurrected by replay. See [distributedtask.CollectionExtractor]
 	// and weaviate/0-weaviate-issues#231.
 	DistributedTaskCollectionExtractors map[string]distributedtask.CollectionExtractor
+	// DistributedTaskTargetExtractors mirror the collection extractors for
+	// per-target cascade deletion (drop-vector marker introduction).
+	DistributedTaskTargetExtractors map[string]distributedtask.TargetExtractor
 
 	ReplicaMovementEnabled bool
 
@@ -366,6 +369,9 @@ func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fs
 	// records survive. weaviate/0-weaviate-issues#231.
 	for namespace, extractor := range cfg.DistributedTaskCollectionExtractors {
 		distributedTasksManager.RegisterCollectionExtractor(namespace, extractor)
+	}
+	for namespace, extractor := range cfg.DistributedTaskTargetExtractors {
+		distributedTasksManager.RegisterTargetExtractor(namespace, extractor)
 	}
 
 	var dynusersLister namespaces.DynusersNamespaceLister

--- a/test/acceptance/drop_vector_index/redrop_test.go
+++ b/test/acceptance/drop_vector_index/redrop_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -104,7 +105,15 @@ func testRedropAfterRecreate() func(t *testing.T) {
 			// only the previous drop's records exist when reconciliation runs.
 			setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusCOLD)
 			setTenantStatusEventually(t, className, tenant2, models.TenantActivityStatusCOLD)
-			dropTargetVector(t, className, dropped)
+			// The first drop's task may still be SWAPPING for a moment after
+			// its finalize removed the marker; a re-drop in that window is
+			// refused ("still completing") and is retryable by contract.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				_, err := helper.Client(t).Schema.SchemaObjectsVectorsDelete(
+					clschema.NewSchemaObjectsVectorsDeleteParams().
+						WithClassName(className).WithVectorIndexName(dropped), nil)
+				assert.NoError(collect, err)
+			}, 30*time.Second, 250*time.Millisecond)
 			setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusHOT)
 			setTenantStatusEventually(t, className, tenant2, models.TenantActivityStatusHOT)
 		})

--- a/test/acceptance/drop_vector_index/redrop_test.go
+++ b/test/acceptance/drop_vector_index/redrop_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-// testRedropAfterRecreate pins the closed-epoch fence end to end: drop a
-// vector, let it finalize, re-create the name and write new vectors, then
-// re-drop through an all-cold window so the fresh enqueue mints no task while
-// the previous drop's FINISHED records still exist. The re-drop must re-clean
-// the re-created vectors — adopting the stale records' coverage would finalize
-// with the new vectors never stripped.
+// testRedropAfterRecreate pins the generation token end to end: drop a
+// vector, let it finalize, re-create the name and write new vectors, add a
+// NEW tenant, then re-drop through an all-cold window so the fresh enqueue
+// mints no task while the previous drop's FINISHED records still exist. The
+// grown tenant set is the shape that broke record-only epoch inference (the
+// stale records look "incomplete" against it); the marker-introduction purge
+// removes them before they can be inherited — the re-drop must re-clean every
+// tenant, never finalize over the re-created vectors.
 func testRedropAfterRecreate() func(t *testing.T) {
 	return func(t *testing.T) {
 		const (
@@ -39,15 +41,16 @@ func testRedropAfterRecreate() func(t *testing.T) {
 			dim       = 32
 			perTenant = 8
 			tenant    = "tenant-1"
+			tenant2   = "tenant-2" // created between the drops — the grown-set twist
 		)
 
-		insert := func(t *testing.T, idBase int) {
+		insert := func(t *testing.T, target string, idBase int) {
 			batch := make([]*models.Object, perTenant)
 			for i := range perTenant {
 				batch[i] = &models.Object{
 					ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-0000000024%02d", idBase+i)),
 					Class:      className,
-					Tenant:     tenant,
+					Tenant:     target,
 					Properties: map[string]any{"name": fmt.Sprintf("object-%d", idBase+i)},
 					Vectors: models.Vectors{
 						dropped: randVec(dim, float32(idBase+i)),
@@ -78,37 +81,44 @@ func testRedropAfterRecreate() func(t *testing.T) {
 				clschema.NewSchemaObjectsCreateParams().WithObjectClass(cls), nil)
 			require.NoError(t, err)
 			helper.CreateTenants(t, className, []*models.Tenant{{Name: tenant}})
-			insert(t, 0)
+			insert(t, tenant, 0)
 
 			dropTargetVector(t, className, dropped)
 			eventuallyTargetVectorRemoved(t, className, dropped)
 		})
 
-		t.Run("re-create the name and write new vectors", func(t *testing.T) {
+		t.Run("re-create the name, write new vectors, add a tenant", func(t *testing.T) {
 			cls := helper.GetClass(t, className)
 			cls.VectorConfig[dropped] = noneVectorConfig()
 			_, err := helper.Client(t).Schema.SchemaObjectsUpdate(
 				clschema.NewSchemaObjectsUpdateParams().WithClassName(className).WithObjectClass(cls), nil)
 			require.NoError(t, err)
-			insert(t, 50)
+			insert(t, tenant, 50)
+
+			helper.CreateTenants(t, className, []*models.Tenant{{Name: tenant2}})
+			insert(t, tenant2, 80)
 		})
 
 		t.Run("re-drop through an all-cold window", func(t *testing.T) {
 			// Cold BEFORE the drop: the fresh enqueue then mints no task, and
 			// only the previous drop's records exist when reconciliation runs.
 			setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusCOLD)
+			setTenantStatusEventually(t, className, tenant2, models.TenantActivityStatusCOLD)
 			dropTargetVector(t, className, dropped)
 			setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusHOT)
+			setTenantStatusEventually(t, className, tenant2, models.TenantActivityStatusHOT)
 		})
 
-		t.Run("the re-drop re-cleans instead of adopting stale coverage", func(t *testing.T) {
+		t.Run("the re-drop re-cleans every tenant instead of adopting stale coverage", func(t *testing.T) {
 			eventuallyTargetVectorRemoved(t, className, dropped)
-			objs := listTenantObjectsWithVectors(t, className, tenant)
-			require.Len(t, objs, 2*perTenant)
-			for _, obj := range objs {
-				require.NotContains(t, obj.Vectors, dropped,
-					"the re-dropped vectors must be stripped, not finalized over")
-				require.Equal(t, dim, vecDim(t, obj.Vectors[sibling]))
+			for tenantName, want := range map[string]int{tenant: 2 * perTenant, tenant2: perTenant} {
+				objs := listTenantObjectsWithVectors(t, className, tenantName)
+				require.Len(t, objs, want)
+				for _, obj := range objs {
+					require.NotContains(t, obj.Vectors, dropped,
+						"the re-dropped vectors must be stripped, not finalized over")
+					require.Equal(t, dim, vecDim(t, obj.Vectors[sibling]))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
