### PR TITLE
Drop derived file names when recovering an aborted compaction

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -455,27 +455,26 @@ func (s *segment) close() error {
 	return nil
 }
 
+// sidecarPaths returns the paths of the files derived from the segment: bloom
+// filters, count net additions and metadata.
+func (s *segment) sidecarPaths() []string {
+	paths := make([]string, 0, 3+int(s.secondaryIndexCount))
+	paths = append(paths, s.bloomFilterPath())
+	for i := 0; i < int(s.secondaryIndexCount); i++ {
+		paths = append(paths, s.bloomFilterSecondaryPath(i))
+	}
+	return append(paths, s.countNetPath(), s.metadataPath())
+}
+
 func (s *segment) dropImmediately() error {
 	// support for persisting bloom filters and cnas was added in v1.17,
 	// therefore the files may not be present on segments created with previous
 	// versions. By using RemoveAll, which does not error on NotExists, these
 	// drop calls are backward-compatible:
-	if err := os.RemoveAll(s.bloomFilterPath()); err != nil {
-		return fmt.Errorf("drop bloom filter: %w", err)
-	}
-
-	for i := 0; i < int(s.secondaryIndexCount); i++ {
-		if err := os.RemoveAll(s.bloomFilterSecondaryPath(i)); err != nil {
-			return fmt.Errorf("drop bloom filter: %w", err)
+	for _, path := range s.sidecarPaths() {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("drop %s: %w", filepath.Base(path), err)
 		}
-	}
-
-	if err := os.RemoveAll(s.countNetPath()); err != nil {
-		return fmt.Errorf("drop count net additions file: %w", err)
-	}
-
-	if err := os.RemoveAll(s.metadataPath()); err != nil {
-		return fmt.Errorf("drop metadata file: %w", err)
 	}
 
 	// for the segment itself, we're not using RemoveAll, but Remove. If there
@@ -493,22 +492,10 @@ func (s *segment) dropMarked() error {
 	// therefore the files may not be present on segments created with previous
 	// versions. By using RemoveAll, which does not error on NotExists, these
 	// drop calls are backward-compatible:
-	if err := s.removeAllMarked(s.bloomFilterPath()); err != nil {
-		return fmt.Errorf("drop previously marked bloom filter: %w", err)
-	}
-
-	for i := 0; i < int(s.secondaryIndexCount); i++ {
-		if err := s.removeAllMarked(s.bloomFilterSecondaryPath(i)); err != nil {
-			return fmt.Errorf("drop previously marked secondary bloom filter: %w", err)
+	for _, path := range s.sidecarPaths() {
+		if err := s.removeAllMarked(path); err != nil {
+			return fmt.Errorf("drop previously marked %s: %w", filepath.Base(path), err)
 		}
-	}
-
-	if err := s.removeAllMarked(s.countNetPath()); err != nil {
-		return fmt.Errorf("drop previously marked count net additions file: %w", err)
-	}
-
-	if err := s.removeAllMarked(s.metadataPath()); err != nil {
-		return fmt.Errorf("drop previously marked metadata file: %w", err)
 	}
 
 	if s.segmentFileSuperseded {
@@ -573,29 +560,9 @@ func (s *segment) markSidecarsForDeletion() error {
 	// support for persisting bloom filters and cnas was added in v1.17,
 	// therefore the files may not be present on segments created with previous
 	// versions. If we get a not exist error, we ignore it.
-	if err := s.markDeleted(s.bloomFilterPath()); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("mark bloom filter deleted: %w", err)
-		}
-	}
-
-	for i := 0; i < int(s.secondaryIndexCount); i++ {
-		if err := s.markDeleted(s.bloomFilterSecondaryPath(i)); err != nil {
-			if !os.IsNotExist(err) {
-				return fmt.Errorf("mark secondary bloom filter deleted: %w", err)
-			}
-		}
-	}
-
-	if err := s.markDeleted(s.countNetPath()); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("mark count net additions file deleted: %w", err)
-		}
-	}
-
-	if err := s.markDeleted(s.metadataPath()); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("mark metadata file deleted: %w", err)
+	for _, path := range s.sidecarPaths() {
+		if err := s.markDeleted(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("mark %s deleted: %w", filepath.Base(path), err)
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -25,7 +25,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/byteops"
 
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/diskio"
 )
 
@@ -88,8 +87,7 @@ func (s *segment) initBloomFilter(overwrite bool, existingFilesList map[string]i
 				return nil
 			}
 
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !canRecomputeSidecar(err) {
 				return err
 			}
 
@@ -177,8 +175,7 @@ func (s *segment) initSecondaryBloomFilter(pos int, overwrite bool, existingFile
 				return nil
 			}
 
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !canRecomputeSidecar(err) {
 				return err
 			}
 

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -318,6 +318,11 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 				return nil, fmt.Errorf("delete already compacted right segment %s: %w", rightSegmentFilename, err)
 			}
 			delete(files, rightSegmentFilename)
+			// the compacted segment is renamed to the same name below and would
+			// otherwise try to load the derived files that were just deleted
+			for _, path := range rightSegment.sidecarPaths() {
+				delete(files, filepath.Base(path))
+			}
 
 			err = diskio.Fsync(sg.dir)
 			if err != nil {

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -17,7 +17,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,6 +220,158 @@ func TestSegmentGroupInit_RemovesStrayTempFiles(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCompactionRecoveryDropsRightSegmentDerivedFiles covers an aborted
+// compaction where only the right source segment is left: it is deleted
+// together with its derived files, and the compacted segment takes over its
+// name, so those derived files must not be looked up when it is loaded.
+func TestCompactionRecoveryDropsRightSegmentDerivedFiles(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		useBloomFilter   bool
+		calcCNA          bool
+		writeMetadata    bool
+		secondaryIndices uint16
+		infoInFileName   bool
+		// enable the metadata file only for the recovering bucket, so the segments
+		// on disk still have separate derived files
+		metadataOnRecovery bool
+		// number of derived files per extension expected after the recovery
+		wantDerivedFiles map[string]int
+	}{
+		{
+			name: "cna", calcCNA: true, infoInFileName: true,
+			wantDerivedFiles: map[string]int{".cna": 1},
+		},
+		{
+			name: "bloom filter", useBloomFilter: true, infoInFileName: true,
+			wantDerivedFiles: map[string]int{".bloom": 1},
+		},
+		{
+			name: "bloom filter and cna", useBloomFilter: true, calcCNA: true, infoInFileName: true,
+			wantDerivedFiles: map[string]int{".bloom": 1, ".cna": 1},
+		},
+		{
+			name: "secondary bloom filters", useBloomFilter: true, calcCNA: true, secondaryIndices: 2, infoInFileName: true,
+			wantDerivedFiles: map[string]int{".bloom": 3, ".cna": 1},
+		},
+		{
+			name: "metadata", useBloomFilter: true, calcCNA: true, writeMetadata: true, infoInFileName: true,
+			wantDerivedFiles: map[string]int{".metadata": 1},
+		},
+		{
+			name: "metadata enabled on recovery", useBloomFilter: true, calcCNA: true, metadataOnRecovery: true, infoInFileName: true,
+			wantDerivedFiles: map[string]int{".metadata": 1},
+		},
+		{
+			name: "without segment info in file name", useBloomFilter: true, calcCNA: true, infoInFileName: false,
+			wantDerivedFiles: map[string]int{".bloom": 1, ".cna": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithUseBloomFilter(tt.useBloomFilter),
+				WithCalcCountNetAdditions(tt.calcCNA),
+				WithWriteMetadata(tt.writeMetadata),
+				WithSecondaryIndices(tt.secondaryIndices),
+				WithWriteSegmentInfoIntoFileName(tt.infoInFileName),
+			}
+
+			srcDir := t.TempDir()
+			b, err := NewBucketCreator().NewBucket(ctx, srcDir, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			require.NoError(t, err)
+
+			for i := range 20 {
+				var secondaryKeys []SecondaryKeyOption
+				for pos := range int(tt.secondaryIndices) {
+					secondaryKeys = append(secondaryKeys, WithSecondaryKey(pos, fmt.Appendf(nil, "sec%d-%d", pos, i)))
+				}
+				require.NoError(t, b.Put(fmt.Appendf(nil, "hello%d", i), fmt.Appendf(nil, "world%d", i), secondaryKeys...))
+				if i == 9 {
+					require.NoError(t, b.FlushMemtable())
+				}
+			}
+			require.NoError(t, b.FlushMemtable())
+			require.Len(t, b.disk.segments, 2)
+
+			leftID := segmentID(filepath.Base(b.disk.segments[0].getPath()))
+			rightID := segmentID(filepath.Base(b.disk.segments[1].getPath()))
+
+			// keep the right segment and its derived files as they were before the
+			// compaction started
+			backupDir := t.TempDir()
+			copyFilesWithPrefix(t, srcDir, backupDir, "segment-"+rightID+".")
+
+			once, err := b.disk.compactOnce(ctx)
+			require.NoError(t, err)
+			require.True(t, once)
+			require.NoError(t, b.Shutdown(ctx))
+
+			// the compacted segment is still a tmp file, the left source segment is
+			// already gone
+			extraInfo := ""
+			if tt.infoInFileName {
+				extraInfo = ".l1.s0"
+			}
+			testDir := t.TempDir()
+			copyFile(t, filepath.Join(srcDir, singleDbFile(t, srcDir)),
+				filepath.Join(testDir, fmt.Sprintf("segment-%s_%s%s.db.tmp", leftID, rightID, extraInfo)))
+			copyFilesWithPrefix(t, backupDir, testDir, "segment-")
+
+			recoveryOpts := opts
+			if tt.metadataOnRecovery {
+				recoveryOpts = append(slices.Clone(opts), WithWriteMetadata(true))
+			}
+			b2, err := NewBucketCreator().NewBucket(ctx, testDir, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), recoveryOpts...)
+			require.NoError(t, err)
+			defer b2.Shutdown(ctx)
+
+			for i := range 20 {
+				value, err := b2.Get(fmt.Appendf(nil, "hello%d", i))
+				require.NoError(t, err)
+				require.Equal(t, fmt.Sprintf("world%d", i), string(value))
+			}
+
+			fileTypes := countFileTypes(t, testDir)
+			for _, ext := range []string{".bloom", ".cna", ".metadata"} {
+				require.Equal(t, tt.wantDerivedFiles[ext], fileTypes[ext], "number of %s files", ext)
+			}
+		})
+	}
+}
+
+func copyFilesWithPrefix(t *testing.T, srcDir, destDir, prefix string) {
+	t.Helper()
+	entries, err := os.ReadDir(srcDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), prefix) {
+			copyFile(t, filepath.Join(srcDir, entry.Name()), filepath.Join(destDir, entry.Name()))
+		}
+	}
+}
+
+func singleDbFile(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var found []string
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".db" {
+			found = append(found, entry.Name())
+		}
+	}
+	require.Len(t, found, 1)
+	return found[0]
 }
 
 func copyFile(t *testing.T, src, dest string) {

--- a/adapters/repos/db/lsmkv/segment_metadata.go
+++ b/adapters/repos/db/lsmkv/segment_metadata.go
@@ -14,7 +14,6 @@ package lsmkv
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,8 +54,7 @@ func (s *segment) initMetadata(metrics *Metrics, overwrite bool, exists existsOn
 			if err == nil {
 				return true, nil // successfully loaded
 			}
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !canRecomputeSidecar(err) {
 				return false, err
 			}
 

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -27,6 +28,13 @@ import (
 // any pre-computed data this is a recoverable issue, as the data can simply be
 // re-computed at read-time.
 var ErrInvalidChecksum = errors.New("invalid checksum")
+
+// canRecomputeSidecar reports whether a failed load of a bloom filter, count net
+// additions or metadata file can be resolved by computing it again: the file is
+// corrupt, or it is gone even though the file list said it exists.
+func canRecomputeSidecar(err error) bool {
+	return errors.Is(err, ErrInvalidChecksum) || errors.Is(err, fs.ErrNotExist)
+}
 
 const CountNetAdditionsFileSuffix = ".cna"
 
@@ -65,8 +73,7 @@ func (s *segment) initCountNetAdditions(exists existsOnLowerSegmentsFn, overwrit
 				return nil
 			}
 
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !canRecomputeSidecar(err) {
 				return err
 			}
 

--- a/adapters/repos/db/lsmkv/segment_test.go
+++ b/adapters/repos/db/lsmkv/segment_test.go
@@ -189,6 +189,68 @@ func TestSegment_StripTmpExtensions(t *testing.T) {
 	}
 }
 
+// TestSegment_ListedDerivedFileMissingOnDisk covers a derived file that the
+// file list says exists while it is gone from disk: it is computed again
+// instead of failing the segment load.
+func TestSegment_ListedDerivedFileMissingOnDisk(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	existsOnLower := func(key []byte) (bool, error) { return false, nil }
+
+	tests := []struct {
+		name          string
+		writeMetadata bool
+		missingSuffix string
+	}{
+		{name: "bloom filter", missingSuffix: ".bloom"},
+		{name: "secondary bloom filter", missingSuffix: ".secondary.0.bloom"},
+		{name: "cna", missingSuffix: ".cna"},
+		{name: "metadata", writeMetadata: true, missingSuffix: ".metadata"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			expectedFileTypes := map[string]int{".db": 1, ".bloom": 3, ".cna": 1}
+			if tt.writeMetadata {
+				expectedFileTypes = map[string]int{".db": 1, ".metadata": 1}
+			}
+			createSegmentFilesUsingBucket(t, ctx, logger, dir, "segment-1234567890.db", []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithUseBloomFilter(true),
+				WithCalcCountNetAdditions(true),
+				WithWriteMetadata(tt.writeMetadata),
+				WithSecondaryIndices(2),
+			}, expectedFileTypes)
+
+			fileList := map[string]int64{}
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			for i := range entries {
+				info, err := entries[i].Info()
+				require.NoError(t, err)
+				fileList[entries[i].Name()] = info.Size()
+			}
+
+			missingFile := "segment-1234567890" + tt.missingSuffix
+			require.Contains(t, fileList, missingFile)
+			require.NoError(t, os.Remove(filepath.Join(dir, missingFile)))
+
+			seg, err := newSegment(filepath.Join(dir, "segment-1234567890.db"), logger, nil,
+				existsOnLower, segmentConfig{
+					useBloomFilter:        true,
+					calcCountNetAdditions: true,
+					writeMetadata:         tt.writeMetadata,
+					fileList:              fileList,
+				})
+			require.NoError(t, err)
+			defer seg.close()
+
+			require.FileExists(t, filepath.Join(dir, missingFile))
+		})
+	}
+}
+
 func createSegmentFilesUsingBucket(t *testing.T, ctx context.Context, logger logrus.FieldLogger, path, segmentFilename string,
 	bucketOptions []BucketOption, expectedFileTypes map[string]int,
 ) {


### PR DESCRIPTION
### What's being changed:

When only the right source segment survived an aborted compaction, it is deleted with its derived files and the compacted segment is renamed to the same base name. The derived file names stayed in the file list, so loading the recompacted segment tried to read a bloom filter, cna or metadata file that no longer exists and the whole bucket failed to open.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
