### PR TITLE
Fix shard shutdown backup and wrong error return

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -311,6 +311,12 @@ func (i *Index) descriptorWithHardlinks(ctx context.Context, backupID string, de
 func (i *Index) backupShardWithHardlinks(ctx context.Context, name string, classBaseDescrs []*backup.ClassDescriptor, stagingRoot string) (*backup.ShardDescriptor, error) {
 	shardBaseDescr := i.collectShardBaseDescrs(name, classBaseDescrs)
 
+	// Deferred before backupLock so it runs after the unlock: dropping the last
+	// shard reference can run the shard teardown inline, and doing that under
+	// backupLock blocks every write to the shard for the teardown's duration.
+	releaseShard := func() {}
+	defer func() { releaseShard() }()
+
 	i.backupLock.Lock(name)
 	defer i.backupLock.Unlock(name)
 
@@ -363,7 +369,7 @@ func (i *Index) backupShardWithHardlinks(ctx context.Context, name string, class
 	if err != nil {
 		return nil, fmt.Errorf("prevent shutdown of shard %v: %w", name, err)
 	}
-	defer release()
+	releaseShard = release
 
 	i.shardCreateLocks.Unlock(name)
 	shardCreateLocksHeld = false

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -855,6 +855,81 @@ func TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked(t *testing.T) {
 	idx.shardCreateLocks.RUnlock(shardName)
 }
 
+// Asserts the shard reference is dropped only after backupLock is unlocked, on
+// every return that follows preventShutdown. Dropping the last reference can run
+// the shard teardown inline, which under backupLock blocks all writes to the shard.
+func TestBackupShardWithHardlinks_ReleasesShardAfterBackupLock(t *testing.T) {
+	className := "TestClass"
+	shardName := "test-shard"
+	snapshotFile := "objects/segment-0001.db"
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		snapshotErr error
+		// missingBigFile makes FillFileInfo stat a file that is absent from the staging dir.
+		missingBigFile bool
+		expectedErr    string
+	}{
+		{name: "success"},
+		{name: "snapshot fails", snapshotErr: errors.New("out of disk"), expectedErr: "snapshot shard"},
+		{name: "file info fails", missingBigFile: true, expectedErr: "gather shard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shardState := NewMultiTenantShardingStateBuilder().
+				AddTenant(shardName, models.TenantActivityStatusHOT).
+				WithReplicationFactor(1).
+				Build()
+			idx := newDescriptorTestIndex(t, t.TempDir(), className, shardState)
+
+			var released, backupLockFreeAtRelease bool
+			mockShard := NewMockShardLike(t)
+			mockShard.EXPECT().preventShutdown().Return(func() {
+				released = true
+				backupLockFreeAtRelease = idx.backupLock.TryRLock(shardName)
+				if backupLockFreeAtRelease {
+					idx.backupLock.RUnlock(shardName)
+				}
+			}, nil)
+			mockShard.EXPECT().
+				CreateBackupSnapshot(mock.Anything, mock.Anything, mock.Anything).
+				RunAndReturn(func(_ context.Context, sd *backup.ShardDescriptor, _ string) ([]string, error) {
+					if tt.snapshotErr != nil {
+						return nil, tt.snapshotErr
+					}
+					sd.Name = shardName
+					sd.Node = "node1"
+					return []string{snapshotFile}, nil
+				})
+			idx.shards.Store(shardName, mockShard)
+
+			var baseDescrs []*backup.ClassDescriptor
+			if tt.missingBigFile {
+				baseDescrs = []*backup.ClassDescriptor{{
+					BackupID: "base-backup",
+					Shards: []*backup.ShardDescriptor{{
+						Name:          shardName,
+						BigFilesChunk: map[string]backup.BigFileInfo{snapshotFile: {Size: 1}},
+					}},
+				}}
+			}
+
+			_, err := idx.backupShardWithHardlinks(ctx, shardName, baseDescrs, t.TempDir())
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.True(t, released, "shard reference must be released")
+			assert.True(t, backupLockFreeAtRelease,
+				"backupLock must be unlocked before the shard reference is dropped")
+		})
+	}
+}
+
 // Asserts both locks are released on the preventShutdown error path — guards
 // the shardCreateLocksHeld bookkeeping that supports the early-release.
 func TestBackupShardWithHardlinks_PreventShutdownErrorReleasesLocks(t *testing.T) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1808,6 +1808,9 @@ func (i *Index) multiObjectByID(ctx context.Context,
 					err = errors.Wrapf(err, "local shard %s", shardId(i.ID(), shardName))
 				}
 			}()
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			objects, err = i.remote.MultiGetObjects(ctx, shardName, extractIDsFromMulti(group.ids))
 			if err != nil {

--- a/adapters/repos/db/index_multi_object_by_id_test.go
+++ b/adapters/repos/db/index_multi_object_by_id_test.go
@@ -1,0 +1,81 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	"github.com/weaviate/weaviate/entities/multi"
+)
+
+// TestMultiObjectByIDLocalReadError asserts that a failed read on a local shard
+// surfaces to the caller. Returning the objects collected so far with a nil error
+// would report a partial result as a complete one.
+func TestMultiObjectByIDLocalReadError(t *testing.T) {
+	className := "MultiObjectByIDLocalRead"
+
+	tests := []struct {
+		name string
+		// corrupt reports whether the stored object is replaced by an
+		// undecodable value before it is read back.
+		corrupt   bool
+		wantErr   bool
+		wantFound bool
+	}{
+		{name: "readable object", corrupt: false, wantErr: false, wantFound: true},
+		{name: "undecodable object", corrupt: true, wantErr: true, wantFound: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			shard, idx := testShard(t, ctx, className, func(i *Index) {
+				i.shardResolver = resolver.NewShardResolver(className, false, i.getSchema)
+			})
+
+			obj := testObject(className)
+			require.NoError(t, shard.PutObject(ctx, obj))
+
+			if test.corrupt {
+				key, err := uuid.MustParse(obj.ID().String()).MarshalBinary()
+				require.NoError(t, err)
+				docID := make([]byte, 8)
+				binary.LittleEndian.PutUint64(docID, obj.DocID)
+				// marshaller version 2 does not exist, so decoding fails
+				require.NoError(t, shard.Store().Bucket(helpers.ObjectsBucketLSM).
+					Put(key, []byte{2}, lsmkv.WithSecondaryKey(
+						helpers.ObjectsBucketLSMDocIDSecondaryIndex, docID)))
+			}
+
+			found, err := idx.multiObjectByID(ctx,
+				[]multi.Identifier{{ID: obj.ID().String(), ClassName: className}}, "")
+
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, found, 1)
+			if test.wantFound {
+				require.NotNil(t, found[0])
+				require.Equal(t, obj.ID(), found[0].ID())
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

More bugs/problems found during shutdown work:
- Backups are holding the shutdown lock while tearing down a shard (which can take a bit)
- multiObjecById did not return its error

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
